### PR TITLE
feat: expose extracted HFS volumes through File Manager APIs

### DIFF
--- a/src/disk_image.rs
+++ b/src/disk_image.rs
@@ -23,8 +23,26 @@ const HFSPLUS_FILE_USER_INFO_OFFSET: usize = 48;
 #[derive(Debug)]
 pub struct DiskImageContents {
     pub volume_name: String,
+    pub volume_info: DiskImageVolumeInfo,
+    pub driver_name: String,
     pub dirs: Vec<String>,
     pub files: Vec<DiskImageFile>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct DiskImageVolumeInfo {
+    pub attributes: u16,
+    pub file_count: u16,
+    pub allocation_block_count: u16,
+    pub allocation_block_size: u32,
+    pub clump_size: u32,
+    pub free_blocks: u16,
+    pub bitmap_start: u16,
+    pub allocation_pointer: u16,
+    pub allocation_start: u16,
+    pub next_catalog_id: u32,
+    pub created_date: u32,
+    pub modified_date: u32,
 }
 
 #[derive(Debug)]
@@ -60,6 +78,7 @@ pub fn extract_dc42_or_hfs(bytes: &[u8]) -> Result<Option<DiskImageContents>, St
 
     let volume = HfsVolume::parse(bytes).map_err(|e| format!("failed to parse HFS image: {e}"))?;
     let volume_name = clean_component(&volume.volume_name).unwrap_or_else(|| "Disk Image".into());
+    let volume_info = hfs_volume_info(filesystem, volume.files.len());
     let mut dirs = vec![volume_name.clone()];
 
     for dir in &volume.dirs {
@@ -96,9 +115,47 @@ pub fn extract_dc42_or_hfs(bytes: &[u8]) -> Result<Option<DiskImageContents>, St
     dirs.dedup();
     Ok(Some(DiskImageContents {
         volume_name,
+        volume_info,
+        driver_name: ".AppleCD".to_string(),
         dirs,
         files,
     }))
+}
+
+fn hfs_volume_info(bytes: &[u8], file_count: usize) -> DiskImageVolumeInfo {
+    let read_u16 = |offset: usize| {
+        bytes
+            .get(offset..offset + 2)
+            .map(|raw| u16::from_be_bytes([raw[0], raw[1]]))
+            .unwrap_or(0)
+    };
+    let read_u32 = |offset: usize| {
+        bytes
+            .get(offset..offset + 4)
+            .map(|raw| u32::from_be_bytes([raw[0], raw[1], raw[2], raw[3]]))
+            .unwrap_or(0)
+    };
+    DiskImageVolumeInfo {
+        attributes: read_u16(1024 + 10),
+        file_count: {
+            let catalog_count = read_u16(1024 + 12);
+            if catalog_count == 0 {
+                file_count.min(u16::MAX as usize) as u16
+            } else {
+                catalog_count
+            }
+        },
+        allocation_block_count: read_u16(1024 + 18),
+        allocation_block_size: read_u32(1024 + 20),
+        clump_size: read_u32(1024 + 24),
+        free_blocks: read_u16(1024 + 34),
+        bitmap_start: read_u16(1024 + 14),
+        allocation_pointer: read_u16(1024 + 16),
+        allocation_start: read_u16(1024 + 28),
+        next_catalog_id: read_u32(1024 + 30),
+        created_date: read_u32(1024 + 2),
+        modified_date: read_u32(1024 + 6),
+    }
 }
 
 fn raw_filesystem_signature(bytes: &[u8]) -> Option<u16> {
@@ -178,6 +235,8 @@ fn extract_hfsplus(bytes: &[u8]) -> Result<DiskImageContents, String> {
     dirs.dedup();
     Ok(DiskImageContents {
         volume_name,
+        volume_info: DiskImageVolumeInfo::default(),
+        driver_name: ".AppleCD".to_string(),
         dirs,
         files,
     })

--- a/src/game/launch.rs
+++ b/src/game/launch.rs
@@ -785,6 +785,7 @@ fn insert_forks_into_vfs(
 struct Payload {
     dirs: Vec<String>,
     files: Vec<PayloadFile>,
+    volumes: Vec<(String, crate::disk_image::DiskImageVolumeInfo, String)>,
     skipped_disk_image_errors: Vec<String>,
 }
 
@@ -1128,6 +1129,7 @@ fn payload_from_forks(
         return Ok(Payload {
             dirs: Vec::new(),
             files: vec![file],
+            volumes: Vec::new(),
             skipped_disk_image_errors: Vec::new(),
         });
     }
@@ -1187,6 +1189,7 @@ fn payload_from_forks(
             creator,
             finder_flags,
         }],
+        volumes: Vec::new(),
         skipped_disk_image_errors,
     })
 }
@@ -1216,6 +1219,7 @@ fn payload_from_disk_image(image: crate::disk_image::DiskImageContents) -> Resul
     Ok(Payload {
         dirs: image.dirs,
         files,
+        volumes: vec![(image.volume_name, image.volume_info, image.driver_name)],
         skipped_disk_image_errors: Vec::new(),
     })
 }
