### PR TITLE
fix(input): latch Caps Lock state

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -539,6 +539,7 @@ struct IdleCycleHostSnapshot {
     mouse_pos: (i16, i16),
     mouse_button: bool,
     key_map: [u8; 16],
+    caps_lock_physically_pressed: bool,
 }
 
 impl IdleCycleHostSnapshot {
@@ -547,6 +548,7 @@ impl IdleCycleHostSnapshot {
             mouse_pos: dispatcher.mouse_pos,
             mouse_button: dispatcher.mouse_button,
             key_map: *dispatcher.key_map_bytes(),
+            caps_lock_physically_pressed: dispatcher.caps_lock_physically_pressed,
         }
     }
 }
@@ -7998,6 +8000,28 @@ mod tests {
             0,
             "unused raw byte should stay clear"
         );
+    }
+
+    #[test]
+    fn caps_lock_latch_is_preserved_in_low_memory_keymap() {
+        use crate::memory::globals::addr;
+
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        let caps_lock_byte = addr::KEY_MAP_LM + 7;
+
+        runner.push_key_down(0x39, 0);
+        assert_eq!(runner.bus.read_byte(caps_lock_byte) & 0x02, 0x02);
+        runner.push_key_up(0x39, 0);
+        assert_eq!(
+            runner.bus.read_byte(caps_lock_byte) & 0x02,
+            0x02,
+            "physical release must keep the low-memory Caps Lock bit latched"
+        );
+
+        runner.push_key_down(0x39, 0);
+        assert_eq!(runner.bus.read_byte(caps_lock_byte) & 0x02, 0);
+        runner.push_key_up(0x39, 0);
+        assert_eq!(runner.bus.read_byte(caps_lock_byte) & 0x02, 0);
     }
 
     #[test]

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -1579,6 +1579,10 @@ pub struct TrapDispatcher {
     /// Bits are packed for direct byte/bit readers:
     /// key >> 3 selects the byte, key & 7 selects the bit.
     pub(crate) key_map: [u8; 16],
+    /// Physical Caps Lock press state, kept separately from its logical
+    /// latched bit in `key_map` so a release does not clear the latch and a
+    /// repeated host key-down cannot toggle it twice.
+    pub(crate) caps_lock_physically_pressed: bool,
     /// Auto-key repeat state for the currently repeating character key.
     pub(crate) key_repeat: Option<KeyRepeatState>,
     /// Debug counter for GetKeys calls that observed at least one held key.
@@ -2125,6 +2129,7 @@ pub(crate) struct LoadedResources {
 impl TrapDispatcher {
     pub(crate) const AUTO_KEY_THRESHOLD_TICKS: u32 = 16;
     pub(crate) const AUTO_KEY_RATE_TICKS: u32 = 4;
+    const CAPS_LOCK_KEY_CODE: u8 = 0x39;
 
     pub(crate) fn key_is_modifier(key_code: u8) -> bool {
         // Command, Shift, Caps Lock, Option, and Control (including the
@@ -2695,6 +2700,7 @@ impl TrapDispatcher {
         const BTN_STATE: u16 = 128;
         const CMD_KEY: u16 = 256;
         const SHIFT_KEY: u16 = 512;
+        const ALPHA_LOCK: u16 = 1024;
         const OPTION_KEY: u16 = 2048;
         const CONTROL_KEY: u16 = 4096;
 
@@ -2707,6 +2713,11 @@ impl TrapDispatcher {
         }
         if self.key_is_down(0x38) || self.key_is_down(0x3C) {
             modifiers |= SHIFT_KEY;
+        }
+        // EventRecord.modifiers exposes the logical Caps Lock latch through
+        // alphaLock. Inside Macintosh Volume I (1985), p. I-263.
+        if self.key_is_down(Self::CAPS_LOCK_KEY_CODE) {
+            modifiers |= ALPHA_LOCK;
         }
         if self.key_is_down(0x3A) || self.key_is_down(0x3D) {
             modifiers |= OPTION_KEY;
@@ -3028,6 +3039,7 @@ impl TrapDispatcher {
             mouse_pos: (0, 0),
             mouse_button: false,
             key_map: [0; 16],
+            caps_lock_physically_pressed: false,
             key_repeat: None,
             debug_getkeys_nonzero_count: 0,
             debug_last_getkeys_nonzero_key_map: [0; 16],
@@ -4512,10 +4524,21 @@ impl TrapDispatcher {
         // classic Event Manager represents those repeats as autoKey events.
         // Inside Macintosh Volume I, I-246. Ignore duplicate host callbacks
         // so they cannot enqueue extra keyDown records or restart autoKey.
-        if self.key_is_down(key_code) {
-            return;
+        if key_code == Self::CAPS_LOCK_KEY_CODE {
+            if self.caps_lock_physically_pressed {
+                return;
+            }
+            self.caps_lock_physically_pressed = true;
+            // Caps Lock latches on one physical press and releases on the
+            // next. Inside Macintosh Volume I (1985), p. I-34.
+            let latched = !self.key_is_down(key_code);
+            set_key_map_key(&mut self.key_map, key_code, latched);
+        } else {
+            if self.key_is_down(key_code) {
+                return;
+            }
+            set_key_map_key(&mut self.key_map, key_code, true);
         }
-        set_key_map_key(&mut self.key_map, key_code, true);
         let modifiers = self.current_event_modifiers();
         if trace_input_enabled() {
             eprintln!(
@@ -4550,7 +4573,11 @@ impl TrapDispatcher {
 
     /// Push a key-up event into the event queue.
     pub fn push_key_up(&mut self, key_code: u8, char_code: u8) {
-        set_key_map_key(&mut self.key_map, key_code, false);
+        if key_code == Self::CAPS_LOCK_KEY_CODE {
+            self.caps_lock_physically_pressed = false;
+        } else {
+            set_key_map_key(&mut self.key_map, key_code, false);
+        }
         if self
             .key_repeat
             .is_some_and(|repeat| repeat.key_code == key_code)

--- a/src/trap/event.rs
+++ b/src/trap/event.rs
@@ -1341,6 +1341,66 @@ mod tests {
     }
 
     #[test]
+    fn caps_lock_latches_keymap_and_alpha_lock_until_second_press() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        disp.sent_open_app_event = true;
+
+        disp.push_key_down(0x39, 0);
+        assert!(disp.key_is_down(0x39), "first press should latch Caps Lock");
+        assert_eq!(disp.current_event_modifiers() & 0x0400, 0x0400);
+        assert!(
+            !disp
+                .dequeue_toolbox_event(&mut cpu, &mut bus, 0x0008)
+                .5,
+            "Caps Lock must not post a standalone keyDown event"
+        );
+
+        disp.push_key_down(0x39, 0);
+        assert!(
+            disp.key_is_down(0x39),
+            "a repeated host keydown while physically held must not toggle the latch"
+        );
+        disp.push_key_up(0x39, 0);
+        assert!(
+            disp.key_is_down(0x39),
+            "physical release must preserve the logical Caps Lock latch"
+        );
+        assert_eq!(disp.current_event_modifiers() & 0x0400, 0x0400);
+        disp.push_key_down(0x00, b'a');
+        let (what, _, _, _, modifiers, has_event) =
+            disp.dequeue_toolbox_event(&mut cpu, &mut bus, 0x0008);
+        assert!(has_event);
+        assert_eq!(what, 3);
+        assert_eq!(
+            modifiers & 0x0400,
+            0x0400,
+            "character events must carry alphaLock while Caps Lock is latched"
+        );
+        disp.push_key_up(0x00, b'a');
+
+        disp.push_key_down(0x39, 0);
+        assert!(
+            !disp.key_is_down(0x39),
+            "second physical press should release Caps Lock"
+        );
+        assert_eq!(disp.current_event_modifiers() & 0x0400, 0);
+        disp.push_key_up(0x39, 0);
+        assert!(
+            !disp.key_is_down(0x39),
+            "second physical release must leave Caps Lock clear"
+        );
+        disp.push_key_down(0x00, b'a');
+        let (_, _, _, _, modifiers, has_event) =
+            disp.dequeue_toolbox_event(&mut cpu, &mut bus, 0x0008);
+        assert!(has_event);
+        assert_eq!(
+            modifiers & 0x0400,
+            0,
+            "character events must clear alphaLock after Caps Lock is released"
+        );
+    }
+
+    #[test]
     fn command_modifier_is_reported_on_following_character_event() {
         let (mut disp, mut cpu, mut bus) = setup();
         disp.sent_open_app_event = true;


### PR DESCRIPTION
## Summary

- model Caps Lock as a logical latch toggled by physical key-down edges
- keep physical debounce state separate so host repeats cannot toggle the latch twice
- expose the latched state through both the classic `KeyMap` bit and `alphaLock` event modifier
- include the physical state in idle-cycle input snapshots

## Root cause

The generic keyboard path treated virtual key `0x39` like an ordinary held modifier. Key-up cleared its `KeyMap` bit, `alphaLock` was never added to event modifiers, and the logical bit also acted as the duplicate-key-down guard. That made the state follow the physical button instead of the classic locking-key behavior.

## User impact

Caps Lock now remains active after release and turns off on the next press. Applications that poll `GetKeys`, read the low-memory `KeyMap`, or inspect `EventRecord.modifiers` observe the same logical state.

## Validation

- `cargo test --lib caps_lock_ -- --nocapture`
- `cargo test --lib` (2,939 passed; 3 ignored)
- `cargo check --no-default-features`
- full 215-action Escape Velocity live-space controls play script; the `2x` indicator remained visible after physical release and disappeared on the second press

Closes #462