### PR TITLE
fix: clip fully occluded background dialogs

### DIFF
--- a/src/trap/dialog.rs
+++ b/src/trap/dialog.rs
@@ -5025,6 +5025,10 @@ impl super::TrapDispatcher {
         if !self.window_visible(bus, dialog_ptr) {
             return;
         }
+        let vis_handle = bus.read_long(dialog_ptr + 24);
+        if vis_handle != 0 && Self::region_handle_rect(bus, vis_handle).is_none() {
+            return;
+        }
         let Some(items) = self.dialog_items.get(&dialog_ptr).cloned() else {
             return;
         };
@@ -5971,6 +5975,18 @@ impl super::TrapDispatcher {
         skip_pictures: bool,
         dialog_ptr: u32,
     ) {
+        // DrawDialog renders through the dialog window's port, so QuickDraw
+        // clips every item to that port's visRgn. HLE dialog primitives write
+        // directly to the framebuffer; bail out when the Window Manager has
+        // made the dialog fully occluded rather than letting a background
+        // dialog overwrite the windows in front of it.
+        if dialog_ptr != 0 {
+            let vis_handle = bus.read_long(dialog_ptr + 24);
+            if vis_handle != 0 && Self::region_handle_rect(bus, vis_handle).is_none() {
+                self.dialog_initial_draw_deferred.remove(&dialog_ptr);
+                return;
+            }
+        }
         self.ensure_dialog_background_saved(bus, dialog_ptr, bounds);
         self.dialog_initial_draw_deferred.remove(&dialog_ptr);
 
@@ -24806,6 +24822,65 @@ mod tests {
             assert_eq!(bus.read_byte(probe_addr), 0); // white in 8bpp CLUT
         } else {
             assert_eq!(bus.read_byte(probe_addr) & probe_bit, 0);
+        }
+    }
+
+    #[test]
+    fn draw_dialog_does_not_paint_a_fully_occluded_dialog() {
+        // Dialog items draw through the dialog port and are clipped by its
+        // visRgn (Inside Macintosh Volume I, I-309). An empty visRgn means a
+        // window in front completely covers this dialog.
+        let (mut disp, mut cpu, mut bus) = setup();
+        let dialog_ptr = bus.alloc(170);
+        let (screen_base, row_bytes, _w, _h, pixel_size) = disp.screen_mode;
+
+        bus.write_word(dialog_ptr + 8, 0);
+        bus.write_word(dialog_ptr + 10, 0);
+        bus.write_word(dialog_ptr + 16, 0);
+        bus.write_word(dialog_ptr + 18, 0);
+        bus.write_word(dialog_ptr + 20, 30);
+        bus.write_word(dialog_ptr + 22, 40);
+        let empty_vis_data = bus.alloc(10);
+        bus.write_word(empty_vis_data, 10);
+        bus.write_long(empty_vis_data + 2, 0);
+        bus.write_long(empty_vis_data + 6, 0);
+        let empty_vis = bus.alloc(4);
+        bus.write_long(empty_vis, empty_vis_data);
+        bus.write_long(dialog_ptr + 24, empty_vis);
+        disp.dialog_items.insert(
+            dialog_ptr,
+            vec![DialogItem {
+                item_type: 8,
+                rect: (0, 0, 16, 32),
+                text: "Hidden".to_string(),
+                resource_id: 0,
+                proc_ptr: 0,
+                sel_start: 0,
+                sel_end: 0,
+            }],
+        );
+
+        let probe_x = 4u32;
+        let probe_y = 4u32;
+        let probe_addr = if pixel_size == 8 {
+            screen_base + probe_y * row_bytes + probe_x
+        } else {
+            screen_base + probe_y * row_bytes + (probe_x / 8)
+        };
+        let probe_bit = 1 << (7 - (probe_x % 8));
+        if pixel_size == 8 {
+            bus.write_byte(probe_addr, 0xFF);
+        } else {
+            bus.write_byte(probe_addr, bus.read_byte(probe_addr) | probe_bit);
+        }
+
+        bus.write_long(TEST_SP, dialog_ptr);
+        let result = disp.dispatch_dialog(true, 0x181, &mut cpu, &mut bus);
+        assert!(result.unwrap().is_ok());
+        if pixel_size == 8 {
+            assert_eq!(bus.read_byte(probe_addr), 0xFF);
+        } else {
+            assert_ne!(bus.read_byte(probe_addr) & probe_bit, 0);
         }
     }
 

--- a/src/trap/framebuffer.rs
+++ b/src/trap/framebuffer.rs
@@ -4315,6 +4315,10 @@ impl super::TrapDispatcher {
             .dialog_visible_snapshots
             .iter()
             .filter_map(|(&dialog_ptr, snapshot)| {
+                let vis_handle = bus.read_long(dialog_ptr + 24);
+                if vis_handle != 0 && Self::region_handle_rect(bus, vis_handle).is_none() {
+                    return None;
+                }
                 // A dialog the application painted itself owns its pixels;
                 // replaying the snapshot the HLE captured before the app drew
                 // would repaint the stale contents.
@@ -6009,6 +6013,48 @@ mod redraw_chrome_tests {
             bus.read_byte(screen_base + 12 * 64 + 12),
             0x77,
             "the exposed part of a retained background dialog should still be restored"
+        );
+    }
+
+    #[test]
+    fn restore_visible_dialog_snapshots_skips_fully_occluded_dialogs() {
+        let (mut disp, _cpu, mut bus) = setup_with_port();
+        let screen_base = bus.alloc(64 * 64);
+        disp.screen_mode = (screen_base, 64, 64, 64, 8);
+        bus.write_long(0x0824, screen_base);
+
+        let bounds = (10, 10, 30, 30);
+        for y in 10..30u32 {
+            for x in 10..30u32 {
+                bus.write_byte(screen_base + y * 64 + x, 0x22);
+            }
+        }
+        let stale_pixels = disp.save_dialog_pixels(&bus, bounds);
+
+        let dialog_ptr = bus.alloc(170);
+        let vis_data = bus.alloc(10);
+        bus.write_word(vis_data, 10);
+        bus.write_long(vis_data + 2, 0);
+        bus.write_long(vis_data + 6, 0);
+        let vis_handle = bus.alloc(4);
+        bus.write_long(vis_handle, vis_data);
+        bus.write_long(dialog_ptr + 24, vis_handle);
+        disp.dialog_visible_snapshots.insert(
+            dialog_ptr,
+            super::super::dispatch::PersistentDialogSnapshot {
+                bounds,
+                pixels: stale_pixels,
+            },
+        );
+
+        let probe = screen_base + 18 * 64 + 18;
+        bus.write_byte(probe, 0x77);
+        disp.restore_visible_dialog_snapshots(&mut bus);
+
+        assert_eq!(
+            bus.read_byte(probe),
+            0x77,
+            "a fully occluded dialog snapshot must not overwrite its front window"
         );
     }
 

--- a/src/trap/window.rs
+++ b/src/trap/window.rs
@@ -2192,6 +2192,10 @@ impl super::TrapDispatcher {
             // already placed us.
             return;
         }
+        let covered_rect = Self::region_handle_rect(
+            bus,
+            bus.read_long(window_ptr + Self::WINDOW_STRUC_RGN_OFFSET),
+        );
         self.window_list.retain(|&w| w != window_ptr);
         if behind == 0 {
             self.window_list.push(window_ptr);
@@ -2217,6 +2221,22 @@ impl super::TrapDispatcher {
         }
         if self.front_window != window_ptr {
             self.sync_cached_front_window_render_state(bus);
+        }
+        // Creation draws a visible window before the Pascal `behind`
+        // parameter is applied. If that parameter moves it behind existing
+        // windows, its freshly drawn pixels have clobbered the windows that
+        // remain in front. Add the overlap to each affected window's update
+        // region so its application can repaint the exposed content.
+        if let Some(rect) = covered_rect {
+            let windows = self.window_list.clone();
+            for &window in &windows {
+                if window == window_ptr {
+                    break;
+                }
+                if self.window_visible(bus, window) {
+                    self.invalidate_window_global_rect(bus, window, rect);
+                }
+            }
         }
     }
 
@@ -6757,6 +6777,69 @@ mod tests {
             (10, 20, 110, 220),
             "cached front-window geometry must follow the visible front after behind=NIL reorders"
         );
+    }
+
+    #[test]
+    fn apply_behind_parameter_invalidates_windows_clobbered_during_creation() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        bus.write_word(crate::memory::globals::addr::MBAR_HEIGHT, 0);
+        let screen_base = bus.alloc(800 * 600);
+        bus.write_long(0x0824, screen_base);
+        disp.set_screen_mode_for_test(screen_base, 800, 800, 600, 8);
+
+        let existing = bus.alloc(256);
+        disp.init_cgraf_window(
+            &mut bus,
+            &mut cpu,
+            existing,
+            screen_base,
+            20,
+            20,
+            300,
+            400,
+            "Existing",
+            4,
+            true,
+            false,
+            false,
+            0,
+        );
+        disp.validate_window_rect(&mut bus, existing, (0, 0, 280, 380));
+
+        let created = bus.alloc(256);
+        disp.init_cgraf_window(
+            &mut bus,
+            &mut cpu,
+            created,
+            screen_base,
+            60,
+            80,
+            180,
+            300,
+            "Created",
+            1,
+            true,
+            false,
+            true,
+            0,
+        );
+        disp.validate_window_rect(&mut bus, created, (0, 0, 120, 220));
+
+        disp.apply_behind_parameter(&mut bus, created, existing);
+
+        assert_eq!(disp.window_list, vec![existing, created]);
+        let update = super::super::TrapDispatcher::region_handle_rect(
+            &bus,
+            bus.read_long(existing + super::super::TrapDispatcher::WINDOW_UPDATE_RGN_OFFSET),
+        );
+        assert!(
+            update.is_some(),
+            "the window left in front must redraw pixels clobbered by creation"
+        );
+        assert!(disp
+            .event_queue
+            .iter()
+            .any(|event| event.what == 6 && event.message == existing));
     }
 
     #[test]


### PR DESCRIPTION
Closes #608.

## Summary

- invalidate front-window content clobbered while a visible window is created and then reordered behind it
- honor an empty dialog `visRgn` in HLE dialog redraw, text-item redraw, and retained-snapshot composition
- cover each occlusion path with focused regression tests

## Validation

- `cargo fmt --all -- --check`
- `cargo test --lib` (2952 passed, 3 ignored)