### PR TITLE
perf(runner): budget idle-cycle probes per site and tick; cap the journal

### DIFF
--- a/src/memory/bus.rs
+++ b/src/memory/bus.rs
@@ -491,7 +491,21 @@ pub struct MacMemoryBus {
     /// An out-of-range write makes the probe unverifiable even though the
     /// normal bus retains its legacy warn-and-ignore behavior.
     write_probe_invalid: bool,
+    /// The journal outgrew [`WRITE_PROBE_MAX_ENTRIES`] and was dropped: the
+    /// probed cycle was doing work, not waiting. Sticky until the runner
+    /// takes it, so the verdict survives the journal's disappearance.
+    write_probe_overflowed: bool,
 }
+
+/// An exact-state probe journals the bytes an idle cycle writes: a spilled
+/// register or two, an event record, a saved keymap -- tens of bytes, a few
+/// hundred at most. A journal past this many distinct addresses is not
+/// watching a wait; it is watching real work, and while it stays open every
+/// guest store pays a hash insert and fastmem is suspended for the whole
+/// core. Past the cap the probe is voided on the spot so normal fast paths
+/// resume immediately, and the runner backs off from that site for the rest
+/// of the tick.
+pub(crate) const WRITE_PROBE_MAX_ENTRIES: usize = 4096;
 
 /// RAM storage - either owned vector or borrowed slice
 enum RamStorage {
@@ -875,6 +889,7 @@ impl MacMemoryBus {
             alloc_bucket_sizes: HashMap::new(),
             write_probe_original: None,
             write_probe_invalid: false,
+            write_probe_overflowed: false,
         };
         bus.write_word(super::globals::addr::ROM85, 0x7FFF);
 
@@ -966,6 +981,7 @@ impl MacMemoryBus {
             alloc_bucket_sizes: HashMap::new(),
             write_probe_original: None,
             write_probe_invalid: false,
+            write_probe_overflowed: false,
         }
     }
 
@@ -974,12 +990,20 @@ impl MacMemoryBus {
     pub(crate) fn begin_write_probe(&mut self) {
         self.write_probe_original = Some(HashMap::new());
         self.write_probe_invalid = false;
+        self.write_probe_overflowed = false;
     }
 
     /// Discard an incomplete write probe and restore normal fast-memory use.
     pub(crate) fn cancel_write_probe(&mut self) {
         self.write_probe_original = None;
         self.write_probe_invalid = false;
+        self.write_probe_overflowed = false;
+    }
+
+    /// Report -- and clear -- whether the most recent probe's journal
+    /// overflowed [`WRITE_PROBE_MAX_ENTRIES`] and was dropped.
+    pub(crate) fn take_write_probe_overflow(&mut self) -> bool {
+        std::mem::take(&mut self.write_probe_overflowed)
     }
 
     /// Finish a write probe and report whether guest RAM is byte-for-byte
@@ -993,6 +1017,7 @@ impl MacMemoryBus {
                 .into_iter()
                 .all(|(address, value)| self.ram.get_in_bounds(address as usize) == value);
         self.write_probe_invalid = false;
+        self.write_probe_overflowed = false;
         unchanged
     }
 
@@ -1006,11 +1031,17 @@ impl MacMemoryBus {
             return;
         }
         let original = self.ram.get_in_bounds(address as usize);
-        self.write_probe_original
+        let journal = self
+            .write_probe_original
             .as_mut()
-            .expect("write probe checked above")
-            .entry(address)
-            .or_insert(original);
+            .expect("write probe checked above");
+        journal.entry(address).or_insert(original);
+        if journal.len() > WRITE_PROBE_MAX_ENTRIES {
+            // Too much written for a wait cycle: void the probe now so the
+            // fast paths (and fastmem) come back for the work in progress.
+            self.write_probe_original = None;
+            self.write_probe_overflowed = true;
+        }
     }
 
     /// Allocate memory from heap.
