### PR TITLE
perf: direct-index the native-trap table

### DIFF
--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -983,8 +983,6 @@ pub(crate) struct InverseTableCacheEntry {
     pub bytes: Vec<u8>,
 }
 
-/// Trap dispatcher with resource fork access and emulator state.
-
 /// Native trap dispatch table.
 ///
 /// Consulted on every A-line trap dispatch. The default `HashMap` paid
@@ -1063,12 +1061,9 @@ impl TrapWordMap {
             }
         }
     }
-
-    pub(crate) fn contains_key(&self, trap: &u16) -> bool {
-        self.get(trap).is_some()
-    }
 }
 
+/// Trap dispatcher with resource fork access and emulator state.
 pub struct TrapDispatcher {
     /// Synthetic keyboard and mouse entries exposed by the ADB Manager.
     pub(crate) adb: crate::adb::AdbManager,

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -984,6 +984,51 @@ pub(crate) struct InverseTableCacheEntry {
 }
 
 /// Trap dispatcher with resource fork access and emulator state.
+
+/// Native trap dispatch table.
+///
+/// Consulted on every A-line trap dispatch, but it holds only the handful of
+/// traps a program has installed native handlers for. At that size a hash map
+/// costs more than the lookup it protects: the default hasher dominated, and
+/// even with a cheap hasher the SwissTable group probe remained visible in
+/// profiles of `dispatch`. A linear scan over a couple of `u16` keys needs
+/// neither.
+///
+/// The API mirrors the `HashMap` methods previously used so call sites are
+/// unchanged.
+#[derive(Debug, Default, Clone)]
+pub(crate) struct TrapWordMap {
+    entries: Vec<(u16, u32)>,
+}
+
+impl TrapWordMap {
+    pub(crate) fn get(&self, trap: &u16) -> Option<&u32> {
+        self.entries
+            .iter()
+            .find(|(word, _)| word == trap)
+            .map(|(_, handler)| handler)
+    }
+
+    pub(crate) fn insert(&mut self, trap: u16, handler: u32) -> Option<u32> {
+        match self.entries.iter_mut().find(|(word, _)| *word == trap) {
+            Some(slot) => Some(std::mem::replace(&mut slot.1, handler)),
+            None => {
+                self.entries.push((trap, handler));
+                None
+            }
+        }
+    }
+
+    pub(crate) fn remove(&mut self, trap: &u16) -> Option<u32> {
+        let index = self.entries.iter().position(|(word, _)| word == trap)?;
+        Some(self.entries.swap_remove(index).1)
+    }
+
+    pub(crate) fn contains_key(&self, trap: &u16) -> bool {
+        self.entries.iter().any(|(word, _)| word == trap)
+    }
+}
+
 pub struct TrapDispatcher {
     /// Synthetic keyboard and mouse entries exposed by the ADB Manager.
     pub(crate) adb: crate::adb::AdbManager,
@@ -1772,7 +1817,7 @@ pub struct TrapDispatcher {
     /// and a native handler exists, the dispatcher simulates a JSR to the handler
     /// instead of running HLE code. This allows CRT-installed handlers (LoadSeg,
     /// UnloadSeg, ExitToShell) to run natively with proper code relocation.
-    pub(crate) native_trap_table: HashMap<u16, u32>,
+    pub(crate) native_trap_table: TrapWordMap,
     /// Most recent original call for each active native trap handler. Entries
     /// are replaced by a newer call and consumed when a handler invokes its
     /// saved old trap address.
@@ -3052,7 +3097,7 @@ impl TrapDispatcher {
             fill_black_override: None,
             recording_picture: None,
             recording_picture_bitmap: None,
-            native_trap_table: HashMap::new(),
+            native_trap_table: TrapWordMap::default(),
             pending_native_trap_calls: HashMap::new(),
             bits_proc_reentry: None,
             timer_tasks: Vec::new(),

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -987,45 +987,85 @@ pub(crate) struct InverseTableCacheEntry {
 
 /// Native trap dispatch table.
 ///
-/// Consulted on every A-line trap dispatch, but it holds only the handful of
-/// traps a program has installed native handlers for. At that size a hash map
-/// costs more than the lookup it protects: the default hasher dominated, and
-/// even with a cheap hasher the SwissTable group probe remained visible in
-/// profiles of `dispatch`. A linear scan over a couple of `u16` keys needs
-/// neither.
+/// Consulted on every A-line trap dispatch. The default `HashMap` paid
+/// SipHash plus a SwissTable probe per lookup, and a linear scan is
+/// unbounded: `SetTrapAddress`/`NSetTrapAddress` can populate arbitrarily
+/// many slots, so an application that patches many traps would make the
+/// hottest dispatch path O(n).
 ///
-/// The API mirrors the `HashMap` methods previously used so call sites are
-/// unchanged.
-#[derive(Debug, Default, Clone)]
+/// Every key producer normalizes into two bands — the Operating System
+/// table `0xA000..=0xA0FF` (`trap_address_table_key`, and dispatch's
+/// `0xA000 | (trap & 0x00FF)`) and the Toolbox table `0xA800..=0xABFF`
+/// (`0xA800 | (trap & 0x03FF)`) — 1,280 possible keys in total, so the
+/// table direct-indexes them: O(1) for any occupancy, no hashing, no
+/// probe, ~10 KB once. Keys outside the two bands (which no production
+/// caller generates) go to a spill list so the `HashMap`-shaped contract
+/// stays total; the dispatch path never touches it because its keys are
+/// in-band by construction.
+#[derive(Debug, Clone)]
 pub(crate) struct TrapWordMap {
-    entries: Vec<(u16, u32)>,
+    bands: Box<[Option<u32>; Self::SLOTS]>,
+    spill: Vec<(u16, u32)>,
+}
+
+impl Default for TrapWordMap {
+    fn default() -> Self {
+        Self {
+            bands: Box::new([None; Self::SLOTS]),
+            spill: Vec::new(),
+        }
+    }
 }
 
 impl TrapWordMap {
+    const OS_SLOTS: usize = 0x100;
+    const TOOL_SLOTS: usize = 0x400;
+    const SLOTS: usize = Self::OS_SLOTS + Self::TOOL_SLOTS;
+
+    fn slot(trap: u16) -> Option<usize> {
+        match trap {
+            0xA000..=0xA0FF => Some(usize::from(trap - 0xA000)),
+            0xA800..=0xABFF => Some(Self::OS_SLOTS + usize::from(trap - 0xA800)),
+            _ => None,
+        }
+    }
+
     pub(crate) fn get(&self, trap: &u16) -> Option<&u32> {
-        self.entries
-            .iter()
-            .find(|(word, _)| word == trap)
-            .map(|(_, handler)| handler)
+        match Self::slot(*trap) {
+            Some(index) => self.bands[index].as_ref(),
+            None => self
+                .spill
+                .iter()
+                .find(|(word, _)| word == trap)
+                .map(|(_, handler)| handler),
+        }
     }
 
     pub(crate) fn insert(&mut self, trap: u16, handler: u32) -> Option<u32> {
-        match self.entries.iter_mut().find(|(word, _)| *word == trap) {
-            Some(slot) => Some(std::mem::replace(&mut slot.1, handler)),
-            None => {
-                self.entries.push((trap, handler));
-                None
-            }
+        match Self::slot(trap) {
+            Some(index) => self.bands[index].replace(handler),
+            None => match self.spill.iter_mut().find(|(word, _)| *word == trap) {
+                Some(slot) => Some(std::mem::replace(&mut slot.1, handler)),
+                None => {
+                    self.spill.push((trap, handler));
+                    None
+                }
+            },
         }
     }
 
     pub(crate) fn remove(&mut self, trap: &u16) -> Option<u32> {
-        let index = self.entries.iter().position(|(word, _)| word == trap)?;
-        Some(self.entries.swap_remove(index).1)
+        match Self::slot(*trap) {
+            Some(index) => self.bands[index].take(),
+            None => {
+                let index = self.spill.iter().position(|(word, _)| word == trap)?;
+                Some(self.spill.swap_remove(index).1)
+            }
+        }
     }
 
     pub(crate) fn contains_key(&self, trap: &u16) -> bool {
-        self.entries.iter().any(|(word, _)| word == trap)
+        self.get(trap).is_some()
     }
 }
 
@@ -6231,6 +6271,46 @@ mod tests {
         assert_eq!(map.insert(0xA146, 0x4000), Some(0x3000));
         assert_eq!(map.remove(&0xA146), Some(0x4000));
         assert_eq!(map.get(&0xA146), None);
+    }
+
+    #[test]
+    fn trap_word_map_stays_exact_at_full_occupancy_and_off_band() {
+        // SetTrapAddress can populate every slot of both trap tables, so
+        // fill them completely: 256 OS words and 1,024 Toolbox words.
+        let mut map = super::TrapWordMap::default();
+        for os in 0xA000u16..=0xA0FF {
+            assert_eq!(map.insert(os, u32::from(os) | 0x10_0000), None);
+        }
+        for tool in 0xA800u16..=0xABFF {
+            assert_eq!(map.insert(tool, u32::from(tool) | 0x20_0000), None);
+        }
+        // Every lookup is exact at full occupancy — the boundary the
+        // linear-scan design regressed on.
+        for os in 0xA000u16..=0xA0FF {
+            assert_eq!(map.get(&os), Some(&(u32::from(os) | 0x10_0000)));
+        }
+        for tool in 0xA800u16..=0xABFF {
+            assert_eq!(map.get(&tool), Some(&(u32::from(tool) | 0x20_0000)));
+        }
+        // Replacement and removal stay exact with every slot occupied.
+        assert_eq!(map.insert(0xA9F0, 0xDEAD), Some(0xA9F0 | 0x20_0000));
+        assert_eq!(map.remove(&0xA9F0), Some(0xDEAD));
+        assert_eq!(map.get(&0xA9F0), None);
+        assert_eq!(
+            map.get(&0xA9F1),
+            Some(&(0xA9F1 | 0x20_0000)),
+            "neighbors survive"
+        );
+        // The band boundaries themselves: words between the OS and
+        // Toolbox tables, and past the Toolbox table, are storable and
+        // retrievable (spill), and absent ones stay absent.
+        for off_band in [0x01F4u16, 0xA100, 0xA7FF, 0xAC00, 0xFFFF] {
+            assert_eq!(map.get(&off_band), None);
+            assert_eq!(map.insert(off_band, 0xBEEF), None);
+            assert_eq!(map.get(&off_band), Some(&0xBEEF));
+            assert_eq!(map.remove(&off_band), Some(0xBEEF));
+            assert_eq!(map.get(&off_band), None);
+        }
     }
 
     use super::*;

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -6207,6 +6207,32 @@ impl Default for TrapDispatcher {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn trap_word_map_preserves_the_hashmap_contract() {
+        let mut map = super::TrapWordMap::default();
+        // First insert returns None; lookup sees it.
+        assert_eq!(map.insert(0xA9F0, 0x1000), None);
+        assert_eq!(map.get(&0xA9F0), Some(&0x1000));
+        assert_eq!(map.get(&0xA9F1), None, "absent key misses");
+        // Replacement returns the previous handler and keeps one entry.
+        assert_eq!(map.insert(0xA9F0, 0x2000), Some(0x1000));
+        assert_eq!(map.get(&0xA9F0), Some(&0x2000));
+        // A second key coexists.
+        assert_eq!(map.insert(0xA146, 0x3000), None);
+        assert_eq!(map.get(&0xA9F0), Some(&0x2000));
+        assert_eq!(map.get(&0xA146), Some(&0x3000));
+        // Removal returns the value exactly once and clears lookup.
+        assert_eq!(map.remove(&0xA9F0), Some(0x2000));
+        assert_eq!(map.remove(&0xA9F0), None, "second remove is a miss");
+        assert_eq!(map.get(&0xA9F0), None);
+        // The untouched key survives its neighbor's removal.
+        assert_eq!(map.get(&0xA146), Some(&0x3000));
+        // Replace-then-remove on the survivor behaves like HashMap too.
+        assert_eq!(map.insert(0xA146, 0x4000), Some(0x3000));
+        assert_eq!(map.remove(&0xA146), Some(0x4000));
+        assert_eq!(map.get(&0xA146), None);
+    }
+
     use super::*;
     use crate::cpu::{CpuOps, Register};
     use crate::trap::menu::MenuTrackingState;

--- a/src/trap/memory.rs
+++ b/src/trap/memory.rs
@@ -6949,7 +6949,7 @@ mod tests {
             "bare Toolbox trap numbers must install under their canonical A-line word"
         );
         assert!(
-            !dispatcher.native_trap_table.contains_key(&0x01F4),
+            dispatcher.native_trap_table.get(&0x01F4).is_none(),
             "the raw bare trap number is not a dispatchable trap-table key"
         );
     }


### PR DESCRIPTION
Closes #455.

## Summary

`native_trap_table` becomes a **direct-indexed table** over the two
normalized trap bands. Every key producer — dispatch's
`0xA800 | (trap & 0x03FF)` / `0xA000 | (trap & 0x00FF)` and
`trap_address_table_key` behind `SetTrapAddress`/`NSetTrapAddress` in
all its variants — normalizes into the Operating System band
(`0xA000..=0xA0FF`, 256 slots) or the Toolbox band (`0xA800..=0xABFF`,
1,024 slots), so a 1,280-slot array covers the entire reachable key
space: **O(1) at any occupancy**, no hashing, no probe, ~10 KB
allocated once. Off-band keys (which no production caller generates)
go to a spill list so the `HashMap`-shaped contract stays total; the
dispatch path never touches it because its keys are in-band by
construction. All 22 call sites are unchanged.

This revision replaces the linear-scan version reviewed earlier:
`SetTrapAddress` can populate arbitrarily many slots, so a scan made
the hottest dispatch path O(n) in patched-trap count. Direct indexing
is bounded without a threshold heuristic.

The motivation stands: the previous `HashMap` paid SipHash plus a
SwissTable probe per lookup — SipHash dominated hashing samples, and
with a cheap hasher the group probe remained the self-time hotspot of
`dispatch` (`pcmpeqb`/`pmovmskb` in disassembly).

## How this was measured

**Harness:** `systemless --headless --max-instructions 900000000` —
deterministic (no window, no input, no frame pacing), which also means
startup/dialog-weighted and unpaced. **Instrument:** `/usr/bin/sample
<pid> 90 1` (90 s at 1 ms) after warm-up, two independent profiles per
arm. **Metric:** each symbol's share of non-idle self-time samples,
all threads, blocking-wait samples excluded — share rather than wall
clock because the harness kills the process when sampling ends and
wall-clock A/B drifted up to 42% between identical binaries. **Arms:**
base is `master`; the candidate carried all three hygiene changes
(#454, #455, #456) together, so per-change attribution rests on symbol
specificity — the rows below are symbols only this change touches.

Caveat specific to this row: "SipHash share" is whole-process hashing
time — every std `HashMap` with the default hasher contributes — so it
cannot reach zero; the delta is the part this table accounted for.

## Result (measured on exactly this revision, base = current master)

"Hashing frames" below = the standard library's SipHash `write` plus
`BuildHasher::hash_one` dispatcher frames — the out-of-line hashing
cost the default-hasher table paid per lookup.

| metric | base (2 profiles) | with this table |
|---|---:|---:|
| hashing frames, share of non-idle samples | 5.10% / 5.83% | **3.07% / 3.00%** |
| `TrapDispatcher::dispatch` self time | 5.51% / 5.70% | 5.22% / 5.50% |

The candidate arm's spread is 0.07pp and the base arm's 0.73pp; the
conservative delta (worst candidate vs best base, −2.0pp) is roughly
3× the worst spread. Hashing does not reach zero because other
`HashMap`s in the process still hash; the delta is this table's part.

One claim stays downgraded from the earlier round: disassembly showed
the SwissTable probe as `dispatch`'s self-time hotspot, but `dispatch`
self time is flat within noise here too — the measured benefit is the
hashing elimination; probe removal and the bounded worst case are
design properties, the latter guaranteed by the full-occupancy test
rather than by a profile. Gameplay component is direction-only
(hashing ~1% of non-idle gameplay CPU, of which this table is part).

How the design evolved: the first revision used a linear scan on a
"the table holds a handful of entries" assumption, and the review
correctly rejected it — `SetTrapAddress`/`NSetTrapAddress` put the
occupancy in the guest's hands, making every A-line lookup O(n) in
patched-trap count. The scan-era cache argument against direct
indexing (a sparsely touched multi-KB table) only held under that same
guaranteed-tiny-occupancy assumption; with repetition-driven locality
the hot slots stay resident regardless of table size, so direct
indexing wins on every axis that matters here: O(1) at any occupancy,
no hashing, no probe, no threshold heuristic.

## Coverage

Two tests pin the contract:

- The `HashMap` contract the call sites rely on: `insert` returning the
  previous value on replacement and `None` on first insert, `remove`
  returning the removed value exactly once, present/absent lookups, and
  a replace-then-remove sequence.
- **The many-entry boundary**: both bands filled completely (256 OS +
  1,024 Toolbox words), every lookup exact at full occupancy,
  replacement/removal exact with every slot occupied and neighbors
  surviving, plus off-band words (between and beyond the bands)
  storable/removable through the spill and absent otherwise.

## Validation

- `cargo build --release`, `cargo test --release` — full suite green

