### PR TITLE
perf(macos): cache native application identity by path

### DIFF
--- a/src/bin/systemless.rs
+++ b/src/bin/systemless.rs
@@ -587,6 +587,21 @@ impl App {
 
     #[cfg(target_os = "macos")]
     fn sync_native_application_identity(&mut self) {
+        // Icon discovery parses the application's resource fork and decodes
+        // its BNDL/FREF/ICN# family. The launched path is the cache key and is
+        // available without doing that work, so reject the normal unchanged-
+        // application case before rebuilding the full identity every frame.
+        // A foreground application switch changes `launched_app_path` and
+        // therefore still refreshes the native name, icon, and window title.
+        let application_unchanged = self
+            .runner
+            .as_ref()
+            .and_then(|runner| runner.dispatcher().launched_app_path())
+            .is_some_and(|path| self.native_app_path.as_deref() == Some(path));
+        if application_unchanged {
+            return;
+        }
+
         let Some(identity) = self
             .runner
             .as_ref()
@@ -594,9 +609,6 @@ impl App {
         else {
             return;
         };
-        if self.native_app_path.as_deref() == Some(identity.path.as_str()) {
-            return;
-        }
 
         self.native_menu.set_app_name(identity.name.clone());
         native_application::set_application_icon(identity.icon.as_ref());


### PR DESCRIPTION
## Summary

Avoid rebuilding the macOS-facing application identity on every host frame when the foreground Classic application has not changed.

The frame loop calls `sync_native_application_identity` after emulation. Previously that method called `loaded_application_identity` before it compared the resulting path with `native_app_path`. Building the identity can:

- inspect VFS metadata and the selected resource fork;
- parse the resource map;
- resolve BNDL and FREF mappings; and
- decode ICN# family data for the native application icon.

This change compares the inexpensive `launched_app_path` with the cached path first. The full name/icon/title rebuild still occurs when no identity has been cached or when the foreground application path changes.

## Why the path is the cache key

The host identity is derived from the selected Classic executable, and `loaded_application_identity` itself begins with `launched_app_path`. A foreground application switch changes that path, which invalidates the cache and refreshes the native menu name, icon, and window title. If no launched path is available, this retains the old behavior and continues trying to resolve an identity.

## Profiling

Workload: stationary EV Override gameplay on an Intel Mac. Each profile used `/usr/bin/sample` for 15 seconds at a 1 ms interval.

The paired release binaries were built from the same local all-pending-performance stack and differed only by this source change. That stack included the pending bulk color-table decode and m68k trace work, so these numbers describe the incremental cost on top of those changes rather than pristine master.

| run | before: samples in `sync_native_application_identity` | after |
|---:|---:|---:|
| 1 | 76 | 0 |
| 2 | 121 | 0 |
| 3 | 83 | — |

The before median is 83 of about 15,000 samples, or approximately 0.55% of one host core. Resource-fork parsing beneath this stack also disappears from both after profiles.

Exact binaries:

- before SHA-256: `1483e34c780714add673735815c5e8a004405b976ceb9233b277fddcdf7b1c92`
- after SHA-256: `c5f590422d5a289cb8e930a103f61f7be1e4f5145f186044f7516c57ea182b77`

Guest execution varied enough between intervals that the whole-process samples do not justify claiming a precise total-CPU reduction. The supported claim is narrower: this repeatable per-frame identity/resource-fork hotspot went from a median 83 samples to zero.

## Validation

- `cargo check --bin systemless`
- `cargo test application_icon --lib` (6 passed)
- `rustfmt --edition 2021 --check src/bin/systemless.rs`
- EV Override launch and stationary gameplay profiling with the native application identity active

The existing repository-wide `cargo fmt --check` still reports unrelated formatting differences on current master; the changed file passes rustfmt independently.