@@ -1940,6 +1971,42 @@ mod tests {
         bus.write_byte(0x102, 0xCC);
 
         assert!(!bus.finish_write_probe_unchanged());
+    }
+
+    #[test]
+    fn write_probe_overflow_voids_the_journal_and_restores_fast_paths() {
+        let mut bus = MacMemoryBus::new(64 * 1024);
+
+        bus.begin_write_probe();
+        assert!(bus.fast_mem_window().is_none());
+        // Restore-perfect writes to as many distinct addresses as the cap
+        // admits keep the probe alive and verifiable...
+        for address in 0..WRITE_PROBE_MAX_ENTRIES as u32 {
+            bus.write_byte(0x1000 + address, 0);
+        }
+        assert!(bus.fast_mem_window().is_none());
+        assert!(!bus.take_write_probe_overflow());
+        // ...one more distinct address is more than a wait cycle writes:
+        // the journal is dropped on the spot, the fast paths (and fastmem)
+        // return, and the probe can no longer verify.
+        bus.write_byte(0x1000 + WRITE_PROBE_MAX_ENTRIES as u32, 0);
+        assert!(bus.fast_mem_window().is_some());
+        assert!(!bus.finish_write_probe_unchanged());
+        assert!(bus.take_write_probe_overflow());
+        assert!(
+            !bus.take_write_probe_overflow(),
+            "the overflow verdict is consumed once"
+        );
+
+        // Rewriting one address many times is one journal entry, not many.
+        bus.begin_write_probe();
+        for _ in 0..(4 * WRITE_PROBE_MAX_ENTRIES) {
+            bus.write_long(0x2000, 0x1234_5678);
+        }
+        assert!(bus.fast_mem_window().is_none());
+        bus.write_long(0x2000, 0);
+        assert!(bus.finish_write_probe_unchanged());
+        assert!(!bus.take_write_probe_overflow());
     }
 
     #[test]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -927,6 +927,7 @@ static WS_FAIL_MEM: AtomicU64 = AtomicU64::new(0);
 static WS_CANCEL_TRAP: AtomicU64 = AtomicU64::new(0);
 static WS_PARKED: AtomicU64 = AtomicU64::new(0);
 static WS_PERIOD_STEPS: AtomicU64 = AtomicU64::new(0);
+static WS_PROBE_OVERFLOWS: AtomicU64 = AtomicU64::new(0);
 static WS_CANCEL_TRAP_WORDS: std::sync::Mutex<Option<std::collections::BTreeMap<u16, u64>>> =
     std::sync::Mutex::new(None);
 
