### PR TITLE
perf(runner): prove and park exact idle cycles

### DIFF
--- a/src/memory/bus.rs
+++ b/src/memory/bus.rs
@@ -453,6 +453,16 @@ pub struct MacMemoryBus {
     /// bucket so its full capacity is recovered. Absent for blocks
     /// produced by the bump path or the exact-size fast path.
     alloc_bucket_sizes: HashMap<u32, u32>,
+    /// Original byte values for a short, explicitly requested execution
+    /// probe. While present, fast-memory and bulk-write paths are disabled so
+    /// every guest and HLE write passes through `write_byte`. Comparing the
+    /// journal with final RAM proves whether a candidate execution cycle left
+    /// guest memory unchanged, while still allowing temporary stack writes
+    /// that are restored before the cycle closes.
+    write_probe_original: Option<HashMap<u32, u8>>,
+    /// An out-of-range write makes the probe unverifiable even though the
+    /// normal bus retains its legacy warn-and-ignore behavior.
+    write_probe_invalid: bool,
 }
 
 /// RAM storage - either owned vector or borrowed slice
@@ -756,9 +766,11 @@ impl MacMemoryBus {
             return;
         }
         #[cfg(debug_assertions)]
-        let fast = !WATCHPOINT_ARMED.load(Ordering::Relaxed) && fb_write_trace_range().is_none();
+        let fast = !WATCHPOINT_ARMED.load(Ordering::Relaxed)
+            && fb_write_trace_range().is_none()
+            && self.write_probe_original.is_none();
         #[cfg(not(debug_assertions))]
-        let fast = fb_write_trace_range().is_none();
+        let fast = fb_write_trace_range().is_none() && self.write_probe_original.is_none();
         let count_usize = count as usize;
         let src_end = (src as u64).saturating_add(count as u64);
         let dst_end = (dst as u64).saturating_add(count as u64);
@@ -803,6 +815,8 @@ impl MacMemoryBus {
             free_blocks: HashMap::new(),
             alloc_sizes: HashMap::new(),
             alloc_bucket_sizes: HashMap::new(),
+            write_probe_original: None,
+            write_probe_invalid: false,
         };
         bus.write_word(super::globals::addr::ROM85, 0x7FFF);
 
@@ -878,7 +892,53 @@ impl MacMemoryBus {
             free_blocks: HashMap::new(),
             alloc_sizes: HashMap::new(),
             alloc_bucket_sizes: HashMap::new(),
+            write_probe_original: None,
+            write_probe_invalid: false,
         }
+    }
+
+    /// Begin journaling original RAM bytes for an exact-state execution
+    /// probe. Calling this again discards the previous incomplete probe.
+    pub(crate) fn begin_write_probe(&mut self) {
+        self.write_probe_original = Some(HashMap::new());
+        self.write_probe_invalid = false;
+    }
+
+    /// Discard an incomplete write probe and restore normal fast-memory use.
+    pub(crate) fn cancel_write_probe(&mut self) {
+        self.write_probe_original = None;
+        self.write_probe_invalid = false;
+    }
+
+    /// Finish a write probe and report whether guest RAM is byte-for-byte
+    /// identical at every address written during the probe.
+    pub(crate) fn finish_write_probe_unchanged(&mut self) -> bool {
+        let Some(original) = self.write_probe_original.take() else {
+            return false;
+        };
+        let unchanged = !self.write_probe_invalid
+            && original
+                .into_iter()
+                .all(|(address, value)| self.ram.get_in_bounds(address as usize) == value);
+        self.write_probe_invalid = false;
+        unchanged
+    }
+
+    #[inline]
+    fn record_write_probe_byte(&mut self, address: u32) {
+        if self.write_probe_original.is_none() {
+            return;
+        }
+        if address >= self.ram_size {
+            self.write_probe_invalid = true;
+            return;
+        }
+        let original = self.ram.get_in_bounds(address as usize);
+        self.write_probe_original
+            .as_mut()
+            .expect("write probe checked above")
+            .entry(address)
+            .or_insert(original);
     }
 
     /// Allocate memory from heap.
