### PR TITLE
fix(device): hide unavailable AppleTalk drivers

### DIFF
--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -216,11 +216,11 @@ impl super::TrapDispatcher {
     pub(crate) const RES_MAP_CHANGED_ATTR: u16 = 0x0020;
     pub(crate) const RES_MAP_READ_ONLY_ATTR: u16 = 0x0080;
 
-    fn is_synthetic_driver_name(filename: &str) -> bool {
-        matches!(
-            filename,
-            ".AIn" | ".AOut" | ".BIn" | ".BOut" | ".MPP" | ".ATP" | ".XPP"
-        )
+    fn is_available_synthetic_driver_name(filename: &str) -> bool {
+        // Driver presence is a capability probe. Keep this list limited to
+        // services backed by the HLE: AppleTalk's .MPP/.ATP/.XPP drivers must
+        // remain absent until their control, status, and protocol paths exist.
+        matches!(filename, ".AIn" | ".AOut" | ".BIn" | ".BOut")
     }
 
     fn address_is_loaded_code(&self, address: u32) -> bool {
@@ -3774,7 +3774,7 @@ impl super::TrapDispatcher {
                     bus.write_word(pb + 16, 0); // noErr
                     cpu.write_reg(Register::D0, 0);
                     eprintln!("[TRAP] PBOpen -> refnum={} vfs=\"{}\"", refnum, vfs_name);
-                } else if Self::is_synthetic_driver_name(&filename) {
+                } else if Self::is_available_synthetic_driver_name(&filename) {
                     let refnum = self.next_refnum;
                     self.next_refnum += 1;
                     self.synthetic_drivers.insert(refnum, filename.clone());
@@ -13205,6 +13205,28 @@ mod tests {
         call(&mut disp, false, 0x01, &mut cpu, &mut bus).unwrap();
         assert_eq!(cpu.read_reg(Register::D0), 0);
         assert!(!disp.synthetic_drivers.contains_key(&refnum));
+    }
+
+    #[test]
+    fn pbopen_does_not_advertise_unavailable_appletalk_drivers() {
+        for driver_name in [
+            b".MPP".as_slice(),
+            b".ATP".as_slice(),
+            b".XPP".as_slice(),
+        ] {
+            let (mut disp, mut cpu, mut bus) = setup();
+            let pb = 0x300000u32;
+            setup_param_block(&mut bus, &mut cpu, pb, driver_name);
+            bus.write_word(pb + 16, 0x7FFF);
+            bus.write_word(pb + 24, 0x7FFF);
+
+            call(&mut disp, false, 0x00, &mut cpu, &mut bus).unwrap();
+
+            assert_eq!(cpu.read_reg(Register::D0), (-43i32) as u32);
+            assert_eq!(bus.read_word(pb + 16), (-43i16) as u16);
+            assert_eq!(bus.read_word(pb + 24), 0);
+            assert!(disp.synthetic_drivers.is_empty());
+        }
     }
 
     // ================================================================

--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -220,7 +220,15 @@ impl super::TrapDispatcher {
         // Driver presence is a capability probe. Keep this list limited to
         // services backed by the HLE: AppleTalk's .MPP/.ATP/.XPP drivers must
         // remain absent until their control, status, and protocol paths exist.
-        matches!(filename, ".AIn" | ".AOut" | ".BIn" | ".BOut")
+        [".AIn", ".AOut", ".BIn", ".BOut"]
+            .iter()
+            .any(|driver| filename.eq_ignore_ascii_case(driver))
+    }
+
+    fn is_unavailable_appletalk_driver_name(filename: &str) -> bool {
+        [".MPP", ".ATP", ".XPP"]
+            .iter()
+            .any(|driver| filename.eq_ignore_ascii_case(driver))
     }
 
     fn address_is_loaded_code(&self, address: u32) -> bool {
@@ -3785,6 +3793,13 @@ impl super::TrapDispatcher {
                         "[TRAP] PBOpen -> synthetic driver refnum={} name=\"{}\"",
                         refnum, filename
                     );
+                } else if Self::is_unavailable_appletalk_driver_name(&filename) {
+                    // A missing Device Manager driver reports dInstErr, not
+                    // the File Manager's fnfErr (Inside Macintosh Volume II,
+                    // II-183).
+                    eprintln!("[TRAP] PBOpen: driver is not installed");
+                    bus.write_word(pb + 16, (-26i16) as u16); // dInstErr
+                    cpu.write_reg(Register::D0, (-26i32) as u32);
                 } else {
                     eprintln!("[TRAP] PBOpen: file not found in VFS");
                     bus.write_word(pb + 16, (-43i16) as u16); // fnfErr
@@ -13181,7 +13196,7 @@ mod tests {
     fn pbopen_synthetic_driver_refnum_supports_read_write_close() {
         let (mut disp, mut cpu, mut bus) = setup();
         let pb = 0x300000u32;
-        setup_param_block(&mut bus, &mut cpu, pb, b".AIn");
+        setup_param_block(&mut bus, &mut cpu, pb, b".ain");
 
         call(&mut disp, false, 0x00, &mut cpu, &mut bus).unwrap();
 
@@ -13209,11 +13224,7 @@ mod tests {
 
     #[test]
     fn pbopen_does_not_advertise_unavailable_appletalk_drivers() {
-        for driver_name in [
-            b".MPP".as_slice(),
-            b".ATP".as_slice(),
-            b".XPP".as_slice(),
-        ] {
+        for driver_name in [b".mpp".as_slice(), b".AtP".as_slice(), b".xPp".as_slice()] {
             let (mut disp, mut cpu, mut bus) = setup();
             let pb = 0x300000u32;
             setup_param_block(&mut bus, &mut cpu, pb, driver_name);
@@ -13222,8 +13233,8 @@ mod tests {
 
             call(&mut disp, false, 0x00, &mut cpu, &mut bus).unwrap();
 
-            assert_eq!(cpu.read_reg(Register::D0), (-43i32) as u32);
-            assert_eq!(bus.read_word(pb + 16), (-43i16) as u16);
+            assert_eq!(cpu.read_reg(Register::D0), (-26i32) as u32);
+            assert_eq!(bus.read_word(pb + 16), (-26i16) as u16);
             assert_eq!(bus.read_word(pb + 24), 0);
             assert!(disp.synthetic_drivers.is_empty());
         }
@@ -13246,6 +13257,8 @@ mod tests {
             (-43i32) as u32,
             "D0 should be fnfErr"
         );
+        assert_eq!(bus.read_word(pb + 16), (-43i16) as u16);
+        assert_eq!(bus.read_word(pb + 24), 0);
     }
 
     // ================================================================


### PR DESCRIPTION
## Summary

- stop advertising `.MPP`, `.ATP`, and `.XPP` as available synthetic drivers
- return Device Manager `dInstErr` for those unavailable driver names while ordinary missing files retain File Manager `fnfErr`
- keep the modeled serial input/output drivers available
- add regression coverage proving unavailable AppleTalk opens clear `ioRefNum` and install no synthetic driver

## Root cause

The synthetic-driver allowlist treated AppleTalk driver names as equivalent to modeled serial drivers. `PBOpen(".MPP")` therefore returned `noErr` and a positive refnum even though Systemless has no AppleTalk control, status, or protocol implementation. Applications interpreted that successful open as a usable networking capability.

The allowlist now represents only services backed by the HLE, and missing Device Manager driver names follow the documented driver-installation error path.

## Validation

- `cargo test --lib pbopen_does_not_advertise_unavailable_appletalk_drivers`
- `cargo test --lib pb_open_not_found`
- `cargo test --lib pbopen_synthetic_driver_refnum_supports_read_write_close`
- `cargo test --lib` (2,941 passed; 3 ignored)
- `cargo check --no-default-features`

Closes #484