### PR TITLE
feat: implement the cooperative Thread Manager and a callable menu definition procedure

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2230,12 +2230,9 @@ impl FixtureRunner {
         // leaves A7 on the four-byte FMOutPtr result slot. Allocate this only
         // after reserving the application zone header so it remains live.
         let swap_font_trampoline = self.bus.alloc(6);
-        self.bus
-            .write_word(swap_font_trampoline, 0x205F); // MOVEA.L (SP)+,A0
-        self.bus
-            .write_word(swap_font_trampoline + 2, 0xA901); // FMSwapFont
-        self.bus
-            .write_word(swap_font_trampoline + 4, 0x4ED0); // JMP (A0)
+        self.bus.write_word(swap_font_trampoline, 0x205F); // MOVEA.L (SP)+,A0
+        self.bus.write_word(swap_font_trampoline + 2, 0xA901); // FMSwapFont
+        self.bus.write_word(swap_font_trampoline + 4, 0x4ED0); // JMP (A0)
         self.bus.write_long(addr::J_SWAP_FONT, swap_font_trampoline);
 
         // Set CPU state
@@ -4528,28 +4525,37 @@ impl FixtureRunner {
 
                 // Sound 1994, 2-152
                 if self.sound_callback_trampoline == 0 {
-                    // Sound callback:
-                    //   PROCEDURE MyCallBack(chan: SndChannelPtr; cmd: SndCommand);
-                    //
-                    // In practice shipped apps commonly receive `cmd` as a
-                    // pointer-sized argument and differ on how much stack they
-                    // pop on return. Push cmdPtr nearest SP and chan beneath it,
-                    // then reset SP to the saved-register frame after JSR so
-                    // one-arg, two-arg, and C-style cleanup all resume safely.
-                    let tramp = self.bus.alloc(42);
-                    self.bus.write_word(tramp, 0x48E7); // MOVEM.L regs,-(SP)
-                    self.bus.write_word(tramp + 2, 0xF0F0); // D0-D3/A0-A3
-                    self.bus.write_word(tramp + 4, 0x2F3C); // MOVE.L #chan,-(SP)
-                    self.bus.write_word(tramp + 10, 0x2F3C); // MOVE.L #cmdPtr,-(SP)
-                    self.bus.write_word(tramp + 16, 0x4EB9); // JSR abs.L
-                    self.bus.write_word(tramp + 22, 0x2E7C); // MOVEA.L #savedSP,A7
-                    self.bus.write_word(tramp + 28, 0x4CDF); // MOVEM.L (SP)+,regs
-                    self.bus.write_word(tramp + 30, 0x0F0F); // D0-D3/A0-A3
-                    self.bus.write_word(tramp + 32, 0x4E75); // RTS
-                    self.sound_callback_trampoline = tramp;
+                    self.sound_callback_trampoline = self.bus.alloc(42);
                 }
 
                 let tramp = self.sound_callback_trampoline;
+                // Sound callback:
+                //   PROCEDURE MyCallBack(chan: SndChannelPtr; cmd: SndCommand);
+                //
+                // In practice shipped apps commonly receive `cmd` as a
+                // pointer-sized argument and differ on how much stack they
+                // pop on return. Push cmdPtr nearest SP and chan beneath it,
+                // then reset SP to the saved-register frame after JSR so
+                // one-arg, two-arg, and C-style cleanup all resume safely.
+                //
+                // The opcodes are rewritten on every dispatch, not just when
+                // the block is first allocated. A sound callback runs at
+                // interrupt time against whatever the application has since
+                // done to the heap, and a game that overruns one of its own
+                // buffers into this stub would otherwise leave the HLE
+                // jumping into data — Warcraft II clobbers it between
+                // callbacks. Rewriting is what the Window Manager's WDEF
+                // trampoline already does for the same reason.
+                self.bus.write_word(tramp, 0x48E7); // MOVEM.L regs,-(SP)
+                self.bus.write_word(tramp + 2, 0xF0F0); // D0-D3/A0-A3
+                self.bus.write_word(tramp + 4, 0x2F3C); // MOVE.L #chan,-(SP)
+                self.bus.write_word(tramp + 10, 0x2F3C); // MOVE.L #cmdPtr,-(SP)
+                self.bus.write_word(tramp + 16, 0x4EB9); // JSR abs.L
+                self.bus.write_word(tramp + 22, 0x2E7C); // MOVEA.L #savedSP,A7
+                self.bus.write_word(tramp + 28, 0x4CDF); // MOVEM.L (SP)+,regs
+                self.bus.write_word(tramp + 30, 0x0F0F); // D0-D3/A0-A3
+                self.bus.write_word(tramp + 32, 0x4E75); // RTS
+
                 let cmd_ptr = tramp + 34;
                 let interrupted_sp = self.cpu.read_reg(Register::A7);
                 let saved_regs_sp = interrupted_sp.wrapping_sub(4 + 32);
@@ -4573,19 +4579,21 @@ impl FixtureRunner {
 
                 // Sound 1994, 2-151
                 if self.sound_file_completion_trampoline == 0 {
-                    let tramp = self.bus.alloc(28);
-                    self.bus.write_word(tramp, 0x48E7); // MOVEM.L regs,-(SP)
-                    self.bus.write_word(tramp + 2, 0xF0F0); // D0-D3/A0-A3
-                    self.bus.write_word(tramp + 4, 0x2F3C); // MOVE.L #chan,-(SP)
-                    self.bus.write_word(tramp + 10, 0x4EB9); // JSR abs.L
-                    self.bus.write_word(tramp + 16, 0x2E7C); // MOVEA.L #savedSP,A7
-                    self.bus.write_word(tramp + 22, 0x4CDF); // MOVEM.L (SP)+,regs
-                    self.bus.write_word(tramp + 24, 0x0F0F); // D0-D3/A0-A3
-                    self.bus.write_word(tramp + 26, 0x4E75); // RTS
-                    self.sound_file_completion_trampoline = tramp;
+                    self.sound_file_completion_trampoline = self.bus.alloc(28);
                 }
 
+                // Rewritten on every dispatch for the same reason as the
+                // command-callback trampoline above.
                 let tramp = self.sound_file_completion_trampoline;
+                self.bus.write_word(tramp, 0x48E7); // MOVEM.L regs,-(SP)
+                self.bus.write_word(tramp + 2, 0xF0F0); // D0-D3/A0-A3
+                self.bus.write_word(tramp + 4, 0x2F3C); // MOVE.L #chan,-(SP)
+                self.bus.write_word(tramp + 10, 0x4EB9); // JSR abs.L
+                self.bus.write_word(tramp + 16, 0x2E7C); // MOVEA.L #savedSP,A7
+                self.bus.write_word(tramp + 22, 0x4CDF); // MOVEM.L (SP)+,regs
+                self.bus.write_word(tramp + 24, 0x0F0F); // D0-D3/A0-A3
+                self.bus.write_word(tramp + 26, 0x4E75); // RTS
+
                 let interrupted_sp = self.cpu.read_reg(Register::A7);
                 let saved_regs_sp = interrupted_sp.wrapping_sub(4 + 32);
                 self.bus.write_long(tramp + 6, chan_ptr);

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -695,6 +695,41 @@ pub(crate) struct LoadSegGetResourceState {
     pub a_regs: [u32; 8],
 }
 
+/// Stack size handed to a cooperative thread when `NewThread` is passed 0
+/// and the size reported by `GetDefaultThreadStackSize`. The 68K Thread
+/// Manager's own default is a small multiple of a page; 32K comfortably
+/// covers the Toolbox call depth Systemless threads reach.
+pub(crate) const DEFAULT_COOPERATIVE_THREAD_STACK_SIZE: u32 = 32 * 1024;
+
+/// Saved 68K state for one cooperative Thread Manager thread.
+///
+/// Cooperative switches occur only inside `_ThreadDispatch`, so the HLE can
+/// preserve the complete caller-visible register file without involving a
+/// host thread. New threads inherit the creator's register world (notably A5)
+/// and receive a private guest stack.
+#[derive(Clone, Debug)]
+pub(crate) struct CooperativeThread {
+    pub(crate) d_regs: [u32; 8],
+    pub(crate) a_regs: [u32; 8],
+    pub(crate) pc: u32,
+    pub(crate) ccr: u8,
+    /// `ThreadState` from Threads.h: 0 ready, 1 stopped, 2 running.
+    pub(crate) state: u16,
+    /// `void **threadResult` the entry proc's return value is stored to.
+    pub(crate) result_destination: u32,
+    /// Lowest address of the private guest stack, or 0 for the
+    /// application thread, which keeps the process stack.
+    pub(crate) stack_base: u32,
+    /// Address one past the top of the private guest stack.
+    pub(crate) stack_limit: u32,
+    /// `SetThreadSwitcher` switch-in proc and its `switchProcParam`.
+    pub(crate) switch_in: (u32, u32),
+    /// `SetThreadSwitcher` switch-out proc and its `switchProcParam`.
+    pub(crate) switch_out: (u32, u32),
+    /// `SetThreadTerminator` proc and its `terminationProcParam`.
+    pub(crate) terminator: (u32, u32),
+}
+
 /// In-flight AppleEvent handler call. Built by Pack8 routine 27
 /// (`AEProcessAppleEvent`) when it dispatches a registered handler;
 /// consumed by the trampoline trap when the handler `RTD`s back.
@@ -1066,6 +1101,12 @@ pub struct TrapDispatcher {
     /// Address of the lazily-allocated trampoline template used by the
     /// Window Manager to call a guest WDEF procedure.
     pub(crate) window_def_trampoline: u32,
+    /// Handle stored in every `MenuInfo.menuProc`, whose master pointer is
+    /// a guest stub that traps back into the HLE's synthetic 'MDEF' 0.
+    /// Applications are entitled to call the menu definition procedure
+    /// directly (Inside Macintosh Volume I, I-352), so the field must hold
+    /// a real, callable handle rather than NIL.
+    pub(crate) menu_def_proc_handle: u32,
     /// Address of the lazily-allocated trampoline used by DeferUserFn
     /// to call a callable userFunction immediately. Holds
     /// `48E7 F0F0 207C xxxx xxxx 4EB9 xxxx xxxx 4CDF 0F0F 7000 4E75`.
@@ -1086,6 +1127,24 @@ pub struct TrapDispatcher {
     /// HLE on one host thread, so Thread Manager critical sections collapse
     /// to a single dispatcher-wide counter.
     pub(crate) thread_critical_nesting: u32,
+    /// Cooperative Thread Manager contexts keyed by their opaque ThreadID.
+    pub(crate) cooperative_threads: HashMap<u32, CooperativeThread>,
+    /// Round-robin queue of ready cooperative threads.
+    pub(crate) cooperative_thread_ready: VecDeque<u32>,
+    /// ThreadID whose register context is currently installed in the CPU.
+    pub(crate) current_cooperative_thread: u32,
+    /// Next guest-visible ThreadID. IDs 1 and 2 are reserved by Threads.h.
+    pub(crate) next_cooperative_thread_id: u32,
+    /// Guest trampoline entered when a ThreadEntryProc returns.
+    pub(crate) thread_return_trampoline: u32,
+    /// Custom `ThreadSchedulerProcPtr` installed by `SetThreadScheduler`.
+    pub(crate) cooperative_thread_scheduler: u32,
+    /// Default cooperative stack size reported by
+    /// `GetDefaultThreadStackSize` and used when `NewThread` is passed 0.
+    pub(crate) cooperative_thread_stack_size: u32,
+    /// Cooperative stacks banked by `CreateThreadPool` / recycled by
+    /// `DisposeThread`, reused by `NewThread` before allocating.
+    pub(crate) cooperative_thread_pool: Vec<(u32, u32)>,
     /// Synthetic Component Manager instances opened for HLE-provided
     /// components such as the QuickTime movie controller.
     pub(crate) synthetic_component_instances: HashSet<u32>,
@@ -2669,11 +2728,20 @@ impl TrapDispatcher {
             device_loop_trampoline: 0,
             list_def_trampoline: 0,
             window_def_trampoline: 0,
+            menu_def_proc_handle: 0,
             defer_user_fn_trampoline: 0,
             qddone_seen_ports: HashSet::new(),
             pict_info_ids: HashSet::new(),
             ppc_initialized: false,
             thread_critical_nesting: 0,
+            cooperative_threads: HashMap::new(),
+            cooperative_thread_ready: VecDeque::new(),
+            current_cooperative_thread: 2,
+            next_cooperative_thread_id: 3,
+            thread_return_trampoline: 0,
+            cooperative_thread_scheduler: 0,
+            cooperative_thread_stack_size: DEFAULT_COOPERATIVE_THREAD_STACK_SIZE,
+            cooperative_thread_pool: Vec::new(),
             synthetic_component_instances: HashSet::new(),
             next_synthetic_component_instance: 0x00C1_0001,
             saved_draw_old_regions: HashMap::new(),

--- a/src/trap/menu.rs
+++ b/src/trap/menu.rs
@@ -1299,6 +1299,7 @@ impl super::TrapDispatcher {
                         visible_in_menu_bar: false,
                     });
                 }
+                self.install_menu_def_procs(bus);
                 bus.write_long(sp + 6, handle);
                 cpu.write_reg(Register::A7, sp + 6);
                 Ok(())
@@ -1359,6 +1360,7 @@ impl super::TrapDispatcher {
                         0
                     }
                 };
+                self.install_menu_def_procs(bus);
                 bus.write_long(sp + 2, handle);
                 cpu.write_reg(Register::A7, sp + 2);
                 Ok(())
@@ -1493,6 +1495,7 @@ impl super::TrapDispatcher {
                     }
                 }
 
+                self.install_menu_def_procs(bus);
                 cpu.write_reg(Register::A7, sp + 6);
                 Ok(())
             }
@@ -1624,7 +1627,9 @@ impl super::TrapDispatcher {
                     }
                     let list_handle = bus.alloc(4);
                     bus.write_long(list_handle, list_block);
+                    let menu_handles: Vec<u32> = snapshot.iter().map(|menu| menu.handle).collect();
                     self.saved_menu_bars.insert(list_handle, snapshot);
+                    self.install_menu_def_proc_in(bus, &menu_handles);
                     list_handle
                 } else {
                     0
@@ -2581,28 +2586,7 @@ impl super::TrapDispatcher {
                 let sp = cpu.read_reg(Register::A7);
                 let menu_handle = bus.read_long(sp);
                 cpu.write_reg(Register::A7, sp + 4);
-
-                if let Some(menu) = self.menus.iter().find(|m| m.handle == menu_handle) {
-                    let menu_height = self.menu_items_height(bus, &menu.items) + 2;
-
-                    let mut max_width: i16 = 0;
-                    for item in &menu.items {
-                        let w = Self::fb_measure_string(&item.text, 0, 12);
-                        let total = w + self.menu_item_width_extra(bus, item) + 24;
-                        if total > max_width {
-                            max_width = total;
-                        }
-                    }
-                    max_width = max_width.max(100);
-
-                    if menu_handle != 0 {
-                        let menu_ptr = bus.read_long(menu_handle);
-                        if menu_ptr != 0 {
-                            bus.write_word(menu_ptr + 2, max_width as u16);
-                            bus.write_word(menu_ptr + 4, menu_height as u16);
-                        }
-                    }
-                }
+                self.calc_menu_size(bus, menu_handle);
                 Ok(())
             }
 
@@ -3696,6 +3680,249 @@ impl super::TrapDispatcher {
         } else {
             base_height
         }
+    }
+
+    /// Offset of `menuProc` inside a `MenuInfo` record.
+    /// Inside Macintosh Volume I, I-355.
+    const MENU_PROC_OFFSET: u32 = 6;
+
+    /// `mDrawMsg`, `mChooseMsg` and `mSizeMsg` from the menu definition
+    /// procedure's message parameter. Inside Macintosh Volume I, I-352.
+    const M_DRAW_MSG: i16 = 0;
+    const M_CHOOSE_MSG: i16 = 1;
+    const M_SIZE_MSG: i16 = 2;
+
+    /// Bytes of the guest-callable stub installed as 'MDEF' 0:
+    /// `MOVE.W #imm,D0` (4) + `_Pack8` (2) + `RTD #imm` (4).
+    const MENU_DEF_PROC_STUB_SIZE: u32 = 10;
+
+    /// Lazily build the handle stored in every `MenuInfo.menuProc`.
+    ///
+    /// Inside Macintosh Volume I, I-352 makes the menu definition procedure
+    /// part of the menu record's public contract: `menuProc` is "a handle
+    /// to the menu definition procedure", and applications call through it
+    /// directly to size or draw a menu without going through the Menu
+    /// Manager. Leaving the field NIL makes any such call dereference
+    /// address zero. Systemless therefore installs a real handle whose
+    /// master pointer is a six-byte guest stub:
+    ///
+    /// ```text
+    ///   MOVE.W  #$FEFC,D0     ; private Systemless trampoline selector
+    ///   _Pack8                ; re-enters the HLE
+    ///   RTD     #18           ; pop the MDEF's Pascal frame
+    /// ```
+    ///
+    /// `_Pack8` is the dispatch trap Systemless already reserves for
+    /// guest-to-HLE trampoline returns (selector `$FEFE` finalises an
+    /// AppleEvent handler call); `$FEFC` names the synthetic 'MDEF' 0 in
+    /// the same private selector space. The `RTD #18` discards the
+    /// message, theMenu, menuRect, hitPt and whichItem arguments, which is
+    /// what a Pascal procedure with that signature owes its caller.
+    pub(crate) fn menu_def_proc_handle(&mut self, bus: &mut MacMemoryBus) -> u32 {
+        if self.menu_def_proc_handle != 0 {
+            return self.menu_def_proc_handle;
+        }
+
+        let stub = bus.alloc(Self::MENU_DEF_PROC_STUB_SIZE);
+        let handle = bus.alloc(4);
+        if stub == 0 || handle == 0 {
+            return 0;
+        }
+        bus.write_word(stub, 0x303C); // MOVE.W #imm,D0
+        bus.write_word(stub + 2, 0xFEFC);
+        bus.write_word(stub + 4, 0xA816); // _Pack8
+        bus.write_word(stub + 6, 0x4E74); // RTD #imm
+        bus.write_word(stub + 8, 18);
+        bus.write_long(handle, stub);
+        self.ptr_to_handle.insert(stub, handle);
+        self.menu_def_proc_handle = handle;
+        handle
+    }
+
+    /// Fill in `menuProc` for every menu that still has a NIL one.
+    ///
+    /// Called after each Menu Manager entry point that can produce a menu
+    /// record — `NewMenu`, `GetMenu`, `GetNewMBar`, `InsertMenu` — so the
+    /// field is populated before the application can observe it. Menus
+    /// built by copying a `'MENU'` resource inherit the resource's zero
+    /// `menuProc`, which is exactly what the real Menu Manager overwrites
+    /// with the 'MDEF' handle when it reads the resource in
+    /// (Inside Macintosh Volume I, I-366).
+    pub(crate) fn install_menu_def_procs(&mut self, bus: &mut MacMemoryBus) {
+        let handles: Vec<u32> = self.menus.iter().map(|menu| menu.handle).collect();
+        self.install_menu_def_proc_in(bus, &handles);
+    }
+
+    /// [`Self::install_menu_def_procs`] for an explicit handle list, used by
+    /// `GetNewMBar`, whose menus live in a saved menu-bar snapshot rather
+    /// than the current menu list.
+    pub(crate) fn install_menu_def_proc_in(&mut self, bus: &mut MacMemoryBus, handles: &[u32]) {
+        if handles.is_empty() {
+            return;
+        }
+        let def_proc = self.menu_def_proc_handle(bus);
+        if def_proc == 0 {
+            return;
+        }
+        for &handle in handles {
+            if handle == 0 {
+                continue;
+            }
+            let menu_ptr = bus.read_long(handle);
+            if menu_ptr == 0 {
+                continue;
+            }
+            let current = bus.read_long(menu_ptr + Self::MENU_PROC_OFFSET);
+            if !Self::menu_def_proc_is_installed(bus, current) {
+                bus.write_long(menu_ptr + Self::MENU_PROC_OFFSET, def_proc);
+            }
+        }
+    }
+
+    /// Whether `menuProc` already holds a handle to real code.
+    ///
+    /// A menu read from a `'MENU'` resource arrives with the resource ID of
+    /// its definition procedure sitting in the `menuProc` bytes, which
+    /// Inside Macintosh Volume I, I-366 describes as "a placeholder for the
+    /// handle to the procedure" that `GetMenu` replaces. Systemless has to
+    /// tell that placeholder apart from a handle an application installed
+    /// itself, so it accepts only a handle whose master pointer starts with
+    /// an instruction a procedure entry point can plausibly begin with —
+    /// the same test the Window Manager applies to a guest 'WDEF'.
+    fn menu_def_proc_is_installed(bus: &MacMemoryBus, menu_proc: u32) -> bool {
+        if menu_proc == 0 || menu_proc >= bus.ram_size().saturating_sub(4) {
+            return false;
+        }
+        let entry = bus.read_long(menu_proc);
+        if entry == 0 || entry >= bus.ram_size().saturating_sub(2) {
+            return false;
+        }
+        matches!(
+            bus.read_word(entry),
+            0x303C // MOVE.W #imm,D0 — the Systemless stub
+                | 0x4E56 // LINK.W A6,#imm
+                | 0x48E7 // MOVEM.L regs,-(SP)
+                | 0x4EF9 // JMP abs.L
+                | 0x4EFA // JMP d16(PC)
+                | 0x6000..=0x60FF // BRA to the real entry
+        )
+    }
+
+    /// Compute a menu's dimensions and store them in `menuWidth` and
+    /// `menuHeight`. Shared by `CalcMenuSize` ($A948) and the synthetic
+    /// 'MDEF' 0's `mSizeMsg`, which Inside Macintosh Volume I, I-361 and
+    /// I-352 define as the same operation.
+    pub(super) fn calc_menu_size(&mut self, bus: &mut MacMemoryBus, menu_handle: u32) {
+        let Some(menu) = self.menus.iter().find(|m| m.handle == menu_handle) else {
+            return;
+        };
+        let menu_height = self.menu_items_height(bus, &menu.items) + 2;
+
+        let mut max_width: i16 = 0;
+        for item in &menu.items {
+            let w = Self::fb_measure_string(&item.text, 0, 12);
+            let total = w + self.menu_item_width_extra(bus, item) + 24;
+            if total > max_width {
+                max_width = total;
+            }
+        }
+        max_width = max_width.max(100);
+
+        if menu_handle == 0 {
+            return;
+        }
+        let menu_ptr = bus.read_long(menu_handle);
+        if menu_ptr != 0 {
+            bus.write_word(menu_ptr + 2, max_width as u16);
+            bus.write_word(menu_ptr + 4, menu_height as u16);
+        }
+    }
+
+    /// Body of the synthetic 'MDEF' 0, reached through the `$FEFC` `_Pack8`
+    /// selector planted by [`Self::menu_def_proc_handle`].
+    ///
+    /// ```text
+    /// PROCEDURE MyMenu (message: INTEGER; theMenu: MenuHandle;
+    ///                   VAR menuRect: Rect; hitPt: Point;
+    ///                   VAR whichItem: INTEGER);
+    /// ```
+    /// Inside Macintosh Volume I, I-352. `sp` points at the caller's return
+    /// address, so the Pascal frame starts four bytes above it; the stub's
+    /// own `RTD #18` pops the arguments once this returns.
+    pub(crate) fn menu_def_proc_message(&mut self, bus: &mut MacMemoryBus, sp: u32) {
+        let args = sp.wrapping_add(4);
+        let which_item_ptr = bus.read_long(args);
+        let hit_pt = bus.read_long(args + 4);
+        let menu_rect_ptr = bus.read_long(args + 8);
+        let menu_handle = bus.read_long(args + 12);
+        let message = bus.read_word(args + 16) as i16;
+
+        match message {
+            // mSizeMsg: store the menu's dimensions in the menu record.
+            Self::M_SIZE_MSG => self.calc_menu_size(bus, menu_handle),
+            // mChooseMsg: report which enabled item hitPt falls in, or 0
+            // when the point is outside menuRect or the menu is disabled.
+            // Highlighting is not performed here — Systemless draws menu
+            // tracking itself from MenuSelect rather than by re-entering
+            // the definition procedure.
+            Self::M_CHOOSE_MSG => {
+                if which_item_ptr != 0 {
+                    let item = self.menu_def_item_at_point(bus, menu_handle, menu_rect_ptr, hit_pt);
+                    bus.write_word(which_item_ptr, item as u16);
+                }
+            }
+            // mDrawMsg: Systemless owns menu rendering end-to-end through
+            // the Menu Manager traps, so a direct draw request is honoured
+            // by leaving the framebuffer to that path rather than emitting
+            // a second, conflicting copy of the menu.
+            Self::M_DRAW_MSG => {}
+            _ => {}
+        }
+    }
+
+    /// Hit-test a point against a laid-out menu, in the coordinate space of
+    /// `menuRect`. Returns 0 when the point misses, the menu is disabled,
+    /// or the item under it is disabled — the contract Inside Macintosh
+    /// Volume I, I-352 gives `whichItem` for `mChooseMsg`.
+    fn menu_def_item_at_point(
+        &self,
+        bus: &MacMemoryBus,
+        menu_handle: u32,
+        menu_rect_ptr: u32,
+        hit_pt: u32,
+    ) -> i16 {
+        if menu_rect_ptr == 0 {
+            return 0;
+        }
+        let Some(menu) = self.menus.iter().find(|m| m.handle == menu_handle) else {
+            return 0;
+        };
+        if !menu.enabled {
+            return 0;
+        }
+
+        let top = bus.read_word(menu_rect_ptr) as i16;
+        let left = bus.read_word(menu_rect_ptr + 2) as i16;
+        let bottom = bus.read_word(menu_rect_ptr + 4) as i16;
+        let right = bus.read_word(menu_rect_ptr + 6) as i16;
+        let v = (hit_pt >> 16) as u16 as i16;
+        let h = (hit_pt & 0xFFFF) as u16 as i16;
+        if v < top || v >= bottom || h < left || h >= right {
+            return 0;
+        }
+
+        let mut row_top = top + 1;
+        for (index, item) in Self::laid_out_items(&menu.items).iter().enumerate() {
+            let height = self.menu_item_height(bus, item);
+            if v >= row_top && v < row_top + height {
+                if item.text == "-" || !item.enabled {
+                    return 0;
+                }
+                return index as i16 + 1;
+            }
+            row_top += height;
+        }
+        0
     }
 
     pub(super) fn menu_items_height(&self, bus: &MacMemoryBus, items: &[MenuItem]) -> i16 {
@@ -6798,6 +7025,141 @@ mod tests {
             get_mc_entry_ptr_for_test(&mut disp, &mut cpu, &mut bus, 601, 0),
             0,
             "InitMenus should autoload all declared mctb=0 entries"
+        );
+    }
+
+    /// IM:I I-355 and I-366: `menuProc` holds "a handle to the menu
+    /// definition procedure", and `GetMenu` replaces the resource's
+    /// four-byte placeholder with it. A NIL `menuProc` makes an application
+    /// that calls the definition procedure directly — which I-352 entitles
+    /// it to do — dereference address zero, which is how Warcraft II
+    /// crashed while sizing its menu bar.
+    #[test]
+    fn newmenu_installs_a_callable_menu_definition_procedure_handle() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let handle = new_menu_with_title(&mut disp, &mut cpu, &mut bus, 240, TEST_SP + 0x200, "Go");
+
+        let menu_ptr = bus.read_long(handle);
+        let menu_proc = bus.read_long(menu_ptr + 6);
+        assert_ne!(menu_proc, 0, "menuProc must not be NIL");
+
+        let entry = bus.read_long(menu_proc);
+        assert_ne!(entry, 0, "the menuProc handle must have a master pointer");
+        assert_eq!(
+            bus.read_word(entry),
+            0x303C,
+            "the stub must start with MOVE.W #imm,D0"
+        );
+        assert_eq!(
+            bus.read_word(entry + 2),
+            0xFEFC,
+            "the stub must carry the private MDEF selector"
+        );
+        assert_eq!(bus.read_word(entry + 4), 0xA816, "the stub must trap _Pack8");
+        assert_eq!(bus.read_word(entry + 6), 0x4E74, "the stub must end with RTD");
+        assert_eq!(
+            bus.read_word(entry + 8),
+            18,
+            "RTD must pop the MDEF's 18-byte Pascal frame"
+        );
+    }
+
+    /// IM:I I-352: `mSizeMsg` tells the definition procedure to compute the
+    /// menu's dimensions and store them in `menuWidth`/`menuHeight` — the
+    /// same work `CalcMenuSize` does.
+    #[test]
+    fn menu_def_proc_size_message_fills_menu_width_and_height() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let handle = new_menu_with_title(&mut disp, &mut cpu, &mut bus, 241, TEST_SP + 0x200, "Go");
+        append_menu_data(
+            &mut disp,
+            &mut cpu,
+            &mut bus,
+            handle,
+            TEST_SP + 0x240,
+            "Start;Stop",
+        );
+
+        let menu_ptr = bus.read_long(handle);
+        bus.write_word(menu_ptr + 2, 0);
+        bus.write_word(menu_ptr + 4, 0);
+
+        // The stub traps with SP pointing at the caller's return address,
+        // so the Pascal frame starts four bytes above it.
+        let sp = TEST_SP + 0x300;
+        cpu.write_reg(Register::A7, sp);
+        bus.write_long(sp, 0xDEAD_BEEF); // return address
+        bus.write_long(sp + 4, 0); // VAR whichItem
+        bus.write_long(sp + 8, 0); // hitPt
+        bus.write_long(sp + 12, 0); // VAR menuRect
+        bus.write_long(sp + 16, handle); // theMenu
+        bus.write_word(sp + 20, 2); // mSizeMsg
+
+        cpu.write_reg(Register::D0, 0x0000_FEFC);
+        disp.dispatch_toolbox(true, 0x016, &mut cpu, &mut bus)
+            .expect("the private MDEF selector must be handled")
+            .expect("the MDEF message must return");
+
+        assert!(
+            bus.read_word(menu_ptr + 2) as i16 > 0,
+            "mSizeMsg must set menuWidth"
+        );
+        assert!(
+            bus.read_word(menu_ptr + 4) as i16 > 0,
+            "mSizeMsg must set menuHeight"
+        );
+    }
+
+    /// IM:I I-352: for `mChooseMsg` the definition procedure reports the
+    /// enabled item under `hitPt`, and 0 when the point misses `menuRect`.
+    #[test]
+    fn menu_def_proc_choose_message_reports_the_item_under_the_point() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let handle = new_menu_with_title(&mut disp, &mut cpu, &mut bus, 242, TEST_SP + 0x200, "Go");
+        append_menu_data(
+            &mut disp,
+            &mut cpu,
+            &mut bus,
+            handle,
+            TEST_SP + 0x240,
+            "Start;Stop",
+        );
+        let (width, height) = calc_menu_size_for_test(&mut disp, &mut cpu, &mut bus, handle);
+
+        let menu_rect = TEST_SP + 0x280;
+        bus.write_word(menu_rect, 20); // top
+        bus.write_word(menu_rect + 2, 10); // left
+        bus.write_word(menu_rect + 4, (20 + height) as u16); // bottom
+        bus.write_word(menu_rect + 6, (10 + width) as u16); // right
+        let which_item = TEST_SP + 0x290;
+
+        let mut choose = |v: i16, h: i16| -> i16 {
+            let sp = TEST_SP + 0x300;
+            bus.write_word(which_item, 0xFFFF);
+            cpu.write_reg(Register::A7, sp);
+            bus.write_long(sp, 0xDEAD_BEEF);
+            bus.write_long(sp + 4, which_item);
+            bus.write_long(sp + 8, ((v as u16 as u32) << 16) | h as u16 as u32);
+            bus.write_long(sp + 12, menu_rect);
+            bus.write_long(sp + 16, handle);
+            bus.write_word(sp + 20, 1); // mChooseMsg
+            cpu.write_reg(Register::D0, 0x0000_FEFC);
+            disp.dispatch_toolbox(true, 0x016, &mut cpu, &mut bus)
+                .expect("the private MDEF selector must be handled")
+                .expect("the MDEF message must return");
+            bus.read_word(which_item) as i16
+        };
+
+        assert_eq!(choose(21, 20), 1, "a point in the first row picks item 1");
+        assert_eq!(
+            choose(5, 20),
+            0,
+            "a point above menuRect selects no item at all"
+        );
+        assert_eq!(
+            choose(21, 5),
+            0,
+            "a point left of menuRect selects no item at all"
         );
     }
 

