### PR TITLE
feat: implement the full Thread Manager selector table for cooperative threads

### DIFF
--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -712,6 +712,12 @@ pub(crate) struct LoadSegGetResourceState {
     pub a_regs: [u32; 8],
 }
 
+/// Stack size handed to a cooperative thread when `NewThread` is passed 0
+/// and the size reported by `GetDefaultThreadStackSize`. The 68K Thread
+/// Manager's own default is a small multiple of a page; 32K comfortably
+/// covers the Toolbox call depth Systemless threads reach.
+pub(crate) const DEFAULT_COOPERATIVE_THREAD_STACK_SIZE: u32 = 32 * 1024;
+
 /// Saved 68K state for one cooperative Thread Manager thread.
 ///
 /// Cooperative switches occur only inside `_ThreadDispatch`, so the HLE can
@@ -724,8 +730,21 @@ pub(crate) struct CooperativeThread {
     pub(crate) a_regs: [u32; 8],
     pub(crate) pc: u32,
     pub(crate) ccr: u8,
+    /// `ThreadState` from Threads.h: 0 ready, 1 stopped, 2 running.
     pub(crate) state: u16,
+    /// `void **threadResult` the entry proc's return value is stored to.
     pub(crate) result_destination: u32,
+    /// Lowest address of the private guest stack, or 0 for the
+    /// application thread, which keeps the process stack.
+    pub(crate) stack_base: u32,
+    /// Address one past the top of the private guest stack.
+    pub(crate) stack_limit: u32,
+    /// `SetThreadSwitcher` switch-in proc and its `switchProcParam`.
+    pub(crate) switch_in: (u32, u32),
+    /// `SetThreadSwitcher` switch-out proc and its `switchProcParam`.
+    pub(crate) switch_out: (u32, u32),
+    /// `SetThreadTerminator` proc and its `terminationProcParam`.
+    pub(crate) terminator: (u32, u32),
 }
 
 /// In-flight AppleEvent handler call. Built by Pack8 routine 27
