### PR TITLE
perf: stop cloning the window list on every event poll

### DIFF
--- a/src/trap/window.rs
+++ b/src/trap/window.rs
@@ -4810,7 +4810,11 @@ mod tests {
         );
         let region_ptr = bus.alloc(10);
         bus.write_word(region_ptr, 10);
-        let rect = if dirty { (0i16, 0i16, 10i16, 10i16) } else { (0, 0, 0, 0) };
+        let rect = if dirty {
+            (0i16, 0i16, 10i16, 10i16)
+        } else {
+            (0, 0, 0, 0)
+        };
         bus.write_word(region_ptr + 2, rect.0 as u16);
         bus.write_word(region_ptr + 4, rect.1 as u16);
         bus.write_word(region_ptr + 6, rect.2 as u16);
@@ -4834,21 +4838,27 @@ mod tests {
         let back = make_window(&mut bus, true, true);
         disp.window_list = vec![front, middle, back];
         disp.front_window = front;
-        let event = disp.pending_update_event(&bus, 0xFFFF).expect("update event");
+        let event = disp
+            .pending_update_event(&bus, 0xFFFF)
+            .expect("update event");
         assert_eq!(event.what, 6, "updateEvt");
         assert_eq!(event.message, middle, "first dirty window front-to-back");
 
         // An invisible dirty window ahead of a visible dirty one is skipped.
         let hidden = make_window(&mut bus, false, true);
         disp.window_list = vec![hidden, back];
-        let event = disp.pending_update_event(&bus, 0xFFFF).expect("update event");
+        let event = disp
+            .pending_update_event(&bus, 0xFFFF)
+            .expect("update event");
         assert_eq!(event.message, back, "visibility still gates selection");
 
         // Empty list: the front window serves as the fallback...
         let lone = make_window(&mut bus, true, true);
         disp.window_list = Vec::new();
         disp.front_window = lone;
-        let event = disp.pending_update_event(&bus, 0xFFFF).expect("fallback event");
+        let event = disp
+            .pending_update_event(&bus, 0xFFFF)
+            .expect("fallback event");
         assert_eq!(event.message, lone, "front-window fallback on empty list");
 
         // ...and no fallback exists when it is unset, or when the update
@@ -4856,7 +4866,10 @@ mod tests {
         disp.front_window = 0;
         assert!(disp.pending_update_event(&bus, 0xFFFF).is_none());
         disp.front_window = lone;
-        assert!(disp.pending_update_event(&bus, 0xFFBF).is_none(), "mask gates");
+        assert!(
+            disp.pending_update_event(&bus, 0xFFBF).is_none(),
+            "mask gates"
+        );
     }
 
     fn install_wind_resource(

--- a/src/trap/window.rs
+++ b/src/trap/window.rs
@@ -4802,6 +4802,63 @@ mod tests {
         assert_eq!(bus.read_word(sp + 4), 0);
     }
 
+    fn make_window(bus: &mut crate::memory::MacMemoryBus, visible: bool, dirty: bool) -> u32 {
+        let window_ptr = bus.alloc(160);
+        bus.write_byte(
+            window_ptr + super::super::TrapDispatcher::WINDOW_VISIBLE_OFFSET,
+            if visible { 0xFF } else { 0 },
+        );
+        let region_ptr = bus.alloc(10);
+        bus.write_word(region_ptr, 10);
+        let rect = if dirty { (0i16, 0i16, 10i16, 10i16) } else { (0, 0, 0, 0) };
+        bus.write_word(region_ptr + 2, rect.0 as u16);
+        bus.write_word(region_ptr + 4, rect.1 as u16);
+        bus.write_word(region_ptr + 6, rect.2 as u16);
+        bus.write_word(region_ptr + 8, rect.3 as u16);
+        let handle = bus.alloc(4);
+        bus.write_long(handle, region_ptr);
+        bus.write_long(
+            window_ptr + super::super::TrapDispatcher::WINDOW_UPDATE_RGN_OFFSET,
+            handle,
+        );
+        window_ptr
+    }
+
+    #[test]
+    fn pending_update_event_selects_front_to_back_and_falls_back_when_list_is_empty() {
+        let (mut disp, _cpu, mut bus) = setup();
+        // Front-to-back selection: the front window is clean, the middle is
+        // the first dirty one, the back is also dirty; the middle must win.
+        let front = make_window(&mut bus, true, false);
+        let middle = make_window(&mut bus, true, true);
+        let back = make_window(&mut bus, true, true);
+        disp.window_list = vec![front, middle, back];
+        disp.front_window = front;
+        let event = disp.pending_update_event(&bus, 0xFFFF).expect("update event");
+        assert_eq!(event.what, 6, "updateEvt");
+        assert_eq!(event.message, middle, "first dirty window front-to-back");
+
+        // An invisible dirty window ahead of a visible dirty one is skipped.
+        let hidden = make_window(&mut bus, false, true);
+        disp.window_list = vec![hidden, back];
+        let event = disp.pending_update_event(&bus, 0xFFFF).expect("update event");
+        assert_eq!(event.message, back, "visibility still gates selection");
+
+        // Empty list: the front window serves as the fallback...
+        let lone = make_window(&mut bus, true, true);
+        disp.window_list = Vec::new();
+        disp.front_window = lone;
+        let event = disp.pending_update_event(&bus, 0xFFFF).expect("fallback event");
+        assert_eq!(event.message, lone, "front-window fallback on empty list");
+
+        // ...and no fallback exists when it is unset, or when the update
+        // bit is masked out.
+        disp.front_window = 0;
+        assert!(disp.pending_update_event(&bus, 0xFFFF).is_none());
+        disp.front_window = lone;
+        assert!(disp.pending_update_event(&bus, 0xFFBF).is_none(), "mask gates");
+    }
+
     fn install_wind_resource(
         disp: &mut super::super::TrapDispatcher,
         bus: &mut crate::memory::MacMemoryBus,

--- a/src/trap/window.rs
+++ b/src/trap/window.rs
@@ -2361,13 +2361,21 @@ impl super::TrapDispatcher {
             return None;
         }
 
-        let mut windows = self.window_list.clone();
-        if windows.is_empty() && self.front_window != 0 {
-            windows.push(self.front_window);
-        }
+        // Iterate the window list in place. This runs on the event-polling
+        // path, which a Mac event loop hits constantly, so cloning the list
+        // just to walk it dominated allocation in whole-application
+        // profiles. The front window is a fallback only when the list is
+        // empty, which `chain` expresses without a temporary.
+        let fallback = if self.window_list.is_empty() && self.front_window != 0 {
+            Some(self.front_window)
+        } else {
+            None
+        };
 
-        windows
-            .into_iter()
+        self.window_list
+            .iter()
+            .copied()
+            .chain(fallback)
             .find(|&window_ptr| {
                 self.window_visible(bus, window_ptr)
                     && self.window_update_rect(bus, window_ptr).is_some()


### PR DESCRIPTION
Closes #454.

## Summary

`pending_update_event` no longer clones the window list to iterate it.
The clone existed only so the front window could be pushed as a fallback
when the list is empty; a borrowing iterator with a chained fallback
expresses the same thing without allocating. Reached by three call paths
per poll (runner poll, dialog filter real-event check, window trap
handler).

## How this was measured

**Harness:** `systemless --headless --max-instructions 900000000` —
deterministic (no window, no input, no frame pacing), which also means
startup/dialog-weighted and unpaced. **Instrument:** `/usr/bin/sample
<pid> 90 1` (90 s at 1 ms) after warm-up, two independent profiles per
arm. **Metric:** each symbol's share of non-idle self-time samples,
all threads, blocking-wait samples excluded — share rather than wall
clock because the harness kills the process when sampling ends and
wall-clock A/B drifted up to 42% between identical binaries. **Arms:**
base is `master`; the candidate carried all three hygiene changes
(#454, #455, #456) together, so per-change attribution rests on symbol
specificity — the rows below are symbols only this change touches.

## Result

| metric | base (2 profiles) | with fix | base-to-base noise |
|---|---:|---:|---:|
| allocator share of samples | 19.15% / 19.37% | **0.05% / 0.08%** | 0.22pp |
| samples allocating under `trap::window::*pending*` | 6,205 / 6,694 | **0 / 0** | — |

The second row is the positive control: the specific call path this
removes goes to exactly zero — a falsifiable named-symbol prediction.

**Scope, stated plainly:** this is a headless-throughput and idle-CPU
improvement, not a frame-rate one. In two capped gameplay captures this
path is 0.00% of non-idle CPU. Anyone running `--headless` (tests, CI,
batch) executes the poll unpaced where this cost dominates; a paced GUI
still pays the clone at frame cadence while idle in dialogs and menus.

## Coverage

New test `pending_update_event_selects_front_to_back_and_falls_back_when_list_is_empty`
pins the behavior the change must preserve: front-to-back selection
(first dirty window wins, clean front skipped), visibility gating
(hidden dirty window skipped), the empty-list front-window fallback,
no event when the fallback is unset, and the event-mask gate.

## Validation

- `cargo build --release`, `cargo test --release` — full suite green
- No behavioural change: same iteration order, same fallback condition,
  same returned event
