### PR TITLE
fix(resource): expose application resource map

### DIFF
--- a/src/managers/resource/parser.rs
+++ b/src/managers/resource/parser.rs
@@ -47,6 +47,12 @@ pub struct ResourceFork {
     /// All resources indexed by (type, id)
     resources: HashMap<(ResourceType, i16), Resource>,
     pub map_attrs: u16,
+    /// Serialized resource-map bytes retained for guest code that walks
+    /// `TopMapHndl` directly instead of using Resource Manager traps.
+    map: Vec<u8>,
+    /// Complete serialized fork retained for native Resource Manager code
+    /// that reads the already-open application resource fork through PBRead.
+    serialized: Vec<u8>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -66,6 +72,14 @@ impl ResourceFork {
 
     pub fn map_attrs(&self) -> u16 {
         self.map_attrs
+    }
+
+    pub(crate) fn map(&self) -> &[u8] {
+        &self.map
+    }
+
+    pub(crate) fn serialized(&self) -> &[u8] {
+        &self.serialized
     }
 
     #[cfg(test)]
@@ -91,6 +105,8 @@ impl ResourceFork {
                     )
                 })
                 .collect(),
+            map: Vec::new(),
+            serialized: Vec::new(),
         }
     }
 }
@@ -234,7 +250,9 @@ impl ResourceFork {
 
         let mut fork = ResourceFork {
             map_attrs: u16::from_be_bytes([map[22], map[23]]),
-            ..ResourceFork::default()
+            resources: HashMap::new(),
+            map: map.to_vec(),
+            serialized: data.to_vec(),
         };
 
         // Parse type list

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -5748,6 +5748,10 @@ impl TrapDispatcher {
     /// Load resources into guest memory for trap access.
     /// Loads ALL resource types from the fork (not just a hardcoded whitelist).
     pub fn load_resources(&mut self, fork: &ResourceFork, bus: &mut MacMemoryBus) {
+        if let Some(app_path) = self.launched_app_path.as_ref() {
+            self.vfs
+                .insert(format!("__rsrc__{}", app_path), fork.serialized().to_vec());
+        }
         let file = self.allocate_resource_fork(fork, bus);
         self.resource_file_order
             .insert(0, Self::resource_reference_order(fork));
@@ -5820,6 +5824,41 @@ impl TrapDispatcher {
             current_file: 0,
         });
         bus.write_word(0x0A5A, 0);
+
+        // Some classic runtimes locate relocation resources by walking the
+        // Resource Manager's guest-visible map through TopMapHndl. Keep the
+        // HLE indexes above, but also expose the serialized application map
+        // and populate its reference-record handles.
+        if !fork.map().is_empty() {
+            let map_ptr = bus.alloc(fork.map().len() as u32);
+            bus.write_bytes(map_ptr, fork.map());
+            bus.write_long(map_ptr + 16, 0); // no older map in this minimal chain
+            bus.write_word(map_ptr + 20, 0); // application resource-map refnum
+
+            let map_handle = bus.alloc(4);
+            bus.write_long(map_handle, map_ptr);
+            bus.write_long(0x0A50, map_handle); // TopMapHndl
+
+            let mut resources: Vec<_> = fork.resources().values().collect();
+            resources.sort_by_key(|resource| (resource.res_type, resource.id));
+            for resource in resources {
+                let ptr = self
+                    .resources
+                    .as_ref()
+                    .and_then(|loaded| loaded.files.get(&0))
+                    .and_then(|file| file.loaded.get(&(resource.res_type, resource.id)))
+                    .copied()
+                    .unwrap_or(0);
+                let handle = self.get_or_create_resource_handle_in_file(
+                    bus,
+                    resource.res_type,
+                    resource.id,
+                    ptr,
+                    0,
+                );
+                bus.write_long(map_ptr + resource.reference_offset as u32 + 8, handle);
+            }
+        }
     }
 
     pub(crate) fn register_resource_file(&mut self, refnum: u16, file: ResourceFileMap) {
@@ -6840,6 +6879,41 @@ mod tests {
         assert!(disp.remove_vfs_path_relative_to_launched_app("Plug-Ins/MAGMA"));
         assert!(!disp.vfs.contains_key("Game Folder/Plug-Ins/MAGMA"));
         assert!(!disp.vfs_rsrc.contains_key("Game Folder/Plug-Ins/MAGMA"));
+    }
+
+    #[test]
+    fn load_resources_exposes_application_map_and_fork_to_native_runtime_code() {
+        let serialized = make_single_resource_fork_bytes(*b"TEST", 7, b"payload");
+        let fork = ResourceFork::parse(&serialized).unwrap();
+        let reference_offset = fork.get(*b"TEST", 7).unwrap().reference_offset as u32;
+        let mut bus = MacMemoryBus::new(4 * 1024 * 1024);
+        let mut disp = TrapDispatcher::new();
+        disp.set_launched_app_path("Game Folder/Game App");
+
+        disp.load_resources(&fork, &mut bus);
+
+        let map_handle = bus.read_long(0x0A50);
+        let map_ptr = bus.read_long(map_handle);
+        let resource_handle = bus.read_long(map_ptr + reference_offset + 8);
+        let resource_ptr = bus.read_long(resource_handle);
+
+        assert_ne!(map_handle, 0, "TopMapHndl must address the application map");
+        assert_eq!(
+            bus.read_long(map_ptr + 16),
+            0,
+            "map chain terminates at NIL"
+        );
+        assert_eq!(
+            bus.read_word(map_ptr + 20),
+            0,
+            "map belongs to the app file"
+        );
+        assert_eq!(bus.read_bytes(resource_ptr, 7), b"payload");
+        assert_eq!(
+            disp.vfs.get("__rsrc__Game Folder/Game App"),
+            Some(&serialized),
+            "native PBRead must see the open application resource fork"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #579

## Cause

Systemless indexed application resources only in host-side Resource Manager state. Classic runtimes that walk `TopMapHndl` directly therefore saw a NIL map, failed to install their relocation hooks, and later treated segment-relative code targets as low-memory addresses. Native resource-map code also could not read the already-open application resource fork through its FCB because the serialized fork was not mounted on that path.

## Fix

- retain the serialized resource map and complete fork when parsing resources
- publish an application resource-map handle through `TopMapHndl`
- populate each resource reference record with its live guest handle
- expose the serialized application resource fork to native `PBRead` calls

## Evidence

The authentic issue reproducer now completes relocation, initializes QuickDraw, opens its scenario data, and reaches `ExitToShell` with a valid tick count instead of recursively re-entering startup and wrapping `TickCount` to `$FFFFFFFF`.

## Tests

- `cargo test --lib load_resources_exposes_application_map_and_fork_to_native_runtime_code --no-default-features`
- `cargo test --lib --no-default-features` (2,941 passed, 3 ignored)
- authentic issue #579 application startup probe