### PR TITLE
perf(quickdraw): bulk-decode guest color tables

### DIFF
--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -16613,6 +16613,32 @@ impl super::TrapDispatcher {
         u32::from((entry as u16) & 0x00FF)
     }
 
+    /// Overlay the entries of a guest ColorTable on the current Color Manager
+    /// CLUT. A ColorSpec is four consecutive big-endian words: the logical
+    /// index followed by red, green, and blue. Reading the contiguous array in
+    /// one operation avoids four memory-bus dispatches for every entry while
+    /// still consulting guest memory on every call. The latter is important:
+    /// applications may animate or directly modify an offscreen ColorTable.
+    fn read_color_table_ptr_clut(&self, bus: &MacMemoryBus, ctab_ptr: u32) -> [[u16; 3]; 256] {
+        let entry_count = usize::from(bus.read_word(ctab_ptr.wrapping_add(6)).min(255)) + 1;
+        let byte_count = entry_count * 8;
+        let mut entries = [0u8; 256 * 8];
+        bus.read_bytes_into(ctab_ptr.wrapping_add(8), &mut entries[..byte_count]);
+
+        // Treat guest ColorTables as overrides on top of the Color Manager CLUT.
+        // Some scratch/offscreen tables do not populate every logical index;
+        // zero-filling the rest would collapse unrelated indices to black.
+        let mut clut = self.color_manager_clut;
+        for entry in entries[..byte_count].chunks_exact(8) {
+            let value = u16::from_be_bytes([entry[0], entry[1]]) as usize;
+            let red = u16::from_be_bytes([entry[2], entry[3]]);
+            let green = u16::from_be_bytes([entry[4], entry[5]]);
+            let blue = u16::from_be_bytes([entry[6], entry[7]]);
+            clut[value.min(255)] = [red, green, blue];
+        }
+        clut
+    }
+
     /// Read a 256-entry CLUT from a CTabHandle in guest memory.
     /// Falls back to the device CLUT if the handle is NULL.
     /// Imaging With QuickDraw 1994, p. 4-82
