### PR TITLE
fix: render missing Times sizes from host outlines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2197,6 +2197,7 @@ dependencies = [
 name = "systemless"
 version = "0.11.1"
 dependencies = [
+ "ab_glyph",
  "clap",
  "cpal",
  "hfs-reader",
@@ -2216,6 +2217,8 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tracing",
+ "wasm-bindgen",
+ "web-sys",
  "winit",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,20 @@ gui = [
 # Off by default so it stays out of the published public API and docs.
 test-support = []
 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+ab_glyph = "0.2.32"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = "0.2.114"
+web-sys = { version = "0.3.91", features = [
+    "CanvasRenderingContext2d",
+    "Document",
+    "HtmlCanvasElement",
+    "ImageData",
+    "TextMetrics",
+    "Window",
+] }
+
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = { version = "0.5.2", optional = true }
 objc2-app-kit = { version = "0.2.2", optional = true, features = ["NSApplication", "NSBitmapImageRep", "NSCell", "NSGraphics", "NSImage", "NSImageRep", "NSMenu", "NSMenuItem"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,7 @@ pub mod display;
 mod error;
 pub mod game;
 pub mod loader;
+mod mac_roman;
 pub mod machine_profile;
 pub mod managers;
 pub mod memory;

--- a/src/mac_roman.rs
+++ b/src/mac_roman.rs
@@ -1,0 +1,54 @@
+//! Mac Roman byte-to-Unicode translation shared by guest text consumers.
+//!
+//! Guest strings remain bytes until a consumer needs a Unicode scalar for a
+//! host outline API. In particular, byte `0xC9` is one horizontal-ellipsis
+//! character, not three ASCII periods; preserving that distinction keeps its
+//! advance and bitmap consistent with the selected face.
+
+const HIGH: [char; 128] = [
+    '\u{00C4}', '\u{00C5}', '\u{00C7}', '\u{00C9}', '\u{00D1}', '\u{00D6}', '\u{00DC}', '\u{00E1}',
+    '\u{00E0}', '\u{00E2}', '\u{00E4}', '\u{00E3}', '\u{00E5}', '\u{00E7}', '\u{00E9}', '\u{00E8}',
+    '\u{00EA}', '\u{00EB}', '\u{00ED}', '\u{00EC}', '\u{00EE}', '\u{00EF}', '\u{00F1}', '\u{00F3}',
+    '\u{00F2}', '\u{00F4}', '\u{00F6}', '\u{00F5}', '\u{00FA}', '\u{00F9}', '\u{00FB}', '\u{00FC}',
+    '\u{2020}', '\u{00B0}', '\u{00A2}', '\u{00A3}', '\u{00A7}', '\u{2022}', '\u{00B6}', '\u{00DF}',
+    '\u{00AE}', '\u{00A9}', '\u{2122}', '\u{00B4}', '\u{00A8}', '\u{2260}', '\u{00C6}', '\u{00D8}',
+    '\u{221E}', '\u{00B1}', '\u{2264}', '\u{2265}', '\u{00A5}', '\u{00B5}', '\u{2202}', '\u{2211}',
+    '\u{220F}', '\u{03C0}', '\u{222B}', '\u{00AA}', '\u{00BA}', '\u{03A9}', '\u{00E6}', '\u{00F8}',
+    '\u{00BF}', '\u{00A1}', '\u{00AC}', '\u{221A}', '\u{0192}', '\u{2248}', '\u{2206}', '\u{00AB}',
+    '\u{00BB}', '\u{2026}', '\u{00A0}', '\u{00C0}', '\u{00C3}', '\u{00D5}', '\u{0152}', '\u{0153}',
+    '\u{2013}', '\u{2014}', '\u{201C}', '\u{201D}', '\u{2018}', '\u{2019}', '\u{00F7}', '\u{25CA}',
+    '\u{00FF}', '\u{0178}', '\u{2044}', '\u{20AC}', '\u{2039}', '\u{203A}', '\u{FB01}', '\u{FB02}',
+    '\u{2021}', '\u{00B7}', '\u{201A}', '\u{201E}', '\u{2030}', '\u{00C2}', '\u{00CA}', '\u{00C1}',
+    '\u{00CB}', '\u{00C8}', '\u{00CD}', '\u{00CE}', '\u{00CF}', '\u{00CC}', '\u{00D3}', '\u{00D4}',
+    '\u{F8FF}', '\u{00D2}', '\u{00DA}', '\u{00DB}', '\u{00D9}', '\u{0131}', '\u{02C6}', '\u{02DC}',
+    '\u{00AF}', '\u{02D8}', '\u{02D9}', '\u{02DA}', '\u{00B8}', '\u{02DD}', '\u{02DB}', '\u{02C7}',
+];
+
+pub(crate) fn decode_byte(byte: u8) -> char {
+    if byte < 0x80 {
+        byte as char
+    } else {
+        HIGH[(byte - 0x80) as usize]
+    }
+}
+
+pub(crate) fn encode_char(ch: char) -> Option<u8> {
+    if ch.is_ascii() {
+        Some(ch as u8)
+    } else {
+        HIGH.iter()
+            .position(|&candidate| candidate == ch)
+            .map(|index| index as u8 + 0x80)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn horizontal_ellipsis_is_mac_roman_c9() {
+        assert_eq!(decode_byte(0xC9), '\u{2026}');
+        assert_eq!(encode_char('\u{2026}'), Some(0xC9));
+    }
+}

--- a/src/quickdraw/fonts/host_outline.rs
+++ b/src/quickdraw/fonts/host_outline.rs
@@ -1,0 +1,621 @@
+//! Host-provided outline-font fallback.
+//!
+//! A Classic application names a font family and point size; it does not
+//! embed the resulting screen bitmap.  When the guest has no matching font
+//! resource, a translation layer may use a host-installed equivalent before
+//! falling back to Systemless's OFL bitmap catalogue.  The provider lowers an
+//! outline once into the same [`FontFace`] representation as an `NFNT`, so
+//! QuickDraw's drawing path remains platform-independent and does not call a
+//! host font API per glyph.
+//!
+//! The current rasterizer intentionally thresholds coverage to monochrome.
+//! Executing TrueType hinting instructions and offering the configurable
+//! smoothing introduced in Mac OS 8.5 are separate future compatibility
+//! features; neither is approximated implicitly here.
+
+use super::FontFace;
+
+#[cfg(any(target_os = "linux", target_arch = "wasm32", test))]
+const TIMES_FAMILY_PREFERENCE: &[&str] = &[
+    "Times",
+    "Times New Roman",
+    // Common metric-compatible installations on Linux.  Do not silently
+    // choose an arbitrary desktop serif: that could change guest layout.
+    "Liberation Serif",
+    "Nimbus Roman",
+];
+
+/// Apply one family preference policy independently of the platform's font
+/// discovery mechanism. Keeping this decision outside `fontdb` and browser
+/// Canvas makes its ordering deterministic and directly unit-testable.
+#[cfg(any(target_os = "linux", test))]
+fn resolve_preferred_times<T>(mut resolve: impl FnMut(&str) -> Option<T>) -> Option<T> {
+    TIMES_FAMILY_PREFERENCE
+        .iter()
+        .find_map(|family| resolve(family))
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+mod platform {
+    use super::FontFace;
+    use crate::quickdraw::fonts::{FontMetrics, Glyph, FONT_TIMES};
+    use ab_glyph::{point, Font, FontVec, PxScale, ScaleFont};
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+    use std::sync::{LazyLock, Mutex};
+
+    #[cfg(any(target_os = "linux", test))]
+    fn parse_fontconfig_match(family: &str, output: &[u8]) -> Option<(PathBuf, u32)> {
+        let result = std::str::from_utf8(output).ok()?;
+        let mut lines = result.lines();
+        let matched_families = lines.next()?;
+        // Fontconfig always supplies *some* fallback. Accept it only when it
+        // really is the family currently being tried, preserving our explicit
+        // preference order rather than silently taking an arbitrary serif.
+        if !matched_families
+            .split(',')
+            .any(|matched| matched.trim().eq_ignore_ascii_case(family))
+        {
+            return None;
+        }
+        let path = PathBuf::from(lines.next()?);
+        let collection_index = lines.next()?.parse().ok()?;
+        Some((path, collection_index))
+    }
+
+    #[cfg(target_os = "macos")]
+    fn locate_times() -> Option<(PathBuf, u32)> {
+        // Times is installed in macOS's read-only system-font directory.  A
+        // targeted lookup avoids scanning the very large downloadable-font
+        // catalogue merely to locate this standard family.
+        [
+            "/System/Library/Fonts/Times.ttc",
+            "/System/Library/Fonts/Supplemental/Times New Roman.ttf",
+            "/Library/Fonts/Microsoft/Times New Roman.ttf",
+        ]
+        .into_iter()
+        .map(PathBuf::from)
+        .find(|path| path.is_file())
+        .map(|path| (path, 0))
+    }
+
+    #[cfg(target_os = "linux")]
+    fn locate_times() -> Option<(PathBuf, u32)> {
+        fn fontconfig_match(family: &str) -> Option<(PathBuf, u32)> {
+            // `fc-match` consults Fontconfig's existing cache. Unlike
+            // `fontdb::load_system_fonts`, it does not make every Systemless
+            // process recursively enumerate and parse all installed fonts.
+            let output = std::process::Command::new("fc-match")
+                .args([
+                    "--format=%{family}\n%{file}\n%{index}\n",
+                    &format!("{family}:style=Regular"),
+                ])
+                .output()
+                .ok()?;
+            if !output.status.success() {
+                return None;
+            }
+            let (path, collection_index) = parse_fontconfig_match(family, &output.stdout)?;
+            path.is_file().then_some((path, collection_index))
+        }
+
+        super::resolve_preferred_times(fontconfig_match).or_else(|| {
+            // Minimal systems sometimes ship the face but no `fc-match`.
+            [
+                "/usr/share/fonts/truetype/msttcorefonts/Times_New_Roman.ttf",
+                "/usr/share/fonts/truetype/msttcorefonts/times.ttf",
+                "/usr/share/fonts/truetype/liberation2/LiberationSerif-Regular.ttf",
+                "/usr/share/fonts/truetype/liberation/LiberationSerif-Regular.ttf",
+                "/usr/share/fonts/opentype/urw-base35/NimbusRoman-Regular.otf",
+            ]
+            .into_iter()
+            .map(PathBuf::from)
+            .find(|path| path.is_file())
+            .map(|path| (path, 0))
+        })
+    }
+
+    #[cfg(target_os = "windows")]
+    fn locate_times() -> Option<(PathBuf, u32)> {
+        let mut directories = Vec::with_capacity(2);
+        if let Some(windows) = std::env::var_os("WINDIR") {
+            directories.push(PathBuf::from(windows).join("Fonts"));
+        }
+        if let Some(local) = std::env::var_os("LOCALAPPDATA") {
+            directories.push(PathBuf::from(local).join("Microsoft/Windows/Fonts"));
+        }
+        for name in [
+            // Standard Windows Times New Roman file name.
+            "times.ttf",
+            "Times New Roman.ttf",
+            "LiberationSerif-Regular.ttf",
+            "NimbusRoman-Regular.otf",
+        ] {
+            if let Some(path) = directories
+                .iter()
+                .map(|directory| directory.join(name))
+                .find(|path| path.is_file())
+            {
+                return Some((path, 0));
+            }
+        }
+        None
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+    fn locate_times() -> Option<(PathBuf, u32)> {
+        None
+    }
+
+    /// Locate the regular host face once. On platforms whose discovery API
+    /// builds a system-wide database, retain only the chosen path and
+    /// collection index rather than every installed font's metadata.
+    static TIMES_SOURCE: LazyLock<Option<(PathBuf, u32)>> = LazyLock::new(locate_times);
+
+    type CachedGlyph = Option<(&'static Glyph, &'static [u8])>;
+
+    static FACES: LazyLock<Mutex<HashMap<(i16, i16), Option<&'static FontFace>>>> =
+        LazyLock::new(|| Mutex::new(HashMap::new()));
+    static MAC_ROMAN_GLYPHS: LazyLock<Mutex<HashMap<(i16, i16, u8), CachedGlyph>>> =
+        LazyLock::new(|| Mutex::new(HashMap::new()));
+
+    fn round_metric(value: f32) -> i16 {
+        value.round().clamp(i16::MIN as f32, i16::MAX as f32) as i16
+    }
+
+    fn classic_point_to_px_scale(font: &impl Font, point_size: f32) -> Option<PxScale> {
+        // `Font::pt_to_px_scale` deliberately assumes the modern 96-dpi CSS
+        // reference pixel. Classic QuickDraw's screen fonts use the original
+        // Macintosh 72-dpi mapping, where N points correspond to N pixels per
+        // em. ab_glyph's PxScale is the full font height rather than the em,
+        // so preserve its height/units-per-em conversion while omitting the
+        // modern 96/72 enlargement.
+        let units_per_em = font.units_per_em()?;
+        Some(PxScale::from(
+            point_size * font.height_unscaled() / units_per_em,
+        ))
+    }
+
+    fn source_for_font(font_id: i16) -> Option<&'static (PathBuf, u32)> {
+        match font_id {
+            FONT_TIMES => TIMES_SOURCE.as_ref(),
+            _ => None,
+        }
+    }
+
+    fn load_font(font_id: i16) -> Option<FontVec> {
+        let (path, collection_index) = source_for_font(font_id)?;
+        FontVec::try_from_vec_and_index(std::fs::read(path).ok()?, *collection_index).ok()
+    }
+
+    fn rasterize_character(
+        font: &FontVec,
+        scale: PxScale,
+        character: char,
+        data: &mut Vec<u8>,
+    ) -> Option<Glyph> {
+        let scaled = font.as_scaled(scale);
+        let id = scaled.glyph_id(character);
+        if id.0 == 0 {
+            return None;
+        }
+        let advance = round_metric(scaled.h_advance(id)).max(0);
+        let data_offset = data.len();
+        let Some(outlined) =
+            scaled.outline_glyph(id.with_scale_and_position(scale, point(0.0, 0.0)))
+        else {
+            return Some(Glyph {
+                width: 0,
+                height: 0,
+                advance: u8::try_from(advance).ok()?,
+                origin_x: 0,
+                origin_y: 0,
+                data_offset,
+            });
+        };
+
+        let bounds = outlined.px_bounds();
+        let width = bounds.width() as usize;
+        let height = bounds.height() as usize;
+        let mut coverage = vec![0u8; width.saturating_mul(height)];
+        outlined.draw(|x, y, amount| {
+            let index = y as usize * width + x as usize;
+            if let Some(pixel) = coverage.get_mut(index) {
+                // Pre-8.5 QuickDraw screen strikes are monochrome. Preserve
+                // the outline shape without silently opting the guest into a
+                // later system's configurable font-smoothing policy.
+                *pixel = if amount >= 0.5 { 255 } else { 0 };
+            }
+        });
+        data.extend_from_slice(&coverage);
+        Some(Glyph {
+            width: u8::try_from(width).ok()?,
+            height: u8::try_from(height).ok()?,
+            advance: u8::try_from(advance).ok()?,
+            origin_x: i8::try_from(bounds.min.x as i16).ok()?,
+            origin_y: i8::try_from(bounds.min.y as i16).ok()?,
+            data_offset,
+        })
+    }
+
+    fn rasterize_face(font_id: i16, size: i16) -> Option<&'static FontFace> {
+        let font = load_font(font_id)?;
+        let size = size.max(1);
+        let scale = classic_point_to_px_scale(&font, size as f32)?;
+        let scaled = font.as_scaled(scale);
+        let metrics = FontMetrics {
+            ascent: scaled.ascent().ceil() as i16,
+            descent: (-scaled.descent()).ceil() as i16,
+            wid_max: 0,
+            leading: scaled.line_gap().round().max(0.0) as i16,
+        };
+
+        let mut glyphs = Vec::with_capacity(95);
+        let mut data = Vec::new();
+        let mut widest_advance = 0i16;
+        for code in b' '..=b'~' {
+            let glyph = rasterize_character(&font, scale, code as char, &mut data)?;
+            widest_advance = widest_advance.max(i16::from(glyph.advance));
+            glyphs.push(glyph);
+        }
+        let data = Box::leak(data.into_boxed_slice());
+        Some(Box::leak(Box::new(FontFace {
+            font_id,
+            size,
+            metrics: FontMetrics {
+                wid_max: widest_advance,
+                ..metrics
+            },
+            glyphs: Box::leak(glyphs.into_boxed_slice()),
+            data,
+        })))
+    }
+
+    fn rasterize_mac_roman_glyph(
+        font_id: i16,
+        size: i16,
+        mac_code: u8,
+    ) -> Option<(&'static Glyph, &'static [u8])> {
+        let font = load_font(font_id)?;
+        let size = size.max(1);
+        let scale = classic_point_to_px_scale(&font, size as f32)?;
+        let character = crate::mac_roman::decode_byte(mac_code);
+        let mut data = Vec::new();
+        let mut glyph = rasterize_character(&font, scale, character, &mut data)?;
+        glyph.data_offset = 0;
+        let data: &'static [u8] = Box::leak(data.into_boxed_slice());
+        Some((Box::leak(Box::new(glyph)), data))
+    }
+
+    pub(crate) fn get(font_id: i16, size: i16) -> Option<&'static FontFace> {
+        source_for_font(font_id)?;
+        let size = if size == 0 { 12 } else { size };
+        let key = (font_id, size);
+        let mut faces = FACES.lock().expect("host outline font cache poisoned");
+        if let Some(face) = faces.get(&key) {
+            return *face;
+        }
+        let face = rasterize_face(font_id, size);
+        faces.insert(key, face);
+        face
+    }
+
+    pub(crate) fn get_macroman(
+        font_id: i16,
+        size: i16,
+        mac_code: u8,
+    ) -> Option<(&'static Glyph, &'static [u8])> {
+        source_for_font(font_id)?;
+        let size = if size == 0 { 12 } else { size };
+        let key = (font_id, size, mac_code);
+        let mut glyphs = MAC_ROMAN_GLYPHS
+            .lock()
+            .expect("host outline Mac Roman glyph cache poisoned");
+        if let Some(glyph) = glyphs.get(&key) {
+            return *glyph;
+        }
+        let glyph = rasterize_mac_roman_glyph(font_id, size, mac_code);
+        glyphs.insert(key, glyph);
+        glyph
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn installed_times_rasterizes_as_a_cached_24_point_face() {
+            let Some(first) = get(FONT_TIMES, 24) else {
+                // The portable fallback is the supported behavior on a macOS
+                // installation that genuinely lacks the system family.
+                return;
+            };
+            let second = get(FONT_TIMES, 24).expect("cached face disappeared");
+            assert!(std::ptr::eq(first, second));
+            assert_eq!(first.font_id, FONT_TIMES);
+            assert_eq!(first.size, 24);
+            assert_eq!(first.glyphs.len(), 95);
+            assert!(first.metrics.ascent > 0);
+            assert!(first.data.iter().all(|pixel| matches!(pixel, 0 | 255)));
+        }
+
+        #[test]
+        fn installed_times_rasterizes_the_mac_roman_ellipsis() {
+            let Some((first, first_data)) = get_macroman(FONT_TIMES, 24, 0xC9) else {
+                return;
+            };
+            let (second, second_data) =
+                get_macroman(FONT_TIMES, 24, 0xC9).expect("cached ellipsis disappeared");
+            assert!(std::ptr::eq(first, second));
+            assert!(std::ptr::eq(first_data, second_data));
+            assert!(first.width > 0);
+            assert!(first.advance > 0);
+            assert!(first_data.iter().any(|&pixel| pixel == 255));
+        }
+
+        #[test]
+        fn classic_point_scale_does_not_apply_the_modern_96_dpi_enlargement() {
+            let Some((path, collection_index)) = TIMES_SOURCE.as_ref() else {
+                return;
+            };
+            let font = FontVec::try_from_vec_and_index(
+                std::fs::read(path).expect("installed Times unreadable"),
+                *collection_index,
+            )
+            .expect("installed Times unparsable");
+            let classic = classic_point_to_px_scale(&font, 24.0).expect("invalid font metrics");
+            let modern = font.pt_to_px_scale(24.0).expect("invalid font metrics");
+            assert!((classic.x * 4.0 - modern.x * 3.0).abs() < 0.01);
+            assert!((classic.y * 4.0 - modern.y * 3.0).abs() < 0.01);
+        }
+
+        #[test]
+        fn fontconfig_result_must_name_the_requested_family() {
+            assert_eq!(
+                parse_fontconfig_match(
+                    "Times New Roman",
+                    b"Times New Roman,Times New Roman\n/fonts/times.ttf\n2\n",
+                ),
+                Some((PathBuf::from("/fonts/times.ttf"), 2)),
+            );
+            assert_eq!(
+                parse_fontconfig_match("Times New Roman", b"DejaVu Serif\n/fonts/dejavu.ttf\n0\n",),
+                None,
+            );
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub(super) use platform::get;
+#[cfg(not(target_arch = "wasm32"))]
+pub(super) use platform::get_macroman;
+
+#[cfg(target_arch = "wasm32")]
+mod browser {
+    use super::{FontFace, TIMES_FAMILY_PREFERENCE};
+    use crate::quickdraw::fonts::{FontMetrics, Glyph, FONT_TIMES};
+    use std::collections::HashMap;
+    use std::sync::{LazyLock, Mutex};
+    use wasm_bindgen::JsCast;
+    use web_sys::{CanvasRenderingContext2d, HtmlCanvasElement};
+
+    type CachedGlyph = Option<(&'static Glyph, &'static [u8])>;
+
+    static FACES: LazyLock<Mutex<HashMap<(i16, i16), Option<&'static FontFace>>>> =
+        LazyLock::new(|| Mutex::new(HashMap::new()));
+    static MAC_ROMAN_GLYPHS: LazyLock<Mutex<HashMap<(i16, i16, u8), CachedGlyph>>> =
+        LazyLock::new(|| Mutex::new(HashMap::new()));
+
+    fn context(width: u32, height: u32) -> Option<(HtmlCanvasElement, CanvasRenderingContext2d)> {
+        let document = web_sys::window()?.document()?;
+        let canvas = document
+            .create_element("canvas")
+            .ok()?
+            .dyn_into::<HtmlCanvasElement>()
+            .ok()?;
+        canvas.set_width(width);
+        canvas.set_height(height);
+        let context = canvas
+            .get_context("2d")
+            .ok()??
+            .dyn_into::<CanvasRenderingContext2d>()
+            .ok()?;
+        Some((canvas, context))
+    }
+
+    fn css_font(font_id: i16, size: i16) -> Option<String> {
+        if font_id != FONT_TIMES {
+            return None;
+        }
+        let families = TIMES_FAMILY_PREFERENCE
+            .iter()
+            .map(|family| format!("\"{family}\""))
+            .collect::<Vec<_>>()
+            .join(", ");
+        // A browser cannot enumerate host font files. The explicit list keeps
+        // the same preference policy as desktop, while `serif` lets the user
+        // agent supply its Times-compatible default on restricted browsers.
+        Some(format!("{}px {families}, serif", size.max(1)))
+    }
+
+    fn rasterize_character(
+        measuring: &CanvasRenderingContext2d,
+        css_font: &str,
+        character: char,
+        data: &mut Vec<u8>,
+    ) -> Option<Glyph> {
+        let text = character.to_string();
+        let metrics = measuring.measure_text(&text).ok()?;
+        let advance = metrics.width().round().clamp(0.0, u8::MAX as f64) as u8;
+        // Canvas reports distances *from* the alignment point. Convert those
+        // to an integer bitmap box relative to the guest pen, preserving
+        // negative left bearings and right overhangs.
+        let origin_x = (-metrics.actual_bounding_box_left()).floor() as i16;
+        let right = metrics.actual_bounding_box_right().ceil() as i16;
+        let origin_y = (-metrics.actual_bounding_box_ascent()).floor() as i16;
+        let bottom = metrics.actual_bounding_box_descent().ceil() as i16;
+        let width = u32::try_from((right - origin_x).max(0)).ok()?;
+        let height = u32::try_from((bottom - origin_y).max(0)).ok()?;
+        let data_offset = data.len();
+        if width == 0 || height == 0 {
+            return Some(Glyph {
+                width: 0,
+                height: 0,
+                advance,
+                origin_x: 0,
+                origin_y: 0,
+                data_offset,
+            });
+        }
+
+        let padding = 2u32;
+        let (_, drawing) = context(width + padding * 2, height + padding * 2)?;
+        drawing.set_font(css_font);
+        drawing.set_text_baseline("alphabetic");
+        drawing.set_fill_style_str("white");
+        drawing
+            .fill_text(
+                &text,
+                f64::from(padding) - f64::from(origin_x),
+                f64::from(padding) - f64::from(origin_y),
+            )
+            .ok()?;
+        let pixels = drawing
+            .get_image_data(
+                f64::from(padding),
+                f64::from(padding),
+                f64::from(width),
+                f64::from(height),
+            )
+            .ok()?
+            .data();
+        data.extend(
+            pixels
+                .chunks_exact(4)
+                .map(|rgba| if rgba[3] >= 128 { 255 } else { 0 }),
+        );
+        Some(Glyph {
+            width: u8::try_from(width).ok()?,
+            height: u8::try_from(height).ok()?,
+            advance,
+            origin_x: i8::try_from(origin_x).ok()?,
+            origin_y: i8::try_from(origin_y).ok()?,
+            data_offset,
+        })
+    }
+
+    fn rasterize_face(font_id: i16, size: i16) -> Option<&'static FontFace> {
+        let size = size.max(1);
+        let rough_extent = u32::try_from(i32::from(size) * 4 + 32).ok()?;
+        let (_, measuring) = context(rough_extent, rough_extent)?;
+        let css_font = css_font(font_id, size)?;
+        measuring.set_font(&css_font);
+        measuring.set_text_baseline("alphabetic");
+
+        let mut glyphs = Vec::with_capacity(95);
+        let mut data = Vec::new();
+        let mut widest_advance = 0i16;
+        let mut face_ascent = 0i16;
+        let mut face_descent = 0i16;
+        for code in b' '..=b'~' {
+            let glyph = rasterize_character(&measuring, &css_font, code as char, &mut data)?;
+            widest_advance = widest_advance.max(i16::from(glyph.advance));
+            face_ascent = face_ascent.max(-i16::from(glyph.origin_y));
+            face_descent = face_descent.max(i16::from(glyph.origin_y) + i16::from(glyph.height));
+            glyphs.push(glyph);
+        }
+
+        Some(Box::leak(Box::new(FontFace {
+            font_id,
+            size,
+            metrics: FontMetrics {
+                ascent: face_ascent,
+                descent: face_descent,
+                wid_max: widest_advance,
+                leading: 0,
+            },
+            glyphs: Box::leak(glyphs.into_boxed_slice()),
+            data: Box::leak(data.into_boxed_slice()),
+        })))
+    }
+
+    fn rasterize_mac_roman_glyph(
+        font_id: i16,
+        size: i16,
+        mac_code: u8,
+    ) -> Option<(&'static Glyph, &'static [u8])> {
+        let size = size.max(1);
+        let rough_extent = u32::try_from(i32::from(size) * 4 + 32).ok()?;
+        let (_, measuring) = context(rough_extent, rough_extent)?;
+        let css_font = css_font(font_id, size)?;
+        measuring.set_font(&css_font);
+        measuring.set_text_baseline("alphabetic");
+        let mut data = Vec::new();
+        let character = crate::mac_roman::decode_byte(mac_code);
+        let mut glyph = rasterize_character(&measuring, &css_font, character, &mut data)?;
+        glyph.data_offset = 0;
+        let data: &'static [u8] = Box::leak(data.into_boxed_slice());
+        Some((Box::leak(Box::new(glyph)), data))
+    }
+
+    pub(crate) fn get(font_id: i16, size: i16) -> Option<&'static FontFace> {
+        css_font(font_id, size)?;
+        let size = if size == 0 { 12 } else { size };
+        let key = (font_id, size);
+        let mut faces = FACES.lock().expect("browser outline font cache poisoned");
+        if let Some(face) = faces.get(&key) {
+            return *face;
+        }
+        let face = rasterize_face(font_id, size);
+        faces.insert(key, face);
+        face
+    }
+
+    pub(crate) fn get_macroman(
+        font_id: i16,
+        size: i16,
+        mac_code: u8,
+    ) -> Option<(&'static Glyph, &'static [u8])> {
+        css_font(font_id, size)?;
+        let size = if size == 0 { 12 } else { size };
+        let key = (font_id, size, mac_code);
+        let mut glyphs = MAC_ROMAN_GLYPHS
+            .lock()
+            .expect("browser outline Mac Roman glyph cache poisoned");
+        if let Some(glyph) = glyphs.get(&key) {
+            return *glyph;
+        }
+        let glyph = rasterize_mac_roman_glyph(font_id, size, mac_code);
+        glyphs.insert(key, glyph);
+        glyph
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub(super) use browser::get;
+#[cfg(target_arch = "wasm32")]
+pub(super) use browser::get_macroman;
+
+#[cfg(test)]
+mod policy_tests {
+    use super::*;
+
+    #[test]
+    fn times_family_preference_is_deterministic() {
+        let available = ["Nimbus Roman", "Times New Roman"];
+        let selected = resolve_preferred_times(|family| {
+            available.iter().position(|available| *available == family)
+        });
+        assert_eq!(
+            selected.map(|index| available[index]),
+            Some("Times New Roman")
+        );
+    }
+
+    #[test]
+    fn times_family_preference_has_no_arbitrary_desktop_serif() {
+        let selected = resolve_preferred_times(|family| (family == "DejaVu Serif").then_some(()));
+        assert_eq!(selected, None);
+    }
+}

--- a/src/quickdraw/fonts/mod.rs
+++ b/src/quickdraw/fonts/mod.rs
@@ -1,16 +1,24 @@
-//! Original systemless bitmap fonts + Mac font-family routing.
+//! Classic Mac font-family routing and runtime glyph faces.
 //!
-//! Text renders by blitting pre-computed 8-bit coverage bitmaps out of
-//! the [`pixel_font`] modules — no runtime rasterization, no hinting
-//! decisions, no threshold knobs, no CLUT-closest-match. Every glyph
-//! pixel is exactly 0 or 255, so the downstream `ShapeOp::Glyph`
-//! partial-alpha branch never fires.
+//! QuickDraw ultimately consumes one platform-independent [`FontFace`]:
+//! metrics plus monochrome glyph bitmaps. The selection path handles four
+//! compatibility cases, in precedence order:
 //!
-//! Each face is authored as hand-editable ASCII art in a `pixel_font`
-//! module and lowered to static glyph tables by `const fn` at compile
-//! time — no offline baker, no external font asset. The systemless
-//! faces are named after Australian native plants and stand in for the
-//! classic Mac families, which survive only as internal compatibility
+//! 1. an exact bitmap strike embedded in the guest's resource fork;
+//! 2. an exact compatible strike from Systemless's original bitmap catalogue;
+//! 3. an exact requested size rasterized from an accepted host outline; and
+//! 4. a scaled compatible bitmap when no exact-size face exists.
+//!
+//! Keeping every source in the same representation makes text measurement
+//! and drawing select identical metrics. Coverage bytes are always 0 or 255,
+//! so this does not silently enable a later Mac OS font-smoothing policy.
+//!
+//! The bundled faces are authored as hand-editable ASCII art in a
+//! [`pixel_font`] module and lowered to static glyph tables by `const fn` at
+//! compile time—no offline baker or bundled third-party font asset. Host
+//! outlines remain installed system assets and are never redistributed.
+//! Systemless's faces are named after Australian native plants and stand in
+//! for classic Mac families, which survive only as internal compatibility
 //! identifiers:
 //!
 //! | Mac font family (compat ID)                        | systemless face |
@@ -29,6 +37,7 @@
 //! notice.
 
 pub mod heuristics;
+mod host_outline;
 pub mod override_format;
 pub mod pixel_font;
 
@@ -607,13 +616,33 @@ pub fn get_font_face_scaled(font_id: i16, size: i16) -> (&'static FontFace, i16)
 }
 
 fn get_font_face_scaled_impl(font_id: i16, size: i16) -> (&'static FontFace, i16) {
+    // Case 1: an application-provided resource strike or explicit user
+    // override.
+    //
+    // Case 2: an exact built-in strike for this compatibility ID. Both are
+    // already in the renderer's native bitmap representation.
     if let Some(face) = get_font_face(font_id, size) {
         return (face, 1);
     }
     if let Some(fb) = fallback_font_id(font_id) {
+        // A classic family can map to an original Systemless face. Preserve
+        // an exact strike before consulting the host so applications that
+        // expect the established bitmap metrics do not change layout.
         if let Some(face) = get_font_face(fb, size) {
             return (face, 1);
         }
+        // Case 3: *Inside Macintosh: Text* (1993), pp. 4-18–4-23 says
+        // selection is performed on a size basis. An outline can produce the
+        // requested size directly; only when no exact outline is available do
+        // we apply the documented bitmap scaling search (2x, 1/2x, next
+        // larger, next smaller). The host provider currently maps only the
+        // standard Times family and never redistributes host font data.
+        if let Some(face) = host_outline::get(font_id, size) {
+            return (face, 1);
+        }
+        // Case 4: there is no exact face. Reuse an integer-related bitmap
+        // strike and let the existing glyph blitter scale it, matching the
+        // fallback behavior used before host outline support was added.
         for scale in [2i16, 3] {
             let base_size = size / scale;
             if base_size * scale == size {
@@ -656,13 +685,25 @@ pub fn get_macroman_glyph(
             return Some((&hit.glyph, face.data));
         }
     }
-    let face = MACROMAN_TABLE
+    if let Some(face) = MACROMAN_TABLE
         .iter()
-        .find(|f| f.font_id == font_id && f.size == size)?;
-    face.glyphs
-        .iter()
-        .find(|e| e.mac_code == mac_code)
-        .map(|e| (&e.glyph, face.data))
+        .find(|f| f.font_id == font_id && f.size == size)
+    {
+        if let Some(hit) = face.glyphs.iter().find(|entry| entry.mac_code == mac_code) {
+            return Some((&hit.glyph, face.data));
+        }
+    }
+
+    // Extended characters must come from the same face as ASCII text. A
+    // resource or exact bitmap face therefore keeps precedence; use a host
+    // glyph only when the host outline is the face selected at this size.
+    let host = host_outline::get(font_id, size)?;
+    let (selected, scale) = get_font_face_scaled_impl(font_id, size);
+    if scale == 1 && std::ptr::eq(selected, host) {
+        host_outline::get_macroman(font_id, size, mac_code)
+    } else {
+        None
+    }
 }
 
 pub fn get_italic_glyph(
@@ -798,6 +839,27 @@ mod tests {
         let face = get_font_face_or_default(FONT_CHICAGO, 12);
         assert_eq!(face.font_id, FONT_CHICAGO);
         assert_eq!(face.size, 12);
+    }
+
+    #[test]
+    fn exact_times_compatible_bitmap_precedes_host_outline() {
+        let (face, scale) = get_font_face_scaled(FONT_TIMES, 18);
+        assert_eq!(face.font_id, FONT_NEWYORK);
+        assert_eq!(face.size, 18);
+        assert_eq!(scale, 1);
+    }
+
+    #[test]
+    fn missing_times_bitmap_uses_exact_size_host_outline_when_available() {
+        let Some(host) = host_outline::get(FONT_TIMES, 24) else {
+            // A host without an accepted family exercises the bundled bitmap
+            // fallback instead; absence is supported rather than a failure.
+            return;
+        };
+        let (selected, scale) = get_font_face_scaled(FONT_TIMES, 24);
+        assert!(std::ptr::eq(selected, host));
+        assert_eq!(selected.size, 24);
+        assert_eq!(scale, 1);
     }
 
     #[test]

--- a/src/quickdraw/text.rs
+++ b/src/quickdraw/text.rs
@@ -11,16 +11,22 @@
 //! synthesised by the runtime shear-blit at draw time.
 
 use crate::quickdraw::fonts::{
-    get_font_face_or_default, get_italic_glyph as get_italic_glyph_fn, get_macroman_glyph,
+    get_font_face_scaled, get_italic_glyph as get_italic_glyph_fn, get_macroman_glyph,
     override_format, FontMetrics, Glyph,
 };
 
 pub fn get_font_metrics(font_id: i16, size: i16) -> FontMetrics {
-    get_font_face_or_default(font_id, size).metrics
+    // Resolve through the same selection path as DrawChar/DrawString. In
+    // particular, a host outline at the requested size must not be drawn with
+    // metrics from the bitmap face that would otherwise be scaled.
+    get_font_face_scaled(font_id, size).0.metrics
 }
 
 pub fn get_glyph(font_id: i16, size: i16, ch: char) -> Option<(&'static Glyph, &'static [u8])> {
-    let face = get_font_face_or_default(font_id, size);
+    // Callers that need the bitmap scale obtain it from
+    // `get_font_face_scaled`; selecting the glyph through that same function
+    // keeps measurement and drawing on one face.
+    let face = get_font_face_scaled(font_id, size).0;
     let glyphs = face.glyphs;
     let data = face.data;
 
@@ -41,6 +47,14 @@ pub fn get_glyph(font_id: i16, size: i16, ch: char) -> Option<(&'static Glyph, &
     let mac_code = ch as u32;
     if (0x80..=0xFF).contains(&mac_code) {
         return macroman_or_ascii_fallback(font_id, size, mac_code as u8);
+    }
+
+    // HLE strings are decoded to Unicode before rendering. Map representable
+    // non-ASCII scalars back to their guest byte so resource, bitmap, and host
+    // outline faces all select the same Mac Roman glyph. In particular,
+    // U+2026 is the single character at Mac Roman $C9, not three periods.
+    if let Some(mac_code) = crate::mac_roman::encode_char(ch).filter(|&code| code >= 0x80) {
+        return macroman_or_ascii_fallback(font_id, size, mac_code);
     }
 
     // Unicode codepoints emitted directly by HLE code paths that don't
@@ -81,7 +95,7 @@ fn override_symbol_glyph(
     size: i16,
     index: usize,
 ) -> Option<(&'static Glyph, &'static [u8])> {
-    let face = get_font_face_or_default(font_id, size);
+    let face = get_font_face_scaled(font_id, size).0;
     let glyph = face.glyphs.get(index)?;
     if glyph.width == 0 && glyph.height == 0 && glyph.advance == 0 {
         return None;
@@ -123,4 +137,37 @@ pub fn get_glyph_italic(
 
 pub fn get_underline_thickness(_font_id: i16, _size: i16) -> i16 {
     1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::quickdraw::fonts::{get_font_face_scaled, FONT_TIMES};
+
+    #[test]
+    fn glyphs_and_metrics_use_the_same_selected_face() {
+        let (face, _) = get_font_face_scaled(FONT_TIMES, 24);
+        let (glyph, data) = get_glyph(FONT_TIMES, 24, 'W').expect("printable glyph missing");
+        let expected = &face.glyphs[(b'W' - b' ') as usize];
+        assert!(std::ptr::eq(glyph, expected));
+        assert!(std::ptr::eq(data, face.data));
+
+        let metrics = get_font_metrics(FONT_TIMES, 24);
+        assert_eq!(metrics.ascent, face.metrics.ascent);
+        assert_eq!(metrics.descent, face.metrics.descent);
+        assert_eq!(metrics.wid_max, face.metrics.wid_max);
+        assert_eq!(metrics.leading, face.metrics.leading);
+    }
+
+    #[test]
+    fn host_times_renders_mac_roman_horizontal_ellipsis() {
+        let Some((glyph, data)) = get_glyph(FONT_TIMES, 24, '\u{2026}') else {
+            // A host without a Times-compatible outline keeps using the
+            // portable bitmap fallback, which has no extended table yet.
+            return;
+        };
+        assert!(glyph.width > 0);
+        assert!(glyph.advance > 0);
+        assert!(data.iter().any(|&pixel| pixel == 255));
+    }
 }

--- a/src/trap/dialog.rs
+++ b/src/trap/dialog.rs
@@ -4,7 +4,7 @@ use super::dispatch::{
     DialogItem, DialogPopupDraw, DialogPopupTrackingState, DialogTrackingState,
     PendingDialogPopupMenu, PersistentDialogSnapshot, QueuedEvent, RetainedModalDialogClickState,
 };
-use super::types::{decode_mac_roman_for_render, Rect, ShapeOp};
+use super::types::{decode_mac_roman_for_render, encode_mac_roman_lossy, Rect, ShapeOp};
 use crate::cpu::{CpuOps, Register};
 use crate::display::CursorImage;
 use crate::memory::{MacMemoryBus, MemoryBus};
@@ -8077,8 +8077,12 @@ impl super::TrapDispatcher {
         }
 
         let substituted = self.apply_param_text(text);
-        let text_bytes = substituted.as_bytes();
-        let lines = self.te_wrap_lines(font_id, self.tx_size, text_bytes, max_width);
+        // DialogItem stores decoded host text, while TextEdit measures and
+        // breaks the original guest encoding. Convert back before layout so a
+        // Mac Roman character such as the $C9 ellipsis remains one byte rather
+        // than being measured as its multi-byte UTF-8 representation.
+        let text_bytes = encode_mac_roman_lossy(&substituted);
+        let lines = self.te_wrap_lines(font_id, self.tx_size, &text_bytes, max_width);
 
         for (start, end) in lines {
             let mut trimmed_end = end;
@@ -8090,10 +8094,7 @@ impl super::TrapDispatcher {
                 // IM:I I-405 to I-406: statText draws like editText text
                 // inside the display rectangle, including wrap and clipping,
                 // but without the editText frame.
-                let line: String = text_bytes[start..trimmed_end]
-                    .iter()
-                    .map(|&byte| byte as char)
-                    .collect();
+                let line = decode_mac_roman_for_render(&text_bytes[start..trimmed_end]);
                 Self::fb_draw_string(
                     bus,
                     screen_base,

--- a/src/trap/types.rs
+++ b/src/trap/types.rs
@@ -46,35 +46,10 @@ pub struct StringBuffer {
     pub pixels: Vec<u8>,
 }
 
-const MAC_ROMAN_HIGH: [char; 128] = [
-    '\u{00C4}', '\u{00C5}', '\u{00C7}', '\u{00C9}', '\u{00D1}', '\u{00D6}', '\u{00DC}', '\u{00E1}',
-    '\u{00E0}', '\u{00E2}', '\u{00E4}', '\u{00E3}', '\u{00E5}', '\u{00E7}', '\u{00E9}', '\u{00E8}',
-    '\u{00EA}', '\u{00EB}', '\u{00ED}', '\u{00EC}', '\u{00EE}', '\u{00EF}', '\u{00F1}', '\u{00F3}',
-    '\u{00F2}', '\u{00F4}', '\u{00F6}', '\u{00F5}', '\u{00FA}', '\u{00F9}', '\u{00FB}', '\u{00FC}',
-    '\u{2020}', '\u{00B0}', '\u{00A2}', '\u{00A3}', '\u{00A7}', '\u{2022}', '\u{00B6}', '\u{00DF}',
-    '\u{00AE}', '\u{00A9}', '\u{2122}', '\u{00B4}', '\u{00A8}', '\u{2260}', '\u{00C6}', '\u{00D8}',
-    '\u{221E}', '\u{00B1}', '\u{2264}', '\u{2265}', '\u{00A5}', '\u{00B5}', '\u{2202}', '\u{2211}',
-    '\u{220F}', '\u{03C0}', '\u{222B}', '\u{00AA}', '\u{00BA}', '\u{03A9}', '\u{00E6}', '\u{00F8}',
-    '\u{00BF}', '\u{00A1}', '\u{00AC}', '\u{221A}', '\u{0192}', '\u{2248}', '\u{2206}', '\u{00AB}',
-    '\u{00BB}', '\u{2026}', '\u{00A0}', '\u{00C0}', '\u{00C3}', '\u{00D5}', '\u{0152}', '\u{0153}',
-    '\u{2013}', '\u{2014}', '\u{201C}', '\u{201D}', '\u{2018}', '\u{2019}', '\u{00F7}', '\u{25CA}',
-    '\u{00FF}', '\u{0178}', '\u{2044}', '\u{20AC}', '\u{2039}', '\u{203A}', '\u{FB01}', '\u{FB02}',
-    '\u{2021}', '\u{00B7}', '\u{201A}', '\u{201E}', '\u{2030}', '\u{00C2}', '\u{00CA}', '\u{00C1}',
-    '\u{00CB}', '\u{00C8}', '\u{00CD}', '\u{00CE}', '\u{00CF}', '\u{00CC}', '\u{00D3}', '\u{00D4}',
-    '\u{F8FF}', '\u{00D2}', '\u{00DA}', '\u{00DB}', '\u{00D9}', '\u{0131}', '\u{02C6}', '\u{02DC}',
-    '\u{00AF}', '\u{02D8}', '\u{02D9}', '\u{02DA}', '\u{00B8}', '\u{02DD}', '\u{02DB}', '\u{02C7}',
-];
-
 pub(crate) fn decode_mac_roman(bytes: &[u8]) -> String {
     bytes
         .iter()
-        .map(|&byte| {
-            if byte < 0x80 {
-                byte as char
-            } else {
-                MAC_ROMAN_HIGH[(byte - 0x80) as usize]
-            }
-        })
+        .map(|&byte| crate::mac_roman::decode_byte(byte))
         .collect()
 }
 
@@ -88,12 +63,16 @@ pub(crate) fn decode_mac_roman_for_render(bytes: &[u8]) -> String {
             // expand common punctuation into renderable equivalents instead of
             // letting it become replacement or blank glyphs. IM:I I-247.
             0xA5 => out.push('*'),
-            0xC9 => out.push_str("..."),
+            // Keep the horizontal ellipsis as one character. TextEdit line
+            // breaking operates on guest-encoded bytes; expanding this to
+            // three ASCII periods would give it the wrong character count
+            // and advance. The glyph layer maps U+2026 back to Mac Roman C9.
+            0xC9 => out.push('\u{2026}'),
             0xCA => out.push(' '),
             0xD0 | 0xD1 => out.push('-'),
             0xD2 | 0xD3 => out.push('"'),
             0xD4 | 0xD5 => out.push('\''),
-            _ => out.push(MAC_ROMAN_HIGH[(byte - 0x80) as usize]),
+            _ => out.push(crate::mac_roman::decode_byte(byte)),
         }
     }
     out
@@ -102,17 +81,7 @@ pub(crate) fn decode_mac_roman_for_render(bytes: &[u8]) -> String {
 pub(crate) fn encode_mac_roman_lossy(value: &str) -> Vec<u8> {
     value
         .chars()
-        .map(|ch| {
-            if ch.is_ascii() {
-                ch as u8
-            } else {
-                MAC_ROMAN_HIGH
-                    .iter()
-                    .position(|&candidate| candidate == ch)
-                    .map(|idx| idx as u8 + 0x80)
-                    .unwrap_or(b'?')
-            }
-        })
+        .map(|ch| crate::mac_roman::encode_char(ch).unwrap_or(b'?'))
         .collect()
 }
 
@@ -202,10 +171,14 @@ mod tests {
     }
 
     #[test]
-    fn mac_roman_render_decode_expands_classic_punctuation() {
+    fn mac_roman_render_decode_preserves_classic_ellipsis_as_one_character() {
         assert_eq!(
             decode_mac_roman_for_render(b"Choose Monitor\xC9"),
-            "Choose Monitor..."
+            "Choose Monitor\u{2026}"
+        );
+        assert_eq!(
+            encode_mac_roman_lossy(&decode_mac_roman_for_render(b"Choose Monitor\xC9")),
+            b"Choose Monitor\xC9"
         );
         assert_eq!(decode_mac_roman_for_render(b"Marathon\xD5s"), "Marathon's");
     }


### PR DESCRIPTION
## Summary

QuickDraw applications request a font family and point size. When Systemless had no exact bitmap strike for that request, it could only scale a compatible bundled bitmap. EV Override requests 24-point Times for its introduction; the old fallback selected an unrelated-looking bitmap face with different metrics, producing visibly wrong text and layout.

This adds an exact-size host-outline fallback while keeping guest and bundled resources authoritative.

The selection order is now:

1. exact application resource or explicit override;
2. exact compatible Systemless bitmap strike;
3. exact-size accepted host outline;
4. the existing integer-scaled compatible bitmap fallback.

This follows the size-selection model described in *Inside Macintosh: Text*, pp. 4-18–4-23: an available outline can produce the requested size directly, while bitmap strikes require a size fallback/scaling search.

## Implementation

- Adds `ab_glyph` for native outline parsing and rasterization. Font files remain host assets and are not redistributed.
- Locates Times with targeted platform-specific lookup rather than a full system-font scan:
  - macOS: known system and supplemental Times paths;
  - Windows: the system and per-user font directories;
  - Linux: cached Fontconfig lookup, followed by a small fixed-path fallback.
- Uses the same family preference on every platform: Times, Times New Roman, Liberation Serif, then Nimbus Roman. Nimbus Roman is only a last-resort metric-compatible Linux fallback.
- Uses Canvas2D in WebAssembly, with the same family preference followed by the browser's generic serif fallback.
- Lowers every selected outline once into Systemless's existing `FontFace` representation and caches it, so measurement and drawing use the same metrics and glyph source.
- Thresholds coverage to monochrome pixels. This does not silently opt a Classic application into later font smoothing.
- Centralizes Mac Roman translation and renders extended characters from the selected face. In particular, byte `$C9` remains one horizontal-ellipsis character rather than three ASCII periods, preserving TextEdit character counts, line breaking, advance, and glyph selection.

Only Times is admitted as a host-outline family in this change. If no accepted host font is present, the existing bitmap fallback remains available.

### Why Times only?

A host-font mapping changes layout, not just appearance: different advances and vertical metrics can change line breaks, clipping, and dialog geometry. A generic name substitution would therefore be unsafe. Helvetica is not normally present on Windows and Arial is not identical; Courier and Courier New can differ in vertical metrics; and classic screen families such as Chicago, Geneva, and Monaco are bitmap-oriented, so an arbitrary modern outline can be less compatible than Systemless's existing bitmap scaling. Linux frequently supplies metric-compatible replacements rather than the original families as well.

Times is the deliberately narrow first mapping because this change has direct evidence for it: EV Override requests Times at a size for which Systemless has no exact strike, the old scaled fallback is visibly wrong, and the result was compared with the application under System 7.5.3. The provider is structured so additional families can be admitted later, but each mapping should specify acceptable platform equivalents and include layout tests before it changes application typography.

## Visual evidence

### Font selection

Before, the missing Times strike fell through to the scaled bitmap fallback.

<img width="752" height="624" alt="Screenshot 2026-07-31 at 5 22 33 PM" src="https://github.com/user-attachments/assets/a1b44f47-7843-45d7-abed-f9612b43f684" />

After, the requested Times size is rasterized from the host outline.

<img width="752" height="624" alt="Screenshot 2026-07-31 at 5 12 28 PM" src="https://github.com/user-attachments/assets/588defb0-559f-40f0-9487-7a5ded23ae3f" />


### Extended Mac Roman punctuation

Before: The two Mac Roman `$C9` ellipses are missing.

<img width="752" height="624" alt="Screenshot 2026-07-31 at 7 18 54 PM" src="https://github.com/user-attachments/assets/cad2f932-4761-4692-9ee7-376011f0e276" />

After: The two ellipses are now rendered by the selected Times face.

<img width="736" height="594" alt="Screenshot 2026-07-31 at 7 12 57 PM" src="https://github.com/user-attachments/assets/fca783a0-ba4d-462e-800c-4e123efaa031" />


### WebAssembly

<img width="834" height="726" alt="Screenshot 2026-07-31 at 7 55 41 PM" src="https://github.com/user-attachments/assets/ad2f0d12-7b2a-4873-b402-6a282cbe83f8" />

The full local website frontend renders the same Times text and both ellipses through the Canvas2D provider.

For comparison, the same introduction was also checked in Basilisk II running System 7.5.3. It uses monochrome Times text without smoothing.

<img width="912" height="740" alt="Screenshot 2026-07-31 at 7 10 38 PM" src="https://github.com/user-attachments/assets/1ebcf9e3-242d-4d32-b5f4-95f1576e4595" />

Testing in Basilisk II proved that Systemless is still not rendering Times with ideal rasterization (see e.g. the horizontal bars in the lowercase letter “e” on the macOS frontend; also note the heavier font weight in the WebAssembly frontend). Adding TrueType hinting is therefore listed under “Follow-up work.”

## Testing

- `cargo fmt --check`
- `cargo test --lib`: 2,861 passed, 3 ignored, 0 failed
- `cargo check --target wasm32-unknown-unknown --no-default-features --lib`
- `cargo check --target x86_64-unknown-linux-gnu --no-default-features --lib`
- `cargo check --target x86_64-pc-windows-msvc --no-default-features --lib`
- native macOS EV Override smoke test
- browser-level Canvas probe using the real Systemless WASM font provider:
  - `PASS: browser Times 24 rendered Mac Roman $C9 as 20x4, advance 24, 24 lit pixels; face metrics ascent 18, descent 6, leading 0`
- full `systemless-web` frontend smoke test with EV Override: Times rendered correctly and both ellipses were visible

The Linux and Windows paths are compile-checked here; the macOS and WebAssembly paths additionally received live rendering tests.

## Follow-up work

- execute TrueType hinting, or otherwise improve monochrome outline rasterization, so small text more closely matches classic hinted strikes;
- model configurable Mac OS 8.5-style font smoothing separately;
- admit additional host outline families only with explicit family mappings and layout tests.
