### PR TITLE
fix: preserve MacRoman HFS volume names

### DIFF
--- a/src/disk_image.rs
+++ b/src/disk_image.rs
@@ -11,6 +11,8 @@ use std::{
 
 use hfs_reader::HfsVolume;
 
+use crate::mac_roman::decode_mac_roman;
+
 const HFS_SIGNATURE: u16 = 0x4244;
 const HFS_PLUS_SIGNATURE: u16 = 0x482B;
 const HFSX_SIGNATURE: u16 = 0x4858;
@@ -23,6 +25,8 @@ const HFSPLUS_FORK_DATA: u8 = 0x00;
 const HFSPLUS_FORK_RESOURCE: u8 = 0xFF;
 const HFSPLUS_CATALOG_FILE_RECORD: u16 = 0x0002;
 const HFSPLUS_FILE_USER_INFO_OFFSET: usize = 48;
+const HFS_MDB_VOLUME_NAME_OFFSET: usize = 1024 + 36;
+const HFS_MAX_VOLUME_NAME_LEN: usize = 27;
 
 #[derive(Debug)]
 pub struct DiskImageContents {
@@ -65,7 +69,9 @@ pub fn extract_dc42_or_hfs(bytes: &[u8]) -> Result<Option<DiskImageContents>, St
 
     let volume =
         HfsVolume::parse(filesystem).map_err(|e| format!("failed to parse HFS image: {e}"))?;
-    let volume_name = clean_component(&volume.volume_name).unwrap_or_else(|| "Disk Image".into());
+    let volume_name = hfs_volume_name_from_mdb(filesystem)
+        .or_else(|| clean_component(&volume.volume_name))
+        .unwrap_or_else(|| "Disk Image".into());
     let mut dirs = vec![volume_name.clone()];
 
     for dir in &volume.dirs {
@@ -123,6 +129,22 @@ fn filesystem_payload(bytes: &[u8]) -> &[u8] {
         .and_then(|(start, end)| bytes.get(start..end))
         .or_else(|| apple_hfs_partition_range(bytes).and_then(|(start, end)| bytes.get(start..end)))
         .unwrap_or(bytes)
+}
+
+fn hfs_volume_name_from_mdb(filesystem: &[u8]) -> Option<String> {
+    if raw_filesystem_signature(filesystem) != Some(HFS_SIGNATURE) {
+        return None;
+    }
+    // The HFS master directory block stores its authoritative volume name as
+    // a Str27 Pascal string. Decode those bytes directly because hfs-reader's
+    // host-path representation has already replaced non-ASCII characters.
+    let name_len = *filesystem.get(HFS_MDB_VOLUME_NAME_OFFSET)? as usize;
+    if name_len == 0 || name_len > HFS_MAX_VOLUME_NAME_LEN {
+        return None;
+    }
+    let name_start = HFS_MDB_VOLUME_NAME_OFFSET + 1;
+    let name = filesystem.get(name_start..name_start.checked_add(name_len)?)?;
+    clean_component(&decode_mac_roman(name))
 }
 
 /// Locate the first supported HFS-family partition in an Apple Partition Map image.
@@ -628,6 +650,31 @@ fn clean_component(raw: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn decodes_hfs_mdb_volume_name_as_mac_roman() {
+        let mut filesystem = vec![0; HFS_MDB_VOLUME_NAME_OFFSET + 9];
+        filesystem[1024..1026].copy_from_slice(&HFS_SIGNATURE.to_be_bytes());
+        filesystem[HFS_MDB_VOLUME_NAME_OFFSET] = 8;
+        filesystem[HFS_MDB_VOLUME_NAME_OFFSET + 1..].copy_from_slice(b"TETRIS\xA51");
+
+        assert_eq!(
+            hfs_volume_name_from_mdb(&filesystem).as_deref(),
+            Some("TETRIS•1")
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_hfs_mdb_volume_name_bounds() {
+        let mut filesystem = vec![0; HFS_MDB_VOLUME_NAME_OFFSET + 2];
+        filesystem[1024..1026].copy_from_slice(&HFS_SIGNATURE.to_be_bytes());
+
+        filesystem[HFS_MDB_VOLUME_NAME_OFFSET] = 28;
+        assert_eq!(hfs_volume_name_from_mdb(&filesystem), None);
+
+        filesystem[HFS_MDB_VOLUME_NAME_OFFSET] = 2;
+        assert_eq!(hfs_volume_name_from_mdb(&filesystem), None);
+    }
 
     #[test]
     fn detects_raw_hfs_volume_signature() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,7 @@ mod error;
 pub mod game;
 pub mod loader;
 pub mod machine_profile;
+mod mac_roman;
 pub mod managers;
 pub mod memory;
 pub mod menu_model;

--- a/src/mac_roman.rs
+++ b/src/mac_roman.rs
@@ -1,0 +1,69 @@
+//! Shared conversion between classic Mac Roman bytes and Unicode text.
+
+const MAC_ROMAN_HIGH: [char; 128] = [
+    '\u{00C4}', '\u{00C5}', '\u{00C7}', '\u{00C9}', '\u{00D1}', '\u{00D6}', '\u{00DC}', '\u{00E1}',
+    '\u{00E0}', '\u{00E2}', '\u{00E4}', '\u{00E3}', '\u{00E5}', '\u{00E7}', '\u{00E9}', '\u{00E8}',
+    '\u{00EA}', '\u{00EB}', '\u{00ED}', '\u{00EC}', '\u{00EE}', '\u{00EF}', '\u{00F1}', '\u{00F3}',
+    '\u{00F2}', '\u{00F4}', '\u{00F6}', '\u{00F5}', '\u{00FA}', '\u{00F9}', '\u{00FB}', '\u{00FC}',
+    '\u{2020}', '\u{00B0}', '\u{00A2}', '\u{00A3}', '\u{00A7}', '\u{2022}', '\u{00B6}', '\u{00DF}',
+    '\u{00AE}', '\u{00A9}', '\u{2122}', '\u{00B4}', '\u{00A8}', '\u{2260}', '\u{00C6}', '\u{00D8}',
+    '\u{221E}', '\u{00B1}', '\u{2264}', '\u{2265}', '\u{00A5}', '\u{00B5}', '\u{2202}', '\u{2211}',
+    '\u{220F}', '\u{03C0}', '\u{222B}', '\u{00AA}', '\u{00BA}', '\u{03A9}', '\u{00E6}', '\u{00F8}',
+    '\u{00BF}', '\u{00A1}', '\u{00AC}', '\u{221A}', '\u{0192}', '\u{2248}', '\u{2206}', '\u{00AB}',
+    '\u{00BB}', '\u{2026}', '\u{00A0}', '\u{00C0}', '\u{00C3}', '\u{00D5}', '\u{0152}', '\u{0153}',
+    '\u{2013}', '\u{2014}', '\u{201C}', '\u{201D}', '\u{2018}', '\u{2019}', '\u{00F7}', '\u{25CA}',
+    '\u{00FF}', '\u{0178}', '\u{2044}', '\u{20AC}', '\u{2039}', '\u{203A}', '\u{FB01}', '\u{FB02}',
+    '\u{2021}', '\u{00B7}', '\u{201A}', '\u{201E}', '\u{2030}', '\u{00C2}', '\u{00CA}', '\u{00C1}',
+    '\u{00CB}', '\u{00C8}', '\u{00CD}', '\u{00CE}', '\u{00CF}', '\u{00CC}', '\u{00D3}', '\u{00D4}',
+    '\u{F8FF}', '\u{00D2}', '\u{00DA}', '\u{00DB}', '\u{00D9}', '\u{0131}', '\u{02C6}', '\u{02DC}',
+    '\u{00AF}', '\u{02D8}', '\u{02D9}', '\u{02DA}', '\u{00B8}', '\u{02DD}', '\u{02DB}', '\u{02C7}',
+];
+
+pub(crate) fn decode_mac_roman(bytes: &[u8]) -> String {
+    bytes
+        .iter()
+        .map(|&byte| {
+            if byte < 0x80 {
+                byte as char
+            } else {
+                MAC_ROMAN_HIGH[(byte - 0x80) as usize]
+            }
+        })
+        .collect()
+}
+
+pub(crate) fn decode_mac_roman_for_render(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len());
+    for &byte in bytes {
+        match byte {
+            0x00..=0x7F => out.push(byte as char),
+            // The HLE chrome renderer only has ASCII glyphs plus a few symbol
+            // slots, so expand common punctuation into renderable forms.
+            0xA5 => out.push('*'),
+            0xC9 => out.push_str("..."),
+            0xCA => out.push(' '),
+            0xD0 | 0xD1 => out.push('-'),
+            0xD2 | 0xD3 => out.push('"'),
+            0xD4 | 0xD5 => out.push('\''),
+            _ => out.push(MAC_ROMAN_HIGH[(byte - 0x80) as usize]),
+        }
+    }
+    out
+}
+
+pub(crate) fn encode_mac_roman_lossy(value: &str) -> Vec<u8> {
+    value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii() {
+                ch as u8
+            } else {
+                MAC_ROMAN_HIGH
+                    .iter()
+                    .position(|&candidate| candidate == ch)
+                    .map(|idx| idx as u8 + 0x80)
+                    .unwrap_or(b'?')
+            }
+        })
+        .collect()
+}

--- a/src/trap/types.rs
+++ b/src/trap/types.rs
@@ -46,75 +46,9 @@ pub struct StringBuffer {
     pub pixels: Vec<u8>,
 }
 
-const MAC_ROMAN_HIGH: [char; 128] = [
-    '\u{00C4}', '\u{00C5}', '\u{00C7}', '\u{00C9}', '\u{00D1}', '\u{00D6}', '\u{00DC}', '\u{00E1}',
-    '\u{00E0}', '\u{00E2}', '\u{00E4}', '\u{00E3}', '\u{00E5}', '\u{00E7}', '\u{00E9}', '\u{00E8}',
-    '\u{00EA}', '\u{00EB}', '\u{00ED}', '\u{00EC}', '\u{00EE}', '\u{00EF}', '\u{00F1}', '\u{00F3}',
-    '\u{00F2}', '\u{00F4}', '\u{00F6}', '\u{00F5}', '\u{00FA}', '\u{00F9}', '\u{00FB}', '\u{00FC}',
-    '\u{2020}', '\u{00B0}', '\u{00A2}', '\u{00A3}', '\u{00A7}', '\u{2022}', '\u{00B6}', '\u{00DF}',
-    '\u{00AE}', '\u{00A9}', '\u{2122}', '\u{00B4}', '\u{00A8}', '\u{2260}', '\u{00C6}', '\u{00D8}',
-    '\u{221E}', '\u{00B1}', '\u{2264}', '\u{2265}', '\u{00A5}', '\u{00B5}', '\u{2202}', '\u{2211}',
-    '\u{220F}', '\u{03C0}', '\u{222B}', '\u{00AA}', '\u{00BA}', '\u{03A9}', '\u{00E6}', '\u{00F8}',
-    '\u{00BF}', '\u{00A1}', '\u{00AC}', '\u{221A}', '\u{0192}', '\u{2248}', '\u{2206}', '\u{00AB}',
-    '\u{00BB}', '\u{2026}', '\u{00A0}', '\u{00C0}', '\u{00C3}', '\u{00D5}', '\u{0152}', '\u{0153}',
-    '\u{2013}', '\u{2014}', '\u{201C}', '\u{201D}', '\u{2018}', '\u{2019}', '\u{00F7}', '\u{25CA}',
-    '\u{00FF}', '\u{0178}', '\u{2044}', '\u{20AC}', '\u{2039}', '\u{203A}', '\u{FB01}', '\u{FB02}',
-    '\u{2021}', '\u{00B7}', '\u{201A}', '\u{201E}', '\u{2030}', '\u{00C2}', '\u{00CA}', '\u{00C1}',
-    '\u{00CB}', '\u{00C8}', '\u{00CD}', '\u{00CE}', '\u{00CF}', '\u{00CC}', '\u{00D3}', '\u{00D4}',
-    '\u{F8FF}', '\u{00D2}', '\u{00DA}', '\u{00DB}', '\u{00D9}', '\u{0131}', '\u{02C6}', '\u{02DC}',
-    '\u{00AF}', '\u{02D8}', '\u{02D9}', '\u{02DA}', '\u{00B8}', '\u{02DD}', '\u{02DB}', '\u{02C7}',
-];
-
-pub(crate) fn decode_mac_roman(bytes: &[u8]) -> String {
-    bytes
-        .iter()
-        .map(|&byte| {
-            if byte < 0x80 {
-                byte as char
-            } else {
-                MAC_ROMAN_HIGH[(byte - 0x80) as usize]
-            }
-        })
-        .collect()
-}
-
-pub(crate) fn decode_mac_roman_for_render(bytes: &[u8]) -> String {
-    let mut out = String::with_capacity(bytes.len());
-    for &byte in bytes {
-        match byte {
-            0x00..=0x7F => out.push(byte as char),
-            // Classic dialog/control strings use Mac Roman. The HLE chrome
-            // renderer only has ASCII glyphs plus a few symbol slots today, so
-            // expand common punctuation into renderable equivalents instead of
-            // letting it become replacement or blank glyphs. IM:I I-247.
-            0xA5 => out.push('*'),
-            0xC9 => out.push_str("..."),
-            0xCA => out.push(' '),
-            0xD0 | 0xD1 => out.push('-'),
-            0xD2 | 0xD3 => out.push('"'),
-            0xD4 | 0xD5 => out.push('\''),
-            _ => out.push(MAC_ROMAN_HIGH[(byte - 0x80) as usize]),
-        }
-    }
-    out
-}
-
-pub(crate) fn encode_mac_roman_lossy(value: &str) -> Vec<u8> {
-    value
-        .chars()
-        .map(|ch| {
-            if ch.is_ascii() {
-                ch as u8
-            } else {
-                MAC_ROMAN_HIGH
-                    .iter()
-                    .position(|&candidate| candidate == ch)
-                    .map(|idx| idx as u8 + 0x80)
-                    .unwrap_or(b'?')
-            }
-        })
-        .collect()
-}
+pub(crate) use crate::mac_roman::{
+    decode_mac_roman, decode_mac_roman_for_render, encode_mac_roman_lossy,
+};
 
 #[allow(dead_code)]
 impl StringBuffer {


### PR DESCRIPTION
Closes #335

## Summary

- decode the authoritative HFS MDB `Str27` volume name directly from the filesystem payload
- preserve non-ASCII MacRoman characters in volume identities instead of inheriting lossy host-path substitutions
- move shared MacRoman conversion into a neutral internal module used by both disk-image and trap code
- validate MDB signature, length, and slice bounds before decoding

## Verification

- focused valid MacRoman and invalid MDB-bound tests
- existing MacRoman round-trip and render-decoding tests
- `cargo test --quiet` (2,894 passed, 3 ignored; auxiliary suites green)
- `git diff --check`