### PR TITLE
build: update m68k to 0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1196,9 +1196,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "m68k"
-version = "0.3.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e402ea841b837d13611bc1c373abc53213ab4e93f653f79cc829fc2d4b111c45"
+checksum = "ad5d9c86aa821297e93fe0d4968c0f3eeef07073a58e8dc1e62b1d58b9fe48a1"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ default-run = "systemless"
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
-m68k = { version = "0.3.2", features = ["jit"] }
+m68k = { version = "0.7.1", features = ["jit"] }
 thiserror = "2"
 tracing = "0.1"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Summary

- update the `m68k` dependency from 0.3.2 to 0.7.1
- retain the existing `jit` feature
- refresh the locked crate checksum without changing other dependencies

The update incorporates the upstream boundary-hook, interrupt-entry, 68020 timing, exact-width bit-field, and JIT improvements released since 0.3.2. No Systemless source adaptation was required.

## Validation

- `cargo build --locked --all-targets --all-features`
- `cargo test --locked --all-features`
- `cargo test --locked --no-default-features`
- `cargo +1.93.0 build --locked --all-targets --all-features`
- `cargo +1.93.0 test --locked --all-features`
- strict all-feature API documentation build
- `cargo publish --locked --dry-run`

Closes #406