### PR TITLE
fix: fill kiosk margins around centered game surfaces

### DIFF
--- a/src/trap/framebuffer.rs
+++ b/src/trap/framebuffer.rs
@@ -985,6 +985,129 @@ impl super::TrapDispatcher {
         }
     }
 
+    /// Fill the exposed framebuffer around a large centered presentation
+    /// rectangle with the darkest active indexed color. Systemless suppresses
+    /// the classic desktop in kiosk mode, so centered game surfaces sit on a
+    /// black stage while their pixels remain untouched.
+    pub(super) fn fill_kiosk_stage_around_rect(
+        &self,
+        bus: &mut MacMemoryBus,
+        rect: (i16, i16, i16, i16),
+    ) -> bool {
+        let (screen_base, row_bytes, screen_width, screen_height, pixel_size) =
+            self.get_screen_params();
+        let (top, left, bottom, right) = rect;
+        let width = right.saturating_sub(left);
+        let height = bottom.saturating_sub(top);
+        let large = width >= (screen_width / 2).max(1) && height >= (screen_height / 2).max(1);
+        let centered = left >= 0
+            && top >= 0
+            && (screen_width - right - left).abs() <= 1
+            && (screen_height - bottom - top).abs() <= 1;
+        if !self.menu_bar_hidden
+            || !large
+            || !centered
+            || (width >= screen_width && height >= screen_height)
+        {
+            return false;
+        }
+
+        let black_index = self
+            .device_clut
+            .iter()
+            .enumerate()
+            .min_by_key(|(_, rgb)| u32::from(rgb[0]) + u32::from(rgb[1]) + u32::from(rgb[2]))
+            .map(|(index, _)| index as u8)
+            .unwrap_or(255);
+        for (margin_top, margin_left, margin_bottom, margin_right) in [
+            (0, 0, top, screen_width),
+            (bottom, 0, screen_height, screen_width),
+            (top, 0, bottom, left),
+            (top, right, bottom, screen_width),
+        ] {
+            if pixel_size == 8 {
+                Self::fb_fill_rect_index(
+                    bus,
+                    screen_base,
+                    row_bytes,
+                    pixel_size,
+                    screen_width,
+                    screen_height,
+                    margin_top,
+                    margin_left,
+                    margin_bottom,
+                    margin_right,
+                    black_index,
+                );
+            } else {
+                Self::fb_fill_rect(
+                    bus,
+                    screen_base,
+                    row_bytes,
+                    pixel_size,
+                    screen_width,
+                    screen_height,
+                    margin_top,
+                    margin_left,
+                    margin_bottom,
+                    margin_right,
+                    true,
+                );
+            }
+        }
+        true
+    }
+
+    pub(super) fn kiosk_stage_margins_are_uniform(
+        &self,
+        bus: &MacMemoryBus,
+        rect: (i16, i16, i16, i16),
+    ) -> bool {
+        let (screen_base, row_bytes, screen_width, screen_height, pixel_size) =
+            self.get_screen_params();
+        if pixel_size != 8 {
+            return false;
+        }
+        let (top, left, bottom, right) = rect;
+        if top < 0
+            || left < 0
+            || bottom > screen_height
+            || right > screen_width
+            || top >= bottom
+            || left >= right
+        {
+            return false;
+        }
+
+        let mut margin_index = None;
+        let mut pixels = vec![0; screen_width as usize];
+        for y in 0..screen_height {
+            let ranges = if y < top || y >= bottom {
+                [(0, screen_width), (0, 0)]
+            } else {
+                [(0, left), (right, screen_width)]
+            };
+            for (start, end) in ranges {
+                let length = end.saturating_sub(start) as usize;
+                if length == 0 {
+                    continue;
+                }
+                bus.read_bytes_into(
+                    screen_base + y as u32 * row_bytes + start as u32,
+                    &mut pixels[..length],
+                );
+                for &pixel in &pixels[..length] {
+                    match margin_index {
+                        Some(expected) if pixel != expected => return false,
+                        None => margin_index = Some(pixel),
+                        _ => {}
+                    }
+                }
+            }
+        }
+        margin_index.is_some()
+    }
+
     /// Fill a rectangle in the framebuffer
     pub(crate) fn fb_fill_rect(
         bus: &mut MacMemoryBus,
@@ -4494,13 +4617,14 @@ impl super::TrapDispatcher {
                 self.invert_menu_item(bus, tracking.highlighted_item);
             }
         }
