### PR TITLE
fix(sound): route legacy driver writes

### DIFF
--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -3914,7 +3914,8 @@ impl super::TrapDispatcher {
             // FSWrite ($A003): Writes to output_dir or VFS
             (false, 0x03) => {
                 let pb = cpu.read_reg(Register::A0);
-                let ref_num = bus.read_word(pb + 24);
+                let ref_num_word = bus.read_word(pb + 24);
+                let ref_num = ref_num_word as i16;
                 let buffer = bus.read_long(pb + 32);
                 let request_count = bus.read_long(pb + 36) as usize;
                 let pos_mode = bus.read_word(pb + 44);
@@ -3924,8 +3925,27 @@ impl super::TrapDispatcher {
                     ref_num, buffer, request_count, pos_mode, pos_offset
                 );
 
-                let Some(filename) = self.open_files.get(&ref_num).cloned() else {
-                    if self.synthetic_drivers.contains_key(&ref_num) {
+                // Device Manager reference numbers are signed. The ROM Sound
+                // Driver occupies unit 3 / reference number -4 and accepts
+                // free-form synthesizer records through the same FSWrite API.
+                if ref_num < 0 {
+                    let result = if ref_num == -4 {
+                        if self.write_legacy_sound_driver_buffer(bus, buffer, request_count) {
+                            0
+                        } else {
+                            -20 // writErr
+                        }
+                    } else {
+                        -21 // badUnitErr
+                    };
+                    bus.write_long(pb + 40, if result == 0 { request_count as u32 } else { 0 });
+                    bus.write_word(pb + 16, result as u16);
+                    cpu.write_reg(Register::D0, (result as i32) as u32);
+                    return Some(Ok(()));
+                }
+
+                let Some(filename) = self.open_files.get(&ref_num_word).cloned() else {
+                    if self.synthetic_drivers.contains_key(&ref_num_word) {
                         bus.write_long(pb + 40, request_count as u32);
                         bus.write_word(pb + 16, 0);
                         cpu.write_reg(Register::D0, 0);
@@ -3941,7 +3961,7 @@ impl super::TrapDispatcher {
                 let (new_pos, host_sync_bytes) = {
                     let file_buf = self.vfs.entry(filename.clone()).or_default();
                     let file_len = file_buf.len();
-                    let cur_pos = *self.file_positions.get(&ref_num).unwrap_or(&0);
+                    let cur_pos = *self.file_positions.get(&ref_num_word).unwrap_or(&0);
                     let Ok(start) =
                         Self::resolve_file_mark_position(pos_mode, pos_offset, cur_pos, file_len)
                     else {
@@ -3969,7 +3989,7 @@ impl super::TrapDispatcher {
                     (end, sync)
                 };
 
-                self.file_positions.insert(ref_num, new_pos);
+                self.file_positions.insert(ref_num_word, new_pos);
                 bus.write_long(pb + 40, request_count as u32);
                 bus.write_long(pb + 46, new_pos as u32);
 
@@ -13594,6 +13614,52 @@ mod tests {
 
         assert_eq!(cpu.read_reg(Register::D0), (-51i32) as u32);
         assert_eq!(bus.read_word(pb + 16), (-51i16) as u16);
+        assert_eq!(bus.read_long(pb + 40), 0);
+    }
+
+    #[test]
+    fn fs_write_routes_signed_sound_driver_refnum_to_mixer() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let pb = 0x300000u32;
+        let write_buf = 0x310000u32;
+        let request_count = 5024u32;
+        cpu.write_reg(Register::A0, pb);
+        bus.write_word(pb + 24, (-4i16) as u16);
+        bus.write_long(pb + 32, write_buf);
+        bus.write_long(pb + 36, request_count);
+
+        bus.write_word(write_buf, 0); // free-form synthesizer
+        bus.write_long(write_buf + 2, 0x0001_0000); // one output period per sample
+        let waveform = vec![0xE0; request_count as usize - 6];
+        bus.write_bytes(write_buf + 6, &waveform);
+
+        call(&mut disp, false, 0x03, &mut cpu, &mut bus).unwrap();
+
+        assert_eq!(cpu.read_reg(Register::D0), 0);
+        assert_eq!(bus.read_word(pb + 16), 0);
+        assert_eq!(bus.read_long(pb + 40), request_count);
+        assert!(
+            disp.sound_manager.channels.iter().any(|channel| channel.is_playing()),
+            "the Sound Driver payload should reach an active mixer channel"
+        );
+        let mixed = disp.sound_manager.mix_frame(3);
+        assert_eq!(mixed.len(), 3);
+        assert!(mixed.iter().any(|sample| *sample != 0x80));
+    }
+
+    #[test]
+    fn fs_write_unknown_negative_refnum_returns_baduniterr() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let pb = 0x300000u32;
+        cpu.write_reg(Register::A0, pb);
+        bus.write_word(pb + 24, (-9i16) as u16);
+        bus.write_long(pb + 32, 0x310000);
+        bus.write_long(pb + 36, 4);
+
+        call(&mut disp, false, 0x03, &mut cpu, &mut bus).unwrap();
+
+        assert_eq!(cpu.read_reg(Register::D0), (-21i32) as u32);
+        assert_eq!(bus.read_word(pb + 16), (-21i16) as u16);
         assert_eq!(bus.read_long(pb + 40), 0);
     }
 

--- a/src/trap/sound.rs
+++ b/src/trap/sound.rs
@@ -143,6 +143,54 @@ impl super::TrapDispatcher {
         self.sound_manager.channels.push(chan);
     }
 
+    /// Submit a Sound Driver free-form synthesizer buffer to the host mixer.
+    /// Inside Macintosh Volume II describes the record as a zero mode word,
+    /// a 16.16 duration measured in 44.93 microsecond output periods, and the
+    /// unsigned 8-bit waveform bytes that fill the remainder of the write.
+    pub(super) fn write_legacy_sound_driver_buffer(
+        &mut self,
+        bus: &mut MacMemoryBus,
+        buffer: u32,
+        count: usize,
+    ) -> bool {
+        const FREE_FORM_HEADER_SIZE: usize = 6;
+        if buffer == 0
+            || count <= FREE_FORM_HEADER_SIZE
+            || bus.read_word(buffer) != 0
+        {
+            return false;
+        }
+
+        let duration = bus.read_long(buffer + 2);
+        if duration == 0 {
+            return false;
+        }
+        let sample_rate_fixed = (((crate::sound::RATE_22KHZ_FIXED as u64) << 16)
+            / duration as u64)
+            .min(u32::MAX as u64) as u32;
+        let samples = bus.read_bytes(
+            buffer + FREE_FORM_HEADER_SIZE as u32,
+            count - FREE_FORM_HEADER_SIZE,
+        );
+
+        let guest_ptr = bus.alloc(GUEST_SND_CHANNEL_SIZE);
+        if guest_ptr == 0 {
+            return false;
+        }
+        let mut channel = SndChannel::new(guest_ptr, true);
+        channel.mark_auto_dispose_when_idle();
+        channel.play_buffer(samples, sample_rate_fixed, sound::PlaybackKind::Buffer, 0);
+        self.sound_manager.channels.push(channel);
+        if trace_sound_enabled() {
+            eprintln!(
+                "[SOUND] legacy free-form write samples={} rate=${:08X}",
+                count - FREE_FORM_HEADER_SIZE,
+                sample_rate_fixed
+            );
+        }
+        true
+    }
+
     pub(crate) fn dispatch_sound<C: CpuOps>(
         &mut self,
         is_tool: bool,


### PR DESCRIPTION
## Summary

- interpret `FSWrite` reference numbers as signed before file/device dispatch
- route the ROM Sound Driver reference through a free-form synthesizer decoder backed by the existing mixer
- preserve File Manager `rfNumErr` behavior for unknown positive references and return `badUnitErr` for unknown device units
- add focused coverage for a 5,024-byte Sound Driver write and signed dispatch behavior

## Testing

- `cargo test --lib`
- `cargo check --no-default-features`
- end-to-end legacy Sound Driver startup-write fixture

Closes #485