@@ -1114,9 +1174,11 @@ impl MacMemoryBus {
     #[inline]
     pub fn copy_ram_bytes(&mut self, src: u32, dst: u32, len: u32) -> bool {
         #[cfg(debug_assertions)]
-        let fast = !WATCHPOINT_ARMED.load(Ordering::Relaxed) && fb_write_trace_range().is_none();
+        let fast = !WATCHPOINT_ARMED.load(Ordering::Relaxed)
+            && fb_write_trace_range().is_none()
+            && self.write_probe_original.is_none();
         #[cfg(not(debug_assertions))]
-        let fast = fb_write_trace_range().is_none();
+        let fast = fb_write_trace_range().is_none() && self.write_probe_original.is_none();
         let src_end = (src as u64).saturating_add(len as u64);
         let dst_end = (dst as u64).saturating_add(len as u64);
         if src_end > self.ram_size as u64 || dst_end > self.ram_size as u64 {
@@ -1140,9 +1202,11 @@ impl MacMemoryBus {
     #[inline]
     pub fn copy_mapped_ram_bytes(&mut self, src: u32, dst: u32, len: u32, map: &[u8; 256]) -> bool {
         #[cfg(debug_assertions)]
-        let fast = !WATCHPOINT_ARMED.load(Ordering::Relaxed) && fb_write_trace_range().is_none();
+        let fast = !WATCHPOINT_ARMED.load(Ordering::Relaxed)
+            && fb_write_trace_range().is_none()
+            && self.write_probe_original.is_none();
         #[cfg(not(debug_assertions))]
-        let fast = fb_write_trace_range().is_none();
+        let fast = fb_write_trace_range().is_none() && self.write_probe_original.is_none();
         let src_end = (src as u64).saturating_add(len as u64);
         let dst_end = (dst as u64).saturating_add(len as u64);
         if src_end > self.ram_size as u64 || dst_end > self.ram_size as u64 {
@@ -1194,6 +1258,7 @@ impl MacMemoryBus {
             || mem_read_trace_active()
             || mem_write_trace_active()
             || watchpoint_armed()
+            || self.write_probe_original.is_some()
         {
             return None;
         }
@@ -1269,6 +1334,7 @@ impl MemoryBus for MacMemoryBus {
     }
 
     fn write_byte(&mut self, address: u32, value: u8) {
+        self.record_write_probe_byte(address);
         maybe_log_mem_write(address, 1, value as u32);
 
         // Optional release-mode FB-write tracer. Cheap when unset (one
@@ -1432,9 +1498,11 @@ impl MemoryBus for MacMemoryBus {
 
         // Fast path: watchpoint disarmed + tracer disabled + write fully in-bounds.
         #[cfg(debug_assertions)]
-        let fast = !WATCHPOINT_ARMED.load(Ordering::Relaxed) && fb_write_trace_range().is_none();
+        let fast = !WATCHPOINT_ARMED.load(Ordering::Relaxed)
+            && fb_write_trace_range().is_none()
+            && self.write_probe_original.is_none();
         #[cfg(not(debug_assertions))]
-        let fast = fb_write_trace_range().is_none();
+        let fast = fb_write_trace_range().is_none() && self.write_probe_original.is_none();
         if fast && (address as u64) + 2 <= (self.ram_size as u64) {
             self.ram.write_word_in_bounds(address as usize, value);
             return;
@@ -1451,9 +1519,11 @@ impl MemoryBus for MacMemoryBus {
         maybe_log_mem_write(address, 4, value);
 
         #[cfg(debug_assertions)]
-        let fast = !WATCHPOINT_ARMED.load(Ordering::Relaxed) && fb_write_trace_range().is_none();
+        let fast = !WATCHPOINT_ARMED.load(Ordering::Relaxed)
+            && fb_write_trace_range().is_none()
+            && self.write_probe_original.is_none();
         #[cfg(not(debug_assertions))]
-        let fast = fb_write_trace_range().is_none();
+        let fast = fb_write_trace_range().is_none() && self.write_probe_original.is_none();
         if fast && (address as u64) + 4 <= (self.ram_size as u64) {
             self.ram.write_long_in_bounds(address as usize, value);
             return;
@@ -1507,9 +1577,11 @@ impl MemoryBus for MacMemoryBus {
     #[inline]
     fn write_bytes(&mut self, address: u32, data: &[u8]) {
         #[cfg(debug_assertions)]
-        let fast = !WATCHPOINT_ARMED.load(Ordering::Relaxed) && fb_write_trace_range().is_none();
+        let fast = !WATCHPOINT_ARMED.load(Ordering::Relaxed)
+            && fb_write_trace_range().is_none()
+            && self.write_probe_original.is_none();
         #[cfg(not(debug_assertions))]
-        let fast = fb_write_trace_range().is_none();
+        let fast = fb_write_trace_range().is_none() && self.write_probe_original.is_none();
         let end = (address as u64).saturating_add(data.len() as u64);
         if fast && end <= self.ram_size as u64 {
             self.ram.write_bytes_in_bounds(address as usize, data);
@@ -1523,9 +1595,11 @@ impl MemoryBus for MacMemoryBus {
     #[inline]
     fn fill_zeros(&mut self, address: u32, len: u32) {
         #[cfg(debug_assertions)]
-        let fast = !WATCHPOINT_ARMED.load(Ordering::Relaxed) && fb_write_trace_range().is_none();
+        let fast = !WATCHPOINT_ARMED.load(Ordering::Relaxed)
+            && fb_write_trace_range().is_none()
+            && self.write_probe_original.is_none();
         #[cfg(not(debug_assertions))]
-        let fast = fb_write_trace_range().is_none();
+        let fast = fb_write_trace_range().is_none() && self.write_probe_original.is_none();
         let end = (address as u64).saturating_add(len as u64);
         if fast && end <= self.ram_size as u64 {
             self.ram
@@ -1540,9 +1614,11 @@ impl MemoryBus for MacMemoryBus {
     #[inline]
     fn fill_bytes(&mut self, address: u32, len: u32, value: u8) {
         #[cfg(debug_assertions)]
-        let fast = !WATCHPOINT_ARMED.load(Ordering::Relaxed) && fb_write_trace_range().is_none();
+        let fast = !WATCHPOINT_ARMED.load(Ordering::Relaxed)
+            && fb_write_trace_range().is_none()
+            && self.write_probe_original.is_none();
         #[cfg(not(debug_assertions))]
-        let fast = fb_write_trace_range().is_none();
+        let fast = fb_write_trace_range().is_none() && self.write_probe_original.is_none();
         let end = (address as u64).saturating_add(len as u64);
         if fast && end <= self.ram_size as u64 {
             self.ram
@@ -1562,6 +1638,45 @@ impl MemoryBus for MacMemoryBus {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn write_probe_accepts_temporary_writes_that_restore_original_bytes() {
+        let mut bus = MacMemoryBus::new(1024);
+        bus.write_long(0x100, 0x1122_3344);
+
+        bus.begin_write_probe();
+        assert!(bus.fast_mem_window().is_none());
+        bus.write_word(0x100, 0xAABB);
+        bus.write_byte(0x102, 0xCC);
+        bus.write_long(0x100, 0x1122_3344);
+
+        assert!(bus.finish_write_probe_unchanged());
+        assert!(bus.fast_mem_window().is_some());
+    }
+
+    #[test]
+    fn write_probe_rejects_a_changed_final_byte() {
+        let mut bus = MacMemoryBus::new(1024);
+        bus.write_long(0x100, 0x1122_3344);
+
+        bus.begin_write_probe();
+        bus.write_byte(0x102, 0xCC);
+
+        assert!(!bus.finish_write_probe_unchanged());
+    }
+
+    #[test]
+    fn write_probe_observes_bulk_and_copy_fast_paths() {
+        let mut bus = MacMemoryBus::new(1024);
+        bus.write_bytes(0x100, &[1, 2, 3, 4]);
+        bus.write_bytes(0x200, &[5, 6, 7, 8]);
+
+        bus.begin_write_probe();
+        bus.write_bytes(0x100, &[9, 2, 3, 4]);
+        assert!(bus.copy_ram_bytes(0x200, 0x204, 4));
+
+        assert!(!bus.finish_write_probe_unchanged());
+    }
 
     #[test]
     fn test_big_endian_word() {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -419,6 +419,135 @@ enum AdvanceResult {
     TooFar,
 }
 
+/// Architecturally visible processor state at a candidate idle-cycle
+/// boundary. JIT caches, prefetch bookkeeping, and remaining host batch cycles
+/// are deliberately excluded: they affect execution speed, not guest results.
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct CpuArchitecturalSnapshot {
+    dar: [u32; 16],
+    dar_save: [u32; 16],
+    sr_save: u16,
+    ppc: u32,
+    stack_pointers: [u32; 8],
+    pc: u32,
+    sr: u16,
+    vbr: u32,
+    sfc: u32,
+    dfc: u32,
+    cacr: u32,
+    caar: u32,
+    itt: [u32; 2],
+    dtt: [u32; 2],
+    ir: u32,
+    fpr: [u64; 8],
+    fpiar: u32,
+    fpsr: u32,
+    fpcr: u32,
+    mmu: [u32; 16],
+    int_level: u32,
+    stopped: u32,
+    change_of_flow: bool,
+    prefetch: [u32; 2],
+    run_mode: u32,
+    fpu_just_reset: bool,
+    reset_cycles: u32,
+    virq_state: u32,
+    nmi_pending: u32,
+    exception_processing: bool,
+}
+
+impl CpuArchitecturalSnapshot {
+    fn capture(cpu: &m68k::CpuCore) -> Self {
+        Self {
+            dar: cpu.dar,
+            dar_save: cpu.dar_save,
+            sr_save: cpu.sr_save,
+            ppc: cpu.ppc,
+            stack_pointers: cpu.sp,
+            pc: cpu.pc,
+            sr: cpu.get_sr(),
+            vbr: cpu.vbr,
+            sfc: cpu.sfc,
+            dfc: cpu.dfc,
+            cacr: cpu.cacr,
+            caar: cpu.caar,
+            itt: [cpu.itt0, cpu.itt1],
+            dtt: [cpu.dtt0, cpu.dtt1],
+            ir: cpu.ir,
+            fpr: cpu.fpr.map(f64::to_bits),
+            fpiar: cpu.fpiar,
+            fpsr: cpu.fpsr,
+            fpcr: cpu.fpcr,
+            mmu: [
+                cpu.mmu_crp_aptr,
+                cpu.mmu_crp_limit,
+                cpu.mmu_srp_aptr,
+                cpu.mmu_srp_limit,
+                cpu.mmu_tc,
+                u32::from(cpu.mmu_sr),
+                cpu.mmu_tt0,
+                cpu.mmu_tt1,
+                cpu.urp,
+                cpu.srp,
+                cpu.tc,
+                cpu.mmusr,
+                cpu.dacr0,
+                cpu.dacr1,
+                cpu.iacr0,
+                cpu.iacr1,
+            ],
+            int_level: cpu.int_level,
+            stopped: cpu.stopped,
+            change_of_flow: cpu.change_of_flow,
+            prefetch: [cpu.pref_addr, cpu.pref_data],
+            run_mode: cpu.run_mode,
+            fpu_just_reset: cpu.fpu_just_reset,
+            reset_cycles: cpu.reset_cycles,
+            virq_state: cpu.virq_state,
+            nmi_pending: cpu.nmi_pending,
+            exception_processing: cpu.exception_processing,
+        }
+    }
+}
+
+struct IdleCycleProbe {
+    trap_pc: u32,
+    tick: u32,
+    cpu: CpuArchitecturalSnapshot,
+}
+
+/// Host-side Event Manager inputs that are not stored in guest RAM. A proven
+/// idle cycle may remain parked across frontend calls only while these inputs
+/// are unchanged and the Event Manager still has no deliverable event.
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct IdleCycleHostSnapshot {
+    mouse_pos: (i16, i16),
+    mouse_button: bool,
+    key_map: [u8; 16],
+}
+
+impl IdleCycleHostSnapshot {
+    fn capture(dispatcher: &TrapDispatcher) -> Self {
+        Self {
+            mouse_pos: dispatcher.mouse_pos,
+            mouse_button: dispatcher.mouse_button,
+            key_map: *dispatcher.key_map_bytes(),
+        }
+    }
+}
+
+/// A complete null-event cycle that has already been proven to be an exact
+/// identity operation. The bus write journal remains armed while the frontend
+/// owns execution, so any guest-memory mutation invalidates the parked state
+/// without hashing the whole emulated address space every frame.
+struct ProvenIdleCycleSleep {
+    trap_pc: u32,
+    wake_tick: u32,
+    tick: u32,
+    cpu: CpuArchitecturalSnapshot,
+    host: IdleCycleHostSnapshot,
+}
+
 // Layout for dialog callback scratch region.
 const DIALOG_DRAW_TRAMPOLINE_OFFSET: u32 = 0x00;
 const DIALOG_FILTER_TRAMPOLINE_OFFSET: u32 = 0x40;
@@ -710,6 +839,18 @@ pub struct FixtureRunner {
     /// and HLE trap costs are deducted. When this reaches zero or below, the
     /// tick advances and the budget is refilled from `instructions_per_tick`.
     tick_budget: i32,
+    /// Most recent null-event boundary seen in the current host execution
+    /// slice. A second same-tick visit starts an exact-state cycle probe; no
+    /// optimization is enabled by this observation alone.
+    idle_cycle_last_seen: Option<(u32, u32)>,
+    /// One-cycle proof in progress. The paired memory-bus journal disables
+    /// direct fast-memory stores until this call site repeats or the proof is
+    /// canceled by a non-quiescent trap.
+    idle_cycle_probe: Option<IdleCycleProbe>,
+    /// Proven null-event cycle parked at its post-trap boundary. Unlike an
+    /// in-progress proof, this may cross frontend slices: a second write
+    /// journal plus CPU/input/event checks revoke it before any reuse.
+    idle_cycle_sleep: Option<ProvenIdleCycleSleep>,
     /// Tick value saved when menu tracking starts.  While set, run_steps caps
     /// its tick_override to this value so the game clock is frozen — matching
     /// the real Mac where MenuSelect blocks the application event loop.
@@ -825,6 +966,9 @@ impl FixtureRunner {
             instructions_per_tick: INSTRUCTIONS_PER_TICK,
             wait_sleep_cap_in_headless: None,
             tick_budget: INSTRUCTIONS_PER_TICK as i32,
+            idle_cycle_last_seen: None,
+            idle_cycle_probe: None,
+            idle_cycle_sleep: None,
             frozen_ticks: None,
             timer_trampoline: 0,
             vbl_trampoline: 0,
@@ -2468,6 +2612,221 @@ impl FixtureRunner {
         false
     }
 
+    /// Cancel only a same-slice observation. A proven sleep has its own write
+    /// guard and intentionally survives the frontend boundary.
+    fn cancel_idle_cycle_observation(&mut self) {
+        if self.idle_cycle_probe.is_some() {
+            self.bus.cancel_write_probe();
+        }
+        self.idle_cycle_probe = None;
+        self.idle_cycle_last_seen = None;
+    }
+
+    fn cancel_idle_cycle_detector(&mut self) {
+        self.bus.cancel_write_probe();
+        self.idle_cycle_probe = None;
+        self.idle_cycle_last_seen = None;
+        self.idle_cycle_sleep = None;
+    }
+
+    fn begin_idle_cycle_probe(&mut self, trap_pc: u32, tick: u32, cpu: CpuArchitecturalSnapshot) {
+        self.bus.begin_write_probe();
+        self.idle_cycle_probe = Some(IdleCycleProbe { trap_pc, tick, cpu });
+        self.idle_cycle_last_seen = Some((trap_pc, tick));
+    }
+
+    fn park_proven_idle_cycle(&mut self, trap_pc: u32, wake_tick: u32) {
+        self.bus.cancel_write_probe();
+        self.idle_cycle_probe = None;
+        self.idle_cycle_last_seen = None;
+
+        let tick = self.dispatcher.tick_count;
+        self.idle_cycle_sleep = Some(ProvenIdleCycleSleep {
+            trap_pc,
+            wake_tick,
+            tick,
+            cpu: CpuArchitecturalSnapshot::capture(&self.cpu.core),
+            host: IdleCycleHostSnapshot::capture(&self.dispatcher),
+        });
+        // No guest code runs while parked. This second journal therefore
+        // catches every bus-visible mutation made by the frontend or an HLE
+        // subsystem between slices, without scanning all guest RAM.
+        self.bus.begin_write_probe();
+    }
+
+    /// Reuse a proven identity cycle without executing it again. The proof is
+    /// valid across a frontend boundary only if CPU state, every bus-visible
+    /// memory write, host input state, the event stream, and SystemTask's
+    /// periodic-work condition all remain quiescent. Any mismatch resumes the
+    /// guest at the ordinary proven boundary.
+    fn try_resume_proven_idle_cycle(&mut self, tick_cap: Option<u32>) -> bool {
+        let Some(sleep) = self.idle_cycle_sleep.take() else {
+            return false;
+        };
+
+        let memory_unchanged = self.bus.finish_write_probe_unchanged();
+        let cpu_unchanged = sleep.cpu == CpuArchitecturalSnapshot::capture(&self.cpu.core);
+        let tick_unchanged =
+            self.dispatcher.tick_count == sleep.tick && self.bus.read_long(0x016A) == sleep.tick;
+        let host_unchanged = sleep.host == IdleCycleHostSnapshot::capture(&self.dispatcher);
+        let can_observe_events = self.active_interrupt_callback.is_none()
+            && self.dispatcher.key_repeat.is_none()
+            && self.dispatcher.pending_launch_app.is_none()
+            && !self.dispatcher.system_task_has_periodic_work();
+        let event_stream_empty = can_observe_events
+            && self
+                .dispatcher
+                .peek_toolbox_event(&self.bus, u16::MAX)
+                .is_none();
+
+        if !memory_unchanged
+            || !cpu_unchanged
+            || !tick_unchanged
+            || !host_unchanged
+            || !event_stream_empty
+        {
+            self.cancel_idle_cycle_detector();
+            return false;
+        }
+
+        let Some(cap) = tick_cap else {
+            self.cancel_idle_cycle_detector();
+            return false;
+        };
+        match self.advance_until_tick(sleep.wake_tick, Some(cap)) {
+            AdvanceResult::CapHit => {
+                self.park_proven_idle_cycle(sleep.trap_pc, sleep.wake_tick);
+                true
+            }
+            AdvanceResult::Advanced => {
+                self.cancel_idle_cycle_detector();
+                false
+            }
+            AdvanceResult::Interrupted | AdvanceResult::TooFar => {
+                self.cancel_idle_cycle_detector();
+                false
+            }
+        }
+    }
+
+    /// Record whether a returned HLE trap remained quiescent during an exact
+    /// cycle probe. Null GetNextEvent/EventAvail calls are deterministic while
+    /// the frontend is executing on its event thread: newly arrived host input
+    /// cannot be injected until the slice returns. SystemTask is quiescent only
+    /// while the HLE has no periodic desk-accessory or driver work.
+    fn note_idle_cycle_trap_result(&mut self, opcode: u16) -> bool {
+        let null_event = matches!(
+            canonical_trap_number(opcode),
+            (true, 0x0170) | (true, 0x0171)
+        ) && self.bus.read_word(self.cpu.core.a(7)) == 0;
+        if self.idle_cycle_probe.is_none() {
+            return null_event;
+        }
+        let quiescent = match canonical_trap_number(opcode) {
+            (true, 0x0170) | (true, 0x0171) => null_event,
+            // GlobalToLocal is a deterministic transform whose inputs and
+            // outputs are entirely represented by CPU registers and guest
+            // memory. The exact-state journal therefore observes every
+            // consequence without needing a separate host-state condition.
+            (true, 0x0071) => true,
+            (true, 0x01B4) => !self.dispatcher.system_task_has_periodic_work(),
+            _ => false,
+        };
+        if !quiescent {
+            self.cancel_idle_cycle_detector();
+        }
+        null_event
+    }
+
+    /// Prove that a complete idle event-loop iteration returned to the same
+    /// architectural CPU and guest-memory state, then advance only to the
+    /// first known dependency: the next guest tick, the GUI wall-clock cap, or
+    /// an interrupt.
+    ///
+    /// The first same-tick repeat starts a one-cycle write journal; a third
+    /// visit closes it. This warm-up is evidence collection, not an eligibility
+    /// threshold. Any changed final byte, CPU state, non-null event, unknown
+    /// trap, periodic SystemTask work, tick change, or interrupt rejects the
+    /// proof and leaves normal execution in place.
+    fn try_exact_idle_cycle_fastfwd(
+        &mut self,
+        trap_pc: u32,
+        wake_tick: u32,
+        tick_cap: Option<u32>,
+    ) -> bool {
+        let Some(cap) = tick_cap else {
+            return false;
+        };
+        let tick = self.dispatcher.tick_count;
+        let cpu = CpuArchitecturalSnapshot::capture(&self.cpu.core);
+
+        if let Some(probe) = self.idle_cycle_probe.take() {
+            let memory_unchanged = self.bus.finish_write_probe_unchanged();
+            let exact_repeat = probe.trap_pc == trap_pc
+                && probe.tick == tick
+                && probe.cpu == cpu
+                && memory_unchanged;
+            if exact_repeat {
+                self.idle_cycle_last_seen = Some((trap_pc, tick));
+                if tick >= cap {
+                    self.park_proven_idle_cycle(trap_pc, wake_tick);
+                    return true;
+                }
+                match self.advance_until_tick(wake_tick, Some(cap)) {
+                    AdvanceResult::CapHit => {
+                        self.park_proven_idle_cycle(trap_pc, wake_tick);
+                        return true;
+                    }
+                    AdvanceResult::Advanced => {
+                        self.cancel_idle_cycle_detector();
+                        return false;
+                    }
+                    AdvanceResult::Interrupted | AdvanceResult::TooFar => {
+                        self.cancel_idle_cycle_detector();
+                        return false;
+                    }
+                }
+            }
+
+            if probe.trap_pc == trap_pc && probe.tick == tick {
+                // The loop may still be converging (for example, it updated a
+                // cached mouse position on the prior pass). Prove the next
+                // complete iteration from this new state.
+                self.begin_idle_cycle_probe(trap_pc, tick, cpu);
+            } else {
+                self.idle_cycle_last_seen = Some((trap_pc, tick));
+            }
+            return false;
+        }
+
+        if self.idle_cycle_last_seen == Some((trap_pc, tick)) {
+            self.begin_idle_cycle_probe(trap_pc, tick, cpu);
+        } else {
+            self.idle_cycle_last_seen = Some((trap_pc, tick));
+        }
+        false
+    }
+
+    /// Observe an entire null-event state-machine pass rather than a specific
+    /// compiler template. The proof starts at the post-GetNextEvent boundary
+    /// and closes only when execution returns to that exact trap site with the
+    /// same CPU state and identical final values for every RAM byte written in
+    /// between. A successful proof can safely park only until the next tick:
+    /// unlike a decoded timeout predicate, arbitrary guest code may begin
+    /// tick-dependent work then.
+    fn try_exact_null_event_cycle_fastfwd(&mut self, trap_pc: u32, tick_cap: Option<u32>) -> bool {
+        if let Some(probe) = self.idle_cycle_probe.as_ref() {
+            // Avoid switching between multiple event sites while a complete
+            // cycle is being measured.
+            if probe.trap_pc != trap_pc {
+                return false;
+            }
+        }
+
+        let wake_tick = self.dispatcher.tick_count.wrapping_add(1);
+        self.try_exact_idle_cycle_fastfwd(trap_pc, wake_tick, tick_cap)
+    }
+
     /// Template E: signed computed-deadline variant.
     ///   SUBQ.W  #4, A7
     ///   _TickCount
@@ -2850,6 +3209,12 @@ impl FixtureRunner {
         sound_work_only: bool,
         finish_frame: bool,
     ) -> (usize, bool) {
+        // An unfinished proof may never span a frontend scheduling boundary.
+        // A *completed* proof is different: it remains parked behind a second
+        // memory-write journal and exact CPU/input/event guards, all checked
+        // before it can be reused below.
+        self.cancel_idle_cycle_observation();
+
         // Freeze ticks while menu/control tracking is active. ModalDialog
         // refires still return to the GUI for intermediate rendering, but
         // they must not freeze ticks: EV's pilot dialogs keep Sound/VBL/Time
@@ -3046,6 +3411,10 @@ impl FixtureRunner {
                         active_interrupt_callback.resume_sp
                     );
                 }
+            }
+
+            if !sound_work_only && self.try_resume_proven_idle_cycle(tick_cap) {
+                break;
             }
 
             if pc == 0 {
@@ -3287,6 +3656,24 @@ impl FixtureRunner {
                     // past it).
                     let pc = self.cpu.core.ppc;
 
+                    // An exact-cycle probe permits only event polling, the
+                    // periodic-work-free SystemTask call, and the TickCount
+                    // observation that closes the cycle. Any other HLE trap
+                    // may have host-side state not represented by the guest
+                    // CPU/RAM snapshot, so reject the proof before dispatch.
+                    if self.idle_cycle_probe.is_some()
+                        && !matches!(
+                            canonical_trap_number(opcode),
+                            (true, 0x0170) // GetNextEvent
+                                | (true, 0x0171) // EventAvail
+                                | (true, 0x0071) // GlobalToLocal (pure guest-state transform)
+                                | (true, 0x01B4) // SystemTask
+                                | (true, 0x0175) // TickCount
+                        )
+                    {
+                        self.cancel_idle_cycle_detector();
+                    }
+
                     // --- Runner-inline fast paths for hot traps ---
                     //
                     // Rule of thumb: only inline a trap's body here if
@@ -3523,6 +3910,13 @@ impl FixtureRunner {
                             self.dispatcher.trap_histogram[idx].saturating_add(1);
                         self.dispatcher.inline_skipped[idx] =
                             self.dispatcher.inline_skipped[idx].saturating_add(1);
+                        let null_event = self.note_idle_cycle_trap_result(opcode);
+                        if null_event
+                            && spin_wait_fastfwd_enabled_for(yield_for_ui, tick_cap)
+                            && self.try_exact_null_event_cycle_fastfwd(pc, tick_cap)
+                        {
+                            break;
+                        }
                         continue;
                     }
 
@@ -3532,6 +3926,7 @@ impl FixtureRunner {
                         .dispatch(opcode, &mut self.cpu, &mut self.bus)
                     {
                         Ok(()) => {
+                            let null_event = self.note_idle_cycle_trap_result(opcode);
                             let extra_tick_cost = hle_trap_extra_tick_cost(opcode)
                                 .saturating_add(self.dispatcher.take_hle_tick_cost());
                             if extra_tick_cost > 0
@@ -3652,6 +4047,12 @@ impl FixtureRunner {
                                 }
                                 continue;
                             }
+                            if null_event
+                                && spin_wait_fastfwd_enabled_for(yield_for_ui, tick_cap)
+                                && self.try_exact_null_event_cycle_fastfwd(pc, tick_cap)
+                            {
+                                break;
+                            }
                         }
                         Err(Error::Halted) => {
                             if matches!(opcode, 0xA9F2 | 0xA9F4)
@@ -3711,6 +4112,7 @@ impl FixtureRunner {
             self.dispatcher.instruction_count = self.total_instructions;
         }
 
+        self.cancel_idle_cycle_observation();
         if finish_frame {
             self.finish_host_frame(audio_samples, sound_interrupt_dispatched || sound_work_only);
         }
@@ -3865,6 +4267,9 @@ impl FixtureRunner {
     }
 
     fn advance_guest_tick(&mut self) -> u32 {
+        // A same-tick cycle proof is invalid as soon as any ordinary clock
+        // advancement or interrupt work occurs during the observed cycle.
+        self.cancel_idle_cycle_detector();
         let new_tick = self.bus.read_long(0x016A).wrapping_add(1);
         self.bus.write_long(0x016A, new_tick);
         self.dispatcher.tick_count = new_tick;
@@ -9444,6 +9849,242 @@ mod tests {
                 runner.dispatcher.tick_count,
             );
         }
+    }
+
+    #[test]
+    fn exact_idle_cycle_requires_cpu_and_memory_repeat() {
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        let trap_pc = 0x0002_0000u32;
+        let sp = 0x0010_0000u32;
+        let scratch = 0x0020_0000u32;
+        runner.cpu.write_reg(Register::PC, trap_pc + 2);
+        runner.cpu.core.ppc = trap_pc;
+        runner.cpu.core.ir = 0xA975;
+        runner.cpu.write_reg(Register::A7, sp);
+        runner.bus.write_long(sp, 100);
+        runner.bus.write_long(scratch, 0x1122_3344);
+        runner.bus.write_long(0x016A, 100);
+        runner.dispatcher.tick_count = 100;
+        assert!(!runner.try_exact_idle_cycle_fastfwd(trap_pc, 200, Some(105)));
+        assert!(!runner.try_exact_idle_cycle_fastfwd(trap_pc, 200, Some(105)));
+        assert!(runner.idle_cycle_probe.is_some());
+        assert!(runner.bus.fast_mem_window().is_none());
+
+        // A complete guest iteration may use its stack and locals as long as
+        // it restores every touched byte before returning to the boundary.
+        runner.bus.write_long(scratch, 0xAABB_CCDD);
+        runner.bus.write_long(scratch, 0x1122_3344);
+        runner.note_idle_cycle_trap_result(0xA971); // null EventAvail result at SP
+
+        assert!(runner.try_exact_idle_cycle_fastfwd(trap_pc, 200, Some(105)));
+        assert_eq!(runner.dispatcher.tick_count, 105);
+        assert_eq!(runner.bus.read_long(0x016A), 105);
+        assert_eq!(runner.bus.read_long(sp), 100);
+        assert!(runner.idle_cycle_probe.is_none());
+        assert!(runner.idle_cycle_sleep.is_some());
+        assert!(
+            runner.bus.fast_mem_window().is_none(),
+            "the parked sleep keeps a write guard armed across the frontend boundary"
+        );
+
+        runner.dispatcher.sent_open_app_event = true;
+        assert!(runner.try_resume_proven_idle_cycle(Some(110)));
+        assert_eq!(runner.dispatcher.tick_count, 110);
+        assert_eq!(runner.bus.read_long(sp), 100);
+        assert!(runner.idle_cycle_sleep.is_some());
+
+        runner.push_mouse_down(20, 30);
+        assert!(
+            !runner.try_resume_proven_idle_cycle(Some(115)),
+            "new host input must revoke a proof before the guest event loop is skipped"
+        );
+        assert_eq!(runner.dispatcher.tick_count, 110);
+        assert!(runner.idle_cycle_sleep.is_none());
+        assert!(runner.bus.fast_mem_window().is_some());
+    }
+
+    #[test]
+    fn exact_idle_cycle_rejects_an_architectural_cpu_change() {
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        let trap_pc = 0x0002_0000u32;
+        runner.cpu.write_reg(Register::PC, trap_pc + 2);
+        runner.cpu.core.ppc = trap_pc;
+        runner.cpu.core.ir = 0xA970;
+        runner.cpu.write_reg(Register::A7, 0x0010_0000);
+        runner.bus.write_long(0x016A, 100);
+        runner.dispatcher.tick_count = 100;
+
+        assert!(!runner.try_exact_idle_cycle_fastfwd(trap_pc, 101, Some(100)));
+        assert!(!runner.try_exact_idle_cycle_fastfwd(trap_pc, 101, Some(100)));
+        assert!(runner.idle_cycle_probe.is_some());
+
+        runner.cpu.write_reg(Register::D3, 1);
+        assert!(!runner.try_exact_idle_cycle_fastfwd(trap_pc, 101, Some(100)));
+        assert_eq!(runner.dispatcher.tick_count, 100);
+        assert!(runner.idle_cycle_sleep.is_none());
+        assert!(
+            runner.idle_cycle_probe.is_some(),
+            "a changed state may start a new observation but must not reuse the old proof"
+        );
+    }
+
+    #[test]
+    fn exact_null_event_cycle_covers_the_complete_guest_state_machine() {
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        let code = 0x0002_0000u32;
+        let event = 0x0020_0000u32;
+        let delay_base = 0x0021_0000u32;
+        let tick_base = 0x0022_0000u32;
+        let flag_base = 0x0023_0000u32;
+        let stack = 0x0010_0000u32;
+
+        // loop:
+        //   SUBQ.W  #2,A7                 ; Boolean result slot
+        //   MOVE.W  #-1,-(A7)             ; every event type
+        //   PEA      event
+        //   _GetNextEvent
+        //   TST.W   (A7)+
+        //   PEA      event.where
+        //   _GlobalToLocal
+        //   _SystemTask
+        //   SUBQ.W  #4,A7                 ; TickCount result slot
+        //   _TickCount
+        //   MOVE.W  16(A0),D0             ; event/timeout predicate
+        //   EXT.L   D0
+        //   ADD.L   32(A1),D0
+        //   CMP.L   (A7)+,D0
+        //   SLT     D0
+        //   TST.W   48(A2)
+        //   SNE     D1
+        //   OR.B    D1,D0
+        //   BEQ.W   loop
+        //
+        // The event record is overwritten with host coordinates and then
+        // converted to local coordinates on every pass. The write journal
+        // must compare final values, not reject the temporary overwrite. The
+        // post-TickCount words deliberately resemble a compiler-generated
+        // event/timeout predicate. The proof is based on the complete cycle's
+        // observed state, not on recognizing that instruction sequence.
+        for (offset, word) in [
+            (0, 0x554F),
+            (2, 0x3F3C),
+            (4, 0xFFFF),
+            (6, 0x4879),
+            (8, (event >> 16) as u16),
+            (10, event as u16),
+            (12, 0xA970),
+            (14, 0x4A5F),
+            (16, 0x4879),
+            (18, ((event + 10) >> 16) as u16),
+            (20, (event + 10) as u16),
+            (22, 0xA871),
+            (24, 0xA9B4),
+            (26, 0x594F),
+            (28, 0xA975),
+            (30, 0x3028),
+            (32, 16),
+            (34, 0x48C0),
+            (36, 0xD0A9),
+            (38, 32),
+            (40, 0xB09F),
+            (42, 0x5DC0),
+            (44, 0x4A6A),
+            (46, 48),
+            (48, 0x56C1),
+            (50, 0x8001),
+            (52, 0x6700),
+            (54, 0xFFCA),
+        ] {
+            runner.bus.write_word(code + offset, word);
+        }
+        runner.cpu.write_reg(Register::PC, code);
+        runner.cpu.write_reg(Register::A7, stack);
+        runner.cpu.write_reg(Register::A0, delay_base);
+        runner.cpu.write_reg(Register::A1, tick_base);
+        runner.cpu.write_reg(Register::A2, flag_base);
+        runner.cpu.write_reg(Register::D0, 0);
+        runner.cpu.write_reg(Register::D1, 0);
+        runner.bus.write_word(delay_base + 16, 5);
+        runner.bus.write_long(tick_base + 32, 100);
+        runner.bus.write_word(flag_base + 48, 0);
+        runner.bus.write_long(0x016A, 100);
+        runner.dispatcher.tick_count = 100;
+        runner.dispatcher.sent_open_app_event = true;
+
+        let (_, running) = runner.run_steps_internal(1_000, Some(100), 0, true, false, false);
+        assert!(running);
+        let sleep = runner
+            .idle_cycle_sleep
+            .as_ref()
+            .expect("the complete null-event state machine should prove an identity cycle");
+        assert_eq!(sleep.trap_pc, code + 12);
+        assert_eq!(sleep.wake_tick, 101);
+
+        assert!(!runner.try_resume_proven_idle_cycle(Some(101)));
+        assert_eq!(runner.dispatcher.tick_count, 101);
+        assert!(runner.idle_cycle_sleep.is_none());
+        assert_eq!(runner.cpu.core.pc, code + 14);
+    }
+
+    #[test]
+    fn proven_idle_cycle_stops_sleeping_at_its_known_dependency() {
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        let trap_pc = 0x0002_0000u32;
+        let sp = 0x0010_0000u32;
+        runner.cpu.write_reg(Register::PC, trap_pc + 2);
+        runner.cpu.core.ppc = trap_pc;
+        runner.cpu.core.ir = 0xA975;
+        runner.cpu.write_reg(Register::A7, sp);
+        runner.bus.write_long(0x016A, 100);
+        runner.dispatcher.tick_count = 100;
+        runner.dispatcher.sent_open_app_event = true;
+
+        runner.park_proven_idle_cycle(trap_pc, 103);
+        assert!(!runner.try_resume_proven_idle_cycle(Some(110)));
+        assert_eq!(runner.dispatcher.tick_count, 103);
+        assert!(runner.idle_cycle_sleep.is_none());
+        assert!(runner.bus.fast_mem_window().is_some());
+    }
+
+    #[test]
+    fn exact_idle_cycle_rejects_changed_memory_and_non_quiescent_traps() {
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        let trap_pc = 0x0002_0000u32;
+        let scratch = 0x0020_0000u32;
+        runner.cpu.write_reg(Register::PC, trap_pc + 2);
+        runner.cpu.core.ppc = trap_pc;
+        runner.cpu.core.ir = 0xA975;
+        runner.cpu.write_reg(Register::A7, 0x0010_0000);
+        runner.bus.write_long(0x016A, 100);
+        runner.dispatcher.tick_count = 100;
+        assert!(!runner.try_exact_idle_cycle_fastfwd(trap_pc, 200, Some(105)));
+        assert!(!runner.try_exact_idle_cycle_fastfwd(trap_pc, 200, Some(105)));
+        runner.bus.write_byte(scratch, 1);
+        assert!(!runner.try_exact_idle_cycle_fastfwd(trap_pc, 200, Some(105)));
+        assert_eq!(runner.dispatcher.tick_count, 100);
+
+        runner.note_idle_cycle_trap_result(0xA8AD); // PtInRect has host-side HLE semantics
+        assert!(runner.idle_cycle_probe.is_none());
+        assert!(runner.idle_cycle_last_seen.is_none());
+        assert!(runner.bus.fast_mem_window().is_some());
+    }
+
+    #[test]
+    fn ordinary_tick_advance_cancels_an_exact_idle_cycle_probe() {
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        let trap_pc = 0x0002_0000u32;
+        runner.cpu.write_reg(Register::PC, trap_pc + 2);
+        runner.bus.write_long(0x016A, 100);
+        runner.dispatcher.tick_count = 100;
+        assert!(!runner.try_exact_idle_cycle_fastfwd(trap_pc, 200, Some(105)));
+        assert!(!runner.try_exact_idle_cycle_fastfwd(trap_pc, 200, Some(105)));
+        assert!(runner.idle_cycle_probe.is_some());
+
+        runner.advance_guest_tick();
+
+        assert!(runner.idle_cycle_probe.is_none());
+        assert!(runner.idle_cycle_last_seen.is_none());
+        assert!(runner.bus.fast_mem_window().is_some());
     }
 
     /// Regression gate for the TickCount spin fast-forward template A

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -683,6 +683,19 @@ fn force_button_true_at_pc() -> Option<u32> {
 }
 
 impl super::TrapDispatcher {
+    /// Whether `SystemTask` currently has periodic Desk Manager work to do.
+    ///
+    /// Inside Macintosh Volume I, I-442 and I-444 through I-445, specifies
+    /// that `SystemTask` calls the control routines of open desk accessories
+    /// and other device drivers whose `dNeedTime`/`drvrDelay` period has
+    /// elapsed. Systemless does not yet model that periodic DA/driver chain,
+    /// so the current HLE implementation has no observable work. Keeping the
+    /// decision behind this runtime query gives future DA/driver support a
+    /// single place to revoke transparent execution.
+    pub(crate) fn system_task_has_periodic_work(&self) -> bool {
+        false
+    }
+
     const LIST_RVIEW_OFFSET: u32 = 0;
     const LIST_PORT_OFFSET: u32 = 8;
     const LIST_INDENT_OFFSET: u32 = 12;
@@ -4894,7 +4907,7 @@ impl super::TrapDispatcher {
             }
 
             // SystemTask ($A9B4)
-            // Per IM:I I-440: "For each open desk accessory (or other
+            // Per IM:I I-442: "For each open desk accessory (or other
             // device driver performing periodic actions), SystemTask
             // causes the accessory to perform the periodic action
             // defined for it, if any such action has been defined and
@@ -4903,22 +4916,21 @@ impl super::TrapDispatcher {
             // often as possible, usually once every time through your
             // main event loop."
             // PROCEDURE SystemTask;
-            // Inside Macintosh Volume I, I-440
+            // Inside Macintosh Volume I, I-442; periodic driver state is
+            // described at I-444 through I-445.
             //
-            // Calling convention (Tool-bit PROCEDURE per IM:I I-440):
+            // Calling convention (Tool-bit PROCEDURE per IM:I I-442):
             //   no inputs, no FUNCTION result slot, no Pascal stack
             //   argument frame. A7 is preserved across the call.
             //
             // MPW Universal Headers Desk.h:
             //   EXTERN_API(void) SystemTask(void) ONEWORDINLINE(0xA9B4);
             //
-            // HLE compromise: Systemless models no Desk Accessories, no
-            // DRVR chain, no DCE table, no Time Manager periodic-task
-            // queue — every component the trap would walk is empty.
-            // The implementation is `Ok(())` (a true no-op). Apps
-            // universally call SystemTask once per main-event-loop
-            // iteration; the call is correctly a no-op since no DA is
-            // registered.
+            // HLE compromise: Systemless models no open Desk Accessories or
+            // periodic device-driver chain, so every component this trap
+            // would currently visit is empty. The implementation is
+            // `Ok(())`; `system_task_has_periodic_work` is the runtime gate
+            // that must become true before either subsystem is implemented.
             //
             // Behavioral contract:
             //   - register-only Tool-bit PROCEDURE calling convention
@@ -18260,9 +18272,14 @@ mod tests {
     // SystemTask ($A9B4)
     #[test]
     fn systemtask_procedure_call_preserves_stack_pointer() {
-        // IM:I 1985, p. I-440: PROCEDURE SystemTask;
+        // IM:I 1985, p. I-442: PROCEDURE SystemTask;
         let (mut disp, mut cpu, mut bus) = setup();
         let sp_before = cpu.read_reg(Register::A7);
+
+        assert!(
+            !disp.system_task_has_periodic_work(),
+            "the transparent path is valid only while no periodic DA/driver work is modeled"
+        );
 
         let result = disp.dispatch_toolbox(true, 0x1B4, &mut cpu, &mut bus);
         assert!(result.is_some());
@@ -18278,7 +18295,7 @@ mod tests {
     // single call might mask.
     #[test]
     fn systemtask_five_call_composition_preserves_stack_pointer() {
-        // IM:I 1985, p. I-440: PROCEDURE SystemTask;
+        // IM:I 1985, p. I-442: PROCEDURE SystemTask;
         let (mut disp, mut cpu, mut bus) = setup();
         let sp_before = cpu.read_reg(Register::A7);
 


### PR DESCRIPTION
## Summary

Prove complete, quiescent null-event cycles at runtime and park the guest until the first dependency that can change their result.

This is intentionally broader than recognizing another compiler-specific delay loop. It observes a full pass through an application's event state machine, beginning at the post-`GetNextEvent` boundary, and accepts it only after the code returns to the same trap site with:

- identical architectural 68k state;
- identical final values for every guest-memory byte written during the cycle;
- no non-null event or unknown/non-quiescent Toolbox trap;
- unchanged host mouse, button, modifier, and key-map state;
- unchanged `TickCount` during the proof;
- no pending key repeat, launch, interrupt callback, or periodic `SystemTask` work.

After proof, the runner executes no guest code until the next guest tick or the current frontend cap/interrupt. A second write journal remains active across frontend slices; any CPU, memory, host-input, event-stream, or periodic-work change revokes the sleep and resumes normal execution at the proven boundary.

The implementation journals original bytes rather than snapshotting all guest RAM. Temporary writes that restore their old value are accepted, while any changed final byte rejects the proof. Direct and bulk memory paths participate in the same journal.

The reusable source, comments, test names, and commit message do not identify a particular application.

## Why an aggressive intervention is needed

3 in Three exhibits pathological behavior under the previous runner: its foreground loop can consume a host core while repeatedly executing a compiler-generated event state machine that is semantically idle. It took several days of profiling, rejected instruction-pattern experiments, clock/pacing investigation, and ablation to identify a conservative general solution.

Unlike a simple delay loop, this state machine calls `GetNextEvent`, performs coordinate/input housekeeping including `GlobalToLocal`, calls `SystemTask`, reads `TickCount`, evaluates predicates, and returns to the same architectural state. Matching one backward branch or one instruction window was either incomplete or brittle. Proving the complete cycle captures the semantic fact that matters: the iteration had no externally visible effect and cannot produce a different answer before a known dependency changes.

Lemmings is designed differently. Its main loop predominantly waits in direct `TickCount` comparison forms already covered by the older decoded templates, so it did not expose this failure mode. The new detector is therefore dramatic for 3 in Three but only a small secondary benefit for Lemmings.

## Profiling and ablation

All captures used optimized x86-64 macOS builds and a 30-second `/usr/bin/sample` interval. The metric below is top-of-stack samples in `FixtureRunner::run_steps_internal`, approximately one sample per millisecond of CPU time.

### Exact detector, decoded matchers held constant

| 3 in Three active intro | Runner samples | Approx. one-core CPU |
|---|---:|---:|
| All decoded matchers, no exact proof | 2,986 / 24,191 | 12.34% |
| Same decoded matchers + exact proof | 26 / 24,881 | 0.10% |

That is a 99.1% reduction in runner CPU, or roughly 115x fewer samples.

The detector also remains effective without the other local candidate layers: exact proof alone measured 302 / 24,682 samples (1.22%). The final trimmed stack—computed-deadline support plus exact proof, after removing two unhelpful layers—measured 35 / 23,992 (0.15%).

### Cross-check

| Lemmings Level 1 | Runner samples | Approx. one-core CPU |
|---|---:|---:|
| Decoded matchers, no exact proof | 139 / 24,673 | 0.56% |
| With exact proof | 118 / 24,851 | 0.47% |

The small Lemmings difference confirms both the workload distinction and the absence of a regression. Interactive testing covered the 3 in Three intro and Lemmings Level 1, including input, graphics, and audio.

Two candidate prerequisites were explicitly rejected after ablation:

- caching a `GlobalToLocal` diagnostic environment lookup changed 1.22% to 1.09%, within noise;
- a compiler-specific event-or-timeout matcher changed 0.13% to 0.10% after exact proof, also within noise and subsumed by the general detector.

Neither rejected change is included.

## Classic Mac OS semantics

Inside Macintosh Volume I, I-257..I-258 documents that `GetNextEvent` returns a null event and `FALSE` when no selected event is available. The detector begins only after observing that null result; it does not turn `GetNextEvent` itself into a blocking call.

Inside Macintosh Volume I, I-442 says applications should call `SystemTask` as often as possible and at least every sixtieth of a second. I-444..I-445 explains that `SystemTask` may invoke periodic desk-accessory/driver work according to `drvrDelay`. Accordingly, `SystemTask` is proof-safe only while the runtime reports that no such periodic work is registered.

"Parking ends at the next guest tick" means the detector skips only the remaining repetitions for the current `TickCount` value—at most one Classic Mac OS tick, approximately 1/60 second. The proof establishes that a complete loop iteration returns to identical CPU and final memory state while `TickCount`, host input, the event stream, and the permitted trap results remain unchanged. It does **not** claim that the loop will remain inert after time advances: the application may take a different branch, redraw, or make periodic work eligible as soon as `TickCount` increments. Therefore the runner chooses `current_tick + 1` as the first possible dependency, advances no farther than that (or an earlier frontend cap/interrupt), updates the normal low-memory tick value, and resumes ordinary guest execution at the proven boundary. The guest then executes the next iteration itself and observes the new time normally. Cross-slice memory journaling plus host-input/event checks revoke the park even earlier if any other dependency changes. This is why the optimization can remove millions of same-tick repetitions without skipping an arbitrary delay or suppressing tick-dependent behavior.

## Prior art

Basilisk II and SheepShaver use the same high-level principle—stop executing a guest idle path and wait on the host—but implement it by patching a known system `SynchIdleTime` routine:

- [Basilisk II patches `SynchIdleTime`](https://github.com/cebix/macemu/blob/96e512bd6376e78a2869f16dcc8a9028bce5ee72/BasiliskII/src/rsrc_patches.cpp#L57-L79)
- [Basilisk II checks the low-memory event queue before sleeping](https://github.com/cebix/macemu/blob/96e512bd6376e78a2869f16dcc8a9028bce5ee72/BasiliskII/src/emul_op.cpp#L560-L565)
- [Basilisk II host `idle_wait`/`idle_resume`](https://github.com/cebix/macemu/blob/96e512bd6376e78a2869f16dcc8a9028bce5ee72/BasiliskII/src/Unix/timer_unix.cpp#L330-L401)
- [SheepShaver patches the ROM idle routine](https://github.com/cebix/macemu/blob/96e512bd6376e78a2869f16dcc8a9028bce5ee72/SheepShaver/src/rom_patches.cpp#L2315-L2329)
- [SheepShaver's idle emulation operation](https://github.com/cebix/macemu/blob/96e512bd6376e78a2869f16dcc8a9028bce5ee72/SheepShaver/src/emul_op.cpp#L477-L488)

Systemless has no System ROM idle routine to patch and must handle application-owned event loops. Runtime proof is therefore more general and more conservative: it derives eligibility from complete CPU, final-memory, host-state, event, and trap quiescence instead of recognizing a fixed ROM entry point and synthesizing its result.

## Tests

- exact CPU and final-memory repeat required;
- an architectural register mismatch rejects proof;
- a complete compiler-shaped `GetNextEvent`/`GlobalToLocal`/`SystemTask`/`TickCount` loop is covered;
- the known next-tick dependency wakes the guest;
- changed memory and non-quiescent traps reject proof;
- an ordinary tick cancels an in-progress probe;
- temporary restored writes are accepted;
- changed final bytes are rejected;
- bulk/copy fast paths participate in the journal;
- full library suite: 2,768 passed, 0 failed, 3 ignored.

This PR is stacked on #136. The two optimizations are kept in separate commits because they solve different idle-loop forms and each has independent profiling evidence. Until #136 merges, GitHub's `master` comparison necessarily shows both fork commits; the exact-cycle commit by itself can be reviewed at [this one-commit comparison](https://github.com/rlanday/systemless/compare/perf/computed-tickcount-waits...perf/exact-idle-final). Once #136 merges, this PR will automatically reduce to the exact-cycle commit alone.
