### PR TITLE
fix: launch large universal applications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1774,9 +1774,9 @@ dependencies = [
 
 [[package]]
 name = "ppc"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f815c8257fce8ef79853cfa25dd23d361924e0cfbff07af11cfa295d3d26a23c"
+checksum = "71a947b9def1642a9ac9e1a0827c6574c10512165b2d7f50bf1403f933eb226d"
 
 [[package]]
 name = "prettyplease"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ default-run = "systemless"
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
 m68k = { version = "0.7.1", features = ["jit"] }
-ppc = "0.3.1"
+ppc = "0.4.0"
 thiserror = "2"
 tracing = "0.1"
 serde = { version = "1", features = ["derive"] }

--- a/src/game/launch.rs
+++ b/src/game/launch.rs
@@ -7,7 +7,8 @@
 use crate::loader::cfrg::{parse_cfrg_resource, select_powerpc_application_fragment, WHOLE_FORK};
 use crate::loader::pef::{parse_pef_header, parse_pef_loader_header, resolve_pef_main_entry};
 use crate::loader::ppc::{
-    PpcVfsDirectory, PpcVfsFileRecord, PpcVfsResourceFileRecord, PpcVfsResourceRecord,
+    PpcCfmLibraryFragment, PpcVfsDirectory, PpcVfsFileRecord, PpcVfsResourceFileRecord,
+    PpcVfsResourceRecord,
 };
 use crate::loader::LoadedApp;
 use crate::managers::resource::ResourceFork;
@@ -2088,6 +2089,26 @@ fn load_selected_executable(
                     executable.name
                 )
             })?;
