### PR TITLE
fix: upgrade m68k to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1196,9 +1196,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "m68k"
-version = "0.2.5"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e917ea9fbc8cbad2547a740d0d5c85c1936ad5b754d92a70efb3f1bb148b16"
+checksum = "40fc752c0efbc5b4eb865a2718b8711d66dd56485f07be271c50db89cfdfe5c9"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "systemless"
 version = "0.10.0"
 edition = "2021"
+rust-version = "1.93"
 # Emulator code is GPL-3.0-or-later; the bitmap font artwork in
 # src/quickdraw/fonts/pixel_font/ is additionally under OFL-1.1 (see OFL.txt).
 license = "GPL-3.0-or-later AND OFL-1.1"
@@ -16,7 +17,7 @@ default-run = "systemless"
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
-m68k = "0.2.5"
+m68k = "0.3.0"
 thiserror = "2"
 tracing = "0.1"
 serde = { version = "1", features = ["derive"] }

--- a/src/cpu/mod.rs
+++ b/src/cpu/mod.rs
@@ -3,7 +3,7 @@
 //! Hosts the 68k interpreter that drives the HLE Toolbox dispatch
 //! path.
 
-use crate::memory::{MacMemoryBus, MemoryBus};
+use crate::memory::MacMemoryBus;
 
 pub use m68k::HleHandler;
 
