### PR TITLE
refactor: remove obsolete CPU and menu bar overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,11 @@ Common runner options:
 ```sh
 systemless --headless --max-instructions 5000000 path/to/app.sit
 systemless --arrows-as-numpad path/to/game.sit
-systemless --show-menu-bar path/to/app.sit
-systemless --cpu-mhz 25 path/to/app.sit
 ```
+
+The desktop runner uses the canonical machine profile automatically. On macOS,
+guest menus are mirrored into the native menu bar; other platforms render the
+classic menu bar according to the guest application's own visibility state.
 
 Systemless accepts StuffIt archives, MacBinary files, and raw/macOS resource forks.
 Archives may contain multiple files; Systemless populates the in-memory VFS and
@@ -256,7 +258,6 @@ name.
 | -------- | ------ |
 | `SYSTEMLESS_LOAD_EXECUTABLE` | Selects an executable from a multi-app archive by substring. |
 | `SYSTEMLESS_ORIGINAL_FONTS_DIR` | Loads optional runtime font override blobs. |
-| `SYSTEMLESS_SHOW_MENU_BAR` | Shows classic Mac menu chrome by default. |
 | `SYSTEMLESS_TRACE_LOAD` | Logs archive, VFS, resource, and startup loading diagnostics. |
 | `SYSTEMLESS_TRACE_LOADSEG` | Logs Segment Loader jump-table patching. |
 | `SYSTEMLESS_TRACE_TRAP_COUNTS` | Prints trap dispatch frequency summaries. |

--- a/src/bin/systemless.rs
+++ b/src/bin/systemless.rs
@@ -7,7 +7,7 @@
 //!
 //! ```sh
 //! cargo run --release -- [--headless] [--max-instructions N] \
-//!     [--cpu-mhz N] [--show-menu-bar] [--arrows-as-numpad] <game>
+//!     [--arrows-as-numpad] <game>
 //! ```
 //!
 //! Disable the GUI deps with `--no-default-features` to build a
@@ -41,6 +41,8 @@ use systemless::debug_overlay::DebugOverlayFrameStats;
 use systemless::display;
 use systemless::game;
 use systemless::runner::FixtureRunner;
+#[cfg(target_os = "macos")]
+use systemless::runner::MenuBarPolicy;
 use systemless::trap::dispatch::ScreenCopyBitsRect;
 
 #[cfg(not(target_os = "macos"))]
@@ -112,17 +114,9 @@ struct Cli {
     )]
     literal_arrows: bool,
 
-    /// Emulate the requested CPU clock speed
-    #[arg(long, value_name = "N")]
-    cpu_mhz: Option<f64>,
-
     /// Stop a headless run after this many instructions
     #[arg(long, value_name = "N")]
     max_instructions: Option<usize>,
