### PR TITLE
fix: install per-device gamma tables for indexed display output

### DIFF
--- a/src/bin/systemless.rs
+++ b/src/bin/systemless.rs
@@ -976,6 +976,7 @@ impl App {
 
         let screen_mode = runner.dispatcher().screen_mode;
         let device_clut = runner.dispatcher().device_clut;
+        let device_gamma = runner.dispatcher().device_gamma;
         let cursor = runner.dispatcher().cursor().cloned();
         let mouse_pos = runner.dispatcher().mouse_position();
 
@@ -1310,7 +1311,10 @@ impl App {
                 }
             }
             let content = self.window_sized_content_rect.unwrap_or(stable_content);
-            let palette = display::argb_palette_from_clut(&device_clut);
+            let palette = display::argb_palette_from_clut_with_gamma(
+                &device_clut,
+                &device_gamma,
+            );
             if let Some(surface) = self.surface.as_mut() {
                 let presented_directly = surface
                     .present_guest_frame(
@@ -1338,7 +1342,13 @@ impl App {
         }
 
         let mut frame_argb = std::mem::take(&mut self.frame_argb);
-        display::render_screen_argb(runner.bus(), screen_mode, &device_clut, &mut frame_argb);
+        display::render_screen_argb_with_gamma(
+            runner.bus(),
+            screen_mode,
+            &device_clut,
+            &device_gamma,
+            &mut frame_argb,
+        );
         if let Some(cursor) = cursor.as_ref() {
             display::render_cursor_argb(&mut frame_argb, game_w, game_h, cursor, mouse_pos);
         }
@@ -2032,10 +2042,11 @@ fn save_screenshot(runner: &FixtureRunner, num: usize) {
         return;
     }
 
-    let rgba = display::render_screen(
+    let rgba = display::render_screen_with_gamma(
         runner.bus(),
         runner.dispatcher().screen_mode,
         &runner.dispatcher().device_clut,
+        &runner.dispatcher().device_gamma,
     );
 
     let img = image::RgbImage::from_fn(w, h, |x, y| {

--- a/src/display.rs
+++ b/src/display.rs
@@ -19,6 +19,16 @@ const LETTERBOX_MIN_FLOOD_RATIO_DEN: usize = 4;
 const LETTERBOX_EDGE_TRIM_LIMIT: usize = 32;
 
 pub type RgbaPalette = [u32; 256];
+
+/// Per-channel display transfer tables applied after truncating a 16-bit
+/// QuickDraw color component to its most-significant byte.
+pub type DisplayGamma = [[u8; 256]; 3];
+
+/// Return the modeled display transfer table used before a guest installs one
+/// through the video driver's `cscSetGamma` control call.
+pub fn default_display_gamma() -> DisplayGamma {
+    [MAC_ROM_GAMMA_LUT; 3]
+}
 const UNUSED_RGBA_PALETTE: RgbaPalette = [0; 256];
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -79,9 +89,19 @@ pub fn render_screen(
     screen_mode: (u32, u32, u16, u16, u16),
     device_clut: &[[u16; 3]; 256],
 ) -> Vec<u8> {
+    render_screen_with_gamma(bus, screen_mode, device_clut, &default_display_gamma())
+}
+
+/// Render the current screen using the active video-device gamma table.
+pub fn render_screen_with_gamma(
+    bus: &MacMemoryBus,
+    screen_mode: (u32, u32, u16, u16, u16),
+    device_clut: &[[u16; 3]; 256],
+    device_gamma: &DisplayGamma,
+) -> Vec<u8> {
     let (_, _, scrn_w, scrn_h, _) = screen_mode;
     let mut pixels = Vec::with_capacity(scrn_w as usize * scrn_h as usize * 4);
-    render_screen_into(bus, screen_mode, device_clut, &mut pixels);
+    render_screen_into_with_gamma(bus, screen_mode, device_clut, device_gamma, &mut pixels);
     pixels
 }
 
@@ -92,8 +112,26 @@ pub fn render_screen_into(
     device_clut: &[[u16; 3]; 256],
     pixels: &mut Vec<u8>,
 ) {
+    render_screen_into_with_gamma(
+        bus,
+        screen_mode,
+        device_clut,
+        &default_display_gamma(),
+        pixels,
+    );
+}
+
+/// Render the current screen into a reusable RGBA buffer using the active
+/// video-device gamma table.
+pub fn render_screen_into_with_gamma(
+    bus: &MacMemoryBus,
+    screen_mode: (u32, u32, u16, u16, u16),
+    device_clut: &[[u16; 3]; 256],
+    device_gamma: &DisplayGamma,
+    pixels: &mut Vec<u8>,
+) {
     if matches!(screen_mode.4, 4 | 8) {
-        let palette = rgba_palette_from_clut(device_clut);
+        let palette = rgba_palette_from_clut_with_gamma(device_clut, device_gamma);
         render_screen_with_rgba_palette_into(bus, screen_mode, &palette, pixels);
     } else {
         render_screen_with_rgba_palette_into(bus, screen_mode, &UNUSED_RGBA_PALETTE, pixels);
@@ -101,9 +139,16 @@ pub fn render_screen_into(
 }
 
 pub fn rgba_palette_from_clut(device_clut: &[[u16; 3]; 256]) -> RgbaPalette {
+    rgba_palette_from_clut_with_gamma(device_clut, &default_display_gamma())
+}
+
+pub fn rgba_palette_from_clut_with_gamma(
+    device_clut: &[[u16; 3]; 256],
+    device_gamma: &DisplayGamma,
+) -> RgbaPalette {
     let mut palette = [0u32; 256];
     for (index, slot) in palette.iter_mut().enumerate() {
-        let [r, g, b] = clut_to_rgba8(device_clut, index as u8);
+        let [r, g, b] = clut_to_rgba8_with_gamma(device_clut, device_gamma, index as u8);
         *slot = rgba_word(r, g, b);
     }
     palette
@@ -530,6 +575,25 @@ pub fn screen_pixel_rgb(
     x: u32,
     y: u32,
 ) -> Option<[u8; 3]> {
+    screen_pixel_rgb_with_gamma(
+        bus,
+        screen_mode,
+        device_clut,
+        &default_display_gamma(),
+        x,
+        y,
+    )
+}
+
+/// Sample one screen pixel using the active video-device gamma table.
+pub fn screen_pixel_rgb_with_gamma(
+    bus: &MacMemoryBus,
+    screen_mode: (u32, u32, u16, u16, u16),
+    device_clut: &[[u16; 3]; 256],
+    device_gamma: &DisplayGamma,
+    x: u32,
+    y: u32,
+) -> Option<[u8; 3]> {
     let (scrn_base, row_bytes, scrn_w, scrn_h, pixel_size) = screen_mode;
     let w = scrn_w as u32;
     let h = scrn_h as u32;
@@ -541,7 +605,11 @@ pub fn screen_pixel_rgb(
         8 => {
             let addr = scrn_base + y * row_bytes + x;
             let pixel = bus.read_byte(addr);
-            Some(clut_to_rgba8(device_clut, pixel))
+            Some(clut_to_rgba8_with_gamma(
+                device_clut,
+                device_gamma,
+                pixel,
+            ))
         }
         4 => {
             let addr = scrn_base + y * row_bytes + x / 2;
@@ -551,7 +619,11 @@ pub fn screen_pixel_rgb(
             } else {
                 packed & 0x0F
             };
-            Some(clut_to_rgba8(device_clut, pixel))
+            Some(clut_to_rgba8_with_gamma(
+                device_clut,
+                device_gamma,
+                pixel,
+            ))
         }
         1 => {
             let addr = scrn_base + y * row_bytes + x / 8;
@@ -577,6 +649,23 @@ pub fn render_screen_argb(
     device_clut: &[[u16; 3]; 256],
     pixels: &mut Vec<u32>,
 ) {
+    render_screen_argb_with_gamma(
+        bus,
+        screen_mode,
+        device_clut,
+        &default_display_gamma(),
+        pixels,
+    );
+}
+
+/// Render the current screen to ARGB using the active video-device gamma table.
+pub fn render_screen_argb_with_gamma(
+    bus: &MacMemoryBus,
+    screen_mode: (u32, u32, u16, u16, u16),
+    device_clut: &[[u16; 3]; 256],
+    device_gamma: &DisplayGamma,
+    pixels: &mut Vec<u32>,
+) {
     let (scrn_base, row_bytes, scrn_w, scrn_h, pixel_size) = screen_mode;
     let w = scrn_w as usize;
     let h = scrn_h as usize;
@@ -591,7 +680,7 @@ pub fn render_screen_argb(
 
     let fb = bus.ram_slice(scrn_base, row_bytes * scrn_h as u32);
 
-    let palette = argb_palette_from_clut(device_clut);
+    let palette = argb_palette_from_clut_with_gamma(device_clut, device_gamma);
     match pixel_size {
         8 => {
             for gy in 0..h {
@@ -639,13 +728,20 @@ pub fn render_screen_argb(
 /// presenters use this same conversion so their palette output is bit-for-bit
 /// identical to the software renderer.
 pub fn argb_palette_from_clut(device_clut: &[[u16; 3]; 256]) -> [u32; 256] {
+    argb_palette_from_clut_with_gamma(device_clut, &default_display_gamma())
+}
+
+pub fn argb_palette_from_clut_with_gamma(
+    device_clut: &[[u16; 3]; 256],
+    device_gamma: &DisplayGamma,
+) -> [u32; 256] {
     let mut palette = [0u32; 256];
     for (dst, rgb) in palette.iter_mut().zip(device_clut.iter()) {
         let [r, g, b] = *rgb;
         *dst = 0xFF000000
-            | (u32::from(clut_component_to_u8(r)) << 16)
-            | (u32::from(clut_component_to_u8(g)) << 8)
-            | u32::from(clut_component_to_u8(b));
+            | (u32::from(clut_component_to_u8_with_gamma(r, &device_gamma[0])) << 16)
+            | (u32::from(clut_component_to_u8_with_gamma(g, &device_gamma[1])) << 8)
+            | u32::from(clut_component_to_u8_with_gamma(b, &device_gamma[2]));
     }
     palette
 }
@@ -1354,11 +1450,19 @@ pub fn clut_to_argb(clut: &[[u16; 3]; 256], index: u8) -> u32 {
 }
 
 fn clut_to_rgba8(clut: &[[u16; 3]; 256], index: u8) -> [u8; 3] {
+    clut_to_rgba8_with_gamma(clut, &default_display_gamma(), index)
+}
+
+fn clut_to_rgba8_with_gamma(
+    clut: &[[u16; 3]; 256],
+    device_gamma: &DisplayGamma,
+    index: u8,
+) -> [u8; 3] {
     let [r, g, b] = clut[index as usize];
     [
-        clut_component_to_u8(r),
-        clut_component_to_u8(g),
-        clut_component_to_u8(b),
+        clut_component_to_u8_with_gamma(r, &device_gamma[0]),
+        clut_component_to_u8_with_gamma(g, &device_gamma[1]),
+        clut_component_to_u8_with_gamma(b, &device_gamma[2]),
     ]
 }
 
@@ -1367,23 +1471,18 @@ fn rgba_word(r: u8, g: u8, b: u8) -> u32 {
     u32::from_le_bytes([r, g, b, 0xFF])
 }
 
+#[cfg(test)]
 fn clut_component_to_u8(component: u16) -> u8 {
-    MAC_ROM_GAMMA_LUT[(component >> 8) as usize]
+    clut_component_to_u8_with_gamma(component, &MAC_ROM_GAMMA_LUT)
 }
 
-/// Mac ROM gamma LUT applied after `>> 8` truncation of 16-bit CLUT entries.
-/// Matches BasiliskII's video gamma path (the `SetEntries` handler's
-/// `have_gamma` branch).
-/// Values empirically derived from paired-pixel observations
-/// on 01_ambrosia_splash — every Systemless palette top-byte mapped 100% of the
-/// time to the Basilisk-rendered value below. 16 observed pairs linearly
-/// interpolated to 256 entries.
-///
-/// The authoritative "Mac HiRes Std Gamma" LUT from BasiliskII's
-/// `slot_rom.cpp` `defaultGamma` resource was tested as a swap-in. Result
-/// was a small regression — EV's effective gamma does not match the
-/// standard HiRes gamma on non-grid inputs. Kept the linear-interpolated
-/// LUT.
+fn clut_component_to_u8_with_gamma(component: u16, gamma: &[u8; 256]) -> u8 {
+    gamma[(component >> 8) as usize]
+}
+
+/// Modeled default display transfer table, applied after truncating 16-bit
+/// Color QuickDraw components to their most-significant byte. Runtime
+/// `cscSetGamma` tables replace this default in device state.
 const MAC_ROM_GAMMA_LUT: [u8; 256] = [
     0x00, 0x02, 0x05, 0x07, 0x09, 0x0B, 0x0E, 0x10, 0x12, 0x15, 0x17, 0x19, 0x1C, 0x1E, 0x20, 0x22,
     0x25, 0x27, 0x28, 0x2A, 0x2B, 0x2D, 0x2E, 0x2F, 0x31, 0x32, 0x34, 0x35, 0x37, 0x38, 0x39, 0x3B,
@@ -1406,20 +1505,18 @@ const MAC_ROM_GAMMA_LUT: [u8; 256] = [
 #[cfg(test)]
 mod tests {
     use super::{
-        argb_palette_from_clut, clut_component_to_u8, clut_to_argb,
+        argb_palette_from_clut, argb_palette_from_clut_with_gamma, clut_component_to_u8,
+        clut_to_argb,
         normalize_centered_compact_mac_viewport_margins_rgba, render_cursor, render_cursor_argb,
         render_screen_argb, render_screen_into, render_screen_with_rgba_palette_into,
-        rgba_palette_from_clut, screen_pixel_rgb, CursorImage,
+        rgba_palette_from_clut, screen_pixel_rgb, screen_pixel_rgb_with_gamma, CursorImage,
     };
     use crate::memory::{MacMemoryBus, MemoryBus};
 
     #[test]
-    fn clut_component_applies_mac_rom_gamma() {
-        // Endpoints fixed to raw values.
+    fn clut_component_applies_the_modeled_device_default() {
         assert_eq!(clut_component_to_u8(0x0000), 0x00);
         assert_eq!(clut_component_to_u8(0xFFFF), 0xFF);
-        // Mac palette grid values map to the 16 pairs observed from
-        // `01_ambrosia_splash` (empirical derivation).
         assert_eq!(clut_component_to_u8(0x4444), 0x66);
         assert_eq!(clut_component_to_u8(0x6666), 0x87);
         assert_eq!(clut_component_to_u8(0xAAAA), 0xC0);
@@ -1433,6 +1530,20 @@ mod tests {
         let argb = clut_to_argb(&clut, 7);
         assert_eq!(argb, 0xFF66A5DA);
         assert_eq!(argb_palette_from_clut(&clut)[7], argb);
+    }
+
+    #[test]
+    fn argb_palette_applies_each_installed_gamma_channel() {
+        let mut clut = [[0u16; 3]; 256];
+        clut[7] = [0x1212, 0x3434, 0x5656];
+        let mut gamma = [[0u8; 256]; 3];
+        gamma[0][0x12] = 0xA1;
+        gamma[1][0x34] = 0xB2;
+        gamma[2][0x56] = 0xC3;
+
+        let palette = argb_palette_from_clut_with_gamma(&clut, &gamma);
+
+        assert_eq!(palette[7], 0xFFA1B2C3);
     }
 
     #[test]
@@ -1655,6 +1766,15 @@ mod tests {
         assert_eq!(
             screen_pixel_rgb(&bus, (base, 4, 2, 1, 8), &clut, 2, 0),
             None
+        );
+
+        let mut gamma = [[0u8; 256]; 3];
+        gamma[0][0x44] = 0x11;
+        gamma[1][0x88] = 0x22;
+        gamma[2][0xCC] = 0x33;
+        assert_eq!(
+            screen_pixel_rgb_with_gamma(&bus, (base, 4, 2, 1, 8), &clut, &gamma, 1, 0),
+            Some([0x11, 0x22, 0x33])
         );
     }
 

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -1696,6 +1696,10 @@ pub struct TrapDispatcher {
     /// Initialized to the standard Mac 8-bit system palette. Updated by SetEntries trap
     /// and low-level video driver cscSetEntries. Used for DISPLAY rendering only.
     pub device_clut: [[u16; 3]; 256],
+    /// Per-channel transfer tables installed by the video driver's
+    /// `cscSetGamma` control call. These affect presentation only; the device
+    /// and Color Manager CLUTs retain the guest's uncorrected 16-bit values.
+    pub device_gamma: crate::display::DisplayGamma,
     /// Color Manager CLUT for 8bpp mode. Updated only by high-level SetEntries ($AA3F)
     /// and ActivatePalette — NOT by low-level video driver palette fades.
     /// Used by QuickDraw shape drawing (PaintRect, etc.) for RGB→index mapping,
@@ -2216,7 +2220,12 @@ impl TrapDispatcher {
             frame, self.tick_count, self.trap_count, safe_label
         );
         let path = dir.join(&filename);
-        let mut rgba = crate::display::render_screen(bus, self.screen_mode, &self.device_clut);
+        let mut rgba = crate::display::render_screen_with_gamma(
+            bus,
+            self.screen_mode,
+            &self.device_clut,
+            &self.device_gamma,
+        );
         if let Some(cursor) = self.cursor() {
             crate::display::render_cursor(
                 &mut rgba,
@@ -3017,6 +3026,7 @@ impl TrapDispatcher {
                 )
             },
             device_clut: Self::standard_mac_8bpp_clut(),
+            device_gamma: crate::display::default_display_gamma(),
             color_manager_clut: Self::standard_mac_8bpp_clut(),
             inverse_table_cache: Vec::new(),
             clut_protected: [false; 256],

--- a/src/trap/memory.rs
+++ b/src/trap/memory.rs
@@ -339,6 +339,86 @@ fn memory_manager_trap_updates_dispatcher_ccr(is_tool: bool, trap_num: u16) -> b
 }
 
 impl super::TrapDispatcher {
+    /// Install a video-device gamma table from a `VDGammaRecord`.
+    ///
+    /// Universal Interfaces 3.4 `Video.h` defines `VDGammaRecord.csGTable`
+    /// as a `GammaTbl` pointer and the six-word variable-length table header.
+    /// BasiliskII `video.cpp::set_gamma_table` supplies the validation and
+    /// channel-layout oracle used here.
+    fn install_device_gamma(&mut self, bus: &MacMemoryBus, vd_gamma_ptr: u32) -> u32 {
+        if vd_gamma_ptr == 0 || vd_gamma_ptr.saturating_add(4) > bus.ram_size() {
+            return PARAM_ERR;
+        }
+        if bus
+            .get_alloc_size(vd_gamma_ptr)
+            .is_some_and(|size| size < 4)
+        {
+            return PARAM_ERR;
+        }
+
+        let gamma_ptr = bus.read_long(vd_gamma_ptr);
+        if gamma_ptr == 0 {
+            let identity = std::array::from_fn(|index| index as u8);
+            self.device_gamma = [identity; 3];
+            return NO_ERR;
+        }
+
+        let Some(header_end) = gamma_ptr.checked_add(12) else {
+            return PARAM_ERR;
+        };
+        if header_end > bus.ram_size() {
+            return PARAM_ERR;
+        }
+
+        let version = bus.read_word(gamma_ptr);
+        let gamma_type = bus.read_word(gamma_ptr + 2);
+        let formula_size = u32::from(bus.read_word(gamma_ptr + 4));
+        let channel_count = u32::from(bus.read_word(gamma_ptr + 6));
+        let data_count = u32::from(bus.read_word(gamma_ptr + 8));
+        let data_width = u32::from(bus.read_word(gamma_ptr + 10));
+
+        if version != 0
+            || gamma_type != 0
+            || !matches!(channel_count, 1 | 3)
+            || data_width > 8
+            || data_count != (1u32 << data_width)
+        {
+            return PARAM_ERR;
+        }
+
+        let Some(data_base) = header_end.checked_add(formula_size) else {
+            return PARAM_ERR;
+        };
+        let Some(data_len) = channel_count.checked_mul(data_count) else {
+            return PARAM_ERR;
+        };
+        let Some(table_end) = data_base.checked_add(data_len) else {
+            return PARAM_ERR;
+        };
+        if table_end > bus.ram_size() {
+            return PARAM_ERR;
+        }
+        if bus
+            .get_alloc_size(gamma_ptr)
+            .is_some_and(|size| table_end - gamma_ptr > size)
+        {
+            return PARAM_ERR;
+        }
+
+        let shift = 8 - data_width;
+        let mut installed = [[0u8; 256]; 3];
+        for (channel, output) in installed.iter_mut().enumerate() {
+            let source_channel = if channel_count == 1 { 0 } else { channel as u32 };
+            let source_base = data_base + source_channel * data_count;
+            for (input, value) in output.iter_mut().enumerate() {
+                let source_index = (input as u32) >> shift;
+                *value = bus.read_byte(source_base + source_index);
+            }
+        }
+        self.device_gamma = installed;
+        NO_ERR
+    }
+
     fn sync_vbl_links(&mut self, bus: &mut MacMemoryBus) {
         if self.system_vbl_queue_anchor == 0 {
             let anchor = bus.alloc_synthetic(14);
@@ -1999,6 +2079,7 @@ impl super::TrapDispatcher {
             // and cscSetEntries (csCode=3) via VDSetEntryRecord; returns noErr.
             (false, 0x04) => {
                 let pb = cpu.read_reg(Register::A0);
+                let mut control_result = NO_ERR;
                 if pb != 0 {
                     let cs_code = bus.read_word(pb + 26) as i16;
                     // cscSetMode (csCode=2): switch mode/page and return base address.
@@ -2130,76 +2211,28 @@ impl super::TrapDispatcher {
                         }
                     }
 
-                    // cscSetGamma (csCode=4): install a per-channel gamma
-                    // correction table. csParam[0..3] stores a Ptr to a
-                    // GammaTbl in Pascal format (version, type, formula size,
-                    // chan count, data count, data width, data bytes).
-                    //
-                    // Systemless does NOT yet install a runtime gamma — we have
-                    // a fixed Mac HiRes linear-interpolated gamma LUT in
-                    // `display.rs`. Stub returns noErr.
-                    //
-                    // Designing Cards and Drivers 3rd Ed 1992, p. 245-248
-                    // Inside Macintosh: Devices 1994, p. 6-71
-                    if cs_code == 4 && trace_video_driver_enabled() {
-                        let gamma_ptr = bus.read_long(pb + 28);
-                        let g_version = if gamma_ptr != 0 {
-                            bus.read_word(gamma_ptr) as i16
-                        } else {
-                            -1
-                        };
-                        let g_type = if gamma_ptr != 0 {
-                            bus.read_word(gamma_ptr + 2) as i16
-                        } else {
-                            -1
-                        };
-                        let g_formula_size = if gamma_ptr != 0 {
-                            bus.read_word(gamma_ptr + 4) as i16
-                        } else {
-                            -1
-                        };
-                        let g_chan_cnt = if gamma_ptr != 0 {
-                            bus.read_word(gamma_ptr + 6) as i16
-                        } else {
-                            -1
-                        };
-                        let g_data_cnt = if gamma_ptr != 0 {
-                            bus.read_word(gamma_ptr + 8) as i16
-                        } else {
-                            -1
-                        };
-                        let g_data_width = if gamma_ptr != 0 {
-                            bus.read_word(gamma_ptr + 10) as i16
-                        } else {
-                            -1
-                        };
-                        eprintln!(
-                                "[VIDEO] cscSetGamma gamma_ptr=${:08X} version={} type={} formulaSize={} chanCnt={} dataCnt={} dataWidth={}",
-                                gamma_ptr,
-                                g_version,
-                                g_type,
-                                g_formula_size,
-                                g_chan_cnt,
-                                g_data_cnt,
-                                g_data_width,
+                    // cscSetGamma (csCode=4): csParam points to a
+                    // VDGammaRecord whose first longword is the GammaTbl Ptr.
+                    // Universal Interfaces 3.4 Video.h (`VDGammaRecord`,
+                    // `GammaTbl`); BasiliskII video.cpp `set_gamma_table`.
+                    if cs_code == 4 {
+                        let vd_gamma_ptr = bus.read_long(pb + 28);
+                        control_result = self.install_device_gamma(bus, vd_gamma_ptr);
+                        if trace_video_driver_enabled() {
+                            let gamma_ptr = if vd_gamma_ptr != 0 {
+                                bus.read_long(vd_gamma_ptr)
+                            } else {
+                                0
+                            };
+                            eprintln!(
+                                "[VIDEO] cscSetGamma record=${:08X} table=${:08X} result={}",
+                                vd_gamma_ptr, gamma_ptr, control_result as i32,
                             );
-                        // Preview first 16 data bytes for confirmation
-                        if gamma_ptr != 0 && g_data_cnt > 0 && g_data_width == 8 {
-                            let data_base = gamma_ptr + 12 + g_formula_size.max(0) as u32;
-                            let preview_n = g_data_cnt.min(16) as u32;
-                            let mut bytes = Vec::with_capacity(preview_n as usize);
-                            for i in 0..preview_n {
-                                bytes.push(bus.read_byte(data_base + i));
-                            }
-                            eprintln!("[VIDEO]   gamma data[0..{}] = {:02X?}", preview_n, bytes);
                         }
                     }
-                    // Succeed without applying — keeps Marathon from
-                    // thinking its gamma setup failed. Actual gamma
-                    // application pending full implementation.
-                    bus.write_word(pb + 16, 0); // ioResult = noErr
+                    bus.write_word(pb + 16, control_result as u16);
                 }
-                cpu.write_reg(Register::D0, 0);
+                cpu.write_reg(Register::D0, control_result);
                 Ok(())
             }
 
@@ -9397,6 +9430,166 @@ mod tests {
             0x00ABCDEF,
             "SetMode should not write csBaseAddr past a short stack parameter block"
         );
+    }
+
+    #[test]
+    fn control_set_gamma_installs_one_channel_table_from_vdgamma_record() {
+        let (mut dispatcher, mut cpu, mut bus) = setup();
+        let pb = 0x300000u32;
+        let record = bus.alloc(4);
+        let table = bus.alloc(12 + 2 + 16);
+
+        bus.write_word(table, 0); // gVersion
+        bus.write_word(table + 2, 0); // gType
+        bus.write_word(table + 4, 2); // gFormulaSize
+        bus.write_word(table + 6, 1); // gChanCnt
+        bus.write_word(table + 8, 16); // gDataCnt
+        bus.write_word(table + 10, 4); // gDataWidth
+        bus.write_word(table + 12, 0xA5A5); // skipped formula bytes
+        for index in 0..16u32 {
+            bus.write_byte(table + 14 + index, (index * 17) as u8);
+        }
+        bus.write_long(record, table);
+        bus.write_word(pb + 26, 4); // cscSetGamma
+        bus.write_long(pb + 28, record);
+        cpu.write_reg(Register::A0, pb);
+
+        dispatcher
+            .dispatch_memory(false, 0x04, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(cpu.read_reg(Register::D0), 0);
+        assert_eq!(bus.read_word(pb + 16), 0);
+        for channel in &dispatcher.device_gamma {
+            assert_eq!(channel[0x00], 0x00);
+            assert_eq!(channel[0x1F], 0x11);
+            assert_eq!(channel[0xAB], 0xAA);
+            assert_eq!(channel[0xFF], 0xFF);
+        }
+    }
+
+    #[test]
+    fn control_set_gamma_keeps_three_channels_distinct() {
+        let (mut dispatcher, mut cpu, mut bus) = setup();
+        let pb = 0x300000u32;
+        let record = bus.alloc(4);
+        let table = bus.alloc(12 + 3 * 256);
+
+        bus.write_word(table, 0);
+        bus.write_word(table + 2, 0);
+        bus.write_word(table + 4, 0);
+        bus.write_word(table + 6, 3);
+        bus.write_word(table + 8, 256);
+        bus.write_word(table + 10, 8);
+        for index in 0..256u32 {
+            bus.write_byte(table + 12 + index, index as u8);
+            bus.write_byte(table + 12 + 256 + index, 255 - index as u8);
+            bus.write_byte(table + 12 + 512 + index, 0x42);
+        }
+        bus.write_long(record, table);
+        bus.write_word(pb + 26, 4);
+        bus.write_long(pb + 28, record);
+        cpu.write_reg(Register::A0, pb);
+
+        dispatcher
+            .dispatch_memory(false, 0x04, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(dispatcher.device_gamma[0][0xA5], 0xA5);
+        assert_eq!(dispatcher.device_gamma[1][0xA5], 0x5A);
+        assert_eq!(dispatcher.device_gamma[2][0xA5], 0x42);
+        dispatcher.device_clut[7] = [0xA5A5; 3];
+        let raw_clut = dispatcher.device_clut;
+        let palette = crate::display::argb_palette_from_clut_with_gamma(
+            &dispatcher.device_clut,
+            &dispatcher.device_gamma,
+        );
+        assert_eq!(palette[7], 0xFFA55A42);
+        assert_eq!(dispatcher.device_clut, raw_clut);
+    }
+
+    #[test]
+    fn control_set_gamma_rejects_malformed_table_without_changing_state() {
+        let (mut dispatcher, mut cpu, mut bus) = setup();
+        let pb = 0x300000u32;
+        let record = bus.alloc(4);
+        let table = bus.alloc(12 + 16);
+        let before = dispatcher.device_gamma;
+
+        bus.write_word(table, 0);
+        bus.write_word(table + 2, 0);
+        bus.write_word(table + 4, 0);
+        bus.write_word(table + 6, 2); // unsupported channel count
+        bus.write_word(table + 8, 16);
+        bus.write_word(table + 10, 4);
+        bus.write_long(record, table);
+        bus.write_word(pb + 26, 4);
+        bus.write_long(pb + 28, record);
+        cpu.write_reg(Register::A0, pb);
+
+        dispatcher
+            .dispatch_memory(false, 0x04, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(cpu.read_reg(Register::D0), (-50i32) as u32);
+        assert_eq!(bus.read_word(pb + 16), (-50i16) as u16);
+        assert_eq!(dispatcher.device_gamma, before);
+    }
+
+    #[test]
+    fn control_set_gamma_rejects_truncated_allocated_table() {
+        let (mut dispatcher, mut cpu, mut bus) = setup();
+        let pb = 0x300000u32;
+        let record = bus.alloc(4);
+        let table = bus.alloc(12 + 8);
+        let before = dispatcher.device_gamma;
+
+        bus.write_word(table, 0);
+        bus.write_word(table + 2, 0);
+        bus.write_word(table + 4, 0);
+        bus.write_word(table + 6, 1);
+        bus.write_word(table + 8, 16);
+        bus.write_word(table + 10, 4);
+        bus.write_long(record, table);
+        bus.write_word(pb + 26, 4);
+        bus.write_long(pb + 28, record);
+        cpu.write_reg(Register::A0, pb);
+
+        dispatcher
+            .dispatch_memory(false, 0x04, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(cpu.read_reg(Register::D0), (-50i32) as u32);
+        assert_eq!(dispatcher.device_gamma, before);
+    }
+
+    #[test]
+    fn control_set_gamma_null_table_restores_linear_ramp() {
+        let (mut dispatcher, mut cpu, mut bus) = setup();
+        let pb = 0x300000u32;
+        let record = bus.alloc(4);
+        dispatcher.device_gamma = [[0x42; 256]; 3];
+
+        bus.write_long(record, 0);
+        bus.write_word(pb + 26, 4);
+        bus.write_long(pb + 28, record);
+        cpu.write_reg(Register::A0, pb);
+
+        dispatcher
+            .dispatch_memory(false, 0x04, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(cpu.read_reg(Register::D0), 0);
+        for channel in &dispatcher.device_gamma {
+            assert_eq!(channel[0x00], 0x00);
+            assert_eq!(channel[0x7F], 0x7F);
+            assert_eq!(channel[0xFF], 0xFF);
+        }
     }
 
     #[test]


### PR DESCRIPTION
Fixes #339.

## Summary

- store gamma transfer tables beside the active device CLUT while preserving raw palette values
- validate the documented `VDGammaRecord` and `GammaTbl` layouts, including one- and three-channel tables, null reset, and malformed or truncated inputs
- apply active gamma state consistently in native, software, headless, captured-frame, palette, and pixel-sampling output paths
- retain the existing modeled device default until a successful control call replaces it

## Validation

- `cargo test --lib --features test-support` (2,904 passed, 3 ignored)
- `cargo test --all-targets --no-run`
- focused one-channel, three-channel, formula-bearing, null-reset, malformed, truncated, raw-CLUT-preservation, palette, and pixel-sampling coverage