### PR TITLE
fix: preserve resident resources and stable trap startup state

### DIFF
--- a/src/memory/bus.rs
+++ b/src/memory/bus.rs
@@ -450,6 +450,8 @@ pub struct MacMemoryBus {
     heap_ptr: u32,
     /// Systemless-owned executable/data stubs grow downward outside the guest heap.
     synthetic_ptr: u32,
+    /// Guest writes cannot modify synthesized ROM-like instruction stubs.
+    readonly_code_ranges: Vec<(u32, u32)>,
     /// Free list: maps aligned_size → stack of recycled addresses
     free_blocks: HashMap<u32, Vec<u32>>,
     /// Tracks the aligned size of each allocation (address → aligned_size)
@@ -774,7 +776,12 @@ impl MacMemoryBus {
     /// byte-at-a-time (preserving the overlap-handling order from
     /// Inside Macintosh II-44) when the fast path doesn't apply.
     pub fn block_move(&mut self, src: u32, dst: u32, count: u32) {
-        if count == 0 {
+        // `Size` is a signed Macintosh LONGINT. A negative byte count is
+        // invalid; treating its bit pattern as an unsigned length would let
+        // a malformed guest call overwrite the entire emulated address
+        // space. The ROM routine leaves the destination untouched for this
+        // case, while the trap wrapper reports noErr in D0.
+        if (count as i32) <= 0 {
             return;
         }
         #[cfg(debug_assertions)]
@@ -786,7 +793,11 @@ impl MacMemoryBus {
         let count_usize = count as usize;
         let src_end = (src as u64).saturating_add(count as u64);
         let dst_end = (dst as u64).saturating_add(count as u64);
-        if fast && src_end <= self.ram_size as u64 && dst_end <= self.ram_size as u64 {
+        if fast
+            && !self.readonly_code_overlaps(dst, count)
+            && src_end <= self.ram_size as u64
+            && dst_end <= self.ram_size as u64
+        {
             let ram_size_usize = self.ram_size as usize;
             if let Some(ram) = self.ram.slice_at_mut(0, ram_size_usize) {
                 let src_range = (src as usize)..(src as usize + count_usize);
@@ -824,6 +835,7 @@ impl MacMemoryBus {
             globals: LowMemGlobals::new(),
             heap_ptr: 0x200000, // Start heap at 2MB
             synthetic_ptr: screen_buffer_start,
+            readonly_code_ranges: Vec::new(),
             free_blocks: HashMap::new(),
             alloc_sizes: HashMap::new(),
             alloc_bucket_sizes: HashMap::new(),
@@ -902,6 +914,7 @@ impl MacMemoryBus {
             globals,
             heap_ptr: 0x200000,
             synthetic_ptr: screen_buffer_start,
+            readonly_code_ranges: Vec::new(),
             free_blocks: HashMap::new(),
             alloc_sizes: HashMap::new(),
             alloc_bucket_sizes: HashMap::new(),
@@ -1059,6 +1072,26 @@ impl MacMemoryBus {
         self.synthetic_ptr = ptr;
         self.fill_bytes(ptr, aligned, 0);
         ptr
+    }
+
+    pub(crate) fn protect_readonly_code(&mut self, address: u32, len: u32) {
+        if len != 0 {
+            self.readonly_code_ranges
+                .push((address, address.saturating_add(len)));
+        }
+    }
+
+    pub(crate) fn write_readonly_code_word(&mut self, address: u32, value: u16) {
+        if (address as u64) + 2 <= self.ram_size as u64 {
+            self.ram.write_word_in_bounds(address as usize, value);
+        }
+    }
+
+    fn readonly_code_overlaps(&self, address: u32, len: u32) -> bool {
+        let end = (address as u64).saturating_add(len as u64);
+        self.readonly_code_ranges.iter().any(|&(start, stop)| {
+            (start as u64) < end && (stop as u64) > address as u64
+        })
     }
 
     /// Allocate memory from the heap with a stronger start-address alignment.
@@ -1349,6 +1382,9 @@ impl MemoryBus for MacMemoryBus {
     }
 
     fn write_byte(&mut self, address: u32, value: u8) {
+        if self.readonly_code_overlaps(address, 1) {
+            return;
+        }
         self.record_write_probe_byte(address);
         maybe_log_mem_write(address, 1, value as u32);
 
@@ -1509,6 +1545,9 @@ impl MemoryBus for MacMemoryBus {
     /// needs per-byte dispatch through `write_byte`.
     #[inline]
     fn write_word(&mut self, address: u32, value: u16) {
+        if self.readonly_code_overlaps(address, 2) {
+            return;
+        }
         maybe_log_mem_write(address, 2, value as u32);
 
         // Fast path: watchpoint disarmed + tracer disabled + write fully in-bounds.
@@ -1531,6 +1570,9 @@ impl MemoryBus for MacMemoryBus {
     /// Same fast-path optimisation as `write_word`.
     #[inline]
     fn write_long(&mut self, address: u32, value: u32) {
+        if self.readonly_code_overlaps(address, 4) {
+            return;
+        }
         maybe_log_mem_write(address, 4, value);
 
         #[cfg(debug_assertions)]
@@ -1591,6 +1633,9 @@ impl MemoryBus for MacMemoryBus {
     /// trigger; same for the FB-write tracer.
     #[inline]
     fn write_bytes(&mut self, address: u32, data: &[u8]) {
+        if self.readonly_code_overlaps(address, data.len() as u32) {
+            return;
+        }
         #[cfg(debug_assertions)]
         let fast = !WATCHPOINT_ARMED.load(Ordering::Relaxed)
             && fb_write_trace_range().is_none()
@@ -1609,6 +1654,9 @@ impl MemoryBus for MacMemoryBus {
 
     #[inline]
     fn fill_zeros(&mut self, address: u32, len: u32) {
+        if self.readonly_code_overlaps(address, len) {
+            return;
+        }
         #[cfg(debug_assertions)]
         let fast = !WATCHPOINT_ARMED.load(Ordering::Relaxed)
             && fb_write_trace_range().is_none()
@@ -1628,6 +1676,9 @@ impl MemoryBus for MacMemoryBus {
 
     #[inline]
     fn fill_bytes(&mut self, address: u32, len: u32, value: u8) {
+        if self.readonly_code_overlaps(address, len) {
+            return;
+        }
         #[cfg(debug_assertions)]
         let fast = !WATCHPOINT_ARMED.load(Ordering::Relaxed)
             && fb_write_trace_range().is_none()

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -5369,10 +5369,16 @@ impl TrapDispatcher {
     ) -> u32 {
         let canonical_trap_word = 0xA800 | (trap_word & 0x03FF);
         if let Some(&addr) = self.tool_trap_trampolines.get(&canonical_trap_word) {
+            // The returned address represents a ROM trap entry. Re-seed the
+            // synthetic instruction on every lookup so guest code that
+            // temporarily writes through the saved address cannot corrupt a
+            // later JSR through the same trap pointer.
+            bus.write_readonly_code_word(addr, canonical_trap_word | 0x0400);
             return addr;
         }
-        let addr = bus.alloc(2);
-        bus.write_word(addr, canonical_trap_word | 0x0400);
+        let addr = bus.alloc_synthetic(2);
+        bus.write_readonly_code_word(addr, canonical_trap_word | 0x0400);
+        bus.protect_readonly_code(addr, 2);
         self.tool_trap_trampolines.insert(canonical_trap_word, addr);
         addr
     }
@@ -5385,11 +5391,31 @@ impl TrapDispatcher {
         let res_type = Self::normalize_ostype(res_type);
         let resources = self.resources.as_ref()?;
         let refnum = self.current_resource_refnum();
-        resources
-            .files
-            .get(&refnum)
-            .and_then(|file| file.named.get(&(res_type, name.to_string())).copied())
-            .map(|(id, ptr)| (refnum, id, ptr))
+        let file = resources.files.get(&refnum)?;
+        if let Some((id, ptr)) = file.named.get(&(res_type, name.to_string())).copied() {
+            return Some((refnum, id, ptr));
+        }
+        if name.is_empty() {
+            // Unnamed resources have no entry in `named`, but the Resource
+            // Manager treats their name as the empty Str255 for a named
+            // lookup. Keep the result deterministic in the same resource-map
+            // ID order used by the on-disk loader.
+            let mut unnamed: Vec<(i16, u32)> = file
+                .loaded
+                .iter()
+                .filter_map(|(&(candidate_type, id), &ptr)| {
+                    (candidate_type == res_type
+                        && !file.names_by_id.contains_key(&(candidate_type, id)))
+                    .then_some((id, ptr))
+                })
+                .collect();
+            unnamed.sort_unstable_by_key(|(id, _)| *id);
+            return unnamed
+                .into_iter()
+                .next()
+                .map(|(id, ptr)| (refnum, id, ptr));
+        }
+        None
     }
 
     /// Collect every named resource of `res_type` reachable through the
@@ -5449,6 +5475,21 @@ impl TrapDispatcher {
             for ((rt, n), (id, ptr)) in &file.named {
                 if *rt == res_type && n.to_lowercase() == needle_lower {
                     return Some((refnum, *id, *ptr));
+                }
+            }
+            if name.is_empty() {
+                let mut unnamed: Vec<(i16, u32)> = file
+                    .loaded
+                    .iter()
+                    .filter_map(|(&(candidate_type, id), &ptr)| {
+                        (candidate_type == res_type
+                            && !file.names_by_id.contains_key(&(candidate_type, id)))
+                        .then_some((id, ptr))
+                    })
+                    .collect();
+                unnamed.sort_unstable_by_key(|(id, _)| *id);
+                if let Some((id, ptr)) = unnamed.into_iter().next() {
+                    return Some((refnum, id, ptr));
                 }
             }
         }
@@ -5987,8 +6028,10 @@ impl TrapDispatcher {
         };
         if !auto_pop {
             if let Some(&handler_addr) = self.native_trap_table.get(&base_trap) {
-                // Simulate JSR to native handler: push return PC, jump to handler
-                let return_pc = cpu.read_reg(Register::PC); // past A-line instruction
+                // Simulate JSR to native handler: push return PC, jump to
+                // handler. The CPU core has already advanced PC past the
+                // two-byte A-line opcode before dispatch reaches here.
+                let return_pc = cpu.read_reg(Register::PC);
                 let sp = cpu.read_reg(Register::A7);
                 let new_sp = sp.wrapping_sub(4);
                 bus.write_long(new_sp, return_pc);
@@ -6099,7 +6142,9 @@ impl Default for TrapDispatcher {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cpu::{CpuOps, Register};
     use crate::trap::menu::MenuTrackingState;
+    use crate::trap::test_helpers::setup;
     use std::collections::VecDeque;
 
     fn make_single_resource_fork_bytes(res_type: [u8; 4], res_id: i16, data: &[u8]) -> Vec<u8> {
@@ -6168,6 +6213,23 @@ mod tests {
         bytes[56..58].copy_from_slice(&0u16.to_be_bytes()); // plain style
         bytes[58..60].copy_from_slice(&(font_resource_id as u16).to_be_bytes());
         bytes
+    }
+
+    #[test]
+    fn native_trap_dispatch_returns_past_the_a_line_opcode() {
+        let (mut dispatcher, mut cpu, mut bus) = setup();
+        let trap_pc = 0x0020_0000u32;
+        let handler_addr = 0x0021_0000u32;
+        let sp = 0x003F_FF00u32;
+        dispatcher.native_trap_table.insert(0xA9F0, handler_addr);
+        cpu.write_reg(Register::PC, trap_pc + 2);
+        cpu.write_reg(Register::A7, sp);
+
+        dispatcher.dispatch(0xA9F0, &mut cpu, &mut bus).unwrap();
+
+        assert_eq!(cpu.read_reg(Register::PC), handler_addr);
+        assert_eq!(cpu.read_reg(Register::A7), sp - 4);
+        assert_eq!(bus.read_long(sp - 4), trap_pc + 2);
     }
 
     #[test]

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -717,6 +717,16 @@ pub(crate) struct LoadSegGetResourceState {
     pub a_regs: [u32; 8],
 }
 
+/// Original A-line call state retained while a handler installed through
+/// SetTrapAddress runs. A handler may call the old trap address later, after
+/// changing its stack frame, so old-trap recovery cannot infer this state
+/// from A6 or from the handler's instruction shape.
+#[derive(Clone, Debug)]
+pub(crate) struct NativeTrapCallState {
+    pub return_pc: u32,
+    pub argument_sp: u32,
+}
+
 /// Stack size handed to a cooperative thread when `NewThread` is passed 0
 /// and the size reported by `GetDefaultThreadStackSize`. The 68K Thread
 /// Manager's own default is a small multiple of a page; 32K comfortably
@@ -1025,6 +1035,9 @@ pub struct TrapDispatcher {
     /// Canonical resource bytes keyed by (resource-file refnum, type, id).
     /// Used to reload unloaded resources without reparsing the whole fork.
     pub(crate) resource_backing_data: HashMap<(u16, [u8; 4], i16), Vec<u8>>,
+    /// Resource-map entries whose data is currently resident in a guest
+    /// master pointer. Parser backing allocations do not imply residency.
+    pub(crate) resident_resources: HashSet<(u16, [u8; 4], i16)>,
     /// Movie Toolbox handles returned by NewMovieFromFile/NewMovie-style traps.
     pub(crate) movie_states: HashMap<u32, MovieState>,
     /// Maps a movie-controller component instance to the Movie it drives, set
@@ -1748,6 +1761,10 @@ pub struct TrapDispatcher {
     /// instead of running HLE code. This allows CRT-installed handlers (LoadSeg,
     /// UnloadSeg, ExitToShell) to run natively with proper code relocation.
     pub(crate) native_trap_table: HashMap<u16, u32>,
+    /// Most recent original call for each active native trap handler. Entries
+    /// are replaced by a newer call and consumed when a handler invokes its
+    /// saved old trap address.
+    pub(crate) pending_native_trap_calls: HashMap<u16, NativeTrapCallState>,
     /// Re-entrancy guard for the CopyBits `grafProcs.bitsProc` bottleneck:
     /// `(bitsProc address, stack pointer at the tail call)`. A custom bitsProc
     /// normally reaches the real transfer by calling CopyBits again; without
@@ -2771,6 +2788,7 @@ impl TrapDispatcher {
             detached_handle_files: HashMap::new(),
             resources: None,
             resource_backing_data: HashMap::new(),
+            resident_resources: HashSet::new(),
             movie_states: HashMap::new(),
             movie_by_controller: HashMap::new(),
             movie_error: 0,
@@ -3015,6 +3033,7 @@ impl TrapDispatcher {
             recording_picture: None,
             recording_picture_bitmap: None,
             native_trap_table: HashMap::new(),
+            pending_native_trap_calls: HashMap::new(),
             bits_proc_reentry: None,
             timer_tasks: Vec::new(),
             timer_current_subtick: 0,
@@ -5005,6 +5024,8 @@ impl TrapDispatcher {
         }
         self.clear_resource_file_backing_data(refnum);
         self.clear_resource_file_handle_index(refnum);
+        self.resident_resources
+            .retain(|(entry_refnum, _, _)| *entry_refnum != refnum);
 
         if !closed {
             return false;
@@ -5391,31 +5412,11 @@ impl TrapDispatcher {
         let res_type = Self::normalize_ostype(res_type);
         let resources = self.resources.as_ref()?;
         let refnum = self.current_resource_refnum();
-        let file = resources.files.get(&refnum)?;
-        if let Some((id, ptr)) = file.named.get(&(res_type, name.to_string())).copied() {
-            return Some((refnum, id, ptr));
-        }
-        if name.is_empty() {
-            // Unnamed resources have no entry in `named`, but the Resource
-            // Manager treats their name as the empty Str255 for a named
-            // lookup. Keep the result deterministic in the same resource-map
-            // ID order used by the on-disk loader.
-            let mut unnamed: Vec<(i16, u32)> = file
-                .loaded
-                .iter()
-                .filter_map(|(&(candidate_type, id), &ptr)| {
-                    (candidate_type == res_type
-                        && !file.names_by_id.contains_key(&(candidate_type, id)))
-                    .then_some((id, ptr))
-                })
-                .collect();
-            unnamed.sort_unstable_by_key(|(id, _)| *id);
-            return unnamed
-                .into_iter()
-                .next()
-                .map(|(id, ptr)| (refnum, id, ptr));
-        }
-        None
+        resources
+            .files
+            .get(&refnum)
+            .and_then(|file| file.named.get(&(res_type, name.to_string())).copied())
+            .map(|(id, ptr)| (refnum, id, ptr))
     }
 
     /// Collect every named resource of `res_type` reachable through the
@@ -5475,21 +5476,6 @@ impl TrapDispatcher {
             for ((rt, n), (id, ptr)) in &file.named {
                 if *rt == res_type && n.to_lowercase() == needle_lower {
                     return Some((refnum, *id, *ptr));
-                }
-            }
-            if name.is_empty() {
-                let mut unnamed: Vec<(i16, u32)> = file
-                    .loaded
-                    .iter()
-                    .filter_map(|(&(candidate_type, id), &ptr)| {
-                        (candidate_type == res_type
-                            && !file.names_by_id.contains_key(&(candidate_type, id)))
-                        .then_some((id, ptr))
-                    })
-                    .collect();
-                unnamed.sort_unstable_by_key(|(id, _)| *id);
-                if let Some((id, ptr)) = unnamed.into_iter().next() {
-                    return Some((refnum, id, ptr));
                 }
             }
         }
@@ -6033,6 +6019,13 @@ impl TrapDispatcher {
                 // two-byte A-line opcode before dispatch reaches here.
                 let return_pc = cpu.read_reg(Register::PC);
                 let sp = cpu.read_reg(Register::A7);
+                self.pending_native_trap_calls.insert(
+                    base_trap,
+                    NativeTrapCallState {
+                        return_pc,
+                        argument_sp: sp,
+                    },
+                );
                 let new_sp = sp.wrapping_sub(4);
                 bus.write_long(new_sp, return_pc);
                 cpu.write_reg(Register::A7, new_sp);

--- a/src/trap/memory.rs
+++ b/src/trap/memory.rs
@@ -630,6 +630,7 @@ impl super::TrapDispatcher {
                     }
                 }
                 self.detached_handles.remove(&handle);
+                self.forget_resource_residency_for_handle(handle);
                 self.forget_resource_handle_index_for_handle(handle);
                 self.loaded_handles.remove(&handle);
                 self.resource_handle_files.remove(&handle);
@@ -1002,6 +1003,7 @@ impl super::TrapDispatcher {
                     .tool_trap_trampolines
                     .values()
                     .any(|&addr| addr == handler_addr);
+                self.pending_native_trap_calls.remove(&trap_table_key);
                 if is_legacy_fakeptr || is_trampoline {
                     self.native_trap_table.remove(&trap_table_key);
                 } else {
@@ -3585,6 +3587,7 @@ impl super::TrapDispatcher {
                             bus.free(master_ptr);
                         }
                     }
+                    self.forget_resource_residency_for_handle(handle);
                     bus.write_long(handle, 0); // set master pointer to NIL
                     cpu.write_reg(Register::D0, 0); // noErr
                 }

--- a/src/trap/memory.rs
+++ b/src/trap/memory.rs
@@ -1287,7 +1287,8 @@ impl super::TrapDispatcher {
             // diverge: FreeMem returns the SUM of free blocks
             // (potentially fragmented), MaxMem returns the
             // largest single contiguous free block (smaller than
-            // FreeMem when the heap is fragmented), CompactMem
+            // FreeMem when the heap is fragmented) plus the
+            // application-zone growth allowance in A0, CompactMem
             // returns the largest block AFTER compacting purgeable
             // resources. In our flat allocator there's no
             // fragmentation to expose, so the three traps share
@@ -1310,11 +1311,22 @@ impl super::TrapDispatcher {
             // contiguous block in D0, total free in A0
             // FUNCTION MaxMem(VAR grow: Size): Size;
             // Inside Macintosh Volume II, II-39
-            // MaxMem ($A01D): Per IM:II II-39 returns largest contiguous free block in D0 and total free in A0 (assembly-language convention); Systemless returns free_heap_estimate in D0 and the same value in A0 (no fragmentation modeled, so largest contiguous == total free). $A11D variant (with grow zone) dispatches to the same arm via the OS-trap low-byte (0x1D) decode.
+            // MaxMem ($A01D): Per IM:II II-39 and Memory 1992 2-74, the
+            // largest contiguous block is returned in D0 and the number of
+            // bytes by which the application zone can grow is returned in
+            // A0. Systemless launches expand the application zone to its
+            // ApplLimit during startup, so A0 is normally zero; retain the
+            // low-memory calculation for tests or clients that leave a gap
+            // between bkLim and ApplLimit. $A11D dispatches to this arm via
+            // the OS-trap low-byte (0x1D) decode.
             (false, 0x1D) => {
                 let free = free_heap_estimate(bus);
                 cpu.write_reg(Register::D0, free);
-                cpu.write_reg(Register::A0, free);
+                let zone = bus.read_long(addr::APP_L_ZONE);
+                let bk_lim = if zone != 0 { bus.read_long(zone) } else { 0 };
+                let appl_limit = bus.read_long(addr::APPL_LIMIT);
+                let grow = appl_limit.saturating_sub(bk_lim);
+                cpu.write_reg(Register::A0, grow);
                 Ok(())
             }
 
@@ -8760,8 +8772,26 @@ mod tests {
         );
         assert_eq!(
             cpu.read_reg(Register::A0),
-            24 * 1024 * 1024,
-            "MaxMem should return 24MB clamp floor in A0"
+            0,
+            "MaxMem should return zero application-zone growth after MaxApplZone"
+        );
+    }
+
+    #[test]
+    fn test_max_mem_returns_application_zone_growth_in_a0() {
+        let (mut dispatcher, mut cpu, mut bus) = setup();
+        let zone = 0x180000;
+        bus.write_long(crate::memory::globals::addr::APP_L_ZONE, zone);
+        bus.write_long(zone, zone + 0x1000); // bkLim
+        bus.write_long(crate::memory::globals::addr::APPL_LIMIT, zone + 0x3000);
+
+        let result = dispatcher.dispatch_memory(false, 0x1D, &mut cpu, &mut bus);
+        assert!(result.is_some(), "MaxMem should be handled");
+        assert!(result.unwrap().is_ok(), "MaxMem should succeed");
+        assert_eq!(
+            cpu.read_reg(Register::A0),
+            0x2000,
+            "MaxMem should return the application-zone growth allowance in A0"
         );
     }
 

--- a/src/trap/memory.rs
+++ b/src/trap/memory.rs
@@ -510,6 +510,15 @@ impl super::TrapDispatcher {
             // NewPtr / NewPtrClear / NewPtrSys ($A01E): Allocates via `bus.alloc()`, returns ptr in A0; CLEAR variant ($A31E) zeros memory per IM:II II-37
             (false, 0x1E) => {
                 let size = cpu.read_reg(Register::D0);
+                // `Size` is a signed Macintosh LONGINT. Reject negative
+                // requests before converting them into an unsigned heap
+                // allocation; otherwise an error value can wrap the bump
+                // pointer and scribble across guest memory.
+                if (size as i32) < 0 {
+                    cpu.write_reg(Register::A0, 0);
+                    write_memory_result(cpu, bus, MEM_FULL_ERR);
+                    return Some(Ok(()));
+                }
                 let ptr = bus.alloc(size);
                 if ptr == 0 && size > 0 {
                     cpu.write_reg(Register::A0, 0);
@@ -539,6 +548,13 @@ impl super::TrapDispatcher {
             // Inside Macintosh Volume II, II-27
             (false, 0x22) => {
                 let size = cpu.read_reg(Register::D0);
+                // `Size` is a signed Macintosh LONGINT; negative sizes are
+                // invalid and must not be passed to the unsigned allocator.
+                if (size as i32) < 0 {
+                    cpu.write_reg(Register::A0, 0);
+                    write_memory_result(cpu, bus, MEM_FULL_ERR);
+                    return Some(Ok(()));
+                }
                 let ptr = bus.alloc(size);
                 if ptr == 0 && size > 0 {
                     cpu.write_reg(Register::A0, 0);
@@ -4406,6 +4422,34 @@ mod tests {
     }
 
     #[test]
+    fn negative_new_ptr_size_returns_mem_full_without_heap_wrap() {
+        let (mut dispatcher, mut cpu, mut bus) = setup();
+        bus.write_long(addr::J_CRSR_TASK, 0x1234_5678);
+        cpu.write_reg(Register::D0, (-108i32) as u32);
+
+        let result = dispatcher.dispatch_memory(false, 0x1E, &mut cpu, &mut bus);
+
+        assert!(result.is_some() && result.unwrap().is_ok());
+        assert_eq!(cpu.read_reg(Register::A0), 0);
+        assert_eq!(cpu.read_reg(Register::D0), (-108i32) as u32);
+        assert_eq!(bus.read_long(addr::J_CRSR_TASK), 0x1234_5678);
+    }
+
+    #[test]
+    fn negative_new_handle_size_returns_mem_full_without_heap_wrap() {
+        let (mut dispatcher, mut cpu, mut bus) = setup();
+        bus.write_long(addr::J_CRSR_TASK, 0x1234_5678);
+        cpu.write_reg(Register::D0, (-108i32) as u32);
+
+        let result = dispatcher.dispatch_memory(false, 0x22, &mut cpu, &mut bus);
+
+        assert!(result.is_some() && result.unwrap().is_ok());
+        assert_eq!(cpu.read_reg(Register::A0), 0);
+        assert_eq!(cpu.read_reg(Register::D0), (-108i32) as u32);
+        assert_eq!(bus.read_long(addr::J_CRSR_TASK), 0x1234_5678);
+    }
+
+    #[test]
     fn new_ptr_extends_stale_application_zone_past_successful_allocation() {
         let (mut dispatcher, mut cpu, mut bus) = setup();
         let app_zone = 0x0020_0000;
@@ -6659,6 +6703,7 @@ mod tests {
             first_addr, 0,
             "tool-trap trampoline address should be nonzero"
         );
+        bus.write_word(first_addr, 0);
 
         cpu.write_reg(Register::D0, 0xA89F);
         let result = dispatcher.dispatch_memory(true, 0x346, &mut cpu, &mut bus);
@@ -6674,6 +6719,11 @@ mod tests {
             cpu.read_reg(Register::A0),
             first_addr,
             "tool-trap trampoline lookup should be stable"
+        );
+        assert_eq!(
+            bus.read_word(first_addr),
+            0xAC9F,
+            "repeated lookup should restore the ROM-like auto-pop trap word"
         );
         assert_eq!(
             cpu.read_reg(Register::A7),
@@ -6743,6 +6793,25 @@ mod tests {
                 "BlockMove should behave like memmove for overlapping ranges"
             );
         }
+    }
+
+    #[test]
+    fn test_block_move_negative_count_is_noop() {
+        let (mut dispatcher, mut cpu, mut bus) = setup();
+        let src = 0x300000u32;
+        let dst = 0x310000u32;
+        bus.write_bytes(src, &[0xDE, 0xAD, 0xBE, 0xEF]);
+        bus.write_bytes(dst, &[0x11, 0x22, 0x33, 0x44]);
+
+        cpu.write_reg(Register::A0, src);
+        cpu.write_reg(Register::A1, dst);
+        cpu.write_reg(Register::D0, 0xFFFF_FF81);
+
+        let result = dispatcher.dispatch_memory(false, 0x2E, &mut cpu, &mut bus);
+        assert!(result.is_some(), "BlockMove should be handled");
+        assert!(result.unwrap().is_ok(), "BlockMove should succeed");
+        assert_eq!(cpu.read_reg(Register::D0), 0);
+        assert_eq!(bus.read_bytes(dst, 4), vec![0x11, 0x22, 0x33, 0x44]);
     }
 
     #[test]

--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -243,6 +243,18 @@ impl super::TrapDispatcher {
             && address >= base
     }
 
+    fn native_loadseg_handler_is_jump_table(&self, bus: &MacMemoryBus) -> bool {
+        self.native_trap_table
+            .get(&0xA9F0)
+            .copied()
+            .is_some_and(|handler| {
+                // The native CRT shim is installed through a loaded jump-table
+                // entry. A stale/resource pointer can also appear in the trap
+                // table, but it must not be fed into old-trap recovery.
+                bus.read_word(handler) == 0x4EF9 && bus.read_long(handler + 2) != 0
+            })
+    }
+
     /// Minimal serialized resource fork containing an empty resource map.
     fn empty_resource_fork_bytes() -> Vec<u8> {
         let mut bytes = vec![0u8; 46];
@@ -2412,6 +2424,9 @@ impl super::TrapDispatcher {
 
                 let auto_pop_old_trap = (self.current_trap_word & 0x0400) != 0;
                 let original_trap_return = self.current_trap_caller;
+                let native_loadseg_handler = self.native_loadseg_handler_is_jump_table(bus);
+                let native_return =
+                    bus.read_long(cpu.read_reg(Register::A6).wrapping_add(4));
 
                 // A native segment-loader shim can tail-call the previous
                 // `_LoadSeg` address returned by GetToolTrapAddress. The
@@ -2421,9 +2436,7 @@ impl super::TrapDispatcher {
                 // Think C entry from that saved return address, patch the
                 // resident segment, and let the normal auto-pop epilogue
                 // return to the shim continuation.
-                if is_loadseg_trampoline && auto_pop_old_trap {
-                    let native_return =
-                        bus.read_long(cpu.read_reg(Register::A6).wrapping_add(4));
+                if is_loadseg_trampoline && auto_pop_old_trap && native_loadseg_handler {
                     // The native shim tail-jumps through the saved old trap.
                     // Its return PC is the start of the next MPW jump-table
                     // entry: the first word is the routine offset, followed
@@ -2456,7 +2469,10 @@ impl super::TrapDispatcher {
                 // handler frame from which to recover a jump-table entry.
                 // CODE is already resident in that case, so preserve the
                 // caller's return path as a successful no-op.
-                if is_loadseg_trampoline && self.segment_map.contains_key(&trampoline_segment) {
+                if is_loadseg_trampoline
+                    && (native_loadseg_handler || native_return == 0)
+                    && self.segment_map.contains_key(&trampoline_segment)
+                {
                     if trace_loadseg_enabled() {
                         eprintln!(
                             "[TRAP] LoadSeg(seg={}, fmt=resident-trampoline) entry=${:08X}",
@@ -11199,6 +11215,25 @@ mod tests {
         assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 4);
         assert_eq!(cpu.read_reg(Register::PC), return_pc);
         assert_eq!(cpu.read_reg(Register::D0), 25);
+    }
+
+    #[test]
+    fn loadseg_recovery_requires_a_jmp_l_native_handler() {
+        let (mut disp, _cpu, mut bus) = setup();
+        let handler = 0x300000u32;
+        disp.native_trap_table.insert(0xA9F0, handler);
+
+        assert!(!disp.native_loadseg_handler_is_jump_table(&bus));
+
+        bus.write_word(handler, 0x4EB9);
+        bus.write_long(handler + 2, 0x310000);
+        assert!(!disp.native_loadseg_handler_is_jump_table(&bus));
+
+        bus.write_word(handler, 0x4EF9);
+        assert!(disp.native_loadseg_handler_is_jump_table(&bus));
+
+        bus.write_long(handler + 2, 0);
+        assert!(!disp.native_loadseg_handler_is_jump_table(&bus));
     }
 
     #[test]

--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -2311,15 +2311,17 @@ impl super::TrapDispatcher {
 
                 if let Some(h) = handle {
                     eprintln!("[TRAP] Get1NamedResource -> handle ${:08X}", h);
+                    cpu.write_reg(Register::A0, h);
                     bus.write_long(sp + 8, h);
                     cpu.write_reg(Register::A7, sp + 8);
                     cpu.write_reg(Register::D0, 0);
                     bus.write_word(0x0A60, 0); // ResErr = noErr
                 } else {
                     eprintln!("[TRAP] Get1NamedResource -> NULL (not found)");
+                    cpu.write_reg(Register::A0, 0);
                     bus.write_long(sp + 8, 0);
                     cpu.write_reg(Register::A7, sp + 8);
-                    cpu.write_reg(Register::D0, -192i32 as u32);
+                    cpu.write_reg(Register::D0, 0);
                     bus.write_word(0x0A60, (-192i16) as u16); // ResErr = resNotFound
                 }
                 Ok(())
@@ -2401,8 +2403,68 @@ impl super::TrapDispatcher {
                 let pc = cpu.read_reg(Register::PC); // past A9F0
                 let a9f0_addr = pc.wrapping_sub(2);
 
+                let trampoline_segment = cpu.read_reg(Register::D0) as i16;
+                let is_loadseg_trampoline = self
+                    .tool_trap_trampolines
+                    .get(&0xA9F0)
+                    .copied()
+                    .is_some_and(|addr| addr == a9f0_addr);
+
                 let auto_pop_old_trap = (self.current_trap_word & 0x0400) != 0;
                 let original_trap_return = self.current_trap_caller;
+
+                // A native segment-loader shim can tail-call the previous
+                // `_LoadSeg` address returned by GetToolTrapAddress. The
+                // auto-pop trampoline has no CODE jump-table bytes of its
+                // own, but the native handler's link frame retains the
+                // original caller return address at A6+4. Recover the
+                // Think C entry from that saved return address, patch the
+                // resident segment, and let the normal auto-pop epilogue
+                // return to the shim continuation.
+                if is_loadseg_trampoline && auto_pop_old_trap {
+                    let native_return =
+                        bus.read_long(cpu.read_reg(Register::A6).wrapping_add(4));
+                    // The native shim tail-jumps through the saved old trap.
+                    // Its return PC is the start of the next MPW jump-table
+                    // entry: the first word is the routine offset, followed
+                    // by the usual MOVE.W/_LoadSeg glue. The shim's D0 is the
+                    // zero-based CODE resource number to load.
+                    let entry = native_return;
+                    if native_return != 0 && self.segment_map.contains_key(&trampoline_segment) {
+                        if trace_loadseg_enabled() {
+                            eprintln!(
+                                "[TRAP] LoadSeg(seg={}, fmt=mpw-native-oldtrap) entry=${:08X} return=${:08X}",
+                                trampoline_segment, entry, native_return
+                            );
+                        }
+                        // Re-enter the patched entry rather than the raw
+                        // offset word at the native return address. The
+                        // auto-pop epilogue would otherwise restore that
+                        // same raw address after finish_loadseg returns.
+                        self.preserve_auto_pop_pc_once = true;
+                        return Some(self.finish_loadseg(
+                            bus,
+                            cpu,
+                            trampoline_segment,
+                            entry,
+                            true,
+                        ));
+                    }
+                }
+
+                // A standalone trampoline call has no enclosing native
+                // handler frame from which to recover a jump-table entry.
+                // CODE is already resident in that case, so preserve the
+                // caller's return path as a successful no-op.
+                if is_loadseg_trampoline && self.segment_map.contains_key(&trampoline_segment) {
+                    if trace_loadseg_enabled() {
+                        eprintln!(
+                            "[TRAP] LoadSeg(seg={}, fmt=resident-trampoline) entry=${:08X}",
+                            trampoline_segment, a9f0_addr
+                        );
+                    }
+                    return Some(Ok(()));
+                }
 
                 // Detect format: in standard format, [A9F0-4] = 3F3C (MOVE.W).
                 // In Think C format, A9F0 is at entry+0 and [A9F0+2] = 0x0000.
@@ -10063,6 +10125,62 @@ mod tests {
             handle, 0,
             "handle should be non-zero for found named resource"
         );
+        assert_eq!(
+            cpu.read_reg(Register::A0),
+            handle,
+            "found named resource handle should be returned in A0"
+        );
+    }
+
+    #[test]
+    fn get1_named_resource_empty_name_finds_unnamed_resource() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let data_ptr = bus.alloc(4);
+        bus.write_bytes(data_ptr, &[0x10, 0x20, 0x30, 0x40]);
+        disp.resources = Some(LoadedResources {
+            files: HashMap::from([(
+                0,
+                ResourceFileMap {
+                    loaded: HashMap::from([((*b"CODE", 25), data_ptr)]),
+                    named: HashMap::new(),
+                    names_by_id: HashMap::new(),
+                    attrs: HashMap::new(),
+                    map_attrs: 0,
+                },
+            )]),
+            names: HashMap::new(),
+            search_order: vec![0],
+            current_file: 0,
+        });
+
+        let name_addr = 0x200000u32;
+        write_pstring(&mut bus, name_addr, b"");
+        bus.write_long(TEST_SP, name_addr);
+        bus.write_long(TEST_SP + 4, u32::from_be_bytes(*b"CODE"));
+
+        call(&mut disp, true, 0x020, &mut cpu, &mut bus).unwrap();
+
+        let handle = bus.read_long(TEST_SP + 8);
+        assert_ne!(handle, 0);
+        assert_eq!(cpu.read_reg(Register::A0), handle);
+        assert_eq!(bus.read_word(0x0A60), 0);
+    }
+
+    #[test]
+    fn get1_named_resource_miss_returns_nil_in_a0() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let name_addr = 0x200000u32;
+        write_pstring(&mut bus, name_addr, b"Missing");
+
+        bus.write_long(TEST_SP, name_addr);
+        bus.write_long(TEST_SP + 4, u32::from_be_bytes(*b"STR "));
+
+        call(&mut disp, true, 0x020, &mut cpu, &mut bus).unwrap();
+
+        assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 8);
+        assert_eq!(cpu.read_reg(Register::A0), 0);
+        assert_eq!(cpu.read_reg(Register::D0), 0);
+        assert_eq!(bus.read_long(TEST_SP + 8), 0);
     }
 
     #[test]
@@ -11062,6 +11180,25 @@ mod tests {
         assert_eq!(bus.read_word(old_trap_stub), 0xADF0);
         assert_eq!(bus.read_word(old_trap_stub + 2), 0x0000);
         assert_eq!(bus.read_word(old_trap_stub + 4), 0x4EB9);
+    }
+
+    #[test]
+    fn loadseg_auto_pop_trampoline_accepts_resident_segment_in_d0() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        disp.register_segments(HashMap::from([(25i16, 0x220000u32)]));
+
+        let trampoline = disp.get_or_create_tool_trap_trampoline(&mut bus, 0xA9F0);
+        let return_pc = 0x280000u32;
+        bus.write_long(TEST_SP, return_pc);
+        cpu.write_reg(Register::A7, TEST_SP);
+        cpu.write_reg(Register::PC, trampoline + 2);
+        cpu.write_reg(Register::D0, 25);
+
+        call_trap_word(&mut disp, 0xADF0, &mut cpu, &mut bus).unwrap();
+
+        assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 4);
+        assert_eq!(cpu.read_reg(Register::PC), return_pc);
+        assert_eq!(cpu.read_reg(Register::D0), 25);
     }
 
     #[test]

--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -243,18 +243,6 @@ impl super::TrapDispatcher {
             && address >= base
     }
 
-    fn native_loadseg_handler_is_jump_table(&self, bus: &MacMemoryBus) -> bool {
-        self.native_trap_table
-            .get(&0xA9F0)
-            .copied()
-            .is_some_and(|handler| {
-                // The native CRT shim is installed through a loaded jump-table
-                // entry. A stale/resource pointer can also appear in the trap
-                // table, but it must not be fed into old-trap recovery.
-                bus.read_word(handler) == 0x4EF9 && bus.read_long(handler + 2) != 0
-            })
-    }
-
     /// Minimal serialized resource fork containing an empty resource map.
     fn empty_resource_fork_bytes() -> Vec<u8> {
         let mut bytes = vec![0u8; 46];
@@ -765,6 +753,7 @@ impl super::TrapDispatcher {
         refnum: u16,
     ) -> u32 {
         let key = (refnum, res_type, res_id);
+        let recorded_resident = self.resident_resources.contains(&key);
         if let Some(handle) = self.resource_handles_by_key.get(&key).copied() {
             if let Some((existing_ptr, existing_type, existing_id)) =
                 self.loaded_handles.get(&handle).copied()
@@ -780,11 +769,12 @@ impl super::TrapDispatcher {
                     // later lookup with loading enabled should fill it and restore
                     // the reverse ptr->handle ownership so RecoverHandle keeps
                     // working after the refill.
-                    if self.res_load && bus.read_long(handle) == 0 {
+                    if bus.read_long(handle) == 0 && (self.res_load || recorded_resident) {
                         bus.write_long(handle, existing_ptr);
                         self.add_resource_materialization_tick_cost(bus, existing_ptr);
                     }
-                    if existing_ptr != 0 {
+                    if bus.read_long(handle) != 0 && existing_ptr != 0 {
+                        self.resident_resources.insert(key);
                         self.ptr_to_handle.insert(existing_ptr, handle);
                     }
                     return handle;
@@ -798,11 +788,13 @@ impl super::TrapDispatcher {
         // an empty handle (master pointer NIL) for resource data that is not
         // already in memory. Keep the true data pointer in loaded_handles so
         // LoadResource can populate the master pointer later.
-        bus.write_long(handle, if self.res_load { ptr } else { 0 });
+        let materialize = self.res_load || recorded_resident;
+        bus.write_long(handle, if materialize { ptr } else { 0 });
         self.loaded_handles.insert(handle, (ptr, res_type, res_id));
         self.resource_handle_files.insert(handle, refnum);
         self.remember_resource_handle_index(handle, key.0, key.1, key.2);
-        if self.res_load && ptr != 0 {
+        if materialize && ptr != 0 {
+            self.resident_resources.insert(key);
             self.ptr_to_handle.insert(ptr, handle);
             self.add_resource_materialization_tick_cost(bus, ptr);
         }
@@ -1018,11 +1010,26 @@ impl super::TrapDispatcher {
 
     fn restore_loaded_resource_handle(&mut self, handle: u32, ptr: u32) {
         self.ptr_to_handle.insert(ptr, handle);
+        if let (Some((_, res_type, res_id)), Some(refnum)) = (
+            self.loaded_handles.get(&handle).copied(),
+            self.resource_handle_files.get(&handle).copied(),
+        ) {
+            self.resident_resources.insert((refnum, res_type, res_id));
+        }
         self.detached_handles.remove(&handle);
         if let Some(refnum) = self.detached_handle_files.remove(&handle) {
             // A reload should repair any stale detached-file bookkeeping so
             // later Resource Manager queries still see a live resource.
             self.resource_handle_files.insert(handle, refnum);
+        }
+    }
+
+    pub(crate) fn forget_resource_residency_for_handle(&mut self, handle: u32) {
+        if let (Some((_, res_type, res_id)), Some(refnum)) = (
+            self.loaded_handles.get(&handle).copied(),
+            self.resource_handle_files.get(&handle).copied(),
+        ) {
+            self.resident_resources.remove(&(refnum, res_type, res_id));
         }
     }
 
@@ -1858,6 +1865,7 @@ impl super::TrapDispatcher {
                         // immutable backing bytes so a later GetResource can reload the
                         // original fork data, but do not let the file's live map keep
                         // pointing at this now-private buffer.
+                        self.forget_resource_residency_for_handle(handle);
                         self.forget_resource_live_map_entry_for_handle(handle);
                         self.forget_resource_handle_index_for_handle(handle);
                         self.loaded_handles.remove(&handle);
@@ -1939,6 +1947,7 @@ impl super::TrapDispatcher {
                     }
                     let attrs = self.resource_attributes_for_handle(handle).unwrap_or(0);
                     if (attrs & Self::RES_CHANGED_ATTR) == 0 {
+                        self.forget_resource_residency_for_handle(handle);
                         let resource_record = self.resource_record_for_handle(handle);
                         let can_reload = resource_record
                             .map(|(refnum, record_type, record_id)| {
@@ -2415,7 +2424,6 @@ impl super::TrapDispatcher {
                 let pc = cpu.read_reg(Register::PC); // past A9F0
                 let a9f0_addr = pc.wrapping_sub(2);
 
-                let trampoline_segment = cpu.read_reg(Register::D0) as i16;
                 let is_loadseg_trampoline = self
                     .tool_trap_trampolines
                     .get(&0xA9F0)
@@ -2424,72 +2432,18 @@ impl super::TrapDispatcher {
 
                 let auto_pop_old_trap = (self.current_trap_word & 0x0400) != 0;
                 let original_trap_return = self.current_trap_caller;
-                let native_loadseg_handler = self.native_loadseg_handler_is_jump_table(bus);
-                let native_return =
-                    bus.read_long(cpu.read_reg(Register::A6).wrapping_add(4));
-
-                // A native segment-loader shim can tail-call the previous
-                // `_LoadSeg` address returned by GetToolTrapAddress. The
-                // auto-pop trampoline has no CODE jump-table bytes of its
-                // own, but the native handler's link frame retains the
-                // original caller return address at A6+4. Recover the
-                // Think C entry from that saved return address, patch the
-                // resident segment, and let the normal auto-pop epilogue
-                // return to the shim continuation.
-                if is_loadseg_trampoline && auto_pop_old_trap && native_loadseg_handler {
-                    // The native shim tail-jumps through the saved old trap.
-                    // Its return PC is the start of the next MPW jump-table
-                    // entry: the first word is the routine offset, followed
-                    // by the usual MOVE.W/_LoadSeg glue. The shim's D0 is the
-                    // zero-based CODE resource number to load.
-                    let entry = native_return;
-                    if native_return != 0 && self.segment_map.contains_key(&trampoline_segment) {
-                        if trace_loadseg_enabled() {
-                            eprintln!(
-                                "[TRAP] LoadSeg(seg={}, fmt=mpw-native-oldtrap) entry=${:08X} return=${:08X}",
-                                trampoline_segment, entry, native_return
-                            );
-                        }
-                        // Re-enter the patched entry rather than the raw
-                        // offset word at the native return address. The
-                        // auto-pop epilogue would otherwise restore that
-                        // same raw address after finish_loadseg returns.
-                        self.preserve_auto_pop_pc_once = true;
-                        return Some(self.finish_loadseg(
-                            bus,
-                            cpu,
-                            trampoline_segment,
-                            entry,
-                            true,
-                        ));
-                    }
-                }
-
-                // A standalone trampoline call has no enclosing native
-                // handler frame from which to recover a jump-table entry.
-                // CODE is already resident in that case, so preserve the
-                // caller's return path as a successful no-op.
-                if is_loadseg_trampoline
-                    && (native_loadseg_handler || native_return == 0)
-                    && self.segment_map.contains_key(&trampoline_segment)
-                {
-                    if trace_loadseg_enabled() {
-                        eprintln!(
-                            "[TRAP] LoadSeg(seg={}, fmt=resident-trampoline) entry=${:08X}",
-                            trampoline_segment, a9f0_addr
-                        );
-                    }
-                    return Some(Ok(()));
-                }
+                let native_call = (is_loadseg_trampoline && auto_pop_old_trap)
+                    .then(|| self.pending_native_trap_calls.remove(&0xA9F0))
+                    .flatten();
 
                 // Detect format: in standard format, [A9F0-4] = 3F3C (MOVE.W).
                 // In Think C format, A9F0 is at entry+0 and [A9F0+2] = 0x0000.
                 //
                 // Native LoadSeg handlers save the previous trap address via
                 // GetTrapAddress and later jump to its auto-pop form (e.g.
-                // $ADF0). At that point PC names the tiny old-trap stub, not
-                // the original jump-table entry. Use the auto-pop return
-                // address to recover the caller's entry instead.
+                // $ADF0). The dispatcher records the original A-line return
+                // PC and argument SP before entering any installed handler,
+                // so recovery does not depend on that handler's stack frame.
                 let old_trap_standard = auto_pop_old_trap
                     && original_trap_return.is_some_and(|return_pc| {
                         bus.read_word(return_pc.wrapping_sub(6)) == 0x3F3C
@@ -2502,33 +2456,57 @@ impl super::TrapDispatcher {
                         (bus.read_word(trap_addr) & !0x0400u16) == 0xA9F0
                             && bus.read_word(trap_addr + 2) == 0x0000
                     });
+                let native_old_trap_standard = native_call.as_ref().is_some_and(|call| {
+                    bus.read_word(call.return_pc.wrapping_sub(6)) == 0x3F3C
+                        && (bus.read_word(call.return_pc.wrapping_sub(2)) & !0x0400u16) == 0xA9F0
+                });
+                let native_old_trap_think = native_call.as_ref().is_some_and(|call| {
+                    let trap_addr = call.return_pc.wrapping_sub(2);
+                    (bus.read_word(trap_addr) & !0x0400u16) == 0xA9F0
+                        && bus.read_word(trap_addr + 2) == 0x0000
+                });
 
                 let word_before_seg = bus.read_word(a9f0_addr.wrapping_sub(4));
                 let is_standard = old_trap_standard || word_before_seg == 0x3F3C;
 
-                let (seg_num, entry_addr, fmt, refresh_from_resource) = if old_trap_standard {
-                    let return_pc = original_trap_return.unwrap();
-                    let sn = bus.read_word(sp) as i16;
-                    cpu.write_reg(Register::A7, sp + 2);
-                    (sn, return_pc.wrapping_sub(8), "mpw-oldtrap", true)
-                } else if old_trap_think {
-                    let return_pc = original_trap_return.unwrap();
-                    let entry = return_pc.wrapping_sub(2);
-                    let sn = bus.read_word(entry + 6) as i16;
-                    (sn, entry, "thinkc-oldtrap", true)
-                } else if is_standard {
-                    // Standard: seg# was pushed by MOVE.W, pop it
-                    let sn = bus.read_word(sp) as i16;
-                    cpu.write_reg(Register::A7, sp + 2);
-                    // Entry starts 6 bytes before A9F0
-                    (sn, a9f0_addr.wrapping_sub(6), "mpw", false)
-                } else {
-                    // Think C: A9F0 at entry+0, seg# at entry+6, offset at entry+4
-                    // Stack has JSR return address (don't pop segment number)
-                    let entry = a9f0_addr; // A9F0 IS entry+0
-                    let sn = bus.read_word(entry + 6) as i16;
-                    (sn, entry, "thinkc", false)
-                };
+                let (seg_num, entry_addr, fmt, refresh_from_resource) =
+                    if native_old_trap_standard {
+                        let call = native_call.as_ref().unwrap();
+                        let sn = bus.read_word(call.argument_sp) as i16;
+                        (
+                            sn,
+                            call.return_pc.wrapping_sub(8),
+                            "mpw-native-oldtrap",
+                            true,
+                        )
+                    } else if native_old_trap_think {
+                        let call = native_call.as_ref().unwrap();
+                        let entry = call.return_pc.wrapping_sub(2);
+                        let sn = bus.read_word(entry + 6) as i16;
+                        (sn, entry, "thinkc-native-oldtrap", true)
+                    } else if old_trap_standard {
+                        let return_pc = original_trap_return.unwrap();
+                        let sn = bus.read_word(sp) as i16;
+                        cpu.write_reg(Register::A7, sp + 2);
+                        (sn, return_pc.wrapping_sub(8), "mpw-oldtrap", true)
+                    } else if old_trap_think {
+                        let return_pc = original_trap_return.unwrap();
+                        let entry = return_pc.wrapping_sub(2);
+                        let sn = bus.read_word(entry + 6) as i16;
+                        (sn, entry, "thinkc-oldtrap", true)
+                    } else if is_standard {
+                        // Standard: seg# was pushed by MOVE.W, pop it
+                        let sn = bus.read_word(sp) as i16;
+                        cpu.write_reg(Register::A7, sp + 2);
+                        // Entry starts 6 bytes before A9F0
+                        (sn, a9f0_addr.wrapping_sub(6), "mpw", false)
+                    } else {
+                        // Think C: A9F0 at entry+0, seg# at entry+6, offset at entry+4
+                        // Stack has JSR return address (don't pop segment number)
+                        let entry = a9f0_addr; // A9F0 IS entry+0
+                        let sn = bus.read_word(entry + 6) as i16;
+                        (sn, entry, "thinkc", false)
+                    };
 
                 let trace_loadseg = trace_loadseg_enabled();
                 if trace_loadseg {
@@ -10149,40 +10127,6 @@ mod tests {
     }
 
     #[test]
-    fn get1_named_resource_empty_name_finds_unnamed_resource() {
-        let (mut disp, mut cpu, mut bus) = setup();
-        let data_ptr = bus.alloc(4);
-        bus.write_bytes(data_ptr, &[0x10, 0x20, 0x30, 0x40]);
-        disp.resources = Some(LoadedResources {
-            files: HashMap::from([(
-                0,
-                ResourceFileMap {
-                    loaded: HashMap::from([((*b"CODE", 25), data_ptr)]),
-                    named: HashMap::new(),
-                    names_by_id: HashMap::new(),
-                    attrs: HashMap::new(),
-                    map_attrs: 0,
-                },
-            )]),
-            names: HashMap::new(),
-            search_order: vec![0],
-            current_file: 0,
-        });
-
-        let name_addr = 0x200000u32;
-        write_pstring(&mut bus, name_addr, b"");
-        bus.write_long(TEST_SP, name_addr);
-        bus.write_long(TEST_SP + 4, u32::from_be_bytes(*b"CODE"));
-
-        call(&mut disp, true, 0x020, &mut cpu, &mut bus).unwrap();
-
-        let handle = bus.read_long(TEST_SP + 8);
-        assert_ne!(handle, 0);
-        assert_eq!(cpu.read_reg(Register::A0), handle);
-        assert_eq!(bus.read_word(0x0A60), 0);
-    }
-
-    #[test]
     fn get1_named_resource_miss_returns_nil_in_a0() {
         let (mut disp, mut cpu, mut bus) = setup();
         let name_addr = 0x200000u32;
@@ -11199,41 +11143,47 @@ mod tests {
     }
 
     #[test]
-    fn loadseg_auto_pop_trampoline_accepts_resident_segment_in_d0() {
+    fn loadseg_native_old_trap_recovers_the_recorded_original_call() {
         let (mut disp, mut cpu, mut bus) = setup();
-        disp.register_segments(HashMap::from([(25i16, 0x220000u32)]));
+        let seg_addr = 0x220000u32;
+        bus.write_word(seg_addr, 0x0000);
+        bus.write_word(seg_addr + 2, 0x0000);
+        disp.register_segments(HashMap::from([(2i16, seg_addr)]));
+
+        let entry_addr = 0x240000u32;
+        bus.write_word(entry_addr, 0x0010);
+        bus.write_word(entry_addr + 2, 0x3F3C);
+        bus.write_word(entry_addr + 4, 0x0002);
+        bus.write_word(entry_addr + 6, 0xA9F0);
+
+        // SetTrapAddress accepts an arbitrary routine entry. Its first
+        // instruction and stack-frame convention are deliberately irrelevant
+        // to recovery of the original A-line call.
+        let handler = 0x300000u32;
+        bus.write_word(handler, 0x4E71); // NOP
+        disp.native_trap_table.insert(0xA9F0, handler);
+        cpu.write_reg(Register::PC, entry_addr + 8);
+        cpu.write_reg(Register::A7, TEST_SP);
+        bus.write_word(TEST_SP, 2);
+
+        disp.dispatch(0xA9F0, &mut cpu, &mut bus).unwrap();
+        assert_eq!(cpu.read_reg(Register::PC), handler);
+        assert_eq!(cpu.read_reg(Register::A7), TEST_SP - 4);
 
         let trampoline = disp.get_or_create_tool_trap_trampoline(&mut bus, 0xA9F0);
-        let return_pc = 0x280000u32;
-        bus.write_long(TEST_SP, return_pc);
-        cpu.write_reg(Register::A7, TEST_SP);
+        let handler_sp = TEST_SP - 0x100;
+        bus.write_long(handler_sp, 0x310000);
+        cpu.write_reg(Register::A7, handler_sp);
         cpu.write_reg(Register::PC, trampoline + 2);
-        cpu.write_reg(Register::D0, 25);
 
         call_trap_word(&mut disp, 0xADF0, &mut cpu, &mut bus).unwrap();
 
-        assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 4);
-        assert_eq!(cpu.read_reg(Register::PC), return_pc);
-        assert_eq!(cpu.read_reg(Register::D0), 25);
-    }
-
-    #[test]
-    fn loadseg_recovery_requires_a_jmp_l_native_handler() {
-        let (mut disp, _cpu, mut bus) = setup();
-        let handler = 0x300000u32;
-        disp.native_trap_table.insert(0xA9F0, handler);
-
-        assert!(!disp.native_loadseg_handler_is_jump_table(&bus));
-
-        bus.write_word(handler, 0x4EB9);
-        bus.write_long(handler + 2, 0x310000);
-        assert!(!disp.native_loadseg_handler_is_jump_table(&bus));
-
-        bus.write_word(handler, 0x4EF9);
-        assert!(disp.native_loadseg_handler_is_jump_table(&bus));
-
-        bus.write_long(handler + 2, 0);
-        assert!(!disp.native_loadseg_handler_is_jump_table(&bus));
+        assert_eq!(cpu.read_reg(Register::PC), entry_addr + 2);
+        assert_eq!(cpu.read_reg(Register::A7), handler_sp + 4);
+        assert_eq!(bus.read_word(entry_addr), 2);
+        assert_eq!(bus.read_word(entry_addr + 2), 0x4EF9);
+        assert_eq!(bus.read_long(entry_addr + 4), seg_addr + 4 + 0x0010);
+        assert!(!disp.pending_native_trap_calls.contains_key(&0xA9F0));
     }
 
     #[test]

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -15528,17 +15528,6 @@ impl super::TrapDispatcher {
             if index >= 1 && (index as usize) <= candidates.len() {
                 let (res_id, _refnum, ptr) = candidates[(index - 1) as usize];
                 let handle = self.get_or_create_resource_handle(bus, res_type, res_id, ptr);
-                // GetIndResource may return a resource whose data is already
-                // resident even while SetResLoad(FALSE) is active. The
-                // archive loader materializes resource bytes up front, so
-                // `ptr` is an in-memory resident allocation rather than an
-                // on-disk-only placeholder. Preserve that pointer for the
-                // indexed lookup; callers such as MacApp dereference seg!
-                // and mem! handles immediately after enumeration.
-                if !self.res_load && bus.read_long(handle) == 0 && ptr != 0 {
-                    bus.write_long(handle, ptr);
-                    self.ptr_to_handle.insert(ptr, handle);
-                }
                 eprintln!(
                     "[TRAP] {}('{}', {}) -> id={} handle=${:08X}",
                     trap_name, type_str, index, res_id, handle
@@ -21174,7 +21163,7 @@ mod tests {
     }
 
     #[test]
-    fn get_ind_resource_returns_resident_data_when_loading_is_disabled() {
+    fn get_ind_resource_keeps_unloaded_data_empty_when_loading_is_disabled() {
         let (mut disp, mut cpu, mut bus) = setup();
         let data_ptr = bus.alloc(8);
         bus.write_bytes(data_ptr, &[0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80]);
@@ -21201,10 +21190,45 @@ mod tests {
         assert!(result.is_some() && result.unwrap().is_ok());
         let handle = bus.read_long(TEST_SP + 6);
         assert_ne!(handle, 0);
-        assert_eq!(bus.read_long(handle), data_ptr);
+        assert_eq!(bus.read_long(handle), 0);
+        assert!(!disp.resident_resources.contains(&(0, *b"seg!", 1)));
         assert_eq!(cpu.read_reg(Register::A0), handle);
         assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 6);
         assert_eq!(bus.read_word(0x0A60), 0);
+    }
+
+    #[test]
+    fn get_ind_resource_preserves_data_loaded_before_set_res_load_false() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let data_ptr = bus.alloc(8);
+        bus.write_bytes(data_ptr, &[0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80]);
+        disp.resources = Some(LoadedResources {
+            files: HashMap::from([(
+                0,
+                ResourceFileMap {
+                    loaded: HashMap::from([((*b"seg!", 1), data_ptr)]),
+                    ..ResourceFileMap::default()
+                },
+            )]),
+            names: HashMap::new(),
+            search_order: vec![0],
+            current_file: 0,
+        });
+
+        for res_load in [true, false] {
+            disp.res_load = res_load;
+            cpu.write_reg(Register::A7, TEST_SP);
+            bus.write_word(TEST_SP, 1);
+            bus.write_long(TEST_SP + 2, u32::from_be_bytes(*b"seg!"));
+            bus.write_long(TEST_SP + 6, 0);
+
+            let result = disp.dispatch_toolbox(true, 0x19D, &mut cpu, &mut bus);
+            assert!(result.is_some() && result.unwrap().is_ok());
+            let handle = bus.read_long(TEST_SP + 6);
+            assert_ne!(handle, 0);
+            assert_eq!(bus.read_long(handle), data_ptr);
+        }
+        assert!(disp.resident_resources.contains(&(0, *b"seg!", 1)));
     }
 
     // GetNamedResource ($A9A1)

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -8255,13 +8255,15 @@ impl super::TrapDispatcher {
                 if let Some(handle) = handle {
                     eprintln!("[TRAP] GetNamedResource -> handle ${:08X}", handle);
                     bus.write_word(0x0A60, 0); // ResErr = noErr
+                    cpu.write_reg(Register::A0, handle);
                     cpu.write_reg(Register::D0, 0);
                     bus.write_long(sp + 8, handle);
                     cpu.write_reg(Register::A7, sp + 8);
                 } else {
                     eprintln!("[TRAP] GetNamedResource -> NULL (not found)");
                     bus.write_word(0x0A60, (-192i16) as u16); // ResErr = resNotFound
-                    cpu.write_reg(Register::D0, (-192i32) as u32);
+                    cpu.write_reg(Register::A0, 0);
+                    cpu.write_reg(Register::D0, 0);
                     bus.write_long(sp + 8, 0);
                     cpu.write_reg(Register::A7, sp + 8);
                 }
@@ -15526,6 +15528,17 @@ impl super::TrapDispatcher {
             if index >= 1 && (index as usize) <= candidates.len() {
                 let (res_id, _refnum, ptr) = candidates[(index - 1) as usize];
                 let handle = self.get_or_create_resource_handle(bus, res_type, res_id, ptr);
+                // GetIndResource may return a resource whose data is already
+                // resident even while SetResLoad(FALSE) is active. The
+                // archive loader materializes resource bytes up front, so
+                // `ptr` is an in-memory resident allocation rather than an
+                // on-disk-only placeholder. Preserve that pointer for the
+                // indexed lookup; callers such as MacApp dereference seg!
+                // and mem! handles immediately after enumeration.
+                if !self.res_load && bus.read_long(handle) == 0 && ptr != 0 {
+                    bus.write_long(handle, ptr);
+                    self.ptr_to_handle.insert(ptr, handle);
+                }
                 eprintln!(
                     "[TRAP] {}('{}', {}) -> id={} handle=${:08X}",
                     trap_name, type_str, index, res_id, handle
@@ -21160,6 +21173,40 @@ mod tests {
         }
     }
 
+    #[test]
+    fn get_ind_resource_returns_resident_data_when_loading_is_disabled() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let data_ptr = bus.alloc(8);
+        bus.write_bytes(data_ptr, &[0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80]);
+        disp.res_load = false;
+        disp.resources = Some(LoadedResources {
+            files: HashMap::from([(
+                0,
+                ResourceFileMap {
+                    loaded: HashMap::from([((*b"seg!", 1), data_ptr)]),
+                    ..ResourceFileMap::default()
+                },
+            )]),
+            names: HashMap::new(),
+            search_order: vec![0],
+            current_file: 0,
+        });
+
+        bus.write_word(TEST_SP, 1);
+        bus.write_long(TEST_SP + 2, u32::from_be_bytes(*b"seg!"));
+        bus.write_long(TEST_SP + 6, 0);
+
+        let result = disp.dispatch_toolbox(true, 0x19D, &mut cpu, &mut bus);
+
+        assert!(result.is_some() && result.unwrap().is_ok());
+        let handle = bus.read_long(TEST_SP + 6);
+        assert_ne!(handle, 0);
+        assert_eq!(bus.read_long(handle), data_ptr);
+        assert_eq!(cpu.read_reg(Register::A0), handle);
+        assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 6);
+        assert_eq!(bus.read_word(0x0A60), 0);
+    }
+
     // GetNamedResource ($A9A1)
     #[test]
     fn test_get_named_resource_searches_resource_chain() {
@@ -21206,7 +21253,9 @@ mod tests {
         assert_eq!(cpu.read_reg(Register::A7), sp + 8);
         assert_eq!(cpu.read_reg(Register::D0), 0);
         assert_eq!(bus.read_word(0x0A60), 0);
-        assert_ne!(bus.read_long(sp + 8), 0);
+        let handle = bus.read_long(sp + 8);
+        assert_ne!(handle, 0);
+        assert_eq!(cpu.read_reg(Register::A0), handle);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- return Handle/nil results from `GetNamedResource` and `Get1NamedResource` in `A0`
- distinguish resource-fork backing bytes from guest-resident resource data when `SetResLoad(FALSE)` is active
- reject signed-negative `NewPtr`/`NewHandle` sizes and negative `BlockMove` counts
- keep synthesized tool-trap entries stable and recover native old-trap calls from dispatcher-recorded call state
- return the documented `MaxMem` largest block in `D0` and application-zone growth in `A0`
- add focused regression coverage for unloaded/resident resources, arbitrary native handler entries, memory bounds, and trap contracts

## Root cause

Resource-fork parsing eagerly creates internal backing allocations, but those bytes are not necessarily resident through a guest resource handle. Treating every backing pointer as resident made `SetResLoad(FALSE)` ineffective. The Resource Manager now tracks residency explicitly and preserves a master pointer only when the resource was genuinely loaded.

A handler installed with `SetTrapAddress` may have any routine entry or stack-frame convention. The dispatcher now records the original A-line return PC and argument SP before entering a native handler, then validates the documented MPW/Think C jump-table form if that handler invokes its saved old `_LoadSeg` address. Recovery no longer reads A6 or requires a `JMP.L` prologue.

## Evidence

The Warlords II demo previously reached its `seg!`, `mem!`, and `res!` initialization and `Get1NamedResource('CODE', 'Main')` without an HLE error. Its remaining bounded run is a guest `uncompress_world` phase at `$00562B04-$00562B46`; issue #273 remains open for that later qualification boundary.

## Validation

- `cargo test --lib --features test-support -q`: 2,876 passed, 3 ignored
- `cargo check --no-default-features`
- `cargo publish --locked --dry-run --allow-dirty`
- focused `GetIndResource`, `LoadSeg`, named-resource, `MaxMem`, and negative-size tests pass

Refs #273