+        self.fill_kiosk_stage_for_centered_game_surface(bus, self.front_window);
         self.capture_gui_frame(bus, "redraw_chrome");
     }
 }
 
 #[cfg(test)]
 mod redraw_chrome_tests {
-    use super::super::dispatch::DialogItem;
+    use super::super::dispatch::{DialogItem, ScreenCopyBitsRect};
     use super::super::test_helpers::setup_with_port;
     use super::super::TrapDispatcher;
     use crate::memory::MemoryBus;
@@ -4543,6 +4667,150 @@ mod redraw_chrome_tests {
         disp.restore_screen_rect_pixels(&mut bus, saved.0, saved.1, saved.2, saved.3, &saved.4);
         assert_eq!(bus.read_byte(screen_base), 0xA5);
         assert_eq!(bus.read_byte(screen_base + 1), 0x5A);
+    }
+
+    #[test]
+    fn redraw_chrome_finishes_centered_plain_game_window_on_black_stage() {
+        let (mut disp, _cpu, mut bus) = setup_with_port();
+        let (screen_base, row_bytes, screen_w, screen_h, pixel_size) = disp.screen_mode;
+        bus.fill_bytes(screen_base, row_bytes * screen_h as u32, 0);
+        TrapDispatcher::fb_fill_rect_index(
+            &mut bus,
+            screen_base,
+            row_bytes,
+            pixel_size,
+            screen_w as i16,
+            screen_h as i16,
+            60,
+            80,
+            540,
+            720,
+            42,
+        );
+
+        // A 640x480 plainDBox front window centered on the 800x600 screen.
+        // Its BitMap shares the screen, so redraw_chrome's compositor leaves
+        // these already-composed pixels in place before applying the stage.
+        bus.write_word(PORT_PTR + 8, (-60i16) as u16);
+        bus.write_word(PORT_PTR + 10, (-80i16) as u16);
+        bus.write_word(PORT_PTR + 12, 540);
+        bus.write_word(PORT_PTR + 14, 720);
+        bus.write_word(PORT_PTR + 16, 0);
+        bus.write_word(PORT_PTR + 18, 0);
+        bus.write_word(PORT_PTR + 20, 480);
+        bus.write_word(PORT_PTR + 22, 640);
+        bus.write_byte(PORT_PTR + WINDOW_VISIBLE_OFFSET, 0xFF);
+        disp.front_window = PORT_PTR;
+        disp.window_list = vec![PORT_PTR];
+        disp.window_bounds = (60, 80, 540, 720);
+        disp.window_proc_id = 2;
+        disp.window_proc_ids.insert(PORT_PTR, 2);
+        disp.menu_bar_hidden = true;
+        disp.device_clut = [[0xFFFF, 0xFFFF, 0xFFFF]; 256];
+        disp.device_clut[37] = [0, 0, 0];
+
+        disp.redraw_chrome(&mut bus);
+
+        assert_eq!(bus.read_byte(screen_base), 37);
+        assert_eq!(bus.read_byte(screen_base + 300 * row_bytes + 40), 37);
+        assert_eq!(bus.read_byte(screen_base + 300 * row_bytes + 400), 42);
+        assert_eq!(bus.read_byte(screen_base + 599 * row_bytes + 799), 37);
+    }
+
+    #[test]
+    fn redraw_chrome_does_not_stage_centered_document_window() {
+        let (mut disp, _cpu, mut bus) = setup_with_port();
+        let (screen_base, row_bytes, _screen_w, screen_h, _) = disp.screen_mode;
+        bus.fill_bytes(screen_base, row_bytes * screen_h as u32, 0);
+        bus.write_word(PORT_PTR + 8, (-60i16) as u16);
+        bus.write_word(PORT_PTR + 10, (-80i16) as u16);
+        bus.write_word(PORT_PTR + 12, 540);
+        bus.write_word(PORT_PTR + 14, 720);
+        bus.write_word(PORT_PTR + 20, 480);
+        bus.write_word(PORT_PTR + 22, 640);
+        bus.write_byte(PORT_PTR + WINDOW_VISIBLE_OFFSET, 0xFF);
+        disp.front_window = PORT_PTR;
+        disp.window_list = vec![PORT_PTR];
+        disp.window_bounds = (60, 80, 540, 720);
+        disp.window_proc_id = 0;
+        disp.window_proc_ids.insert(PORT_PTR, 0);
+        disp.menu_bar_hidden = true;
+        disp.device_clut = [[0xFFFF, 0xFFFF, 0xFFFF]; 256];
+        disp.device_clut[37] = [0, 0, 0];
+        disp.last_screen_copybits_rect = Some(ScreenCopyBitsRect {
+            src_top: 0,
+            src_left: 0,
+            src_bottom: 480,
+            src_right: 640,
+            dst_top: 60,
+            dst_left: 80,
+            dst_bottom: 540,
+            dst_right: 720,
+        });
+
+        disp.redraw_chrome(&mut bus);
+
+        assert_eq!(bus.read_byte(screen_base), 0);
+    }
+
+    #[test]
+    fn redraw_chrome_stages_last_centered_copybits_surface_with_stale_window_record() {
+        let (mut disp, _cpu, mut bus) = setup_with_port();
+        let (screen_base, row_bytes, screen_w, screen_h, pixel_size) = disp.screen_mode;
+        bus.fill_bytes(screen_base, row_bytes * screen_h as u32, 0);
+        TrapDispatcher::fb_fill_rect_index(
+            &mut bus,
+            screen_base,
+            row_bytes,
+            pixel_size,
+            screen_w as i16,
+            screen_h as i16,
+            100,
+            80,
+            500,
+            720,
+            42,
+        );
+
+        bus.write_word(PORT_PTR + 8, 0);
+        bus.write_word(PORT_PTR + 10, 0);
+        bus.write_word(PORT_PTR + 12, screen_h);
+        bus.write_word(PORT_PTR + 14, screen_w);
+        bus.write_word(PORT_PTR + 16, 0);
+        bus.write_word(PORT_PTR + 18, 0);
+        bus.write_word(PORT_PTR + 20, screen_h);
+        bus.write_word(PORT_PTR + 22, screen_w);
+        bus.write_byte(PORT_PTR + WINDOW_VISIBLE_OFFSET, 0);
+        bus.write_word(crate::memory::globals::addr::MBAR_HEIGHT, 0);
+        disp.front_window = PORT_PTR;
+        disp.window_list = vec![PORT_PTR];
+        disp.window_bounds = (0, 0, screen_h as i16, screen_w as i16);
+        disp.window_proc_id = 2;
+        disp.window_proc_ids.remove(&PORT_PTR);
+        disp.menu_bar_hidden = true;
+        disp.device_clut = [[0xFFFF, 0xFFFF, 0xFFFF]; 256];
+        disp.device_clut[37] = [0, 0, 0];
+        disp.last_screen_copybits_rect = Some(ScreenCopyBitsRect {
+            src_top: 0,
+            src_left: 0,
+            src_bottom: 200,
+            src_right: 320,
+            dst_top: 100,
+            dst_left: 80,
+            dst_bottom: 500,
+            dst_right: 720,
+        });
+
+        assert!(disp.kiosk_stage_margins_are_uniform(&bus, (100, 80, 500, 720)));
+
+        disp.redraw_chrome(&mut bus);
+
+        assert_eq!(bus.read_byte(screen_base), 37);
+        assert_eq!(bus.read_byte(screen_base + 300 * row_bytes + 40), 37);
+        assert_eq!(bus.read_byte(screen_base + 300 * row_bytes + 400), 42);
+        assert_eq!(bus.read_byte(screen_base + 599 * row_bytes + 799), 37);
+        bus.write_byte(screen_base + 1, 38);
+        assert!(!disp.kiosk_stage_margins_are_uniform(&bus, (100, 80, 500, 720)));
     }
 
     fn track_manual_cport(disp: &mut TrapDispatcher, bus: &crate::memory::MacMemoryBus, port: u32) {

--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -19470,84 +19470,20 @@ impl super::TrapDispatcher {
     }
 
     fn fill_kiosk_letterbox_for_copybits(&self, bus: &mut MacMemoryBus, rect: ScreenCopyBitsRect) {
-        let (screen_base, row_bytes, screen_width, screen_height, pixel_size) = self.screen_mode;
         let src_width = rect.src_right.saturating_sub(rect.src_left);
         let src_height = rect.src_bottom.saturating_sub(rect.src_top);
         let dst_width = rect.dst_right.saturating_sub(rect.dst_left);
         let dst_height = rect.dst_bottom.saturating_sub(rect.dst_top);
-        let large = dst_width >= (screen_width as i16 / 2).max(1)
-            && dst_height >= (screen_height as i16 / 2).max(1);
-        let centered = rect.dst_left >= 0
-            && rect.dst_top >= 0
-            && (screen_width as i16 - rect.dst_right - rect.dst_left).abs() <= 1
-            && (screen_height as i16 - rect.dst_bottom - rect.dst_top).abs() <= 1;
-        if !self.menu_bar_hidden
-            || !large
-            || !centered
-            || src_width != dst_width
-            || src_height != dst_height
-            || (dst_width >= screen_width as i16 && dst_height >= screen_height as i16)
-        {
+        if src_width != dst_width || src_height != dst_height {
             return;
         }
 
-        // A game can install a palette where the conventional index 255 is
-        // no longer black. Derive the margin index from the active hardware
-        // CLUT after the blit has completed; doing this before an overlapping
-        // screen-to-screen CopyBits would destroy source pixels.
-        let black_index = self
-            .device_clut
-            .iter()
-            .enumerate()
-            .min_by_key(|(_, rgb)| u32::from(rgb[0]) + u32::from(rgb[1]) + u32::from(rgb[2]))
-            .map(|(index, _)| index as u8)
-            .unwrap_or(255);
-        for (top, left, bottom, right) in [
-            (0, 0, rect.dst_top, screen_width as i16),
-            (
-                rect.dst_bottom,
-                0,
-                screen_height as i16,
-                screen_width as i16,
-            ),
-            (rect.dst_top, 0, rect.dst_bottom, rect.dst_left),
-            (
-                rect.dst_top,
-                rect.dst_right,
-                rect.dst_bottom,
-                screen_width as i16,
-            ),
-        ] {
-            if pixel_size == 8 {
-                Self::fb_fill_rect_index(
-                    bus,
-                    screen_base,
-                    row_bytes,
-                    pixel_size,
-                    screen_width as i16,
-                    screen_height as i16,
-                    top,
-                    left,
-                    bottom,
-                    right,
-                    black_index,
-                );
-            } else {
-                Self::fb_fill_rect(
-                    bus,
-                    screen_base,
-                    row_bytes,
-                    pixel_size,
-                    screen_width as i16,
-                    screen_height as i16,
-                    top,
-                    left,
-                    bottom,
-                    right,
-                    true,
-                );
-            }
-        }
+        // Run after the blit so overlapping screen-to-screen copies cannot
+        // lose source pixels while the margins are cleared.
+        self.fill_kiosk_stage_around_rect(
+            bus,
+            (rect.dst_top, rect.dst_left, rect.dst_bottom, rect.dst_right),
+        );
     }
 
     /// Address of a replacement `grafProcs.bitsProc` on the current port, or

--- a/src/trap/window.rs
+++ b/src/trap/window.rs
@@ -1232,6 +1232,36 @@ impl super::TrapDispatcher {
         true
     }
 
+    pub(super) fn fill_kiosk_stage_for_centered_game_surface(
+        &self,
+        bus: &mut MacMemoryBus,
+        window_ptr: u32,
+    ) {
+        let valid_front_window = window_ptr != 0
+            && window_ptr == self.front_window
+            && self.window_visible(bus, window_ptr);
+        let plain_game_window = valid_front_window && self.window_proc_id(window_ptr) == 2;
+        if plain_game_window {
+            if self
+                .fill_kiosk_stage_around_rect(bus, self.window_global_port_rect(bus, window_ptr))
+            {
+                return;
+            }
+        } else if valid_front_window {
+            return;
+        }
+
+        // A game may replace or dispose its WindowRecord after presenting a
+        // centered surface with CopyBits. Keep that explicit guest destination
+        // as the aperture when its exposed bands remain one uniform index.
+        if let Some(rect) = self.last_screen_copybits_rect {
+            let destination = (rect.dst_top, rect.dst_left, rect.dst_bottom, rect.dst_right);
+            if self.kiosk_stage_margins_are_uniform(bus, destination) {
+                self.fill_kiosk_stage_around_rect(bus, destination);
+            }
+        }
+    }
+
     fn move_window_to_global(
         &mut self,
         bus: &mut MacMemoryBus,


### PR DESCRIPTION
Closes #338

## Summary

- fill exposed margins after Systemless finishes composing a centered game surface
- use the darkest active CLUT entry without changing game-surface pixels
- retain explicit centered CopyBits geometry when a game invalidates its WindowRecord
- leave centered document windows and non-uniform fullscreen edges unchanged

## Validation

- cargo test --quiet (2,895 passed, 3 ignored)
- Bonkheads menu: 62.90% to 98.90% strict match against BasiliskII; gameplay remains 98.00% / 97.58%
- Prince of Persia launch and menu: 53.33% to 100.00% strict match against BasiliskII