### PR TITLE
fix(memory): keep application allocations inside the zone boundary

### DIFF
--- a/src/trap/memory.rs
+++ b/src/trap/memory.rs
@@ -75,6 +75,49 @@ fn reconcile_application_zone_limit(bus: &mut MacMemoryBus, old_limit: u32, new_
     bus.write_long(app_zone + 12, adjusted_free.min(zone_size)); // zcbFree
 }
 
+/// Keep the guest-visible application zone large enough to contain a
+/// successful application-heap allocation.
+///
+/// Systemless eagerly materializes loaded resources in the same backing heap
+/// used by Memory Manager traps. That can advance the backing allocator past a
+/// SIZE-resource-derived `ApplLimit` before a later `NewPtr` call succeeds.
+/// Classic clients validate pointers against the current zone's `[zone,
+/// bkLim)` span, so returning a pointer above stale `bkLim` makes a successful
+/// Memory Manager allocation appear invalid. Inside Macintosh: Memory (1992),
+/// pp. 1-20..1-21 defines `bkLim` as the address immediately beyond the zone.
+///
+/// The newly exposed span has already been consumed by backing allocations,
+/// so this deliberately does not add it to `zcbFree`.
+fn include_application_allocation_in_zone(bus: &mut MacMemoryBus, ptr: u32, size: u32) {
+    if ptr == 0 {
+        return;
+    }
+    let app_zone = bus.read_long(addr::APP_L_ZONE);
+    if app_zone == 0 || ptr < app_zone {
+        return;
+    }
+    let allocation_end = ptr.saturating_add(MacMemoryBus::allocation_bucket_size(size));
+    let old_bk_lim = bus.read_long(app_zone);
+    if allocation_end <= old_bk_lim {
+        return;
+    }
+
+    bus.write_long(app_zone, allocation_end); // bkLim
+
+    let old_appl_limit = bus.read_long(addr::APPL_LIMIT);
+    if allocation_end > old_appl_limit {
+        bus.write_long(addr::APPL_LIMIT, allocation_end);
+        if bus.read_long(addr::BUF_PTR) == old_appl_limit {
+            bus.write_long(addr::BUF_PTR, allocation_end);
+        }
+    }
+
+    let heap_end = bus.read_long(addr::HEAP_END);
+    if allocation_end > heap_end {
+        bus.write_long(addr::HEAP_END, allocation_end);
+    }
+}
+
 fn init_zone_header(
     bus: &mut MacMemoryBus,
     start: u32,
@@ -472,6 +515,12 @@ impl super::TrapDispatcher {
                     cpu.write_reg(Register::A0, 0);
                     write_memory_result(cpu, bus, MEM_FULL_ERR);
                 } else {
+                    // Trap bit 10 selects the system-heap variants. Keep the
+                    // application-zone header synchronized only for ordinary
+                    // NewPtr/NewPtrClear allocations.
+                    if (self.current_trap_word & 0x0400) == 0 {
+                        include_application_allocation_in_zone(bus, ptr, size);
+                    }
                     // Check CLEAR bit (bit 9 = 0x0200 in trap word)
                     if (self.current_trap_word & 0x0200) != 0 && size > 0 {
                         bus.fill_zeros(ptr, size);
@@ -4454,6 +4503,81 @@ mod tests {
             0,
             "NewPtr should set D0 to 0 (noErr)"
         );
+    }
+
+    #[test]
+    fn new_ptr_extends_stale_application_zone_past_successful_allocation() {
+        let (mut dispatcher, mut cpu, mut bus) = setup();
+        let app_zone = 0x0020_0000;
+        let old_limit = 0x0020_1000;
+        let allocation_start = 0x0020_2000;
+        let size = 0x100;
+        let original_free = 0x800;
+
+        bus.write_long(addr::APP_L_ZONE, app_zone);
+        bus.write_long(addr::THE_ZONE, app_zone);
+        bus.write_long(addr::HEAP_END, app_zone + 64);
+        bus.write_long(addr::APPL_LIMIT, old_limit);
+        bus.write_long(addr::BUF_PTR, old_limit);
+        bus.write_long(app_zone, old_limit); // bkLim
+        bus.write_long(app_zone + 12, original_free); // zcbFree
+        bus.reserve_heap_until(allocation_start);
+
+        // $A11E is the ordinary NewPtr entry point used by MPW clients.
+        dispatcher.current_trap_word = 0xA11E;
+        cpu.write_reg(Register::D0, size);
+        let result = dispatcher.dispatch_memory(false, 0x1E, &mut cpu, &mut bus);
+        assert!(result.is_some(), "NewPtr should be handled");
+        assert!(result.unwrap().is_ok(), "NewPtr should succeed");
+
+        let ptr = cpu.read_reg(Register::A0);
+        let allocation_end = ptr + size;
+        assert_eq!(ptr, allocation_start);
+        assert_eq!(
+            bus.read_long(app_zone),
+            allocation_end,
+            "bkLim must remain immediately beyond every successful application-zone allocation"
+        );
+        assert_eq!(bus.read_long(addr::APPL_LIMIT), allocation_end);
+        assert_eq!(bus.read_long(addr::BUF_PTR), allocation_end);
+        assert_eq!(bus.read_long(addr::HEAP_END), allocation_end);
+        assert_eq!(
+            bus.read_long(app_zone + 12),
+            original_free,
+            "already-consumed backing span must not be added to zcbFree"
+        );
+        assert!(
+            ptr >= app_zone && ptr < bus.read_long(app_zone),
+            "a successful NewPtr result must pass the classic [zone, bkLim) validity test"
+        );
+    }
+
+    #[test]
+    fn new_ptr_sys_does_not_extend_application_zone() {
+        let (mut dispatcher, mut cpu, mut bus) = setup();
+        let app_zone = 0x0020_0000;
+        let old_limit = 0x0020_1000;
+        let allocation_start = 0x0020_2000;
+
+        bus.write_long(addr::APP_L_ZONE, app_zone);
+        bus.write_long(addr::THE_ZONE, app_zone);
+        bus.write_long(addr::HEAP_END, old_limit);
+        bus.write_long(addr::APPL_LIMIT, old_limit);
+        bus.write_long(app_zone, old_limit); // bkLim
+        bus.reserve_heap_until(allocation_start);
+
+        dispatcher.current_trap_word = 0xA51E; // NewPtrSys
+        cpu.write_reg(Register::D0, 0x100);
+        let result = dispatcher.dispatch_memory(false, 0x1E, &mut cpu, &mut bus);
+        assert!(result.is_some() && result.unwrap().is_ok());
+        assert_eq!(cpu.read_reg(Register::A0), allocation_start);
+        assert_eq!(
+            bus.read_long(app_zone),
+            old_limit,
+            "system-heap allocations must not widen the application zone"
+        );
+        assert_eq!(bus.read_long(addr::APPL_LIMIT), old_limit);
+        assert_eq!(bus.read_long(addr::HEAP_END), old_limit);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- extend the guest-visible application-zone boundary when an ordinary `NewPtr` allocation succeeds beyond stale `bkLim`
- keep `ApplLimit`, `BufPtr`, and `HeapEnd` coherent with the widened zone
- leave system-heap variants isolated from the application zone
- add regression coverage for both application and system `NewPtr` variants

## Root cause

Systemless can materialize loaded resources before a later Memory Manager allocation. The backing allocator may therefore advance beyond a `SIZE`-resource-derived application-zone limit. An ordinary `NewPtr` could succeed above stale `bkLim`, causing classic clients that validate pointers against `[zone, bkLim)` to reject a valid allocation.

This was visible in Bad Mojo as a discarded palette allocation and corrupted gameplay colours. The fix follows the `bkLim` contract described in *Inside Macintosh: Memory* (1992), pp. 1-20–1-21.

Fixes #101.

## Validation

- `cargo test --lib` — 2,720 passed, 3 ignored
- `cargo test trap::memory::tests --lib` — 235 passed
- canonical Bad Mojo gameplay smoke — reaches the live scene and accepts right-arrow input
- canonical four-frame oracle comparison — 99.40% strict / 99.68% perceptual overall; every frame above 99.1% strict
- `git diff --check`

The repository-wide `cargo fmt --check` remains affected by formatting differences already present outside this change; the added code is formatted.