### PR TITLE
perf: buffer common 8-bit CopyMask rows

### DIFF
--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -13618,6 +13618,162 @@ impl super::TrapDispatcher {
                 let no_mask_scaling =
                     mask_w == dst_w && mask_h == dst_h && mask_w > 0 && mask_h > 0;
 
+                // The overwhelmingly common indexed CopyMask shape is an
+                // unscaled 8-bit sprite gated by a 1-bit mask. The generic
+                // loop below deliberately supports every admitted depth and
+                // scaling combination, but pays for two bounds/depth
+                // dispatches per destination pixel through
+                // `read_bitmap_pixel`. Prove that the clipped source and mask
+                // spans are wholly in bounds, then fetch each span once per
+                // row and retain the existing masked byte writes. Keeping the
+                // writes per opaque pixel preserves framebuffer tracing and
+                // watchpoint behavior; palette translation remains identical.
+                let clipped_width = i32::from(clip_r) - i32::from(clip_l);
+                let clipped_height = i32::from(clip_b) - i32::from(clip_t);
+                let src_clip_top =
+                    i32::from(src_top) + (i32::from(clip_t) - i32::from(dst_top));
+                let src_clip_left =
+                    i32::from(src_left) + (i32::from(clip_l) - i32::from(dst_left));
+                let src_clip_bottom = src_clip_top + clipped_height;
+                let src_clip_right = src_clip_left + clipped_width;
+                let mask_clip_top =
+                    i32::from(mask_top) + (i32::from(clip_t) - i32::from(dst_top));
+                let mask_clip_left =
+                    i32::from(mask_left) + (i32::from(clip_l) - i32::from(dst_left));
+                let mask_clip_bottom = mask_clip_top + clipped_height;
+                let mask_clip_right = mask_clip_left + clipped_width;
+                let buffered_geometry_valid = src_info.pixel_size == 8
+                    && mask_info.pixel_size == 1
+                    && dst_info.pixel_size == 8
+                    && no_src_scaling
+                    && no_mask_scaling
+                    && src_clip_top >= i32::from(src_info.bounds_top)
+                    && src_clip_left >= i32::from(src_info.bounds_left)
+                    && src_clip_bottom <= i32::from(src_info.bounds_bottom)
+                    && src_clip_right <= i32::from(src_info.bounds_right)
+                    && mask_clip_top >= i32::from(mask_info.bounds_top)
+                    && mask_clip_left >= i32::from(mask_info.bounds_left)
+                    && mask_clip_bottom <= i32::from(mask_info.bounds_bottom)
+                    && mask_clip_right <= i32::from(mask_info.bounds_right);
+                let buffered_spans_disjoint = if buffered_geometry_valid {
+                    let width = clipped_width as u32;
+                    let height = clipped_height as u32;
+                    let src_row = (src_clip_top - i32::from(src_info.bounds_top)) as u32;
+                    let src_col = (src_clip_left - i32::from(src_info.bounds_left)) as u32;
+                    let mask_row = (mask_clip_top - i32::from(mask_info.bounds_top)) as u32;
+                    let mask_col = (mask_clip_left - i32::from(mask_info.bounds_left)) as u32;
+                    let dst_row = (i32::from(clip_t) - i32::from(dst_info.bounds_top)) as u32;
+                    let dst_col = (i32::from(clip_l) - i32::from(dst_info.bounds_left)) as u32;
+                    let mask_first_byte = mask_col / 8;
+                    let mask_first_bit = mask_col % 8;
+                    let mask_byte_count = (mask_first_bit + width).div_ceil(8);
+
+                    let accessed_span =
+                        |base: u32,
+                         row_bytes: u32,
+                         first_row: u32,
+                         first_col: u32,
+                         rows: u32,
+                         bytes: u32|
+                         -> Option<(u64, u64)> {
+                            if rows == 0
+                                || bytes == 0
+                                || first_col.checked_add(bytes)? > row_bytes
+                            {
+                                return None;
+                            }
+                            let start = u64::from(base)
+                                + u64::from(first_row) * u64::from(row_bytes)
+                                + u64::from(first_col);
+                            let end = u64::from(base)
+                                + u64::from(first_row.checked_add(rows - 1)?)
+                                    * u64::from(row_bytes)
+                                + u64::from(first_col)
+                                + u64::from(bytes);
+                            (end <= u64::from(u32::MAX) + 1).then_some((start, end))
+                        };
+                    let src_span = accessed_span(
+                        src_info.base,
+                        src_info.row_bytes,
+                        src_row,
+                        src_col,
+                        height,
+                        width,
+                    );
+                    let mask_span = accessed_span(
+                        mask_info.base,
+                        mask_info.row_bytes,
+                        mask_row,
+                        mask_first_byte,
+                        height,
+                        mask_byte_count,
+                    );
+                    let dst_span = accessed_span(
+                        dst_info.base,
+                        dst_info.row_bytes,
+                        dst_row,
+                        dst_col,
+                        height,
+                        width,
+                    );
+                    match (src_span, mask_span, dst_span) {
+                        (Some(src), Some(mask), Some(dst)) => {
+                            let disjoint = |a: (u64, u64), b: (u64, u64)| {
+                                a.1 <= b.0 || b.1 <= a.0
+                            };
+                            disjoint(src, dst) && disjoint(mask, dst)
+                        }
+                        _ => false,
+                    }
+                } else {
+                    false
+                };
+                let row_buffered_8bpp_mask =
+                    buffered_geometry_valid && buffered_spans_disjoint;
+                if row_buffered_8bpp_mask {
+                    let width = clipped_width as usize;
+                    let src_col = (src_clip_left - i32::from(src_info.bounds_left)) as u32;
+                    let mask_col = (mask_clip_left - i32::from(mask_info.bounds_left)) as u32;
+                    let dst_col = (clip_l - dst_info.bounds_left) as u32;
+                    let mask_first_byte = mask_col / 8;
+                    let mask_first_bit = (mask_col % 8) as usize;
+                    let mask_byte_count = (mask_first_bit + width).div_ceil(8);
+                    let mut source_row = vec![0u8; width];
+                    let mut mask_row = vec![0u8; mask_byte_count];
+
+                    for dy in clip_t..clip_b {
+                        let relative_y = i32::from(dy) - i32::from(clip_t);
+                        let src_row =
+                            (src_clip_top + relative_y - i32::from(src_info.bounds_top)) as u32;
+                        let mask_row_index =
+                            (mask_clip_top + relative_y - i32::from(mask_info.bounds_top)) as u32;
+                        let dst_row = (dy - dst_info.bounds_top) as u32;
+                        bus.read_bytes_into(
+                            src_info.base + src_row * src_info.row_bytes + src_col,
+                            &mut source_row,
+                        );
+                        bus.read_bytes_into(
+                            mask_info.base + mask_row_index * mask_info.row_bytes + mask_first_byte,
+                            &mut mask_row,
+                        );
+
+                        let dst_row_base = dst_info.base + dst_row * dst_info.row_bytes + dst_col;
+                        for (column, &source_pixel) in source_row.iter().enumerate() {
+                            let mask_bit = mask_first_bit + column;
+                            if mask_row[mask_bit / 8] & (1 << (7 - mask_bit % 8)) == 0 {
+                                continue;
+                            }
+                            let destination_pixel = palette_translation
+                                .as_ref()
+                                .map_or(source_pixel, |translation| {
+                                    translation[source_pixel as usize]
+                                });
+                            bus.write_byte(dst_row_base + column as u32, destination_pixel);
+                        }
+                    }
+                    return Some(Ok(()));
+                }
+
                 for dy in clip_t..clip_b {
                     let sy = if no_src_scaling {
                         i32::from(src_top) + (i32::from(dy) - i32::from(dst_top))
@@ -30709,6 +30865,46 @@ mod tests {
             0b0101_1010,
             "mask bits cleared to 0 should preserve destination bits"
         );
+    }
+
+    #[test]
+    fn copymask_8bpp_handles_non_byte_aligned_mask_spans() {
+        let (mut d, mut cpu, mut bus) = setup();
+        let src_pixmap = bus.alloc(50);
+        let mask_bits = bus.alloc(14);
+        let dst_pixmap = bus.alloc(50);
+        let src_base = bus.alloc(16);
+        let mask_base = bus.alloc(2);
+        let dst_base = bus.alloc(16);
+        write_pixmap_8(&mut bus, src_pixmap, src_base, 16, 1, 0);
+        write_bitmap_1bpp(&mut bus, mask_bits, mask_base, 2, (0, 0, 1, 16));
+        write_pixmap_8(&mut bus, dst_pixmap, dst_base, 16, 1, 0);
+        for column in 0..16u32 {
+            bus.write_byte(src_base + column, 0x20 + column as u8);
+            bus.write_byte(dst_base + column, 0xE0 + column as u8);
+        }
+        // maskRect starts at bit 3 and crosses a byte boundary. Its eight
+        // pixels are 1,0,1,1,0,0,1,0.
+        bus.write_byte(mask_base, 0b0001_0110);
+        bus.write_byte(mask_base + 1, 0b0100_0000);
+
+        let src_rect = bus.alloc(8);
+        let mask_rect = bus.alloc(8);
+        let dst_rect = bus.alloc(8);
+        write_rect(&mut bus, src_rect, 0, 2, 1, 10);
+        write_rect(&mut bus, mask_rect, 0, 3, 1, 11);
+        write_rect(&mut bus, dst_rect, 0, 4, 1, 12);
+        bus.write_long(TEST_SP, dst_rect);
+        bus.write_long(TEST_SP + 4, mask_rect);
+        bus.write_long(TEST_SP + 8, src_rect);
+        bus.write_long(TEST_SP + 12, dst_pixmap);
+        bus.write_long(TEST_SP + 16, mask_bits);
+        bus.write_long(TEST_SP + 20, src_pixmap);
+
+        let result = d.dispatch_quickdraw(true, 0x017, &mut cpu, &mut bus);
+        assert!(result.unwrap().is_ok());
+        let expected = [0x22, 0xE5, 0x24, 0x25, 0xE8, 0xE9, 0x28, 0xEB];
+        assert_eq!(bus.read_bytes(dst_base + 4, 8), expected);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Buffer the common unscaled indexed `CopyMask` source and mask spans once per row instead of calling the generic per-pixel bitmap reader twice for every destination pixel.

This is a guarded fast path for an 8-bit indexed source, 1-bit mask, and 8-bit indexed destination. Scaled copies, other pixel depths, invalid geometry, and source/mask spans that could alias the destination continue through the existing generic implementation.

## Motivation

Whole-app profiling of EV Override showed a significant amount of host CPU time below QuickDraw `CopyMask`. The game uses `CopyMask` repeatedly for masked indexed sprites. The generic implementation is correct and deliberately broad, but its inner loop effectively does this:

```text
for each destination pixel:
    source = read_bitmap_pixel(source_bitmap, source_x, source_y)
    mask = read_bitmap_pixel(mask_bitmap, mask_x, mask_y)
    if mask != 0:
        destination = translate_source_palette_index(source)
        write_byte(destination_address, destination)
```

Each `read_bitmap_pixel` repeats bounds and depth dispatch for a geometry that is constant across the row.

The new path first proves that the clipped source and mask rectangles are in bounds, unscaled, have the expected depths, and do not overlap the destination. It then performs:

```text
for each clipped row:
    source_row = read_contiguous_bytes(source_span)
    mask_row = read_contiguous_bytes(mask_span)
    for each column:
        if mask_row.bit(column) != 0:
            destination = translate_source_palette_index(source_row[column])
            write_byte(destination_address, destination)
```

Destination writes intentionally remain per opaque pixel. That preserves framebuffer tracing and memory-watchpoint behavior. Palette translation is unchanged.

## Performance

Matched whole-application profiling on macOS, in the same stationary gameplay scene:

| Build | Main-thread CPU |
|---|---:|
| `32c6d3a` (`master`) | 26.5% |
| this change | 16.2% |

That is a reduction of 10.3 percentage points, or approximately **38.9%** of the measured main-thread cost.

The later m68k profiling work was deliberately measured on top of this change, so its baseline does not claim this QuickDraw improvement a second time.

## Correctness and fallback behavior

The buffered path is used only when all of the following are proven:

- source and destination are 8-bit indexed bitmaps;
- the mask is 1-bit;
- source and mask geometry are unscaled relative to the destination;
- every clipped source and mask coordinate is inside its bitmap bounds;
- every row span fits its declared row width and 32-bit guest address space;
- source and mask spans are disjoint from the destination span.

If any condition is not satisfied, `CopyMask` uses the existing generic loop unchanged.

The added regression test covers a clipped mask beginning at a non-byte-aligned bit and crossing a byte boundary. Existing tests continue to cover argument ordering, mask-zero preservation, mask-one copies, scaling, indexed palette translation, and live color-icon bitmaps.

## Testing

- `cargo test --lib copymask` — 7 passed
- matched macOS whole-app profile described above
