### PR TITLE
fix: render menu command symbols with built-in fonts

### DIFF
--- a/src/quickdraw/fonts/pixel_font.rs
+++ b/src/quickdraw/fonts/pixel_font.rs
@@ -30,6 +30,7 @@ pub mod geneva18;
 pub mod geneva24;
 pub mod geneva9;
 pub mod london18;
+pub mod menu_symbols;
 pub mod monaco10;
 pub mod monaco12;
 pub mod monaco9;

--- a/src/quickdraw/fonts/pixel_font/menu_symbols.rs
+++ b/src/quickdraw/fonts/pixel_font/menu_symbols.rs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: OFL-1.1
+// Copyright (c) 2026 Ben Letchford. Bitmap glyph artwork under the SIL
+// Open Font License 1.1 (see OFL.txt at the crate root). Reserved Font
+// Name "Systemless".
+//! Systemless-original fallbacks for the special symbols used by the
+//! standard Menu Manager definition procedure. Inside Macintosh Volume I
+//! (1985), pp. I-358 and I-369 define the Command and checkmark character
+//! codes that appear beside menu items.
+
+use super::{data_len, decode_data, decode_glyphs, GlyphSrc};
+use crate::g;
+use crate::quickdraw::fonts::Glyph;
+
+const COMMAND_KEY_SRC: &[GlyphSrc] = &[g!(9, (1, -8),
+    ".##.##."
+    "#..#..#"
+    "#..#..#"
+    ".#####."
+    "#..#..#"
+    "#..#..#"
+    ".##.##."
+)];
+const COMMAND_KEY_LEN: usize = data_len(COMMAND_KEY_SRC);
+static COMMAND_KEY_GLYPHS: [Glyph; 1] = decode_glyphs(COMMAND_KEY_SRC);
+static COMMAND_KEY_DATA: [u8; COMMAND_KEY_LEN] = decode_data(COMMAND_KEY_SRC);
+
+const CHECKMARK_SRC: &[GlyphSrc] = &[g!(9, (1, -7),
+    "......#"
+    ".....##"
+    "#...##."
+    "##.##.."
+    ".###..."
+    "..#...."
+)];
+const CHECKMARK_LEN: usize = data_len(CHECKMARK_SRC);
+static CHECKMARK_GLYPHS: [Glyph; 1] = decode_glyphs(CHECKMARK_SRC);
+static CHECKMARK_DATA: [u8; CHECKMARK_LEN] = decode_data(CHECKMARK_SRC);
+
+pub(crate) fn get_glyph(ch: char) -> Option<(&'static Glyph, &'static [u8])> {
+    match ch {
+        '\u{2318}' => Some((&COMMAND_KEY_GLYPHS[0], &COMMAND_KEY_DATA)),
+        '\u{2713}' => Some((&CHECKMARK_GLYPHS[0], &CHECKMARK_DATA)),
+        _ => None,
+    }
+}