@@ -1228,6 +1232,25 @@ fn insert_payload_into_vfs(
     for dir in payload.dirs {
         let normalized = crate::trap::dispatch::TrapDispatcher::normalize_vfs_path(&dir);
         runner.dispatcher_mut().ensure_vfs_directory(&normalized);
+    }
+
+    for (volume, info, driver_name) in payload.volumes {
+        runner.dispatcher_mut().mount_vfs_volume_with_driver_info(
+            &volume,
+            &driver_name,
+            info.attributes,
+            info.file_count,
+            info.allocation_block_count,
+            info.allocation_block_size,
+            info.clump_size,
+            info.free_blocks,
+            info.bitmap_start,
+            info.allocation_pointer,
+            info.allocation_start,
+            info.next_catalog_id,
+            info.created_date,
+            info.modified_date,
+        );
     }
 
     for file in payload.files {
@@ -1388,12 +1411,12 @@ fn maybe_select_executable(
     // it wins outright over the size/APPL heuristic, which is needed for
     // archives that contain multiple bootable executables and where size
     // alone cannot distinguish the user-facing runtime from tooling.
-    let override_match = executable_name_override()
-        .map(|needle| name.contains(needle.as_str()))
-        .unwrap_or(false);
-    let prev_override_match = match (executable_entry.as_ref(), executable_name_override()) {
-        (Some(prev), Some(needle)) => prev.name.contains(needle.as_str()),
-        _ => false,
+    let override_rank = executable_name_override()
+        .map(|needle| executable_override_rank(name, &needle))
+        .unwrap_or(3);
+    let prev_override_rank = match (executable_entry.as_ref(), executable_name_override()) {
+        (Some(prev), Some(needle)) => executable_override_rank(&prev.name, &needle),
+        _ => 3,
     };
 
     let candidate = ExecutableCandidate {
@@ -1405,10 +1428,8 @@ fn maybe_select_executable(
         creator,
     };
 
-    let take = if override_match && !prev_override_match {
-        true
-    } else if !override_match && prev_override_match {
-        false
+    let take = if override_rank != prev_override_rank {
+        override_rank < prev_override_rank
     } else {
         match executable_entry.as_ref() {
             Some(prev) => candidate.selection_key() > prev.selection_key(),
@@ -1425,6 +1446,18 @@ fn executable_name_override() -> Option<String> {
     std::env::var("SYSTEMLESS_LOAD_EXECUTABLE")
         .ok()
         .filter(|s| !s.is_empty())
+}
+
+fn executable_override_rank(name: &str, needle: &str) -> u8 {
+    if name == needle {
+        0
+    } else if name.ends_with(&format!("/{needle}")) {
+        1
+    } else if name.contains(needle) {
+        2
+    } else {
+        3
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/memory/globals.rs
+++ b/src/memory/globals.rs
@@ -152,6 +152,8 @@ pub mod addr {
     pub const SCREEN_BITS: u32 = 0x083C;
 
     // File Manager globals
+    pub const UTABLE_BASE: u32 = 0x011C; // Base address of the Device Manager unit table
+    pub const UNIT_TABLE_ENTRY_COUNT: u32 = 0x01D2; // Number of entries in the unit table
     pub const SF_SAVE_DISK: u32 = 0x0214; // Negative of volume reference number (word) - Inside Macintosh Volume IV, IV-72
     pub const FCB_S_PTR: u32 = 0x034E; // FCB array pointer
     pub const DEF_VCB_PTR: u32 = 0x0352; // Default VCB pointer

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1914,6 +1914,9 @@ impl FixtureRunner {
         let vfs_metadata = self.dispatcher.vfs_metadata.clone();
         let vfs_directories = self.dispatcher.vfs_directories.clone();
         let vfs_directory_paths = self.dispatcher.vfs_directory_paths.clone();
+        let vfs_volumes = self.dispatcher.vfs_volumes.clone();
+        let vfs_volume_names = self.dispatcher.vfs_volume_names.clone();
+        let next_vfs_volume_ref_num = self.dispatcher.next_vfs_volume_ref_num;
         let locked_files = self.dispatcher.locked_files.clone();
         let next_vfs_dir_id = self.dispatcher.next_vfs_dir_id;
         let next_vfs_file_id = self.dispatcher.next_vfs_file_id;
@@ -1935,6 +1938,9 @@ impl FixtureRunner {
         replacement.dispatcher.vfs_metadata = vfs_metadata;
         replacement.dispatcher.vfs_directories = vfs_directories;
         replacement.dispatcher.vfs_directory_paths = vfs_directory_paths;
+        replacement.dispatcher.vfs_volumes = vfs_volumes;
+        replacement.dispatcher.vfs_volume_names = vfs_volume_names;
+        replacement.dispatcher.next_vfs_volume_ref_num = next_vfs_volume_ref_num;
         replacement.dispatcher.locked_files = locked_files;
         replacement.dispatcher.next_vfs_dir_id = next_vfs_dir_id;
         replacement.dispatcher.next_vfs_file_id = next_vfs_file_id;
@@ -2027,6 +2033,32 @@ impl FixtureRunner {
         }
     }
 
+    fn install_read_only_volume_unit(
+        &mut self,
+        unit_table_ptr: u32,
+        unit_index: usize,
+        volume_ref_num: i16,
+        driver_name: &str,
+        unit_count: &mut u16,
+    ) {
+        let entry_addr = unit_table_ptr.saturating_add((unit_index as u32) * 4);
+        let driver_header = self.bus.alloc(64);
+        let dce_ptr = self.bus.alloc(32);
+        let dce_handle = self.bus.alloc(4);
+        if driver_header == 0 || dce_ptr == 0 || dce_handle == 0 {
+            return;
+        }
+
+        self.bus.fill_bytes(driver_header, 64, 0);
+        self.bus.fill_bytes(dce_ptr, 32, 0);
+        self.bus.write_long(dce_ptr, driver_header); // dCtlDriver
+        self.bus.write_word(dce_ptr + 24, volume_ref_num as u16); // dCtlRefNum
+        self.bus.write_long(dce_handle, dce_ptr);
+        self.bus.write_long(entry_addr, dce_handle);
+        self.write_fixed_pstring(driver_header + 18, driver_name, 31);
+        *unit_count = (*unit_count).max((unit_index as u16).saturating_add(1));
+    }
+
     fn seed_current_application_file_manager_state(&mut self) {
         use crate::memory::globals::addr;
 
@@ -2077,6 +2109,48 @@ impl FixtureRunner {
         self.bus.write_word(addr::VCB_Q_HDR, 0);
         self.bus.write_long(addr::VCB_Q_HDR + 2, vcb_ptr);
         self.bus.write_long(addr::VCB_Q_HDR + 6, vcb_ptr);
+
+        // Files 1985, II-191: UTableBase points to a table of handles to
+        // Device Manager control entries. Read-only disk-image volumes still
+        // need a stable unit-table identity because legacy applications often
+        // inspect the mounted volume's driver before opening its files.
+        let unit_table_ptr = self.bus.alloc(128);
+        if unit_table_ptr != 0 {
+            self.bus.fill_bytes(unit_table_ptr, 128, 0);
+            let mut unit_count = 0u16;
+            let mut mounted_units = vec![(
+                crate::trap::dispatch::BOOT_VOLUME_REF_NUM,
+                crate::trap::dispatch::TrapDispatcher::boot_volume_name().to_string(),
+            )];
+            mounted_units.extend(
+                self.dispatcher
+                    .vfs_volumes
+                    .values()
+                    .map(|volume| (volume.ref_num, volume.driver_name.clone()))
+                    .collect::<Vec<_>>(),
+            );
+            for (volume_ref_num, volume_name) in mounted_units {
+                if volume_ref_num >= 0 {
+                    continue;
+                }
+                let driver_ref_num =
+                    crate::trap::dispatch::TrapDispatcher::vfs_driver_ref_num(volume_ref_num);
+                let unit_index = (-driver_ref_num - 1) as usize;
+                if unit_index >= 32 {
+                    continue;
+                }
+                self.install_read_only_volume_unit(
+                    unit_table_ptr,
+                    unit_index,
+                    driver_ref_num,
+                    &volume_name,
+                    &mut unit_count,
+                );
+            }
+            self.bus.write_long(addr::UTABLE_BASE, unit_table_ptr);
+            self.bus
+                .write_word(addr::UNIT_TABLE_ENTRY_COUNT, unit_count);
+        }
 
         let fcb_buffer = self.bus.alloc(HFS_FCB_BUFFER_SIZE as u32);
         if fcb_buffer == 0 {

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -924,6 +924,26 @@ pub(crate) struct VfsDirectory {
     pub name: String,
 }
 
+#[derive(Clone, Debug)]
+pub(crate) struct VfsVolume {
+    pub ref_num: i16,
+    pub name: String,
+    pub driver_name: String,
+    pub root_dir_id: u32,
+    pub attributes: u16,
+    pub file_count: u16,
+    pub allocation_block_count: u16,
+    pub allocation_block_size: u32,
+    pub clump_size: u32,
+    pub free_blocks: u16,
+    pub bitmap_start: u16,
+    pub allocation_pointer: u16,
+    pub allocation_start: u16,
+    pub next_catalog_id: u32,
+    pub created_date: u32,
+    pub modified_date: u32,
+}
+
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct WorkingDirectory {
     pub ref_num: i16,
@@ -1265,6 +1285,10 @@ pub struct TrapDispatcher {
     pub(crate) vfs_directories: HashMap<String, VfsDirectory>,
     /// Reverse directory lookup by catalog ID.
     pub(crate) vfs_directory_paths: HashMap<u32, String>,
+    /// Read-only disk-image volumes mounted alongside the synthetic boot volume.
+    pub(crate) vfs_volumes: HashMap<i16, VfsVolume>,
+    /// Mounted volume lookup by normalized, case-insensitive name.
+    pub(crate) vfs_volume_names: HashMap<String, i16>,
     /// Open working directories keyed by working directory reference number.
     pub(crate) working_directories: HashMap<i16, WorkingDirectory>,
     /// Open file table: refnum -> filename
@@ -1311,6 +1335,8 @@ pub struct TrapDispatcher {
     pub(crate) default_startup_rec: u32,
     /// Next synthetic catalog directory ID for VFS directories.
     pub(crate) next_vfs_dir_id: u32,
+    /// Next stable negative volume reference for an extracted read-only volume.
+    pub(crate) next_vfs_volume_ref_num: i16,
     /// Next synthetic file ID for VFS files.
     pub(crate) next_vfs_file_id: u32,
     /// Monotonic source for VFS creation and modification timestamps.
@@ -2847,6 +2873,8 @@ impl TrapDispatcher {
             vfs_metadata: HashMap::new(),
             vfs_directories,
             vfs_directory_paths,
+            vfs_volumes: HashMap::new(),
+            vfs_volume_names: HashMap::new(),
             working_directories: HashMap::new(),
             open_files: HashMap::new(),
             synthetic_drivers: HashMap::new(),
@@ -2861,6 +2889,7 @@ impl TrapDispatcher {
             default_os_rec: 0x0001,           // Macintosh Operating System
             default_startup_rec: 0x0000_0000, // zero-filled first-device startup default
             next_vfs_dir_id: 16,
+            next_vfs_volume_ref_num: -2,
             next_vfs_file_id: 32,
             next_vfs_timestamp: 1,
             next_working_dir_refnum: 32,
@@ -3478,6 +3507,101 @@ impl TrapDispatcher {
         BOOT_VOLUME_REF_NUM
     }
 
+    /// Synthetic Device Manager driver reference for a mounted read-only
+    /// volume. Classic driver references are negative and are indexed through
+    /// UTableBase as `-refNum - 1`; keep the boot and extracted volumes on
+    /// distinct deterministic entries.
+    pub(crate) fn vfs_driver_ref_num(volume_ref_num: i16) -> i16 {
+        -5 - (-volume_ref_num - 1).max(0)
+    }
+
+    /// Mount an extracted disk-image root as a read-only File Manager volume.
+    /// The root remains a normal top-level VFS directory for compatibility
+    /// while File Manager calls receive a stable negative volume reference.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn mount_vfs_volume_with_driver_info(
+        &mut self,
+        name: &str,
+        driver_name: &str,
+        attributes: u16,
+        file_count: u16,
+        allocation_block_count: u16,
+        allocation_block_size: u32,
+        clump_size: u32,
+        free_blocks: u16,
+        bitmap_start: u16,
+        allocation_pointer: u16,
+        allocation_start: u16,
+        next_catalog_id: u32,
+        created_date: u32,
+        modified_date: u32,
+    ) -> i16 {
+        let normalized = Self::normalize_vfs_path(name);
+        if normalized.is_empty() || normalized.eq_ignore_ascii_case(BOOT_VOLUME_NAME) {
+            return Self::boot_volume_ref_num();
+        }
+        let key = normalized.to_ascii_lowercase();
+        if let Some(ref_num) = self.vfs_volume_names.get(&key).copied() {
+            return ref_num;
+        }
+
+        let root_dir_id = self.ensure_vfs_directory(&normalized);
+        let mut ref_num = self.next_vfs_volume_ref_num;
+        while ref_num == 0
+            || ref_num == Self::boot_volume_ref_num()
+            || self.vfs_volumes.contains_key(&ref_num)
+        {
+            ref_num = ref_num.saturating_sub(1);
+        }
+        self.next_vfs_volume_ref_num = ref_num.saturating_sub(1);
+        self.vfs_volumes.insert(
+            ref_num,
+            VfsVolume {
+                ref_num,
+                name: normalized,
+                driver_name: driver_name.to_string(),
+                root_dir_id,
+                attributes,
+                file_count,
+                allocation_block_count,
+                allocation_block_size,
+                clump_size,
+                free_blocks,
+                bitmap_start,
+                allocation_pointer,
+                allocation_start,
+                next_catalog_id,
+                created_date,
+                modified_date,
+            },
+        );
+        self.vfs_volume_names.insert(key, ref_num);
+        ref_num
+    }
+
+    pub(crate) fn vfs_volume_by_name(&self, name: &str) -> Option<&VfsVolume> {
+        let key = Self::normalize_vfs_path(name).to_ascii_lowercase();
+        self.vfs_volume_names
+            .get(&key)
+            .and_then(|ref_num| self.vfs_volumes.get(ref_num))
+    }
+
+    pub(crate) fn vfs_volume_for_ref_num(&self, ref_num: i16) -> Option<&VfsVolume> {
+        self.vfs_volumes.get(&ref_num)
+    }
+
+    pub(crate) fn has_vfs_driver_name(&self, name: &str) -> bool {
+        self.vfs_volumes
+            .values()
+            .any(|volume| volume.driver_name.eq_ignore_ascii_case(name))
+    }
+
+    pub(crate) fn vfs_volume_for_path(&self, path: &str) -> Option<&VfsVolume> {
+        let normalized = Self::normalize_vfs_path(path);
+        let root = normalized.split('/').next()?;
+        self.vfs_volume_by_name(root)
+    }
+
     pub(crate) fn boot_volume_ref_num_u16() -> u16 {
         BOOT_VOLUME_REF_NUM as u16
     }
@@ -3650,11 +3774,15 @@ impl TrapDispatcher {
         self.ensure_vfs_file_metadata(&normalized);
         if let Some(metadata) = self.vfs_metadata.get(&normalized).copied() {
             self.default_dir_id = metadata.parent_dir_id;
+            let app_volume_ref = self
+                .vfs_volume_for_path(&normalized)
+                .map(|volume| volume.ref_num)
+                .unwrap_or(Self::boot_volume_ref_num());
             // Open a working directory for the app's parent folder so that
             // PBGetVol returns a WDRefNum and PBGetWDInfo resolves the correct dirID.
             // Inside Macintosh Volume IV, IV-72
             if let Some(wd_ref) =
-                self.open_working_directory(Self::boot_volume_ref_num(), metadata.parent_dir_id, 0)
+                self.open_working_directory(app_volume_ref, metadata.parent_dir_id, 0)
             {
                 self.app_wd_refnum = wd_ref;
             }
@@ -3810,6 +3938,9 @@ impl TrapDispatcher {
         if vref == Self::boot_volume_ref_num() {
             return vref;
         }
+        if self.vfs_volumes.contains_key(&vref) {
+            return vref;
+        }
         if let Some(working_directory) = self.working_directories.get(&vref) {
             return working_directory.volume_ref_num;
         }
@@ -3821,6 +3952,9 @@ impl TrapDispatcher {
         // ioDirID is 0 or 1, and they treat vRefNum=0 + ioDirID=0 as the
         // current default directory. Files 1992, 2-151 to 2-153.
         if dir_id <= 1 {
+            if let Some(volume) = self.vfs_volumes.get(&vref) {
+                return volume.root_dir_id;
+            }
             if let Some(working_directory) = self.working_directories.get(&vref) {
                 return working_directory.dir_id;
             }
@@ -3929,6 +4063,14 @@ impl TrapDispatcher {
                 ref_num: wd_ref_num,
                 volume_ref_num: Self::boot_volume_ref_num(),
                 dir_id: 2,
+                proc_id: 0,
+            });
+        }
+        if let Some(volume) = self.vfs_volume_for_ref_num(wd_ref_num) {
+            return Some(WorkingDirectory {
+                ref_num: wd_ref_num,
+                volume_ref_num: wd_ref_num,
+                dir_id: volume.root_dir_id,
                 proc_id: 0,
             });
         }
@@ -4086,6 +4228,15 @@ impl TrapDispatcher {
         // directory ID 2. Files 1992, 1-27 and 2-85.
         if dir_id == 1 && normalized.eq_ignore_ascii_case(BOOT_VOLUME_NAME) {
             return Some(String::new());
+        }
+        if dir_id == 1 {
+            if let Some(volume) = self.vfs_volume_by_name(&normalized) {
+                return Some(
+                    self.directory_path_for_id(volume.root_dir_id)
+                        .unwrap_or_default()
+                        .to_string(),
+                );
+            }
         }
         // Sort vfs_directories keys before first-match .find() to avoid
         // leaking HashMap hash-randomisation into directory resolution

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -3602,6 +3602,15 @@ impl TrapDispatcher {
         self.vfs_volume_by_name(root)
     }
 
+    /// Return whether a VFS path belongs to an extracted disk-image volume.
+    /// Resource-fork mirrors use a `__rsrc__` prefix, so strip it before
+    /// resolving the volume root. The synthetic boot volume remains writable;
+    /// extracted image volumes are read-only by construction.
+    pub(crate) fn vfs_path_is_read_only(&self, path: &str) -> bool {
+        let path = path.strip_prefix("__rsrc__").unwrap_or(path);
+        self.vfs_volume_for_path(path).is_some()
+    }
+
     pub(crate) fn boot_volume_ref_num_u16() -> u16 {
         BOOT_VOLUME_REF_NUM as u16
     }

--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -6861,7 +6861,11 @@ impl super::TrapDispatcher {
                     let proc_id = bus.read_long(pb + 28);
                     let requested_dir_id = bus.read_long(pb + 48);
                     let base_dir_id = self.resolve_directory_id(vref, requested_dir_id);
-                    let effective_dir_id = if name.is_empty() {
+                    // A PBOpenWD caller may pass ":" to name the directory
+                    // already identified by ioWDDirID. In a partial HFS
+                    // pathname, a lone colon is the current directory, not
+                    // a child directory literally named ":".
+                    let effective_dir_id = if name.is_empty() || name == ":" {
                         base_dir_id
                     } else if let Some(path) =
                         self.find_vfs_directory_in_directory(base_dir_id, &name)
@@ -14203,6 +14207,34 @@ mod tests {
     // ================================================================
     // 26b. FSDispatch ($A260) selector 6 — PBDirCreate
     // ================================================================
+    #[test]
+    fn fsdispatch_pbopenwd_colon_selects_requested_directory() {
+        // Files 1992, 2-201: a lone colon means the directory identified by
+        // ioWDDirID, so PBOpenWD must not search for a child named ":".
+        let (mut disp, mut cpu, mut bus) = setup();
+        let resources_dir_id = disp.ensure_vfs_directory("Game/H&E Resources");
+
+        let pb = 0x300000u32;
+        setup_param_block(&mut bus, &mut cpu, pb, b":");
+        bus.write_word(pb + 16, 0x3FFF); // ioResult poison
+        bus.write_word(pb + 22, super::super::dispatch::BOOT_VOLUME_REF_NUM as u16);
+        bus.write_long(pb + 28, 0x454E_4C54); // arbitrary working-directory user ID
+        bus.write_long(pb + 48, resources_dir_id);
+        cpu.write_reg(Register::D0, 1); // HFSDispatch selector: PBOpenWD
+
+        call(&mut disp, false, 0x60, &mut cpu, &mut bus).unwrap();
+
+        assert_eq!(cpu.read_reg(Register::D0) as i32, 0);
+        assert_eq!(bus.read_word(pb + 16) as i16, 0);
+        let wd_ref = bus.read_word(pb + 22) as i16;
+        assert_ne!(wd_ref, super::super::dispatch::BOOT_VOLUME_REF_NUM);
+        assert_eq!(bus.read_long(pb + 48), resources_dir_id);
+        assert_eq!(
+            disp.working_directory_info(wd_ref).map(|wd| wd.dir_id),
+            Some(resources_dir_id)
+        );
+    }
+
     #[test]
     fn fsdispatch_pbdircreate_creates_child_directory_and_returns_dirid() {
         // PBDirCreate is PBHCreate for directories: it creates a new

--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -3764,7 +3764,9 @@ impl super::TrapDispatcher {
                     bus.write_word(pb + 16, 0); // noErr
                     cpu.write_reg(Register::D0, 0);
                     eprintln!("[TRAP] PBOpen -> refnum={} vfs=\"{}\"", refnum, vfs_name);
-                } else if Self::is_synthetic_driver_name(&filename) {
+                } else if Self::is_synthetic_driver_name(&filename)
+                    || self.has_vfs_driver_name(&filename)
+                {
                     let refnum = self.next_refnum;
                     self.next_refnum += 1;
                     self.synthetic_drivers.insert(refnum, filename.clone());
@@ -4037,20 +4039,29 @@ impl super::TrapDispatcher {
             // dispatcher masks `trap & 0x00FF`, so $A214 PBHGetVol and $A014
             // PBGetVol land on the same low byte and share this arm.
             //
-            // trap-doc: $A014 | PBGetVol | Partial | File Manager & Gestalt — OS Traps | Fills ioVRefNum (-1) and ioNamePtr from boot volume (IM:Files 1992, 2-162)
+            // trap-doc: $A014 | PBGetVol | Partial | File Manager & Gestalt — OS Traps | Fills ioVRefNum and ioNamePtr from the current volume (IM:Files 1992, 2-162)
             // PBHGetVol ($A214): HFS variant aliased onto $A014
             (false, 0x14) => {
                 let pb = cpu.read_reg(Register::A0);
+                let volume_ref_num = self.resolve_volume_ref_num(self.app_wd_refnum);
+                let volume_name = self
+                    .vfs_volume_for_ref_num(volume_ref_num)
+                    .map(|volume| volume.name.as_str())
+                    .unwrap_or(super::TrapDispatcher::boot_volume_name());
                 bus.write_word(pb + 22, self.app_wd_refnum as u16);
                 let name_ptr = bus.read_long(pb + 18);
                 if name_ptr != 0 {
-                    Self::write_pstring(bus, name_ptr, super::TrapDispatcher::boot_volume_name());
+                    Self::write_pstring(bus, name_ptr, volume_name);
                 }
                 // HGetVol fields: ioWDProcID and ioWDVRefNum and ioWDDirID
                 // Always populate these so both PBGetVol and HGetVol callers work.
                 bus.write_long(pb + 28, 0); // ioWDProcID
-                bus.write_word(pb + 32, super::TrapDispatcher::boot_volume_ref_num_u16()); // ioWDVRefNum
-                bus.write_long(pb + 48, self.default_dir_id); // ioWDDirID
+                bus.write_word(pb + 32, volume_ref_num as u16); // ioWDVRefNum
+                let dir_id = self
+                    .working_directory_info(self.app_wd_refnum)
+                    .map(|wd| wd.dir_id)
+                    .unwrap_or(self.default_dir_id);
+                bus.write_long(pb + 48, dir_id); // ioWDDirID
                 bus.write_word(pb + 16, 0); // noErr
                 cpu.write_reg(Register::D0, 0);
                 Ok(())
@@ -4066,43 +4077,96 @@ impl super::TrapDispatcher {
             // PBHGetVInfo and $A007 PBGetVInfo land on the same low
             // byte and share this arm.
             //
-            // PBGetVInfo ($A007): Returns boot volume info and nontrivial free-space figures
+            // PBGetVInfo ($A007): Returns mounted volume info and free-space figures
             // PBHGetVInfo ($A207): HFS variant aliased onto $A007
             (false, 0x07) => {
                 let pb = cpu.read_reg(Register::A0);
                 let volume_index = bus.read_word(pb + 28) as i16;
-                if volume_index > 1 {
+                let volume_info = if volume_index <= 1 {
+                    Some((
+                        super::TrapDispatcher::boot_volume_name().to_string(),
+                        super::TrapDispatcher::boot_volume_ref_num(),
+                        0u16,
+                    ))
+                } else {
+                    let mut mounted = self.vfs_volumes.values().collect::<Vec<_>>();
+                    mounted.sort_by_key(|volume| std::cmp::Reverse(volume.ref_num));
+                    mounted
+                        .get((volume_index - 2) as usize)
+                        .map(|volume| (volume.name.clone(), volume.ref_num, volume.attributes))
+                };
+                let Some((volume_name, volume_ref_num, volume_attributes)) = volume_info else {
                     // Files 1992, 2-145: positive ioVolIndex values walk the
                     // mounted-volume queue, and enumeration ends with nsvErr.
-                    // Systemless currently exposes one mounted boot volume.
                     const NSV_ERR: i16 = -35;
                     bus.write_word(pb + 16, NSV_ERR as u16);
                     cpu.write_reg(Register::D0, NSV_ERR as i32 as u32);
                     return Some(Ok(()));
-                }
+                };
+
+                let mounted_info = self.vfs_volume_for_ref_num(volume_ref_num);
+                let volume_file_count = mounted_info
+                    .map(|volume| volume.file_count)
+                    .filter(|count| *count != 0)
+                    .unwrap_or(100);
+                let allocation_block_count = mounted_info
+                    .map(|volume| volume.allocation_block_count)
+                    .filter(|count| *count != 0)
+                    .unwrap_or(BOOT_VOLUME_ALLOCATION_BLOCKS);
+                let allocation_block_size = mounted_info
+                    .map(|volume| volume.allocation_block_size)
+                    .filter(|size| *size != 0)
+                    .unwrap_or(BOOT_VOLUME_ALLOCATION_BLOCK_SIZE);
+                let clump_size = mounted_info
+                    .map(|volume| volume.clump_size)
+                    .filter(|size| *size != 0)
+                    .unwrap_or(BOOT_VOLUME_ALLOCATION_BLOCK_SIZE);
+                let free_blocks = mounted_info
+                    .map(|volume| volume.free_blocks)
+                    .filter(|count| *count != 0)
+                    .unwrap_or(BOOT_VOLUME_FREE_BLOCKS);
+                let created_date = mounted_info.map(|volume| volume.created_date).unwrap_or(0);
+                let modified_date = mounted_info.map(|volume| volume.modified_date).unwrap_or(0);
+                let bitmap_start = mounted_info.map(|volume| volume.bitmap_start).unwrap_or(0);
+                let allocation_pointer = mounted_info
+                    .map(|volume| volume.allocation_pointer)
+                    .unwrap_or(0);
+                let allocation_start = mounted_info
+                    .map(|volume| volume.allocation_start)
+                    .unwrap_or(0);
+                let next_catalog_id = mounted_info
+                    .map(|volume| volume.next_catalog_id)
+                    .unwrap_or(0);
+                let volume_ordinal = (-volume_ref_num - 1).max(0) as u16;
+                let volume_driver_ref =
+                    super::TrapDispatcher::vfs_driver_ref_num(volume_ref_num);
 
                 let name_ptr = bus.read_long(pb + 18);
                 if name_ptr != 0 {
-                    Self::write_pstring(bus, name_ptr, super::TrapDispatcher::boot_volume_name());
+                    Self::write_pstring(bus, name_ptr, &volume_name);
                 }
-                bus.write_word(pb + 22, super::TrapDispatcher::boot_volume_ref_num_u16());
-                bus.write_long(pb + 30, 0); // ioVCrDate
-                bus.write_long(pb + 34, 0); // ioVLsMod
-                bus.write_word(pb + 38, 0); // ioVAtrb
-                bus.write_word(pb + 40, 100); // ioVNmFls (files on volume)
-                bus.write_word(pb + 42, 0); // ioVBitMap
-                bus.write_word(pb + 44, 0); // ioAllocPtr
+                bus.write_word(pb + 22, volume_ref_num as u16);
+                bus.write_long(pb + 30, created_date); // ioVCrDate
+                bus.write_long(pb + 34, modified_date); // ioVLsMod
+                bus.write_word(pb + 38, volume_attributes); // ioVAtrb
+                bus.write_word(pb + 40, volume_file_count); // ioVNmFls (files on volume)
+                bus.write_word(pb + 42, bitmap_start); // ioVBitMap
+                bus.write_word(pb + 44, allocation_pointer); // ioAllocPtr
 
                 // Files 1992, 2-46 and 2-144: callers multiply the unsigned
                 // ioVFrBlk block count by ioVAlBlkSiz to determine free bytes.
                 // Report a modest 64 MB boot volume so installers and demos
                 // that require scratch space do not reject the system disk.
-                bus.write_word(pb + 46, BOOT_VOLUME_ALLOCATION_BLOCKS); // ioVNmAlBlks
-                bus.write_long(pb + 48, BOOT_VOLUME_ALLOCATION_BLOCK_SIZE); // ioVAlBlkSiz
-                bus.write_long(pb + 52, BOOT_VOLUME_ALLOCATION_BLOCK_SIZE); // ioVClpSiz
-                bus.write_word(pb + 56, 0); // ioAlBlSt
-                bus.write_long(pb + 58, 0); // ioVNxtCNID
-                bus.write_word(pb + 62, BOOT_VOLUME_FREE_BLOCKS); // ioVFrBlk
+                bus.write_word(pb + 46, allocation_block_count); // ioVNmAlBlks
+                bus.write_long(pb + 48, allocation_block_size); // ioVAlBlkSiz
+                bus.write_long(pb + 52, clump_size); // ioVClpSiz
+                bus.write_word(pb + 56, allocation_start); // ioAlBlSt
+                bus.write_long(pb + 58, next_catalog_id); // ioVNxtCNID
+                bus.write_word(pb + 62, free_blocks); // ioVFrBlk
+                bus.write_word(pb + 64, 0x4244); // ioVSigWord (HFS)
+                bus.write_word(pb + 66, volume_ordinal.saturating_add(1)); // ioVDrvInfo
+                bus.write_word(pb + 68, volume_driver_ref as u16); // ioVRefNum (driver)
+                bus.write_word(pb + 70, 0); // ioVFSID (File Manager)
                 bus.write_word(pb + 16, 0); // noErr
                 cpu.write_reg(Register::D0, 0);
                 Ok(())
@@ -4248,6 +4312,7 @@ impl super::TrapDispatcher {
                 let vref = bus.read_word(pb + 22) as i16;
                 let known_by_vref = vref == 0
                     || vref == Self::boot_volume_ref_num()
+                    || self.vfs_volumes.contains_key(&vref)
                     || self.working_directories.contains_key(&vref);
                 let known_by_name = !name.is_empty()
                     && name.eq_ignore_ascii_case(super::TrapDispatcher::boot_volume_name());
@@ -5416,6 +5481,8 @@ impl super::TrapDispatcher {
                 } else if requested_vref == Self::boot_volume_ref_num() {
                     // ioVRefNum = -1: boot volume, use root directory (dirID 2).
                     2
+                } else if let Some(volume) = self.vfs_volume_for_ref_num(requested_vref) {
+                    volume.root_dir_id
                 } else {
                     // Unrecognised volume reference number: nsvErr (-35).
                     // IM:Files 1992, 2-162: "nsvErr — No such volume."
@@ -6762,11 +6829,11 @@ impl super::TrapDispatcher {
                             working_directory.proc_id
                         );
                         if name_ptr != 0 {
-                            Self::write_pstring(
-                                bus,
-                                name_ptr,
-                                super::TrapDispatcher::boot_volume_name(),
-                            );
+                            let volume_name = self
+                                .vfs_volume_for_ref_num(working_directory.volume_ref_num)
+                                .map(|volume| volume.name.as_str())
+                                .unwrap_or(super::TrapDispatcher::boot_volume_name());
+                            Self::write_pstring(bus, name_ptr, volume_name);
                         }
                         bus.write_word(pb + 22, returned_vref as u16);
                         bus.write_long(pb + 28, working_directory.proc_id);
@@ -6795,6 +6862,18 @@ impl super::TrapDispatcher {
                     selector, name_ptr, filename, vref, dir_id, fdir_index
                 );
                 let resolved_vref = self.resolve_volume_ref_num(vref);
+
+                if selector == 0x18 {
+                    // PBCatSearch ($A260, selector $0018): report an
+                    // exhausted read-only catalog search until the full HFS
+                    // catalog cursor is implemented. This is important for
+                    // callers that otherwise retry forever on a zero-match
+                    // noErr response.
+                    bus.write_long(pb + 32, 0); // ioActMatchCount
+                    bus.write_word(pb + 16, (-39i16) as u16); // eofErr
+                    cpu.write_reg(Register::D0, (-39i32) as u32);
+                    return Some(Ok(()));
+                }
 
                 if selector == 6 {
                     // PBDirCreate ($A260, selector 6)
@@ -6931,7 +7010,11 @@ impl super::TrapDispatcher {
                         if name_ptr != 0 {
                             Self::write_pstring(bus, name_ptr, &base_name);
                         }
-                        bus.write_word(pb + 22, super::TrapDispatcher::boot_volume_ref_num_u16()); // ioVRefNum
+                        let file_volume_ref = self
+                            .vfs_volume_for_path(&metadata_name)
+                            .map(|volume| volume.ref_num)
+                            .unwrap_or(super::TrapDispatcher::boot_volume_ref_num());
+                        bus.write_word(pb + 22, file_volume_ref as u16); // ioVRefNum
                         bus.write_word(pb + 30, 0); // filler1
                         bus.write_long(pb + 32, file_id); // ioFCBFlNm
                         bus.write_word(pb + 36, flags); // ioFCBFlags
@@ -6939,7 +7022,7 @@ impl super::TrapDispatcher {
                         bus.write_long(pb + 40, file_len as u32); // ioFCBEOF
                         bus.write_long(pb + 44, file_len as u32); // ioFCBPLen
                         bus.write_long(pb + 48, current_pos as u32); // ioFCBCrPs
-                        bus.write_word(pb + 52, super::TrapDispatcher::boot_volume_ref_num_u16()); // ioFCBVRefNum
+                        bus.write_word(pb + 52, file_volume_ref as u16); // ioFCBVRefNum
                         bus.write_long(pb + 54, 0); // ioFCBClpSiz
                         bus.write_long(pb + 58, parent_dir_id); // ioFCBParID
                         eprintln!(

--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -3748,6 +3748,16 @@ impl super::TrapDispatcher {
 
                 // Look up in VFS (try exact match, then basename match)
                 if let Some(vfs_name) = self.find_vfs_file(&filename) {
+                    let read_only = self.vfs_path_is_read_only(&vfs_name);
+                    let requests_write = matches!(permission, 2 | 3 | 4);
+                    if requests_write && read_only {
+                        // Extracted disk-image volumes are mounted read-only;
+                        // fsCurPerm follows the volume permission and explicit
+                        // write modes fail with wPrErr.
+                        bus.write_word(pb + 16, (-44i16) as u16);
+                        cpu.write_reg(Register::D0, (-44i32) as u32);
+                        return Some(Ok(()));
+                    }
                     let refnum = self.next_refnum;
                     self.next_refnum += 1;
                     self.open_files.insert(refnum, vfs_name.clone());
@@ -3756,7 +3766,7 @@ impl super::TrapDispatcher {
                     // (3), and fsRdWrShPerm (4) explicitly request it.
                     // PBGetFCBInfo exposes the granted mode through bit 8 of
                     // ioFCBFlags (Files 1992, 2-108).
-                    if matches!(permission, 0 | 2 | 3 | 4) {
+                    if matches!(permission, 0 | 2 | 3 | 4) && !read_only {
                         self.write_refnums.insert(refnum);
                     }
                     self.file_positions.insert(refnum, 0);
@@ -3927,6 +3937,13 @@ impl super::TrapDispatcher {
                     return Some(Ok(()));
                 };
 
+                if self.vfs_path_is_read_only(&filename) {
+                    bus.write_long(pb + 40, 0);
+                    bus.write_word(pb + 16, (-44i16) as u16); // wPrErr
+                    cpu.write_reg(Register::D0, (-44i32) as u32);
+                    return Some(Ok(()));
+                }
+
                 let (new_pos, host_sync_bytes) = {
                     let file_buf = self.vfs.entry(filename.clone()).or_default();
                     let file_len = file_buf.len();
@@ -4082,18 +4099,70 @@ impl super::TrapDispatcher {
             (false, 0x07) => {
                 let pb = cpu.read_reg(Register::A0);
                 let volume_index = bus.read_word(pb + 28) as i16;
-                let volume_info = if volume_index <= 1 {
+                let requested_vref = bus.read_word(pb + 22) as i16;
+                let requested_name = Self::read_pb_filename(bus, bus.read_long(pb + 18));
+                let boot_volume = || {
                     Some((
                         super::TrapDispatcher::boot_volume_name().to_string(),
                         super::TrapDispatcher::boot_volume_ref_num(),
                         0u16,
                     ))
-                } else {
-                    let mut mounted = self.vfs_volumes.values().collect::<Vec<_>>();
-                    mounted.sort_by_key(|volume| std::cmp::Reverse(volume.ref_num));
-                    mounted
-                        .get((volume_index - 2) as usize)
+                };
+                let volume_info = if volume_index == 0 {
+                    // Files 1992, 2-145: ioVolIndex == 0 selects a volume by
+                    // ioNamePtr or ioVRefNum instead of enumerating the VCB
+                    // queue. Do not silently turn an unknown vRefNum into the
+                    // boot volume; callers use nsvErr to detect a bad volume.
+                    if !requested_name.is_empty() {
+                        if requested_name
+                            .eq_ignore_ascii_case(super::TrapDispatcher::boot_volume_name())
+                        {
+                            boot_volume()
+                        } else {
+                            self.vfs_volume_by_name(&requested_name).map(|volume| {
+                                (volume.name.clone(), volume.ref_num, volume.attributes)
+                            })
+                        }
+                    } else {
+                        let volume_ref_num = if requested_vref == 0 {
+                            Some(self.resolve_volume_ref_num(self.app_wd_refnum))
+                        } else if requested_vref == super::TrapDispatcher::boot_volume_ref_num()
+                            || self.vfs_volumes.contains_key(&requested_vref)
+                        {
+                            Some(requested_vref)
+                        } else {
+                            self.working_directories
+                                .get(&requested_vref)
+                                .map(|working_directory| working_directory.volume_ref_num)
+                        };
+                        volume_ref_num.and_then(|volume_ref_num| {
+                            if volume_ref_num == super::TrapDispatcher::boot_volume_ref_num() {
+                                boot_volume()
+                            } else {
+                                self.vfs_volume_for_ref_num(volume_ref_num).map(|volume| {
+                                    (volume.name.clone(), volume.ref_num, volume.attributes)
+                                })
+                            }
+                        })
+                    }
+                } else if volume_index > 0 {
+                    let mut mounted = self
+                        .vfs_volumes
+                        .values()
                         .map(|volume| (volume.name.clone(), volume.ref_num, volume.attributes))
+                        .collect::<Vec<_>>();
+                    mounted.sort_by_key(|(_, ref_num, _)| std::cmp::Reverse(*ref_num));
+                    let mut volumes = vec![
+                        (
+                            super::TrapDispatcher::boot_volume_name().to_string(),
+                            super::TrapDispatcher::boot_volume_ref_num(),
+                            0u16,
+                        ),
+                    ];
+                    volumes.extend(mounted);
+                    volumes.get((volume_index - 1) as usize).cloned()
+                } else {
+                    None
                 };
                 let Some((volume_name, volume_ref_num, volume_attributes)) = volume_info else {
                     // Files 1992, 2-145: positive ioVolIndex values walk the
@@ -5158,6 +5227,12 @@ impl super::TrapDispatcher {
                     .vfs_key_for_fsspec(v_ref, dir_id, &filename)
                     .unwrap_or_else(|| super::TrapDispatcher::normalize_hfs_path(&filename));
 
+                if self.vfs_path_is_read_only(&vfs_key) {
+                    bus.write_word(pb + 16, (-44i16) as u16); // wPrErr
+                    cpu.write_reg(Register::D0, (-44i32) as u32);
+                    return Some(Ok(()));
+                }
+
                 // Per IM Files 1992, 2-89, PBCreate returns dupFNErr when the
                 // file already exists. Some shareware/demo titles ship a
                 // marker file (e.g. Meteor Storm's "MS UserKey") inside their
@@ -5259,6 +5334,11 @@ impl super::TrapDispatcher {
                 }
 
                 if let Some(vfs_name) = self.find_vfs_file(&filename) {
+                    if self.vfs_path_is_read_only(&vfs_name) {
+                        bus.write_word(pb + 16, (-44i16) as u16); // wPrErr
+                        cpu.write_reg(Register::D0, (-44i32) as u32);
+                        return Some(Ok(()));
+                    }
                     self.vfs.remove(&vfs_name);
                     self.vfs_rsrc.remove(&vfs_name);
                     self.remove_vfs_entry_metadata(&vfs_name);
@@ -5370,6 +5450,11 @@ impl super::TrapDispatcher {
                     .find_vfs_file_for_hfs_lookup(vref, dir_id, &filename)
                     .or_else(|| self.find_vfs_file(&filename))
                 {
+                    if self.vfs_path_is_read_only(&vfs_name) {
+                        bus.write_word(pb + 16, (-44i16) as u16); // wPrErr
+                        cpu.write_reg(Register::D0, (-44i32) as u32);
+                        return Some(Ok(()));
+                    }
                     let file_type = bus.read_long(pb + 32);
                     let creator = bus.read_long(pb + 36);
                     let finder_flags = bus.read_word(pb + 40);
@@ -5465,8 +5550,23 @@ impl super::TrapDispatcher {
                     0
                 };
 
-                let mut target_volume_ref_num = self.resolve_volume_ref_num(requested_vref);
-                let mut target_dir_id = if let Some(working_directory) =
+                let named_volume = (!name.is_empty()).then(|| {
+                    if name.eq_ignore_ascii_case(super::TrapDispatcher::boot_volume_name()) {
+                        Some((
+                            super::TrapDispatcher::boot_volume_ref_num(),
+                            2u32,
+                        ))
+                    } else {
+                        self.vfs_volume_by_name(&name)
+                            .map(|volume| (volume.ref_num, volume.root_dir_id))
+                    }
+                }).flatten();
+                let mut target_volume_ref_num = named_volume
+                    .map(|(volume_ref_num, _)| volume_ref_num)
+                    .unwrap_or_else(|| self.resolve_volume_ref_num(requested_vref));
+                let mut target_dir_id = if let Some((_, root_dir_id)) = named_volume {
+                    root_dir_id
+                } else if let Some(working_directory) =
                     self.working_directories.get(&requested_vref)
                 {
                     target_volume_ref_num = working_directory.volume_ref_num;
@@ -6220,12 +6320,18 @@ impl super::TrapDispatcher {
                             // the BasiliskII/extfs noErr open behavior, but
                             // still records which access paths requested write
                             // permission.
+                            let read_only = self.vfs_path_is_read_only(&vfs_name);
                             let wants_write = matches!(permission, 2 | 3 | 4);
+                            if wants_write && read_only {
+                                bus.write_word(sp + 10, (-44i16) as u16); // wPrErr
+                                cpu.write_reg(Register::A7, sp + 10);
+                                return Some(Ok(()));
+                            }
 
                             let refnum = self.next_refnum;
                             self.next_refnum += 1;
                             self.open_files.insert(refnum, vfs_name.clone());
-                            if wants_write {
+                            if wants_write && !read_only {
                                 self.write_refnums.insert(refnum);
                             }
                             self.file_positions.insert(refnum, 0);
@@ -6298,6 +6404,12 @@ impl super::TrapDispatcher {
                             );
                         }
 
+                        if self.vfs_path_is_read_only(&vfs_key) {
+                            bus.write_word(sp + 14, (-44i16) as u16); // wPrErr
+                            cpu.write_reg(Register::A7, sp + 14);
+                            return Some(Ok(()));
+                        }
+
                         // dupFNErr (-48): file already exists in VFS.
                         // IM:Files 8528; matches BasiliskII empirical behaviour.
                         let already_exists = self.vfs.contains_key(&vfs_key)
@@ -6347,6 +6459,11 @@ impl super::TrapDispatcher {
                                 cpu.write_reg(Register::A7, sp + 10);
                                 return Some(Ok(()));
                             };
+                            if self.vfs_path_is_read_only(&parent_path) {
+                                bus.write_word(sp + 10, (-44i16) as u16); // wPrErr
+                                cpu.write_reg(Register::A7, sp + 10);
+                                return Some(Ok(()));
+                            }
                             let child_name = super::TrapDispatcher::normalize_hfs_path(&filename);
                             if child_name.is_empty() {
                                 -37i16 // bdNamErr
@@ -6408,18 +6525,29 @@ impl super::TrapDispatcher {
                         let filename = read_fsspec_name(bus, spec_ptr);
                         let vref = bus.read_word(spec_ptr) as i16;
                         let dir_id = bus.read_long(spec_ptr + 2);
+                        let mut read_only = false;
                         let found_in_vfs = if let Some(vfs_name) =
                             self.find_vfs_file_for_hfs_lookup(vref, dir_id, &filename)
                         {
-                            self.vfs.remove(&vfs_name);
-                            self.vfs_rsrc.remove(&vfs_name);
-                            self.remove_vfs_entry_metadata(&vfs_name);
-                            true
+                            read_only = self.vfs_path_is_read_only(&vfs_name);
+                            if read_only {
+                                false
+                            } else {
+                                self.vfs.remove(&vfs_name);
+                                self.vfs_rsrc.remove(&vfs_name);
+                                self.remove_vfs_entry_metadata(&vfs_name);
+                                true
+                            }
                         } else if let Some(vfs_name) = self.find_vfs_file(&filename) {
-                            self.vfs.remove(&vfs_name);
-                            self.vfs_rsrc.remove(&vfs_name);
-                            self.remove_vfs_entry_metadata(&vfs_name);
-                            true
+                            read_only = self.vfs_path_is_read_only(&vfs_name);
+                            if read_only {
+                                false
+                            } else {
+                                self.vfs.remove(&vfs_name);
+                                self.vfs_rsrc.remove(&vfs_name);
+                                self.remove_vfs_entry_metadata(&vfs_name);
+                                true
+                            }
                         } else {
                             false
                         };
@@ -6436,7 +6564,9 @@ impl super::TrapDispatcher {
 
                         // fnfErr (-43) when file not found anywhere.
                         // IM:Files 8603: result code fnfErr.
-                        let err: i16 = if found_in_vfs || found_on_host {
+                        let err: i16 = if read_only {
+                            -44 // wPrErr
+                        } else if found_in_vfs || found_on_host {
                             0
                         } else {
                             -43
@@ -6518,15 +6648,27 @@ impl super::TrapDispatcher {
                         let filename = read_fsspec_name(bus, spec_ptr);
                         let vref = bus.read_word(spec_ptr) as i16;
                         let dir_id = bus.read_long(spec_ptr + 2);
-                        if let Some(vfs_name) =
+                        let result = if let Some(vfs_name) =
                             self.find_vfs_file_for_hfs_lookup(vref, dir_id, &filename)
                         {
-                            let file_type = bus.read_long(finfo_ptr);
-                            let creator = bus.read_long(finfo_ptr + 4);
-                            let finder_flags = bus.read_word(finfo_ptr + 8);
-                            self.set_vfs_entry_finfo(&vfs_name, file_type, creator, finder_flags);
-                        }
-                        bus.write_word(sp + 8, 0); // noErr
+                            if self.vfs_path_is_read_only(&vfs_name) {
+                                -44i16 // wPrErr
+                            } else {
+                                let file_type = bus.read_long(finfo_ptr);
+                                let creator = bus.read_long(finfo_ptr + 4);
+                                let finder_flags = bus.read_word(finfo_ptr + 8);
+                                self.set_vfs_entry_finfo(
+                                    &vfs_name,
+                                    file_type,
+                                    creator,
+                                    finder_flags,
+                                );
+                                0
+                            }
+                        } else {
+                            -43i16 // fnfErr
+                        };
+                        bus.write_word(sp + 8, result as u16);
                         cpu.write_reg(Register::A7, sp + 8);
                         Ok(())
                     }
@@ -6606,6 +6748,12 @@ impl super::TrapDispatcher {
                         }
 
                         if let Some(vfs_key) = rsrc_key {
+                            if wants_write && self.vfs_path_is_read_only(&vfs_key) {
+                                bus.write_word(sp + 6, (-44i16) as u16); // wPrErr
+                                cpu.write_reg(Register::D0, (-44i32) as u32);
+                                cpu.write_reg(Register::A7, sp + 6);
+                                return Some(Ok(()));
+                            }
                             // Dedupe: re-opening the same fork must reuse
                             // the existing refnum, not re-allocate every
                             // resource, and must not change CurResFile.
@@ -13641,6 +13789,42 @@ mod tests {
         assert_eq!(bus.read_pstring(name_buf), b"unchanged");
     }
 
+    #[test]
+    fn pb_hget_vinfo_zero_index_selects_named_read_only_volume() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let volume_ref = disp.mount_vfs_volume_with_driver_info(
+            "Legend CD",
+            ".AppleCD",
+            0x0080,
+            4,
+            1024,
+            512,
+            512,
+            900,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        );
+
+        let pb = 0x300000u32;
+        let name_buf = 0x300100u32;
+        cpu.write_reg(Register::A0, pb);
+        bus.write_long(pb + 18, name_buf);
+        bus.write_pstring(name_buf, b"Legend CD");
+        bus.write_word(pb + 22, 0x1234);
+        bus.write_word(pb + 28, 0); // ioVolIndex: lookup by name
+
+        call(&mut disp, false, 0x07, &mut cpu, &mut bus).unwrap();
+
+        assert_eq!(cpu.read_reg(Register::D0), 0);
+        assert_eq!(bus.read_word(pb + 22), volume_ref as u16);
+        assert_eq!(bus.read_pstring(name_buf), b"Legend CD");
+        assert_eq!(bus.read_word(pb + 38), 0x0080, "ioVAtrb");
+    }
+
     // ================================================================
     // 21. PBGetEOF (0x11)
     // ================================================================
@@ -14883,6 +15067,88 @@ mod tests {
             bus.read_word(addr::SF_SAVE_DISK),
             (-super::super::dispatch::BOOT_VOLUME_REF_NUM) as u16
         );
+    }
+
+    #[test]
+    fn pbsetvol_volume_name_selects_named_volume_root() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let volume_ref = disp.mount_vfs_volume_with_driver_info(
+            "Legend CD",
+            ".AppleCD",
+            0,
+            1,
+            1024,
+            512,
+            512,
+            900,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        );
+        let root_dir_id = disp
+            .vfs_volume_for_ref_num(volume_ref)
+            .expect("mounted volume")
+            .root_dir_id;
+
+        let pb = 0x300000u32;
+        let name_buf = 0x300100u32;
+        cpu.write_reg(Register::A0, pb);
+        bus.write_long(pb + 18, name_buf);
+        bus.write_pstring(name_buf, b"Legend CD");
+        bus.write_word(pb + 22, 0); // name selects the volume
+
+        call(&mut disp, false, 0x15, &mut cpu, &mut bus).unwrap();
+
+        assert_eq!(cpu.read_reg(Register::D0), 0);
+        assert_eq!(bus.read_word(pb + 16), 0);
+        assert_eq!(disp.default_dir_id, root_dir_id);
+        assert_eq!(disp.resolve_volume_ref_num(disp.app_wd_refnum), volume_ref);
+        assert_eq!(bus.read_word(addr::SF_SAVE_DISK), (-volume_ref) as u16);
+    }
+
+    #[test]
+    fn extracted_volume_rejects_write_open_and_fswrite() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let volume_ref = disp.mount_vfs_volume_with_driver_info(
+            "Legend CD",
+            ".AppleCD",
+            0,
+            1,
+            1024,
+            512,
+            512,
+            900,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        );
+        let file_name = "Legend CD/Legend";
+        disp.vfs.insert(file_name.to_string(), vec![1, 2, 3]);
+
+        let pb = 0x300000u32;
+        setup_param_block(&mut bus, &mut cpu, pb, b"Legend CD/Legend");
+        bus.write_word(pb + 22, volume_ref as u16);
+        bus.write_byte(pb + 27, 3); // fsRdWrPerm
+        call(&mut disp, false, 0x00, &mut cpu, &mut bus).unwrap();
+        assert_eq!(cpu.read_reg(Register::D0) as i32, -44, "wPrErr");
+
+        bus.write_byte(pb + 27, 1); // fsRdPerm
+        call(&mut disp, false, 0x00, &mut cpu, &mut bus).unwrap();
+        assert_eq!(cpu.read_reg(Register::D0), 0);
+        let ref_num = bus.read_word(pb + 24);
+        bus.write_word(pb + 24, ref_num);
+        bus.write_long(pb + 32, 0x310000);
+        bus.write_long(pb + 36, 1);
+        bus.write_byte(0x310000, 9);
+        call(&mut disp, false, 0x03, &mut cpu, &mut bus).unwrap();
+        assert_eq!(cpu.read_reg(Register::D0) as i32, -44, "wPrErr");
+        assert_eq!(disp.vfs.get(file_name), Some(&vec![1, 2, 3]));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #326

## Summary
- preserve HFS volume metadata and stable synthetic volume references for extracted read-only images
- implement PBGetVInfo lookup-by-name and lookup-by-reference semantics for ioVolIndex zero while retaining deterministic positive-index enumeration
- resolve PBSetVol and PBHSetVol by named mounted volume as well as volume and working-directory references
- treat a lone PBOpenWD colon as the directory identified by ioWDDirID, matching the classic HFS partial-path contract
- reject writes, creates, deletes, Finder metadata changes, and write-mode data/resource opens on extracted volumes with wPrErr
- keep the boot volume writable and preserve the dependent catalog-search work in #332

## Validation
- cargo test -q --lib trap::resource -- --nocapture (278 passed, 3 ignored before this focused follow-up)
- cargo test -q --lib trap::resource::tests::fsdispatch_pbopenwd_colon_selects_requested_directory -- --nocapture
- cargo check -q
- git diff --check
- branch rebased onto the latest master before the follow-up commits
- headless Lode Runner CD smoke coverage remains on this branch and exercises named-volume selection and the .AppleCD driver path