### PR TITLE
fix(quickdraw): honor application bitmap fonts and face widths

### DIFF
--- a/src/quickdraw/fonts/mod.rs
+++ b/src/quickdraw/fonts/mod.rs
@@ -200,6 +200,198 @@ static MACROMAN_TABLE: LazyLock<&'static [MacRomanFace]> =
 static ITALIC_TABLE: LazyLock<&'static [ItalicFace]> =
     LazyLock::new(|| Box::leak(Vec::<ItalicFace>::new().into_boxed_slice()));
 
+/// Bitmap strikes supplied by the currently loaded Classic Mac application.
+/// The decoded storage is leaked deliberately: font resources are tiny and
+/// glyph references are handed through the renderer as `'static` slices.
+/// A Systemless process hosts one guest application, while replacement lets a
+/// later resource fork with the same family/size take precedence.
+static RESOURCE_FACES: LazyLock<Mutex<HashMap<(i16, i16), &'static FontFace>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+static RESOURCE_MACROMAN_FACES: LazyLock<Mutex<HashMap<(i16, i16), &'static MacRomanFace>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+fn resource_word(data: &[u8], offset: usize) -> Option<u16> {
+    Some(u16::from_be_bytes([
+        *data.get(offset)?,
+        *data.get(offset + 1)?,
+    ]))
+}
+
+/// Decode a classic `FONT`/`NFNT` bitmap strike whose resource ID uses the
+/// standard `family * 128 + pointSize` encoding. The resource bytes stay in
+/// the user's application; Systemless only expands their 1-bit glyph bitmap
+/// into the same runtime coverage representation used by its built-in faces.
+pub(crate) fn register_resource_font_strike(resource_id: i16, bytes: &[u8]) -> bool {
+    const HEADER_LEN: usize = 26;
+    if resource_id <= 0 || bytes.len() < HEADER_LEN {
+        return false;
+    }
+    let font_id = resource_id / 128;
+    let size = resource_id % 128;
+    if size <= 0 {
+        // Family marker resources conventionally live at family * 128 and
+        // contain no strike data.
+        return false;
+    }
+
+    let first_char = resource_word(bytes, 2)
+        .map(usize::from)
+        .unwrap_or(usize::MAX);
+    let last_char = resource_word(bytes, 4).map(usize::from).unwrap_or(0);
+    let wid_max = resource_word(bytes, 6).map(|v| v as i16).unwrap_or(0);
+    let kern_max = resource_word(bytes, 8).map(|v| v as i16).unwrap_or(0);
+    let f_rect_height = resource_word(bytes, 14).map(usize::from).unwrap_or(0);
+    let ow_t_loc = resource_word(bytes, 16).map(usize::from).unwrap_or(0);
+    let ascent = resource_word(bytes, 18).map(|v| v as i16).unwrap_or(0);
+    let descent = resource_word(bytes, 20).map(|v| v as i16).unwrap_or(0);
+    let leading = resource_word(bytes, 22).map(|v| v as i16).unwrap_or(0);
+    let row_words = resource_word(bytes, 24).map(usize::from).unwrap_or(0);
+    if first_char > last_char
+        || last_char > 255
+        || f_rect_height == 0
+        || f_rect_height > u8::MAX as usize
+        || row_words == 0
+    {
+        return false;
+    }
+
+    let bitmap_len = match row_words
+        .checked_mul(2)
+        .and_then(|row_bytes| row_bytes.checked_mul(f_rect_height))
+    {
+        Some(len) => len,
+        None => return false,
+    };
+    let location_offset = HEADER_LEN + bitmap_len;
+    // One glyph per encoded character plus the missing-character glyph; the
+    // location table has one additional terminal entry.
+    let glyph_count = last_char - first_char + 2;
+    let location_count = glyph_count + 1;
+    let location_end = match location_offset.checked_add(location_count * 2) {
+        Some(end) => end,
+        None => return false,
+    };
+    // FontRec.owTLoc is measured in words from the owTLoc field itself
+    // (byte offset 16), not from the start of the resource.
+    let ow_offset = match 16usize.checked_add(ow_t_loc * 2) {
+        Some(offset) => offset,
+        None => return false,
+    };
+    if HEADER_LEN + bitmap_len > bytes.len()
+        || location_end > bytes.len()
+        || ow_offset < location_end
+        || ow_offset.saturating_add(glyph_count * 2) > bytes.len()
+    {
+        return false;
+    }
+    let bitmap_width = row_words * 16;
+    let missing_index = last_char - first_char + 1;
+    let mut coverage = Vec::new();
+
+    let mut decode_index = |mut index: usize| -> Option<Glyph> {
+        if index >= glyph_count {
+            index = missing_index;
+        }
+        let mut ow = resource_word(bytes, ow_offset + index * 2)?;
+        if ow == 0xFFFF && index != missing_index {
+            index = missing_index;
+            ow = resource_word(bytes, ow_offset + index * 2)?;
+        }
+        if ow == 0xFFFF {
+            return None;
+        }
+        let start = resource_word(bytes, location_offset + index * 2)? as usize;
+        let end = resource_word(bytes, location_offset + (index + 1) * 2)? as usize;
+        if end < start || end > bitmap_width || end - start > u8::MAX as usize {
+            return None;
+        }
+        let width = end - start;
+        let data_offset = coverage.len();
+        coverage.reserve(width.saturating_mul(f_rect_height));
+        let row_bytes = row_words * 2;
+        for row in 0..f_rect_height {
+            let row_start = HEADER_LEN + row * row_bytes;
+            for column in start..end {
+                let byte = *bytes.get(row_start + column / 8)?;
+                let mask = 0x80 >> (column & 7);
+                coverage.push(if byte & mask != 0 { 255 } else { 0 });
+            }
+        }
+        // The offset byte is unsigned; adding the (normally negative)
+        // kernMax converts it to the signed displacement from the pen.
+        let origin_x = kern_max.saturating_add(i16::from((ow >> 8) as u8));
+        Some(Glyph {
+            width: width as u8,
+            height: f_rect_height as u8,
+            advance: (ow & 0x00FF) as u8,
+            origin_x: origin_x.clamp(i8::MIN as i16, i8::MAX as i16) as i8,
+            origin_y: (-ascent).clamp(i8::MIN as i16, i8::MAX as i16) as i8,
+            data_offset,
+        })
+    };
+
+    let mut ascii = Vec::with_capacity(95);
+    for code in 0x20usize..=0x7E {
+        let index = code
+            .checked_sub(first_char)
+            .filter(|_| code <= last_char)
+            .unwrap_or(missing_index);
+        ascii.push(decode_index(index).unwrap_or(Glyph {
+            width: 0,
+            height: 0,
+            advance: wid_max.clamp(0, u8::MAX as i16) as u8,
+            origin_x: 0,
+            origin_y: 0,
+            data_offset: 0,
+        }));
+    }
+    let mut macroman = Vec::new();
+    for code in 0x80usize..=0xFF {
+        if code < first_char || code > last_char {
+            continue;
+        }
+        if let Some(glyph) = decode_index(code - first_char) {
+            macroman.push(MacRomanGlyph {
+                mac_code: code as u8,
+                glyph,
+            });
+        }
+    }
+
+    let coverage: &'static [u8] = Box::leak(coverage.into_boxed_slice());
+    let ascii: &'static [Glyph] = Box::leak(ascii.into_boxed_slice());
+    let face = Box::leak(Box::new(FontFace {
+        font_id,
+        size,
+        metrics: FontMetrics {
+            ascent,
+            descent,
+            wid_max,
+            leading,
+        },
+        glyphs: ascii,
+        data: coverage,
+    }));
+    RESOURCE_FACES
+        .lock()
+        .expect("resource font cache poisoned")
+        .insert((font_id, size), face);
+    if !macroman.is_empty() {
+        let glyphs: &'static [MacRomanGlyph] = Box::leak(macroman.into_boxed_slice());
+        let face = Box::leak(Box::new(MacRomanFace {
+            font_id,
+            size,
+            glyphs,
+            data: coverage,
+        }));
+        RESOURCE_MACROMAN_FACES
+            .lock()
+            .expect("resource Mac Roman font cache poisoned")
+            .insert((font_id, size), face);
+    }
+    true
+}
+
 // --- Font ID ↔ name lookup -----------------------------------------------
 
 pub static FONT_NAMES: &[(i16, &str)] = &[
@@ -258,6 +450,14 @@ static OVERRIDES: LazyLock<Mutex<OverrideCache>> =
 pub fn get_font_face(font_id: i16, size: i16) -> Option<&'static FontFace> {
     let size = if size == 0 { 12 } else { size };
     if let Some(face) = get_override_font_face(font_id, size) {
+        return Some(face);
+    }
+    if let Some(face) = RESOURCE_FACES
+        .lock()
+        .expect("resource font cache poisoned")
+        .get(&(font_id, size))
+        .copied()
+    {
         return Some(face);
     }
     get_baked_font_face(font_id, size)
@@ -386,6 +586,16 @@ pub fn get_macroman_glyph(
     mac_code: u8,
 ) -> Option<(&'static Glyph, &'static [u8])> {
     let size = if size == 0 { 12 } else { size };
+    if let Some(face) = RESOURCE_MACROMAN_FACES
+        .lock()
+        .expect("resource Mac Roman font cache poisoned")
+        .get(&(font_id, size))
+        .copied()
+    {
+        if let Some(hit) = face.glyphs.iter().find(|entry| entry.mac_code == mac_code) {
+            return Some((&hit.glyph, face.data));
+        }
+    }
     let face = MACROMAN_TABLE
         .iter()
         .find(|f| f.font_id == font_id && f.size == size)?;

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -4230,6 +4230,9 @@ impl TrapDispatcher {
         res_id: i16,
         data: Vec<u8>,
     ) {
+        if res_type == *b"FONT" || res_type == *b"NFNT" {
+            let _ = crate::quickdraw::fonts::register_resource_font_strike(res_id, &data);
+        }
         self.resource_backing_data
             .insert((refnum, res_type, res_id), data);
     }
@@ -4287,6 +4290,10 @@ impl TrapDispatcher {
 
     pub(crate) fn remember_resource_fork_backing_data(&mut self, refnum: u16, fork: &ResourceFork) {
         for ((res_type, res_id), resource) in fork.resources() {
+            if res_type == b"FONT" || res_type == b"NFNT" {
+                let _ =
+                    crate::quickdraw::fonts::register_resource_font_strike(*res_id, &resource.data);
+            }
             self.resource_backing_data
                 .entry((refnum, *res_type, *res_id))
                 .or_insert_with(|| resource.data.clone());

--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -13602,9 +13602,8 @@ impl super::TrapDispatcher {
             //
             // Stack: SP+0=extra(Fixed, 4). Pops 4.
             //
-            // Future work: respect char_extra when computing glyph
-            // advances in draw_string / draw_char (Systemless currently
-            // stores the value without applying it during text rendering).
+            // draw_char applies the integer portion to each non-space glyph;
+            // spaces use the GrafPort's separate SpaceExtra value.
             (true, 0x223) => {
                 let sp = cpu.read_reg(Register::A7);
                 let extra_fixed = bus.read_long(sp) as i32;
@@ -21351,6 +21350,31 @@ mod tests {
             bus.read_word(addr + 4) as i16,
             bus.read_word(addr + 6) as i16,
         )
+    }
+
+    #[test]
+    fn condensed_outline_uses_plain_text_advance() {
+        // Applications can overlay an outline|condense pass ($28) with a
+        // plain color pass. QuickDraw's one-pixel condense adjustment cancels
+        // the outline adjustment, keeping every glyph registered.
+        let (mut d, _cpu, _bus) = setup();
+        d.tx_face = 0x00;
+        let plain = d.advance_extra();
+        d.tx_face = 0x08;
+        assert_eq!(d.advance_extra(), plain + 1);
+        d.tx_face = 0x20;
+        assert_eq!(d.advance_extra(), plain - 1);
+        d.tx_face = 0x28;
+        assert_eq!(d.advance_extra(), plain);
+    }
+
+    #[test]
+    fn extended_face_adds_one_pixel_to_each_advance() {
+        let (mut d, _cpu, _bus) = setup();
+        d.tx_face = 0x00;
+        let plain = d.advance_extra();
+        d.tx_face = 0x40;
+        assert_eq!(d.advance_extra(), plain + 1);
     }
 
     /// Helper: allocate a simple 10-byte region and its handle at given addresses.

--- a/src/trap/text_render.rs
+++ b/src/trap/text_render.rs
@@ -1101,6 +1101,8 @@ impl super::TrapDispatcher {
         let is_bold = (self.tx_face & 1) != 0;
         let is_outline = (self.tx_face & 8) != 0;
         let is_shadow = (self.tx_face & 16) != 0;
+        let is_condensed = (self.tx_face & 32) != 0;
+        let is_extended = (self.tx_face & 64) != 0;
 
         let mut extra: i16 = if is_bold { 1 } else { 0 };
         if is_outline {
@@ -1109,6 +1111,17 @@ impl super::TrapDispatcher {
         if is_shadow {
             // Note: advance is always +2, but rendering smear uses +3 for size >= 18 (separate calculation)
             extra += 2;
+        }
+        // Classic QuickDraw's algorithmic condense/extend faces adjust the
+        // inter-character advance by one pixel.  Applications commonly pair
+        // `outline | condense`: condense cancels outline's extra pixel so an
+        // outlined pass and a plain-color pass drawn at the same MoveTo point
+        // remain registered character-for-character.
+        if is_condensed {
+            extra -= 1;
+        }
+        if is_extended {
+            extra += 1;
         }
         extra
     }


### PR DESCRIPTION
## Summary

- decode Classic application `FONT` and `NFNT` bitmap strikes when resource forks are registered;
- retain strike metrics, glyph bitmaps, bearings, advances, missing-glyph fallback, and MacRoman glyphs;
- prefer an application-provided strike over Systemless's built-in face for the same family and point size; and
- implement the one-pixel condensed and extended face advance adjustments.

The advance correction is important for layered QuickDraw text. An outline pass adds one pixel to each character advance; an `outline | condense` pass cancels that addition. Without the condense adjustment, an outline and its separately drawn colored interior drift apart progressively across a word.

Decoded strikes are process-lifetime data. Systemless hosts one guest application per process, the resources are small, and replacement by `(family, point size)` lets a later resource fork take precedence without leaving borrowed resource-fork storage behind.

## Validation

- `cargo test --lib`: 2,698 passed, 3 ignored
- `cargo test --bin systemless`: 43 passed
- focused `condensed_outline_uses_plain_text_advance` regression test passes
- manually verified 3 in Three's layered title text

The before/after comparison was produced from the same v0.4.2 integration build and cached viewport. The control build reverted only this commit: in the before image the title is fragmented because its styled passes use fallback metrics; in the after image the complete colored title and outline remain registered.

Before — fallback font metrics separate the layered title passes.
<img width="889" height="636" alt="Screenshot 2026-07-25 at 9 22 24 PM" src="https://github.com/user-attachments/assets/cb9e6d52-1a14-4d44-91e1-0db00e6d48bb" />

After — the application font and face widths keep the layers registered.
<img width="630" height="472" alt="Screenshot 2026-07-25 at 9 08 47 PM" src="https://github.com/user-attachments/assets/50c90393-ff9f-4cb5-95a9-9dc051808840" />


Closes #37
