### PR TITLE
feat: document Homebrew installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ system integration are modeled only where guest-visible behavior matters.
 
 ## Quick Start
 
+Install with Homebrew on macOS:
+
+```sh
+brew install benletchford/tap/systemless
+systemless path/to/app-or-game.sit
+```
+
+Or install from crates.io:
+
 ```sh
 cargo install systemless
 systemless path/to/app-or-game.sit

--- a/src/bin/systemless.rs
+++ b/src/bin/systemless.rs
@@ -1788,6 +1788,29 @@ fn run_headless(game_path: &std::path::Path, max_instructions: usize, show_menu_
 fn main() {
     let args: Vec<String> = std::env::args().collect();
 
+    if args
+        .iter()
+        .skip(1)
+        .any(|arg| matches!(arg.as_str(), "--help" | "-h"))
+    {
+        println!(
+            "Usage: {} [--headless] [--arrows-as-numpad] [--literal-arrows] \
+             [--cpu-mhz N] [--max-instructions N] \
+             [--show-menu-bar] <game>",
+            args[0]
+        );
+        return;
+    }
+
+    if args
+        .iter()
+        .skip(1)
+        .any(|arg| matches!(arg.as_str(), "--version" | "-V"))
+    {
+        println!("systemless {}", env!("CARGO_PKG_VERSION"));
+        return;
+    }
+
     let mut headless = false;
     let mut arrows_as_numpad = DEFAULT_GUI_ARROWS_AS_NUMPAD;
     let mut cpu_mhz: Option<f64> = None;


### PR DESCRIPTION
## Summary

- document the one-command Homebrew installation
- distinguish Homebrew from crates.io installation
- add standard `--help` and `--version` command handling

## User impact

macOS users can install Systemless with:

```sh
brew install benletchford/tap/systemless
```

The new command metadata also gives package managers and users a lightweight
way to verify an installation without launching a game.

## Validation

- `rustfmt --edition 2021 --check src/bin/systemless.rs`
- `cargo test --bin systemless` (39 passed)
- `cargo run --quiet --bin systemless -- --version`
- `cargo run --quiet --bin systemless -- --help`
