### PR TITLE
fix: preserve classic application presentation and timing

### DIFF
--- a/src/bin/desktop/native_application.rs
+++ b/src/bin/desktop/native_application.rs
@@ -10,10 +10,10 @@ use objc2_app_kit::{
 use objc2_foundation::{MainThreadMarker, NSSize};
 use systemless::game::{ApplicationIcon, ApplicationIconRepresentation};
 
-/// Classic Finder icons are artwork, whereas a modern macOS application icon
-/// is a complete canvas. Give the 32px/16px artwork transparent breathing room
-/// instead of letting AppKit enlarge it to fill the entire Dock tile.
-const APPLICATION_ICON_CANVAS_SCALE: usize = 2;
+/// Classic icons are visually denser than modern macOS icons. Keep the guest
+/// artwork at 80% of the canvas so it matches neighboring Dock icon footprints.
+const APPLICATION_ICON_CANVAS_NUMERATOR: usize = 5;
+const APPLICATION_ICON_CANVAS_DENOMINATOR: usize = 4;
 
 /// Replace the running process's Dock/application-switcher icon.
 ///
@@ -26,11 +26,7 @@ pub fn set_application_icon(icon: Option<&ApplicationIcon>) {
 }
 
 fn make_image(icon: &ApplicationIcon) -> Option<objc2::rc::Retained<NSImage>> {
-    let largest = icon.representations.iter().max_by_key(|representation| {
-        u32::from(representation.width) * u32::from(representation.height)
-    })?;
-    let image_width = usize::from(largest.width).checked_mul(APPLICATION_ICON_CANVAS_SCALE)?;
-    let image_height = usize::from(largest.height).checked_mul(APPLICATION_ICON_CANVAS_SCALE)?;
+    let (image_width, image_height) = image_dimensions(icon)?;
     let image = unsafe {
         NSImage::initWithSize(
             NSImage::alloc(),
@@ -71,6 +67,22 @@ fn make_image(icon: &ApplicationIcon) -> Option<objc2::rc::Retained<NSImage>> {
     added.then_some(image)
 }
 
+fn image_dimensions(icon: &ApplicationIcon) -> Option<(usize, usize)> {
+    let largest = icon.representations.iter().max_by_key(|representation| {
+        u32::from(representation.width) * u32::from(representation.height)
+    })?;
+    Some((
+        canvas_dimension(usize::from(largest.width))?,
+        canvas_dimension(usize::from(largest.height))?,
+    ))
+}
+
+fn canvas_dimension(source: usize) -> Option<usize> {
+    source
+        .checked_mul(APPLICATION_ICON_CANVAS_NUMERATOR)?
+        .checked_div(APPLICATION_ICON_CANVAS_DENOMINATOR)
+}
+
 fn padded_representation(
     representation: &ApplicationIconRepresentation,
 ) -> Option<(usize, usize, Vec<u8>)> {
@@ -81,8 +93,8 @@ fn padded_representation(
         return None;
     }
 
-    let width = source_width.checked_mul(APPLICATION_ICON_CANVAS_SCALE)?;
-    let height = source_height.checked_mul(APPLICATION_ICON_CANVAS_SCALE)?;
+    let width = canvas_dimension(source_width)?;
+    let height = canvas_dimension(source_height)?;
     let mut rgba = vec![0; width.checked_mul(height)?.checked_mul(4)?];
     let left = (width - source_width) / 2;
     let top = (height - source_height) / 2;
@@ -99,23 +111,42 @@ fn padded_representation(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use systemless::game::ApplicationIconRepresentation;
 
     #[test]
-    fn classic_icon_artwork_is_centered_on_a_double_sized_canvas() {
+    fn classic_icon_uses_eighty_percent_of_canvas() {
+        let icon = ApplicationIcon {
+            representations: vec![
+                ApplicationIconRepresentation {
+                    width: 32,
+                    height: 32,
+                    rgba: vec![0; 32 * 32 * 4],
+                },
+                ApplicationIconRepresentation {
+                    width: 16,
+                    height: 16,
+                    rgba: vec![0; 16 * 16 * 4],
+                },
+            ],
+        };
+
+        assert_eq!(image_dimensions(&icon), Some((40, 40)));
+        assert_eq!(canvas_dimension(16), Some(20));
+    }
+
+    #[test]
+    fn classic_icon_artwork_is_centered_on_canvas() {
         let representation = ApplicationIconRepresentation {
-            width: 2,
-            height: 2,
-            rgba: vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+            width: 16,
+            height: 16,
+            rgba: vec![255; 16 * 16 * 4],
         };
 
         let (width, height, rgba) = padded_representation(&representation).unwrap();
 
-        assert_eq!((width, height), (4, 4));
-        assert_eq!(&rgba[0..20], &[0; 20]);
-        assert_eq!(&rgba[20..28], &[1, 2, 3, 4, 5, 6, 7, 8]);
-        assert_eq!(&rgba[28..36], &[0; 8]);
-        assert_eq!(&rgba[36..44], &[9, 10, 11, 12, 13, 14, 15, 16]);
-        assert_eq!(&rgba[44..], &[0; 20]);
+        assert_eq!((width, height), (20, 20));
+        assert_eq!(&rgba[..(2 * width + 2) * 4], vec![0; (2 * width + 2) * 4]);
+        assert_eq!(&rgba[(2 * width + 2) * 4..(2 * width + 3) * 4], &[255; 4]);
     }
 
     #[test]

--- a/src/bin/systemless.rs
+++ b/src/bin/systemless.rs
@@ -77,6 +77,13 @@ const AUDIO_CALLBACK_CHUNK_SAMPLES: usize = 32;
 /// updates before it can crop the presentation. Geometry from the manual
 /// CPort already selected by the HLE is authoritative immediately.
 const CONTENT_RECT_CONFIRMATIONS: u16 = 5;
+/// After rejecting a crop, require a longer quiet-margin period before
+/// shrinking again so startup phases cannot make the native window oscillate.
+const CONTENT_RECT_RELEARN_CONFIRMATIONS: u16 = 120;
+/// A learned crop is discarded when substantial drawing persists in the area
+/// it excludes. This catches apps whose large offscreen playfield is only one
+/// part of a full-screen layout without reacting to a cursor or brief overlay.
+const CONTENT_RECT_ACTIVE_MARGIN_PERCENT: usize = 10;
 #[cfg(target_os = "macos")]
 const VIEWPORT_CACHE_FILE: &str = "viewport.json";
 const MAX_AUDIO_MIX_INTERVAL: std::time::Duration = std::time::Duration::from_millis(250);
@@ -291,6 +298,12 @@ struct App {
     content_rect_candidate: Option<(ContentRect, u16)>,
     #[cfg(target_os = "macos")]
     content_rect_copybits_count: u64,
+    #[cfg(target_os = "macos")]
+    content_rect_active_margin_frames: u16,
+    /// Continue looking for a valid crop after active margins forced this run
+    /// back to the full screen; a startup splash may later become letterboxed.
+    #[cfg(target_os = "macos")]
+    content_rect_relearn_after_full: bool,
     /// Previous raw guest frame used only while learning the pixel-content
     /// fallback. Repeated host presentations of one image do not confirm it.
     #[cfg(target_os = "macos")]
@@ -416,6 +429,10 @@ impl App {
             content_rect_candidate: None,
             #[cfg(target_os = "macos")]
             content_rect_copybits_count: 0,
+            #[cfg(target_os = "macos")]
+            content_rect_active_margin_frames: 0,
+            #[cfg(target_os = "macos")]
+            content_rect_relearn_after_full: false,
             #[cfg(target_os = "macos")]
             content_rect_previous_frame: Vec::new(),
             #[cfg(target_os = "macos")]
@@ -958,8 +975,45 @@ impl App {
                 self.content_rect = None;
                 self.content_rect_candidate = None;
                 self.content_rect_copybits_count = 0;
+                self.content_rect_active_margin_frames = 0;
+                self.content_rect_relearn_after_full = false;
                 self.content_rect_previous_frame.clear();
             }
+
+            let framebuffer_len = screen_mode.1.saturating_mul(u32::from(screen_mode.3));
+            let framebuffer = runner.bus().ram_slice(screen_mode.0, framebuffer_len);
+            let full_screen = ContentRect {
+                left: 0,
+                top: 0,
+                width: game_w,
+                height: game_h,
+            };
+            let visible_dialog = runner
+                .dispatcher()
+                .visible_dialog_structure_bounds(runner.bus())
+                .is_some();
+            let active_margin_crop = self.content_rect.filter(|&rect| {
+                rect != full_screen
+                    && !visible_dialog
+                    && screen_mode.4 == 8
+                    && !content_rect_has_inactive_margins_8bpp(
+                        framebuffer,
+                        screen_mode.1 as usize,
+                        usize::from(screen_mode.2),
+                        usize::from(screen_mode.3),
+                        rect,
+                    )
+            });
+            if active_margin_crop.is_some() {
+                self.content_rect_active_margin_frames =
+                    self.content_rect_active_margin_frames.saturating_add(1);
+            } else {
+                self.content_rect_active_margin_frames = 0;
+            }
+            let invalidated_crop = active_margin_crop
+                .filter(|_| self.content_rect_active_margin_frames >= CONTENT_RECT_CONFIRMATIONS);
+            let learning_content_rect =
+                self.content_rect.is_none() || self.content_rect_relearn_after_full;
 
             // A guest-drawn screen frame is stronger evidence than an
             // earlier inferred or cached crop. Keep looking for it after a
@@ -969,35 +1023,81 @@ impl App {
             let framed_rect = runner
                 .dispatcher()
                 .framed_manual_cport_presentation_rect(runner.bus())
-                .and_then(|rect| content_rect_from_copybits(rect, game_w, game_h));
+                .and_then(|rect| content_rect_from_copybits(rect, game_w, game_h))
+                .filter(|&rect| {
+                    !self.content_rect_relearn_after_full
+                        || screen_mode.4 != 8
+                        || content_rect_has_inactive_margins_8bpp(
+                            framebuffer,
+                            screen_mode.1 as usize,
+                            usize::from(screen_mode.2),
+                            usize::from(screen_mode.3),
+                            rect,
+                        )
+                });
             let authoritative_rect = framed_rect.or_else(|| {
-                self.content_rect.is_none().then(|| {
+                learning_content_rect.then(|| {
                     let dispatcher = runner.dispatcher();
                     dispatcher
                         .manual_cport_presentation_rect(runner.bus())
                         .or_else(|| dispatcher.declared_centered_presentation_rect(runner.bus()))
                         .and_then(|rect| content_rect_from_copybits(rect, game_w, game_h))
+                        .filter(|&rect| {
+                            screen_mode.4 != 8
+                                || content_rect_has_inactive_margins_8bpp(
+                                    framebuffer,
+                                    screen_mode.1 as usize,
+                                    usize::from(screen_mode.2),
+                                    usize::from(screen_mode.3),
+                                    rect,
+                                )
+                        })
                 })?
             });
 
-            let framebuffer_len = screen_mode.1.saturating_mul(u32::from(screen_mode.3));
-            let framebuffer = runner.bus().ram_slice(screen_mode.0, framebuffer_len);
-            let mut accepted_rect = authoritative_rect;
-            if self.content_rect.is_none() && accepted_rect.is_none() {
+            let mut accepted_rect = invalidated_crop.map(|_| full_screen);
+            let allow_detection = !self.content_rect_relearn_after_full || !visible_dialog;
+            let mut detected = None;
+            if accepted_rect.is_none() {
+                if self.content_rect_relearn_after_full {
+                    if allow_detection {
+                        detected = authoritative_rect.map(|rect| (rect, 1));
+                    }
+                } else {
+                    accepted_rect = authoritative_rect;
+                }
+            }
+            if learning_content_rect && accepted_rect.is_none() {
                 let copybits_count = runner.dispatcher().copybits_screen_count;
-                let mut detected = None;
-                if copybits_count != self.content_rect_copybits_count {
-                    let confirmations = copybits_count
-                        .saturating_sub(self.content_rect_copybits_count)
-                        .min(u64::from(u16::MAX)) as u16;
+                if detected.is_none()
+                    && allow_detection
+                    && copybits_count != self.content_rect_copybits_count
+                {
+                    let delta = copybits_count.saturating_sub(self.content_rect_copybits_count);
+                    let confirmations = if self.content_rect_relearn_after_full {
+                        1
+                    } else {
+                        delta.min(u64::from(u16::MAX)) as u16
+                    };
                     self.content_rect_copybits_count = copybits_count;
                     detected = runner
                         .dispatcher()
                         .last_screen_copybits_rect
                         .and_then(|rect| content_rect_from_copybits(rect, game_w, game_h))
+                        .filter(|&rect| {
+                            screen_mode.4 != 8
+                                || content_rect_has_inactive_margins_8bpp(
+                                    framebuffer,
+                                    screen_mode.1 as usize,
+                                    usize::from(screen_mode.2),
+                                    usize::from(screen_mode.3),
+                                    rect,
+                                )
+                        })
                         .map(|rect| (rect, confirmations));
                 }
                 if detected.is_none()
+                    && allow_detection
                     && screen_mode.4 == 8
                     && self.content_rect_previous_frame.as_slice() != framebuffer
                 {
@@ -1019,16 +1119,33 @@ impl App {
                         }
                         _ => Some((candidate, confirmations)),
                     };
+                    let required_confirmations = if self.content_rect_relearn_after_full {
+                        CONTENT_RECT_RELEARN_CONFIRMATIONS
+                    } else {
+                        CONTENT_RECT_CONFIRMATIONS
+                    };
                     accepted_rect = self
                         .content_rect_candidate
-                        .filter(|(_, count)| *count >= CONTENT_RECT_CONFIRMATIONS)
+                        .filter(|(_, count)| *count >= required_confirmations)
                         .map(|(rect, _)| rect);
+                } else if self.content_rect_relearn_after_full {
+                    self.content_rect_candidate = None;
                 }
             }
 
             if let Some(rect) = accepted_rect.filter(|rect| self.content_rect != Some(*rect)) {
                 let replacing_provisional_crop = self.content_rect.is_some();
-                if replacing_provisional_crop {
+                if let Some(previous) = invalidated_crop {
+                    eprintln!(
+                        "[SYSTEMLESS] Guest content expanded from {}x{} at ({},{}) to the full {}x{} screen after persistent margin drawing",
+                        previous.width,
+                        previous.height,
+                        previous.left,
+                        previous.top,
+                        game_w,
+                        game_h
+                    );
+                } else if replacing_provisional_crop {
                     eprintln!(
                         "[SYSTEMLESS] Guest content updated from explicit frame: {}x{} at ({},{}) inside {}x{}",
                         rect.width, rect.height, rect.left, rect.top, game_w, game_h
@@ -1041,6 +1158,8 @@ impl App {
                 }
                 self.content_rect = Some(rect);
                 self.content_rect_candidate = None;
+                self.content_rect_active_margin_frames = 0;
+                self.content_rect_relearn_after_full = invalidated_crop.is_some();
                 persist_content_rect(&self.game_path, screen_mode, rect);
                 if let Some(window) = self.window.as_ref() {
                     let current = window.inner_size();
@@ -1550,6 +1669,73 @@ fn detect_centered_content_rect_8bpp(
         width: content_width as u32,
         height: content_height as u32,
     })
+}
+
+/// Return whether the pixels excluded by a proposed crop still look like a
+/// letterbox border. A real border is dominated by one palette index; a HUD or
+/// other independently drawn screen region contains substantial variation.
+fn content_rect_has_inactive_margins_8bpp(
+    framebuffer: &[u8],
+    row_bytes: usize,
+    width: usize,
+    height: usize,
+    content: ContentRect,
+) -> bool {
+    let Ok(left) = usize::try_from(content.left) else {
+        return false;
+    };
+    let Ok(top) = usize::try_from(content.top) else {
+        return false;
+    };
+    let Ok(content_width) = usize::try_from(content.width) else {
+        return false;
+    };
+    let Ok(content_height) = usize::try_from(content.height) else {
+        return false;
+    };
+    let Some(right) = left.checked_add(content_width) else {
+        return false;
+    };
+    let Some(bottom) = top.checked_add(content_height) else {
+        return false;
+    };
+    if content_width == 0
+        || content_height == 0
+        || right > width
+        || bottom > height
+        || row_bytes < width
+        || framebuffer.len() < row_bytes.saturating_mul(height)
+    {
+        return false;
+    }
+    if left == 0 && top == 0 && right == width && bottom == height {
+        return true;
+    }
+
+    let mut histogram = [0usize; 256];
+    let mut total = 0usize;
+    let mut count_pixels = |pixels: &[u8]| {
+        for &pixel in pixels {
+            histogram[usize::from(pixel)] += 1;
+        }
+        total += pixels.len();
+    };
+    for row in 0..top {
+        count_pixels(&framebuffer[row * row_bytes..row * row_bytes + width]);
+    }
+    for row in top..bottom {
+        let pixels = &framebuffer[row * row_bytes..row * row_bytes + width];
+        count_pixels(&pixels[..left]);
+        count_pixels(&pixels[right..]);
+    }
+    for row in bottom..height {
+        count_pixels(&framebuffer[row * row_bytes..row * row_bytes + width]);
+    }
+
+    let dominant = histogram.into_iter().max().unwrap_or(0);
+    let active = total.saturating_sub(dominant);
+    total != 0
+        && active.saturating_mul(100) < total.saturating_mul(CONTENT_RECT_ACTIVE_MARGIN_PERCENT)
 }
 
 fn content_rect_from_copybits(
@@ -3149,6 +3335,37 @@ mod tests {
             detect_centered_content_rect_8bpp(&framebuffer, width, width, height),
             None,
             "a full-screen image must not be cropped"
+        );
+    }
+
+    #[test]
+    fn active_margin_validation_rejects_partial_full_screen_layouts() {
+        let width = 800usize;
+        let height = 600usize;
+        let content = ContentRect {
+            left: 68,
+            top: 0,
+            width: 664,
+            height: 600,
+        };
+        let mut framebuffer = vec![0u8; width * height];
+        for row in 0..height {
+            framebuffer[row * width + 68..row * width + 732].fill(7);
+        }
+        assert!(content_rect_has_inactive_margins_8bpp(
+            &framebuffer,
+            width,
+            width,
+            height,
+            content,
+        ));
+
+        for row in 0..height {
+            framebuffer[row * width + 732..(row + 1) * width].fill(2);
+        }
+        assert!(
+            !content_rect_has_inactive_margins_8bpp(&framebuffer, width, width, height, content,),
+            "a separately drawn side panel must keep the full screen visible"
         );
     }
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -3084,7 +3084,7 @@ impl FixtureRunner {
     /// Template B: memory-target variant.
     ///   MOVE.L (A7)+, Dn
     ///   CMP.L  (d16, An), Dn    ; 4 bytes (opcode word + d16)
-    ///   BLS.S/BLT.S/BLE.S <backward, into the loop body>
+    ///   BLS.S/BLT.S/BLE.S <back-to-SUBQ.W #4,A7 before the _TickCount>
     ///
     /// BLS and BLE exit after the memory target; BLT exits at the target.
     /// Classic compilers use both signed and unsigned comparisons. A signed
@@ -3114,12 +3114,16 @@ impl FixtureRunner {
         if disp8 == 0 {
             return false;
         }
-        // Branch target must be a short backward branch. We don't
-        // insist on an exact target since template B's body runs
-        // BEFORE the _TickCount trap (not just the SUBQ #4, A7).
+        // Only skip the canonical result-slot allocation and _TickCount trap.
+        // A branch farther back may include stateful work (for example, a
+        // calibration counter) that must execute on every iteration.
         let branch_src = pc_after_trap.wrapping_add(6);
         let target = (branch_src.wrapping_add(2) as i32).wrapping_add(disp8) as u32;
-        if target >= pc_after_trap || pc_after_trap.wrapping_sub(target) > 128 {
+        let canonical_target = pc_after_trap.wrapping_sub(4);
+        if target != canonical_target
+            || self.bus.read_word(canonical_target) != 0x594F
+            || self.bus.read_word(canonical_target.wrapping_add(2)) != 0xA975
+        {
             return false;
         }
 
@@ -10399,19 +10403,14 @@ mod tests {
         // $base+4: MOVE.L (A7)+, D0 (0x201F)
         // $base+6: CMP.L (-4, A6), D0 — opcode 0xB0AE, d16=0xFFFC
         //          (1011 000 010 101 110 = 0xB0AE; next word 0xFFFC = -4)
-        // $base+10: BLS.S *-12    (0x63F2) — target = $base+12 + (-14)
-        //           = $base - 2. So target should be BEFORE $base.
+        // $base+10: BLS.S $base   (0x63F4) — back to the canonical preamble
         // $base+12: sentinel NOP  (0x4E71)
         runner.bus.write_word(base, 0x594F);
         runner.bus.write_word(base + 2, 0xA975);
         runner.bus.write_word(base + 4, 0x201F);
         runner.bus.write_word(base + 6, 0xB0AE);
         runner.bus.write_word(base + 8, 0xFFFC);
-        // Branch target must be < pc_after_trap. pc_after_trap = base+4.
-        // Simplest: target = base + 2 → disp = target - (base+12) = -10
-        // (since branch_src = base+10, branch_src+2 = base+12).
-        // disp8 = -10 = 0xF6.
-        runner.bus.write_word(base + 10, 0x63F6);
+        runner.bus.write_word(base + 10, 0x63F4);
         runner.bus.write_word(base + 12, 0x4E71);
 
         // Memory target at -4(A6). A6 points at mid-stack; -4(A6)
@@ -10439,6 +10438,49 @@ mod tests {
         assert_eq!(runner.cpu.read_reg(Register::PC), base + 12);
         // Template B synthesises 3 instructions (MOVE, CMP, BLS).
         assert_eq!(count, 3);
+    }
+
+    /// A memory-target loop with stateful work before `_TickCount` must not be
+    /// fast-forwarded because synthesising the exit would skip that work.
+    #[test]
+    fn spin_fastfwd_template_b_rejects_stateful_pretrap_body() {
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        let base = 0x0001_0000u32;
+        let counter = 0x0001_8000u32;
+        let a6 = 0x0001_9000u32;
+        let sp = 0x0010_0000u32;
+
+        // ADDQ.L #1,(A0,D3.L*4); SUBQ.W #4,A7; _TickCount;
+        // MOVE.L (A7)+,D0; CMP.L (-4,A6),D0; BLS.S back-to-ADDQ.
+        runner.bus.write_word(base, 0x52B0);
+        runner.bus.write_word(base + 2, 0x3C00);
+        runner.bus.write_word(base + 4, 0x594F);
+        runner.bus.write_word(base + 6, 0xA975);
+        runner.bus.write_word(base + 8, 0x201F);
+        runner.bus.write_word(base + 10, 0xB0AE);
+        runner.bus.write_word(base + 12, 0xFFFC);
+        runner.bus.write_word(base + 14, 0x63F0);
+        runner.bus.write_word(base + 16, 0x4E71);
+
+        runner.bus.write_long(counter, 7);
+        runner.bus.write_long(a6 - 4, 400);
+        runner.bus.write_long(0x016A, 100);
+        runner.bus.write_long(sp, 100);
+        runner.dispatcher.tick_count = 100;
+        runner.cpu.write_reg(Register::A0, counter);
+        runner.cpu.write_reg(Register::D3, 0);
+        runner.cpu.write_reg(Register::A6, a6);
+        runner.cpu.write_reg(Register::A7, sp);
+
+        let mut count = 0usize;
+        let hit_cap = runner.try_tickcount_spin_fastfwd(base + 8, None, &mut count);
+
+        assert!(!hit_cap);
+        assert_eq!(runner.guest_tick(), 100);
+        assert_eq!(runner.bus.read_long(counter), 7);
+        assert_eq!(runner.cpu.read_reg(Register::PC), 0);
+        assert_eq!(runner.cpu.read_reg(Register::A7), sp);
+        assert_eq!(count, 0);
     }
 
     #[test]


### PR DESCRIPTION
Closes #260

- Size decoded classic application icons consistently within the macOS icon canvas.
- Revalidate inferred gameplay viewports when excluded margins become active.
- Restrict TickCount memory-target fast-forwarding to canonical side-effect-free wait loops.

Validation:
- `cargo test --manifest-path systemless/Cargo.toml --lib` (2,848 passed, 3 ignored)
- `cargo test --manifest-path systemless/Cargo.toml --bin systemless` (51 passed)
- Headless EV Override speed-dialog script with fast-forward enabled (100%)