### PR TITLE
feat(display): support configurable 4-bit mode

### DIFF
--- a/src/bin/desktop/metal_present.metal
+++ b/src/bin/desktop/metal_present.metal
@@ -82,6 +82,10 @@ fragment float4 guest_raster_fragment(
     if (frame.pixel_size == 8) {
         uint index = framebuffer[y * frame.row_bytes + x];
         argb = palette[index];
+    } else if (frame.pixel_size == 4) {
+        uchar packed = framebuffer[y * frame.row_bytes + x / 2];
+        uint index = (x & 1) == 0 ? packed >> 4 : packed & 0x0F;
+        argb = palette[index];
     } else {
         uchar packed = framebuffer[y * frame.row_bytes + x / 8];
         bool black = (packed & (0x80 >> (x & 7))) != 0;

--- a/src/bin/desktop/metal_present.rs
+++ b/src/bin/desktop/metal_present.rs
@@ -675,7 +675,7 @@ impl MetalPresenter {
         let screen_height = u32::from(height);
         let (content_left, content_top, width, height) = content_rect;
         let (drawable_width, drawable_height) = drawable_size;
-        if !matches!(pixel_size, 1 | 8) {
+        if !matches!(pixel_size, 1 | 4 | 8) {
             return Ok(false);
         }
         if content_left.saturating_add(width) > screen_width
@@ -704,7 +704,11 @@ impl MetalPresenter {
         let (mut uniforms, cursor_data) = cursor
             .map(|(image, position)| guest_cursor_data(Some(image), position))
             .unwrap_or_else(|| guest_cursor_data(None, (0, 0)));
-        let packed_content_left = if pixel_size == 1 { content_left & 7 } else { 0 };
+        let packed_content_left = match pixel_size {
+            1 => content_left & 7,
+            4 => content_left & 1,
+            _ => 0,
+        };
         let packed_origin_left = content_left - packed_content_left;
         uniforms.row_bytes = u32::try_from(visible_layout.visible_row_bytes)
             .map_err(|_| "visible guest row stride exceeds Metal's limit".to_string())?;
@@ -1095,10 +1099,16 @@ fn guest_visible_byte_layout(
 ) -> Option<GuestVisibleByteLayout> {
     let row_stride = usize::try_from(row_bytes).ok()?;
     let (first_byte, byte_end) = match pixel_size {
-        1 => (
-            usize::try_from(left / 8).ok()?,
-            usize::try_from(left.checked_add(width)?.checked_add(7)? / 8).ok()?,
-        ),
+        1 | 4 => {
+            let pixels_per_byte = 8 / u32::from(pixel_size);
+            (
+                usize::try_from(left / pixels_per_byte).ok()?,
+                usize::try_from(
+                    left.checked_add(width)?.checked_add(pixels_per_byte - 1)? / pixels_per_byte,
+                )
+                .ok()?,
+            )
+        }
         8 => (
             usize::try_from(left).ok()?,
             usize::try_from(left.checked_add(width)?).ok()?,
@@ -1213,6 +1223,15 @@ mod tests {
     fn cropped_presentation_packs_only_visible_guest_rows() {
         let layout = guest_visible_byte_layout(800, 8, 80, 104, 640, 392).unwrap();
         assert_eq!(layout.visible_row_bytes * layout.row_count, 250_880);
+    }
+
+    #[test]
+    fn cropped_four_bit_presentation_keeps_nibble_aligned_rows() {
+        let layout = guest_visible_byte_layout(400, 4, 81, 10, 319, 20).unwrap();
+        assert_eq!(layout.first_row_offset, 4_040);
+        assert_eq!(layout.row_stride, 400);
+        assert_eq!(layout.visible_row_bytes, 160);
+        assert_eq!(layout.row_count, 20);
     }
 
     #[test]

--- a/src/bin/systemless.rs
+++ b/src/bin/systemless.rs
@@ -141,6 +141,18 @@ struct Cli {
     /// Start with classic 24-bit guest address translation
     #[arg(long)]
     addressing_24_bit: bool,
+
+    /// Guest indexed display depth
+    #[arg(long, value_name = "BITS", default_value_t = 8, value_parser = parse_screen_depth)]
+    screen_depth: u16,
+}
+
+fn parse_screen_depth(value: &str) -> Result<u16, String> {
+    match value {
+        "4" => Ok(4),
+        "8" => Ok(8),
+        _ => Err("screen depth must be 4 or 8".to_string()),
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
@@ -386,6 +398,8 @@ struct App {
     arrows_as_numpad: bool,
     /// Start the guest with 24-bit rather than 32-bit address translation.
     addressing_24_bit: bool,
+    /// Indexed guest framebuffer depth.
+    screen_depth: u16,
     #[cfg(target_os = "macos")]
     native_integrations: bool,
     #[cfg(target_os = "macos")]
@@ -404,6 +418,7 @@ impl App {
         arrows_as_numpad: bool,
         native_integrations: bool,
         addressing_24_bit: bool,
+        screen_depth: u16,
     ) -> Self {
         #[cfg(not(target_os = "macos"))]
         let _ = native_integrations;
@@ -485,6 +500,7 @@ impl App {
             debug_frame_ms: None,
             arrows_as_numpad,
             addressing_24_bit,
+            screen_depth,
             #[cfg(target_os = "macos")]
             native_integrations,
             #[cfg(target_os = "macos")]
@@ -541,7 +557,8 @@ impl App {
             return;
         }
 
-        let mut runner = game::new_runner_with_addressing(!self.addressing_24_bit);
+        let mut runner =
+            game::new_runner_with_configuration(!self.addressing_24_bit, self.screen_depth);
         #[cfg(target_os = "macos")]
         if self.native_integrations {
             runner.set_menu_bar_policy(MenuBarPolicy::ForceHidden);
@@ -2069,6 +2086,7 @@ fn run_gui(
     arrows_as_numpad: bool,
     native_integrations: bool,
     addressing_24_bit: bool,
+    screen_depth: u16,
 ) {
     let event_loop = EventLoop::new().expect("Failed to create event loop");
     eprintln!(
@@ -2085,6 +2103,7 @@ fn run_gui(
         arrows_as_numpad,
         native_integrations,
         addressing_24_bit,
+        screen_depth,
     );
     // `run_app` is the first point at which `resumed` can create a native
     // window. Finish archive decompression and guest initialization before
@@ -2186,11 +2205,12 @@ fn run_headless(
     game_path: &std::path::Path,
     max_instructions: usize,
     addressing_24_bit: bool,
+    screen_depth: u16,
 ) {
     eprintln!("[HEADLESS] Starting: {}", game_path.display());
     eprintln!("[HEADLESS] Max instructions: {}", max_instructions);
 
-    let mut runner = game::new_runner_with_addressing(!addressing_24_bit);
+    let mut runner = game::new_runner_with_configuration(!addressing_24_bit, screen_depth);
     let app = game::load_game_from_path(&mut runner, game_path).expect("Failed to load game");
     let mut save_store = DesktopSaveStore::for_loaded_archive(game_path, &mut runner);
     eprintln!(
@@ -2271,6 +2291,7 @@ fn main() {
             &game_path,
             cli.max_instructions.unwrap_or(5_000_000),
             cli.addressing_24_bit,
+            cli.screen_depth,
         );
     } else {
         run_gui(
@@ -2278,6 +2299,7 @@ fn main() {
             arrows_as_numpad,
             native_integrations,
             cli.addressing_24_bit,
+            cli.screen_depth,
         );
     }
 }
@@ -2570,6 +2592,8 @@ mod tests {
             "--arrows-as-numpad",
             "--prefer-powerpc",
             "--addressing-24-bit",
+            "--screen-depth",
+            "4",
             "--max-instructions",
             "1234",
             "game.sit",
@@ -2583,6 +2607,7 @@ mod tests {
         assert!(!cli.literal_arrows);
         assert!(cli.prefer_powerpc);
         assert!(cli.addressing_24_bit);
+        assert_eq!(cli.screen_depth, 4);
         assert_eq!(cli.max_instructions, Some(1234));
     }
 
@@ -2651,7 +2676,7 @@ mod tests {
         use systemless::cpu::Register;
         use systemless::memory::MemoryBus;
 
-        let mut app = App::new(PathBuf::from("dummy"), false, true, false);
+        let mut app = App::new(PathBuf::from("dummy"), false, true, false, 8);
         let mut runner = FixtureRunner::new(
             8 * 1024 * 1024,
             systemless::runner::FixtureRunnerConfig::default(),
@@ -2708,6 +2733,7 @@ mod tests {
             DEFAULT_GUI_ARROWS_AS_NUMPAD,
             true,
             false,
+            8,
         );
 
         assert!(
@@ -2985,7 +3011,7 @@ mod tests {
     fn step_frame_mixes_one_audio_frame_when_guest_tick_does_not_advance() {
         let now = std::time::Instant::now();
         let (runner, queued) = gui_runner_with_counting_audio();
-        let mut app = App::new(PathBuf::from("dummy"), false, true, false);
+        let mut app = App::new(PathBuf::from("dummy"), false, true, false, 8);
         app.runner = Some(runner);
         app.start_time = Some(now);
         app.next_frame_time = Some(now);
@@ -3018,7 +3044,7 @@ mod tests {
         runner.bus_mut().write_long(0x016A, 0);
         runner.set_instructions_per_tick((game::MAX_INSTRUCTIONS_PER_FRAME * 2) as u32);
 
-        let mut app = App::new(PathBuf::from("dummy"), false, true, false);
+        let mut app = App::new(PathBuf::from("dummy"), false, true, false, 8);
         app.runner = Some(runner);
         app.start_time = Some(now - FRAME_DURATION);
         app.next_frame_time = Some(now + FRAME_DURATION * 4);
@@ -3116,7 +3142,7 @@ mod tests {
                 exhausted_buffer_index: 0,
             });
 
-        let mut app = App::new(PathBuf::from("dummy"), false, true, false);
+        let mut app = App::new(PathBuf::from("dummy"), false, true, false, 8);
         app.runner = Some(runner);
         app.start_time = Some(scheduled_frame_end);
         app.next_frame_time = Some(scheduled_frame_end);
@@ -3220,7 +3246,7 @@ mod tests {
         );
         runner.dispatcher_mut().sound_manager.channels.push(chan);
 
-        let mut app = App::new(PathBuf::from("dummy"), false, true, false);
+        let mut app = App::new(PathBuf::from("dummy"), false, true, false, 8);
         app.runner = Some(runner);
         app.start_time = Some(now);
         app.next_frame_time = Some(now);
@@ -3248,7 +3274,7 @@ mod tests {
     fn step_frame_recovers_audio_elapsed_during_a_dropped_video_frame() {
         let now = std::time::Instant::now();
         let (runner, queued) = gui_runner_with_counting_audio();
-        let mut app = App::new(PathBuf::from("dummy"), false, true, false);
+        let mut app = App::new(PathBuf::from("dummy"), false, true, false, 8);
         app.runner = Some(runner);
         app.start_time = Some(now);
         app.next_frame_time = Some(now);
@@ -3278,7 +3304,7 @@ mod tests {
         runner.cpu_mut().write_reg(Register::A7, 0x0008_0000);
         runner.set_instructions_per_tick(1);
 
-        let mut app = App::new(PathBuf::from("dummy"), false, true, false);
+        let mut app = App::new(PathBuf::from("dummy"), false, true, false, 8);
         app.runner = Some(runner);
         app.start_time = Some(now - FRAME_DURATION * 2);
         app.next_frame_time = Some(now + FRAME_DURATION);
@@ -3368,7 +3394,7 @@ mod tests {
 
     #[test]
     fn render_gate_waits_for_guest_tick_unless_forced() {
-        let mut app = App::new(PathBuf::from("dummy"), false, true, false);
+        let mut app = App::new(PathBuf::from("dummy"), false, true, false, 8);
         app.runner = Some(FixtureRunner::new(
             8 * 1024 * 1024,
             systemless::runner::FixtureRunnerConfig::default(),

--- a/src/game/launch.rs
+++ b/src/game/launch.rs
@@ -44,21 +44,31 @@ pub const MAX_INSTRUCTIONS_PER_FRAME: usize = 2_000_000;
 
 /// Create a new FixtureRunner with standard configuration.
 pub fn new_runner() -> FixtureRunner {
-    new_runner_with_addressing(true)
+    new_runner_with_configuration(true, 8)
 }
 
 /// Create a runner in either the default 32-bit addressing mode or classic
 /// 24-bit mode, where the upper address byte is ignored by memory accesses.
 pub fn new_runner_with_addressing(addressing_32_bit: bool) -> FixtureRunner {
-    FixtureRunner::new(
-        RAM_SIZE as usize,
-        FixtureRunnerConfig {
-            load_address: 0x10000,
-            max_instructions: MAX_INSTRUCTIONS_PER_FRAME,
-            addressing_32_bit,
-            ..FixtureRunnerConfig::default()
-        },
-    )
+    new_runner_with_configuration(addressing_32_bit, 8)
+}
+
+/// Create a standard runner with the requested indexed screen depth.
+pub fn new_runner_with_screen_depth(screen_depth: u16) -> FixtureRunner {
+    new_runner_with_configuration(true, screen_depth)
+}
+
+/// Create a standard runner with explicit addressing and display modes.
+pub fn new_runner_with_configuration(addressing_32_bit: bool, screen_depth: u16) -> FixtureRunner {
+    let config = FixtureRunnerConfig {
+        load_address: 0x10000,
+        max_instructions: MAX_INSTRUCTIONS_PER_FRAME,
+        addressing_32_bit,
+        ..FixtureRunnerConfig::default()
+    }
+    .with_screen_depth(screen_depth)
+    .expect("frontend selected an unsupported screen depth");
+    FixtureRunner::new(RAM_SIZE as usize, config)
 }
 
 /// Load an application from BinHex, MacBinary, StuffIt, web-pack, or raw

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -15,6 +15,6 @@ pub use application_icon::{
 };
 pub use launch::{
     init_game, load_game, load_game_from_path, new_runner, new_runner_with_addressing,
-    pack_game_sources_for_web, pack_stuffit_for_web, WebPackLoader, MAX_INSTRUCTIONS_PER_FRAME,
-    RAM_SIZE,
+    new_runner_with_configuration, new_runner_with_screen_depth, pack_game_sources_for_web,
+    pack_stuffit_for_web, WebPackLoader, MAX_INSTRUCTIONS_PER_FRAME, RAM_SIZE,
 };

--- a/src/machine_profile.rs
+++ b/src/machine_profile.rs
@@ -73,12 +73,10 @@ impl MachineProfile {
         self.gestalt_fpu_type != 0
     }
 
-    /// Bytes per scanline for an 8bpp screen of this profile's
-    /// geometry. Equal to `screen_width` in this trivial mapping
-    /// (1 byte/pixel at depth 8); kept as a method so deeper
-    /// pixel formats can override later without ripple changes.
+    /// Bytes per scanline for this profile's packed indexed screen.
     pub const fn screen_row_bytes(self) -> u32 {
-        self.screen_width as u32
+        let bytes = (self.screen_width as u32 * self.screen_depth as u32).div_ceil(8);
+        (bytes + 1) & !1
     }
 }
 

--- a/src/memory/bus.rs
+++ b/src/memory/bus.rs
@@ -917,6 +917,14 @@ impl MacMemoryBus {
         bus
     }
 
+    pub(crate) fn configure_screen_depth(&mut self, depth: u16) {
+        debug_assert!(matches!(depth, 4 | 8));
+        let profile = crate::machine_profile::reference_machine_profile();
+        let row_bytes = ((u32::from(profile.screen_width) * u32::from(depth)).div_ceil(8) + 1) & !1;
+        self.write_word(super::globals::addr::SCREEN_ROW, row_bytes as u16);
+        self.write_word(super::globals::addr::SCREEN_BITS + 4, row_bytes as u16);
+    }
+
     /// Create a memory bus wrapping an external RAM slice
     ///
     /// # Safety

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1590,6 +1590,9 @@ pub struct FixtureRunnerConfig {
     /// Use the full 32-bit guest address, or mask memory accesses to the low
     /// 24 bits as on classic Macs running in 24-bit addressing mode.
     pub addressing_32_bit: bool,
+    /// Guest-visible indexed screen depth. Supported values are 4 and 8;
+    /// the default remains 8-bit/256-color mode.
+    pub screen_depth: u16,
 }
 
 impl Default for FixtureRunnerConfig {
@@ -1602,6 +1605,7 @@ impl Default for FixtureRunnerConfig {
             ui_theme: UiThemeId::ClassicSystem7,
             theme_metrics_mode: ThemeMetricsMode::ClassicGuestMetrics,
             addressing_32_bit: true,
+            screen_depth: 8,
         }
     }
 }
@@ -1616,6 +1620,20 @@ struct PpcDecodedDoubleBuffer {
     buffer_ptr: u32,
     flags: u32,
     samples: Vec<crate::sound::StereoSample>,
+}
+
+impl FixtureRunnerConfig {
+    /// Validate and select one of the indexed display depths supported by the
+    /// main framebuffer.
+    pub fn with_screen_depth(mut self, screen_depth: u16) -> std::result::Result<Self, String> {
+        if !matches!(screen_depth, 4 | 8) {
+            return Err(format!(
+                "unsupported screen depth {screen_depth}; expected 4 or 8"
+            ));
+        }
+        self.screen_depth = screen_depth;
+        Ok(self)
+    }
 }
 
 /// Canonical entry point of the systemless library.
@@ -1831,12 +1849,33 @@ impl FixtureRunner {
         } else {
             ram_size.min(0x0100_0000)
         };
+        assert!(
+            matches!(config.screen_depth, 4 | 8),
+            "screen_depth must be 4 or 8"
+        );
         let mut dispatcher = TrapDispatcher::new();
         dispatcher.set_menu_bar_policy(config.menu_bar_policy);
         dispatcher.mmu_mode = u8::from(config.addressing_32_bit);
         dispatcher.set_ui_theme_id(config.ui_theme);
         let mut bus = MacMemoryBus::new(ram_size);
         bus.set_addressing_32_bit(config.addressing_32_bit);
+        bus.configure_screen_depth(config.screen_depth);
+        let profile = crate::machine_profile::reference_machine_profile();
+        let row_bytes =
+            ((u32::from(profile.screen_width) * u32::from(config.screen_depth)).div_ceil(8) + 1)
+                & !1;
+        dispatcher.screen_mode = (
+            bus.read_long(crate::memory::globals::addr::SCRN_BASE),
+            row_bytes,
+            profile.screen_width,
+            profile.screen_height,
+            config.screen_depth,
+        );
+        let (clut, _) = TrapDispatcher::standard_mac_indexed_clut(config.screen_depth)
+            .expect("validated indexed screen depth");
+        dispatcher.device_clut = clut;
+        dispatcher.color_manager_clut = clut;
+        dispatcher.seeded_picture_palette = clut;
         let standard_adb_service = bus.alloc_synthetic(2);
         bus.write_word(standard_adb_service, 0x4E75); // RTS
         dispatcher
@@ -3017,6 +3056,7 @@ impl FixtureRunner {
             ui_theme: self.config.ui_theme,
             theme_metrics_mode: self.config.theme_metrics_mode,
             addressing_32_bit: self.bus.addressing_32_bit(),
+            screen_depth: self.config.screen_depth,
         };
         let menu_bar_policy = self.dispatcher.menu_bar_policy;
         let menu_bar_hidden = self.dispatcher.menu_bar_hidden;
@@ -10282,6 +10322,41 @@ mod tests {
     use std::cell::RefCell;
     use std::collections::{HashMap, VecDeque};
     use std::rc::Rc;
+
+    #[test]
+    fn four_bit_runner_publishes_consistent_screen_metadata() {
+        use crate::memory::globals::addr;
+
+        let config = FixtureRunnerConfig {
+            addressing_32_bit: false,
+            ..FixtureRunnerConfig::default()
+        }
+            .with_screen_depth(4)
+            .expect("4-bit indexed mode should be supported");
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, config);
+        let gdevice_handle = runner.dispatcher.ensure_main_gdevice(&mut runner.bus);
+        let gdevice = runner.bus.read_long(gdevice_handle);
+        let pixmap = runner.bus.read_long(runner.bus.read_long(gdevice + 22));
+        let ctab = runner.bus.read_long(runner.bus.read_long(pixmap + 42));
+
+        assert_eq!(runner.dispatcher.screen_mode.1, 400);
+        assert_eq!(runner.dispatcher.screen_mode.4, 4);
+        assert_eq!(runner.bus.read_word(addr::SCREEN_ROW), 400);
+        assert_eq!(runner.bus.read_word(addr::SCREEN_BITS + 4), 400);
+        assert_eq!(runner.bus.read_word(pixmap + 4), 0x8000 | 400);
+        assert_eq!(runner.bus.read_word(pixmap + 32), 4);
+        assert_eq!(runner.bus.read_word(pixmap + 36), 4);
+        assert_eq!(runner.bus.read_word(ctab + 6), 15);
+        assert_eq!(runner.bus.read_long(gdevice + 42), 4);
+        assert!(!runner.bus.addressing_32_bit());
+        assert_eq!(runner.dispatcher.mmu_mode, 0);
+    }
+
+    #[test]
+    fn runner_config_rejects_nonselectable_screen_depths() {
+        assert!(FixtureRunnerConfig::default().with_screen_depth(1).is_err());
+        assert!(FixtureRunnerConfig::default().with_screen_depth(5).is_err());
+    }
 
     #[derive(Clone, Default)]
     struct CapturingAudioBackend {

--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -15688,10 +15688,14 @@ impl super::TrapDispatcher {
             return self.main_gdevice_handle;
         }
 
-        // Allocate ColorTable for 8-bit (256 entries)
-        // ColorTable record: ctSeed(4) + ctFlags(2) + ctSize(2) + ctTable(256*8)
+        let (screen_base, row_bytes, screen_width, screen_height, screen_depth) = self.screen_mode;
+        let (screen_clut, color_count) = Self::standard_mac_indexed_clut(screen_depth)
+            .expect("main screen uses a supported indexed depth");
+
+        // Allocate the screen's indexed ColorTable.
+        // ColorTable record: ctSeed(4) + ctFlags(2) + ctSize(2) + ctTable(n*8)
         // Inside Macintosh Volume V, V-48, V-135
-        let ct_size: u32 = 8 + 256 * 8; // 2056 bytes
+        let ct_size: u32 = 8 + color_count as u32 * 8;
         let ctab = bus.alloc(ct_size);
         // Executor's C_NewGWorld (qGWorld.cpp:217) initialises the
         // GDevice-backing CTab with `CTAB_SEED(ctab) = (int32_t)depth`
@@ -15701,57 +15705,47 @@ impl super::TrapDispatcher {
         // ship with ctSeed=8 (depth). Initialising here with 8 lets the
         // PICT seed-match identity gate fire without remap on
         // those authored-for-standard PICTs.
-        bus.write_long(ctab, 8); // ctSeed (+0, 4 bytes): depth convention
+        bus.write_long(ctab, u32::from(screen_depth)); // ctSeed: depth convention
         bus.write_word(ctab + 4, 0x8000); // ctFlags (+4, 2 bytes): bit 15 = device color table
-        bus.write_word(ctab + 6, 255); // ctSize (+6, 2 bytes): number of entries - 1
-                                       // Fill with the standard Mac 8bpp color table
-                                       // (matches device_clut initialization).
-        {
-            let std_clut = Self::standard_mac_8bpp_clut();
-            for i in 0u32..256 {
-                let entry = ctab + 8 + i * 8;
-                // The standard 8-bit device table's auxiliary primary and
-                // gray ramps are explicit device-index colors. Palette
-                // Manager explicit colors retain the color already assigned
-                // to their device index when logical palettes are installed.
-                // Inside Macintosh Volume V (1986), pp. V-157..V-160;
-                // Imaging With QuickDraw (1994), Table 4-6, p. 4-93.
-                let usage = if (215..=254).contains(&i) {
-                    (PM_EXPLICIT as u16) << 8
-                } else {
-                    0
-                };
-                bus.write_word(entry, usage); // client ID plus Palette Manager usage
-                bus.write_word(entry + 2, std_clut[i as usize][0]); // red
-                bus.write_word(entry + 4, std_clut[i as usize][1]); // green
-                bus.write_word(entry + 6, std_clut[i as usize][2]); // blue
-            }
+        bus.write_word(ctab + 6, color_count as u16 - 1); // ctSize: entries - 1
+        for i in 0..color_count as u32 {
+            let entry = ctab + 8 + i * 8;
+            // The standard 8-bit device table's auxiliary primary and gray
+            // ramps are explicit device-index colors. Lower-depth standard
+            // tables contain no auxiliary explicit range.
+            // Inside Macintosh Volume V (1986), pp. V-157..V-160;
+            // Imaging With QuickDraw (1994), Table 4-6, p. 4-93.
+            let usage = if screen_depth == 8 && (215..=254).contains(&i) {
+                (PM_EXPLICIT as u16) << 8
+            } else {
+                0
+            };
+            bus.write_word(entry, usage); // client ID plus Palette Manager usage
+            bus.write_word(entry + 2, screen_clut[i as usize][0]);
+            bus.write_word(entry + 4, screen_clut[i as usize][1]);
+            bus.write_word(entry + 6, screen_clut[i as usize][2]);
         }
         let ctab_handle = bus.alloc(4);
         bus.write_long(ctab_handle, ctab);
 
-        // Allocate PixMap for the main screen (800x600 @ 8bpp)
+        // Allocate the main screen PixMap.
         // PixMap record: Imaging With QuickDraw 1994, p.4-5
         let pixmap = bus.alloc(50);
-        let screen_base = bus.ram_size() - 0x80000; // 512KB for 800x600x8bpp
         bus.write_long(pixmap, screen_base); // baseAddr (+0)
-        bus.write_word(
-            pixmap + 4,
-            (REFERENCE_MACHINE_PROFILE.screen_row_bytes() as u16) | 0x8000,
-        ); // rowBytes (+4) with pixmap flag
+        bus.write_word(pixmap + 4, (row_bytes as u16) | 0x8000);
         bus.write_word(pixmap + 6, 0); // bounds.top (+6)
         bus.write_word(pixmap + 8, 0); // bounds.left (+8)
-        bus.write_word(pixmap + 10, REFERENCE_MACHINE_PROFILE.screen_height); // bounds.bottom (+10)
-        bus.write_word(pixmap + 12, REFERENCE_MACHINE_PROFILE.screen_width); // bounds.right (+12)
+        bus.write_word(pixmap + 10, screen_height);
+        bus.write_word(pixmap + 12, screen_width);
         bus.write_word(pixmap + 14, 0); // pmVersion (+14)
         bus.write_word(pixmap + 16, 0); // packType (+16)
         bus.write_long(pixmap + 18, 0); // packSize (+18)
         bus.write_long(pixmap + 22, 0x00480000); // hRes (+22) = 72.0 fixed
         bus.write_long(pixmap + 26, 0x00480000); // vRes (+26) = 72.0 fixed
         bus.write_word(pixmap + 30, 0); // pixelType (+30) (chunky)
-        bus.write_word(pixmap + 32, 8); // pixelSize (+32) (8bpp)
+        bus.write_word(pixmap + 32, screen_depth);
         bus.write_word(pixmap + 34, 1); // cmpCount (+34)
-        bus.write_word(pixmap + 36, 8); // cmpSize (+36)
+        bus.write_word(pixmap + 36, screen_depth);
         bus.write_long(pixmap + 38, 0); // planeBytes (+38)
         bus.write_long(pixmap + 42, ctab_handle); // pmTable (+42) = CTabHandle
         bus.write_long(pixmap + 46, 0); // pmReserved (+46)
@@ -15778,9 +15772,17 @@ impl super::TrapDispatcher {
         bus.write_long(gd + 30, 0); // gdNextGD = NULL (end of chain)
         bus.write_word(gd + 34, 0); // gdRect.top
         bus.write_word(gd + 36, 0); // gdRect.left
-        bus.write_word(gd + 38, REFERENCE_MACHINE_PROFILE.screen_height); // gdRect.bottom
-        bus.write_word(gd + 40, REFERENCE_MACHINE_PROFILE.screen_width); // gdRect.right
-        bus.write_long(gd + 42, 0x0000_0085); // gdMode (current display mode token)
+        bus.write_word(gd + 38, screen_height);
+        bus.write_word(gd + 40, screen_width);
+        // Keep the legacy 800x600 token for the default 8-bit mode. For a
+        // frontend-selected packed depth, expose that depth as the active
+        // Graphics Devices mode identifier so gdMode agrees with pixelSize.
+        let display_mode = if screen_depth == 8 {
+            0x0000_0085
+        } else {
+            u32::from(screen_depth)
+        };
+        bus.write_long(gd + 42, display_mode);
 
         let gd_handle = bus.alloc(4);
         bus.write_long(gd_handle, gd);


### PR DESCRIPTION
## Summary
- add a validated 4-bit or 8-bit display-depth option to the runner and desktop CLI
- keep screen row bytes, low-memory screenBits, the main GDevice/PixMap, color table, and mode reporting consistent
- render packed 4-bit frames through both the CPU and native Metal presentation paths

## Validation
- `cargo test --lib` (2,951 passed, 3 ignored)
- `cargo test --bin systemless` (53 passed)
- `cargo check --all-targets`
- `cargo check --no-default-features`
- Oids 1.4 exits after 1,354,882 instructions in the default 8-bit mode, but remains running through 5,000,000 instructions with `--screen-depth 4`; initialization reports `pixelSize=4` and `rowBytes=400`

Closes #566