### PR TITLE
fix: resolve menu definition procedure handles

### DIFF
--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -1161,6 +1161,11 @@ pub struct TrapDispatcher {
     /// Their behavior is implemented by the Window Manager HLE, but callers
     /// may still fetch the resources directly through GetResource.
     pub(crate) system_wdef_cache: HashMap<i16, u32>,
+    /// Cache of the synthetic ROM `'MDEF'` resource used by standard menus.
+    /// The Menu Manager HLE owns standard drawing and hit testing, but
+    /// MenuInfo.menuProc remains guest-visible and some applications invoke
+    /// the procedure directly.
+    pub(crate) system_mdef_cache: HashMap<i16, u32>,
     /// Cache of allocated tool-trap trampolines for GetTrapAddress.
     /// Each entry is a 2-byte allocation containing the auto-pop
     /// variant of the canonical tool-trap word. When the guest does
@@ -2714,6 +2719,7 @@ impl TrapDispatcher {
             system_clut_cache: HashMap::new(),
             system_kchr_cache: HashMap::new(),
             system_wdef_cache: HashMap::new(),
+            system_mdef_cache: HashMap::new(),
             tool_trap_trampolines: HashMap::new(),
             param_text: [Vec::new(), Vec::new(), Vec::new(), Vec::new()],
             ui_theme_id: UiThemeId::ClassicSystem7,
@@ -4754,6 +4760,32 @@ impl TrapDispatcher {
         bus.write_word(ptr + 6, 0x4297); // CLR.L (SP) — LongInt function result.
         bus.write_word(ptr + 8, 0x4ED0); // JMP (A0).
         self.system_wdef_cache.insert(res_id, ptr);
+        Some(ptr)
+    }
+
+    /// Allocate (and cache) a callable shim for the standard ROM menu
+    /// definition procedure. The Menu Manager HLE performs the built-in
+    /// MDEF behavior, but direct guest calls still use the five-parameter,
+    /// 18-byte Pascal procedure ABI declared by MPW Menus.h. Inside
+    /// Macintosh Volume I, I-352 and I-365.
+    pub(crate) fn synthesize_system_mdef(
+        &mut self,
+        bus: &mut MacMemoryBus,
+        res_id: i16,
+    ) -> Option<u32> {
+        if let Some(&ptr) = self.system_mdef_cache.get(&res_id) {
+            return Some(ptr);
+        }
+        if res_id != 0 {
+            return None;
+        }
+
+        let ptr = bus.alloc(8);
+        bus.write_word(ptr, 0x205F); // MOVEA.L (SP)+,A0 — recover JSR return PC.
+        bus.write_word(ptr + 2, 0xDEFC); // ADDA.W #18,SP — discard MDEF parameters.
+        bus.write_word(ptr + 4, 18);
+        bus.write_word(ptr + 6, 0x4ED0); // JMP (A0).
+        self.system_mdef_cache.insert(res_id, ptr);
         Some(ptr)
     }
 

--- a/src/trap/menu.rs
+++ b/src/trap/menu.rs
@@ -670,6 +670,16 @@ impl super::TrapDispatcher {
         (1008..=1023).contains(&proc_id)
     }
 
+    fn menu_def_proc_handle(&mut self, bus: &mut MacMemoryBus, mdef_id: i16) -> u32 {
+        if let Some((refnum, ptr)) = self.find_or_load_resource_any(bus, *b"MDEF", mdef_id) {
+            return self.get_or_create_resource_handle_in_file(bus, *b"MDEF", mdef_id, ptr, refnum);
+        }
+
+        self.synthesize_system_mdef(bus, mdef_id)
+            .map(|ptr| self.get_or_create_resource_handle_in_file(bus, *b"MDEF", mdef_id, ptr, 0))
+            .unwrap_or(0)
+    }
+
     pub(crate) fn popup_menu_item_title(
         &self,
         bus: &MacMemoryBus,
@@ -1267,7 +1277,8 @@ impl super::TrapDispatcher {
                 bus.write_word(menu_ptr, menu_id as u16);
                 bus.write_word(menu_ptr + 2, 0);
                 bus.write_word(menu_ptr + 4, 0);
-                bus.write_long(menu_ptr + 6, 0);
+                let menu_proc = self.menu_def_proc_handle(bus, 0);
+                bus.write_long(menu_ptr + 6, menu_proc);
                 bus.write_long(menu_ptr + 10, 0xFFFFFFFF); // enable all items
                 let mut title = String::new();
                 if title_ptr != 0 {
@@ -1334,6 +1345,19 @@ impl super::TrapDispatcher {
                                     if resized != 0 {
                                         menu_ptr = resized;
                                     }
+                                }
+                                let menu_proc_placeholder = bus.read_long(menu_ptr + 6);
+                                if !self.loaded_handles.contains_key(&menu_proc_placeholder) {
+                                    let mdef_id = (menu_proc_placeholder >> 16) as u16 as i16;
+                                    let menu_proc = self.menu_def_proc_handle(bus, mdef_id);
+                                    if menu_proc == 0 {
+                                        bus.write_word(0x0A60, (-192i16) as u16);
+                                        cpu.write_reg(Register::D0, -192i32 as u32);
+                                        bus.write_long(sp + 2, 0);
+                                        cpu.write_reg(Register::A7, sp + 2);
+                                        return Some(Ok(()));
+                                    }
+                                    bus.write_long(menu_ptr + 6, menu_proc);
                                 }
                                 let mut parsed = parse_menu_resource(bus, menu_ptr, handle);
                                 if let Some(existing) =
@@ -6848,6 +6872,28 @@ mod tests {
         );
     }
 
+    #[test]
+    fn newmenu_installs_callable_standard_mdef_handle() {
+        // Inside Macintosh Volume I, I-352: NewMenu stores a handle to the
+        // standard menu definition procedure in MenuInfo.menuProc.
+        let (mut disp, mut cpu, mut bus) = setup();
+        let handle = new_menu_with_title(&mut disp, &mut cpu, &mut bus, 232, 0x30B300, "Window");
+        let menu_ptr = bus.read_long(handle);
+        let mdef_handle = bus.read_long(menu_ptr + 6);
+
+        assert_ne!(
+            mdef_handle, 0,
+            "NewMenu must not leave the menuProc field NIL"
+        );
+        let mdef_ptr = bus.read_long(mdef_handle);
+        assert_ne!(mdef_ptr, 0, "standard MDEF handle must be loaded");
+        assert_eq!(
+            bus.read_word(mdef_ptr),
+            0x205F,
+            "standard MDEF shim should begin by recovering the JSR return address"
+        );
+    }
+
     // MTE 1992 p. 3-105: NewMenu does not insert into the current menu list;
     // InsertMenu is required before GetMHandle can find the menu by ID.
     #[test]
@@ -6925,6 +6971,97 @@ mod tests {
             bus.read_word(0x0A60),
             0,
             "GetMenu hit must clear stale resource errors"
+        );
+    }
+
+    #[test]
+    fn getmenu_replaces_standard_mdef_id_placeholder_with_callable_handle() {
+        // Inside Macintosh Volume I, I-127 and I-352: an on-disk MENU stores
+        // its MDEF resource ID followed by a zero word. GetMenu replaces that
+        // four-byte placeholder with the loaded procedure handle.
+        let (mut disp, mut cpu, mut bus) = setup();
+        let menu_ptr = seed_menu_resource(&mut bus, 128, "Game");
+        disp.resources = Some(crate::trap::dispatch::LoadedResources {
+            files: std::collections::HashMap::from([(
+                0,
+                crate::trap::dispatch::ResourceFileMap {
+                    loaded: std::collections::HashMap::from([((*b"MENU", 128), menu_ptr)]),
+                    named: std::collections::HashMap::new(),
+                    names_by_id: std::collections::HashMap::new(),
+                    attrs: std::collections::HashMap::new(),
+                    map_attrs: 0,
+                },
+            )]),
+            names: std::collections::HashMap::new(),
+            search_order: vec![0],
+            current_file: 0,
+        });
+        bus.write_word(TEST_SP, 128);
+
+        disp.dispatch_menu(true, 0x1BF, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+
+        let menu_handle = bus.read_long(cpu.read_reg(Register::A7));
+        let live_menu_ptr = bus.read_long(menu_handle);
+        let mdef_handle = bus.read_long(live_menu_ptr + 6);
+        assert_ne!(
+            mdef_handle, 0,
+            "GetMenu must replace the standard MDEF ID placeholder"
+        );
+        let mdef_ptr = bus.read_long(mdef_handle);
+        assert_ne!(mdef_ptr, 0, "standard MDEF handle must be loaded");
+        assert_eq!(
+            bus.read_word(mdef_ptr),
+            0x205F,
+            "standard MDEF shim should be directly callable by 68k code"
+        );
+    }
+
+    #[test]
+    fn getmenu_resolves_custom_mdef_from_the_resource_chain() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let menu_ptr = seed_menu_resource(&mut bus, 129, "Custom");
+        let mdef_ptr = bus.alloc(2);
+        bus.write_word(menu_ptr + 6, 256);
+        bus.write_word(menu_ptr + 8, 0);
+        bus.write_word(mdef_ptr, 0x4E75); // RTS: sufficient callable test body.
+        disp.resources = Some(crate::trap::dispatch::LoadedResources {
+            files: std::collections::HashMap::from([(
+                0,
+                crate::trap::dispatch::ResourceFileMap {
+                    loaded: std::collections::HashMap::from([
+                        ((*b"MENU", 129), menu_ptr),
+                        ((*b"MDEF", 256), mdef_ptr),
+                    ]),
+                    named: std::collections::HashMap::new(),
+                    names_by_id: std::collections::HashMap::new(),
+                    attrs: std::collections::HashMap::new(),
+                    map_attrs: 0,
+                },
+            )]),
+            names: std::collections::HashMap::new(),
+            search_order: vec![0],
+            current_file: 0,
+        });
+        bus.write_word(TEST_SP, 129);
+
+        disp.dispatch_menu(true, 0x1BF, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+
+        let menu_handle = bus.read_long(cpu.read_reg(Register::A7));
+        let live_menu_ptr = bus.read_long(menu_handle);
+        let mdef_handle = bus.read_long(live_menu_ptr + 6);
+        assert_ne!(
+            mdef_handle,
+            u32::from(256u16) << 16,
+            "GetMenu must replace the raw ID-plus-zero placeholder"
+        );
+        assert_eq!(
+            bus.read_long(mdef_handle),
+            mdef_ptr,
+            "custom MDEF handle should dereference to the loaded resource"
         );
     }
 

--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -1644,6 +1644,19 @@ impl super::TrapDispatcher {
                     }
                 }
 
+                if res_type == *b"MDEF" {
+                    if let Some(ptr) = self.synthesize_system_mdef(bus, res_id) {
+                        let handle = self
+                            .get_or_create_resource_handle_in_file(bus, res_type, res_id, ptr, 0);
+                        cpu.write_reg(Register::A0, handle);
+                        cpu.write_reg(Register::D0, 0);
+                        bus.write_word(0x0A60, 0); // ResErr = noErr
+                        bus.write_long(sp + 6, handle);
+                        cpu.write_reg(Register::A7, sp + 6);
+                        return Some(Ok(()));
+                    }
+                }
+
                 if res_type == *b"KCHR" {
                     if let Some(ptr) = self.synthesize_system_kchr(bus, res_id) {
                         if trace_getresource_enabled() {


### PR DESCRIPTION
## Summary

- resolve the ID-plus-zero MDEF placeholder in loaded MENU resources to a live Resource Manager handle
- synthesize a callable standard MDEF 0 shim with the documented 18-byte Pascal procedure ABI
- give `NewMenu` the same valid standard-MDEF handle contract
- preserve custom MDEF resource identity through the normal resource handle cache

Closes #73.

## Ground truth

Inside Macintosh Volume I, pp. I-127 and I-352, specifies that `GetMenu` loads the referenced menu definition procedure and replaces the MENU resource placeholder with its handle. MPW Universal Interfaces `Menus.h` declares `MenuInfo.menuProc` as `Handle`, the five-parameter `MenuDefProcPtr` ABI, and `GetMenu` as trap `$A9BF`.

## Tests

- `cargo test --lib` — 2,719 passed, 3 ignored
- `cargo check --all-targets` — passed
- regression tests cover `NewMenu`, standard MDEF resolution, and custom MDEF resolution
- clean Systemless 0.7.0 reproduction halted through a NIL `menuProc`; this branch proceeds through the startup dialog, game-window creation, data-directory discovery, and demo data-file loading

`cargo fmt --check` still reports formatting differences already present on `master` in unrelated files; the touched hunks pass `git diff --check`.