### PR TITLE
feat: execute application control definition procedures

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -5613,6 +5613,19 @@ impl FixtureRunner {
                 return true;
             }
         }
+        while let Some(dialog_ptr) = self
+            .dispatcher
+            .modeless_dialog_cdef_draw_queue
+            .pop_front()
+        {
+            if self.dispatcher.arm_dialog_control_def_draws(
+                &mut self.cpu,
+                &mut self.bus,
+                dialog_ptr,
+            ) {
+                return true;
+            }
+        }
         false
     }
 

--- a/src/trap/control.rs
+++ b/src/trap/control.rs
@@ -15,6 +15,10 @@ fn trace_controls_enabled() -> bool {
 }
 
 impl super::TrapDispatcher {
+    const CDEF_DRAW_CNTL_MSG: i16 = 0;
+    const CDEF_TEST_CNTL_MSG: i16 = 1;
+    const CDEF_INIT_CNTL_MSG: i16 = 3;
+    const CDEF_TRAMPOLINE_SIZE: u32 = 64;
     const LOWMEM_AUX_CTL_HEAD: u32 = 0x0CD4;
     const AUX_CTL_NEXT_OFFSET: u32 = 0;
     const AUX_CTL_OWNER_OFFSET: u32 = 4;
@@ -174,6 +178,271 @@ impl super::TrapDispatcher {
             .map(|(_, ptr)| ptr)
             .map(|ptr| self.get_or_create_resource_handle(bus, *b"CDEF", cdef_id, ptr))
             .unwrap_or(0)
+    }
+
+    fn control_def_proc_addr(bus: &MacMemoryBus, ctrl_ptr: u32) -> u32 {
+        let def_handle = bus.read_long(ctrl_ptr + 24);
+        if def_handle == 0 {
+            return 0;
+        }
+        let def_ptr = bus.read_long(def_handle);
+        if def_ptr != 0 {
+            def_ptr
+        } else {
+            def_handle
+        }
+    }
+
+    fn control_def_entry_looks_callable(bus: &MacMemoryBus, proc_addr: u32) -> bool {
+        if proc_addr == 0 {
+            return false;
+        }
+        matches!(
+            bus.read_word(proc_addr),
+            0x4E56 // LINK.W A6,#imm
+                | 0x48E7 // MOVEM.L regs,-(SP)
+                | 0x4EF9 // JMP abs.L
+                | 0x4EFA // JMP pc-relative
+                | 0x6000..=0x60FF // BRA/BRA.S to the real entry
+        )
+    }
+
+    fn control_uses_application_def_proc(&self, bus: &MacMemoryBus, ctrl_ptr: u32) -> bool {
+        let proc_id = self.control_proc_ids.get(&ctrl_ptr).copied().unwrap_or(0);
+        let proc_addr = Self::control_def_proc_addr(bus, ctrl_ptr);
+        let callable = Self::control_def_entry_looks_callable(bus, proc_addr);
+        if trace_controls_enabled() && !matches!(proc_id, 0 | 1 | 2 | 16) {
+            eprintln!(
+                "[CONTROL] CDEF proc_id={} handle=${:08X} entry=${:08X} first=${:04X} callable={}",
+                proc_id,
+                bus.read_long(ctrl_ptr + 24),
+                proc_addr,
+                bus.read_word(proc_addr),
+                callable,
+            );
+        }
+        !matches!(proc_id, 0 | 1 | 2 | 16) && !Self::is_popup_menu_proc_id(proc_id) && callable
+    }
+
+    fn get_or_create_control_def_trampoline(&mut self, bus: &mut MacMemoryBus) -> u32 {
+        if self.control_def_trampoline != 0 {
+            return self.control_def_trampoline;
+        }
+        let tramp = bus.alloc(Self::CDEF_TRAMPOLINE_SIZE);
+        self.control_def_trampoline = tramp;
+        self.control_def_trampoline_chain.push(tramp);
+        tramp
+    }
+
+    fn write_control_def_trampoline(
+        bus: &mut MacMemoryBus,
+        tramp: u32,
+        variant: i16,
+        ctrl_handle: u32,
+        message: i16,
+        param: u32,
+        proc_addr: u32,
+        result_addr: u32,
+        saved_regs_sp: u32,
+        next_trampoline: Option<u32>,
+    ) {
+        bus.write_word(tramp, 0x48E7); // MOVEM.L D0-D3/A0-A3,-(SP)
+        bus.write_word(tramp + 2, 0xF0F0);
+        bus.write_word(tramp + 4, 0x2F3C); // MOVE.L #result,-(SP)
+        bus.write_long(tramp + 6, 0);
+        bus.write_word(tramp + 10, 0x3F3C); // MOVE.W #varCode,-(SP)
+        bus.write_word(tramp + 12, variant as u16);
+        bus.write_word(tramp + 14, 0x2F3C); // MOVE.L #theControl,-(SP)
+        bus.write_long(tramp + 16, ctrl_handle);
+        bus.write_word(tramp + 20, 0x3F3C); // MOVE.W #message,-(SP)
+        bus.write_word(tramp + 22, message as u16);
+        bus.write_word(tramp + 24, 0x2F3C); // MOVE.L #param,-(SP)
+        bus.write_long(tramp + 26, param);
+        bus.write_word(tramp + 30, 0x4EB9); // JSR abs.L
+        bus.write_long(tramp + 32, proc_addr);
+        bus.write_word(tramp + 36, 0x2017); // MOVE.L (A7),D0
+        bus.write_word(tramp + 38, 0x33C0); // MOVE.W D0,abs.L
+        bus.write_long(tramp + 40, result_addr);
+        bus.write_word(tramp + 44, 0x2E7C); // MOVEA.L #savedRegsSP,A7
+        bus.write_long(tramp + 46, saved_regs_sp);
+        bus.write_word(tramp + 50, 0x4CDF); // MOVEM.L (SP)+,D0-D3/A0-A3
+        bus.write_word(tramp + 52, 0x0F0F);
+        match next_trampoline {
+            Some(next) => {
+                bus.write_word(tramp + 54, 0x4EF9); // JMP abs.L
+                bus.write_long(tramp + 56, next);
+            }
+            None => {
+                bus.write_word(tramp + 54, 0x4E75); // RTS
+                bus.write_long(tramp + 56, 0);
+            }
+        }
+    }
+
+    fn arm_control_def_call_chain<C: CpuOps>(
+        &mut self,
+        cpu: &mut C,
+        bus: &mut MacMemoryBus,
+        calls: &[(u32, i16, u32, Option<u32>)],
+    ) -> bool {
+        let callable: Vec<(u32, i16, u32, Option<u32>, i16, u32)> = calls
+            .iter()
+            .filter_map(|&(ctrl_handle, message, param, result_addr)| {
+                let ctrl_ptr = Self::control_record_ptr(bus, ctrl_handle);
+                if ctrl_ptr == 0 || !self.control_uses_application_def_proc(bus, ctrl_ptr) {
+                    return None;
+                }
+                let proc_id = self.control_proc_ids.get(&ctrl_ptr).copied().unwrap_or(0);
+                Some((
+                    ctrl_handle,
+                    message,
+                    param,
+                    result_addr,
+                    proc_id & 0xF,
+                    Self::control_def_proc_addr(bus, ctrl_ptr),
+                ))
+            })
+            .collect();
+        if callable.is_empty() {
+            return false;
+        }
+        let final_sp = cpu.read_reg(Register::A7);
+        let return_pc = cpu.read_reg(Register::PC);
+        let return_slot = final_sp.wrapping_sub(4);
+        let saved_regs_sp = return_slot.wrapping_sub(32);
+        self.get_or_create_control_def_trampoline(bus);
+        while self.control_def_trampoline_chain.len() < callable.len() {
+            self.control_def_trampoline_chain
+                .push(bus.alloc(Self::CDEF_TRAMPOLINE_SIZE));
+        }
+        let trampolines: Vec<u32> = self
+            .control_def_trampoline_chain
+            .iter()
+            .copied()
+            .take(callable.len())
+            .collect();
+
+        for (idx, &(ctrl_handle, message, param, result_addr, variant, proc_addr)) in
+            callable.iter().enumerate()
+        {
+            Self::write_control_def_trampoline(
+                bus,
+                trampolines[idx],
+                variant,
+                ctrl_handle,
+                message,
+                param,
+                proc_addr,
+                result_addr.unwrap_or(trampolines[idx] + 60),
+                saved_regs_sp,
+                trampolines.get(idx + 1).copied(),
+            );
+        }
+
+        bus.write_long(return_slot, return_pc);
+        cpu.write_reg(Register::A7, return_slot);
+        cpu.write_reg(Register::PC, trampolines[0]);
+        true
+    }
+
+    fn arm_control_def_messages<C: CpuOps>(
+        &mut self,
+        cpu: &mut C,
+        bus: &mut MacMemoryBus,
+        ctrl_handle: u32,
+        messages: &[(i16, u32, Option<u32>)],
+    ) -> bool {
+        let calls: Vec<(u32, i16, u32, Option<u32>)> = messages
+            .iter()
+            .map(|&(message, param, result_addr)| (ctrl_handle, message, param, result_addr))
+            .collect();
+        self.arm_control_def_call_chain(cpu, bus, &calls)
+    }
+
+    pub(crate) fn arm_new_dialog_control_defs<C: CpuOps>(
+        &mut self,
+        cpu: &mut C,
+        bus: &mut MacMemoryBus,
+        dialog_ptr: u32,
+    ) -> bool {
+        if dialog_ptr == 0 {
+            return false;
+        }
+        let mut handles = Vec::new();
+        let mut ctrl_handle = bus.read_long(dialog_ptr + 140);
+        while ctrl_handle != 0 {
+            let ctrl_ptr = Self::control_record_ptr(bus, ctrl_handle);
+            if ctrl_ptr == 0 {
+                break;
+            }
+            handles.push(ctrl_handle);
+            ctrl_handle = bus.read_long(ctrl_ptr);
+        }
+
+        let mut calls = Vec::new();
+        for ctrl_handle in handles.into_iter().rev() {
+            let ctrl_ptr = Self::control_record_ptr(bus, ctrl_handle);
+            if !self.control_uses_application_def_proc(bus, ctrl_ptr) {
+                continue;
+            }
+            calls.push((ctrl_handle, Self::CDEF_INIT_CNTL_MSG, 0, None));
+        }
+        if calls.is_empty() {
+            return false;
+        }
+        // Custom CDEFs use dialog-local contrlRect coordinates for both
+        // OpenPicture and DrawPicture, so dispatch them in the owner port.
+        self.set_current_port_state(bus, cpu, dialog_ptr, None);
+        self.arm_control_def_call_chain(cpu, bus, &calls)
+    }
+
+    pub(crate) fn arm_dialog_control_def_draws<C: CpuOps>(
+        &mut self,
+        cpu: &mut C,
+        bus: &mut MacMemoryBus,
+        dialog_ptr: u32,
+    ) -> bool {
+        if dialog_ptr == 0 {
+            return false;
+        }
+        let vis_rgn = bus.read_long(dialog_ptr + 24);
+        if Self::region_handle_rect(bus, vis_rgn).is_none() {
+            return false;
+        }
+        let mut handles = Vec::new();
+        let mut ctrl_handle = bus.read_long(dialog_ptr + 140);
+        while ctrl_handle != 0 {
+            let ctrl_ptr = Self::control_record_ptr(bus, ctrl_handle);
+            if ctrl_ptr == 0 {
+                break;
+            }
+            handles.push(ctrl_handle);
+            ctrl_handle = bus.read_long(ctrl_ptr);
+        }
+
+        let calls: Vec<_> = handles
+            .into_iter()
+            .rev()
+            .filter_map(|ctrl_handle| {
+                let ctrl_ptr = Self::control_record_ptr(bus, ctrl_handle);
+                (self.control_uses_application_def_proc(bus, ctrl_ptr)
+                    && Self::control_vis_is_visible(bus.read_byte(ctrl_ptr + 16)))
+                .then_some((ctrl_handle, Self::CDEF_DRAW_CNTL_MSG, 0, None))
+            })
+            .collect();
+        if calls.is_empty() {
+            return false;
+        }
+        self.set_current_port_state(bus, cpu, dialog_ptr, None);
+        // Establish the retained-dialog baseline before guest drawing. Each
+        // DrawPicture callback then refreshes this snapshot, so frame
+        // composition cannot restore the pre-CDEF shell over the artwork.
+        self.refresh_visible_dialog_snapshot_for_port(bus, dialog_ptr);
+        let armed = self.arm_control_def_call_chain(cpu, bus, &calls);
+        if armed {
+            self.dialog_cdefs_initially_drawn.insert(dialog_ptr);
+        }
+        armed
     }
 
     fn control_aux_reserved_value(&self, bus: &MacMemoryBus, ctrl_handle: u32) -> u32 {
@@ -2094,15 +2363,23 @@ impl super::TrapDispatcher {
                     bus.write_long(window_ptr + 140, handle);
                 }
 
-                // On a real Mac, NewControl with visible=true draws the control
-                // immediately via the CDEF's drawCntl message.
-                // Inside Macintosh Volume I, I-331
-                if visible {
+                let is_application_cdef = self.control_uses_application_def_proc(bus, ctrl_ptr);
+                // On a real Mac, NewControl initializes a custom CDEF and,
+                // when visible, immediately asks it to draw the whole control.
+                // Inside Macintosh Volume I, I-329..I-331.
+                if visible && !is_application_cdef {
                     self.draw_control(cpu, bus, ctrl_ptr);
                 }
 
                 bus.write_long(sp + 26, handle);
                 cpu.write_reg(Register::A7, sp + 26);
+                if is_application_cdef {
+                    let mut messages = vec![(Self::CDEF_INIT_CNTL_MSG, 0, None)];
+                    if visible {
+                        messages.push((Self::CDEF_DRAW_CNTL_MSG, 0, None));
+                    }
+                    self.arm_control_def_messages(cpu, bus, handle, &messages);
+                }
                 Ok(())
             }
 
@@ -2355,6 +2632,7 @@ impl super::TrapDispatcher {
                 let hilite_state = bus.read_word(sp) as u8;
                 let ctrl_handle = bus.read_long(sp + 2);
                 let ctrl_ptr = Self::control_record_ptr(bus, ctrl_handle);
+                cpu.write_reg(Register::A7, sp + 6);
                 if ctrl_ptr != 0 {
                     bus.write_byte(ctrl_ptr + 17, hilite_state);
                     if trace_controls_enabled() {
@@ -2370,7 +2648,14 @@ impl super::TrapDispatcher {
                             self.control_trace_control_fields(bus, ctrl_handle),
                         );
                     }
-                    self.draw_control(cpu, bus, ctrl_ptr);
+                    if !self.arm_control_def_messages(
+                        cpu,
+                        bus,
+                        ctrl_handle,
+                        &[(Self::CDEF_DRAW_CNTL_MSG, 0, None)],
+                    ) {
+                        self.draw_control(cpu, bus, ctrl_ptr);
+                    }
                 } else if trace_controls_enabled() {
                     eprintln!(
                         "[CONTROL] HiliteControl state={} {}",
@@ -2378,7 +2663,6 @@ impl super::TrapDispatcher {
                         self.control_trace_control_fields(bus, ctrl_handle),
                     );
                 }
-                cpu.write_reg(Register::A7, sp + 6);
                 Ok(())
             }
 
@@ -2416,7 +2700,14 @@ impl super::TrapDispatcher {
                 if ctrl_ptr != 0 {
                     let title = Self::read_pascal_string(bus, title_ptr);
                     Self::set_control_title_bytes(bus, ctrl_ptr, &title);
-                    self.draw_control(cpu, bus, ctrl_ptr);
+                    if !self.arm_control_def_messages(
+                        cpu,
+                        bus,
+                        ctrl_handle,
+                        &[(Self::CDEF_DRAW_CNTL_MSG, 0, None)],
+                    ) {
+                        self.draw_control(cpu, bus, ctrl_ptr);
+                    }
                 }
                 Ok(())
             }
@@ -2503,7 +2794,20 @@ impl super::TrapDispatcher {
                         self.control_trace_control_fields(bus, ctrl_handle),
                     );
                 }
-                self.draw_control(cpu, bus, ctrl_ptr);
+                let owner = bus.read_long(ctrl_ptr + 4);
+                let drew_initial_dialog_controls = self.dialog_items.contains_key(&owner)
+                    && !self.dialog_cdefs_initially_drawn.contains(&owner)
+                    && self.arm_dialog_control_def_draws(cpu, bus, owner);
+                if !drew_initial_dialog_controls
+                    && !self.arm_control_def_messages(
+                        cpu,
+                        bus,
+                        ctrl_handle,
+                        &[(Self::CDEF_DRAW_CNTL_MSG, 0, None)],
+                    )
+                {
+                    self.draw_control(cpu, bus, ctrl_ptr);
+                }
                 Ok(())
             }
 
@@ -2618,6 +2922,8 @@ impl super::TrapDispatcher {
                 let ctrl_handle = bus.read_long(sp + 4);
                 let ctrl_ptr = Self::control_record_ptr(bus, ctrl_handle);
 
+                let is_application_cdef =
+                    ctrl_ptr != 0 && self.control_uses_application_def_proc(bus, ctrl_ptr);
                 let mut part: u16 = 0;
                 if ctrl_ptr != 0 {
                     let vis = bus.read_byte(ctrl_ptr + 16);
@@ -2641,6 +2947,15 @@ impl super::TrapDispatcher {
 
                 bus.write_word(sp + 8, part);
                 cpu.write_reg(Register::A7, sp + 8);
+                if is_application_cdef {
+                    let point = ((pt_v as u16 as u32) << 16) | u32::from(pt_h as u16);
+                    self.arm_control_def_messages(
+                        cpu,
+                        bus,
+                        ctrl_handle,
+                        &[(Self::CDEF_TEST_CNTL_MSG, point, Some(sp + 8))],
+                    );
+                }
                 Ok(())
             }
 
@@ -2887,22 +3202,36 @@ impl super::TrapDispatcher {
             (true, 0x169) => {
                 let sp = cpu.read_reg(Register::A7);
                 let window_ptr = bus.read_long(sp);
+                let mut cdef_draw_calls = Vec::new();
 
                 if window_ptr != 0 {
-                    // Collect ctrl_ptrs first to avoid borrow conflicts
+                    // Collect handles and pointers first so application CDEF
+                    // callbacks can be dispatched after the standard controls
+                    // have finished their immediate HLE redraw.
                     let mut ctrl_handle = bus.read_long(window_ptr + 140);
-                    let mut ctrl_ptrs: Vec<u32> = Vec::new();
+                    let mut controls: Vec<(u32, u32)> = Vec::new();
                     while ctrl_handle != 0 {
                         let ctrl_ptr = bus.read_long(ctrl_handle);
                         if ctrl_ptr == 0 {
                             break;
                         }
-                        ctrl_ptrs.push(ctrl_ptr);
+                        controls.push((ctrl_handle, ctrl_ptr));
                         ctrl_handle = bus.read_long(ctrl_ptr);
                     }
 
                     // Draw controls in reverse order (last added = bottom of list = drawn first)
-                    for &ctrl_ptr in ctrl_ptrs.iter().rev() {
+                    for &(ctrl_handle, ctrl_ptr) in controls.iter().rev() {
+                        if self.control_uses_application_def_proc(bus, ctrl_ptr) {
+                            if Self::control_vis_is_visible(bus.read_byte(ctrl_ptr + 16)) {
+                                cdef_draw_calls.push((
+                                    ctrl_handle,
+                                    Self::CDEF_DRAW_CNTL_MSG,
+                                    0,
+                                    None,
+                                ));
+                            }
+                            continue;
+                        }
                         let proc_id = self.control_proc_ids.get(&ctrl_ptr).copied().unwrap_or(0);
                         if Self::is_popup_menu_proc_id(proc_id) {
                             // popupMenuProc needs special MENU resource lookup
@@ -2945,6 +3274,7 @@ impl super::TrapDispatcher {
                 }
 
                 cpu.write_reg(Register::A7, sp + 4);
+                self.arm_control_def_call_chain(cpu, bus, &cdef_draw_calls);
                 Ok(())
             }
 
@@ -2982,18 +3312,18 @@ impl super::TrapDispatcher {
                     None => return Some(Ok(())),
                 };
                 let mut ctrl_handle = bus.read_long(window_ptr + 140);
-                let mut ctrl_ptrs: Vec<u32> = Vec::new();
+                let mut controls: Vec<(u32, u32)> = Vec::new();
                 while ctrl_handle != 0 {
                     let ctrl_ptr = bus.read_long(ctrl_handle);
                     if ctrl_ptr == 0 {
                         break;
                     }
-                    ctrl_ptrs.push(ctrl_ptr);
+                    controls.push((ctrl_handle, ctrl_ptr));
                     ctrl_handle = bus.read_long(ctrl_ptr);
                 }
                 let (ut, ul, ub, ur) = update_rect;
-                for ctrl_ptr in ctrl_ptrs.iter().rev() {
-                    let ctrl_ptr = *ctrl_ptr;
+                let mut cdef_draw_calls = Vec::new();
+                for &(ctrl_handle, ctrl_ptr) in controls.iter().rev() {
                     let ct = bus.read_word(ctrl_ptr + 8) as i16;
                     let cl = bus.read_word(ctrl_ptr + 10) as i16;
                     let cb = bus.read_word(ctrl_ptr + 12) as i16;
@@ -3002,8 +3332,20 @@ impl super::TrapDispatcher {
                     if cb <= ut || cr <= ul || ct >= ub || cl >= ur {
                         continue;
                     }
-                    self.draw_control(cpu, bus, ctrl_ptr);
+                    if self.control_uses_application_def_proc(bus, ctrl_ptr) {
+                        if Self::control_vis_is_visible(bus.read_byte(ctrl_ptr + 16)) {
+                            cdef_draw_calls.push((
+                                ctrl_handle,
+                                Self::CDEF_DRAW_CNTL_MSG,
+                                0,
+                                None,
+                            ));
+                        }
+                    } else {
+                        self.draw_control(cpu, bus, ctrl_ptr);
+                    }
                 }
+                self.arm_control_def_call_chain(cpu, bus, &cdef_draw_calls);
                 Ok(())
             }
 
@@ -3165,6 +3507,11 @@ impl super::TrapDispatcher {
 
                 bus.write_long(sp + 6, handle);
                 cpu.write_reg(Register::A7, sp + 6);
+                let mut messages = vec![(Self::CDEF_INIT_CNTL_MSG, 0, None)];
+                if visibility != 0 {
+                    messages.push((Self::CDEF_DRAW_CNTL_MSG, 0, None));
+                }
+                self.arm_control_def_messages(cpu, bus, handle, &messages);
                 Ok(())
             }
 
@@ -3320,10 +3667,17 @@ impl super::TrapDispatcher {
                         let title_len = bus.read_byte(title_off) as u32;
                         let title_end = title_off.saturating_add(1).saturating_add(title_len);
                         if title_end <= bus.ram_size() {
-                            // popupMenuProc (1008) already has a direct
-                            // renderer in draw_control, so Draw1Control can
-                            // reuse the same control path as DrawControls.
-                            self.draw_control(cpu, bus, ctrl_ptr);
+                            if !self.arm_control_def_messages(
+                                cpu,
+                                bus,
+                                ctrl_handle,
+                                &[(Self::CDEF_DRAW_CNTL_MSG, 0, None)],
+                            ) {
+                                // popupMenuProc (1008) already has a direct
+                                // renderer in draw_control, so Draw1Control can
+                                // reuse the same control path as DrawControls.
+                                self.draw_control(cpu, bus, ctrl_ptr);
+                            }
                             debug_assert_eq!(self.current_gdevice, saved_gdevice);
                         }
                     }
@@ -3903,6 +4257,68 @@ mod tests {
         assert_eq!(bus.read_long(window_ptr + 140), new_head);
         assert_eq!(bus.read_long(new_ptr), old_head);
         assert_eq!(bus.read_long(new_ptr + 4), window_ptr);
+    }
+
+    #[test]
+    fn newcontrol_custom_cdef_arms_init_then_draw_pascal_callbacks() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let sp = 0x300000u32;
+        let return_pc = 0x1234_5678;
+        let window_ptr = bus.alloc(200);
+        let bounds_ptr = bus.alloc(8);
+        let title_ptr = bus.alloc(16);
+        let proc_id = (160i16 << 4) | 5;
+        let cdef_proc = disp.install_test_resource(&mut bus, *b"CDEF", 160, &[0x4E, 0x56, 0, 0]);
+
+        for (offset, value) in [10i16, 20, 40, 100].into_iter().enumerate() {
+            bus.write_word(bounds_ptr + offset as u32 * 2, value as u16);
+        }
+        bus.write_byte(title_ptr, 4);
+        bus.write_bytes(title_ptr + 1, b"Play");
+        cpu.write_reg(Register::A7, sp);
+        cpu.write_reg(Register::PC, return_pc);
+        bus.write_long(sp, 0);
+        bus.write_word(sp + 4, proc_id as u16);
+        bus.write_word(sp + 6, 1);
+        bus.write_word(sp + 8, 0);
+        bus.write_word(sp + 10, 0);
+        bus.write_word(sp + 12, 1);
+        bus.write_long(sp + 14, title_ptr);
+        bus.write_long(sp + 18, bounds_ptr);
+        bus.write_long(sp + 22, window_ptr);
+
+        disp.dispatch_control(true, 0x154, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+
+        let ctrl_handle = bus.read_long(sp + 26);
+        let tramp = disp.control_def_trampoline;
+        assert_ne!(ctrl_handle, 0);
+        assert_ne!(tramp, 0);
+        assert_eq!(cpu.read_reg(Register::PC), tramp);
+        assert_eq!(cpu.read_reg(Register::A7), sp + 22);
+        assert_eq!(bus.read_long(sp + 22), return_pc);
+        assert_eq!(bus.read_word(tramp + 12), 5);
+        assert_eq!(bus.read_long(tramp + 16), ctrl_handle);
+        assert_eq!(
+            bus.read_word(tramp + 22),
+            super::super::TrapDispatcher::CDEF_INIT_CNTL_MSG as u16
+        );
+        assert_eq!(bus.read_long(tramp + 26), 0);
+        assert_eq!(bus.read_long(tramp + 32), cdef_proc);
+        assert_eq!(bus.read_word(tramp + 54), 0x4EF9);
+
+        let draw_tramp = bus.read_long(tramp + 56);
+        assert_ne!(draw_tramp, 0);
+        assert_eq!(bus.read_word(draw_tramp + 12), 5);
+        assert_eq!(bus.read_long(draw_tramp + 16), ctrl_handle);
+        assert_eq!(
+            bus.read_word(draw_tramp + 22),
+            super::super::TrapDispatcher::CDEF_DRAW_CNTL_MSG as u16
+        );
+        assert_eq!(bus.read_long(draw_tramp + 26), 0);
+        assert_eq!(bus.read_long(draw_tramp + 32), cdef_proc);
+        assert_eq!(bus.read_word(draw_tramp + 54), 0x4E75);
     }
 
     // IM:I I-332: DisposeControl takes one ControlHandle argument.
@@ -5296,6 +5712,82 @@ mod tests {
         assert_eq!(bus.read_long(first_ptr), 0);
     }
 
+    #[test]
+    fn drawcontrols_dispatches_visible_application_cdefs_in_control_list_draw_order() {
+        let (mut disp, mut cpu, mut bus) = setup_with_port();
+        let sp = 0x300000u32;
+        let return_pc = 0x1234_5678;
+        let a5 = cpu.read_reg(Register::A5);
+        let qd_globals = bus.read_long(a5);
+        let window_ptr = bus.read_long(qd_globals);
+        let proc_id = (160i16 << 4) | 5;
+        let cdef_proc = disp.install_test_resource(&mut bus, *b"CDEF", 160, &[0x4E, 0x56, 0, 0]);
+
+        let first_ptr = bus.alloc(296);
+        let first_handle = bus.alloc(4);
+        bus.write_long(first_handle, first_ptr);
+        disp.initialize_control_record(
+            &mut bus,
+            first_ptr,
+            window_ptr,
+            (10, 20, 40, 80),
+            b"",
+            true,
+            0,
+            0,
+            1,
+            proc_id,
+            0,
+        );
+        let second_ptr = bus.alloc(296);
+        let second_handle = bus.alloc(4);
+        bus.write_long(second_handle, second_ptr);
+        disp.initialize_control_record(
+            &mut bus,
+            second_ptr,
+            window_ptr,
+            (50, 20, 80, 80),
+            b"",
+            true,
+            0,
+            0,
+            1,
+            proc_id,
+            0,
+        );
+        bus.write_long(first_ptr, 0);
+        bus.write_long(second_ptr, first_handle);
+        bus.write_long(window_ptr + 140, second_handle);
+
+        cpu.write_reg(Register::A7, sp);
+        cpu.write_reg(Register::PC, return_pc);
+        bus.write_long(sp, window_ptr);
+        disp.dispatch_control(true, 0x169, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+
+        let first_tramp = disp.control_def_trampoline;
+        assert_eq!(cpu.read_reg(Register::PC), first_tramp);
+        assert_eq!(cpu.read_reg(Register::A7), sp);
+        assert_eq!(bus.read_long(sp), return_pc);
+        assert_eq!(bus.read_long(first_tramp + 16), first_handle);
+        assert_eq!(
+            bus.read_word(first_tramp + 22),
+            super::super::TrapDispatcher::CDEF_DRAW_CNTL_MSG as u16
+        );
+        assert_eq!(bus.read_long(first_tramp + 32), cdef_proc);
+
+        let second_tramp = bus.read_long(first_tramp + 56);
+        assert_ne!(second_tramp, 0);
+        assert_eq!(bus.read_long(second_tramp + 16), second_handle);
+        assert_eq!(
+            bus.read_word(second_tramp + 22),
+            super::super::TrapDispatcher::CDEF_DRAW_CNTL_MSG as u16
+        );
+        assert_eq!(bus.read_long(second_tramp + 32), cdef_proc);
+        assert_eq!(bus.read_word(second_tramp + 54), 0x4E75);
+    }
+
     // FindControl semantics per IM:I (1985) I-323 and MTE (1992) 5-89.
     #[test]
     fn findcontrol_visible_active_hit_returns_inbutton_and_control_handle() {
@@ -5674,6 +6166,55 @@ mod tests {
             .unwrap();
 
         assert_eq!(cpu.read_reg(Register::A7), sp + 4);
+    }
+
+    #[test]
+    fn testcontrol_custom_cdef_arms_test_message_with_point_and_result_slot() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let sp = 0x300000u32;
+        let return_pc = 0x8765_4321;
+        let proc_id = (160i16 << 4) | 7;
+        let cdef_proc = disp.install_test_resource(&mut bus, *b"CDEF", 160, &[0x4E, 0x56, 0, 0]);
+        let ctrl_ptr = bus.alloc(296);
+        let ctrl_handle = bus.alloc(4);
+        bus.write_long(ctrl_handle, ctrl_ptr);
+        disp.initialize_control_record(
+            &mut bus,
+            ctrl_ptr,
+            0,
+            (10, 20, 40, 80),
+            b"",
+            true,
+            0,
+            0,
+            1,
+            proc_id,
+            0,
+        );
+        cpu.write_reg(Register::A7, sp);
+        cpu.write_reg(Register::PC, return_pc);
+        bus.write_word(sp, 23);
+        bus.write_word(sp + 2, 45);
+        bus.write_long(sp + 4, ctrl_handle);
+        bus.write_word(sp + 8, 0);
+
+        disp.dispatch_control(true, 0x166, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+
+        let tramp = disp.control_def_trampoline;
+        assert_eq!(cpu.read_reg(Register::PC), tramp);
+        assert_eq!(cpu.read_reg(Register::A7), sp + 4);
+        assert_eq!(bus.read_long(sp + 4), return_pc);
+        assert_eq!(bus.read_word(tramp + 12), 7);
+        assert_eq!(bus.read_long(tramp + 16), ctrl_handle);
+        assert_eq!(
+            bus.read_word(tramp + 22),
+            super::super::TrapDispatcher::CDEF_TEST_CNTL_MSG as u16
+        );
+        assert_eq!(bus.read_long(tramp + 26), (23u32 << 16) | 45);
+        assert_eq!(bus.read_long(tramp + 32), cdef_proc);
+        assert_eq!(bus.read_long(tramp + 40), sp + 8);
     }
 
     #[test]

--- a/src/trap/dialog.rs
+++ b/src/trap/dialog.rs
@@ -814,6 +814,12 @@ impl super::TrapDispatcher {
         // their item handle is a draw procedure; queue only the callbacks
         // whose display rectangles intersect the active update region.
         self.queue_modeless_dialog_draw_procs_intersecting(bus, dialog_ptr, update_rect);
+        if !self
+            .modeless_dialog_cdef_draw_queue
+            .contains(&dialog_ptr)
+        {
+            self.modeless_dialog_cdef_draw_queue.push_back(dialog_ptr);
+        }
         true
     }
 
@@ -4451,6 +4457,10 @@ impl super::TrapDispatcher {
             .retain(|(dlg, _), _| *dlg != dialog_ptr);
         self.dialog_popup_candidate_items
             .retain(|(dlg, _)| *dlg != dialog_ptr);
+        self.modeless_dialog_draw_proc_queue
+            .retain(|(dlg, _, _)| *dlg != dialog_ptr);
+        self.modeless_dialog_cdef_draw_queue
+            .retain(|dlg| *dlg != dialog_ptr);
         if self
             .pending_dialog_popup_menu
             .is_some_and(|pending| pending.dialog_ptr == dialog_ptr)
@@ -6092,18 +6102,9 @@ impl super::TrapDispatcher {
                                     hilite == 1,
                                 );
                             }
-                            _ => {
-                                self.draw_button_with_enabled(
-                                    bus,
-                                    abs_top,
-                                    abs_left,
-                                    abs_bottom,
-                                    abs_right,
-                                    &title,
-                                    auto_default_outline && item_num == default_item,
-                                    enabled,
-                                );
-                            }
+                            // Application CDEF pixels are supplied by the
+                            // guest callback after the HLE dialog shell.
+                            _ => {}
                         }
                     } else {
                         self.draw_button_with_enabled(
@@ -6305,18 +6306,9 @@ impl super::TrapDispatcher {
                                     hilite == 1,
                                 );
                             }
-                            _ => {
-                                self.draw_button_with_enabled(
-                                    bus,
-                                    abs_top,
-                                    abs_left,
-                                    abs_bottom,
-                                    abs_right,
-                                    &title,
-                                    auto_default_outline && item_num == default_item,
-                                    enabled,
-                                );
-                            }
+                            // Application CDEF pixels are supplied by the
+                            // guest callback after the HLE dialog shell.
+                            _ => {}
                         }
                     } else {
                         self.draw_button_with_enabled(
@@ -6506,16 +6498,9 @@ impl super::TrapDispatcher {
                                     hilite == 1,
                                 );
                             }
-                            _ => self.draw_button_with_enabled(
-                                bus,
-                                abs_top,
-                                abs_left,
-                                abs_bottom,
-                                abs_right,
-                                &title,
-                                auto_default_outline && item_num == default_item,
-                                enabled,
-                            ),
+                            // Preserve application CDEF pixels across the
+                            // post-callback retained-dialog resnapshot.
+                            _ => {}
                         }
                     } else {
                         self.draw_button_with_enabled(
@@ -8971,6 +8956,8 @@ impl super::TrapDispatcher {
 
         self.dialog_visible_snapshots.remove(&dialog_ptr);
         self.dialog_modal_entered.remove(&dialog_ptr);
+        self.dialog_cdef_draw_pending_snapshot.remove(&dialog_ptr);
+        self.dialog_cdefs_initially_drawn.remove(&dialog_ptr);
         if !was_front && retained_stale_saved_under && self.screen_is_hidden_menu_game_surface(bus)
         {
             let _ = self.restore_dialog_exposure_from_fullscreen_offscreen_port(bus, exposed_rect);
@@ -10063,6 +10050,8 @@ impl super::TrapDispatcher {
                     bus.write_long(sp + 10, 0);
                 }
                 cpu.write_reg(Register::A7, sp + 10);
+                let dialog_ptr = bus.read_long(sp + 10);
+                self.arm_new_dialog_control_defs(cpu, bus, dialog_ptr);
                 Ok(())
             }
 
@@ -10647,6 +10636,12 @@ impl super::TrapDispatcher {
                     // runner trampoline executes guest drawing before the
                     // caller resumes.
                     self.queue_modeless_dialog_draw_procs_intersecting(bus, dialog_ptr, None);
+                    if !self
+                        .modeless_dialog_cdef_draw_queue
+                        .contains(&dialog_ptr)
+                    {
+                        self.modeless_dialog_cdef_draw_queue.push_back(dialog_ptr);
+                    }
                 }
                 cpu.write_reg(Register::A7, sp + 4);
                 Ok(())
@@ -11093,6 +11088,13 @@ impl super::TrapDispatcher {
                 // Re-snapshot rendered_pixels after draw procs or filter proc completes.
                 // rendered_pixels_final is cleared when either is injected; the snapshot
                 // here captures whatever they drew before redraw_chrome can restore it.
+                let cdef_draw_pending_snapshot = self
+                    .dialog_tracking
+                    .as_ref()
+                    .map(|tracking| tracking.dialog_ptr)
+                    .is_some_and(|dialog_ptr| {
+                        self.dialog_cdef_draw_pending_snapshot.remove(&dialog_ptr)
+                    });
                 if let Some(ref tracking) = self.dialog_tracking {
                     if !tracking.rendered_pixels_final {
                         let bounds = tracking.bounds;
@@ -11102,7 +11104,7 @@ impl super::TrapDispatcher {
                         let edit_item = tracking.edit_item;
                         let dialog_ptr = tracking.dialog_ptr;
                         let popup_draws = tracking.popup_draws.clone();
-                        if !tracking.game_managed {
+                        if !tracking.game_managed && !cdef_draw_pending_snapshot {
                             if self.front_window == dialog_ptr {
                                 self.blit_window_to_screen(bus);
                             }
@@ -12446,6 +12448,21 @@ impl super::TrapDispatcher {
                             active_button: None,
                             active_user_item: None,
                         });
+                        // ModalDialog is a re-fire trap. Run application CDEF
+                        // draws after the HLE shell becomes visible, then
+                        // resume at the trap instruction so the next pass can
+                        // snapshot the guest-owned pixels before event
+                        // handling continues.
+                        let after_trap_pc = cpu.read_reg(Register::PC);
+                        cpu.write_reg(Register::PC, after_trap_pc.wrapping_sub(2));
+                        if self.arm_dialog_control_def_draws(cpu, bus, dialog_ptr) {
+                            self.dialog_cdef_draw_pending_snapshot.insert(dialog_ptr);
+                            if let Some(tracking) = self.dialog_tracking.as_mut() {
+                                tracking.rendered_pixels_final = false;
+                            }
+                        } else {
+                            cpu.write_reg(Register::PC, after_trap_pc);
+                        }
                         self.record_modal_dialog_input_trace(
                             "start",
                             dialog_ptr,

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -1122,6 +1122,11 @@ pub struct TrapDispatcher {
     /// Address of the lazily-allocated trampoline template used by the
     /// Window Manager to call a guest WDEF procedure.
     pub(crate) window_def_trampoline: u32,
+    /// Address of the lazily-allocated trampoline template used by the
+    /// Control Manager to call a guest CDEF procedure.
+    pub(crate) control_def_trampoline: u32,
+    /// Reusable trampoline cells for multi-control CDEF callback chains.
+    pub(crate) control_def_trampoline_chain: Vec<u32>,
     /// Address of the lazily-allocated trampoline used by DeferUserFn
     /// to call a callable userFunction immediately. Holds
     /// `48E7 F0F0 207C xxxx xxxx 4EB9 xxxx xxxx 4CDF 0F0F 7000 4E75`.
@@ -1725,6 +1730,8 @@ pub struct TrapDispatcher {
     /// (pic_handle, frame top, left, bottom, right, encoded PICT v2 commands).
     /// Set by OpenPicture, cleared by ClosePicture.
     pub(crate) recording_picture: Option<(u32, i16, i16, i16, i16, Vec<u8>)>,
+    /// Complete bitmap PICT captured by CopyBits during OpenPicture.
+    pub(crate) recording_picture_bitmap: Option<Vec<u8>>,
     /// Native trap dispatch table: maps raw trap word -> native 68K handler address.
     /// Populated by SetTrapAddress ($A047/$A647). When an A-line instruction fires
     /// and a native handler exists, the dispatcher simulates a JSR to the handler
@@ -1790,6 +1797,13 @@ pub struct TrapDispatcher {
     /// controls, snapshotted pixels). On re-entry we skip draw_dialog to
     /// preserve game-drawn custom content (e.g. PICT titles, group boxes).
     pub(crate) dialog_modal_entered: std::collections::HashSet<u32>,
+    /// Dialogs whose application CDEF draw callbacks have just completed and
+    /// whose next ModalDialog re-fire must snapshot those pixels without an
+    /// intervening HLE standard-item redraw.
+    pub(crate) dialog_cdef_draw_pending_snapshot: HashSet<u32>,
+    /// Dialogs whose application CDEF controls have completed at least one
+    /// visible whole-control draw pass.
+    pub(crate) dialog_cdefs_initially_drawn: HashSet<u32>,
     /// Editable dialog items whose initial all-selected text state has already
     /// been replaced by typed input. Keyed by (dialog_ptr, 1-based item number)
     /// so ModalDialog re-entry keeps appending instead of replacing again.
@@ -1803,6 +1817,9 @@ pub struct TrapDispatcher {
     /// ModalDialog. Drained through the same runner trampoline as modal
     /// draw procs.
     pub(crate) modeless_dialog_draw_proc_queue: VecDeque<(u32, u32, i16)>,
+    /// Dialogs whose application CDEF draw callbacks must run after any
+    /// modeless userItem callbacks queued by the same Dialog Manager redraw.
+    pub(crate) modeless_dialog_cdef_draw_queue: VecDeque<u32>,
     /// Dialog currently executing a modeless userItem draw proc.
     pub(crate) active_modeless_dialog_draw_proc: Option<u32>,
     /// Mouse click currently captured by a front modal dialog. This includes
@@ -2769,6 +2786,8 @@ impl TrapDispatcher {
             device_loop_trampoline: 0,
             list_def_trampoline: 0,
             window_def_trampoline: 0,
+            control_def_trampoline: 0,
+            control_def_trampoline_chain: Vec::new(),
             defer_user_fn_trampoline: 0,
             qddone_seen_ports: HashSet::new(),
             pict_info_ids: HashSet::new(),
@@ -2982,6 +3001,7 @@ impl TrapDispatcher {
             next_ct_seed: 1,
             fill_black_override: None,
             recording_picture: None,
+            recording_picture_bitmap: None,
             native_trap_table: HashMap::new(),
             bits_proc_reentry: None,
             timer_tasks: Vec::new(),
@@ -3003,9 +3023,12 @@ impl TrapDispatcher {
             dialog_saved_pixels: HashMap::new(),
             dialog_visible_snapshots: HashMap::new(),
             dialog_modal_entered: std::collections::HashSet::new(),
+            dialog_cdef_draw_pending_snapshot: HashSet::new(),
+            dialog_cdefs_initially_drawn: HashSet::new(),
             dialog_edit_text_modified_items: HashSet::new(),
             dialog_initial_draw_deferred: HashSet::new(),
             modeless_dialog_draw_proc_queue: VecDeque::new(),
+            modeless_dialog_cdef_draw_queue: VecDeque::new(),
             active_modeless_dialog_draw_proc: None,
             retained_modal_dialog_click: None,
             pending_modal_button_dispose_dialog: None,

--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -2915,6 +2915,28 @@ impl super::TrapDispatcher {
                     dst_bottom,
                     dst_right,
                 );
+                if self.recording_picture.is_some() {
+                    let mut source_clut = if src_info.pixel_size == 1 {
+                        [[0u16; 3]; 256]
+                    } else {
+                        self.read_port_clut(bus, src_info.ctab_handle)
+                    };
+                    if src_info.pixel_size == 1 {
+                        source_clut[0] = [self.bg_color.0, self.bg_color.1, self.bg_color.2];
+                        source_clut[1] = [self.fg_color.0, self.fg_color.1, self.fg_color.2];
+                    }
+                    if let Some(snapshot) = Self::encode_bitmap_copy_pict(
+                        bus,
+                        src_info,
+                        &source_clut,
+                        (src_top, src_left, src_bottom, src_right),
+                        (dst_top, dst_left, dst_bottom, dst_right),
+                        mode,
+                    ) {
+                        self.recording_picture_bitmap = Some(snapshot);
+                    }
+                    return Some(Ok(()));
+                }
                 if src_info.row_bytes == 0
                     || dst_info.row_bytes == 0
                     || src_info.pixel_size == 0
@@ -4328,6 +4350,12 @@ impl super::TrapDispatcher {
                 let b = bus.read_word(color_ptr + 4);
                 self.bg_color = (r, g, b);
                 self.sync_current_port_draw_state(bus);
+                if let Some((_, _, _, _, _, commands)) = self.recording_picture.as_mut() {
+                    Self::push_pict_word(commands, 0x001B); // RGBBkCol
+                    for component in [r, g, b] {
+                        Self::push_pict_word(commands, component);
+                    }
+                }
                 if trace_qd_colors_enabled() {
                     eprintln!(
                         "[QD-COLOR] RGBBackColor port=${:08X} ptr=${:08X} rgb=({:04X},{:04X},{:04X}) tick={}",
@@ -8409,6 +8437,7 @@ impl super::TrapDispatcher {
                     frame_right,
                     Vec::new(),
                 ));
+                self.recording_picture_bitmap = None;
 
                 eprintln!(
                     "[TRAP] OpenPicture: handle=${:08X} frame=({},{},{},{})",
@@ -8430,7 +8459,9 @@ impl super::TrapDispatcher {
                 if let Some((handle, top, left, bottom, right, commands)) =
                     self.recording_picture.take()
                 {
-                    let picture = if commands.is_empty() {
+                    let picture = if let Some(snapshot) = self.recording_picture_bitmap.take() {
+                        Some(snapshot)
+                    } else if commands.is_empty() {
                         let mut source = self.resolve_copy_bitmap(bus, self.current_port + 2);
                         if source.base == 0
                             || source.base == u32::MAX
@@ -8454,14 +8485,13 @@ impl super::TrapDispatcher {
                         } else {
                             self.device_clut
                         };
-                        Self::encode_bitmap_snapshot_pict(
+                        Self::encode_bitmap_copy_pict(
                             bus,
                             source,
                             &source_clut,
-                            top,
-                            left,
-                            bottom,
-                            right,
+                            (top, left, bottom, right),
+                            (top, left, bottom, right),
+                            0,
                         )
                     } else {
                         Some(Self::encode_recorded_picture_pict(
@@ -19252,18 +19282,24 @@ impl super::TrapDispatcher {
         picture
     }
 
-    fn encode_bitmap_snapshot_pict(
+    fn encode_bitmap_copy_pict(
         bus: &MacMemoryBus,
         source: CopyBitmapInfo,
         source_clut: &[[u16; 3]; 256],
-        top: i16,
-        left: i16,
-        bottom: i16,
-        right: i16,
+        source_rect: (i16, i16, i16, i16),
+        dest_rect: (i16, i16, i16, i16),
+        mode: i16,
     ) -> Option<Vec<u8>> {
-        let width = u32::try_from(i32::from(right) - i32::from(left)).ok()?;
-        let height = u32::try_from(i32::from(bottom) - i32::from(top)).ok()?;
+        let (src_top, src_left, src_bottom, src_right) = source_rect;
+        let (dst_top, dst_left, dst_bottom, dst_right) = dest_rect;
+        let src_width = u32::try_from(i32::from(src_right) - i32::from(src_left)).ok()?;
+        let src_height = u32::try_from(i32::from(src_bottom) - i32::from(src_top)).ok()?;
+        let width = u32::try_from(i32::from(dst_right) - i32::from(dst_left)).ok()?;
+        let height = u32::try_from(i32::from(dst_bottom) - i32::from(dst_top)).ok()?;
         if width == 0 || height == 0 {
+            return None;
+        }
+        if src_width == 0 || src_height == 0 {
             return None;
         }
 
@@ -19279,7 +19315,7 @@ impl super::TrapDispatcher {
             10 + 1 + 46 + 8 + color_count * 8 + 18 + (row_bytes as usize + 6) * height as usize,
         );
         Self::push_pict_word(&mut picture, 0); // patched after encoding
-        for value in [top, left, bottom, right] {
+        for value in [dst_top, dst_left, dst_bottom, dst_right] {
             Self::push_pict_word(&mut picture, value as u16);
         }
 
@@ -19314,10 +19350,10 @@ impl super::TrapDispatcher {
         for value in [0i16, 0, height as i16, width as i16] {
             Self::push_pict_word(&mut picture, value as u16);
         }
-        for value in [top, left, bottom, right] {
+        for value in [dst_top, dst_left, dst_bottom, dst_right] {
             Self::push_pict_word(&mut picture, value as u16);
         }
-        Self::push_pict_word(&mut picture, 0); // srcCopy
+        Self::push_pict_word(&mut picture, mode as u16);
 
         let pixels_per_byte = 8 / u32::from(pixel_size);
         let pixel_mask = if pixel_size == 8 {
@@ -19329,13 +19365,10 @@ impl super::TrapDispatcher {
         for y in 0..height {
             row.fill(0);
             for x in 0..width {
-                let source_pixel = Self::read_bitmap_pixel(
-                    bus,
-                    &source,
-                    top.saturating_add(y as i16),
-                    left.saturating_add(x as i16),
-                )
-                .unwrap_or_default();
+                let source_y = src_top.saturating_add((y * src_height / height) as i16);
+                let source_x = src_left.saturating_add((x * src_width / width) as i16);
+                let source_pixel =
+                    Self::read_bitmap_pixel(bus, &source, source_y, source_x).unwrap_or_default();
                 let pixel = if pixel_size == 1 {
                     u8::from(source_pixel != 0)
                 } else {
@@ -39677,6 +39710,61 @@ mod tests {
             bus.read_bytes(screen_base, 8),
             original,
             "ClosePicture must retain packed 4-bit pixels for a later DrawPicture"
+        );
+    }
+
+    #[test]
+    fn recorded_copybits_replays_packed_4bpp_pixels_through_the_source_color_table() {
+        let (_d, _cpu, mut bus) = setup();
+        let source_base = bus.alloc(2);
+        bus.write_bytes(source_base, &[0x12, 0x34]);
+        let source = CopyBitmapInfo {
+            base: source_base,
+            row_bytes: 2,
+            bounds_top: 0,
+            bounds_left: 0,
+            bounds_bottom: 1,
+            bounds_right: 4,
+            pixel_size: 4,
+            ctab_handle: 0,
+        };
+        let mut clut = [[0xFFFFu16; 3]; 256];
+        for (index, color) in clut.iter_mut().take(16).enumerate() {
+            let component = (index as u16) * 0x1111;
+            *color = [component, component, component];
+        }
+        let picture = TrapDispatcher::encode_bitmap_copy_pict(
+            &bus,
+            source,
+            &clut,
+            (0, 0, 1, 4),
+            (0, 0, 1, 4),
+            0,
+        )
+        .expect("packed CopyBits should produce a replayable picture");
+        let pic_ptr = bus.alloc(picture.len() as u32);
+        bus.write_bytes(pic_ptr, &picture);
+        let screen_base = bus.alloc(4);
+        bus.fill_zeros(screen_base, 4);
+
+        let (drawn, _) = crate::trap::pict::draw_picture(
+            &mut bus,
+            pic_ptr,
+            0,
+            0,
+            1,
+            4,
+            (screen_base, 4, 4, 1, 8),
+            &clut,
+            0,
+            None,
+        );
+
+        assert!(drawn);
+        assert_eq!(
+            bus.read_bytes(screen_base, 4),
+            vec![1, 2, 3, 4],
+            "OpenPicture/CopyBits artwork must retain packed pixels and its indexed colors"
         );
     }
 

--- a/src/trap/window.rs
+++ b/src/trap/window.rs
@@ -3204,6 +3204,12 @@ impl super::TrapDispatcher {
                         if resolved_user_item_proc {
                             self.queue_modeless_dialog_draw_procs(bus, the_window);
                         }
+                        if !self
+                            .modeless_dialog_cdef_draw_queue
+                            .contains(&the_window)
+                        {
+                            self.modeless_dialog_cdef_draw_queue.push_back(the_window);
+                        }
                     } else {
                         let hilited = bus.read_byte(the_window + Self::WINDOW_HILITED_OFFSET) != 0;
                         if self.window_uses_custom_def_proc(bus, the_window) {


### PR DESCRIPTION
Fixes #129.

Executes callable application CDEF resources through the classic Pascal callback ABI for initialization, drawing, and hit testing. Routes dialog, DrawControls, UpdtControl, Draw1Control, value/title, and highlight redraws through guest CDEFs while preserving standard-control HLE behavior and retained dialog pixels.

Also records indexed CopyBits operations issued inside OpenPicture so CDEF-created artwork replays with its packed pixels and source color table intact.

Validated with:
- full Rust test suite (2,891 tests across library and binaries)
- dialog/theme visual fixture gates and manifest schema gate
- 36 theme no-behavior-drift contracts
- four scripted ModalDialog input traces and the A991 catalogue witness
- Spectre VR application run showing all eight custom splash controls