@@ -1130,6 +1149,14 @@ pub struct TrapDispatcher {
     pub(crate) next_cooperative_thread_id: u32,
     /// Guest trampoline entered when a ThreadEntryProc returns.
     pub(crate) thread_return_trampoline: u32,
+    /// Custom `ThreadSchedulerProcPtr` installed by `SetThreadScheduler`.
+    pub(crate) cooperative_thread_scheduler: u32,
+    /// Default cooperative stack size reported by
+    /// `GetDefaultThreadStackSize` and used when `NewThread` is passed 0.
+    pub(crate) cooperative_thread_stack_size: u32,
+    /// Cooperative stacks banked by `CreateThreadPool` and recycled by
+    /// `DisposeThread`, reused by `NewThread` before allocating.
+    pub(crate) cooperative_thread_pool: Vec<(u32, u32)>,
     /// Synthetic Component Manager instances opened for HLE-provided
     /// components such as the QuickTime movie controller.
     pub(crate) synthetic_component_instances: HashSet<u32>,
@@ -2733,6 +2760,9 @@ impl TrapDispatcher {
             current_cooperative_thread: 2,
             next_cooperative_thread_id: 3,
             thread_return_trampoline: 0,
+            cooperative_thread_scheduler: 0,
+            cooperative_thread_stack_size: DEFAULT_COOPERATIVE_THREAD_STACK_SIZE,
+            cooperative_thread_pool: Vec::new(),
             synthetic_component_instances: HashSet::new(),
             next_synthetic_component_instance: 0x00C1_0001,
             saved_draw_old_regions: HashMap::new(),

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -394,20 +394,18 @@ fn scan_quicktime_atoms(
                     let (parsed_time_scale, parsed_duration) = if version == 0 {
                         (
                             read_quicktime_u32(payload, 12),
-                            read_quicktime_u32(payload, 16)
-                                .map(|value| value.min(i32::MAX as u32)),
+                            read_quicktime_u32(payload, 16).map(|value| value.min(i32::MAX as u32)),
                         )
                     } else if payload.len() >= 32 {
                         (
                             read_quicktime_u32(payload, 20),
-                            read_quicktime_u32(payload, 28)
-                                .map(|value| value.min(i32::MAX as u32)),
+                            read_quicktime_u32(payload, 28).map(|value| value.min(i32::MAX as u32)),
                         )
                     } else {
                         (None, None)
                     };
-                    if let Some(value) = parsed_time_scale
-                        .filter(|value| *value > 0 && *value <= i32::MAX as u32)
+                    if let Some(value) =
+                        parsed_time_scale.filter(|value| *value > 0 && *value <= i32::MAX as u32)
                     {
                         *time_scale = Some(value as i32);
                     }
@@ -444,13 +442,7 @@ fn quicktime_movie_metadata(data: &[u8]) -> ((i16, i16, i16, i16), i32, i32) {
     let mut bounds = None;
     let mut duration = None;
     let mut time_scale = None;
-    scan_quicktime_atoms(
-        data,
-        0,
-        &mut bounds,
-        &mut duration,
-        &mut time_scale,
-    );
+    scan_quicktime_atoms(data, 0, &mut bounds, &mut duration, &mut time_scale);
     (
         bounds.unwrap_or((0, 0, 120, 160)),
         duration.unwrap_or(1),
@@ -726,6 +718,17 @@ impl super::TrapDispatcher {
     const ALIAS_EXTRA_PARENT_DIR_NAME: i16 = 0;
     const ALIAS_EXTRA_END: i16 = -1;
 
+    /// `kApplicationThreadID` from Threads.h — the thread the process
+    /// launches on, which owns the process stack rather than a pooled one.
+    const APPLICATION_THREAD_ID: u32 = 2;
+    /// `ThreadState` values from Threads.h.
+    const THREAD_STATE_READY: u16 = 0;
+    const THREAD_STATE_STOPPED: u16 = 1;
+    const THREAD_STATE_RUNNING: u16 = 2;
+    /// `threadNotFoundErr` and `threadProtocolErr` from Errors.h.
+    const THREAD_NOT_FOUND_ERR: i16 = -617;
+    const THREAD_PROTOCOL_ERR: i16 = -619;
+
     fn capture_cooperative_thread<C: CpuOps>(
         cpu: &C,
         state: u16,
@@ -758,6 +761,11 @@ impl super::TrapDispatcher {
             ccr: cpu.get_ccr(),
             state,
             result_destination,
+            stack_base: 0,
+            stack_limit: 0,
+            switch_in: (0, 0),
+            switch_out: (0, 0),
+            terminator: (0, 0),
         }
     }
 
@@ -804,81 +812,216 @@ impl super::TrapDispatcher {
         self.thread_return_trampoline
     }
 
+    /// Resolve a guest-supplied ThreadID. `kCurrentThreadID` (1) and
+    /// `kNoThreadID` (0) both name the running thread, per Threads.h.
+    fn resolve_cooperative_thread_id(&self, thread_id: u32) -> u32 {
+        if thread_id == 0 || thread_id == 1 {
+            self.current_cooperative_thread
+        } else {
+            thread_id
+        }
+    }
+
+    /// Materialise the record for the thread the process launched on.
+    /// `kApplicationThreadID` exists implicitly from launch, so
+    /// `GetThreadState`, `SetThreadSwitcher` and friends must find it
+    /// without a prior `NewThread`.
+    fn cooperative_thread_mut<C: CpuOps>(
+        &mut self,
+        cpu: &C,
+        thread_id: u32,
+    ) -> Option<&mut CooperativeThread> {
+        if thread_id == Self::APPLICATION_THREAD_ID
+            && !self
+                .cooperative_threads
+                .contains_key(&Self::APPLICATION_THREAD_ID)
+        {
+            let state = if self.current_cooperative_thread == Self::APPLICATION_THREAD_ID {
+                Self::THREAD_STATE_RUNNING
+            } else {
+                Self::THREAD_STATE_READY
+            };
+            let thread = Self::capture_cooperative_thread(cpu, state, 0);
+            self.cooperative_threads
+                .insert(Self::APPLICATION_THREAD_ID, thread);
+        }
+        self.cooperative_threads.get_mut(&thread_id)
+    }
+
+    /// Save the running thread's registers into its record without
+    /// changing its scheduling state.
+    fn save_current_cooperative_thread<C: CpuOps>(&mut self, cpu: &C) {
+        let current_id = self.current_cooperative_thread;
+        let saved = Self::capture_cooperative_thread(cpu, Self::THREAD_STATE_RUNNING, 0);
+        match self.cooperative_thread_mut(cpu, current_id) {
+            Some(thread) => {
+                thread.d_regs = saved.d_regs;
+                thread.a_regs = saved.a_regs;
+                thread.pc = saved.pc;
+                thread.ccr = saved.ccr;
+            }
+            None => {
+                self.cooperative_threads.insert(current_id, saved);
+            }
+        }
+    }
+
+    /// Pick the next ready thread. `suggested_thread` wins when it names a
+    /// ready thread, matching `YieldToThread`; otherwise the ready queue
+    /// runs round-robin, as the stock 68K scheduler does.
+    fn next_ready_cooperative_thread(&mut self, suggested_thread: u32) -> Option<u32> {
+        let current_id = self.current_cooperative_thread;
+        if suggested_thread > 1 && suggested_thread != current_id {
+            if let Some(position) = self
+                .cooperative_thread_ready
+                .iter()
+                .position(|thread_id| *thread_id == suggested_thread)
+            {
+                return self.cooperative_thread_ready.remove(position);
+            }
+        }
+        for _ in 0..self.cooperative_thread_ready.len() {
+            let candidate = self.cooperative_thread_ready.pop_front()?;
+            if candidate == current_id {
+                self.cooperative_thread_ready.push_back(candidate);
+                continue;
+            }
+            let ready = self
+                .cooperative_threads
+                .get(&candidate)
+                .is_some_and(|thread| thread.state == Self::THREAD_STATE_READY);
+            if ready {
+                return Some(candidate);
+            }
+        }
+        None
+    }
+
+    /// Install `next_id` as the running thread. The caller has already
+    /// saved and re-queued the outgoing context.
+    fn switch_to_cooperative_thread<C: CpuOps>(&mut self, cpu: &mut C, next_id: u32) -> bool {
+        let Some(mut next) = self.cooperative_threads.get(&next_id).cloned() else {
+            return false;
+        };
+        if next.state != Self::THREAD_STATE_READY {
+            self.cooperative_thread_ready.push_back(next_id);
+            return false;
+        }
+        next.state = Self::THREAD_STATE_RUNNING;
+        Self::install_cooperative_thread(cpu, &next);
+        self.cooperative_threads.insert(next_id, next);
+        self.current_cooperative_thread = next_id;
+        true
+    }
+
+    /// `YieldToThread` and `YieldToAnyThread`. A yield inside a critical
+    /// section is a no-op: Threads.h documents `ThreadBeginCritical` as
+    /// suppressing scheduling until the matching end.
     fn yield_cooperative_thread<C: CpuOps>(&mut self, cpu: &mut C, suggested_thread: u32) {
-        if self.thread_critical_nesting != 0 {
+        if self.thread_critical_nesting != 0 || self.cooperative_thread_ready.is_empty() {
             return;
         }
 
         let current_id = self.current_cooperative_thread;
-        let result_destination = self
+        self.save_current_cooperative_thread(cpu);
+        if let Some(thread) = self.cooperative_threads.get_mut(&current_id) {
+            if thread.state == Self::THREAD_STATE_RUNNING {
+                thread.state = Self::THREAD_STATE_READY;
+            }
+        }
+        let requeue = self
             .cooperative_threads
             .get(&current_id)
-            .map_or(0, |thread| thread.result_destination);
-        let current = Self::capture_cooperative_thread(cpu, 0, result_destination);
-        self.cooperative_threads.insert(current_id, current);
-        if !self.cooperative_thread_ready.contains(&current_id) {
+            .is_some_and(|thread| thread.state == Self::THREAD_STATE_READY)
+            && !self.cooperative_thread_ready.contains(&current_id);
+        if requeue {
             self.cooperative_thread_ready.push_back(current_id);
         }
 
-        let preferred = if suggested_thread > 1 && suggested_thread != current_id {
-            self.cooperative_thread_ready
-                .iter()
-                .position(|thread_id| *thread_id == suggested_thread)
-                .and_then(|position| self.cooperative_thread_ready.remove(position))
-        } else {
-            None
-        };
-        let next_id = preferred.or_else(|| {
-            let queue_len = self.cooperative_thread_ready.len();
-            for _ in 0..queue_len {
-                let candidate = self.cooperative_thread_ready.pop_front()?;
-                if candidate != current_id {
-                    return Some(candidate);
-                }
-                self.cooperative_thread_ready.push_back(candidate);
+        let restore_running = |dispatcher: &mut Self| {
+            if let Some(thread) = dispatcher.cooperative_threads.get_mut(&current_id) {
+                thread.state = Self::THREAD_STATE_RUNNING;
             }
-            None
-        });
+            dispatcher
+                .cooperative_thread_ready
+                .retain(|thread_id| *thread_id != current_id);
+        };
 
-        let Some(next_id) = next_id else {
+        let Some(next_id) = self.next_ready_cooperative_thread(suggested_thread) else {
+            restore_running(self);
             return;
         };
-        let Some(mut next) = self.cooperative_threads.get(&next_id).cloned() else {
-            return;
-        };
-        if next.state != 0 {
-            return;
+        if !self.switch_to_cooperative_thread(cpu, next_id) {
+            restore_running(self);
         }
-        next.state = 2;
-        self.cooperative_threads.insert(next_id, next.clone());
-        self.current_cooperative_thread = next_id;
-        Self::install_cooperative_thread(cpu, &next);
     }
 
-    fn finish_cooperative_thread<C: CpuOps>(&mut self, cpu: &mut C, bus: &mut MacMemoryBus) {
-        let finished_id = self.current_cooperative_thread;
-        let result = cpu.read_reg(Register::A0);
-        if let Some(finished) = self.cooperative_threads.remove(&finished_id) {
+    /// Retire `thread_id`, storing its entry-proc result and returning its
+    /// stack to the pool so `NewThread` can recycle it.
+    fn retire_cooperative_thread(&mut self, thread_id: u32, result: u32, bus: &mut MacMemoryBus) {
+        if let Some(finished) = self.cooperative_threads.remove(&thread_id) {
             if finished.result_destination != 0 {
                 bus.write_long(finished.result_destination, result);
             }
+            if finished.stack_base != 0 {
+                self.cooperative_thread_pool
+                    .push((finished.stack_base, finished.stack_limit));
+            }
         }
         self.cooperative_thread_ready
-            .retain(|thread_id| *thread_id != finished_id);
+            .retain(|queued| *queued != thread_id);
+    }
 
-        while let Some(next_id) = self.cooperative_thread_ready.pop_front() {
-            let Some(mut next) = self.cooperative_threads.get(&next_id).cloned() else {
-                continue;
-            };
-            if next.state != 0 {
-                continue;
+    /// Entered through the return trampoline when a `ThreadEntryProc`
+    /// returns. The proc's `void *` result arrives in A0, per the 68K
+    /// convention for a pointer-valued result.
+    fn finish_cooperative_thread<C: CpuOps>(&mut self, cpu: &mut C, bus: &mut MacMemoryBus) {
+        let finished_id = self.current_cooperative_thread;
+        let result = cpu.read_reg(Register::A0);
+        self.retire_cooperative_thread(finished_id, result, bus);
+
+        // The finished thread has no context left to return to, so a
+        // successor must be installed. The application thread always has a
+        // live saved context, so it is the backstop.
+        let next = self
+            .next_ready_cooperative_thread(0)
+            .filter(|next_id| *next_id != finished_id);
+        if let Some(next_id) = next {
+            if self.switch_to_cooperative_thread(cpu, next_id) {
+                return;
             }
-            next.state = 2;
-            self.cooperative_threads.insert(next_id, next.clone());
-            self.current_cooperative_thread = next_id;
-            Self::install_cooperative_thread(cpu, &next);
-            return;
         }
+        if let Some(mut application) = self
+            .cooperative_threads
+            .get(&Self::APPLICATION_THREAD_ID)
+            .cloned()
+        {
+            self.cooperative_thread_ready
+                .retain(|queued| *queued != Self::APPLICATION_THREAD_ID);
+            application.state = Self::THREAD_STATE_RUNNING;
+            Self::install_cooperative_thread(cpu, &application);
+            self.cooperative_threads
+                .insert(Self::APPLICATION_THREAD_ID, application);
+            self.current_cooperative_thread = Self::APPLICATION_THREAD_ID;
+        }
+    }
+
+    /// Claim a pooled stack of at least `stack_size` bytes, or allocate a
+    /// fresh one. Returns `(base, limit)`.
+    fn acquire_cooperative_thread_stack(
+        &mut self,
+        bus: &mut MacMemoryBus,
+        stack_size: u32,
+    ) -> (u32, u32) {
+        if let Some(position) = self
+            .cooperative_thread_pool
+            .iter()
+            .position(|(base, limit)| limit.saturating_sub(*base) >= stack_size)
+        {
+            return self.cooperative_thread_pool.swap_remove(position);
+        }
+        let base = bus.alloc(stack_size);
+        (base, base.wrapping_add(stack_size))
     }
 
     fn apple_event_handler_for(&self, event_class: u32, event_id: u32) -> Option<(u32, u32)> {
@@ -3774,8 +3917,7 @@ impl super::TrapDispatcher {
                 state.last_service_tick = Some(now);
                 // Guest ticks run at 60 Hz; the movie time scale is units per
                 // second. rate is a Fixed (16.16) multiplier on real time.
-                let units_per_tick =
-                    (state.time_scale as i64 * state.rate as i64) / (60 * 65536);
+                let units_per_tick = (state.time_scale as i64 * state.rate as i64) / (60 * 65536);
                 let advance = units_per_tick.saturating_mul(elapsed_ticks as i64);
                 let mut new_time = state.current_time as i64 + advance;
                 let mut finished = false;
@@ -3919,12 +4061,7 @@ impl super::TrapDispatcher {
         if super::dispatch::trace_quicktime_enabled() {
             eprintln!(
                 "[QUICKTIME] render movie=${:08X} sample={}/{} time={} -> port=${:08X} box={:?}",
-                movie,
-                target,
-                media_time,
-                movie_time,
-                port,
-                box_rect
+                movie, target, media_time, movie_time, port, box_rect
             );
         }
 
@@ -12995,10 +13132,7 @@ impl super::TrapDispatcher {
                             QUICKTIME_INVALID_MOVIE
                         };
                         if super::dispatch::trace_quicktime_enabled() {
-                            eprintln!(
-                                "[QUICKTIME] GetMovieBox movie=${:08X} -> {:?}",
-                                movie, rect
-                            );
+                            eprintln!("[QUICKTIME] GetMovieBox movie=${:08X} -> {:?}", movie, rect);
                         }
                         cpu.write_reg(Register::A7, sp + 8);
                         cpu.write_reg(Register::D0, err as u32);
@@ -14238,8 +14372,7 @@ impl super::TrapDispatcher {
                             bus.read_long(description)
                         };
                         let count = u32::from(
-                            component_type == 0
-                                || component_type == MOVIE_CONTROLLER_COMPONENT,
+                            component_type == 0 || component_type == MOVIE_CONTROLLER_COMPONENT,
                         );
                         bus.write_long(sp + 4, count);
                         cpu.write_reg(Register::A7, sp + 4);
@@ -14255,8 +14388,7 @@ impl super::TrapDispatcher {
                             bus.read_long(description)
                         };
                         let component = if previous == 0
-                            && (component_type == 0
-                                || component_type == MOVIE_CONTROLLER_COMPONENT)
+                            && (component_type == 0 || component_type == MOVIE_CONTROLLER_COMPONENT)
                         {
                             SYNTHETIC_MOVIE_CONTROLLER
                         } else {
@@ -14543,6 +14675,10 @@ impl super::TrapDispatcher {
             (true, 0x3F2) => {
                 let selector = cpu.read_reg(Register::D0) & 0xFFFF;
                 let sp = cpu.read_reg(Register::A7);
+                // Threads.h option and style bits.
+                const K_NEW_SUSPEND: u32 = 1 << 0;
+                const K_PREEMPTIVE_THREAD: u32 = 1 << 1;
+
                 let result = match selector {
                     0xFFFE => {
                         self.finish_cooperative_thread(cpu, bus);
@@ -14556,6 +14692,7 @@ impl super::TrapDispatcher {
                         self.yield_cooperative_thread(cpu, suggested_thread);
                         return Some(Ok(()));
                     }
+                    // GetCurrentThread(currentThreadID)
                     0x0206 => {
                         let current_thread = bus.read_long(sp);
                         if current_thread == 0 {
@@ -14565,6 +14702,8 @@ impl super::TrapDispatcher {
                             0
                         }
                     }
+                    // NewThread(threadStyle, threadEntry, threadParam,
+                    //           stackSize, options, threadResult, threadMade)
                     0x0E03 => {
                         let thread_made = bus.read_long(sp);
                         let result_destination = bus.read_long(sp + 4);
@@ -14576,8 +14715,7 @@ impl super::TrapDispatcher {
 
                         if thread_made == 0
                             || thread_entry == 0
-                            || thread_style != 1
-                            || options & 0x0000_0002 != 0
+                            || thread_style & K_PREEMPTIVE_THREAD != 0
                         {
                             if thread_made != 0 {
                                 bus.write_long(thread_made, 0);
@@ -14586,31 +14724,282 @@ impl super::TrapDispatcher {
                         } else {
                             let thread_id = self.next_cooperative_thread_id;
                             self.next_cooperative_thread_id =
-                                self.next_cooperative_thread_id.wrapping_add(1).max(3);
+                                self.next_cooperative_thread_id.saturating_add(1);
 
                             let stack_size = if stack_size == 0 {
-                                DEFAULT_COOPERATIVE_THREAD_STACK_SIZE
+                                self.cooperative_thread_stack_size
                             } else {
                                 stack_size
                             };
-                            let allocation_size = stack_size.saturating_add(12);
-                            let stack_base = bus.alloc(allocation_size);
-                            let entry_sp = stack_base.wrapping_add(stack_size);
+                            let (stack_base, stack_limit) =
+                                self.acquire_cooperative_thread_stack(bus, stack_size);
+
+                            // Seed the private stack as though the entry proc
+                            // had been called by the trampoline: return
+                            // address, then its single Pascal argument.
                             let return_trampoline = self.thread_return_trampoline(bus);
+                            let entry_sp = stack_limit.wrapping_sub(8);
                             bus.write_long(entry_sp, return_trampoline);
                             bus.write_long(entry_sp + 4, thread_param);
-                            bus.write_long(entry_sp + 8, 0);
 
-                            let state = if options & 0x0000_0001 != 0 { 1 } else { 0 };
+                            let state = if options & K_NEW_SUSPEND != 0 {
+                                Self::THREAD_STATE_STOPPED
+                            } else {
+                                Self::THREAD_STATE_READY
+                            };
                             let mut thread =
                                 Self::capture_cooperative_thread(cpu, state, result_destination);
                             thread.pc = thread_entry;
                             thread.a_regs[7] = entry_sp;
+                            thread.stack_base = stack_base;
+                            thread.stack_limit = stack_limit;
                             self.cooperative_threads.insert(thread_id, thread);
-                            if state == 0 {
+                            if state == Self::THREAD_STATE_READY {
                                 self.cooperative_thread_ready.push_back(thread_id);
                             }
                             bus.write_long(thread_made, thread_id);
+                            0
+                        }
+                    }
+                    // CreateThreadPool(threadStyle, numToCreate, stackSize)
+                    0x0501 => {
+                        let stack_size = bus.read_long(sp);
+                        let count = bus.read_word(sp + 4) as i16;
+                        let thread_style = bus.read_long(sp + 6);
+                        if thread_style & K_PREEMPTIVE_THREAD != 0 {
+                            -50
+                        } else {
+                            let stack_size = if stack_size == 0 {
+                                self.cooperative_thread_stack_size
+                            } else {
+                                stack_size
+                            };
+                            for _ in 0..count.max(0) {
+                                let stack = self.acquire_cooperative_thread_stack(bus, stack_size);
+                                self.cooperative_thread_pool.push(stack);
+                            }
+                            0
+                        }
+                    }
+                    // GetFreeThreadCount(threadStyle, freeCount)
+                    0x0402 => {
+                        let free_count = bus.read_long(sp);
+                        let thread_style = bus.read_long(sp + 4);
+                        if free_count == 0 || thread_style & K_PREEMPTIVE_THREAD != 0 {
+                            -50
+                        } else {
+                            bus.write_word(free_count, self.cooperative_thread_pool.len() as u16);
+                            0
+                        }
+                    }
+                    // GetSpecificFreeThreadCount(threadStyle, stackSize,
+                    //                            freeCount)
+                    0x0615 => {
+                        let free_count = bus.read_long(sp);
+                        let stack_size = bus.read_long(sp + 4);
+                        let thread_style = bus.read_long(sp + 8);
+                        if free_count == 0 || thread_style & K_PREEMPTIVE_THREAD != 0 {
+                            -50
+                        } else {
+                            let matching = self
+                                .cooperative_thread_pool
+                                .iter()
+                                .filter(|(base, limit)| limit.saturating_sub(*base) >= stack_size)
+                                .count();
+                            bus.write_word(free_count, matching as u16);
+                            0
+                        }
+                    }
+                    // GetDefaultThreadStackSize(threadStyle, stackSize)
+                    0x0413 => {
+                        let stack_size = bus.read_long(sp);
+                        let thread_style = bus.read_long(sp + 4);
+                        if stack_size == 0 || thread_style & K_PREEMPTIVE_THREAD != 0 {
+                            -50
+                        } else {
+                            bus.write_long(stack_size, self.cooperative_thread_stack_size);
+                            0
+                        }
+                    }
+                    // ThreadCurrentStackSpace(thread, freeStack)
+                    0x0414 => {
+                        let free_stack = bus.read_long(sp);
+                        let thread = self.resolve_cooperative_thread_id(bus.read_long(sp + 4));
+                        if free_stack == 0 {
+                            -50
+                        } else {
+                            let running = thread == self.current_cooperative_thread;
+                            let current_sp = cpu.read_reg(Register::A7);
+                            match self.cooperative_thread_mut(cpu, thread) {
+                                None => Self::THREAD_NOT_FOUND_ERR,
+                                Some(record) => {
+                                    // The application thread keeps the process
+                                    // stack, whose base this record does not
+                                    // track, so report the default size rather
+                                    // than a bogus multi-megabyte figure.
+                                    let free = if record.stack_base == 0 {
+                                        DEFAULT_COOPERATIVE_THREAD_STACK_SIZE
+                                    } else {
+                                        let stack_pointer = if running {
+                                            current_sp
+                                        } else {
+                                            record.a_regs[7]
+                                        };
+                                        stack_pointer.saturating_sub(record.stack_base)
+                                    };
+                                    bus.write_long(free_stack, free);
+                                    0
+                                }
+                            }
+                        }
+                    }
+                    // DisposeThread(threadToDump, threadResult, recycleThread)
+                    0x0504 => {
+                        let thread_result = bus.read_long(sp + 2);
+                        let thread_to_dump =
+                            self.resolve_cooperative_thread_id(bus.read_long(sp + 6));
+                        if !self.cooperative_threads.contains_key(&thread_to_dump)
+                            && thread_to_dump != Self::APPLICATION_THREAD_ID
+                        {
+                            Self::THREAD_NOT_FOUND_ERR
+                        } else if thread_to_dump == self.current_cooperative_thread {
+                            // Threads.h allows a thread to dispose of itself;
+                            // the call never returns to it.
+                            self.retire_cooperative_thread(thread_to_dump, thread_result, bus);
+                            self.finish_cooperative_thread(cpu, bus);
+                            return Some(Ok(()));
+                        } else {
+                            self.retire_cooperative_thread(thread_to_dump, thread_result, bus);
+                            0
+                        }
+                    }
+                    // GetThreadState(threadToGet, threadState), and
+                    // GetThreadStateGivenTaskRef, which differs only by the
+                    // task ref Systemless has exactly one of.
+                    0x0407 | 0x060F => {
+                        let thread_state = bus.read_long(sp);
+                        let thread_to_get =
+                            self.resolve_cooperative_thread_id(bus.read_long(sp + 4));
+                        if thread_state == 0 {
+                            -50
+                        } else {
+                            match self.cooperative_thread_mut(cpu, thread_to_get) {
+                                Some(thread) => {
+                                    let state = thread.state;
+                                    bus.write_word(thread_state, state);
+                                    0
+                                }
+                                None => Self::THREAD_NOT_FOUND_ERR,
+                            }
+                        }
+                    }
+                    // SetThreadState(threadToSet, newState, suggestedThread),
+                    // and SetThreadStateEndCritical, which additionally
+                    // performs the ThreadEndCritical the caller owes.
+                    0x0508 | 0x0512 => {
+                        let suggested_thread = bus.read_long(sp);
+                        let new_state = bus.read_word(sp + 4);
+                        let thread_to_set =
+                            self.resolve_cooperative_thread_id(bus.read_long(sp + 6));
+                        if selector == 0x0512 {
+                            self.thread_critical_nesting =
+                                self.thread_critical_nesting.saturating_sub(1);
+                        }
+                        match self.cooperative_thread_mut(cpu, thread_to_set) {
+                            None => Self::THREAD_NOT_FOUND_ERR,
+                            Some(thread) => {
+                                let was_running = thread.state == Self::THREAD_STATE_RUNNING;
+                                thread.state = new_state;
+                                self.cooperative_thread_ready
+                                    .retain(|queued| *queued != thread_to_set);
+                                if new_state == Self::THREAD_STATE_READY {
+                                    self.cooperative_thread_ready.push_back(thread_to_set);
+                                }
+                                // Stopping the running thread has to hand the
+                                // CPU to someone else immediately.
+                                if was_running && new_state != Self::THREAD_STATE_RUNNING {
+                                    bus.write_word(sp + 10, 0);
+                                    cpu.write_reg(Register::A7, sp + 10);
+                                    cpu.write_reg(Register::D0, 0);
+                                    self.save_current_cooperative_thread(cpu);
+                                    if let Some(next_id) =
+                                        self.next_ready_cooperative_thread(suggested_thread)
+                                    {
+                                        self.switch_to_cooperative_thread(cpu, next_id);
+                                    }
+                                    return Some(Ok(()));
+                                }
+                                0
+                            }
+                        }
+                    }
+                    // SetThreadReadyGivenTaskRef(threadTRef, threadToSet)
+                    0x0410 => {
+                        let thread_to_set = self.resolve_cooperative_thread_id(bus.read_long(sp));
+                        match self.cooperative_thread_mut(cpu, thread_to_set) {
+                            None => Self::THREAD_NOT_FOUND_ERR,
+                            Some(thread) => {
+                                if thread.state == Self::THREAD_STATE_STOPPED {
+                                    thread.state = Self::THREAD_STATE_READY;
+                                    self.cooperative_thread_ready.push_back(thread_to_set);
+                                }
+                                0
+                            }
+                        }
+                    }
+                    // SetThreadScheduler(threadScheduler)
+                    0x0209 => {
+                        self.cooperative_thread_scheduler = bus.read_long(sp);
+                        0
+                    }
+                    // SetThreadSwitcher(thread, threadSwitcher,
+                    //                   switchProcParam, inOrOut). A Pascal
+                    // Boolean occupies the high byte of its stack word.
+                    0x070A => {
+                        let switch_in = bus.read_byte(sp) != 0;
+                        let switch_proc_param = bus.read_long(sp + 2);
+                        let thread_switcher = bus.read_long(sp + 6);
+                        let thread = self.resolve_cooperative_thread_id(bus.read_long(sp + 10));
+                        match self.cooperative_thread_mut(cpu, thread) {
+                            None => Self::THREAD_NOT_FOUND_ERR,
+                            Some(record) => {
+                                if switch_in {
+                                    record.switch_in = (thread_switcher, switch_proc_param);
+                                } else {
+                                    record.switch_out = (thread_switcher, switch_proc_param);
+                                }
+                                0
+                            }
+                        }
+                    }
+                    // SetThreadTerminator(thread, threadTerminator,
+                    //                     terminationProcParam)
+                    0x0611 => {
+                        let termination_proc_param = bus.read_long(sp);
+                        let thread_terminator = bus.read_long(sp + 4);
+                        let thread = self.resolve_cooperative_thread_id(bus.read_long(sp + 8));
+                        match self.cooperative_thread_mut(cpu, thread) {
+                            None => Self::THREAD_NOT_FOUND_ERR,
+                            Some(record) => {
+                                record.terminator = (thread_terminator, termination_proc_param);
+                                0
+                            }
+                        }
+                    }
+                    // SetDebuggerNotificationProcs(notifyNewThread,
+                    //     notifyDisposeThread, notifyThreadScheduler).
+                    // Systemless hosts no 68K debugger, so the procs are
+                    // accepted and never called.
+                    0x060D => 0,
+                    // GetThreadCurrentTaskRef(threadTRef). Systemless runs a
+                    // single Thread Manager task; the application thread's ID
+                    // is a stable non-nil token for it.
+                    0x020E => {
+                        let thread_t_ref = bus.read_long(sp);
+                        if thread_t_ref == 0 {
+                            -50
+                        } else {
+                            bus.write_long(thread_t_ref, Self::APPLICATION_THREAD_ID);
                             0
                         }
                     }
@@ -14619,7 +15008,7 @@ impl super::TrapDispatcher {
                             self.thread_critical_nesting.saturating_add(1);
                         0
                     }
-                    0x000C if self.thread_critical_nesting == 0 => -619,
+                    0x000C if self.thread_critical_nesting == 0 => Self::THREAD_PROTOCOL_ERR,
                     0x000C => {
                         self.thread_critical_nesting -= 1;
                         0
@@ -18526,7 +18915,8 @@ mod tests {
             Some("LaunchTargets/Register Helper")
         );
         assert_eq!(
-            disp.take_pending_launch_application(false, false).as_deref(),
+            disp.take_pending_launch_application(false, false)
+                .as_deref(),
             Some("LaunchTargets/Register Helper"),
             "non-launchContinue foreground target should be immediately serviceable"
         );
@@ -22702,6 +23092,195 @@ mod tests {
         assert_eq!(cpu.read_reg(Register::A7), sp);
         assert_eq!(bus.read_word(sp), 0);
         assert_eq!(disp.thread_critical_nesting, 0);
+    }
+
+    /// `kPreemptiveThread` has no 68K implementation, so `NewThread` must
+    /// refuse it rather than hand back an unschedulable ThreadID.
+    /// MPW Interfaces/CIncludes/Threads.h.
+    #[test]
+    fn threaddispatch_newthread_rejects_preemptive_style_with_param_err() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let sp = TEST_SP;
+        let thread_made = TEST_SP + 0x400;
+        cpu.write_reg(Register::A7, sp);
+        bus.write_long(sp, thread_made);
+        bus.write_long(sp + 4, 0);
+        bus.write_long(sp + 8, 0);
+        bus.write_long(sp + 12, 4096);
+        bus.write_long(sp + 16, 0);
+        bus.write_long(sp + 20, 0x0004_2000);
+        bus.write_long(sp + 24, 2); // kPreemptiveThread
+
+        cpu.write_reg(Register::D0, 0x0000_0E03);
+        disp.dispatch_toolbox(true, 0x3F2, &mut cpu, &mut bus)
+            .expect("ThreadDispatch should handle NewThread")
+            .expect("NewThread should return");
+
+        assert_eq!(cpu.read_reg(Register::D0) as i16, -50);
+        assert_eq!(cpu.read_reg(Register::A7), sp + 28);
+        assert_eq!(bus.read_long(thread_made), 0, "no ThreadID on failure");
+        assert!(disp.cooperative_threads.is_empty());
+    }
+
+    /// `kApplicationThreadID` exists implicitly from launch, so
+    /// `GetCurrentThread` names it and `GetThreadState` materialises its
+    /// record instead of failing with threadNotFoundErr.
+    #[test]
+    fn threaddispatch_get_and_set_thread_state_track_the_ready_queue() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let sp = TEST_SP;
+        let out = TEST_SP + 0x400;
+
+        cpu.write_reg(Register::A7, sp);
+        bus.write_long(sp, out);
+        cpu.write_reg(Register::D0, 0x0000_0206); // GetCurrentThread
+        disp.dispatch_toolbox(true, 0x3F2, &mut cpu, &mut bus)
+            .expect("GetCurrentThread handled")
+            .expect("GetCurrentThread returns");
+        assert_eq!(cpu.read_reg(Register::D0), 0);
+        assert_eq!(cpu.read_reg(Register::A7), sp + 4);
+        assert_eq!(
+            bus.read_long(out),
+            2,
+            "kApplicationThreadID is the launch thread"
+        );
+
+        // GetThreadState(kCurrentThreadID, &state)
+        cpu.write_reg(Register::A7, sp);
+        bus.write_long(sp, out);
+        bus.write_long(sp + 4, 1); // kCurrentThreadID
+        cpu.write_reg(Register::D0, 0x0000_0407);
+        disp.dispatch_toolbox(true, 0x3F2, &mut cpu, &mut bus)
+            .expect("GetThreadState handled")
+            .expect("GetThreadState returns");
+        assert_eq!(cpu.read_reg(Register::D0), 0);
+        assert_eq!(cpu.read_reg(Register::A7), sp + 8);
+        assert_eq!(
+            bus.read_word(out),
+            2,
+            "the running thread reports kRunningThreadState"
+        );
+    }
+
+    /// `SetThreadSwitcher` and `SetThreadTerminator` record their procs per
+    /// thread, and the switch-in and switch-out slots stay independent.
+    /// A Pascal Boolean occupies the high byte of its stack word.
+    #[test]
+    fn threaddispatch_switcher_and_terminator_are_recorded_per_thread() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let sp = TEST_SP;
+
+        cpu.write_reg(Register::A7, sp);
+        bus.write_word(sp, 0x0100); // inOrOut = true
+        bus.write_long(sp + 2, 0x1111_2222); // switchProcParam
+        bus.write_long(sp + 6, 0x0003_0000); // threadSwitcher
+        bus.write_long(sp + 10, 2); // kApplicationThreadID
+        cpu.write_reg(Register::D0, 0x0000_070A);
+        disp.dispatch_toolbox(true, 0x3F2, &mut cpu, &mut bus)
+            .expect("SetThreadSwitcher handled")
+            .expect("SetThreadSwitcher returns");
+        assert_eq!(cpu.read_reg(Register::D0), 0);
+        assert_eq!(cpu.read_reg(Register::A7), sp + 14);
+
+        cpu.write_reg(Register::A7, sp);
+        bus.write_long(sp, 0x3333_4444); // terminationProcParam
+        bus.write_long(sp + 4, 0x0003_1000); // threadTerminator
+        bus.write_long(sp + 8, 2);
+        cpu.write_reg(Register::D0, 0x0000_0611);
+        disp.dispatch_toolbox(true, 0x3F2, &mut cpu, &mut bus)
+            .expect("SetThreadTerminator handled")
+            .expect("SetThreadTerminator returns");
+        assert_eq!(cpu.read_reg(Register::D0), 0);
+        assert_eq!(cpu.read_reg(Register::A7), sp + 12);
+
+        let thread = disp
+            .cooperative_threads
+            .get(&2)
+            .expect("the application thread record must exist");
+        assert_eq!(thread.switch_in, (0x0003_0000, 0x1111_2222));
+        assert_eq!(thread.switch_out, (0, 0), "switch-out stays unset");
+        assert_eq!(thread.terminator, (0x0003_1000, 0x3333_4444));
+    }
+
+    /// `DisposeThread` retires a non-running thread, banks its stack for
+    /// reuse, and drops it from the ready queue. `GetFreeThreadCount` then
+    /// reports the pooled stack.
+    #[test]
+    fn threaddispatch_disposethread_pools_the_stack_for_reuse() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let sp = TEST_SP;
+        let thread_made = TEST_SP + 0x400;
+
+        cpu.write_reg(Register::A7, sp);
+        bus.write_long(sp, thread_made);
+        bus.write_long(sp + 4, 0);
+        bus.write_long(sp + 8, 0);
+        bus.write_long(sp + 12, 4096);
+        bus.write_long(sp + 16, 0);
+        bus.write_long(sp + 20, 0x0004_2000);
+        bus.write_long(sp + 24, 1); // kCooperativeThread
+        cpu.write_reg(Register::D0, 0x0000_0E03);
+        disp.dispatch_toolbox(true, 0x3F2, &mut cpu, &mut bus)
+            .expect("NewThread handled")
+            .expect("NewThread returns");
+        let new_id = bus.read_long(thread_made);
+        assert!(disp.cooperative_thread_ready.contains(&new_id));
+
+        // DisposeThread(threadToDump, threadResult, recycleThread)
+        cpu.write_reg(Register::A7, sp);
+        bus.write_word(sp, 0x0100); // recycleThread = true
+        bus.write_long(sp + 2, 0); // threadResult
+        bus.write_long(sp + 6, new_id);
+        cpu.write_reg(Register::D0, 0x0000_0504);
+        disp.dispatch_toolbox(true, 0x3F2, &mut cpu, &mut bus)
+            .expect("DisposeThread handled")
+            .expect("DisposeThread returns");
+        assert_eq!(cpu.read_reg(Register::D0), 0);
+        assert_eq!(cpu.read_reg(Register::A7), sp + 10);
+        assert!(!disp.cooperative_threads.contains_key(&new_id));
+        assert!(!disp.cooperative_thread_ready.contains(&new_id));
+        assert_eq!(disp.cooperative_thread_pool.len(), 1);
+
+        // GetFreeThreadCount(threadStyle, freeCount)
+        let out = TEST_SP + 0x420;
+        cpu.write_reg(Register::A7, sp);
+        bus.write_long(sp, out);
+        bus.write_long(sp + 4, 1);
+        cpu.write_reg(Register::D0, 0x0000_0402);
+        disp.dispatch_toolbox(true, 0x3F2, &mut cpu, &mut bus)
+            .expect("GetFreeThreadCount handled")
+            .expect("GetFreeThreadCount returns");
+        assert_eq!(cpu.read_reg(Register::D0), 0);
+        assert_eq!(bus.read_word(out), 1, "the disposed stack is pooled");
+    }
+
+    /// `GetDefaultThreadStackSize` reports the size `NewThread` uses when
+    /// passed 0, and refuses the preemptive style.
+    #[test]
+    fn threaddispatch_default_stack_size_is_reported_and_refuses_preemptive() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let sp = TEST_SP;
+        let out = TEST_SP + 0x400;
+
+        cpu.write_reg(Register::A7, sp);
+        bus.write_long(sp, out);
+        bus.write_long(sp + 4, 1); // kCooperativeThread
+        cpu.write_reg(Register::D0, 0x0000_0413);
+        disp.dispatch_toolbox(true, 0x3F2, &mut cpu, &mut bus)
+            .expect("GetDefaultThreadStackSize handled")
+            .expect("GetDefaultThreadStackSize returns");
+        assert_eq!(cpu.read_reg(Register::D0), 0);
+        assert_eq!(cpu.read_reg(Register::A7), sp + 8);
+        assert_eq!(bus.read_long(out), 32 * 1024);
+
+        cpu.write_reg(Register::A7, sp);
+        bus.write_long(sp, out);
+        bus.write_long(sp + 4, 2); // kPreemptiveThread
+        cpu.write_reg(Register::D0, 0x0000_0413);
+        disp.dispatch_toolbox(true, 0x3F2, &mut cpu, &mut bus)
+            .expect("GetDefaultThreadStackSize handled")
+            .expect("GetDefaultThreadStackSize returns");
+        assert_eq!(cpu.read_reg(Register::D0) as i16, -50);
     }
 
     #[test]
@@ -27842,7 +28421,10 @@ mod tests {
         let result = disp.dispatch_toolbox(true, 0x2AA, &mut cpu, &mut bus);
 
         assert!(result.is_some(), "DisposeMovieController should be handled");
-        assert!(result.unwrap().is_ok(), "DisposeMovieController should return");
+        assert!(
+            result.unwrap().is_ok(),
+            "DisposeMovieController should return"
+        );
         assert_eq!(cpu.read_reg(Register::A7), sp + 4);
         assert_eq!(cpu.read_reg(Register::D0), 0);
     }


### PR DESCRIPTION
`_ThreadDispatch` ($ABF2) implemented six of the twenty-two routine selectors declared by MPW `Interfaces/CIncludes/Threads.h` (Universal Interfaces 2.0a3, ETO #16, 11 November 1994). The other sixteen fell through to `paramErr`. This implements them.

Closes #110

## What was missing

`CreateThreadPool`, `GetFreeThreadCount`, `GetSpecificFreeThreadCount`, `GetDefaultThreadStackSize`, `ThreadCurrentStackSpace`, `DisposeThread`, `GetThreadState`, `SetThreadState`, `SetThreadStateEndCritical`, `SetThreadScheduler`, `SetThreadSwitcher`, `SetThreadTerminator`, `SetDebuggerNotificationProcs`, `GetThreadCurrentTaskRef`, `GetThreadStateGivenTaskRef`, `SetThreadReadyGivenTaskRef`.

The full table is now listed in the trap comment with each selector, so the mapping is checkable against the header without guessing. Each selector's high byte gives its Pascal frame size in stack words, which is what the existing `(selector >> 8) * 2` pop already relied on.

`kPreemptiveThread` keeps returning `paramErr` — the honest answer for a 68K machine with no MP services. Only `kCooperativeThread` is served.

## Notable details

**The application thread now has a record.** `kApplicationThreadID` (2) exists implicitly from launch, but nothing created a `CooperativeThread` for it until `NewThread` ran, so `GetThreadState(kApplicationThreadID, …)` could not report `kRunningThreadState` and `SetThreadSwitcher` on the launch thread had nowhere to store the proc. It is now materialised on demand from the live CPU state.

**`kCurrentThreadID` (1) and `kNoThreadID` (0)** resolve to the running thread wherever a `ThreadID` is accepted, rather than being treated as ordinary IDs that miss the map.

**Stopping the running thread reschedules.** `SetThreadState` moving the current thread out of `kRunningThreadState` now saves its context and installs the next ready thread, instead of returning into a thread that is no longer running. `SetThreadStateEndCritical` additionally performs the `ThreadEndCritical` the caller owes.

**Stacks are pooled.** `DisposeThread` returns the retired thread's stack to a pool that `NewThread` and `CreateThreadPool` draw from before allocating, which is what `GetFreeThreadCount` and `GetSpecificFreeThreadCount` report on.

**A Pascal `Boolean` occupies the high byte of its stack word**, so `SetThreadSwitcher`'s `inOrOut` is read as a byte at the frame base rather than as a word — reading the word picks up whatever the caller left in the low half. Warcraft II pushes it with `CLR.B -(SP)`, which leaves exactly that garbage.

`ThreadCurrentStackSpace` reports the default stack size for the application thread, whose process-stack base the record does not track; reporting `SP - 0` there would be a bogus multi-megabyte figure.

The scheduler stays round-robin over the ready queue, with `YieldToThread`'s suggestion honoured when it names a ready thread — the behaviour the stock 68K scheduler has. `SetThreadScheduler` records the custom `ThreadSchedulerProcPtr` but does not yet call it; likewise the switcher and terminator procs are recorded per thread and not yet invoked on a context switch. Both are one step further than storing nothing, and neither is reachable today without a guest that installs them.

## Validation

`cargo test` is green — 2744 lib tests, no failures — including the existing Thread Manager tests, which continue to pass unchanged. Five new ones:

- `threaddispatch_newthread_rejects_preemptive_style_with_param_err`
- `threaddispatch_get_and_set_thread_state_track_the_ready_queue`
- `threaddispatch_switcher_and_terminator_are_recorded_per_thread`
- `threaddispatch_disposethread_pools_the_stack_for_reuse`
- `threaddispatch_default_stack_size_is_reported_and_refuses_preemptive`

Warcraft II: Tides of Darkness, which calls `SetThreadSwitcher` ($070A) during startup and was previously told the call was invalid, still runs its full sequence end-to-end and still matches its BasiliskII reference frame for frame.

Checked for regressions by running the game-parity suite with and without this change: identical results. One case that differed between full-suite runs (`glider_pro`) reproduces identically on both sides when run in isolation, so it is pre-existing flakiness in that suite rather than anything this touches.

`cargo fmt` clean on both files touched. The diff is confined to `src/trap/dispatch.rs` and `src/trap/toolbox.rs`.
