### PR TITLE
fix: upgrade m68k to 0.3.1 with native JIT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1196,9 +1196,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "m68k"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40fc752c0efbc5b4eb865a2718b8711d66dd56485f07be271c50db89cfdfe5c9"
+checksum = "a5a27246c9d8514907e1fa813761e649d69ba14ba2fd9e9b7747fcf5812f7830"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ default-run = "systemless"
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
-m68k = "0.3.0"
+m68k = { version = "0.3.1", features = ["jit"] }
 thiserror = "2"
 tracing = "0.1"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Summary

- upgrade m68k from 0.3.0 to 0.3.1
- explicitly enable m68k's new `jit` feature so native `run_batch()` execution retains Cranelift-compiled hot traces
- keep WebAssembly on m68k's portable trace executor without pulling Cranelift into the wasm dependency graph

## Validation

- `cargo test -q`: 2,840 passed, 0 failed, 3 ignored, with all integration suites passing
- `cargo test -q --lib --features test-support`: 2,846 passed, 0 failed, 3 ignored
- `cargo build --all-targets --all-features`
- `cargo check --no-default-features`
- `cargo check --target wasm32-unknown-unknown --no-default-features`
- `cargo package --allow-dirty`
- native dependency graph includes `m68k/jit` and Cranelift
- wasm dependency graph excludes Cranelift
- EV and Marathon gameplay parity gates

Closes #253