### PR TITLE
fix: preserve Sound Manager Pascal callback and dispatch frames

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -4821,8 +4821,8 @@ impl FixtureRunner {
         //
         // Trampoline layout (34 bytes):
         //   +0:  MOVEM.L D0-D3/A0-A3,-(SP)  ; 48E7 F0F0 (save regs)
-        //   +4:  MOVE.L  #exhaustedBuf,-(SP) ; 2F3C xxxx xxxx (push param2 first)
-        //   +10: MOVE.L  #chanPtr,-(SP)       ; 2F3C xxxx xxxx (param1 nearest return)
+        //   +4:  MOVE.L  #chanPtr,-(SP)       ; 2F3C xxxx xxxx (push param1 first)
+        //   +10: MOVE.L  #exhaustedBuf,-(SP)  ; 2F3C xxxx xxxx (param2 nearest return)
         //   +16: JSR     callback             ; 4EB9 xxxx xxxx
         //   +22: MOVEA.L #savedRegsSP,A7      ; ignore guest callback cleanup convention
         //   +28: MOVEM.L (SP)+,D0-D3/A0-A3   ; 4CDF 0F0F (restore regs)
@@ -4832,9 +4832,9 @@ impl FixtureRunner {
             self.bus.write_word(tramp, 0x48E7); // MOVEM.L regs,-(SP)
             self.bus.write_word(tramp + 2, 0xF0F0); // D0-D3/A0-A3
             self.bus.write_word(tramp + 4, 0x2F3C); // MOVE.L #imm,-(SP)
-                                                    // +6..+9: exhausted buf ptr (patched)
+                                                    // +6..+9: chan ptr (patched)
             self.bus.write_word(tramp + 10, 0x2F3C); // MOVE.L #imm,-(SP)
-                                                     // +12..+15: chan ptr (patched)
+                                                     // +12..+15: exhausted buf ptr (patched)
             self.bus.write_word(tramp + 16, 0x4EB9); // JSR abs.L
                                                      // +18..+21: callback addr (patched)
             self.bus.write_word(tramp + 22, 0x2E7C); // MOVEA.L #savedSP,A7
@@ -4848,11 +4848,11 @@ impl FixtureRunner {
         let tramp = self.sound_doubleback_trampoline;
         let interrupted_sp = self.cpu.read_reg(Register::A7);
         let saved_regs_sp = interrupted_sp.wrapping_sub(4 + 32);
-        // Classic Pascal pushes parameters right-to-left. At callback entry,
-        // after JSR has stacked the return address, chan is at SP+4 and the
-        // exhausted buffer is at SP+8. Sound 1994, 2-153.
-        self.bus.write_long(tramp + 6, exhausted_buf_ptr);
-        self.bus.write_long(tramp + 12, cb.chan_ptr);
+        // Classic Pascal pushes parameters left-to-right. At callback entry,
+        // after JSR has stacked the return address, the exhausted buffer is at
+        // SP+4 and chan is at SP+8. Sound 1994, 2-153.
+        self.bus.write_long(tramp + 6, cb.chan_ptr);
+        self.bus.write_long(tramp + 12, exhausted_buf_ptr);
         self.bus.write_long(tramp + 18, cb.callback_addr);
         self.bus.write_long(tramp + 24, saved_regs_sp);
 
@@ -8283,13 +8283,13 @@ mod tests {
         let saved_regs_sp = interrupted_sp - 4 - 32;
         assert_eq!(
             runner.bus.read_long(saved_regs_sp - 4),
-            exhausted_buf_ptr,
-            "the last declared Pascal argument is pushed first"
+            chan_ptr,
+            "the first declared Pascal argument is pushed first"
         );
         assert_eq!(
             runner.bus.read_long(saved_regs_sp - 8),
-            chan_ptr,
-            "the first declared Pascal argument is nearest the return address"
+            exhausted_buf_ptr,
+            "the last declared Pascal argument is nearest the return address"
         );
     }
 

--- a/src/trap/sound.rs
+++ b/src/trap/sound.rs
@@ -275,7 +275,7 @@ impl super::TrapDispatcher {
             // stack arguments. `sound_dispatch_param_bytes` maps those
             // documented literals back to their real frame sizes so clients
             // that pass table values directly do not return through args.
-            // SoundDispatch ($A800): Routes by selector; SndPlayDoubleBuffer ($20) with doubleback callbacks, SndStartFilePlay ($00) plays 'snd ' resources by ID or AIFF file by refnum with async completion callbacks, SndStopFilePlay ($08) stops channel, SndPauseFilePlay ($04) toggles file pause, SndSoundManagerVersion ($0C) returns a Sound Manager 3.x NumVersion; SndChannelStatus ($10) zero-fills 24-byte SCStatus per IM:Sound 2-101 (no async playback so all fields are documented-correct at zero); SndManagerStatus ($14) fills 6-byte SMStatus with smNumChannels = active channel count, default smMaxCPULoad = 100, and zero current load per IM:Sound 2-101 + 2-201; volume selectors ($24/$28/$2C/$30) persist Sound Manager 3.x packed L/R levels
+            // SoundDispatch ($A800): Routes by full selector; SndPlayDoubleBuffer ($20) with doubleback callbacks, SndStartFilePlay ($00) plays 'snd ' resources by ID or AIFF file by refnum with async completion callbacks, SndStopFilePlay ($08) stops channel, SndPauseFilePlay ($04) toggles file pause, SndSoundManagerVersion ($000C0008) returns a Sound Manager 3.x NumVersion, UnsignedFixedMulDiv ($060C0018) computes its 16.16 result and pops its 12-byte frame; SndChannelStatus ($10) zero-fills 24-byte SCStatus per IM:Sound 2-101 (no async playback so all fields are documented-correct at zero); SndManagerStatus ($14) fills 6-byte SMStatus with smNumChannels = active channel count, default smMaxCPULoad = 100, and zero current load per IM:Sound 2-101 + 2-201; volume selectors ($24/$28/$2C/$30) persist Sound Manager 3.x packed L/R levels
             (true, 0x000) => {
                 let sp = cpu.read_reg(Register::A7);
                 let selector = cpu.read_reg(Register::D0);
@@ -288,16 +288,33 @@ impl super::TrapDispatcher {
                     );
                 }
                 match routine {
-                    // SndSoundManagerVersion (routine $0C, sel $000C0008)
-                    // FUNCTION SndSoundManagerVersion: NumVersion;
-                    // Sound 1994, 2-201
+                    // SndSoundManagerVersion and UnsignedFixedMulDiv share
+                    // routine byte $0C across different selector families.
                     0x0C => {
-                        // NumVersion uses the first two bytes for major and
-                        // minor release numbers, followed by release stage.
-                        // Return Sound Manager 3.3.3 final so version gates
-                        // that require 3.1+ take the Sound Manager 3.x path.
-                        // Sound 1994, 2-34.
-                        bus.write_long(sp, 0x0333_8000);
+                        if selector == 0x060C_0018 {
+                            // UnsignedFixedMulDiv(value, multiplier, divisor)
+                            // returns (value * multiplier) / divisor. MPW
+                            // Sound.h declares three 4-byte UnsignedFixed
+                            // arguments and a 4-byte result.
+                            let divisor = bus.read_long(sp);
+                            let multiplier = bus.read_long(sp + 4);
+                            let value = bus.read_long(sp + 8);
+                            let result = if divisor == 0 {
+                                u32::MAX
+                            } else {
+                                ((value as u64 * multiplier as u64) / divisor as u64)
+                                    .min(u32::MAX as u64) as u32
+                            };
+                            bus.write_long(sp + param_bytes, result);
+                            cpu.write_reg(Register::A7, sp + param_bytes);
+                        } else {
+                            // NumVersion uses the first two bytes for major
+                            // and minor release numbers, followed by release
+                            // stage. Return Sound Manager 3.3.3 final so
+                            // version gates that require 3.1+ take the Sound
+                            // Manager 3.x path. Sound 1994, 2-34.
+                            bus.write_long(sp, 0x0333_8000);
+                        }
                     }
 
                     // SndPlayDoubleBuffer (routine $20, sel $00200008)
@@ -3288,6 +3305,25 @@ mod tests {
             0x80,
             "release stage byte must mark a final release"
         );
+    }
+
+    #[test]
+    fn sounddispatch_unsigned_fixed_mul_div_returns_result_and_pops_arguments() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let sp = TEST_SP + 0x80;
+
+        cpu.write_reg(Register::A7, sp);
+        cpu.write_reg(Register::D0, 0x060C_0018); // UnsignedFixedMulDiv
+        bus.write_long(sp, 0x5622_0000); // divisor
+        bus.write_long(sp + 4, 0x5622_0000); // multiplier
+        bus.write_long(sp + 8, 0x0001_0000); // value
+        bus.write_long(sp + 12, 0xDEAD_BEEF); // result placeholder
+
+        let result = disp.dispatch_sound(true, 0x000, &mut cpu, &mut bus);
+
+        assert!(result.unwrap().is_ok());
+        assert_eq!(cpu.read_reg(Register::A7), sp + 12);
+        assert_eq!(bus.read_long(sp + 12), 0x0001_0000);
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- invoke `SndDoubleBackProcPtr` using the Classic Pascal argument order confirmed by MPW caller and callback glue
- dispatch `$060C0018` as `UnsignedFixedMulDiv`, return its 16.16 result, and consume its 12-byte parameter frame
- add regression coverage for both stack contracts

## Root cause

Systemless pushed the double-buffer callback arguments in reverse order. Once audio was driven, SCUMM could not reliably refill the exhausted buffer. It also routed SoundDispatch solely by routine byte, so `$060C0018` collided with `SndSoundManagerVersion`. The trap wrote a version value into the caller's parameters and left those parameters on the stack; SCUMM then restored saved registers from the stale arguments and used `$10000` as a mixer length, eventually clearing live code.

MPW Universal Interfaces declares `SndDoubleBackProcPtr(channel, doubleBufferPtr)` and `UnsignedFixedMulDiv(value, multiplier, divisor)`. Compiled MPW glue confirms the callback stack positions used here.

## Validation

- `cargo test --lib`: 2,747 passed, 0 failed, 3 ignored
- Day of the Tentacle audio-driven play proof: 2/2 assertions through tick 30,603, advancing through the sewer and laboratory sequences into the mansion
- Sam & Max audio-driven play proof: 2/2 assertions through tick 20,604 without an illegal instruction

The repository-wide `cargo fmt --check` remains red on unrelated pre-existing formatting in `master`; the scoped diff passes `git diff --check`.

Closes #117