### PR TITLE
fix(quickdraw): translate indexed CopyMask colors through destination palette

### DIFF
--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -13437,6 +13437,27 @@ impl super::TrapDispatcher {
                 let dst_bottom = bus.read_word(dst_rect_ptr + 4) as i16;
                 let dst_right = bus.read_word(dst_rect_ptr + 6) as i16;
 
+                // Indexed pixels are meaningful only through their source
+                // color table. CopyMask uses that table for source color
+                // information and the current GDevice's table for destination
+                // color information; the destination PixMap's table is not
+                // authoritative. Imaging With QuickDraw (1994), pp. 4-31 and
+                // 3-119--3-120. In particular, equal ctSeed values do not make
+                // raw indices interchangeable when the tables contain
+                // different colors.
+                let dst_ctab_handle =
+                    self.copy_bits_destination_ctab_handle(bus, self.current_port, &dst_info);
+                let src_clut = matches!(src_info.pixel_size, 2 | 4 | 8)
+                    .then(|| self.read_port_clut(bus, src_info.ctab_handle));
+                let dst_clut =
+                    (dst_info.pixel_size == 8).then(|| self.read_port_clut(bus, dst_ctab_handle));
+                let palette_translation = match (src_clut.as_ref(), dst_clut.as_ref()) {
+                    (Some(src_clut), Some(dst_clut)) if src_clut != dst_clut => Some(
+                        self.build_palette_translation(bus, src_clut, dst_clut, dst_ctab_handle),
+                    ),
+                    _ => None,
+                };
+
                 if src_bottom <= src_top
                     || src_right <= src_left
                     || mask_bottom <= mask_top
@@ -13538,9 +13559,14 @@ impl super::TrapDispatcher {
                                 bus.write_byte(addr, new_byte);
                             }
                             8 => {
+                                let dst_pixel = palette_translation
+                                    .as_ref()
+                                    .map_or(src_pixel, |translation| {
+                                        translation[src_pixel as usize]
+                                    });
                                 bus.write_byte(
                                     dst_info.base + row * dst_info.row_bytes + col,
-                                    src_pixel,
+                                    dst_pixel,
                                 );
                             }
                             _ => {} // 16/32 bpp not yet supported
@@ -29945,6 +29971,85 @@ mod tests {
             bus.read_byte(dst_base),
             0b0101_1010,
             "mask bits cleared to 0 should preserve destination bits"
+        );
+    }
+
+    #[test]
+    fn copymask_matches_indexed_source_colors_to_destination_table() {
+        // On indexed devices, CopyMask interprets source pixels through the
+        // source PixMap's color table and writes the matching color from the
+        // current destination GDevice table. The destination PixMap's raw
+        // index at the same numeric position may represent a different color.
+        // Imaging With QuickDraw (1994), pp. 4-31 and 3-119--3-120.
+        let (mut d, mut cpu, mut bus) = setup();
+        let src_pixmap = 0x320100u32;
+        let mask_bits = 0x320200u32;
+        let dst_pixmap = 0x320300u32;
+        let src_base = 0x321000u32;
+        let mask_base = 0x322000u32;
+        let dst_base = 0x323000u32;
+        let src_ctab_handle = 0x324000u32;
+        let dst_ctab_handle = 0x325000u32;
+        let src_rect = 0x326000u32;
+        let mask_rect = 0x326010u32;
+        let dst_rect = 0x326020u32;
+        let red = (0xF123, 0x0123, 0x0234);
+        let unmatched_red = (0xE123, 0x1123, 0x1234);
+
+        write_color_table(
+            &mut bus,
+            src_ctab_handle,
+            0x1111_1111,
+            &[
+                (2, red.0, red.1, red.2),
+                (3, unmatched_red.0, unmatched_red.1, unmatched_red.2),
+            ],
+        );
+        write_color_table(
+            &mut bus,
+            dst_ctab_handle,
+            0x2222_2222,
+            &[
+                (2, 0xFFFF, 0xFFFF, 0x9999),
+                (216, red.0, red.1, red.2),
+                (
+                    217,
+                    unmatched_red.0 + 1,
+                    unmatched_red.1 + 1,
+                    unmatched_red.2 + 1,
+                ),
+            ],
+        );
+        write_pixmap_8(&mut bus, src_pixmap, src_base, 2, 1, src_ctab_handle);
+        write_bitmap_1bpp(&mut bus, mask_bits, mask_base, 1, (0, 0, 1, 2));
+        write_pixmap_8(&mut bus, dst_pixmap, dst_base, 2, 1, dst_ctab_handle);
+        bus.write_byte(src_base, 2);
+        bus.write_byte(src_base + 1, 3);
+        bus.write_byte(mask_base, 0xC0);
+        bus.write_byte(dst_base, 7);
+        bus.write_byte(dst_base + 1, 7);
+
+        write_rect(&mut bus, src_rect, 0, 0, 1, 2);
+        write_rect(&mut bus, mask_rect, 0, 0, 1, 2);
+        write_rect(&mut bus, dst_rect, 0, 0, 1, 2);
+        bus.write_long(TEST_SP, dst_rect);
+        bus.write_long(TEST_SP + 4, mask_rect);
+        bus.write_long(TEST_SP + 8, src_rect);
+        bus.write_long(TEST_SP + 12, dst_pixmap);
+        bus.write_long(TEST_SP + 16, mask_bits);
+        bus.write_long(TEST_SP + 20, src_pixmap);
+
+        let result = d.dispatch_quickdraw(true, 0x017, &mut cpu, &mut bus);
+        assert!(result.unwrap().is_ok());
+        assert_eq!(
+            bus.read_byte(dst_base),
+            216,
+            "CopyMask must preserve the source color rather than its numeric palette index"
+        );
+        assert_eq!(
+            bus.read_byte(dst_base + 1),
+            217,
+            "CopyMask must choose the nearest destination color when no exact match exists"
         );
     }
 


