### PR TITLE
fix: gate launch Apple events on the SIZE capability

### DIFF
--- a/src/loader/mod.rs
+++ b/src/loader/mod.rs
@@ -16,6 +16,10 @@ pub struct ApplicationSizeResource {
 }
 
 impl ApplicationSizeResource {
+    /// `isHighLevelEventAware` is bit 6 of the 16-bit `'SIZE'` flags field.
+    /// Macintosh Toolbox Essentials 1992, pp. 2-30 to 2-32.
+    pub const HIGH_LEVEL_EVENT_AWARE: u16 = 0x0040;
+
     pub fn parse(data: &[u8]) -> Option<Self> {
         if data.len() < 10 {
             return None;
@@ -33,6 +37,10 @@ impl ApplicationSizeResource {
         } else {
             None
         }
+    }
+
+    pub fn is_high_level_event_aware(self) -> bool {
+        self.flags & Self::HIGH_LEVEL_EVENT_AWARE != 0
     }
 }
 
@@ -326,6 +334,13 @@ mod tests {
         assert_eq!(size.preferred_size, 0x0030_0000);
         assert_eq!(size.minimum_size, 0x0020_0000);
         assert_eq!(size.preferred_partition_size(), Some(0x0030_0000));
+        assert!(!size.is_high_level_event_aware());
+
+        let aware = ApplicationSizeResource {
+            flags: size.flags | ApplicationSizeResource::HIGH_LEVEL_EVENT_AWARE,
+            ..size
+        };
+        assert!(aware.is_high_level_event_aware());
     }
 
     #[test]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2108,6 +2108,10 @@ impl FixtureRunner {
         use crate::memory::globals::addr;
         let ram_size = self.bus.ram_size();
 
+        self.dispatcher.application_high_level_event_aware = app
+            .size_resource
+            .is_some_and(ApplicationSizeResource::is_high_level_event_aware);
+
         // Classic Mac OS application code runs in supervisor mode with the
         // processor priority open to level-1 VBL interrupts. The m68k core
         // starts from CPU reset with all interrupts masked; make the launch
@@ -6374,6 +6378,15 @@ fn load_app_generic<M: MemoryBus>(
                 );
             }
         }
+        if let Some(size) = size_resource {
+            eprintln!(
+                "[LOAD] SIZE -1 flags=${:04X} highLevelEventAware={} preferred={} minimum={}",
+                size.flags,
+                size.is_high_level_event_aware(),
+                size.preferred_size,
+                size.minimum_size
+            );
+        }
     }
 
     let a5_base = load_address + header.below_a5;
@@ -7018,6 +7031,36 @@ mod tests {
             runner.dispatcher.tick_count, DEFAULT_LAUNCH_TICKS,
             "TickCount fast path must stay in sync with low-memory Ticks"
         );
