### PR TITLE
fix(quickdraw): frame complex regions as outlines

### DIFF
--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -19255,7 +19255,7 @@ impl super::TrapDispatcher {
         value.clamp(i32::from(i16::MIN), i32::from(i16::MAX)) as i16
     }
 
-    fn inset_region_row(row: &[i16], dh: i16) -> Vec<i16> {
+    pub(super) fn inset_region_row(row: &[i16], dh: i16) -> Vec<i16> {
         if row.is_empty() {
             return Vec::new();
         }
@@ -21384,6 +21384,48 @@ mod tests {
             data_words
         ));
         handle
+    }
+
+    #[test]
+    fn framergn_frames_complex_boundary_without_painting_interior() {
+        // Imaging With QuickDraw (1994), pp. 3-100--3-101: FrameRgn is
+        // equivalent to CopyRgn + InsetRgn + DiffRgn.  A complex region's
+        // interior must therefore remain untouched.
+        let (mut d, mut cpu, mut bus) = setup_with_port();
+        d.current_port = 0x181000;
+        d.pn_size = (1, 1);
+        d.pn_pat = [0xFF; 8];
+        d.pn_mode = 8; // patCopy
+
+        let rgn = bus.alloc(4);
+        let mut rows = vec![vec![10, 20]; 10];
+        // A two-pixel hole makes this a genuinely complex region and gives
+        // FrameRgn an interior boundary to outline as well.
+        rows[5] = vec![10, 14, 16, 20];
+        assert!(TrapDispatcher::write_region_from_rows(
+            &mut bus, rgn, 10, &rows
+        ));
+        assert!(bus.read_word(bus.read_long(rgn)) > super::REGION_HEADER_SIZE as u16);
+
+        d.draw_rgn(&mut cpu, &mut bus, rgn, ShapeOp::Frame);
+
+        let screen = bus.read_long(0x0824);
+        let pixel_is_black = |bus: &MacMemoryBus, y: u32, x: u32| {
+            let byte = bus.read_byte(screen + y * 64 + x / 8);
+            byte & (1 << (7 - (x % 8))) != 0
+        };
+        assert!(
+            pixel_is_black(&bus, 10, 12),
+            "outer boundary must be framed"
+        );
+        assert!(
+            pixel_is_black(&bus, 15, 13),
+            "the boundary around a complex-region hole must be framed"
+        );
+        assert!(
+            !pixel_is_black(&bus, 12, 12),
+            "FrameRgn must not paint a complex region's interior"
+        );
     }
 
     /// Helper: write a BitMap record.

--- a/src/trap/shapes.rs
+++ b/src/trap/shapes.rs
@@ -603,6 +603,58 @@ impl super::TrapDispatcher {
         // and persists until the next y-entry changes it.  See IM:I I-142 and
         // build_region_membership_cache in quickdraw.rs for the full parser.
         let cache = Self::build_region_membership_cache(bus, rgn_handle, bbox.top, bbox.bottom);
+
+        // Imaging With QuickDraw (1994), pp. 3-100--3-101 specifies FrameRgn
+        // as CopyRgn + InsetRgn(pnSize) + DiffRgn: paint the original region
+        // minus its inset, never the whole interior.  InsetRgn's horizontal
+        // erosion shrinks every span; its vertical erosion intersects the
+        // neighbouring rows.  Computing that membership here avoids temporary
+        // guest handles while retaining the documented geometry.
+        if matches!(op, ShapeOp::Frame) {
+            let Some(cache) = cache else {
+                return;
+            };
+            let pen_h = self.pn_size.0.max(0) as i32;
+            let pen_w = self.pn_size.1.max(0);
+            let inset_rows = cache
+                .rows
+                .iter()
+                .map(|row| Self::inset_region_row(row, pen_w))
+                .collect::<Vec<_>>();
+            let top = i32::from(bbox.top);
+            let bottom = i32::from(bbox.bottom);
+
+            self.draw_generic_shape(cpu, bus, &bbox, op, false, |y, x| {
+                let row = i32::from(y) - top;
+                if row < 0
+                    || row >= cache.rows.len() as i32
+                    || !Self::endpoints_contain_point(&cache.rows[row as usize], x)
+                {
+                    return 0;
+                }
+
+                // A zero-sized pen draws no frame, matching the rectangular
+                // shape paths. Otherwise this is membership in the region
+                // produced by InsetRgn(rgn, pnSize.h, pnSize.v).
+                if pen_h == 0 && pen_w == 0 {
+                    return 0;
+                }
+                let first_source_y = i32::from(y) - pen_h;
+                let last_source_y = i32::from(y) + pen_h;
+                let inside_inset = first_source_y >= top
+                    && last_source_y < bottom
+                    && (first_source_y..=last_source_y).all(|source_y| {
+                        Self::endpoints_contain_point(&inset_rows[(source_y - top) as usize], x)
+                    });
+                if inside_inset {
+                    0
+                } else {
+                    255
+                }
+            });
+            return;
+        }
+
         self.draw_generic_shape(cpu, bus, &bbox, op, false, |y, x| {
             if let Some(c) = &cache {
                 let row = (y - c.top) as usize;


### PR DESCRIPTION
## Summary

Implement documented outline semantics for complex QuickDraw regions instead of filling their interiors.

Inside Macintosh: Imaging With QuickDraw (1994), pp. 3-100--3-101 specifies `FrameRgn` in terms of copying the region, insetting the copy by the current pen size, and subtracting the inset from the original. This change computes that membership directly from Systemless's decoded differential scanline representation:

- horizontally inset each row's spans;
- vertically erode the result by intersecting the neighbouring inset rows selected by the pen height; and
- draw only points in the original region that are not in the inset region.

This retains complex outer boundaries and boundaries around holes without allocating temporary guest handles. Rectangular regions continue to use the existing rectangular frame path, and a zero-sized pen produces no frame.

## User-visible effect

3 in Three draws dialogue text inside nonrectangular speech bubbles. The previous implementation painted the entire bubble region after the text was drawn, leaving empty bubbles. With this change, only the border is framed and the text remains visible.

The comparison was made after rebasing onto v0.4.2, which includes upstream's application-painted dialog preservation. A control build containing upstream and every other local fix, but not this commit, still produced two empty bubbles. Adding this commit preserved both strings.

Before — FrameRgn paints both complex-region interiors, erasing the dialogue.
<img width="630" height="472" alt="Screenshot 2026-07-25 at 9 04 55 PM" src="https://github.com/user-attachments/assets/5b5e9ed2-0a75-43ed-be5e-a4e5fe4de2c1" />


After — only the bubble outlines are framed, preserving both strings.
<img width="889" height="636" alt="Screenshot 2026-07-25 at 8 57 33 PM" src="https://github.com/user-attachments/assets/fd9f7413-5ad5-4b3c-8a7b-e6b84c505102" />


## Validation

- `cargo test --lib`: 2,698 passed, 3 ignored
- `cargo test --bin systemless`: 43 passed
- focused `framergn_frames_complex_boundary_without_painting_interior` regression test passes
- manually verified two independently shaped speech bubbles in 3 in Three

Closes #39
