### PR TITLE
fix(dialog): preserve user-item GrafPort state

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -894,6 +894,8 @@ pub struct FixtureRunner {
     /// must not be re-entered by our synthetic tick advancement while the callback
     /// is still unwinding back to interrupted guest code.
     active_interrupt_callback: Option<ActiveInterruptCallback>,
+    /// GrafPort state saved while an application-owned dialog userItem draws.
+    dialog_draw_port_snapshot: Option<crate::trap::dispatch::PortStateSnapshot>,
     /// Tracking trap PC to re-fire after an asynchronous callback returns.
     ///
     /// A timer/VBL callback can be injected while MenuSelect or ModalDialog
@@ -1012,6 +1014,7 @@ impl FixtureRunner {
             adb_callback_trampoline: 0,
             adb_packet_buffer: 0,
             active_interrupt_callback: None,
+            dialog_draw_port_snapshot: None,
             deferred_tracking_refire_pc: None,
             audio: None,
             audio_buffer: Vec::new(),
@@ -3580,6 +3583,18 @@ impl FixtureRunner {
                     self.cpu
                         .core
                         .set_sr_noint_nosp(active_interrupt_callback.sr);
+                    if matches!(
+                        active_interrupt_callback.source,
+                        ActiveInterruptCallbackSource::DialogDrawProc
+                    ) {
+                        if let Some(snapshot) = self.dialog_draw_port_snapshot.take() {
+                            self.dispatcher.restore_current_port_state(
+                                &mut self.bus,
+                                &mut self.cpu,
+                                &snapshot,
+                            );
+                        }
+                    }
                     if let Some((port, gdevice)) = active_interrupt_callback.restore_port {
                         self.dispatcher.set_current_port_state(
                             &mut self.bus,
@@ -5696,11 +5711,14 @@ impl FixtureRunner {
         self.bus.write_word(tramp + 12, item_no as u16);
         self.bus.write_long(tramp + 16, call_addr);
 
-        // The Dialog Manager sets the current port to the dialog before
-        // calling a userItem draw proc. It does not restore an older
-        // application port over the callback's final QuickDraw state.
-        self.dispatcher
-            .set_current_port_state(&mut self.bus, &mut self.cpu, dialog_ptr, None);
+        // The Dialog Manager sets the current port to the dialog before a
+        // userItem draw proc. Preserve the dialog's clean baseline around
+        // application drawing so one item cannot contaminate later redraws.
+        self.dialog_draw_port_snapshot = Some(self.dispatcher.prepare_dialog_user_item_port_state(
+            &mut self.bus,
+            &mut self.cpu,
+            dialog_ptr,
+        ));
 
         // Inject: push current PC, jump to trampoline
         let current_pc = self.cpu.read_reg(Register::PC);
@@ -13360,6 +13378,100 @@ mod tests {
         assert_eq!(
             runner.dispatcher.current_port, dialog_ptr,
             "Dialog Manager must leave the dialog port current after the draw proc"
+        );
+    }
+
+    #[test]
+    fn dialog_draw_proc_restores_parent_grafport_state_and_clip() {
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        let interrupted_pc = 0x0001_0000u32;
+        let interrupted_sp = 0x007F_FFC0u32;
+        let dialog_ptr = runner.bus.alloc(170);
+        let other_port = runner.bus.alloc(170);
+        let proc_addr = 0x0004_2000u32;
+        let clip_rect = 0x0004_2100u32;
+
+        runner.bus.write_word(interrupted_pc, 0x60FE);
+        runner.cpu.write_reg(Register::PC, interrupted_pc);
+        runner.cpu.write_reg(Register::A7, interrupted_sp);
+        for port in [dialog_ptr, other_port] {
+            runner.dispatcher.init_cgraf_window(
+                &mut runner.bus,
+                &mut runner.cpu,
+                port,
+                0,
+                120,
+                180,
+                240,
+                420,
+                "",
+                2,
+                true,
+                false,
+                false,
+                0,
+            );
+        }
+        runner.dispatcher.set_current_port_state(
+            &mut runner.bus,
+            &mut runner.cpu,
+            dialog_ptr,
+            None,
+        );
+        let clip_handle = runner.bus.read_long(dialog_ptr + 28);
+        let clip_ptr = runner.bus.read_long(clip_handle);
+        let expected_clip: Vec<u8> = (0..10)
+            .map(|i| runner.bus.read_byte(clip_ptr + i))
+            .collect();
+
+        runner.bus.write_word(clip_rect, 1);
+        runner.bus.write_word(clip_rect + 2, 2);
+        runner.bus.write_word(clip_rect + 4, 3);
+        runner.bus.write_word(clip_rect + 6, 4);
+        let words = [
+            0x4E56,
+            0x0000, // LINK A6,#0
+            0x3F3C,
+            0x0007, // MOVE.W #7,-(SP), height
+            0x3F3C,
+            0x0006, // MOVE.W #6,-(SP), width
+            0xA89B, // _PenSize
+            0x3F3C,
+            0x000C, // MOVE.W #12,-(SP)
+            0xA89C, // _PenMode
+            0x2F3C,
+            (clip_rect >> 16) as u16,
+            clip_rect as u16, // rect pointer
+            0xA87B,           // _ClipRect
+            0x2F3C,
+            (other_port >> 16) as u16,
+            other_port as u16, // port pointer
+            0xA873,            // _SetPort
+            0x4E5E,
+            0x4E75, // UNLK; RTS
+        ];
+        for (i, word) in words.into_iter().enumerate() {
+            runner.bus.write_word(proc_addr + i as u32 * 2, word);
+        }
+        runner.dispatcher.modeless_dialog_draw_proc_queue =
+            VecDeque::from([(dialog_ptr, proc_addr, 5)]);
+
+        assert!(runner.fire_modeless_dialog_draw_proc());
+        let (_steps, running) = runner.run_steps(64, None);
+
+        assert!(running);
+        assert!(runner.active_interrupt_callback.is_none());
+        assert_eq!(runner.dispatcher.current_port, dialog_ptr);
+        assert_eq!(runner.bus.read_word(dialog_ptr + 52), 1);
+        assert_eq!(runner.bus.read_word(dialog_ptr + 54), 1);
+        assert_eq!(runner.bus.read_word(dialog_ptr + 56), 8);
+        assert_eq!(runner.bus.read_long(dialog_ptr + 28), clip_handle);
+        let restored_clip_ptr = runner.bus.read_long(clip_handle);
+        assert_eq!(
+            (0..10)
+                .map(|i| runner.bus.read_byte(restored_clip_ptr + i))
+                .collect::<Vec<_>>(),
+            expected_clip
         );
     }
 

--- a/src/trap/dialog.rs
+++ b/src/trap/dialog.rs
@@ -4475,6 +4475,7 @@ impl super::TrapDispatcher {
 
     fn clear_dialog_scoped_item_state(&mut self, dialog_ptr: u32) {
         self.dialogs_drawn_by_app.remove(&dialog_ptr);
+        self.dialog_user_item_port_states.remove(&dialog_ptr);
         self.dialog_items.remove(&dialog_ptr);
         self.dialog_item_handles
             .retain(|_, (dlg, _)| *dlg != dialog_ptr);

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -613,6 +613,7 @@ pub(crate) struct PortDrawState {
     pub pn_size: (i16, i16),
     pub pn_mode: i16,
     pub pn_pat: [u8; 8],
+    pub pn_vis: i16,
     pub tx_font: i16,
     pub tx_face: i16,
     pub tx_mode: i16,
@@ -631,12 +632,29 @@ impl Default for PortDrawState {
             pn_size: (1, 1),
             pn_mode: 8,
             pn_pat: [0xFF; 8],
+            pn_vis: 0,
             tx_font: 0,
             tx_face: 0,
             tx_mode: 1,
             tx_size: 0,
         }
     }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct PortRegionSnapshot {
+    pub handle: u32,
+    pub bytes: Vec<u8>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct PortStateSnapshot {
+    pub port: u32,
+    pub gdevice: u32,
+    pub draw_state: PortDrawState,
+    pub port_state_bytes: [u8; 56],
+    pub vis_region: Option<PortRegionSnapshot>,
+    pub clip_region: Option<PortRegionSnapshot>,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -1945,6 +1963,9 @@ pub struct TrapDispatcher {
     pub(crate) modeless_dialog_cdef_draw_queue: VecDeque<u32>,
     /// Dialog currently executing a modeless userItem draw proc.
     pub(crate) active_modeless_dialog_draw_proc: Option<u32>,
+    /// Clean GrafPort baseline established before a dialog's first userItem
+    /// callback. Dialog Manager drawing must not contaminate later callbacks.
+    pub(crate) dialog_user_item_port_states: HashMap<u32, PortStateSnapshot>,
     /// Mouse click currently captured by a front modal dialog. This includes
     /// ModalDialog-retained clicks and app-owned modal button presses.
     pub(crate) retained_modal_dialog_click: Option<RetainedModalDialogClickState>,
@@ -3173,6 +3194,7 @@ impl TrapDispatcher {
             modeless_dialog_draw_proc_queue: VecDeque::new(),
             modeless_dialog_cdef_draw_queue: VecDeque::new(),
             active_modeless_dialog_draw_proc: None,
+            dialog_user_item_port_states: HashMap::new(),
             retained_modal_dialog_click: None,
             pending_modal_button_dispose_dialog: None,
             window_stack: Vec::new(),

--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -18175,6 +18175,7 @@ impl super::TrapDispatcher {
             pn_size: self.pn_size,
             pn_mode: self.pn_mode,
             pn_pat: self.pn_pat,
+            pn_vis: self.pn_vis,
             tx_font: self.tx_font,
             tx_face: self.tx_face,
             tx_mode: self.tx_mode,
@@ -18207,11 +18208,126 @@ impl super::TrapDispatcher {
         self.pn_size = state.pn_size;
         self.pn_mode = state.pn_mode;
         self.pn_pat = state.pn_pat;
+        self.pn_vis = state.pn_vis;
         self.tx_font = state.tx_font;
         self.tx_face = state.tx_face;
         self.tx_mode = state.tx_mode;
         self.tx_size = state.tx_size;
         self.sync_port_draw_state(bus, port);
+    }
+
+    fn capture_port_region(
+        bus: &MacMemoryBus,
+        port: u32,
+        offset: u32,
+    ) -> Option<super::dispatch::PortRegionSnapshot> {
+        let handle = bus.read_long(port + offset);
+        if !Self::guest_range_in_ram(bus, handle, 4) {
+            return None;
+        }
+        let ptr = bus.read_long(handle);
+        if !Self::guest_range_in_ram(bus, ptr, 2) {
+            return None;
+        }
+        let len = u32::from(bus.read_word(ptr));
+        if len < 10 || !Self::guest_range_in_ram(bus, ptr, len) {
+            return None;
+        }
+        let bytes = (0..len).map(|i| bus.read_byte(ptr + i)).collect();
+        Some(super::dispatch::PortRegionSnapshot { handle, bytes })
+    }
+
+    pub(crate) fn capture_current_port_state(
+        &self,
+        bus: &MacMemoryBus,
+    ) -> super::dispatch::PortStateSnapshot {
+        let port = self.current_port;
+        let mut port_state_bytes = [0; 56];
+        if Self::guest_range_in_ram(bus, port.wrapping_add(32), port_state_bytes.len() as u32) {
+            for (i, byte) in port_state_bytes.iter_mut().enumerate() {
+                *byte = bus.read_byte(port + 32 + i as u32);
+            }
+        }
+        super::dispatch::PortStateSnapshot {
+            port,
+            gdevice: self.current_gdevice,
+            draw_state: self.current_draw_state(),
+            port_state_bytes,
+            vis_region: Self::capture_port_region(bus, port, 24),
+            clip_region: Self::capture_port_region(bus, port, 28),
+        }
+    }
+
+    fn restore_port_region(
+        bus: &mut MacMemoryBus,
+        port: u32,
+        offset: u32,
+        region: &super::dispatch::PortRegionSnapshot,
+    ) {
+        bus.write_long(port + offset, region.handle);
+        let Some(ptr) = Self::ensure_region_capacity(bus, region.handle, region.bytes.len() as u32)
+        else {
+            return;
+        };
+        for (i, byte) in region.bytes.iter().copied().enumerate() {
+            bus.write_byte(ptr + i as u32, byte);
+        }
+    }
+
+    pub(crate) fn restore_current_port_state<C: CpuOps>(
+        &mut self,
+        bus: &mut MacMemoryBus,
+        cpu: &mut C,
+        snapshot: &super::dispatch::PortStateSnapshot,
+    ) {
+        self.set_current_port_state(bus, cpu, snapshot.port, Some(snapshot.gdevice));
+        self.fg_color = snapshot.draw_state.fg_color;
+        self.bg_color = snapshot.draw_state.bg_color;
+        self.pm_fg_color = snapshot.draw_state.pm_fg_color;
+        self.pm_bg_color = snapshot.draw_state.pm_bg_color;
+        self.bk_pat = snapshot.draw_state.bk_pat;
+        self.pn_loc = snapshot.draw_state.pn_loc;
+        self.pn_size = snapshot.draw_state.pn_size;
+        self.pn_mode = snapshot.draw_state.pn_mode;
+        self.pn_pat = snapshot.draw_state.pn_pat;
+        self.pn_vis = snapshot.draw_state.pn_vis;
+        self.tx_font = snapshot.draw_state.tx_font;
+        self.tx_face = snapshot.draw_state.tx_face;
+        self.tx_mode = snapshot.draw_state.tx_mode;
+        self.tx_size = snapshot.draw_state.tx_size;
+        self.port_draw_states
+            .insert(snapshot.port, snapshot.draw_state);
+        self.sync_port_draw_state(bus, snapshot.port);
+        for (i, byte) in snapshot.port_state_bytes.iter().copied().enumerate() {
+            bus.write_byte(snapshot.port + 32 + i as u32, byte);
+        }
+        if let Some(region) = &snapshot.vis_region {
+            Self::restore_port_region(bus, snapshot.port, 24, region);
+        }
+        if let Some(region) = &snapshot.clip_region {
+            Self::restore_port_region(bus, snapshot.port, 28, region);
+        }
+    }
+
+    pub(crate) fn prepare_dialog_user_item_port_state<C: CpuOps>(
+        &mut self,
+        bus: &mut MacMemoryBus,
+        cpu: &mut C,
+        dialog_ptr: u32,
+    ) -> super::dispatch::PortStateSnapshot {
+        self.set_current_port_state(bus, cpu, dialog_ptr, None);
+        let snapshot = self
+            .dialog_user_item_port_states
+            .get(&dialog_ptr)
+            .cloned()
+            .unwrap_or_else(|| {
+                let snapshot = self.capture_current_port_state(bus);
+                self.dialog_user_item_port_states
+                    .insert(dialog_ptr, snapshot.clone());
+                snapshot
+            });
+        self.restore_current_port_state(bus, cpu, &snapshot);
+        snapshot
     }
 
     fn load_port_draw_state(&mut self, bus: &MacMemoryBus, port: u32) -> bool {

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -3751,6 +3751,7 @@ impl super::TrapDispatcher {
             pn_size: self.pn_size,
             pn_mode: self.pn_mode,
             pn_pat: self.pn_pat,
+            pn_vis: self.pn_vis,
             tx_font: self.tx_font,
             tx_face: self.tx_face,
             tx_mode: self.tx_mode,
@@ -3768,6 +3769,7 @@ impl super::TrapDispatcher {
         self.pn_size = state.pn_size;
         self.pn_mode = state.pn_mode;
         self.pn_pat = state.pn_pat;
+        self.pn_vis = state.pn_vis;
         self.tx_font = state.tx_font;
         self.tx_face = state.tx_face;
         self.tx_mode = state.tx_mode;


### PR DESCRIPTION
Closes #443.

## Cause

Dialog user-item callbacks inherited the current GrafPort state left by earlier manager and application drawing. In the nested Preferences flow, a 3x3 pen established while drawing dialog chrome became the baseline for later parent user items, producing persistent thick black section borders. Callback changes to the selected port or clip region could leak for the same reason.

## Fix

- Capture a clean per-dialog GrafPort baseline before the first user-item callback.
- Restore that baseline before and after every application-owned user-item draw proc.
- Preserve pen, text, pattern, foreground/background color, visibility, visRgn, clipRgn, current port, and GDevice state without reverting pixels intentionally drawn by the callback.
- Drop the saved baseline when the dialog is disposed.

## Verification

- Added a focused callback regression that mutates pen size, pen mode, clip region, and current port, then verifies the parent state is restored.
- Ran the complete library suite: 2,950 passed, 3 ignored.
- Replayed the reported Preferences → Player Controls → Cancel flow and confirmed parent section borders remain thin while the child is open and after dismissal.