### PR TITLE
fix: render Toolbox chrome through packed indexed framebuffers

### DIFF
--- a/src/trap/framebuffer.rs
+++ b/src/trap/framebuffer.rs
@@ -832,7 +832,7 @@ impl super::TrapDispatcher {
     }
 
     /// Set a single pixel in the framebuffer (screen coordinates).
-    /// Works for both 1bpp and 8bpp screen modes.
+    /// Works for 1bpp, 4bpp, and 8bpp screen modes.
     pub(crate) fn fb_set_pixel(
         bus: &mut MacMemoryBus,
         screen_base: u32,
@@ -857,6 +857,17 @@ impl super::TrapDispatcher {
                     Self::logical_white_pixel_index(bus)
                 },
             );
+        } else if pixel_size == 4 {
+            let addr = screen_base + (y as u32) * row_bytes + (x as u32 / 2);
+            let shift = if x & 1 == 0 { 4 } else { 0 };
+            let mask = 0x0F << shift;
+            let index = if black {
+                Self::logical_black_pixel_index(bus)
+            } else {
+                Self::logical_white_pixel_index(bus)
+            } & 0x0F;
+            let byte = bus.read_byte(addr);
+            bus.write_byte(addr, (byte & !mask) | (index << shift));
         } else {
             let byte_offset = (y as u32) * row_bytes + (x as u32 / 8);
             let bit = 7 - (x as u32 % 8);
@@ -881,6 +892,17 @@ impl super::TrapDispatcher {
         y: i16,
         pixel_index: u8,
     ) {
+        if pixel_size == 4 {
+            if x < 0 || y < 0 || x >= screen_width || y >= screen_height {
+                return;
+            }
+            let addr = screen_base + (y as u32) * row_bytes + (x as u32 / 2);
+            let shift = if x & 1 == 0 { 4 } else { 0 };
+            let mask = 0x0F << shift;
+            let byte = bus.read_byte(addr);
+            bus.write_byte(addr, (byte & !mask) | ((pixel_index & 0x0F) << shift));
+            return;
+        }
         if pixel_size != 8 {
             Self::fb_set_pixel(
                 bus,
@@ -915,6 +937,24 @@ impl super::TrapDispatcher {
         right: i16,
         pixel_index: u8,
     ) {
+        if pixel_size == 4 {
+            for y in top..bottom {
+                for x in left..right {
+                    Self::fb_set_pixel_index(
+                        bus,
+                        screen_base,
+                        row_bytes,
+                        pixel_size,
+                        screen_width,
+                        screen_height,
+                        x,
+                        y,
+                        pixel_index,
+                    );
+                }
+            }
+            return;
+        }
         if pixel_size != 8 {
             Self::fb_fill_rect(
                 bus,
@@ -1052,6 +1092,10 @@ impl super::TrapDispatcher {
         if pixel_size == 8 {
             let addr = screen_base + (y as u32) * row_bytes + (x as u32);
             bus.read_byte(addr) == Self::logical_black_pixel_index(bus)
+        } else if pixel_size == 4 {
+            let addr = screen_base + (y as u32) * row_bytes + (x as u32 / 2);
+            let shift = if x & 1 == 0 { 4 } else { 0 };
+            ((bus.read_byte(addr) >> shift) & 0x0F) == (Self::logical_black_pixel_index(bus) & 0x0F)
         } else {
             let byte_offset = (y as u32) * row_bytes + (x as u32 / 8);
             let bit = 7 - (x as u32 % 8);
@@ -1370,7 +1414,7 @@ impl super::TrapDispatcher {
         let gh = glyph.height as usize;
         let metrics = synthetic_italic
             .map(|(font_id, font_size)| (font_id, font_size, get_font_metrics(font_id, font_size)));
-        let text_index = if pixel_size == 8 {
+        let text_index = if matches!(pixel_size, 4 | 8) {
             Some(pixel_index_override.unwrap_or_else(|| {
                 if black {
                     Self::logical_black_pixel_index(bus)
@@ -2324,7 +2368,7 @@ impl super::TrapDispatcher {
             }
             return;
         }
-        if pixel_size != 8 || screen_w == 0 || screen_h == 0 {
+        if !matches!(pixel_size, 4 | 8) || screen_w == 0 || screen_h == 0 {
             if trace {
                 eprintln!(
                     "[BLIT] skip: screen mode mismatch (pixel_size={}, w={}, h={})",
@@ -2514,6 +2558,29 @@ impl super::TrapDispatcher {
                 }
                 return;
             }
+        }
+
+        if port_pixel_size == 4 {
+            for row in 0..row_count {
+                let src_row = port_base + (src_y_offset + row) * port_rb;
+                let dst_row = screen_base + (dst_y + row) * screen_rb;
+                for col in 0..col_count {
+                    let src_x = src_x_offset + col;
+                    let src_byte = bus.read_byte(src_row + src_x / 2);
+                    let src_index = if src_x & 1 == 0 {
+                        src_byte >> 4
+                    } else {
+                        src_byte & 0x0F
+                    };
+                    let dst_x = dst_x + col;
+                    let dst_addr = dst_row + dst_x / 2;
+                    let dst_shift = if dst_x & 1 == 0 { 4 } else { 0 };
+                    let dst_mask = 0x0F << dst_shift;
+                    let dst_byte = bus.read_byte(dst_addr);
+                    bus.write_byte(dst_addr, (dst_byte & !dst_mask) | (src_index << dst_shift));
+                }
+            }
+            return;
         }
 
         // block_move per row.
@@ -4440,6 +4507,34 @@ mod redraw_chrome_tests {
     const CLIP_RGN: u32 = 0x182200;
     const WINDOW_VISIBLE_OFFSET: u32 = 110;
 
+    #[test]
+    fn indexed_framebuffer_helpers_preserve_adjacent_four_bit_pixels() {
+        let (mut disp, _cpu, mut bus) = setup_with_port();
+        let screen_base = bus.alloc(2);
+        bus.write_byte(screen_base, 0xAB);
+        bus.write_byte(screen_base + 1, 0xCD);
+
+        TrapDispatcher::fb_set_pixel_index(&mut bus, screen_base, 2, 4, 4, 1, 0, 0, 3);
+        TrapDispatcher::fb_set_pixel_index(&mut bus, screen_base, 2, 4, 4, 1, 1, 0, 4);
+        assert_eq!(bus.read_byte(screen_base), 0x34);
+        assert_eq!(bus.read_byte(screen_base + 1), 0xCD);
+
+        TrapDispatcher::fb_fill_rect_index(&mut bus, screen_base, 2, 4, 4, 1, 0, 1, 1, 3, 5);
+        assert_eq!(bus.read_byte(screen_base), 0x35);
+        assert_eq!(bus.read_byte(screen_base + 1), 0x5D);
+
+        disp.screen_mode = (screen_base, 2, 4, 1, 4);
+        let saved = disp
+            .save_screen_rect_pixels(&bus, (0, 1, 1, 3))
+            .expect("packed screen rectangle");
+        assert_eq!(saved.4, vec![5, 5]);
+        bus.write_byte(screen_base, 0xAA);
+        bus.write_byte(screen_base + 1, 0xAA);
+        disp.restore_screen_rect_pixels(&mut bus, saved.0, saved.1, saved.2, saved.3, &saved.4);
+        assert_eq!(bus.read_byte(screen_base), 0xA5);
+        assert_eq!(bus.read_byte(screen_base + 1), 0x5A);
+    }
+
     fn track_manual_cport(disp: &mut TrapDispatcher, bus: &crate::memory::MacMemoryBus, port: u32) {
         disp.cport_ports.insert(port);
         disp.cport_original_pixmaps
@@ -5540,6 +5635,37 @@ mod redraw_chrome_tests {
             bus.read_byte(screen_base + 5 * 64 + 11),
             8,
             "same-RGB entries should remain stable through the translation table"
+        );
+    }
+
+    #[test]
+    fn redraw_chrome_blit_4bpp_to_4bpp_copies_packed_pixels() {
+        let (mut disp, _cpu, mut bus) = setup_with_port();
+
+        let screen_base = bus.alloc(4 * 2);
+        disp.screen_mode = (screen_base, 4, 8, 2, 4);
+        bus.write_long(0x0824, screen_base);
+
+        let (clut, _) = TrapDispatcher::standard_mac_indexed_clut(4).unwrap();
+        let ctab_handle = make_ctab_handle(&mut bus, &clut, 4);
+        let offscreen_base = bus.alloc(4 * 2);
+        let pixmap_handle = install_8bpp_cgrafport(&mut bus, offscreen_base, 4, 8, 2, ctab_handle);
+        let pixmap = bus.read_long(pixmap_handle);
+        bus.write_word(pixmap + 32, 4);
+        bus.write_word(pixmap + 36, 4);
+
+        bus.write_bytes(offscreen_base, &[0x12, 0x34, 0x56, 0x78]);
+        bus.fill_bytes(screen_base, 4 * 2, 0xAA);
+        disp.front_window = PORT_PTR;
+        disp.window_bounds = (0, 0, 2, 8);
+        disp.window_proc_id = 1;
+
+        disp.blit_window_to_screen(&mut bus);
+
+        assert_eq!(bus.read_bytes(screen_base, 4), vec![0x12, 0x34, 0x56, 0x78]);
+        assert_eq!(
+            bus.read_bytes(screen_base + 4, 4),
+            vec![0x00, 0x00, 0x00, 0x00]
         );
     }
 

--- a/src/trap/menu.rs
+++ b/src/trap/menu.rs
@@ -805,7 +805,7 @@ impl super::TrapDispatcher {
         bus: &MacMemoryBus,
         pixel_size: u16,
     ) -> Option<u8> {
-        if pixel_size != 8 {
+        if !matches!(pixel_size, 4 | 8) {
             return None;
         }
 
@@ -834,7 +834,7 @@ impl super::TrapDispatcher {
         menu_id: i16,
         pixel_size: u16,
     ) -> Option<u8> {
-        if pixel_size != 8 {
+        if !matches!(pixel_size, 4 | 8) {
             return None;
         }
 

--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -28510,6 +28510,35 @@ mod tests {
     }
 
     #[test]
+    fn test_fill_rect_basic_grafport_at_screen_writes_packed_4bpp() {
+        let (mut d, mut cpu, mut bus) = setup_with_port();
+        let screen_base = bus.alloc(400 * 600);
+        bus.write_long(0x0824, screen_base);
+        d.screen_mode = (screen_base, 400, 800, 600, 4);
+
+        const PORT_PTR: u32 = 0x181000;
+        bus.write_long(PORT_PTR + 2, screen_base);
+        bus.write_word(PORT_PTR + 6, 400);
+
+        let pixel_addr = screen_base + 30 * 400 + 50;
+        bus.write_byte(pixel_addr, 0xAB);
+        let pat_ptr = 0x300000u32;
+        bus.write_bytes(pat_ptr, &[0xFF; 8]);
+        let rect_ptr = 0x300010u32;
+        write_rect(&mut bus, rect_ptr, 30, 100, 31, 101);
+        bus.write_long(TEST_SP, pat_ptr);
+        bus.write_long(TEST_SP + 4, rect_ptr);
+        let result = d.dispatch_quickdraw(true, 0x0A5, &mut cpu, &mut bus);
+
+        assert!(result.unwrap().is_ok());
+        assert_eq!(
+            bus.read_byte(pixel_addr),
+            0xFB,
+            "4bpp drawing must replace the target nibble and preserve its neighbor"
+        );
+    }
+
+    #[test]
     fn test_frame_oval() {
         let (mut d, mut cpu, mut bus) = setup_with_port();
         let rect_ptr = 0x300000u32;

--- a/src/trap/shapes.rs
+++ b/src/trap/shapes.rs
@@ -1109,13 +1109,14 @@ impl super::TrapDispatcher {
             let right = bus.read_word(port.wrapping_add(14)) as i16;
             // Generic safety net: a basic GrafPort (port_version & 0xC000
             // == 0) is implicitly 1bpp by Mac OS convention. But if `base`
-            // happens to point at an 8bpp screen, per-bit set/clear into
-            // screen bytes corrupts 8bpp pixels. Inside Macintosh V-122:
+            // happens to point at an indexed color screen, per-bit set/clear
+            // into screen bytes corrupts packed pixels. Inside Macintosh V-122:
             // on a color screen, all GrafPorts displayed at the screen
             // base must use the screen's depth.
             let (screen_base_addr, screen_rb, _, _, screen_ps) = self.screen_mode;
-            if screen_ps == 8 && base == screen_base_addr && row_bytes == screen_rb {
-                (base, row_bytes, 8u16, top, left, bottom, right)
+            if matches!(screen_ps, 2 | 4 | 8) && base == screen_base_addr && row_bytes == screen_rb
+            {
+                (base, row_bytes, screen_ps, top, left, bottom, right)
             } else {
                 (base, row_bytes, 1u16, top, left, bottom, right)
             }
@@ -1298,7 +1299,7 @@ impl super::TrapDispatcher {
         // Designing Cards and Drivers 3rd Ed. 1992, p. 245-248
         let fg_idx;
         let bg_idx;
-        if pixel_size == 8 && is_color {
+        if matches!(pixel_size, 2 | 4 | 8) && is_color {
             let pix_map_handle = bus.read_long(port.wrapping_add(2));
             let port_ctab_handle = if pix_map_handle != 0 {
                 let pix_map_ptr = bus.read_long(pix_map_handle);
@@ -1401,43 +1402,44 @@ impl super::TrapDispatcher {
         // (Bayer-dither path superseded the blend) but kept for a future
         // smarter blend path.
         #[allow(unused_variables)]
-        let glyph_clut = if pixel_size == 8 && is_color && matches!(op, ShapeOp::Glyph(_)) {
-            let pix_map_handle = bus.read_long(port.wrapping_add(2));
-            let port_ctab_handle = if pix_map_handle != 0 {
-                let pix_map_ptr = bus.read_long(pix_map_handle);
-                if pix_map_ptr != 0 {
-                    bus.read_long(pix_map_ptr + 42)
+        let glyph_clut =
+            if matches!(pixel_size, 2 | 4 | 8) && is_color && matches!(op, ShapeOp::Glyph(_)) {
+                let pix_map_handle = bus.read_long(port.wrapping_add(2));
+                let port_ctab_handle = if pix_map_handle != 0 {
+                    let pix_map_ptr = bus.read_long(pix_map_handle);
+                    if pix_map_ptr != 0 {
+                        bus.read_long(pix_map_ptr + 42)
+                    } else {
+                        0
+                    }
                 } else {
                     0
-                }
+                };
+                let is_screen_port = pix_base == self.screen_mode.0
+                    && pix_row_bytes == self.screen_mode.1
+                    && pixel_size == self.screen_mode.4;
+                let current_ctab_handle = if port == self.current_port {
+                    self.current_gdevice_ctab_handle(bus)
+                } else {
+                    0
+                };
+                let use_raw_current_ctab = current_ctab_handle != 0
+                    && ctab_uses_noncanonical_black(bus, current_ctab_handle);
+                let ctab_handle = if use_raw_current_ctab {
+                    current_ctab_handle
+                } else {
+                    port_ctab_handle
+                };
+                Some(if is_screen_port {
+                    self.device_clut
+                } else if use_raw_current_ctab {
+                    self.read_ctab_handle_clut(bus, ctab_handle)
+                } else {
+                    self.read_port_clut(bus, ctab_handle)
+                })
             } else {
-                0
+                None
             };
-            let is_screen_port = pix_base == self.screen_mode.0
-                && pix_row_bytes == self.screen_mode.1
-                && pixel_size == self.screen_mode.4;
-            let current_ctab_handle = if port == self.current_port {
-                self.current_gdevice_ctab_handle(bus)
-            } else {
-                0
-            };
-            let use_raw_current_ctab =
-                current_ctab_handle != 0 && ctab_uses_noncanonical_black(bus, current_ctab_handle);
-            let ctab_handle = if use_raw_current_ctab {
-                current_ctab_handle
-            } else {
-                port_ctab_handle
-            };
-            Some(if is_screen_port {
-                self.device_clut
-            } else if use_raw_current_ctab {
-                self.read_ctab_handle_clut(bus, ctab_handle)
-            } else {
-                self.read_port_clut(bus, ctab_handle)
-            })
-        } else {
-            None
-        };
 
         for y in r.top..r.bottom {
             if y < clip_top || y >= clip_bottom {
@@ -1538,6 +1540,49 @@ impl super::TrapDispatcher {
                             bus.write_byte(addr, invert_indexed_pixel(bus.read_byte(addr)))
                         }
                     }
+                } else if matches!(pixel_size, 2 | 4) {
+                    let bits = u32::from(pixel_size);
+                    let pixels_per_byte = 8 / bits;
+                    let byte_col = dx / pixels_per_byte;
+                    if byte_col >= pix_row_bytes {
+                        continue;
+                    }
+                    let shift = 8 - bits - (dx % pixels_per_byte) * bits;
+                    let index_mask = ((1u16 << pixel_size) - 1) as u8;
+                    let addr = pix_base + dy * pix_row_bytes + byte_col;
+                    let byte = bus.read_byte(addr);
+                    let old = (byte >> shift) & index_mask;
+                    let new = match op {
+                        ShapeOp::Paint | ShapeOp::Frame => {
+                            let source_is_black = effective_pn_pat[y.rem_euclid(8) as usize]
+                                & (1 << (7 - x.rem_euclid(8)))
+                                != 0;
+                            apply_boolean_transfer_8(
+                                old,
+                                self.pn_mode,
+                                source_is_black,
+                                fg_idx,
+                                bg_idx,
+                            )
+                        }
+                        ShapeOp::Erase => {
+                            let source_is_black = effective_bk_pat[y.rem_euclid(8) as usize]
+                                & (1 << (7 - x.rem_euclid(8)))
+                                != 0;
+                            apply_boolean_transfer_8(old, 0, source_is_black, fg_idx, bg_idx)
+                        }
+                        ShapeOp::Fill(ref p) => {
+                            let source_is_black =
+                                p[y.rem_euclid(8) as usize] & (1 << (7 - x.rem_euclid(8))) != 0;
+                            apply_boolean_transfer_8(old, 0, source_is_black, fg_idx, bg_idx)
+                        }
+                        ShapeOp::Glyph(mode) => {
+                            apply_boolean_transfer_8(old, mode, true, fg_idx, bg_idx)
+                        }
+                        ShapeOp::Invert => !old,
+                    } & index_mask;
+                    let field_mask = index_mask << shift;
+                    bus.write_byte(addr, (byte & !field_mask) | (new << shift));
                 } else if pixel_size == 32 {
                     let byte_offset = dy * pix_row_bytes + dx * 4;
                     if byte_offset + 4 > (dy + 1) * pix_row_bytes {

--- a/src/trap/window.rs
+++ b/src/trap/window.rs
@@ -1103,12 +1103,25 @@ impl super::TrapDispatcher {
         let mut pixels = Vec::with_capacity(width as usize * height as usize);
         for y in top..bottom {
             for x in left..right {
-                if pixel_size == 8 {
-                    pixels.push(bus.read_byte(screen_base + y as u32 * row_bytes + x as u32));
-                } else {
-                    let byte_offset = y as u32 * row_bytes + x as u32 / 8;
-                    let bit = 7 - (x as u32 % 8);
-                    pixels.push((bus.read_byte(screen_base + byte_offset) >> bit) & 1);
+                match pixel_size {
+                    8 => {
+                        pixels.push(bus.read_byte(screen_base + y as u32 * row_bytes + x as u32));
+                    }
+                    bits @ (2 | 4) => {
+                        let pixels_per_byte = 8 / u32::from(bits);
+                        let byte_offset = y as u32 * row_bytes + x as u32 / pixels_per_byte;
+                        let shift =
+                            8 - u32::from(bits) - (x as u32 % pixels_per_byte) * u32::from(bits);
+                        pixels.push(
+                            (bus.read_byte(screen_base + byte_offset) >> shift)
+                                & ((1u8 << bits) - 1),
+                        );
+                    }
+                    _ => {
+                        let byte_offset = y as u32 * row_bytes + x as u32 / 8;
+                        let bit = 7 - (x as u32 % 8);
+                        pixels.push((bus.read_byte(screen_base + byte_offset) >> bit) & 1);
+                    }
                 }
             }
         }
@@ -1142,6 +1155,18 @@ impl super::TrapDispatcher {
                 }
                 if pixel_size == 8 {
                     bus.write_byte(screen_base + y as u32 * row_bytes + x as u32, pixel);
+                } else if matches!(pixel_size, 2 | 4) {
+                    Self::fb_set_pixel_index(
+                        bus,
+                        screen_base,
+                        row_bytes,
+                        pixel_size,
+                        screen_width,
+                        screen_height,
+                        x,
+                        y,
+                        pixel,
+                    );
                 } else {
                     Self::fb_set_pixel(
                         bus,
@@ -3184,6 +3209,34 @@ impl super::TrapDispatcher {
                         if self.window_uses_custom_def_proc(bus, the_window) {
                             arm_custom_wdef_draw = !was_visible;
                         } else {
+                            let proc_id =
+                                self.window_proc_ids.get(&the_window).copied().unwrap_or(0);
+                            if !was_visible && matches!(proc_id, 1..=3) {
+                                if let Some((top, left, bottom, right)) =
+                                    self.window_content_global_rect(bus, the_window)
+                                {
+                                    let (
+                                        screen_base,
+                                        row_bytes,
+                                        screen_width,
+                                        screen_height,
+                                        pixel_size,
+                                    ) = self.get_screen_params();
+                                    Self::fb_fill_rect(
+                                        bus,
+                                        screen_base,
+                                        row_bytes,
+                                        pixel_size,
+                                        screen_width,
+                                        screen_height,
+                                        top,
+                                        left,
+                                        bottom,
+                                        right,
+                                        false,
+                                    );
+                                }
+                            }
                             self.draw_single_window_chrome_inline(bus, the_window, hilited);
                         }
                     }


### PR DESCRIPTION
## Summary

- read, write, fill, and test logical black pixels in packed 4-bit framebuffers
- render shapes, glyphs, menu chrome, window save-under data, and window blits at packed indexed depths
- treat basic screen-backed GrafPorts as the active indexed screen depth
- clear newly shown standard window content before its first draw

## Root cause

Several Toolbox paths assumed either 1-bit or 8-bit storage. After an application selected 4-bit color, those paths wrote whole bytes or individual 1-bit fragments into packed nibbles, corrupting window chrome, menus, glyphs, and save-under pixels.

## Evidence

The implementation preserves neighboring packed pixels and uses the active device indices for foreground and background colors. The end-to-end 4-bit application path now renders its map, controls, menu bar, and tutorial window through the same packed framebuffer.

## Validation

- full Systemless runtime suite: 2,811 passed, 3 ignored
- focused packed-pixel, packed-fill, save/restore, window-blit, ShowWindow, and basic-GrafPort regressions
- Systemless/BasiliskII visual comparison at 800×600 with original Macintosh fonts

This PR is stacked on #198 because the packed renderer requires the canonical 4-bit device table installed there.

Closes #199