### PR TITLE
fix(gui): derive viewports from guest-drawn frames

### DIFF
--- a/src/bin/systemless.rs
+++ b/src/bin/systemless.rs
@@ -84,7 +84,7 @@ struct ContentRect {
 }
 
 #[cfg(target_os = "macos")]
-#[derive(serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Copy, serde::Deserialize, serde::Serialize)]
 struct CachedContentRect {
     version: u8,
     screen_width: u16,
@@ -101,15 +101,13 @@ fn viewport_cache_path(game_path: &std::path::Path) -> PathBuf {
 #[cfg(target_os = "macos")]
 fn valid_cached_content_rect(cache: &CachedContentRect) -> bool {
     let content = cache.content;
-    cache.version == 1
+    cache.version == 2
         && cache.screen_width != 0
         && cache.screen_height != 0
         && content.width != 0
         && content.height != 0
         && content.left.saturating_add(content.width) <= u32::from(cache.screen_width)
         && content.top.saturating_add(content.height) <= u32::from(cache.screen_height)
-        && content.left == (u32::from(cache.screen_width).saturating_sub(content.width)) / 2
-        && content.top == (u32::from(cache.screen_height).saturating_sub(content.height)) / 2
 }
 
 #[cfg(target_os = "macos")]
@@ -127,7 +125,7 @@ fn persist_content_rect(
     content: ContentRect,
 ) {
     let cache = CachedContentRect {
-        version: 1,
+        version: 2,
         screen_width: screen_mode.2,
         screen_height: screen_mode.3,
         pixel_size: screen_mode.4,
@@ -871,15 +869,24 @@ impl App {
                 self.content_rect_previous_frame.clear();
             }
 
-            let authoritative_rect = (self.content_rect.is_none())
-                .then(|| {
+            // A guest-drawn screen frame is stronger evidence than an
+            // earlier inferred or cached crop. Keep looking for it after a
+            // provisional crop has been accepted: some applications first
+            // blit their unpositioned backing PixMap at (0,0), then draw the
+            // actual presentation frame later in startup.
+            let framed_rect = runner
+                .dispatcher()
+                .framed_manual_cport_presentation_rect(runner.bus())
+                .and_then(|rect| content_rect_from_copybits(rect, game_w, game_h));
+            let authoritative_rect = framed_rect.or_else(|| {
+                self.content_rect.is_none().then(|| {
                     let dispatcher = runner.dispatcher();
                     dispatcher
-                        .declared_centered_presentation_rect(runner.bus())
-                        .or_else(|| dispatcher.manual_cport_presentation_rect(runner.bus()))
-                })
-                .flatten()
-                .and_then(|rect| centered_content_rect_from_copybits(rect, game_w, game_h));
+                        .manual_cport_presentation_rect(runner.bus())
+                        .or_else(|| dispatcher.declared_centered_presentation_rect(runner.bus()))
+                        .and_then(|rect| content_rect_from_copybits(rect, game_w, game_h))
+                })?
+            });
 
             let framebuffer_len = screen_mode.1.saturating_mul(u32::from(screen_mode.3));
             let framebuffer = runner.bus().ram_slice(screen_mode.0, framebuffer_len);
@@ -895,7 +902,7 @@ impl App {
                     detected = runner
                         .dispatcher()
                         .last_screen_copybits_rect
-                        .and_then(|rect| centered_content_rect_from_copybits(rect, game_w, game_h))
+                        .and_then(|rect| content_rect_from_copybits(rect, game_w, game_h))
                         .map(|rect| (rect, confirmations));
                 }
                 if detected.is_none()
@@ -927,26 +934,33 @@ impl App {
                 }
             }
 
-            if self.content_rect.is_none() {
-                if let Some(rect) = accepted_rect {
+            if let Some(rect) = accepted_rect.filter(|rect| self.content_rect != Some(*rect)) {
+                let replacing_provisional_crop = self.content_rect.is_some();
+                if replacing_provisional_crop {
+                    eprintln!(
+                        "[SYSTEMLESS] Guest content updated from explicit frame: {}x{} at ({},{}) inside {}x{}",
+                        rect.width, rect.height, rect.left, rect.top, game_w, game_h
+                    );
+                } else {
                     eprintln!(
                         "[SYSTEMLESS] Guest content: {}x{} at ({},{}) inside {}x{}",
                         rect.width, rect.height, rect.left, rect.top, game_w, game_h
                     );
-                    self.content_rect = Some(rect);
-                    persist_content_rect(&self.game_path, screen_mode, rect);
-                    if let Some(window) = self.window.as_ref() {
-                        let current = window.inner_size();
-                        let integer_scale = (current.width / rect.width)
-                            .min(current.height / rect.height)
-                            .max(1);
-                        let _ = window.request_inner_size(winit::dpi::PhysicalSize::new(
-                            rect.width.saturating_mul(integer_scale),
-                            rect.height.saturating_mul(integer_scale),
-                        ));
-                    }
-                    self.window_sized_content_rect = Some(rect);
                 }
+                self.content_rect = Some(rect);
+                self.content_rect_candidate = None;
+                persist_content_rect(&self.game_path, screen_mode, rect);
+                if let Some(window) = self.window.as_ref() {
+                    let current = window.inner_size();
+                    let integer_scale = (current.width / rect.width)
+                        .min(current.height / rect.height)
+                        .max(1);
+                    let _ = window.request_inner_size(winit::dpi::PhysicalSize::new(
+                        rect.width.saturating_mul(integer_scale),
+                        rect.height.saturating_mul(integer_scale),
+                    ));
+                }
+                self.window_sized_content_rect = Some(rect);
             }
 
             let stable_content = self.content_rect.unwrap_or(ContentRect {
@@ -1446,7 +1460,7 @@ fn detect_centered_content_rect_8bpp(
     })
 }
 
-fn centered_content_rect_from_copybits(
+fn content_rect_from_copybits(
     rect: ScreenCopyBitsRect,
     screen_width: u32,
     screen_height: u32,
@@ -1465,15 +1479,8 @@ fn centered_content_rect_from_copybits(
     let content_height = bottom - top;
     let right_margin = screen_width - right;
     let bottom_margin = screen_height - bottom;
-    let horizontal_tolerance = (screen_width / 100).max(4);
-    let vertical_tolerance = (screen_height / 100).max(4);
     let has_border = left >= 4 || right_margin >= 4 || top >= 4 || bottom_margin >= 4;
-    if !has_border
-        || left.abs_diff(right_margin) > horizontal_tolerance
-        || top.abs_diff(bottom_margin) > vertical_tolerance
-        || content_width < screen_width / 2
-        || content_height < screen_height / 2
-    {
+    if !has_border || content_width < screen_width / 2 || content_height < screen_height / 2 {
         return None;
     }
     Some(ContentRect {
@@ -2901,7 +2908,7 @@ mod tests {
     }
 
     #[test]
-    fn centered_copybits_detection_rejects_fullscreen_and_off_center_blits() {
+    fn copybits_detection_accepts_bordered_off_center_blits() {
         let centered = ScreenCopyBitsRect {
             src_top: 0,
             src_left: 0,
@@ -2913,7 +2920,7 @@ mod tests {
             dst_right: 720,
         };
         assert_eq!(
-            centered_content_rect_from_copybits(centered, 800, 600),
+            content_rect_from_copybits(centered, 800, 600),
             Some(ContentRect {
                 left: 80,
                 top: 60,
@@ -2931,10 +2938,7 @@ mod tests {
             dst_right: 800,
             ..centered
         };
-        assert_eq!(
-            centered_content_rect_from_copybits(fullscreen, 800, 600),
-            None
-        );
+        assert_eq!(content_rect_from_copybits(fullscreen, 800, 600), None);
 
         let off_center = ScreenCopyBitsRect {
             dst_left: 10,
@@ -2942,16 +2946,21 @@ mod tests {
             ..centered
         };
         assert_eq!(
-            centered_content_rect_from_copybits(off_center, 800, 600),
-            None
+            content_rect_from_copybits(off_center, 800, 600),
+            Some(ContentRect {
+                left: 10,
+                top: 60,
+                width: 640,
+                height: 480,
+            })
         );
     }
 
     #[cfg(target_os = "macos")]
     #[test]
-    fn cached_viewport_must_match_centered_guest_screen_geometry() {
+    fn cached_viewport_must_fit_guest_screen_geometry() {
         let valid = CachedContentRect {
-            version: 1,
+            version: 2,
             screen_width: 800,
             screen_height: 600,
             pixel_size: 8,
@@ -2971,7 +2980,16 @@ mod tests {
             },
             ..valid
         };
-        assert!(!valid_cached_content_rect(&off_center));
+        assert!(valid_cached_content_rect(&off_center));
+
+        let out_of_bounds = CachedContentRect {
+            content: ContentRect {
+                left: 700,
+                ..valid.content
+            },
+            ..valid
+        };
+        assert!(!valid_cached_content_rect(&out_of_bounds));
     }
 
     #[test]

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -1499,6 +1499,12 @@ pub struct TrapDispatcher {
     pub copybits_screen_count: u64,
     /// Most recent sizeable CopyBits blit into the screen framebuffer.
     pub last_screen_copybits_rect: Option<ScreenCopyBitsRect>,
+    /// Largest non-fullscreen FrameRect drawn into the screen framebuffer in
+    /// the most recent guest tick that drew one. A matching retained CPort can
+    /// use this explicit guest geometry to locate its framed presentation
+    /// without assuming it is centered.
+    pub(crate) last_screen_frame_rect: Option<ScreenCopyBitsRect>,
+    pub(crate) last_screen_frame_rect_tick: u32,
     /// Count of all screen-affecting trace events captured so far.
     pub screen_event_count: u64,
     /// `screen_event_count` values where the recorded event was specifically
@@ -1533,6 +1539,10 @@ pub struct TrapDispatcher {
     /// Non-GWorld CGrafPorts opened via OpenCPort/InitCPort, tracked so
     /// sync_canonical_offscreen_ctabs_to_clut can reach their pixmaps.
     pub(crate) cport_ports: HashSet<u32>,
+    /// PixMapHandle installed when OpenCPort/InitCPort initialized each
+    /// app-managed CGrafPort. SetPortPix can replace that handle with an
+    /// offscreen scratch image; such a replacement is not an onscreen port.
+    pub(crate) cport_original_pixmaps: HashMap<u32, u32>,
     /// Non-window CGrafPort selected for HLE fallback presentation.
     pub(crate) manual_cport_presented_port: u32,
     /// Sparse snapshot of the screen immediately after presenting the manual
@@ -2798,6 +2808,8 @@ impl TrapDispatcher {
             inline_skipped: Box::new([0u64; 4096]),
             copybits_screen_count: 0,
             last_screen_copybits_rect: None,
+            last_screen_frame_rect: None,
+            last_screen_frame_rect_tick: 0,
             screen_event_count: 0,
             copybits_screen_secs: Vec::new(),
             trace_sink: None,
@@ -2809,6 +2821,7 @@ impl TrapDispatcher {
             disposed_gworld_portbits: HashMap::new(),
             gworld_pixel_states: HashMap::new(),
             cport_ports: HashSet::new(),
+            cport_original_pixmaps: HashMap::new(),
             manual_cport_presented_port: 0,
             manual_cport_screen_witness: Vec::new(),
             recording_polygon: None,

--- a/src/trap/framebuffer.rs
+++ b/src/trap/framebuffer.rs
@@ -2397,14 +2397,70 @@ impl super::TrapDispatcher {
         }
     }
 
-    /// Present a large app-managed CGrafPort when CopyBits did not present it.
-    ///
-    /// This is an HLE compatibility bridge, not a QuickDraw rule: real apps
-    /// are responsible for copying offscreen ports to the screen. Some games
-    /// keep a full-scene PixMap behind an OpenCPort/InitCPort and update it
-    /// directly while their front window remains screen-backed. Without a
-    /// Window Manager or video driver layer to observe that buffer, screenshots
-    /// stay black even though the scene exists in guest memory.
+    /// Explicit screen frame that narrowly encloses a retained app-managed
+    /// CPort PixMap. This correlates guest QuickDraw geometry without assuming
+    /// that the offscreen buffer is centered.
+    pub fn framed_manual_cport_presentation_rect(
+        &self,
+        bus: &MacMemoryBus,
+    ) -> Option<super::dispatch::ScreenCopyBitsRect> {
+        let frame = self.last_screen_frame_rect?;
+        let (_, _, screen_width, screen_height, screen_depth) = self.screen_mode;
+        let frame_width = frame.dst_right.saturating_sub(frame.dst_left);
+        let frame_height = frame.dst_bottom.saturating_sub(frame.dst_top);
+        if frame.dst_top < 0
+            || frame.dst_left < 0
+            || frame.dst_bottom > screen_height as i16
+            || frame.dst_right > screen_width as i16
+            || frame_width <= 0
+            || frame_height <= 0
+        {
+            return None;
+        }
+
+        for &port in &self.cport_ports {
+            if self.window_list.contains(&port)
+                || self.gworld_devices.contains_key(&port)
+                || (bus.read_word(port + 6) & 0xC000) != 0xC000
+            {
+                continue;
+            }
+            let pixmap_handle = bus.read_long(port + 2);
+            let pixmap = (pixmap_handle != 0)
+                .then(|| bus.read_long(pixmap_handle))
+                .unwrap_or(0);
+            if pixmap == 0
+                || (bus.read_long(pixmap) & 0x3FFF_FFFF) == self.screen_mode.0
+                || bus.read_word(pixmap + 32) != screen_depth
+            {
+                continue;
+            }
+            let pixmap_height = (bus.read_word(pixmap + 10) as i16)
+                .saturating_sub(bus.read_word(pixmap + 6) as i16);
+            let pixmap_width = (bus.read_word(pixmap + 12) as i16)
+                .saturating_sub(bus.read_word(pixmap + 8) as i16);
+            let horizontal_frame = frame_width.saturating_sub(pixmap_width);
+            let vertical_frame = frame_height.saturating_sub(pixmap_height);
+
+            // SetPortPix alone does not make this image visible: Imaging With
+            // QuickDraw (1994), pp. 4-86..4-87 explicitly describes it as a
+            // way to draw into a buffer other than the screen. Here the image
+            // dimensions are used only to interpret a narrow FrameRect that
+            // the guest separately drew into the screen framebuffer. The HLE
+            // presentation path still refuses to copy an attached scratch
+            // PixMap merely because its dimensions look plausible.
+            if pixmap_width > 0
+                && pixmap_height > 0
+                && horizontal_frame == vertical_frame
+                && (2..=16).contains(&horizontal_frame)
+                && horizontal_frame % 2 == 0
+            {
+                return Some(frame);
+            }
+        }
+        None
+    }
+
     /// Geometry declared by a large app-managed color port behind a visible,
     /// screen-backed fullscreen window. Games commonly create this port before
     /// drawing their first useful frame, so the frontend can size itself
@@ -2442,10 +2498,8 @@ impl super::TrapDispatcher {
             && (bus.read_word(front + 20) as i16) >= screen_height as i16
             && (bus.read_word(front + 22) as i16) >= screen_width as i16;
         let (top, left, bottom, right) = self.window_bounds;
-        let window_covers_screen = top <= 0
-            && left <= 0
-            && bottom >= screen_height as i16
-            && right >= screen_width as i16;
+        let window_covers_screen =
+            top <= 0 && left <= 0 && bottom >= screen_height as i16 && right >= screen_width as i16;
         if !port_covers_screen && !window_covers_screen {
             return None;
         }
@@ -2463,6 +2517,19 @@ impl super::TrapDispatcher {
                 continue;
             }
             let pixmap_handle = bus.read_long(port + 2);
+            // Imaging With QuickDraw 1994, pp. 4-86..4-87: SetPortPix
+            // replaces the current CGrafPort's portPixMap. It is commonly
+            // used to draw into an offscreen image that the application later
+            // transfers explicitly. Do not infer visibility from a PixMap
+            // attached this way merely because its dimensions look like a
+            // scene buffer.
+            if self
+                .cport_original_pixmaps
+                .get(&port)
+                .is_none_or(|&original| original != pixmap_handle)
+            {
+                continue;
+            }
             let pixmap = (pixmap_handle != 0)
                 .then(|| bus.read_long(pixmap_handle))
                 .unwrap_or(0);
@@ -2599,6 +2666,7 @@ impl super::TrapDispatcher {
         let mut best: Option<Candidate> = None;
         let mut considered_ports = 0u32;
         let mut rejected_shape = 0u32;
+        let mut rejected_replaced_pixmap = 0u32;
         let mut rejected_area = 0u32;
         for &port in &self.cport_ports {
             if port == front_port
@@ -2616,6 +2684,18 @@ impl super::TrapDispatcher {
             let pm_handle = bus.read_long(port + 2);
             if pm_handle == 0 {
                 rejected_shape += 1;
+                continue;
+            }
+            // SetPortPix changes the drawing target; it does not publish that
+            // target to the screen. The manual compatibility bridge is only
+            // allowed to consider the PixMap originally installed by
+            // OpenCPort/InitCPort. IWQD 1994, pp. 4-86..4-87.
+            if self
+                .cport_original_pixmaps
+                .get(&port)
+                .is_none_or(|&original| original != pm_handle)
+            {
+                rejected_replaced_pixmap += 1;
                 continue;
             }
             let pm_ptr = bus.read_long(pm_handle);
@@ -2673,10 +2753,11 @@ impl super::TrapDispatcher {
         let Some(candidate) = best else {
             if trace {
                 eprintln!(
-                    "[BLIT-CPORT] skip: no candidate (tracked={}, considered={}, shape_rejects={}, area_rejects={}, min_area={})",
+                    "[BLIT-CPORT] skip: no candidate (tracked={}, considered={}, shape_rejects={}, replaced_pixmap_rejects={}, area_rejects={}, min_area={})",
                     self.cport_ports.len(),
                     considered_ports,
                     rejected_shape,
+                    rejected_replaced_pixmap,
                     rejected_area,
                     min_area
                 );
@@ -4216,6 +4297,12 @@ mod redraw_chrome_tests {
     const CLIP_RGN: u32 = 0x182200;
     const WINDOW_VISIBLE_OFFSET: u32 = 110;
 
+    fn track_manual_cport(disp: &mut TrapDispatcher, bus: &crate::memory::MacMemoryBus, port: u32) {
+        disp.cport_ports.insert(port);
+        disp.cport_original_pixmaps
+            .insert(port, bus.read_long(port + 2));
+    }
+
     #[test]
     fn fb_fill_pattern_rect_tiles_standard_gray_pattern() {
         let (mut disp, _cpu, mut bus) = setup_with_port();
@@ -5352,6 +5439,34 @@ mod redraw_chrome_tests {
     }
 
     #[test]
+    fn framed_manual_cport_uses_explicit_off_center_guest_geometry() {
+        let (mut disp, _cpu, mut bus) = setup_with_port();
+        let screen_base = bus.alloc(800 * 600);
+        disp.screen_mode = (screen_base, 800, 800, 600, 8);
+
+        let manual_port = bus.alloc(200);
+        let manual_base = bus.alloc(512 * 322);
+        install_8bpp_cgrafport_at(&mut bus, manual_port, manual_base, 512, 512, 322, 0);
+        track_manual_cport(&mut disp, &bus, manual_port);
+        disp.last_screen_frame_rect = Some(crate::trap::dispatch::ScreenCopyBitsRect {
+            src_top: 85,
+            src_left: 141,
+            src_bottom: 413,
+            src_right: 659,
+            dst_top: 85,
+            dst_left: 141,
+            dst_bottom: 413,
+            dst_right: 659,
+        });
+
+        assert_eq!(
+            disp.framed_manual_cport_presentation_rect(&bus),
+            disp.last_screen_frame_rect,
+            "a guest-drawn 518x328 frame should locate its 512x322 retained image without centering it"
+        );
+    }
+
+    #[test]
     fn redraw_chrome_blits_large_manual_cport_centered_when_front_window_is_screen_backed() {
         let (mut disp, _cpu, mut bus) = setup_with_port();
 
@@ -5369,7 +5484,7 @@ mod redraw_chrome_tests {
         let manual_port = bus.alloc(200);
         let manual_base = bus.alloc(640 * 420);
         install_8bpp_cgrafport_at(&mut bus, manual_port, manual_base, 640, 640, 420, 0);
-        disp.cport_ports.insert(manual_port);
+        track_manual_cport(&mut disp, &bus, manual_port);
 
         bus.fill_bytes(manual_base, 640 * 420, 0x44);
         bus.write_byte(manual_base + 419 * 640 + 639, 0x55);
@@ -5452,7 +5567,7 @@ mod redraw_chrome_tests {
         let manual_port = bus.alloc(200);
         let manual_base = bus.alloc(640 * 420);
         install_8bpp_cgrafport_at(&mut bus, manual_port, manual_base, 640, 640, 420, 0);
-        disp.cport_ports.insert(manual_port);
+        track_manual_cport(&mut disp, &bus, manual_port);
 
         bus.fill_bytes(manual_base, 640 * 420, 0x44);
         bus.write_byte(screen_base + 90 * 800 + 80, 0xAA);
@@ -5489,7 +5604,7 @@ mod redraw_chrome_tests {
         let manual_port = bus.alloc(200);
         let manual_base = bus.alloc(640 * 420);
         install_8bpp_cgrafport_at(&mut bus, manual_port, manual_base, 640, 640, 420, 0);
-        disp.cport_ports.insert(manual_port);
+        track_manual_cport(&mut disp, &bus, manual_port);
 
         let dst = screen_base + 90 * 800 + 80;
         bus.fill_bytes(manual_base, 640 * 420, 0x44);
@@ -5529,7 +5644,7 @@ mod redraw_chrome_tests {
         let manual_port = bus.alloc(200);
         let manual_base = bus.alloc(640 * 420);
         install_8bpp_cgrafport_at(&mut bus, manual_port, manual_base, 640, 640, 420, 0);
-        disp.cport_ports.insert(manual_port);
+        track_manual_cport(&mut disp, &bus, manual_port);
 
         let dst = screen_base + 90 * 800 + 80;
         bus.write_byte(manual_base, 0x44);
@@ -5564,7 +5679,7 @@ mod redraw_chrome_tests {
         let manual_base = bus.alloc(656 * 600);
         bus.fill_bytes(manual_base, 656 * 600, 0xFF);
         install_8bpp_cgrafport_at(&mut bus, manual_port, manual_base, 656, 656, 600, 0);
-        disp.cport_ports.insert(manual_port);
+        track_manual_cport(&mut disp, &bus, manual_port);
 
         let covered_probe = screen_base + 300 * 800 + 400;
         disp.blit_large_manual_cport_to_screen(&mut bus);
@@ -5610,7 +5725,7 @@ mod redraw_chrome_tests {
         let manual_base = bus.alloc(656 * 600);
         bus.fill_bytes(manual_base, 656 * 600, 0x44);
         install_8bpp_cgrafport_at(&mut bus, manual_port, manual_base, 656, 656, 600, 0);
-        disp.cport_ports.insert(manual_port);
+        track_manual_cport(&mut disp, &bus, manual_port);
 
         let covered_probe = screen_base + 300 * 800 + 400;
         disp.blit_large_manual_cport_to_screen(&mut bus);
@@ -5644,7 +5759,7 @@ mod redraw_chrome_tests {
         let manual_port = bus.alloc(200);
         let manual_base = bus.alloc(640 * 420);
         install_8bpp_cgrafport_at(&mut bus, manual_port, manual_base, 640, 640, 420, 0);
-        disp.cport_ports.insert(manual_port);
+        track_manual_cport(&mut disp, &bus, manual_port);
 
         bus.write_byte(manual_base, 0x44);
         bus.write_byte(screen_base + 90 * 800 + 80, 0xAA);
@@ -5655,6 +5770,54 @@ mod redraw_chrome_tests {
             bus.read_byte(screen_base + 90 * 800 + 80),
             0xAA,
             "apps already presenting through CopyBits should not be overwritten by the fallback"
+        );
+    }
+
+    #[test]
+    fn redraw_chrome_does_not_present_a_setportpix_scratch_buffer() {
+        let (mut disp, _cpu, mut bus) = setup_with_port();
+
+        let screen_base = bus.alloc(800 * 600);
+        disp.screen_mode = (screen_base, 800, 800, 600, 8);
+        disp.device_clut[0] = [0, 0, 0];
+        bus.fill_bytes(screen_base, 800 * 600, 0);
+        bus.write_long(0x0824, screen_base);
+        install_8bpp_cgrafport(&mut bus, screen_base, 800, 800, 600, 0);
+        bus.write_byte(PORT_PTR + WINDOW_VISIBLE_OFFSET, 0xFF);
+        disp.front_window = PORT_PTR;
+        disp.window_list = vec![PORT_PTR];
+
+        let manual_port = bus.alloc(200);
+        let original_base = bus.alloc(800 * 600);
+        install_8bpp_cgrafport_at(&mut bus, manual_port, original_base, 800, 800, 600, 0);
+        track_manual_cport(&mut disp, &bus, manual_port);
+
+        // SetPortPix replaces the original handle with a scratch PixMap. The
+        // game may draw a complete-looking image there, but Apple documents
+        // it as a different drawing target, not an implicit screen update.
+        let manual_base = bus.alloc(512 * 322);
+        bus.fill_bytes(manual_base, 512 * 322, 0x44);
+        install_8bpp_cgrafport_at(&mut bus, manual_port, manual_base, 512, 512, 322, 0);
+        disp.last_screen_frame_rect = Some(crate::trap::dispatch::ScreenCopyBitsRect {
+            src_top: 85,
+            src_left: 141,
+            src_bottom: 413,
+            src_right: 659,
+            dst_top: 85,
+            dst_left: 141,
+            dst_bottom: 413,
+            dst_right: 659,
+        });
+
+        let centered_probe = screen_base + 139 * 800 + 144;
+        disp.blit_large_manual_cport_to_screen(&mut bus);
+        assert_eq!(bus.read_byte(centered_probe), 0);
+        assert_eq!(disp.manual_cport_presented_port, 0);
+        assert_eq!(disp.declared_centered_presentation_rect(&bus), None);
+        assert_eq!(
+            disp.framed_manual_cport_presentation_rect(&bus),
+            disp.last_screen_frame_rect,
+            "the explicit screen frame may locate the viewport without presenting the attached scratch PixMap"
         );
     }
 
@@ -5675,7 +5838,7 @@ mod redraw_chrome_tests {
         let manual_port = bus.alloc(200);
         let manual_base = bus.alloc(640 * 420);
         install_8bpp_cgrafport_at(&mut bus, manual_port, manual_base, 640, 640, 420, 0);
-        disp.cport_ports.insert(manual_port);
+        track_manual_cport(&mut disp, &bus, manual_port);
 
         let dst = screen_base + 90 * 800 + 80;
         bus.fill_bytes(manual_base, 640 * 420, 0x44);
@@ -5711,7 +5874,7 @@ mod redraw_chrome_tests {
         let manual_port = bus.alloc(200);
         let manual_base = bus.alloc(640 * 420);
         install_8bpp_cgrafport_at(&mut bus, manual_port, manual_base, 640, 640, 420, 0);
-        disp.cport_ports.insert(manual_port);
+        track_manual_cport(&mut disp, &bus, manual_port);
 
         let dst = screen_base + 90 * 800 + 80;
         bus.fill_bytes(manual_base, 640 * 420, 0x44);

--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -1255,6 +1255,7 @@ impl super::TrapDispatcher {
                 // No-op for plain GrafPorts (HashMap::remove returns
                 // None silently); cleans up CGrafPort tracking.
                 self.cport_ports.remove(&port_ptr);
+                self.cport_original_pixmaps.remove(&port_ptr);
                 Ok(())
             }
 
@@ -4309,6 +4310,8 @@ impl super::TrapDispatcher {
                 self.allocate_cport_storage(port_ptr, bus);
                 let _ = self.init_cport(port_ptr, bus, true);
                 self.cport_ports.insert(port_ptr);
+                self.cport_original_pixmaps
+                    .insert(port_ptr, bus.read_long(port_ptr + 2));
 
                 // Set as current port on the active GDevice that seeded the
                 // port's PixMap. Offscreen code can select a freshly-created
@@ -4336,6 +4339,8 @@ impl super::TrapDispatcher {
                 cpu.write_reg(Register::A7, sp + 4);
                 if self.init_cport(port_ptr, bus, false) {
                     self.cport_ports.insert(port_ptr);
+                    self.cport_original_pixmaps
+                        .insert(port_ptr, bus.read_long(port_ptr + 2));
                 }
                 if trace_dialog_ports_enabled() {
                     eprintln!("[DIALOG-PORT] InitCPort port=${:08X}", port_ptr);
@@ -16995,6 +17000,7 @@ impl super::TrapDispatcher {
         }
         bus.free(port);
         self.cport_ports.remove(&port);
+        self.cport_original_pixmaps.remove(&port);
         if self.manual_cport_presented_port == port {
             self.manual_cport_presented_port = 0;
             self.manual_cport_screen_witness.clear();

--- a/src/trap/shapes.rs
+++ b/src/trap/shapes.rs
@@ -1135,6 +1135,52 @@ impl super::TrapDispatcher {
             pix_base == self.screen_mode.0 && touch_top < touch_bottom && touch_left < touch_right;
         if touched_screen {
             self.ensure_dialog_background_saved_for_screen_port(bus, port);
+
+            // A large FrameRect is explicit guest-drawn presentation
+            // geometry. Remember the outermost such frame so the frontend can
+            // correlate it with a retained app-managed CPort instead of
+            // assuming that buffer is centered. FrameRect draws its outline
+            // "just inside" the supplied rectangle (Inside Macintosh:
+            // Imaging With QuickDraw, 1994, p. 3-59), so the rectangle itself
+            // is the visible extent; do not expand it by the pen dimensions.
+            if matches!(op, ShapeOp::Frame) {
+                let width = r.right.saturating_sub(r.left);
+                let height = r.bottom.saturating_sub(r.top);
+                let (_, _, screen_width, screen_height, _) = self.screen_mode;
+                if width >= (screen_width as i16 / 2).max(1)
+                    && height >= (screen_height as i16 / 2).max(1)
+                    && width < screen_width as i16
+                    && height < screen_height as i16
+                {
+                    let candidate = super::dispatch::ScreenCopyBitsRect {
+                        src_top: r.top,
+                        src_left: r.left,
+                        src_bottom: r.bottom,
+                        src_right: r.right,
+                        dst_top: r.top,
+                        dst_left: r.left,
+                        dst_bottom: r.bottom,
+                        dst_right: r.right,
+                    };
+                    let candidate_area = i64::from(width) * i64::from(height);
+                    let current_area = if self.last_screen_frame_rect_tick == self.tick_count {
+                        self.last_screen_frame_rect
+                            .map(|current| {
+                                i64::from(current.dst_right.saturating_sub(current.dst_left))
+                                    * i64::from(current.dst_bottom.saturating_sub(current.dst_top))
+                            })
+                            .unwrap_or(0)
+                    } else {
+                        0
+                    };
+                    if self.last_screen_frame_rect_tick != self.tick_count
+                        || candidate_area > current_area
+                    {
+                        self.last_screen_frame_rect = Some(candidate);
+                        self.last_screen_frame_rect_tick = self.tick_count;
+                    }
+                }
+            }
         }
 
         let vis_region_complex =


### PR DESCRIPTION
## Summary

Extend the integrated viewport system to use an explicit, off-center frame drawn by the guest as authoritative presentation geometry.

The existing centered-port, `CopyBits`, and stable-pixel fallbacks remain available. This change adds stronger evidence for applications that retain an offscreen color port but separately draw the visible frame on screen:

- remember the largest nonfullscreen `FrameRect` drawn into the screen framebuffer during a guest tick;
- correlate that frame with a retained application-managed CPort whose backing dimensions fit narrowly inside it;
- accept bordered off-center `CopyBits` and cache rectangles that fit the guest screen without requiring centered margins;
- allow the explicit frame to replace an earlier provisional or cached crop; and
- retain the original PixMap handle installed by `OpenCPort`/`InitCPort`, preventing a later `SetPortPix` scratch target from being treated as published screen content.

Inside Macintosh: Imaging With QuickDraw (1994), p. 3-59 states that `FrameRect` draws just inside the supplied rectangle. The rectangle itself is therefore the visible outer extent; it must not be expanded by the pen size.

This builds on the centered viewport and dialog-expansion work integrated from #18 rather than replacing it.

## User-visible effect

3 in Three retains a 512x322 image and draws a 518x328 presentation frame at `(141,85)`. The previous fallback selected 512x322 at `(144,139)`, cropping away the dashed frame and top 54 guest rows while including 48 black rows below the real frame. At 3x host scaling those extra rows form the large black band in the control screenshot.

With the explicit frame, Systemless presents the full 518x328 rectangle, including its dashed boundary, and sizes the native window to an integer multiple of that extent.

The before/after comparison used the same v0.4.2 integration state. The control build reverted only this viewport commit.

Before — pixel fallback selects 512×322 at (144,139), cropping the dashed frame and including black rows below.

<img width="880" height="627" alt="Screenshot 2026-07-25 at 10 55 20 PM" src="https://github.com/user-attachments/assets/c9d29087-0580-4854-bdbe-bd3e260ba060" />

After — the guest-drawn FrameRect selects 518×328 at (141,85), preserving the complete dashed boundary.

<img width="630" height="472" alt="Screenshot 2026-07-25 at 9 08 47 PM" src="https://github.com/user-attachments/assets/1681da7f-4355-4218-a346-e7d3c5abfbf9" />

## Menu-bar follow-up

PR #36 mirrors ordinary guest menus into the native macOS menu bar, so the Classic menu bar normally remains outside the presented guest rectangle. Applications with custom MDEF/MBDF procedures may eventually require rendering and tracking the original Classic menu bar inside the guest display. If that compatibility path is added, the crop policy may need to include the guest screen's top edge or temporarily expand beyond the gameplay frame. The viewport decision remains isolated in the presentation-rectangle calculation so that policy can be revised without changing Metal's framebuffer decoder.

## Validation

- `cargo test --lib`: 2,698 passed, 3 ignored
- `cargo test --bin systemless`: 43 passed
- `copybits_detection_accepts_bordered_off_center_blits` passes
- `cached_viewport_must_fit_guest_screen_geometry` covers off-center and out-of-bounds cache entries
- `framed_manual_cport_uses_explicit_off_center_guest_geometry` covers the 518x328 frame around a 512x322 retained image
- `redraw_chrome_does_not_present_a_setportpix_scratch_buffer` verifies that geometry detection does not publish an unrelated drawing target
- manually verified the dashed frame, crop origin, integer-sized window, resizing, and dialog expansion in 3 in Three and Lemmings

Closes #45
