### PR TITLE
fix: synthesize the default System window color table

### DIFF
--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -1222,6 +1222,10 @@ pub struct TrapDispatcher {
     /// resource fork, but some installers call `GetResource('clut', depth)`
     /// directly instead of `GetCTable`.
     pub(crate) system_clut_cache: HashMap<i16, u32>,
+    /// Cache of the synthesized System-file default `'wctb'` resource.
+    /// The Window Manager and some applications fetch this resource directly
+    /// instead of relying only on GetNewCWindow's implicit default.
+    pub(crate) system_wctb_cache: HashMap<i16, u32>,
     /// Cache of synthetic System-file `'KCHR'` resource pointers. The
     /// U.S. Roman keyboard-layout resource ID 0 is present in every
     /// System file and is used directly by apps that call KeyTranslate.
@@ -2836,6 +2840,7 @@ impl TrapDispatcher {
             system_str_cache: HashMap::new(),
             system_cursor_cache: HashMap::new(),
             system_clut_cache: HashMap::new(),
+            system_wctb_cache: HashMap::new(),
             system_kchr_cache: HashMap::new(),
             system_wdef_cache: HashMap::new(),
             system_mdef_cache: HashMap::new(),
@@ -5175,6 +5180,59 @@ impl TrapDispatcher {
             bus.write_word(entry + 6, b);
         }
         self.system_clut_cache.insert(res_id, ptr);
+        Some(ptr)
+    }
+
+    /// Allocate (and cache) the default System-file window color table.
+    /// System 7.5.3 stores this compiled `'wctb'` resource at ID 0; its
+    /// entries are the standard colors used by GetNewCWindow when an
+    /// application does not provide a window-specific table. Macintosh
+    /// Toolbox Essentials (1992), pp. 4-127..4-129.
+    pub(crate) fn synthesize_system_wctb(
+        &mut self,
+        bus: &mut MacMemoryBus,
+        res_id: i16,
+    ) -> Option<u32> {
+        if let Some(&ptr) = self.system_wctb_cache.get(&res_id) {
+            return Some(ptr);
+        }
+        if res_id != 0 {
+            return None;
+        }
+
+        // A compiled 'wctb' starts with six reserved bytes followed by the
+        // entry count minus one. The bytes are copied verbatim by the Window
+        // Manager before it replaces the first four bytes with a live seed.
+        const COLORS: [[u16; 3]; 13] = [
+            [0xFFFF, 0xFFFF, 0xFFFF],
+            [0x0000, 0x0000, 0x0000],
+            [0x0000, 0x0000, 0x0000],
+            [0x0000, 0x0000, 0x0000],
+            [0xFFFF, 0xFFFF, 0xFFFF],
+            [0xFFFF, 0xFFFF, 0xFFFF],
+            [0x0000, 0x0000, 0x0000],
+            [0xFFFF, 0xFFFF, 0xFFFF],
+            [0x0000, 0x0000, 0x0000],
+            [0xCCCC, 0xCCCC, 0xFFFF],
+            [0x0000, 0x0000, 0x0000],
+            [0xCCCC, 0xCCCC, 0xFFFF],
+            [0x3333, 0x3333, 0x6666],
+        ];
+        let ptr = bus.alloc(8 + COLORS.len() as u32 * 8);
+        if ptr == 0 {
+            return None;
+        }
+        bus.write_long(ptr, 0);
+        bus.write_word(ptr + 4, 0);
+        bus.write_word(ptr + 6, COLORS.len() as u16 - 1);
+        for (index, [red, green, blue]) in COLORS.into_iter().enumerate() {
+            let entry = ptr + 8 + index as u32 * 8;
+            bus.write_word(entry, index as u16);
+            bus.write_word(entry + 2, red);
+            bus.write_word(entry + 4, green);
+            bus.write_word(entry + 6, blue);
+        }
+        self.system_wctb_cache.insert(res_id, ptr);
         Some(ptr)
     }
 

--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -1704,6 +1704,19 @@ impl super::TrapDispatcher {
                     }
                 }
 