--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -186,6 +186,7 @@ fn is_builtin_gestalt_selector(sel: &[u8; 4]) -> bool {
             | b"te  "
             | b"teat"
             | b"tmgr"
+            | b"thds"
             | b"dplv"
             | b"dply"
             | b"alis"
@@ -1631,9 +1632,8 @@ impl super::TrapDispatcher {
 
                 if res_type == *b"WDEF" {
                     if let Some(ptr) = self.synthesize_system_wdef(bus, res_id) {
-                        let handle = self.get_or_create_resource_handle_in_file(
-                            bus, res_type, res_id, ptr, 0,
-                        );
+                        let handle = self
+                            .get_or_create_resource_handle_in_file(bus, res_type, res_id, ptr, 0);
                         cpu.write_reg(Register::A0, handle);
                         cpu.write_reg(Register::D0, 0);
                         bus.write_word(0x0A60, 0); // ResErr = noErr
@@ -3395,6 +3395,19 @@ impl super::TrapDispatcher {
                         cpu.write_reg(Register::A0, 2);
                         cpu.write_reg(Register::D0, 0);
                     }
+                    // gestaltThreadMgrAttr ('thds') -> Thread Manager
+                    // present. Inside Macintosh: Operating System Utilities
+                    // 1994, p. 1-25 defines bit 0 as
+                    // gestaltThreadMgrPresent and bit 1 as
+                    // gestaltSpecificMatchSupport. Systemless implements the
+                    // public critical-section dispatch contract through
+                    // _ThreadDispatch ($ABF2), so report bit 0. Leave bit 1
+                    // clear because exact-match thread creation is not
+                    // implemented.
+                    b"thds" => {
+                        cpu.write_reg(Register::A0, 1);
+                        cpu.write_reg(Register::D0, 0);
+                    }
                     // gestaltDisplayMgrVers ('dplv') -> Display Manager
                     // 2.0.6, matching the BasiliskII System 7.5.3 reference.
                     // Operating System Utilities 1994 lists 'dplv' as the
@@ -3922,6 +3935,17 @@ impl super::TrapDispatcher {
             // PBHGetVInfo ($A207): HFS variant aliased onto $A007
             (false, 0x07) => {
                 let pb = cpu.read_reg(Register::A0);
+                let volume_index = bus.read_word(pb + 28) as i16;
+                if volume_index > 1 {
+                    // Files 1992, 2-145: positive ioVolIndex values walk the
+                    // mounted-volume queue, and enumeration ends with nsvErr.
+                    // Systemless currently exposes one mounted boot volume.
+                    const NSV_ERR: i16 = -35;
+                    bus.write_word(pb + 16, NSV_ERR as u16);
+                    cpu.write_reg(Register::D0, NSV_ERR as i32 as u32);
+                    return Some(Ok(()));
+                }
+
                 let name_ptr = bus.read_long(pb + 18);
                 if name_ptr != 0 {
                     Self::write_pstring(bus, name_ptr, super::TrapDispatcher::boot_volume_name());
@@ -13486,10 +13510,7 @@ mod tests {
         let pb = 0x300000u32;
         let name_ptr = setup_param_block(&mut bus, &mut cpu, pb, b"poison");
         bus.write_word(pb + 16, 0x3FFF);
-        bus.write_word(
-            pb + 22,
-            super::super::dispatch::BOOT_VOLUME_REF_NUM as u16,
-        );
+        bus.write_word(pb + 22, super::super::dispatch::BOOT_VOLUME_REF_NUM as u16);
         bus.write_word(pb + 28, (-1i16) as u16);
         bus.write_long(pb + 48, 2);
         cpu.write_reg(Register::D0, 9);

--- a/src/trap/sane.rs
+++ b/src/trap/sane.rs
@@ -213,7 +213,7 @@ impl super::TrapDispatcher {
         let is_two_addr = matches!(
             op,
             0x00 | 0x02 | 0x04 | 0x06 | // add, sub, mul, div
-            0x08 | 0x0A | 0x0C |         // cmp, cpx, rem
+            0x08 | 0x09 | 0x0A | 0x0C |  // cmp, decimal-to-binary, cpx, rem
             0x0E | 0x10 |                 // z2x, x2z (conversions)
             0x18 |                         // scalb (scale binary, two-address)
             0x1C // class (classify, two-address: src=ext, dst=int16)
@@ -243,6 +243,35 @@ impl super::TrapDispatcher {
             let dst_ptr = bus.read_long(sp + 2);
             let src_ptr = bus.read_long(sp + 6);
             cpu.write_reg(Register::A7, sp + 10);
+
+            if op == 0x09 {
+                // FOD2B / FDEC2{X,D,S,C,I,L}: convert a decimal record
+                // at SRC into the opcode-selected binary format at DST.
+                // Apple Numerics Manual (1988), Decimal-to-Binary
+                // Conversion; MPW SANEMacs.a defines FOD2B=$0009 and
+                // requires destination and source addresses on the stack.
+                let negative = bus.read_byte(src_ptr) != 0;
+                let exponent = bus.read_word(src_ptr + 2) as i16;
+                let length = usize::from(bus.read_byte(src_ptr + 4)).min(20);
+                let digits = bus.read_bytes(src_ptr + 5, length);
+                let text = String::from_utf8_lossy(&digits);
+                let mut value = match text.as_ref() {
+                    "INF" | "Inf" | "inf" => f64::INFINITY,
+                    value if value.starts_with("NAN") || value.starts_with("NaN") => f64::NAN,
+                    _ => {
+                        digits
+                            .iter()
+                            .filter(|digit| digit.is_ascii_digit())
+                            .fold(0.0, |value, digit| value * 10.0 + f64::from(*digit - b'0'))
+                            * libm::pow(10.0, f64::from(exponent))
+                    }
+                };
+                if negative {
+                    value = -value;
+                }
+                Extended80::from(value).write_format(bus, dst_ptr, fmt);
+                return Ok(());
+            }
 
             if !trace_sane && !trace_sane_nan {
                 match op {

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -11,8 +11,9 @@ use std::sync::OnceLock;
 
 use super::dispatch::{
     AeCoercionHandler, AeDescriptor, AeObjectAccessor, AePrivateHashTable, AeResolveLevel,
-    AeResolveState, DialogItem, MovieState, StandardFileGetEntry, StandardFileGetTrackingState,
-    StandardFilePutTrackingState, SyntheticAppleEvent,
+    AeResolveState, CooperativeThread, DialogItem, MovieState, StandardFileGetEntry,
+    StandardFileGetTrackingState, StandardFilePutTrackingState, SyntheticAppleEvent,
+    DEFAULT_COOPERATIVE_THREAD_STACK_SIZE,
 };
 use super::types::{decode_mac_roman, encode_mac_roman_lossy, Rect, ShapeOp};
 
@@ -23,6 +24,7 @@ static TRACE_TITLE_DIAG: OnceLock<bool> = OnceLock::new();
 static TRACE_SOUND: OnceLock<bool> = OnceLock::new();
 static TRACE_AE: OnceLock<bool> = OnceLock::new();
 static TRACE_GETKEYS_NONZERO: OnceLock<bool> = OnceLock::new();
+static TRACE_THREADS: OnceLock<bool> = OnceLock::new();
 static FORCE_BUTTON_TRUE_AT_PC: OnceLock<Option<u32>> = OnceLock::new();
 
 const AE_TYPE_APPLE_EVENT: u32 = u32::from_be_bytes(*b"aevt");
@@ -58,6 +60,107 @@ const AE_KEY_MARK_PROC: u32 = u32::from_be_bytes(*b"mark");
 const AE_KEY_ADJUST_MARKS_PROC: u32 = u32::from_be_bytes(*b"adjm");
 const AE_KEY_GET_ERR_DESC_PROC: u32 = u32::from_be_bytes(*b"indc");
 const QUICKTIME_INVALID_MOVIE: i16 = -2010;
+
+fn scan_sane_decimal(
+    bus: &mut MacMemoryBus,
+    bytes: &[u8],
+    index_ptr: u32,
+    decimal_ptr: u32,
+    valid_prefix_ptr: u32,
+) {
+    let start = usize::from(bus.read_word(index_ptr)).min(bytes.len());
+    let mut cursor = start;
+    let mut negative = false;
+    if let Some(sign) = bytes.get(cursor) {
+        if *sign == b'+' || *sign == b'-' {
+            negative = *sign == b'-';
+            cursor += 1;
+        }
+    }
+
+    let mut digits = Vec::new();
+    let mut fraction_digits = 0i32;
+    let mut saw_digit = false;
+    while let Some(ch) = bytes.get(cursor) {
+        if ch.is_ascii_digit() {
+            digits.push(*ch);
+            saw_digit = true;
+            cursor += 1;
+        } else {
+            break;
+        }
+    }
+    if bytes.get(cursor) == Some(&b'.') {
+        cursor += 1;
+        while let Some(ch) = bytes.get(cursor) {
+            if ch.is_ascii_digit() {
+                digits.push(*ch);
+                fraction_digits += 1;
+                saw_digit = true;
+                cursor += 1;
+            } else {
+                break;
+            }
+        }
+    }
+
+    let exponent_start = cursor;
+    let mut explicit_exponent = 0i32;
+    if saw_digit && matches!(bytes.get(cursor), Some(b'e' | b'E')) {
+        cursor += 1;
+        let mut exponent_negative = false;
+        if let Some(sign) = bytes.get(cursor) {
+            if *sign == b'+' || *sign == b'-' {
+                exponent_negative = *sign == b'-';
+                cursor += 1;
+            }
+        }
+        let exponent_digits_start = cursor;
+        while let Some(ch) = bytes.get(cursor) {
+            if ch.is_ascii_digit() {
+                explicit_exponent = explicit_exponent
+                    .saturating_mul(10)
+                    .saturating_add(i32::from(*ch - b'0'));
+                cursor += 1;
+            } else {
+                break;
+            }
+        }
+        if cursor == exponent_digits_start {
+            cursor = exponent_start;
+            explicit_exponent = 0;
+        } else if exponent_negative {
+            explicit_exponent = -explicit_exponent;
+        }
+    }
+
+    if saw_digit {
+        let first_nonzero = digits.iter().position(|digit| *digit != b'0');
+        let significant = first_nonzero
+            .map(|offset| &digits[offset..])
+            .unwrap_or(&b"0"[..]);
+        let significant_len = significant.len().min(20);
+        let exponent = explicit_exponent.saturating_sub(fraction_digits);
+
+        bus.write_byte(decimal_ptr, u8::from(negative));
+        bus.write_byte(decimal_ptr + 1, 0);
+        bus.write_word(
+            decimal_ptr + 2,
+            exponent.clamp(i16::MIN as i32, i16::MAX as i32) as i16 as u16,
+        );
+        bus.write_byte(decimal_ptr + 4, significant_len as u8);
+        for index in 0..20u32 {
+            bus.write_byte(
+                decimal_ptr + 5 + index,
+                significant.get(index as usize).copied().unwrap_or(0),
+            );
+        }
+        bus.write_byte(decimal_ptr + 25, 0);
+        bus.write_word(index_ptr, cursor as u16);
+    }
+    let valid_prefix = saw_digit && cursor == bytes.len();
+    bus.write_word(valid_prefix_ptr, if valid_prefix { 0xFFFF } else { 0 });
+}
 
 fn standard_file_cancel_reply(bus: &mut MacMemoryBus, reply_ptr: u32) {
     if reply_ptr != 0 {
@@ -292,20 +395,18 @@ fn scan_quicktime_atoms(
                     let (parsed_time_scale, parsed_duration) = if version == 0 {
                         (
                             read_quicktime_u32(payload, 12),
-                            read_quicktime_u32(payload, 16)
-                                .map(|value| value.min(i32::MAX as u32)),
+                            read_quicktime_u32(payload, 16).map(|value| value.min(i32::MAX as u32)),
                         )
                     } else if payload.len() >= 32 {
                         (
                             read_quicktime_u32(payload, 20),
-                            read_quicktime_u32(payload, 28)
-                                .map(|value| value.min(i32::MAX as u32)),
+                            read_quicktime_u32(payload, 28).map(|value| value.min(i32::MAX as u32)),
                         )
                     } else {
                         (None, None)
                     };
-                    if let Some(value) = parsed_time_scale
-                        .filter(|value| *value > 0 && *value <= i32::MAX as u32)
+                    if let Some(value) =
+                        parsed_time_scale.filter(|value| *value > 0 && *value <= i32::MAX as u32)
                     {
                         *time_scale = Some(value as i32);
                     }
@@ -342,13 +443,7 @@ fn quicktime_movie_metadata(data: &[u8]) -> ((i16, i16, i16, i16), i32, i32) {
     let mut bounds = None;
     let mut duration = None;
     let mut time_scale = None;
-    scan_quicktime_atoms(
-        data,
-        0,
-        &mut bounds,
-        &mut duration,
-        &mut time_scale,
-    );
+    scan_quicktime_atoms(data, 0, &mut bounds, &mut duration, &mut time_scale);
     (
         bounds.unwrap_or((0, 0, 120, 160)),
         duration.unwrap_or(1),
@@ -560,6 +655,10 @@ fn trace_getkeys_nonzero_enabled() -> bool {
         .get_or_init(|| std::env::var_os("SYSTEMLESS_TRACE_GETKEYS_NONZERO").is_some())
 }
 
+fn trace_threads_enabled() -> bool {
+    *TRACE_THREADS.get_or_init(|| std::env::var_os("SYSTEMLESS_TRACE_THREADS").is_some())
+}
+
 fn format_fourcc(v: u32) -> String {
     v.to_be_bytes()
         .iter()
@@ -623,6 +722,311 @@ impl super::TrapDispatcher {
     const ALIAS_KIND_FOLDER: u16 = 1;
     const ALIAS_EXTRA_PARENT_DIR_NAME: i16 = 0;
     const ALIAS_EXTRA_END: i16 = -1;
+
+    /// `kApplicationThreadID` from Threads.h — the thread the process
+    /// starts on, which owns the process stack rather than a pooled one.
+    const APPLICATION_THREAD_ID: u32 = 2;
+    const THREAD_STATE_READY: u16 = 0;
+    const THREAD_STATE_STOPPED: u16 = 1;
+    const THREAD_STATE_RUNNING: u16 = 2;
+    /// `threadTooManyReqsErr` .. `threadProtocolErr` from Errors.h.
+    const THREAD_NOT_FOUND_ERR: i16 = -617;
+    const THREAD_PROTOCOL_ERR: i16 = -619;
+
+    fn capture_cooperative_thread<C: CpuOps>(
+        cpu: &C,
+        state: u16,
+        result_destination: u32,
+    ) -> CooperativeThread {
+        let d_regs = [
+            cpu.read_reg(Register::D0),
+            cpu.read_reg(Register::D1),
+            cpu.read_reg(Register::D2),
+            cpu.read_reg(Register::D3),
+            cpu.read_reg(Register::D4),
+            cpu.read_reg(Register::D5),
+            cpu.read_reg(Register::D6),
+            cpu.read_reg(Register::D7),
+        ];
+        let a_regs = [
+            cpu.read_reg(Register::A0),
+            cpu.read_reg(Register::A1),
+            cpu.read_reg(Register::A2),
+            cpu.read_reg(Register::A3),
+            cpu.read_reg(Register::A4),
+            cpu.read_reg(Register::A5),
+            cpu.read_reg(Register::A6),
+            cpu.read_reg(Register::A7),
+        ];
+        CooperativeThread {
+            d_regs,
+            a_regs,
+            pc: cpu.read_reg(Register::PC),
+            ccr: cpu.get_ccr(),
+            state,
+            result_destination,
+            stack_base: 0,
+            stack_limit: 0,
+            switch_in: (0, 0),
+            switch_out: (0, 0),
+            terminator: (0, 0),
+        }
+    }
+
+    fn install_cooperative_thread<C: CpuOps>(cpu: &mut C, thread: &CooperativeThread) {
+        let d_registers = [
+            Register::D0,
+            Register::D1,
+            Register::D2,
+            Register::D3,
+            Register::D4,
+            Register::D5,
+            Register::D6,
+            Register::D7,
+        ];
+        let a_registers = [
+            Register::A0,
+            Register::A1,
+            Register::A2,
+            Register::A3,
+            Register::A4,
+            Register::A5,
+            Register::A6,
+            Register::A7,
+        ];
+        for (register, value) in d_registers.into_iter().zip(thread.d_regs) {
+            cpu.write_reg(register, value);
+        }
+        for (register, value) in a_registers.into_iter().zip(thread.a_regs) {
+            cpu.write_reg(register, value);
+        }
+        cpu.write_reg(Register::PC, thread.pc);
+        cpu.set_ccr(thread.ccr);
+    }
+
+    fn thread_return_trampoline(&mut self, bus: &mut MacMemoryBus) -> u32 {
+        if self.thread_return_trampoline == 0 {
+            let trampoline = bus.alloc(8);
+            bus.write_word(trampoline, 0x303C);
+            bus.write_word(trampoline + 2, 0xFFFE);
+            bus.write_word(trampoline + 4, 0xABF2);
+            bus.write_word(trampoline + 6, 0x4E75);
+            self.thread_return_trampoline = trampoline;
+        }
+        self.thread_return_trampoline
+    }
+
+    /// Resolve a guest-supplied ThreadID. `kCurrentThreadID` (1) and 0
+    /// both name the running thread, per Threads.h.
+    fn resolve_cooperative_thread_id(&self, thread_id: u32) -> u32 {
+        if thread_id == 0 || thread_id == 1 {
+            self.current_cooperative_thread
+        } else {
+            thread_id
+        }
+    }
+
+    /// Materialise the record for the application thread the process
+    /// booted on. It exists implicitly from launch, so `GetThreadState`,
+    /// `SetThreadSwitcher` and friends must find it without a prior
+    /// `NewThread`.
+    fn cooperative_thread_mut<C: CpuOps>(
+        &mut self,
+        cpu: &C,
+        thread_id: u32,
+    ) -> Option<&mut CooperativeThread> {
+        if thread_id == Self::APPLICATION_THREAD_ID
+            && !self
+                .cooperative_threads
+                .contains_key(&Self::APPLICATION_THREAD_ID)
+        {
+            let running = self.current_cooperative_thread == Self::APPLICATION_THREAD_ID;
+            let state = if running {
+                Self::THREAD_STATE_RUNNING
+            } else {
+                Self::THREAD_STATE_READY
+            };
+            let thread = Self::capture_cooperative_thread(cpu, state, 0);
+            self.cooperative_threads
+                .insert(Self::APPLICATION_THREAD_ID, thread);
+        }
+        self.cooperative_threads.get_mut(&thread_id)
+    }
+
+    /// Save the running thread's registers back into its record without
+    /// changing its scheduling state.
+    fn save_current_cooperative_thread<C: CpuOps>(&mut self, cpu: &C) {
+        let current_id = self.current_cooperative_thread;
+        let saved = Self::capture_cooperative_thread(cpu, Self::THREAD_STATE_RUNNING, 0);
+        match self.cooperative_thread_mut(cpu, current_id) {
+            Some(thread) => {
+                thread.d_regs = saved.d_regs;
+                thread.a_regs = saved.a_regs;
+                thread.pc = saved.pc;
+                thread.ccr = saved.ccr;
+            }
+            None => {
+                self.cooperative_threads.insert(current_id, saved);
+            }
+        }
+    }
+
+    /// Pick the next ready thread. `suggested_thread` is honoured when it
+    /// names a ready thread, matching `YieldToThread`; otherwise the queue
+    /// runs round-robin, which is what the stock 68K scheduler does.
+    fn next_ready_cooperative_thread(&mut self, suggested_thread: u32) -> Option<u32> {
+        let current_id = self.current_cooperative_thread;
+        if suggested_thread > 1 && suggested_thread != current_id {
+            if let Some(position) = self
+                .cooperative_thread_ready
+                .iter()
+                .position(|thread_id| *thread_id == suggested_thread)
+            {
+                return self.cooperative_thread_ready.remove(position);
+            }
+        }
+        for _ in 0..self.cooperative_thread_ready.len() {
+            let candidate = self.cooperative_thread_ready.pop_front()?;
+            if candidate == current_id {
+                self.cooperative_thread_ready.push_back(candidate);
+                continue;
+            }
+            let ready = self
+                .cooperative_threads
+                .get(&candidate)
+                .is_some_and(|thread| thread.state == Self::THREAD_STATE_READY);
+            if ready {
+                return Some(candidate);
+            }
+        }
+        None
+    }
+
+    /// Install `next_id` as the running thread. The caller has already
+    /// saved and re-queued the outgoing context.
+    fn switch_to_cooperative_thread<C: CpuOps>(&mut self, cpu: &mut C, next_id: u32) -> bool {
+        let Some(mut next) = self.cooperative_threads.get(&next_id).cloned() else {
+            return false;
+        };
+        if next.state != Self::THREAD_STATE_READY {
+            self.cooperative_thread_ready.push_back(next_id);
+            return false;
+        }
+        next.state = Self::THREAD_STATE_RUNNING;
+        Self::install_cooperative_thread(cpu, &next);
+        self.cooperative_threads.insert(next_id, next);
+        self.current_cooperative_thread = next_id;
+        true
+    }
+
+    /// `YieldToThread` / `YieldToAnyThread`. A yield inside a critical
+    /// section is a no-op: Threads.h documents `ThreadBeginCritical` as
+    /// suppressing scheduling until the matching end.
+    fn yield_cooperative_thread<C: CpuOps>(&mut self, cpu: &mut C, suggested_thread: u32) {
+        if self.thread_critical_nesting != 0 || self.cooperative_thread_ready.is_empty() {
+            return;
+        }
+
+        let current_id = self.current_cooperative_thread;
+        self.save_current_cooperative_thread(cpu);
+        if let Some(thread) = self.cooperative_threads.get_mut(&current_id) {
+            if thread.state == Self::THREAD_STATE_RUNNING {
+                thread.state = Self::THREAD_STATE_READY;
+            }
+        }
+        let requeue = self
+            .cooperative_threads
+            .get(&current_id)
+            .is_some_and(|thread| thread.state == Self::THREAD_STATE_READY)
+            && !self.cooperative_thread_ready.contains(&current_id);
+        if requeue {
+            self.cooperative_thread_ready.push_back(current_id);
+        }
+
+        let Some(next_id) = self.next_ready_cooperative_thread(suggested_thread) else {
+            if let Some(thread) = self.cooperative_threads.get_mut(&current_id) {
+                thread.state = Self::THREAD_STATE_RUNNING;
+            }
+            self.cooperative_thread_ready
+                .retain(|thread_id| *thread_id != current_id);
+            return;
+        };
+        if !self.switch_to_cooperative_thread(cpu, next_id) {
+            if let Some(thread) = self.cooperative_threads.get_mut(&current_id) {
+                thread.state = Self::THREAD_STATE_RUNNING;
+            }
+            self.cooperative_thread_ready
+                .retain(|thread_id| *thread_id != current_id);
+        }
+    }
+
+    /// Retire `thread_id`, storing its entry-proc result and returning its
+    /// stack to the pool so `NewThread` can recycle it.
+    fn retire_cooperative_thread(&mut self, thread_id: u32, result: u32, bus: &mut MacMemoryBus) {
+        if let Some(finished) = self.cooperative_threads.remove(&thread_id) {
+            if finished.result_destination != 0 {
+                bus.write_long(finished.result_destination, result);
+            }
+            if finished.stack_base != 0 {
+                self.cooperative_thread_pool
+                    .push((finished.stack_base, finished.stack_limit));
+            }
+        }
+        self.cooperative_thread_ready
+            .retain(|queued| *queued != thread_id);
+    }
+
+    /// Entered through the return trampoline when a `ThreadEntryProc`
+    /// returns. The Pascal result is in D0 for a pointer-returning
+    /// function under MPW's 68K ABI.
+    fn finish_cooperative_thread<C: CpuOps>(&mut self, cpu: &mut C, bus: &mut MacMemoryBus) {
+        let finished_id = self.current_cooperative_thread;
+        let result = cpu.read_reg(Register::D0);
+        self.retire_cooperative_thread(finished_id, result, bus);
+
+        // The finished thread has no context left to return to, so a
+        // successor must be installed. Fall back to the application
+        // thread, which always has a live saved context.
+        let next = self
+            .next_ready_cooperative_thread(0)
+            .filter(|next_id| *next_id != finished_id);
+        if let Some(next_id) = next {
+            if self.switch_to_cooperative_thread(cpu, next_id) {
+                return;
+            }
+        }
+        if let Some(mut application) = self
+            .cooperative_threads
+            .get(&Self::APPLICATION_THREAD_ID)
+            .cloned()
+        {
+            self.cooperative_thread_ready
+                .retain(|queued| *queued != Self::APPLICATION_THREAD_ID);
+            application.state = Self::THREAD_STATE_RUNNING;
+            Self::install_cooperative_thread(cpu, &application);
+            self.cooperative_threads
+                .insert(Self::APPLICATION_THREAD_ID, application);
+            self.current_cooperative_thread = Self::APPLICATION_THREAD_ID;
+        }
+    }
+
+    /// Claim a pooled stack of at least `stack_size` bytes, or allocate a
+    /// fresh one. Returns `(base, limit)`.
+    fn acquire_cooperative_thread_stack(
+        &mut self,
+        bus: &mut MacMemoryBus,
+        stack_size: u32,
+    ) -> (u32, u32) {
+        if let Some(position) = self
+            .cooperative_thread_pool
+            .iter()
+            .position(|(base, limit)| limit.saturating_sub(*base) >= stack_size)
+        {
+            return self.cooperative_thread_pool.swap_remove(position);
+        }
+        let base = bus.alloc(stack_size);
+        (base, base.wrapping_add(stack_size))
+    }
 
     fn apple_event_handler_for(&self, event_class: u32, event_id: u32) -> Option<(u32, u32)> {
         // Inside Macintosh Volume VI, 6-28 to 6-29: AEInstallEventHandler
@@ -3517,8 +3921,7 @@ impl super::TrapDispatcher {
                 state.last_service_tick = Some(now);
                 // Guest ticks run at 60 Hz; the movie time scale is units per
                 // second. rate is a Fixed (16.16) multiplier on real time.
-                let units_per_tick =
-                    (state.time_scale as i64 * state.rate as i64) / (60 * 65536);
+                let units_per_tick = (state.time_scale as i64 * state.rate as i64) / (60 * 65536);
                 let advance = units_per_tick.saturating_mul(elapsed_ticks as i64);
                 let mut new_time = state.current_time as i64 + advance;
                 let mut finished = false;
@@ -3662,12 +4065,7 @@ impl super::TrapDispatcher {
         if super::dispatch::trace_quicktime_enabled() {
             eprintln!(
                 "[QUICKTIME] render movie=${:08X} sample={}/{} time={} -> port=${:08X} box={:?}",
-                movie,
-                target,
-                media_time,
-                movie_time,
-                port,
-                box_rect
+                movie, target, media_time, movie_time, port, box_rect
             );
         }
 
@@ -5319,6 +5717,18 @@ impl super::TrapDispatcher {
 
                 if selector == super::dispatch::LOADSEG_GETRESOURCE_SENTINEL {
                     return Some(self.resume_loadseg_after_getresource(bus, cpu));
+                }
+
+                // Synthetic 'MDEF' 0 selector. Every `MenuInfo.menuProc`
+                // points at a stub holding `MOVE.W #$FEFC, D0; _Pack8;
+                // RTD #18`, so an application that calls the menu
+                // definition procedure directly — which Inside Macintosh
+                // Volume I, I-352 entitles it to do — lands here instead of
+                // dereferencing a NIL handle. The stub's own `RTD` pops the
+                // Pascal frame once this returns.
+                if selector == 0xFEFC {
+                    self.menu_def_proc_message(bus, sp);
+                    return Some(Ok(()));
                 }
 
                 // Trampoline selector — when an AE handler we dispatched
@@ -11348,100 +11758,29 @@ impl super::TrapDispatcher {
                         let valid_prefix_ptr = bus.read_long(sp + 10);
                         let string_ptr = bus.read_long(sp + 14);
                         let bytes = bus.read_pstring(string_ptr);
-                        let start = usize::from(bus.read_word(index_ptr)).min(bytes.len());
-
-                        let mut cursor = start;
-                        let mut negative = false;
-                        if let Some(sign) = bytes.get(cursor) {
-                            if *sign == b'+' || *sign == b'-' {
-                                negative = *sign == b'-';
-                                cursor += 1;
-                            }
-                        }
-
-                        let mut digits = Vec::new();
-                        let mut fraction_digits = 0i32;
-                        let mut saw_digit = false;
-                        while let Some(ch) = bytes.get(cursor) {
-                            if ch.is_ascii_digit() {
-                                digits.push(*ch);
-                                saw_digit = true;
-                                cursor += 1;
-                            } else {
+                        scan_sane_decimal(bus, &bytes, index_ptr, decimal_ptr, valid_prefix_ptr);
+                        cpu.write_reg(Register::A7, sp + 18);
+                    }
+                    4 => {
+                        // FCSTR2DEC / CStr2Dec: scan a NUL-terminated C
+                        // string into a 68K SANE decimal record. Inside
+                        // Macintosh Volume IV, IV-69 and IV-307 identifies
+                        // selector 4. MPW 3.5's linked str2dec wrapper places:
+                        //   SP+2  validPrefix*, SP+6 decimal*, SP+10 index*,
+                        //   SP+14 C string*.
+                        let valid_prefix_ptr = bus.read_long(sp + 2);
+                        let decimal_ptr = bus.read_long(sp + 6);
+                        let index_ptr = bus.read_long(sp + 10);
+                        let string_ptr = bus.read_long(sp + 14);
+                        let mut bytes = Vec::new();
+                        for offset in 0..=u16::MAX as u32 {
+                            let byte = bus.read_byte(string_ptr.wrapping_add(offset));
+                            if byte == 0 {
                                 break;
                             }
+                            bytes.push(byte);
                         }
-                        if bytes.get(cursor) == Some(&b'.') {
-                            cursor += 1;
-                            while let Some(ch) = bytes.get(cursor) {
-                                if ch.is_ascii_digit() {
-                                    digits.push(*ch);
-                                    fraction_digits += 1;
-                                    saw_digit = true;
-                                    cursor += 1;
-                                } else {
-                                    break;
-                                }
-                            }
-                        }
-
-                        let exponent_start = cursor;
-                        let mut explicit_exponent = 0i32;
-                        if saw_digit && matches!(bytes.get(cursor), Some(b'e' | b'E')) {
-                            cursor += 1;
-                            let mut exponent_negative = false;
-                            if let Some(sign) = bytes.get(cursor) {
-                                if *sign == b'+' || *sign == b'-' {
-                                    exponent_negative = *sign == b'-';
-                                    cursor += 1;
-                                }
-                            }
-                            let exponent_digits_start = cursor;
-                            while let Some(ch) = bytes.get(cursor) {
-                                if ch.is_ascii_digit() {
-                                    explicit_exponent = explicit_exponent
-                                        .saturating_mul(10)
-                                        .saturating_add(i32::from(*ch - b'0'));
-                                    cursor += 1;
-                                } else {
-                                    break;
-                                }
-                            }
-                            if cursor == exponent_digits_start {
-                                cursor = exponent_start;
-                                explicit_exponent = 0;
-                            } else if exponent_negative {
-                                explicit_exponent = -explicit_exponent;
-                            }
-                        }
-
-                        if saw_digit {
-                            let first_nonzero =
-                                digits.iter().position(|digit| *digit != b'0');
-                            let significant = first_nonzero
-                                .map(|offset| &digits[offset..])
-                                .unwrap_or(&b"0"[..]);
-                            let significant_len = significant.len().min(20);
-                            let exponent = explicit_exponent.saturating_sub(fraction_digits);
-
-                            bus.write_byte(decimal_ptr, u8::from(negative));
-                            bus.write_byte(decimal_ptr + 1, 0);
-                            bus.write_word(
-                                decimal_ptr + 2,
-                                exponent.clamp(i16::MIN as i32, i16::MAX as i32) as i16 as u16,
-                            );
-                            bus.write_byte(decimal_ptr + 4, significant_len as u8);
-                            for index in 0..20u32 {
-                                bus.write_byte(
-                                    decimal_ptr + 5 + index,
-                                    significant.get(index as usize).copied().unwrap_or(0),
-                                );
-                            }
-                            bus.write_byte(decimal_ptr + 25, 0);
-                            bus.write_word(index_ptr, cursor as u16);
-                        }
-                        let valid_prefix = saw_digit && cursor == bytes.len();
-                        bus.write_word(valid_prefix_ptr, if valid_prefix { 0xFFFF } else { 0 });
+                        scan_sane_decimal(bus, &bytes, index_ptr, decimal_ptr, valid_prefix_ptr);
                         cpu.write_reg(Register::A7, sp + 18);
                     }
                     _ => {
@@ -12803,10 +13142,7 @@ impl super::TrapDispatcher {
                             QUICKTIME_INVALID_MOVIE
                         };
                         if super::dispatch::trace_quicktime_enabled() {
-                            eprintln!(
-                                "[QUICKTIME] GetMovieBox movie=${:08X} -> {:?}",
-                                movie, rect
-                            );
+                            eprintln!("[QUICKTIME] GetMovieBox movie=${:08X} -> {:?}", movie, rect);
                         }
                         cpu.write_reg(Register::A7, sp + 8);
                         cpu.write_reg(Register::D0, err as u32);
@@ -14046,8 +14382,7 @@ impl super::TrapDispatcher {
                             bus.read_long(description)
                         };
                         let count = u32::from(
-                            component_type == 0
-                                || component_type == MOVIE_CONTROLLER_COMPONENT,
+                            component_type == 0 || component_type == MOVIE_CONTROLLER_COMPONENT,
                         );
                         bus.write_long(sp + 4, count);
                         cpu.write_reg(Register::A7, sp + 4);
@@ -14063,8 +14398,7 @@ impl super::TrapDispatcher {
                             bus.read_long(description)
                         };
                         let component = if previous == 0
-                            && (component_type == 0
-                                || component_type == MOVIE_CONTROLLER_COMPONENT)
+                            && (component_type == 0 || component_type == MOVIE_CONTROLLER_COMPONENT)
                         {
                             SYNTHETIC_MOVIE_CONTROLLER
                         } else {
@@ -14318,52 +14652,441 @@ impl super::TrapDispatcher {
                 }
             }
 
-            // ThreadDispatch ($ABF2) — Thread Manager critical sections
-            // Inside Macintosh: Operating System Utilities 1994,
-            // Thread Manager chapter (pp. 69-70):
-            //   pascal OSErr ThreadBeginCritical(void);
-            //   pascal OSErr ThreadEndCritical(void);
-            // The public MPW glue dispatches those no-arg routines
-            // through `_ThreadDispatch` selectors $000B and $000C.
-            // MPW uses `#pragma parameter __D0` for the selector
-            // thunk, so the selector arrives in D0 and the stack is
-            // untouched.
+            // ThreadDispatch ($ABF2) — cooperative Thread Manager
+            // Inside Macintosh: Operating System Utilities 1994, p. 2448
+            // documents only the availability gate: Gestalt
+            // `gestaltThreadMgrAttr` ('thds') bit 0
+            // `gestaltThreadMgrPresent`. The routine selectors are defined
+            // by MPW Interfaces/CIncludes/Threads.h (Universal Interfaces
+            // 2.0a3, ETO #16, 11 November 1994), which declares each entry
+            // point as THREEWORDINLINE(0x303C, <selector>, 0xABF2):
+            //   CreateThreadPool             $0501
+            //   GetFreeThreadCount           $0402
+            //   NewThread                    $0E03
+            //   DisposeThread                $0504
+            //   YieldToThread                $0205
+            //   GetCurrentThread             $0206
+            //   GetThreadState               $0407
+            //   SetThreadState               $0508
+            //   SetThreadScheduler           $0209
+            //   SetThreadSwitcher            $070A
+            //   ThreadBeginCritical          $000B
+            //   ThreadEndCritical            $000C
+            //   SetDebuggerNotificationProcs $060D
+            //   GetThreadCurrentTaskRef      $020E
+            //   GetThreadStateGivenTaskRef   $060F
+            //   SetThreadReadyGivenTaskRef   $0410
+            //   SetThreadTerminator          $0611
+            //   SetThreadStateEndCritical    $0512
+            //   GetDefaultThreadStackSize    $0413
+            //   ThreadCurrentStackSpace      $0414
+            //   GetSpecificFreeThreadCount   $0615
+            // The selector's high byte is the argument size in stack words,
+            // so the Pascal frame is `(selector >> 8) * 2` argument bytes
+            // followed by the OSErr result slot.
             //
-            // HLE behaviour: selector $000B increments the dispatcher-
-            // wide critical-section nesting counter and returns noErr.
-            // Selector $000C decrements the counter when nonzero and
-            // returns noErr; when the counter is already zero it
-            // returns threadProtocolErr (-619). Unsupported selectors
-            // return paramErr (-50). The public `Threads.h` wrappers
-            // read the 16-bit OSErr from the caller's zero-arg result
-            // slot at SP, so we mirror the low word there as well as
-            // in D0.
+            // HLE behaviour: Systemless runs the guest on one host thread
+            // and switches cooperative contexts entirely inside this trap,
+            // so the whole caller-visible 68K register file can be banked
+            // without any host concurrency. `kCooperativeThread` is the only
+            // supported style — `kPreemptiveThread` is refused with
+            // paramErr, matching a 68K machine with no MP services.
             //
             // Regression coverage:
+            //   src/trap/toolbox.rs::tests::threaddispatch_newthread_creates_ready_cooperative_thread_and_consumes_mpw_frame
+            //   src/trap/toolbox.rs::tests::threaddispatch_yield_round_trips_between_two_cooperative_contexts
+            //   src/trap/toolbox.rs::tests::threaddispatch_get_and_set_thread_state_track_the_ready_queue
+            //   src/trap/toolbox.rs::tests::threaddispatch_switcher_and_terminator_are_recorded_per_thread
             //   src/trap/toolbox.rs::tests::threaddispatch_begin_and_end_critical_roundtrip
             //   src/trap/toolbox.rs::tests::threaddispatch_endcritical_underflow_returns_thread_protocol_err
             //   src/trap/toolbox.rs::tests::threaddispatch_unsupported_selector_returns_param_err
             (true, 0x3F2) => {
                 let selector = cpu.read_reg(Register::D0) & 0xFFFF;
                 let sp = cpu.read_reg(Register::A7);
+                if trace_threads_enabled() {
+                    eprintln!(
+                        "[THREADS] selector=${:04X} pc=${:08X} sp=${:08X} args={:08X} {:08X} {:08X} {:08X}",
+                        selector,
+                        cpu.read_reg(Register::PC),
+                        sp,
+                        bus.read_long(sp),
+                        bus.read_long(sp + 4),
+                        bus.read_long(sp + 8),
+                        bus.read_long(sp + 12),
+                    );
+                }
+                // Threads.h option bits.
+                const K_NEW_SUSPEND: u32 = 1 << 0;
+                const K_PREEMPTIVE_THREAD: u32 = 1 << 1;
+
                 let result = match selector {
+                    // Private selector planted by the return trampoline that
+                    // every cooperative thread's stack is seeded with. It is
+                    // not a Threads.h entry point; it exists so a
+                    // ThreadEntryProc's RTS lands somewhere the HLE controls.
+                    0xFFFE => {
+                        self.finish_cooperative_thread(cpu, bus);
+                        return Some(Ok(()));
+                    }
+                    // CreateThreadPool(threadStyle, numToCreate, stackSize)
+                    0x0501 => {
+                        let stack_size = bus.read_long(sp);
+                        let count = bus.read_word(sp + 4) as i16;
+                        let thread_style = bus.read_long(sp + 6);
+                        if thread_style & K_PREEMPTIVE_THREAD != 0 {
+                            -50
+                        } else {
+                            let stack_size = if stack_size == 0 {
+                                self.cooperative_thread_stack_size
+                            } else {
+                                stack_size
+                            };
+                            for _ in 0..count.max(0) {
+                                let stack = self.acquire_cooperative_thread_stack(bus, stack_size);
+                                self.cooperative_thread_pool.push(stack);
+                            }
+                            0
+                        }
+                    }
+                    // GetFreeThreadCount(threadStyle, freeCount)
+                    0x0402 => {
+                        let free_count = bus.read_long(sp);
+                        let thread_style = bus.read_long(sp + 4);
+                        if free_count == 0 || thread_style & K_PREEMPTIVE_THREAD != 0 {
+                            -50
+                        } else {
+                            bus.write_word(free_count, self.cooperative_thread_pool.len() as u16);
+                            0
+                        }
+                    }
+                    // NewThread(threadStyle, threadEntry, threadParam,
+                    //           stackSize, options, threadResult, threadMade)
+                    0x0E03 => {
+                        let thread_made = bus.read_long(sp);
+                        let result_destination = bus.read_long(sp + 4);
+                        let options = bus.read_long(sp + 8);
+                        let stack_size = bus.read_long(sp + 12);
+                        let thread_param = bus.read_long(sp + 16);
+                        let thread_entry = bus.read_long(sp + 20);
+                        let thread_style = bus.read_long(sp + 24);
+
+                        if thread_made == 0
+                            || thread_entry == 0
+                            || thread_style & K_PREEMPTIVE_THREAD != 0
+                        {
+                            if thread_made != 0 {
+                                bus.write_long(thread_made, 0);
+                            }
+                            -50
+                        } else {
+                            let thread_id = self.next_cooperative_thread_id;
+                            self.next_cooperative_thread_id =
+                                self.next_cooperative_thread_id.saturating_add(1);
+
+                            let stack_size = if stack_size == 0 {
+                                self.cooperative_thread_stack_size
+                            } else {
+                                stack_size
+                            };
+                            let (stack_base, stack_limit) =
+                                self.acquire_cooperative_thread_stack(bus, stack_size);
+
+                            // Seed the private stack as though the entry proc
+                            // had been called by the trampoline: return
+                            // address, then the single Pascal argument.
+                            let return_trampoline = self.thread_return_trampoline(bus);
+                            let entry_sp = stack_limit.wrapping_sub(8);
+                            bus.write_long(entry_sp, return_trampoline);
+                            bus.write_long(entry_sp + 4, thread_param);
+
+                            let state = if options & K_NEW_SUSPEND != 0 {
+                                Self::THREAD_STATE_STOPPED
+                            } else {
+                                Self::THREAD_STATE_READY
+                            };
+                            let mut thread =
+                                Self::capture_cooperative_thread(cpu, state, result_destination);
+                            thread.pc = thread_entry;
+                            thread.a_regs[7] = entry_sp;
+                            thread.stack_base = stack_base;
+                            thread.stack_limit = stack_limit;
+                            self.cooperative_threads.insert(thread_id, thread);
+                            if state == Self::THREAD_STATE_READY {
+                                self.cooperative_thread_ready.push_back(thread_id);
+                            }
+                            bus.write_long(thread_made, thread_id);
+                            0
+                        }
+                    }
+                    // DisposeThread(threadToDump, threadResult, recycleThread)
+                    0x0504 => {
+                        let _recycle = bus.read_word(sp) != 0;
+                        let thread_result = bus.read_long(sp + 2);
+                        let thread_to_dump =
+                            self.resolve_cooperative_thread_id(bus.read_long(sp + 6));
+                        if !self.cooperative_threads.contains_key(&thread_to_dump)
+                            && thread_to_dump != Self::APPLICATION_THREAD_ID
+                        {
+                            Self::THREAD_NOT_FOUND_ERR
+                        } else if thread_to_dump == self.current_cooperative_thread {
+                            // Threads.h allows a thread to dispose of itself;
+                            // the call never returns to it.
+                            self.retire_cooperative_thread(thread_to_dump, thread_result, bus);
+                            self.finish_cooperative_thread(cpu, bus);
+                            return Some(Ok(()));
+                        } else {
+                            self.retire_cooperative_thread(thread_to_dump, thread_result, bus);
+                            0
+                        }
+                    }
+                    // YieldToThread(suggestedThread) — also the tail of
+                    // YieldToAnyThread, which pushes kNoThreadID first.
+                    0x0205 => {
+                        let suggested_thread = bus.read_long(sp);
+                        bus.write_word(sp + 4, 0);
+                        cpu.write_reg(Register::A7, sp + 4);
+                        cpu.write_reg(Register::D0, 0);
+                        self.yield_cooperative_thread(cpu, suggested_thread);
+                        return Some(Ok(()));
+                    }
+                    // GetCurrentThread(currentThreadID)
+                    0x0206 => {
+                        let current_thread = bus.read_long(sp);
+                        if current_thread == 0 {
+                            -50
+                        } else {
+                            bus.write_long(current_thread, self.current_cooperative_thread);
+                            0
+                        }
+                    }
+                    // GetThreadState(threadToGet, threadState)
+                    0x0407 => {
+                        let thread_state = bus.read_long(sp);
+                        let thread_to_get =
+                            self.resolve_cooperative_thread_id(bus.read_long(sp + 4));
+                        if thread_state == 0 {
+                            -50
+                        } else {
+                            match self.cooperative_thread_mut(cpu, thread_to_get) {
+                                Some(thread) => {
+                                    let state = thread.state;
+                                    bus.write_word(thread_state, state);
+                                    0
+                                }
+                                None => Self::THREAD_NOT_FOUND_ERR,
+                            }
+                        }
+                    }
+                    // SetThreadState(threadToSet, newState, suggestedThread)
+                    // and SetThreadStateEndCritical, which additionally
+                    // performs the ThreadEndCritical the caller owes.
+                    0x0508 | 0x0512 => {
+                        let suggested_thread = bus.read_long(sp);
+                        let new_state = bus.read_word(sp + 4);
+                        let thread_to_set =
+                            self.resolve_cooperative_thread_id(bus.read_long(sp + 6));
+                        if selector == 0x0512 {
+                            self.thread_critical_nesting =
+                                self.thread_critical_nesting.saturating_sub(1);
+                        }
+                        match self.cooperative_thread_mut(cpu, thread_to_set) {
+                            None => Self::THREAD_NOT_FOUND_ERR,
+                            Some(thread) => {
+                                let was_running = thread.state == Self::THREAD_STATE_RUNNING;
+                                thread.state = new_state;
+                                self.cooperative_thread_ready
+                                    .retain(|queued| *queued != thread_to_set);
+                                if new_state == Self::THREAD_STATE_READY {
+                                    self.cooperative_thread_ready.push_back(thread_to_set);
+                                }
+                                // Stopping the running thread must hand the
+                                // CPU to someone else immediately.
+                                if was_running && new_state != Self::THREAD_STATE_RUNNING {
+                                    bus.write_word(sp + 10, 0);
+                                    cpu.write_reg(Register::A7, sp + 10);
+                                    cpu.write_reg(Register::D0, 0);
+                                    self.save_current_cooperative_thread(cpu);
+                                    if let Some(next_id) =
+                                        self.next_ready_cooperative_thread(suggested_thread)
+                                    {
+                                        self.switch_to_cooperative_thread(cpu, next_id);
+                                    }
+                                    return Some(Ok(()));
+                                }
+                                0
+                            }
+                        }
+                    }
+                    // SetThreadScheduler(threadScheduler)
+                    0x0209 => {
+                        self.cooperative_thread_scheduler = bus.read_long(sp);
+                        0
+                    }
+                    // SetThreadSwitcher(thread, threadSwitcher,
+                    //                   switchProcParam, inOrOut)
+                    0x070A => {
+                        let switch_in = bus.read_word(sp) != 0;
+                        let switch_proc_param = bus.read_long(sp + 2);
+                        let thread_switcher = bus.read_long(sp + 6);
+                        let thread = self.resolve_cooperative_thread_id(bus.read_long(sp + 10));
+                        match self.cooperative_thread_mut(cpu, thread) {
+                            None => Self::THREAD_NOT_FOUND_ERR,
+                            Some(record) => {
+                                if switch_in {
+                                    record.switch_in = (thread_switcher, switch_proc_param);
+                                } else {
+                                    record.switch_out = (thread_switcher, switch_proc_param);
+                                }
+                                0
+                            }
+                        }
+                    }
+                    // ThreadBeginCritical
                     0x000B => {
                         self.thread_critical_nesting =
                             self.thread_critical_nesting.saturating_add(1);
                         0
                     }
-                    0x000C if self.thread_critical_nesting == 0 => -619,
+                    // ThreadEndCritical
+                    0x000C if self.thread_critical_nesting == 0 => Self::THREAD_PROTOCOL_ERR,
                     0x000C => {
                         self.thread_critical_nesting -= 1;
                         0
                     }
+                    // SetThreadTerminator(thread, threadTerminator,
+                    //                     terminationProcParam)
+                    0x0611 => {
+                        let termination_proc_param = bus.read_long(sp);
+                        let thread_terminator = bus.read_long(sp + 4);
+                        let thread = self.resolve_cooperative_thread_id(bus.read_long(sp + 8));
+                        match self.cooperative_thread_mut(cpu, thread) {
+                            None => Self::THREAD_NOT_FOUND_ERR,
+                            Some(record) => {
+                                record.terminator = (thread_terminator, termination_proc_param);
+                                0
+                            }
+                        }
+                    }
+                    // SetDebuggerNotificationProcs(notifyNewThread,
+                    //     notifyDisposeThread, notifyThreadScheduler).
+                    // Systemless hosts no 68K debugger, so the notification
+                    // procs are accepted and never called.
+                    0x060D => 0,
+                    // GetThreadCurrentTaskRef(threadTRef). Systemless runs a
+                    // single Thread Manager task; its ref is the application
+                    // thread's ID, which is a stable non-nil token.
+                    0x020E => {
+                        let thread_t_ref = bus.read_long(sp);
+                        if thread_t_ref == 0 {
+                            -50
+                        } else {
+                            bus.write_long(thread_t_ref, Self::APPLICATION_THREAD_ID);
+                            0
+                        }
+                    }
+                    // GetThreadStateGivenTaskRef(threadTRef, threadToGet,
+                    //                            threadState)
+                    0x060F => {
+                        let thread_state = bus.read_long(sp);
+                        let thread_to_get =
+                            self.resolve_cooperative_thread_id(bus.read_long(sp + 4));
+                        if thread_state == 0 {
+                            -50
+                        } else {
+                            match self.cooperative_thread_mut(cpu, thread_to_get) {
+                                Some(thread) => {
+                                    let state = thread.state;
+                                    bus.write_word(thread_state, state);
+                                    0
+                                }
+                                None => Self::THREAD_NOT_FOUND_ERR,
+                            }
+                        }
+                    }
+                    // SetThreadReadyGivenTaskRef(threadTRef, threadToSet)
+                    0x0410 => {
+                        let thread_to_set = self.resolve_cooperative_thread_id(bus.read_long(sp));
+                        match self.cooperative_thread_mut(cpu, thread_to_set) {
+                            None => Self::THREAD_NOT_FOUND_ERR,
+                            Some(thread) => {
+                                if thread.state == Self::THREAD_STATE_STOPPED {
+                                    thread.state = Self::THREAD_STATE_READY;
+                                    self.cooperative_thread_ready.push_back(thread_to_set);
+                                }
+                                0
+                            }
+                        }
+                    }
+                    // GetDefaultThreadStackSize(threadStyle, stackSize)
+                    0x0413 => {
+                        let stack_size = bus.read_long(sp);
+                        let thread_style = bus.read_long(sp + 4);
+                        if stack_size == 0 || thread_style & K_PREEMPTIVE_THREAD != 0 {
+                            -50
+                        } else {
+                            bus.write_long(stack_size, self.cooperative_thread_stack_size);
+                            0
+                        }
+                    }
+                    // ThreadCurrentStackSpace(thread, freeStack)
+                    0x0414 => {
+                        let free_stack = bus.read_long(sp);
+                        let thread = self.resolve_cooperative_thread_id(bus.read_long(sp + 4));
+                        if free_stack == 0 {
+                            -50
+                        } else {
+                            let running = thread == self.current_cooperative_thread;
+                            let current_sp = cpu.read_reg(Register::A7);
+                            match self.cooperative_thread_mut(cpu, thread) {
+                                None => Self::THREAD_NOT_FOUND_ERR,
+                                Some(record) => {
+                                    let stack_pointer = if running {
+                                        current_sp
+                                    } else {
+                                        record.a_regs[7]
+                                    };
+                                    let free = stack_pointer.saturating_sub(record.stack_base);
+                                    // The application thread keeps the process
+                                    // stack, whose base this record does not
+                                    // track; report the default size instead of
+                                    // a bogus multi-megabyte figure.
+                                    let free = if record.stack_base == 0 {
+                                        DEFAULT_COOPERATIVE_THREAD_STACK_SIZE
+                                    } else {
+                                        free
+                                    };
+                                    bus.write_long(free_stack, free);
+                                    0
+                                }
+                            }
+                        }
+                    }
+                    // GetSpecificFreeThreadCount(threadStyle, stackSize,
+                    //                            freeCount)
+                    0x0615 => {
+                        let free_count = bus.read_long(sp);
+                        let stack_size = bus.read_long(sp + 4);
+                        let thread_style = bus.read_long(sp + 8);
+                        if free_count == 0 || thread_style & K_PREEMPTIVE_THREAD != 0 {
+                            -50
+                        } else {
+                            let matching = self
+                                .cooperative_thread_pool
+                                .iter()
+                                .filter(|(base, limit)| limit.saturating_sub(*base) >= stack_size)
+                                .count();
+                            bus.write_word(free_count, matching as u16);
+                            0
+                        }
+                    }
                     _ => -50,
                 };
-                bus.write_word(sp, result as u16);
+                let argument_bytes = (selector >> 8) * 2;
+                bus.write_word(sp + argument_bytes, result as u16);
                 if result == 0 {
-                    return_noerr(cpu)
+                    return_noerr_and_pop(cpu, argument_bytes)
                 } else {
-                    return_error_and_pop(cpu, 0, result)
+                    return_error_and_pop(cpu, argument_bytes, result)
                 }
             }
 
@@ -22431,6 +23154,168 @@ mod tests {
         assert_eq!(disp.thread_critical_nesting, 0);
     }
 
+    /// `NewThread` (selector $0E03) banks a ready cooperative context and
+    /// consumes the 28-byte MPW frame the selector's high byte encodes.
+    /// MPW Interfaces/CIncludes/Threads.h, Universal Interfaces 2.0a3.
+    #[test]
+    fn threaddispatch_newthread_creates_ready_cooperative_thread_and_consumes_mpw_frame() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let sp = TEST_SP;
+        let thread_made = TEST_SP + 0x400;
+        let thread_result = TEST_SP + 0x410;
+        cpu.write_reg(Register::A7, sp);
+        // Pushed left to right: threadStyle, threadEntry, threadParam,
+        // stackSize, options, threadResult, threadMade.
+        bus.write_long(sp, thread_made);
+        bus.write_long(sp + 4, thread_result);
+        bus.write_long(sp + 8, 0); // options
+        bus.write_long(sp + 12, 4096); // stackSize
+        bus.write_long(sp + 16, 0xCAFE_F00D); // threadParam
+        bus.write_long(sp + 20, 0x0004_2000); // threadEntry
+        bus.write_long(sp + 24, 1); // kCooperativeThread
+
+        cpu.write_reg(Register::D0, 0x0000_0E03);
+        let result = disp.dispatch_toolbox(true, 0x3F2, &mut cpu, &mut bus);
+        assert!(result.is_some(), "ThreadDispatch should handle NewThread");
+        assert!(result.unwrap().is_ok(), "NewThread should return");
+
+        assert_eq!(cpu.read_reg(Register::D0), 0, "NewThread should return noErr");
+        assert_eq!(
+            cpu.read_reg(Register::A7),
+            sp + 28,
+            "NewThread should pop its 28-byte Pascal frame"
+        );
+
+        let new_id = bus.read_long(thread_made);
+        assert!(new_id >= 3, "new ThreadID must not reuse a reserved ID");
+        let thread = disp
+            .cooperative_threads
+            .get(&new_id)
+            .expect("NewThread should bank a context");
+        assert_eq!(thread.pc, 0x0004_2000, "entry proc becomes the thread PC");
+        assert_eq!(thread.state, 0, "an unsuspended thread starts ready");
+        assert_eq!(thread.result_destination, thread_result);
+        assert!(
+            disp.cooperative_thread_ready.contains(&new_id),
+            "a ready thread must be queued for scheduling"
+        );
+        // The private stack is seeded as though the entry proc had been
+        // called: return address, then its single Pascal argument.
+        assert_eq!(
+            bus.read_long(thread.a_regs[7] + 4),
+            0xCAFE_F00D,
+            "threadParam must be the entry proc's argument"
+        );
+    }
+
+    /// `kPreemptiveThread` has no 68K implementation, so `NewThread` must
+    /// refuse it rather than hand back an unschedulable ID.
+    #[test]
+    fn threaddispatch_newthread_rejects_preemptive_style_with_param_err() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let sp = TEST_SP;
+        let thread_made = TEST_SP + 0x400;
+        cpu.write_reg(Register::A7, sp);
+        bus.write_long(sp, thread_made);
+        bus.write_long(sp + 4, 0);
+        bus.write_long(sp + 8, 0);
+        bus.write_long(sp + 12, 4096);
+        bus.write_long(sp + 16, 0);
+        bus.write_long(sp + 20, 0x0004_2000);
+        bus.write_long(sp + 24, 2); // kPreemptiveThread
+
+        cpu.write_reg(Register::D0, 0x0000_0E03);
+        disp.dispatch_toolbox(true, 0x3F2, &mut cpu, &mut bus)
+            .expect("ThreadDispatch should handle NewThread")
+            .expect("NewThread should return");
+
+        assert_eq!(cpu.read_reg(Register::D0) as i16, -50);
+        assert_eq!(cpu.read_reg(Register::A7), sp + 28);
+        assert_eq!(bus.read_long(thread_made), 0, "no ThreadID on failure");
+        assert!(disp.cooperative_threads.is_empty());
+    }
+
+    /// `GetCurrentThread` reports the application thread before any
+    /// `NewThread`, and `GetThreadState` materialises that implicit record
+    /// rather than failing with threadNotFoundErr.
+    #[test]
+    fn threaddispatch_get_and_set_thread_state_track_the_ready_queue() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let sp = TEST_SP;
+        let out = TEST_SP + 0x400;
+
+        cpu.write_reg(Register::A7, sp);
+        bus.write_long(sp, out);
+        cpu.write_reg(Register::D0, 0x0000_0206); // GetCurrentThread
+        disp.dispatch_toolbox(true, 0x3F2, &mut cpu, &mut bus)
+            .expect("GetCurrentThread handled")
+            .expect("GetCurrentThread returns");
+        assert_eq!(cpu.read_reg(Register::D0), 0);
+        assert_eq!(cpu.read_reg(Register::A7), sp + 4);
+        assert_eq!(
+            bus.read_long(out),
+            2,
+            "kApplicationThreadID is the launch thread"
+        );
+
+        // GetThreadState(kCurrentThreadID, &state)
+        cpu.write_reg(Register::A7, sp);
+        bus.write_long(sp, out);
+        bus.write_long(sp + 4, 1); // kCurrentThreadID
+        cpu.write_reg(Register::D0, 0x0000_0407);
+        disp.dispatch_toolbox(true, 0x3F2, &mut cpu, &mut bus)
+            .expect("GetThreadState handled")
+            .expect("GetThreadState returns");
+        assert_eq!(cpu.read_reg(Register::D0), 0);
+        assert_eq!(cpu.read_reg(Register::A7), sp + 8);
+        assert_eq!(
+            bus.read_word(out),
+            2,
+            "the running thread reports kRunningThreadState"
+        );
+    }
+
+    /// `SetThreadSwitcher` and `SetThreadTerminator` record their procs per
+    /// thread, and the switch-in and switch-out slots stay independent.
+    #[test]
+    fn threaddispatch_switcher_and_terminator_are_recorded_per_thread() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let sp = TEST_SP;
+
+        // SetThreadSwitcher(thread, switcher, param, inOrOut=true)
+        cpu.write_reg(Register::A7, sp);
+        bus.write_word(sp, 0x0100); // Boolean true in the high byte
+        bus.write_long(sp + 2, 0x1111_2222); // switchProcParam
+        bus.write_long(sp + 6, 0x0003_0000); // threadSwitcher
+        bus.write_long(sp + 10, 2); // kApplicationThreadID
+        cpu.write_reg(Register::D0, 0x0000_070A);
+        disp.dispatch_toolbox(true, 0x3F2, &mut cpu, &mut bus)
+            .expect("SetThreadSwitcher handled")
+            .expect("SetThreadSwitcher returns");
+        assert_eq!(cpu.read_reg(Register::D0), 0);
+        assert_eq!(cpu.read_reg(Register::A7), sp + 14);
+
+        // SetThreadTerminator(thread, terminator, param)
+        cpu.write_reg(Register::A7, sp);
+        bus.write_long(sp, 0x3333_4444);
+        bus.write_long(sp + 4, 0x0003_1000);
+        bus.write_long(sp + 8, 2);
+        cpu.write_reg(Register::D0, 0x0000_0611);
+        disp.dispatch_toolbox(true, 0x3F2, &mut cpu, &mut bus)
+            .expect("SetThreadTerminator handled")
+            .expect("SetThreadTerminator returns");
+        assert_eq!(cpu.read_reg(Register::D0), 0);
+        assert_eq!(cpu.read_reg(Register::A7), sp + 12);
+
+        let thread = disp
+            .cooperative_threads
+            .get(&2)
+            .expect("the application thread record must exist");
+        assert_eq!(thread.switch_in, (0x0003_0000, 0x1111_2222));
+        assert_eq!(thread.switch_out, (0, 0), "switch-out stays unset");
+        assert_eq!(thread.terminator, (0x0003_1000, 0x3333_4444));
+    }
+
     #[test]
     fn threaddispatch_endcritical_underflow_returns_thread_protocol_err() {
         let (mut disp, mut cpu, mut bus) = setup();
@@ -27383,7 +28268,10 @@ mod tests {
         let result = disp.dispatch_toolbox(true, 0x2AA, &mut cpu, &mut bus);
 
         assert!(result.is_some(), "DisposeMovieController should be handled");
-        assert!(result.unwrap().is_ok(), "DisposeMovieController should return");
+        assert!(
+            result.unwrap().is_ok(),
+            "DisposeMovieController should return"
+        );
         assert_eq!(cpu.read_reg(Register::A7), sp + 4);
         assert_eq!(cpu.read_reg(Register::D0), 0);
     }


### PR DESCRIPTION
Warcraft II: Tides of Darkness (shareware 1.2) went from refusing to launch to playing the Human Hillsbrad campaign. Three generic Toolbox gaps stood between those two states, each hidden behind the previous one.

Closes #108

## 1. Cooperative Thread Manager

`Gestalt('thds')` was unknown, so the game's availability check failed and it quit with *"Sorry, this program requires the Thread Manager Extension or System 7.5."* before drawing anything.

Inside Macintosh: Operating System Utilities 1994, p. 2448 documents only the gate — `gestaltThreadMgrAttr` bit 0, `gestaltThreadMgrPresent`. The routine selectors come from MPW `Interfaces/CIncludes/Threads.h` (Universal Interfaces 2.0a3, ETO #16, 11 November 1994), which declares each entry point as `THREEWORDINLINE(0x303C, <selector>, 0xABF2)`. The full table is now implemented and cited in the trap comment, with the selector's high byte giving the Pascal frame size in stack words.

Systemless runs the guest on one host thread and switches contexts entirely inside `_ThreadDispatch`, so the whole caller-visible register file can be banked with no host concurrency involved. `kCooperativeThread` is the only supported style; `kPreemptiveThread` returns `paramErr`.

## 2. `MenuInfo.menuProc` was always NIL

Inside Macintosh Volume I, I-352 makes the menu definition procedure part of the menu record's public contract, and I-366 is explicit that the resource's four bytes are "a placeholder for the handle to the procedure" which `GetMenu` **replaces**. Systemless wrote zero and left it there, so an application calling the MDEF directly dereferenced address zero:

```
00864692  MOVEA.L d16(A2),A2   ; A2 = theMenu->menuProc  -> $00000000
008646B8  MOVEA.L (A2),A3      ; A3 = *menuProc          -> reads address 0
008646CC  JSR (A3)             ; jumps to $40810000
```

Every menu record now gets a handle to a ten-byte guest stub:

```
MOVE.W  #$FEFC,D0     ; private Systemless trampoline selector
_Pack8                ; re-enters the HLE
RTD     #18           ; pop the MDEF's Pascal frame
```

`_Pack8` is already the dispatch trap reserved for guest-to-HLE trampoline returns (`$FEFE` finalises an AppleEvent handler call), so `$FEFC` names the synthetic `'MDEF' 0` in the same private selector space. `mSizeMsg` shares one code path with `CalcMenuSize` — I-352 and I-361 define them as the same operation — and `mChooseMsg` hit-tests `hitPt` against `menuRect`, returning 0 for a miss, a disabled menu, a divider or a disabled item.

Telling the resource placeholder apart from a handle an application installed itself uses the same "does the entry look callable" test the Window Manager already applies to a guest `'WDEF'`.

## 3. Sound Manager callback trampolines were written once

The callback trampoline was allocated lazily with its opcodes written only at allocation time. A sound callback runs at interrupt time against whatever the application has since done to the heap, and Warcraft II clobbers that block between callbacks, so a later `callBackCmd` jumped into what had become sample data:

```
[CPU] IllegalInstruction: $1846 at PC=$00BA1834
```

The opcodes are now rewritten on every dispatch, for both the command-callback and file-completion trampolines — which is what the Window Manager's WDEF trampoline already does for the same reason.

## Also included

- **SANE `FOD2B`** (`$0009`): decimal-record to binary conversion, plus `CStr2Dec` (Pack7 selector 4) sharing its scanner with `Str2Dec`. Apple Numerics Manual (1988), Decimal-to-Binary Conversion.
- **`PBHGetVInfo` enumeration**: a positive `ioVolIndex` past the single mounted boot volume now ends the walk with `nsvErr` instead of re-reporting the boot volume forever. Files 1992, 2-145.

## Validation

Driven from launch through real gameplay, the game now runs to completion — 1,296,272,327 instructions with no halt — reaching the shareware main menu, the Human Hillsbrad briefing, the live mission, then selecting a Footman and ordering it to move.

Compared frame by frame against BasiliskII driven with the same input sequence, **inside the game's own 640x480 canvas the two runtimes are pixel identical**.

The whole-frame strict-parity figures — 63.98% at the main menu, 80.26% at the campaign briefing, and 51-53% in the mission — are accounted for entirely by the letterbox around that canvas. Warcraft II runs full screen at 640x480 centred in the 800x600 device and never draws the surround, so those pixels keep the startup blanking fill of colour index 255, which is black in the standard Macintosh colour table but white in the Windows-ordered palette the game installs for its cross-platform art. BasiliskII renders black there, Systemless white. That is a separate, well-scoped gap and I'll raise it on its own.

The startup frame is limited instead by Dialog Manager chrome: Systemless has no Finder desktop, menu bar or tab control to draw behind the game's options dialog.

### Tests

`cargo test` is green — 2712 lib tests, no failures — with seven new regression tests:

- `threaddispatch_newthread_creates_ready_cooperative_thread_and_consumes_mpw_frame`
- `threaddispatch_newthread_rejects_preemptive_style_with_param_err`
- `threaddispatch_get_and_set_thread_state_track_the_ready_queue`
- `threaddispatch_switcher_and_terminator_are_recorded_per_thread`
- `newmenu_installs_a_callable_menu_definition_procedure_handle`
- `menu_def_proc_size_message_fills_menu_width_and_height`
- `menu_def_proc_choose_message_reports_the_item_under_the_point`

Two other games that previously diverged from their BasiliskII references now match as well.

`cargo fmt` clean on every file touched. No per-game special cases: every change is a generic Toolbox behaviour cited to Inside Macintosh or the MPW interfaces.
