### PR TITLE
fix: preserve painted margins around centered blits

### DIFF
--- a/src/trap/framebuffer.rs
+++ b/src/trap/framebuffer.rs
@@ -1079,6 +1079,33 @@ impl super::TrapDispatcher {
             return false;
         }
 
+        // Reject common composed-screen cases before walking every exposed
+        // pixel. A disagreement between any two samples proves the margins
+        // are nonuniform; agreement is not treated as proof, so the complete
+        // scan below remains the authority before any pixels are replaced.
+        let middle_y = top + (bottom - top) / 2;
+        let middle_x = left + (right - left) / 2;
+        let samples = [
+            (0, 0),
+            (0, screen_width - 1),
+            (screen_height - 1, 0),
+            (screen_height - 1, screen_width - 1),
+            (top - 1, middle_x),
+            (bottom, middle_x),
+            (middle_y, left - 1),
+            (middle_y, right),
+        ];
+        let first_sample = bus.read_byte(screen_base);
+        if samples.iter().any(|&(y, x)| {
+            y >= 0
+                && x >= 0
+                && y < screen_height
+                && x < screen_width
+                && bus.read_byte(screen_base + y as u32 * row_bytes + x as u32) != first_sample
+        }) {
+            return false;
+        }
+
         let mut margin_index = None;
         let mut pixels = vec![0; screen_width as usize];
         for y in 0..screen_height {

--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -19553,12 +19553,19 @@ impl super::TrapDispatcher {
             return;
         }
 
+        let destination = (rect.dst_top, rect.dst_left, rect.dst_bottom, rect.dst_right);
+        // CopyBits owns only its destination rectangle; a large centered blit
+        // may still be an overlay within a larger application composition.
+        // On indexed color screens, require uniform exposed bands before
+        // replacing them with kiosk-stage black. Imaging With QuickDraw
+        // (1994), pp. 3-112 to 3-114.
+        if self.screen_mode.4 == 8 && !self.kiosk_stage_margins_are_uniform(bus, destination) {
+            return;
+        }
+
         // Run after the blit so overlapping screen-to-screen copies cannot
         // lose source pixels while the margins are cleared.
-        self.fill_kiosk_stage_around_rect(
-            bus,
-            (rect.dst_top, rect.dst_left, rect.dst_bottom, rect.dst_right),
-        );
+        self.fill_kiosk_stage_around_rect(bus, destination);
     }
 
     /// Address of a replacement `grafProcs.bitsProc` on the current port, or
@@ -23191,6 +23198,65 @@ mod tests {
         assert_eq!(
             bus.read_byte(screen_base + (u32::from(height) - 1) * row_bytes + u32::from(width) - 1),
             37
+        );
+    }
+
+    #[test]
+    fn centered_copybits_preserves_nonuniform_application_surround() {
+        let (mut d, _cpu, mut bus) = setup();
+        let (screen_base, row_bytes, _width, height, _) = d.screen_mode;
+        let framebuffer_len = row_bytes * u32::from(height);
+        bus.fill_bytes(screen_base, framebuffer_len, 37);
+        for (offset, pixel) in [
+            (139 * row_bytes + 400, 0x11),
+            (460 * row_bytes + 400, 0x22),
+            (300 * row_bytes + 149, 0x33),
+            (300 * row_bytes + 650, 0x44),
+        ] {
+            bus.write_byte(screen_base + offset, pixel);
+        }
+        let before = bus.read_bytes(screen_base, framebuffer_len as usize);
+        d.menu_bar_hidden = true;
+        d.device_clut = [[0xFFFF, 0xFFFF, 0xFFFF]; 256];
+        d.device_clut[37] = [0, 0, 0];
+
+        d.fill_kiosk_letterbox_for_copybits(
+            &mut bus,
+            ScreenCopyBitsRect {
+                src_top: 0,
+                src_left: 0,
+                src_bottom: 320,
+                src_right: 500,
+                dst_top: 140,
+                dst_left: 150,
+                dst_bottom: 460,
+                dst_right: 650,
+            },
+        );
+
+        assert!(
+            bus.read_bytes(screen_base, framebuffer_len as usize) == before,
+            "a centered overlay must not erase a nonuniform application-painted surround"
+        );
+    }
+
+    #[test]
+    fn centered_kiosk_copybits_keeps_monochrome_black_margins() {
+        let (mut d, _cpu, mut bus) = setup();
+        let (screen_base, _, width, height, _) = d.screen_mode;
+        let row_bytes = u32::from(width as u16).div_ceil(8);
+        d.screen_mode.1 = row_bytes;
+        d.screen_mode.4 = 1;
+        bus.fill_bytes(screen_base, row_bytes * u32::from(height), 0x00);
+        d.menu_bar_hidden = true;
+
+        d.fill_kiosk_letterbox_for_copybits(&mut bus, centered_640x480_copybits_rect());
+
+        assert_eq!(bus.read_byte(screen_base), 0xFF);
+        assert_eq!(
+            bus.read_byte(screen_base + 300 * row_bytes + 400 / 8),
+            0x00,
+            "the monochrome CopyBits destination must remain untouched"
         );
     }
 


### PR DESCRIPTION
Closes #413.

## Problem

Systemless treated every large, centered, unscaled `CopyBits` destination as a standalone kiosk surface. A centered application overlay could therefore replace already-painted controls and artwork in the surrounding bands with palette black.

## Design

- Require 8-bit indexed bands outside the destination rectangle to be uniform before staging them.
- Use representative samples only for safe early rejection; a complete scan remains required before any pixels are replaced.
- Retain the existing monochrome kiosk behavior.
- Add regression coverage for a centered 500x320 overlay with black outer corners and nonuniform application-painted bands.

## Evidence

The public reproduction reaches the centered overlay with its surrounding controls and artwork intact, then continues deterministically through 1,345 guest ticks with the same instruction count as the baseline. The measured hot-path rate remains within the observed baseline range.

## Validation

- `cargo test --lib --no-default-features --features test-support` (2,921 passed, 3 ignored)
- `cargo check --no-default-features`
- `RUSTDOCFLAGS='-D warnings -D rustdoc::private_intra_doc_links' cargo doc --no-deps --all-features`
- `cargo package --locked --no-verify --allow-dirty`
- `cargo build --all-targets --all-features`
- `cargo clippy --lib --all-features` (passes with the existing warning baseline)
- Deterministic end-to-end route through the centered composition and subsequent interaction

`cargo fmt --check` and all-target Clippy continue to report the repository's existing nonblocking baseline; the changed hunks add no new finding.