--- a/src/quickdraw/text.rs
+++ b/src/quickdraw/text.rs
@@ -54,12 +54,18 @@ pub fn get_glyph(font_id: i16, size: i16, ch: char) -> Option<(&'static Glyph, &
         {
             return Some(hit);
         }
+        if let Some(hit) = crate::quickdraw::fonts::pixel_font::menu_symbols::get_glyph(ch) {
+            return Some(hit);
+        }
         return get_macroman_glyph(font_id, size, 0x11);
     }
     if ch == '\u{2713}' {
         if let Some(hit) =
             override_symbol_glyph(font_id, size, override_format::CHECKMARK_SYMBOL_GLYPH_INDEX)
         {
+            return Some(hit);
+        }
+        if let Some(hit) = crate::quickdraw::fonts::pixel_font::menu_symbols::get_glyph(ch) {
             return Some(hit);
         }
         return get_macroman_glyph(font_id, size, 0x12);
@@ -123,4 +129,24 @@ pub fn get_glyph_italic(
 
 pub fn get_underline_thickness(_font_id: i16, _size: i16) -> i16 {
     1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::get_glyph;
+
+    #[test]
+    fn built_in_system_font_renders_menu_symbols() {
+        for (symbol, name) in [('\u{2318}', "Command"), ('\u{2713}', "checkmark")] {
+            let (glyph, data) = get_glyph(0, 12, symbol)
+                .unwrap_or_else(|| panic!("{name} symbol should resolve to a bitmap glyph"));
+            let glyph_len = usize::from(glyph.width) * usize::from(glyph.height);
+            assert!(
+                data[glyph.data_offset..glyph.data_offset + glyph_len]
+                    .iter()
+                    .any(|pixel| *pixel != 0),
+                "{name} symbol should contain visible pixels"
+            );
+        }
+    }
 }

--- a/src/trap/menu.rs
+++ b/src/trap/menu.rs
@@ -9436,6 +9436,13 @@ mod tests {
             .expect(
                 "classic command-key glyph should have a pixel outside the provider command marker",
             );
+        let command_left = rect.3 - 25;
+        let command_symbol_pixel = (row_top..row_bottom)
+            .flat_map(|y| (command_left..(command_left + 7)).map(move |x| (x, y)))
+            .find(|(x, y)| {
+                screen_pixel_is_set(&classic_bus, classic_base, classic_row_bytes, *x, *y)
+            })
+            .expect("classic command-key equivalent should draw the Command symbol itself");
 
         assert!(
             screen_pixel_is_set(
@@ -9456,6 +9463,16 @@ mod tests {
                 command_pixel.1
             ),
             "systemless-default row chrome should preserve the full command-key equivalent"
+        );
+        assert!(
+            screen_pixel_is_set(
+                &themed_bus,
+                themed_base,
+                themed_row_bytes,
+                command_symbol_pixel.0,
+                command_symbol_pixel.1
+            ),
+            "systemless-default row chrome should preserve the Command symbol itself"
         );
 
         clear_1bpp_screen(&mut themed_bus, themed_base, themed_row_bytes, 342);
@@ -9491,6 +9508,16 @@ mod tests {
                 command_pixel.1
             ),
             "highlighted systemless-default row chrome should preserve the full command-key equivalent"
+        );
+        assert!(
+            screen_pixel_is_set(
+                &themed_bus,
+                themed_base,
+                themed_row_bytes,
+                command_symbol_pixel.0,
+                command_symbol_pixel.1
+            ),
+            "highlighted systemless-default row chrome should preserve the Command symbol itself"
         );
     }
 


### PR DESCRIPTION
Closes #395.

## Problem

The menu renderer emitted Command and checkmark characters, but the built-in font catalogue had no bitmap for either symbol. Missing glyphs still advanced the pen, so command equivalents appeared as bare shortcut characters. The existing dropdown test only looked for any ink in the combined shortcut column and therefore passed on the key glyph alone.

## Design

- add OFL-licensed, Systemless-original Command and checkmark fallback bitmaps
- retain runtime font-override precedence
- assert distinct Command-symbol pixels in classic and Systemless Default dropdowns, both normal and highlighted

Inside Macintosh Volume I documents the special character codes and the Menu Manager placement semantics.

## Evidence

A fresh 800x600 8-bit interactive route held an Orders menu open in both Systemless and BasiliskII. Systemless now shows Command-plus-key semantics on enabled and dimmed rows, and the underlying interactive state resumes after dismissal.

## Validation

- cargo test --lib --features test-support — 2,932 passed; 3 ignored
- cargo check --no-default-features
- cargo package --locked --allow-dirty
- cargo build --all-targets --all-features
- rustfmt --check on all changed Rust files
- fresh Systemless and BasiliskII route with live guest timing
- repository-wide cargo fmt --all -- --check still reaches existing formatting drift
- cargo clippy --all-targets --all-features still reaches the existing erasing-op test lint in src/trap/cinepak.rs; no diagnostic points to changed code