### PR TITLE
fix: deliver asynchronous file read completions

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -513,6 +513,7 @@ enum ActiveInterruptCallbackSource {
     SoundCallback,
     SoundFileCompletion,
     SoundDoubleBack,
+    FileCompletion,
     DialogDrawProc,
     DialogFilterProc,
     MenuHook,
@@ -742,6 +743,9 @@ pub struct FixtureRunner {
     /// Guest-memory address of the SndStartFilePlay completion trampoline.
     /// Allocated once on first use and reused for all file completion routines.
     sound_file_completion_trampoline: u32,
+    /// Guest-memory trampoline used to invoke File Manager asynchronous
+    /// completion procedures.
+    file_completion_trampoline: u32,
     /// Guest-memory address of the dialog userItem draw proc trampoline (26 bytes).
     /// Allocated once on first use and reused for all subsequent draw proc calls.
     dialog_draw_trampoline: u32,
@@ -831,6 +835,7 @@ impl FixtureRunner {
             sound_doubleback_trampoline: 0,
             sound_callback_trampoline: 0,
             sound_file_completion_trampoline: 0,
+            file_completion_trampoline: 0,
             dialog_draw_trampoline: 0,
             dialog_filter_trampoline: 0,
             menu_hook_trampoline: 0,
@@ -2696,6 +2701,13 @@ impl FixtureRunner {
                 break;
             }
 
+            // File Manager async completions are interrupt work. Deliver a
+            // completed request before the foreground application can inspect
+            // or reuse its parameter block.
+            if !sound_work_only && self.active_interrupt_callback.is_none() {
+                self.fire_file_completion_callback();
+            }
+
             // Sound callbacks are interrupt work. If a previous slice queued
             // one, dispatch it before running more foreground guest code. Do
             // not drain the whole queue in one CPU slice: double-buffer
@@ -4496,6 +4508,43 @@ impl FixtureRunner {
         self.cpu.write_reg(Register::PC, trampoline);
     }
 
+    /// Publish and optionally deliver one completed asynchronous File Manager
+    /// request.
+    ///
+    /// A File Manager completion procedure receives A0 pointing at the
+    /// parameter block and D0 equal to its final `ioResult`.
+    /// Inside Macintosh: Files (1992), 2-238.
+    fn fire_file_completion_callback(&mut self) -> bool {
+        if self.active_interrupt_callback.is_some() {
+            return false;
+        }
+
+        let Some(completion) = self.dispatcher.pending_file_completions.pop_front() else {
+            return false;
+        };
+
+        self.bus
+            .write_word(completion.parameter_block + 16, completion.result as u16);
+        if completion.completion_addr == 0 {
+            return false;
+        }
+
+        if self.file_completion_trampoline == 0 {
+            let tramp = self.bus.alloc_synthetic(8);
+            self.bus.write_word(tramp, 0x4EB9); // JSR abs.L
+            self.bus.write_word(tramp + 6, 0x4E75); // RTS
+            self.file_completion_trampoline = tramp;
+        }
+
+        let tramp = self.file_completion_trampoline;
+        self.bus.write_long(tramp + 2, completion.completion_addr);
+        self.inject_interrupt_callback(ActiveInterruptCallbackSource::FileCompletion, tramp);
+        self.cpu.write_reg(Register::A0, completion.parameter_block);
+        self.cpu
+            .write_reg(Register::D0, completion.result as i32 as u32);
+        true
+    }
+
     /// Fire pending Sound Manager callback procedures and file completion routines.
     fn fire_sound_callbacks(&mut self) -> bool {
         if self.active_interrupt_callback.is_some() {
@@ -5981,8 +6030,8 @@ mod tests {
         SndChannel, SndCommand, OUTPUT_RATE,
     };
     use crate::trap::dispatch::{
-        DialogItem, DialogTrackingState, PendingWaitNextEventReturn, QueuedEvent, TimerTask,
-        VblTask,
+        DialogItem, DialogTrackingState, PendingFileCompletion, PendingWaitNextEventReturn,
+        QueuedEvent, TimerTask, VblTask,
     };
     use std::cell::RefCell;
     use std::collections::{HashMap, VecDeque};
@@ -8166,6 +8215,57 @@ mod tests {
         assert_eq!(runner.bus.read_word(cmd_ptr), crate::sound::cmd::CALLBACK);
         assert_eq!(runner.bus.read_word(cmd_ptr + 2), 0x1234);
         assert_eq!(runner.bus.read_long(cmd_ptr + 4), 0x0001_43FC);
+    }
+
+    #[test]
+    fn file_completion_callback_uses_documented_registers_and_restores_foreground() {
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        let interrupted_pc = 0x0001_0000;
+        let interrupted_sp = 0x007F_FFC0;
+        let parameter_block = runner.bus.alloc(64);
+        let callback_addr = runner.bus.alloc(2);
+
+        runner.bus.write_word(callback_addr, 0x4E75); // RTS
+        for offset in (0..20).step_by(2) {
+            runner.bus.write_word(interrupted_pc + offset, 0x4E71); // NOP
+        }
+        runner.cpu.write_reg(Register::PC, interrupted_pc);
+        runner.cpu.write_reg(Register::A7, interrupted_sp);
+        runner.cpu.write_reg(Register::A0, 0x1111_1111);
+        runner.cpu.write_reg(Register::D0, 0x2222_2222);
+        runner
+            .dispatcher
+            .pending_file_completions
+            .push_back(PendingFileCompletion {
+                parameter_block,
+                completion_addr: callback_addr,
+                result: -39,
+            });
+
+        assert!(runner.fire_file_completion_callback());
+        assert_eq!(runner.bus.read_word(parameter_block + 16) as i16, -39);
+        assert_eq!(runner.cpu.read_reg(Register::A0), parameter_block);
+        assert_eq!(runner.cpu.read_reg(Register::D0) as i32, -39);
+        assert!(matches!(
+            runner.active_interrupt_callback.map(|active| active.source),
+            Some(ActiveInterruptCallbackSource::FileCompletion)
+        ));
+        assert!(
+            runner
+                .bus
+                .get_alloc_size(runner.file_completion_trampoline)
+                .is_none(),
+            "Systemless-owned completion trampoline must stay outside the guest heap"
+        );
+
+        let (_, running) = runner.run_steps(6, None);
+
+        assert!(running);
+        assert!(runner.active_interrupt_callback.is_none());
+        assert_eq!(runner.cpu.read_reg(Register::A7), interrupted_sp);
+        assert_eq!(runner.cpu.read_reg(Register::A0), 0x1111_1111);
+        assert_eq!(runner.cpu.read_reg(Register::D0), 0x2222_2222);
+        assert!(!runner.is_halted());
     }
 
     #[test]

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -51,6 +51,13 @@ pub(crate) struct RecentFileRead {
     pub(crate) bytes_read: usize,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct PendingFileCompletion {
+    pub(crate) parameter_block: u32,
+    pub(crate) completion_addr: u32,
+    pub(crate) result: i16,
+}
+
 // Env-var lookups are cached via OnceLock. Tests/diagnostics that want
 // to toggle these at runtime cannot — values are read ONCE at first call.
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -1208,6 +1215,9 @@ pub struct TrapDispatcher {
     pub(crate) file_positions: HashMap<u16, usize>,
     /// Most recent successful PBRead/FSRead from a data fork.
     pub(crate) recent_file_read: Option<RecentFileRead>,
+    /// Completed asynchronous File Manager requests awaiting `ioResult`
+    /// publication and optional completion-procedure delivery.
+    pub(crate) pending_file_completions: VecDeque<PendingFileCompletion>,
     /// Set of VFS keys whose `ioFlAttrib` lock bit is set.
     /// Maintained by SetFilLock/HSetFLock ($A041/$A241) and
     /// RstFilLock/HRstFLock ($A042/$A242); read by
@@ -2734,6 +2744,7 @@ impl TrapDispatcher {
             write_refnums: HashSet::new(),
             file_positions: HashMap::new(),
             recent_file_read: None,
+            pending_file_completions: VecDeque::new(),
             locked_files: HashSet::new(),
             next_refnum: 100,
             mmu_mode: 1,                      // true32b — 32-bit addressing by default

--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -3685,12 +3685,14 @@ impl super::TrapDispatcher {
                 Ok(())
             }
 
-            // PBRead ($A002)
+            // PBRead/PBReadAsync ($A002/$A402)
             // Reads bytes from an open file, including PBRead newline mode.
             // FUNCTION PBRead (paramBlock: ParmBlkPtr; async: Boolean): OSErr;
-            // Files 1992, 2-121 to 2-122
+            // Files 1992, 2-84, 2-121 to 2-122, 2-238
             (false, 0x02) => {
                 let pb = cpu.read_reg(Register::A0);
+                let async_call = (self.current_trap_word & 0x0400) != 0;
+                let completion_addr = bus.read_long(pb + 12);
                 let ref_num = bus.read_word(pb + 24);
                 let buffer = bus.read_long(pb + 32);
                 let request_count = bus.read_long(pb + 36) as usize;
@@ -3705,54 +3707,57 @@ impl super::TrapDispatcher {
                     if let Some(file_buf) = self.vfs.get(&filename) {
                         let file_len = file_buf.len();
                         let cur_pos = *self.file_positions.get(&ref_num).unwrap_or(&0);
-                        let Ok(start) = Self::resolve_file_mark_position(
+                        match Self::resolve_file_mark_position(
                             pos_mode, pos_offset, cur_pos, file_len,
-                        ) else {
-                            bus.write_word(pb + 16, (-40i16) as u16); // posErr
-                            bus.write_long(pb + 40, 0);
-                            bus.write_long(pb + 46, cur_pos as u32);
-                            cpu.write_reg(Register::D0, (-40i32) as u32);
-                            return Some(Ok(()));
-                        };
-                        let start = start.min(file_len);
-                        let avail = file_len - start;
-                        let max_read = request_count.min(avail);
-                        let newline_mode = (pos_mode & 0x0080) != 0;
-                        let newline_char = (pos_mode >> 8) as u8;
-                        let newline_offset = if newline_mode {
-                            file_buf[start..start + max_read]
-                                .iter()
-                                .position(|&byte| byte == newline_char)
-                        } else {
-                            None
-                        };
-                        let bytes_read =
-                            newline_offset.map(|offset| offset + 1).unwrap_or(max_read);
-                        let stopped_at_newline = newline_offset.is_some();
+                        ) {
+                            Err(_) => {
+                                bus.write_word(pb + 16, (-40i16) as u16); // posErr
+                                bus.write_long(pb + 40, 0);
+                                bus.write_long(pb + 46, cur_pos as u32);
+                                cpu.write_reg(Register::D0, (-40i32) as u32);
+                            }
+                            Ok(start) => {
+                                let start = start.min(file_len);
+                                let avail = file_len - start;
+                                let max_read = request_count.min(avail);
+                                let newline_mode = (pos_mode & 0x0080) != 0;
+                                let newline_char = (pos_mode >> 8) as u8;
+                                let newline_offset = if newline_mode {
+                                    file_buf[start..start + max_read]
+                                        .iter()
+                                        .position(|&byte| byte == newline_char)
+                                } else {
+                                    None
+                                };
+                                let bytes_read =
+                                    newline_offset.map(|offset| offset + 1).unwrap_or(max_read);
+                                let stopped_at_newline = newline_offset.is_some();
 
-                        bus.write_bytes(buffer, &file_buf[start..start + bytes_read]);
+                                bus.write_bytes(buffer, &file_buf[start..start + bytes_read]);
 
-                        self.file_positions.insert(ref_num, start + bytes_read);
-                        bus.write_long(pb + 40, bytes_read as u32);
-                        bus.write_long(pb + 46, (start + bytes_read) as u32);
-                        self.recent_file_read = Some(super::dispatch::RecentFileRead {
-                            ref_num,
-                            filename: filename.clone(),
-                            buffer,
-                            start,
-                            bytes_read,
-                        });
+                                self.file_positions.insert(ref_num, start + bytes_read);
+                                bus.write_long(pb + 40, bytes_read as u32);
+                                bus.write_long(pb + 46, (start + bytes_read) as u32);
+                                self.recent_file_read = Some(super::dispatch::RecentFileRead {
+                                    ref_num,
+                                    filename: filename.clone(),
+                                    buffer,
+                                    start,
+                                    bytes_read,
+                                });
 
-                        if !stopped_at_newline && bytes_read < request_count {
-                            eprintln!(
-                                "[TRAP] PBRead -> eofErr (read {} of {} from pos {})",
-                                bytes_read, request_count, start
-                            );
-                            bus.write_word(pb + 16, (-39i16) as u16); // eofErr
-                            cpu.write_reg(Register::D0, (-39i32) as u32);
-                        } else {
-                            bus.write_word(pb + 16, 0);
-                            cpu.write_reg(Register::D0, 0);
+                                if !stopped_at_newline && bytes_read < request_count {
+                                    eprintln!(
+                                        "[TRAP] PBRead -> eofErr (read {} of {} from pos {})",
+                                        bytes_read, request_count, start
+                                    );
+                                    bus.write_word(pb + 16, (-39i16) as u16); // eofErr
+                                    cpu.write_reg(Register::D0, (-39i32) as u32);
+                                } else {
+                                    bus.write_word(pb + 16, 0);
+                                    cpu.write_reg(Register::D0, 0);
+                                }
+                            }
                         }
                     } else {
                         eprintln!("[TRAP] PBRead -> fnfErr (file not in VFS)");
@@ -3772,6 +3777,24 @@ impl super::TrapDispatcher {
                     bus.write_word(pb + 16, (-51i16) as u16); // rfNumErr
                     bus.write_long(pb + 40, 0);
                     cpu.write_reg(Register::D0, (-51i32) as u32);
+                }
+
+                if async_call {
+                    let result = cpu.read_reg(Register::D0) as i16;
+                    self.pending_file_completions.push_back(
+                        super::dispatch::PendingFileCompletion {
+                            parameter_block: pb,
+                            completion_addr,
+                            result,
+                        },
+                    );
+                    // A successfully queued asynchronous request returns noErr.
+                    // ioResult remains positive until the request completes.
+                    bus.write_word(pb + 16, 1);
+                    cpu.write_reg(Register::D0, 0);
+                } else {
+                    // The File Manager clears ioCompletion for synchronous calls.
+                    bus.write_long(pb + 12, 0);
                 }
                 Ok(())
             }
@@ -12731,6 +12754,65 @@ mod tests {
         assert_eq!(bus.read_byte(read_buf), 10);
         assert_eq!(bus.read_byte(read_buf + 1), 20);
         assert_eq!(bus.read_byte(read_buf + 2), 30);
+    }
+
+    #[test]
+    fn pb_read_async_queues_completion_and_leaves_ioresult_in_progress() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let pb = 0x300000u32;
+        let read_buf = 0x310000u32;
+        let completion_addr = 0x320000u32;
+
+        disp.vfs
+            .insert("AsyncData".to_string(), vec![10, 20, 30, 40]);
+        disp.open_files.insert(100, "AsyncData".to_string());
+        disp.file_positions.insert(100, 0);
+        cpu.write_reg(Register::A0, pb);
+        bus.write_long(pb + 12, completion_addr);
+        bus.write_word(pb + 24, 100);
+        bus.write_long(pb + 32, read_buf);
+        bus.write_long(pb + 36, 4);
+        bus.write_word(pb + 44, 0);
+        bus.write_long(pb + 46, 0);
+
+        call_trap_word(&mut disp, 0xA402, &mut cpu, &mut bus).unwrap();
+
+        assert_eq!(cpu.read_reg(Register::D0), 0, "queueing returns noErr");
+        assert_eq!(bus.read_word(pb + 16), 1, "ioResult stays in progress");
+        assert_eq!(bus.read_long(pb + 40), 4);
+        assert_eq!(bus.read_bytes(read_buf, 4), vec![10, 20, 30, 40]);
+        assert_eq!(
+            disp.pending_file_completions.pop_front(),
+            Some(super::super::dispatch::PendingFileCompletion {
+                parameter_block: pb,
+                completion_addr,
+                result: 0,
+            })
+        );
+    }
+
+    #[test]
+    fn pb_read_sync_clears_completion_and_returns_final_result_directly() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let pb = 0x300000u32;
+
+        disp.vfs.insert("Empty".to_string(), Vec::new());
+        disp.open_files.insert(100, "Empty".to_string());
+        disp.file_positions.insert(100, 0);
+        cpu.write_reg(Register::A0, pb);
+        bus.write_long(pb + 12, 0x320000);
+        bus.write_word(pb + 24, 100);
+        bus.write_long(pb + 32, 0x310000);
+        bus.write_long(pb + 36, 1);
+        bus.write_word(pb + 44, 0);
+        bus.write_long(pb + 46, 0);
+
+        call_trap_word(&mut disp, 0xA002, &mut cpu, &mut bus).unwrap();
+
+        assert_eq!(cpu.read_reg(Register::D0) as i32, -39);
+        assert_eq!(bus.read_word(pb + 16) as i16, -39);
+        assert_eq!(bus.read_long(pb + 12), 0);
+        assert!(disp.pending_file_completions.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- preserve bit 10 when dispatching `$A402` `PBReadAsync`
- queue completed reads with an in-progress `ioResult`, then publish their final result before returning foreground control
- invoke File Manager completion procedures with A0 pointing to the parameter block and D0 matching `ioResult`
- keep the completion trampoline in Systemless synthetic memory and restore interrupted foreground state

Closes #87.

## Root cause

Systemless canonicalized `$A402` to `$A002` and immediately applied synchronous `PBRead` behavior. Day of the Tentacle's streaming state machine depends on the asynchronous completion procedure, so it repeatedly submitted the same 160-byte trailer read and remained on a black frame.

## Validation

- `cargo test --lib --quiet` — 2,722 passed, 3 ignored
- `cargo check --all-targets` — passed
- focused tests cover async queue state, synchronous behavior, completion A0/D0 values, foreground register/stack restoration, and synthetic trampoline allocation
- the Day of the Tentacle reproduction crosses the former `$A402` reread loop and continues into its main window and data-load path; the next visual compatibility blocker remains separately diagnosable

The change is generic File Manager behavior and contains no game-specific code.