### PR TITLE
fix: support HyperCard fonts, menus, and window scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,10 +217,10 @@ applications requesting a family by name or ID still resolve to a sensible face
 | **Jarrah**      | Heavy system / UI sans | Chicago (0) |
 | **Kurrajong**   | Humanist body sans     | Geneva (3), Application (1), Helvetica (21); Venice (5), London (6), Cairo (11) |
 | **Mallee**    | Monospace              | Monaco (4), Courier (22) |
-| **Ironbark**    | Serif                  | New York (2), Times (20) |
+| **Ironbark**    | Serif                  | New York (2), Palatino (16), Times (20) |
 
 Sizes: Jarrah 9/12; Kurrajong 9/10/12/14/18/24 (+ Application 12, Helvetica 12);
-Mallee 9/10/12; Ironbark 12/14/18.
+Mallee 9/10/12; Ironbark 12/14/18 (with 2× scaling for 24).
 
 Every face is hand-drawn glyph by glyph in a consistent house style, with
 advances, side-bearings and x-height / cap height conformed to the original Mac

--- a/src/bin/systemless.rs
+++ b/src/bin/systemless.rs
@@ -1350,9 +1350,12 @@ impl App {
 
         #[cfg(not(target_os = "macos"))]
         {
-            let scale = (buf_w / game_w).min(buf_h / game_h).max(1) as usize;
-            let draw_w = game_w as usize * scale;
-            let draw_h = game_h as usize * scale;
+            let (draw_x, draw_y, draw_w, draw_h) =
+                aspect_fit_dimensions(game_w, game_h, buf_w, buf_h);
+            let draw_x = draw_x as usize;
+            let draw_y = draw_y as usize;
+            let draw_w = draw_w as usize;
+            let draw_h = draw_h as usize;
             let mut scaled_row = std::mem::take(&mut self.scaled_row);
 
             let Some(surface) = self.surface.as_mut() else {
@@ -1373,30 +1376,28 @@ impl App {
 
             let mut buffer = surface.buffer_mut().expect("Failed to get buffer");
 
-            if draw_w != buf_w as usize || draw_h != buf_h as usize {
+            if draw_x != 0 || draw_y != 0 || draw_w != buf_w as usize || draw_h != buf_h as usize {
                 buffer.fill(0xFF000000);
             }
 
-            if scale == 1 {
+            if draw_w == game_w as usize && draw_h == game_h as usize {
                 for row in 0..game_h as usize {
                     let src_row = &frame_argb[row * game_w as usize..(row + 1) * game_w as usize];
-                    let dst_offset = row * buf_w as usize;
+                    let dst_offset = (draw_y + row) * buf_w as usize + draw_x;
                     buffer[dst_offset..dst_offset + game_w as usize].copy_from_slice(src_row);
                 }
             } else {
                 scaled_row.resize(draw_w, 0xFF000000);
-                for row in 0..game_h as usize {
-                    let src_row = &frame_argb[row * game_w as usize..(row + 1) * game_w as usize];
-                    for (dst_chunk, &pixel) in
-                        scaled_row.chunks_exact_mut(scale).zip(src_row.iter())
-                    {
-                        dst_chunk.fill(pixel);
+                for row in 0..draw_h {
+                    let source_y = row * game_h as usize / draw_h;
+                    let src_row =
+                        &frame_argb[source_y * game_w as usize..(source_y + 1) * game_w as usize];
+                    for (destination_x, pixel) in scaled_row.iter_mut().enumerate() {
+                        let source_x = destination_x * game_w as usize / draw_w;
+                        *pixel = src_row[source_x];
                     }
-                    let dst_row_start = row * scale * buf_w as usize;
-                    for repeat in 0..scale {
-                        let dst_offset = dst_row_start + repeat * buf_w as usize;
-                        buffer[dst_offset..dst_offset + draw_w].copy_from_slice(&scaled_row);
-                    }
+                    let dst_offset = (draw_y + row) * buf_w as usize + draw_x;
+                    buffer[dst_offset..dst_offset + draw_w].copy_from_slice(&scaled_row);
                 }
             }
 
@@ -1409,6 +1410,38 @@ impl App {
         self.force_next_render = false;
         self.render_headroom = Self::next_render_headroom(render_start.elapsed());
     }
+}
+
+fn aspect_fit_dimensions(
+    source_width: u32,
+    source_height: u32,
+    drawable_width: u32,
+    drawable_height: u32,
+) -> (u32, u32, u32, u32) {
+    if source_width == 0 || source_height == 0 || drawable_width == 0 || drawable_height == 0 {
+        return (0, 0, 0, 0);
+    }
+
+    let width_limited = u64::from(drawable_width) * u64::from(source_height)
+        <= u64::from(drawable_height) * u64::from(source_width);
+    let (width, height) = if width_limited {
+        (
+            drawable_width,
+            (u64::from(drawable_width) * u64::from(source_height) / u64::from(source_width)) as u32,
+        )
+    } else {
+        (
+            (u64::from(drawable_height) * u64::from(source_width) / u64::from(source_height))
+                as u32,
+            drawable_height,
+        )
+    };
+    (
+        (drawable_width - width) / 2,
+        (drawable_height - height) / 2,
+        width,
+        height,
+    )
 }
 
 fn physical_to_mac_in_viewport(
@@ -3362,6 +3395,25 @@ mod tests {
         assert!(
             !content_rect_has_inactive_margins_8bpp(&framebuffer, width, width, height, content,),
             "a separately drawn side panel must keep the full screen visible"
+        );
+    }
+
+    #[test]
+    fn software_presenter_aspect_fits_and_centers_wide_windows() {
+        assert_eq!(
+            aspect_fit_dimensions(800, 600, 1920, 1080),
+            (240, 0, 1440, 1080),
+            "a 4:3 guest should fill a 16:9 window vertically"
+        );
+        assert_eq!(
+            aspect_fit_dimensions(800, 600, 1280, 960),
+            (0, 0, 1280, 960),
+            "matching aspect ratios should fill the drawable"
+        );
+        assert_eq!(
+            aspect_fit_dimensions(800, 600, 600, 800),
+            (0, 175, 600, 450),
+            "portrait windows should center the guest vertically"
         );
     }
 

--- a/src/memory/globals.rs
+++ b/src/memory/globals.rs
@@ -61,6 +61,10 @@ pub mod addr {
     pub const SOUND_LEVEL: u32 = 0x027F;
 
     // Menu Manager globals
+    /// MenuList: handle to the current Menu Manager menu list.
+    /// Inside Macintosh Volume III (1985), low-memory globals table;
+    /// Inside Macintosh Volume V (1986), pp. V-228–V-230.
+    pub const MENU_LIST: u32 = 0x0A1C;
     pub const MBAR_HEIGHT: u32 = 0x0BAA; // Menu bar height in pixels (word) - Inside Macintosh V, V-245
     pub const MENU_FLASH: u32 = 0x0A24; // Number of times menu item blinks (word) - Inside Macintosh Volume I, I-361
 

--- a/src/quickdraw/fonts/heuristics.rs
+++ b/src/quickdraw/fonts/heuristics.rs
@@ -21,6 +21,7 @@ pub const FONT_TORONTO: i16 = 9;
 pub const FONT_SEATTLE: i16 = 10;
 pub const FONT_CAIRO: i16 = 11;
 pub const FONT_LOSANGELES: i16 = 12;
+pub const FONT_PALATINO: i16 = 16;
 pub const FONT_TIMES: i16 = 20;
 pub const FONT_HELVETICA: i16 = 21;
 pub const FONT_COURIER: i16 = 22;

--- a/src/quickdraw/fonts/mod.rs
+++ b/src/quickdraw/fonts/mod.rs
@@ -18,7 +18,7 @@
 //! | Chicago                                            | Jarrah          |
 //! | Geneva / Application / Helvetica                   | Kurrajong       |
 //! | Monaco / Courier                                   | Mallee        |
-//! | New York / Times                                   | Ironbark        |
+//! | New York / Palatino / Times                        | Ironbark        |
 //! | Venice                                             | Wattle           |
 //! | London                                             | Karri           |
 //! | Cairo                                              | Grevillea          |
@@ -41,7 +41,7 @@ use std::sync::{LazyLock, Mutex};
 pub use self::heuristics::{
     FONT_APPLICATION, FONT_ATHENS, FONT_CAIRO, FONT_CHICAGO, FONT_COURIER, FONT_GENEVA,
     FONT_HELVETICA, FONT_LONDON, FONT_LOSANGELES, FONT_MOBILE, FONT_MONACO, FONT_NEWYORK,
-    FONT_SANFRAN, FONT_SEATTLE, FONT_SYMBOL, FONT_TIMES, FONT_TORONTO, FONT_VENICE,
+    FONT_PALATINO, FONT_SANFRAN, FONT_SEATTLE, FONT_SYMBOL, FONT_TIMES, FONT_TORONTO, FONT_VENICE,
 };
 
 /// Single-character bitmap descriptor: dimensions + offset into the
@@ -468,6 +468,7 @@ pub static FONT_NAMES: &[(i16, &str)] = &[
     (9, "Toronto"),
     (11, "Cairo"),
     (12, "Los Angeles"),
+    (16, "Palatino"),
     (20, "Times"),
     (21, "Helvetica"),
     (22, "Courier"),
@@ -590,7 +591,7 @@ fn get_baked_font_face(font_id: i16, size: i16) -> Option<&'static FontFace> {
 fn fallback_font_id(font_id: i16) -> Option<i16> {
     match font_id {
         1 => Some(FONT_GENEVA),
-        FONT_TIMES => Some(FONT_NEWYORK),
+        FONT_PALATINO | FONT_TIMES => Some(FONT_NEWYORK),
         FONT_HELVETICA => Some(FONT_GENEVA),
         FONT_COURIER => Some(FONT_MONACO),
         _ => None,
@@ -836,6 +837,18 @@ mod tests {
     fn fallback_courier_to_monaco() {
         let face = get_font_face_or_default(FONT_COURIER, 12);
         assert_eq!(face.font_id, FONT_MONACO);
+    }
+
+    #[test]
+    fn palatino_uses_the_original_ironbark_serif_face() {
+        assert_eq!(font_id_for_name("Palatino"), Some(FONT_PALATINO));
+        assert_eq!(font_name_for_id(FONT_PALATINO), Some("Palatino"));
+
+        for size in [12, 14, 18, 24] {
+            let (face, scale) = get_font_face_scaled(FONT_PALATINO, size);
+            assert_eq!(face.font_id, FONT_NEWYORK);
+            assert_eq!(i16::from(face.size) * scale, size);
+        }
     }
 
     #[test]

--- a/src/trap/menu.rs
+++ b/src/trap/menu.rs
@@ -1187,6 +1187,63 @@ impl super::TrapDispatcher {
         true
     }
 
+    fn sync_guest_menu_list(&mut self, bus: &mut MacMemoryBus) {
+        let regular = self
+            .menus
+            .iter()
+            .filter(|menu| menu.in_menu_bar && !menu.hierarchical)
+            .collect::<Vec<_>>();
+        let hierarchical = self
+            .menus
+            .iter()
+            .filter(|menu| menu.in_menu_bar && menu.hierarchical)
+            .collect::<Vec<_>>();
+
+        let title_lefts = self
+            .menu_title_regions_with_indices()
+            .into_iter()
+            .filter_map(|(index, left, _)| self.menus.get(index).map(|menu| (menu.handle, left)))
+            .collect::<std::collections::HashMap<_, _>>();
+        let last_right = self
+            .menu_title_regions_with_indices()
+            .into_iter()
+            .last()
+            .map(|(_, _, right)| right)
+            .unwrap_or(0);
+
+        // System 7's DynamicMenuList contains a six-byte header, one
+        // six-byte MenuRec per regular menu, lastHMenu + menuTitleSave,
+        // then one six-byte HMenuRec per hierarchical/pop-up menu.
+        // Inside Macintosh Volume V (1986), pp. V-228–V-230.
+        let mut bytes = Vec::with_capacity(12 + 6 * (regular.len() + hierarchical.len()));
+        bytes.extend_from_slice(&((regular.len() * 6) as i16).to_be_bytes());
+        bytes.extend_from_slice(&last_right.to_be_bytes());
+        bytes.extend_from_slice(&0i16.to_be_bytes());
+        for menu in regular {
+            bytes.extend_from_slice(&menu.handle.to_be_bytes());
+            bytes.extend_from_slice(
+                &title_lefts
+                    .get(&menu.handle)
+                    .copied()
+                    .unwrap_or(0)
+                    .to_be_bytes(),
+            );
+        }
+        bytes.extend_from_slice(&((hierarchical.len() * 6) as i16).to_be_bytes());
+        bytes.extend_from_slice(&0u32.to_be_bytes());
+        for menu in hierarchical {
+            bytes.extend_from_slice(&menu.handle.to_be_bytes());
+            bytes.extend_from_slice(&0i16.to_be_bytes());
+        }
+
+        let mut handle = bus.read_long(addr::MENU_LIST);
+        if handle == 0 {
+            handle = bus.alloc(4);
+            bus.write_long(addr::MENU_LIST, handle);
+        }
+        let _ = self.replace_handle_bytes(bus, handle, &bytes);
+    }
+
     fn ensure_menu_record_capacity(
         &mut self,
         bus: &mut MacMemoryBus,
@@ -1250,6 +1307,7 @@ impl super::TrapDispatcher {
             (true, 0x130) => {
                 let _ = self.ensure_menu_color_table_handle(bus);
                 self.load_menu_color_resource(bus, 0);
+                self.sync_guest_menu_list(bus);
                 Ok(())
             }
 
@@ -1517,6 +1575,8 @@ impl super::TrapDispatcher {
                     }
                 }
 
+                self.sync_guest_menu_list(bus);
+
                 cpu.write_reg(Register::A7, sp + 6);
                 Ok(())
             }
@@ -1551,6 +1611,7 @@ impl super::TrapDispatcher {
                 // information table.
                 self.menus.clear();
                 self.clear_menu_color_table_entries(bus);
+                self.sync_guest_menu_list(bus);
                 Ok(())
             }
 
@@ -1593,6 +1654,7 @@ impl super::TrapDispatcher {
                 cpu.write_reg(Register::A7, sp + 4);
                 if let Some(saved) = self.saved_menu_bars.get(&menu_list).cloned() {
                     self.menus = saved;
+                    self.sync_guest_menu_list(bus);
                 }
                 Ok(())
             }
@@ -1687,7 +1749,23 @@ impl super::TrapDispatcher {
                 cpu.write_reg(Register::A7, sp + 8);
 
                 let res_type = res_type_word.to_be_bytes();
-                let entries = self.named_resources_of_type(res_type);
+                let mut entries = self.named_resources_of_type(res_type);
+                if res_type == *b"FONT" {
+                    // Systemless's built-in bitmap families are HLE data, not
+                    // guest FONT resources. AddResMenu must nevertheless make
+                    // those installed families visible to applications that
+                    // build a Font menu from the Font Manager resource type.
+                    // Inside Macintosh Volume I (1985), pp. I-217, I-353.
+                    for &(id, name) in crate::quickdraw::fonts::FONT_NAMES {
+                        if id == crate::quickdraw::fonts::FONT_APPLICATION
+                            || entries.iter().any(|(_, entry)| entry == name)
+                        {
+                            continue;
+                        }
+                        entries.push((id, name.to_string()));
+                    }
+                    entries.sort_by_key(|(id, _)| *id);
+                }
 
                 let mut touched: Option<Menu> = None;
                 if let Some(menu) = self.menus.iter_mut().find(|m| m.handle == menu_handle) {
@@ -2357,6 +2435,7 @@ impl super::TrapDispatcher {
                 let menu_handle = bus.read_long(sp);
                 cpu.write_reg(Register::A7, sp + 4);
                 self.menus.retain(|m| m.handle != menu_handle);
+                self.sync_guest_menu_list(bus);
                 if menu_handle != 0 {
                     let menu_ptr = bus.read_long(menu_handle);
                     if menu_ptr != 0 {
@@ -2384,6 +2463,7 @@ impl super::TrapDispatcher {
                 let menu_id = bus.read_word(sp) as i16;
                 cpu.write_reg(Register::A7, sp + 2);
                 self.menus.retain(|m| m.id != menu_id);
+                self.sync_guest_menu_list(bus);
                 // IM:V 1986 p. V-244: DeleteMenu removes all color
                 // entries for the deleted menu ID from MenuCInfo.
                 self.filter_menu_color_table_entries(bus, |id, _item| id != menu_id);
@@ -6087,6 +6167,38 @@ mod tests {
         }
     }
 
+    #[test]
+    fn addresmenu_exposes_builtin_font_families_without_guest_resources() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let handle = new_menu_with_title(&mut disp, &mut cpu, &mut bus, 331, 0x306A00, "Font");
+
+        cpu.write_reg(Register::A7, TEST_SP);
+        bus.write_long(TEST_SP, u32::from_be_bytes(*b"FONT"));
+        bus.write_long(TEST_SP + 4, handle);
+        assert!(
+            disp.dispatch_menu(true, 0x14D, &mut cpu, &mut bus)
+                .unwrap()
+                .is_ok(),
+            "AddResMenu should succeed"
+        );
+
+        let menu = disp
+            .menus
+            .iter()
+            .find(|menu| menu.handle == handle)
+            .expect("font menu should remain registered");
+        for expected in ["Chicago", "Geneva", "Monaco", "New York", "Palatino"] {
+            assert!(
+                menu.items.iter().any(|item| item.text == expected),
+                "built-in family {expected} should appear in the Font menu"
+            );
+        }
+        assert!(
+            !menu.items.iter().any(|item| item.text == "Application"),
+            "the applFont selector is not a user-facing family"
+        );
+    }
+
     // IM:I I-360: SetItemStyle takes one Style value, one item index,
     // and one MenuHandle argument.
     #[test]
@@ -6923,6 +7035,65 @@ mod tests {
             get_mhandle_for_id(&mut disp, &mut cpu, &mut bus, menu_id),
             handle,
             "GetMHandle should return the NewMenu handle after InsertMenu"
+        );
+    }
+
+    // IM:V 1986 pp. V-228–V-230: applications may inspect the MenuList
+    // low-memory global directly. Keep its DynamicMenuList records in sync
+    // with InsertMenu and DeleteMenu, not just the host-side menu model.
+    #[test]
+    fn insert_and_delete_menu_sync_the_guest_dynamic_menu_list() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        assert!(
+            disp.dispatch_menu(true, 0x130, &mut cpu, &mut bus)
+                .unwrap()
+                .is_ok(),
+            "InitMenus should succeed"
+        );
+
+        let menu_list = bus.read_long(crate::memory::globals::addr::MENU_LIST);
+        assert_ne!(menu_list, 0, "InitMenus should install a MenuList handle");
+        let empty_list = bus.read_long(menu_list);
+        assert_ne!(empty_list, 0, "MenuList handle should dereference");
+        assert_eq!(bus.read_word(empty_list), 0, "lastMenu should start empty");
+        assert_eq!(
+            bus.read_word(empty_list + 6),
+            0,
+            "lastHMenu should start empty"
+        );
+
+        let menu_id = 231i16;
+        let handle = new_menu_with_title(&mut disp, &mut cpu, &mut bus, menu_id, 0x30B200, "Home");
+        insert_menu(&mut disp, &mut cpu, &mut bus, handle);
+
+        let inserted_list = bus.read_long(menu_list);
+        assert_eq!(
+            bus.read_word(inserted_list),
+            6,
+            "one regular MenuRec should occupy six bytes"
+        );
+        assert_eq!(
+            bus.read_long(inserted_list + 6),
+            handle,
+            "MenuRec should expose the inserted menu handle"
+        );
+        assert_eq!(
+            bus.read_word(inserted_list + 12),
+            0,
+            "lastHMenu should follow the regular MenuRec"
+        );
+
+        delete_menu_by_id(&mut disp, &mut cpu, &mut bus, menu_id);
+        let deleted_list = bus.read_long(menu_list);
+        assert_eq!(
+            bus.read_word(deleted_list),
+            0,
+            "DeleteMenu should remove the regular MenuRec"
+        );
+        assert_eq!(
+            bus.read_word(deleted_list + 6),
+            0,
+            "lastHMenu should return to the empty-list offset"
         );
     }
 


### PR DESCRIPTION
## Summary

- recognize Palatino as a classic compatibility family backed by the original OFL-licensed Ironbark bitmap face
- expose built-in font families through `AddResMenu('FONT')`, so applications can build complete Font menus without guest font resources
- keep the guest-visible low-memory `MenuList` synchronized with Menu Manager operations
- aspect-fit and center software-rendered output at fractional scales instead of leaving a 1× image in the top-left of large windows

## Root cause

Systemless knew its built-in fonts only inside the HLE renderer, kept the active menu list only in host state, and used integer-only top-left scaling in the non-macOS presenter. Classic applications that enumerate font resources or inspect `MenuList` therefore saw incomplete system state, while a 1920×1080 software surface displayed an 800×600 guest at 1×.

## Impact

HyperCard 2.1 now starts without its missing-font or menu errors, presents Palatino text through the project-original Ironbark face, populates its Font menu, navigates cards, and opens its companion Help stack without a font warning. A 4:3 guest on a 1920×1080 software surface now renders at 1440×1080 with centered side pillars.

## Validation

- `cargo test` (3,658 library tests passed, 3 ignored; 52 desktop tests passed; 4 packer tests passed; doc test passed)
- deterministic HyperCard 2.1 startup, card navigation, File menu, Font menu, and Help-stack checkpoints
- BasiliskII oracle comparison for startup, Home-stack layout, navigation, and menu behavior

Closes #648