@@ -949,9 +950,10 @@ pub fn dump_wait_stats() {
         return;
     }
     eprintln!(
-        "[WAIT-STATS] anchor_calls={} probe_starts={} exact_repeats={} parked={} period_steps={} fail_tick={} fail_cpu={} fail_mem={} cancel_trap={}",
+        "[WAIT-STATS] anchor_calls={} probe_starts={} probe_overflows={} exact_repeats={} parked={} period_steps={} fail_tick={} fail_cpu={} fail_mem={} cancel_trap={}",
         WS_ANCHOR_CALLS.load(AtomicOrdering::Relaxed),
         WS_PROBE_STARTS.load(AtomicOrdering::Relaxed),
+        WS_PROBE_OVERFLOWS.load(AtomicOrdering::Relaxed),
         WS_EXACT_REPEATS.load(AtomicOrdering::Relaxed),
         WS_PARKED.load(AtomicOrdering::Relaxed),
         WS_PERIOD_STEPS.load(AtomicOrdering::Relaxed),
@@ -1301,6 +1303,17 @@ struct IdleCycleProbe {
 /// covers the measured EV Override crawl; 4 leaves headroom without
 /// letting genuinely progressing loops hold a write journal open long.
 const IDLE_CYCLE_MAX_PERIOD: u8 = 4;
+
+/// Probes the prover will start at one poll site within one tick. A genuine
+/// wait proves on its first probe (or its second, when the loop's first
+/// iteration still carries setup); a site whose probes keep failing on
+/// changed memory or CPU state is polling while it works. Without a budget
+/// such a site re-arms a fresh write journal on every arrival -- EV
+/// Override's boot started 928,781 probes in 17 s, 926,295 of them failing
+/// on memory -- and each journal costs a hash insert per store plus fastmem
+/// withdrawn for the whole core. Past the budget the site is left alone
+/// until the tick changes.
+const IDLE_CYCLE_MAX_PROBES_PER_TICK: u8 = 2;
 
 /// Host-side Event Manager inputs that are not stored in guest RAM. A proven
 /// idle cycle may remain parked across frontend calls only while these inputs
@@ -1712,6 +1725,12 @@ pub struct FixtureRunner {
     /// direct fast-memory stores until this call site repeats or the proof is
     /// canceled by a non-quiescent trap.
     idle_cycle_probe: Option<IdleCycleProbe>,
+    /// Probes started at (site, tick) so far; one past
+    /// [`IDLE_CYCLE_MAX_PROBES_PER_TICK`] means the site was refused a probe
+    /// (or overflowed a journal): it is polling while it works (EV
+    /// Override's boot and speed calibration poll TickCount between bursts
+    /// of computation) and is not re-probed until the tick moves on.
+    idle_cycle_site_probes: Option<(u32, u32, u8)>,
     /// Proven null-event cycle parked at its post-trap boundary. Unlike an
     /// in-progress proof, this may cross frontend slices: a second write
     /// journal plus CPU/input/event checks revoke it before any reuse.
@@ -1906,6 +1925,7 @@ impl FixtureRunner {
             tick_budget: INSTRUCTIONS_PER_TICK as i32,
             idle_cycle_last_seen: None,
             idle_cycle_probe: None,
+            idle_cycle_site_probes: None,
             idle_cycle_sleep: None,
             frozen_ticks: None,
             timer_trampoline: 0,
@@ -4077,7 +4097,34 @@ impl FixtureRunner {
         self.idle_cycle_sleep = None;
     }
 
+    /// True once (site, tick) has been refused a probe -- or overflowed a
+    /// journal -- this tick: the count sits one past the budget.
+    fn idle_cycle_site_is_busy(&self, trap_pc: u32, tick: u32) -> bool {
+        matches!(
+            self.idle_cycle_site_probes,
+            Some((site, site_tick, probes))
+                if site == trap_pc && site_tick == tick && probes > IDLE_CYCLE_MAX_PROBES_PER_TICK
+        )
+    }
+
+    /// Mark (site, tick) busy for the rest of the tick: it works between polls.
+    fn mark_idle_cycle_site_busy(&mut self, trap_pc: u32, tick: u32) {
+        self.idle_cycle_site_probes = Some((trap_pc, tick, IDLE_CYCLE_MAX_PROBES_PER_TICK + 1));
+        self.idle_cycle_last_seen = None;
+    }
+
     fn begin_idle_cycle_probe(&mut self, trap_pc: u32, tick: u32, cpu: CpuArchitecturalSnapshot) {
+        let probes = match self.idle_cycle_site_probes {
+            Some((site, site_tick, probes)) if site == trap_pc && site_tick == tick => probes,
+            _ => 0,
+        };
+        if probes >= IDLE_CYCLE_MAX_PROBES_PER_TICK {
+            // Budget spent: this site keeps failing to prove within the
+            // tick, so it is working, not waiting. No journal.
+            self.mark_idle_cycle_site_busy(trap_pc, tick);
+            return;
+        }
+        self.idle_cycle_site_probes = Some((trap_pc, tick, probes + 1));
         if wait_stats_enabled() {
             WS_PROBE_STARTS.fetch_add(1, AtomicOrdering::Relaxed);
         }
@@ -4210,9 +4257,25 @@ impl FixtureRunner {
         tick_cap: Option<u32>,
     ) -> bool {
         let tick = self.dispatcher.tick_count;
+        if self.idle_cycle_site_is_busy(trap_pc, tick) {
+            // This site spent its probe budget (or overflowed a journal)
+            // this tick: it is working between polls, not waiting.
+            return false;
+        }
         let cpu = CpuArchitecturalSnapshot::capture(&self.cpu.core);
 
         if let Some(probe) = self.idle_cycle_probe.take() {
+            if self.bus.take_write_probe_overflow() {
+                // The journal blew past its cap since the probe began, so
+                // this cycle did real work. The bus already dropped the
+                // journal and restored its fast paths; drop the observation
+                // too and back off from the site until the tick changes.
+                if wait_stats_enabled() {
+                    WS_PROBE_OVERFLOWS.fetch_add(1, AtomicOrdering::Relaxed);
+                }
+                self.mark_idle_cycle_site_busy(probe.trap_pc, probe.tick);
+                return false;
+            }
             let same_site_tick = probe.trap_pc == trap_pc && probe.tick == tick;
             if same_site_tick && probe.cpu == cpu {
                 // A cycle of whatever small period closed on its origin
@@ -16146,6 +16209,107 @@ mod tests {
         assert_eq!(runner.dispatcher.tick_count, 110);
         assert!(runner.idle_cycle_sleep.is_none());
         assert!(runner.bus.fast_mem_window().is_some());
+    }
+
+    #[test]
+    fn busy_poller_overflows_one_journal_then_backs_off_for_the_tick() {
+        // EV Override's boot and speed calibration poll TickCount between
+        // bursts of real work. Such a site must cost at most one capped
+        // journal per tick, never a journal that grows with the work.
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        let trap_pc = 0x0002_0000u32;
+        let work = 0x0030_0000u32;
+        runner.cpu.write_reg(Register::A7, 0x0010_0000);
+        runner.dispatcher.tick_count = 100;
+
+        assert!(!runner.try_exact_idle_cycle_fastfwd(trap_pc, 200, Some(105)));
+        assert!(!runner.try_exact_idle_cycle_fastfwd(trap_pc, 200, Some(105)));
+        assert!(runner.idle_cycle_probe.is_some());
+        assert!(runner.bus.fast_mem_window().is_none());
+
+        // The "cycle" writes far more than a wait ever does.
+        for offset in 0..(2 * crate::memory::bus::WRITE_PROBE_MAX_ENTRIES as u32) {
+            runner.bus.write_byte(work + offset, 0xAA);
+        }
+        assert!(
+            runner.bus.fast_mem_window().is_some(),
+            "the bus voids an overflowing journal immediately, without waiting for the runner"
+        );
+
+        // Back at the site: the observation is dropped and the site is
+        // marked busy for this tick, so later same-tick arrivals do not
+        // re-arm a journal that would only overflow again.
+        assert!(!runner.try_exact_idle_cycle_fastfwd(trap_pc, 200, Some(105)));
+        assert!(runner.idle_cycle_probe.is_none());
+        assert!(runner.idle_cycle_site_is_busy(trap_pc, 100));
+        for _ in 0..4 {
+            assert!(!runner.try_exact_idle_cycle_fastfwd(trap_pc, 200, Some(105)));
+            assert!(runner.idle_cycle_probe.is_none());
+            assert!(runner.bus.fast_mem_window().is_some());
+        }
+        assert_eq!(
+            runner.dispatcher.tick_count, 100,
+            "a busy site is never fast-forwarded"
+        );
+
+        // A new tick lifts the back-off: the site is observed afresh.
+        runner.dispatcher.tick_count = 101;
+        assert!(!runner.try_exact_idle_cycle_fastfwd(trap_pc, 200, Some(105)));
+        assert!(!runner.try_exact_idle_cycle_fastfwd(trap_pc, 200, Some(105)));
+        assert!(runner.idle_cycle_probe.is_some());
+        assert!(runner.bus.fast_mem_window().is_none());
+    }
+
+    #[test]
+    fn a_site_that_keeps_failing_gets_two_probes_per_tick_then_none() {
+        // The boot storm: EV Override started 928,781 probes in 17 s of
+        // boot, 926,295 failing on changed memory, because a failed probe
+        // was re-armed on the very next same-tick arrival. Now a site gets
+        // a first probe and one retry per tick, then nothing until the
+        // tick changes -- and every arrival in between costs no journal.
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        let trap_pc = 0x0002_0000u32;
+        let scratch = 0x0020_0000u32;
+        runner.cpu.write_reg(Register::A7, 0x0010_0000);
+        runner.dispatcher.tick_count = 100;
+
+        // Arrival 1: baseline. Arrival 2: probe #1 armed.
+        assert!(!runner.try_exact_idle_cycle_fastfwd(trap_pc, 200, Some(105)));
+        assert!(!runner.try_exact_idle_cycle_fastfwd(trap_pc, 200, Some(105)));
+        assert!(runner.idle_cycle_probe.is_some());
+        // Work that does not restore memory; arrival 3 fails on memory and
+        // re-arms once (probe #2).
+        runner.bus.write_long(scratch, 0x1111_1111);
+        assert!(!runner.try_exact_idle_cycle_fastfwd(trap_pc, 200, Some(105)));
+        assert!(runner.idle_cycle_probe.is_some(), "one retry is allowed");
+        assert!(runner.bus.fast_mem_window().is_none());
+        // More work; arrival 4 fails again: budget spent, no journal, and
+        // every later same-tick arrival is a plain return.
+        runner.bus.write_long(scratch, 0x2222_2222);
+        assert!(!runner.try_exact_idle_cycle_fastfwd(trap_pc, 200, Some(105)));
+        assert!(runner.idle_cycle_probe.is_none());
+        assert!(runner.bus.fast_mem_window().is_some());
+        for _ in 0..8 {
+            runner.bus.write_long(scratch, 0x3333_3333);
+            assert!(!runner.try_exact_idle_cycle_fastfwd(trap_pc, 200, Some(105)));
+            assert!(runner.idle_cycle_probe.is_none());
+            assert!(runner.bus.fast_mem_window().is_some());
+        }
+        assert_eq!(runner.dispatcher.tick_count, 100);
+
+        // Next tick: the site is observed afresh, and a cycle that now
+        // restores its writes proves and parks exactly as before.
+        runner.dispatcher.tick_count = 101;
+        runner.bus.write_long(0x016A, 101);
+        assert!(!runner.try_exact_idle_cycle_fastfwd(trap_pc, 200, Some(105)));
+        assert!(!runner.try_exact_idle_cycle_fastfwd(trap_pc, 200, Some(105)));
+        assert!(runner.idle_cycle_probe.is_some());
+        runner.bus.write_long(scratch, 0xAAAA_AAAA);
+        runner.bus.write_long(scratch, 0x3333_3333);
+        runner.note_idle_cycle_trap_result(0xA971);
+        assert!(runner.try_exact_idle_cycle_fastfwd(trap_pc, 200, Some(105)));
+        assert_eq!(runner.dispatcher.tick_count, 105);
+        assert!(runner.idle_cycle_sleep.is_some());
     }
 
     #[test]


### PR DESCRIPTION
From Claude Fable 5, working with @rlanday. One of three independent startup PRs (with #663 and #664); each stands alone.

## What

An exact-state idle-cycle probe (#138 / #644) journals the original value of every guest byte written between two same-tick visits to a poll site, so the proof can verify that a candidate wait cycle restored all of guest RAM. While a journal is open, every guest store loses its in-bounds fast path (`write_long` → `write_word` → `write_byte`, one hash insert per byte) and the m68k fastmem window is withdrawn for the whole core.

Two things made that expensive at sites that poll a journal-complete trap **between bursts of real work** — EV Override's boot and its "measuring the speed of your computer" calibration are exactly that shape:

1. **A failed probe was re-armed on the very next same-tick arrival.** Wait-stats over 17 s of EV Override boot on v0.16.0: `probe_starts=928,781`, `fail_mem=926,295` — ~55,000 fresh journals per second, each paying its `HashMap` growth and each suspending fastmem for the work that followed. (Aside: this is also where the "crawl residual `fail_mem` ≈ 929K" in the #644 discussion came from — those counters are cumulative from process start; it was the boot.)
2. **The journal had no size bound.**

**Fix.** Budget probes at two per (site, tick): a first probe and one retry — a loop whose first iteration still carries setup proves on the second — and past that the site is left alone until the tick changes. Cap the journal at 4,096 distinct addresses: past it the bus voids the probe on the spot (fast paths and fastmem return mid-burst) and the runner marks the site busy for the tick. A genuine wait proves on its first or second probe and writes tens of bytes, so neither bound can reject it; the crawl proof from #644 is untouched. Wait-stats gains `probe_overflows`.

## Evidence

Same 17 s boot, same binary lineage, wait-stats at close:

| | v0.16.0 | this PR |
|---|---|---|
| `anchor_calls` | 934,116 | 934,064 |
| `probe_starts` | **928,781** | **60** |
| `fail_mem` / `fail_cpu` | 926,295 / 1,243 | 30 / 30 |
| `probe_overflows` | – | 0 |

Instruments Time Profiler on the v0.16.0 baseline, from the first instruction: under `run_steps_internal`, `write_byte` towers of `hashbrown::raw::RawTable::reserve_rehash` (162 ms) + `hash_one` (46 ms) under `dispatch_move` alone, with parallel towers under the other store paths — plus the boot running without fastmem. With this PR those towers are gone from the profile.

Whole-boot effect is reported on the combined branch in #663's description (the three PRs together: instructions retired −33 % from launch to the registration dialog); this PR is the part that removes the journal churn and restores fastmem during boot.

## Tests

- Bus: restore-perfect writes up to the cap keep the probe verifiable; one more distinct address voids the journal on the spot, restores `fast_mem_window()`, makes `finish_write_probe_unchanged()` false, and reports the overflow exactly once; rewriting one address many times is one entry.
- Runner: a busy poller overflows one journal and is not re-probed for the rest of the tick; a site whose probes keep failing on memory gets exactly two per tick, then plain returns with fastmem available; the next tick re-probes and a genuine cycle proves and parks as before.
- Full lib suite passes (3,775).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M3pHH4jDhVuFn8ZeWwkKmA

