### PR TITLE
fix: preserve MacRoman HFS volume names

### DIFF
--- a/src/disk_image.rs
+++ b/src/disk_image.rs
@@ -83,7 +83,12 @@ pub fn extract_dc42_or_hfs(bytes: &[u8]) -> Result<Option<DiskImageContents>, St
 
     let volume =
         HfsVolume::parse(filesystem).map_err(|e| format!("failed to parse HFS image: {e}"))?;
-    let volume_name = clean_component(&volume.volume_name).unwrap_or_else(|| "Disk Image".into());
+    // hfs-reader currently replaces MacRoman bytes outside ASCII in the
+    // volume name. Read the MDB Pascal string directly so games and clients
+    // retain identities such as the original Tetris disks' bullet separator.
+    let volume_name = hfs_volume_name(filesystem)
+        .or_else(|| clean_component(&volume.volume_name))
+        .unwrap_or_else(|| "Disk Image".into());
     let volume_info = hfs_volume_info(filesystem, volume.files.len());
     let mut dirs = vec![volume_name.clone()];
 
@@ -126,6 +131,20 @@ pub fn extract_dc42_or_hfs(bytes: &[u8]) -> Result<Option<DiskImageContents>, St
         dirs,
         files,
     }))
+}
+
+fn hfs_volume_name(bytes: &[u8]) -> Option<String> {
+    const MDB_OFFSET: usize = 1024;
+    const VOLUME_NAME_OFFSET: usize = MDB_OFFSET + 36;
+    if raw_filesystem_signature(bytes) != Some(HFS_SIGNATURE) {
+        return None;
+    }
+    let length = *bytes.get(VOLUME_NAME_OFFSET)? as usize;
+    if !(1..=27).contains(&length) {
+        return None;
+    }
+    let raw = bytes.get(VOLUME_NAME_OFFSET + 1..VOLUME_NAME_OFFSET + 1 + length)?;
+    clean_component(&crate::trap::decode_mac_roman(raw))
 }
 
 fn hfs_volume_info(bytes: &[u8], file_count: usize) -> DiskImageVolumeInfo {
@@ -694,6 +713,16 @@ mod tests {
         bytes[1024..1026].copy_from_slice(&HFS_SIGNATURE.to_be_bytes());
 
         assert!(looks_like_dc42_or_hfs(&bytes));
+    }
+
+    #[test]
+    fn preserves_mac_roman_hfs_volume_names() {
+        let mut bytes = vec![0; 2048];
+        bytes[1024..1026].copy_from_slice(&HFS_SIGNATURE.to_be_bytes());
+        bytes[1060] = 8;
+        bytes[1061..1069].copy_from_slice(b"Tetris\xA52");
+
+        assert_eq!(hfs_volume_name(&bytes).as_deref(), Some("Tetris•2"));
     }
 
     #[test]

--- a/src/trap/mod.rs
+++ b/src/trap/mod.rs
@@ -34,6 +34,7 @@ mod sound;
 mod text_render;
 mod toolbox;
 mod types;
+pub(crate) use types::decode_mac_roman;
 mod window;
 
 pub use dispatch::TrapDispatcher;


### PR DESCRIPTION
## Summary

- decode the authoritative HFS MDB volume-name Pascal string with Systemless's MacRoman decoder
- fall back to the dependency-provided name only when the MDB name is unavailable or invalid
- cover a bullet-separated classic volume name with a regression test

## Root cause

The HFS reader dependency replaces MacRoman bytes outside ASCII while parsing volume names. That changes identities such as the original Macintosh Tetris disks from `TETRIS•1` / `Tetris•2` to underscore variants, even though the MDB still contains the exact bytes.

Reading the 1–27 byte HFS volume name directly from the MDB preserves the media identity while retaining the existing path-safety normalization.

## Validation

- `rustfmt --check src/disk_image.rs`
- `cargo test -q disk_image::tests` (12 passed)
- `git diff --check`
- rebuilt a two-source web pack from the original 800K Tetris disks and verified the exact bullet-separated root names launch through the authentic title, setup, and live game board

## Stack

This draft targets `dev/lode-runner-cd-gameplay` while #334 awaits approval. After that prerequisite lands, this PR can be retargeted to the default branch and rebased without a merge commit.

Closes #335