+    }
+
+    #[test]
+    fn init_app_propagates_size_high_level_event_capability() {
+        let code0 = minimal_code0(0, 0x2000, 0, 0);
+        let unaware_size = size_resource_bytes(0, 0x0008_0000, 0x0008_0000);
+        let unaware_fork_bytes = make_resource_fork_bytes(&[
+            (*b"CODE", 0, code0.as_slice()),
+            (*b"SIZE", -1, unaware_size.as_slice()),
+        ]);
+        let unaware_fork =
+            ResourceFork::parse(&unaware_fork_bytes).expect("parse unaware app fork");
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        let unaware_app = runner.load_app(&unaware_fork).expect("load unaware app");
+        runner.init_app(&unaware_app);
+        assert!(!runner.dispatcher.application_high_level_event_aware);
+
+        let aware_size = size_resource_bytes(
+            ApplicationSizeResource::HIGH_LEVEL_EVENT_AWARE,
+            0x0008_0000,
+            0x0008_0000,
+        );
+        let aware_fork_bytes = make_resource_fork_bytes(&[
+            (*b"CODE", 0, code0.as_slice()),
+            (*b"SIZE", -1, aware_size.as_slice()),
+        ]);
+        let aware_fork = ResourceFork::parse(&aware_fork_bytes).expect("parse aware app fork");
+        let aware_app = runner.load_app(&aware_fork).expect("load aware app");
+        runner.init_app(&aware_app);
+        assert!(runner.dispatcher.application_high_level_event_aware);
     }
 
     #[test]

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -1536,6 +1536,11 @@ pub struct TrapDispatcher {
     /// On a real Mac, the Finder sends this Apple Event at launch.
     /// Macintosh Toolbox Essentials 1992, p. 5-90
     pub(crate) sent_open_app_event: bool,
+    /// Whether the application's `'SIZE'` resource declares
+    /// `isHighLevelEventAware`. The Process Manager defaults this capability
+    /// to false when the resource or flag is absent.
+    /// Macintosh Toolbox Essentials 1992, pp. 2-30 to 2-32.
+    pub(crate) application_high_level_event_aware: bool,
     /// Full trap word currently being dispatched. Some OS traps share the
     /// low 8-bit trap number and require bit 8 to distinguish variants.
     pub(crate) current_trap_word: u16,
@@ -2915,6 +2920,7 @@ impl TrapDispatcher {
             flushed_update_events: VecDeque::new(),
             system_event_mask: 0xFFEF, // everyEvent - keyUpMask
             sent_open_app_event: false,
+            application_high_level_event_aware: false,
             current_trap_word: 0,
             current_trap_caller: None,
             pending_wait_sleep_ticks: 0,

--- a/src/trap/event.rs
+++ b/src/trap/event.rs
@@ -239,7 +239,14 @@ impl super::TrapDispatcher {
     }
 
     fn enqueue_open_application_event_if_needed(&mut self, event_mask: u16) {
-        if self.sent_open_app_event || (event_mask & Self::HIGH_LEVEL_EVENT_MASK) == 0 {
+        // The Finder sends required launch Apple events only to applications
+        // whose 'SIZE' resource declares isHighLevelEventAware. Applications
+        // without that resource or flag default to false.
+        // Macintosh Toolbox Essentials 1992, pp. 2-30 to 2-32 and 5-90.
+        if !self.application_high_level_event_aware
+            || self.sent_open_app_event
+            || (event_mask & Self::HIGH_LEVEL_EVENT_MASK) == 0
+        {
             return;
         }
 

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -16637,6 +16637,7 @@ mod tests {
     #[test]
     fn test_wait_next_event_synthesizes_open_app() {
         let (mut disp, mut cpu, mut bus) = setup();
+        disp.application_high_level_event_aware = true;
         assert!(!disp.sent_open_app_event);
         let sp = TEST_SP;
         let event_ptr = 0x200000u32;
@@ -16673,6 +16674,25 @@ mod tests {
         let result2 = disp.dispatch_toolbox(true, 0x060, &mut cpu, &mut bus);
         assert!(result2.unwrap().is_ok());
         assert_eq!(bus.read_word(sp + 14), 0); // no event
+    }
+
+    #[test]
+    fn wait_next_event_skips_open_app_for_high_level_unaware_application() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let sp = TEST_SP;
+        let event_ptr = 0x200000u32;
+        bus.write_long(sp, 0);
+        bus.write_long(sp + 4, 0);
+        bus.write_long(sp + 8, event_ptr);
+        bus.write_word(sp + 12, 0x0400);
+        bus.write_word(sp + 14, 0xBEEF);
+
+        let result = disp.dispatch_toolbox(true, 0x060, &mut cpu, &mut bus);
+        assert!(result.is_some());
+        assert!(result.unwrap().is_ok());
+        assert_eq!(bus.read_word(sp + 14), 0);
+        assert_eq!(bus.read_word(event_ptr), 0);
+        assert!(!disp.sent_open_app_event);
     }
 
     // EventAvail ($A971) — with event (peeks, does not remove)
@@ -16804,6 +16824,7 @@ mod tests {
     #[test]
     fn test_event_avail_synthesizes_open_app_without_consuming() {
         let (mut disp, mut cpu, mut bus) = setup();
+        disp.application_high_level_event_aware = true;
         let sp = TEST_SP;
         let event_ptr = 0x200000u32;
         bus.write_long(sp, event_ptr);
@@ -16824,6 +16845,7 @@ mod tests {
     #[test]
     fn test_get_next_event_synthesizes_open_app() {
         let (mut disp, mut cpu, mut bus) = setup();
+        disp.application_high_level_event_aware = true;
         let sp = TEST_SP;
         let event_ptr = 0x200000u32;
         bus.write_long(sp, event_ptr);


### PR DESCRIPTION
## Summary

- parse the `isHighLevelEventAware` bit from the application SIZE resource
- propagate that capability into the event dispatcher at launch
- synthesize `kAEOpenApplication` only for applications that declared support

## Root cause

Systemless synthesized an open-application Apple event for every executable. Pre-System-7 applications that do not declare high-level-event awareness can poll the high-level-event mask without installing AppleEvent handlers, so the unsolicited event diverts their startup path.

## Evidence

Macintosh Toolbox Essentials documents `isHighLevelEventAware` as bit 6 of the SIZE flags field. The launch event is now gated by that Process Manager capability instead of being globally enabled.

## Validation

- full Systemless runtime suite: 2,811 passed, 3 ignored
- focused aware and unaware launch-event regressions
- existing launch-event tests explicitly declare awareness

Closes #196