### PR TITLE
fix(audio): recover buffered lead after frontend stalls

### DIFF
--- a/src/audio.rs
+++ b/src/audio.rs
@@ -265,11 +265,25 @@ impl SharedAudioState {
             return [0.0, 0.0];
         }
 
-        if self.underrun_samples > 0 && trace_audio_enabled() {
-            eprintln!(
-                "[AUDIO] underrun ended after {} samples",
-                self.underrun_samples
-            );
+        // Once the stream underruns, consuming the first small refill
+        // immediately leaves it permanently balanced on empty: the GUI and
+        // device produce/consume at the same average rate, so ordinary timer
+        // jitter becomes a train of audible gaps. Hold silence until the
+        // original safety lead has been rebuilt, then resume continuously.
+        if self.underrun_samples > 0 && self.buffer.len() < host_audio_prefill_samples() {
+            self.underrun_samples = self.underrun_samples.saturating_add(1);
+            self.source_phase = 0.0;
+            self.last_frame = [0.0, 0.0];
+            return [0.0, 0.0];
+        }
+
+        if self.underrun_samples > 0 {
+            if trace_audio_enabled() {
+                eprintln!(
+                    "[AUDIO] underrun ended after {} samples",
+                    self.underrun_samples
+                );
+            }
             self.underrun_samples = 0;
         }
 
@@ -734,7 +748,7 @@ mod tests {
     }
 
     #[test]
-    fn host_audio_resume_after_underrun_starts_at_next_queued_frame() {
+    fn host_audio_resume_after_underrun_rebuilds_lead_then_starts_at_next_frame() {
         let mut state = SharedAudioState {
             buffer: std::collections::VecDeque::new(),
             source_phase: 0.75,
@@ -745,6 +759,13 @@ mod tests {
 
         assert_eq!(state.next_frame(44_100), [0.0, 0.0]);
         state.queue_frames(&[[0x90, 0x91], [0xA0, 0xA1]], 2);
+        assert_eq!(
+            state.next_frame(44_100),
+            [0.0, 0.0],
+            "a short refill must be held instead of immediately underrunning again"
+        );
+        let remaining = host_audio_prefill_samples() - 2;
+        state.queue_frames(&vec![[0x80, 0x80]; remaining], remaining);
 
         let first = state.next_frame(crate::sound::OUTPUT_RATE * 2);
         assert_eq!(
@@ -753,7 +774,11 @@ mod tests {
                 SharedAudioState::u8_to_f32(0x90),
                 SharedAudioState::u8_to_f32(0x91)
             ],
-            "after a starvation gap, host playback should restart on the first queued effect sample"
+            "after rebuilding its safety lead, playback should restart on the first queued effect sample"
+        );
+        assert_eq!(
+            state.underrun_samples, 0,
+            "successful playback must leave underrun recovery mode"
         );
     }
 }

--- a/src/bin/systemless.rs
+++ b/src/bin/systemless.rs
@@ -54,6 +54,7 @@ const CPU_BATCH_INSTRUCTIONS: usize = 10_000;
 const SOUND_CALLBACK_SLICE_INSTRUCTIONS: usize = CPU_BATCH_INSTRUCTIONS;
 const SOUND_CALLBACK_RESERVED_INSTRUCTIONS_PER_FRAME: usize = 25_000;
 const AUDIO_CALLBACK_CHUNK_SAMPLES: usize = 32;
+const MAX_AUDIO_MIX_INTERVAL: std::time::Duration = std::time::Duration::from_millis(250);
 const DEFAULT_GUI_ARROWS_AS_NUMPAD: bool = false;
 
 #[cfg(target_os = "macos")]
@@ -126,6 +127,10 @@ struct App {
     cpu_instruction_credit: f64,
     /// Fractional host samples carried between GUI slices to preserve rate.
     audio_sample_remainder: f64,
+    /// Wall-clock instant represented by the most recently queued audio.
+    /// Unlike video, audio cannot simply drop a late host frame without
+    /// starving the device ring buffer.
+    last_audio_mix_time: Option<std::time::Instant>,
     /// Current mouse position in physical window pixels
     mouse_physical: (f64, f64),
     /// Current game screen dimensions (tracks screen_mode changes)
@@ -178,6 +183,7 @@ impl App {
             next_cpu_budget_time: None,
             cpu_instruction_credit: 0.0,
             audio_sample_remainder: 0.0,
+            last_audio_mix_time: None,
             mouse_physical: (0.0, 0.0),
             current_screen_width: INITIAL_SCREEN_WIDTH,
             current_screen_height: INITIAL_SCREEN_HEIGHT,
@@ -425,8 +431,23 @@ impl App {
             self.next_cpu_budget_time = Some(cpu_deadline);
             game::MAX_INSTRUCTIONS_PER_FRAME
         };
+        let audio_interval = self
+            .last_audio_mix_time
+            .replace(now)
+            .map(|previous| now.saturating_duration_since(previous))
+            .unwrap_or(FRAME_DURATION)
+            .min(MAX_AUDIO_MIX_INTERVAL);
         let audio_samples =
-            Self::audio_samples_for_duration(FRAME_DURATION, &mut self.audio_sample_remainder);
+            Self::audio_samples_for_duration(audio_interval, &mut self.audio_sample_remainder);
+        if std::env::var_os("SYSTEMLESS_TRACE_AUDIO").is_some()
+            && audio_interval > FRAME_DURATION + FRAME_DURATION / 2
+        {
+            eprintln!(
+                "[AUDIO] recovering {:.1} ms of host time ({} source samples)",
+                audio_interval.as_secs_f64() * 1000.0,
+                audio_samples
+            );
+        }
 
         let runner = self.runner.as_mut().expect("runner checked above");
 
@@ -1898,6 +1919,26 @@ mod tests {
             first_refill_frame <= AUDIO_CALLBACK_CHUNK_SAMPLES + 1,
             "doubleback refill should be serviced between late-audio chunks, not after a long silence tail; first refill frame={}",
             first_refill_frame
+        );
+    }
+
+    #[test]
+    fn step_frame_recovers_audio_elapsed_during_a_dropped_video_frame() {
+        let now = std::time::Instant::now();
+        let (runner, queued) = gui_runner_with_counting_audio();
+        let mut app = App::new(PathBuf::from("dummy"), false, None, false);
+        app.runner = Some(runner);
+        app.start_time = Some(now);
+        app.next_frame_time = Some(now);
+        app.last_audio_mix_time =
+            Some(std::time::Instant::now() - std::time::Duration::from_millis(100));
+
+        app.step_frame();
+
+        assert!(
+            (4_400..=4_600).contains(&*queued.borrow()),
+            "100 ms of elapsed host time should queue about 2,205 stereo frames, got {} bytes",
+            *queued.borrow()
         );
     }
 


### PR DESCRIPTION
Closes #13

### Summary

- derive GUI audio production from elapsed wall time independently of video frame scheduling
- cap a single recovery interval at 250 ms
- after an underrun, hold silence until the existing 90 ms safety lead is rebuilt
- preserve queued audio and resume from its first frame
- add regression coverage for a 100 ms frontend stall and post-underrun recovery

The GUI previously produced exactly one frame's worth of audio per frontend update. When the frame scheduler intentionally dropped a late video update, it also dropped that duration of audio, permanently draining the device queue's safety lead. If the queue then underruns, immediately consuming the first small refill keeps playback balanced at the empty edge and turns ordinary scheduling jitter into repeated audible gaps.

This change keeps video frame dropping intact while accounting for elapsed audio time separately. It does not change CPU or VBL pacing.

### Verification

- `cargo test --lib host_audio_` — 11 passed
- `cargo test --bin systemless step_frame_recovers_audio_elapsed_during_a_dropped_video_frame` — 1 passed
- `cargo test --lib` — 2,633 passed, 3 ignored
- `cargo test --bin systemless` — 26 passed
