### PR TITLE
fix(control): preserve disabled popup titles

### DIFF
--- a/src/trap/control.rs
+++ b/src/trap/control.rs
@@ -988,7 +988,16 @@ impl super::TrapDispatcher {
             // in contrlMax, so retain the pixel width as private CDEF state.
             // Macintosh Toolbox Essentials 1992, pp. 5-25 to 5-27.
             self.popup_control_title_widths.insert(ctrl_ptr, max);
-            self.create_popup_control_private_data(bus, min)
+            let data = self.create_popup_control_private_data(bus, min);
+            let item_count = self
+                .menus
+                .iter()
+                .rev()
+                .find(|menu| menu.id == min)
+                .map_or(0, |menu| menu.items.len().min(i16::MAX as usize) as i16);
+            bus.write_word(ctrl_ptr + 20, 1);
+            bus.write_word(ctrl_ptr + 22, item_count as u16);
+            data
         } else {
             0
         };
@@ -5263,10 +5272,9 @@ mod tests {
                 1009,
                 0,
             );
+            assert_eq!(bus.read_word(ctrl_ptr + 20), 1);
+            assert_eq!(bus.read_word(ctrl_ptr + 22), 1);
             bus.write_byte(ctrl_ptr + 17, hilite);
-            // The standard pop-up CDEF replaces the creation-time title width
-            // in contrlMax with the number of menu items.
-            bus.write_word(ctrl_ptr + 22, 1);
             assert_eq!(disp.popup_control_title_width(ctrl_ptr, 1), 60);
             disp.draw_control(&mut cpu, &mut bus, ctrl_ptr);
         }

--- a/src/trap/control.rs
+++ b/src/trap/control.rs
@@ -983,6 +983,11 @@ impl super::TrapDispatcher {
         let def_proc_handle = self.control_def_proc_handle(bus, proc_id);
         bus.write_long(ctrl_ptr + 24, def_proc_handle);
         let contrl_data = if Self::is_popup_menu_proc_id(proc_id) {
+            // `max` is the title width only while the pop-up is being
+            // created. The standard CDEF then publishes the menu item count
+            // in contrlMax, so retain the pixel width as private CDEF state.
+            // Macintosh Toolbox Essentials 1992, pp. 5-25 to 5-27.
+            self.popup_control_title_widths.insert(ctrl_ptr, max);
             self.create_popup_control_private_data(bus, min)
         } else {
             0
@@ -1058,6 +1063,7 @@ impl super::TrapDispatcher {
             }
             self.release_control_aux_record(bus, ctrl_handle);
             self.control_proc_ids.remove(&ctrl_ptr);
+            self.popup_control_title_widths.remove(&ctrl_ptr);
             bus.free(ctrl_ptr);
         }
         bus.free(ctrl_handle);
@@ -1109,6 +1115,13 @@ impl super::TrapDispatcher {
             }
         }
         fallback_menu_id
+    }
+
+    pub(crate) fn popup_control_title_width(&self, ctrl_ptr: u32, fallback: i16) -> i16 {
+        self.popup_control_title_widths
+            .get(&ctrl_ptr)
+            .copied()
+            .unwrap_or(fallback)
     }
 
     /// Draw a single control based on its procID, using QuickDraw primitives
