### PR TITLE
fix(cpu): preserve executing code during overwrite

### DIFF
--- a/src/memory/bus.rs
+++ b/src/memory/bus.rs
@@ -459,6 +459,13 @@ pub struct MacMemoryBus {
     /// the overwhelmingly common case reject in two comparisons instead of
     /// scanning the list.
     readonly_code_span: Option<(u32, u32)>,
+    /// Original bytes for resident CODE segments that may be executing while
+    /// a startup decompressor overwrites their backing handles. A cache line
+    /// is activated only when execution encounters an overwritten opcode,
+    /// modeling the 68040 instruction cache without hiding ordinary data
+    /// writes from the guest.
+    executable_snapshots: Vec<ExecutableSnapshot>,
+    execution_pc: u32,
     /// Free list: maps aligned_size → stack of recycled addresses
     free_blocks: HashMap<u32, Vec<u32>>,
     /// Tracks the aligned size of each allocation (address → aligned_size)
@@ -478,6 +485,12 @@ pub struct MacMemoryBus {
     /// An out-of-range write makes the probe unverifiable even though the
     /// normal bus retains its legacy warn-and-ignore behavior.
     write_probe_invalid: bool,
+}
+
+struct ExecutableSnapshot {
+    start: u32,
+    bytes: Vec<u8>,
+    active_line: Option<u32>,
 }
 
 /// RAM storage - either owned vector or borrowed slice
@@ -844,6 +857,8 @@ impl MacMemoryBus {
             synthetic_ptr: screen_buffer_start,
             readonly_code_ranges: Vec::new(),
             readonly_code_span: None,
+            executable_snapshots: Vec::new(),
+            execution_pc: 0,
             free_blocks: HashMap::new(),
             alloc_sizes: HashMap::new(),
             alloc_bucket_sizes: HashMap::new(),
@@ -903,6 +918,57 @@ impl MacMemoryBus {
         bus
     }
 
+    pub(crate) fn register_executable_snapshot(&mut self, start: u32, bytes: Vec<u8>) {
+        if !bytes.is_empty() {
+            self.executable_snapshots.push(ExecutableSnapshot {
+                start,
+                bytes,
+                active_line: None,
+            });
+        }
+    }
+
+    pub(crate) fn set_execution_pc(&mut self, pc: u32) {
+        self.execution_pc = pc;
+    }
+
+    pub(crate) fn execution_pc_uses_snapshot(&self) -> bool {
+        self.read_executable_snapshot_word(self.execution_pc)
+            .is_some()
+    }
+
+    pub(crate) fn recover_overwritten_executable(&mut self, address: u32) -> bool {
+        for snapshot in &mut self.executable_snapshots {
+            let end = snapshot.start.saturating_add(snapshot.bytes.len() as u32);
+            if address >= snapshot.start && address.saturating_add(2) <= end {
+                let offset = (address - snapshot.start) as usize;
+                let original =
+                    u16::from_be_bytes([snapshot.bytes[offset], snapshot.bytes[offset + 1]]);
+                if original == self.ram.read_word_in_bounds(address as usize) {
+                    return false;
+                }
+                snapshot.active_line = Some(address & !0xF);
+                return true;
+            }
+        }
+        false
+    }
+
+    pub(crate) fn read_executable_snapshot_word(&self, address: u32) -> Option<u16> {
+        self.executable_snapshots.iter().find_map(|snapshot| {
+            let line = snapshot.active_line?;
+            if address < line || address.saturating_add(2) > line.saturating_add(16) {
+                return None;
+            }
+            if address < snapshot.start {
+                return None;
+            }
+            let offset = (address - snapshot.start) as usize;
+            let bytes = snapshot.bytes.get(offset..offset + 2)?;
+            Some(u16::from_be_bytes([bytes[0], bytes[1]]))
+        })
+    }
+
     /// Create a memory bus wrapping an external RAM slice
     ///
     /// # Safety
@@ -924,6 +990,8 @@ impl MacMemoryBus {
             synthetic_ptr: screen_buffer_start,
             readonly_code_ranges: Vec::new(),
             readonly_code_span: None,
+            executable_snapshots: Vec::new(),
+            execution_pc: 0,
             free_blocks: HashMap::new(),
             alloc_sizes: HashMap::new(),
             alloc_bucket_sizes: HashMap::new(),

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -101,12 +101,20 @@ impl m68k::AddressBus for MacMemoryBus {
     fn write_long(&mut self, addr: u32, val: u32) {
         MemoryBus::write_long(self, addr, val)
     }
+    #[inline]
+    fn read_immediate_word(&mut self, addr: u32) -> u16 {
+        self.read_executable_snapshot_word(addr)
+            .unwrap_or_else(|| MemoryBus::read_word(self, addr))
+    }
 
     /// Guest RAM is one flat side-effect-free array, so expose it all to
     /// the m68k batch loop. Returns `None` while bus-access diagnostics
     /// (tracers/watchpoints) are active so they keep seeing every access.
     #[inline]
     fn fast_mem(&mut self) -> Option<m68k::FastMem> {
+        if self.execution_pc_uses_snapshot() {
+            return None;
+        }
         let (ptr, len) = self.fast_mem_window()?;
         Some(m68k::FastMem { ptr, base: 0, len })
     }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1836,6 +1836,12 @@ impl FixtureRunner {
     /// yourself (e.g. building a custom test fixture).
     pub fn load_app(&mut self, fork: &ResourceFork) -> Option<LoadedApp> {
         let app = load_app_generic(fork, &mut self.bus, self.config.load_address)?;
+        for code in fork.get_all_code().into_iter().filter(|code| code.id != 0) {
+            if let Some(&start) = app.segment_bases.get(&code.id) {
+                let bytes = self.bus.read_bytes(start, code.data.len());
+                self.bus.register_executable_snapshot(start, bytes);
+            }
+        }
         let heap_start = app_heap_start_for_loaded_app(&app);
 
         // Resource data is allocated after direct CODE/global loading. Reserve
@@ -3503,6 +3509,7 @@ impl FixtureRunner {
             }
 
             let pc = self.cpu.read_reg(Register::PC);
+            self.bus.set_execution_pc(pc);
             // Defer reading SP until needed. sp is only used by the
             // interrupt-callback match (rare), the env-gated
             // trace_buffer path, and the PC-bounds error branch.
@@ -3852,6 +3859,11 @@ impl FixtureRunner {
                     return (count, false);
                 }
                 BatchExit::IllegalInstruction { opcode } => {
+                    let pc = self.cpu.core.ppc;
+                    if self.bus.recover_overwritten_executable(pc) {
+                        self.cpu.write_reg(Register::PC, pc);
+                        continue;
+                    }
                     eprintln!(
                         "[CPU] IllegalInstruction: ${:04X} at PC=${:08X}",
                         opcode, self.cpu.core.pc
@@ -6332,9 +6344,14 @@ impl FixtureRunner {
                 self.trace_buffer.push_back((pc, opcode, a0, sp, a6, a5));
             }
 
+            self.bus.set_execution_pc(pc);
             match self.cpu.step(&mut self.bus) {
                 StepResult::Ok => {}
                 StepResult::Stopped => {
+                    if self.bus.recover_overwritten_executable(self.cpu.core.ppc) {
+                        self.cpu.write_reg(Register::PC, self.cpu.core.ppc);
+                        continue;
+                    }
                     if trace_load_enabled() {
                         let stopped_pc = self.cpu.read_reg(Register::PC);
                         let opcode = self.bus.read_word(stopped_pc);
@@ -7529,6 +7546,35 @@ mod tests {
             code1_base + 0x28,
             "MPW far offsets must not be adjusted by the 40-byte header twice"
         );
+    }
+
+    #[test]
+    fn resident_code_finishes_an_overwritten_startup_loop_from_cached_line() {
+        let base = 0x0001_0000u32;
+        let code0 = minimal_code0(0x1000, 0x1000, 0, 0);
+        let mut code1 = vec![0x00, 0x00, 0x42, 0x19, 0x51, 0xC9, 0xFF, 0xFC, 0x60, 0xFE];
+        code1.resize(16, 0x4E);
+        let fork_bytes = make_resource_fork_bytes(&[
+            (*b"CODE", 0, code0.as_slice()),
+            (*b"CODE", 1, code1.as_slice()),
+        ]);
+        let fork = ResourceFork::parse(&fork_bytes).expect("parse synthetic app fork");
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        runner.config.load_address = base;
+
+        let app = runner.load_app(&fork).expect("load app");
+        let loop_pc = app.segment_bases[&1] + 2;
+        let destination = loop_pc + 2;
+        runner.cpu.write_reg(Register::A1, destination);
+        runner.cpu.write_reg(Register::D1, 0);
+        runner.cpu.write_reg(Register::A7, 0x007F_F000);
+        runner.cpu.write_reg(Register::PC, loop_pc);
+
+        let (_, still_running) = runner.run_steps(4, None);
+
+        assert!(still_running);
+        assert_eq!(runner.bus.read_word(loop_pc + 2), 0x00C9);
+        assert_eq!(runner.cpu.read_reg(Register::PC), loop_pc + 6);
     }
 
     #[test]


### PR DESCRIPTION
Closes #580.

Self-decompressing launchers can overwrite the backing bytes of the resident CODE segment they are still executing. The loader placement only changed where the failure occurred because the startup loop intentionally expands through its own segment, while a real 68040 continues from its instruction cache.

This snapshots resident CODE at load time and activates the affected 16-byte instruction-cache line only when an illegal fetch differs from the loaded bytes. Normal guest data reads and writes still observe the decompressed memory, while opcode fetches can finish the active startup line. Both the batch and precise execution paths recover consistently.

Verification:
- `cargo test --lib --quiet` (2,950 passed, 3 ignored)
- `cargo check --no-default-features --quiet`
- `cargo clippy --lib --quiet`
- `cargo fmt --all -- --check`
- Real Alone in the Dark CD installer passes the former 290,305-instruction / 22-trap illegal-opcode halt and reaches 32 Toolbox traps without halting.