### PR TITLE
feat(display): support selectable one-bit mode

### DIFF
--- a/src/bin/systemless.rs
+++ b/src/bin/systemless.rs
@@ -149,9 +149,10 @@ struct Cli {
 
 fn parse_screen_depth(value: &str) -> Result<u16, String> {
     match value {
+        "1" => Ok(1),
         "4" => Ok(4),
         "8" => Ok(8),
-        _ => Err("screen depth must be 4 or 8".to_string()),
+        _ => Err("screen depth must be 1, 4, or 8".to_string()),
     }
 }
 
@@ -2609,6 +2610,14 @@ mod tests {
         assert!(cli.addressing_24_bit);
         assert_eq!(cli.screen_depth, 4);
         assert_eq!(cli.max_instructions, Some(1234));
+    }
+
+    #[test]
+    fn cli_accepts_one_bit_screen_depth() {
+        let cli = Cli::try_parse_from(["systemless", "--screen-depth", "1", "game.sit"])
+            .expect("one-bit display depth should parse");
+
+        assert_eq!(cli.screen_depth, 1);
     }
 
     #[test]

--- a/src/display.rs
+++ b/src/display.rs
@@ -138,7 +138,7 @@ pub fn render_screen_into_with_gamma(
     device_gamma: &DisplayGamma,
     pixels: &mut Vec<u8>,
 ) {
-    if matches!(screen_mode.4, 4 | 8) {
+    if matches!(screen_mode.4, 1 | 4 | 8) {
         let palette = rgba_palette_from_clut_with_gamma(device_clut, device_gamma);
         render_screen_with_rgba_palette_into(bus, screen_mode, &palette, pixels);
     } else {

--- a/src/memory/bus.rs
+++ b/src/memory/bus.rs
@@ -930,7 +930,7 @@ impl MacMemoryBus {
     }
 
     pub(crate) fn configure_screen_depth(&mut self, depth: u16) {
-        debug_assert!(matches!(depth, 4 | 8));
+        debug_assert!(matches!(depth, 1 | 4 | 8));
         let profile = crate::machine_profile::reference_machine_profile();
         let row_bytes = ((u32::from(profile.screen_width) * u32::from(depth)).div_ceil(8) + 1) & !1;
         self.write_word(super::globals::addr::SCREEN_ROW, row_bytes as u16);

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1595,7 +1595,7 @@ pub struct FixtureRunnerConfig {
     /// Use the full 32-bit guest address, or mask memory accesses to the low
     /// 24 bits as on classic Macs running in 24-bit addressing mode.
     pub addressing_32_bit: bool,
-    /// Guest-visible indexed screen depth. Supported values are 4 and 8;
+    /// Guest-visible indexed screen depth. Supported values are 1, 4, and 8;
     /// the default remains 8-bit/256-color mode.
     pub screen_depth: u16,
 }
@@ -1631,9 +1631,9 @@ impl FixtureRunnerConfig {
     /// Validate and select one of the indexed display depths supported by the
     /// main framebuffer.
     pub fn with_screen_depth(mut self, screen_depth: u16) -> std::result::Result<Self, String> {
-        if !matches!(screen_depth, 4 | 8) {
+        if !matches!(screen_depth, 1 | 4 | 8) {
             return Err(format!(
-                "unsupported screen depth {screen_depth}; expected 4 or 8"
+                "unsupported screen depth {screen_depth}; expected 1, 4, or 8"
             ));
         }
         self.screen_depth = screen_depth;
@@ -1855,8 +1855,8 @@ impl FixtureRunner {
             ram_size.min(0x0100_0000)
         };
         assert!(
-            matches!(config.screen_depth, 4 | 8),
-            "screen_depth must be 4 or 8"
+            matches!(config.screen_depth, 1 | 4 | 8),
+            "screen_depth must be 1, 4, or 8"
         );
         let mut dispatcher = TrapDispatcher::new();
         dispatcher.set_menu_bar_policy(config.menu_bar_policy);
@@ -10358,8 +10358,32 @@ mod tests {
     }
 
     #[test]
+    fn one_bit_runner_publishes_consistent_screen_metadata() {
+        use crate::memory::globals::addr;
+
+        let config = FixtureRunnerConfig::default()
+            .with_screen_depth(1)
+            .expect("1-bit monochrome mode should be supported");
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, config);
+        let gdevice_handle = runner.dispatcher.ensure_main_gdevice(&mut runner.bus);
+        let gdevice = runner.bus.read_long(gdevice_handle);
+        let pixmap = runner.bus.read_long(runner.bus.read_long(gdevice + 22));
+        let ctab = runner.bus.read_long(runner.bus.read_long(pixmap + 42));
+
+        assert_eq!(runner.dispatcher.screen_mode.1, 100);
+        assert_eq!(runner.dispatcher.screen_mode.4, 1);
+        assert_eq!(runner.bus.read_word(addr::SCREEN_ROW), 100);
+        assert_eq!(runner.bus.read_word(addr::SCREEN_BITS + 4), 100);
+        assert_eq!(runner.bus.read_word(pixmap + 4), 0x8000 | 100);
+        assert_eq!(runner.bus.read_word(pixmap + 32), 1);
+        assert_eq!(runner.bus.read_word(pixmap + 36), 1);
+        assert_eq!(runner.bus.read_word(ctab + 6), 1);
+        assert_eq!(runner.bus.read_long(gdevice + 42), 1);
+    }
+
+    #[test]
     fn runner_config_rejects_nonselectable_screen_depths() {
-        assert!(FixtureRunnerConfig::default().with_screen_depth(1).is_err());
+        assert!(FixtureRunnerConfig::default().with_screen_depth(2).is_err());
         assert!(FixtureRunnerConfig::default().with_screen_depth(5).is_err());
     }
 


### PR DESCRIPTION
## Summary

- accept one-bit framebuffer depth in runner and memory-bus configuration
- publish consistent one-bit QuickDraw/GDevice metadata and a two-entry palette
- accept `--screen-depth 1` in the desktop CLI
- cover runner metadata and CLI parsing with focused regressions

## Verification

- `cargo test --lib one_bit_runner_publishes_consistent_screen_metadata`
- `cargo test --bin systemless cli_accepts_one_bit_screen_depth`
- Beyond Dark Castle renders its title, menu, opening courtyard, HUD, movement, and jump animation in native monochrome mode

This is stacked on #568 because it extends the configurable 4/8-bit display API introduced there.

Closes #591.