### PR TITLE
fix: preserve black kiosk margins around transient windows

### DIFF
--- a/src/trap/framebuffer.rs
+++ b/src/trap/framebuffer.rs
@@ -4668,6 +4668,22 @@ mod redraw_chrome_tests {
     const CLIP_RGN: u32 = 0x182200;
     const WINDOW_VISIBLE_OFFSET: u32 = 110;
 
+    fn set_window_structure_rect(
+        bus: &mut crate::memory::MacMemoryBus,
+        window_ptr: u32,
+        rect: (i16, i16, i16, i16),
+    ) {
+        let region = bus.alloc(10);
+        bus.write_word(region, 10);
+        bus.write_word(region + 2, rect.0 as u16);
+        bus.write_word(region + 4, rect.1 as u16);
+        bus.write_word(region + 6, rect.2 as u16);
+        bus.write_word(region + 8, rect.3 as u16);
+        let handle = bus.alloc(4);
+        bus.write_long(handle, region);
+        bus.write_long(window_ptr + 114, handle);
+    }
+
     #[test]
     fn indexed_framebuffer_helpers_preserve_adjacent_four_bit_pixels() {
         let (mut disp, _cpu, mut bus) = setup_with_port();
@@ -4742,6 +4758,202 @@ mod redraw_chrome_tests {
         assert_eq!(bus.read_byte(screen_base + 300 * row_bytes + 40), 37);
         assert_eq!(bus.read_byte(screen_base + 300 * row_bytes + 400), 42);
         assert_eq!(bus.read_byte(screen_base + 599 * row_bytes + 799), 37);
+    }
+
+    #[test]
+    fn kiosk_stage_uses_last_centered_copybits_beneath_small_game_window() {
+        let (mut disp, _cpu, mut bus) = setup_with_port();
+        let (screen_base, row_bytes, screen_w, screen_h, pixel_size) = disp.screen_mode;
+        bus.fill_bytes(screen_base, row_bytes * screen_h as u32, 0);
+        TrapDispatcher::fb_fill_rect_index(
+            &mut bus,
+            screen_base,
+            row_bytes,
+            pixel_size,
+            screen_w as i16,
+            screen_h as i16,
+            60,
+            80,
+            540,
+            720,
+            255,
+        );
+        TrapDispatcher::fb_fill_rect_index(
+            &mut bus,
+            screen_base,
+            row_bytes,
+            pixel_size,
+            screen_w as i16,
+            screen_h as i16,
+            193,
+            240,
+            406,
+            560,
+            42,
+        );
+
+        // A small transient game window is frontmost over the last centered
+        // screen CopyBits surface that establishes the kiosk aperture.
+        bus.write_word(PORT_PTR + 8, (-193i16) as u16);
+        bus.write_word(PORT_PTR + 10, (-240i16) as u16);
+        bus.write_word(PORT_PTR + 16, 0);
+        bus.write_word(PORT_PTR + 18, 0);
+        bus.write_word(PORT_PTR + 20, 213);
+        bus.write_word(PORT_PTR + 22, 320);
+        bus.write_byte(PORT_PTR + WINDOW_VISIBLE_OFFSET, 0xFF);
+        set_window_structure_rect(&mut bus, PORT_PTR, (185, 232, 414, 568));
+        disp.front_window = PORT_PTR;
+        disp.window_list = vec![PORT_PTR];
+        disp.window_proc_ids.insert(PORT_PTR, 1);
+        disp.last_screen_copybits_rect = Some(ScreenCopyBitsRect {
+            src_top: 0,
+            src_left: 0,
+            src_bottom: 480,
+            src_right: 640,
+            dst_top: 60,
+            dst_left: 80,
+            dst_bottom: 540,
+            dst_right: 720,
+        });
+        disp.menu_bar_hidden = true;
+        disp.device_clut = [[0xFFFF, 0xFFFF, 0xFFFF]; 256];
+        disp.device_clut[255] = [0, 0, 0];
+
+        disp.fill_kiosk_stage_for_centered_game_surface(&mut bus, PORT_PTR);
+
+        assert_eq!(bus.read_byte(screen_base), 255);
+        assert_eq!(bus.read_byte(screen_base + 300 * row_bytes + 100), 255);
+        assert_eq!(bus.read_byte(screen_base + 300 * row_bytes + 400), 42);
+        assert_eq!(bus.read_byte(screen_base + 599 * row_bytes + 799), 255);
+
+        bus.fill_bytes(screen_base, row_bytes * screen_h as u32, 0);
+        TrapDispatcher::fb_fill_rect_index(
+            &mut bus,
+            screen_base,
+            row_bytes,
+            pixel_size,
+            screen_w as i16,
+            screen_h as i16,
+            60,
+            80,
+            540,
+            720,
+            255,
+        );
+        bus.write_byte(screen_base + 1, 7);
+        let before = bus.read_bytes(screen_base, (row_bytes * screen_h as u32) as usize);
+
+        disp.fill_kiosk_stage_for_centered_game_surface(&mut bus, PORT_PTR);
+
+        assert_eq!(
+            bus.read_bytes(screen_base, before.len()),
+            before,
+            "nonuniform application-painted margins must remain unchanged"
+        );
+    }
+
+    #[test]
+    fn kiosk_stage_preserves_transient_frames_crossing_the_saved_aperture() {
+        for (proc_id, content, structure) in [
+            (1i16, (60i16, 80i16, 213i16, 320i16), (52, 72, 221, 328)),
+            (3i16, (400i16, 600i16, 540i16, 720i16), (399, 599, 543, 723)),
+        ] {
+            let (mut disp, _cpu, mut bus) = setup_with_port();
+            let (screen_base, row_bytes, screen_w, screen_h, pixel_size) = disp.screen_mode;
+            bus.fill_bytes(screen_base, row_bytes * screen_h as u32, 0);
+            TrapDispatcher::fb_fill_rect_index(
+                &mut bus,
+                screen_base,
+                row_bytes,
+                pixel_size,
+                screen_w as i16,
+                screen_h as i16,
+                60,
+                80,
+                540,
+                720,
+                255,
+            );
+            bus.write_word(PORT_PTR + 8, content.0.wrapping_neg() as u16);
+            bus.write_word(PORT_PTR + 10, content.1.wrapping_neg() as u16);
+            bus.write_word(PORT_PTR + 16, 0);
+            bus.write_word(PORT_PTR + 18, 0);
+            bus.write_word(PORT_PTR + 20, content.2.wrapping_sub(content.0) as u16);
+            bus.write_word(PORT_PTR + 22, content.3.wrapping_sub(content.1) as u16);
+            bus.write_byte(PORT_PTR + WINDOW_VISIBLE_OFFSET, 0xFF);
+            set_window_structure_rect(&mut bus, PORT_PTR, structure);
+            disp.front_window = PORT_PTR;
+            disp.window_list = vec![PORT_PTR];
+            disp.window_proc_ids.insert(PORT_PTR, proc_id);
+            disp.last_screen_copybits_rect = Some(ScreenCopyBitsRect {
+                src_top: 0,
+                src_left: 0,
+                src_bottom: 480,
+                src_right: 640,
+                dst_top: 60,
+                dst_left: 80,
+                dst_bottom: 540,
+                dst_right: 720,
+            });
+            disp.menu_bar_hidden = true;
+            disp.device_clut = [[0xFFFF, 0xFFFF, 0xFFFF]; 256];
+            disp.device_clut[255] = [0, 0, 0];
+
+            disp.fill_kiosk_stage_for_centered_game_surface(&mut bus, PORT_PTR);
+
+            assert_eq!(
+                bus.read_byte(screen_base),
+                0,
+                "proc {proc_id} structure crossing the aperture must suppress the stage fill"
+            );
+        }
+    }
+
+    #[test]
+    fn kiosk_stage_skips_transient_windows_without_structure_geometry() {
+        let (mut disp, _cpu, mut bus) = setup_with_port();
+        let (screen_base, row_bytes, screen_w, screen_h, pixel_size) = disp.screen_mode;
+        bus.fill_bytes(screen_base, row_bytes * screen_h as u32, 0);
+        TrapDispatcher::fb_fill_rect_index(
+            &mut bus,
+            screen_base,
+            row_bytes,
+            pixel_size,
+            screen_w as i16,
+            screen_h as i16,
+            60,
+            80,
+            540,
+            720,
+            255,
+        );
+        bus.write_word(PORT_PTR + 8, (-193i16) as u16);
+        bus.write_word(PORT_PTR + 10, (-240i16) as u16);
+        bus.write_word(PORT_PTR + 16, 0);
+        bus.write_word(PORT_PTR + 18, 0);
+        bus.write_word(PORT_PTR + 20, 213);
+        bus.write_word(PORT_PTR + 22, 320);
+        bus.write_byte(PORT_PTR + WINDOW_VISIBLE_OFFSET, 0xFF);
+        disp.front_window = PORT_PTR;
+        disp.window_list = vec![PORT_PTR];
+        disp.window_proc_ids.insert(PORT_PTR, 1);
+        disp.last_screen_copybits_rect = Some(ScreenCopyBitsRect {
+            src_top: 0,
+            src_left: 0,
+            src_bottom: 480,
+            src_right: 640,
+            dst_top: 60,
+            dst_left: 80,
+            dst_bottom: 540,
+            dst_right: 720,
+        });
+        disp.menu_bar_hidden = true;
+        disp.device_clut = [[0xFFFF, 0xFFFF, 0xFFFF]; 256];
+        disp.device_clut[255] = [0, 0, 0];
+
+        disp.fill_kiosk_stage_for_centered_game_surface(&mut bus, PORT_PTR);
+
+        assert_eq!(bus.read_byte(screen_base), 0);
     }
 
     #[test]

--- a/src/trap/window.rs
+++ b/src/trap/window.rs
@@ -1284,14 +1284,35 @@ impl super::TrapDispatcher {
         let valid_front_window = window_ptr != 0
             && window_ptr == self.front_window
             && self.window_visible(bus, window_ptr);
-        let plain_game_window = valid_front_window && self.window_proc_id(window_ptr) == 2;
-        if plain_game_window {
-            if self
-                .fill_kiosk_stage_around_rect(bus, self.window_global_port_rect(bus, window_ptr))
-            {
+        if valid_front_window {
+            let front_proc_id = self.window_proc_id(window_ptr);
+            let front_rect = self.window_global_port_rect(bus, window_ptr);
+            if front_proc_id == 2 && self.fill_kiosk_stage_around_rect(bus, front_rect) {
                 return;
             }
-        } else if valid_front_window {
+
+            if !Self::window_is_document_proc(front_proc_id) {
+                if let (Some(rect), Some(front_structure)) = (
+                    self.last_screen_copybits_rect,
+                    self.window_structure_rect(bus, window_ptr),
+                ) {
+                    let destination =
+                        (rect.dst_top, rect.dst_left, rect.dst_bottom, rect.dst_right);
+                    // The structure region includes the frame and content. Checking only the
+                    // content port could let the kiosk fill overwrite a dialog border or shadow.
+                    // Inside Macintosh: Macintosh Toolbox Essentials (1992), p. 4-12
+                    let contains_front = destination.0 <= front_structure.0
+                        && destination.1 <= front_structure.1
+                        && destination.2 >= front_structure.2
+                        && destination.3 >= front_structure.3;
+                    if contains_front
+                        && self.kiosk_stage_margins_are_uniform(bus, destination)
+                        && self.fill_kiosk_stage_around_rect(bus, destination)
+                    {
+                        return;
+                    }
+                }
+            }
             return;
         }
 


### PR DESCRIPTION
Closes #424.

## Problem

When a small non-document game window becomes frontmost over a previously centered 640×480 presentation, Systemless stops applying the kiosk-stage fallback. The active palette can therefore expose white outer margins around otherwise correct artwork.

## Design

- Reuse the last centered screen `CopyBits` destination as the kiosk aperture beneath a contained transient window.
- Require the full transient-window structure region, including frame and shadow, to remain inside that aperture; skip the fallback when structure geometry is unavailable.
- Retain the existing full uniform-margin scan before replacing any pixels, so application-painted compositions remain untouched.
- Add regression coverage for a uniform white stage, a nonuniform application-owned surround, dBox and altDBox structures crossing an aperture edge, and missing structure geometry.

## Evidence

A deterministic route reaches live gameplay, transitions to the centered game-owned window, and preserves the artwork while changing exactly the 172,800 pixels outside the 640×480 aperture from white to the active palette darkest entry. The route completes at the same guest tick and instruction count as the baseline. A fresh run of the reviewed revision completed the transition at guest tick 6562 with the 320×213 front window intact and every outer framebuffer probe mapped to the active black index.

## Validation

- `cargo test --lib --no-default-features kiosk -- --nocapture`
- `cargo test --lib --no-default-features --features test-support`
- `cargo check --no-default-features`
- `cargo clippy --lib --all-features`
- `RUSTDOCFLAGS="-D warnings -D rustdoc::private_intra_doc_links" cargo doc --no-deps --all-features`
- `cargo build --all-targets --all-features`
- `cargo package --locked --allow-dirty`
- Deterministic end-to-end gameplay transition with an exact aperture-difference check.

`cargo fmt --all -- --check` continues to report pre-existing formatting drift; the changed hunks are rustfmt-clean.