### PR TITLE
Fix concurrent Time Manager callback starvation

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -4212,7 +4212,8 @@ impl FixtureRunner {
             .dispatcher
             .timer_tasks
             .iter_mut()
-            .find(|task| task.active && current_tick >= task.fire_at_tick)
+            .filter(|task| task.active && current_tick >= task.fire_at_tick)
+            .min_by_key(|task| task.fire_at_tick)
         {
             let task_ptr = task.task_ptr;
             let tm_addr = task.tm_addr;
@@ -7693,6 +7694,26 @@ mod tests {
         assert!(
             runner.dispatcher.timer_tasks[1].active,
             "a second task due on the same tick must remain queued"
+        );
+
+        // The delivered task may re-prime itself from its callback. It must not
+        // jump ahead of an older task that is still waiting for delivery.
+        runner.dispatcher.timer_tasks[0].active = true;
+        runner.dispatcher.timer_tasks[0].fire_at_tick = 11;
+        runner.active_interrupt_callback = None;
+        runner.cpu.write_reg(Register::PC, interrupted_pc);
+        runner.cpu.write_reg(Register::A7, interrupted_sp);
+
+        runner.fire_timer_tasks(11);
+
+        assert!(
+            runner.dispatcher.timer_tasks[0].active,
+            "the newly re-primed task must wait behind the older due task"
+        );
+        assert!(!runner.dispatcher.timer_tasks[1].active);
+        assert_eq!(
+            runner.bus.read_long(runner.timer_trampoline + 6),
+            0x0039_3900
         );
     }
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -4207,17 +4207,19 @@ impl FixtureRunner {
             return;
         }
 
-        // Collect tasks that need to fire (avoid borrow issues)
-        let mut to_fire: Vec<(u32, u32)> = Vec::new(); // (task_ptr, tm_addr)
-        for task in &mut self.dispatcher.timer_tasks {
-            if task.active && current_tick >= task.fire_at_tick {
-                to_fire.push((task.task_ptr, task.tm_addr));
-                task.active = false; // Mark as fired; callback may re-prime
-            }
-        }
-
         // Fire at most one task per tick to avoid deep nesting
-        if let Some((task_ptr, tm_addr)) = to_fire.into_iter().next() {
+        if let Some(task) = self
+            .dispatcher
+            .timer_tasks
+            .iter_mut()
+            .find(|task| task.active && current_tick >= task.fire_at_tick)
+        {
+            let task_ptr = task.task_ptr;
+            let tm_addr = task.tm_addr;
+            // Mark only the task being delivered as fired. Other tasks that
+            // expire on the same tick must remain active for a later interrupt.
+            task.active = false;
+
             if tm_addr == 0 {
                 return;
             }
@@ -7659,6 +7661,38 @@ mod tests {
         assert!(
             runner.dispatcher.timer_tasks[0].active,
             "the next due timer should remain queued until foreground code gets a slice"
+        );
+    }
+
+    #[test]
+    fn simultaneous_timer_callbacks_keep_undelivered_tasks_active() {
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        let interrupted_pc = 0x0001_0000;
+        let interrupted_sp = 0x007F_FFC0;
+
+        runner.cpu.write_reg(Register::PC, interrupted_pc);
+        runner.cpu.write_reg(Register::A7, interrupted_sp);
+        runner.dispatcher.timer_tasks.extend([
+            TimerTask {
+                task_ptr: 0x0039_38C8,
+                tm_addr: 0x0002_0000,
+                active: true,
+                fire_at_tick: 10,
+            },
+            TimerTask {
+                task_ptr: 0x0039_3900,
+                tm_addr: 0x0002_1000,
+                active: true,
+                fire_at_tick: 10,
+            },
+        ]);
+
+        runner.fire_timer_tasks(10);
+
+        assert!(!runner.dispatcher.timer_tasks[0].active);
+        assert!(
+            runner.dispatcher.timer_tasks[1].active,
+            "a second task due on the same tick must remain queued"
         );
     }
 


### PR DESCRIPTION
## What changed

- keep due Time Manager tasks active until their callback is actually selected for delivery
- select the oldest due task before a recurring task that has just re-primed itself
- cover same-tick expiry and re-priming fairness with a focused runner regression test

## Why

Day of the Tentacle installs a recurring Revised Time Manager task and a one-shot opening-sequence task. Both can become due on the same coarse guest tick. Systemless previously deactivated both while delivering only the first; after preserving the second, fixed queue-order selection still allowed the recurring first task to starve the older callback forever.

The resulting behavior is generic Time Manager scheduling. No title-specific code or assets are included.

Fixes #89.

## Validation

- `cargo test` — 2720 passed, 3 ignored
- `cargo check --all-targets`
- `git diff --check`
- authentic Day of the Tentacle demo probe, combined only for validation with the async file-completion change in #88: the previously black opening window renders the same purple opening spiral seen in the BasiliskII oracle

This PR is independent of #88 at the source level; both fixes are currently required to reach the demonstrated game path.