### PR TITLE
fix(display): preserve direct driver palette values

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -29,6 +29,14 @@ pub type DisplayGamma = [[u8; 256]; 3];
 pub fn default_display_gamma() -> DisplayGamma {
     [MAC_ROM_GAMMA_LUT; 3]
 }
+
+/// Return the linear transfer used for palettes written directly to the video
+/// driver. Those values have already passed through the guest's palette
+/// preparation and must not receive the Color Manager compatibility curve.
+pub fn linear_display_gamma() -> DisplayGamma {
+    let identity = std::array::from_fn(|index| index as u8);
+    [identity; 3]
+}
 const UNUSED_RGBA_PALETTE: RgbaPalette = [0; 256];
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -1472,9 +1480,8 @@ fn clut_component_to_u8_with_gamma(component: u16, gamma: &[u8; 256]) -> u8 {
     gamma[(component >> 8) as usize]
 }
 
-/// Modeled default display transfer table, applied after truncating 16-bit
-/// Color QuickDraw components to their most-significant byte. Runtime
-/// `cscSetGamma` tables replace this default in device state.
+/// Compatibility transfer for high-level Color Manager palette values. Direct
+/// video-driver palettes select a linear transfer in device state instead.
 const MAC_ROM_GAMMA_LUT: [u8; 256] = [
     0x00, 0x02, 0x05, 0x07, 0x09, 0x0B, 0x0E, 0x10, 0x12, 0x15, 0x17, 0x19, 0x1C, 0x1E, 0x20, 0x22,
     0x25, 0x27, 0x28, 0x2A, 0x2B, 0x2D, 0x2E, 0x2F, 0x31, 0x32, 0x34, 0x35, 0x37, 0x38, 0x39, 0x3B,

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -1792,6 +1792,7 @@ pub struct TrapDispatcher {
     /// `cscSetGamma` control call. These affect presentation only; the device
     /// and Color Manager CLUTs retain the guest's uncorrected 16-bit values.
     pub device_gamma: crate::display::DisplayGamma,
+    pub device_gamma_explicit: bool,
     /// Color Manager CLUT for 8bpp mode. Updated only by high-level SetEntries ($AA3F)
     /// and ActivatePalette — NOT by low-level video driver palette fades.
     /// Used by QuickDraw shape drawing (PaintRect, etc.) for RGB→index mapping,
@@ -3129,6 +3130,7 @@ impl TrapDispatcher {
             },
             device_clut: Self::standard_mac_8bpp_clut(),
             device_gamma: crate::display::default_display_gamma(),
+            device_gamma_explicit: false,
             color_manager_clut: Self::standard_mac_8bpp_clut(),
             inverse_table_cache: Vec::new(),
             clut_protected: [false; 256],

--- a/src/trap/memory.rs
+++ b/src/trap/memory.rs
@@ -358,8 +358,8 @@ impl super::TrapDispatcher {
 
         let gamma_ptr = bus.read_long(vd_gamma_ptr);
         if gamma_ptr == 0 {
-            let identity = std::array::from_fn(|index| index as u8);
-            self.device_gamma = [identity; 3];
+            self.device_gamma = crate::display::linear_display_gamma();
+            self.device_gamma_explicit = true;
             return NO_ERR;
         }
 
@@ -420,6 +420,7 @@ impl super::TrapDispatcher {
             }
         }
         self.device_gamma = installed;
+        self.device_gamma_explicit = true;
         NO_ERR
     }
 
@@ -2206,6 +2207,13 @@ impl super::TrapDispatcher {
                             }
                         }
                         // Apply palette BEFORE logging so screenshots see updated CLUT.
+                        // A direct driver palette contains presentation-ready
+                        // values. Keep explicit guest gamma authoritative, but
+                        // otherwise stop applying the compatibility transfer
+                        // used by the emulated high-level Color Manager path.
+                        if !self.device_gamma_explicit {
+                            self.device_gamma = crate::display::linear_display_gamma();
+                        }
                         self.apply_set_entries(bus, cs_table, cs_start, safe_count);
                         if let Err(err) = self.record_trace_event(
                             bus,
@@ -9437,6 +9445,65 @@ mod tests {
             0x00ABCDEF,
             "SetMode should not write csBaseAddr past a short stack parameter block"
         );
+    }
+
+    #[test]
+    fn control_set_entries_selects_linear_transfer_for_direct_driver_palette() {
+        let (mut dispatcher, mut cpu, mut bus) = setup();
+        let pb = 0x300000u32;
+        let record = bus.alloc(8);
+        let table = bus.alloc(8);
+
+        bus.write_word(table, 7);
+        bus.write_word(table + 2, 0x4444);
+        bus.write_word(table + 4, 0x8888);
+        bus.write_word(table + 6, 0xCCCC);
+        bus.write_long(record, table);
+        bus.write_word(record + 4, (-1i16) as u16);
+        bus.write_word(record + 6, 0);
+        bus.write_word(pb + 26, 3);
+        bus.write_long(pb + 28, record);
+        cpu.write_reg(Register::A0, pb);
+
+        dispatcher
+            .dispatch_memory(false, 0x04, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(dispatcher.device_clut[7], [0x4444, 0x8888, 0xCCCC]);
+        assert_eq!(dispatcher.device_gamma[0][0x44], 0x44);
+        assert_eq!(dispatcher.device_gamma[1][0x88], 0x88);
+        assert_eq!(dispatcher.device_gamma[2][0xCC], 0xCC);
+        assert!(!dispatcher.device_gamma_explicit);
+    }
+
+    #[test]
+    fn control_set_entries_preserves_explicit_gamma() {
+        let (mut dispatcher, mut cpu, mut bus) = setup();
+        let pb = 0x300000u32;
+        let record = bus.alloc(8);
+        let table = bus.alloc(8);
+        dispatcher.device_gamma = [[0x42; 256]; 3];
+        dispatcher.device_gamma_explicit = true;
+
+        bus.write_word(table, 7);
+        bus.write_word(table + 2, 0x4444);
+        bus.write_word(table + 4, 0x8888);
+        bus.write_word(table + 6, 0xCCCC);
+        bus.write_long(record, table);
+        bus.write_word(record + 4, (-1i16) as u16);
+        bus.write_word(record + 6, 0);
+        bus.write_word(pb + 26, 3);
+        bus.write_long(pb + 28, record);
+        cpu.write_reg(Register::A0, pb);
+
+        dispatcher
+            .dispatch_memory(false, 0x04, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(dispatcher.device_gamma, [[0x42; 256]; 3]);
+        assert!(dispatcher.device_gamma_explicit);
     }
 
     #[test]

--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -21778,6 +21778,9 @@ impl super::TrapDispatcher {
         if !Self::set_entries_request_in_range(bus, table_ptr, start, count) {
             return;
         }
+        if !self.device_gamma_explicit {
+            self.device_gamma = crate::display::default_display_gamma();
+        }
         let incoming_default_palette = start == 0
             && count == 255
             && Self::table_looks_like_scaled_canonical_system_8bpp(bus, table_ptr);


### PR DESCRIPTION
Closes #397.

## Summary

- use a linear presentation transfer for palettes installed through `cscSetEntries`
- retain the existing Color Manager compatibility transfer for high-level palette writes
- preserve explicit guest `cscSetGamma` tables across subsequent palette updates

## Validation

- `cargo test --lib` (2,951 passed, 3 ignored)
- Abuse gameplay: 65.76% strict / 95.99% perceptual, up from 48.55% / 90.34%
- direct-driver and explicit-gamma focused unit coverage