### PR TITLE
feat: pack multi-source HFS game releases for web

### DIFF
--- a/src/bin/systemless-pack-web.rs
+++ b/src/bin/systemless-pack-web.rs
@@ -7,32 +7,50 @@ use clap::Parser;
 #[command(
     name = "systemless-pack-web",
     version,
-    about = "Pack a StuffIt archive for the Systemless web player"
+    about = "Pack StuffIt archives and HFS disk images for the Systemless web player"
 )]
 struct Cli {
-    /// StuffIt archive to pack
+    /// Primary StuffIt archive or HFS disk image to pack
     #[arg(value_name = "INPUT")]
     input: PathBuf,
 
     /// Destination for the packed archive
     #[arg(value_name = "OUTPUT")]
     output: PathBuf,
+
+    /// Additional StuffIt archive or HFS disk image to merge
+    #[arg(long = "additional-input", value_name = "INPUT")]
+    additional_inputs: Vec<PathBuf>,
+
+    /// Retain files at or below this normalized classic Mac path
+    #[arg(long = "include-prefix", value_name = "PATH")]
+    include_prefixes: Vec<String>,
 }
 
 fn main() -> Result<(), String> {
     let cli = Cli::parse();
 
-    let input_bytes =
-        fs::read(&cli.input).map_err(|e| format!("could not read {}: {e}", cli.input.display()))?;
-    let packed = systemless::game::pack_stuffit_for_web(&input_bytes)?;
+    let mut input_paths = vec![cli.input.clone()];
+    input_paths.extend(cli.additional_inputs);
+    let input_bytes = input_paths
+        .iter()
+        .map(|path| fs::read(path).map_err(|e| format!("could not read {}: {e}", path.display())))
+        .collect::<Result<Vec<_>, _>>()?;
+    let source_refs = input_bytes.iter().map(Vec::as_slice).collect::<Vec<_>>();
+    let include_prefixes = cli
+        .include_prefixes
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    let packed = systemless::game::pack_game_sources_for_web(&source_refs, &include_prefixes)?;
     fs::write(&cli.output, &packed)
         .map_err(|e| format!("could not write {}: {e}", cli.output.display()))?;
 
     eprintln!(
-        "packed {} -> {} ({} KB -> {} KB)",
-        cli.input.display(),
+        "packed {} source(s) -> {} ({} KB -> {} KB)",
+        input_paths.len(),
         cli.output.display(),
-        input_bytes.len() / 1024,
+        input_bytes.iter().map(Vec::len).sum::<usize>() / 1024,
         packed.len() / 1024
     );
     Ok(())
@@ -50,6 +68,27 @@ mod tests {
 
         assert_eq!(cli.input, PathBuf::from("input.sit"));
         assert_eq!(cli.output, PathBuf::from("output.kpk"));
+        assert!(cli.additional_inputs.is_empty());
+        assert!(cli.include_prefixes.is_empty());
+    }
+
+    #[test]
+    fn cli_parses_additional_sources_and_include_prefixes() {
+        let cli = Cli::try_parse_from([
+            "systemless-pack-web",
+            "application.sit",
+            "game.kpk",
+            "--additional-input",
+            "cd.img",
+            "--include-prefix",
+            "Game",
+            "--include-prefix",
+            "Game CD/Data",
+        ])
+        .expect("multi-source options should parse");
+
+        assert_eq!(cli.additional_inputs, vec![PathBuf::from("cd.img")]);
+        assert_eq!(cli.include_prefixes, vec!["Game", "Game CD/Data"]);
     }
 
     #[test]

--- a/src/game/launch.rs
+++ b/src/game/launch.rs
@@ -60,6 +60,52 @@ pub fn pack_stuffit_for_web(file_data: &[u8]) -> Result<Vec<u8>, String> {
         SitArchive::parse(file_data).map_err(|e| format!("Failed to parse StuffIt: {:?}", e))?;
 
     let file_entries = collect_stuffit_payload_files(&archive)?;
+    pack_payload_files_for_web(file_entries)
+}
+
+/// Prepack one or more supported game containers into a single web pack.
+///
+/// This is useful for CD-based games whose application and read-only data
+/// volume were distributed separately. Optional path prefixes retain only the
+/// runtime files needed from large compilation discs.
+pub fn pack_game_sources_for_web(
+    sources: &[&[u8]],
+    include_prefixes: &[&str],
+) -> Result<Vec<u8>, String> {
+    let mut file_entries = Vec::new();
+    for source in sources {
+        if is_stuffit_archive(source) {
+            let archive = SitArchive::parse(source)
+                .map_err(|e| format!("Failed to parse StuffIt: {:?}", e))?;
+            file_entries.extend(collect_stuffit_payload_files(&archive)?);
+        } else if let Some(image) = crate::disk_image::extract_dc42_or_hfs(source)? {
+            file_entries.extend(payload_from_disk_image(image)?.files);
+        } else {
+            return Err("Game source is not a StuffIt archive or HFS disk image".to_string());
+        }
+    }
+
+    if !include_prefixes.is_empty() {
+        let normalized_prefixes = include_prefixes
+            .iter()
+            .map(|prefix| crate::trap::dispatch::TrapDispatcher::normalize_vfs_path(prefix))
+            .collect::<Vec<_>>();
+        file_entries.retain(|entry| {
+            let path = crate::trap::dispatch::TrapDispatcher::normalize_vfs_path(&entry.name);
+            normalized_prefixes
+                .iter()
+                .any(|prefix| vfs_path_matches_remove(&path, prefix))
+        });
+    }
+
+    if file_entries.is_empty() {
+        return Err("No files matched the requested game sources".to_string());
+    }
+
+    pack_payload_files_for_web(file_entries)
+}
+
+fn pack_payload_files_for_web(file_entries: Vec<PayloadFile>) -> Result<Vec<u8>, String> {
     let mut out = Vec::new();
     out.extend_from_slice(WEB_PACK_MAGIC);
     out.extend_from_slice(&(file_entries.len() as u32).to_be_bytes());
@@ -1417,6 +1463,46 @@ fn read_u32_be(buf: &[u8], offset: &mut usize) -> Result<u32, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn web_pack_sources_accept_hfs_images_and_filter_by_classic_mac_path() {
+        let mut builder = hfsplus::testutil::HfsPlusImageBuilder::new();
+        builder.add_file("keep.dat", b"runtime data", 0o100644);
+        builder.add_file("drop.dat", b"unrelated demo", 0o100644);
+        let image = builder.build();
+
+        let packed = pack_game_sources_for_web(&[&image], &["HFS+ Disk Image:keep.dat"])
+            .expect("HFS source should pack");
+
+        assert_eq!(&packed[0..4], WEB_PACK_MAGIC);
+        assert_eq!(u32::from_be_bytes(packed[4..8].try_into().unwrap()), 1);
+        let mut offset = 8;
+        let name_len = read_u16_be(&packed, &mut offset).unwrap() as usize;
+        let name = read_exact(&packed, &mut offset, name_len).unwrap();
+        assert_eq!(name, b"HFS+ Disk Image/keep.dat");
+    }
+
+    #[test]
+    fn web_pack_sources_merge_files_from_multiple_images() {
+        let mut application_builder = hfsplus::testutil::HfsPlusImageBuilder::new();
+        application_builder.add_file("Application", b"application fork", 0o100644);
+        let application_image = application_builder.build();
+        let mut data_builder = hfsplus::testutil::HfsPlusImageBuilder::new();
+        data_builder.add_file("Level001", b"level data", 0o100644);
+        let data_image = data_builder.build();
+
+        let packed = pack_game_sources_for_web(&[&application_image, &data_image], &[])
+            .expect("multiple HFS sources should merge");
+
+        assert_eq!(&packed[0..4], WEB_PACK_MAGIC);
+        assert_eq!(u32::from_be_bytes(packed[4..8].try_into().unwrap()), 2);
+        assert!(packed
+            .windows(b"HFS+ Disk Image/Application".len())
+            .any(|window| window == b"HFS+ Disk Image/Application"));
+        assert!(packed
+            .windows(b"HFS+ Disk Image/Level001".len())
+            .any(|window| window == b"HFS+ Disk Image/Level001"));
+    }
 
     fn make_single_resource_fork_bytes(res_type: [u8; 4], res_id: i16, data: &[u8]) -> Vec<u8> {
         let data_offset = 16u32;

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -7,6 +7,6 @@
 pub mod launch;
 
 pub use launch::{
-    init_game, load_game, load_game_from_path, new_runner, pack_stuffit_for_web, WebPackLoader,
-    MAX_INSTRUCTIONS_PER_FRAME, RAM_SIZE,
+    init_game, load_game, load_game_from_path, new_runner, pack_game_sources_for_web,
+    pack_stuffit_for_web, WebPackLoader, MAX_INSTRUCTIONS_PER_FRAME, RAM_SIZE,
 };


### PR DESCRIPTION
## Summary

- let `systemless-pack-web` merge repeated `--additional-input` containers into one web pack
- accept HFS disk images as well as StuffIt archives while preserving data forks, resource forks, Finder metadata, and classic Mac paths
- add repeatable `--include-prefix` filtering for large data discs and retain the existing single-archive API

## Root cause

The web packer parsed exactly one StuffIt archive. Authentic releases that shipped the Macintosh application separately from an HFS CD could not produce one deployable Systemless asset, so absolute opens against the original CD volume failed even though the executable itself loaded.

## Evidence

The clean branch rebuilt Bolo 1.0.7 from its separate application archive and original HFS data partition. The resulting 341 MiB pack loads `Level001` and the original room, sound, music, and picture files, reaches Level 1, and runs live paddle/ball gameplay.

## Validation

- `rustfmt --check src/bin/systemless-pack-web.rs src/game/launch.rs src/game/mod.rs`
- `cargo test --lib web_pack_sources`
- `cargo test --bin systemless-pack-web`
- `cargo check --no-default-features`
- authentic two-source pack reproduced byte-for-byte with SHA-256 `42db0f9d71a0eaea19ffb456ccfed392ca0c20961a529f4e623682c06954e736`

Closes #169