### PR TITLE
fix(files): resolve the volume root through its parent ID

### DIFF
--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -3807,6 +3807,12 @@ impl TrapDispatcher {
         if normalized.is_empty() {
             return None;
         }
+        // HFS identifies a volume's root using its volume reference number,
+        // reserved parent directory ID 1, and volume name. The root itself has
+        // directory ID 2. Files 1992, 1-27 and 2-85.
+        if dir_id == 1 && normalized.eq_ignore_ascii_case(BOOT_VOLUME_NAME) {
+            return Some(String::new());
+        }
         // Sort vfs_directories keys before first-match .find() to avoid
         // leaking HashMap hash-randomisation into directory resolution
         // (and from there into resource load order, allocation order, and

--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -13755,6 +13755,39 @@ mod tests {
     }
 
     #[test]
+    fn fsdispatch_pbgetcatinfo_resolves_root_by_parent_id_and_volume_name() {
+        // Files 1992, 1-27 and 2-85: the File Manager assigns parent dirID 1
+        // to a volume's root so callers can identify it consistently by
+        // volume reference number, parent directory ID, and volume name.
+        let (mut disp, mut cpu, mut bus) = setup();
+
+        let pb = 0x300000u32;
+        let name_ptr = setup_param_block(
+            &mut bus,
+            &mut cpu,
+            pb,
+            super::super::dispatch::BOOT_VOLUME_NAME.as_bytes(),
+        );
+        bus.write_word(pb + 16, 0x3FFF);
+        bus.write_word(pb + 22, super::super::dispatch::BOOT_VOLUME_REF_NUM as u16);
+        bus.write_word(pb + 28, 0);
+        bus.write_long(pb + 48, 1);
+        cpu.write_reg(Register::D0, 9);
+
+        call(&mut disp, false, 0x60, &mut cpu, &mut bus).unwrap();
+
+        assert_eq!(cpu.read_reg(Register::D0) as i32, 0);
+        assert_eq!(bus.read_word(pb + 16) as i16, 0);
+        assert_eq!(
+            bus.read_pstring(name_ptr),
+            super::super::dispatch::BOOT_VOLUME_NAME.as_bytes()
+        );
+        assert_eq!(bus.read_byte(pb + 30), 0x10);
+        assert_eq!(bus.read_long(pb + 48), 2);
+        assert_eq!(bus.read_long(pb + 100), 1);
+    }
+
+    #[test]
     fn fsdispatch_pbgetcatinfo_finds_resource_only_file() {
         let (mut disp, mut cpu, mut bus) = setup();
 


### PR DESCRIPTION
## Root cause

Systemless models the HFS root directory as ID 2 with reserved parent ID 1, but directory-by-name lookup treated ID 1 as an ordinary missing directory. A valid catalogue query using `(boot volume, parent ID 1, volume name)` therefore returned `fnfErr` instead of the root directory.

## Change

Teach generic VFS directory resolution to map the reserved root-parent ID plus the case-insensitive boot-volume name to the existing root path. Add a focused `PBGetCatInfo` regression test that verifies root ID 2 and parent ID 1 are returned.

## Validation

- Confirmed the focused test fails with `fnfErr` before the implementation
- `cargo test fsdispatch_pbgetcatinfo --lib`: 5 passed
- Re-ran the 68K installer that exposed the defect: it now resolves `MacintoshHD` through parent ID 1 and advances from the initial destination error to installing 15 of 16 payloads
- `git diff --check`: passed
- Touched additions match rustfmt; whole-tree `cargo fmt --all -- --check` still reports pre-existing formatting differences outside this change

Closes #152