+            let library_fragments = ResourceFork::parse(&rsrc)
+                .and_then(|fork| fork.get(*b"cfrg", 0).cloned())
+                .and_then(|resource| parse_cfrg_resource(&resource.data))
+                .map(|cfrg| {
+                    cfrg.fragments
+                        .into_iter()
+                        .filter_map(|fragment| {
+                            if !fragment.is_powerpc_library_data_fork() {
+                                return None;
+                            }
+                            let range = fragment.data_fork_range(data.len())?;
+                            Some(PpcCfmLibraryFragment {
+                                name: fragment.name,
+                                bytes: data.get(range)?.to_vec(),
+                            })
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+            loaded.seed_cfm_library_fragments(library_fragments);
             loaded.seed_vfs_directories(
                 ppc_vfs.directories,
                 ppc_vfs.default_dir_id,

--- a/src/loader/cfrg.rs
+++ b/src/loader/cfrg.rs
@@ -50,6 +50,12 @@ impl CfrgFragment {
             && self.location == LOCATION_ON_DISK_FLAT
     }
 
+    pub fn is_powerpc_library_data_fork(&self) -> bool {
+        self.architecture == ARCH_POWERPC
+            && self.usage == USAGE_LIB
+            && self.location == LOCATION_ON_DISK_FLAT
+    }
+
     pub fn data_fork_range(&self, data_fork_len: usize) -> Option<Range<usize>> {
         if self.location != LOCATION_ON_DISK_FLAT {
             return None;

--- a/src/loader/ppc.rs
+++ b/src/loader/ppc.rs
@@ -98,6 +98,8 @@ pub const PPC_FRAG_HAD_UNRESOLVEDS: i16 = -2807;
 pub const PPC_FRAG_NO_MEM: i16 = -2809;
 pub const PPC_FRAG_NO_ADDR_SPACE: i16 = -2810;
 pub const PPC_FRAG_LIB_CONN_ERR: i16 = -2817;
+pub const PPC_FRAG_CONNECTION_ID_NOT_FOUND: i16 = -2801;
+pub const PPC_FRAG_SYMBOL_NOT_FOUND: i16 = -2802;
 pub const PPC_FRAG_CORRUPT_ERR: i16 = -2820;
 pub const PPC_FRAG_USER_INIT_PROC_ERR: i16 = -2821;
 pub const PPC_FRAG_ARCH_ERR: i16 = -2823;
@@ -130,6 +132,7 @@ const PPC_LINKAGE_SAVED_CR_OFFSET: u32 = 4;
 const PPC_LINKAGE_SAVED_LR_OFFSET: u32 = 8;
 const PPC_LINKAGE_SAVED_RTOC_OFFSET: u32 = 20;
 const PPC_MIXED_MODE_RETURN_PC: u32 = PPC_IMPORT_TRAP_BASE - 4;
+const PPC_APPLICATION_INIT_RETURN_PC: u32 = PPC_IMPORT_TRAP_BASE - 0x100;
 const PPC_MIXED_MODE_TRAP: u16 = 0xAAFE;
 const PPC_ROUTINE_DESCRIPTOR_VERSION: u8 = 7;
 const PPC_ROUTINE_DESCRIPTOR_HEADER_SIZE: u32 = 12;
@@ -259,6 +262,9 @@ const PPC_MAIN_VIS_RGN_HANDLE: u32 = 0x02f0_0b00;
 const PPC_MAIN_VIS_RGN: u32 = 0x02f0_0c00;
 const PPC_MAIN_CLIP_RGN_HANDLE: u32 = 0x02f0_0d00;
 const PPC_MAIN_CLIP_RGN: u32 = 0x02f0_0e00;
+const PPC_PORT_LIST_HANDLE: u32 = 0x02f0_1300;
+const PPC_PORT_LIST: u32 = 0x02f0_1400;
+const PPC_PORT_LIST_ADDR: u32 = 0x0d66;
 const PPC_APPLICATION_ZONE: u32 = 0x02f0_2000;
 const PPC_SYSTEM_ZONE: u32 = 0x02f0_2100;
 const PPC_ZONE_STORAGE_SIZE: usize = 64;
@@ -824,6 +830,8 @@ pub enum PpcImportDispatcherTarget {
     KillPicture,
     Gestalt,
     GetSharedLibrary,
+    FindSymbol,
+    CloseConnection,
     GetMemFragment,
     InitCursor,
     HideCursor,
@@ -853,6 +861,7 @@ pub enum PpcImportDispatcherTarget {
     FixMul,
     FixDiv,
     Long2Fix,
+    Fix2Long,
     MoveTo,
     Move,
     LineTo,
@@ -963,6 +972,13 @@ pub enum PpcImportDispatcherTarget {
     SetItemMark,
     CheckItem,
     GetNewMBar,
+    LMGetMenuList,
+    LMGetPaintWhite,
+    LMSetPaintWhite,
+    LMSetResumeProc,
+    LMSetACount,
+    LMSetANumber,
+    LMSetDlgFont,
     ClearMenuBar,
     SetMenuBar,
     GetMenuHandle,
@@ -999,10 +1015,13 @@ pub enum PpcImportDispatcherTarget {
     GetPixBaseAddr,
     LockPixels,
     UnlockPixels,
+    GetPixelsState,
+    SetPixelsState,
     NoPurgePixels,
     SetRect,
     SectRect,
     UnionRect,
+    EqualRect,
     SetPt,
     AddPt,
     SubPt,
@@ -1060,6 +1079,7 @@ pub enum PpcImportDispatcherTarget {
     SndPlay,
     SndChannelStatus,
     SndGetInfo,
+    ParseSndHeader,
     SndDoCommand,
     SndDoImmediate,
     SndPlayDoubleBuffer,
@@ -1084,6 +1104,7 @@ pub enum PpcImportDispatcherTarget {
     GetEOF,
     PBGetEOF,
     SetEOF,
+    AllocContig,
     PBSetEOF,
     GetFPos,
     SetFPos,
@@ -1193,6 +1214,8 @@ pub enum PpcImportDispatcherTarget {
     StillDown,
     GetKeys,
     GetDateTime,
+    ReadDateTime,
+    ReadLocation,
     GetTime,
     Delay,
     GetDblTime,
@@ -1248,6 +1271,7 @@ pub enum PpcImportDispatcherTarget {
     P2CStr,
     C2PStr,
     GetCurrentProcess,
+    SameProcess,
     GetProcessInformation,
     ParamText,
     AlertReturnDefault,
@@ -1694,11 +1718,12 @@ impl PpcFetchObserver for PpcHleFetchObserver<'_> {
             .unwrap_or(true);
         if ppc_trace_regs_enabled() && in_range && r27_matches && r3_matches {
             eprintln!(
-                "[PPC-TRACE] fetch pc=${:08X} word=${:08X} lr=${:08X} sp=${:08X} r3=${:08X} r4=${:08X} r5=${:08X} r12=${:08X} r27=${:08X} r28=${:08X} r29=${:08X} r30=${:08X} r31=${:08X}",
+                "[PPC-TRACE] fetch pc=${:08X} word=${:08X} lr=${:08X} sp=${:08X} rtoc=${:08X} r3=${:08X} r4=${:08X} r5=${:08X} r12=${:08X} r27=${:08X} r28=${:08X} r29=${:08X} r30=${:08X} r31=${:08X}",
                 pc,
                 word,
                 cpu.lr,
                 cpu.gpr[1],
+                cpu.gpr[2],
                 cpu.gpr[3],
                 cpu.gpr[4],
                 cpu.gpr[5],
@@ -2634,6 +2659,12 @@ pub struct PpcCfmConnection {
     pub main_addr: u32,
     pub init_addr: u32,
     pub term_addr: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PpcCfmLibraryFragment {
+    pub name: String,
+    pub bytes: Vec<u8>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -4303,6 +4334,7 @@ pub struct PpcLoadedApp {
     pub(crate) dialog_callback_stack: Vec<PpcDialogCallbackState>,
     pub(crate) apple_events: PpcAppleEventState,
     pub cfm_connections: Vec<PpcCfmConnection>,
+    pub cfm_library_fragments: Vec<PpcCfmLibraryFragment>,
     pub next_cfm_connection_id: u32,
     pub ptrs: Vec<PpcPtrRecord>,
     pub free_ptr_blocks: Vec<PpcPtrRecord>,
@@ -7384,6 +7416,7 @@ impl PpcLoadedApp {
         let mut dialog_callback_stack = std::mem::take(&mut self.dialog_callback_stack);
         let mut apple_events = std::mem::take(&mut self.apple_events);
         let mut cfm_connections = std::mem::take(&mut self.cfm_connections);
+        let mut cfm_library_fragments = std::mem::take(&mut self.cfm_library_fragments);
         let mut next_cfm_connection_id = self.next_cfm_connection_id;
         let mut ptrs = std::mem::take(&mut self.ptrs);
         let mut free_ptr_blocks = std::mem::take(&mut self.free_ptr_blocks);
@@ -7849,6 +7882,7 @@ impl PpcLoadedApp {
                         &mut dialog_callback_stack,
                         &mut apple_events,
                         &mut cfm_connections,
+                        &mut cfm_library_fragments,
                         &mut next_cfm_connection_id,
                         &mut imports,
                         &mut import_count,
@@ -8126,6 +8160,7 @@ impl PpcLoadedApp {
         self.dialog_callback_stack = dialog_callback_stack;
         self.apple_events = apple_events;
         self.cfm_connections = cfm_connections;
+        self.cfm_library_fragments = cfm_library_fragments;
         self.next_cfm_connection_id = next_cfm_connection_id;
         self.imports = imports;
         self.import_count = import_count;
@@ -8252,6 +8287,10 @@ impl PpcLoadedApp {
     pub fn set_launched_app_path(&mut self, path: impl Into<String>) {
         self.launched_app_path = Some(ppc_normalize_vfs_path(&path.into()));
         self.refresh_apple_event_launch_capability();
+    }
+
+    pub fn seed_cfm_library_fragments(&mut self, fragments: Vec<PpcCfmLibraryFragment>) {
+        self.cfm_library_fragments = fragments;
     }
 
     pub fn seed_vfs_files_and_resources(
@@ -12173,6 +12212,29 @@ pub fn load_pef_application_with_config(
             offset: loader.main_offset,
         },
     )?;
+    let special_tvector = |section_index: i32, offset: u32| -> Option<(u32, u32, u32)> {
+        if section_index < 0 {
+            return None;
+        }
+        let section_index = usize::try_from(section_index).ok()?;
+        let section = mapped_sections
+            .iter()
+            .find(|section| section.index == section_index)?;
+        let offset = usize::try_from(offset).ok()?;
+        let entry = read_u32(&section.bytes, offset)?;
+        let rtoc = read_u32(&section.bytes, offset.checked_add(4)?)?;
+        let descriptor = section.base.checked_add(offset as u32)?;
+        Some((descriptor, entry, rtoc))
+    };
+    let init_tvector = special_tvector(loader.init_section, loader.init_offset);
+    let term_tvector = special_tvector(loader.term_section, loader.term_offset);
+    if loader.init_section >= 0 && init_tvector.is_none() {
+        return Err(PpcLoadError::PefParse);
+    }
+    if loader.term_section >= 0 && term_tvector.is_none() {
+        return Err(PpcLoadError::PefParse);
+    }
+    let main_tvector = main_section.base + loader.main_offset;
 
     let stack_size = normalize_stack_size(config.stack_size)?;
     let stack_base =
@@ -12206,6 +12268,9 @@ pub fn load_pef_application_with_config(
     let mut memory = PpcSectionMem::new();
     memory.add_region(PPC_HALT_PC, vec![0u8; PPC_LOW_MEMORY_SIZE]);
     let _ = memory.write_u16_be(PPC_MBAR_HEIGHT_ADDR, 20);
+    // PaintOne normally starts with PaintWhite enabled. Carbon's generated
+    // low-memory accessors preserve this flag around window creation.
+    let _ = memory.write_u16_be(0x09dc, 1);
     // Inside Macintosh Volume V (1986), pp. V-592--V-593, documents the
     // MMU32Bit low-memory byte at $0CB2. Native PowerPC processes always use
     // 32-bit addressing.
@@ -12259,6 +12324,14 @@ pub fn load_pef_application_with_config(
     memory.add_region(PPC_MAIN_VIS_RGN, vec![0u8; 10]);
     memory.add_region(PPC_MAIN_CLIP_RGN_HANDLE, vec![0u8; 4]);
     memory.add_region(PPC_MAIN_CLIP_RGN, vec![0u8; 10]);
+    memory.add_region(PPC_PORT_LIST_HANDLE, vec![0u8; 4]);
+    memory.add_region(PPC_PORT_LIST, vec![0u8; 2]);
+    // PortList is a QuickDraw-owned handle whose first word is the number of
+    // registered ports. Keep a valid empty list even though native clients
+    // normally reach it through the Window Manager instead of low memory.
+    let _ = memory.write_u32_be(PPC_PORT_LIST_ADDR, PPC_PORT_LIST_HANDLE);
+    let _ = memory.write_u32_be(PPC_PORT_LIST_HANDLE, PPC_PORT_LIST);
+    let _ = memory.write_u16_be(PPC_PORT_LIST, 0);
     memory.add_region(PPC_APPLICATION_ZONE, vec![0u8; PPC_ZONE_STORAGE_SIZE]);
     memory.add_region(PPC_SYSTEM_ZONE, vec![0u8; PPC_ZONE_STORAGE_SIZE]);
     ppc_seed_zone_header(
@@ -12298,6 +12371,50 @@ pub fn load_pef_application_with_config(
         vec![0u8; usize::try_from(stack_base - PPC_HEAP_BASE).unwrap()],
     );
 
+    let mut heap_cursor = PPC_HEAP_BASE;
+    let mut cfm_connections = Vec::new();
+    let mut next_cfm_connection_id = PPC_FIRST_CFM_CONNECTION_ID;
+    let startup = if let Some((init_addr, init_entry, init_rtoc)) = init_tvector {
+        // Inside Macintosh: PowerPC System Software (1994), pp. 3-15--3-18
+        // requires CFM to call a fragment initializer before its main routine.
+        // Keep a guest-visible copy of the PEF as an in-memory fragment locator
+        // so the initializer receives the documented InitBlock contract.
+        let fragment_size = u32::try_from(data.len()).map_err(|_| PpcLoadError::AddressOverflow)?;
+        let fragment_addr = ppc_heap_alloc(
+            &mut memory,
+            &mut heap_cursor,
+            stack_base,
+            fragment_size,
+            false,
+        );
+        if fragment_addr == 0 || memory.write_bytes(fragment_addr, data).is_none() {
+            return Err(PpcLoadError::AddressOverflow);
+        }
+        let init_block = ppc_create_mem_fragment_init_block(
+            &mut memory,
+            &mut heap_cursor,
+            stack_base,
+            PPC_FIRST_CFM_CONNECTION_ID,
+            fragment_addr,
+            fragment_size,
+            "application",
+        )
+        .map_err(|_| PpcLoadError::AddressOverflow)?;
+        let trampoline = ppc_application_init_return_trampoline(entry_pc, rtoc);
+        memory.add_readonly_region(PPC_APPLICATION_INIT_RETURN_PC, trampoline);
+        cfm_connections.push(PpcCfmConnection {
+            id: PPC_FIRST_CFM_CONNECTION_ID,
+            library_name: "application".to_string(),
+            main_addr: main_tvector,
+            init_addr,
+            term_addr: term_tvector.map_or(0, |(addr, _, _)| addr),
+        });
+        next_cfm_connection_id += 1;
+        Some((init_entry, init_rtoc, init_block))
+    } else {
+        None
+    };
+
     let stack_pointer = PPC_STACK_TOP - PPC_INITIAL_STACK_FRAME_SIZE;
     let mut stack = vec![0u8; stack_size as usize];
     let sp_offset = usize::try_from(stack_pointer - stack_base).unwrap();
@@ -12305,10 +12422,11 @@ pub fn load_pef_application_with_config(
     memory.add_region(stack_base, stack);
     let mut cpu = PpcCpu::new();
     cpu.alignment_policy = PpcAlignmentPolicy::EmulateData;
-    cpu.pc = entry_pc;
+    cpu.pc = startup.map_or(entry_pc, |(entry, _, _)| entry);
     cpu.gpr[1] = stack_pointer;
-    cpu.gpr[2] = rtoc;
-    cpu.lr = PPC_HALT_PC;
+    cpu.gpr[2] = startup.map_or(rtoc, |(_, init_rtoc, _)| init_rtoc);
+    cpu.gpr[3] = startup.map_or(0, |(_, _, init_block)| init_block);
+    cpu.lr = startup.map_or(PPC_HALT_PC, |_| PPC_APPLICATION_INIT_RETURN_PC);
 
     Ok(PpcLoadedApp {
         cpu,
@@ -12319,7 +12437,7 @@ pub fn load_pef_application_with_config(
         stack_size,
         stack_pointer,
         heap_base: PPC_HEAP_BASE,
-        heap_cursor: PPC_HEAP_BASE,
+        heap_cursor,
         heap_limit: stack_base,
         last_mem_error: 0,
         heap_maximized: false,
@@ -12333,8 +12451,9 @@ pub fn load_pef_application_with_config(
         stdc_qsort_stack: Vec::new(),
         dialog_callback_stack: Vec::new(),
         apple_events: PpcAppleEventState::default(),
-        cfm_connections: Vec::new(),
-        next_cfm_connection_id: PPC_FIRST_CFM_CONNECTION_ID,
+        cfm_connections,
+        cfm_library_fragments: Vec::new(),
+        next_cfm_connection_id,
         ptrs: Vec::new(),
         free_ptr_blocks: Vec::new(),
         handles: Vec::new(),
@@ -13424,7 +13543,22 @@ fn dispatcher_target_for_import(
         ("InterfaceLib", "DrawPicture") => PpcImportDispatcherTarget::DrawPicture,
         ("InterfaceLib", "KillPicture") => PpcImportDispatcherTarget::KillPicture,
         ("InterfaceLib", "Gestalt") => PpcImportDispatcherTarget::Gestalt,
-        ("InterfaceLib", "GetSharedLibrary") => PpcImportDispatcherTarget::GetSharedLibrary,
+        // Universal Interfaces exposes Code Fragment Manager entry points
+        // through several compatibility libraries across classic and Carbon
+        // runtimes. Treat the library name as an export namespace alias; the
+        // calling convention and API contract are identical.
+        (
+            "InterfaceLib" | "CodeFragmentMgr" | "CarbonCore.vlib" | "CFMPriv_CarbonCore",
+            "GetSharedLibrary",
+        ) => PpcImportDispatcherTarget::GetSharedLibrary,
+        (
+            "InterfaceLib" | "CodeFragmentMgr" | "CarbonCore.vlib" | "CFMPriv_CarbonCore",
+            "FindSymbol",
+        ) => PpcImportDispatcherTarget::FindSymbol,
+        (
+            "InterfaceLib" | "CodeFragmentMgr" | "CarbonCore.vlib" | "CFMPriv_CarbonCore",
+            "CloseConnection",
+        ) => PpcImportDispatcherTarget::CloseConnection,
         ("InterfaceLib", "GetMemFragment") => PpcImportDispatcherTarget::GetMemFragment,
         ("InterfaceLib", "InitCursor") => PpcImportDispatcherTarget::InitCursor,
         ("InterfaceLib", "HideCursor") => PpcImportDispatcherTarget::HideCursor,
@@ -13454,6 +13588,7 @@ fn dispatcher_target_for_import(
         ("InterfaceLib", "FixMul") => PpcImportDispatcherTarget::FixMul,
         ("InterfaceLib", "FixDiv") => PpcImportDispatcherTarget::FixDiv,
         ("InterfaceLib", "Long2Fix") => PpcImportDispatcherTarget::Long2Fix,
+        ("InterfaceLib", "Fix2Long") => PpcImportDispatcherTarget::Fix2Long,
         ("InterfaceLib", "NewMenu") => PpcImportDispatcherTarget::NewMenu,
         ("InterfaceLib", "DisposeMenu") => PpcImportDispatcherTarget::DisposeMenu,
         ("InterfaceLib", "GetMenu") => PpcImportDispatcherTarget::GetMenu,
@@ -13480,6 +13615,14 @@ fn dispatcher_target_for_import(
         ("InterfaceLib", "SetItemMark") => PpcImportDispatcherTarget::SetItemMark,
         ("InterfaceLib", "CheckItem") => PpcImportDispatcherTarget::CheckItem,
         ("InterfaceLib", "GetNewMBar") => PpcImportDispatcherTarget::GetNewMBar,
+        ("InterfaceLib", "LMGetMenuList") => PpcImportDispatcherTarget::LMGetMenuList,
+        ("InterfaceLib", "LMGetPaintWhite") => PpcImportDispatcherTarget::LMGetPaintWhite,
+        ("InterfaceLib", "LMSetPaintWhite") => PpcImportDispatcherTarget::LMSetPaintWhite,
+        ("InterfaceLib", "LMSetResumeProc") => PpcImportDispatcherTarget::LMSetResumeProc,
+        ("InterfaceLib", "LMSetACount") => PpcImportDispatcherTarget::LMSetACount,
+        ("InterfaceLib", "LMSetANumber") => PpcImportDispatcherTarget::LMSetANumber,
+        ("InterfaceLib", "LMSetDlgFont") => PpcImportDispatcherTarget::LMSetDlgFont,
+        ("InterfaceLib", "ErrorSound") => PpcImportDispatcherTarget::NoOpPreserve,
         ("InterfaceLib", "ClearMenuBar") => PpcImportDispatcherTarget::ClearMenuBar,
         ("InterfaceLib", "SetMenuBar") => PpcImportDispatcherTarget::SetMenuBar,
         ("InterfaceLib", "GetMenuHandle") => PpcImportDispatcherTarget::GetMenuHandle,
@@ -13672,10 +13815,13 @@ fn dispatcher_target_for_import(
         ("InterfaceLib", "GetPixBaseAddr") => PpcImportDispatcherTarget::GetPixBaseAddr,
         ("InterfaceLib", "LockPixels") => PpcImportDispatcherTarget::LockPixels,
         ("InterfaceLib", "UnlockPixels") => PpcImportDispatcherTarget::UnlockPixels,
+        ("InterfaceLib", "GetPixelsState") => PpcImportDispatcherTarget::GetPixelsState,
+        ("InterfaceLib", "SetPixelsState") => PpcImportDispatcherTarget::SetPixelsState,
         ("InterfaceLib", "NoPurgePixels") => PpcImportDispatcherTarget::NoPurgePixels,
         ("InterfaceLib", "SetRect") => PpcImportDispatcherTarget::SetRect,
         ("InterfaceLib", "SectRect") => PpcImportDispatcherTarget::SectRect,
         ("InterfaceLib", "UnionRect") => PpcImportDispatcherTarget::UnionRect,
+        ("InterfaceLib", "EqualRect") => PpcImportDispatcherTarget::EqualRect,
         ("InterfaceLib", "SetPt") => PpcImportDispatcherTarget::SetPt,
         ("InterfaceLib", "PtInRect") => PpcImportDispatcherTarget::PtInRect,
         ("InterfaceLib", "SetOrigin") => PpcImportDispatcherTarget::SetOrigin,
@@ -13770,6 +13916,9 @@ fn dispatcher_target_for_import(
         | ("InterfaceLib", "PBGetEOFSync")
         | ("InterfaceLib", "PBGetEOFAsync") => PpcImportDispatcherTarget::PBGetEOF,
         ("InterfaceLib", "SetEOF") => PpcImportDispatcherTarget::SetEOF,
+        ("InterfaceLib", "AllocContig") | ("InterfaceLib", "Allocate") => {
+            PpcImportDispatcherTarget::AllocContig
+        }
         ("InterfaceLib", "PBSetEOF")
         | ("InterfaceLib", "PBSetEOFSync")
         | ("InterfaceLib", "PBSetEOFAsync") => PpcImportDispatcherTarget::PBSetEOF,
@@ -13917,6 +14066,8 @@ fn dispatcher_target_for_import(
         ("InterfaceLib", "StillDown") => PpcImportDispatcherTarget::StillDown,
         ("InterfaceLib", "GetKeys") => PpcImportDispatcherTarget::GetKeys,
         ("InterfaceLib", "GetDateTime") => PpcImportDispatcherTarget::GetDateTime,
+        ("InterfaceLib", "ReadDateTime") => PpcImportDispatcherTarget::ReadDateTime,
+        ("InterfaceLib", "ReadLocation") => PpcImportDispatcherTarget::ReadLocation,
         ("InterfaceLib", "GetTime") => PpcImportDispatcherTarget::GetTime,
         ("InterfaceLib", "Delay") => PpcImportDispatcherTarget::Delay,
         ("InterfaceLib", "GetDblTime") => PpcImportDispatcherTarget::GetDblTime,
@@ -13956,7 +14107,10 @@ fn dispatcher_target_for_import(
         ("InterfaceLib", "c2pstr") | ("InterfaceLib", "C2PStr") => {
             PpcImportDispatcherTarget::C2PStr
         }
-        ("InterfaceLib", "GetCurrentProcess") => PpcImportDispatcherTarget::GetCurrentProcess,
+        ("InterfaceLib", "GetCurrentProcess" | "GetFrontProcess") => {
+            PpcImportDispatcherTarget::GetCurrentProcess
+        }
+        ("InterfaceLib", "SameProcess") => PpcImportDispatcherTarget::SameProcess,
         ("InterfaceLib", "GetProcessInformation") => {
             PpcImportDispatcherTarget::GetProcessInformation
         }
@@ -13984,6 +14138,7 @@ fn dispatcher_target_for_import(
         ("InterfaceLib", "SndPlay") => PpcImportDispatcherTarget::SndPlay,
         ("InterfaceLib", "SndChannelStatus") => PpcImportDispatcherTarget::SndChannelStatus,
         ("SoundLib" | "InterfaceLib", "SndGetInfo") => PpcImportDispatcherTarget::SndGetInfo,
+        ("SoundLib", "ParseSndHeader") => PpcImportDispatcherTarget::ParseSndHeader,
         ("InterfaceLib", "SndDoImmediate") => PpcImportDispatcherTarget::SndDoImmediate,
         ("InterfaceLib", "SndDoCommand") => PpcImportDispatcherTarget::SndDoCommand,
         ("InterfaceLib", "SndPlayDoubleBuffer") => PpcImportDispatcherTarget::SndPlayDoubleBuffer,
@@ -14055,9 +14210,9 @@ fn dispatcher_target_for_import(
             PpcImportDispatcherTarget::GetToolTrapAddress
         }
         ("InterfaceLib", "GetOSTrapAddress") => PpcImportDispatcherTarget::GetOSTrapAddress,
-        ("InterfaceLib", "SetToolTrapAddress") | ("InterfaceLib", "SetToolboxTrapAddress") => {
-            PpcImportDispatcherTarget::SetToolTrapAddress
-        }
+        ("InterfaceLib", "SetToolTrapAddress")
+        | ("InterfaceLib", "SetToolboxTrapAddress")
+        | ("InterfaceLib", "NSetTrapAddress") => PpcImportDispatcherTarget::SetToolTrapAddress,
         ("InterfaceLib", "LMGetCurrentA5") => PpcImportDispatcherTarget::LMGetCurrentA5,
         ("InterfaceLib", "InsTime") | ("InterfaceLib", "InsXTime") => {
             PpcImportDispatcherTarget::InsTime
@@ -14245,6 +14400,7 @@ fn dispatch_supported_import(
     dialog_callback_stack: &mut Vec<PpcDialogCallbackState>,
     apple_events: &mut PpcAppleEventState,
     cfm_connections: &mut Vec<PpcCfmConnection>,
+    cfm_library_fragments: &mut Vec<PpcCfmLibraryFragment>,
     next_cfm_connection_id: &mut u32,
     imports: &mut Vec<PpcImportBinding>,
     import_count: &mut u32,
@@ -14972,6 +15128,33 @@ fn dispatch_supported_import(
             *current_resource_refnum,
             last_resource_error,
         ))),
+        PpcImportDispatcherTarget::LMGetMenuList => {
+            Some(PpcImportAction::Return(toolbox_startup.current_menu_bar))
+        }
+        PpcImportDispatcherTarget::LMGetPaintWhite => Some(PpcImportAction::Return(u32::from(
+            memory.read_u16_be(0x09dc).unwrap_or(1) != 0,
+        ))),
+        PpcImportDispatcherTarget::LMSetPaintWhite => {
+            let _ = memory.write_u16_be(0x09dc, u16::from(cpu.gpr[3] != 0));
+            Some(PpcImportAction::ReturnPreserve)
+        }
+        PpcImportDispatcherTarget::LMSetResumeProc => {
+            let _ = memory.write_u32_be(crate::memory::globals::addr::RESUME_PROC, cpu.gpr[3]);
+            Some(PpcImportAction::ReturnPreserve)
+        }
+        PpcImportDispatcherTarget::LMSetACount => {
+            let _ =
+                memory.write_u16_be(crate::memory::globals::addr::ALERT_STAGE, cpu.gpr[3] as u16);
+            Some(PpcImportAction::ReturnPreserve)
+        }
+        PpcImportDispatcherTarget::LMSetANumber => {
+            let _ = memory.write_u16_be(crate::memory::globals::addr::ANUMBER, cpu.gpr[3] as u16);
+            Some(PpcImportAction::ReturnPreserve)
+        }
+        PpcImportDispatcherTarget::LMSetDlgFont => {
+            let _ = memory.write_u16_be(crate::memory::globals::addr::DLG_FONT, cpu.gpr[3] as u16);
+            Some(PpcImportAction::ReturnPreserve)
+        }
         PpcImportDispatcherTarget::ClearMenuBar => {
             // Macintosh Toolbox Essentials (1992), p. 3-110: ClearMenuBar
             // removes every menu from the current list without disposing the
@@ -15401,6 +15584,9 @@ fn dispatch_supported_import(
             cpu.gpr[4] as i32,
         ) as u32)),
         PpcImportDispatcherTarget::Long2Fix => Some(PpcImportAction::Return(ppc_long_to_fix(
+            cpu.gpr[3] as i32,
+        ) as u32)),
+        PpcImportDispatcherTarget::Fix2Long => Some(PpcImportAction::Return(ppc_fix_to_long(
             cpu.gpr[3] as i32,
         ) as u32)),
         PpcImportDispatcherTarget::MoveTo => {
@@ -16658,6 +16844,28 @@ fn dispatch_supported_import(
             ppc_unlock_pixels(gworlds, cpu.gpr[3]);
             Some(PpcImportAction::ReturnPreserve)
         }
+        PpcImportDispatcherTarget::GetPixelsState => {
+            let state = gworlds
+                .iter()
+                .find(|record| record.pixmap_handle == cpu.gpr[3])
+                .map(|record| {
+                    (u32::from(!record.pixels_no_purge) << 6)
+                        | (u32::from(record.pixels_locked) << 7)
+                })
+                .unwrap_or(0);
+            Some(PpcImportAction::Return(state))
+        }
+        PpcImportDispatcherTarget::SetPixelsState => {
+            if let Some(record) = gworlds
+                .iter_mut()
+                .find(|record| record.pixmap_handle == cpu.gpr[3])
+            {
+                let state = cpu.gpr[4];
+                record.pixels_no_purge = state & (1 << 6) == 0;
+                record.pixels_locked = state & (1 << 7) != 0;
+            }
+            Some(PpcImportAction::ReturnPreserve)
+        }
         PpcImportDispatcherTarget::NoPurgePixels => {
             ppc_no_purge_pixels(gworlds, cpu.gpr[3]);
             Some(PpcImportAction::ReturnPreserve)
@@ -16712,6 +16920,12 @@ fn dispatch_supported_import(
                 let _ = ppc_write_rect(memory, cpu.gpr[5], top, left, bottom, right);
             }
             Some(PpcImportAction::ReturnPreserve)
+        }
+        PpcImportDispatcherTarget::EqualRect => {
+            let equal = ppc_read_rect(memory, cpu.gpr[3])
+                .zip(ppc_read_rect(memory, cpu.gpr[4]))
+                .is_some_and(|(first, second)| first == second);
+            Some(PpcImportAction::Return(u32::from(equal)))
         }
         PpcImportDispatcherTarget::SetPt => {
             let point_ptr = cpu.gpr[3];
@@ -16894,11 +17108,29 @@ fn dispatch_supported_import(
         PpcImportDispatcherTarget::Gestalt => Some(PpcImportAction::Return(ppc_i16_result(
             ppc_gestalt(cpu, memory),
         ))),
-        PpcImportDispatcherTarget::GetSharedLibrary => {
-            Some(PpcImportAction::Return(ppc_i16_result(
-                ppc_get_shared_library(cpu, memory, cfm_connections, next_cfm_connection_id),
-            )))
-        }
+        PpcImportDispatcherTarget::GetSharedLibrary => Some(ppc_get_shared_library(
+            cpu,
+            memory,
+            heap_cursor,
+            heap_limit,
+            cfm_connections,
+            cfm_library_fragments,
+            next_cfm_connection_id,
+            imports,
+            import_count,
+            import_binding_indices,
+        )),
+        PpcImportDispatcherTarget::FindSymbol => Some(ppc_find_symbol(
+            cpu,
+            memory,
+            cfm_connections,
+            imports,
+            import_count,
+            import_binding_indices,
+        )),
+        PpcImportDispatcherTarget::CloseConnection => Some(PpcImportAction::Return(
+            ppc_i16_result(ppc_close_connection(cpu, memory, cfm_connections)),
+        )),
         PpcImportDispatcherTarget::GetMemFragment => Some(ppc_get_mem_fragment(
             cpu,
             memory,
@@ -17354,6 +17586,9 @@ fn dispatch_supported_import(
         ))),
         PpcImportDispatcherTarget::SetEOF => Some(PpcImportAction::Return(ppc_i16_result(
             ppc_set_eof(cpu, files, vfs_files),
+        ))),
+        PpcImportDispatcherTarget::AllocContig => Some(PpcImportAction::Return(ppc_i16_result(
+            ppc_alloc_contig(cpu, memory, files),
         ))),
         PpcImportDispatcherTarget::PBSetEOF => Some(PpcImportAction::Return(ppc_i16_result(
             ppc_pb_set_eof(cpu, memory, files, vfs_files),
@@ -18689,6 +18924,25 @@ fn dispatch_supported_import(
             }
             Some(PpcImportAction::ReturnPreserve)
         }
+        PpcImportDispatcherTarget::ReadDateTime => {
+            let secs_ptr = cpu.gpr[3];
+            let result = if secs_ptr != 0 && ppc_memory_can_write_bytes(memory, secs_ptr, 4) {
+                let _ = memory.write_u32_be(secs_ptr, PPC_FIXED_MAC_TIME);
+                PPC_NO_ERR
+            } else {
+                PPC_PARAM_ERR
+            };
+            Some(PpcImportAction::Return(ppc_i16_result(result)))
+        }
+        PpcImportDispatcherTarget::ReadLocation => {
+            // Operating System Utilities (1994), pp. 4-29 and 4-46: an
+            // unset 12-byte MachineLocation record reads as all zeroes.
+            let location = cpu.gpr[3];
+            if location != 0 && ppc_memory_can_write_bytes(memory, location, 12) {
+                let _ = memory.write_bytes(location, &[0; 12]);
+            }
+            Some(PpcImportAction::ReturnPreserve)
+        }
         PpcImportDispatcherTarget::GetTime => {
             ppc_seconds_to_date(memory, PPC_FIXED_MAC_TIME, cpu.gpr[3]);
             Some(PpcImportAction::ReturnPreserve)
@@ -19011,6 +19265,9 @@ fn dispatch_supported_import(
         PpcImportDispatcherTarget::GetCurrentProcess => Some(PpcImportAction::Return(
             ppc_i16_result(ppc_get_current_process(cpu, memory)),
         )),
+        PpcImportDispatcherTarget::SameProcess => Some(PpcImportAction::Return(ppc_i16_result(
+            ppc_same_process(cpu, memory),
+        ))),
         PpcImportDispatcherTarget::GetProcessInformation => Some(PpcImportAction::Return(
             ppc_i16_result(ppc_get_process_information(
                 cpu,
@@ -19214,6 +19471,9 @@ fn dispatch_supported_import(
         )),
         PpcImportDispatcherTarget::SndGetInfo => Some(PpcImportAction::Return(ppc_i16_result(
             ppc_snd_get_info(cpu, memory, sound),
+        ))),
+        PpcImportDispatcherTarget::ParseSndHeader => Some(PpcImportAction::Return(ppc_i16_result(
+            ppc_parse_snd_header(cpu, memory, handles),
         ))),
         PpcImportDispatcherTarget::SndDoCommand => Some(PpcImportAction::Return(ppc_i16_result(
             ppc_snd_do_command(cpu, memory, sound),
@@ -35889,6 +36149,37 @@ fn ppc_get_current_process(cpu: &PpcCpu, memory: &mut PpcSectionMem) -> i16 {
     PPC_NO_ERR
 }
 
+fn ppc_same_process(cpu: &PpcCpu, memory: &mut PpcSectionMem) -> i16 {
+    let first = cpu.gpr[3];
+    let second = cpu.gpr[4];
+    let result_ptr = cpu.gpr[5];
+    if first == 0 || second == 0 || result_ptr == 0 {
+        return PPC_PARAM_ERR;
+    }
+    let Some(first_high) = memory.read_u32_be(first) else {
+        return PPC_PARAM_ERR;
+    };
+    let Some(first_low) = memory.read_u32_be(first + 4) else {
+        return PPC_PARAM_ERR;
+    };
+    let Some(second_high) = memory.read_u32_be(second) else {
+        return PPC_PARAM_ERR;
+    };
+    let Some(second_low) = memory.read_u32_be(second + 4) else {
+        return PPC_PARAM_ERR;
+    };
+    if memory
+        .write_u8(
+            result_ptr,
+            u8::from(first_high == second_high && first_low == second_low),
+        )
+        .is_none()
+    {
+        return PPC_PARAM_ERR;
+    }
+    PPC_NO_ERR
+}
+
 fn ppc_get_process_information(
     cpu: &PpcCpu,
     memory: &mut PpcSectionMem,
@@ -36035,6 +36326,15 @@ fn ppc_new_routine_descriptor(
     last_mem_error: &mut i16,
 ) -> u32 {
     let proc_ptr = cpu.gpr[3];
+    if ppc_hle_trace_enabled() {
+        eprintln!(
+            "[PPC-TRACE] NewRoutineDescriptor proc=${proc_ptr:08X} words=({:08X?},{:08X?}) procInfo=${:08X} isa={}",
+            memory.read_u32_be(proc_ptr),
+            memory.read_u32_be(proc_ptr.wrapping_add(4)),
+            cpu.gpr[4],
+            cpu.gpr[5],
+        );
+    }
     if proc_ptr == 0 {
         return 0;
     }
@@ -36429,6 +36729,14 @@ fn ppc_call_universal_proc(
 ) -> Option<PpcImportAction> {
     let proc_ptr = cpu.gpr[3];
     let proc_info = cpu.gpr[4];
+    if ppc_hle_trace_enabled() {
+        eprintln!(
+            "[PPC-TRACE] CallUniversalProc upp=${proc_ptr:08X} words=({:08X?},{:08X?}) procInfo=${proc_info:08X} sp=${:08X}",
+            memory.read_u32_be(proc_ptr),
+            memory.read_u32_be(proc_ptr.wrapping_add(4)),
+            cpu.gpr[1],
+        );
+    }
     let final_pc = cpu.lr;
     let restore_rtoc = cpu.gpr[2];
     let return_gpr3 = ppc_call_universal_proc_return_gpr3(proc_info);
@@ -36446,6 +36754,22 @@ fn ppc_call_universal_proc(
             selector,
             arguments.as_deref(),
         );
+    }
+    if memory.read_u32_be(proc_ptr) == Some(0x40c0_007c)
+        && memory.read_u32_be(proc_ptr.wrapping_add(4)) == Some(0x0700_4e75)
+    {
+        // Canonical 68K critical-section UPP:
+        //   MOVE.W SR,D0; ORI.W #$0700,SR; RTS
+        // Native PowerPC runtimes invoke it through Mixed Mode to mask
+        // interrupts and retain the previous SR. Systemless has no guest
+        // interrupt priority while executing PPC code, so return a stable
+        // unmasked user SR token for the matching restore shim.
+        return Some(PpcImportAction::Return(0));
+    }
+    if memory.read_u32_be(proc_ptr) == Some(0x46c0_4e75) {
+        // Matching 68K restore UPP: MOVE.W D0,SR; RTS. The PPC HLE never
+        // changed an interrupt mask, so consuming the saved token is a no-op.
+        return Some(PpcImportAction::ReturnPreserve);
     }
     let target = ppc_resolve_callback_target(memory, proc_ptr, restore_rtoc, selector)?;
     memory.read_u32_be(target.entry)?;
@@ -36707,6 +37031,140 @@ fn ppc_snd_get_info(cpu: &PpcCpu, memory: &mut PpcSectionMem, sound: &PpcSoundSt
     } else {
         PPC_PARAM_ERR
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PpcParsedSndHeader {
+    format: u32,
+    num_channels: u16,
+    sample_size: u16,
+    sample_rate: u32,
+    sample_count: u32,
+    buffer: u32,
+    num_frames: u32,
+    data_offset: u32,
+}
+
+fn ppc_parse_snd_header(
+    cpu: &PpcCpu,
+    memory: &mut PpcSectionMem,
+    handles: &[PpcHandleRecord],
+) -> i16 {
+    let handle = cpu.gpr[3];
+    let info_ptr = cpu.gpr[4];
+    let num_frames_ptr = cpu.gpr[5];
+    let data_offset_ptr = cpu.gpr[6];
+    if info_ptr == 0
+        || num_frames_ptr == 0
+        || data_offset_ptr == 0
+        || !ppc_memory_can_write_bytes(memory, info_ptr, 28)
+        || !ppc_memory_can_write_bytes(memory, num_frames_ptr, 4)
+        || !ppc_memory_can_write_bytes(memory, data_offset_ptr, 4)
+    {
+        return PPC_PARAM_ERR;
+    }
+    let Some(record) = handles.iter().find(|record| record.handle == handle) else {
+        return PPC_PARAM_ERR;
+    };
+    let Some(resource_ptr) = memory.read_u32_be(handle) else {
+        return PPC_PARAM_ERR;
+    };
+    if resource_ptr == 0 || resource_ptr != record.ptr {
+        return PPC_PARAM_ERR;
+    }
+    let Some(header_offset) = ppc_sound_header_offset(memory, resource_ptr) else {
+        return PPC_BAD_FORMAT;
+    };
+    let Some(parsed) = ppc_parse_snd_header_fields(memory, resource_ptr, header_offset) else {
+        return PPC_BAD_FORMAT;
+    };
+
+    let writes = [
+        memory.write_u32_be(info_ptr, 0),
+        memory.write_u32_be(info_ptr + 4, parsed.format),
+        memory.write_u16_be(info_ptr + 8, parsed.num_channels),
+        memory.write_u16_be(info_ptr + 10, parsed.sample_size),
+        memory.write_u32_be(info_ptr + 12, parsed.sample_rate),
+        memory.write_u32_be(info_ptr + 16, parsed.sample_count),
+        memory.write_u32_be(info_ptr + 20, parsed.buffer),
+        memory.write_u32_be(info_ptr + 24, 0),
+        memory.write_u32_be(num_frames_ptr, parsed.num_frames),
+        memory.write_u32_be(data_offset_ptr, parsed.data_offset),
+    ];
+    if writes.iter().all(Option::is_some) {
+        PPC_NO_ERR
+    } else {
+        PPC_PARAM_ERR
+    }
+}
+
+/// Parse the sampled-sound header embedded in a format-1 or format-2 `snd `
+/// resource. Sound Manager 3.0's ParseSndHeader reports a SoundComponentData
+/// record plus the frame count and resource-relative start of the sample data.
+fn ppc_parse_snd_header_fields(
+    memory: &mut PpcSectionMem,
+    resource_ptr: u32,
+    header_offset: u32,
+) -> Option<PpcParsedSndHeader> {
+    const STD_SH: u8 = 0x00;
+    const CMP_SH: u8 = 0xfe;
+    const EXT_SH: u8 = 0xff;
+    const RAW_FORMAT: u32 = u32::from_be_bytes(*b"raw ");
+    const TWOS_FORMAT: u32 = u32::from_be_bytes(*b"twos");
+
+    let header = resource_ptr.checked_add(header_offset)?;
+    let sample_ptr = memory.read_u32_be(header)?;
+    let sample_rate = memory.read_u32_be(header.checked_add(8)?)?;
+    let encode = memory.read_u8(header.checked_add(20)?)?;
+    let (format, num_channels, sample_size, sample_count, num_frames, inline_offset) = match encode
+    {
+        STD_SH => {
+            let length = memory.read_u32_be(header.checked_add(4)?)?;
+            (RAW_FORMAT, 1, 8, length, length, 22)
+        }
+        EXT_SH => {
+            let channels = memory.read_u32_be(header.checked_add(4)?)?;
+            let channels = u16::try_from(channels).ok()?;
+            let frames = memory.read_u32_be(header.checked_add(22)?)?;
+            let sample_size = memory.read_u16_be(header.checked_add(48)?)?;
+            let format = match sample_size {
+                8 => RAW_FORMAT,
+                16 => TWOS_FORMAT,
+                _ => return None,
+            };
+            (format, channels, sample_size, frames, frames, 64)
+        }
+        CMP_SH => {
+            let channels = memory.read_u32_be(header.checked_add(4)?)?;
+            let channels = u16::try_from(channels).ok()?;
+            let frames = memory.read_u32_be(header.checked_add(22)?)?;
+            let format = memory.read_u32_be(header.checked_add(40)?)?;
+            let sample_size = memory.read_u16_be(header.checked_add(62)?)?;
+            (format, channels, sample_size, frames, frames, 64)
+        }
+        _ => return None,
+    };
+    let inline_data = header.checked_add(inline_offset)?;
+    let buffer = if sample_ptr == 0 {
+        inline_data
+    } else {
+        sample_ptr
+    };
+    let data_offset = if sample_ptr == 0 {
+        header_offset.checked_add(inline_offset)?
+    } else {
+        sample_ptr.checked_sub(resource_ptr).unwrap_or(0)
+    };
+    Some(PpcParsedSndHeader {
+        format,
+        num_channels,
+        sample_size,
+        sample_rate,
+        sample_count,
+        buffer,
+        num_frames,
+        data_offset,
+    })
 }
 
 fn ppc_snd_do_immediate(
@@ -40838,9 +41296,16 @@ fn ppc_gestalt_response(selector: u32) -> Option<(u32, i16)> {
 fn ppc_get_shared_library(
     cpu: &mut PpcCpu,
     memory: &mut PpcSectionMem,
+    heap_cursor: &mut u32,
+    heap_limit: u32,
     cfm_connections: &mut Vec<PpcCfmConnection>,
+    cfm_library_fragments: &mut Vec<PpcCfmLibraryFragment>,
     next_cfm_connection_id: &mut u32,
-) -> i16 {
+    imports: &mut Vec<PpcImportBinding>,
+    import_count: &mut u32,
+    import_binding_indices: &mut Vec<Option<usize>>,
+) -> PpcImportAction {
+    let return_error = |error| PpcImportAction::Return(ppc_i16_result(error));
     let lib_name_ptr = cpu.gpr[3];
     let _arch_type = cpu.gpr[4];
     let find_flags = cpu.gpr[5];
@@ -40848,18 +41313,18 @@ fn ppc_get_shared_library(
     let main_addr_ptr = cpu.gpr[7];
     let err_name_ptr = cpu.gpr[8];
     if lib_name_ptr == 0 || conn_id_ptr == 0 || main_addr_ptr == 0 {
-        return PPC_PARAM_ERR;
+        return return_error(PPC_PARAM_ERR);
     }
 
     let Some(lib_name_bytes) = ppc_read_pstring_bytes(memory, lib_name_ptr) else {
-        return PPC_PARAM_ERR;
+        return return_error(PPC_PARAM_ERR);
     };
     let lib_name = decode_mac_roman(&lib_name_bytes);
     if lib_name.trim().is_empty() {
-        return PPC_FRAG_LIB_NOT_FOUND;
+        return return_error(PPC_FRAG_LIB_NOT_FOUND);
     }
 
-    let connection = if find_flags != PPC_CFM_LOAD_NEW_COPY {
+    let existing_connection = if find_flags != PPC_CFM_LOAD_NEW_COPY {
         cfm_connections
             .iter()
             .find(|connection| connection.library_name.eq_ignore_ascii_case(&lib_name))
@@ -40867,22 +41332,78 @@ fn ppc_get_shared_library(
     } else {
         None
     };
-    let connection = match connection {
+    let mut initialization = None;
+    let connection = match existing_connection {
         Some(connection) => connection,
         None => {
             let id = *next_cfm_connection_id;
             if id == 0 || id > PPC_CFM_MAIN_STUB_COUNT {
-                return PPC_FRAG_LIB_CONN_ERR;
+                return return_error(PPC_FRAG_LIB_CONN_ERR);
             }
             let Some(next_id) = next_cfm_connection_id.checked_add(1) else {
-                return PPC_FRAG_LIB_CONN_ERR;
+                return return_error(PPC_FRAG_LIB_CONN_ERR);
             };
-            let connection = PpcCfmConnection {
-                id,
-                library_name: lib_name,
-                main_addr: ppc_cfm_main_stub_addr(id),
-                init_addr: 0,
-                term_addr: 0,
+            let fragment = cfm_library_fragments
+                .iter()
+                .find(|fragment| fragment.name.eq_ignore_ascii_case(&lib_name))
+                .cloned();
+            let connection = if let Some(fragment) = fragment {
+                let fragment_size = match u32::try_from(fragment.bytes.len()) {
+                    Ok(size) => size,
+                    Err(_) => return return_error(PPC_FRAG_NO_MEM),
+                };
+                let fragment_addr =
+                    ppc_heap_alloc(memory, heap_cursor, heap_limit, fragment_size, false);
+                if fragment_addr == 0
+                    || memory.write_bytes(fragment_addr, &fragment.bytes).is_none()
+                {
+                    return return_error(PPC_FRAG_NO_MEM);
+                }
+                let prepared = match ppc_prepare_mem_fragment(
+                    &fragment.bytes,
+                    memory,
+                    heap_cursor,
+                    heap_limit,
+                    imports,
+                    import_count,
+                    import_binding_indices,
+                ) {
+                    Ok(prepared) => prepared,
+                    Err(error) => return return_error(error),
+                };
+                let connection = PpcCfmConnection {
+                    id,
+                    library_name: lib_name.clone(),
+                    main_addr: prepared.main_addr,
+                    init_addr: prepared.init_addr,
+                    term_addr: prepared.term_addr,
+                };
+                if prepared.init_addr != 0 {
+                    let init_block = match ppc_create_mem_fragment_init_block(
+                        memory,
+                        heap_cursor,
+                        heap_limit,
+                        id,
+                        fragment_addr,
+                        fragment_size,
+                        &lib_name,
+                    ) {
+                        Ok(block) => block,
+                        Err(error) => return return_error(error),
+                    };
+                    initialization = Some((prepared.init_addr, init_block));
+                }
+                connection
+            } else {
+                // System libraries without a supplied PEF remain synthetic
+                // CFM connections whose optional main routine is a no-op.
+                PpcCfmConnection {
+                    id,
+                    library_name: lib_name.clone(),
+                    main_addr: ppc_cfm_main_stub_addr(id),
+                    init_addr: 0,
+                    term_addr: 0,
+                }
             };
             cfm_connections.push(connection.clone());
             *next_cfm_connection_id = next_id;
@@ -40895,12 +41416,126 @@ fn ppc_get_shared_library(
             .write_u32_be(main_addr_ptr, connection.main_addr)
             .is_none()
     {
-        return PPC_PARAM_ERR;
+        return return_error(PPC_PARAM_ERR);
     }
     if err_name_ptr != 0 && memory.write_u8(err_name_ptr, 0).is_none() {
-        return PPC_PARAM_ERR;
+        return return_error(PPC_PARAM_ERR);
     }
+    let Some((init_addr, init_block)) = initialization else {
+        return return_error(PPC_NO_ERR);
+    };
+    let (Some(entry), Some(rtoc)) = (
+        memory.read_u32_be(init_addr),
+        memory.read_u32_be(init_addr.wrapping_add(4)),
+    ) else {
+        return return_error(PPC_FRAG_CORRUPT_ERR);
+    };
+    if entry == 0 || ppc_install_native_call_arguments(cpu, memory, &[init_block]).is_none() {
+        return return_error(PPC_FRAG_CORRUPT_ERR);
+    }
+    let final_pc = cpu.lr;
+    let restore_rtoc = cpu.gpr[2];
+    cpu.gpr[12] = init_addr;
+    PpcImportAction::CallNative {
+        entry,
+        rtoc,
+        return_pc: PPC_MIXED_MODE_RETURN_PC,
+        final_pc,
+        restore_rtoc,
+        return_gpr3: PpcNativeReturnGpr3::ZeroOrSet {
+            zero: ppc_i16_result(PPC_NO_ERR),
+            nonzero: ppc_i16_result(PPC_FRAG_USER_INIT_PROC_ERR),
+        },
+    }
+}
+
+fn ppc_close_connection(
+    cpu: &PpcCpu,
+    memory: &mut PpcSectionMem,
+    cfm_connections: &mut Vec<PpcCfmConnection>,
+) -> i16 {
+    // Inside Macintosh: PowerPC System Software (1994), p. 3-23:
+    // CloseConnection receives a pointer to a ConnectionID, invalidates that
+    // connection, and reports fragConnectionIDNotFound for an unknown ID.
+    let connection_id_ptr = cpu.gpr[3];
+    let Some(connection_id) = memory.read_u32_be(connection_id_ptr) else {
+        return PPC_PARAM_ERR;
+    };
+    let Some(index) = cfm_connections
+        .iter()
+        .position(|connection| connection.id == connection_id)
+    else {
+        return PPC_FRAG_CONNECTION_ID_NOT_FOUND;
+    };
+
+    cfm_connections.remove(index);
+    let _ = memory.write_u32_be(connection_id_ptr, 0);
     PPC_NO_ERR
+}
+
+fn ppc_find_symbol(
+    cpu: &PpcCpu,
+    memory: &mut PpcSectionMem,
+    cfm_connections: &[PpcCfmConnection],
+    imports: &mut Vec<PpcImportBinding>,
+    import_count: &mut u32,
+    import_binding_indices: &mut Vec<Option<usize>>,
+) -> PpcImportAction {
+    // Inside Macintosh: PowerPC System Software (1994), pp. 3-24--3-25.
+    let connection_id = cpu.gpr[3];
+    let symbol_name_ptr = cpu.gpr[4];
+    let symbol_addr_ptr = cpu.gpr[5];
+    let symbol_class_ptr = cpu.gpr[6];
+    let Some(connection) = cfm_connections
+        .iter()
+        .find(|connection| connection.id == connection_id)
+    else {
+        return PpcImportAction::Return(ppc_i16_result(PPC_FRAG_CONNECTION_ID_NOT_FOUND));
+    };
+    let Some(symbol_name) =
+        ppc_read_pstring_bytes(memory, symbol_name_ptr).map(|name| decode_mac_roman(&name))
+    else {
+        return PpcImportAction::Return(ppc_i16_result(PPC_PARAM_ERR));
+    };
+    let target = dispatcher_target_for_import(&connection.library_name, &symbol_name);
+    if target == PpcImportDispatcherTarget::Unsupported || *import_count >= PPC_IMPORT_CAPACITY {
+        return PpcImportAction::Return(ppc_i16_result(PPC_FRAG_SYMBOL_NOT_FOUND));
+    }
+
+    let symbol_index = *import_count;
+    let address = match import_address_for(symbol_index, 2) {
+        Ok(address) => address,
+        Err(_) => return PpcImportAction::Return(ppc_i16_result(PPC_FRAG_NO_ADDR_SPACE)),
+    };
+    let trap_pc = match import_trap_pc(symbol_index) {
+        Ok(address) => address,
+        Err(_) => return PpcImportAction::Return(ppc_i16_result(PPC_FRAG_NO_ADDR_SPACE)),
+    };
+    let binding_index = imports.len();
+    imports.push(PpcImportBinding {
+        library_index: u32::MAX,
+        symbol_index,
+        library_name: connection.library_name.clone(),
+        symbol_name,
+        class: 2,
+        weak: false,
+        address,
+        tvector_address: Some(address),
+        trap_pc,
+        dispatcher_target: target,
+    });
+    if import_binding_indices.len() <= symbol_index as usize {
+        import_binding_indices.resize(symbol_index as usize + 1, None);
+    }
+    import_binding_indices[symbol_index as usize] = Some(binding_index);
+    *import_count += 1;
+
+    if memory.write_u32_be(symbol_addr_ptr, address).is_none()
+        || memory.write_u8(symbol_class_ptr, 2).is_none()
+    {
+        return PpcImportAction::Return(ppc_i16_result(PPC_PARAM_ERR));
+    }
+    PpcImportAction::Return(ppc_i16_result(PPC_NO_ERR))
 }
 
 fn ppc_get_mem_fragment(
@@ -43273,6 +43908,17 @@ fn ppc_long_to_fix(value: i32) -> i32 {
         i32::MIN
     } else {
         value << 16
+    }
+}
+
+fn ppc_fix_to_long(value: i32) -> i32 {
+    // Operating System Utilities (1994), p. 3-44: round to the nearest
+    // integer, with exact halves rounded away from zero.
+    let value = i64::from(value);
+    if value >= 0 {
+        ((value + 0x8000) >> 16) as i32
+    } else {
+        -(((-value + 0x8000) >> 16) as i32)
     }
 }
 
@@ -60189,6 +60835,21 @@ fn ppc_get_eof(
     }
 }
 
+fn ppc_alloc_contig(cpu: &PpcCpu, memory: &mut PpcSectionMem, files: &[PpcFileRecord]) -> i16 {
+    // Files (1992), pp. 2-119--2-120: AllocContig reserves physical file
+    // blocks without changing logical EOF. The virtual filesystem has no
+    // physical allocation map, so a valid open fork can satisfy the request.
+    let ref_num = ppc_ref_num_from_gpr(cpu.gpr[3]);
+    let count_ptr = cpu.gpr[4];
+    if !files.iter().any(|file| file.ref_num == ref_num) {
+        return PPC_RF_NUM_ERR;
+    }
+    if count_ptr == 0 || !ppc_memory_can_write_bytes(memory, count_ptr, 4) {
+        return PPC_PARAM_ERR;
+    }
+    PPC_NO_ERR
+}
+
 fn ppc_set_eof(
     cpu: &mut PpcCpu,
     files: &mut [PpcFileRecord],
@@ -62598,6 +63259,29 @@ fn import_trap_bytes(count: usize) -> Vec<u8> {
     bytes
 }
 
+fn ppc_application_init_return_trampoline(main_entry: u32, main_rtoc: u32) -> Vec<u8> {
+    // r3 is the initializer's OSErr. A failed initializer terminates launch;
+    // success restores the main routine's TOC and branches to its entry point.
+    // The generated code is ordinary PowerPC ABI glue, not an HLE import.
+    let words = [
+        0x2c03_0000, // cmpwi r3, 0
+        0x4082_0020, // bne failure
+        0x3c40_0000 | (main_rtoc >> 16),
+        0x6042_0000 | (main_rtoc & 0xffff),
+        0x3d80_0000 | (main_entry >> 16),
+        0x618c_0000 | (main_entry & 0xffff),
+        0x7d89_03a6, // mtctr r12
+        0x4e80_0420, // bctr
+        0x3980_0000, // failure: li r12, 0
+        0x7d89_03a6, // mtctr r12
+        0x4e80_0420, // bctr
+    ];
+    words
+        .into_iter()
+        .flat_map(u32::to_be_bytes)
+        .collect::<Vec<_>>()
+}
+
 fn alignment_bytes(power: u8) -> Result<u32, PpcLoadError> {
     if power >= 31 {
         return Err(PpcLoadError::AddressOverflow);
@@ -63870,6 +64554,15 @@ mod tests {
         );
         assert_eq!(loaded.cpu.gpr[2], PPC_DATA_BASE);
         assert_eq!(loaded.memory.read_u32_be(PPC_CFM_MAIN_STUB_BASE), Some(BLR));
+        assert_eq!(
+            loaded.memory.read_u32_be(PPC_PORT_LIST_ADDR),
+            Some(PPC_PORT_LIST_HANDLE)
+        );
+        assert_eq!(
+            loaded.memory.read_u32_be(PPC_PORT_LIST_HANDLE),
+            Some(PPC_PORT_LIST)
+        );
+        assert_eq!(loaded.memory.read_u16_be(PPC_PORT_LIST), Some(0));
         assert_eq!(loaded.memory.read_u32_be(0), Some(0));
         assert!(loaded.memory.write_u32_be(0, 0xdead_beef).is_some());
         assert_eq!(loaded.memory.read_u32_be(0), Some(0xdead_beef));
@@ -63938,13 +64631,13 @@ mod tests {
         assert!(!bindings[0].weak);
 
         assert_eq!(bindings[1].symbol_name, "FindSymbol");
-        assert_eq!(bindings[1].address, 0);
+        assert_eq!(bindings[1].address, PPC_IMPORT_TRAP_BASE + 4);
         assert_eq!(bindings[1].tvector_address, None);
         assert_eq!(bindings[1].trap_pc, PPC_IMPORT_TRAP_BASE + 4);
         assert!(bindings[1].weak);
         assert_eq!(
             bindings[1].dispatcher_target,
-            PpcImportDispatcherTarget::UnresolvedWeak
+            PpcImportDispatcherTarget::FindSymbol
         );
     }
 

--- a/src/machine_profile.rs
+++ b/src/machine_profile.rs
@@ -91,7 +91,9 @@ impl MachineProfile {
 pub const BASILISK_II_PLAY_PROFILE: MachineProfile = MachineProfile {
     model_id: 14,
     gestalt_machine_type: 20,
-    system_version_bcd: 0x0753,
+    // Mac OS 8.1 is the last release supported on 68040 Macs and provides
+    // the late-classic Toolbox surface exposed by this HLE profile.
+    system_version_bcd: 0x0810,
     gestalt_native_cpu_type: 4,
     gestalt_processor_type: 5,
     gestalt_fpu_type: 3,

--- a/src/memory/bus.rs
+++ b/src/memory/bus.rs
@@ -476,6 +476,11 @@ pub struct MacMemoryBus {
     free_blocks: HashMap<u32, Vec<u32>>,
     /// Tracks the aligned size of each allocation (address → aligned_size)
     alloc_sizes: HashMap<u32, u32>,
+    /// Direct-loaded application image spans that guest heap allocations must
+    /// skip. A relocated A5 world can leave usable heap both below and above
+    /// the image, so advancing the bump pointer past it would discard most of
+    /// the application partition.
+    reserved_heap_ranges: Vec<(u32, u32)>,
     /// For best-fit allocations, the bucket capacity the block came from
     /// (always >= `alloc_sizes[addr]`). On free, the block returns to this
     /// bucket so its full capacity is recovered. Absent for blocks
@@ -872,6 +877,7 @@ impl MacMemoryBus {
             readonly_code_span: None,
             free_blocks: HashMap::new(),
             alloc_sizes: HashMap::new(),
+            reserved_heap_ranges: Vec::new(),
             alloc_bucket_sizes: HashMap::new(),
             write_probe_original: None,
             write_probe_invalid: false,
@@ -963,6 +969,7 @@ impl MacMemoryBus {
             readonly_code_span: None,
             free_blocks: HashMap::new(),
             alloc_sizes: HashMap::new(),
+            reserved_heap_ranges: Vec::new(),
             alloc_bucket_sizes: HashMap::new(),
             write_probe_original: None,
             write_probe_invalid: false,
@@ -1036,6 +1043,34 @@ impl MacMemoryBus {
         self.heap_ptr = self.heap_ptr.max(aligned);
     }
 
+    /// Prevent heap allocations from overlapping a direct-loaded guest range
+    /// while preserving usable partition space before it.
+    pub(crate) fn reserve_heap_range(&mut self, start_addr: u32, end_addr: u32) {
+        let start = start_addr & !3;
+        let end = (end_addr.saturating_add(3)) & !3;
+        if start >= end {
+            return;
+        }
+        self.reserved_heap_ranges.push((start, end));
+        self.reserved_heap_ranges.sort_unstable();
+    }
+
+    fn bump_allocation_address(&self, size: u32, alignment: u32) -> Option<(u32, u32)> {
+        let mut ptr = (self.heap_ptr + alignment - 1) & !(alignment - 1);
+        loop {
+            let new_ptr = ptr.checked_add(size)?;
+            let overlap = self
+                .reserved_heap_ranges
+                .iter()
+                .find(|&&(start, end)| ptr < end && new_ptr > start);
+            if let Some(&(_, end)) = overlap {
+                ptr = (end + alignment - 1) & !(alignment - 1);
+                continue;
+            }
+            return Some((ptr, new_ptr));
+        }
+    }
+
     pub fn alloc(&mut self, size: u32) -> u32 {
         let aligned = Self::allocation_bucket_size(size); // 4-byte align, unique zero-size blocks
 
@@ -1082,8 +1117,9 @@ impl MacMemoryBus {
         }
 
         // Bump allocate
-        let ptr = self.heap_ptr;
-        let new_ptr = ptr + aligned;
+        let Some((ptr, new_ptr)) = self.bump_allocation_address(aligned, 4) else {
+            return 0;
+        };
 
         if new_ptr >= self.synthetic_floor {
             eprintln!(
@@ -1201,8 +1237,9 @@ impl MacMemoryBus {
             return addr;
         }
 
-        let ptr = (self.heap_ptr + alignment - 1) & !(alignment - 1);
-        let new_ptr = ptr + aligned;
+        let Some((ptr, new_ptr)) = self.bump_allocation_address(aligned, alignment) else {
+            return 0;
+        };
 
         if new_ptr >= self.synthetic_floor {
             eprintln!(
@@ -2131,6 +2168,22 @@ mod tests {
             first + 12,
             "re-reserving the same zone-header range must not create a second gap"
         );
+    }
+
+    #[test]
+    fn reserved_heap_range_preserves_space_before_direct_loaded_image() {
+        let mut bus = MacMemoryBus::new(16 * 1024 * 1024);
+        let image_start = 0x0080_0000;
+        let image_end = 0x0090_0000;
+        bus.reserve_heap(64);
+        bus.reserve_heap_range(image_start, image_end);
+
+        let lower_start = bus.alloc(image_start - (0x0020_0000 + 64));
+        assert_eq!(lower_start, 0x0020_0000 + 64);
+        let above_image = bus.alloc(4);
+
+        assert_eq!(above_image, image_end);
+        assert_eq!(bus.get_alloc_size(above_image), Some(4));
     }
 
     #[test]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1057,10 +1057,7 @@ fn tracking_refire_should_freeze_ticks(opcode: u16) -> bool {
 /// filter callbacks before their next presentation boundary. Other retained
 /// managers can coexist with modeless dialogs, but do not own those callbacks.
 fn tracking_refire_uses_dialog_callbacks(opcode: u16) -> bool {
-    matches!(
-        opcode & !0x0400,
-        0xA991 | 0xA985 | 0xA986 | 0xA987 | 0xA988
-    )
+    matches!(opcode & !0x0400, 0xA991 | 0xA985 | 0xA986 | 0xA987 | 0xA988)
 }
 
 /// Retained managers with their own event loops must keep guest ticks moving
@@ -2986,13 +2983,14 @@ impl FixtureRunner {
     pub fn load_app(&mut self, fork: &ResourceFork) -> Option<LoadedApp> {
         let app = load_app_generic(fork, &mut self.bus, self.config.load_address)?;
         let heap_start = app_heap_start_for_loaded_app(&app);
+        let image_start = app_image_start_for_loaded_app(&app);
 
-        // Resource data is allocated after direct CODE/global loading. Reserve
-        // the app-zone header at the actual heap start so early app resources
-        // cannot land in loader-owned memory or under `bkLim`/`hFstFree`.
-        // Inside Macintosh Volume II, II-22.
-        self.bus
-            .reserve_heap_until(heap_start.saturating_add(APP_ZONE_HEADER_SIZE));
+        // A relocated A5 world leaves valid application-heap space below the
+        // direct-loaded image. Reserve the image itself, plus the zone header,
+        // without throwing that lower partition space away.
+        // Inside Macintosh: Memory (1992), pp. 1-7 to 1-9 and 2-19.
+        self.bus.reserve_heap(APP_ZONE_HEADER_SIZE);
+        self.bus.reserve_heap_range(image_start, heap_start);
         self.dispatcher.load_resources(fork, &mut self.bus);
 
         let segments: HashMap<i16, u32> = app.segment_bases.iter().map(|(&k, &v)| (k, v)).collect();
@@ -3498,8 +3496,7 @@ impl FixtureRunner {
         // Apps and the Memory Manager read the zone header to determine
         // available memory. zcbFree (offset +12) must reflect free bytes.
         // Reserve heap space so alloc() doesn't overwrite the zone header.
-        self.bus
-            .reserve_heap_until(allocation_heap_start.saturating_add(zone_header_size));
+        self.bus.reserve_heap(zone_header_size);
         let zone_size = appl_limit.saturating_sub(visible_zone_start);
         let free_bytes = zone_size.saturating_sub(zone_header_size);
         self.bus.write_long(visible_zone_start, appl_limit); // bkLim: end of zone
@@ -5076,9 +5073,10 @@ impl FixtureRunner {
                 let frame_ret = self.bus.read_long(a6.wrapping_add(4));
                 let frame_arg = self.bus.read_word(a6.wrapping_add(8));
                 eprintln!(
-                    "[TRACE-PC-RANGE] pc=${:08X} op=${:04X} ccr=${:02X} d0=${:08X} d1=${:08X} d2=${:08X} d3=${:08X} d4=${:08X} d5=${:08X} d6=${:08X} d7=${:08X} a0=${:08X} a1=${:08X} a2=${:08X} a3=${:08X} a4=${:08X} a5=${:08X} a6=${:08X} sp=${:08X} stack0=${:08X} stack4=${:08X} stack8=${:04X} frame_ret=${:08X} frame_arg=${:04X}",
+                    "[TRACE-PC-RANGE] pc=${:08X} op=${:04X} next=${:08X} ccr=${:02X} d0=${:08X} d1=${:08X} d2=${:08X} d3=${:08X} d4=${:08X} d5=${:08X} d6=${:08X} d7=${:08X} a0=${:08X} a1=${:08X} a2=${:08X} a3=${:08X} a4=${:08X} a5=${:08X} a6=${:08X} sp=${:08X} stack0=${:08X} stack4=${:08X} stack8=${:04X} frame_ret=${:08X} frame_arg=${:04X}",
                     pc,
                     self.bus.read_word(pc),
+                    self.bus.read_long(pc.wrapping_add(2)),
                     self.cpu.core.get_ccr(),
                     self.cpu.read_reg(Register::D0),
                     self.cpu.read_reg(Register::D1),
@@ -10336,8 +10334,8 @@ mod tests {
             addressing_32_bit: false,
             ..FixtureRunnerConfig::default()
         }
-            .with_screen_depth(4)
-            .expect("4-bit indexed mode should be supported");
+        .with_screen_depth(4)
+        .expect("4-bit indexed mode should be supported");
         let mut runner = FixtureRunner::new(8 * 1024 * 1024, config);
         let gdevice_handle = runner.dispatcher.ensure_main_gdevice(&mut runner.bus);
         let gdevice = runner.bus.read_long(gdevice_handle);
@@ -10643,7 +10641,7 @@ mod tests {
         let app = runner.load_app(&fork).expect("load app");
         let (_, bgas_ptr) = runner
             .dispatcher
-            .find_resource_any(*b"BGAS", 128)
+            .find_or_load_resource_any(&mut runner.bus, *b"BGAS", 128)
             .expect("BGAS resource loaded");
         assert_eq!(runner.bus.read_bytes(bgas_ptr, bgas.len()), bgas);
 
@@ -10748,7 +10746,7 @@ mod tests {
         let heap_start = app_heap_start_for_loaded_app(&app);
         let (_, marker_ptr) = runner
             .dispatcher
-            .find_resource_any(*b"BGAS", 128)
+            .find_or_load_resource_any(&mut runner.bus, *b"BGAS", 128)
             .expect("BGAS resource loaded");
         assert!(
             marker_ptr >= heap_start + APP_ZONE_HEADER_SIZE,
@@ -10947,7 +10945,7 @@ mod tests {
         // (1993), pp. 1-8 to 1-9.
         let (_, resource_ptr) = runner
             .dispatcher
-            .find_resource_any(*b"SHAP", 128)
+            .find_or_load_resource_any(&mut runner.bus, *b"SHAP", 128)
             .expect("large resource registered");
         assert_ne!(
             resource_ptr, 0,
@@ -10981,14 +10979,15 @@ mod tests {
         let mut runner = FixtureRunner::new(32 * 1024 * 1024, FixtureRunnerConfig::default());
 
         let app = runner.load_app(&fork).expect("load app");
-        let allocation_heap_start = app_heap_start_for_loaded_app(&app);
+        let image_start = app_image_start_for_loaded_app(&app);
         let (_, marker_ptr) = runner
             .dispatcher
-            .find_resource_any(*b"BGAS", 128)
+            .find_or_load_resource_any(&mut runner.bus, *b"BGAS", 128)
             .expect("BGAS resource loaded");
+        let marker_end = marker_ptr + marker.len() as u32;
         assert!(
-            marker_ptr >= allocation_heap_start + APP_ZONE_HEADER_SIZE,
-            "preloaded resources must still allocate above the relocated image"
+            marker_end <= image_start || marker_ptr >= app.loaded_image_end,
+            "resource allocation must not overlap the relocated image"
         );
 
         runner.init_app(&app);
@@ -11563,6 +11562,7 @@ mod tests {
             dialog_callback_stack: Vec::new(),
             apple_events: Default::default(),
             cfm_connections: Vec::new(),
+            cfm_library_fragments: Vec::new(),
             next_cfm_connection_id: 1,
             ptrs: Vec::new(),
             free_ptr_blocks: Vec::new(),
@@ -11689,6 +11689,7 @@ mod tests {
             dialog_callback_stack: Vec::new(),
             apple_events: Default::default(),
             cfm_connections: Vec::new(),
+            cfm_library_fragments: Vec::new(),
             next_cfm_connection_id: 1,
             ptrs: Vec::new(),
             free_ptr_blocks: Vec::new(),
@@ -12513,6 +12514,7 @@ mod tests {
             dialog_callback_stack: Vec::new(),
             apple_events: Default::default(),
             cfm_connections: Vec::new(),
+            cfm_library_fragments: Vec::new(),
             next_cfm_connection_id: 1,
             ptrs: Vec::new(),
             free_ptr_blocks: Vec::new(),
@@ -12668,6 +12670,7 @@ mod tests {
             dialog_callback_stack: Vec::new(),
             apple_events: Default::default(),
             cfm_connections: Vec::new(),
+            cfm_library_fragments: Vec::new(),
             next_cfm_connection_id: 1,
             ptrs: Vec::new(),
             free_ptr_blocks: Vec::new(),
@@ -13056,6 +13059,7 @@ mod tests {
             dialog_callback_stack: Vec::new(),
             apple_events: Default::default(),
             cfm_connections: Vec::new(),
+            cfm_library_fragments: Vec::new(),
             next_cfm_connection_id: 1,
             ptrs: Vec::new(),
             free_ptr_blocks: Vec::new(),
@@ -13400,6 +13404,7 @@ mod tests {
             dialog_callback_stack: Vec::new(),
             apple_events: Default::default(),
             cfm_connections: Vec::new(),
+            cfm_library_fragments: Vec::new(),
             next_cfm_connection_id: 1,
             ptrs: Vec::new(),
             free_ptr_blocks: Vec::new(),

--- a/src/trap/dialog.rs
+++ b/src/trap/dialog.rs
@@ -360,7 +360,11 @@ impl super::TrapDispatcher {
         purgeable: bool,
         load_if_missing: bool,
     ) -> Option<(u32, u32)> {
-        let (refnum, ptr) = self.find_resource_any(res_type, res_id)?;
+        let (refnum, ptr) = if load_if_missing {
+            self.find_or_load_resource_any(bus, res_type, res_id)?
+        } else {
+            self.find_resource_any(res_type, res_id)?
+        };
         let handle = if load_if_missing {
             let handle =
                 self.get_or_create_resource_handle_in_file(bus, res_type, res_id, ptr, refnum);
@@ -3448,7 +3452,7 @@ impl super::TrapDispatcher {
                     handle
                 }
                 32 => self
-                    .find_resource_any(*b"ICON", item.resource_id)
+                    .find_or_load_resource_any(bus, *b"ICON", item.resource_id)
                     .map(|(_, ptr)| {
                         self.get_or_create_resource_handle(bus, *b"ICON", item.resource_id, ptr)
                     })
@@ -3462,7 +3466,7 @@ impl super::TrapDispatcher {
                     }
                 }
                 7 => self
-                    .find_resource_any(*b"CNTL", item.resource_id)
+                    .find_or_load_resource_any(bus, *b"CNTL", item.resource_id)
                     .map(|(_, cntl_ptr)| {
                         let value = bus.read_word(cntl_ptr + 8) as i16;
                         let vis_word = bus.read_word(cntl_ptr + 10);
@@ -3500,7 +3504,7 @@ impl super::TrapDispatcher {
                     })
                     .unwrap_or(0),
                 64 => self
-                    .find_resource_any(*b"PICT", item.resource_id)
+                    .find_or_load_resource_any(bus, *b"PICT", item.resource_id)
                     .map(|(_, ptr)| {
                         self.get_or_create_resource_handle(bus, *b"PICT", item.resource_id, ptr)
                     })
@@ -4064,7 +4068,7 @@ impl super::TrapDispatcher {
         position: u16,
         default_item: i16,
     ) -> bool {
-        let Some((_, ditl_data)) = self.find_resource_any(*b"DITL", items_id) else {
+        let Some((_, ditl_data)) = self.find_or_load_resource_any(bus, *b"DITL", items_id) else {
             return false;
         };
         let ditl_len = bus.get_alloc_size(ditl_data).unwrap_or(0);
@@ -5848,8 +5852,7 @@ impl super::TrapDispatcher {
         if let Some((red, green, blue)) = self.window_semantic_color(bus, dialog_ptr, 0) {
             let (screen_base, row_bytes, screen_width, screen_height, pixel_size) =
                 self.get_screen_params();
-            let pixel_index =
-                super::pict::closest_clut_index(red, green, blue, &self.device_clut);
+            let pixel_index = super::pict::closest_clut_index(red, green, blue, &self.device_clut);
             Self::fb_fill_rect_index(
                 bus,
                 screen_base,
@@ -6001,12 +6004,8 @@ impl super::TrapDispatcher {
         let content_color = self.window_semantic_color(bus, dialog_ptr, 0);
         if !game_managed {
             if let Some((red, green, blue)) = content_color {
-                let pixel_index = super::pict::closest_clut_index(
-                    red,
-                    green,
-                    blue,
-                    &self.device_clut,
-                );
+                let pixel_index =
+                    super::pict::closest_clut_index(red, green, blue, &self.device_clut);
                 Self::fb_fill_rect_index(
                     bus,
                     screen_base,
@@ -6279,16 +6278,18 @@ impl super::TrapDispatcher {
                 // Icon (32)
                 32 => {
                     if !skip_pictures && item.resource_id != 0 {
-                        let drew_cicn = self
-                            .find_resource_any(*b"cicn", item.resource_id)
-                            .is_some_and(|(_, icon_ptr)| {
-                                self.draw_cicn_icon(
-                                    bus, abs_top, abs_left, abs_bottom, abs_right, icon_ptr,
-                                )
-                            });
+                        let drew_cicn = if let Some((_, icon_ptr)) =
+                            self.find_or_load_resource_any(bus, *b"cicn", item.resource_id)
+                        {
+                            self.draw_cicn_icon(
+                                bus, abs_top, abs_left, abs_bottom, abs_right, icon_ptr,
+                            )
+                        } else {
+                            false
+                        };
                         if !drew_cicn {
                             if let Some((_, icon_ptr)) =
-                                self.find_resource_any(*b"ICON", item.resource_id)
+                                self.find_or_load_resource_any(bus, *b"ICON", item.resource_id)
                             {
                                 // ICON resource: 32x32 1-bit bitmap = 128 bytes
                                 // Inside Macintosh Volume I, I-205
@@ -6305,7 +6306,7 @@ impl super::TrapDispatcher {
                     // fully-outside clip happens above the match).
                     if !skip_pictures && item.resource_id != 0 {
                         if let Some((_, pic_ptr)) =
-                            self.find_resource_any(*b"PICT", item.resource_id)
+                            self.find_or_load_resource_any(bus, *b"PICT", item.resource_id)
                         {
                             // Draw PICT into the item's display rectangle
                             let device_ct_seed =
@@ -8073,16 +8074,7 @@ impl super::TrapDispatcher {
             }
         }
         let (top, left, bottom, right) = Self::dialog_item_screen_rect(bounds, item.rect);
-        self.draw_button_with_enabled(
-            bus,
-            top,
-            left,
-            bottom,
-            right,
-            &item.text,
-            is_default,
-            true,
-        );
+        self.draw_button_with_enabled(bus, top, left, bottom, right, &item.text, is_default, true);
     }
 
     /// Draw a checkbox item.
@@ -10222,26 +10214,35 @@ impl super::TrapDispatcher {
     }
 
     fn handle_dialog_button_tracking(&mut self, bus: &mut MacMemoryBus) {
-        let Some((dialog_ptr, bounds, mouse_down, item_no, rect, title, is_default, highlighted, item_type)) =
-            self.dialog_tracking.as_ref().and_then(|tracking| {
-                tracking.active_button.as_ref().map(|button| {
-                    (
-                        tracking.dialog_ptr,
-                        tracking.bounds,
-                        button.mouse_down.clone(),
-                        button.item_no,
-                        button.rect,
-                        button.title.clone(),
-                        button.is_default,
-                        button.highlighted,
-                        tracking
-                            .items
-                            .get(button.item_no.saturating_sub(1) as usize)
-                            .map(|item| item.item_type)
-                            .unwrap_or(4),
-                    )
-                })
+        let Some((
+            dialog_ptr,
+            bounds,
+            mouse_down,
+            item_no,
+            rect,
+            title,
+            is_default,
+            highlighted,
+            item_type,
+        )) = self.dialog_tracking.as_ref().and_then(|tracking| {
+            tracking.active_button.as_ref().map(|button| {
+                (
+                    tracking.dialog_ptr,
+                    tracking.bounds,
+                    button.mouse_down.clone(),
+                    button.item_no,
+                    button.rect,
+                    button.title.clone(),
+                    button.is_default,
+                    button.highlighted,
+                    tracking
+                        .items
+                        .get(button.item_no.saturating_sub(1) as usize)
+                        .map(|item| item.item_type)
+                        .unwrap_or(4),
+                )
             })
+        })
         else {
             return;
         };
@@ -10462,7 +10463,7 @@ impl super::TrapDispatcher {
 
                 // Look up DLOG resource
                 let dlog_ptr = self
-                    .find_resource_any(*b"DLOG", dialog_id)
+                    .find_or_load_resource_any(bus, *b"DLOG", dialog_id)
                     .map(|(_, ptr)| ptr);
 
                 if let Some(dlog_data) = dlog_ptr {
@@ -10473,7 +10474,7 @@ impl super::TrapDispatcher {
 
                     // Look up DITL resource
                     let ditl_info = self
-                        .find_resource_any(*b"DITL", items_id)
+                        .find_or_load_resource_any(bus, *b"DITL", items_id)
                         .map(|(_, ptr)| ptr);
 
                     let Some(ditl_data) = ditl_info else {
@@ -10548,7 +10549,7 @@ impl super::TrapDispatcher {
                     }
 
                     let items_handle = if let Some((_, ditl_handle_ptr)) =
-                        self.find_resource_any(*b"DITL", items_id)
+                        self.find_or_load_resource_any(bus, *b"DITL", items_id)
                     {
                         let handle = bus.alloc(4);
                         bus.write_long(handle, ditl_handle_ptr);
@@ -10558,8 +10559,7 @@ impl super::TrapDispatcher {
                     };
                     // A matching DCTab is copied and associated before the
                     // dialog's initial visible shell is drawn.
-                    let dialog_color_table =
-                        self.copy_dialog_color_table_resource(bus, dialog_id);
+                    let dialog_color_table = self.copy_dialog_color_table_resource(bus, dialog_id);
                     // Honor the DLOG resource's visible flag per IM:I I-424.
                     let dlg_ptr = self.finish_dialog_creation(
                         bus,
@@ -10696,7 +10696,7 @@ impl super::TrapDispatcher {
                 // binary. Inside Macintosh Volume I, I-422 (ALRT
                 // template) and I-426 (DITL).
                 let alrt_ptr = self
-                    .find_resource_any(*b"ALRT", alert_id)
+                    .find_or_load_resource_any(bus, *b"ALRT", alert_id)
                     .map(|(_, ptr)| ptr);
                 let result: i16 = if let Some(alrt_data) = alrt_ptr {
                     let alrt_len = bus.get_alloc_size(alrt_data).unwrap_or(0);
@@ -10814,7 +10814,8 @@ impl super::TrapDispatcher {
                                 top, left, bottom, right
                             ));
                         } else {
-                            let ditl_match = self.find_resource_any(*b"DITL", items_id);
+                            let ditl_match =
+                                self.find_or_load_resource_any(bus, *b"DITL", items_id);
                             detail.push_str(&format!(
                                 " bounds=({},{},{},{}) itemsID={} ditl={}",
                                 top,
@@ -18130,7 +18131,11 @@ mod tests {
         let table_handle = bus.read_long(aux_ptr + TrapDispatcher::AUX_WIN_CTABLE_OFFSET);
         let table_ptr = bus.read_long(table_handle);
         assert_ne!(table_ptr, resource_ptr, "GetNewDialog must copy the DCTab");
-        assert_ne!(bus.read_long(table_ptr), 0, "the copied table gets a fresh seed");
+        assert_ne!(
+            bus.read_long(table_ptr),
+            0,
+            "the copied table gets a fresh seed"
+        );
         assert_eq!(bus.read_word(table_ptr + 6), 4);
         assert_eq!(
             (

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -4972,6 +4972,7 @@ impl TrapDispatcher {
         fork: &ResourceFork,
         bus: &mut MacMemoryBus,
     ) -> ResourceFileMap {
+        const RES_PRELOAD_ATTR: u8 = 0x04;
         let mut loaded = HashMap::new();
         let mut named = HashMap::new();
         let mut names_by_id = HashMap::new();
@@ -4980,9 +4981,20 @@ impl TrapDispatcher {
         let mut sorted_resources: Vec<_> = fork.resources().iter().collect();
         sorted_resources.sort_by_key(|((res_type, id), _)| (*res_type, *id));
         for ((res_type, id), res) in sorted_resources {
-            let ptr = bus.alloc(res.data.len() as u32);
-            bus.write_bytes(ptr, &res.data);
-            Self::zero_loaded_resource_padding(bus, ptr, res.data.len() as u32);
+            // OpenResFile reads the resource map plus only resources carrying
+            // resPreload; ordinary resource data stays on disk until requested.
+            // SetResLoad(FALSE) also suppresses preloading.
+            // Inside Macintosh Volume I (1985), I-111, I-115, I-118.
+            let ptr = if self.res_load && res.attrs & RES_PRELOAD_ATTR != 0 {
+                let ptr = bus.alloc(res.data.len() as u32);
+                if ptr != 0 {
+                    bus.write_bytes(ptr, &res.data);
+                    Self::zero_loaded_resource_padding(bus, ptr, res.data.len() as u32);
+                }
+                ptr
+            } else {
+                0
+            };
             loaded.insert((*res_type, *id), ptr);
             attrs.insert((*res_type, *id), res.attrs);
             if let Some(ref name) = res.name {
@@ -4997,6 +5009,15 @@ impl TrapDispatcher {
             attrs,
             map_attrs: 0,
         }
+    }
+
+    fn remember_preloaded_resource_residency(&mut self, refnum: u16, file: &ResourceFileMap) {
+        self.resident_resources.extend(
+            file.loaded
+                .iter()
+                .filter(|(_, ptr)| **ptr != 0)
+                .map(|(&(res_type, res_id), _)| (refnum, res_type, res_id)),
+        );
     }
 
     fn resource_reference_order(fork: &ResourceFork) -> Vec<([u8; 4], i16)> {
@@ -5898,6 +5919,7 @@ impl TrapDispatcher {
                 .insert(format!("__rsrc__{}", app_path), fork.serialized().to_vec());
         }
         let file = self.allocate_resource_fork(fork, bus);
+        self.remember_preloaded_resource_residency(0, &file);
         self.resource_file_order
             .insert(0, Self::resource_reference_order(fork));
         self.clear_resource_file_backing_data(0);
@@ -6032,6 +6054,7 @@ impl TrapDispatcher {
         refnum: u16,
     ) -> usize {
         let incoming = self.allocate_resource_fork(fork, bus);
+        self.remember_preloaded_resource_residency(refnum, &incoming);
         let incoming_order = Self::resource_reference_order(fork);
         let count = incoming.loaded.len();
         let resources = self.resources.get_or_insert_with(|| LoadedResources {
@@ -6076,6 +6099,7 @@ impl TrapDispatcher {
         refnum: u16,
     ) {
         let file = self.allocate_resource_fork(fork, bus);
+        self.remember_preloaded_resource_residency(refnum, &file);
         self.resource_file_order
             .insert(refnum, Self::resource_reference_order(fork));
         let count = file.loaded.len();
@@ -6625,6 +6649,15 @@ mod tests {
     use std::collections::VecDeque;
 
     fn make_single_resource_fork_bytes(res_type: [u8; 4], res_id: i16, data: &[u8]) -> Vec<u8> {
+        make_single_resource_fork_bytes_with_attrs(res_type, res_id, data, 0)
+    }
+
+    fn make_single_resource_fork_bytes_with_attrs(
+        res_type: [u8; 4],
+        res_id: i16,
+        data: &[u8],
+        attrs: u8,
+    ) -> Vec<u8> {
         let data_offset = 16u32;
         let data_length = (4 + data.len()) as u32;
         let map_offset = data_offset + data_length;
@@ -6660,6 +6693,7 @@ mod tests {
         let ref_list_start = map_start + type_list_offset as usize + ref_list_offset as usize;
         bytes[ref_list_start..ref_list_start + 2].copy_from_slice(&(res_id as u16).to_be_bytes());
         bytes[ref_list_start + 2..ref_list_start + 4].copy_from_slice(&0xFFFFu16.to_be_bytes());
+        bytes[ref_list_start + 4] = attrs;
         bytes[ref_list_start + 5..ref_list_start + 8].copy_from_slice(&0u32.to_be_bytes()[1..4]);
 
         bytes
@@ -7028,7 +7062,7 @@ mod tests {
 
     #[test]
     fn load_resources_exposes_application_map_and_fork_to_native_runtime_code() {
-        let serialized = make_single_resource_fork_bytes(*b"TEST", 7, b"payload");
+        let serialized = make_single_resource_fork_bytes_with_attrs(*b"TEST", 7, b"payload", 0x04);
         let fork = ResourceFork::parse(&serialized).unwrap();
         let reference_offset = fork.get(*b"TEST", 7).unwrap().reference_offset as u32;
         let mut bus = MacMemoryBus::new(4 * 1024 * 1024);
@@ -7082,11 +7116,59 @@ mod tests {
             1
         );
 
-        let (_, app_ptr) = disp.find_resource_any(*b"TEST", 1).unwrap();
-        let (_, companion_ptr) = disp.find_resource_any(*b"TEST", 2).unwrap();
+        let (_, app_ptr) = disp
+            .find_or_load_resource_any(&mut bus, *b"TEST", 1)
+            .unwrap();
+        let (_, companion_ptr) = disp
+            .find_or_load_resource_any(&mut bus, *b"TEST", 2)
+            .unwrap();
         assert_eq!(bus.read_bytes(app_ptr, 3), b"app");
         assert_eq!(bus.read_bytes(companion_ptr, 4), b"side");
         assert_eq!(disp.count_resources(*b"TEST", true), 2);
+    }
+
+    #[test]
+    fn opening_resource_fork_defers_non_preload_data_until_requested() {
+        let payload = vec![0xA5; 1024 * 1024];
+        let serialized = make_single_resource_fork_bytes(*b"TEST", 7, &payload);
+        let fork = ResourceFork::parse(&serialized).unwrap();
+        let mut bus = MacMemoryBus::new(4 * 1024 * 1024);
+        let mut disp = TrapDispatcher::new();
+        let heap_before = bus.heap_bump_ptr();
+
+        disp.load_resources(&fork, &mut bus);
+
+        let heap_after_open = bus.heap_bump_ptr();
+        assert!(
+            heap_after_open - heap_before < payload.len() as u32,
+            "opening the resource map must not copy ordinary resource data into the guest heap"
+        );
+        assert_eq!(
+            disp.resources.as_ref().unwrap().files[&0].loaded[&(*b"TEST", 7)],
+            0
+        );
+
+        let (_, ptr) = disp
+            .find_or_load_resource_any(&mut bus, *b"TEST", 7)
+            .expect("GetResource-style lookup should materialize deferred data");
+        assert_eq!(bus.read_bytes(ptr, payload.len()), payload);
+        assert!(bus.heap_bump_ptr() - heap_after_open >= payload.len() as u32);
+    }
+
+    #[test]
+    fn opening_resource_fork_materializes_respreload_data() {
+        let serialized =
+            make_single_resource_fork_bytes_with_attrs(*b"TEST", 7, b"preloaded", 0x04);
+        let fork = ResourceFork::parse(&serialized).unwrap();
+        let mut bus = MacMemoryBus::new(4 * 1024 * 1024);
+        let mut disp = TrapDispatcher::new();
+
+        disp.load_resources(&fork, &mut bus);
+
+        let ptr = disp.resources.as_ref().unwrap().files[&0].loaded[&(*b"TEST", 7)];
+        assert_ne!(ptr, 0);
+        assert_eq!(bus.read_bytes(ptr, 9), b"preloaded");
+        assert!(disp.resident_resources.contains(&(0, *b"TEST", 7)));
     }
 
     // Lock the `is_tracking_refire` contract — returns true exactly when

--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -14728,6 +14728,172 @@ impl super::TrapDispatcher {
                         bus.write_long(sp + 6, 0);
                         cpu.write_reg(Register::A7, sp + 6);
                     }
+                    // DMGetDisplayIDByGDevice(GDHandle, DisplayIDType *, Boolean)
+                    // -> OSErr. Display IDs remain stable while a device is
+                    // attached; the single-display model uses ID 1, matching
+                    // the native PowerPC Display Manager path.
+                    // Apple's Optimizing Display Modes and Window Buffers
+                    // (2007), p. 26.
+                    0x051F => {
+                        let fail_to_main = bus.read_word(sp) != 0;
+                        let display_id_ptr = bus.read_long(sp + 2);
+                        let requested_gdh = bus.read_long(sp + 6);
+                        let main_gdh = self.ensure_main_gdevice(bus);
+                        let result =
+                            if display_id_ptr != 0 && (requested_gdh == main_gdh || fail_to_main) {
+                                bus.write_long(display_id_ptr, 1);
+                                0
+                            } else {
+                                -50i16
+                            };
+                        bus.write_word(sp + 10, result as u16);
+                        cpu.write_reg(Register::A7, sp + 10);
+                        cpu.write_reg(Register::D0, result as i32 as u32);
+                    }
+                    // DMNewDisplayModeList(DisplayIDType, UInt32, UInt32,
+                    //                      DMListIndexType *, DMListType *)
+                    // -> OSErr. Universal Interfaces 3.4.1 Displays.h models
+                    // the list as opaque and exposes entries through selector
+                    // $37; advertise the active single-screen indexed mode.
+                    0x0A36 => {
+                        let list_out = bus.read_long(sp);
+                        let count_out = bus.read_long(sp + 4);
+                        let display_id = bus.read_long(sp + 16);
+                        let result = if display_id != 1 || list_out == 0 || count_out == 0 {
+                            -50i16
+                        } else {
+                            const LIST_SIZE: u32 = 256;
+                            const ENTRY_OFFSET: u32 = 0x10;
+                            const SWITCH_INFO_OFFSET: u32 = 0x30;
+                            const RESOLUTION_INFO_OFFSET: u32 = 0x40;
+                            const TIMING_INFO_OFFSET: u32 = 0x60;
+                            const DEPTH_BLOCK_OFFSET: u32 = 0x78;
+                            const DEPTH_INFO_OFFSET: u32 = 0x90;
+                            const VP_BLOCK_OFFSET: u32 = 0xA8;
+                            const NAME_OFFSET: u32 = 0xD8;
+
+                            let list = bus.alloc(LIST_SIZE);
+                            if list == 0 {
+                                -108i16 // memFullErr
+                            } else {
+                                bus.fill_zeros(list, LIST_SIZE);
+                                let entry = list + ENTRY_OFFSET;
+                                let switch_info = list + SWITCH_INFO_OFFSET;
+                                let resolution = list + RESOLUTION_INFO_OFFSET;
+                                let timing = list + TIMING_INFO_OFFSET;
+                                let depth_block = list + DEPTH_BLOCK_OFFSET;
+                                let depth_info = list + DEPTH_INFO_OFFSET;
+                                let vp_block = list + VP_BLOCK_OFFSET;
+                                let name = list + NAME_OFFSET;
+                                let (_, row_bytes, width, height, pixel_size) = self.screen_mode;
+
+                                bus.write_long(list, u32::from_be_bytes(*b"DML1"));
+                                bus.write_long(list + 4, display_id);
+                                bus.write_long(entry + 4, switch_info);
+                                bus.write_long(entry + 8, resolution);
+                                bus.write_long(entry + 12, timing);
+                                bus.write_long(entry + 16, depth_block);
+                                bus.write_long(entry + 20, 1);
+                                bus.write_long(entry + 24, name);
+
+                                bus.write_word(switch_info, 0x85);
+                                bus.write_long(switch_info + 2, 0x80);
+                                bus.write_long(switch_info + 8, self.screen_mode.0);
+
+                                bus.write_long(resolution + 4, 0x80);
+                                bus.write_long(resolution + 8, u32::from(width));
+                                bus.write_long(resolution + 12, u32::from(height));
+                                bus.write_long(resolution + 16, 60 << 16);
+                                bus.write_long(resolution + 20, 0x85);
+                                bus.write_long(timing, 0x80);
+
+                                bus.write_long(depth_block, 1);
+                                bus.write_long(depth_block + 4, depth_info);
+                                bus.write_long(depth_info, switch_info);
+                                bus.write_long(depth_info + 4, vp_block);
+                                bus.write_word(vp_block + 4, row_bytes as u16);
+                                bus.write_word(vp_block + 6, 0);
+                                bus.write_word(vp_block + 8, 0);
+                                bus.write_word(vp_block + 10, height);
+                                bus.write_word(vp_block + 12, width);
+                                bus.write_long(vp_block + 22, 72 << 16);
+                                bus.write_long(vp_block + 26, 72 << 16);
+                                bus.write_word(vp_block + 32, u16::from(pixel_size));
+                                bus.write_word(vp_block + 34, 1);
+                                bus.write_word(vp_block + 36, u16::from(pixel_size));
+                                let mode_name = if pixel_size <= 8 {
+                                    format!("{} x {}, {} Colors", width, height, 1u32 << pixel_size)
+                                } else {
+                                    format!("{} x {}, {}-bit Color", width, height, pixel_size)
+                                };
+                                let mode_name = mode_name.as_bytes();
+                                let name_len = mode_name.len().min(31);
+                                bus.write_byte(name, name_len as u8);
+                                bus.write_bytes(name + 1, &mode_name[..name_len]);
+
+                                bus.write_long(count_out, 1);
+                                bus.write_long(list_out, list);
+                                0
+                            }
+                        };
+                        bus.write_word(sp + 20, result as u16);
+                        cpu.write_reg(Register::A7, sp + 20);
+                        cpu.write_reg(Register::D0, result as i32 as u32);
+                    }
+                    // DMDisposeList(DMListType) -> OSErr.
+                    0x022C => {
+                        let list = bus.read_long(sp);
+                        let result = if bus.read_long(list) == u32::from_be_bytes(*b"DML1") {
+                            bus.free(list);
+                            0
+                        } else {
+                            -50i16
+                        };
+                        bus.write_word(sp + 4, result as u16);
+                        cpu.write_reg(Register::A7, sp + 4);
+                        cpu.write_reg(Register::D0, result as i32 as u32);
+                    }
+                    0x0A37 => {
+                        let user_data = bus.read_long(sp);
+                        let callback = bus.read_long(sp + 4);
+                        let item_index = bus.read_long(sp + 12);
+                        let list = bus.read_long(sp + 16);
+                        if callback == 0
+                            || bus.read_long(list) != u32::from_be_bytes(*b"DML1")
+                            || !matches!(item_index, 0 | 1)
+                        {
+                            bus.write_word(sp + 20, (-50i16) as u16);
+                            cpu.write_reg(Register::A7, sp + 20);
+                            cpu.write_reg(Register::D0, (-50i32) as u32);
+                        } else {
+                            // DMGetIndexedDisplayModeFromList calls the iterator
+                            // as (userData, itemIndex, entry). Return through a
+                            // tiny cleanup thunk so both RTS and RTD-style UPPs
+                            // resume with the DisplayDispatch result slot atop
+                            // the caller's stack.
+                            let resume_sp = sp + 20;
+                            let return_pc = cpu.read_reg(Register::PC);
+                            let cleanup = bus.alloc(12);
+                            if cleanup == 0 {
+                                bus.write_word(resume_sp, (-108i16) as u16);
+                                cpu.write_reg(Register::A7, resume_sp);
+                                cpu.write_reg(Register::D0, (-108i32) as u32);
+                            } else {
+                                bus.write_word(cleanup, 0x2E7C); // MOVEA.L #resume_sp,A7
+                                bus.write_long(cleanup + 2, resume_sp);
+                                bus.write_word(cleanup + 6, 0x4EF9); // JMP return_pc
+                                bus.write_long(cleanup + 8, return_pc);
+                                bus.write_word(resume_sp, 0);
+                                bus.write_long(sp + 16, user_data);
+                                bus.write_long(sp + 12, item_index);
+                                bus.write_long(sp + 8, list + 0x10);
+                                bus.write_long(sp + 4, cleanup);
+                                cpu.write_reg(Register::A7, sp + 4);
+                                cpu.write_reg(Register::PC, callback);
+                                cpu.write_reg(Register::D0, 0);
+                            }
+                        }
+                    }
                     // DMBeginConfigureDisplays(Handle *displayState) -> OSErr.
                     // BasiliskII returns the main GDevice handle as the begin
                     // token and stores the same handle through *displayState.
@@ -36363,6 +36529,26 @@ mod tests {
         assert!(result.unwrap().is_ok());
         assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 6);
         assert_eq!(bus.read_long(TEST_SP + 6), 0);
+    }
+
+    #[test]
+    fn displaydispatch_maps_main_gdevice_to_stable_display_id() {
+        let (mut d, mut cpu, mut bus) = setup();
+        let main_gdh = d.ensure_main_gdevice(&mut bus);
+        let display_id_ptr = 0x0031_0F00u32;
+
+        cpu.write_reg(Register::D0, 0x051F);
+        bus.write_word(TEST_SP, 0); // failToMain
+        bus.write_long(TEST_SP + 2, display_id_ptr);
+        bus.write_long(TEST_SP + 6, main_gdh);
+        bus.write_word(TEST_SP + 10, 0xA55A);
+        let result = d.dispatch_quickdraw(true, 0x3EB, &mut cpu, &mut bus);
+
+        assert!(result.unwrap().is_ok());
+        assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 10);
+        assert_eq!(bus.read_word(TEST_SP + 10), 0);
+        assert_eq!(cpu.read_reg(Register::D0), 0);
+        assert_eq!(bus.read_long(display_id_ptr), 1);
     }
 
     #[test]

--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -3426,7 +3426,7 @@ impl super::TrapDispatcher {
                         cpu.write_reg(Register::A0, 0x0001);
                         cpu.write_reg(Register::D0, 0);
                     }
-                    // gestaltSystemVersion ('sysv') -> System 7.5.3
+                    // gestaltSystemVersion ('sysv') -> the canonical profile version.
                     b"sysv" => {
                         cpu.write_reg(
                             Register::A0,
@@ -4228,6 +4228,12 @@ impl super::TrapDispatcher {
                 let volume_index = bus.read_word(pb + 28) as i16;
                 let requested_vref = bus.read_word(pb + 22) as i16;
                 let requested_name = Self::read_pb_filename(bus, bus.read_long(pb + 18));
+                if super::dispatch::trace_resfile_enabled() {
+                    eprintln!(
+                        "[TRAP] PBHGetVInfo index={} vref={} name={:?}",
+                        volume_index, requested_vref, requested_name
+                    );
+                }
                 let boot_volume = || {
                     Some((
                         super::TrapDispatcher::boot_volume_name().to_string(),
@@ -4240,7 +4246,27 @@ impl super::TrapDispatcher {
                     // ioNamePtr or ioVRefNum instead of enumerating the VCB
                     // queue. Do not silently turn an unknown vRefNum into the
                     // boot volume; callers use nsvErr to detect a bad volume.
-                    if !requested_name.is_empty() {
+                    if requested_vref != 0 {
+                        let volume_ref_num = if requested_vref
+                            == super::TrapDispatcher::boot_volume_ref_num()
+                            || self.vfs_volumes.contains_key(&requested_vref)
+                        {
+                            Some(requested_vref)
+                        } else {
+                            self.working_directories
+                                .get(&requested_vref)
+                                .map(|working_directory| working_directory.volume_ref_num)
+                        };
+                        volume_ref_num.and_then(|volume_ref_num| {
+                            if volume_ref_num == super::TrapDispatcher::boot_volume_ref_num() {
+                                boot_volume()
+                            } else {
+                                self.vfs_volume_for_ref_num(volume_ref_num).map(|volume| {
+                                    (volume.name.clone(), volume.ref_num, volume.attributes)
+                                })
+                            }
+                        })
+                    } else if !requested_name.is_empty() {
                         if requested_name
                             .eq_ignore_ascii_case(super::TrapDispatcher::boot_volume_name())
                         {
@@ -4251,17 +4277,7 @@ impl super::TrapDispatcher {
                             })
                         }
                     } else {
-                        let volume_ref_num = if requested_vref == 0 {
-                            Some(self.resolve_volume_ref_num(self.app_wd_refnum))
-                        } else if requested_vref == super::TrapDispatcher::boot_volume_ref_num()
-                            || self.vfs_volumes.contains_key(&requested_vref)
-                        {
-                            Some(requested_vref)
-                        } else {
-                            self.working_directories
-                                .get(&requested_vref)
-                                .map(|working_directory| working_directory.volume_ref_num)
-                        };
+                        let volume_ref_num = Some(self.resolve_volume_ref_num(self.app_wd_refnum));
                         volume_ref_num.and_then(|volume_ref_num| {
                             if volume_ref_num == super::TrapDispatcher::boot_volume_ref_num() {
                                 boot_volume()
@@ -15015,7 +15031,7 @@ mod tests {
         cpu.write_reg(Register::A0, pb);
         bus.write_long(pb + 18, name_buf);
         bus.write_pstring(name_buf, b"Legend CD");
-        bus.write_word(pb + 22, 0x1234);
+        bus.write_word(pb + 22, 0);
         bus.write_word(pb + 28, 0); // ioVolIndex: lookup by name
 
         call(&mut disp, false, 0x07, &mut cpu, &mut bus).unwrap();
@@ -15080,6 +15096,12 @@ mod tests {
         call(&mut disp, false, 0x07, &mut cpu, &mut bus).unwrap();
         assert_eq!(cpu.read_reg(Register::D0) as i32, 0);
         assert_eq!(bus.read_word(pb + 22), volume_ref as u16);
+        assert_eq!(bus.read_pstring(name_buf), b"Reference Disk");
+
+        bus.write_pstring(name_buf, b"stale output buffer");
+        bus.write_word(pb + 22, volume_ref as u16);
+        call(&mut disp, false, 0x07, &mut cpu, &mut bus).unwrap();
+        assert_eq!(cpu.read_reg(Register::D0) as i32, 0);
         assert_eq!(bus.read_pstring(name_buf), b"Reference Disk");
 
         bus.write_pstring(name_buf, b"Missing Disk");


### PR DESCRIPTION
## Summary

- defer ordinary resource payloads until requested and reserve direct-loaded application image ranges without discarding lower heap space
- load embedded PowerPC CFM library fragments, complete the application initializer transition, and add the late-classic APIs required by universal applications
- correct `PBHGetVInfo` volume-reference precedence and add the Display Manager compatibility used by the 68K slice
- update to `ppc` 0.4.0 for PowerPC time-base reads

## Validation

- `cargo build --all-targets --all-features`
- `cargo test --lib --features test-support` (3,782 passed, 3 ignored)
- `cargo check --no-default-features`
- `RUSTDOCFLAGS='-D warnings -D rustdoc::private_intra_doc_links' cargo doc --all-features --locked --no-deps --document-private-items`
- `cargo publish --locked --dry-run`
- PowerPC launch reaches and renders the complete title artwork
- 68K launch initializes File Tool, scans the full data set, and renders the publisher splash

Closes #658.
Closes #659.