### PR TITLE
fix: activate queued launches when caller exits

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1783,10 +1783,14 @@ impl FixtureRunner {
         Ok(())
     }
 
-    fn service_pending_launch_application(&mut self, event_yield_reached: bool) -> bool {
+    fn service_pending_launch_application(
+        &mut self,
+        event_yield_reached: bool,
+        caller_exited: bool,
+    ) -> bool {
         let Some(path) = self
             .dispatcher
-            .take_pending_launch_application(event_yield_reached)
+            .take_pending_launch_application(event_yield_reached, caller_exited)
         else {
             return false;
         };
@@ -3275,7 +3279,7 @@ impl FixtureRunner {
                             self.dispatcher.trap_histogram[idx].saturating_add(1);
                         self.dispatcher.inline_skipped[idx] =
                             self.dispatcher.inline_skipped[idx].saturating_add(1);
-                        if self.service_pending_launch_application(true) {
+                        if self.service_pending_launch_application(true, false) {
                             if self.halted {
                                 return (count, false);
                             }
@@ -3446,9 +3450,10 @@ impl FixtureRunner {
                             // Service any pending Delay ticks immediately after
                             // the trap dispatch, before the next instruction.
                             self.service_delay_ticks(tick_cap);
-                            if self.service_pending_launch_application(event_manager_yield_trap(
-                                opcode,
-                            )) {
+                            if self.service_pending_launch_application(
+                                event_manager_yield_trap(opcode),
+                                false,
+                            ) {
                                 if self.halted {
                                     return (count, false);
                                 }
@@ -3456,6 +3461,14 @@ impl FixtureRunner {
                             }
                         }
                         Err(Error::Halted) => {
+                            if matches!(opcode, 0xA9F2 | 0xA9F4)
+                                && self.service_pending_launch_application(false, true)
+                            {
+                                if self.halted {
+                                    return (count, false);
+                                }
+                                continue;
+                            }
                             // Surface the auto-pop caller PC if the
                             // halted trap was called via JSR through a
                             // trampoline. Without this, the halt log
@@ -6582,10 +6595,10 @@ mod tests {
             .queue_pending_launch_application("Apps/Register Helper", true);
 
         assert!(
-            !runner.service_pending_launch_application(false),
+            !runner.service_pending_launch_application(false, false),
             "launchContinue target must wait for an Event Manager yield"
         );
-        let switched = runner.service_pending_launch_application(true);
+        let switched = runner.service_pending_launch_application(true, false);
 
         assert!(
             switched,
@@ -6664,7 +6677,7 @@ mod tests {
             .dispatcher
             .queue_pending_launch_application("Apps/Register Helper", false);
 
-        let switched = runner.service_pending_launch_application(false);
+        let switched = runner.service_pending_launch_application(false, false);
 
         assert!(
             switched,
@@ -9589,6 +9602,42 @@ mod tests {
         assert!(
             runner.halted_by_exit_to_shell(),
             "ExitToShell halt must be classified as a clean application exit"
+        );
+    }
+
+    #[test]
+    fn exit_to_shell_activates_launch_target_queued_until_event_yield() {
+        let helper_code0 = minimal_code0(0, 0x2000, 0, 0);
+        let helper_fork_bytes = make_resource_fork_bytes(&[(*b"CODE", 0, &helper_code0)]);
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        let base = 0x0001_0000u32;
+
+        runner
+            .dispatcher
+            .vfs
+            .insert("Apps/Register Helper".to_string(), Vec::new());
+        runner
+            .dispatcher
+            .vfs_rsrc
+            .insert("Apps/Register Helper".to_string(), helper_fork_bytes);
+        runner.dispatcher.ensure_vfs_catalog();
+        runner
+            .dispatcher
+            .queue_pending_launch_application("Apps/Register Helper", true);
+        runner.bus.write_word(base, 0xA9F4); // _ExitToShell
+        runner.cpu.write_reg(Register::PC, base);
+        runner.cpu.write_reg(Register::A7, 0x0010_0000);
+
+        let (_steps, running) = runner.run_steps(1, None);
+
+        assert!(
+            running,
+            "ExitToShell should activate a valid queued launch target"
+        );
+        assert!(!runner.is_halted());
+        assert_eq!(
+            runner.dispatcher.launched_app_path.as_deref(),
+            Some("Apps/Register Helper")
         );
     }
 

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -885,6 +885,7 @@ pub(crate) struct WorkingDirectory {
 pub(crate) struct PendingLaunchApplication {
     pub path: String,
     pub after_event_yield: bool,
+    pub after_caller_exit: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -3336,17 +3337,29 @@ impl TrapDispatcher {
         self.pending_launch_app = Some(PendingLaunchApplication {
             path: normalized,
             after_event_yield,
+            after_caller_exit: false,
+        });
+    }
+
+    pub(crate) fn queue_background_launch_application(&mut self, name: &str) {
+        let normalized = Self::normalize_vfs_path(name);
+        self.pending_launch_app = Some(PendingLaunchApplication {
+            path: normalized,
+            after_event_yield: false,
+            after_caller_exit: true,
         });
     }
 
     pub(crate) fn take_pending_launch_application(
         &mut self,
         event_yield_reached: bool,
+        caller_exited: bool,
     ) -> Option<String> {
-        let ready = self
-            .pending_launch_app
-            .as_ref()
-            .is_some_and(|pending| !pending.after_event_yield || event_yield_reached);
+        let ready = self.pending_launch_app.as_ref().is_some_and(|pending| {
+            caller_exited
+                || ((!pending.after_event_yield || event_yield_reached)
+                    && !pending.after_caller_exit)
+        });
         if ready {
             self.pending_launch_app.take().map(|pending| pending.path)
         } else {

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -4883,7 +4883,9 @@ impl super::TrapDispatcher {
             // are queued for the runner to load into a fresh application
             // heap; launchContinue launches begin when the caller next
             // yields through the Event Manager, matching Processes 1994
-            // p. 2-15. launchDontSwitch remains a bookkeeping-only path.
+            // p. 2-15. A launchDontSwitch target remains deferred until
+            // the caller exits, when it becomes the only runnable app and
+            // is promoted into Systemless's foreground process slot.
             // On launch failure, LaunchApplication returns 0 in the
             // launchProcessSN / launchPreferredSize / launchMinimumSize /
             // launchAvailableSize fields so callers do not observe stale
@@ -4945,9 +4947,13 @@ impl super::TrapDispatcher {
                 cpu.write_reg(Register::D0, launch_result);
                 let queued_foreground_launch =
                     launch_result == 0 && launch_target.is_some() && !launch_dont_switch;
-                if queued_foreground_launch {
+                if launch_result == 0 {
                     if let Some(app_path) = launch_target.as_deref() {
-                        self.queue_pending_launch_application(app_path, launch_continue);
+                        if launch_dont_switch {
+                            self.queue_background_launch_application(app_path);
+                        } else {
+                            self.queue_pending_launch_application(app_path, launch_continue);
+                        }
                     }
                 }
                 if launch_continue || queued_foreground_launch {
@@ -18468,11 +18474,11 @@ mod tests {
             Some("LaunchTargets/Register Helper")
         );
         assert!(
-            disp.take_pending_launch_application(false).is_none(),
+            disp.take_pending_launch_application(false, false).is_none(),
             "launchContinue target should not start until an Event Manager yield"
         );
         assert_eq!(
-            disp.take_pending_launch_application(true).as_deref(),
+            disp.take_pending_launch_application(true, false).as_deref(),
             Some("LaunchTargets/Register Helper")
         );
     }
@@ -18520,14 +18526,14 @@ mod tests {
             Some("LaunchTargets/Register Helper")
         );
         assert_eq!(
-            disp.take_pending_launch_application(false).as_deref(),
+            disp.take_pending_launch_application(false, false).as_deref(),
             Some("LaunchTargets/Register Helper"),
             "non-launchContinue foreground target should be immediately serviceable"
         );
     }
 
     #[test]
-    fn launchapplication_launchdontswitch_records_existing_target_without_queueing() {
+    fn launchapplication_launchdontswitch_defers_existing_target_until_caller_exit() {
         let (mut disp, mut cpu, mut bus) = setup();
         let sp_before = cpu.read_reg(Register::A7);
         let launch_pb = bus.alloc(64);
@@ -18569,8 +18575,13 @@ mod tests {
             Some("LaunchTargets/Register Helper")
         );
         assert!(
-            disp.take_pending_launch_application(true).is_none(),
-            "launchDontSwitch target should not queue a foreground app switch"
+            disp.take_pending_launch_application(true, false).is_none(),
+            "launchDontSwitch target must remain in the background while its caller runs"
+        );
+        assert_eq!(
+            disp.take_pending_launch_application(false, true).as_deref(),
+            Some("LaunchTargets/Register Helper"),
+            "launchDontSwitch target should become runnable when its caller exits"
         );
     }
 


### PR DESCRIPTION
## Summary

- retain valid `LaunchApplication` targets that are deferred until an Event Manager yield
- activate a queued target when its caller exits before reaching that yield
- defer `launchDontSwitch` targets while the caller remains active and promote them on caller termination
- preserve Systemless's existing immediate foreground-launch behavior

Closes #79.

## Tests

- `cargo test --lib` — 2,720 passed, 3 ignored
- `cargo check --all-targets` — passed
- focused trap coverage verifies `launchDontSwitch` stays deferred until caller termination
- focused runner coverage verifies `_ExitToShell` switches to a valid queued VFS application rather than halting
- an existing VFS launcher using `launchContinue | launchNoFileFlags | launchUseMinimum` now hands off to its resource-fork application when it calls `_ExitToShell` before an Event Manager yield

The change is limited to generic Systemless Process Manager HLE and runner application-switch behavior.