### PR TITLE
fix(files): preserve relative pathname components

### DIFF
--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -3307,6 +3307,32 @@ impl TrapDispatcher {
             .cloned()
     }
 
+    pub(crate) fn find_case_insensitive_relative_key<'a, I>(keys: I, target: &str) -> Option<String>
+    where
+        I: IntoIterator<Item = &'a String>,
+    {
+        let normalized_target = Self::normalize_vfs_path(target);
+        if !normalized_target.contains('/') {
+            return None;
+        }
+        // A leading colon denotes a partial HFS pathname whose directory
+        // components remain significant. Match the whole normalized suffix
+        // on a component boundary before any basename-only compatibility
+        // fallback can discard those components.
+        // Inside Macintosh: Files (1992), pp. 2-27 to 2-30.
+        let suffix = format!("/{normalized_target}").to_ascii_lowercase();
+        let mut sorted: Vec<&String> = keys.into_iter().collect();
+        sorted.sort_unstable();
+        sorted
+            .into_iter()
+            .find(|key| {
+                Self::normalize_vfs_path(key)
+                    .to_ascii_lowercase()
+                    .ends_with(&suffix)
+            })
+            .cloned()
+    }
+
     pub(crate) fn ensure_vfs_directory(&mut self, path: &str) -> u32 {
         let normalized = Self::normalize_vfs_path(path);
         if normalized.is_empty() {
@@ -5389,6 +5415,11 @@ impl TrapDispatcher {
             .find(|key| Self::normalize_vfs_path(key).eq_ignore_ascii_case(&normalized))
         {
             return Some(found.clone());
+        }
+        if let Some(found) =
+            Self::find_case_insensitive_relative_key(sorted_keys.iter().copied(), &normalized)
+        {
+            return Some(found);
         }
         let hfs_basename = hfs_normalized
             .rsplit('/')

--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -7643,6 +7643,12 @@ impl super::TrapDispatcher {
         }) {
             return Some(found.clone());
         }
+        if let Some(found) = super::TrapDispatcher::find_case_insensitive_relative_key(
+            sorted_keys.iter().copied(),
+            &normalized,
+        ) {
+            return Some(found);
+        }
         let hfs_basename = hfs_normalized
             .rsplit('/')
             .next()
@@ -7937,6 +7943,34 @@ mod tests {
             disp.resource_attributes_for_handle(handle).unwrap_or(0) & changed,
             0,
             "SetResPurge(TRUE) should clear the changed flag through MoveHHi"
+        );
+    }
+
+    #[test]
+    fn find_vfs_file_prefers_relative_path_components_before_basename() {
+        let mut disp = super::super::TrapDispatcher::new();
+        disp.vfs
+            .insert("MacPopulous/BigColourData/LOAD.PIC".to_string(), vec![1]);
+        disp.vfs
+            .insert("MacPopulous/ColourData/LOAD.PIC".to_string(), vec![2]);
+
+        assert_eq!(
+            disp.find_vfs_file(":ColourData:load.pic"),
+            Some("MacPopulous/ColourData/LOAD.PIC".to_string())
+        );
+    }
+
+    #[test]
+    fn find_vfs_rsrc_file_prefers_relative_path_components_before_basename() {
+        let mut disp = super::super::TrapDispatcher::new();
+        disp.vfs_rsrc
+            .insert("MacPopulous/BigColourData/LOAD.PIC".to_string(), vec![1]);
+        disp.vfs_rsrc
+            .insert("MacPopulous/ColourData/LOAD.PIC".to_string(), vec![2]);
+
+        assert_eq!(
+            disp.find_vfs_rsrc_file(":ColourData:load.pic"),
+            Some("MacPopulous/ColourData/LOAD.PIC".to_string())
         );
     }
 


### PR DESCRIPTION
## Summary

- resolve multi-component relative HFS pathnames by their full component suffix before basename fallback
- keep case-insensitive deterministic matching for data and resource forks
- prevent sibling directory names such as `BigColourData` from satisfying `:ColourData:load.pic`

## Root cause

The VFS first checked an exact normalized path and then fell straight back to a volume-wide basename match. When an archive retained a containing application folder, `:ColourData:load.pic` was not an exact root path, and lexical basename fallback selected `BigColourData/LOAD.PIC` before `ColourData/LOAD.PIC`. The directory components in the HFS partial pathname were discarded.

This partially addresses #118: Populous now loads its intended small-colour title asset, restoring the complete wordmark and copyright block. A separate Window Manager visibility defect still causes the title to be drawn in both overlapping windows, so this PR intentionally does not close the issue.

## Validation

- `cargo test --quiet --lib --no-default-features`: 2,764 passed, 3 ignored
- focused data-fork and resource-fork tests reproduce `BigColourData` versus `ColourData` ambiguity
- Populous runtime trace resolves `:ColourData:load.pic` to `MacPopulous/ColourData/LOAD.PIC` instead of `MacPopulous/BigColourData/LOAD.PIC`
- `git diff --check`

Reference: *Inside Macintosh: Files* (1992), pp. 2-27 to 2-30.