### PR TITLE
fix(event): initialize classic double-click interval

### DIFF
--- a/src/memory/globals.rs
+++ b/src/memory/globals.rs
@@ -28,6 +28,12 @@ pub mod addr {
     /// MemErr: current value of MemError (word).
     /// Inside Macintosh Volume IV, IV-80; low-memory table IV-246.
     pub const MEM_ERR: u32 = 0x0220;
+    /// DoubleTime: maximum TickCount interval recognized as a double-click.
+    /// Classic applications commonly read this long directly instead of
+    /// calling through the Event Manager.
+    /// Inside Macintosh Volume I, I-260 documents the value and global name;
+    /// MPW SysEqu.h defines `DoubleTime` at $02F0.
+    pub const DOUBLE_TIME: u32 = 0x02F0;
     pub const ROM85: u32 = 0x028E; // Version number of ROM (word) - Inside Macintosh V, V-578
 
     /// SdVolume: current speaker volume (1 byte, low-order three bits).
@@ -350,6 +356,11 @@ mod tests {
         // Other heavily-load-bearing globals; a regression in any
         // of these has been historically catastrophic.
         assert_eq!(addr::TICKS, 0x016A, "Ticks per IM:II II-387");
+        assert_eq!(
+            addr::DOUBLE_TIME,
+            0x02F0,
+            "DoubleTime at $02F0 per MPW SysEqu.h; semantics documented in IM:I I-260"
+        );
         assert_eq!(
             addr::RND_SEED,
             0x0156,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -483,6 +483,10 @@ pub const DEFAULT_REALTIME_INSTRUCTIONS_PER_SECOND: f64 = DEFAULT_REALTIME_CPU_M
 // This lower value lets scripted harnesses run quickly without being wall-clock-paced.
 const INSTRUCTIONS_PER_TICK: u32 = 12_000;
 const DEFAULT_LAUNCH_TICKS: u32 = 600;
+/// Default double-click interval: 20 VBL ticks, approximately one third of a
+/// second. This is the conventional classic Mac OS setting exposed through
+/// the low-memory `DoubleTime` global.
+const DEFAULT_DOUBLE_TIME_TICKS: u32 = 20;
 const MAC_EPOCH_OFFSET_FROM_UNIX: u64 = 2_082_844_800;
 const CURSOR_TASK_NOOP_ADDR: u32 = 0x0000_0060;
 
@@ -1959,6 +1963,12 @@ impl FixtureRunner {
             .app_start_time
             .unwrap_or_else(current_mac_epoch_seconds);
         self.bus.write_long(addr::TIME, time);
+        // DoubleTime ($02F0): maximum interval between mouseDown events that
+        // constitutes a double-click. RAM starts zeroed, but zero makes the
+        // canonical unsigned comparison `(thisClick - lastClick) < DoubleTime`
+        // impossible. Lemmings uses that exact sequence for its nuke control.
+        self.bus
+            .write_long(addr::DOUBLE_TIME, DEFAULT_DOUBLE_TIME_TICKS);
         // RndSeed ($0156): system random seed initialized during boot.
         // On a real Mac, the boot code seeds this from the real-time clock
         // so that programs that read it directly (without calling Random)
@@ -6108,6 +6118,25 @@ mod tests {
         assert_eq!(
             runner.dispatcher.tick_count, DEFAULT_LAUNCH_TICKS,
             "TickCount fast path must stay in sync with low-memory Ticks"
+        );
+    }
+
+    #[test]
+    fn init_app_seeds_classic_double_click_interval() {
+        use crate::memory::globals::addr;
+
+        let code0 = minimal_code0(0, 0x2000, 0, 0);
+        let fork_bytes = make_resource_fork_bytes(&[(*b"CODE", 0, &code0)]);
+        let fork = ResourceFork::parse(&fork_bytes).expect("parse synthetic app fork");
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+
+        let app = runner.load_app(&fork).expect("load app");
+        runner.init_app(&app);
+
+        assert_eq!(
+            runner.bus.read_long(addr::DOUBLE_TIME),
+            DEFAULT_DOUBLE_TIME_TICKS,
+            "a zero DoubleTime makes every application-level double-click test fail"
         );
     }
 


### PR DESCRIPTION
Closes #7

### Summary

- Add the `DoubleTime` low-memory global at `$02F0`, as defined by MPW
  `SysEqu.h`.
- Seed it to 20 VBL ticks during application initialization.
- Add regression coverage for both the address and initialized value.

Classic applications may read `DoubleTime` directly instead of asking the
Event Manager to classify clicks. Leaving the zero-initialized RAM value in
place makes the canonical unsigned interval check impossible to satisfy.

This caused Lemmings' double-click-only nuke control to ignore every attempt.
The fix is generic low-memory initialization; it contains no Lemmings-specific
matching or behavior.

`Inside Macintosh`, Volume I, p. I-260 documents `GetDblTime` and notes that
assembly-language programs can read the value from the global variable
`DoubleTime`. It does not specify the global's address. MPW `SysEqu.h` defines
`DoubleTime` at `$02F0`.

### Verification

- `cargo test --lib init_app_seeds_classic_double_click_interval`
- `cargo test --lib low_mem_global_addresses_match_inside_macintosh`
- Manual Lemmings gameplay: the nuke control responds to a double-click.
