### PR TITLE
perf: startup and idle event-loop hygiene (window-list clone, trap-table scan, launch path)

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1875,6 +1875,12 @@ impl FixtureRunner {
             .fill_bytes(scrn_base, row_bytes * scrn_height as u32, 0xFF);
     }
 
+    /// Loading an application is a once-per-launch operation, but its caller
+    /// runs on the per-batch path. Left to itself the optimiser inlined this
+    /// whole body there, giving the hot function a 34 KB stack frame; keep it
+    /// out of line so the common case stays a cheap `Option` check.
+    #[cold]
+    #[inline(never)]
     fn switch_to_launched_application(
         &mut self,
         app_path: &str,

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -984,6 +984,51 @@ pub(crate) struct InverseTableCacheEntry {
 }
 
 /// Trap dispatcher with resource fork access and emulator state.
+
+/// Native trap dispatch table.
+///
+/// Consulted on every A-line trap dispatch, but it holds only the handful of
+/// traps a program has installed native handlers for. At that size a hash map
+/// costs more than the lookup it protects: the default hasher dominated, and
+/// even with a cheap hasher the SwissTable group probe remained visible in
+/// profiles of `dispatch`. A linear scan over a couple of `u16` keys needs
+/// neither.
+///
+/// The API mirrors the `HashMap` methods previously used so call sites are
+/// unchanged.
+#[derive(Debug, Default, Clone)]
+pub(crate) struct TrapWordMap {
+    entries: Vec<(u16, u32)>,
+}
+
+impl TrapWordMap {
+    pub(crate) fn get(&self, trap: &u16) -> Option<&u32> {
+        self.entries
+            .iter()
+            .find(|(word, _)| word == trap)
+            .map(|(_, handler)| handler)
+    }
+
+    pub(crate) fn insert(&mut self, trap: u16, handler: u32) -> Option<u32> {
+        match self.entries.iter_mut().find(|(word, _)| *word == trap) {
+            Some(slot) => Some(std::mem::replace(&mut slot.1, handler)),
+            None => {
+                self.entries.push((trap, handler));
+                None
+            }
+        }
+    }
+
+    pub(crate) fn remove(&mut self, trap: &u16) -> Option<u32> {
+        let index = self.entries.iter().position(|(word, _)| word == trap)?;
+        Some(self.entries.swap_remove(index).1)
+    }
+
+    pub(crate) fn contains_key(&self, trap: &u16) -> bool {
+        self.entries.iter().any(|(word, _)| word == trap)
+    }
+}
+
 pub struct TrapDispatcher {
     /// Synthetic keyboard and mouse entries exposed by the ADB Manager.
     pub(crate) adb: crate::adb::AdbManager,
@@ -1772,7 +1817,7 @@ pub struct TrapDispatcher {
     /// and a native handler exists, the dispatcher simulates a JSR to the handler
     /// instead of running HLE code. This allows CRT-installed handlers (LoadSeg,
     /// UnloadSeg, ExitToShell) to run natively with proper code relocation.
-    pub(crate) native_trap_table: HashMap<u16, u32>,
+    pub(crate) native_trap_table: TrapWordMap,
     /// Most recent original call for each active native trap handler. Entries
     /// are replaced by a newer call and consumed when a handler invokes its
     /// saved old trap address.
@@ -3052,7 +3097,7 @@ impl TrapDispatcher {
             fill_black_override: None,
             recording_picture: None,
             recording_picture_bitmap: None,
-            native_trap_table: HashMap::new(),
+            native_trap_table: TrapWordMap::default(),
             pending_native_trap_calls: HashMap::new(),
             bits_proc_reentry: None,
             timer_tasks: Vec::new(),

--- a/src/trap/window.rs
+++ b/src/trap/window.rs
@@ -2361,13 +2361,21 @@ impl super::TrapDispatcher {
             return None;
         }
 
-        let mut windows = self.window_list.clone();
-        if windows.is_empty() && self.front_window != 0 {
-            windows.push(self.front_window);
-        }
+        // Iterate the window list in place. This runs on the event-polling
+        // path, which a Mac event loop hits constantly, so cloning the list
+        // just to walk it dominated allocation in whole-application
+        // profiles. The front window is a fallback only when the list is
+        // empty, which `chain` expresses without a temporary.
+        let fallback = if self.window_list.is_empty() && self.front_window != 0 {
+            Some(self.front_window)
+        } else {
+            None
+        };
 
-        windows
-            .into_iter()
+        self.window_list
+            .iter()
+            .copied()
+            .chain(fallback)
             .find(|&window_ptr| {
                 self.window_visible(bus, window_ptr)
                     && self.window_update_rect(bus, window_ptr).is_some()


### PR DESCRIPTION
## Summary

Three small fixes to costs on the event-poll and per-batch paths, in
three commits:

1. **`pending_update_event` no longer clones the window list to iterate
   it** (`trap/window.rs`). The clone existed only so the front window
   could be pushed as a fallback when the list is empty; a borrowing
   iterator with a chained fallback expresses the same thing without
   allocating. Reached by three call paths per poll.
2. **`native_trap_table` becomes a linear scan** (`trap/dispatch.rs`).
   The table is consulted on every A-line dispatch but holds only the
   handful of traps a program installs native handlers for. A hash map
   costs more than the lookup it protects at that size: SipHash
   dominated, and with a cheap hasher the SwissTable group probe was
   still the self-time hotspot of `dispatch` (`pcmpeqb`/`pmovmskb` in
   disassembly). A scan over a couple of `u16` keys needs neither. The
   type keeps the `HashMap`-shaped API, so all call sites are unchanged.
3. **The application-launch path is kept out of the hot loop**
   (`runner.rs`). `switch_to_launched_application` runs at most once per
   launch, but the optimiser inlined its 93-line body into
   `service_pending_launch_application` — called from three sites in the
   per-batch loop — leaving that function a 34 KB stack frame (visible
   as `addq $0x84e8, %rsp` in its epilogue). `#[cold]`
   `#[inline(never)]` keeps the common case a cheap `Option` check.

## What this buys, honestly scoped

**This is a startup / idle-loop / headless improvement, not a frame-rate
one.** In two capped (`--cpu-mhz 25`) gameplay captures the window
event-poll path does not appear at all (0.00% of non-idle CPU), so no
gameplay effect should be expected from (1) or (3). Change (2) has a
small live gameplay component (hashing is ~1% of non-idle gameplay CPU,
of which this table is part), stated as direction-only.

Where it does pay:

- **Headless throughput.** Anyone running `--headless` — the test
  harness, CI, batch runs — executes the event loop unpaced, where these
  costs dominate.
- **Idle CPU in the GUI.** A paced session still polls at frame cadence
  and paid the clone on every poll; eliminating it lowers CPU share,
  heat, and battery while sitting in dialogs and menus.

## Measured on exactly this branch (deterministic headless A/B, two profiles per arm)

| metric | base | with fixes | noise (base-to-base) | attribution |
|---|---:|---:|---:|---|
| allocator share of samples | 19.15% / 19.37% | **0.05% / 0.08%** | 0.22pp | change 1 |
| samples allocating under `trap::window::*pending*` | 6,205 / 6,694 | **0 / 0** | — | change 1 (positive control) |
| SipHash share | 4.62% / 4.52% | **3.19% / 2.62%** | 0.10pp | change 2 |
| `service_pending_launch_application` self time | 2.66% / 2.66% | **0.42% / 0.50%** | 0.00pp | change 3 |
| guest instructions per fixed ~116 s window | 151.5M / 138.5M | 213.0M / 161.0M | — | combined |

The positive control is the second row: the specific call path change 1
removes goes to exactly zero — a falsifiable named-symbol prediction, not
an aggregate. Every quoted effect is at least an order of magnitude above
its base-to-base noise.

Throughput is **+29% median**, but stated with its spread: the candidate
arm's two runs differ by 28%, so the conservative slowest-candidate vs
fastest-base comparison is **+6%**. The per-symbol table is the reliable
evidence; the throughput figures are corroboration.

**One claim downgraded by this measurement.** Disassembly showed the
SwissTable group probe as the self-time hotspot of `dispatch`, and an
earlier (sleep-contaminated) round suggested its removal was visible.
On this clean round `dispatch` self time is flat within noise (+0.9%
normalised against `run_steps_internal`). Change 2's *measured* benefit
is the SipHash elimination above; the probe removal is a code
simplification whose effect is below this harness's resolution, and the
commit message says so.

## How this was measured

`systemless --headless --max-instructions N` runs the guest
deterministically — no window, no input, no frame pacing — so an A/B
pair is reproducible without a human driving a session. Profiles are
`/usr/bin/sample` at 1 ms over a 90 s window after warm-up; the metric
is share of samples per symbol, which is robust to background load.
Wall clock is not usable in this harness (the process is killed when
sampling ends), so throughput is guest instructions completed within
the fixed window. Headless is startup- and dialog-dominated and unpaced,
which is exactly why its numbers are quoted for that mode and not for
gameplay.

## Validation

- `cargo build --release`, `cargo test --release` — full suite per
  change on independent branches, and on the combined branch
- Change 1: no behavioural change (same iteration order, same fallback
  condition, same returned event)
- Change 2: the `TrapWordMap` type preserves the `HashMap` contract used
  at the call sites, including `insert` returning the previous value
- Change 3: attribute-only; no code change

<!-- Drafted by Claude Fable 5, 2026-08-08. -->
