### PR TITLE
fix(menu): honor guest menu bar reveals

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -820,9 +820,10 @@ impl Default for FixtureRunnerConfig {
 ///    [`halted_by_exit_to_shell`](Self::halted_by_exit_to_shell) classifies
 ///    the common clean application-exit path.
 ///
-/// **Defaults:** kiosk mode (Mac menu bar suppressed regardless of the
-/// guest's `MBarHeight`); arrow keys NOT remapped to numpad. Override
-/// each via [`set_menu_bar_visible`](Self::set_menu_bar_visible) /
+/// **Defaults:** kiosk launch presentation (Mac menu bar initially
+/// suppressed until the guest explicitly reveals it); arrow keys NOT
+/// remapped to numpad. Override each via
+/// [`set_menu_bar_visible`](Self::set_menu_bar_visible) /
 /// [`set_arrows_as_numpad`](Self::set_arrows_as_numpad) or the
 /// `SYSTEMLESS_SHOW_MENU_BAR` env var.
 ///
@@ -974,10 +975,11 @@ impl FixtureRunner {
     /// [`crate::game::RAM_SIZE`] provides the canonical profile-driven size;
     /// tests and specialized embedders may choose a smaller allocation.
     ///
-    /// The dispatcher defaults to **kiosk mode** (Mac menu bar
-    /// suppressed, regardless of the guest's `MBarHeight`). Call
-    /// [`set_menu_bar_visible`](Self::set_menu_bar_visible) to opt back
-    /// in to the original Mac menu-bar behaviour.
+    /// The dispatcher defaults to an initial **kiosk presentation**. The Mac
+    /// menu bar starts suppressed, then returns if the guest explicitly
+    /// transitions `MBarHeight` from zero to a positive value. Call
+    /// [`set_menu_bar_visible`](Self::set_menu_bar_visible) to override that
+    /// launch behavior.
     pub fn new(ram_size: usize, config: FixtureRunnerConfig) -> Self {
         let mut dispatcher = TrapDispatcher::new();
         dispatcher.set_ui_theme_id(config.ui_theme);
@@ -1174,17 +1176,13 @@ impl FixtureRunner {
 
     /// Show or hide the Mac menu bar.
     ///
-    /// systemless runs in **kiosk mode** by default — the Mac menu bar is
-    /// suppressed regardless of the guest's `MBarHeight` ($0BAA) value
-    /// and `DrawMenuBar` is a no-op. This matches the typical embedding
-    /// case (running a single classic Mac game inside a fullscreen
-    /// host window) where the host owns the chrome and the guest's
-    /// menu bar would just diverge from the original-machine
-    /// appearance whenever the cursor entered `y < 20`.
+    /// Systemless starts in a kiosk presentation by default, suppressing the
+    /// menu bar until the guest explicitly hides and reveals it through
+    /// `MBarHeight` ($0BAA). This keeps launch chrome out of game surfaces
+    /// while allowing applications to expose their own menu commands later.
     ///
-    /// Pass `true` to opt back in to original Mac behavior — for
-    /// example, when running a Mac *application* that relies on the
-    /// menu bar as its primary user surface.
+    /// Pass `true` to show menu chrome whenever guest state permits. Pass
+    /// `false` to force suppression across later guest reveal transitions.
     ///
     /// The same toggle is also accessible via the `SYSTEMLESS_SHOW_MENU_BAR`
     /// environment variable (set to any value to show) and via
@@ -1196,6 +1194,8 @@ impl FixtureRunner {
     /// Inside Macintosh Volume V, V-245 (MBarHeight global).
     pub fn set_menu_bar_visible(&mut self, visible: bool) {
         self.dispatcher.menu_bar_hidden = !visible;
+        self.dispatcher.menu_bar_hidden_forced = !visible;
+        self.dispatcher.menu_bar_guest_reveal_armed = false;
     }
 
     /// Returns true when the Mac menu bar is currently being rendered.
@@ -1911,7 +1911,9 @@ impl FixtureRunner {
             ui_theme: self.config.ui_theme,
             theme_metrics_mode: self.config.theme_metrics_mode,
         };
-        let menu_bar_visible = self.menu_bar_visible();
+        let menu_bar_hidden = self.dispatcher.menu_bar_hidden;
+        let menu_bar_hidden_forced = self.dispatcher.menu_bar_hidden_forced;
+        let menu_bar_guest_reveal_armed = self.dispatcher.menu_bar_guest_reveal_armed;
         let instructions_per_tick = self.instructions_per_tick;
         let wait_sleep_cap_in_headless = self.wait_sleep_cap_in_headless;
         let app_start_time = self.app_start_time;
@@ -1934,7 +1936,9 @@ impl FixtureRunner {
         let next_working_dir_refnum = self.dispatcher.next_working_dir_refnum;
 
         let mut replacement = FixtureRunner::new(ram_size, config);
-        replacement.set_menu_bar_visible(menu_bar_visible);
+        replacement.dispatcher.menu_bar_hidden = menu_bar_hidden;
+        replacement.dispatcher.menu_bar_hidden_forced = menu_bar_hidden_forced;
+        replacement.dispatcher.menu_bar_guest_reveal_armed = menu_bar_guest_reveal_armed;
         replacement.instructions_per_tick = instructions_per_tick;
         replacement.tick_budget = instructions_per_tick as i32;
         replacement.wait_sleep_cap_in_headless = wait_sleep_cap_in_headless;
@@ -13774,11 +13778,16 @@ mod tests {
             !runner.menu_bar_visible(),
             "kiosk default: menu_bar_visible() must report false"
         );
+        assert!(
+            !runner.dispatcher().menu_bar_hidden_forced,
+            "default kiosk suppression must remain releasable by guest state"
+        );
         runner.set_menu_bar_visible(true);
         assert!(
             runner.menu_bar_visible(),
             "after set_menu_bar_visible(true), menu_bar_visible() must report true"
         );
+        assert!(!runner.dispatcher().menu_bar_hidden_forced);
         runner.set_menu_bar_visible(false);
         assert!(
             !runner.menu_bar_visible(),
@@ -13789,7 +13798,11 @@ mod tests {
         // field but forget to wire it through the toggle.
         assert!(
             runner.dispatcher().menu_bar_hidden,
-            "set_menu_bar_visible(false) must clear the kiosk-bypass bit"
+            "set_menu_bar_visible(false) must restore menu-bar suppression"
+        );
+        assert!(
+            runner.dispatcher().menu_bar_hidden_forced,
+            "set_menu_bar_visible(false) must retain suppression across guest reveals"
         );
     }
 

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -1529,17 +1529,17 @@ pub struct TrapDispatcher {
     /// and MBarHeight was 0). While set, the menu bar is suppressed even if
     /// the game temporarily restores MBarHeight (e.g. on cursor-at-top).
     pub fullscreen_locked: bool,
-    /// Host-controlled override for menu bar visibility. When true, the menu
-    /// bar is suppressed regardless of game state — unlike `fullscreen_locked`
-    /// which the emulator auto-clears when the game writes MBarHeight > 0.
-    /// Defaults to `true` so the HLE renders like a kiosk by default; the
-    /// menu bar is a Mac OS chrome surface that has no analogue in a game-
-    /// only runtime, and showing it diverges screenshots from the
-    /// original-machine reference whenever the cursor hovers `y < 20`.
-    /// Set `SYSTEMLESS_SHOW_MENU_BAR=1` (or assign `menu_bar_hidden = false`
-    /// after construction) to opt back in for environments where the menu
-    /// bar IS the user-facing surface (e.g. running a Mac app, not a game).
+    /// Current host-side menu bar suppression. This starts enabled for kiosk
+    /// presentation, but a guest transition from `MBarHeight == 0` to a
+    /// positive height releases that initial suppression unless the host has
+    /// explicitly forced it through `FixtureRunner::set_menu_bar_visible`.
     pub menu_bar_hidden: bool,
+    /// Whether menu-bar suppression was explicitly forced by the host rather
+    /// than inherited from the default launch presentation.
+    pub(crate) menu_bar_hidden_forced: bool,
+    /// Set after observing a guest-hidden menu bar so a later positive
+    /// `MBarHeight` can be recognized as an explicit guest reveal.
+    pub(crate) menu_bar_guest_reveal_armed: bool,
     /// Sound Manager state (channels, playback buffers).
     pub sound_manager: crate::sound::SoundManager,
     /// Menus loaded from MENU resources, in order of insertion
@@ -3027,6 +3027,8 @@ impl TrapDispatcher {
             // host a Mac app (rather than a game) can opt back in via
             // `SYSTEMLESS_SHOW_MENU_BAR=1`.
             menu_bar_hidden: std::env::var_os("SYSTEMLESS_SHOW_MENU_BAR").is_none(),
+            menu_bar_hidden_forced: false,
+            menu_bar_guest_reveal_armed: false,
             sound_manager: crate::sound::SoundManager::new(),
             menus: Vec::new(),
             saved_menu_bars: HashMap::new(),

--- a/src/trap/framebuffer.rs
+++ b/src/trap/framebuffer.rs
@@ -4352,6 +4352,15 @@ impl super::TrapDispatcher {
         let menu_bar_height = bus.read_word(crate::memory::globals::addr::MBAR_HEIGHT) as i16;
         let (_, _, screen_w, screen_h, _) = self.screen_mode;
 
+        if menu_bar_height <= 0 {
+            self.menu_bar_guest_reveal_armed = true;
+        } else if self.menu_bar_guest_reveal_armed {
+            self.menu_bar_guest_reveal_armed = false;
+            if !self.menu_bar_hidden_forced {
+                self.menu_bar_hidden = false;
+            }
+        }
+
         // Detect fullscreen: the front window covers the entire screen
         // (top <= 0, left <= 0, bottom >= screen_h, right >= screen_w)
         // and MBarHeight is 0.  Once detected, lock fullscreen mode so
@@ -5384,6 +5393,89 @@ mod redraw_chrome_tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn redraw_chrome_releases_initial_kiosk_after_guest_menu_bar_reveal() {
+        let (mut disp, mut cpu, mut bus) = setup_with_port();
+        let screen_base = bus.alloc(800 * 600);
+        disp.screen_mode = (screen_base, 800, 800, 600, 8);
+        bus.write_long(crate::memory::globals::addr::SCREEN_BITS, screen_base);
+        disp.menus.push(super::super::menu::Menu {
+            id: 1,
+            title: String::from("File"),
+            items: Vec::new(),
+            enabled: true,
+            handle: 0,
+            in_menu_bar: true,
+            hierarchical: false,
+            visible_in_menu_bar: true,
+        });
+        disp.front_window = 0;
+        disp.menu_bar_hidden = true;
+
+        bus.fill_bytes(screen_base, 800 * 20, 0xAA);
+        bus.write_word(crate::memory::globals::addr::MBAR_HEIGHT, 20);
+        disp.redraw_chrome(&mut bus);
+        assert_eq!(bus.read_byte(screen_base + 10 * 800 + 400), 0xAA);
+
+        disp.dispatch_menu(true, 0x137, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+        assert!(!disp.menu_bar_hidden);
+        assert_ne!(bus.read_byte(screen_base + 10 * 800 + 400), 0xAA);
+
+        disp.menu_bar_hidden = true;
+        disp.menu_bar_guest_reveal_armed = false;
+        bus.fill_bytes(screen_base, 800 * 20, 0xAA);
+
+        bus.write_word(crate::memory::globals::addr::MBAR_HEIGHT, 0);
+        disp.redraw_chrome(&mut bus);
+        bus.write_word(crate::memory::globals::addr::MBAR_HEIGHT, 20);
+        disp.redraw_chrome(&mut bus);
+
+        assert!(
+            !disp.menu_bar_hidden,
+            "a positive guest MBarHeight after fullscreen must release initial kiosk suppression"
+        );
+        assert_ne!(
+            bus.read_byte(screen_base + 10 * 800 + 400),
+            0xAA,
+            "the compositor must paint installed menu titles after the guest reveal"
+        );
+        assert_eq!(
+            disp.menu_title_hit_test(18),
+            Some(0),
+            "the revealed title must retain its Menu Manager hit region"
+        );
+
+        bus.fill_bytes(screen_base, 800 * 20, 0x55);
+        bus.write_word(crate::memory::globals::addr::MBAR_HEIGHT, 0);
+        disp.redraw_chrome(&mut bus);
+        assert_eq!(
+            bus.read_byte(screen_base + 10 * 800 + 400),
+            0x55,
+            "the reverse guest transition must not leave menu chrome over application pixels"
+        );
+
+        disp.menu_bar_hidden = true;
+        disp.menu_bar_hidden_forced = true;
+        bus.fill_bytes(screen_base, 800 * 20, 0x66);
+        disp.redraw_chrome(&mut bus);
+        bus.write_word(crate::memory::globals::addr::MBAR_HEIGHT, 20);
+        disp.redraw_chrome(&mut bus);
+        disp.dispatch_menu(true, 0x137, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+        assert!(
+            disp.menu_bar_hidden,
+            "an explicit host force-hide must survive guest reveal requests"
+        );
+        assert_eq!(
+            bus.read_byte(screen_base + 10 * 800 + 400),
+            0x66,
+            "forced suppression must keep menu chrome out of the framebuffer"
+        );
     }
 
     #[test]

--- a/src/trap/menu.rs
+++ b/src/trap/menu.rs
@@ -1528,6 +1528,12 @@ impl super::TrapDispatcher {
             // DrawMenuBar ($A937): Renders menu-bar titles for menus currently
             // in the menu list (InsertMenu-installed) per IM:I I-352/I-354.
             (true, 0x137) => {
+                if bus.read_word(crate::memory::globals::addr::MBAR_HEIGHT) > 0
+                    && !self.menu_bar_hidden_forced
+                {
+                    self.menu_bar_hidden = false;
+                    self.menu_bar_guest_reveal_armed = false;
+                }
                 self.draw_menu_bar_to_fb(bus);
                 Ok(())
             }


### PR DESCRIPTION
## Summary

- treat the default kiosk setting as launch-only suppression that guest menu-bar reveal requests can release
- honor both positive-height `DrawMenuBar` calls and observed `MBarHeight` hide/reveal transitions
- preserve a distinct explicit host force-hide setting across guest transitions and application relaunches
- cover reveal painting, title hit geometry, reverse hiding, and permanent suppression

## Testing

- `cargo test redraw_chrome_releases_initial_kiosk_after_guest_menu_bar_reveal --lib --quiet`
- `cargo test menu_bar --lib --quiet`
- `cargo test drawmenubar --lib --quiet`
- `cargo test set_menu_bar_visible_round_trips_through_public_api --lib --quiet`
- `cargo test --lib --quiet` (2,940 passed, 3 ignored)
- end-to-end fullscreen guest menu-bar reveal with visual verification

Closes #457