### PR TITLE
feat(memory): support 24-bit address translation

### DIFF
--- a/src/bin/systemless.rs
+++ b/src/bin/systemless.rs
@@ -137,6 +137,10 @@ struct Cli {
     /// Prefer a native PowerPC slice when a classic 68K slice is also available
     #[arg(long)]
     prefer_powerpc: bool,
+
+    /// Start with classic 24-bit guest address translation
+    #[arg(long)]
+    addressing_24_bit: bool,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
@@ -380,6 +384,8 @@ struct App {
     debug_frame_ms: Option<f64>,
     /// Remap arrow keys to numpad equivalents (for keyboards without a numpad)
     arrows_as_numpad: bool,
+    /// Start the guest with 24-bit rather than 32-bit address translation.
+    addressing_24_bit: bool,
     #[cfg(target_os = "macos")]
     native_integrations: bool,
     #[cfg(target_os = "macos")]
@@ -393,7 +399,12 @@ struct App {
 }
 
 impl App {
-    fn new(game_path: PathBuf, arrows_as_numpad: bool, native_integrations: bool) -> Self {
+    fn new(
+        game_path: PathBuf,
+        arrows_as_numpad: bool,
+        native_integrations: bool,
+        addressing_24_bit: bool,
+    ) -> Self {
         #[cfg(not(target_os = "macos"))]
         let _ = native_integrations;
         #[cfg(target_os = "macos")]
@@ -473,6 +484,7 @@ impl App {
             debug_host_fps: None,
             debug_frame_ms: None,
             arrows_as_numpad,
+            addressing_24_bit,
             #[cfg(target_os = "macos")]
             native_integrations,
             #[cfg(target_os = "macos")]
@@ -529,7 +541,7 @@ impl App {
             return;
         }
 
-        let mut runner = game::new_runner();
+        let mut runner = game::new_runner_with_addressing(!self.addressing_24_bit);
         #[cfg(target_os = "macos")]
         if self.native_integrations {
             runner.set_menu_bar_policy(MenuBarPolicy::ForceHidden);
@@ -2051,7 +2063,12 @@ impl ApplicationHandler for App {
     }
 }
 
-fn run_gui(game_path: PathBuf, arrows_as_numpad: bool, native_integrations: bool) {
+fn run_gui(
+    game_path: PathBuf,
+    arrows_as_numpad: bool,
+    native_integrations: bool,
+    addressing_24_bit: bool,
+) {
     let event_loop = EventLoop::new().expect("Failed to create event loop");
     eprintln!(
         "[SYSTEMLESS] GUI arrow keys: {}",
@@ -2062,7 +2079,12 @@ fn run_gui(game_path: PathBuf, arrows_as_numpad: bool, native_integrations: bool
         }
     );
 
-    let mut app = App::new(game_path, arrows_as_numpad, native_integrations);
+    let mut app = App::new(
+        game_path,
+        arrows_as_numpad,
+        native_integrations,
+        addressing_24_bit,
+    );
     // `run_app` is the first point at which `resumed` can create a native
     // window. Finish archive decompression and guest initialization before
     // entering the event loop so startup never exposes an empty host window.
@@ -2159,11 +2181,15 @@ fn save_screenshot(runner: &FixtureRunner, num: usize) {
     eprintln!("[HEADLESS] Screenshot #{}: {} (ticks={})", num, path, ticks);
 }
 
-fn run_headless(game_path: &std::path::Path, max_instructions: usize) {
+fn run_headless(
+    game_path: &std::path::Path,
+    max_instructions: usize,
+    addressing_24_bit: bool,
+) {
     eprintln!("[HEADLESS] Starting: {}", game_path.display());
     eprintln!("[HEADLESS] Max instructions: {}", max_instructions);
 
-    let mut runner = game::new_runner();
+    let mut runner = game::new_runner_with_addressing(!addressing_24_bit);
     let app = game::load_game_from_path(&mut runner, game_path).expect("Failed to load game");
     let mut save_store = DesktopSaveStore::for_loaded_archive(game_path, &mut runner);
     eprintln!(
@@ -2240,9 +2266,18 @@ fn main() {
     eprintln!("[SYSTEMLESS] Game: {}", game_path.display());
 
     if cli.headless {
-        run_headless(&game_path, cli.max_instructions.unwrap_or(5_000_000));
+        run_headless(
+            &game_path,
+            cli.max_instructions.unwrap_or(5_000_000),
+            cli.addressing_24_bit,
+        );
     } else {
-        run_gui(game_path, arrows_as_numpad, native_integrations);
+        run_gui(
+            game_path,
+            arrows_as_numpad,
+            native_integrations,
+            cli.addressing_24_bit,
+        );
     }
 }
 
@@ -2533,6 +2568,7 @@ mod tests {
             "--no-native-integrations",
             "--arrows-as-numpad",
             "--prefer-powerpc",
+            "--addressing-24-bit",
             "--max-instructions",
             "1234",
             "game.sit",
@@ -2545,6 +2581,7 @@ mod tests {
         assert!(cli.arrows_as_numpad);
         assert!(!cli.literal_arrows);
         assert!(cli.prefer_powerpc);
+        assert!(cli.addressing_24_bit);
         assert_eq!(cli.max_instructions, Some(1234));
     }
 
@@ -2613,7 +2650,7 @@ mod tests {
         use systemless::cpu::Register;
         use systemless::memory::MemoryBus;
 
-        let mut app = App::new(PathBuf::from("dummy"), false, true);
+        let mut app = App::new(PathBuf::from("dummy"), false, true, false);
         let mut runner = FixtureRunner::new(
             8 * 1024 * 1024,
             systemless::runner::FixtureRunnerConfig::default(),
@@ -2665,7 +2702,12 @@ mod tests {
 
     #[test]
     fn gui_defaults_to_literal_arrow_controls() {
-        let app = App::new(PathBuf::from("dummy"), DEFAULT_GUI_ARROWS_AS_NUMPAD, true);
+        let app = App::new(
+            PathBuf::from("dummy"),
+            DEFAULT_GUI_ARROWS_AS_NUMPAD,
+            true,
+            false,
+        );
 
         assert!(
             !app.arrows_as_numpad,
@@ -2942,7 +2984,7 @@ mod tests {
     fn step_frame_mixes_one_audio_frame_when_guest_tick_does_not_advance() {
         let now = std::time::Instant::now();
         let (runner, queued) = gui_runner_with_counting_audio();
-        let mut app = App::new(PathBuf::from("dummy"), false, true);
+        let mut app = App::new(PathBuf::from("dummy"), false, true, false);
         app.runner = Some(runner);
         app.start_time = Some(now);
         app.next_frame_time = Some(now);
@@ -2975,7 +3017,7 @@ mod tests {
         runner.bus_mut().write_long(0x016A, 0);
         runner.set_instructions_per_tick((game::MAX_INSTRUCTIONS_PER_FRAME * 2) as u32);
 
-        let mut app = App::new(PathBuf::from("dummy"), false, true);
+        let mut app = App::new(PathBuf::from("dummy"), false, true, false);
         app.runner = Some(runner);
         app.start_time = Some(now - FRAME_DURATION);
         app.next_frame_time = Some(now + FRAME_DURATION * 4);
@@ -3073,7 +3115,7 @@ mod tests {
                 exhausted_buffer_index: 0,
             });
 
-        let mut app = App::new(PathBuf::from("dummy"), false, true);
+        let mut app = App::new(PathBuf::from("dummy"), false, true, false);
         app.runner = Some(runner);
         app.start_time = Some(scheduled_frame_end);
         app.next_frame_time = Some(scheduled_frame_end);
@@ -3177,7 +3219,7 @@ mod tests {
         );
         runner.dispatcher_mut().sound_manager.channels.push(chan);
 
-        let mut app = App::new(PathBuf::from("dummy"), false, true);
+        let mut app = App::new(PathBuf::from("dummy"), false, true, false);
         app.runner = Some(runner);
         app.start_time = Some(now);
         app.next_frame_time = Some(now);
@@ -3205,7 +3247,7 @@ mod tests {
     fn step_frame_recovers_audio_elapsed_during_a_dropped_video_frame() {
         let now = std::time::Instant::now();
         let (runner, queued) = gui_runner_with_counting_audio();
-        let mut app = App::new(PathBuf::from("dummy"), false, true);
+        let mut app = App::new(PathBuf::from("dummy"), false, true, false);
         app.runner = Some(runner);
         app.start_time = Some(now);
         app.next_frame_time = Some(now);
@@ -3235,7 +3277,7 @@ mod tests {
         runner.cpu_mut().write_reg(Register::A7, 0x0008_0000);
         runner.set_instructions_per_tick(1);
 
-        let mut app = App::new(PathBuf::from("dummy"), false, true);
+        let mut app = App::new(PathBuf::from("dummy"), false, true, false);
         app.runner = Some(runner);
         app.start_time = Some(now - FRAME_DURATION * 2);
         app.next_frame_time = Some(now + FRAME_DURATION);
@@ -3325,7 +3367,7 @@ mod tests {
 
     #[test]
     fn render_gate_waits_for_guest_tick_unless_forced() {
-        let mut app = App::new(PathBuf::from("dummy"), false, true);
+        let mut app = App::new(PathBuf::from("dummy"), false, true, false);
         app.runner = Some(FixtureRunner::new(
             8 * 1024 * 1024,
             systemless::runner::FixtureRunnerConfig::default(),

--- a/src/game/launch.rs
+++ b/src/game/launch.rs
@@ -33,11 +33,18 @@ pub const MAX_INSTRUCTIONS_PER_FRAME: usize = 2_000_000;
 
 /// Create a new FixtureRunner with standard configuration.
 pub fn new_runner() -> FixtureRunner {
+    new_runner_with_addressing(true)
+}
+
+/// Create a runner in either the default 32-bit addressing mode or classic
+/// 24-bit mode, where the upper address byte is ignored by memory accesses.
+pub fn new_runner_with_addressing(addressing_32_bit: bool) -> FixtureRunner {
     FixtureRunner::new(
         RAM_SIZE as usize,
         FixtureRunnerConfig {
             load_address: 0x10000,
             max_instructions: MAX_INSTRUCTIONS_PER_FRAME,
+            addressing_32_bit,
             ..FixtureRunnerConfig::default()
         },
     )

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -14,6 +14,7 @@ pub use application_icon::{
     ApplicationIconRepresentation, ApplicationIdentity,
 };
 pub use launch::{
-    init_game, load_game, load_game_from_path, new_runner, pack_game_sources_for_web,
-    pack_stuffit_for_web, WebPackLoader, MAX_INSTRUCTIONS_PER_FRAME, RAM_SIZE,
+    init_game, load_game, load_game_from_path, new_runner, new_runner_with_addressing,
+    pack_game_sources_for_web, pack_stuffit_for_web, WebPackLoader, MAX_INSTRUCTIONS_PER_FRAME,
+    RAM_SIZE,
 };

--- a/src/memory/bus.rs
+++ b/src/memory/bus.rs
@@ -445,6 +445,9 @@ pub trait MemoryBus {
 pub struct MacMemoryBus {
     ram: RamStorage,
     ram_size: u32,
+    /// Whether guest addresses use all 32 bits. In 24-bit mode the upper
+    /// byte is metadata and every memory access wraps through the low 24 bits.
+    addressing_32_bit: bool,
     globals: LowMemGlobals,
     /// Heap allocation pointer (grows upward from 0x200000)
     heap_ptr: u32,
@@ -798,9 +801,17 @@ impl MacMemoryBus {
         #[cfg(not(debug_assertions))]
         let fast = fb_write_trace_range().is_none() && self.write_probe_original.is_none();
         let count_usize = count as usize;
+        let translated_src = self.range_translates_contiguously(src, count_usize);
+        let translated_dst = self.range_translates_contiguously(dst, count_usize);
+        let src_for_overlap = self.translate_guest_address(src);
+        let dst_for_overlap = self.translate_guest_address(dst);
+        let src = translated_src.unwrap_or(src);
+        let dst = translated_dst.unwrap_or(dst);
         let src_end = (src as u64).saturating_add(count as u64);
         let dst_end = (dst as u64).saturating_add(count as u64);
         if fast
+            && translated_src.is_some()
+            && translated_dst.is_some()
             && !self.readonly_code_overlaps(dst, count)
             && src_end <= self.ram_size as u64
             && dst_end <= self.ram_size as u64
@@ -813,7 +824,9 @@ impl MacMemoryBus {
             }
         }
         // Fallback with explicit overlap handling (IM II-44).
-        if dst > src && dst < src.saturating_add(count) {
+        if dst_for_overlap > src_for_overlap
+            && dst_for_overlap < src_for_overlap.saturating_add(count)
+        {
             for i in (0..count).rev() {
                 let b = self.read_byte(src.wrapping_add(i));
                 self.write_byte(dst.wrapping_add(i), b);
@@ -839,6 +852,7 @@ impl MacMemoryBus {
         let mut bus = Self {
             ram: RamStorage::Owned(vec![0; ram_size]),
             ram_size: ram_size as u32,
+            addressing_32_bit: true,
             globals: LowMemGlobals::new(),
             heap_ptr: 0x200000, // Start heap at 2MB
             synthetic_ptr: screen_buffer_start,
@@ -919,6 +933,7 @@ impl MacMemoryBus {
         Self {
             ram: RamStorage::External(ram_ptr, ram_size),
             ram_size: ram_size as u32,
+            addressing_32_bit: true,
             globals,
             heap_ptr: 0x200000,
             synthetic_ptr: screen_buffer_start,
@@ -1247,9 +1262,17 @@ impl MacMemoryBus {
             && self.write_probe_original.is_none();
         #[cfg(not(debug_assertions))]
         let fast = fb_write_trace_range().is_none() && self.write_probe_original.is_none();
+        let translated_src = self.range_translates_contiguously(src, len as usize);
+        let translated_dst = self.range_translates_contiguously(dst, len as usize);
+        let src = translated_src.unwrap_or(src);
+        let dst = translated_dst.unwrap_or(dst);
         let src_end = (src as u64).saturating_add(len as u64);
         let dst_end = (dst as u64).saturating_add(len as u64);
-        if src_end > self.ram_size as u64 || dst_end > self.ram_size as u64 {
+        if translated_src.is_none()
+            || translated_dst.is_none()
+            || src_end > self.ram_size as u64
+            || dst_end > self.ram_size as u64
+        {
             return false;
         }
         if fast {
@@ -1275,9 +1298,17 @@ impl MacMemoryBus {
             && self.write_probe_original.is_none();
         #[cfg(not(debug_assertions))]
         let fast = fb_write_trace_range().is_none() && self.write_probe_original.is_none();
+        let translated_src = self.range_translates_contiguously(src, len as usize);
+        let translated_dst = self.range_translates_contiguously(dst, len as usize);
+        let src = translated_src.unwrap_or(src);
+        let dst = translated_dst.unwrap_or(dst);
         let src_end = (src as u64).saturating_add(len as u64);
         let dst_end = (dst as u64).saturating_add(len as u64);
-        if src_end > self.ram_size as u64 || dst_end > self.ram_size as u64 {
+        if translated_src.is_none()
+            || translated_dst.is_none()
+            || src_end > self.ram_size as u64
+            || dst_end > self.ram_size as u64
+        {
             return false;
         }
         if fast {
@@ -1317,12 +1348,43 @@ impl MacMemoryBus {
         self.ram_size
     }
 
+    /// Select the guest MMU address width. The default is 32-bit addressing.
+    pub fn set_addressing_32_bit(&mut self, enabled: bool) {
+        self.addressing_32_bit = enabled;
+    }
+
+    /// Whether guest memory accesses currently use all 32 address bits.
+    pub fn addressing_32_bit(&self) -> bool {
+        self.addressing_32_bit
+    }
+
+    #[inline]
+    pub fn translate_guest_address(&self, address: u32) -> u32 {
+        if self.addressing_32_bit {
+            address
+        } else {
+            address & 0x00FF_FFFF
+        }
+    }
+
+    #[inline]
+    fn range_translates_contiguously(&self, address: u32, len: usize) -> Option<u32> {
+        let translated = self.translate_guest_address(address);
+        let address_space_end = if self.addressing_32_bit {
+            u64::from(u32::MAX) + 1
+        } else {
+            0x0100_0000
+        };
+        ((translated as u64).saturating_add(len as u64) <= address_space_end).then_some(translated)
+    }
+
     /// Raw window over guest RAM for the m68k fastmem path, or `None`
     /// while any per-access diagnostic (framebuffer-write tracer, memory
     /// read/write tracer, watchpoint) needs to observe individual bus
     /// accesses — fastmem reads/writes bypass those hooks entirely.
     pub(crate) fn fast_mem_window(&mut self) -> Option<(*mut u8, u32)> {
-        if fb_write_trace_range().is_some()
+        if !self.addressing_32_bit
+            || fb_write_trace_range().is_some()
             || mem_read_trace_active()
             || mem_write_trace_active()
             || watchpoint_armed()
@@ -1354,6 +1416,7 @@ impl MacMemoryBus {
 impl MemoryBus for MacMemoryBus {
     #[inline]
     fn read_byte(&self, address: u32) -> u8 {
+        let address = self.translate_guest_address(address);
         let v = if address < self.ram_size {
             self.ram.get_in_bounds(address as usize)
         } else if let Some(value) = Self::boot_rom_shadow_byte(address) {
@@ -1375,7 +1438,9 @@ impl MemoryBus for MacMemoryBus {
     /// the byte-by-byte path when the read straddles `self.ram_size`.
     #[inline]
     fn read_word(&self, address: u32) -> u16 {
-        let v = if (address as u64) + 2 <= (self.ram_size as u64) {
+        let translated = self.range_translates_contiguously(address, 2);
+        let v = if translated.is_some_and(|address| (address as u64) + 2 <= self.ram_size as u64) {
+            let address = translated.unwrap();
             self.ram.read_word_in_bounds(address as usize)
         } else {
             let hi = self.read_byte(address) as u16;
@@ -1392,7 +1457,9 @@ impl MemoryBus for MacMemoryBus {
     /// slice index when the 4 bytes lie wholly within `self.ram_size`.
     #[inline]
     fn read_long(&self, address: u32) -> u32 {
-        let v = if (address as u64) + 4 <= (self.ram_size as u64) {
+        let translated = self.range_translates_contiguously(address, 4);
+        let v = if translated.is_some_and(|address| (address as u64) + 4 <= self.ram_size as u64) {
+            let address = translated.unwrap();
             self.ram.read_long_in_bounds(address as usize)
         } else {
             let hi = self.read_word(address) as u32;
@@ -1404,6 +1471,7 @@ impl MemoryBus for MacMemoryBus {
     }
 
     fn write_byte(&mut self, address: u32, value: u8) {
+        let address = self.translate_guest_address(address);
         if self.readonly_code_overlaps(address, 1) {
             return;
         }
@@ -1571,7 +1639,9 @@ impl MemoryBus for MacMemoryBus {
     /// needs per-byte dispatch through `write_byte`.
     #[inline]
     fn write_word(&mut self, address: u32, value: u16) {
-        if self.readonly_code_overlaps(address, 2) {
+        let translated = self.range_translates_contiguously(address, 2);
+        let protected_address = translated.unwrap_or(address);
+        if self.readonly_code_overlaps(protected_address, 2) {
             return;
         }
         maybe_log_mem_write(address, 2, value as u32);
@@ -1583,7 +1653,8 @@ impl MemoryBus for MacMemoryBus {
             && self.write_probe_original.is_none();
         #[cfg(not(debug_assertions))]
         let fast = fb_write_trace_range().is_none() && self.write_probe_original.is_none();
-        if fast && (address as u64) + 2 <= (self.ram_size as u64) {
+        if fast && translated.is_some_and(|address| (address as u64) + 2 <= self.ram_size as u64) {
+            let address = translated.unwrap();
             self.ram.write_word_in_bounds(address as usize, value);
             return;
         }
@@ -1596,7 +1667,9 @@ impl MemoryBus for MacMemoryBus {
     /// Same fast-path optimisation as `write_word`.
     #[inline]
     fn write_long(&mut self, address: u32, value: u32) {
-        if self.readonly_code_overlaps(address, 4) {
+        let translated = self.range_translates_contiguously(address, 4);
+        let protected_address = translated.unwrap_or(address);
+        if self.readonly_code_overlaps(protected_address, 4) {
             return;
         }
         maybe_log_mem_write(address, 4, value);
@@ -1607,7 +1680,8 @@ impl MemoryBus for MacMemoryBus {
             && self.write_probe_original.is_none();
         #[cfg(not(debug_assertions))]
         let fast = fb_write_trace_range().is_none() && self.write_probe_original.is_none();
-        if fast && (address as u64) + 4 <= (self.ram_size as u64) {
+        if fast && translated.is_some_and(|address| (address as u64) + 4 <= self.ram_size as u64) {
+            let address = translated.unwrap();
             self.ram.write_long_in_bounds(address as usize, value);
             return;
         }
@@ -1621,8 +1695,10 @@ impl MemoryBus for MacMemoryBus {
     /// that pulls more than a few bytes at once.
     #[inline]
     fn read_bytes(&self, address: u32, len: usize) -> Vec<u8> {
+        let translated = self.range_translates_contiguously(address, len);
+        let address = translated.unwrap_or(address);
         let end = (address as u64).saturating_add(len as u64);
-        if end <= self.ram_size as u64 {
+        if translated.is_some() && end <= self.ram_size as u64 {
             if let Some(slice) = self.ram.slice_at(address as usize, len) {
                 return slice.to_vec();
             }
@@ -1641,8 +1717,10 @@ impl MemoryBus for MacMemoryBus {
     #[inline]
     fn read_bytes_into(&self, address: u32, dst: &mut [u8]) {
         let len = dst.len();
+        let translated = self.range_translates_contiguously(address, len);
+        let address = translated.unwrap_or(address);
         let end = (address as u64).saturating_add(len as u64);
-        if end <= self.ram_size as u64 {
+        if translated.is_some() && end <= self.ram_size as u64 {
             if let Some(slice) = self.ram.slice_at(address as usize, len) {
                 dst.copy_from_slice(slice);
                 return;
@@ -1659,7 +1737,9 @@ impl MemoryBus for MacMemoryBus {
     /// trigger; same for the FB-write tracer.
     #[inline]
     fn write_bytes(&mut self, address: u32, data: &[u8]) {
-        if self.readonly_code_overlaps(address, data.len() as u32) {
+        let translated = self.range_translates_contiguously(address, data.len());
+        let protected_address = translated.unwrap_or(address);
+        if self.readonly_code_overlaps(protected_address, data.len() as u32) {
             return;
         }
         #[cfg(debug_assertions)]
@@ -1668,8 +1748,9 @@ impl MemoryBus for MacMemoryBus {
             && self.write_probe_original.is_none();
         #[cfg(not(debug_assertions))]
         let fast = fb_write_trace_range().is_none() && self.write_probe_original.is_none();
+        let address = translated.unwrap_or(address);
         let end = (address as u64).saturating_add(data.len() as u64);
-        if fast && end <= self.ram_size as u64 {
+        if fast && translated.is_some() && end <= self.ram_size as u64 {
             self.ram.write_bytes_in_bounds(address as usize, data);
             return;
         }
@@ -1680,7 +1761,9 @@ impl MemoryBus for MacMemoryBus {
 
     #[inline]
     fn fill_zeros(&mut self, address: u32, len: u32) {
-        if self.readonly_code_overlaps(address, len) {
+        let translated = self.range_translates_contiguously(address, len as usize);
+        let protected_address = translated.unwrap_or(address);
+        if self.readonly_code_overlaps(protected_address, len) {
             return;
         }
         #[cfg(debug_assertions)]
@@ -1689,8 +1772,9 @@ impl MemoryBus for MacMemoryBus {
             && self.write_probe_original.is_none();
         #[cfg(not(debug_assertions))]
         let fast = fb_write_trace_range().is_none() && self.write_probe_original.is_none();
+        let address = translated.unwrap_or(address);
         let end = (address as u64).saturating_add(len as u64);
-        if fast && end <= self.ram_size as u64 {
+        if fast && translated.is_some() && end <= self.ram_size as u64 {
             self.ram
                 .fill_zeros_in_bounds(address as usize, len as usize);
             return;
@@ -1702,7 +1786,9 @@ impl MemoryBus for MacMemoryBus {
 
     #[inline]
     fn fill_bytes(&mut self, address: u32, len: u32, value: u8) {
-        if self.readonly_code_overlaps(address, len) {
+        let translated = self.range_translates_contiguously(address, len as usize);
+        let protected_address = translated.unwrap_or(address);
+        if self.readonly_code_overlaps(protected_address, len) {
             return;
         }
         #[cfg(debug_assertions)]
@@ -1711,8 +1797,9 @@ impl MemoryBus for MacMemoryBus {
             && self.write_probe_original.is_none();
         #[cfg(not(debug_assertions))]
         let fast = fb_write_trace_range().is_none() && self.write_probe_original.is_none();
+        let address = translated.unwrap_or(address);
         let end = (address as u64).saturating_add(len as u64);
-        if fast && end <= self.ram_size as u64 {
+        if fast && translated.is_some() && end <= self.ram_size as u64 {
             self.ram
                 .fill_bytes_in_bounds(address as usize, len as usize, value);
             return;
@@ -1730,6 +1817,52 @@ impl MemoryBus for MacMemoryBus {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn twenty_four_bit_mode_translates_scalar_and_bulk_accesses() {
+        let mut bus = MacMemoryBus::new(2 * 1024 * 1024);
+        bus.set_addressing_32_bit(false);
+
+        bus.write_byte(0x0301_0000, 0x12);
+        bus.write_word(0x0401_0002, 0x3456);
+        bus.write_long(0xA501_0004, 0x789A_BCDE);
+        bus.write_bytes(0x7F01_0008, &[1, 2, 3, 4]);
+
+        assert_eq!(bus.read_byte(0x0001_0000), 0x12);
+        assert_eq!(bus.read_word(0x0001_0002), 0x3456);
+        assert_eq!(bus.read_long(0x0001_0004), 0x789A_BCDE);
+        assert_eq!(bus.read_bytes(0x0001_0008, 4), [1, 2, 3, 4]);
+        assert_eq!(bus.read_long(0xEE01_0004), 0x789A_BCDE);
+    }
+
+    #[test]
+    fn twenty_four_bit_accesses_wrap_at_the_address_space_boundary() {
+        let mut bus = MacMemoryBus::new(0x0100_0000);
+        bus.set_addressing_32_bit(false);
+        bus.write_byte(0x00FF_FFFF, 0x12);
+        bus.write_byte(0, 0x34);
+
+        assert_eq!(bus.read_word(0xABFF_FFFF), 0x1234);
+        assert_eq!(bus.read_bytes(0xCDFF_FFFF, 2), [0x12, 0x34]);
+
+        bus.write_word(0xEFFF_FFFF, 0x5678);
+        assert_eq!(bus.read_byte(0x00FF_FFFF), 0x56);
+        assert_eq!(bus.read_byte(0), 0x78);
+    }
+
+    #[test]
+    fn thirty_two_bit_mode_preserves_tagged_addresses() {
+        let mut bus = MacMemoryBus::new(2 * 1024 * 1024);
+        bus.write_byte(0x0001_0000, 0x5A);
+
+        assert_eq!(bus.read_byte(0x0301_0000), 0);
+        assert_eq!(bus.read_byte(0x0001_0000), 0x5A);
+        assert!(bus.fast_mem_window().is_some());
+
+        bus.set_addressing_32_bit(false);
+        assert_eq!(bus.read_byte(0x0301_0000), 0x5A);
+        assert!(bus.fast_mem_window().is_none());
+    }
 
     #[test]
     fn new_bus_publishes_default_screen_row_bytes() {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1481,6 +1481,9 @@ pub struct FixtureRunnerConfig {
     /// Declares whether theme rendering preserves classic guest metrics or opts
     /// into future themed hit/measurement behavior.
     pub theme_metrics_mode: ThemeMetricsMode,
+    /// Use the full 32-bit guest address, or mask memory accesses to the low
+    /// 24 bits as on classic Macs running in 24-bit addressing mode.
+    pub addressing_32_bit: bool,
 }
 
 impl Default for FixtureRunnerConfig {
@@ -1492,6 +1495,7 @@ impl Default for FixtureRunnerConfig {
             menu_bar_policy: MenuBarPolicy::GuestControlled,
             ui_theme: UiThemeId::ClassicSystem7,
             theme_metrics_mode: ThemeMetricsMode::ClassicGuestMetrics,
+            addressing_32_bit: true,
         }
     }
 }
@@ -1713,10 +1717,20 @@ impl FixtureRunner {
     /// [`FixtureRunnerConfig`] or through
     /// [`set_menu_bar_policy`](Self::set_menu_bar_policy).
     pub fn new(ram_size: usize, config: FixtureRunnerConfig) -> Self {
+        // A 24-bit address space can expose at most 16 MiB. Keep all allocated
+        // guest structures, the stack, and framebuffer below that boundary so
+        // masking the flag byte cannot alias a high-memory layout onto low RAM.
+        let ram_size = if config.addressing_32_bit {
+            ram_size
+        } else {
+            ram_size.min(0x0100_0000)
+        };
         let mut dispatcher = TrapDispatcher::new();
         dispatcher.set_menu_bar_policy(config.menu_bar_policy);
+        dispatcher.mmu_mode = u8::from(config.addressing_32_bit);
         dispatcher.set_ui_theme_id(config.ui_theme);
         let mut bus = MacMemoryBus::new(ram_size);
+        bus.set_addressing_32_bit(config.addressing_32_bit);
         let standard_adb_service = bus.alloc_synthetic(2);
         bus.write_word(standard_adb_service, 0x4E75); // RTS
         dispatcher
@@ -1987,7 +2001,7 @@ impl FixtureRunner {
             // bus impl. Tag explicitly when the read landed at an
             // address beyond the configured guest RAM.
             let opcode = self.bus.read_word(cur);
-            let unmapped = cur >= self.bus.ram_size();
+            let unmapped = self.bus.translate_guest_address(cur) >= self.bus.ram_size();
             let (mnemonic, size) = if unmapped {
                 ("<unmapped>".to_string(), 2)
             } else {
@@ -2896,6 +2910,7 @@ impl FixtureRunner {
             menu_bar_policy: self.config.menu_bar_policy,
             ui_theme: self.config.ui_theme,
             theme_metrics_mode: self.config.theme_metrics_mode,
+            addressing_32_bit: self.bus.addressing_32_bit(),
         };
         let menu_bar_policy = self.dispatcher.menu_bar_policy;
         let menu_bar_hidden = self.dispatcher.menu_bar_hidden;
@@ -3183,7 +3198,8 @@ impl FixtureRunner {
         // Inside Macintosh: Memory 1992, p. 4-25 says applications can test
         // this low-memory byte directly; Systemless's TrapDispatcher already
         // defaults SwapMMUMode to true32b and Gestalt('addr') bit 0 to set.
-        self.bus.write_byte(addr::MMU32_BIT, 1);
+        self.bus
+            .write_byte(addr::MMU32_BIT, u8::from(self.bus.addressing_32_bit()));
         // Initialize Ticks ($016A) to a realistic post-boot value.
         // On a real Mac, hundreds of ticks elapse during the boot ROM,
         // system extensions, and Finder startup before the application
@@ -4790,7 +4806,8 @@ impl FixtureRunner {
                 return (count, false);
             }
 
-            if pc >= self.bus.ram_size() || pc < 0x60 {
+            let translated_pc = self.bus.translate_guest_address(pc);
+            if translated_pc >= self.bus.ram_size() || translated_pc < 0x60 {
                 // Read opcode + sp on-demand in the error branch.
                 let opcode = self.bus.read_word(pc);
                 let sp = self.cpu.read_reg(Register::A7);
@@ -9479,7 +9496,8 @@ impl FixtureRunner {
 
             // Safety Trigger: If PC jumps outside RAM or to Low Mem, stop immediately
             // Allow $60+ since CRT relocation installs trampolines in low memory
-            if pc >= self.bus.ram_size() || (pc < 0x60 && pc > 0) {
+            let translated_pc = self.bus.translate_guest_address(pc);
+            if translated_pc >= self.bus.ram_size() || (translated_pc < 0x60 && pc > 0) {
                 eprintln!(
                     "[RUN] CRITICAL: PC jumped to invalid address ${:08X}! Halting trace.",
                     pc
@@ -13749,6 +13767,57 @@ mod tests {
     }
 
     #[test]
+    fn init_app_can_start_in_twenty_four_bit_addressing_mode() {
+        let mut runner = FixtureRunner::new(
+            8 * 1024 * 1024,
+            FixtureRunnerConfig {
+                addressing_32_bit: false,
+                ..FixtureRunnerConfig::default()
+            },
+        );
+        let app = LoadedApp {
+            ppc: None,
+            code0_header: Code0Header {
+                above_a5: 0,
+                below_a5: 0x2000,
+                jump_table_size: 0,
+                jump_table_offset: 0,
+            },
+            a5_base: 0x0040_0000,
+            jump_table: Vec::new(),
+            segment_bases: HashMap::new(),
+            loaded_image_end: 0,
+            initial_sp: 0x007F_FFC0,
+            size_resource: None,
+        };
+
+        runner.init_app(&app);
+
+        assert!(!runner.bus.addressing_32_bit());
+        assert_eq!(runner.bus.ram_size(), 8 * 1024 * 1024);
+        assert_eq!(runner.dispatcher.mmu_mode, 0);
+        assert_eq!(
+            runner
+                .bus
+                .read_byte(crate::memory::globals::addr::MMU32_BIT),
+            0
+        );
+    }
+
+    #[test]
+    fn twenty_four_bit_runner_caps_guest_ram_at_sixteen_megabytes() {
+        let runner = FixtureRunner::new(
+            64 * 1024 * 1024,
+            FixtureRunnerConfig {
+                addressing_32_bit: false,
+                ..FixtureRunnerConfig::default()
+            },
+        );
+
+        assert_eq!(runner.bus.ram_size(), 0x0100_0000);
+    }
+
+    #[test]
     fn init_app_seeds_callable_swap_mmu_mode_trap_table_entry() {
         let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
         let app = LoadedApp {
@@ -13805,6 +13874,12 @@ mod tests {
                 .read_byte(crate::memory::globals::addr::MMU32_BIT),
             0,
             "the indirect call should update the requested addressing mode"
+        );
+        runner.bus.write_long(0x0002_1000, 0x1234_5678);
+        assert_eq!(
+            runner.bus.read_long(0xAB02_1000),
+            0x1234_5678,
+            "SwapMMUMode must change actual guest address translation"
         );
     }
 

--- a/src/trap/memory.rs
+++ b/src/trap/memory.rs
@@ -1108,8 +1108,13 @@ impl super::TrapDispatcher {
             // StripAddress ($A055)
             // Strips the high byte of a 24-bit address. No-op in 32-bit mode.
             // Inside Macintosh Volume V, V-593
-            // StripAddress ($A055): Returns A0 unchanged
-            (false, 0x55) => Ok(()),
+            // StripAddress ($A055): Removes the flag byte in 24-bit mode.
+            (false, 0x55) => {
+                if !bus.addressing_32_bit() {
+                    cpu.write_reg(Register::A0, cpu.read_reg(Register::A0) & 0x00FF_FFFF);
+                }
+                Ok(())
+            }
 
             // SwapMMUMode ($A05D)
             // Sets the addressing mode to the value in D0 (0=24-bit, 1=32-bit)
@@ -1121,6 +1126,7 @@ impl super::TrapDispatcher {
                 let new_mode = cpu.read_reg(Register::D0) & 0xFF;
                 let old_mode = self.mmu_mode as u32;
                 self.mmu_mode = (new_mode & 1) as u8;
+                bus.set_addressing_32_bit(self.mmu_mode != 0);
                 bus.write_byte(addr::MMU32_BIT, self.mmu_mode);
                 cpu.write_reg(Register::D0, old_mode);
                 Ok(())
@@ -6972,12 +6978,19 @@ mod tests {
     #[test]
     fn test_strip_address() {
         let (mut dispatcher, mut cpu, mut bus) = setup();
+        cpu.write_reg(Register::A0, 0xAB12_3456);
         let result = dispatcher.dispatch_memory(false, 0x55, &mut cpu, &mut bus);
         assert!(result.is_some(), "StripAddress should be handled");
         assert!(
             result.unwrap().is_ok(),
             "StripAddress should succeed (no-op)"
         );
+        assert_eq!(cpu.read_reg(Register::A0), 0xAB12_3456);
+
+        bus.set_addressing_32_bit(false);
+        let result = dispatcher.dispatch_memory(false, 0x55, &mut cpu, &mut bus);
+        assert!(result.unwrap().is_ok());
+        assert_eq!(cpu.read_reg(Register::A0), 0x0012_3456);
     }
 
     #[test]

--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -3742,7 +3742,7 @@ impl super::TrapDispatcher {
                     // addressing read this and ExitToShell with a
                     // "needs 32-bit addressing" alert if bit 0 is clear.
                     b"addr" => {
-                        cpu.write_reg(Register::A0, 0b111);
+                        cpu.write_reg(Register::A0, 0b110 | u32::from(self.mmu_mode != 0));
                         cpu.write_reg(Register::D0, 0);
                     }
                     // gestaltHardwareAttr ('hdwr') -> low-level hardware attrs.
@@ -13379,6 +13379,21 @@ mod tests {
 
         assert_eq!(cpu.read_reg(Register::A0), 4);
         assert_eq!(cpu.read_reg(Register::D0), 0);
+    }
+
+    #[test]
+    fn gestalt_addressing_attributes_follow_current_mmu_mode() {
+        let (mut disp, mut cpu, mut bus) = setup();
+
+        cpu.write_reg(Register::D0, u32::from_be_bytes(*b"addr"));
+        call(&mut disp, false, 0xAD, &mut cpu, &mut bus).unwrap();
+        assert_eq!(cpu.read_reg(Register::A0), 0b111);
+
+        disp.mmu_mode = 0;
+        bus.set_addressing_32_bit(false);
+        cpu.write_reg(Register::D0, u32::from_be_bytes(*b"addr"));
+        call(&mut disp, false, 0xAD, &mut cpu, &mut bus).unwrap();
+        assert_eq!(cpu.read_reg(Register::A0), 0b110);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add an explicit `--addressing-24-bit` startup mode while preserving the existing 32-bit default
- translate scalar, bulk, block-move, instruction-fetch, and diagnostic guest addresses through the low 24 bits
- synchronize real translation with `SwapMMUMode`, `MMU32Bit`, `StripAddress`, and Gestalt addressing attributes
- keep 24-bit guest allocation below the 16 MiB address-space boundary and disable direct fast memory while translation is active

## Validation

- `cargo fmt --all -- --check`
- `cargo test --lib -q` — 2,954 passed, 3 ignored
- `cargo test --bin systemless -q` — 52 passed
- `cargo check --all-targets -q`
- `cargo check --no-default-features -q`
- `git diff --check`

Closes #567