@@ -1315,8 +1328,16 @@ impl super::TrapDispatcher {
                 let menu_id = self.popup_control_menu_id(bus, ctrl_ptr, min);
                 let selected = value.max(1) as usize;
                 let item_title = self.popup_menu_item_title(bus, menu_id, selected);
+                let title_width = self.popup_control_title_width(ctrl_ptr, max);
                 let (draw_top, draw_left, draw_bottom, draw_right) = self.popup_control_box_rect(
-                    bus, abs_top, abs_left, abs_bottom, abs_right, menu_id, max, proc_id,
+                    bus,
+                    abs_top,
+                    abs_left,
+                    abs_bottom,
+                    abs_right,
+                    menu_id,
+                    title_width,
+                    proc_id,
                 );
                 self.draw_popup_control_label(
                     bus,
@@ -5184,6 +5205,88 @@ mod tests {
                 "inactive {label} title should use a visible palette blend without a gray ramp"
             );
         }
+    }
+
+    #[test]
+    fn inactive_popup_label_and_selected_title_use_live_device_palette() {
+        let (mut disp, mut cpu, mut bus) = setup_with_port();
+        let screen_base = bus.alloc(256 * 128);
+        let row_bytes = 256u32;
+        disp.set_screen_mode_for_test(screen_base, row_bytes, 256, 128, 8);
+        disp.device_clut = [[0x2020, 0x4040, 0x6060]; 256];
+        disp.device_clut[0] = [0xFFFF, 0xFFFF, 0xFFFF];
+        disp.device_clut[255] = [0, 0, 0];
+        bus.write_long(0x0824, screen_base);
+        bus.write_word(0x0828, row_bytes as u16);
+        for offset in 0..(row_bytes * 128) {
+            bus.write_byte(screen_base + offset, 0);
+        }
+
+        let window_ptr = disp.current_port;
+        bus.write_word(window_ptr + 8, 0);
+        bus.write_word(window_ptr + 10, 0);
+        bus.write_word(window_ptr + 16, 0);
+        bus.write_word(window_ptr + 18, 0);
+        bus.write_word(window_ptr + 20, 128);
+        bus.write_word(window_ptr + 22, 256);
+        let menu_ptr = bus.alloc(256);
+        let menu_handle = bus.alloc(4);
+        bus.write_long(menu_handle, menu_ptr);
+        disp.menus.push(Menu {
+            id: 900,
+            title: "Files".to_string(),
+            items: vec![MenuItem {
+                text: "Demo Map".to_string(),
+                icon: 0,
+                key_equiv: 0,
+                mark: 0,
+                style: 0,
+                enabled: true,
+            }],
+            enabled: true,
+            handle: menu_handle,
+            in_menu_bar: false,
+            hierarchical: false,
+            visible_in_menu_bar: false,
+        });
+
+        for (top, hilite) in [(20, 255), (52, 0)] {
+            let (_handle, ctrl_ptr) = disp.create_control_record(
+                &mut bus,
+                window_ptr,
+                (top, 20, top + 20, 220),
+                b"Map:",
+                true,
+                1,
+                900,
+                60,
+                1009,
+                0,
+            );
+            bus.write_byte(ctrl_ptr + 17, hilite);
+            // The standard pop-up CDEF replaces the creation-time title width
+            // in contrlMax with the number of menu items.
+            bus.write_word(ctrl_ptr + 22, 1);
+            assert_eq!(disp.popup_control_title_width(ctrl_ptr, 1), 60);
+            disp.draw_control(&mut cpu, &mut bus, ctrl_ptr);
+        }
+
+        assert!(
+            count_pixel_index(&bus, screen_base, row_bytes, 20, 20, 40, 80, 1) > 8,
+            "inactive popup label should use a visible palette blend"
+        );
+        assert!(
+            count_pixel_index(&bus, screen_base, row_bytes, 20, 90, 40, 170, 1) > 8,
+            "inactive popup selected title should use a visible palette blend"
+        );
+        assert!(
+            count_pixel_index(&bus, screen_base, row_bytes, 52, 20, 72, 80, 255) > 8,
+            "enabled popup label should retain active black ink"
+        );
+        assert!(
+            count_pixel_index(&bus, screen_base, row_bytes, 52, 90, 72, 170, 255) > 8,
+            "enabled popup selected title should retain active black ink"
+        );
     }
 
     /// An active push-button title must resolve its ink against the colour

