### PR TITLE
Correct SoundDoubleBack Pascal argument order

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -4708,8 +4708,8 @@ impl FixtureRunner {
         //
         // Trampoline layout (34 bytes):
         //   +0:  MOVEM.L D0-D3/A0-A3,-(SP)  ; 48E7 F0F0 (save regs)
-        //   +4:  MOVE.L  #chanPtr,-(SP)       ; 2F3C xxxx xxxx (Pascal param1 = deeper)
-        //   +10: MOVE.L  #exhaustedBuf,-(SP) ; 2F3C xxxx xxxx (Pascal param2 = top)
+        //   +4:  MOVE.L  #exhaustedBuf,-(SP) ; 2F3C xxxx xxxx (push param2 first)
+        //   +10: MOVE.L  #chanPtr,-(SP)       ; 2F3C xxxx xxxx (param1 nearest return)
         //   +16: JSR     callback             ; 4EB9 xxxx xxxx
         //   +22: MOVEA.L #savedRegsSP,A7      ; ignore guest callback cleanup convention
         //   +28: MOVEM.L (SP)+,D0-D3/A0-A3   ; 4CDF 0F0F (restore regs)
@@ -4719,9 +4719,9 @@ impl FixtureRunner {
             self.bus.write_word(tramp, 0x48E7); // MOVEM.L regs,-(SP)
             self.bus.write_word(tramp + 2, 0xF0F0); // D0-D3/A0-A3
             self.bus.write_word(tramp + 4, 0x2F3C); // MOVE.L #imm,-(SP)
-                                                    // +6..+9: chan ptr (patched)
+                                                    // +6..+9: exhausted buf ptr (patched)
             self.bus.write_word(tramp + 10, 0x2F3C); // MOVE.L #imm,-(SP)
-                                                     // +12..+15: exhausted buf ptr (patched)
+                                                     // +12..+15: chan ptr (patched)
             self.bus.write_word(tramp + 16, 0x4EB9); // JSR abs.L
                                                      // +18..+21: callback addr (patched)
             self.bus.write_word(tramp + 22, 0x2E7C); // MOVEA.L #savedSP,A7
@@ -4735,8 +4735,11 @@ impl FixtureRunner {
         let tramp = self.sound_doubleback_trampoline;
         let interrupted_sp = self.cpu.read_reg(Register::A7);
         let saved_regs_sp = interrupted_sp.wrapping_sub(4 + 32);
-        self.bus.write_long(tramp + 6, cb.chan_ptr);
-        self.bus.write_long(tramp + 12, exhausted_buf_ptr);
+        // Classic Pascal pushes parameters right-to-left. At callback entry,
+        // after JSR has stacked the return address, chan is at SP+4 and the
+        // exhausted buffer is at SP+8. Sound 1994, 2-153.
+        self.bus.write_long(tramp + 6, exhausted_buf_ptr);
+        self.bus.write_long(tramp + 12, cb.chan_ptr);
         self.bus.write_long(tramp + 18, cb.callback_addr);
         self.bus.write_long(tramp + 24, saved_regs_sp);
 
@@ -7947,13 +7950,13 @@ mod tests {
         let saved_regs_sp = interrupted_sp - 4 - 32;
         assert_eq!(
             runner.bus.read_long(saved_regs_sp - 4),
-            chan_ptr,
-            "first declared Pascal argument is deeper on the stack"
+            exhausted_buf_ptr,
+            "the last declared Pascal argument is pushed first"
         );
         assert_eq!(
             runner.bus.read_long(saved_regs_sp - 8),
-            exhausted_buf_ptr,
-            "last declared Pascal argument is nearest the return address"
+            chan_ptr,
+            "the first declared Pascal argument is nearest the return address"
         );
     }
 


### PR DESCRIPTION
Closes #95.

## Summary

- push `SndDoubleBackProcPtr` parameters right-to-left as required by the classic Pascal ABI
- present `chan` at callback `SP+4` and `exhaustedBuffer` at `SP+8`
- update the focused trampoline test to lock down the documented stack layout

## Evidence

*Inside Macintosh: Sound* (1994), pp. 2-72–2-73 and 2-153 documents the doubleback signature and interrupt-time contract.

The DOTT callback itself loads `8(A6)` as the exhausted buffer and follows `dbUserInfo`. With the previous order it received the channel record there; after the second callback, mixer-state corruption led to invalid guest control flow. With this change applied to the DOTT compatibility stack, the second callback returns normally and the opening cinematic continues advancing through guest tick 1801 without an invalid-PC or illegal-instruction halt.

## Validation

- `cargo test sound_doubleback_callback_trampoline -- --nocapture` (2 passed)
- `cargo test sound_doubleback -- --nocapture` (4 passed)
- `git diff --check`
- DOTT stacked play probe survives both opening doubleback callbacks and continues the cinematic

## Stack

This draft targets `dev/day-of-the-tentacle-sub-vbl-timers` (#92). Non-silent audio and full Systemless/Basilisk gameplay parity remain release gates; this PR fixes the bounded callback ABI/control-flow defect only.