@@ -67,20 +67,13 @@ pub struct M68kCpu {
     /// Exposed so callers can reach interpreter-specific APIs not
     /// surfaced by the [`CpuOps`] trait.
     pub core: m68k::CpuCore,
-    /// One-shot suppression for the synthetic custom zero-divide-handler
-    /// watch installed by [`Self::run_batch`]. After expanding the exception
-    /// frame, the next batch must execute the watched handler entry.
-    skip_format_two_handler_watch: Option<u32>,
 }
 
 impl M68kCpu {
     pub fn new() -> Self {
         let mut core = m68k::CpuCore::new();
         core.set_cpu_type(crate::machine_profile::REFERENCE_MACHINE_PROFILE.cpu_type());
-        Self {
-            core,
-            skip_format_two_handler_watch: None,
-        }
+        Self { core }
     }
 
     /// `#[inline]` — called many times per instruction. The match
@@ -155,56 +148,7 @@ impl M68kCpu {
         max_instructions: u32,
         watch_pcs: &[u32],
     ) -> m68k::BatchResult {
-        let zero_divide_handler = bus.read_long(0x0014);
-        let suppress_handler_watch =
-            self.skip_format_two_handler_watch == Some(self.core.pc);
-        if suppress_handler_watch {
-            self.skip_format_two_handler_watch = None;
-        }
-        let handler_already_watched = watch_pcs.contains(&zero_divide_handler);
-        let should_intercept_zero_divide = zero_divide_handler != 0
-            && zero_divide_handler != 0x0000_00FE
-            && !suppress_handler_watch
-            && (handler_already_watched || watch_pcs.len() < 3);
-        let mut extended_watches = [0u32; 3];
-        let active_watches = if should_intercept_zero_divide && !handler_already_watched {
-            extended_watches[..watch_pcs.len()].copy_from_slice(watch_pcs);
-            extended_watches[watch_pcs.len()] = zero_divide_handler;
-            &extended_watches[..watch_pcs.len() + 1]
-        } else {
-            watch_pcs
-        };
-
-        let batch = self.core.run_batch(bus, max_instructions, active_watches);
-        if should_intercept_zero_divide
-            && matches!(
-                batch.exit,
-                m68k::BatchExit::WatchedPc { pc } if pc == zero_divide_handler
-            )
-            && bus.read_word(self.core.ppc) & 0xFFC0 == 0x4C40
-        {
-            // A 68020+ zero-divide fault uses a format-2 exception frame:
-            // SR, next PC, format/vector word, then the faulting instruction
-            // address. The m68k backend currently emits a format-0 frame for
-            // all synchronous exceptions. Classic applications can install a
-            // vector-5 handler that consumes the format-2 address field (Dark
-            // Forces does so to skip a four-byte DIVSL), so expand the frame
-            // before entering a non-default guest handler.
-            //
-            // Motorola M68000 Family Programmer's Reference Manual (1992),
-            // §6.3.4, format-2 stack frame.
-            let old_sp = self.core.a(7);
-            let saved_sr = bus.read_word(old_sp);
-            let saved_pc = bus.read_long(old_sp + 2);
-            let new_sp = old_sp.wrapping_sub(4);
-            bus.write_word(new_sp, saved_sr);
-            bus.write_long(new_sp + 2, saved_pc);
-            bus.write_word(new_sp + 6, 0x2014);
-            bus.write_long(new_sp + 8, self.core.ppc);
-            self.core.set_a(7, new_sp);
-            self.skip_format_two_handler_watch = Some(zero_divide_handler);
-        }
-        batch
+        self.core.run_batch(bus, max_instructions, watch_pcs)
     }
 
     /// `#[inline]` — called once per M68K instruction. The wrapper
@@ -297,7 +241,7 @@ mod tests {
         cpu.write_reg(Register::D1, 0);
         cpu.write_reg(Register::D2, 0);
 
-        let first = cpu.run_batch(&mut bus, 10, &[]);
+        let first = cpu.run_batch(&mut bus, 1, &[]);
         assert_eq!(first.instructions, 1);
         assert_eq!(cpu.read_reg(Register::PC), handler);
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -419,9 +419,10 @@ enum AdvanceResult {
     TooFar,
 }
 
-/// Architecturally visible processor state at a candidate idle-cycle
-/// boundary. JIT caches, prefetch bookkeeping, and remaining host batch cycles
-/// are deliberately excluded: they affect execution speed, not guest results.
+/// Processor state that can affect guest execution at a candidate idle-cycle
+/// boundary. JIT/decode caches and remaining host batch cycles are deliberately
+/// excluded, while precise prefetch and loop-mode state remain part of the
+/// proof.
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct CpuArchitecturalSnapshot {
     dar: [u32; 16],
@@ -436,18 +437,26 @@ struct CpuArchitecturalSnapshot {
     dfc: u32,
     cacr: u32,
     caar: u32,
+    cacr_pending_ops: u32,
     itt: [u32; 2],
     dtt: [u32; 2],
     ir: u32,
-    fpr: [u64; 8],
+    fpr: [m68k::fpu::FloatX80; 8],
     fpiar: u32,
     fpsr: u32,
     fpcr: u32,
-    mmu: [u32; 16],
+    mmu: [u32; 14],
+    pmmu_enabled: bool,
     int_level: u32,
     stopped: u32,
     change_of_flow: bool,
-    prefetch: [u32; 2],
+    loop_mode: bool,
+    loop_body_word: u16,
+    loop_dbcc_word: u16,
+    prefetch: [u16; 2],
+    prefetch_count: u8,
+    consume_without_prefetch: bool,
+    pending_sync_clocks: u32,
     run_mode: u32,
     fpu_just_reset: bool,
     reset_cycles: u32,
@@ -471,10 +480,11 @@ impl CpuArchitecturalSnapshot {
             dfc: cpu.dfc,
             cacr: cpu.cacr,
             caar: cpu.caar,
+            cacr_pending_ops: cpu.cacr_pending_ops,
             itt: [cpu.itt0, cpu.itt1],
             dtt: [cpu.dtt0, cpu.dtt1],
             ir: cpu.ir,
-            fpr: cpu.fpr.map(f64::to_bits),
+            fpr: cpu.fpr,
             fpiar: cpu.fpiar,
             fpsr: cpu.fpsr,
             fpcr: cpu.fpcr,
@@ -484,22 +494,27 @@ impl CpuArchitecturalSnapshot {
                 cpu.mmu_srp_aptr,
                 cpu.mmu_srp_limit,
                 cpu.mmu_tc,
-                u32::from(cpu.mmu_sr),
+                cpu.mmu_sr,
                 cpu.mmu_tt0,
                 cpu.mmu_tt1,
-                cpu.urp,
-                cpu.srp,
-                cpu.tc,
-                cpu.mmusr,
                 cpu.dacr0,
                 cpu.dacr1,
                 cpu.iacr0,
                 cpu.iacr1,
+                cpu.pcr,
+                cpu.buscr,
             ],
+            pmmu_enabled: cpu.pmmu_enabled,
             int_level: cpu.int_level,
             stopped: cpu.stopped,
             change_of_flow: cpu.change_of_flow,
-            prefetch: [cpu.pref_addr, cpu.pref_data],
+            loop_mode: cpu.loop_mode,
+            loop_body_word: cpu.loop_body_word,
+            loop_dbcc_word: cpu.loop_dbcc_word,
+            prefetch: cpu.prefetch_queue,
+            prefetch_count: cpu.prefetch_count,
+            consume_without_prefetch: cpu.consume_without_prefetch,
+            pending_sync_clocks: cpu.pending_sync_clocks,
             run_mode: cpu.run_mode,
             fpu_just_reset: cpu.fpu_just_reset,
             reset_cycles: cpu.reset_cycles,
@@ -10015,6 +10030,36 @@ mod tests {
                 runner.dispatcher.tick_count,
             );
         }
+    }
+
+    #[test]
+    fn idle_snapshot_preserves_extended_cpu_state() {
+        let mut cpu = m68k::CpuCore::new();
+        cpu.fpr[0] = m68k::fpu::FloatX80::from_extended(0x3FFF, 0x8000_0000_0000_0000);
+        let baseline = CpuArchitecturalSnapshot::capture(&cpu);
+
+        cpu.fpr[0].mantissa ^= 1;
+        assert_ne!(
+            baseline,
+            CpuArchitecturalSnapshot::capture(&cpu),
+            "80-bit FPU precision must participate in an idle-cycle proof"
+        );
+
+        cpu.fpr[0].mantissa ^= 1;
+        cpu.mmu_crp_aptr = 0x1234_5000;
+        assert_ne!(
+            baseline,
+            CpuArchitecturalSnapshot::capture(&cpu),
+            "canonical MMU state must participate in an idle-cycle proof"
+        );
+
+        cpu.mmu_crp_aptr = 0;
+        cpu.prefetch_queue[1] = 0x4E71;
+        assert_ne!(
+            baseline,
+            CpuArchitecturalSnapshot::capture(&cpu),
+            "precise prefetch state must participate in an idle-cycle proof"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- upgrade the m68k backend from 0.2.5 to 0.3.0 and declare its Rust 1.93 MSRV
- rely on m68k's native 68020 format-two group-2 exception frames instead of rewriting them in Systemless
- preserve the expanded 80-bit FPU, MMU, prefetch, loop-mode, and cache-operation state in idle-cycle proofs

## Validation

- `cargo test -q`: 2,840 passed, 0 failed, 3 ignored, with all integration suites passing
- `cargo test -q --lib --features test-support`: 2,846 passed, 0 failed, 3 ignored
- `cargo build --all-targets --all-features`
- `cargo check --no-default-features`
- `cargo check --target wasm32-unknown-unknown --no-default-features`
- `cargo package --allow-dirty`
- dependent play, catalogue, and benchmark workspace tests
- native EV and Marathon gameplay parity gates
- catalogue A/B comparison against m68k 0.2.5: identical 544 passes and identical 50 known failures
- browser EV A/B comparison: identical gameplay milestone, instruction/tick/trap counts, screenshot checkpoint, and known game-audio assertion; browser audio smoke passes in both

Closes #250