### PR TITLE
fix(sound): dispatch legacy Sound Driver writes

### DIFF
--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -1351,6 +1351,9 @@ pub struct TrapDispatcher {
     pub(crate) open_files: HashMap<u16, String>,
     /// Synthetic Device Manager drivers opened by name via PBOpen/OpenDriver.
     pub(crate) synthetic_drivers: HashMap<u16, String>,
+    /// Guest SndChannel storage used by writes to the ROM Sound Driver
+    /// reference number (-4). Allocated lazily on the first StartSound write.
+    pub(crate) legacy_sound_driver_channel: Option<u32>,
     /// Refnums opened with write permission (fsRdWrPerm=3 or fsWrPerm=2).
     /// Used to enforce opWrErr (-49) per IM:Files 9578.
     pub(crate) write_refnums: std::collections::HashSet<u16>,
@@ -2958,6 +2961,7 @@ impl TrapDispatcher {
             working_directories: HashMap::new(),
             open_files: HashMap::new(),
             synthetic_drivers: HashMap::new(),
+            legacy_sound_driver_channel: None,
             write_refnums: HashSet::new(),
             file_positions: HashMap::new(),
             recent_file_read: None,

--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -3918,8 +3918,22 @@ impl super::TrapDispatcher {
                 let pos_offset = bus.read_long(pb + 46) as i32;
                 eprintln!(
                     "[TRAP] FSWrite ref={} buf=${:08X} count={} posMode={} posOff={}",
-                    ref_num, buffer, request_count, pos_mode, pos_offset
+                    ref_num as i16, buffer, request_count, pos_mode, pos_offset
                 );
+
+                let signed_ref_num = ref_num as i16;
+                if signed_ref_num < 0 {
+                    let result =
+                        self.write_device_driver(bus, signed_ref_num, buffer, request_count);
+                    let (err, actual_count) = match result {
+                        Ok(actual_count) => (0i16, actual_count),
+                        Err(err) => (err, 0),
+                    };
+                    bus.write_long(pb + 40, actual_count as u32);
+                    bus.write_word(pb + 16, err as u16);
+                    cpu.write_reg(Register::D0, err as i32 as u32);
+                    return Some(Ok(()));
+                }
 
                 let Some(filename) = self.open_files.get(&ref_num).cloned() else {
                     if self.synthetic_drivers.contains_key(&ref_num) {
@@ -13471,6 +13485,52 @@ mod tests {
         assert_eq!(bus.read_long(pb + 40), 4);
         let file_data = disp.vfs.get("WriteMe").unwrap();
         assert_eq!(file_data, &[0xAA, 0xBB, 0xCC, 0xDD]);
+    }
+
+    #[test]
+    fn fs_write_dispatches_signed_sound_driver_refnum_to_audio() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let pb = 0x300000u32;
+        let synth = 0x310000u32;
+        cpu.write_reg(Register::A0, pb);
+        bus.write_word(pb + 24, (-4i16) as u16); // .Sound driver
+        bus.write_long(pb + 32, synth);
+        bus.write_long(pb + 36, 5_024);
+        bus.write_byte(crate::memory::globals::addr::SD_VOLUME, 7);
+
+        bus.write_word(synth, 0); // ffMode
+        bus.write_long(synth + 2, 0x0000_8000); // half-rate sampling factor
+        for offset in 0..5_018u32 {
+            bus.write_byte(synth + 6 + offset, (offset & 0xFF) as u8);
+        }
+
+        call(&mut disp, false, 0x03, &mut cpu, &mut bus).unwrap();
+
+        assert_eq!(cpu.read_reg(Register::D0), 0);
+        assert_eq!(bus.read_word(pb + 16), 0);
+        assert_eq!(bus.read_long(pb + 40), 5_024);
+        assert_eq!(disp.sound_manager.channels.len(), 1);
+        let mixed = disp.sound_manager.mix_frame(512);
+        assert!(!mixed.is_empty());
+        assert!(mixed.iter().any(|sample| *sample != 0x80));
+    }
+
+    #[test]
+    fn fs_write_routes_unknown_negative_refnum_through_device_manager() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let pb = 0x300000u32;
+        cpu.write_reg(Register::A0, pb);
+        bus.write_word(pb + 24, (-7i16) as u16);
+        bus.write_long(pb + 32, 0x310000);
+        bus.write_long(pb + 36, 4);
+        bus.write_long(pb + 40, 0xFFFF_FFFF);
+
+        call(&mut disp, false, 0x03, &mut cpu, &mut bus).unwrap();
+
+        assert_eq!(cpu.read_reg(Register::D0), (-21i32) as u32); // badUnitErr
+        assert_eq!(bus.read_word(pb + 16), (-21i16) as u16);
+        assert_eq!(bus.read_long(pb + 40), 0);
+        assert!(disp.sound_manager.channels.is_empty());
     }
 
     #[test]

--- a/src/trap/sound.rs
+++ b/src/trap/sound.rs
@@ -242,11 +242,14 @@ impl super::TrapDispatcher {
             return Err(PARAM_ERR);
         }
 
+        // FTSoundRec phases are byte offsets into their 256-byte waveforms,
+        // while rates are 16.16 fixed-point increments (Inside Macintosh
+        // Volume II, II-227). Normalize both into the same accumulator scale.
         let mut phases = [
-            u64::from(bus.read_long(record + 6)),
-            u64::from(bus.read_long(record + 14)),
-            u64::from(bus.read_long(record + 22)),
-            u64::from(bus.read_long(record + 30)),
+            u64::from(bus.read_long(record + 6)) << 16,
+            u64::from(bus.read_long(record + 14)) << 16,
+            u64::from(bus.read_long(record + 22)) << 16,
+            u64::from(bus.read_long(record + 30)) << 16,
         ];
         let rates = [
             u64::from(bus.read_long(record + 2)),
@@ -2995,6 +2998,34 @@ mod tests {
         let four_tone_mix = disp.sound_manager.mix_frame(128);
         assert!(four_tone_mix.iter().any(|sample| *sample != 0x80));
         assert_eq!(disp.sound_manager.channels.len(), 1);
+    }
+
+    #[test]
+    fn four_tone_phase_is_a_waveform_byte_offset() {
+        let (_disp, _cpu, mut bus) = setup();
+        let synth = 0x310000;
+        let record = 0x311000;
+        let wave = 0x312000;
+        bus.write_word(synth, 1);
+        bus.write_long(synth + 2, record);
+        bus.write_word(record, 1);
+        bus.write_long(record + 2, 0);
+        bus.write_long(record + 6, 1);
+        for voice in 1..4u32 {
+            bus.write_long(record + 2 + voice * 8, 0);
+            bus.write_long(record + 6 + voice * 8, 0);
+        }
+        bus.write_long(record + 34, wave);
+        bus.write_long(record + 38, 0);
+        bus.write_long(record + 42, 0);
+        bus.write_long(record + 46, 0);
+        bus.write_byte(wave, 0x20);
+        bus.write_byte(wave + 1, 0xE0);
+
+        let (samples, _) =
+            super::super::TrapDispatcher::decode_four_tone_synth(&bus, synth, 6).unwrap();
+
+        assert_eq!(samples[0], 0xE0);
     }
 
     /// Locks in `parse_aiff_samples` end-to-end decoding — the entry

--- a/src/trap/sound.rs
+++ b/src/trap/sound.rs
@@ -27,6 +27,9 @@ const SAMPLED_SYNTH_ID: i16 = 5;
 const SOUND_MANAGER_3_SYNTH_VERSION: u32 = 0x0003_0000;
 const SOUND_DRIVER_REF_NUM: i16 = -4;
 const LEGACY_SOUND_SAMPLE_RATE: u32 = 22_257;
+/// Maximum mono PCM retained for one decoded legacy Sound Driver request.
+/// Compact tone records can otherwise expand to hours of host-side audio.
+const LEGACY_SOUND_DECODE_LIMIT_SAMPLES: usize = sound::OUTPUT_RATE as usize * 60;
 const BAD_UNIT_ERR: i16 = -21;
 const WRITE_ERR: i16 = -20;
 const PARAM_ERR: i16 = -50;
@@ -133,7 +136,9 @@ impl super::TrapDispatcher {
                 return Err(MEM_FULL_ERR);
             }
             self.clear_guest_sound_channel_state(bus, ptr);
-            self.sound_manager.channels.push(SndChannel::new(ptr, false));
+            self.sound_manager
+                .channels
+                .push(SndChannel::new(ptr, false));
             self.legacy_sound_driver_channel = Some(ptr);
             ptr
         };
@@ -169,7 +174,10 @@ impl super::TrapDispatcher {
         if sampling_factor == 0 {
             return Err(PARAM_ERR);
         }
-        let samples = bus.read_bytes(buffer + 6, request_count - 6);
+        let sample_count = request_count.checked_sub(6).ok_or(PARAM_ERR)?;
+        let mut samples = Self::reserve_legacy_sound_samples(sample_count)?;
+        samples.resize(sample_count, 0);
+        bus.read_bytes_into(buffer + 6, &mut samples);
         let sample_rate_fixed = (u64::from(LEGACY_SOUND_SAMPLE_RATE)
             .saturating_mul(u64::from(sampling_factor)))
         .min(u64::from(u32::MAX)) as u32;
@@ -184,8 +192,8 @@ impl super::TrapDispatcher {
         if request_count < 8 {
             return Err(PARAM_ERR);
         }
-        let mut samples = Vec::new();
         let triplet_count = (request_count - 2) / 6;
+        let mut total_sample_count = 0usize;
         for index in 0..triplet_count {
             let tone = buffer + 2 + index as u32 * 6;
             let count = bus.read_word(tone);
@@ -195,15 +203,39 @@ impl super::TrapDispatcher {
                 break;
             }
 
-            let sample_count = (u64::from(sound::OUTPUT_RATE) * u64::from(duration) / 60)
-                .min(usize::MAX as u64) as usize;
+            let sample_count = (sound::OUTPUT_RATE as usize)
+                .checked_mul(usize::from(duration))
+                .ok_or(MEM_FULL_ERR)?
+                / 60;
+            total_sample_count = total_sample_count
+                .checked_add(sample_count)
+                .filter(|total| *total <= LEGACY_SOUND_DECODE_LIMIT_SAMPLES)
+                .ok_or(MEM_FULL_ERR)?;
+        }
+        if total_sample_count == 0 {
+            return Err(PARAM_ERR);
+        }
+
+        let mut samples = Self::reserve_legacy_sound_samples(total_sample_count)?;
+        for index in 0..triplet_count {
+            let tone = buffer + 2 + index as u32 * 6;
+            let count = bus.read_word(tone);
+            let amplitude = bus.read_word(tone + 2);
+            let duration = bus.read_word(tone + 4);
+            if count == 0 && amplitude == 0 && duration == 0 {
+                break;
+            }
+
+            let sample_count = (sound::OUTPUT_RATE as usize)
+                .checked_mul(usize::from(duration))
+                .ok_or(MEM_FULL_ERR)?
+                / 60;
             let half_period = if count == 0 {
                 usize::MAX
             } else {
                 ((u64::from(sound::OUTPUT_RATE) * u64::from(count)) / (2 * 783_360)).max(1) as usize
             };
             let magnitude = i32::from(amplitude.min(255)) / 2;
-            samples.reserve(sample_count);
             for sample in 0..sample_count {
                 let polarity = if (sample / half_period) & 1 == 0 {
                     1
@@ -213,9 +245,7 @@ impl super::TrapDispatcher {
                 samples.push((0x80 + polarity * magnitude).clamp(0, 255) as u8);
             }
         }
-        if samples.is_empty() {
-            return Err(PARAM_ERR);
-        }
+        debug_assert_eq!(samples.len(), total_sample_count);
         Ok((samples, sound::OUTPUT_RATE << 16))
     }
 
@@ -236,11 +266,14 @@ impl super::TrapDispatcher {
             return Err(PARAM_ERR);
         }
         let duration = bus.read_word(record);
-        let sample_count = (u64::from(sound::OUTPUT_RATE) * u64::from(duration) / 60)
-            .min(usize::MAX as u64) as usize;
+        let sample_count = (sound::OUTPUT_RATE as usize)
+            .checked_mul(usize::from(duration))
+            .ok_or(MEM_FULL_ERR)?
+            / 60;
         if sample_count == 0 {
             return Err(PARAM_ERR);
         }
+        let mut samples = Self::reserve_legacy_sound_samples(sample_count)?;
 
         // FTSoundRec phases are byte offsets into their 256-byte waveforms,
         // while rates are 16.16 fixed-point increments (Inside Macintosh
@@ -266,18 +299,15 @@ impl super::TrapDispatcher {
         if waves.iter().all(|wave| *wave == 0) {
             return Err(PARAM_ERR);
         }
-        if waves.iter().any(|wave| {
-            *wave != 0
-                && wave
-                    .checked_add(256)
-                    .is_none_or(|end| end > bus.ram_size())
-        }) {
+        if waves
+            .iter()
+            .any(|wave| *wave != 0 && wave.checked_add(256).is_none_or(|end| end > bus.ram_size()))
+        {
             return Err(PARAM_ERR);
         }
 
         let hardware_to_output =
             ((u64::from(LEGACY_SOUND_SAMPLE_RATE)) << 16) / u64::from(sound::OUTPUT_RATE);
-        let mut samples = Vec::with_capacity(sample_count);
         for _ in 0..sample_count {
             let mut sum = 0i32;
             let mut voices = 0i32;
@@ -295,6 +325,17 @@ impl super::TrapDispatcher {
             samples.push((mixed + 0x80).clamp(0, 255) as u8);
         }
         Ok((samples, sound::OUTPUT_RATE << 16))
+    }
+
+    fn reserve_legacy_sound_samples(sample_count: usize) -> std::result::Result<Vec<u8>, i16> {
+        if sample_count > LEGACY_SOUND_DECODE_LIMIT_SAMPLES {
+            return Err(MEM_FULL_ERR);
+        }
+        let mut samples = Vec::new();
+        samples
+            .try_reserve_exact(sample_count)
+            .map_err(|_| MEM_FULL_ERR)?;
+        Ok(samples)
     }
 
     fn clear_guest_sound_channel_state(&self, bus: &mut MacMemoryBus, chan_ptr: u32) {
@@ -2875,7 +2916,7 @@ mod tests {
         decode_double_buffer_samples, decode_mace3_mono_to_u8, decode_mace6_mono_to_u8,
         extended80_to_f64, parse_aiff_samples, synth_sys_beep_samples,
         GUEST_SND_CHANNEL_Q_HEAD_OFFSET, GUEST_SND_CHANNEL_Q_LENGTH_OFFSET,
-        GUEST_SND_CHANNEL_Q_TAIL_OFFSET, GUEST_SND_CHANNEL_SIZE, SAMPLED_SYNTH_ID,
+        GUEST_SND_CHANNEL_Q_TAIL_OFFSET, GUEST_SND_CHANNEL_SIZE, MEM_FULL_ERR, SAMPLED_SYNTH_ID,
         SOUND_MANAGER_3_SYNTH_VERSION,
     };
     use crate::cpu::{CpuOps, Register};
@@ -2957,9 +2998,21 @@ mod tests {
     }
 
     #[test]
-    fn legacy_sound_driver_decodes_square_and_four_tone_synths() {
+    fn legacy_sound_driver_decodes_supported_synths() {
         let (mut disp, _cpu, mut bus) = setup();
         bus.write_byte(crate::memory::globals::addr::SD_VOLUME, 7);
+
+        let free_form = 0x2F0000;
+        bus.write_word(free_form, 0);
+        bus.write_long(free_form + 2, 0x0001_0000);
+        bus.write_bytes(free_form + 6, &[0x20, 0xE0, 0x20, 0xE0]);
+
+        assert_eq!(
+            disp.write_device_driver(&mut bus, -4, free_form, 10),
+            Ok(10)
+        );
+        let free_form_mix = disp.sound_manager.mix_frame(4);
+        assert!(free_form_mix.iter().any(|sample| *sample != 0x80));
 
         let square = 0x300000;
         bus.write_word(square, (-1i16) as u16);
@@ -2998,6 +3051,26 @@ mod tests {
         let four_tone_mix = disp.sound_manager.mix_frame(128);
         assert!(four_tone_mix.iter().any(|sample| *sample != 0x80));
         assert_eq!(disp.sound_manager.channels.len(), 1);
+    }
+
+    #[test]
+    fn square_wave_synth_rejects_oversized_decoded_output() {
+        let (mut disp, _cpu, mut bus) = setup();
+        let square = 0x300000;
+        bus.write_word(square, (-1i16) as u16);
+        for index in 0..2u32 {
+            let tone = square + 2 + index * 6;
+            bus.write_word(tone, 14_243);
+            bus.write_word(tone + 2, 255);
+            bus.write_word(tone + 4, u16::MAX);
+        }
+
+        assert_eq!(
+            disp.write_device_driver(&mut bus, -4, square, 14),
+            Err(MEM_FULL_ERR)
+        );
+        assert!(disp.sound_manager.channels.is_empty());
+        assert_eq!(disp.legacy_sound_driver_channel, None);
     }
 
     #[test]

--- a/src/trap/sound.rs
+++ b/src/trap/sound.rs
@@ -25,6 +25,12 @@ const SQUARE_WAVE_SYNTH_ID: i16 = 1;
 const WAVE_TABLE_SYNTH_ID: i16 = 3;
 const SAMPLED_SYNTH_ID: i16 = 5;
 const SOUND_MANAGER_3_SYNTH_VERSION: u32 = 0x0003_0000;
+const SOUND_DRIVER_REF_NUM: i16 = -4;
+const LEGACY_SOUND_SAMPLE_RATE: u32 = 22_257;
+const BAD_UNIT_ERR: i16 = -21;
+const WRITE_ERR: i16 = -20;
+const PARAM_ERR: i16 = -50;
+const MEM_FULL_ERR: i16 = -108;
 
 use std::sync::OnceLock;
 static TRACE_SOUND: OnceLock<bool> = OnceLock::new();
@@ -72,6 +78,222 @@ fn synth_sys_beep_samples() -> Vec<u8> {
 }
 
 impl super::TrapDispatcher {
+    /// Dispatch a Device Manager write selected by a signed driver refnum.
+    /// Negative refnums identify unit-table drivers; the ROM Sound Driver is
+    /// unit 3/refnum -4. Unknown negative units are not File Manager paths.
+    pub(crate) fn write_device_driver(
+        &mut self,
+        bus: &mut MacMemoryBus,
+        ref_num: i16,
+        buffer: u32,
+        request_count: usize,
+    ) -> std::result::Result<usize, i16> {
+        match ref_num {
+            SOUND_DRIVER_REF_NUM => {
+                self.write_legacy_sound_driver(bus, buffer, request_count)?;
+                Ok(request_count)
+            }
+            _ => Err(BAD_UNIT_ERR),
+        }
+    }
+
+    /// Decode a Sound Driver synthesizer buffer and submit it to the existing
+    /// PCM mixer. StartSound is defined as a Device Manager Write with
+    /// ioRefNum=-4, ioBuffer=synthRec, and ioReqCount=numBytes.
+    /// Inside Macintosh Volume II (1985), pp. II-228 to II-232.
+    fn write_legacy_sound_driver(
+        &mut self,
+        bus: &mut MacMemoryBus,
+        buffer: u32,
+        request_count: usize,
+    ) -> std::result::Result<(), i16> {
+        let request_count_u32 = u32::try_from(request_count).map_err(|_| PARAM_ERR)?;
+        if buffer == 0
+            || request_count < 2
+            || buffer
+                .checked_add(request_count_u32)
+                .is_none_or(|end| end > bus.ram_size())
+        {
+            return Err(PARAM_ERR);
+        }
+
+        let mode = bus.read_word(buffer) as i16;
+        let (samples, sample_rate_fixed) = match mode {
+            0 => Self::decode_free_form_synth(bus, buffer, request_count)?,
+            -1 => Self::decode_square_wave_synth(bus, buffer, request_count)?,
+            1 => Self::decode_four_tone_synth(bus, buffer, request_count)?,
+            _ => return Err(WRITE_ERR),
+        };
+
+        let channel_ptr = if let Some(ptr) = self.legacy_sound_driver_channel {
+            ptr
+        } else {
+            let ptr = bus.alloc_synthetic(GUEST_SND_CHANNEL_SIZE);
+            if ptr == 0 {
+                return Err(MEM_FULL_ERR);
+            }
+            self.clear_guest_sound_channel_state(bus, ptr);
+            self.sound_manager.channels.push(SndChannel::new(ptr, false));
+            self.legacy_sound_driver_channel = Some(ptr);
+            ptr
+        };
+
+        let level = u32::from(bus.read_byte(crate::memory::globals::addr::SD_VOLUME) & 7);
+        let gain = level * 0x0100 / 7;
+        let packed_gain = gain | (gain << 16);
+        let channel = self
+            .sound_manager
+            .find_channel_mut(channel_ptr)
+            .ok_or(WRITE_ERR)?;
+        channel.set_volume(packed_gain);
+        channel.play_buffer(samples, sample_rate_fixed, sound::PlaybackKind::Buffer, 0);
+
+        if trace_sound_enabled() {
+            eprintln!(
+                "[SOUND] Sound Driver write mode={} bytes={} rate=${:08X} channel=${:08X}",
+                mode, request_count, sample_rate_fixed, channel_ptr
+            );
+        }
+        Ok(())
+    }
+
+    fn decode_free_form_synth(
+        bus: &MacMemoryBus,
+        buffer: u32,
+        request_count: usize,
+    ) -> std::result::Result<(Vec<u8>, u32), i16> {
+        if request_count <= 6 {
+            return Err(PARAM_ERR);
+        }
+        let sampling_factor = bus.read_long(buffer + 2);
+        if sampling_factor == 0 {
+            return Err(PARAM_ERR);
+        }
+        let samples = bus.read_bytes(buffer + 6, request_count - 6);
+        let sample_rate_fixed = (u64::from(LEGACY_SOUND_SAMPLE_RATE)
+            .saturating_mul(u64::from(sampling_factor)))
+        .min(u64::from(u32::MAX)) as u32;
+        Ok((samples, sample_rate_fixed))
+    }
+
+    fn decode_square_wave_synth(
+        bus: &MacMemoryBus,
+        buffer: u32,
+        request_count: usize,
+    ) -> std::result::Result<(Vec<u8>, u32), i16> {
+        if request_count < 8 {
+            return Err(PARAM_ERR);
+        }
+        let mut samples = Vec::new();
+        let triplet_count = (request_count - 2) / 6;
+        for index in 0..triplet_count {
+            let tone = buffer + 2 + index as u32 * 6;
+            let count = bus.read_word(tone);
+            let amplitude = bus.read_word(tone + 2);
+            let duration = bus.read_word(tone + 4);
+            if count == 0 && amplitude == 0 && duration == 0 {
+                break;
+            }
+
+            let sample_count = (u64::from(sound::OUTPUT_RATE) * u64::from(duration) / 60)
+                .min(usize::MAX as u64) as usize;
+            let half_period = if count == 0 {
+                usize::MAX
+            } else {
+                ((u64::from(sound::OUTPUT_RATE) * u64::from(count)) / (2 * 783_360)).max(1) as usize
+            };
+            let magnitude = i32::from(amplitude.min(255)) / 2;
+            samples.reserve(sample_count);
+            for sample in 0..sample_count {
+                let polarity = if (sample / half_period) & 1 == 0 {
+                    1
+                } else {
+                    -1
+                };
+                samples.push((0x80 + polarity * magnitude).clamp(0, 255) as u8);
+            }
+        }
+        if samples.is_empty() {
+            return Err(PARAM_ERR);
+        }
+        Ok((samples, sound::OUTPUT_RATE << 16))
+    }
+
+    fn decode_four_tone_synth(
+        bus: &MacMemoryBus,
+        buffer: u32,
+        request_count: usize,
+    ) -> std::result::Result<(Vec<u8>, u32), i16> {
+        if request_count < 6 {
+            return Err(PARAM_ERR);
+        }
+        let record = bus.read_long(buffer + 2);
+        if record == 0
+            || record
+                .checked_add(50)
+                .is_none_or(|end| end > bus.ram_size())
+        {
+            return Err(PARAM_ERR);
+        }
+        let duration = bus.read_word(record);
+        let sample_count = (u64::from(sound::OUTPUT_RATE) * u64::from(duration) / 60)
+            .min(usize::MAX as u64) as usize;
+        if sample_count == 0 {
+            return Err(PARAM_ERR);
+        }
+
+        let mut phases = [
+            u64::from(bus.read_long(record + 6)),
+            u64::from(bus.read_long(record + 14)),
+            u64::from(bus.read_long(record + 22)),
+            u64::from(bus.read_long(record + 30)),
+        ];
+        let rates = [
+            u64::from(bus.read_long(record + 2)),
+            u64::from(bus.read_long(record + 10)),
+            u64::from(bus.read_long(record + 18)),
+            u64::from(bus.read_long(record + 26)),
+        ];
+        let waves = [
+            bus.read_long(record + 34),
+            bus.read_long(record + 38),
+            bus.read_long(record + 42),
+            bus.read_long(record + 46),
+        ];
+        if waves.iter().all(|wave| *wave == 0) {
+            return Err(PARAM_ERR);
+        }
+        if waves.iter().any(|wave| {
+            *wave != 0
+                && wave
+                    .checked_add(256)
+                    .is_none_or(|end| end > bus.ram_size())
+        }) {
+            return Err(PARAM_ERR);
+        }
+
+        let hardware_to_output =
+            ((u64::from(LEGACY_SOUND_SAMPLE_RATE)) << 16) / u64::from(sound::OUTPUT_RATE);
+        let mut samples = Vec::with_capacity(sample_count);
+        for _ in 0..sample_count {
+            let mut sum = 0i32;
+            let mut voices = 0i32;
+            for voice in 0..4 {
+                if waves[voice] == 0 {
+                    continue;
+                }
+                let index = ((phases[voice] >> 16) & 0xFF) as u32;
+                sum += i32::from(bus.read_byte(waves[voice] + index)) - 0x80;
+                voices += 1;
+                phases[voice] =
+                    phases[voice].wrapping_add((rates[voice] * hardware_to_output) >> 16);
+            }
+            let mixed = if voices == 0 { 0 } else { sum / voices };
+            samples.push((mixed + 0x80).clamp(0, 255) as u8);
+        }
+        Ok((samples, sound::OUTPUT_RATE << 16))
+    }
+
     fn clear_guest_sound_channel_state(&self, bus: &mut MacMemoryBus, chan_ptr: u32) {
         if chan_ptr == 0 {
             return;
@@ -93,6 +315,9 @@ impl super::TrapDispatcher {
     }
 
     fn release_sound_channel(&mut self, bus: &mut MacMemoryBus, chan_ptr: u32) {
+        if self.legacy_sound_driver_channel == Some(chan_ptr) {
+            self.legacy_sound_driver_channel = None;
+        }
         self.sound_manager
             .pending_callbacks
             .retain(|pending| pending.chan_ptr != chan_ptr);
@@ -2726,6 +2951,50 @@ mod tests {
         assert_ne!(snd_ptr, 0, "sound data allocation must succeed");
         write_minimal_format2_snd_handle(bus, snd_handle, snd_ptr, format_word);
         (snd_handle, snd_ptr)
+    }
+
+    #[test]
+    fn legacy_sound_driver_decodes_square_and_four_tone_synths() {
+        let (mut disp, _cpu, mut bus) = setup();
+        bus.write_byte(crate::memory::globals::addr::SD_VOLUME, 7);
+
+        let square = 0x300000;
+        bus.write_word(square, (-1i16) as u16);
+        bus.write_word(square + 2, 14_243); // pitch period
+        bus.write_word(square + 4, 255); // amplitude
+        bus.write_word(square + 6, 1); // one tick
+        bus.write_word(square + 8, 0); // terminating triplet
+        bus.write_word(square + 10, 0);
+        bus.write_word(square + 12, 0);
+
+        assert_eq!(disp.write_device_driver(&mut bus, -4, square, 14), Ok(14));
+        let square_mix = disp.sound_manager.mix_frame(128);
+        assert!(square_mix.iter().any(|sample| *sample != 0x80));
+
+        let synth = 0x310000;
+        let record = 0x311000;
+        let wave = 0x312000;
+        bus.write_word(synth, 1);
+        bus.write_long(synth + 2, record);
+        bus.write_word(record, 1); // one tick
+        bus.write_long(record + 2, 0x0001_0000); // voice 1 rate
+        bus.write_long(record + 6, 0); // voice 1 phase
+        for voice in 1..4u32 {
+            bus.write_long(record + 2 + voice * 8, 0);
+            bus.write_long(record + 6 + voice * 8, 0);
+        }
+        bus.write_long(record + 34, wave);
+        bus.write_long(record + 38, 0);
+        bus.write_long(record + 42, 0);
+        bus.write_long(record + 46, 0);
+        for offset in 0..256u32 {
+            bus.write_byte(wave + offset, 0xE0);
+        }
+
+        assert_eq!(disp.write_device_driver(&mut bus, -4, synth, 6), Ok(6));
+        let four_tone_mix = disp.sound_manager.mix_frame(128);
+        assert!(four_tone_mix.iter().any(|sample| *sample != 0x80));
+        assert_eq!(disp.sound_manager.channels.len(), 1);
     }
 
     /// Locks in `parse_aiff_samples` end-to-end decoding — the entry


### PR DESCRIPTION
## Summary

- treat negative `FSWrite` reference numbers as Device Manager drivers instead of File Manager refs
- decode legacy `.Sound` free-form, square-wave, and four-tone synth buffers into the existing PCM mixer
- interpret each `FTSoundRec` phase as its documented waveform byte offset before applying 16.16 rates
- bound decoded legacy PCM expansion with checked arithmetic and fallible allocation
- keep the internal legacy channel outside the guest heap and preserve existing positive-refnum file behavior

## Root cause

`FSWrite` read `ioRefNum` as an unsigned value, so the ROM Sound Driver reference number `-4` became `65532` and failed the File Manager lookup with `rfNumErr`. The four-tone decoder also treated a raw byte-offset phase as if it were already a 16.16 accumulator, causing nonzero starting phases to select the wrong waveform byte. Finally, compact square-wave records could expand guest-controlled durations into unbounded host allocations.

## Validation

- `cargo test --lib four_tone_phase_is_a_waveform_byte_offset`
- `cargo test --lib legacy_sound_driver_decodes_supported_synths`
- `cargo test --lib square_wave_synth_rejects_oversized_decoded_output`
- `cargo test --lib` (2,942 passed; 3 ignored)
- `cargo check --no-default-features`

Closes #485