### PR TITLE
fix: honor resolved color GrafPort pixel fields

### DIFF
--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -1658,6 +1658,10 @@ pub struct TrapDispatcher {
     pub(crate) current_port: u32,
     /// Per-port pen/color/text state restored by SetPort and SetGWorld.
     pub(crate) port_draw_states: HashMap<u32, PortDrawState>,
+    /// Bit 0/1 mark CGrafPort fgColor/bkColor fields that QuickDraw has
+    /// resolved through a color-setting call. Once resolved, guest writes to
+    /// those indexed pixel fields remain authoritative for drawing.
+    pub(crate) resolved_port_color_fields: HashMap<u32, u8>,
     /// Associated GDevice handle for each offscreen GWorld port.
     pub(crate) gworld_devices: HashMap<u32, u32>,
     /// Compatibility map for `&port->portBits` addresses (key = `port + 2`)
@@ -2997,6 +3001,7 @@ impl TrapDispatcher {
             current_gdevice: 0,
             current_port: 0,
             port_draw_states: HashMap::new(),
+            resolved_port_color_fields: HashMap::new(),
             gworld_devices: HashMap::new(),
             disposed_gworld_portbits: HashMap::new(),
             gworld_pixel_states: HashMap::new(),

--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -1274,6 +1274,7 @@ impl super::TrapDispatcher {
                 // None silently); cleans up CGrafPort tracking.
                 self.cport_ports.remove(&port_ptr);
                 self.cport_original_pixmaps.remove(&port_ptr);
+                self.resolved_port_color_fields.remove(&port_ptr);
                 Ok(())
             }
 
@@ -4254,6 +4255,7 @@ impl super::TrapDispatcher {
                 self.fg_color = Self::legacy_qd_color_to_rgb(color);
                 self.pm_fg_color = None;
                 self.sync_current_port_draw_state(bus);
+                self.resolve_current_port_color_pixels(bus, true, false);
                 if trace_qd_colors_enabled() {
                     eprintln!(
                         "[QD-COLOR] ForeColor port=${:08X} color=${:08X} rgb=({:04X},{:04X},{:04X}) tick={}",
@@ -4287,6 +4289,7 @@ impl super::TrapDispatcher {
                 self.bg_color = Self::legacy_qd_color_to_rgb(color);
                 self.pm_bg_color = None;
                 self.sync_current_port_draw_state(bus);
+                self.resolve_current_port_color_pixels(bus, false, true);
                 if trace_qd_colors_enabled() {
                     eprintln!(
                         "[QD-COLOR] BackColor port=${:08X} color=${:08X} rgb=({:04X},{:04X},{:04X}) tick={}",
@@ -4324,6 +4327,7 @@ impl super::TrapDispatcher {
                 self.fg_color = (r, g, b);
                 self.pm_fg_color = None;
                 self.sync_current_port_draw_state(bus);
+                self.resolve_current_port_color_pixels(bus, true, false);
                 if let Some((_, _, _, _, _, commands)) = self.recording_picture.as_mut() {
                     Self::push_pict_word(commands, 0x001A); // RGBFgCol
                     for component in [r, g, b] {
@@ -4354,6 +4358,7 @@ impl super::TrapDispatcher {
                 self.bg_color = (r, g, b);
                 self.pm_bg_color = None;
                 self.sync_current_port_draw_state(bus);
+                self.resolve_current_port_color_pixels(bus, false, true);
                 if let Some((_, _, _, _, _, commands)) = self.recording_picture.as_mut() {
                     Self::push_pict_word(commands, 0x001B); // RGBBkCol
                     for component in [r, g, b] {
@@ -4940,6 +4945,12 @@ impl super::TrapDispatcher {
                         // reserved for that palette entry; Systemless' single
                         // GDevice allocation maps it to the same index.
                         bus.write_long(self.current_port + 80, (entry as u16 & 0x00FF) as u32);
+                        *self
+                            .resolved_port_color_fields
+                            .entry(self.current_port)
+                            .or_default() |= 0x01;
+                    } else {
+                        self.resolve_current_port_color_pixels(bus, true, false);
                     }
                     if trace_qd_colors_enabled() {
                         eprintln!(
@@ -4983,6 +4994,12 @@ impl super::TrapDispatcher {
                         && (bus.read_word(self.current_port + 6) & 0xC000) == 0xC000
                     {
                         bus.write_long(self.current_port + 84, (entry as u16 & 0x00FF) as u32);
+                        *self
+                            .resolved_port_color_fields
+                            .entry(self.current_port)
+                            .or_default() |= 0x02;
+                    } else {
+                        self.resolve_current_port_color_pixels(bus, false, true);
                     }
                     if trace_qd_colors_enabled() {
                         eprintln!(
@@ -17983,6 +18000,7 @@ impl super::TrapDispatcher {
             self.manual_cport_screen_witness.clear();
         }
         self.port_draw_states.remove(&port);
+        self.resolved_port_color_fields.remove(&port);
     }
 
     pub(super) fn effective_destination_ctab_handle(
@@ -18481,6 +18499,38 @@ impl super::TrapDispatcher {
         self.sync_port_draw_state(bus, self.current_port);
     }
 
+    fn resolve_current_port_color_pixels(
+        &mut self,
+        bus: &mut MacMemoryBus,
+        foreground: bool,
+        background: bool,
+    ) {
+        let port = self.current_port;
+        if port == 0
+            || !self.port_allows_draw_state_memory_sync(bus, port)
+            || (bus.read_word(port + 6) & 0xC000) != 0xC000
+        {
+            return;
+        }
+
+        if foreground {
+            let pixel = Self::nearest_palette_index(
+                &self.device_clut,
+                [self.fg_color.0, self.fg_color.1, self.fg_color.2],
+            );
+            bus.write_long(port + 80, u32::from(pixel));
+            *self.resolved_port_color_fields.entry(port).or_default() |= 0x01;
+        }
+        if background {
+            let pixel = Self::nearest_palette_index(
+                &self.device_clut,
+                [self.bg_color.0, self.bg_color.1, self.bg_color.2],
+            );
+            bus.write_long(port + 84, u32::from(pixel));
+            *self.resolved_port_color_fields.entry(port).or_default() |= 0x02;
+        }
+    }
+
     fn sync_port_draw_state(&self, bus: &mut MacMemoryBus, port: u32) {
         if port == 0 {
             return;
@@ -18527,24 +18577,7 @@ impl super::TrapDispatcher {
         bus.write_word(port + 70, encode_text_face_style(self.tx_face));
         bus.write_word(port + 72, self.tx_mode as u16);
         bus.write_word(port + 74, self.tx_size as u16);
-        let (fg_pixel, bg_pixel) = if is_cgrafport {
-            // A CGrafPort's fgColor/bkColor fields contain the pixel values
-            // supplied by the Color Manager, while rgbFgColor/rgbBkColor
-            // retain the requested colors.  Inside Macintosh Volume V,
-            // pp. V-48 and V-163.  Keeping the old QuickDraw constants here
-            // made every non-black/white PmForeColor selection look like
-            // pixel zero to software that inspects the port record.
-            (
-                u32::from(Self::nearest_palette_index(
-                    &self.device_clut,
-                    [self.fg_color.0, self.fg_color.1, self.fg_color.2],
-                )),
-                u32::from(Self::nearest_palette_index(
-                    &self.device_clut,
-                    [self.bg_color.0, self.bg_color.1, self.bg_color.2],
-                )),
-            )
-        } else {
+        if !is_cgrafport {
             let fg_legacy = if self.fg_color == (0, 0, 0) {
                 0x00000021
             } else if self.fg_color == (0xFFFF, 0xFFFF, 0xFFFF) {
@@ -18559,10 +18592,14 @@ impl super::TrapDispatcher {
             } else {
                 0
             };
-            (fg_legacy, bg_legacy)
-        };
-        bus.write_long(port + 80, fg_pixel);
-        bus.write_long(port + 84, bg_pixel);
+            bus.write_long(port + 80, fg_legacy);
+            bus.write_long(port + 84, bg_legacy);
+        }
+        // A CGrafPort's fgColor/bkColor fields are resolved pixel values,
+        // independent from rgbFgColor/rgbBkColor. Applications and the Color
+        // Manager may update those pixels directly, so unrelated pen or text
+        // synchronization must preserve them. Inside Macintosh Volume V,
+        // pp. V-48 and V-163.
     }
 
     fn known_port(&self, port: u32) -> bool {
@@ -33271,6 +33308,40 @@ mod tests {
         assert!(result.unwrap().is_ok());
         assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 4);
         assert_eq!(d.fg_color, (0xF2D7, 0x0856, 0x84EC));
+    }
+
+    #[test]
+    fn fore_color_resolves_the_cgrafport_foreground_pixel() {
+        let (mut d, mut cpu, mut bus) = setup_with_port();
+        let port = 0x181000u32;
+        bus.write_word(port + 6, 0xC000);
+        d.set_current_port_state(&mut bus, &mut cpu, port, None);
+        d.device_clut = [[0, 0, 0]; 256];
+        d.device_clut[42] = [0xF2D7, 0x0856, 0x84EC];
+        bus.write_long(TEST_SP, 139);
+
+        let result = d.dispatch_quickdraw(true, 0x062, &mut cpu, &mut bus);
+
+        assert!(result.unwrap().is_ok());
+        assert_eq!(bus.read_long(port + 80), 42);
+    }
+
+    #[test]
+    fn unrelated_cgrafport_state_sync_preserves_resolved_color_pixels() {
+        let (mut d, mut cpu, mut bus) = setup_with_port();
+        let port = 0x181000u32;
+        bus.write_word(port + 6, 0xC000);
+        d.set_current_port_state(&mut bus, &mut cpu, port, None);
+        bus.write_long(port + 80, 95);
+        bus.write_long(port + 84, 181);
+
+        d.pn_loc = (12, 34);
+        d.sync_current_port_draw_state(&mut bus);
+
+        assert_eq!(bus.read_long(port + 80), 95);
+        assert_eq!(bus.read_long(port + 84), 181);
+        assert_eq!(bus.read_word(port + 48), 12);
+        assert_eq!(bus.read_word(port + 50), 34);
     }
 
     #[test]

--- a/src/trap/shapes.rs
+++ b/src/trap/shapes.rs
@@ -128,6 +128,22 @@ fn shape_palette_index_for_rgb(
     super::pict::closest_clut_index(rgb[0], rgb[1], rgb[2], clut)
 }
 
+fn indexed_shape_color_index(
+    port_pixel: u32,
+    effective_rgb: (u16, u16, u16),
+    pixel_size: u16,
+    clut: &[[u16; 3]; 256],
+    port_pixel_is_resolved: bool,
+    generated_rgb: bool,
+) -> u8 {
+    if generated_rgb || !port_pixel_is_resolved {
+        let (r, g, b) = effective_rgb;
+        shape_palette_index_for_rgb([r, g, b], pixel_size, clut)
+    } else {
+        (port_pixel as u8) & ((1u16 << pixel_size) - 1) as u8
+    }
+}
+
 fn ctab_rgb_for_value(bus: &MacMemoryBus, ctab_handle: u32, wanted_value: u8) -> Option<[u16; 3]> {
     if ctab_handle == 0 {
         return None;
@@ -1353,10 +1369,35 @@ impl super::TrapDispatcher {
             } else {
                 self.read_port_clut(bus, ctab_handle)
             };
-            let (r, g, b) = effective_fg_color;
-            fg_idx = shape_palette_index_for_rgb([r, g, b], pixel_size, &port_clut);
-            let (r, g, b) = effective_bg_color;
-            bg_idx = shape_palette_index_for_rgb([r, g, b], pixel_size, &port_clut);
+            let resolved_color_fields = self
+                .resolved_port_color_fields
+                .get(&port)
+                .copied()
+                .unwrap_or(0);
+            // A CGrafPort stores the already-resolved destination pixel in
+            // fgColor/bkColor. Applications may edit those fields directly,
+            // while rgbFgColor/rgbBkColor retain the logical colors. Re-running
+            // the RGB inverse lookup here loses that distinction, especially
+            // while an indexed palette is being animated. Generated RGB pixel
+            // patterns are the exception because their color does not come
+            // from the port fields.
+            // Inside Macintosh Volume V, pp. V-48 and V-163
+            fg_idx = indexed_shape_color_index(
+                bus.read_long(port + 80),
+                effective_fg_color,
+                pixel_size,
+                &port_clut,
+                (resolved_color_fields & 0x01) != 0,
+                generated_pen_rgb.is_some(),
+            );
+            bg_idx = indexed_shape_color_index(
+                bus.read_long(port + 84),
+                effective_bg_color,
+                pixel_size,
+                &port_clut,
+                (resolved_color_fields & 0x02) != 0,
+                generated_back_rgb.is_some(),
+            );
             if trace_dialog_text_enabled() && matches!(op, ShapeOp::Glyph(_)) {
                 eprintln!(
                     "[DIALOG-TEXT] Glyph colors port=${:08X} fgRGB=({:04X},{:04X},{:04X}) bgRGB=({:04X},{:04X},{:04X}) fgIdx={} bgIdx={}",
@@ -1740,7 +1781,8 @@ impl super::TrapDispatcher {
 mod tests {
     use super::{
         apply_boolean_transfer_1, apply_boolean_transfer_8, blend_rgb, fg_bg_low_contrast,
-        lighten_stem_alpha, normalize_boolean_transfer_mode, shape_palette_index_for_rgb,
+        indexed_shape_color_index, lighten_stem_alpha, normalize_boolean_transfer_mode,
+        shape_palette_index_for_rgb,
     };
 
     #[test]
@@ -1764,6 +1806,36 @@ mod tests {
         assert_eq!(
             shape_palette_index_for_rgb([0x6666, 0xFFFF, 0xFFFF], 8, &clut),
             12
+        );
+    }
+
+    #[test]
+    fn indexed_cgrafport_shapes_honor_the_resolved_port_pixel() {
+        let mut clut = [[0, 0, 0]; 256];
+        clut[95] = [0x0000, 0x7B60, 0x0000];
+        clut[181] = [0xAB90, 0x7C50, 0x9570];
+
+        assert_eq!(
+            indexed_shape_color_index(
+                95,
+                (0xF2D7, 0x0856, 0x84EC),
+                8,
+                &clut,
+                true,
+                false,
+            ),
+            95
+        );
+        assert_eq!(
+            indexed_shape_color_index(
+                95,
+                (0xF2D7, 0x0856, 0x84EC),
+                8,
+                &clut,
+                true,
+                true,
+            ),
+            181
         );
     }
 


### PR DESCRIPTION
## Summary

- keep a color GrafPort’s resolved `fgColor` and `bkColor` pixel values independent from its logical RGB colors
- preserve application-written indexed pixels during unrelated pen and text state synchronization
- continue resolving internal RGB-only drawing until QuickDraw has established an authoritative port pixel

## Verification

- `cargo test --quiet`
- replayed the public Bonkheads archive (`e0f909205dc13ea1ccf3e66c406212983f9cd1c66255b0354bf9c2b808dfe821`) at 60- and 660-tick title-menu checkpoints
- confirmed score headings and rows now follow the indexed green/yellow phases observed in BasiliskII

Closes #354