### PR TITLE
perf: adopt cached PowerPC basic blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1773,9 +1773,9 @@ dependencies = [
 
 [[package]]
 name = "ppc"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87d40ae627917451c3933cce67f6c8e0bc7f93fcabedd528f97acfbb965271b8"
+checksum = "f815c8257fce8ef79853cfa25dd23d361924e0cfbff07af11cfa295d3d26a23c"
 
 [[package]]
 name = "prettyplease"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ default-run = "systemless"
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
 m68k = { version = "0.7.1", features = ["jit"] }
-ppc = "0.3.0"
+ppc = "0.3.1"
 thiserror = "2"
 tracing = "0.1"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
Closes #638.

Updates `ppc` to 0.3.1 so immutable PEF code uses the released portable basic-block cache in native and WebAssembly builds.

Validation: the PowerPC HLE allocation regression passes against the published crate; the same release runner workload reduced steady 12k-cycle slices from roughly 0.23–0.49 ms to 0.17–0.18 ms.