### PR TITLE
perf: bound the read-only code check on the guest write path

### DIFF
--- a/src/memory/bus.rs
+++ b/src/memory/bus.rs
@@ -1111,9 +1111,9 @@ impl MacMemoryBus {
         if end <= span_start as u64 || address as u64 >= span_end as u64 {
             return false;
         }
-        self.readonly_code_ranges.iter().any(|&(start, stop)| {
-            (start as u64) < end && (stop as u64) > address as u64
-        })
+        self.readonly_code_ranges
+            .iter()
+            .any(|&(start, stop)| (start as u64) < end && (stop as u64) > address as u64)
     }
 
     /// Allocate memory from the heap with a stronger start-address alignment.

--- a/src/memory/bus.rs
+++ b/src/memory/bus.rs
@@ -452,6 +452,13 @@ pub struct MacMemoryBus {
     synthetic_ptr: u32,
     /// Guest writes cannot modify synthesized ROM-like instruction stubs.
     readonly_code_ranges: Vec<(u32, u32)>,
+    /// Half-open bounding box over `readonly_code_ranges`, maintained on
+    /// insert. Every guest write consults the protection list, but the
+    /// ranges are synthetic-region trampolines clustered well away from the
+    /// heap, stack and framebuffer that real writes target -- so this lets
+    /// the overwhelmingly common case reject in two comparisons instead of
+    /// scanning the list.
+    readonly_code_span: Option<(u32, u32)>,
     /// Free list: maps aligned_size → stack of recycled addresses
     free_blocks: HashMap<u32, Vec<u32>>,
     /// Tracks the aligned size of each allocation (address → aligned_size)
@@ -836,6 +843,7 @@ impl MacMemoryBus {
             heap_ptr: 0x200000, // Start heap at 2MB
             synthetic_ptr: screen_buffer_start,
             readonly_code_ranges: Vec::new(),
+            readonly_code_span: None,
             free_blocks: HashMap::new(),
             alloc_sizes: HashMap::new(),
             alloc_bucket_sizes: HashMap::new(),
@@ -915,6 +923,7 @@ impl MacMemoryBus {
             heap_ptr: 0x200000,
             synthetic_ptr: screen_buffer_start,
             readonly_code_ranges: Vec::new(),
+            readonly_code_span: None,
             free_blocks: HashMap::new(),
             alloc_sizes: HashMap::new(),
             alloc_bucket_sizes: HashMap::new(),
@@ -1076,8 +1085,12 @@ impl MacMemoryBus {
 
     pub(crate) fn protect_readonly_code(&mut self, address: u32, len: u32) {
         if len != 0 {
-            self.readonly_code_ranges
-                .push((address, address.saturating_add(len)));
+            let end = address.saturating_add(len);
+            self.readonly_code_ranges.push((address, end));
+            self.readonly_code_span = Some(match self.readonly_code_span {
+                Some((lo, hi)) => (lo.min(address), hi.max(end)),
+                None => (address, end),
+            });
         }
     }
 
@@ -1088,7 +1101,16 @@ impl MacMemoryBus {
     }
 
     fn readonly_code_overlaps(&self, address: u32, len: u32) -> bool {
+        // Reject outside the bounding box first: this runs on every guest
+        // write, and protected stubs occupy a small clustered region that
+        // ordinary writes never touch.
+        let Some((span_start, span_end)) = self.readonly_code_span else {
+            return false;
+        };
         let end = (address as u64).saturating_add(len as u64);
+        if end <= span_start as u64 || address as u64 >= span_end as u64 {
+            return false;
+        }
         self.readonly_code_ranges.iter().any(|&(start, stop)| {
             (start as u64) < end && (stop as u64) > address as u64
         })
@@ -1389,15 +1411,19 @@ impl MemoryBus for MacMemoryBus {
         maybe_log_mem_write(address, 1, value as u32);
 
         // Optional release-mode FB-write tracer. Cheap when unset (one
-        // atomic load + None branch).
-        maybe_log_fb_write(address, value);
+        // atomic load + None branch). The range is read once and shared
+        // with the disassembly companion below rather than fetched twice.
+        let fb_trace = fb_write_trace_range();
+        if fb_trace.is_some() {
+            maybe_log_fb_write(address, value);
+        }
         // Companion disassembly window: when both FB_WRITE_RANGE and
         // FB_WRITE_DISASM are set, dump the 8 instruction bytes at PC
         // alongside an m68k-disassembled mnemonic for each write that
         // falls in the watched range. Lets release-build pixel-
         // divergence investigations identify the 68k blit loop
         // responsible without a debug build.
-        if let Some((start, end)) = fb_write_trace_range() {
+        if let Some((start, end)) = fb_trace {
             if address >= start && address <= end && fb_write_disasm_enabled() {
                 let pc = CURRENT_PC.with(|p| *p.borrow());
                 if pc != 0 && (pc as u64 + 8) <= self.ram_size as u64 {
@@ -2015,6 +2041,38 @@ mod tests {
             "byte before write_bytes window"
         );
         assert_eq!(bus.read_byte(0x13E8), 0xCC, "byte after write_bytes window");
+    }
+
+    #[test]
+    fn readonly_code_protection_survives_the_bounding_box_fast_path() {
+        // Every guest write consults the protection list through a bounding
+        // box, so verify the fast reject cannot let a protected write
+        // through and cannot block an ordinary one -- including with
+        // several disjoint ranges, where the box spans the gap between
+        // them.
+        let mut bus = MacMemoryBus::new(64 * 1024);
+        bus.write_byte(0x2000, 0x11);
+        bus.write_byte(0x4000, 0x22);
+        bus.write_byte(0x3000, 0x33); // inside the future span, unprotected
+        bus.protect_readonly_code(0x2000, 2);
+        bus.protect_readonly_code(0x4000, 2);
+
+        // Protected: writes are dropped at every width.
+        bus.write_byte(0x2000, 0xFF);
+        bus.write_word(0x4000, 0xFFFF);
+        bus.write_long(0x2000, 0xFFFF_FFFF);
+        assert_eq!(bus.read_byte(0x2000), 0x11, "protected byte is unchanged");
+        assert_eq!(bus.read_byte(0x4000), 0x22, "protected byte is unchanged");
+
+        // Inside the bounding box but between the ranges: still writable.
+        bus.write_byte(0x3000, 0x44);
+        assert_eq!(bus.read_byte(0x3000), 0x44, "the gap stays writable");
+
+        // Outside the bounding box entirely: the fast-reject path.
+        bus.write_byte(0x0100, 0x55);
+        bus.write_byte(0x8000, 0x66);
+        assert_eq!(bus.read_byte(0x0100), 0x55, "below the span is writable");
+        assert_eq!(bus.read_byte(0x8000), 0x66, "above the span is writable");
     }
 
     #[test]


### PR DESCRIPTION
Closes #453.

## Summary

Every guest write consults `readonly_code_overlaps`, which scanned the
protected-range list linearly. This adds a bounding box over those ranges
so the overwhelmingly common write rejects in two comparisons.

## Why it matters

Reads pay nothing comparable, and the asymmetry is stark. In a capped
(`--cpu-mhz 25`) gameplay capture, decomposed across all threads with
blocking waits excluded:

| Method | capture A | capture B |
|---|---:|---:|
| `write_byte` | **6.04%** | **5.66%** |
| `write_word` | 2.40% | 2.44% |
| `write_long` | 1.24% | 1.32% |
| `read_byte` | **0.06%** | **0.05%** |
| all writes | 9.68% | 9.42% |

`write_byte` costs ~100× `read_byte` (95× and 112× in the two captures)
because it runs the range scan, a write probe, and three env-gated hooks,
while `read_byte` goes straight to memory.

The protected ranges are synthetic-region trap trampolines, allocated
together and well away from the heap, stack and framebuffer that real guest
writes target — so a bounding box rejects almost every write without
touching the list.

## Measured effect

Deterministic headless A/B, two profiles per arm:

| | base | candidate |
|---|---:|---:|
| `write_byte` share of samples | 0.53% | **0.16%** |

**This is the load-bearing result for the claim above.** `readonly_code_overlaps`
is inlined into `write_byte`, so a profile alone cannot separate the scan's
cost from the rest of the function — the causal story had to be tested, not
asserted. Removing the scan removes ~70% of `write_byte`'s self time, which
confirms the scan was its dominant cost.

The absolute figure here is small because this startup-weighted workload does
few guest writes; the role of this A/B is the causal test, not the magnitude.
The gameplay magnitude is measured directly in the next section.

Base-to-base spread on this metric is 0.01pp.

## Measured in gameplay (same-generation A/B)

Two capped (`--cpu-mhz 25`) GUI sessions on identical binaries except this
fix, host-sampled for 90 s of play each, decomposed across all threads
with blocking waits excluded:

| metric | baseline | with fix |
|---|---:|---:|
| `write_byte` self time | 1.51% | **0.36%** (−76%) |
| all bus writes | 2.51% | **0.64%** |

The −76% matches the earlier headless prediction (~70%), confirming the
range scan was the dominant cost of the write path.

Why these absolute shares are smaller than the ~6% quoted above: the two
capture generations attribute differently. This build generation's
cross-crate LTO inlines most bus accesses into the interpreter frame,
where they are invisible to symbol attribution — only the out-of-line
copies are counted here. The measured −1.87pp of non-idle CPU is
therefore a **lower bound** on the fix's total effect; the inlined copies
receive the same fix but cannot be separately counted. The sessions are
human-played and not length-matched, so no throughput claim is made.

The measured binaries were built on the 0.12.2-generation master; this
branch is based on current master (0.12.8). `src/memory/bus.rs` is
unchanged between the two, so the measurements apply to the submitted
code exactly.

## How this was measured

Primary evidence is a capped (`--cpu-mhz 25`) GUI capture of steady-state
gameplay — the configuration the application actually runs in. The cap matters
because uncapped execution is elastic: the guest does as much work as the host
allows, so CPU share conflates efficiency with throughput.

The capture is decomposed across **all threads with blocking waits excluded**.
Scoping to the emulator thread alone hides real work on the audio and render
threads, and including waits swamps the sample with idle: in these captures
over 90% of raw samples are blocking syscalls. Two independent captures agree
within a point on the figures above.

Before/after is measured on the deterministic `--headless` harness using
share-of-samples per symbol. Wall clock is not usable there: the process is
killed once sampling finishes, so every run reports the same duration by
construction, and wall-clock A/B on this machine drifted up to 42% between
runs of an *identical* binary in any case.

## Correctness

The box is only ever **widened**, never narrowed, so it cannot reject a
write the scan would have allowed; it only ever short-circuits to the same
answer. When an address does land inside the box, the existing scan runs
unchanged.

The added test covers what a wrong implementation would get wrong: two
disjoint protected ranges with a writable gap between them, so the box
deliberately spans memory it must **not** protect, plus protected writes at
all three widths and ordinary writes on both sides of the box.

Also hoists a duplicated `fb_write_trace_range()` lookup in `write_byte`
so the untraced path reads it once rather than twice.

## Validation

- `cargo build --release`, `cargo test --release` — full suite green
- New test: `readonly_code_protection_survives_the_bounding_box_fast_path`

<!-- Drafted by Claude Opus 5, 2026-08-06. -->


