### PR TITLE
fix: preserve resource references and map enumeration order

### DIFF
--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -1112,6 +1112,9 @@ pub struct TrapDispatcher {
     pub(crate) detached_handle_files: HashMap<u32, u16>,
     /// Resource fork reference (loaded into memory)
     pub(crate) resources: Option<LoadedResources>,
+    /// On-disk resource reference order for each parsed resource file.
+    /// Inside Macintosh Volume I (1985), p. I-129.
+    pub(crate) resource_file_order: HashMap<u16, Vec<([u8; 4], i16)>>,
     /// Canonical resource bytes keyed by (resource-file refnum, type, id).
     /// Used to reload unloaded resources without reparsing the whole fork.
     pub(crate) resource_backing_data: HashMap<(u16, [u8; 4], i16), Vec<u8>>,
@@ -2896,6 +2899,7 @@ impl TrapDispatcher {
             detached_handle_files: HashMap::new(),
             resources: None,
             resource_backing_data: HashMap::new(),
+            resource_file_order: HashMap::new(),
             resident_resources: HashSet::new(),
             movie_states: HashMap::new(),
             movie_by_controller: HashMap::new(),
@@ -4790,6 +4794,15 @@ impl TrapDispatcher {
         }
     }
 
+    fn resource_reference_order(fork: &ResourceFork) -> Vec<([u8; 4], i16)> {
+        let mut resources: Vec<_> = fork.resources().values().collect();
+        resources.sort_by_key(|resource| resource.reference_offset);
+        resources
+            .into_iter()
+            .map(|resource| (resource.res_type, resource.id))
+            .collect()
+    }
+
     pub(crate) fn remember_resource_backing_data(
         &mut self,
         refnum: u16,
@@ -4984,7 +4997,7 @@ impl TrapDispatcher {
             .remove(&(refnum, res_type, res_id));
     }
 
-    pub(crate) fn forget_resource_live_map_entry_for_handle(&mut self, handle: u32) {
+    pub(crate) fn unload_resource_live_map_entry_for_handle(&mut self, handle: u32) {
         let Some((ptr, res_type, res_id)) = self.loaded_handles.get(&handle).copied() else {
             return;
         };
@@ -5000,11 +5013,13 @@ impl TrapDispatcher {
         };
 
         if file.loaded.get(&(res_type, res_id)).copied() == Some(ptr) {
-            file.loaded.remove(&(res_type, res_id));
+            file.loaded.insert((res_type, res_id), 0);
         }
-        file.named.retain(|(named_type, _), (named_id, named_ptr)| {
-            !(*named_type == res_type && *named_id == res_id && *named_ptr == ptr)
-        });
+        for ((named_type, _), (named_id, named_ptr)) in &mut file.named {
+            if *named_type == res_type && *named_id == res_id && *named_ptr == ptr {
+                *named_ptr = 0;
+            }
+        }
     }
 
     pub(crate) fn clear_resource_file_handle_index(&mut self, refnum: u16) {
@@ -5156,6 +5171,7 @@ impl TrapDispatcher {
             closed = true;
         }
         self.clear_resource_file_backing_data(refnum);
+        self.resource_file_order.remove(&refnum);
         self.clear_resource_file_handle_index(refnum);
         self.resident_resources
             .retain(|(entry_refnum, _, _)| *entry_refnum != refnum);
@@ -5673,6 +5689,8 @@ impl TrapDispatcher {
     /// Loads ALL resource types from the fork (not just a hardcoded whitelist).
     pub fn load_resources(&mut self, fork: &ResourceFork, bus: &mut MacMemoryBus) {
         let file = self.allocate_resource_fork(fork, bus);
+        self.resource_file_order
+            .insert(0, Self::resource_reference_order(fork));
         self.clear_resource_file_backing_data(0);
         self.remember_resource_fork_backing_data(0, fork);
         // Log resource types summary including nrct check.
@@ -5770,6 +5788,7 @@ impl TrapDispatcher {
         refnum: u16,
     ) -> usize {
         let incoming = self.allocate_resource_fork(fork, bus);
+        let incoming_order = Self::resource_reference_order(fork);
         let count = incoming.loaded.len();
         let resources = self.resources.get_or_insert_with(|| LoadedResources {
             files: HashMap::new(),
@@ -5794,6 +5813,12 @@ impl TrapDispatcher {
         for (key, attrs) in incoming.attrs {
             target.attrs.entry(key).or_insert(attrs);
         }
+        let order = self.resource_file_order.entry(refnum).or_default();
+        for key in incoming_order {
+            if !order.contains(&key) {
+                order.push(key);
+            }
+        }
         self.remember_resource_fork_backing_data(refnum, fork);
         count
     }
@@ -5807,6 +5832,8 @@ impl TrapDispatcher {
         refnum: u16,
     ) {
         let file = self.allocate_resource_fork(fork, bus);
+        self.resource_file_order
+            .insert(refnum, Self::resource_reference_order(fork));
         let count = file.loaded.len();
         if trace_sound_enabled() {
             let mut type_counts: HashMap<[u8; 4], usize> = HashMap::new();

--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -755,7 +755,7 @@ impl super::TrapDispatcher {
         let key = (refnum, res_type, res_id);
         let recorded_resident = self.resident_resources.contains(&key);
         if let Some(handle) = self.resource_handles_by_key.get(&key).copied() {
-            if let Some((existing_ptr, existing_type, existing_id)) =
+            if let Some((mut existing_ptr, existing_type, existing_id)) =
                 self.loaded_handles.get(&handle).copied()
             {
                 if existing_type == res_type
@@ -769,6 +769,11 @@ impl super::TrapDispatcher {
                     // later lookup with loading enabled should fill it and restore
                     // the reverse ptr->handle ownership so RecoverHandle keeps
                     // working after the refill.
+                    if existing_ptr == 0 && ptr != 0 {
+                        existing_ptr = ptr;
+                        self.loaded_handles
+                            .insert(handle, (ptr, existing_type, existing_id));
+                    }
                     if bus.read_long(handle) == 0 && (self.res_load || recorded_resident) {
                         bus.write_long(handle, existing_ptr);
                         self.add_resource_materialization_tick_cost(bus, existing_ptr);
@@ -842,7 +847,7 @@ impl super::TrapDispatcher {
         })
     }
 
-    fn reload_resource_data_from_file(
+    pub(crate) fn reload_resource_data_from_file(
         &mut self,
         bus: &mut MacMemoryBus,
         refnum: u16,
@@ -1122,6 +1127,9 @@ impl super::TrapDispatcher {
                             .retain(|(t, _), (id, _)| !(*t == res_type && *id == res_id));
                     }
                 }
+                if let Some(order) = self.resource_file_order.get_mut(&refnum) {
+                    order.retain(|key| *key != (res_type, res_id));
+                }
                 self.forget_resource_backing_data(refnum, res_type, res_id);
                 bus.write_word(0x0A60, 0);
                 true
@@ -1134,6 +1142,9 @@ impl super::TrapDispatcher {
                         file.named
                             .retain(|(t, _), (id, _)| !(*t == res_type && *id == res_id));
                     }
+                }
+                if let Some(order) = self.resource_file_order.get_mut(&current_refnum) {
+                    order.retain(|key| *key != (res_type, res_id));
                 }
                 self.forget_resource_backing_data(current_refnum, res_type, res_id);
                 self.forget_resource_handle_index_for_handle(handle);
@@ -1208,6 +1219,10 @@ impl super::TrapDispatcher {
         file.loaded.insert((res_type, new_id), ptr);
         file.attrs.insert((res_type, new_id), attrs);
         file.map_attrs |= Self::RES_MAP_CHANGED_ATTR;
+        self.resource_file_order
+            .entry(current_refnum)
+            .or_default()
+            .push((res_type, new_id));
 
         if name_ptr != 0 {
             let name_bytes = bus.read_pstring(name_ptr);
@@ -1860,12 +1875,11 @@ impl super::TrapDispatcher {
                                 bus.write_long(handle, detached_ptr);
                             }
                         }
-                        // Detaching severs the handle from the resource map. Keep the
-                        // immutable backing bytes so a later GetResource can reload the
-                        // original fork data, but do not let the file's live map keep
-                        // pointing at this now-private buffer.
+                        // Detaching severs this handle from the resource map without
+                        // deleting the resource reference. Mark its shared data as
+                        // unloaded so a later lookup reloads pristine fork bytes.
+                        self.unload_resource_live_map_entry_for_handle(handle);
                         self.forget_resource_residency_for_handle(handle);
-                        self.forget_resource_live_map_entry_for_handle(handle);
                         self.forget_resource_handle_index_for_handle(handle);
                         self.loaded_handles.remove(&handle);
                         if let Some(refnum) = self.resource_handle_files.remove(&handle) {
@@ -2836,6 +2850,13 @@ impl super::TrapDispatcher {
                             {
                                 self.remember_resource_backing_data(refnum, res_type, new_id, data);
                             }
+                            if let Some(order) = self.resource_file_order.get_mut(&refnum) {
+                                if let Some(key) =
+                                    order.iter_mut().find(|key| **key == (res_type, old_id))
+                                {
+                                    *key = (res_type, new_id);
+                                }
+                            }
                         }
 
                         if let Some(resources) = self.resources.as_mut() {
@@ -2935,6 +2956,10 @@ impl super::TrapDispatcher {
                         if let Some(file) = resources.files.get_mut(&refnum) {
                             // Add to loaded map
                             file.loaded.insert((res_type, res_id), ptr);
+                            self.resource_file_order
+                                .entry(refnum)
+                                .or_default()
+                                .push((res_type, res_id));
                             // Set resChanged attribute
                             let entry = file.attrs.entry((res_type, res_id)).or_insert(0);
                             *entry |= Self::RES_CHANGED_ATTR as u8;
@@ -7146,14 +7171,35 @@ impl super::TrapDispatcher {
     /// real guest-bus allocation. Both traps therefore return the
     /// same byte count from `bus.get_alloc_size`.
     fn handle_resource_size_query<C: CpuOps>(
-        &self,
+        &mut self,
         bus: &mut MacMemoryBus,
         cpu: &mut C,
     ) -> Result<()> {
         let sp = cpu.read_reg(Register::A7);
         let handle = bus.read_long(sp);
 
-        let size: i32 = if let Some((ptr, _, _)) = self.loaded_handles.get(&handle).copied() {
+        let identity = self.loaded_handles.get(&handle).copied();
+        let ptr = match identity {
+            Some((0, res_type, res_id)) if self.res_load => self
+                .resource_handle_files
+                .get(&handle)
+                .copied()
+                .and_then(|refnum| {
+                    self.reload_resource_data_from_file(bus, refnum, res_type, res_id)
+                })
+                .unwrap_or(0),
+            Some((ptr, _, _)) => ptr,
+            None => 0,
+        };
+        if ptr != 0 && identity.is_some_and(|(old_ptr, _, _)| old_ptr == 0) {
+            if let Some(entry) = self.loaded_handles.get_mut(&handle) {
+                entry.0 = ptr;
+            }
+            bus.write_long(handle, ptr);
+            self.restore_loaded_resource_handle(handle, ptr);
+        }
+
+        let size: i32 = if identity.is_some() {
             // IM:I I-121 keys validity on whether the handle is a Resource
             // Manager handle, not on whether the handle's master pointer is
             // currently non-NIL (SetResLoad(FALSE) can return empty handles).
@@ -8820,6 +8866,39 @@ mod tests {
         assert_eq!(bus.read_byte(shared_ptr + 3), 0x40);
     }
 
+    #[test]
+    fn detach_resource_keeps_unloaded_resource_map_reference_reloadable() {
+        // Inside Macintosh Volume I (1985), p. I-122: DetachResource makes
+        // the handle ordinary, but the resource remains in its file. A later
+        // lookup must therefore still count and reload the resource.
+        let (mut disp, mut cpu, mut bus) = setup();
+        let original = [0x10u8, 0x20, 0x30, 0x40];
+        let shared_ptr = setup_resources(&mut disp, &mut bus, b"CODE", 1, &original);
+        let handle = disp.get_or_create_resource_handle(&mut bus, *b"CODE", 1, shared_ptr);
+
+        bus.write_long(TEST_SP, handle);
+        call(&mut disp, true, 0x192, &mut cpu, &mut bus).unwrap();
+
+        assert_eq!(disp.count_resources(*b"CODE", true), 1);
+        assert_eq!(
+            disp.resources
+                .as_ref()
+                .unwrap()
+                .files
+                .get(&0)
+                .unwrap()
+                .loaded
+                .get(&(*b"CODE", 1)),
+            Some(&0)
+        );
+        let (refnum, reloaded_ptr) = disp
+            .find_or_load_resource_current(&mut bus, *b"CODE", 1)
+            .unwrap();
+        assert_eq!(refnum, 0);
+        assert_ne!(reloaded_ptr, shared_ptr);
+        assert_eq!(bus.read_bytes(reloaded_ptr, original.len()), original);
+    }
+
     // Inside Macintosh Volume I (1985), p. I-122: DetachResource must not
     // detach resChanged resources, but ResError still returns noErr.
     #[test]
@@ -8886,7 +8965,7 @@ mod tests {
     }
 
     #[test]
-    fn detach_resource_unloads_live_map_entry_but_keeps_backing_data_reloadable() {
+    fn detach_resource_unloads_map_data_but_keeps_reference_reloadable() {
         let (mut disp, mut cpu, mut bus) = setup();
 
         let original = [0x50, 0x61, 0x6B, 0x20, 0xAA, 0xBB];
@@ -8923,7 +9002,7 @@ mod tests {
                 .unwrap()
                 .loaded
                 .get(&(*b"Pak ", 12000)),
-            None
+            Some(&0)
         );
 
         cpu.write_reg(Register::A7, TEST_SP);
@@ -9414,6 +9493,32 @@ mod tests {
         assert_eq!(new_sp, TEST_SP + 4);
         assert_eq!(bus.read_long(new_sp) as i32, bytes.len() as i32);
         assert_eq!(bus.read_word(0x0A60), 0);
+    }
+
+    #[test]
+    fn size_resource_reloads_nil_backing_pointer_when_loading_is_enabled() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let bytes = [0x11u8, 0x22, 0x33, 0x44];
+        let data_ptr = setup_resources(&mut disp, &mut bus, b"CODE", 1, &bytes);
+        let handle = disp.get_or_create_resource_handle(&mut bus, *b"CODE", 1, data_ptr);
+        disp.loaded_handles.insert(handle, (0, *b"CODE", 1));
+        disp.resources
+            .as_mut()
+            .unwrap()
+            .files
+            .get_mut(&0)
+            .unwrap()
+            .loaded
+            .insert((*b"CODE", 1), 0);
+        bus.write_long(handle, 0);
+        disp.res_load = true;
+
+        bus.write_long(TEST_SP, handle);
+        call(&mut disp, true, 0x1A5, &mut cpu, &mut bus).unwrap();
+
+        assert_eq!(bus.read_long(TEST_SP + 4), bytes.len() as u32);
+        assert_ne!(bus.read_long(handle), 0);
+        assert_eq!(bus.read_bytes(bus.read_long(handle), bytes.len()), bytes);
     }
 
     #[test]

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -16025,32 +16025,51 @@ impl super::TrapDispatcher {
                 self.resource_search_order()
             };
 
-            let mut out: Vec<(i16, u16, u32)> = chain
+            let out: Vec<(i16, u16, u32)> = chain
                 .into_iter()
                 .filter_map(|refnum| resources.files.get(&refnum).map(|file| (refnum, file)))
                 .flat_map(|(refnum, file)| {
-                    file.loaded
-                        .iter()
-                        .filter(|((t, _), _)| *t == res_type)
-                        .map(move |((_, id), ptr)| (*id, refnum, *ptr))
-                        .collect::<Vec<_>>()
+                    let resource_order = self.resource_file_order.get(&refnum);
+                    if resource_order.is_none_or(|order| order.is_empty()) {
+                        let mut entries: Vec<_> = file
+                            .loaded
+                            .iter()
+                            .filter(|((t, _), _)| *t == res_type)
+                            .map(|((_, id), ptr)| (*id, refnum, *ptr))
+                            .collect();
+                        entries.sort_by_key(|&(id, _, _)| id);
+                        entries
+                    } else {
+                        resource_order
+                            .unwrap()
+                            .iter()
+                            .filter(|(entry_type, _)| *entry_type == res_type)
+                            .filter_map(|(_, id)| {
+                                file.loaded
+                                    .get(&(res_type, *id))
+                                    .map(|ptr| (*id, refnum, *ptr))
+                            })
+                            .collect()
+                    }
                 })
                 .collect();
-            // Stable, deterministic order: by resource id ascending. Real
-            // ROM iterates the resource map in map order, but Systemless's
-            // HashMap-backed loaded table has no map order to speak of —
-            // sorting by id is the documented Get*IndResource contract
-            // ("returns handles to all resources of the given type", IM:IV-15)
-            // and matches the in-file behaviour of the existing
-            // GetIndResource arm prior to this split.
-            out.sort_by_key(|&(id, _, _)| id);
+            // Synthetic/test maps predate explicit reference ordering, so keep
+            // their deterministic numeric-ID fallback. Parsed forks preserve
+            // the order of their on-disk reference lists above.
             out
         });
 
         if let Some(candidates) = candidates {
             if index >= 1 && (index as usize) <= candidates.len() {
-                let (res_id, _refnum, ptr) = candidates[(index - 1) as usize];
-                let handle = self.get_or_create_resource_handle(bus, res_type, res_id, ptr);
+                let (res_id, refnum, ptr) = candidates[(index - 1) as usize];
+                let ptr = if ptr == 0 && self.res_load {
+                    self.reload_resource_data_from_file(bus, refnum, res_type, res_id)
+                        .unwrap_or(0)
+                } else {
+                    ptr
+                };
+                let handle =
+                    self.get_or_create_resource_handle_in_file(bus, res_type, res_id, ptr, refnum);
                 eprintln!(
                     "[TRAP] {}('{}', {}) -> id={} handle=${:08X}",
                     trap_name, type_str, index, res_id, handle
@@ -21718,6 +21737,76 @@ mod tests {
         assert_eq!(cpu.read_reg(Register::A0), handle);
         assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 6);
         assert_eq!(bus.read_word(0x0A60), 0);
+    }
+
+    #[test]
+    fn get_ind_resource_reloads_released_map_entry_when_loading_is_enabled() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let bytes = vec![0x10, 0x20, 0x30, 0x40];
+        disp.resources = Some(LoadedResources {
+            files: HashMap::from([(
+                0,
+                ResourceFileMap {
+                    loaded: HashMap::from([((*b"CODE", 1), 0)]),
+                    ..ResourceFileMap::default()
+                },
+            )]),
+            names: HashMap::new(),
+            search_order: vec![0],
+            current_file: 0,
+        });
+        disp.remember_resource_backing_data(0, *b"CODE", 1, bytes.clone());
+        let handle = disp.get_or_create_resource_handle_in_file(&mut bus, *b"CODE", 1, 0, 0);
+        assert_eq!(bus.read_long(handle), 0);
+        disp.res_load = true;
+        bus.write_word(TEST_SP, 1);
+        bus.write_long(TEST_SP + 2, u32::from_be_bytes(*b"CODE"));
+        bus.write_long(TEST_SP + 6, 0);
+
+        let result = disp.dispatch_toolbox(true, 0x00E, &mut cpu, &mut bus);
+
+        assert!(result.is_some() && result.unwrap().is_ok());
+        assert_eq!(bus.read_long(TEST_SP + 6), handle);
+        let ptr = bus.read_long(handle);
+        assert_ne!(ptr, 0);
+        assert_eq!(bus.read_bytes(ptr, bytes.len()), bytes);
+        assert_eq!(disp.loaded_handles.get(&handle).unwrap().0, ptr);
+        assert_eq!(disp.resource_handle_files.get(&handle), Some(&0));
+    }
+
+    #[test]
+    fn get_ind_resource_preserves_resource_map_reference_order() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let first_ptr = bus.alloc(4);
+        let second_ptr = bus.alloc(4);
+        disp.resources = Some(LoadedResources {
+            files: HashMap::from([(
+                0,
+                ResourceFileMap {
+                    loaded: HashMap::from([
+                        ((*b"CODE", 1), second_ptr),
+                        ((*b"CODE", 2), first_ptr),
+                    ]),
+                    ..ResourceFileMap::default()
+                },
+            )]),
+            names: HashMap::new(),
+            search_order: vec![0],
+            current_file: 0,
+        });
+        disp.resource_file_order
+            .insert(0, vec![(*b"CODE", 2), (*b"CODE", 1)]);
+
+        bus.write_word(TEST_SP, 1);
+        bus.write_long(TEST_SP + 2, u32::from_be_bytes(*b"CODE"));
+        bus.write_long(TEST_SP + 6, 0);
+
+        let result = disp.dispatch_toolbox(true, 0x00E, &mut cpu, &mut bus);
+
+        assert!(result.is_some() && result.unwrap().is_ok());
+        let handle = bus.read_long(TEST_SP + 6);
+        assert_eq!(bus.read_long(handle), first_ptr);
+        assert_eq!(disp.loaded_handles.get(&handle).unwrap().2, 2);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- keep detached resources represented in their resource map while unloading shared data
- reload NIL indexed resource handles and reconnect existing master pointers
- preserve resource reference-list order for indexed enumeration

## Cause

`DetachResource` removed the resource-map entry entirely, and indexed enumeration then sorted the remaining hash-map entries by numeric ID. Applications that enumerate and checksum resources therefore saw the wrong resource set and order.

## Evidence

TaskMaker 2.2.3 now enumerates `CODE` and `TEXT` resources in their on-disk reference-list order. Its computed integrity checksum is `02C3`, matching its embedded `CSTR` value, and startup completes without damage dialog 777.

## Tests

- `cargo test` (2,953 passed, 3 ignored; all binary and doc tests passed)
- TaskMaker 2.2.3 scripted startup through tick 810; checksum `02C3`; no damage dialog

Closes #575
