### PR TITLE
fix: resolve bitmap strikes through FOND associations

### DIFF
--- a/src/quickdraw/fonts/mod.rs
+++ b/src/quickdraw/fonts/mod.rs
@@ -217,20 +217,80 @@ fn resource_word(data: &[u8], offset: usize) -> Option<u16> {
     ]))
 }
 
-/// Decode a classic `FONT`/`NFNT` bitmap strike whose resource ID uses the
-/// standard `family * 128 + pointSize` encoding. The resource bytes stay in
-/// the user's application; Systemless only expands their 1-bit glyph bitmap
-/// into the same runtime coverage representation used by its built-in faces.
+/// One entry from a font family (`FOND`) resource's association table.
+///
+/// `font_resource_id` identifies an `NFNT`, `FONT`, or `sfnt` resource;
+/// unlike old-style `FONT` IDs, an `NFNT` ID does not encode its family or
+/// point size. *Inside Macintosh: Text* (1993), pp. 4-47–4-48 and 4-95–4-96.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct FondAssociation {
+    pub family_id: i16,
+    pub size: i16,
+    pub style: u16,
+    pub font_resource_id: i16,
+}
+
+/// Decode the mandatory association table that immediately follows a
+/// `FOND` resource's 52-byte `FamRec` header.
+pub(crate) fn parse_fond_associations(
+    fond_resource_id: i16,
+    bytes: &[u8],
+) -> Option<Vec<FondAssociation>> {
+    const FAM_REC_LEN: usize = 52;
+    const ASSOCIATION_LEN: usize = 6;
+    let count_minus_one = resource_word(bytes, FAM_REC_LEN)? as i16;
+    if count_minus_one < -1 {
+        return None;
+    }
+    let count = usize::try_from(i32::from(count_minus_one) + 1).ok()?;
+    let table_len = count.checked_mul(ASSOCIATION_LEN)?;
+    let table_end = FAM_REC_LEN.checked_add(2)?.checked_add(table_len)?;
+    if table_end > bytes.len() {
+        return None;
+    }
+
+    let mut associations = Vec::with_capacity(count);
+    for index in 0..count {
+        let offset = FAM_REC_LEN + 2 + index * ASSOCIATION_LEN;
+        associations.push(FondAssociation {
+            // The family number used by Font Manager clients is the FOND
+            // resource ID. FamRec.ffFamID redundantly records that value.
+            family_id: fond_resource_id,
+            size: resource_word(bytes, offset)? as i16,
+            style: resource_word(bytes, offset + 2)?,
+            font_resource_id: resource_word(bytes, offset + 4)? as i16,
+        });
+    }
+    Some(associations)
+}
+
+/// Decode a classic `FONT` bitmap strike whose resource ID uses the original
+/// `family * 128 + pointSize` encoding. `NFNT` resources normally use the
+/// arbitrary IDs recorded by a `FOND` association table and should call
+/// [`register_resource_font_strike_for_family`] instead.
 pub(crate) fn register_resource_font_strike(resource_id: i16, bytes: &[u8]) -> bool {
-    const HEADER_LEN: usize = 26;
-    if resource_id <= 0 || bytes.len() < HEADER_LEN {
+    if resource_id <= 0 {
         return false;
     }
-    let font_id = resource_id / 128;
+    let family_id = resource_id / 128;
     let size = resource_id % 128;
     if size <= 0 {
-        // Family marker resources conventionally live at family * 128 and
-        // contain no strike data.
+        return false;
+    }
+    register_resource_font_strike_for_family(family_id, size, bytes)
+}
+
+/// Decode and register a bitmap strike under the family and point size from
+/// its `FOND` association entry. The resource bytes stay in the user's
+/// application; Systemless expands their 1-bit glyph bitmap into the same
+/// runtime coverage representation used by its built-in faces.
+pub(crate) fn register_resource_font_strike_for_family(
+    family_id: i16,
+    size: i16,
+    bytes: &[u8],
+) -> bool {
+    const HEADER_LEN: usize = 26;
+    if family_id < 0 || size <= 0 || bytes.len() < HEADER_LEN {
         return false;
     }
 
@@ -361,7 +421,7 @@ pub(crate) fn register_resource_font_strike(resource_id: i16, bytes: &[u8]) -> b
     let coverage: &'static [u8] = Box::leak(coverage.into_boxed_slice());
     let ascii: &'static [Glyph] = Box::leak(ascii.into_boxed_slice());
     let face = Box::leak(Box::new(FontFace {
-        font_id,
+        font_id: family_id,
         size,
         metrics: FontMetrics {
             ascent,
@@ -375,11 +435,11 @@ pub(crate) fn register_resource_font_strike(resource_id: i16, bytes: &[u8]) -> b
     RESOURCE_FACES
         .lock()
         .expect("resource font cache poisoned")
-        .insert((font_id, size), face);
+        .insert((family_id, size), face);
     if !macroman.is_empty() {
         let glyphs: &'static [MacRomanGlyph] = Box::leak(macroman.into_boxed_slice());
         let face = Box::leak(Box::new(MacRomanFace {
-            font_id,
+            font_id: family_id,
             size,
             glyphs,
             data: coverage,
@@ -387,7 +447,7 @@ pub(crate) fn register_resource_font_strike(resource_id: i16, bytes: &[u8]) -> b
         RESOURCE_MACROMAN_FACES
             .lock()
             .expect("resource Mac Roman font cache poisoned")
-            .insert((font_id, size), face);
+            .insert((family_id, size), face);
     }
     true
 }
@@ -632,6 +692,71 @@ pub fn get_italic_glyph(
 mod tests {
     use super::*;
     use std::fs;
+
+    fn minimal_nfnt() -> Vec<u8> {
+        // One encoded character plus the missing-character glyph. The bitmap
+        // is one row by one word; location and offset/width tables follow it.
+        let mut bytes = vec![0u8; 38];
+        bytes[2..4].copy_from_slice(&32u16.to_be_bytes()); // firstChar
+        bytes[4..6].copy_from_slice(&32u16.to_be_bytes()); // lastChar
+        bytes[6..8].copy_from_slice(&1u16.to_be_bytes()); // widMax
+        bytes[14..16].copy_from_slice(&1u16.to_be_bytes()); // fRectHeight
+        bytes[16..18].copy_from_slice(&9u16.to_be_bytes()); // owTLoc: 16 + 9*2 = 34
+        bytes[18..20].copy_from_slice(&1u16.to_be_bytes()); // ascent
+        bytes[24..26].copy_from_slice(&1u16.to_be_bytes()); // rowWords
+        bytes[26] = 0xC0; // one pixel for each of the two glyphs
+        bytes[28..30].copy_from_slice(&0u16.to_be_bytes());
+        bytes[30..32].copy_from_slice(&1u16.to_be_bytes());
+        bytes[32..34].copy_from_slice(&2u16.to_be_bytes());
+        bytes[34..36].copy_from_slice(&1u16.to_be_bytes()); // offset 0, advance 1
+        bytes[36..38].copy_from_slice(&1u16.to_be_bytes());
+        bytes
+    }
+
+    #[test]
+    fn fond_associations_map_arbitrary_bitmap_resource_ids() {
+        let mut fond = vec![0u8; 66];
+        fond[2..4].copy_from_slice(&1234u16.to_be_bytes()); // redundant ffFamID
+        fond[52..54].copy_from_slice(&1u16.to_be_bytes()); // two entries minus one
+        fond[54..56].copy_from_slice(&12u16.to_be_bytes());
+        fond[56..58].copy_from_slice(&0u16.to_be_bytes());
+        fond[58..60].copy_from_slice(&42u16.to_be_bytes());
+        fond[60..62].copy_from_slice(&18u16.to_be_bytes());
+        fond[62..64].copy_from_slice(&1u16.to_be_bytes());
+        fond[64..66].copy_from_slice(&(-32000i16 as u16).to_be_bytes());
+
+        assert_eq!(
+            parse_fond_associations(16000, &fond),
+            Some(vec![
+                FondAssociation {
+                    family_id: 16000,
+                    size: 12,
+                    style: 0,
+                    font_resource_id: 42,
+                },
+                FondAssociation {
+                    family_id: 16000,
+                    size: 18,
+                    style: 1,
+                    font_resource_id: -32000,
+                },
+            ])
+        );
+    }
+
+    #[test]
+    fn resource_strike_can_register_under_fond_family_and_size() {
+        let family_id = 30001;
+        assert!(register_resource_font_strike_for_family(
+            family_id,
+            17,
+            &minimal_nfnt(),
+        ));
+        let face = get_font_face(family_id, 17).expect("FOND-associated face should resolve");
+        assert_eq!(face.font_id, family_id);
+        assert_eq!(face.size, 17);
+        assert_eq!(face.metrics.ascent, 1);
+    }
 
     fn distinctive_override_blob() -> override_format::Blob {
         let glyphs: Vec<Glyph> = (0..override_format::GLYPH_COUNT)

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -4463,11 +4463,13 @@ impl TrapDispatcher {
         res_id: i16,
         data: Vec<u8>,
     ) {
-        if res_type == *b"FONT" || res_type == *b"NFNT" {
-            let _ = crate::quickdraw::fonts::register_resource_font_strike(res_id, &data);
-        }
         self.resource_backing_data
             .insert((refnum, res_type, res_id), data);
+        if res_type == *b"FONT" || res_type == *b"NFNT" {
+            self.register_resource_font_backing(refnum, res_id);
+        } else if res_type == *b"FOND" {
+            self.register_fond_associated_strikes(refnum, res_id);
+        }
     }
 
     pub(crate) fn loaded_resource_handle_size(data_size: u32) -> u32 {
@@ -4523,13 +4525,103 @@ impl TrapDispatcher {
 
     pub(crate) fn remember_resource_fork_backing_data(&mut self, refnum: u16, fork: &ResourceFork) {
         for ((res_type, res_id), resource) in fork.resources() {
-            if res_type == b"FONT" || res_type == b"NFNT" {
-                let _ =
-                    crate::quickdraw::fonts::register_resource_font_strike(*res_id, &resource.data);
-            }
             self.resource_backing_data
                 .entry((refnum, *res_type, *res_id))
                 .or_insert_with(|| resource.data.clone());
+        }
+        // Parse every FOND only after the complete resource fork is present.
+        // HashMap iteration order is intentionally unspecified, while an
+        // NFNT's arbitrary resource ID is meaningful only through its FOND
+        // association. Inside Macintosh: Text (1993), pp. 4-13 and 4-95.
+        for ((res_type, res_id), _) in fork.resources() {
+            if res_type == b"FONT" || res_type == b"NFNT" {
+                self.register_resource_font_backing(refnum, *res_id);
+            }
+        }
+    }
+
+    fn fond_associations_for_font_resource(
+        &self,
+        refnum: u16,
+        font_resource_id: i16,
+    ) -> Vec<crate::quickdraw::fonts::FondAssociation> {
+        self.resource_backing_data
+            .iter()
+            .filter(|((entry_refnum, res_type, _), _)| {
+                *entry_refnum == refnum && res_type == b"FOND"
+            })
+            .filter_map(|((_, _, fond_id), bytes)| {
+                crate::quickdraw::fonts::parse_fond_associations(*fond_id, bytes)
+            })
+            .flatten()
+            .filter(|association| association.font_resource_id == font_resource_id)
+            .collect()
+    }
+
+    fn register_resource_font_backing(&self, refnum: u16, font_resource_id: i16) {
+        let Some((res_type, bytes)) = [*b"NFNT", *b"FONT"].iter().find_map(|res_type| {
+            self.resource_backing_data
+                .get(&(refnum, *res_type, font_resource_id))
+                .map(|bytes| (*res_type, bytes))
+        }) else {
+            return;
+        };
+        let associations = self.fond_associations_for_font_resource(refnum, font_resource_id);
+        if associations.is_empty() {
+            // Standalone old-style FONT resources retain the original
+            // family*128+size convention. NFNT IDs are arbitrary and only
+            // acquire a family and size through a FOND association, which may
+            // not have been loaded yet.
+            if res_type == *b"FONT" {
+                let _ = crate::quickdraw::fonts::register_resource_font_strike(
+                    font_resource_id,
+                    bytes,
+                );
+            }
+            return;
+        }
+
+        for association in associations {
+            // The renderer currently synthesizes bold/italic/etc. from the
+            // plain strike. Do not accidentally install an intrinsic styled
+            // strike as the family's plain face when both share a point size.
+            if association.style & 0x00FF != 0 {
+                continue;
+            }
+            let registered = crate::quickdraw::fonts::register_resource_font_strike_for_family(
+                association.family_id,
+                association.size,
+                bytes,
+            );
+            if registered && std::env::var_os("SYSTEMLESS_TRACE_FONT_TRAPS").is_some() {
+                eprintln!(
+                    "[FONT] FOND {} maps {}pt style ${:04X} to bitmap resource {}",
+                    association.family_id,
+                    association.size,
+                    association.style,
+                    association.font_resource_id,
+                );
+            }
+        }
+    }
+
+    fn register_fond_associated_strikes(&self, refnum: u16, fond_resource_id: i16) {
+        let Some(fond_bytes) = self
+            .resource_backing_data
+            .get(&(refnum, *b"FOND", fond_resource_id))
+        else {
+            return;
+        };
+        let Some(associations) =
+            crate::quickdraw::fonts::parse_fond_associations(fond_resource_id, fond_bytes)
+        else {
+            return;
+        };
+        for font_resource_id in associations
+            .iter()
+            .map(|association| association.font_resource_id)
+        {
+            self.register_resource_font_backing(refnum, font_resource_id);
         }
     }
 
@@ -5873,6 +5965,52 @@ mod tests {
         bytes[ref_list_start + 5..ref_list_start + 8].copy_from_slice(&0u32.to_be_bytes()[1..4]);
 
         bytes
+    }
+
+    fn minimal_test_nfnt() -> Vec<u8> {
+        let mut bytes = vec![0u8; 38];
+        bytes[2..4].copy_from_slice(&32u16.to_be_bytes());
+        bytes[4..6].copy_from_slice(&32u16.to_be_bytes());
+        bytes[6..8].copy_from_slice(&1u16.to_be_bytes());
+        bytes[14..16].copy_from_slice(&1u16.to_be_bytes());
+        bytes[16..18].copy_from_slice(&9u16.to_be_bytes());
+        bytes[18..20].copy_from_slice(&1u16.to_be_bytes());
+        bytes[24..26].copy_from_slice(&1u16.to_be_bytes());
+        bytes[26] = 0xC0;
+        bytes[28..30].copy_from_slice(&0u16.to_be_bytes());
+        bytes[30..32].copy_from_slice(&1u16.to_be_bytes());
+        bytes[32..34].copy_from_slice(&2u16.to_be_bytes());
+        bytes[34..36].copy_from_slice(&1u16.to_be_bytes());
+        bytes[36..38].copy_from_slice(&1u16.to_be_bytes());
+        bytes
+    }
+
+    fn test_fond(font_resource_id: i16, size: i16) -> Vec<u8> {
+        let mut bytes = vec![0u8; 60];
+        bytes[52..54].copy_from_slice(&0u16.to_be_bytes()); // one association minus one
+        bytes[54..56].copy_from_slice(&(size as u16).to_be_bytes());
+        bytes[56..58].copy_from_slice(&0u16.to_be_bytes()); // plain style
+        bytes[58..60].copy_from_slice(&(font_resource_id as u16).to_be_bytes());
+        bytes
+    }
+
+    #[test]
+    fn fond_associations_register_nfnt_independent_of_resource_load_order() {
+        let nfnt = minimal_test_nfnt();
+
+        let mut fond_first = TrapDispatcher::new();
+        fond_first.remember_resource_backing_data(7, *b"FOND", 30010, test_fond(42, 15));
+        fond_first.remember_resource_backing_data(7, *b"NFNT", 42, nfnt.clone());
+        let face = crate::quickdraw::fonts::get_font_face(30010, 15)
+            .expect("FOND loaded before NFNT should register the associated face");
+        assert_eq!((face.font_id, face.size), (30010, 15));
+
+        let mut nfnt_first = TrapDispatcher::new();
+        nfnt_first.remember_resource_backing_data(8, *b"NFNT", 43, nfnt);
+        nfnt_first.remember_resource_backing_data(8, *b"FOND", 30011, test_fond(43, 16));
+        let face = crate::quickdraw::fonts::get_font_face(30011, 16)
+            .expect("FOND loaded after NFNT should register the associated face");
+        assert_eq!((face.font_id, face.size), (30011, 16));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- parse the mandatory association table that follows a FOND FamRec
- register bitmap NFNT/FONT strikes under the family and point size named by that association
- make registration independent of whether the FOND or bitmap resource loads first
- retain the legacy family * 128 + pointSize decoding only for standalone old-style FONT resources

## Problem

System's Twilight ships bitmap font strikes whose NFNT resource IDs are arbitrary. Systemless treated those IDs as though they encoded the family and point size directly. The requested family therefore failed to resolve and QuickDraw fell back to an unrelated built-in face or scaled the wrong strike.

This was visible in two ways:

- narrative text used a much smaller point size than requested
- speech-bubble text used the wrong face and metrics

## Why this is the Classic Mac OS behavior

Inside Macintosh: Text describes the FOND association table as the mapping from a font family and size/style to its FONT, NFNT, or sfnt resource. NFNT resource IDs do not carry the old family/size encoding.

The implementation parses the 52-byte FamRec header plus the mandatory association table, then maps each plain bitmap strike to the FOND family ID and point size. Styled associations are not installed as plain faces because the current renderer synthesizes QuickDraw styles. Standalone old-style FONT resources keep the historical resource-ID fallback.

References are included in the source comments:

- Inside Macintosh: Text (1993), pp. 4-47–4-48
- Inside Macintosh: Text (1993), pp. 4-95–4-96

## Resource-loading behavior

Resource forks do not guarantee that FOND and NFNT resources are observed in a convenient order. The loader therefore retries the association in both directions:

- when a bitmap strike arrives, look for an already-loaded FOND
- when a FOND arrives, look for already-loaded bitmap strikes

The resource bytes remain guest-provided; this change does not bundle proprietary font data.

## Tests

Added regression coverage for:

- arbitrary NFNT IDs mapped through a FOND association
- registration under the associated family and point size
- FOND-before-NFNT loading
- NFNT-before-FOND loading
- the standalone old-style FONT fallback

## Visual verification

Before:
<img width="912" height="744" alt="Screenshot 2026-07-30 at 11 36 24 AM" src="https://github.com/user-attachments/assets/9e74805a-1686-4e7b-bbeb-7cc213e441c3" />
<img width="912" height="744" alt="Screenshot 2026-07-30 at 11 36 40 AM" src="https://github.com/user-attachments/assets/664a4dbc-3b4f-4dc0-ae9a-3fed207036aa" />

After:
<img width="912" height="744" alt="Screenshot 2026-07-30 at 11 33 24 AM" src="https://github.com/user-attachments/assets/171ba1d7-8766-4c59-8095-bbd05d363240" />
<img width="912" height="744" alt="Screenshot 2026-07-30 at 11 32 54 AM" src="https://github.com/user-attachments/assets/198bbf0d-5ea0-49d9-80b9-907fe8ae5263" />


The crop and viewport behavior visible around the game is separate work and is intentionally not part of this PR.

Closes #201