@@ -16632,22 +16658,7 @@ impl super::TrapDispatcher {
         if ctab_ptr == 0 {
             return self.color_manager_clut;
         }
-        let ct_size = bus.read_word(ctab_ptr + 6) as u32;
-        // Treat guest ColorTables as overrides on top of the Color Manager CLUT.
-        // Marathon builds scratch/offscreen tables that do not always populate
-        // every entry; zero-filling the rest collapses unrelated indices to black
-        // during 8bpp CopyBits palette remapping.
-        let mut clut = self.color_manager_clut;
-        for i in 0..=ct_size.min(255) {
-            let entry = ctab_ptr + 8 + i * 8;
-            let value = bus.read_word(entry) as usize;
-            let r = bus.read_word(entry + 2);
-            let g = bus.read_word(entry + 4);
-            let b = bus.read_word(entry + 6);
-            let idx = value.min(255);
-            clut[idx] = [r, g, b];
-        }
-        clut
+        self.read_color_table_ptr_clut(bus, ctab_ptr)
     }
 
     fn read_indexed_destination_clut(
@@ -16680,18 +16691,7 @@ impl super::TrapDispatcher {
         if ctab_ptr == 0 {
             return self.color_manager_clut;
         }
-        let ct_size = bus.read_word(ctab_ptr + 6) as u32;
-        let mut clut = self.color_manager_clut;
-        for i in 0..=ct_size.min(255) {
-            let entry = ctab_ptr + 8 + i * 8;
-            let value = bus.read_word(entry) as usize;
-            let r = bus.read_word(entry + 2);
-            let g = bus.read_word(entry + 4);
-            let b = bus.read_word(entry + 6);
-            let idx = value.min(255);
-            clut[idx] = [r, g, b];
-        }
-        clut
+        self.read_color_table_ptr_clut(bus, ctab_ptr)
     }
 
     pub(super) fn uses_canonical_system_8bpp_clut(clut: &[[u16; 3]; 256]) -> bool {
@@ -24746,6 +24746,15 @@ mod tests {
         let clut = d.read_port_clut(&bus, ctab_handle);
 
         assert_eq!(clut[5], [0x1111, 0x2222, 0x3333]);
+
+        // ColorTables are movable guest objects and applications can update
+        // their entries directly. Bulk decoding must not turn into an
+        // implicit stale cache between QuickDraw calls.
+        bus.write_word(entry + 2, 0xAAAA);
+        bus.write_word(entry + 4, 0xBBBB);
+        bus.write_word(entry + 6, 0xCCCC);
+        let updated_clut = d.read_port_clut(&bus, ctab_handle);
+        assert_eq!(updated_clut[5], [0xAAAA, 0xBBBB, 0xCCCC]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Bulk-read each guest QuickDraw `ColorTable` and decode its contiguous `ColorSpec` array from a host byte slice, rather than dispatching four guest-memory word reads for every palette entry.

Both port/source color tables and indexed destination color tables use the shared decoder. The table is still read from guest memory on every QuickDraw call; this change does not introduce a palette cache.

## Motivation

Whole-application profiling of EV Override's stationary gameplay showed guest `ColorTable` decoding as a major remaining QuickDraw cost. Indexed `CopyMask` and related blits need live source and destination palettes to perform this conversion:

```text
source palette index -> source RGB -> destination palette index
```

A `ColorSpec` is 8 contiguous bytes containing four big-endian words:

```text
struct ColorSpec {
    uint16_t value;  // logical palette index
    uint16_t red;
    uint16_t green;
    uint16_t blue;
};
```

The old decoder effectively performed:

```text
clut = current_color_manager_clut
for entry in guest_color_table:
    value = bus.read_word(entry + 0)
    red   = bus.read_word(entry + 2)
    green = bus.read_word(entry + 4)
    blue  = bus.read_word(entry + 6)
    clut[min(value, 255)] = [red, green, blue]
```

For a 256-entry table, that is 1,024 generic memory-bus dispatches per decode, in addition to reading the table header. A color-translating blit may need more than one table.

The new decoder performs:

```text
count = min(ctSize, 255) + 1
bytes = bus.read_contiguous_bytes(ctTable, count * 8)

clut = current_color_manager_clut
for each 8-byte ColorSpec in bytes:
    decode value, red, green, and blue as big-endian words
    clut[min(value, 255)] = [red, green, blue]
```

This retains the existing overlay semantics. Guest scratch and offscreen tables may update only selected logical indices, so entries not named by the table continue to come from the live Color Manager CLUT rather than being zero-filled.

## Relationship to other performance work

This PR's Systemless diff is a single commit directly on Systemless v0.11.4; it does **not** depend on unmerged m68k-rs code.

The performance experiment deliberately held the pending CPU work constant in both builds:

- [m68k-rs #57: JIT guarded indexed scans](https://github.com/benletchford/m68k-rs/pull/57)
- [m68k-rs #59: JIT packed lookup generator loops](https://github.com/benletchford/m68k-rs/pull/59), stacked on the preceding m68k-rs PR

This makes the numbers below the incremental benefit of this QuickDraw change after both pending m68k optimizations, rather than comparing different CPU cores or double-counting their improvements.

[Systemless #277](https://github.com/benletchford/systemless/pull/277) is also already present in v0.11.4. That PR buffers source pixel and mask spans for common `CopyMask` rows. This PR addresses a separate remaining cost: decoding the palette metadata used to translate those pixels. The two changes complement rather than supersede one another.

## Performance

Method:

- Intel macOS host
- EV Override, same stationary gameplay scene
- three 15-second `/usr/bin/sample` captures per build at 1 ms intervals
- baseline Systemless: v0.11.4 (`012a7c5`)
- baseline m68k for both A and B: local `b1a49d0`, containing [m68k-rs #57](https://github.com/benletchford/m68k-rs/pull/57) and [m68k-rs #59](https://github.com/benletchford/m68k-rs/pull/59)
- candidate: the identical baseline plus only `b7d9b4a`

Inclusive sample counts:

| Metric | Baseline runs | Candidate runs | Median change |
|---|---:|---:|---:|
| ColorTable decoder | 769, 759, 895 | 112, 120, 155 | 769 -> 120 (**-84.4%**) |
| emulation runner | 3,228, 3,291, 3,673 | 2,358, 2,311, 2,608 | 3,291 -> 2,358 (**-28.3%**) |

The generic guest `read_word` top-of-stack median fell from 609 to 50 samples (**-91.8%**). Each matched runner pair improved independently by approximately 27-30%, so the result was consistent across all three captures.

## Correctness

- `ctSize` remains clamped to the 256-entry QuickDraw limit.
- Logical palette indices retain the previous clamp to index 255.
- Unspecified logical indices retain the current Color Manager CLUT values.
- Null table handles retain the existing fallback behavior.
- The decoder rereads guest memory on every call. A regression test mutates the guest `ColorTable` between two reads and verifies that the second result observes the new RGB values, preventing an accidental stale cache.

## Testing

- `cargo test test_read_port_clut_uses_guest_table_for_non_screen_ctab --lib --features test-support`
- `cargo check`
- matched six-profile macOS A/B run described above
