### PR TITLE
fix: upgrade m68k to 0.3.2 and correct Rustdocs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,11 @@ jobs:
       - name: Headless library build (no default features)
         run: cargo check --no-default-features
 
+      - name: Build API documentation
+        env:
+          RUSTDOCFLAGS: -D warnings -D rustdoc::private_intra_doc_links
+        run: cargo doc --all-features --locked --no-deps --document-private-items
+
       # Catch packaging/metadata problems before a release ever runs.
       - name: Package dry-run
         run: cargo publish --locked --dry-run

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1196,9 +1196,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "m68k"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5a27246c9d8514907e1fa813761e649d69ba14ba2fd9e9b7747fcf5812f7830"
+checksum = "e402ea841b837d13611bc1c373abc53213ab4e93f653f79cc829fc2d4b111c45"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ default-run = "systemless"
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
-m68k = { version = "0.3.1", features = ["jit"] }
+m68k = { version = "0.3.2", features = ["jit"] }
 thiserror = "2"
 tracing = "0.1"
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@
 Systemless is a high-level runtime for 68k classic Macintosh applications and
 games, written in Rust.
 
-It interprets guest 68k code with the [`m68k`](https://crates.io/crates/m68k)
-crate and handles Mac OS A-line traps in native Rust. That lets packaged Mac
-applications run without a Mac ROM image, a full System install, or hardware
-emulation.
+It executes guest 68k code with the [`m68k`](https://crates.io/crates/m68k)
+crate and handles Mac OS A-line traps in native Rust. Native builds explicitly
+enable m68k's Cranelift JIT for eligible hot traces; WebAssembly uses its
+portable trace executor. That lets packaged Mac applications run without a Mac
+ROM image, a full System install, or hardware emulation.
 
 See it running in the browser: **[Marathon](https://systemless.org/marathon)**
 and **[Escape Velocity](https://systemless.org/escape-velocity)**. More demos

--- a/src/cpu/mod.rs
+++ b/src/cpu/mod.rs
@@ -1,15 +1,17 @@
-//! CPU Backend - m68k wrapper
+//! CPU backend built on the [`m68k`] crate.
 //!
-//! Hosts the 68k interpreter that drives the HLE Toolbox dispatch
-//! path.
+//! [`M68kCpu`] initializes the canonical guest CPU model and exposes both
+//! precise single-instruction stepping and JIT-enabled native batch execution.
+//! WebAssembly builds retain the same batch API through m68k's portable trace
+//! executor.
 
 use crate::memory::MacMemoryBus;
 
 pub use m68k::HleHandler;
 
-/// 68k CPU register identifiers — eight data registers (D0–D7),
-/// eight address registers (A0–A7, with A7 doubling as the user
-/// stack pointer), and the program counter.
+/// 68k CPU register identifiers: eight data registers (D0–D7), eight
+/// address registers (A0–A7, with A7 selecting the active stack pointer),
+/// and the program counter.
 #[derive(Debug, Clone, Copy)]
 pub enum Register {
     D0,
@@ -34,19 +36,21 @@ pub enum Register {
 /// Outcome of a single 68k instruction step. Returned by
 /// [`FixtureRunner::step`](crate::runner::FixtureRunner::step).
 pub enum StepResult {
-    /// Instruction executed normally; advance PC and continue.
+    /// The instruction completed normally and execution may continue.
     Ok,
-    /// CPU has reached a halt state (`STOP` instruction or external
-    /// stop signal). The runner should not step again until reset.
+    /// The CPU executed `STOP`, or the wrapper normalized an unsupported
+    /// terminal condition to a stopped result.
     Stopped,
-    /// Instruction was an A-line trap; the carried `u16` is the trap
-    /// word that the dispatcher should route to a handler.
+    /// The instruction was an A-line trap; the carried value is the trap word
+    /// for the dispatcher.
     Aline(u16),
 }
 
-/// Trait the trap dispatcher uses to read/write CPU state without
-/// pulling in the full 68k interpreter type — lets handlers be
-/// generic over both the production [`M68kCpu`] and test fakes.
+/// Register interface used by the trap dispatcher.
+///
+/// Keeping handlers generic over this subset lets them operate on both the
+/// production [`M68kCpu`] backend and test doubles without exposing the full
+/// m68k architectural state.
 pub trait CpuOps {
     /// Read the current value of a single register.
     fn read_reg(&self, reg: Register) -> u32;
@@ -54,32 +58,34 @@ pub trait CpuOps {
     fn write_reg(&mut self, reg: Register, value: u32);
     /// Read the condition code register (CCR) byte.
     fn get_ccr(&self) -> u8;
-    /// Set the condition code register (CCR) for SANE FCMP results.
-    /// Bits: X(4) N(3) Z(2) V(1) C(0)
+    /// Set the condition code register (CCR).
+    ///
+    /// The low five bits are X(4), N(3), Z(2), V(1), and C(0).
     fn set_ccr(&mut self, ccr: u8);
 }
 
-/// 68k CPU wrapper holding the [`m68k`] interpreter core. CPU type
-/// is fixed at construction to match the canonical machine profile
-/// ([`crate::machine_profile::REFERENCE_MACHINE_PROFILE`]).
+/// Systemless wrapper around [`m68k::CpuCore`].
+///
+/// Construction selects the CPU type from
+/// [`crate::machine_profile::REFERENCE_MACHINE_PROFILE`]. Callers with a
+/// specialized embedding may subsequently reconfigure the public core.
 pub struct M68kCpu {
-    /// Underlying [`m68k::CpuCore`] instance — registers, flags, PC.
-    /// Exposed so callers can reach interpreter-specific APIs not
-    /// surfaced by the [`CpuOps`] trait.
+    /// Complete m68k CPU state and execution API.
+    ///
+    /// This is public for diagnostics and specialized embedding beyond the
+    /// register-only [`CpuOps`] interface.
     pub core: m68k::CpuCore,
 }
 
 impl M68kCpu {
+    /// Create a CPU configured for the canonical Systemless machine profile.
     pub fn new() -> Self {
         let mut core = m68k::CpuCore::new();
         core.set_cpu_type(crate::machine_profile::REFERENCE_MACHINE_PROFILE.cpu_type());
         Self { core }
     }
 
-    /// `#[inline]` — called many times per instruction. The match
-    /// compiles to a small jump table; inlining lets LLVM optimize
-    /// individual callsites (where `reg` is often a constant) down to
-    /// direct field reads.
+    /// Read one data, address, or program-counter register.
     #[inline]
     pub fn read_reg(&self, reg: Register) -> u32 {
         match reg {
@@ -103,6 +109,7 @@ impl M68kCpu {
         }
     }
 
+    /// Write one data, address, or program-counter register.
     #[inline]
     pub fn write_reg(&mut self, reg: Register, value: u32) {
         match reg {
@@ -126,18 +133,24 @@ impl M68kCpu {
         }
     }
 
+    /// Return whether the CPU is stopped by a `STOP` instruction.
     #[inline]
     pub fn is_stopped(&self) -> bool {
         self.core.is_stopped()
     }
 
+    /// Reset the CPU from the initial stack-pointer and program-counter vectors.
     pub fn reset(&mut self, bus: &mut MacMemoryBus) {
         self.core.reset(bus);
     }
 
-    /// Execute up to `max_instructions` instructions inside the m68k
-    /// core's JIT-enabled batch loop, returning on the first event the
-    /// runner must handle (trap, stop, watched PC, or budget out).
+    /// Execute at most `max_instructions` through m68k's throughput path.
+    ///
+    /// Native builds enable Cranelift compilation for eligible hot traces;
+    /// WebAssembly executes the same traces through the portable executor.
+    /// Execution returns on the first event the runner must handle: a trap,
+    /// stopped CPU, watched PC, or exhausted instruction budget.
+    ///
     /// See [`m68k::CpuCore::run_batch`] for the exit/accounting
     /// contract; the trapping instruction is *not* included in
     /// `instructions` and `core.ppc` holds its address.
@@ -151,11 +164,12 @@ impl M68kCpu {
         self.core.run_batch(bus, max_instructions, watch_pcs)
     }
 
-    /// `#[inline]` — called once per M68K instruction. The wrapper
-    /// converts `m68k::StepResult` to `systemless::StepResult`; inlining
-    /// lets LLVM fold the match into the caller's decision tree.
-    /// Consumes the result by value to avoid reference-materialize on
-    /// the hot path.
+    /// Execute one instruction through m68k's precise stepping path.
+    ///
+    /// Systemless surfaces completed instructions, A-line traps, and STOP
+    /// directly. F-line exits retain the legacy no-op behavior and return
+    /// [`StepResult::Ok`]; illegal instructions, `TRAP`, and `BKPT` exits are
+    /// reported and converted to [`StepResult::Stopped`].
     #[inline]
     pub fn step(&mut self, bus: &mut MacMemoryBus) -> StepResult {
         match self.core.step(bus) {

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,7 +1,7 @@
 //! Shared framebuffer rendering for all Systemless frontends.
 //!
-//! Produces RGBA `Vec<u8>` pixel buffers from emulator screen memory,
-//! supporting both 1bpp monochrome and 8bpp color modes.
+//! Produces RGBA pixel buffers from guest screen memory, supporting 1bpp
+//! monochrome plus 4bpp and 8bpp indexed-color modes.
 
 use crate::memory::{MacMemoryBus, MemoryBus};
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,7 +25,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// * [`Error::Trace`] — recording-side error from the cross-runtime
 ///   parity trace sink (filesystem write, JSON serialisation, etc).
 ///   Surfaces only when a trace sink is installed via
-///   `set_trace_sink`.
+///   [`FixtureRunner::set_trace_sink`](crate::runner::FixtureRunner::set_trace_sink).
 #[derive(Debug, Error)]
 pub enum Error {
     /// The dispatcher reached an A-line trap word with no matching

--- a/src/game/launch.rs
+++ b/src/game/launch.rs
@@ -1,8 +1,8 @@
 //! Shared game loading and initialization for all Systemless frontends.
 //!
-//! Consolidates ROM loading (BinHex + MacBinary + StuffIt), runner
-//! initialization, and post-load configuration so all frontends behave
-//! identically.
+//! Consolidates application loading (BinHex, MacBinary, StuffIt, and web
+//! packs), runner initialization, and post-load configuration so all
+//! frontends behave identically.
 
 use crate::loader::LoadedApp;
 use crate::managers::resource::ResourceFork;
@@ -18,7 +18,7 @@ fn is_web_pack(file_data: &[u8]) -> bool {
     file_data.starts_with(WEB_PACK_MAGIC) || file_data.starts_with(LEGACY_WEB_PACK_MAGIC)
 }
 
-/// Standard RAM size for all frontends (32 MB).
+/// Standard frontend RAM size from the canonical machine profile.
 pub const RAM_SIZE: u32 = crate::machine_profile::REFERENCE_MACHINE_PROFILE.ram_size_bytes;
 
 /// Max instructions to execute per GUI/WASM frame.
@@ -38,7 +38,8 @@ pub fn new_runner() -> FixtureRunner {
     )
 }
 
-/// Load a game ROM from raw file bytes (BinHex, MacBinary, StuffIt archive, or raw resource fork).
+/// Load an application from BinHex, MacBinary, StuffIt, web-pack, or raw
+/// resource-fork bytes.
 ///
 /// Handles StuffIt archives (populates VFS with all entries, finds executable),
 /// MacBinary files, and macOS resource fork paths. Returns the LoadedApp on success.

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -1,8 +1,8 @@
 //! Shared game loading helpers.
 //!
-//! [`launch`] handles runner setup and ROM/archive ingestion (MacBinary,
-//! StuffIt, web-pack), VFS population, executable selection, post-load
-//! init.
+//! [`launch`] handles runner setup, application/archive ingestion (BinHex,
+//! MacBinary, StuffIt, and web packs), VFS population, executable selection,
+//! and post-load initialization.
 
 pub mod launch;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,12 +2,25 @@
 //!
 //! `systemless` runs Mac OS Toolbox apps without a real ROM by intercepting
 //! 68k A-line trap instructions (`$A000`–`$AFFF`) and dispatching them
-//! to native Rust handlers — the QuickDraw, Window Manager, Resource
-//! Manager, Sound Manager, SANE, and the rest of the Toolbox are
-//! reimplemented natively. The 68k CPU itself is interpreted by the
-//! [`m68k`] crate.
+//! to native Rust handlers. QuickDraw, the Window Manager, the Resource
+//! Manager, the Sound Manager, SANE, and the rest of the supported Toolbox
+//! surface are reimplemented in Rust. The [`m68k`] crate executes guest CPU
+//! instructions and models generation-specific architectural state.
 //!
-//! See the crate's `README.md` for the architecture overview.
+//! # Execution model
+//!
+//! [`FixtureRunner`](runner::FixtureRunner) owns the CPU, guest memory, and
+//! Toolbox dispatcher. Precise single-instruction work uses
+//! [`m68k::CpuCore::step`]. Budgeted execution uses
+//! [`m68k::CpuCore::run_batch`], with FastMem for ordinary guest RAM and
+//! Cranelift-compiled hot traces on native targets. WebAssembly uses m68k's
+//! portable trace executor; the guest-visible CPU and HLE contracts are the
+//! same in both modes.
+//!
+//! The library exposes the full [`m68k::CpuCore`] through
+//! [`M68kCpu::core`](cpu::M68kCpu::core) for diagnostics and specialized
+//! embedding, while [`cpu::CpuOps`] is the narrower register interface used by
+//! Toolbox handlers.
 //!
 //! # Quick start
 //!
@@ -31,6 +44,8 @@
 //! ```
 //!
 //! [`m68k`]: https://crates.io/crates/m68k
+
+#![deny(rustdoc::broken_intra_doc_links)]
 
 mod adb;
 pub mod audio;

--- a/src/managers/mod.rs
+++ b/src/managers/mod.rs
@@ -1,5 +1,6 @@
-//! Toolbox managers
+//! Host-side data structures for Toolbox managers.
 //!
-//! Minimal implementation - only resource parsing.
+//! Resource-fork parsing and lookup live here; executable trap behavior is
+//! implemented under [`crate::trap`].
 
 pub mod resource;

--- a/src/memory/bus.rs
+++ b/src/memory/bus.rs
@@ -441,7 +441,7 @@ pub trait MemoryBus {
     }
 }
 
-/// Mac memory bus with RAM, ROM, and low-memory globals
+/// Flat guest RAM with low-memory globals, allocation state, and diagnostics.
 pub struct MacMemoryBus {
     ram: RamStorage,
     ram_size: u32,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -620,7 +620,7 @@ fn vfs_fork_hash(bytes: &[u8]) -> u64 {
     }
     hash
 }
-/// Default emulated CPU speed for realtime frontends (Mac IIci-class 68030).
+/// Default emulated CPU speed from the canonical machine profile.
 pub const DEFAULT_REALTIME_CPU_MHZ: f64 =
     crate::machine_profile::REFERENCE_MACHINE_PROFILE.realtime_cpu_mhz;
 /// Shared default realtime CPU budget used by the GUI runner and scripted
@@ -798,9 +798,9 @@ impl Default for FixtureRunnerConfig {
 
 /// Canonical entry point of the systemless library.
 ///
-/// `FixtureRunner` owns the three pieces of guest state — the [`M68kCpu`]
-/// interpreter, the [`MacMemoryBus`], and the [`TrapDispatcher`] (Toolbox
-/// + OS trap handlers) — and exposes the load / step / halt-inspect
+/// `FixtureRunner` owns the three pieces of guest state: the [`M68kCpu`]
+/// backend, the [`MacMemoryBus`], and the [`TrapDispatcher`] (Toolbox and OS
+/// trap handlers). It exposes the load, execute, and halt-inspection
 /// surface that drives them.
 ///
 /// **Lifecycle:**
@@ -841,9 +841,12 @@ pub struct FixtureRunner {
     halted_sp: Option<u32>,
     /// D0 register at the point of halt.
     halted_d0: Option<u32>,
-    /// Total guest instructions retired by the interpreter.
+    /// Total guest instructions accounted by the runner.
+    ///
+    /// This includes instructions retired by m68k, intercepted trap opcodes,
+    /// and instructions represented by proven idle-loop acceleration.
     total_instructions: u64,
-    /// Number of interpreted guest instructions per `Ticks` increment.
+    /// Number of guest instructions charged per `Ticks` increment.
     instructions_per_tick: u32,
     /// Optional cap on per-WaitNextEvent-call sleep tick advance in headless
     /// mode (when `run_steps` is called without a `tick_override`). `None`
@@ -953,15 +956,15 @@ pub struct FixtureRunner {
 
 impl FixtureRunner {
     /// Construct a fresh runner with `ram_size` bytes of guest RAM and
-    /// the given [`FixtureRunnerConfig`]. The CPU starts halted at
-    /// PC = 0; the framebuffer is whatever bytes the host allocator
-    /// hands us. Call [`load_app`](Self::load_app) (or the higher-level
+    /// the given [`FixtureRunnerConfig`]. The CPU begins at PC = 0 with reset
+    /// vectors not yet loaded, and guest RAM is zero-initialized. Call
+    /// [`load_app`](Self::load_app) (or the higher-level
     /// `systemless::game::load_game`) to populate guest memory and seed the
     /// run state, then drive the guest with [`run_steps`](Self::run_steps).
     ///
-    /// `ram_size` is typically 4 MiB to 16 MiB — most games never push
-    /// past 8 MiB. The runner allocates a single contiguous host
-    /// region of this size; bumping it costs only the upfront alloc.
+    /// The runner allocates one contiguous host region of `ram_size` bytes.
+    /// [`crate::game::RAM_SIZE`] provides the canonical profile-driven size;
+    /// tests and specialized embedders may choose a smaller allocation.
     ///
     /// The dispatcher defaults to **kiosk mode** (Mac menu bar
     /// suppressed, regardless of the guest's `MBarHeight`). Call
@@ -1192,10 +1195,11 @@ impl FixtureRunner {
         !self.dispatcher.menu_bar_hidden
     }
 
-    /// Disassemble M68K instructions starting at `pc` for `count`
-    /// instruction words. Returns one entry per word: `(pc, mnemonic,
-    /// size_in_bytes)`. The size includes any operand words consumed
-    /// by the instruction; advance `pc` by `size` to reach the next.
+    /// Disassemble `count` M68K instructions starting at `pc`.
+    ///
+    /// Returns `(pc, mnemonic, size_in_bytes)` for each instruction. The size
+    /// includes extension words; advance `pc` by `size` to reach the next
+    /// instruction.
     ///
     /// Unknown opcodes (including A-line traps and other reserved
     /// patterns) come back as `DC.W $XXXX` with size 2 — the same
@@ -1215,9 +1219,9 @@ impl FixtureRunner {
             // bus.read_word returns 0 for OOB rather than panicking,
             // so wrap-around safety is a property of the underlying
             // bus impl. Tag explicitly when the read landed at an
-            // address we know is past the framebuffer.
+            // address beyond the configured guest RAM.
             let opcode = self.bus.read_word(cur);
-            let unmapped = (cur as u64) >= (8 * 1024 * 1024);
+            let unmapped = cur >= self.bus.ram_size();
             let (mnemonic, size) = if unmapped {
                 ("<unmapped>".to_string(), 2)
             } else {
@@ -1802,11 +1806,12 @@ impl FixtureRunner {
         })
     }
 
-    /// Execute exactly one 68k instruction. Returns the per-step result
-    /// (continue / halted / unimplemented opcode). Most embedders
-    /// should call [`run_steps`](Self::run_steps) instead — it amortises
-    /// the per-step bookkeeping (tick advancement, halt detection,
-    /// trace ring filling) across the whole budget.
+    /// Execute exactly one 68k instruction through the precise CPU path.
+    ///
+    /// The result distinguishes ordinary completion, STOP, and an A-line trap.
+    /// Most embedders should call [`run_steps`](Self::run_steps) instead; it
+    /// amortizes tick advancement, halt detection, and trace collection across
+    /// the instruction budget.
     pub fn step(&mut self) -> StepResult {
         self.cpu.step(&mut self.bus)
     }
@@ -13280,6 +13285,21 @@ mod tests {
         assert!(
             out[2].1.contains("NOP"),
             "third entry must be the second NOP we seeded"
+        );
+    }
+
+    #[test]
+    fn disassemble_at_uses_the_configured_ram_boundary() {
+        let mut runner =
+            FixtureRunner::new(16 * 1024 * 1024, FixtureRunnerConfig::default());
+        let pc = 12 * 1024 * 1024;
+        runner.bus.write_word(pc, 0x4E71);
+
+        let out = runner.disassemble_at(pc, 1);
+        assert_eq!(out.len(), 1);
+        assert!(
+            out[0].1.contains("NOP"),
+            "mapped RAM above 8 MiB must not be reported as unmapped"
         );
     }
 }

--- a/src/sound.rs
+++ b/src/sound.rs
@@ -1,7 +1,7 @@
 //! Sound Manager state and mixing engine.
 //!
 //! Holds per-channel playback state and produces mixed PCM output each frame.
-//! Reference: Inside Macintosh: Sound 1994; references/executor/src/sound/sound.cpp
+//! Reference: *Inside Macintosh: Sound* (1994).
 
 /// Output sample rate in Hz.
 pub const OUTPUT_RATE: u32 = 22050;

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -6,7 +6,7 @@
 //! event/snapshot data types and the [`TraceSink`] trait the dispatcher
 //! emits to. The concrete sink — which persists events, snapshots, and
 //! framebuffer dumps — lives outside this crate and is installed via
-//! `Runner::set_trace_sink`.
+//! [`FixtureRunner::set_trace_sink`](crate::runner::FixtureRunner::set_trace_sink).
 //!
 //! Recording is opt-in (no sink installed = no cost) and the runtime is
 //! agnostic to how a sink stores what it receives.

--- a/src/trap/mod.rs
+++ b/src/trap/mod.rs
@@ -7,7 +7,7 @@
 //! - `quickdraw` — QuickDraw (port, pen, text, shapes, CopyBits, etc.)
 //! - `menu` — Menu Manager (NewMenu, DrawMenuBar, etc.)
 //! - `window` — Window Manager (NewWindow, GetNewWindow, etc.)
-//! - `dialog` — Dialog Manager + Cursor Manager stubs
+//! - `dialog` — Dialog Manager + Cursor Manager
 //! - `toolbox` — Toolbox utilities (Random, TickCount, Sound, etc.)
 //! - `shapes` — Shape computation helpers (draw_rect, draw_oval, etc.)
 //! - `text_render` — Text rendering helpers (draw_char, draw_string, etc.)

--- a/src/ui_theme.rs
+++ b/src/ui_theme.rs
@@ -1,4 +1,4 @@
-//! Internal UI theme contract for dialog/menu/control rendering.
+//! UI theme contract for dialog, menu, control, and text rendering.
 //!
 //! The first boundary is intentionally semantic and non-invasive: the default
 //! `classic-system7` provider represents the current renderer, while


### PR DESCRIPTION
## Summary

- upgrade m68k from 0.3.1 to 0.3.2 while preserving the native `jit` feature
- audit and correct crate/module/type/method Rustdocs for the current CPU execution, loader, display, memory, tracing, and theme contracts
- add a blocking private-item rustdoc CI build with warnings and private intra-doc links denied
- make `disassemble_at` honor the configured RAM size instead of a stale 8 MiB boundary exposed by the documentation audit

## Validation

- strict private-item rustdoc build with warnings denied
- `cargo test --doc --all-features`: 1 passed
- `cargo test -q`: 2,841 passed, 0 failed, 3 ignored, integration suites passing
- `cargo test -q --lib --features test-support`: 2,847 passed, 0 failed, 3 ignored
- `cargo build --all-targets --all-features`
- `cargo check --no-default-features`
- `cargo check --target wasm32-unknown-unknown --no-default-features`
- `cargo package --allow-dirty`
- native graph includes m68k/jit; wasm graph excludes Cranelift
- benchmark tests plus EV and Marathon gameplay parity

Closes #256