### PR TITLE
perf: keep the application-launch path out of the hot loop

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1875,6 +1875,12 @@ impl FixtureRunner {
             .fill_bytes(scrn_base, row_bytes * scrn_height as u32, 0xFF);
     }
 
+    /// Loading an application is a once-per-launch operation, but its caller
+    /// runs on the per-batch path. Left to itself the optimiser inlined this
+    /// whole body there, giving the hot function a 34 KB stack frame; keep it
+    /// out of line so the common case stays a cheap `Option` check.
+    #[cold]
+    #[inline(never)]
     fn switch_to_launched_application(
         &mut self,
         app_path: &str,


### PR DESCRIPTION
Closes #456.

## Summary

Keep the application-launch path out of the hot loop.
`switch_to_launched_application` runs at most once per launch, but the
optimiser inlined its 93-line body into
`service_pending_launch_application` — called from three sites in the
per-batch loop — leaving that function a 34 KB stack frame
(`addq $0x84e8, %rsp` in its epilogue). `#[cold]` `#[inline(never)]`
keeps the common case a cheap `Option` check. Attribute-only; no code
change.

## How this was measured

**Harness:** `systemless --headless --max-instructions 900000000` —
deterministic (no window, no input, no frame pacing), which also means
startup/dialog-weighted and unpaced. **Instrument:** `/usr/bin/sample
<pid> 90 1` (90 s at 1 ms) after warm-up, two independent profiles per
arm. **Metric:** each symbol's share of non-idle self-time samples,
all threads, blocking-wait samples excluded — share rather than wall
clock because the harness kills the process when sampling ends and
wall-clock A/B drifted up to 42% between identical binaries. **Arms:**
base is `master`; the candidate carried all three hygiene changes
(#454, #455, #456) together, so per-change attribution rests on symbol
specificity — the rows below are symbols only this change touches.

## Result

| metric | base (2 profiles) | with fix | base-to-base noise |
|---|---:|---:|---:|
| `service_pending_launch_application` self time | 2.66% / 2.66% | **0.42% / 0.50%** | 0.00pp |

Headless-harness metric; the per-batch loop runs unpaced there. No new
behavior to cover — the change is two attributes on an existing
function; the full suite exercises the launch path as before.

## Validation

- `cargo build --release`, `cargo test --release` — full suite green
