### PR TITLE
fix: strip synthetic Unix volumes from HFS paths

### DIFF
--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -3229,10 +3229,13 @@ impl TrapDispatcher {
     }
 
     pub(crate) fn normalize_hfs_path(name: &str) -> String {
-        if Self::is_unix_tmp_path(name) {
-            return Self::normalize_vfs_path(name);
+        // MPW fixtures address the synthetic host mount as "Unix:", while
+        // the VFS stores that volume's contents directly at its root.
+        let path = name.strip_prefix("Unix:").unwrap_or(name);
+        if Self::is_unix_tmp_path(path) {
+            return Self::normalize_vfs_path(path);
         }
-        name.split(':')
+        path.split(':')
             .filter(|component| !component.is_empty() && *component != ".")
             .map(Self::encode_hfs_component_for_vfs)
             .collect::<Vec<_>>()
@@ -6053,6 +6056,18 @@ mod tests {
                 "100%{VFS_HFS_LITERAL_SLASH}Done"
             )),
             "100%/Done"
+        );
+    }
+
+    #[test]
+    fn hfs_path_encoding_strips_the_synthetic_unix_volume() {
+        assert_eq!(
+            TrapDispatcher::normalize_hfs_path("Unix:assertions.txt"),
+            "assertions.txt"
+        );
+        assert_eq!(
+            TrapDispatcher::normalize_hfs_path("Unix:Folder:100%/Done"),
+            format!("Folder/100%{VFS_HFS_LITERAL_SLASH}Done")
         );
     }
 


### PR DESCRIPTION
## Summary

- strip the synthetic `Unix:` host-volume prefix before preserving HFS path components
- retain literal slash encoding and `/tmp` handling
- add focused coverage for root and nested fixture paths

## Root cause

The component-preserving HFS normalizer treated `Unix:` as a real directory component. MPW fixtures therefore created paths such as `Unix/assertions.txt`, while the fixture harness reads `assertions.txt` from the VFS root.

## Validation

- `cargo test hfs_path_encoding_strips_the_synthetic_unix_volume -- --nocapture`
- `cargo test hfs_path_encoding_preserves_literal_slashes_and_percent_sequences -- --nocapture`
- `cargo test -q` — 2,796 passed, 3 ignored
- focused MPW `lines` fixture — 9,612-byte `fixture_dump.bin` created and validated
- focused `a000_file_io_lifecycle` catalogue fixture — `assertions.txt` and `golden.raw` created and validated
- full catalogue cascade reduced from 572 failures to 51; the remaining failures are independent pre-existing or separately tracked regressions

Closes #180
