### PR TITLE
fix: support Warcraft II palette and icon probes

### DIFF
--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -606,6 +606,8 @@ pub(crate) struct ControlTrackingState {
 pub(crate) struct PortDrawState {
     pub fg_color: (u16, u16, u16),
     pub bg_color: (u16, u16, u16),
+    pub pm_fg_color: Option<(u32, i16)>,
+    pub pm_bg_color: Option<(u32, i16)>,
     pub bk_pat: [u8; 8],
     pub pn_loc: (i16, i16),
     pub pn_size: (i16, i16),
@@ -622,6 +624,8 @@ impl Default for PortDrawState {
         Self {
             fg_color: (0, 0, 0),
             bg_color: (0xFFFF, 0xFFFF, 0xFFFF),
+            pm_fg_color: None,
+            pm_bg_color: None,
             bk_pat: [0x00; 8],
             pn_loc: (0, 0),
             pn_size: (1, 1),
@@ -1316,6 +1320,12 @@ pub struct TrapDispatcher {
     pub(crate) fg_color: (u16, u16, u16),
     /// Current background color (RGBColor: R, G, B)
     pub(crate) bg_color: (u16, u16, u16),
+    /// Palette handle and entry retained by PmForeColor/RestoreFore.
+    /// SaveFore serializes these GrafVars fields through ColorSpec when set.
+    pub(crate) pm_fg_color: Option<(u32, i16)>,
+    /// Palette handle and entry retained by PmBackColor/RestoreBack.
+    /// SaveBack serializes these GrafVars fields through ColorSpec when set.
+    pub(crate) pm_bg_color: Option<(u32, i16)>,
     /// Requested colors for PixPats initialized by MakeRGBPat, keyed by
     /// PixPatHandle. The ROM expands these into depth-specific pattern data;
     /// HLE keeps the source RGB so color fills can resolve it for the current
@@ -2843,6 +2853,8 @@ impl TrapDispatcher {
             output_dir: None,
             fg_color: (0, 0, 0),
             bg_color: (0xFFFF, 0xFFFF, 0xFFFF),
+            pm_fg_color: None,
+            pm_bg_color: None,
             makergbpat_colors: HashMap::new(),
             // Default HiliteRGB used before an application calls HiliteColor.
             // The System 7.5.3 BasiliskII reference resolves this to EV's

--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -4252,6 +4252,7 @@ impl super::TrapDispatcher {
                 let sp = cpu.read_reg(Register::A7);
                 let color = bus.read_long(sp);
                 self.fg_color = Self::legacy_qd_color_to_rgb(color);
+                self.pm_fg_color = None;
                 self.sync_current_port_draw_state(bus);
                 if trace_qd_colors_enabled() {
                     eprintln!(
@@ -4284,6 +4285,7 @@ impl super::TrapDispatcher {
                 let sp = cpu.read_reg(Register::A7);
                 let color = bus.read_long(sp);
                 self.bg_color = Self::legacy_qd_color_to_rgb(color);
+                self.pm_bg_color = None;
                 self.sync_current_port_draw_state(bus);
                 if trace_qd_colors_enabled() {
                     eprintln!(
@@ -4320,6 +4322,7 @@ impl super::TrapDispatcher {
                 let g = bus.read_word(color_ptr + 2);
                 let b = bus.read_word(color_ptr + 4);
                 self.fg_color = (r, g, b);
+                self.pm_fg_color = None;
                 self.sync_current_port_draw_state(bus);
                 if let Some((_, _, _, _, _, commands)) = self.recording_picture.as_mut() {
                     Self::push_pict_word(commands, 0x001A); // RGBFgCol
@@ -4349,6 +4352,7 @@ impl super::TrapDispatcher {
                 let g = bus.read_word(color_ptr + 2);
                 let b = bus.read_word(color_ptr + 4);
                 self.bg_color = (r, g, b);
+                self.pm_bg_color = None;
                 self.sync_current_port_draw_state(bus);
                 if let Some((_, _, _, _, _, commands)) = self.recording_picture.as_mut() {
                     Self::push_pict_word(commands, 0x001B); // RGBBkCol
@@ -4914,7 +4918,9 @@ impl super::TrapDispatcher {
             (true, 0x297) => {
                 let sp = cpu.read_reg(Register::A7);
                 let entry = bus.read_word(sp) as i16;
-                if let Some((rgb, usage)) = self.palette_entry_rgb_for_current_window(bus, entry) {
+                if let Some((palette, rgb, usage)) =
+                    self.palette_entry_rgb_for_current_window(bus, entry)
+                {
                     let explicit = (usage & PM_EXPLICIT) != 0;
                     self.fg_color = if explicit {
                         let index = (entry as usize) & 0xFF;
@@ -4923,6 +4929,7 @@ impl super::TrapDispatcher {
                     } else {
                         (rgb[0], rgb[1], rgb[2])
                     };
+                    self.pm_fg_color = Some((palette, entry));
                     self.sync_current_port_draw_state(bus);
                     if (explicit || (usage & PM_ANIMATED) != 0)
                         && self.current_port != 0
@@ -4958,7 +4965,9 @@ impl super::TrapDispatcher {
             (true, 0x298) => {
                 let sp = cpu.read_reg(Register::A7);
                 let entry = bus.read_word(sp) as i16;
-                if let Some((rgb, usage)) = self.palette_entry_rgb_for_current_window(bus, entry) {
+                if let Some((palette, rgb, usage)) =
+                    self.palette_entry_rgb_for_current_window(bus, entry)
+                {
                     let explicit = (usage & PM_EXPLICIT) != 0;
                     self.bg_color = if explicit {
                         let index = (entry as usize) & 0xFF;
@@ -4967,6 +4976,7 @@ impl super::TrapDispatcher {
                     } else {
                         (rgb[0], rgb[1], rgb[2])
                     };
+                    self.pm_bg_color = Some((palette, entry));
                     self.sync_current_port_draw_state(bus);
                     if (explicit || (usage & PM_ANIMATED) != 0)
                         && self.current_port != 0
@@ -6026,41 +6036,57 @@ impl super::TrapDispatcher {
                 }
 
                 if d0_selector == 0x0C19 || d0_selector == 0x1219 {
-                    // GetGray has two selector encodings in the wild. The
-                    // documented Palette Manager table uses $1219, while
-                    // C callers commonly use the compact $0C19 frame with
-                    // pointer arguments. The latter is the form emitted by
-                    // Warcraft II's Color QuickDraw startup path:
+                    // GetGray (PaletteDispatch selectors $0C19 and $1219)
+                    // Finds a device-representable intermediate color.
+                    // FUNCTION GetGray(device: GDHandle; backGround: RGBColor;
+                    //                  VAR foreGround: RGBColor): Boolean;
+                    // Both selector encodings use the same pointer frame:
                     //   SP+0  foreGround (RGBColor *)
                     //   SP+4  backGround (RGBColor *)
                     //   SP+8  device (GDHandle)
                     //   SP+12 Boolean result slot
-                    // Inside Macintosh: Imaging With QuickDraw 1994,
-                    // pp. 4-81..4-82, defines the midpoint behavior and the
-                    // TRUE/FALSE result contract.
+                    // Imaging With QuickDraw (1994), pp. 4-81 to 4-82.
                     let foreground = bus.read_long(sp);
                     let background = bus.read_long(sp + 4);
-                    let _device = bus.read_long(sp + 8);
-                    if foreground != 0 && background != 0 {
-                        for offset in [0, 2, 4] {
-                            let back = bus.read_word(background + offset);
-                            let fore = bus.read_word(foreground + offset);
-                            bus.write_word(foreground + offset, (back / 2) + (fore / 2));
+                    let device = bus.read_long(sp + 8);
+                    let mut found = false;
+                    if Self::guest_range_in_ram(bus, foreground, 6)
+                        && Self::guest_range_in_ram(bus, background, 6)
+                    {
+                        let foreground_rgb = [
+                            bus.read_word(foreground),
+                            bus.read_word(foreground + 2),
+                            bus.read_word(foreground + 4),
+                        ];
+                        let background_rgb = [
+                            bus.read_word(background),
+                            bus.read_word(background + 2),
+                            bus.read_word(background + 4),
+                        ];
+                        if let Some(intermediate) = self.gdevice_intermediate_color(
+                            bus,
+                            device,
+                            background_rgb,
+                            foreground_rgb,
+                        ) {
+                            bus.write_word(foreground, intermediate[0]);
+                            bus.write_word(foreground + 2, intermediate[1]);
+                            bus.write_word(foreground + 4, intermediate[2]);
+                            found = true;
                         }
                     }
-                    bus.write_word(sp + 12, 0x0100);
-                    cpu.write_reg(Register::D0, 0x0100);
+                    let boolean = if found { 0x0100 } else { 0 };
+                    bus.write_word(sp + 12, boolean as u16);
+                    cpu.write_reg(Register::D0, boolean);
                     cpu.write_reg(Register::A7, sp + 12);
                     return Some(Ok(()));
                 }
 
                 if matches!(d0_selector, 0x040D | 0x040E | 0x040F | 0x0410) {
-                    // The MPW C frame emitted by the target passes a
-                    // ColorSpec pointer for all four routines. A ColorSpec
-                    // with value == 0 represents an RGB color; Systemless
-                    // has one active color grafPort, so palette-entry state
-                    // is not needed to preserve these startup calls.
-                    //
+                    // SaveFore/SaveBack serialize either direct RGB state
+                    // (value 0) or the GrafVars palette handle plus entry
+                    // index over ColorSpec.rgb (value 1). RestoreFore and
+                    // RestoreBack reverse that overlay.
                     // Inside Macintosh Volume VI (1991), pp. 20-21 to
                     // 20-22; Table C-3 selectors $040D-$0410.
                     let color_ptr = bus.read_long(sp);
@@ -6070,28 +6096,66 @@ impl super::TrapDispatcher {
                         } else {
                             self.bg_color
                         };
+                        let palette_color = if d0_selector == 0x040D {
+                            self.pm_fg_color
+                        } else {
+                            self.pm_bg_color
+                        };
                         if color_ptr != 0 {
-                            bus.write_word(color_ptr, 0);
-                            bus.write_word(color_ptr + 2, color.0);
-                            bus.write_word(color_ptr + 4, color.1);
-                            bus.write_word(color_ptr + 6, color.2);
+                            if let Some((palette, entry)) = palette_color {
+                                bus.write_word(color_ptr, 1);
+                                bus.write_long(color_ptr + 2, palette);
+                                bus.write_word(color_ptr + 6, entry as u16);
+                            } else {
+                                bus.write_word(color_ptr, 0);
+                                bus.write_word(color_ptr + 2, color.0);
+                                bus.write_word(color_ptr + 4, color.1);
+                                bus.write_word(color_ptr + 6, color.2);
+                            }
                         }
-                    } else {
-                        if color_ptr != 0 {
-                            let value = bus.read_word(color_ptr);
-                            if value == 0 {
-                                let color = (
-                                    bus.read_word(color_ptr + 2),
-                                    bus.read_word(color_ptr + 4),
-                                    bus.read_word(color_ptr + 6),
-                                );
-                                if d0_selector == 0x040F {
-                                    self.fg_color = color;
-                                } else {
-                                    self.bg_color = color;
+                    } else if color_ptr != 0 {
+                        let value = bus.read_word(color_ptr);
+                        let foreground = d0_selector == 0x040F;
+                        if value == 0 {
+                            let color = (
+                                bus.read_word(color_ptr + 2),
+                                bus.read_word(color_ptr + 4),
+                                bus.read_word(color_ptr + 6),
+                            );
+                            if foreground {
+                                self.fg_color = color;
+                                self.pm_fg_color = None;
+                            } else {
+                                self.bg_color = color;
+                                self.pm_bg_color = None;
+                            }
+                        } else if value == 1 {
+                            let palette = bus.read_long(color_ptr + 2);
+                            let entry = bus.read_word(color_ptr + 6) as i16;
+                            if foreground {
+                                self.pm_fg_color = Some((palette, entry));
+                            } else {
+                                self.pm_bg_color = Some((palette, entry));
+                            }
+                            if entry >= 0 {
+                                if let Some((rgb, usage, _tolerance)) =
+                                    Self::read_palette_color_info(bus, palette, entry as u16)
+                                {
+                                    let color = if usage & (PM_EXPLICIT | PM_ANIMATED) != 0 {
+                                        let [r, g, b] = self.device_clut[(entry as usize) & 0xFF];
+                                        (r, g, b)
+                                    } else {
+                                        (rgb[0], rgb[1], rgb[2])
+                                    };
+                                    if foreground {
+                                        self.fg_color = color;
+                                    } else {
+                                        self.bg_color = color;
+                                    }
                                 }
                             }
                         }
+                        self.sync_current_port_draw_state(bus);
                     }
                     cpu.write_reg(Register::A7, sp + 4);
                     return Some(Ok(()));
@@ -15758,6 +15822,123 @@ impl super::TrapDispatcher {
         )
     }
 
+    fn closest_available_color(target: [u16; 3], colors: &[[u16; 3]]) -> Option<usize> {
+        colors
+            .iter()
+            .enumerate()
+            .min_by_key(|(_, color)| {
+                let dr = i64::from(color[0]) - i64::from(target[0]);
+                let dg = i64::from(color[1]) - i64::from(target[1]);
+                let db = i64::from(color[2]) - i64::from(target[2]);
+                dr * dr + dg * dg + db * db
+            })
+            .map(|(index, _)| index)
+    }
+
+    fn quantize_direct_component(component: u16, bits: u16) -> u16 {
+        if bits >= 16 {
+            return component;
+        }
+        let levels = (1u32 << bits) - 1;
+        let level = (u32::from(component) * levels + 0x7FFF) / 0xFFFF;
+        ((level * 0xFFFF + levels / 2) / levels) as u16
+    }
+
+    /// Return the best device-representable color strictly between the two
+    /// requested colors. GetGray leaves the foreground unchanged when device
+    /// quantization cannot produce a distinguishable third color.
+    ///
+    /// Imaging With QuickDraw (1994), pp. 4-81 to 4-82.
+    fn gdevice_intermediate_color(
+        &mut self,
+        bus: &mut MacMemoryBus,
+        device: u32,
+        background: [u16; 3],
+        foreground: [u16; 3],
+    ) -> Option<[u16; 3]> {
+        let device = if device != 0 {
+            device
+        } else if self.current_gdevice != 0 {
+            self.current_gdevice
+        } else {
+            self.ensure_main_gdevice(bus)
+        };
+        if !Self::guest_range_in_ram(bus, device, 4) {
+            return None;
+        }
+        let gd = bus.read_long(device);
+        if !Self::guest_range_in_ram(bus, gd, 46) {
+            return None;
+        }
+        let pixmap_handle = bus.read_long(gd + 22);
+        if !Self::guest_range_in_ram(bus, pixmap_handle, 4) {
+            return None;
+        }
+        let pixmap = bus.read_long(pixmap_handle);
+        if !Self::guest_range_in_ram(bus, pixmap, 46) {
+            return None;
+        }
+
+        let midpoint = [
+            ((u32::from(background[0]) + u32::from(foreground[0])) / 2) as u16,
+            ((u32::from(background[1]) + u32::from(foreground[1])) / 2) as u16,
+            ((u32::from(background[2]) + u32::from(foreground[2])) / 2) as u16,
+        ];
+        let pixel_type = bus.read_word(pixmap + 30);
+        let pixel_size = bus.read_word(pixmap + 32);
+        if pixel_type == 16 || pixel_size > 8 {
+            let component_bits = bus.read_word(pixmap + 36).clamp(1, 16);
+            let quantize = |rgb: [u16; 3]| {
+                [
+                    Self::quantize_direct_component(rgb[0], component_bits),
+                    Self::quantize_direct_component(rgb[1], component_bits),
+                    Self::quantize_direct_component(rgb[2], component_bits),
+                ]
+            };
+            let candidate = quantize(midpoint);
+            return (candidate != quantize(background) && candidate != quantize(foreground))
+                .then_some(candidate);
+        }
+
+        let ctab_handle = bus.read_long(pixmap + 42);
+        if !Self::guest_range_in_ram(bus, ctab_handle, 4) {
+            return None;
+        }
+        let ctab = bus.read_long(ctab_handle);
+        if !Self::guest_range_in_ram(bus, ctab, 8) {
+            return None;
+        }
+        let depth_entries = if pixel_size < 8 {
+            1usize << pixel_size
+        } else {
+            256
+        };
+        let last_entry = bus.read_word(ctab + 6) as i16;
+        if last_entry < 0 {
+            return None;
+        }
+        let entries = (last_entry as usize + 1).min(depth_entries).min(256);
+        let entries_base = ctab.checked_add(8)?;
+        if entries == 0 || !Self::guest_range_in_ram(bus, entries_base, (entries * 8) as u32) {
+            return None;
+        }
+        let colors: Vec<[u16; 3]> = (0..entries)
+            .map(|index| {
+                let entry = entries_base + index as u32 * 8;
+                [
+                    bus.read_word(entry + 2),
+                    bus.read_word(entry + 4),
+                    bus.read_word(entry + 6),
+                ]
+            })
+            .collect();
+        let background_index = Self::closest_available_color(background, &colors)?;
+        let foreground_index = Self::closest_available_color(foreground, &colors)?;
+        let midpoint_index = Self::closest_available_color(midpoint, &colors)?;
+        (midpoint_index != background_index && midpoint_index != foreground_index)
+            .then_some(colors[midpoint_index])
+    }
+
     fn record_gdevice_depth_mode(
         &mut self,
         bus: &mut MacMemoryBus,
@@ -16397,7 +16578,7 @@ impl super::TrapDispatcher {
         &self,
         bus: &MacMemoryBus,
         entry: i16,
-    ) -> Option<([u16; 3], i16)> {
+    ) -> Option<(u32, [u16; 3], i16)> {
         if entry < 0 {
             return None;
         }
@@ -16407,7 +16588,7 @@ impl super::TrapDispatcher {
         }
         let (rgb, usage, _tolerance) =
             Self::read_palette_color_info(bus, palette_handle, entry as u16)?;
-        Some((rgb, usage))
+        Some((palette_handle, rgb, usage))
     }
 
     fn palette_entry_to_device_index(&self, bus: &MacMemoryBus, entry: i16) -> u32 {
@@ -16415,7 +16596,8 @@ impl super::TrapDispatcher {
             return 0;
         }
 
-        if let Some((rgb, usage)) = self.palette_entry_rgb_for_current_window(bus, entry) {
+        if let Some((_palette, rgb, usage)) = self.palette_entry_rgb_for_current_window(bus, entry)
+        {
             if (usage & PM_EXPLICIT) != 0 {
                 return u32::from((entry as u16) & 0x00FF);
             }
@@ -17924,6 +18106,8 @@ impl super::TrapDispatcher {
         PortDrawState {
             fg_color: self.fg_color,
             bg_color: self.bg_color,
+            pm_fg_color: self.pm_fg_color,
+            pm_bg_color: self.pm_bg_color,
             bk_pat: self.bk_pat,
             pn_loc: self.pn_loc,
             pn_size: self.pn_size,
@@ -17954,6 +18138,8 @@ impl super::TrapDispatcher {
             .unwrap_or_default();
         self.fg_color = state.fg_color;
         self.bg_color = state.bg_color;
+        self.pm_fg_color = state.pm_fg_color;
+        self.pm_bg_color = state.pm_bg_color;
         self.bk_pat = state.bk_pat;
         self.pn_loc = state.pn_loc;
         self.pn_size = state.pn_size;
@@ -17994,6 +18180,8 @@ impl super::TrapDispatcher {
             bus.read_word(port + 44),
             bus.read_word(port + 46),
         );
+        self.pm_fg_color = cached.pm_fg_color;
+        self.pm_bg_color = cached.pm_bg_color;
         self.bk_pat = cached.bk_pat;
         self.pn_loc = (
             bus.read_word(port + 48) as i16,
@@ -35753,11 +35941,31 @@ mod tests {
     }
 
     #[test]
-    fn palettedispatch_d0_compact_getgray_writes_midpoint_and_boolean_result() {
+    fn palettedispatch_d0_compact_getgray_writes_best_available_device_color() {
         // The compact C calling convention uses selector $0C19 and passes
         // pointers to both RGBColor records. Its 12-byte argument frame is
         // followed by a two-byte Boolean result slot.
         let (mut d, mut cpu, mut bus) = setup();
+        let gdevice = d.ensure_main_gdevice(&mut bus);
+        let gd = bus.read_long(gdevice);
+        let pixmap = bus.read_long(bus.read_long(gd + 22));
+        let ctab = bus.read_long(bus.read_long(pixmap + 42));
+        bus.write_word(pixmap + 32, 2);
+        bus.write_word(ctab + 6, 2);
+        for (index, rgb) in [
+            [0x0000, 0x4000, 0xFFFF],
+            [0x8000, 0x6000, 0x8000],
+            [0xFFFF, 0x8000, 0x0000],
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let entry = ctab + 8 + index as u32 * 8;
+            bus.write_word(entry, index as u16);
+            bus.write_word(entry + 2, rgb[0]);
+            bus.write_word(entry + 4, rgb[1]);
+            bus.write_word(entry + 6, rgb[2]);
+        }
         let background = bus.alloc(6);
         let foreground = bus.alloc(6);
         for (offset, value) in [(0, 0x0000), (2, 0x4000), (4, 0xFFFF)] {
@@ -35770,7 +35978,7 @@ mod tests {
         cpu.write_reg(Register::D0, 0x0C19);
         bus.write_long(TEST_SP, foreground);
         bus.write_long(TEST_SP + 4, background);
-        bus.write_long(TEST_SP + 8, 0x00DE_ADBE);
+        bus.write_long(TEST_SP + 8, gdevice);
         bus.write_word(TEST_SP + 12, 0xBEEF);
 
         let result = d.dispatch_quickdraw(true, 0x2A2, &mut cpu, &mut bus);
@@ -35778,9 +35986,48 @@ mod tests {
         assert!(result.unwrap().is_ok());
         assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 12);
         assert_eq!(bus.read_word(TEST_SP + 12), 0x0100);
-        assert_eq!(bus.read_word(foreground), 0x7FFF);
+        assert_eq!(bus.read_word(foreground), 0x8000);
         assert_eq!(bus.read_word(foreground + 2), 0x6000);
-        assert_eq!(bus.read_word(foreground + 4), 0x7FFF);
+        assert_eq!(bus.read_word(foreground + 4), 0x8000);
+    }
+
+    #[test]
+    fn palettedispatch_d0_getgray_leaves_foreground_when_device_has_no_third_color() {
+        let (mut d, mut cpu, mut bus) = setup();
+        let gdevice = d.ensure_main_gdevice(&mut bus);
+        let gd = bus.read_long(gdevice);
+        let pixmap = bus.read_long(bus.read_long(gd + 22));
+        let ctab = bus.read_long(bus.read_long(pixmap + 42));
+        bus.write_word(pixmap + 32, 1);
+        bus.write_word(ctab + 6, 1);
+        for (index, rgb) in [[0x0000; 3], [0xFFFF; 3]].into_iter().enumerate() {
+            let entry = ctab + 8 + index as u32 * 8;
+            bus.write_word(entry, index as u16);
+            bus.write_word(entry + 2, rgb[0]);
+            bus.write_word(entry + 4, rgb[1]);
+            bus.write_word(entry + 6, rgb[2]);
+        }
+        let background = bus.alloc(6);
+        let foreground = bus.alloc(6);
+        for offset in [0, 2, 4] {
+            bus.write_word(background + offset, 0);
+            bus.write_word(foreground + offset, 0xFFFF);
+        }
+
+        cpu.write_reg(Register::D0, 0x1219);
+        bus.write_long(TEST_SP, foreground);
+        bus.write_long(TEST_SP + 4, background);
+        bus.write_long(TEST_SP + 8, gdevice);
+        bus.write_word(TEST_SP + 12, 0xBEEF);
+
+        let result = d.dispatch_quickdraw(true, 0x2A2, &mut cpu, &mut bus);
+
+        assert!(result.unwrap().is_ok());
+        assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 12);
+        assert_eq!(bus.read_word(TEST_SP + 12), 0);
+        for offset in [0, 2, 4] {
+            assert_eq!(bus.read_word(foreground + offset), 0xFFFF);
+        }
     }
 
     #[test]
@@ -35840,6 +36087,68 @@ mod tests {
             };
             assert_eq!(actual, expected);
         }
+    }
+
+    #[test]
+    fn palettedispatch_save_and_restore_preserve_palette_handle_and_entry() {
+        let (mut d, mut cpu, mut bus) = setup();
+        let palette = d.create_palette_from_ctab(&mut bus, 4, 0, super::PM_TOLERANT, 0);
+        let palette_ptr = TrapDispatcher::palette_ptr(&bus, palette);
+        let foreground_rgb = [0x1111, 0x2222, 0x3333];
+        let background_rgb = [0xAAAA, 0xBBBB, 0xCCCC];
+        TrapDispatcher::write_palette_color_info(
+            &mut bus,
+            palette_ptr,
+            2,
+            foreground_rgb,
+            super::PM_TOLERANT,
+            0,
+        );
+        TrapDispatcher::write_palette_color_info(
+            &mut bus,
+            palette_ptr,
+            3,
+            background_rgb,
+            super::PM_TOLERANT,
+            0,
+        );
+        d.pm_fg_color = Some((palette, 2));
+        d.pm_bg_color = Some((palette, 3));
+        let foreground = bus.alloc(8);
+        let background = bus.alloc(8);
+
+        for (selector, pointer, entry) in [(0x040D, foreground, 2), (0x040E, background, 3)] {
+            cpu.write_reg(Register::D0, selector);
+            cpu.write_reg(Register::A7, TEST_SP);
+            bus.write_long(TEST_SP, pointer);
+            let result = d.dispatch_quickdraw(true, 0x2A2, &mut cpu, &mut bus);
+            assert!(result.unwrap().is_ok());
+            assert_eq!(bus.read_word(pointer), 1);
+            assert_eq!(bus.read_long(pointer + 2), palette);
+            assert_eq!(bus.read_word(pointer + 6), entry);
+        }
+
+        d.pm_fg_color = None;
+        d.pm_bg_color = None;
+        d.fg_color = (0, 0, 0);
+        d.bg_color = (0, 0, 0);
+        for (selector, pointer) in [(0x040F, foreground), (0x0410, background)] {
+            cpu.write_reg(Register::D0, selector);
+            cpu.write_reg(Register::A7, TEST_SP);
+            bus.write_long(TEST_SP, pointer);
+            let result = d.dispatch_quickdraw(true, 0x2A2, &mut cpu, &mut bus);
+            assert!(result.unwrap().is_ok());
+        }
+        assert_eq!(d.pm_fg_color, Some((palette, 2)));
+        assert_eq!(d.pm_bg_color, Some((palette, 3)));
+        assert_eq!(
+            d.fg_color,
+            (foreground_rgb[0], foreground_rgb[1], foreground_rgb[2])
+        );
+        assert_eq!(
+            d.bg_color,
+            (background_rgb[0], background_rgb[1], background_rgb[2])
+        );
     }
 
     fn prepare_animatepalette_negative_span_case(

--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -6025,6 +6025,78 @@ impl super::TrapDispatcher {
                     return Some(Ok(()));
                 }
 
+                if d0_selector == 0x0C19 || d0_selector == 0x1219 {
+                    // GetGray has two selector encodings in the wild. The
+                    // documented Palette Manager table uses $1219, while
+                    // C callers commonly use the compact $0C19 frame with
+                    // pointer arguments. The latter is the form emitted by
+                    // Warcraft II's Color QuickDraw startup path:
+                    //   SP+0  foreGround (RGBColor *)
+                    //   SP+4  backGround (RGBColor *)
+                    //   SP+8  device (GDHandle)
+                    //   SP+12 Boolean result slot
+                    // Inside Macintosh: Imaging With QuickDraw 1994,
+                    // pp. 4-81..4-82, defines the midpoint behavior and the
+                    // TRUE/FALSE result contract.
+                    let foreground = bus.read_long(sp);
+                    let background = bus.read_long(sp + 4);
+                    let _device = bus.read_long(sp + 8);
+                    if foreground != 0 && background != 0 {
+                        for offset in [0, 2, 4] {
+                            let back = bus.read_word(background + offset);
+                            let fore = bus.read_word(foreground + offset);
+                            bus.write_word(foreground + offset, (back / 2) + (fore / 2));
+                        }
+                    }
+                    bus.write_word(sp + 12, 0x0100);
+                    cpu.write_reg(Register::D0, 0x0100);
+                    cpu.write_reg(Register::A7, sp + 12);
+                    return Some(Ok(()));
+                }
+
+                if matches!(d0_selector, 0x040D | 0x040E | 0x040F | 0x0410) {
+                    // The MPW C frame emitted by the target passes a
+                    // ColorSpec pointer for all four routines. A ColorSpec
+                    // with value == 0 represents an RGB color; Systemless
+                    // has one active color grafPort, so palette-entry state
+                    // is not needed to preserve these startup calls.
+                    //
+                    // Inside Macintosh Volume VI (1991), pp. 20-21 to
+                    // 20-22; Table C-3 selectors $040D-$0410.
+                    let color_ptr = bus.read_long(sp);
+                    if matches!(d0_selector, 0x040D | 0x040E) {
+                        let color = if d0_selector == 0x040D {
+                            self.fg_color
+                        } else {
+                            self.bg_color
+                        };
+                        if color_ptr != 0 {
+                            bus.write_word(color_ptr, 0);
+                            bus.write_word(color_ptr + 2, color.0);
+                            bus.write_word(color_ptr + 4, color.1);
+                            bus.write_word(color_ptr + 6, color.2);
+                        }
+                    } else {
+                        if color_ptr != 0 {
+                            let value = bus.read_word(color_ptr);
+                            if value == 0 {
+                                let color = (
+                                    bus.read_word(color_ptr + 2),
+                                    bus.read_word(color_ptr + 4),
+                                    bus.read_word(color_ptr + 6),
+                                );
+                                if d0_selector == 0x040F {
+                                    self.fg_color = color;
+                                } else {
+                                    self.bg_color = color;
+                                }
+                            }
+                        }
+                    }
+                    cpu.write_reg(Register::A7, sp + 4);
+                    return Some(Ok(()));
+                }
+
                 // HasDepth / SetDepth use THREEWORDINLINE(0x303C, sel, 0xAAA2)
                 // which emits MOVE.W #sel, D0 then _PaletteDispatch.
                 // Real ROM convention: selector in D0, no selector word on stack.
@@ -15670,7 +15742,19 @@ impl super::TrapDispatcher {
     fn is_public_palette_dispatch_selector(selector: u16) -> bool {
         matches!(
             selector,
-            0x0002 | 0x0003 | 0x0015 | 0x0417 | 0x0616 | 0x0A13 | 0x0A14 | 0x1219
+            0x0002
+                | 0x0003
+                | 0x0015
+                | 0x040D
+                | 0x040E
+                | 0x040F
+                | 0x0410
+                | 0x0417
+                | 0x0616
+                | 0x0A13
+                | 0x0A14
+                | 0x0C19
+                | 0x1219
         )
     }
 
@@ -35666,6 +35750,96 @@ mod tests {
         assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 4);
         assert_eq!(d.device_clut[42], [0xAAAA, 0xBBBB, 0xCCCC]);
         assert_eq!(d.color_manager_clut[42], [0xAAAA, 0xBBBB, 0xCCCC]);
+    }
+
+    #[test]
+    fn palettedispatch_d0_compact_getgray_writes_midpoint_and_boolean_result() {
+        // The compact C calling convention uses selector $0C19 and passes
+        // pointers to both RGBColor records. Its 12-byte argument frame is
+        // followed by a two-byte Boolean result slot.
+        let (mut d, mut cpu, mut bus) = setup();
+        let background = bus.alloc(6);
+        let foreground = bus.alloc(6);
+        for (offset, value) in [(0, 0x0000), (2, 0x4000), (4, 0xFFFF)] {
+            bus.write_word(background + offset, value);
+        }
+        for (offset, value) in [(0, 0xFFFF), (2, 0x8000), (4, 0x0000)] {
+            bus.write_word(foreground + offset, value);
+        }
+
+        cpu.write_reg(Register::D0, 0x0C19);
+        bus.write_long(TEST_SP, foreground);
+        bus.write_long(TEST_SP + 4, background);
+        bus.write_long(TEST_SP + 8, 0x00DE_ADBE);
+        bus.write_word(TEST_SP + 12, 0xBEEF);
+
+        let result = d.dispatch_quickdraw(true, 0x2A2, &mut cpu, &mut bus);
+
+        assert!(result.unwrap().is_ok());
+        assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 12);
+        assert_eq!(bus.read_word(TEST_SP + 12), 0x0100);
+        assert_eq!(bus.read_word(foreground), 0x7FFF);
+        assert_eq!(bus.read_word(foreground + 2), 0x6000);
+        assert_eq!(bus.read_word(foreground + 4), 0x7FFF);
+    }
+
+    #[test]
+    fn palettedispatch_d0_save_fore_and_back_write_colorspecs() {
+        let (mut d, mut cpu, mut bus) = setup();
+        d.fg_color = (0x1111, 0x2222, 0x3333);
+        d.bg_color = (0xAAAA, 0xBBBB, 0xCCCC);
+        let foreground = bus.alloc(8);
+        let background = bus.alloc(8);
+
+        for (selector, pointer, color) in [
+            (0x040D, foreground, d.fg_color),
+            (0x040E, background, d.bg_color),
+        ] {
+            cpu.write_reg(Register::D0, selector);
+            cpu.write_reg(Register::A7, TEST_SP);
+            bus.write_long(TEST_SP, pointer);
+            let result = d.dispatch_quickdraw(true, 0x2A2, &mut cpu, &mut bus);
+            assert!(result.unwrap().is_ok());
+            assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 4);
+            assert_eq!(bus.read_word(pointer), 0);
+            assert_eq!(bus.read_word(pointer + 2), color.0);
+            assert_eq!(bus.read_word(pointer + 4), color.1);
+            assert_eq!(bus.read_word(pointer + 6), color.2);
+        }
+    }
+
+    #[test]
+    fn palettedispatch_d0_restore_fore_and_back_read_colorspecs() {
+        let (mut d, mut cpu, mut bus) = setup();
+        let foreground = bus.alloc(8);
+        let background = bus.alloc(8);
+        for (pointer, color) in [
+            (foreground, (0x1111, 0x2222, 0x3333)),
+            (background, (0xAAAA, 0xBBBB, 0xCCCC)),
+        ] {
+            bus.write_word(pointer, 0);
+            bus.write_word(pointer + 2, color.0);
+            bus.write_word(pointer + 4, color.1);
+            bus.write_word(pointer + 6, color.2);
+        }
+
+        for (selector, pointer, expected) in [
+            (0x040F, foreground, (0x1111, 0x2222, 0x3333)),
+            (0x0410, background, (0xAAAA, 0xBBBB, 0xCCCC)),
+        ] {
+            cpu.write_reg(Register::D0, selector);
+            cpu.write_reg(Register::A7, TEST_SP);
+            bus.write_long(TEST_SP, pointer);
+            let result = d.dispatch_quickdraw(true, 0x2A2, &mut cpu, &mut bus);
+            assert!(result.unwrap().is_ok());
+            assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 4);
+            let actual = if selector == 0x040F {
+                d.fg_color
+            } else {
+                d.bg_color
+            };
+            assert_eq!(actual, expected);
+        }
     }
 
     fn prepare_animatepalette_negative_span_case(

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -14836,12 +14836,17 @@ impl super::TrapDispatcher {
             //
             // Regression coverage:
             //   src/trap/toolbox.rs::tests::icondispatch_*
-            // IconDispatch ($ABC9): MMTB 1993 ch.5 14879+15191. D0 selector. Gestalt 'icon' → gestaltIconUtilitiesPresent. HLE: selector $0000 returns noErr and pops the inline selector frame; unsupported selectors return paramErr (-50) and still pop the same frame. Apps fall back to legacy $A9BB/$AA1F monochrome/color icon traps.
+            // IconDispatch ($ABC9): MMTB 1993 ch.5 14879+15191. D0 selector. Gestalt 'icon' → gestaltIconUtilitiesPresent. HLE: selector $0000 returns noErr and pops the inline selector frame; unsupported selectors return paramErr (-50) and still pop the same frame. Warcraft II's private $0613 and $0500 probes carry 12- and 10-byte frames respectively, while the public no-op probe uses the established 8-byte frame. Apps fall back to legacy $A9BB/$AA1F monochrome/color icons.
             (true, 0x3C9) => {
                 let selector = cpu.read_reg(Register::D0) & 0xFFFF;
+                let pop_bytes = match selector {
+                    0x0613 => 12,
+                    0x0500 => 10,
+                    _ => 8,
+                };
                 match selector {
-                    0 => return_noerr_and_pop(cpu, 8),
-                    _ => return_error_and_pop(cpu, 8, -50),
+                    0 => return_noerr_and_pop(cpu, pop_bytes),
+                    _ => return_error_and_pop(cpu, pop_bytes, -50),
                 }
             }
 
@@ -23331,6 +23336,21 @@ mod tests {
         assert_eq!(cpu.read_reg(Register::A0), 0x4444_5555);
         assert_eq!(cpu.read_reg(Register::A1), 0x6666_7777);
         assert_eq!(cpu.read_reg(Register::A7), sp_before + 8);
+    }
+
+    #[test]
+    fn icondispatch_private_selectors_pop_their_observed_frames() {
+        let (mut disp, mut cpu, mut bus) = setup();
+
+        for (selector, pop_bytes) in [(0x0613, 12), (0x0500, 10)] {
+            cpu.write_reg(Register::A7, TEST_SP);
+            cpu.write_reg(Register::D0, selector);
+            let result = disp.dispatch_toolbox(true, 0x3C9, &mut cpu, &mut bus);
+
+            assert!(result.unwrap().is_ok());
+            assert_eq!(cpu.read_reg(Register::D0) as i16, -50);
+            assert_eq!(cpu.read_reg(Register::A7), TEST_SP + pop_bytes);
+        }
     }
 
     #[test]

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -3460,6 +3460,8 @@ impl super::TrapDispatcher {
         super::dispatch::PortDrawState {
             fg_color: self.fg_color,
             bg_color: self.bg_color,
+            pm_fg_color: self.pm_fg_color,
+            pm_bg_color: self.pm_bg_color,
             bk_pat: self.bk_pat,
             pn_loc: self.pn_loc,
             pn_size: self.pn_size,
@@ -3475,6 +3477,8 @@ impl super::TrapDispatcher {
     fn restore_qd_state(&mut self, state: super::dispatch::PortDrawState) {
         self.fg_color = state.fg_color;
         self.bg_color = state.bg_color;
+        self.pm_fg_color = state.pm_fg_color;
+        self.pm_bg_color = state.pm_bg_color;
         self.bk_pat = state.bk_pat;
         self.pn_loc = state.pn_loc;
         self.pn_size = state.pn_size;
@@ -14810,12 +14814,11 @@ impl super::TrapDispatcher {
             // CodeFragmentDispatch (CFM) ($AA5A): PPC SS 1994 ch.6 1770. D0 selector. Gestalt 'cfrg' → gestaltCFMPresent=0. HLE: D0=0, registers + stack preserved (68K-only — fat binaries fall back to 68K fork).
             (true, 0x25A) => return_noerr(cpu),
 
-            // IconDispatch ($ABC9) — Icon Utilities
-            // Inside Macintosh: More Macintosh Toolbox (1993),
-            // pp. 5-18 and 5-71:
-            // Icon Utilities availability is gated by
-            // `gestaltIconUtilitiesAttr`, and the routines are invoked
-            // through `_IconDispatch` with routine selectors.
+            // IconDispatch ($ABC9)
+            // Dispatches Icon Utilities routines selected in D0.
+            // Selector-specific Pascal frames; the low byte records argument words.
+            // More Macintosh Toolbox (1993), pp. 5-18 and 5-71.
+            // Icon Utilities availability is gated by `gestaltIconUtilitiesAttr`.
             // Selector convention: D0 = routine number; routines
             // include PlotIconID, NewIconSuite, AddIconToSuite,
             // GetIconFromSuite, ForEachIconDo, GetIconCacheData,
@@ -14827,24 +14830,64 @@ impl super::TrapDispatcher {
             // routed through IconDispatch.
             // Gestalt: `gestaltIconUtilitiesAttr = 'icon'`.
             //
-            // HLE behaviour: D0=0 (noErr), all other registers
-            // preserved, and the dispatcher advances A7 by 8 bytes
-            // on return. Apps that probe Gestalt see "absent" and
-            // fall back to the legacy trap surface for monochrome /
-            // color icons (which Systemless implements via $A9BB
-            // GetIcon / $AA1E GetCIcon / etc.).
+            // The selector's low byte is the Pascal argument count in words.
+            // Some 68K glue presents that public selector byte-swapped in D0;
+            // normalize only values from the published table, then derive the
+            // frame size instead of special-casing individual routines.
             //
-            // Regression coverage:
-            //   src/trap/toolbox.rs::tests::icondispatch_*
-            // IconDispatch ($ABC9): MMTB 1993 ch.5 14879+15191. D0 selector. Gestalt 'icon' → gestaltIconUtilitiesPresent. HLE: selector $0000 returns noErr and pops the inline selector frame; unsupported selectors return paramErr (-50) and still pop the same frame. Warcraft II's private $0613 and $0500 probes carry 12- and 10-byte frames respectively, while the public no-op probe uses the established 8-byte frame. Apps fall back to legacy $A9BB/$AA1F monochrome/color icons.
+            // Regression coverage: src/trap/toolbox.rs::tests::icondispatch_*
+            // Unsupported public selectors return paramErr (-50) after consuming
+            // the selector-derived frame; $0000 retains the noErr probe behavior.
             (true, 0x3C9) => {
-                let selector = cpu.read_reg(Register::D0) & 0xFFFF;
-                let pop_bytes = match selector {
-                    0x0613 => 12,
-                    0x0500 => 10,
-                    _ => 8,
+                let raw_selector = (cpu.read_reg(Register::D0) & 0xFFFF) as u16;
+                let is_public = |selector| {
+                    matches!(
+                        selector,
+                        0x0702
+                            | 0x1702
+                            | 0x0203
+                            | 0x1603
+                            | 0x1904
+                            | 0x1A04
+                            | 0x1B04
+                            | 0x1C04
+                            | 0x0005
+                            | 0x0105
+                            | 0x0B05
+                            | 0x0306
+                            | 0x0406
+                            | 0x0606
+                            | 0x0806
+                            | 0x0906
+                            | 0x0D06
+                            | 0x1006
+                            | 0x1306
+                            | 0x1D06
+                            | 0x1E06
+                            | 0x1F06
+                            | 0x0E07
+                            | 0x1107
+                            | 0x1407
+                            | 0x0A08
+                            | 0x0508
+                            | 0x0F09
+                            | 0x1209
+                            | 0x1509
+                    )
                 };
-                match selector {
+                let selector = if is_public(raw_selector) {
+                    raw_selector
+                } else if is_public(raw_selector.swap_bytes()) {
+                    raw_selector.swap_bytes()
+                } else {
+                    raw_selector
+                };
+                let pop_bytes = if is_public(selector) {
+                    u32::from(selector & 0x00FF) * 2
+                } else {
+                    8
+                };
+                match raw_selector {
                     0 => return_noerr_and_pop(cpu, pop_bytes),
                     _ => return_error_and_pop(cpu, pop_bytes, -50),
                 }
@@ -23298,7 +23341,7 @@ mod tests {
         let (mut disp, mut cpu, mut bus) = setup();
         let sp = TEST_SP;
         cpu.write_reg(Register::A7, sp);
-        cpu.write_reg(Register::D0, 0x0000_050B); // representative unsupported selector
+        cpu.write_reg(Register::D0, 0x0000_BEEF); // unsupported in either byte order
         bus.write_long(sp, 0x1122_3344);
         bus.write_long(sp + 4, 0x5566_7788);
 
@@ -23339,10 +23382,10 @@ mod tests {
     }
 
     #[test]
-    fn icondispatch_private_selectors_pop_their_observed_frames() {
+    fn icondispatch_public_selectors_derive_frames_after_byte_order_normalization() {
         let (mut disp, mut cpu, mut bus) = setup();
 
-        for (selector, pop_bytes) in [(0x0613, 12), (0x0500, 10)] {
+        for (selector, pop_bytes) in [(0x1306, 12), (0x0613, 12), (0x0005, 10), (0x0500, 10)] {
             cpu.write_reg(Register::A7, TEST_SP);
             cpu.write_reg(Register::D0, selector);
             let result = disp.dispatch_toolbox(true, 0x3C9, &mut cpu, &mut bus);


### PR DESCRIPTION
## Summary

- Implement GetGray against the supplied graphics device, including indexed/direct-color quantization and the documented FALSE/unchanged result when no distinct intermediate color exists.
- Preserve both direct RGB and palette-entry GrafVars state across SaveFore, SaveBack, RestoreFore, RestoreBack, and port switches.
- Normalize Icon Utilities selectors against the published table and derive Pascal frame sizes from their public encoding.
- Add focused regression coverage for device-aware color selection, palette state round trips, and canonical/byte-swapped selector frames.

## Root cause

Warcraft II's startup path exercised Palette Manager and Icon Utilities dispatcher contracts that Systemless only approximated. The incomplete GetGray result handling and fixed IconDispatch frame size could misalign the saved return address before the live Hillsbrad mission.

## Validation

- `cargo test --lib --features test-support -q`: 2,867 passed, 3 ignored.
- `cargo check --no-default-features`
- `cargo publish --locked --dry-run --allow-dirty`
- The Warcraft II replay reaches the Human Hillsbrad map, selects a Footman, and visibly orders it to move.
- Historical BasiliskII oracle comparison passes the six-frame G3 parity floor; a fresh Docker-backed BasiliskII run was unavailable in this environment.

Closes #270
Closes #271