### PR TITLE
fix: return canonical Pascal Booleans from Standard File

### DIFF
--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -184,7 +184,11 @@ fn standard_file_put_reply_old(bus: &mut MacMemoryBus, reply_ptr: u32, vref: i16
     if reply_ptr == 0 {
         return;
     }
-    bus.write_byte(reply_ptr, 0xFF); // good = TRUE
+    // Inside Macintosh, Volume I, p. I-86 ("Pascal Data Types") specifies
+    // BOOLEAN as one byte with its value in bit 0. Write canonical TRUE (1),
+    // leaving its seven non-value bits clear; callers may compare a record
+    // field directly with the ordinal value of TRUE.
+    bus.write_byte(reply_ptr, 1); // good = TRUE
     bus.write_byte(reply_ptr + 1, 0); // copy = FALSE
     bus.write_long(reply_ptr + 2, 0); // fType
     bus.write_word(reply_ptr + 6, vref as u16);
@@ -202,7 +206,7 @@ fn standard_file_get_reply_old(
     if reply_ptr == 0 {
         return;
     }
-    bus.write_byte(reply_ptr, 0xFF); // good = TRUE
+    bus.write_byte(reply_ptr, 1); // good = TRUE
     bus.write_byte(reply_ptr + 1, 0); // copy = FALSE
     bus.write_long(reply_ptr + 2, file_type);
     bus.write_word(reply_ptr + 6, wd_ref as u16);
@@ -221,8 +225,8 @@ fn standard_file_put_reply_modern(
     if reply_ptr == 0 {
         return;
     }
-    bus.write_byte(reply_ptr, 0xFF); // sfGood = TRUE
-    bus.write_byte(reply_ptr + 1, if replacing { 0xFF } else { 0 }); // sfReplacing
+    bus.write_byte(reply_ptr, 1); // sfGood = TRUE
+    bus.write_byte(reply_ptr + 1, u8::from(replacing)); // sfReplacing
     bus.write_long(reply_ptr + 2, 0); // sfType
     bus.write_word(reply_ptr + 6, vref as u16); // sfFile.vRefNum
     bus.write_long(reply_ptr + 8, dir_id); // sfFile.parID
@@ -247,7 +251,7 @@ fn standard_file_get_reply_modern(
     if reply_ptr == 0 {
         return;
     }
-    bus.write_byte(reply_ptr, 0xFF); // sfGood = TRUE
+    bus.write_byte(reply_ptr, 1); // sfGood = TRUE
     bus.write_byte(reply_ptr + 1, 0); // sfReplacing = FALSE
     bus.write_long(reply_ptr + 2, file_type); // sfType
     bus.write_word(reply_ptr + 6, vref as u16); // sfFile.vRefNum
@@ -23786,7 +23790,7 @@ mod tests {
         assert!(result.is_some());
         assert!(result.unwrap().is_ok());
 
-        assert_eq!(bus.read_byte(reply_ptr), 0xFF);
+        assert_eq!(bus.read_byte(reply_ptr), 1);
         assert_eq!(bus.read_byte(reply_ptr + 1), 0);
         assert_eq!(bus.read_long(reply_ptr + 2), u32::from_be_bytes(*b"PIL "));
         assert_eq!(
@@ -23832,7 +23836,7 @@ mod tests {
         assert!(result.is_some());
         assert!(result.unwrap().is_ok());
 
-        assert_eq!(bus.read_byte(reply_ptr), 0xFF);
+        assert_eq!(bus.read_byte(reply_ptr), 1);
         assert_eq!(bus.read_long(reply_ptr + 2), u32::from_be_bytes(*b"DATA"));
         assert_eq!(
             bus.read_word(reply_ptr + 6),
@@ -23871,7 +23875,7 @@ mod tests {
         assert!(result.is_some());
         assert!(result.unwrap().is_ok());
 
-        assert_eq!(bus.read_byte(reply_ptr), 0xFF);
+        assert_eq!(bus.read_byte(reply_ptr), 1);
         assert_eq!(bus.read_long(reply_ptr + 2), u32::from_be_bytes(*b"Flux"));
         assert_eq!(
             bus.read_word(reply_ptr + 6),
@@ -24011,7 +24015,7 @@ mod tests {
         assert!(open.unwrap().is_ok());
 
         assert!(!disp.is_standard_file_get_tracking());
-        assert_eq!(bus.read_byte(reply_ptr), 0xFF);
+        assert_eq!(bus.read_byte(reply_ptr), 1);
         assert_eq!(bus.read_long(reply_ptr + 2), u32::from_be_bytes(*b"PIL "));
         assert_eq!(
             bus.read_word(reply_ptr + 6),
@@ -24068,7 +24072,7 @@ mod tests {
         let wd_info = disp
             .working_directory_info(wd_ref)
             .expect("SFGetFile should return a WDRefNum for the selected file directory");
-        assert_eq!(bus.read_byte(reply_ptr), 0xFF);
+        assert_eq!(bus.read_byte(reply_ptr), 1);
         assert_eq!(bus.read_byte(reply_ptr + 1), 0);
         assert_eq!(bus.read_long(reply_ptr + 2), u32::from_be_bytes(*b"PIL "));
         assert_eq!(wd_info.dir_id, pilots_dir);
@@ -24129,7 +24133,7 @@ mod tests {
             .working_directory_info(wd_ref)
             .expect("SFGetFile GUI path should return a WDRefNum");
         assert!(!disp.is_standard_file_get_tracking());
-        assert_eq!(bus.read_byte(reply_ptr), 0xFF);
+        assert_eq!(bus.read_byte(reply_ptr), 1);
         assert_eq!(bus.read_long(reply_ptr + 2), u32::from_be_bytes(*b"PIL "));
         assert_eq!(wd_info.dir_id, pilots_dir);
         assert_eq!(bus.read_pstring(reply_ptr + 10), b"Ace".to_vec());
@@ -24156,7 +24160,7 @@ mod tests {
         assert!(result.is_some());
         assert!(result.unwrap().is_ok());
 
-        assert_eq!(bus.read_byte(reply_ptr), 0xFF);
+        assert_eq!(bus.read_byte(reply_ptr), 1);
         assert_eq!(bus.read_byte(reply_ptr + 1), 0);
         assert_eq!(
             bus.read_word(reply_ptr + 6),
@@ -24192,8 +24196,8 @@ mod tests {
         assert!(result.is_some());
         assert!(result.unwrap().is_ok());
 
-        assert_eq!(bus.read_byte(reply_ptr), 0xFF);
-        assert_eq!(bus.read_byte(reply_ptr + 1), 0xFF);
+        assert_eq!(bus.read_byte(reply_ptr), 1);
+        assert_eq!(bus.read_byte(reply_ptr + 1), 1);
         assert_eq!(bus.read_long(reply_ptr + 8), pilots_dir);
         assert_eq!(bus.read_pstring(reply_ptr + 12), b"Existing Pilot".to_vec());
         assert_eq!(cpu.read_reg(Register::A7), sp + 14);
@@ -24254,7 +24258,7 @@ mod tests {
         assert!(accept.unwrap().is_ok());
         assert!(!disp.is_standard_file_put_tracking());
 
-        assert_eq!(bus.read_byte(reply_ptr), 0xFF);
+        assert_eq!(bus.read_byte(reply_ptr), 1);
         assert_eq!(bus.read_byte(reply_ptr + 1), 0);
         assert_eq!(bus.read_long(reply_ptr + 8), pilots_dir);
         assert_eq!(bus.read_pstring(reply_ptr + 12), b"Rick".to_vec());
@@ -24359,7 +24363,7 @@ mod tests {
         assert!(result.is_some());
         assert!(result.unwrap().is_ok());
 
-        assert_eq!(bus.read_byte(reply_ptr), 0xFF);
+        assert_eq!(bus.read_byte(reply_ptr), 1);
         assert_eq!(bus.read_byte(reply_ptr + 1), 0);
         assert_eq!(
             bus.read_word(reply_ptr + 6),
@@ -24395,7 +24399,7 @@ mod tests {
         let wd_info = disp
             .working_directory_info(wd_ref)
             .expect("SFPutFile should return a WDRefNum for the save directory");
-        assert_eq!(bus.read_byte(reply_ptr), 0xFF);
+        assert_eq!(bus.read_byte(reply_ptr), 1);
         assert_eq!(wd_info.dir_id, pilots_dir);
         assert_eq!(bus.read_pstring(reply_ptr + 10), b"Old Pilot".to_vec());
         assert_eq!(cpu.read_reg(Register::A7), sp + 22);
@@ -24445,7 +24449,7 @@ mod tests {
             .working_directory_info(wd_ref)
             .expect("SFPutFile GUI path should return a WDRefNum for the save directory");
         assert!(!disp.is_standard_file_put_tracking());
-        assert_eq!(bus.read_byte(reply_ptr), 0xFF);
+        assert_eq!(bus.read_byte(reply_ptr), 1);
         assert_eq!(wd_info.dir_id, pilots_dir);
         assert_eq!(bus.read_pstring(reply_ptr + 10), b"Old Pilot".to_vec());
         assert_eq!(cpu.read_reg(Register::A7), sp + 22);


### PR DESCRIPTION
## Summary

- return canonical Pascal `TRUE` (`1`) in the one-byte Boolean fields of old and modern Standard File replies
- keep all non-value bits clear rather than encoding true as `$FF`
- apply the same representation to `sfReplacing`
- update old and modern Get/Put regression tests to assert the documented representation

## Why

Inside Macintosh, Volume I, p. I-86, “Pascal Data Types,” specifies `BOOLEAN` as a one-byte type whose value is stored in bit 0. Standard File’s `good`, `sfGood`, and `sfReplacing` fields are Boolean record fields.

The previous `$FF` representation made bit 0 true but also set all seven non-value bits. Code compiled with the assumption that a Boolean record field contains the canonical ordinal value of `TRUE` can compare the byte directly with `1` and reject `$FF`.

3 in Three exposes this with the original `SFPutFile` interface. The Save dialog accepted a filename, but the application rejected the returned `SFReply.good` before calling the File Manager. Consequently no file was created, and the next Open dialog reported “No matching files.”

With this change, the same interactive test produced the expected sequence:

- `PBCreate("Boolean Test")`
- `PBOpen` followed by a 498-byte `FSWrite`
- desktop persistence of the created file
- a subsequent Open listed the file
- selecting it produced a successful `PBOpen` and 498-byte `PBRead`

The application then reaches a separate post-open Yes/No dialog, confirming that Standard File selection and File Manager I/O have completed. That downstream dialog issue is outside this PR.

## Scope

This changes only the representation of successful Standard File Boolean fields. Cancellation remains `FALSE` (`0`), and the reply layouts, stack behavior, WDRefNums, FSSpecs, file filtering, and dialog tracking are unchanged.

The desktop save-directory policy is deliberately not part of this PR; that design is tracked separately in #156.

## Tests

- `cargo test --lib standard_get_file` — 7 passed
- `cargo test --lib standard_put_file` — 4 passed
- `cargo test --lib sf_get_file` — 3 passed
- `cargo test --lib sf_put_file` — 3 passed
- `cargo test --lib` — 2,771 passed, 3 ignored
- interactive 3 in Three Save → Open verification described above

Closes #179