### PR TITLE
perf: update retained dialog snapshots by damaged region

### DIFF
--- a/src/trap/dialog.rs
+++ b/src/trap/dialog.rs
@@ -5169,15 +5169,32 @@ impl super::TrapDispatcher {
         bounds: (i16, i16, i16, i16),
         screen_rect: (i16, i16, i16, i16),
     ) {
+        let screen_params = self.get_screen_params();
+        let Some(saved) = self.dialog_saved_pixels.get_mut(&dialog_ptr) else {
+            return;
+        };
+        Self::refresh_saved_pixel_buffer_after_screen_draw(
+            bus,
+            screen_params,
+            bounds,
+            screen_rect,
+            saved,
+        );
+    }
+
+    fn refresh_saved_pixel_buffer_after_screen_draw(
+        bus: &MacMemoryBus,
+        screen_params: (u32, u32, i16, i16, u16),
+        bounds: (i16, i16, i16, i16),
+        screen_rect: (i16, i16, i16, i16),
+        saved: &mut [u8],
+    ) {
         let save_rect = Self::dialog_saved_pixel_rect(bounds);
         let Some(intersection) = Self::rect_intersection(save_rect, screen_rect) else {
             return;
         };
 
-        let (screen_base, row_bytes, screen_w, screen_h, pixel_size) = self.get_screen_params();
-        let Some(saved) = self.dialog_saved_pixels.get_mut(&dialog_ptr) else {
-            return;
-        };
+        let (screen_base, row_bytes, screen_w, screen_h, pixel_size) = screen_params;
         let (save_top, save_left, save_bottom, save_right) = save_rect;
         let row_width = save_right.saturating_sub(save_left) as usize;
         let row_count = save_bottom.saturating_sub(save_top) as usize;
@@ -6628,6 +6645,48 @@ impl super::TrapDispatcher {
         let pixels = self.save_dialog_pixels(bus, bounds);
         self.dialog_visible_snapshots
             .insert(port, PersistentDialogSnapshot { bounds, pixels });
+    }
+
+    pub(crate) fn refresh_visible_dialog_snapshot_region_for_port(
+        &mut self,
+        bus: &MacMemoryBus,
+        port: u32,
+        screen_rect: (i16, i16, i16, i16),
+    ) {
+        if port == 0 || screen_rect.0 >= screen_rect.2 || screen_rect.1 >= screen_rect.3 {
+            return;
+        }
+        let Some(bounds) = self
+            .dialog_visible_snapshots
+            .get(&port)
+            .map(|snapshot| snapshot.bounds)
+            .or_else(|| {
+                if self.dialog_items.contains_key(&port) && self.window_visible(bus, port) {
+                    Some(Self::dialog_screen_bounds(bus, port))
+                } else {
+                    None
+                }
+            })
+        else {
+            return;
+        };
+
+        let screen_params = self.get_screen_params();
+        if let Some(snapshot) = self.dialog_visible_snapshots.get_mut(&port) {
+            Self::refresh_saved_pixel_buffer_after_screen_draw(
+                bus,
+                screen_params,
+                bounds,
+                screen_rect,
+                &mut snapshot.pixels,
+            );
+        } else {
+            // The first authoritative draw still needs a complete baseline;
+            // later draws can update only the pixels they touched.
+            let pixels = self.save_dialog_pixels(bus, bounds);
+            self.dialog_visible_snapshots
+                .insert(port, PersistentDialogSnapshot { bounds, pixels });
+        }
     }
 
     pub(crate) fn refresh_visible_dialog_snapshot_after_bulk_port_draw(

--- a/src/trap/framebuffer.rs
+++ b/src/trap/framebuffer.rs
@@ -5418,6 +5418,111 @@ mod redraw_chrome_tests {
     }
 
     #[test]
+    fn refresh_visible_dialog_snapshot_region_updates_only_touched_pixels() {
+        let (mut disp, _cpu, mut bus) = setup_with_port();
+
+        let screen_base = bus.alloc(64 * 64);
+        disp.screen_mode = (screen_base, 64, 64, 64, 8);
+        bus.write_long(0x0824, screen_base);
+
+        for y in 0..40u32 {
+            for x in 0..40u32 {
+                bus.write_byte(screen_base + y * 64 + x, 0x11);
+            }
+        }
+
+        let dialog_ptr = 0x00D1_A106;
+        let bounds = (10, 10, 30, 30);
+        let pixels = disp.save_dialog_pixels(&bus, bounds);
+        disp.dialog_visible_snapshots.insert(
+            dialog_ptr,
+            super::super::dispatch::PersistentDialogSnapshot { bounds, pixels },
+        );
+
+        let touched_probe = screen_base + 12 * 64 + 12;
+        let untouched_probe = screen_base + 20 * 64 + 20;
+        bus.write_byte(touched_probe, 0x77);
+        bus.write_byte(untouched_probe, 0x88);
+        disp.refresh_visible_dialog_snapshot_region_for_port(
+            &bus,
+            dialog_ptr,
+            (12, 12, 13, 13),
+        );
+
+        bus.write_byte(touched_probe, 0x00);
+        bus.write_byte(untouched_probe, 0x00);
+        disp.restore_visible_dialog_snapshots(&mut bus);
+
+        assert_eq!(bus.read_byte(touched_probe), 0x77);
+        assert_eq!(
+            bus.read_byte(untouched_probe),
+            0x11,
+            "pixels outside the reported QuickDraw damage must retain their prior snapshot value"
+        );
+    }
+
+    #[test]
+    fn refresh_visible_dialog_snapshot_region_preserves_untouched_packed_pixels() {
+        for pixel_size in [1u16, 2, 4] {
+            let (mut disp, _cpu, mut bus) = setup_with_port();
+            let row_bytes = 64 * u32::from(pixel_size) / 8;
+            let screen_base = bus.alloc(row_bytes * 64);
+            disp.screen_mode = (screen_base, row_bytes, 64, 64, pixel_size);
+            bus.write_long(0x0824, screen_base);
+
+            let dialog_ptr = 0x00D1_A106;
+            let bounds = (8, 8, 24, 24);
+            let pixels = disp.save_dialog_pixels(&bus, bounds);
+            disp.dialog_visible_snapshots.insert(
+                dialog_ptr,
+                super::super::dispatch::PersistentDialogSnapshot { bounds, pixels },
+            );
+
+            let touched = (12u32, 12u32);
+            let untouched = (20u32, 20u32);
+            let pixels_per_byte = 8 / u32::from(pixel_size);
+            let pixel_mask = |x: u32| {
+                let shift = 8
+                    - u32::from(pixel_size)
+                    - (x % pixels_per_byte) * u32::from(pixel_size);
+                (((1u16 << pixel_size) - 1) as u8) << shift
+            };
+            let pixel_addr = |x: u32, y: u32| screen_base + y * row_bytes + x / pixels_per_byte;
+
+            bus.write_byte(pixel_addr(touched.0, touched.1), pixel_mask(touched.0));
+            bus.write_byte(
+                pixel_addr(untouched.0, untouched.1),
+                pixel_mask(untouched.0),
+            );
+            disp.refresh_visible_dialog_snapshot_region_for_port(
+                &bus,
+                dialog_ptr,
+                (
+                    touched.1 as i16,
+                    touched.0 as i16,
+                    touched.1 as i16 + 1,
+                    touched.0 as i16 + 1,
+                ),
+            );
+
+            bus.write_byte(pixel_addr(touched.0, touched.1), 0);
+            bus.write_byte(pixel_addr(untouched.0, untouched.1), 0);
+            disp.restore_visible_dialog_snapshots(&mut bus);
+
+            assert_ne!(
+                bus.read_byte(pixel_addr(touched.0, touched.1)) & pixel_mask(touched.0),
+                0,
+                "{pixel_size}-bit touched pixel should be retained"
+            );
+            assert_eq!(
+                bus.read_byte(pixel_addr(untouched.0, untouched.1)) & pixel_mask(untouched.0),
+                0,
+                "{pixel_size}-bit pixel outside the damage rect should keep its prior value"
+            );
+        }
+    }
+
+    #[test]
     fn fb_fill_rect_uses_active_ctab_brightest_entry_for_white() {
         let (mut disp, _cpu, mut bus) = setup_with_port();
 

--- a/src/trap/shapes.rs
+++ b/src/trap/shapes.rs
@@ -1397,17 +1397,22 @@ impl super::TrapDispatcher {
                             let dy = (y - bounds_top) as u32;
                             bus.write_bytes(pix_base + dy * pix_row_bytes + dx, &row);
                         }
+                        let screen_rect = (
+                            top.saturating_sub(bounds_top),
+                            left.saturating_sub(bounds_left),
+                            bottom.saturating_sub(bounds_top),
+                            right.saturating_sub(bounds_left),
+                        );
                         self.refresh_dialog_saved_pixels_after_screen_draw(
                             bus,
                             port,
-                            (
-                                top.saturating_sub(bounds_top),
-                                left.saturating_sub(bounds_left),
-                                bottom.saturating_sub(bounds_top),
-                                right.saturating_sub(bounds_left),
-                            ),
+                            screen_rect,
                         );
-                        self.refresh_visible_dialog_snapshot_for_port(bus, port);
+                        self.refresh_visible_dialog_snapshot_region_for_port(
+                            bus,
+                            port,
+                            screen_rect,
+                        );
                         return;
                     }
                 }
@@ -1681,17 +1686,14 @@ impl super::TrapDispatcher {
             }
         }
         if touched_screen {
-            self.refresh_dialog_saved_pixels_after_screen_draw(
-                bus,
-                port,
-                (
-                    touch_top.saturating_sub(bounds_top),
-                    touch_left.saturating_sub(bounds_left),
-                    touch_bottom.saturating_sub(bounds_top),
-                    touch_right.saturating_sub(bounds_left),
-                ),
+            let screen_rect = (
+                touch_top.saturating_sub(bounds_top),
+                touch_left.saturating_sub(bounds_left),
+                touch_bottom.saturating_sub(bounds_top),
+                touch_right.saturating_sub(bounds_left),
             );
-            self.refresh_visible_dialog_snapshot_for_port(bus, port);
+            self.refresh_dialog_saved_pixels_after_screen_draw(bus, port, screen_rect);
+            self.refresh_visible_dialog_snapshot_region_for_port(bus, port, screen_rect);
         }
 
         if trace_menu_redraw_enabled() {


### PR DESCRIPTION
## Summary

Retained dialog snapshots now absorb ordinary QuickDraw shape damage by updating only the pixels in the shape's screen-space damage rectangle. The previous path allocated and copied the entire visible dialog after every small rectangle or shape draw.

This keeps the existing correctness model:

- the first authoritative draw still captures a complete baseline;
- bulk or otherwise unbounded drawing still uses the existing full-snapshot path;
- ordinary shape drawing uses the exact screen rectangle it already reports to saved-under maintenance;
- pixels outside that rectangle retain their previous snapshot contents;
- 1-, 2-, and 4-bit packed framebuffers update only the affected bit fields, while 8-bit framebuffers copy the affected byte spans.

The shared regional-copy helper is used for both saved-under pixels and retained visible-dialog pixels, so the two caches cannot drift into different packed-pixel behavior.

## Why

System's Twilight exposed a pathological case in its Random Data dialog. The application continues animating the scene while the modal dialog is visible. The animation consists of many small QuickDraw rectangle operations. Each operation previously called the full retained-dialog snapshot path, which allocated a new buffer and recopied the whole dialog even though only a small rectangle had changed.

This PR is code-independent of #231 and is based directly on current master. PR #231 makes the Random Data dialog remain open correctly, which provides a convenient sustained workload for profiling this separate performance problem.

## Profiling

Measured on an Intel Mac with the same debug build, 512×342 guest display, Random Data dialog left open, and a 20-second sample in both cases:

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Process CPU snapshot | 70.9% | 15.1% | -79% |
| Active emulator-slice samples | 8,544 | 1,591 | -81% |
| Full dialog save/allocation samples | 6,626 | 260 | -96% |

Before, 7,109 sampled stacks passed through the per-shape full visible-dialog refresh, with 6,626 reaching save_dialog_pixels and Vec::resize. Afterward, the per-shape full refresh is absent; regional update work accounts for only a few dozen sampled stacks. The remaining 260 full saves come from ModalDialog's conservative post-filter-callback snapshot and are no longer the dominant cost.

The CPU number is a point-in-time process reading, while the stack counts come from the complete 20-second samples. Both runs used the same interaction state and build configuration.

## Tests

- cargo test --lib: 2,827 passed, 3 ignored
- regional 8-bit snapshot test verifies that touched pixels advance while untouched pixels keep their previous snapshot value
- packed 1-, 2-, and 4-bit test verifies bit-level updates do not absorb changes outside the damage rectangle
- existing saved-under background tracking tests pass
- manual System's Twilight Random Data dialog test: dialog remains visible and renders correctly while the background animation continues
