### PR TITLE
fix(driver): hide unavailable network drivers

### DIFF
--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -216,11 +216,11 @@ impl super::TrapDispatcher {
     pub(crate) const RES_MAP_CHANGED_ATTR: u16 = 0x0020;
     pub(crate) const RES_MAP_READ_ONLY_ATTR: u16 = 0x0080;
 
+    /// Return whether an HLE-backed driver is available to open. Driver
+    /// presence is a capability promise, so protocol drivers must stay absent
+    /// until their control, status, and data paths are implemented together.
     fn is_synthetic_driver_name(filename: &str) -> bool {
-        matches!(
-            filename,
-            ".AIn" | ".AOut" | ".BIn" | ".BOut" | ".MPP" | ".ATP" | ".XPP"
-        )
+        matches!(filename, ".AIn" | ".AOut" | ".BIn" | ".BOut")
     }
 
     fn address_is_loaded_code(&self, address: u32) -> bool {
@@ -13212,6 +13212,23 @@ mod tests {
         call(&mut disp, false, 0x01, &mut cpu, &mut bus).unwrap();
         assert_eq!(cpu.read_reg(Register::D0), 0);
         assert!(!disp.synthetic_drivers.contains_key(&refnum));
+    }
+
+    #[test]
+    fn pbopen_does_not_advertise_unavailable_network_drivers() {
+        for driver_name in [b".MPP".as_slice(), b".ATP", b".XPP"] {
+            let (mut disp, mut cpu, mut bus) = setup();
+            let pb = 0x300000u32;
+            setup_param_block(&mut bus, &mut cpu, pb, driver_name);
+            bus.write_word(pb + 24, 0xFFFF);
+
+            call(&mut disp, false, 0x00, &mut cpu, &mut bus).unwrap();
+
+            assert_eq!(cpu.read_reg(Register::D0), (-43i32) as u32);
+            assert_eq!(bus.read_word(pb + 16), (-43i16) as u16);
+            assert_eq!(bus.read_word(pb + 24), 0);
+            assert!(disp.synthetic_drivers.is_empty());
+        }
     }
 
     // ================================================================


### PR DESCRIPTION
## Summary

- treat synthetic driver presence as a capability contract
- stop exposing `.MPP`, `.ATP`, and `.XPP` until their networking control, status, and data paths exist
- retain the implemented serial driver compatibility paths
- add regression coverage that unavailable protocol drivers fail without installing a synthetic refnum

## Testing

- `cargo test --lib`
- `cargo check --no-default-features`
- end-to-end unavailable-network action fixture

Closes #484