### PR TITLE
fix(memory): reserve callback code below framebuffer

### DIFF
--- a/src/memory/bus.rs
+++ b/src/memory/bus.rs
@@ -12,6 +12,7 @@ use super::globals::LowMemGlobals;
 
 const LEGACY_SOUND_BUFFER_WORDS: u32 = 370;
 const LEGACY_SOUND_BUFFER_BYTES: u32 = LEGACY_SOUND_BUFFER_WORDS * 2;
+const SYNTHETIC_RESERVE_BYTES: u32 = 64 * 1024;
 // System 7.5.3 on the Quadra 650 leaves exception vector 0 pointing to
 // $40810000. A BasiliskII oracle capture of that ROM establishes the word at
 // offset 6 as $0372. Keep the shadow deliberately narrow: bytes outside this
@@ -375,6 +376,13 @@ pub trait MemoryBus {
     /// Get the total RAM size
     fn ram_size(&self) -> u32;
 
+    /// Highest address available to the application heap, globals, and stack.
+    /// Implementations may reserve RAM above this boundary for emulated
+    /// hardware and host-owned callback code.
+    fn application_memory_limit(&self) -> u32 {
+        self.ram_size()
+    }
+
     /// Read a Pascal string (length-prefixed) from memory. Delegates
     /// to [`Self::read_bytes`] for the data so the underlying slice
     /// fast path on [`MacMemoryBus`] applies.
@@ -453,6 +461,8 @@ pub struct MacMemoryBus {
     heap_ptr: u32,
     /// Systemless-owned executable/data stubs grow downward outside the guest heap.
     synthetic_ptr: u32,
+    /// Lower bound of the fixed reservation for future synthetic allocations.
+    synthetic_floor: u32,
     /// Guest writes cannot modify synthesized ROM-like instruction stubs.
     readonly_code_ranges: Vec<(u32, u32)>,
     /// Half-open bounding box over `readonly_code_ranges`, maintained on
@@ -849,6 +859,7 @@ impl MacMemoryBus {
         } else {
             ram_size as u32
         };
+        let synthetic_floor = screen_buffer_start.saturating_sub(SYNTHETIC_RESERVE_BYTES);
         let mut bus = Self {
             ram: RamStorage::Owned(vec![0; ram_size]),
             ram_size: ram_size as u32,
@@ -856,6 +867,7 @@ impl MacMemoryBus {
             globals: LowMemGlobals::new(),
             heap_ptr: 0x200000, // Start heap at 2MB
             synthetic_ptr: screen_buffer_start,
+            synthetic_floor,
             readonly_code_ranges: Vec::new(),
             readonly_code_span: None,
             free_blocks: HashMap::new(),
@@ -938,6 +950,7 @@ impl MacMemoryBus {
         } else {
             ram_size as u32
         };
+        let synthetic_floor = screen_buffer_start.saturating_sub(SYNTHETIC_RESERVE_BYTES);
         Self {
             ram: RamStorage::External(ram_ptr, ram_size),
             ram_size: ram_size as u32,
@@ -945,6 +958,7 @@ impl MacMemoryBus {
             globals,
             heap_ptr: 0x200000,
             synthetic_ptr: screen_buffer_start,
+            synthetic_floor,
             readonly_code_ranges: Vec::new(),
             readonly_code_span: None,
             free_blocks: HashMap::new(),
@@ -1071,10 +1085,10 @@ impl MacMemoryBus {
         let ptr = self.heap_ptr;
         let new_ptr = ptr + aligned;
 
-        if new_ptr >= self.synthetic_ptr {
+        if new_ptr >= self.synthetic_floor {
             eprintln!(
                 "[ALLOC] Out of memory: requesting {} bytes, heap at ${:08X}, limit ${:08X}",
-                size, ptr, self.synthetic_ptr
+                size, ptr, self.synthetic_floor
             );
             return 0; // Return NULL; callers must check and set memFullErr
         }
@@ -1094,10 +1108,10 @@ impl MacMemoryBus {
         let Some(ptr) = self.synthetic_ptr.checked_sub(aligned) else {
             return 0;
         };
-        if ptr <= self.heap_ptr {
+        if ptr < self.synthetic_floor {
             eprintln!(
-                "[ALLOC] Out of synthetic memory: requesting {} bytes, heap at ${:08X}, synthetic at ${:08X}",
-                size, self.heap_ptr, self.synthetic_ptr
+                "[ALLOC] Out of synthetic memory: requesting {} bytes, floor at ${:08X}, synthetic at ${:08X}",
+                size, self.synthetic_floor, self.synthetic_ptr
             );
             return 0;
         }
@@ -1190,10 +1204,10 @@ impl MacMemoryBus {
         let ptr = (self.heap_ptr + alignment - 1) & !(alignment - 1);
         let new_ptr = ptr + aligned;
 
-        if new_ptr >= self.synthetic_ptr {
+        if new_ptr >= self.synthetic_floor {
             eprintln!(
                 "[ALLOC] Out of memory: requesting {} bytes aligned to {}, heap at ${:08X}, limit ${:08X}",
-                size, alignment, self.heap_ptr, self.synthetic_ptr
+                size, alignment, self.heap_ptr, self.synthetic_floor
             );
             return 0;
         }
@@ -1820,6 +1834,10 @@ impl MemoryBus for MacMemoryBus {
     fn ram_size(&self) -> u32 {
         self.ram_size
     }
+
+    fn application_memory_limit(&self) -> u32 {
+        self.synthetic_floor
+    }
 }
 
 #[cfg(test)]
@@ -2004,6 +2022,27 @@ mod tests {
         assert!(synthetic > second_guest);
         assert_eq!(bus.read_bytes(synthetic, 24), vec![0; 24]);
         assert_eq!(bus.get_alloc_size(synthetic), None);
+    }
+
+    #[test]
+    fn synthetic_reservation_has_a_stable_guest_memory_boundary() {
+        let mut bus = MacMemoryBus::new(8 * 1024 * 1024);
+        let application_limit = bus.application_memory_limit();
+
+        bus.reserve_heap_until(application_limit - 4);
+        assert_eq!(
+            bus.alloc(4),
+            0,
+            "guest allocations must stop at the reservation"
+        );
+
+        let whole_reservation = bus.alloc_synthetic(SYNTHETIC_RESERVE_BYTES);
+        assert_eq!(whole_reservation, application_limit);
+        assert_eq!(
+            bus.alloc_synthetic(4),
+            0,
+            "synthetic allocations must not escape their reservation"
+        );
     }
 
     #[test]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -75,6 +75,9 @@ const APP_HEAP_FLOOR: u32 = 0x0020_0000;
 const APP_ZONE_HEADER_SIZE: u32 = 64;
 const APP_STACK_SAFETY_MARGIN: u32 = 0x2000;
 const DEFAULT_LOAD_ADDRESS: u32 = 0x0001_0000;
+const APP_QD_GLOBALS_RESERVE: u32 = 48 * 1024;
+const APP_LOADER_CLEAR_RESERVE: u32 = 0x40000;
+const APP_HIGH_MEMORY_RESERVE: u32 = 2 * 1024 * 1024;
 const APPLICATION_RESOURCE_REFNUM: u16 = 2;
 const HFS_FCB_SIZE: u16 = 94;
 const HFS_FCB_BUFFER_SIZE: u16 = 2 + HFS_FCB_SIZE;
@@ -1507,7 +1510,7 @@ fn load_address_for_size_partition(
     configured_load_address: u32,
     header: &Code0Header,
     size_resource: Option<ApplicationSizeResource>,
-    ram_size: u32,
+    application_memory_limit: u32,
 ) -> u32 {
     if configured_load_address != DEFAULT_LOAD_ADDRESS {
         return configured_load_address;
@@ -1532,16 +1535,18 @@ fn load_address_for_size_partition(
         return configured_load_address;
     }
 
-    // Leave space above the relocated image for stack/screen buffers in
-    // small synthetic runners. The standard frontends use 32 MB, so large
-    // SIZE-partition apps still get the Mac-like high A5 placement.
-    let max_reasonable_load = ram_size.saturating_sub(2 * 1024 * 1024);
     let relocated_load = align4(desired_a5.saturating_sub(header.below_a5));
-    if relocated_load < max_reasonable_load {
-        relocated_load
-    } else {
-        configured_load_address
-    }
+    let loader_headroom = header
+        .below_a5
+        .saturating_add(header.above_a5)
+        .saturating_add(APP_QD_GLOBALS_RESERVE)
+        .saturating_add(APP_LOADER_CLEAR_RESERVE)
+        .saturating_add(APP_HIGH_MEMORY_RESERVE);
+    let max_safe_load = application_memory_limit.saturating_sub(loader_headroom) & !3;
+
+    relocated_load
+        .min(max_safe_load)
+        .max(configured_load_address)
 }
 
 /// Host presentation policy for the classic Mac menu bar.
@@ -9938,7 +9943,7 @@ fn load_app_generic<M: MemoryBus>(
         configured_load_address,
         &header,
         size_resource,
-        bus.ram_size(),
+        bus.application_memory_limit(),
     );
     if trace_load_enabled() {
         eprintln!(
@@ -9972,11 +9977,10 @@ fn load_app_generic<M: MemoryBus>(
     // For classic Mac apps, above_a5 defines the space needed above A5.
     // However, some apps place QuickDraw globals at higher offsets (e.g., A5+39KB).
     // Add 48KB reserve to accommodate most classic apps.
-    let qd_globals_reserve = 48 * 1024; // 48KB reserve for QD globals
-    let globals_end = a5_base + header.above_a5 + qd_globals_reserve;
+    let globals_end = a5_base + header.above_a5 + APP_QD_GLOBALS_RESERVE;
 
     // Clear A5 world
-    let globals_zero_end = globals_end + 0x40000;
+    let globals_zero_end = globals_end + APP_LOADER_CLEAR_RESERVE;
     bus.fill_zeros(load_address, globals_zero_end.saturating_sub(load_address));
     bus.write_long(0x0904, a5_base); // CurrentA5
     bus.write_word(0x0934, header.jump_table_offset as u16); // CurJTOffset - Inside Macintosh Volume II, II-62
@@ -10289,8 +10293,9 @@ fn load_app_generic<M: MemoryBus>(
         eprintln!("[LOAD] Loaded image end=${:08X}", loaded_image_end);
     }
 
-    // Stack at top of RAM
-    let stack_top = bus.ram_size() - 16;
+    // Keep the application stack below Systemless-owned callback code and
+    // the framebuffer reservation at the top of RAM.
+    let stack_top = bus.application_memory_limit() - 16;
 
     Some(LoadedApp {
         ppc: None,
@@ -10836,6 +10841,28 @@ mod tests {
             app.a5_base - APP_HEAP_FLOOR >= 750 * 1024,
             "Spectre-style startup gates compare A5 - GetZone against a 750K floor"
         );
+    }
+
+    #[test]
+    fn large_size_partition_does_not_overwrite_synthetic_callbacks() {
+        let below_a5 = 0x7AF4;
+        let code0 = minimal_code0(0x11F8, below_a5, 0, 0);
+        let partition = 63 * 1024 * 1024;
+        let size = size_resource_bytes(0x5880, partition, partition);
+        let fork_bytes = make_resource_fork_bytes(&[(*b"CODE", 0, &code0), (*b"SIZE", -1, &size)]);
+        let fork = ResourceFork::parse(&fork_bytes).expect("parse synthetic app fork");
+        let mut runner = FixtureRunner::new(64 * 1024 * 1024, FixtureRunnerConfig::default());
+        let callback = runner.bus.alloc_synthetic(2);
+        runner.bus.write_word(callback, 0x4E75);
+
+        let app = runner.load_app(&fork).expect("load app");
+
+        assert_eq!(runner.bus.read_word(callback), 0x4E75);
+        assert!(
+            app.loaded_image_end + APP_HIGH_MEMORY_RESERVE <= runner.bus.application_memory_limit(),
+            "the loaded image must leave room for the application heap and stack"
+        );
+        assert!(app.initial_sp < callback);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- reserve a fixed 64 KiB Systemless-owned callback region below the framebuffer
- expose a stable application-memory ceiling so guest heap, stack, and oversized `SIZE` relocations cannot enter that region
- preserve 2 MiB of high-memory heap/stack headroom when clamping large application partitions
- add regressions for both sides of the reservation and for callback survival during a large-partition load

## Cause

Synthetic trap callbacks previously grew downward from the framebuffer while the guest stack and large application partitions still treated the top of RAM as usable. After Monkey Island accepted its 256-color prompt, guest writes overwrote the callback at `$03F7FFF8`; the next dispatch jumped through data and execution entered the framebuffer.

## Evidence

With the checksum-pinned image from #623, the prior build became striped and stopped advancing at tick 4236. This branch reaches tick 4304 with `800x600x8` active, `halted=false`, and no striped framebuffer.

## Tests

- `cargo fmt --check`
- `cargo test --workspace` (2953 passed, 3 ignored; all binary and doc tests passed)
- `cargo clippy --workspace --all-targets` (passes with existing warnings)
- exact #623 replay with original fonts disabled

Closes #623