### PR TITLE
Pace revised Time Manager callbacks

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2716,6 +2716,13 @@ impl FixtureRunner {
                 break;
             }
 
+            if !sound_work_only && self.active_interrupt_callback.is_none() {
+                self.fire_timer_tasks_at(self.current_timer_subtick());
+                if self.active_interrupt_callback.is_some() {
+                    continue;
+                }
+            }
+
             // Service blocking traps (Delay, WaitNextEvent sleep).
             if !sound_work_only {
                 if self.service_wait_sleep_ticks(tick_cap) {
@@ -2824,10 +2831,6 @@ impl FixtureRunner {
                         active_interrupt_callback.source,
                         ActiveInterruptCallbackSource::DialogDrawProc
                     );
-                    let completed_timer = matches!(
-                        active_interrupt_callback.source,
-                        ActiveInterruptCallbackSource::Timer
-                    );
                     let completed_modeless_dialog_draw_proc = completed_dialog_draw_proc
                         && self.dispatcher.active_modeless_dialog_draw_proc.is_some();
                     if completed_dialog_draw_proc {
@@ -2836,12 +2839,6 @@ impl FixtureRunner {
                     }
                     self.active_interrupt_callback = None;
                     self.refill_foreground_budget_after_async_return();
-                    if completed_timer {
-                        self.fire_timer_tasks(self.guest_tick());
-                        if self.active_interrupt_callback.is_some() {
-                            continue;
-                        }
-                    }
                     if completed_modeless_dialog_draw_proc && self.fire_modeless_dialog_draw_proc()
                     {
                         continue;
@@ -4213,31 +4210,42 @@ impl FixtureRunner {
     ///   4. Restores D0-D3/A0-A3 via MOVEM.L from the stack
     ///   5. RTS back to the interrupted code
     fn fire_timer_tasks(&mut self, current_tick: u32) {
+        self.fire_timer_tasks_at(current_tick as u64 * 1_000_000);
+    }
+
+    fn current_timer_subtick(&self) -> u64 {
+        const SUBTICKS_PER_TICK: u64 = 1_000_000;
+        let tick_base = self.guest_tick() as u64 * SUBTICKS_PER_TICK;
+        if self.tick_budget <= 0 {
+            return tick_base;
+        }
+        let instructions_per_tick = self.instructions_per_tick.max(1) as i64;
+        let remaining = (self.tick_budget as i64).clamp(0, instructions_per_tick);
+        let elapsed = instructions_per_tick - remaining;
+        tick_base + (elapsed as u64 * SUBTICKS_PER_TICK) / instructions_per_tick as u64
+    }
+
+    fn fire_timer_tasks_at(&mut self, current_subtick: u64) {
         if self.active_interrupt_callback.is_some() {
             return;
         }
-
-        const SUBTICKS_PER_TICK: u64 = 1_000_000;
-        let target_subtick = current_tick as u64 * SUBTICKS_PER_TICK;
 
         // Fire at most one task at a time to avoid nested callbacks.
         if let Some(task) = self
             .dispatcher
             .timer_tasks
             .iter_mut()
-            .filter(|task| task.active && target_subtick >= task.fire_at_subtick)
+            .filter(|task| task.active && current_subtick >= task.fire_at_subtick)
             .min_by_key(|task| task.fire_at_subtick)
         {
             let task_ptr = task.task_ptr;
             let tm_addr = task.tm_addr;
-            self.dispatcher.timer_current_subtick = task.fire_at_subtick;
-            self.dispatcher.timer_callback_active = true;
+            self.dispatcher.timer_current_subtick = current_subtick;
             // Mark only the task being delivered as fired. Other tasks that
             // expire on the same tick must remain active for a later interrupt.
             task.active = false;
 
             if tm_addr == 0 {
-                self.dispatcher.timer_callback_active = false;
                 return;
             }
 
@@ -4317,8 +4325,7 @@ impl FixtureRunner {
             }
             self.cpu.write_reg(Register::PC, tramp);
         } else {
-            self.dispatcher.timer_current_subtick = target_subtick;
-            self.dispatcher.timer_callback_active = false;
+            self.dispatcher.timer_current_subtick = current_subtick;
         }
     }
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -4230,12 +4230,18 @@ impl FixtureRunner {
             return;
         }
 
+        const SUBTICKS_PER_TICK: u64 = 1_000_000;
+        let current_tick = (current_subtick / SUBTICKS_PER_TICK) as u32;
         // Fire at most one task at a time to avoid nested callbacks.
         if let Some(task) = self
             .dispatcher
             .timer_tasks
             .iter_mut()
-            .filter(|task| task.active && current_subtick >= task.fire_at_subtick)
+            .filter(|task| {
+                task.active
+                    && current_subtick >= task.fire_at_subtick
+                    && task.last_fired_tick != Some(current_tick)
+            })
             .min_by_key(|task| task.fire_at_subtick)
         {
             let task_ptr = task.task_ptr;
@@ -4244,6 +4250,13 @@ impl FixtureRunner {
             // Mark only the task being delivered as fired. Other tasks that
             // expire on the same tick must remain active for a later interrupt.
             task.active = false;
+            task.last_fired_tick = Some(current_tick);
+            // The revised Time Manager clears the qType active bit when the
+            // delay expires, before invoking tmAddr. A callback can therefore
+            // observe that its task is inactive and safely PrimeTime it again.
+            // Inside Macintosh: Processes (1994), pp. 3-6 and 3-20.
+            let q_type = self.bus.read_word(task_ptr + 4);
+            self.bus.write_word(task_ptr + 4, q_type & 0x7FFF);
 
             if tm_addr == 0 {
                 return;
@@ -7570,6 +7583,7 @@ mod tests {
         runner.cpu.write_reg(Register::A6, 0xCCCC_0000);
         runner.cpu.write_reg(Register::A7, interrupted_sp);
         runner.cpu.core.set_ccr(0x1F);
+        runner.bus.write_word(0x0039_38C8 + 4, 0x8001);
 
         runner.dispatcher.timer_tasks.push(TimerTask {
             task_ptr: 0x0039_38C8,
@@ -7577,6 +7591,7 @@ mod tests {
             active: true,
             fire_at_tick: 10,
             fire_at_subtick: 10_000_000,
+            last_fired_tick: None,
         });
 
         runner.fire_timer_tasks(10);
@@ -7597,6 +7612,11 @@ mod tests {
         assert_eq!(active.d_regs[7], 0x7777_7777);
         assert_eq!(active.sr & 0x001F, 0x001F);
         assert_eq!(active.ccr, 0x1F);
+        assert_eq!(
+            runner.bus.read_word(0x0039_38C8 + 4),
+            1,
+            "an expired Time Manager task must be inactive before tmAddr runs"
+        );
 
         assert_ne!(runner.timer_trampoline, 0);
         assert_eq!(runner.cpu.read_reg(Register::PC), runner.timer_trampoline);
@@ -7623,6 +7643,7 @@ mod tests {
             active: true,
             fire_at_tick: 101,
             fire_at_subtick: 101_000_000,
+            last_fired_tick: None,
         });
 
         let (steps, running) = runner.run_steps(1, Some(101));
@@ -7661,6 +7682,7 @@ mod tests {
             active: true,
             fire_at_tick: 101,
             fire_at_subtick: 100_200_000,
+            last_fired_tick: None,
         });
 
         let steps = runner.instructions_per_tick as usize / 4;
@@ -7705,6 +7727,7 @@ mod tests {
             active: true,
             fire_at_tick: 102,
             fire_at_subtick: 102_000_000,
+            last_fired_tick: None,
         });
 
         let (steps, running) = runner.run_steps(1, None);
@@ -7743,6 +7766,7 @@ mod tests {
                 active: true,
                 fire_at_tick: 10,
                 fire_at_subtick: 10_000_000,
+                last_fired_tick: None,
             },
             TimerTask {
                 task_ptr: 0x0039_3900,
@@ -7750,6 +7774,7 @@ mod tests {
                 active: true,
                 fire_at_tick: 10,
                 fire_at_subtick: 10_000_000,
+                last_fired_tick: None,
             },
         ]);
 
@@ -7781,6 +7806,51 @@ mod tests {
             runner.bus.read_long(runner.timer_trampoline + 6),
             0x0039_3900
         );
+    }
+
+    #[test]
+    fn self_reprimed_timer_waits_for_the_next_vbl_service() {
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        let interrupted_pc = 0x0001_0000;
+        let interrupted_sp = 0x007F_FFC0;
+        let task_ptr = 0x0039_38C8;
+
+        runner.cpu.write_reg(Register::PC, interrupted_pc);
+        runner.cpu.write_reg(Register::A7, interrupted_sp);
+        runner.dispatcher.timer_tasks.push(TimerTask {
+            task_ptr,
+            tm_addr: 0x0002_0000,
+            active: true,
+            fire_at_tick: 10,
+            fire_at_subtick: 10_100_000,
+            last_fired_tick: None,
+        });
+
+        runner.fire_timer_tasks_at(10_100_000);
+        assert_eq!(runner.dispatcher.timer_tasks[0].last_fired_tick, Some(10));
+
+        // Model the callback returning and re-priming itself for another
+        // revised Time Manager deadline inside the same VBL.
+        runner.active_interrupt_callback = None;
+        runner.cpu.write_reg(Register::PC, interrupted_pc);
+        runner.cpu.write_reg(Register::A7, interrupted_sp);
+        runner.dispatcher.timer_tasks[0].active = true;
+        runner.dispatcher.timer_tasks[0].fire_at_tick = 11;
+        runner.dispatcher.timer_tasks[0].fire_at_subtick = 10_300_000;
+
+        runner.fire_timer_tasks_at(10_300_000);
+        assert!(
+            runner.active_interrupt_callback.is_none(),
+            "one queue element must not monopolize the same VBL"
+        );
+        assert!(runner.dispatcher.timer_tasks[0].active);
+
+        runner.fire_timer_tasks_at(11_000_000);
+        assert!(
+            runner.active_interrupt_callback.is_some(),
+            "the re-primed element becomes eligible at the next VBL service"
+        );
+        assert_eq!(runner.dispatcher.timer_tasks[0].last_fired_tick, Some(11));
     }
 
     #[test]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -7642,6 +7642,40 @@ mod tests {
     }
 
     #[test]
+    fn sub_vbl_timer_callback_fires_before_next_guest_tick() {
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        let interrupted_pc = 0x0001_0000;
+        let interrupted_sp = 0x007F_FFC0;
+        let callback_addr = 0x0002_0000;
+
+        runner.bus.write_word(interrupted_pc, 0x60FE); // BRA.S to self
+        runner.bus.write_word(callback_addr, 0x4E75); // RTS
+        runner.cpu.write_reg(Register::PC, interrupted_pc);
+        runner.cpu.write_reg(Register::A7, interrupted_sp);
+        runner.bus.write_long(0x016A, 100);
+        runner.dispatcher.tick_count = 100;
+        runner.tick_budget = runner.instructions_per_tick as i32;
+        runner.dispatcher.timer_tasks.push(TimerTask {
+            task_ptr: 0x0039_38C8,
+            tm_addr: callback_addr,
+            active: true,
+            fire_at_tick: 101,
+            fire_at_subtick: 100_200_000,
+        });
+
+        let steps = runner.instructions_per_tick as usize / 4;
+        let (executed, running) = runner.run_steps(steps, None);
+        let (_, still_running) = runner.run_steps(1, None);
+
+        assert!(running);
+        assert!(still_running);
+        assert_eq!(executed, steps);
+        assert_eq!(runner.guest_tick(), 100);
+        assert!(!runner.dispatcher.timer_tasks[0].active);
+        assert_ne!(runner.timer_trampoline, 0);
+    }
+
+    #[test]
     fn timer_callback_return_runs_foreground_before_next_due_timer() {
         let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
         let interrupted_pc = 0x0001_0000;

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2824,6 +2824,10 @@ impl FixtureRunner {
                         active_interrupt_callback.source,
                         ActiveInterruptCallbackSource::DialogDrawProc
                     );
+                    let completed_timer = matches!(
+                        active_interrupt_callback.source,
+                        ActiveInterruptCallbackSource::Timer
+                    );
                     let completed_modeless_dialog_draw_proc = completed_dialog_draw_proc
                         && self.dispatcher.active_modeless_dialog_draw_proc.is_some();
                     if completed_dialog_draw_proc {
@@ -2832,6 +2836,12 @@ impl FixtureRunner {
                     }
                     self.active_interrupt_callback = None;
                     self.refill_foreground_budget_after_async_return();
+                    if completed_timer {
+                        self.fire_timer_tasks(self.guest_tick());
+                        if self.active_interrupt_callback.is_some() {
+                            continue;
+                        }
+                    }
                     if completed_modeless_dialog_draw_proc && self.fire_modeless_dialog_draw_proc()
                     {
                         continue;
@@ -4207,21 +4217,27 @@ impl FixtureRunner {
             return;
         }
 
-        // Fire at most one task per tick to avoid deep nesting
+        const SUBTICKS_PER_TICK: u64 = 1_000_000;
+        let target_subtick = current_tick as u64 * SUBTICKS_PER_TICK;
+
+        // Fire at most one task at a time to avoid nested callbacks.
         if let Some(task) = self
             .dispatcher
             .timer_tasks
             .iter_mut()
-            .filter(|task| task.active && current_tick >= task.fire_at_tick)
-            .min_by_key(|task| task.fire_at_tick)
+            .filter(|task| task.active && target_subtick >= task.fire_at_subtick)
+            .min_by_key(|task| task.fire_at_subtick)
         {
             let task_ptr = task.task_ptr;
             let tm_addr = task.tm_addr;
+            self.dispatcher.timer_current_subtick = task.fire_at_subtick;
+            self.dispatcher.timer_callback_active = true;
             // Mark only the task being delivered as fired. Other tasks that
             // expire on the same tick must remain active for a later interrupt.
             task.active = false;
 
             if tm_addr == 0 {
+                self.dispatcher.timer_callback_active = false;
                 return;
             }
 
@@ -4300,6 +4316,9 @@ impl FixtureRunner {
                 );
             }
             self.cpu.write_reg(Register::PC, tramp);
+        } else {
+            self.dispatcher.timer_current_subtick = target_subtick;
+            self.dispatcher.timer_callback_active = false;
         }
     }
 
@@ -7550,6 +7569,7 @@ mod tests {
             tm_addr: 0x0004_1234,
             active: true,
             fire_at_tick: 10,
+            fire_at_subtick: 10_000_000,
         });
 
         runner.fire_timer_tasks(10);
@@ -7595,6 +7615,7 @@ mod tests {
             tm_addr: callback_addr,
             active: true,
             fire_at_tick: 101,
+            fire_at_subtick: 101_000_000,
         });
 
         let (steps, running) = runner.run_steps(1, Some(101));
@@ -7642,6 +7663,7 @@ mod tests {
             tm_addr: callback_addr,
             active: true,
             fire_at_tick: 102,
+            fire_at_subtick: 102_000_000,
         });
 
         let (steps, running) = runner.run_steps(1, None);
@@ -7679,12 +7701,14 @@ mod tests {
                 tm_addr: 0x0002_0000,
                 active: true,
                 fire_at_tick: 10,
+                fire_at_subtick: 10_000_000,
             },
             TimerTask {
                 task_ptr: 0x0039_3900,
                 tm_addr: 0x0002_1000,
                 active: true,
                 fire_at_tick: 10,
+                fire_at_subtick: 10_000_000,
             },
         ]);
 
@@ -7700,6 +7724,7 @@ mod tests {
         // jump ahead of an older task that is still waiting for delivery.
         runner.dispatcher.timer_tasks[0].active = true;
         runner.dispatcher.timer_tasks[0].fire_at_tick = 11;
+        runner.dispatcher.timer_tasks[0].fire_at_subtick = 11_000_000;
         runner.active_interrupt_callback = None;
         runner.cpu.write_reg(Register::PC, interrupted_pc);
         runner.cpu.write_reg(Register::A7, interrupted_sp);

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -666,6 +666,9 @@ pub struct TimerTask {
     /// Tick count at which this task should fire.
     /// Computed from current ticks + delay when PrimeTime is called.
     pub fire_at_tick: u32,
+    /// Revised Time Manager deadline in millionths of a 60 Hz guest tick.
+    /// This preserves negative PrimeTime microsecond delays below one VBL.
+    pub fire_at_subtick: u64,
 }
 
 /// An installed Vertical Retrace Manager task.
@@ -1675,6 +1678,11 @@ pub struct TrapDispatcher {
     /// Installed Time Manager tasks.
     /// Processes 1994, 3-14
     pub(crate) timer_tasks: Vec<TimerTask>,
+    /// Exact Time Manager time while a callback is being delivered.
+    pub(crate) timer_current_subtick: u64,
+    /// Whether PrimeTime should schedule relative to an interrupt deadline
+    /// rather than the coarser low-memory TickCount value.
+    pub(crate) timer_callback_active: bool,
     /// Installed Vertical Retrace Manager tasks.
     /// Processes 1994, 4-6 to 4-7
     pub(crate) vbl_tasks: Vec<VblTask>,
@@ -2909,6 +2917,8 @@ impl TrapDispatcher {
             native_trap_table: HashMap::new(),
             bits_proc_reentry: None,
             timer_tasks: Vec::new(),
+            timer_current_subtick: 0,
+            timer_callback_active: false,
             vbl_tasks: Vec::new(),
             system_vbl_queue_anchor: 0,
             primary_vbl_slot: 0,

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -1680,9 +1680,6 @@ pub struct TrapDispatcher {
     pub(crate) timer_tasks: Vec<TimerTask>,
     /// Exact Time Manager time while a callback is being delivered.
     pub(crate) timer_current_subtick: u64,
-    /// Whether PrimeTime should schedule relative to an interrupt deadline
-    /// rather than the coarser low-memory TickCount value.
-    pub(crate) timer_callback_active: bool,
     /// Installed Vertical Retrace Manager tasks.
     /// Processes 1994, 4-6 to 4-7
     pub(crate) vbl_tasks: Vec<VblTask>,
@@ -2918,7 +2915,6 @@ impl TrapDispatcher {
             bits_proc_reentry: None,
             timer_tasks: Vec::new(),
             timer_current_subtick: 0,
-            timer_callback_active: false,
             vbl_tasks: Vec::new(),
             system_vbl_queue_anchor: 0,
             primary_vbl_slot: 0,

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -669,6 +669,13 @@ pub struct TimerTask {
     /// Revised Time Manager deadline in millionths of a 60 Hz guest tick.
     /// This preserves negative PrimeTime microsecond delays below one VBL.
     pub fire_at_subtick: u64,
+    /// VBL tick in which this task was most recently dispatched.
+    ///
+    /// BasiliskII's Time Manager services an individual queue element at
+    /// most once per VBL even when its revised/extended delay is shorter.
+    /// Retaining the sub-tick deadline still orders concurrent tasks without
+    /// allowing one self-repriming task to monopolize the interrupt queue.
+    pub last_fired_tick: Option<u32>,
 }
 
 /// An installed Vertical Retrace Manager task.

--- a/src/trap/memory.rs
+++ b/src/trap/memory.rs
@@ -1722,11 +1722,9 @@ impl super::TrapDispatcher {
                     let us = (-delay) as u64;
                     (us * 60).max(1)
                 };
-                let current_subtick = if self.timer_callback_active {
-                    self.timer_current_subtick
-                } else {
-                    current_ticks as u64 * SUBTICKS_PER_TICK
-                };
+                let current_subtick = self
+                    .timer_current_subtick
+                    .max(current_ticks as u64 * SUBTICKS_PER_TICK);
                 let fire_at_subtick = current_subtick.saturating_add(delay_subticks);
                 let fire_at = fire_at_subtick.div_ceil(SUBTICKS_PER_TICK) as u32;
                 if let Some(task) = self.timer_tasks.iter_mut().find(|t| t.task_ptr == task_ptr) {

--- a/src/trap/memory.rs
+++ b/src/trap/memory.rs
@@ -1676,6 +1676,7 @@ impl super::TrapDispatcher {
                     tm_addr,
                     active: false,
                     fire_at_tick: 0,
+                    fire_at_subtick: 0,
                 });
                 // InsTime clears the qType high-order bit (task inactive until PrimeTime).
                 // Processes 1994, 3-12: "InsTime procedure initially clears this bit."
@@ -1707,24 +1708,31 @@ impl super::TrapDispatcher {
                 let task_ptr = cpu.read_reg(Register::A0);
                 let delay = cpu.read_reg(Register::D0) as i32;
                 let current_ticks = bus.read_long(0x016A);
+                const SUBTICKS_PER_TICK: u64 = 1_000_000;
                 // Convert delay to 60.15 Hz ticks (VBL rate per Guide to Macintosh Family
                 // Hardware, 2nd Ed., p. 6-798: "once every 16.63 ms").
                 // We use 60 (not 60.15) to keep integer arithmetic exact for common
-                // millisecond values and avoid spurious ceil rounding.
+                // millisecond values.
                 // Positive = milliseconds, negative = negated microseconds.
-                // Round up so coarse tick emulation never fires earlier than requested.
-                let delay_ticks = if delay == 0 {
-                    1 // Fire ASAP (next tick)
+                let delay_subticks = if delay == 0 {
+                    SUBTICKS_PER_TICK // Fire ASAP (next tick)
                 } else if delay > 0 {
-                    (((delay as u64) * 60).div_ceil(1000) as u32).max(1)
+                    (delay as u64) * 60_000
                 } else {
                     let us = (-delay) as u64;
-                    ((us * 60).div_ceil(1_000_000) as u32).max(1)
+                    (us * 60).max(1)
                 };
-                let fire_at = current_ticks.wrapping_add(delay_ticks);
+                let current_subtick = if self.timer_callback_active {
+                    self.timer_current_subtick
+                } else {
+                    current_ticks as u64 * SUBTICKS_PER_TICK
+                };
+                let fire_at_subtick = current_subtick.saturating_add(delay_subticks);
+                let fire_at = fire_at_subtick.div_ceil(SUBTICKS_PER_TICK) as u32;
                 if let Some(task) = self.timer_tasks.iter_mut().find(|t| t.task_ptr == task_ptr) {
                     task.active = true;
                     task.fire_at_tick = fire_at;
+                    task.fire_at_subtick = fire_at_subtick;
                     // Re-read tmAddr in case it changed between InsTime and PrimeTime
                     task.tm_addr = bus.read_long(task_ptr + 6);
                 }
@@ -9099,6 +9107,37 @@ mod tests {
         assert_eq!(
             task.fire_at_tick, 102,
             "33 ms should round up to two 60 Hz ticks from TickCount 100"
+        );
+    }
+
+    #[test]
+    fn test_prime_time_preserves_negative_microsecond_deadline() {
+        let (mut dispatcher, mut cpu, mut bus) = setup();
+        let task_ptr = 0x200000;
+
+        bus.write_long(0x016A, 100);
+        cpu.write_reg(Register::A0, task_ptr);
+        dispatcher
+            .dispatch_memory(false, 0x58, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+
+        cpu.write_reg(Register::A0, task_ptr);
+        cpu.write_reg(Register::D0, (-3333_i32) as u32);
+        dispatcher
+            .dispatch_memory(false, 0x5A, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+
+        let task = dispatcher
+            .timer_tasks
+            .iter()
+            .find(|task| task.task_ptr == task_ptr)
+            .expect("timer task should be queued");
+        assert_eq!(task.fire_at_tick, 101);
+        assert_eq!(
+            task.fire_at_subtick, 100_199_980,
+            "3,333 microseconds should remain below one 60 Hz guest tick"
         );
     }
 

--- a/src/trap/memory.rs
+++ b/src/trap/memory.rs
@@ -1677,6 +1677,7 @@ impl super::TrapDispatcher {
                     active: false,
                     fire_at_tick: 0,
                     fire_at_subtick: 0,
+                    last_fired_tick: None,
                 });
                 // InsTime clears the qType high-order bit (task inactive until PrimeTime).
                 // Processes 1994, 3-12: "InsTime procedure initially clears this bit."


### PR DESCRIPTION
## What changed

- retain Revised Time Manager deadlines below one 60 Hz guest tick
- schedule negative `PrimeTime` counts in microsecond-resolution fixed-point time
- interleave non-nested timer delivery with foreground execution inside a guest tick
- preserve deadline ordering across concurrent Time Manager records
- prevent a self-reprimed record from monopolizing the same VBL service interval
- clear the documented `qType` active bit before invoking `tmAddr`
- add focused coverage for `-3333` µs conversion, sub-VBL first delivery, concurrent fairness, `qType`, and next-VBL re-eligibility

## Why

Day of the Tentacle installs several extended Time Manager records. The earlier VBL-only implementation delivered only one overdue record and starved its peers. The first sub-VBL implementation corrected that starvation but allowed the same record to re-prime and fire repeatedly within one VBL, producing roughly 9–10 `PrimeTime` calls per tick and racing through the opening.

A BasiliskII trap trace shows the reference System 7 queue settling at three `PrimeTime` calls per tick: one for each active record. This update preserves sub-VBL deadlines for initial delivery and ordering while making every record wait until the next VBL service interval before firing again.

The `qType` transition follows *Inside Macintosh: Processes* (1994), pp. 3-6 and 3-20: the active bit is cleared when the timer expires, before the task routine runs.

The implementation is generic and contains no title-specific timing or assets.

Addresses #91.

## Validation

- `cargo test timer_ -- --nocapture` — 6 passed
- `cargo test prime_time -- --nocapture` — 3 passed
- `git diff --check`
- Day of the Tentacle reference trace: stable 3 `PrimeTime` calls per guest tick after timer setup
- matched-cadence DOTT probe: Systemless reaches the LucasArts company frame at relative guest tick 1200; the reference capture is at relative trace tick approximately 1156, instead of Systemless racing ahead to the river scene

## Stack

This PR targets `dev/day-of-the-tentacle-concurrent-timers` because it builds on the generic fairness change in #90. It should be reviewed after #90.