### PR TITLE
fix(macos): drain Metal worker autoreleases

### DIFF
--- a/src/bin/desktop/metal_present.rs
+++ b/src/bin/desktop/metal_present.rs
@@ -16,7 +16,7 @@ use std::sync::{Arc, Condvar, Mutex};
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
-use objc2::rc::Retained;
+use objc2::rc::{autoreleasepool, Retained};
 use objc2::runtime::{NSObject, ProtocolObject};
 use objc2::{msg_send, msg_send_id};
 use objc2_foundation::{ns_string, CGRect, MainThreadMarker};
@@ -267,7 +267,10 @@ impl GuestRenderWorker {
             drop(state);
 
             let wait_start = Instant::now();
-            let drawable = unsafe { self.layer.nextDrawable() };
+            // This is a raw Rust worker rather than an AppKit-created thread,
+            // so it has no ambient Objective-C autorelease pool. Drain the
+            // temporary QuartzCore objects created while acquiring a drawable.
+            let drawable = autoreleasepool(|_| unsafe { self.layer.nextDrawable() });
             let drawable_wait = wait_start.elapsed();
 
             let mut state = mailbox
@@ -298,10 +301,12 @@ impl GuestRenderWorker {
             drop(state);
 
             let render_start = Instant::now();
-            let result = match drawable {
+            // Command buffers, pass descriptors, and driver bookkeeping may
+            // also autorelease objects while encoding the frame.
+            let result = autoreleasepool(|_| match drawable {
                 Some(drawable) => self.submit(&submission, &drawable),
                 None => Ok(()),
-            };
+            });
             let render_time = render_start.elapsed();
 
             let mut state = mailbox


### PR DESCRIPTION
## Summary

- drain Objective-C autoreleases created by `CAMetalLayer::nextDrawable` on the raw Rust presenter thread
- drain temporary Metal command-buffer, render-pass, and driver objects after each encoded frame
- keep the existing drawable ownership, mailbox synchronization, and presentation behavior unchanged

## Cause

The asynchronous Metal presenter runs on a thread created with `std::thread`, not an AppKit-managed thread. It therefore has no ambient Objective-C autorelease pool. QuartzCore and Metal create autoreleased bookkeeping objects while acquiring and encoding each drawable; those objects accumulated for the lifetime of the worker.

This was visible as a frame-rate-dependent memory leak. After a warm Lemmings run, `heap` reported:

| live object | before | after |
| --- | ---: | ---: |
| `CAMetalDrawable` | 12,053 | 1 |
| `IOSurfaceSharedEvent` | 12,052 | 1 |

The matching `NSMutableArray` and `NSDictionary` populations also stopped growing.

## Memory measurements

Measured on an Intel Mac running Lemmings with the native Metal presenter:

- before: physical footprint grew from 39 MB to 56 MB; IOSurface residency grew from 7.96 MB to 15.4 MB
- after: initial physical footprint was 37 MB and reached 41 MB while warming the emulator/JIT; IOSurface residency remained fixed at 7.96 MB

The guest's nominal 64 MB RAM allocation is sparse: only about 3.6 MB of its pages were resident. The observed growth was therefore presenter bookkeeping, not guest RAM or the amount of 68k code translated by the JIT.

## CPU check

A 20-second post-change sample showed autorelease pool creation in only 5 of approximately 20,000 samples per persistent thread. The largest remaining application CPU costs were still 68k execution (`FixtureRunner::run_steps_internal` and `m68k::core::mem_ops::execute_mem_op`), so the fix has no measurable presentation-performance penalty.

## Validation

- `rustfmt --edition 2021 --check src/bin/desktop/metal_present.rs`
- `cargo check --bin systemless`
- `cargo test --bin systemless metal_present` (6 passed)
- live Lemmings heap/footprint comparison described above