+                if res_type == *b"wctb" {
+                    if let Some(ptr) = self.synthesize_system_wctb(bus, res_id) {
+                        let handle = self
+                            .get_or_create_resource_handle_in_file(bus, res_type, res_id, ptr, 0);
+                        cpu.write_reg(Register::A0, handle);
+                        cpu.write_reg(Register::D0, 0);
+                        bus.write_word(0x0A60, 0); // ResErr = noErr
+                        bus.write_long(sp + 6, handle);
+                        cpu.write_reg(Register::A7, sp + 6);
+                        return Some(Ok(()));
+                    }
+                }
+
                 if res_type == *b"MDEF" {
                     if let Some(ptr) = self.synthesize_system_mdef(bus, res_id) {
                         let handle = self
@@ -8257,6 +8270,38 @@ mod tests {
         assert_eq!(bus.read_word(black + 2), 0, "entry 255 red");
         assert_eq!(bus.read_word(black + 4), 0, "entry 255 green");
         assert_eq!(bus.read_word(black + 6), 0, "entry 255 blue");
+    }
+
+    #[test]
+    fn get_resource_synthesizes_default_system_wctb_zero() {
+        let (mut disp, mut cpu, mut bus) = setup();
+
+        let sp = TEST_SP;
+        bus.write_word(sp, 0u16);
+        bus.write_long(sp + 2, u32::from_be_bytes(*b"wctb"));
+
+        call(&mut disp, true, 0x1A0, &mut cpu, &mut bus).unwrap();
+
+        let new_sp = cpu.read_reg(Register::A7);
+        assert_eq!(new_sp, TEST_SP + 6, "SP should advance by 6");
+        let handle = bus.read_long(new_sp);
+        assert_ne!(handle, 0, "synthetic system wctb must return a handle");
+        assert_eq!(cpu.read_reg(Register::A0), handle);
+        assert_eq!(cpu.read_reg(Register::D0), 0);
+        assert_eq!(bus.read_word(0x0A60), 0, "ResErr should be noErr");
+
+        let wctb = bus.read_long(handle);
+        assert_ne!(wctb, 0, "synthetic system wctb handle must be loaded");
+        assert_eq!(bus.read_word(wctb + 6), 12, "default table has 13 entries");
+        assert_eq!(bus.read_word(wctb + 8), 0, "first entry index");
+        assert_eq!(bus.read_word(wctb + 10), 0xFFFF, "first entry red");
+        assert_eq!(bus.read_word(wctb + 12), 0xFFFF, "first entry green");
+        assert_eq!(bus.read_word(wctb + 14), 0xFFFF, "first entry blue");
+        let last = wctb + 8 + 12 * 8;
+        assert_eq!(bus.read_word(last), 12, "last entry index");
+        assert_eq!(bus.read_word(last + 2), 0x3333, "last entry red");
+        assert_eq!(bus.read_word(last + 4), 0x3333, "last entry green");
+        assert_eq!(bus.read_word(last + 6), 0x6666, "last entry blue");
     }
 
     #[test]

--- a/src/trap/window.rs
+++ b/src/trap/window.rs
@@ -150,6 +150,7 @@ impl super::TrapDispatcher {
         let resource_ptr = self
             .find_resource_any(*b"wctb", table_id)
             .map(|(_, ptr)| ptr)
+            .or_else(|| self.synthesize_system_wctb(bus, 0))
             .unwrap_or(0);
         if resource_ptr == 0 {
             return 0;


### PR DESCRIPTION
Fixes #302

Some classic 68K applications fetch the System-file `wctb` resource directly during startup. Systemless has no physical System resource fork, so the default table must be synthesized as a standard compiled resource.

This change:
- synthesizes the System 7 default 13-entry `wctb` resource for ID 0;
- exposes it through `GetResource` when no application resource exists; and
- uses the same fallback in `GetNewCWindow`.

Tests: `cargo test get_resource_synthesizes_default_system_wctb_zero -- --nocapture`.