--- a/src/trap/dialog.rs
+++ b/src/trap/dialog.rs
@@ -6112,10 +6112,11 @@ impl super::TrapDispatcher {
                                 let menu_id = self.popup_control_menu_id(bus, ctrl_ptr, min);
                                 let selected = value.max(1) as usize;
                                 let item_title = self.popup_menu_item_title(bus, menu_id, selected);
+                                let title_width = self.popup_control_title_width(ctrl_ptr, max);
                                 let (draw_top, draw_left, draw_bottom, draw_right) = self
                                     .popup_control_box_rect(
                                         bus, abs_top, abs_left, abs_bottom, abs_right, menu_id,
-                                        max, proc_id,
+                                        title_width, proc_id,
                                     );
                                 self.draw_popup_control_label(
                                     bus,
@@ -6319,10 +6320,11 @@ impl super::TrapDispatcher {
                                 let menu_id = self.popup_control_menu_id(bus, ctrl_ptr, min);
                                 let selected = value.max(1) as usize;
                                 let item_title = self.popup_menu_item_title(bus, menu_id, selected);
+                                let title_width = self.popup_control_title_width(ctrl_ptr, max);
                                 let (draw_top, draw_left, draw_bottom, draw_right) = self
                                     .popup_control_box_rect(
                                         bus, abs_top, abs_left, abs_bottom, abs_right, menu_id,
-                                        max, proc_id,
+                                        title_width, proc_id,
                                     );
                                 self.draw_popup_control_label(
                                     bus,
@@ -6516,10 +6518,11 @@ impl super::TrapDispatcher {
                                 let menu_id = self.popup_control_menu_id(bus, ctrl_ptr, min);
                                 let selected = value.max(1) as usize;
                                 let item_title = self.popup_menu_item_title(bus, menu_id, selected);
+                                let title_width = self.popup_control_title_width(ctrl_ptr, max);
                                 let (draw_top, draw_left, draw_bottom, draw_right) = self
                                     .popup_control_box_rect(
                                         bus, abs_top, abs_left, abs_bottom, abs_right, menu_id,
-                                        max, proc_id,
+                                        title_width, proc_id,
                                     );
                                 self.draw_popup_control_label(
                                     bus,
@@ -7089,8 +7092,6 @@ impl super::TrapDispatcher {
             return;
         }
 
-        let (screen_base, row_bytes, screen_width, screen_height, pixel_size) =
-            self.get_screen_params();
         let font_id = 0i16;
         let font_size = 12i16;
         let metrics = get_font_metrics(font_id, font_size);
@@ -7099,22 +7100,19 @@ impl super::TrapDispatcher {
         let text_x = (text_right - text_width).max(left);
         let text_y = top + ((bottom - top) + metrics.ascent - metrics.descent) / 2;
 
-        Self::fb_draw_string(
+        self.draw_control_label_text(
             bus,
-            screen_base,
-            row_bytes,
-            pixel_size,
-            screen_width,
-            screen_height,
+            top,
+            left,
+            bottom,
+            popup_left,
             text_x,
             text_y,
             title,
             font_id,
             font_size,
+            !enabled,
         );
-        if !enabled {
-            self.dim_rect(bus, top, left, bottom, popup_left);
-        }
     }
 
     pub(crate) fn draw_popup_control_with_state(

--- a/src/trap/dialog.rs
+++ b/src/trap/dialog.rs
@@ -6115,8 +6115,14 @@ impl super::TrapDispatcher {
                                 let title_width = self.popup_control_title_width(ctrl_ptr, max);
                                 let (draw_top, draw_left, draw_bottom, draw_right) = self
                                     .popup_control_box_rect(
-                                        bus, abs_top, abs_left, abs_bottom, abs_right, menu_id,
-                                        title_width, proc_id,
+                                        bus,
+                                        abs_top,
+                                        abs_left,
+                                        abs_bottom,
+                                        abs_right,
+                                        menu_id,
+                                        title_width,
+                                        proc_id,
                                     );
                                 self.draw_popup_control_label(
                                     bus,
@@ -6323,8 +6329,14 @@ impl super::TrapDispatcher {
                                 let title_width = self.popup_control_title_width(ctrl_ptr, max);
                                 let (draw_top, draw_left, draw_bottom, draw_right) = self
                                     .popup_control_box_rect(
-                                        bus, abs_top, abs_left, abs_bottom, abs_right, menu_id,
-                                        title_width, proc_id,
+                                        bus,
+                                        abs_top,
+                                        abs_left,
+                                        abs_bottom,
+                                        abs_right,
+                                        menu_id,
+                                        title_width,
+                                        proc_id,
                                     );
                                 self.draw_popup_control_label(
                                     bus,
@@ -6521,8 +6533,14 @@ impl super::TrapDispatcher {
                                 let title_width = self.popup_control_title_width(ctrl_ptr, max);
                                 let (draw_top, draw_left, draw_bottom, draw_right) = self
                                     .popup_control_box_rect(
-                                        bus, abs_top, abs_left, abs_bottom, abs_right, menu_id,
-                                        title_width, proc_id,
+                                        bus,
+                                        abs_top,
+                                        abs_left,
+                                        abs_bottom,
+                                        abs_right,
+                                        menu_id,
+                                        title_width,
+                                        proc_id,
                                     );
                                 self.draw_popup_control_label(
                                     bus,
@@ -7101,17 +7119,7 @@ impl super::TrapDispatcher {
         let text_y = top + ((bottom - top) + metrics.ascent - metrics.descent) / 2;
 
         self.draw_control_label_text(
-            bus,
-            top,
-            left,
-            bottom,
-            popup_left,
-            text_x,
-            text_y,
-            title,
-            font_id,
-            font_size,
-            !enabled,
+            bus, top, left, bottom, popup_left, text_x, text_y, title, font_id, font_size, !enabled,
         );
     }
 
@@ -28465,7 +28473,8 @@ mod tests {
         assert_eq!(bus.read_word(ctrl_ptr + 12) as i16, 30);
         assert_eq!(bus.read_word(ctrl_ptr + 14) as i16, 140);
         assert_eq!(bus.read_word(ctrl_ptr + 18) as i16, 2);
-        assert_eq!(bus.read_word(ctrl_ptr + 20) as i16, 1300);
+        assert_eq!(bus.read_word(ctrl_ptr + 20) as i16, 1);
+        assert_eq!(bus.read_word(ctrl_ptr + 22) as i16, 0);
         assert_eq!(disp.control_proc_ids.get(&ctrl_ptr), Some(&1009));
         assert_eq!(
             disp.dialog_control_handles.get(&handle),

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -1973,6 +1973,10 @@ pub struct TrapDispatcher {
     /// Used by DrawControls to dispatch to the correct rendering routine.
     /// Inside Macintosh Volume I, I-331
     pub(crate) control_proc_ids: HashMap<u32, i16>,
+    /// Creation-time pop-up title widths keyed by ControlRecord pointer.
+    /// The standard pop-up CDEF replaces `contrlMax` with the menu item count,
+    /// so the original pixel width must remain in its private state.
+    pub(crate) popup_control_title_widths: HashMap<u32, i16>,
     /// The menu ID of the most recently inserted menu (via InsertMenu).
     /// Cleared when a type-0 userItem GetDItem is called immediately after.
     pub(crate) last_inserted_menu_id: Option<i16>,
@@ -3180,6 +3184,7 @@ impl TrapDispatcher {
             list_states: HashMap::new(),
             textedit_states: HashMap::new(),
             control_proc_ids: HashMap::new(),
+            popup_control_title_widths: HashMap::new(),
             last_inserted_menu_id: None,
             pending_dialog_popup_menu: None,
             dialog_item_popup_menus: HashMap::new(),


### PR DESCRIPTION
## Summary

- preserve each standard pop-up control's creation-time title width after publishing `contrlMin = 1` and `contrlMax = menu item count`
- draw inactive external labels and selected-item titles with the existing live-device-CLUT-aware inactive ink
- bound enabled and inactive selected-item titles to the pop-up content area
- leave pop-up chrome, tracking, and theme state unchanged

## Root cause

The pop-up renderer reused the current `contrlMax` as the title width even though the standard CDEF contract repurposes that field for the menu item count after creation. The creation path cached the width but initially failed to publish the documented post-creation range. Separately, inactive labels were checker-cleared after drawing with active ink, while inactive selected-item text was skipped entirely. Under a custom indexed palette, both paths made the text unreadable.

## Validation

- `cargo test --lib inactive_popup_label_and_selected_title_use_live_device_palette`
- `cargo test --lib` (2,938 passed; 3 ignored)
- `cargo check --no-default-features`
- focused assertions verify `contrlMin` and `contrlMax` immediately after control creation

Closes #500