-
-    /// Show the classic Mac menu bar
-    #[arg(long)]
-    show_menu_bar: bool,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
@@ -338,10 +332,6 @@ struct App {
     next_frame_time: Option<std::time::Instant>,
     /// Adaptive CPU/render split for the single-threaded GUI loop.
     render_headroom: std::time::Duration,
-    /// Wall-clock boundary up to which GUI CPU time has been budgeted.
-    next_cpu_budget_time: Option<std::time::Instant>,
-    /// Fractional guest instructions carried between GUI slices.
-    cpu_instruction_credit: f64,
     /// Fractional host samples carried between GUI slices to preserve rate.
     audio_sample_remainder: f64,
     /// Wall-clock instant represented by the most recently queued audio.
@@ -370,14 +360,6 @@ struct App {
     debug_frame_ms: Option<f64>,
     /// Remap arrow keys to numpad equivalents (for keyboards without a numpad)
     arrows_as_numpad: bool,
-    /// Optional GUI CPU cap in instructions per second (cpu_mhz × 1_000_000).
-    emulated_ips: Option<f64>,
-    /// CLI override of the default-hidden menu bar. When true, the
-    /// HLE renders the menu bar even though the dispatcher's
-    /// `menu_bar_hidden` defaults to true. Wired through to
-    /// `runner.dispatcher_mut().menu_bar_hidden = false` at runner
-    /// construction.
-    show_menu_bar: bool,
     #[cfg(target_os = "macos")]
     native_menu: native_menu::NativeMenuBridge,
     #[cfg(target_os = "macos")]
@@ -389,12 +371,7 @@ struct App {
 }
 
 impl App {
-    fn new(
-        game_path: PathBuf,
-        arrows_as_numpad: bool,
-        cpu_mhz: Option<f64>,
-        show_menu_bar: bool,
-    ) -> Self {
+    fn new(game_path: PathBuf, arrows_as_numpad: bool) -> Self {
         #[cfg(target_os = "macos")]
         let native_menu_app_name = game_path
             .file_stem()
@@ -457,8 +434,6 @@ impl App {
             start_time: None,
             next_frame_time: None,
             render_headroom: MIN_RENDER_HEADROOM,
-            next_cpu_budget_time: None,
-            cpu_instruction_credit: 0.0,
             audio_sample_remainder: 0.0,
             last_audio_mix_time: None,
             mouse_physical: (0.0, 0.0),
@@ -474,8 +449,6 @@ impl App {
             debug_host_fps: None,
             debug_frame_ms: None,
             arrows_as_numpad,
-            emulated_ips: cpu_mhz.map(|mhz| mhz * 1_000_000.0),
-            show_menu_bar,
             #[cfg(target_os = "macos")]
             native_menu: native_menu::NativeMenuBridge::new(native_menu_app_name),
             #[cfg(target_os = "macos")]
@@ -530,9 +503,8 @@ impl App {
         }
 
         let mut runner = game::new_runner();
-        if self.show_menu_bar {
-            runner.set_menu_bar_visible(true);
-        }
+        #[cfg(target_os = "macos")]
+        runner.set_menu_bar_policy(MenuBarPolicy::ForceHidden);
         let app =
             game::load_game_from_path(&mut runner, &self.game_path).expect("Failed to load game");
         let mut save_store = DesktopSaveStore::for_loaded_archive(&self.game_path, &mut runner);
@@ -638,13 +610,6 @@ impl App {
         self.runner
             .as_ref()
             .is_some_and(FixtureRunner::halted_by_exit_to_shell)
-    }
-
-    fn cpu_budget_for_duration(duration: std::time::Duration, ips: f64, credit: &mut f64) -> usize {
-        *credit += duration.as_secs_f64() * ips;
-        let budget = credit.floor().min(game::MAX_INSTRUCTIONS_PER_FRAME as f64) as usize;
-        *credit -= budget as f64;
-        budget
     }
 
     /// Wall-clock origin such that `tick_due_at(origin, now)` equals `guest_tick`.
@@ -766,19 +731,7 @@ impl App {
             .map(|d| d.max(now))
             .unwrap_or(now);
 
-        let slice_budget = if let Some(ips) = self.emulated_ips {
-            let cpu_interval_start = self.next_cpu_budget_time.unwrap_or(now);
-            let cpu_interval = cpu_deadline
-                .checked_duration_since(cpu_interval_start)
-                .unwrap_or_default();
-            let budget =
-                Self::cpu_budget_for_duration(cpu_interval, ips, &mut self.cpu_instruction_credit);
-            self.next_cpu_budget_time = Some(cpu_deadline);
-            budget
-        } else {
-            self.next_cpu_budget_time = Some(cpu_deadline);
-            game::MAX_INSTRUCTIONS_PER_FRAME
-        };
+        let slice_budget = game::MAX_INSTRUCTIONS_PER_FRAME;
         let audio_interval = self
             .last_audio_mix_time
             .replace(now)
@@ -1960,11 +1913,7 @@ impl ApplicationHandler for App {
         // Schedule the next host frame. If startup/resource loading makes us
         // miss a full presentation interval, drop the missed host frame instead
         // of running immediate catch-up frames that bunch audio and graphics.
-        let (next_target, dropped_missed_frame) = Self::next_frame_target(now, next);
-        if dropped_missed_frame {
-            self.next_cpu_budget_time = Some(now);
-            self.cpu_instruction_credit = 0.0;
-        }
+        let (next_target, _) = Self::next_frame_target(now, next);
         self.next_frame_time = Some(next_target);
         event_loop.set_control_flow(ControlFlow::WaitUntil(next_target));
 
@@ -2019,12 +1968,8 @@ impl ApplicationHandler for App {
     }
 }
 
-fn run_gui(game_path: PathBuf, arrows_as_numpad: bool, cpu_mhz: Option<f64>, show_menu_bar: bool) {
+fn run_gui(game_path: PathBuf, arrows_as_numpad: bool) {
     let event_loop = EventLoop::new().expect("Failed to create event loop");
-    match cpu_mhz {
-        Some(mhz) => eprintln!("[SYSTEMLESS] GUI CPU cap: {:.1} MHz", mhz),
-        None => eprintln!("[SYSTEMLESS] GUI CPU cap: uncapped"),
-    }
     eprintln!(
         "[SYSTEMLESS] GUI arrow keys: {}",
         if arrows_as_numpad {
@@ -2034,7 +1979,7 @@ fn run_gui(game_path: PathBuf, arrows_as_numpad: bool, cpu_mhz: Option<f64>, sho
         }
     );
 
-    let mut app = App::new(game_path, arrows_as_numpad, cpu_mhz, show_menu_bar);
+    let mut app = App::new(game_path, arrows_as_numpad);
     // `run_app` is the first point at which `resumed` can create a native
     // window. Finish archive decompression and guest initialization before
     // entering the event loop so startup never exposes an empty host window.
@@ -2072,16 +2017,11 @@ fn save_screenshot(runner: &FixtureRunner, num: usize) {
     eprintln!("[HEADLESS] Screenshot #{}: {} (ticks={})", num, path, ticks);
 }
 
-fn run_headless(game_path: &std::path::Path, max_instructions: usize, show_menu_bar: bool) {
+fn run_headless(game_path: &std::path::Path, max_instructions: usize) {
     eprintln!("[HEADLESS] Starting: {}", game_path.display());
     eprintln!("[HEADLESS] Max instructions: {}", max_instructions);
 
     let mut runner = game::new_runner();
-    if show_menu_bar {
-        // CLI override of the default kiosk-mode hide. See
-        // FixtureRunner::set_menu_bar_visible for the rationale.
-        runner.set_menu_bar_visible(true);
-    }
     let app = game::load_game_from_path(&mut runner, game_path).expect("Failed to load game");
     let mut save_store = DesktopSaveStore::for_loaded_archive(game_path, &mut runner);
     eprintln!(
@@ -2147,13 +2087,9 @@ fn main() {
     eprintln!("[SYSTEMLESS] Game: {}", game_path.display());
 
     if cli.headless {
-        run_headless(
-            &game_path,
-            cli.max_instructions.unwrap_or(5_000_000),
-            cli.show_menu_bar,
-        );
+        run_headless(&game_path, cli.max_instructions.unwrap_or(5_000_000));
     } else {
-        run_gui(game_path, arrows_as_numpad, cli.cpu_mhz, cli.show_menu_bar);
+        run_gui(game_path, arrows_as_numpad);
     }
 }
 
@@ -2442,11 +2378,8 @@ mod tests {
             "systemless",
             "--headless",
             "--arrows-as-numpad",
-            "--cpu-mhz",
-            "25.5",
             "--max-instructions",
             "1234",
-            "--show-menu-bar",
             "game.sit",
         ])
         .expect("runner options should parse");
@@ -2455,9 +2388,7 @@ mod tests {
         assert!(cli.headless);
         assert!(cli.arrows_as_numpad);
         assert!(!cli.literal_arrows);
-        assert_eq!(cli.cpu_mhz, Some(25.5));
         assert_eq!(cli.max_instructions, Some(1234));
-        assert!(cli.show_menu_bar);
     }
 
     #[test]
@@ -2480,16 +2411,19 @@ mod tests {
     }
 
     #[test]
-    fn cli_rejects_missing_game_invalid_values_and_unknown_options() {
+    fn cli_rejects_missing_game_removed_options_and_unknown_options() {
         let missing_game =
             Cli::try_parse_from(["systemless"]).expect_err("game path should be required");
-        let invalid_value = Cli::try_parse_from(["systemless", "--cpu-mhz", "fast", "game.sit"])
-            .expect_err("CPU clock should be numeric");
+        let removed_cpu = Cli::try_parse_from(["systemless", "--cpu-mhz", "25", "game.sit"])
+            .expect_err("removed CPU option should be rejected");
+        let removed_menu = Cli::try_parse_from(["systemless", "--show-menu-bar", "game.sit"])
+            .expect_err("removed menu option should be rejected");
         let unknown_option = Cli::try_parse_from(["systemless", "--wat", "game.sit"])
             .expect_err("unknown options should be rejected");
 
         assert_eq!(missing_game.kind(), ErrorKind::MissingRequiredArgument);
-        assert_eq!(invalid_value.kind(), ErrorKind::ValueValidation);
+        assert_eq!(removed_cpu.kind(), ErrorKind::UnknownArgument);
+        assert_eq!(removed_menu.kind(), ErrorKind::UnknownArgument);
         assert_eq!(unknown_option.kind(), ErrorKind::UnknownArgument);
     }
 
@@ -2522,7 +2456,7 @@ mod tests {
         use systemless::cpu::Register;
         use systemless::memory::MemoryBus;
 
-        let mut app = App::new(PathBuf::from("dummy"), false, None, false);
+        let mut app = App::new(PathBuf::from("dummy"), false);
         let mut runner = FixtureRunner::new(
             8 * 1024 * 1024,
             systemless::runner::FixtureRunnerConfig::default(),
@@ -2574,12 +2508,7 @@ mod tests {
 
     #[test]
     fn gui_defaults_to_literal_arrow_controls() {
-        let app = App::new(
-            PathBuf::from("dummy"),
-            DEFAULT_GUI_ARROWS_AS_NUMPAD,
-            None,
-            false,
-        );
+        let app = App::new(PathBuf::from("dummy"), DEFAULT_GUI_ARROWS_AS_NUMPAD);
 
         assert!(
             !app.arrows_as_numpad,
@@ -2856,7 +2785,7 @@ mod tests {
     fn step_frame_mixes_one_audio_frame_when_guest_tick_does_not_advance() {
         let now = std::time::Instant::now();
         let (runner, queued) = gui_runner_with_counting_audio();
-        let mut app = App::new(PathBuf::from("dummy"), false, None, false);
+        let mut app = App::new(PathBuf::from("dummy"), false);
         app.runner = Some(runner);
         app.start_time = Some(now);
         app.next_frame_time = Some(now);
@@ -2887,13 +2816,12 @@ mod tests {
         runner.cpu_mut().write_reg(Register::PC, pc);
         runner.cpu_mut().write_reg(Register::A7, 0x0008_0000);
         runner.bus_mut().write_long(0x016A, 0);
-        runner.set_instructions_per_tick(1_000_000);
+        runner.set_instructions_per_tick((game::MAX_INSTRUCTIONS_PER_FRAME * 2) as u32);
 
-        let mut app = App::new(PathBuf::from("dummy"), false, Some(1.0), false);
+        let mut app = App::new(PathBuf::from("dummy"), false);
         app.runner = Some(runner);
         app.start_time = Some(now - FRAME_DURATION);
         app.next_frame_time = Some(now + FRAME_DURATION * 4);
-        app.next_cpu_budget_time = Some(now);
         app.last_presented_guest_tick = Some(0);
         app.force_next_render = false;
 
@@ -2988,7 +2916,7 @@ mod tests {
                 exhausted_buffer_index: 0,
             });
 
-        let mut app = App::new(PathBuf::from("dummy"), false, None, false);
+        let mut app = App::new(PathBuf::from("dummy"), false);
         app.runner = Some(runner);
         app.start_time = Some(scheduled_frame_end);
         app.next_frame_time = Some(scheduled_frame_end);
@@ -3092,7 +3020,7 @@ mod tests {
         );
         runner.dispatcher_mut().sound_manager.channels.push(chan);
 
-        let mut app = App::new(PathBuf::from("dummy"), false, None, false);
+        let mut app = App::new(PathBuf::from("dummy"), false);
         app.runner = Some(runner);
         app.start_time = Some(now);
         app.next_frame_time = Some(now);
@@ -3120,7 +3048,7 @@ mod tests {
     fn step_frame_recovers_audio_elapsed_during_a_dropped_video_frame() {
         let now = std::time::Instant::now();
         let (runner, queued) = gui_runner_with_counting_audio();
-        let mut app = App::new(PathBuf::from("dummy"), false, None, false);
+        let mut app = App::new(PathBuf::from("dummy"), false);
         app.runner = Some(runner);
         app.start_time = Some(now);
         app.next_frame_time = Some(now);
@@ -3150,7 +3078,7 @@ mod tests {
         runner.cpu_mut().write_reg(Register::A7, 0x0008_0000);
         runner.set_instructions_per_tick(1);
 
-        let mut app = App::new(PathBuf::from("dummy"), false, None, false);
+        let mut app = App::new(PathBuf::from("dummy"), false);
         app.runner = Some(runner);
         app.start_time = Some(now - FRAME_DURATION * 2);
         app.next_frame_time = Some(now + FRAME_DURATION);
@@ -3162,31 +3090,6 @@ mod tests {
             "one GUI frame should queue about 367 stereo frames, got {} bytes",
             *queued.borrow()
         );
-    }
-
-    #[test]
-    fn cpu_budget_for_duration_preserves_average_mhz() {
-        let mut credit = 0.0;
-        let mut total = 0usize;
-        let ips = systemless::runner::DEFAULT_REALTIME_INSTRUCTIONS_PER_SECOND;
-
-        total += App::cpu_budget_for_duration(
-            FRAME_DURATION.saturating_sub(MIN_RENDER_HEADROOM),
-            ips,
-            &mut credit,
-        );
-        for _ in 1..120 {
-            total += App::cpu_budget_for_duration(FRAME_DURATION, ips, &mut credit);
-        }
-
-        let total_duration = FRAME_DURATION
-            .saturating_sub(MIN_RENDER_HEADROOM)
-            .as_secs_f64()
-            + FRAME_DURATION.as_secs_f64() * 119.0;
-        let expected = (total_duration * ips).floor() as usize;
-        assert_eq!(total, expected);
-        assert!(credit >= 0.0);
-        assert!(credit < 1.0);
     }
 
     #[test]
@@ -3255,7 +3158,7 @@ mod tests {
 
     #[test]
     fn render_gate_waits_for_guest_tick_unless_forced() {
-        let mut app = App::new(PathBuf::from("dummy"), false, None, false);
+        let mut app = App::new(PathBuf::from("dummy"), false);
         app.runner = Some(FixtureRunner::new(
             8 * 1024 * 1024,
             systemless::runner::FixtureRunnerConfig::default(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,8 +27,8 @@
 //! ```no_run
 //! use systemless::runner::{FixtureRunner, FixtureRunnerConfig};
 //!
-//! // Allocate an 8 MiB guest, default config (kiosk mode — Mac menu
-//! // bar suppressed; arrow keys not remapped to numpad).
+//! // Allocate an 8 MiB guest with guest-controlled menu visibility and
+//! // arrow keys left as literal arrow keys.
 //! let config = FixtureRunnerConfig::default();
 //! let mut runner = FixtureRunner::new(8 * 1024 * 1024, config);
 //!

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -758,10 +758,24 @@ fn load_address_for_size_partition(
     }
 }
 
+/// Host presentation policy for the classic Mac menu bar.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum MenuBarPolicy {
+    /// Follow the guest's `MBarHeight` and fullscreen state.
+    #[default]
+    GuestControlled,
+    /// Begin with kiosk presentation, then return control to the guest after
+    /// an explicit `DrawMenuBar` request or a real hide-and-reveal transition.
+    InitialKiosk,
+    /// Keep the guest menu bar suppressed regardless of guest state.
+    ForceHidden,
+}
+
 /// Configuration knobs for [`FixtureRunner`]. Use
 /// [`FixtureRunnerConfig::default`] for the canonical defaults
 /// (10M-instruction budget, 0x10000 load base, arrow-keys NOT
-/// remapped to numpad) — only override fields you actually need.
+/// remapped to numpad, guest-controlled menu bar) — only override fields you
+/// actually need.
 pub struct FixtureRunnerConfig {
     /// Hard cap on instructions executed by the simpler unbounded
     /// [`FixtureRunner::run`] entry point. Not consulted by
@@ -777,6 +791,9 @@ pub struct FixtureRunnerConfig {
     /// Useful on keyboards without a numeric keypad, since many classic Mac games use
     /// the numpad for movement. Inside Macintosh Volume V, V-191.
     pub arrows_as_numpad: bool,
+    /// Host presentation policy for the classic Mac menu bar. The default
+    /// honors guest `MBarHeight` and fullscreen transitions.
+    pub menu_bar_policy: MenuBarPolicy,
     /// Selected UI rendering provider. The default `classic-system7` provider
     /// represents the existing renderer; non-classic themes are explicit and
     /// must not alter guest-visible Toolbox behavior in classic metrics mode.
@@ -792,6 +809,7 @@ impl Default for FixtureRunnerConfig {
             max_instructions: 10_000_000,
             load_address: DEFAULT_LOAD_ADDRESS,
             arrows_as_numpad: false,
+            menu_bar_policy: MenuBarPolicy::GuestControlled,
             ui_theme: UiThemeId::ClassicSystem7,
             theme_metrics_mode: ThemeMetricsMode::ClassicGuestMetrics,
         }
@@ -820,11 +838,9 @@ impl Default for FixtureRunnerConfig {
 ///    [`halted_by_exit_to_shell`](Self::halted_by_exit_to_shell) classifies
 ///    the common clean application-exit path.
 ///
-/// **Defaults:** kiosk mode (Mac menu bar suppressed regardless of the
-/// guest's `MBarHeight`); arrow keys NOT remapped to numpad. Override
-/// each via [`set_menu_bar_visible`](Self::set_menu_bar_visible) /
-/// [`set_arrows_as_numpad`](Self::set_arrows_as_numpad) or the
-/// `SYSTEMLESS_SHOW_MENU_BAR` env var.
+/// **Defaults:** guest-controlled Mac menu-bar visibility; arrow keys NOT
+/// remapped to numpad. Frontends can select a kiosk policy through
+/// [`set_menu_bar_policy`](Self::set_menu_bar_policy).
 ///
 /// See `examples/run_headless.rs` for a runnable end-to-end example.
 pub struct FixtureRunner {
@@ -974,12 +990,13 @@ impl FixtureRunner {
     /// [`crate::game::RAM_SIZE`] provides the canonical profile-driven size;
     /// tests and specialized embedders may choose a smaller allocation.
     ///
-    /// The dispatcher defaults to **kiosk mode** (Mac menu bar
-    /// suppressed, regardless of the guest's `MBarHeight`). Call
-    /// [`set_menu_bar_visible`](Self::set_menu_bar_visible) to opt back
-    /// in to the original Mac menu-bar behaviour.
+    /// The dispatcher follows the guest's menu-bar state by default. Frontends
+    /// that own the surrounding chrome can select an explicit kiosk policy in
+    /// [`FixtureRunnerConfig`] or through
+    /// [`set_menu_bar_policy`](Self::set_menu_bar_policy).
     pub fn new(ram_size: usize, config: FixtureRunnerConfig) -> Self {
         let mut dispatcher = TrapDispatcher::new();
+        dispatcher.set_menu_bar_policy(config.menu_bar_policy);
         dispatcher.set_ui_theme_id(config.ui_theme);
         let mut bus = MacMemoryBus::new(ram_size);
         let standard_adb_service = bus.alloc_synthetic(2);
@@ -1172,34 +1189,35 @@ impl FixtureRunner {
             .preserves_classic_guest_metrics()
     }
 
-    /// Show or hide the Mac menu bar.
+    /// Select the host presentation policy for the classic Mac menu bar.
+    pub fn set_menu_bar_policy(&mut self, policy: MenuBarPolicy) {
+        self.config.menu_bar_policy = policy;
+        self.dispatcher.set_menu_bar_policy(policy);
+    }
+
+    /// Return the current host presentation policy for the menu bar.
+    pub fn menu_bar_policy(&self) -> MenuBarPolicy {
+        self.dispatcher.menu_bar_policy
+    }
+
+    /// Compatibility toggle for embedders using the older boolean API.
     ///
-    /// systemless runs in **kiosk mode** by default — the Mac menu bar is
-    /// suppressed regardless of the guest's `MBarHeight` ($0BAA) value
-    /// and `DrawMenuBar` is a no-op. This matches the typical embedding
-    /// case (running a single classic Mac game inside a fullscreen
-    /// host window) where the host owns the chrome and the guest's
-    /// menu bar would just diverge from the original-machine
-    /// appearance whenever the cursor entered `y < 20`.
-    ///
-    /// Pass `true` to opt back in to original Mac behavior — for
-    /// example, when running a Mac *application* that relies on the
-    /// menu bar as its primary user surface.
-    ///
-    /// The same toggle is also accessible via the `SYSTEMLESS_SHOW_MENU_BAR`
-    /// environment variable (set to any value to show) and via
-    /// `systemless --show-menu-bar`. This library method is the
-    /// preferred entry point for library embedders that don't want
-    /// to depend on environment-variable plumbing.
+    /// `true` restores guest-controlled visibility. `false` permanently hides
+    /// the bar; game frontends that only need an initial kiosk presentation
+    /// should use [`MenuBarPolicy::InitialKiosk`] instead.
     ///
     /// Inside Macintosh Volume I, I-354 (DrawMenuBar);
     /// Inside Macintosh Volume V, V-245 (MBarHeight global).
     pub fn set_menu_bar_visible(&mut self, visible: bool) {
-        self.dispatcher.menu_bar_hidden = !visible;
+        self.set_menu_bar_policy(if visible {
+            MenuBarPolicy::GuestControlled
+        } else {
+            MenuBarPolicy::ForceHidden
+        });
     }
 
-    /// Returns true when the Mac menu bar is currently being rendered.
-    /// In the default kiosk configuration this returns `false`.
+    /// Returns whether host policy currently permits the Mac menu bar to be
+    /// rendered. Guest `MBarHeight` and fullscreen state may still hide it.
     pub fn menu_bar_visible(&self) -> bool {
         !self.dispatcher.menu_bar_hidden
     }
@@ -1908,10 +1926,13 @@ impl FixtureRunner {
             max_instructions: self.config.max_instructions,
             load_address: self.config.load_address,
             arrows_as_numpad: self.config.arrows_as_numpad,
+            menu_bar_policy: self.config.menu_bar_policy,
             ui_theme: self.config.ui_theme,
             theme_metrics_mode: self.config.theme_metrics_mode,
         };
-        let menu_bar_visible = self.menu_bar_visible();
+        let menu_bar_policy = self.dispatcher.menu_bar_policy;
+        let menu_bar_hidden = self.dispatcher.menu_bar_hidden;
+        let initial_kiosk_guest_hide_observed = self.dispatcher.initial_kiosk_guest_hide_observed;
         let instructions_per_tick = self.instructions_per_tick;
         let wait_sleep_cap_in_headless = self.wait_sleep_cap_in_headless;
         let app_start_time = self.app_start_time;
@@ -1934,7 +1955,10 @@ impl FixtureRunner {
         let next_working_dir_refnum = self.dispatcher.next_working_dir_refnum;
 
         let mut replacement = FixtureRunner::new(ram_size, config);
-        replacement.set_menu_bar_visible(menu_bar_visible);
+        replacement.dispatcher.menu_bar_policy = menu_bar_policy;
+        replacement.dispatcher.menu_bar_hidden = menu_bar_hidden;
+        replacement.dispatcher.initial_kiosk_guest_hide_observed =
+            initial_kiosk_guest_hide_observed;
         replacement.instructions_per_tick = instructions_per_tick;
         replacement.tick_budget = instructions_per_tick as i32;
         replacement.wait_sleep_cap_in_headless = wait_sleep_cap_in_headless;
@@ -4515,6 +4539,8 @@ impl FixtureRunner {
         // A same-tick cycle proof is invalid as soon as any ordinary clock
         // advancement or interrupt work occurs during the observed cycle.
         self.cancel_idle_cycle_detector();
+        self.dispatcher
+            .refresh_menu_bar_policy_from_guest(&self.bus);
         let new_tick = self.bus.read_long(0x016A).wrapping_add(1);
         self.bus.write_long(0x016A, new_tick);
         self.dispatcher.tick_count = new_tick;
@@ -13794,45 +13820,46 @@ mod tests {
     }
 
     #[test]
-    fn set_menu_bar_visible_round_trips_through_public_api() {
-        // Pins the FixtureRunner::set_menu_bar_visible / menu_bar_visible
-        // pair as the public-API entry point for the kiosk-mode toggle.
-        // Library embedders should not need to reach through
-        // dispatcher_mut() into TrapDispatcher::menu_bar_hidden — the
-        // method-based surface keeps the kiosk-on-by-default contract
-        // discoverable from the FixtureRunner type alone.
-        //
-        // Default (constructor): kiosk on → menu bar NOT visible.
-        // After set_menu_bar_visible(true): menu bar IS visible.
-        // After set_menu_bar_visible(false): kiosk back on.
-        // Skip when SYSTEMLESS_SHOW_MENU_BAR is set in the test env —
-        // the env var pre-seeds menu_bar_hidden = false at construction
-        // and would race the round-trip assertion.
-        if std::env::var_os("SYSTEMLESS_SHOW_MENU_BAR").is_some() {
-            return;
-        }
+    fn menu_bar_policy_defaults_to_guest_control_and_supports_explicit_kiosk_modes() {
         let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
-        assert!(
-            !runner.menu_bar_visible(),
-            "kiosk default: menu_bar_visible() must report false"
-        );
-        runner.set_menu_bar_visible(true);
+        assert_eq!(runner.menu_bar_policy(), MenuBarPolicy::GuestControlled);
         assert!(
             runner.menu_bar_visible(),
-            "after set_menu_bar_visible(true), menu_bar_visible() must report true"
+            "library runners should permit guest menu chrome by default"
         );
+
+        runner.set_menu_bar_policy(MenuBarPolicy::InitialKiosk);
+        assert_eq!(runner.menu_bar_policy(), MenuBarPolicy::InitialKiosk);
+        assert!(!runner.menu_bar_visible());
+
         runner.set_menu_bar_visible(false);
-        assert!(
-            !runner.menu_bar_visible(),
-            "after set_menu_bar_visible(false), menu_bar_visible() must report false"
-        );
-        // Internal field stays in sync with the public API — guards
-        // against future refactors that introduce a parallel state
-        // field but forget to wire it through the toggle.
-        assert!(
-            runner.dispatcher().menu_bar_hidden,
-            "set_menu_bar_visible(false) must clear the kiosk-bypass bit"
-        );
+        assert_eq!(runner.menu_bar_policy(), MenuBarPolicy::ForceHidden);
+        assert!(!runner.menu_bar_visible());
+
+        runner.set_menu_bar_visible(true);
+        assert_eq!(runner.menu_bar_policy(), MenuBarPolicy::GuestControlled);
+        assert!(runner.menu_bar_visible());
+    }
+
+    #[test]
+    fn initial_kiosk_releases_after_guest_hides_and_reveals_menu_bar() {
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        runner.set_menu_bar_policy(MenuBarPolicy::InitialKiosk);
+        runner.dispatcher.front_window = 1;
+
+        runner
+            .bus
+            .write_word(crate::memory::globals::addr::MBAR_HEIGHT, 0);
+        runner.force_advance_guest_tick();
+        assert_eq!(runner.menu_bar_policy(), MenuBarPolicy::InitialKiosk);
+        assert!(!runner.menu_bar_visible());
+
+        runner
+            .bus
+            .write_word(crate::memory::globals::addr::MBAR_HEIGHT, 20);
+        runner.force_advance_guest_tick();
+        assert_eq!(runner.menu_bar_policy(), MenuBarPolicy::GuestControlled);
+        assert!(runner.menu_bar_visible());
     }
 
     #[test]

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -1529,16 +1529,16 @@ pub struct TrapDispatcher {
     /// and MBarHeight was 0). While set, the menu bar is suppressed even if
     /// the game temporarily restores MBarHeight (e.g. on cursor-at-top).
     pub fullscreen_locked: bool,
-    /// Host-controlled override for menu bar visibility. When true, the menu
-    /// bar is suppressed regardless of game state — unlike `fullscreen_locked`
-    /// which the emulator auto-clears when the game writes MBarHeight > 0.
-    /// Defaults to `true` so the HLE renders like a kiosk by default; the
-    /// menu bar is a Mac OS chrome surface that has no analogue in a game-
-    /// only runtime, and showing it diverges screenshots from the
-    /// original-machine reference whenever the cursor hovers `y < 20`.
-    /// Set `SYSTEMLESS_SHOW_MENU_BAR=1` (or assign `menu_bar_hidden = false`
-    /// after construction) to opt back in for environments where the menu
-    /// bar IS the user-facing surface (e.g. running a Mac app, not a game).
+    /// Host presentation policy for the classic Mac menu bar.
+    pub(crate) menu_bar_policy: crate::runner::MenuBarPolicy,
+    /// Whether an initial-kiosk frontend has observed the guest genuinely hide
+    /// the menu bar after creating a window. A later reveal releases the kiosk
+    /// suppression back to guest control; an explicit DrawMenuBar request does
+    /// so immediately.
+    pub(crate) initial_kiosk_guest_hide_observed: bool,
+    /// Effective host suppression bit used by rendering and hit-testing paths.
+    /// Guest-controlled runners default to `false`; explicit frontend policy
+    /// may set it while leaving `fullscreen_locked` to model guest state.
     pub menu_bar_hidden: bool,
     /// Sound Manager state (channels, playback buffers).
     pub sound_manager: crate::sound::SoundManager,
@@ -2130,6 +2130,20 @@ impl TrapDispatcher {
     pub(crate) const AUTO_KEY_THRESHOLD_TICKS: u32 = 16;
     pub(crate) const AUTO_KEY_RATE_TICKS: u32 = 4;
     const CAPS_LOCK_KEY_CODE: u8 = 0x39;
+
+    pub(crate) fn set_menu_bar_policy(&mut self, policy: crate::runner::MenuBarPolicy) {
+        self.menu_bar_policy = policy;
+        self.initial_kiosk_guest_hide_observed = false;
+        self.menu_bar_hidden = !matches!(policy, crate::runner::MenuBarPolicy::GuestControlled);
+    }
+
+    pub(crate) fn release_initial_menu_bar_kiosk(&mut self) {
+        if self.menu_bar_policy == crate::runner::MenuBarPolicy::InitialKiosk {
+            self.menu_bar_policy = crate::runner::MenuBarPolicy::GuestControlled;
+            self.initial_kiosk_guest_hide_observed = false;
+            self.menu_bar_hidden = false;
+        }
+    }
 
     pub(crate) fn key_is_modifier(key_code: u8) -> bool {
         // Command, Shift, Caps Lock, Option, and Control (including the
@@ -3020,13 +3034,9 @@ impl TrapDispatcher {
             go_away_flag: false,
             window_list: Vec::new(),
             fullscreen_locked: false,
-            // Default to hiding the menu bar — the HLE is a game runtime,
-            // not a Finder, and a leaking menu bar at `y < 20` is the
-            // single biggest source of visual glitches where the classic
-            // menu bar bleeds into the game's top rows. Frontends that
-            // host a Mac app (rather than a game) can opt back in via
-            // `SYSTEMLESS_SHOW_MENU_BAR=1`.
-            menu_bar_hidden: std::env::var_os("SYSTEMLESS_SHOW_MENU_BAR").is_none(),
+            menu_bar_policy: crate::runner::MenuBarPolicy::GuestControlled,
+            initial_kiosk_guest_hide_observed: false,
+            menu_bar_hidden: false,
             sound_manager: crate::sound::SoundManager::new(),
             menus: Vec::new(),
             saved_menu_bars: HashMap::new(),

--- a/src/trap/framebuffer.rs
+++ b/src/trap/framebuffer.rs
@@ -4320,6 +4320,20 @@ impl super::TrapDispatcher {
         }
     }
 
+    pub(crate) fn refresh_menu_bar_policy_from_guest(&mut self, bus: &MacMemoryBus) {
+        if self.menu_bar_policy != crate::runner::MenuBarPolicy::InitialKiosk {
+            return;
+        }
+
+        let menu_bar_height = bus.read_word(crate::memory::globals::addr::MBAR_HEIGHT) as i16;
+        if menu_bar_height <= 0 && self.front_window != 0 {
+            self.initial_kiosk_guest_hide_observed = true;
+        } else if menu_bar_height > 0 && self.initial_kiosk_guest_hide_observed {
+            self.menu_bar_policy = crate::runner::MenuBarPolicy::GuestControlled;
+            self.menu_bar_hidden = false;
+        }
+    }
+
     /// Redraw the menu bar and window chrome into the framebuffer.
     ///
     /// On a real Mac, the Window Manager maintains these UI elements and redraws
@@ -4327,6 +4341,8 @@ impl super::TrapDispatcher {
     /// so game drawing (explosions, etc.) can overwrite them. This method restores
     /// the chrome and should be called after each frame of emulation.
     pub fn redraw_chrome(&mut self, bus: &mut MacMemoryBus) {
+        self.refresh_menu_bar_policy_from_guest(bus);
+
         // Blit front window's port pixels to screen framebuffer if they differ.
         // On real Mac OS the Window Manager composites windows to the screen.
         // In HLE, games draw to the window's GrafPort which may have a different
@@ -5441,9 +5457,8 @@ mod redraw_chrome_tests {
     }
 
     /// Counterpart to the kiosk-mode test above: when `menu_bar_hidden
-    /// = false` (app-style hosting), `redraw_chrome` MUST paint the
-    /// menu bar so menus are reachable. This pins the env-var-driven
-    /// opt-out (SYSTEMLESS_SHOW_MENU_BAR=1 → menu_bar_hidden=false).
+    /// = false` (guest-controlled hosting), `redraw_chrome` MUST paint
+    /// the menu bar so menus are reachable.
     #[test]
     fn redraw_chrome_paints_menu_bar_when_not_hidden() {
         let (mut disp, _cpu, mut bus) = setup_with_port();

--- a/src/trap/menu.rs
+++ b/src/trap/menu.rs
@@ -1528,6 +1528,10 @@ impl super::TrapDispatcher {
             // DrawMenuBar ($A937): Renders menu-bar titles for menus currently
             // in the menu list (InsertMenu-installed) per IM:I I-352/I-354.
             (true, 0x137) => {
+                // Initial kiosk mode is only a frontend launch policy. A
+                // guest DrawMenuBar call is an explicit request to present its
+                // menus, so ownership returns to the guest before rendering.
+                self.release_initial_menu_bar_kiosk();
                 self.draw_menu_bar_to_fb(bus);
                 Ok(())
             }
@@ -8673,6 +8677,38 @@ mod tests {
         let result = disp.dispatch_menu(true, 0x137, &mut cpu, &mut bus);
         assert!(result.is_some(), "DrawMenuBar should be handled");
         assert!(result.unwrap().is_ok(), "DrawMenuBar should succeed");
+    }
+
+    #[test]
+    fn draw_menu_bar_releases_initial_kiosk_policy() {
+        let (mut disp, mut cpu, mut bus) = setup_with_port();
+        disp.set_menu_bar_policy(crate::runner::MenuBarPolicy::InitialKiosk);
+
+        let result = disp.dispatch_menu(true, 0x137, &mut cpu, &mut bus);
+
+        assert!(result.is_some(), "DrawMenuBar should be handled");
+        assert!(result.unwrap().is_ok(), "DrawMenuBar should succeed");
+        assert_eq!(
+            disp.menu_bar_policy,
+            crate::runner::MenuBarPolicy::GuestControlled
+        );
+        assert!(!disp.menu_bar_hidden);
+    }
+
+    #[test]
+    fn draw_menu_bar_preserves_force_hidden_policy() {
+        let (mut disp, mut cpu, mut bus) = setup_with_port();
+        disp.set_menu_bar_policy(crate::runner::MenuBarPolicy::ForceHidden);
+
+        let result = disp.dispatch_menu(true, 0x137, &mut cpu, &mut bus);
+
+        assert!(result.is_some(), "DrawMenuBar should be handled");
+        assert!(result.unwrap().is_ok(), "DrawMenuBar should succeed");
+        assert_eq!(
+            disp.menu_bar_policy,
+            crate::runner::MenuBarPolicy::ForceHidden
+        );
+        assert!(disp.menu_bar_hidden);
     }
 
     #[test]

--- a/src/trap/window.rs
+++ b/src/trap/window.rs
@@ -2589,7 +2589,7 @@ impl super::TrapDispatcher {
         if fullscreen_visible {
             // Real full-screen game windows start from an erased content area
             // using the Window Manager desktop/background. In Systemless's
-            // default kiosk mode the Mac menu bar/desktop is suppressed, so
+            // explicit kiosk mode the Mac menu bar/desktop is suppressed, so
             // exposed areas should stay on the black host stage rather than
             // flash the classic white desktop. When callers opt into the menu
             // bar, keep the normal Mac white background.
@@ -6642,6 +6642,7 @@ mod tests {
     #[test]
     fn test_new_cwindow_0x245() {
         let (mut disp, mut cpu, mut bus) = setup();
+        disp.set_menu_bar_policy(crate::runner::MenuBarPolicy::ForceHidden);
         let screen_base = bus.alloc((800 * 600) as u32);
         bus.write_long(0x0824, screen_base);
         disp.screen_mode = (screen_base, 800, 800, 600, 8);
@@ -6683,7 +6684,7 @@ mod tests {
         // Verify it creates a CGrafPort: portVersion at offset +6 should have 0xC000
         let port_version = bus.read_word(window_ptr + 6);
         assert_eq!(port_version, 0xC000, "NewCWindow should set CGrafPort flag");
-        // In default kiosk mode the Mac desktop is hidden, so fullscreen
+        // In explicit kiosk mode the Mac desktop is hidden, so fullscreen
         // windows erase exposed framebuffer areas to the black host stage.
         assert_eq!(
             bus.read_byte(screen_base),
@@ -6695,6 +6696,7 @@ mod tests {
     #[test]
     fn kiosk_new_cwindow_suppresses_initial_document_chrome_erase() {
         let (mut disp, mut cpu, mut bus) = setup();
+        disp.set_menu_bar_policy(crate::runner::MenuBarPolicy::ForceHidden);
         let screen_base = bus.alloc((800 * 600) as u32);
         bus.write_long(0x0824, screen_base);
         disp.screen_mode = (screen_base, 800, 800, 600, 8);


### PR DESCRIPTION
## Summary

- remove the obsolete `--cpu-mhz` CLI option and its GUI-only instruction-cap machinery
- remove `--show-menu-bar` and `SYSTEMLESS_SHOW_MENU_BAR`
- make guest-controlled menu visibility the library default
- add explicit initial-kiosk and force-hidden frontend policies while preserving native macOS menu mirroring

## Why

The CPU override duplicated the canonical machine profile while only affecting one frontend pacing path. Menu presentation was similarly expressed as a global boolean, which made kiosk behavior the library default and conflated frontend chrome policy with guest `MBarHeight` and `DrawMenuBar` state.

The new policy keeps the emulation core guest-controlled by default. Frontends can request an initial kiosk presentation that releases when the guest explicitly draws or reveals its menu bar, or force the framebuffer menu bar hidden when menus are presented natively.

## Validation

- `cargo fmt --all --check`
- `cargo test --lib` (2,955 passed; 3 ignored)
- `cargo test --bin systemless` (51 passed)
- `cargo check --no-default-features --lib`

Closes #625