### PR TITLE
fix: ignore stale ModalDialog filter results before callbacks

### DIFF
--- a/src/trap/dialog.rs
+++ b/src/trap/dialog.rs
@@ -11114,12 +11114,24 @@ impl super::TrapDispatcher {
                     if filter_proc != 0 {
                         let result_addr = self.dialog_filter_result_addr;
                         let tracking_dialog_ptr = tracking.dialog_ptr;
+                        let filter_event = self
+                            .dialog_tracking
+                            .as_mut()
+                            .and_then(|t| t.last_filter_event.take());
+                        // The scratch result belongs to the most recently
+                        // completed filter callback, not merely to whichever
+                        // ModalDialog happens to be active now. A newly opened
+                        // dialog can otherwise inherit TRUE from the filter of
+                        // the preceding dialog and return before its own filter
+                        // has received an event. IM:I I-415 defines the result
+                        // only as the response to the event passed to filterProc.
+                        let filter_result_valid = filter_event.is_some();
                         let filter_result_word = if result_addr != 0 {
                             bus.read_word(result_addr)
                         } else {
                             0
                         };
-                        let filter_returned_true = if result_addr != 0 {
+                        let filter_returned_true = if filter_result_valid && result_addr != 0 {
                             // Stack-based Pascal BOOLEAN results are encoded
                             // in bit 0 of the high-order byte, not as any
                             // nonzero word. Inside Macintosh Volume I,
@@ -11133,10 +11145,6 @@ impl super::TrapDispatcher {
                         if filter_returned_true && item_hit_ptr != 0 {
                             hit = bus.read_word(item_hit_ptr) as i16;
                         }
-                        let filter_event = self
-                            .dialog_tracking
-                            .as_mut()
-                            .and_then(|t| t.last_filter_event.take());
                         if trace_dialog_filter_enabled() {
                             eprintln!(
                                 "[DIALOG-FILTER] result dialog=${:08X} result_word=${:04X} returned_true={} item_hit={} item_hit_ptr=${:08X}",
@@ -29659,6 +29667,63 @@ mod tests {
         assert!(result.unwrap().is_ok());
         assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 8);
         assert_eq!(bus.read_word(item_hit_ptr), 1);
+    }
+
+    #[test]
+    fn modal_dialog_ignores_stale_filter_result_before_first_callback() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let dialog_ptr = 0x200000u32;
+        let item_hit_ptr = 0x300000u32;
+        let result_addr = 0x300100u32;
+
+        // A preceding dialog's filter returned TRUE. The shared callback
+        // scratch is deliberately left intact when a second dialog starts.
+        bus.write_word(result_addr, 0x0100);
+        bus.write_word(item_hit_ptr, 0);
+        disp.dialog_filter_result_addr = result_addr;
+        disp.dialog_tracking = Some(crate::trap::dispatch::DialogTrackingState {
+            dialog_ptr,
+            bounds: (100, 200, 200, 360),
+            title: String::new(),
+            proc_id: 2,
+            items: vec![DialogItem {
+                item_type: 4,
+                rect: (20, 30, 60, 110),
+                text: String::from("OK"),
+                resource_id: 0,
+                proc_ptr: 0,
+                sel_start: 0,
+                sel_end: 0,
+            }],
+            default_item: 1,
+            cancel_item: 0,
+            edit_text: String::new(),
+            edit_item: 0,
+            saved_pixels: Vec::new(),
+            stack_ptr: TEST_SP,
+            item_hit_ptr,
+            rendered_pixels: Vec::new(),
+            flash_remaining: 0,
+            flash_delay: 0,
+            flash_item: 0,
+            edit_text_modified: false,
+            draw_proc_queue: VecDeque::new(),
+            draw_procs_done: true,
+            rendered_pixels_final: true,
+            filter_proc: 0x149F0,
+            game_managed: false,
+            last_filter_event: None,
+            popup_draws: Vec::new(),
+            active_popup: None,
+            active_button: None,
+            active_user_item: None,
+        });
+
+        let result = disp.dispatch_dialog(true, 0x191, &mut cpu, &mut bus);
+        assert!(result.unwrap().is_ok());
+        assert_eq!(cpu.read_reg(Register::A7), TEST_SP);
+        assert_eq!(bus.read_word(item_hit_ptr), 0);
+        assert!(disp.dialog_tracking.is_some());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- associate the shared ModalDialog filter-result scratch value with an actual completed filter callback
- prevent a newly opened modal dialog from inheriting TRUE from a preceding dialog
- retain the documented behavior that a filter may return TRUE with itemHit = 0 once that filter has actually processed an event
- add regression coverage for consecutive modal dialogs sharing callback scratch memory

## Problem

System's Twilight exposed this with its Random Data dialog. A preceding modal dialog's filter returned the canonical Pascal Boolean TRUE (`0x0100` in the stack word). The next dialog began tracking with `last_filter_event = None`, but the ModalDialog re-fire path read the shared scratch word before invoking the new dialog's filter. It therefore returned immediately with `itemHit = 0`, and the application disposed the dialog as soon as it appeared.

This was timing-independent stale state, not a mouse-up delivery problem and not the earlier `0xFF` versus `0x01` Boolean representation issue.

Inside Macintosh Volume I, I-415 defines the filter result as the response to the event ModalDialog passes to `filterProc`: FALSE asks ModalDialog to handle that event; TRUE asks ModalDialog to return immediately. A scratch value from an earlier filter invocation has no meaning before the current dialog's filter receives an event.

## Fix

Consume `last_filter_event` before interpreting the result scratch and consider the result valid only when that completed-event marker exists. This scopes the existing scratch word to its callback without changing the Pascal Boolean decoding or legitimate TRUE-with-zero-itemHit behavior.

The source and test remain application-neutral; the application name appears only here as the reproducer.

## Testing

- `cargo test modal_dialog_ --lib`: 32 passed
- `cargo test modal_dialog_ignores_stale_filter_result_before_first_callback --lib`: passed on current master (v0.9.13)
- Manual before: in System's Twilight, Random Data appeared briefly and immediately closed
- Manual after: Random Data remains open until an enabled dialog item is selected