### PR DESCRIPTION
## Summary

- interpret indexed `CopyMask` source pixels through the source PixMap color table
- match those RGB colors into the current destination GDevice color table
- reuse the existing exact/nearest palette matcher and retain the raw-index fast path when the tables are identical
- add regression coverage for both an exact destination color and the closest available destination color

## Problem

`CopyMask` previously copied the numeric source pixel value directly into an 8-bit destination. An indexed pixel is not a color by itself: its RGB meaning comes from its PixMap color table. If source index 2 is red but destination index 2 is yellow, copying the byte `2` changes the displayed color.

3 in Three did not expose this because its tested animation paths used `CopyBits`, whose indexed translation path was already implemented. System's Twilight uses a different sprite pipeline:

1. copy the affected screen rectangle to a staging PixMap
2. restore the old saved background
3. save the background at the new position
4. draw the character into the staging PixMap through a one-bit mask with `CopyMask`
5. copy the staging rectangle back to the screen

The source sprite table stores its red ramp at low indices while the destination device table uses those same indices for yellow and keeps the matching reds at other indices. The first three steps preserve the expected colors; step 4 previously wrote the low indices verbatim, so the main red character and two other characters turned yellow after they moved.

## QuickDraw behavior

*Inside Macintosh: Imaging With QuickDraw* (1994), pp. 3-119–3-120, says that the special considerations documented for `CopyBits` also apply to `CopyMask`. Page 4-31 specifies that indexed pixel images use the source PixMap color table for source color information and the current GDevice color table for destination color information; the destination PixMap's own color table is not authoritative for this conversion.

The resulting operation is:

```text
source index -> source RGB -> exact/closest destination RGB -> destination index
```

The destination palette is not modified. When it has no exact RGB entry, QuickDraw selects the closest available destination color.

## Implementation

For 2-, 4-, and 8-bit indexed sources copied into an 8-bit destination, `CopyMask` now:

1. resolves the destination color table using the same current-GDevice logic as `CopyBits`
2. reads the source and destination color tables
3. builds the existing 256-entry exact/nearest translation when those tables differ
4. applies the translated destination index only where the mask is set

Identical color tables continue to copy raw indices without a translation lookup.

## Validation

Automated:

```text
cargo test copymask_ --lib
6 passed; 0 failed
```

The regression test covers:

- source index 2 representing red while destination index 2 represents yellow, with the same red at destination index 216
- a source RGB with no exact destination entry, which selects the nearest color at destination index 217
- the mask gate and existing `CopyMask` behavior through the focused test set

Manual testing used the original System's Twilight executable from an HFS disk image and the same new-game movement sequence in debug builds made from the same upstream revision:

- before: the red character becomes yellow after movement
<img width="912" height="744" alt="Screenshot 2026-07-29 at 4 54 51 PM" src="https://github.com/user-attachments/assets/80fb90e4-7da5-46b9-8732-f3b9e47efeb7" />

- after: the character remains red after movement
<img width="912" height="744" alt="Screenshot 2026-07-29 at 4 56 34 PM" src="https://github.com/user-attachments/assets/aeb5ab6e-9f03-49bd-9751-89de49eaf822" />

Before/after screenshots were captured at the same scene and window geometry.

## Known limitations

This is a focused correction to the indexed path, not a claim that all QuickDraw mask behavior is implemented:

- `CopyMask` currently writes only 1-bit and 8-bit destinations; 16- and 32-bit direct-color destinations remain unsupported.
- `CopyMask` source pixel decoding currently covers 1-, 2-, 4-, and 8-bit data; direct-color sources remain unsupported.
- `CopyDeepMask` does not yet have equivalent complete indexed-color conversion, direct-color support, or all 8-bit transfer-mode semantics.
- Systemless's closest-color machinery approximates the ROM inverse-table behavior. It does not yet reproduce every custom color-search procedure and Palette Manager reservation nuance.

Those gaps predate this change and are deliberately left for separate, testable work.

Closes #178