### PR TITLE
fix: deliver mouse input to custom ADB service routines

### DIFF
--- a/src/adb.rs
+++ b/src/adb.rs
@@ -1,0 +1,240 @@
+//! Apple Desktop Bus device-table and input-packet state.
+
+use std::collections::VecDeque;
+
+/// One entry in the ADB Manager's device table.
+///
+/// Inside Macintosh Volume V (1986), pp. V-367 to V-370.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct AdbDeviceEntry {
+    pub current_address: u8,
+    pub handler_id: u8,
+    pub original_address: u8,
+    pub service_routine: u32,
+    pub data_area: u32,
+}
+
+/// One Talk-register-0 delivery to a registered ADB service routine.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct PendingAdbPacket {
+    pub packet: [u8; 3],
+    pub service_routine: u32,
+    pub data_area: u32,
+    pub command: u8,
+}
+
+pub(crate) struct AdbManager {
+    devices: [AdbDeviceEntry; 2],
+    pending_packets: VecDeque<PendingAdbPacket>,
+    standard_service_routine: u32,
+    last_mouse_position: (i16, i16),
+    last_mouse_button: bool,
+}
+
+impl AdbManager {
+    pub(crate) fn new() -> Self {
+        Self {
+            devices: [
+                AdbDeviceEntry {
+                    current_address: 2,
+                    handler_id: 2,
+                    original_address: 2,
+                    service_routine: 0,
+                    data_area: 0,
+                },
+                AdbDeviceEntry {
+                    current_address: 3,
+                    handler_id: 1,
+                    original_address: 3,
+                    service_routine: 0,
+                    data_area: 0,
+                },
+            ],
+            pending_packets: VecDeque::new(),
+            standard_service_routine: 0,
+            last_mouse_position: (0, 0),
+            last_mouse_button: false,
+        }
+    }
+
+    pub(crate) fn device_count(&self) -> u8 {
+        self.devices.len() as u8
+    }
+
+    pub(crate) fn device_by_index(&self, index: u8) -> Option<AdbDeviceEntry> {
+        index
+            .checked_sub(1)
+            .and_then(|index| self.devices.get(index as usize))
+            .copied()
+    }
+
+    pub(crate) fn device_by_address(&self, address: u8) -> Option<AdbDeviceEntry> {
+        self.devices
+            .iter()
+            .find(|entry| entry.current_address == address)
+            .copied()
+    }
+
+    pub(crate) fn set_device_handler(
+        &mut self,
+        address: u8,
+        service_routine: u32,
+        data_area: u32,
+        mouse_button: bool,
+    ) -> bool {
+        let Some(entry) = self
+            .devices
+            .iter_mut()
+            .find(|entry| entry.current_address == address)
+        else {
+            return false;
+        };
+        entry.service_routine = service_routine;
+        entry.data_area = data_area;
+        if entry.original_address == 3 {
+            // Frontends provide absolute host coordinates, while a custom
+            // ADB driver consumes relative deltas and owns its cursor state.
+            // Reset the bridge so the first host position is delivered as a
+            // complete delta stream rather than relative to the HLE standard
+            // driver's hidden host-side baseline.
+            self.last_mouse_position = (0, 0);
+            self.last_mouse_button = mouse_button;
+            self.pending_packets.clear();
+        }
+        true
+    }
+
+    pub(crate) fn install_standard_service_routine(&mut self, service_routine: u32) {
+        self.standard_service_routine = service_routine;
+        for entry in &mut self.devices {
+            entry.service_routine = service_routine;
+        }
+    }
+
+    pub(crate) fn flush(&mut self, address: u8) {
+        self.pending_packets
+            .retain(|packet| packet.command >> 4 != address);
+    }
+
+    pub(crate) fn note_mouse_state(&mut self, position: (i16, i16), button: bool) {
+        let Some(mouse) = self.device_by_address(3) else {
+            return;
+        };
+        let mut remaining_v = i32::from(position.0) - i32::from(self.last_mouse_position.0);
+        let mut remaining_h = i32::from(position.1) - i32::from(self.last_mouse_position.1);
+        let button_changed = button != self.last_mouse_button;
+        self.last_mouse_position = position;
+        self.last_mouse_button = button;
+
+        if mouse.service_routine == 0 || mouse.service_routine == self.standard_service_routine {
+            return;
+        }
+
+        let mut first = true;
+        while first || remaining_v != 0 || remaining_h != 0 {
+            first = false;
+            if remaining_v == 0 && remaining_h == 0 && !button_changed {
+                break;
+            }
+            let delta_v = remaining_v.clamp(-64, 63) as i8;
+            let delta_h = remaining_h.clamp(-64, 63) as i8;
+            remaining_v -= i32::from(delta_v);
+            remaining_h -= i32::from(delta_h);
+
+            // A standard 100/200-dpi mouse returns two seven-bit signed
+            // deltas. Bit 7 is clear while the corresponding button is down;
+            // the one-button mouse always reports its second button as up.
+            // Inside Macintosh Volume V (1986), pp. V-364 to V-366.
+            let vertical = (delta_v as u8 & 0x7F) | if button { 0x00 } else { 0x80 };
+            let horizontal = (delta_h as u8 & 0x7F) | 0x80;
+            self.pending_packets.push_back(PendingAdbPacket {
+                packet: [2, vertical, horizontal],
+                service_routine: mouse.service_routine,
+                data_area: mouse.data_area,
+                command: (mouse.current_address << 4) | 0x0C,
+            });
+        }
+    }
+
+    pub(crate) fn pop_pending_packet(&mut self) -> Option<PendingAdbPacket> {
+        self.pending_packets.pop_front()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn pending_packet_count(&self) -> usize {
+        self.pending_packets.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mouse_motion_is_split_into_signed_seven_bit_talk_zero_packets() {
+        let mut adb = AdbManager::new();
+        assert!(adb.set_device_handler(3, 0x0012_3456, 0x0065_4321, false));
+
+        adb.note_mouse_state((-80, 80), false);
+
+        assert_eq!(adb.pending_packet_count(), 2);
+        assert_eq!(
+            adb.pop_pending_packet(),
+            Some(PendingAdbPacket {
+                packet: [2, 0xC0, 0xBF],
+                service_routine: 0x0012_3456,
+                data_area: 0x0065_4321,
+                command: 0x3C,
+            })
+        );
+        assert_eq!(
+            adb.pop_pending_packet(),
+            Some(PendingAdbPacket {
+                packet: [2, 0xF0, 0x91],
+                service_routine: 0x0012_3456,
+                data_area: 0x0065_4321,
+                command: 0x3C,
+            })
+        );
+    }
+
+    #[test]
+    fn mouse_button_transitions_queue_zero_delta_packets() {
+        let mut adb = AdbManager::new();
+        assert!(adb.set_device_handler(3, 0x0012_3456, 0, false));
+
+        adb.note_mouse_state((0, 0), true);
+        adb.note_mouse_state((0, 0), false);
+
+        assert_eq!(adb.pop_pending_packet().unwrap().packet, [2, 0x00, 0x80]);
+        assert_eq!(adb.pop_pending_packet().unwrap().packet, [2, 0x80, 0x80]);
+    }
+
+    #[test]
+    fn standard_mouse_service_does_not_duplicate_event_manager_input() {
+        let mut adb = AdbManager::new();
+        adb.install_standard_service_routine(0x0012_3456);
+
+        adb.note_mouse_state((100, 200), true);
+
+        assert_eq!(adb.pending_packet_count(), 0);
+    }
+
+    #[test]
+    fn flush_discards_only_packets_for_the_selected_device() {
+        let mut adb = AdbManager::new();
+        assert!(adb.set_device_handler(3, 0x0012_3456, 0, false));
+        adb.note_mouse_state((10, 20), false);
+        adb.pending_packets.push_back(PendingAdbPacket {
+            packet: [1, 0, 0],
+            service_routine: 0x0065_4321,
+            data_area: 0,
+            command: 0x2C,
+        });
+
+        adb.flush(3);
+
+        assert_eq!(adb.pending_packet_count(), 1);
+        assert_eq!(adb.pop_pending_packet().unwrap().command, 0x2C);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@
 //!
 //! [`m68k`]: https://crates.io/crates/m68k
 
+mod adb;
 pub mod audio;
 pub mod binhex;
 pub mod cpu;

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -636,6 +636,7 @@ fn current_mac_epoch_seconds() -> u32 {
 
 #[derive(Clone, Copy, Debug)]
 enum ActiveInterruptCallbackSource {
+    Adb,
     Timer,
     Vbl,
     CursorTask,
@@ -864,6 +865,9 @@ pub struct FixtureRunner {
     /// Guest-memory address of the low-memory `JCrsrTask` callback trampoline.
     /// Allocated once on first use and reused for cursor task callbacks.
     cursor_task_trampoline: u32,
+    /// Guest-memory trampoline and packet buffer for ADB service routines.
+    adb_callback_trampoline: u32,
+    adb_packet_buffer: u32,
     /// Currently executing Time Manager callback, if any.
     ///
     /// Real timer delivery happens from interrupt context, so the same timer source
@@ -951,9 +955,15 @@ impl FixtureRunner {
     pub fn new(ram_size: usize, config: FixtureRunnerConfig) -> Self {
         let mut dispatcher = TrapDispatcher::new();
         dispatcher.set_ui_theme_id(config.ui_theme);
+        let mut bus = MacMemoryBus::new(ram_size);
+        let standard_adb_service = bus.alloc_synthetic(2);
+        bus.write_word(standard_adb_service, 0x4E75); // RTS
+        dispatcher
+            .adb
+            .install_standard_service_routine(standard_adb_service);
         Self {
             cpu: M68kCpu::new(),
-            bus: MacMemoryBus::new(ram_size),
+            bus,
             dispatcher,
             config,
             trace_buffer: std::collections::VecDeque::with_capacity(2000),
@@ -973,6 +983,8 @@ impl FixtureRunner {
             timer_trampoline: 0,
             vbl_trampoline: 0,
             cursor_task_trampoline: 0,
+            adb_callback_trampoline: 0,
+            adb_packet_buffer: 0,
             active_interrupt_callback: None,
             audio: None,
             audio_buffer: Vec::new(),
@@ -3249,6 +3261,7 @@ impl FixtureRunner {
             // or reuse its parameter block.
             if !sound_work_only && self.active_interrupt_callback.is_none() {
                 self.fire_file_completion_callback();
+                self.fire_adb_callback();
             }
 
             // Sound callbacks are interrupt work. If a previous slice queued
@@ -5176,6 +5189,47 @@ impl FixtureRunner {
         self.cpu.write_reg(Register::A0, completion.parameter_block);
         self.cpu
             .write_reg(Register::D0, completion.result as i32 as u32);
+        true
+    }
+
+    /// Deliver one pending ADB Talk-register-0 packet to the service routine
+    /// installed through SetADBInfo.
+    ///
+    /// A0 points to the Pascal-string packet, A1 to the service routine,
+    /// A2 to its registered data area, and D0 contains the command byte.
+    /// Inside Macintosh Volume V (1986), pp. V-367 to V-371.
+    fn fire_adb_callback(&mut self) -> bool {
+        if self.active_interrupt_callback.is_some() {
+            return false;
+        }
+        let Some(packet) = self.dispatcher.adb.pop_pending_packet() else {
+            return false;
+        };
+        if packet.service_routine == 0 {
+            return false;
+        }
+
+        if self.adb_callback_trampoline == 0 {
+            let tramp = self.bus.alloc_synthetic(8);
+            self.bus.write_word(tramp, 0x4EB9); // JSR abs.L
+            self.bus.write_word(tramp + 6, 0x4E75); // RTS
+            self.adb_callback_trampoline = tramp;
+        }
+        if self.adb_packet_buffer == 0 {
+            self.adb_packet_buffer = self.bus.alloc_synthetic(4);
+        }
+
+        let tramp = self.adb_callback_trampoline;
+        self.bus.write_long(tramp + 2, packet.service_routine);
+        for (offset, byte) in packet.packet.into_iter().enumerate() {
+            self.bus
+                .write_byte(self.adb_packet_buffer + offset as u32, byte);
+        }
+        self.inject_interrupt_callback(ActiveInterruptCallbackSource::Adb, tramp);
+        self.cpu.write_reg(Register::A0, self.adb_packet_buffer);
+        self.cpu.write_reg(Register::A1, packet.service_routine);
+        self.cpu.write_reg(Register::A2, packet.data_area);
+        self.cpu.write_reg(Register::D0, u32::from(packet.command));
         true
     }
 
@@ -9309,6 +9363,62 @@ mod tests {
         assert_eq!(runner.cpu.read_reg(Register::A7), interrupted_sp);
         assert_eq!(runner.cpu.read_reg(Register::A0), 0x1111_1111);
         assert_eq!(runner.cpu.read_reg(Register::D0), 0x2222_2222);
+        assert!(!runner.is_halted());
+    }
+
+    #[test]
+    fn adb_mouse_callback_uses_documented_registers_and_restores_foreground() {
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        let interrupted_pc = 0x0001_0000;
+        let interrupted_sp = 0x007F_FFC0;
+        let callback_addr = runner.bus.alloc(2);
+        let data_area = runner.bus.alloc(16);
+
+        runner.bus.write_word(callback_addr, 0x4E75); // RTS
+        for offset in (0..20).step_by(2) {
+            runner.bus.write_word(interrupted_pc + offset, 0x4E71); // NOP
+        }
+        runner.cpu.write_reg(Register::PC, interrupted_pc);
+        runner.cpu.write_reg(Register::A7, interrupted_sp);
+        runner.cpu.write_reg(Register::A0, 0x1111_1111);
+        runner.cpu.write_reg(Register::A1, 0x2222_2222);
+        runner.cpu.write_reg(Register::A2, 0x3333_3333);
+        runner.cpu.write_reg(Register::D0, 0x4444_4444);
+        assert!(runner.dispatcher.adb.set_device_handler(
+            3,
+            callback_addr,
+            data_area,
+            false,
+        ));
+        runner.dispatcher.adb.note_mouse_state((5, -10), true);
+
+        assert!(runner.fire_adb_callback());
+        let packet_ptr = runner.cpu.read_reg(Register::A0);
+        assert_eq!(runner.bus.read_bytes(packet_ptr, 3), &[2, 5, 0xF6]);
+        assert_eq!(runner.cpu.read_reg(Register::A1), callback_addr);
+        assert_eq!(runner.cpu.read_reg(Register::A2), data_area);
+        assert_eq!(runner.cpu.read_reg(Register::D0), 0x3C);
+        assert!(matches!(
+            runner.active_interrupt_callback.map(|active| active.source),
+            Some(ActiveInterruptCallbackSource::Adb)
+        ));
+        assert!(
+            runner
+                .bus
+                .get_alloc_size(runner.adb_callback_trampoline)
+                .is_none(),
+            "Systemless-owned ADB trampoline must stay outside the guest heap"
+        );
+
+        let (_, running) = runner.run_steps(6, None);
+
+        assert!(running);
+        assert!(runner.active_interrupt_callback.is_none());
+        assert_eq!(runner.cpu.read_reg(Register::A7), interrupted_sp);
+        assert_eq!(runner.cpu.read_reg(Register::A0), 0x1111_1111);
+        assert_eq!(runner.cpu.read_reg(Register::A1), 0x2222_2222);
+        assert_eq!(runner.cpu.read_reg(Register::A2), 0x3333_3333);
+        assert_eq!(runner.cpu.read_reg(Register::D0), 0x4444_4444);
         assert!(!runner.is_halted());
     }
 

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -970,6 +970,8 @@ pub(crate) struct InverseTableCacheEntry {
 
 /// Trap dispatcher with resource fork access and emulator state.
 pub struct TrapDispatcher {
+    /// Synthetic keyboard and mouse entries exposed by the ADB Manager.
+    pub(crate) adb: crate::adb::AdbManager,
     /// Loaded resources by handle -> (ptr, type, id)
     pub(crate) loaded_handles: HashMap<u32, (u32, [u8; 4], i16)>,
     /// Fast index from (resource-file refnum, type, id) to its live handle.
@@ -2716,6 +2718,7 @@ impl TrapDispatcher {
         vfs_directory_paths.insert(2, String::new());
 
         let mut dispatcher = Self {
+            adb: crate::adb::AdbManager::new(),
             loaded_handles: HashMap::new(),
             resource_handles_by_key: HashMap::new(),
             handle_state_bits: HashMap::new(),
@@ -4068,6 +4071,7 @@ impl TrapDispatcher {
     /// Coordinates are in Mac screen space (0,0 = top-left of screen).
     pub fn set_mouse_position(&mut self, v: i16, h: i16) {
         self.mouse_pos = (v, h);
+        self.adb.note_mouse_state(self.mouse_pos, self.mouse_button);
     }
 
     pub(crate) fn has_unmatched_queued_mouse_down(&self) -> bool {
@@ -4086,6 +4090,7 @@ impl TrapDispatcher {
     pub fn push_mouse_down(&mut self, v: i16, h: i16) {
         self.mouse_button = true;
         self.mouse_pos = (v, h);
+        self.adb.note_mouse_state(self.mouse_pos, self.mouse_button);
         let modifiers = self.current_event_modifiers();
         self.event_queue.push_back(QueuedEvent {
             what: 1, // mouseDown
@@ -4104,6 +4109,7 @@ impl TrapDispatcher {
     pub fn push_mouse_up(&mut self, v: i16, h: i16) {
         self.mouse_pos = (v, h);
         self.mouse_button = false;
+        self.adb.note_mouse_state(self.mouse_pos, self.mouse_button);
         let modifiers = self.current_event_modifiers();
         self.event_queue.push_back(QueuedEvent {
             what: 2, // mouseUp

--- a/src/trap/memory.rs
+++ b/src/trap/memory.rs
@@ -3341,88 +3341,26 @@ impl super::TrapDispatcher {
             // Returns the number of ADB devices.
             // FUNCTION CountADBs: INTEGER;
             // Inside Macintosh Volume V, V-372
-            //
-            // Returns count in D0. We report 2 devices (keyboard + mouse).
-            //
-            // CountADBs ($A077): Returns 2 (keyboard + mouse) per IM:V V-372
             (false, 0x77) => {
-                cpu.write_reg(Register::D0, 2); // keyboard + mouse
+                cpu.write_reg(Register::D0, u32::from(self.adb.device_count()));
                 Ok(())
             }
 
-            // GetIndADB ($A078) — ADB Manager
-            //
-            // Per IM:V V-373: "GetIndADB returns information from the
-            // ADB device-table entry whose index number is given by
-            // devTableIndex. ... GetIndADB returns the current ADB
-            // address of the device. If it is unable to complete
-            // execution successfully, GetIndADB returns a negative
-            // value."
-            //
-            // Per IM:V V-373 + IM:Devices 1994 pp. 5-43..5-44:
-            // GetIndADB is an OS-bit trap with register-only ABI.
-            //   On entry  A0 = pointer to ADBDataBlock
-            //             D0 = devTableIndex (byte, range 1..CountADBs)
-            //   On exit   D0 = positive current ADB address (byte) OR
-            //                  negative error code (byte)
-            //
-            // ADBDataBlock layout (IM:V V-373, 10 bytes):
-            //     +0  devType        SignedByte  {handler ID}
-            //     +1  origADBAddr    SignedByte  {original ADB addr}
-            //     +2  dbServiceRtPtr Ptr (4)     {service routine}
-            //     +6  dbDataAreaAddr Ptr (4)     {data area for rtn}
-            //
-            // MPW Universal Headers (DeskBus.h) exposes GetIndADB
-            // as an inline OS trap with `#pragma parameter __D0
-            // GetIndADB(__A0, __D0)` mapping the FUNCTION result to
-            // D0, the info pointer to A0, and devTableIndex to D0:
-            //   #pragma parameter __D0 GetIndADB(__A0, __D0)
-            //   EXTERN_API( ADBAddress )
-            //   GetIndADB(ADBDataBlock *info, short devTableIndex)
-            //     ONEWORDINLINE(0xA078);
-            //
-            // BasiliskII-vs-Systemless note (they agree on the documented
-            // API surface; only the specific byte values written
-            // through *info diverge): BasiliskII System 7.5.3 ROM
-            // walks its real ADB device table populated by the boot
-            // sequence, writing actual handler-ID + service-routine
-            // + data-area-pointer bytes. Systemless HLE hardcodes the
-            // System 7.5 default-address scheme from IM:V V-364..V-365
-            // (index 1 -> keyboard at ADB address 2, index 2 -> mouse
-            // at ADB address 3) and zero-fills devType / service-rtn
-            // / data-area fields since neither pointer is meaningful
-            // in the HLE event model. Both engines agree on:
-            //   * positive ADB-address return for valid indices
-            //   * negative error return for out-of-range indices
-            //   * caller's ADBDataBlock written through A0
-            // The documented API-surface behavior matches Apple; the
-            // per-byte exact values do NOT (kx_GetIndADB rec_b1 contents
-            // differ byte-for-byte between BII and Systemless).
-            //
-            // Regression coverage (in-Rust):
-            //   getindadb_returns_device_info
-            //   src/trap/memory.rs `mod tests`:
-            //     - getindadb_valid_index_returns_positive_adb_address
-            //     - getindadb_out_of_range_index_returns_negative_result
-            //     - getindadb_writes_adbdatablock_for_valid_index
-            //     - getindadb_preserves_caller_memory_beyond_adbdatablock
+            // GetIndADB ($A078)
+            // Returns a device-table entry selected by its one-based index.
+            // FUNCTION GetIndADB(VAR info: ADBDataBlock; devTableIndex: INTEGER): ADBAddress;
+            // Inside Macintosh Volume V, V-373
             (false, 0x78) => {
                 let index = cpu.read_reg(Register::D0) & 0xFF;
                 let info_ptr = cpu.read_reg(Register::A0);
-                if let Some(adb_addr) = match index {
-                    1 => Some(2u32), // keyboard
-                    2 => Some(3u32), // mouse
-                    _ => None,
-                } {
+                if let Some(entry) = self.adb.device_by_index(index as u8) {
                     if info_ptr != 0 {
-                        // ADBDataBlock: devType(1), origADBAddr(1), dbServiceRtPtr(4), dbDataAreaAddr(4).
-                        // HLE exposes two canonical devices and zeroes pointer fields.
-                        for i in 0..10u32 {
-                            bus.write_byte(info_ptr + i, 0);
-                        }
-                        bus.write_byte(info_ptr + 1, adb_addr as u8);
+                        bus.write_byte(info_ptr, entry.handler_id);
+                        bus.write_byte(info_ptr + 1, entry.original_address);
+                        bus.write_long(info_ptr + 2, entry.service_routine);
+                        bus.write_long(info_ptr + 6, entry.data_area);
                     }
-                    cpu.write_reg(Register::D0, adb_addr);
+                    cpu.write_reg(Register::D0, u32::from(entry.current_address));
                 } else {
                     // IM:Devices 5-43 / IM:V V-373: unknown entry -> negative result.
                     cpu.write_reg(Register::D0, 0xFFFF_FFFF);
@@ -3434,16 +3372,20 @@ impl super::TrapDispatcher {
             // Returns ADB device info by address.
             // FUNCTION GetADBInfo(VAR info: ADBDataBlock; adbAddr: ADBAddress): OSErr;
             // Inside Macintosh Volume V, V-373
-            //
-            // GetADBInfo ($A079): Zero-fills the 10-byte ADBDataBlock, returns noErr per IM:V V-373
             (false, 0x79) => {
+                let address = (cpu.read_reg(Register::D0) & 0xFF) as u8;
                 let info_ptr = cpu.read_reg(Register::A0);
-                if info_ptr != 0 {
-                    for i in 0..10u32 {
-                        bus.write_byte(info_ptr + i, 0);
+                if let Some(entry) = self.adb.device_by_address(address) {
+                    if info_ptr != 0 {
+                        bus.write_byte(info_ptr, entry.handler_id);
+                        bus.write_byte(info_ptr + 1, entry.original_address);
+                        bus.write_long(info_ptr + 2, entry.service_routine);
+                        bus.write_long(info_ptr + 6, entry.data_area);
                     }
+                    cpu.write_reg(Register::D0, 0); // noErr
+                } else {
+                    cpu.write_reg(Register::D0, 0xFFFF_FFFF);
                 }
-                cpu.write_reg(Register::D0, 0); // noErr
                 Ok(())
             }
 
@@ -3451,10 +3393,17 @@ impl super::TrapDispatcher {
             // Sets ADB device info.
             // FUNCTION SetADBInfo(VAR info: ADBSetInfoBlock; adbAddr: ADBAddress): OSErr;
             // Inside Macintosh Volume V, V-374
-            // No-op.
-            //
-            // SetADBInfo ($A07A): Returns noErr per IM:V V-374
             (false, 0x7A) => {
+                let address = (cpu.read_reg(Register::D0) & 0xFF) as u8;
+                let info_ptr = cpu.read_reg(Register::A0);
+                if info_ptr != 0 {
+                    self.adb.set_device_handler(
+                        address,
+                        bus.read_long(info_ptr),
+                        bus.read_long(info_ptr + 4),
+                        self.mouse_button,
+                    );
+                }
                 cpu.write_reg(Register::D0, 0); // noErr
                 Ok(())
             }
@@ -3468,71 +3417,15 @@ impl super::TrapDispatcher {
             // ADBReInit ($A07B): Per IM:V V-371
             (false, 0x7B) => Ok(()),
 
-            // ADBOp ($A07C) — ADB Manager
-            //
-            // Per IM:V V-368: "ADBOp is used to send commands to ADB
-            // devices. The data parameter points to a data buffer; the
-            // compRout parameter points to a completion routine; the
-            // buffer parameter points to a data area for the
-            // completion routine; and the commandNum parameter is the
-            // ADB command byte."
-            //
-            // Per IM:V V-371 + Devices 1994 pp. 5-39..5-45: ADBOp is
-            // an OS-bit trap with a register-only ABI — the C-visible
-            // Pascal signature `FUNCTION ADBOp(data: Ptr;
-            // compRout: ProcPtr; buffer: Ptr; commandNum: INTEGER):
-            // OSErr` is informational; the actual interface is
-            // A0=ADBOpBlock pointer, D0=commandNum (byte), D0=OSErr
-            // result. No Pascal stack arguments are consumed.
-            //
-            // ADBOpBlock layout (IM:V V-368, 12 bytes):
-            //     +0  dataBuffPtr      Ptr {data buffer}
-            //     +4  opServiceRtPtr   Ptr {completion routine}
-            //     +8  opDataAreaPtr    Ptr {data area for service rtn}
-            //
-            // ADB command byte format (IM:V V-368 Table 35):
-            //     bits 7..4 = ADB device address (0..15)
-            //     bits 3..2 = command type:
-            //                   00 = SendReset (reserved/internal)
-            //                   01 = Flush
-            //                   10 = Listen
-            //                   11 = Talk
-            //     bits 1..0 = ADB register (0..3) for Listen/Talk
-            //
-            // MPW Universal Headers: <Devices.h> exposes ADBOp via
-            // an inline thunk; callers wishing to capture the D0
-            // result use `#pragma parameter __D0 kx_ADBOp(__A0, __D0)
-            // pascal long kx_ADBOp(Ptr block, short commandNum) =
-            // {0xA07C};` to map the FUNCTION result and arg registers.
-            //
-            // Inside Macintosh Volume V (1986), pp. V-367 to V-368
-            // Inside Macintosh: Devices (1994), pp. 5-39 to 5-45
-            //
-            // BasiliskII-vs-Systemless divergence on D0 return value:
-            //   BasiliskII System 7.5.3 ROM returns a non-zero result
-            //   code in D0 for synthetic ADBOp calls with no completion
-            //   routine wired (the emulated ADB Manager rejects calls
-            //   it cannot complete asynchronously). Systemless HLE returns
-            //   D0 = 0 unconditionally per its Stub (no-op)
-            //   classification — ADB hardware events are sourced by
-            //   the host event loop, so the ADB command queue is
-            //   silently accepted as a no-op.
-            //
-            //   The Apple-canonical "ADBOp returns noErr on queued
-            //   accept" contract from IM:V V-368 is pinned in-Rust via
-            //   the `adbop_returns_noerr_when_command_queue_accepts_request`
-            //   regression test below, since the engines disagree on
-            //   the absolute D0 value.
-            //
-            //   Both share the register-only OS-bit-trap calling
-            //   convention (A0 + D0 inputs, D0 output, no Pascal stack
-            //   frame).
-            //
-            // Regression coverage:
-            //   src/trap/memory.rs::tests::adbop_returns_noerr_when_command_queue_accepts_request
-            //   src/trap/memory.rs::tests::adbop_uses_a0_parameter_block_and_d0_commandnum_without_stack_arguments
-            //   src/trap/memory.rs::tests::adbop_repeated_calls_balance_stack_no_drift
+            // ADBOp ($A07C)
+            // Sends a command to an ADB device; Flush clears queued HLE packets.
+            // FUNCTION ADBOp(data: Ptr; compRout: ProcPtr; buffer: Ptr; commandNum: INTEGER): OSErr;
+            // Inside Macintosh Volume V, V-367 to V-368
             (false, 0x7C) => {
+                let command = (cpu.read_reg(Register::D0) & 0xFF) as u8;
+                if command & 0x0F == 1 {
+                    self.adb.flush(command >> 4);
+                }
                 cpu.write_reg(Register::D0, 0); // noErr
                 Ok(())
             }
@@ -10671,8 +10564,8 @@ mod tests {
         assert!(result.unwrap().is_ok(), "GetIndADB should return");
         assert_eq!(
             bus.read_byte(info),
-            0,
-            "GetIndADB should write devType field in info block"
+            2,
+            "GetIndADB should report the extended-keyboard handler ID"
         );
         assert_eq!(
             bus.read_byte(info + 1),
@@ -10761,13 +10654,13 @@ mod tests {
         assert!(result.unwrap().is_ok(), "GetADBInfo should return");
         assert_eq!(
             bus.read_byte(info),
-            0,
-            "device handler byte should be written"
+            1,
+            "GetADBInfo should report the standard mouse handler ID"
         );
         assert_eq!(
             bus.read_byte(info + 1),
-            0,
-            "original-address byte should be written"
+            3,
+            "GetADBInfo should report the mouse's original address"
         );
         assert_eq!(
             bus.read_long(info + 2),
@@ -10820,6 +10713,21 @@ mod tests {
             cpu.read_reg(Register::D0),
             0,
             "SetADBInfo nominal path should return noErr in D0"
+        );
+
+        cpu.write_reg(Register::A0, info + 16);
+        cpu.write_reg(Register::D0, 2);
+        let get_result = dispatcher.dispatch_memory(false, 0x79, &mut cpu, &mut bus);
+        assert!(get_result.unwrap().is_ok(), "GetADBInfo should return");
+        assert_eq!(
+            bus.read_long(info + 18),
+            0x00AA_5500,
+            "GetADBInfo should return the installed service routine"
+        );
+        assert_eq!(
+            bus.read_long(info + 22),
+            0x00CC_7700,
+            "GetADBInfo should return the installed data area"
         );
     }
 


### PR DESCRIPTION
## Summary

- model the keyboard and mouse entries in the ADB device table and persist handlers installed through `SetADBInfo`
- translate host mouse movement and button changes into Talk-register-0 packets for custom guest service routines
- invoke those routines with the documented registers while restoring interrupted foreground state
- keep the standard Event Manager path unchanged and implement device-specific ADB Flush behavior

## Why

Apeiron replaces the standard mouse service routine and reads input directly from ADB. Systemless previously reported placeholder table entries and treated `SetADBInfo` as a no-op, so the game could not detect or control its mouse.

## Validation

- Apeiron reaches live gameplay and its ship moves and fires through the custom ADB routine
- `cargo test --lib --features test-support` — 2,782 passed, 3 ignored
- `cargo test adb --lib` — 22 passed
- `rustfmt --check src/adb.rs`
- `git diff --check`
- `cargo clippy --all-targets --all-features` reaches an existing denied `clippy::erasing_op` finding in `src/trap/cinepak.rs:572`; the ADB changes add no lint findings

Fixes #148