### PR TITLE
perf: decompress StuffIt forks on every core

### DIFF
--- a/src/game/launch.rs
+++ b/src/game/launch.rs
@@ -15,7 +15,7 @@ use crate::memory::MemoryBus;
 use crate::runner::{FixtureRunner, FixtureRunnerConfig};
 use std::io::{Cursor, Read};
 use std::path::Component;
-use stuffit::SitArchive;
+use stuffit::{SitArchive, SitEntry};
 
 const LEGACY_WEB_PACK_MAGIC: &[u8; 4] = b"KPK1";
 const WEB_PACK_MAGIC: &[u8; 4] = b"KPK2";
@@ -268,9 +268,71 @@ pub fn init_game(runner: &mut FixtureRunner, app: &LoadedApp) {
     }
 }
 
+/// Decompress the forks of every file entry, in archive order.
+///
+/// Fork decompression dominates a desktop launch -- EV Override's 10.8 MB
+/// SIT-5 archive costs ~1.5 s of arithmetic decoding on one core, 29% of the
+/// whole boot (Instruments, from first instruction) -- and every entry is
+/// independent: `SitEntry::decompressed_forks` takes `&self` and is
+/// documented for parallel use. Decode with one worker per available core,
+/// handing out entries through a shared counter so a few large forks cannot
+/// strand the other workers. Results (and the first error, if any) come back
+/// in entry order, so callers behave exactly as the sequential loop did. On
+/// wasm32 (no threads) and for single-entry archives this is the plain
+/// sequential loop.
+type DecodedForks = Vec<Result<(Vec<u8>, Vec<u8>), stuffit::SitError>>;
+fn decompress_file_entries(entries: &[&SitEntry]) -> DecodedForks {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let workers = std::thread::available_parallelism()
+            .map(|cores| cores.get())
+            .unwrap_or(1)
+            .min(entries.len());
+        if workers > 1 {
+            let next = std::sync::atomic::AtomicUsize::new(0);
+            let mut decoded: DecodedForks = Vec::with_capacity(entries.len());
+            decoded.resize_with(entries.len(), || Ok((Vec::new(), Vec::new())));
+            std::thread::scope(|scope| {
+                let handles: Vec<_> = (0..workers)
+                    .map(|_| {
+                        scope.spawn(|| {
+                            let mut local = Vec::new();
+                            loop {
+                                let index = next.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                                let Some(entry) = entries.get(index) else {
+                                    break;
+                                };
+                                local.push((index, entry.decompressed_forks()));
+                            }
+                            local
+                        })
+                    })
+                    .collect();
+                for handle in handles {
+                    for (index, result) in handle.join().expect("fork-decode worker panicked") {
+                        decoded[index] = result;
+                    }
+                }
+            });
+            return decoded;
+        }
+    }
+    entries
+        .iter()
+        .map(|entry| entry.decompressed_forks())
+        .collect()
+}
+
 fn load_stuffit(runner: &mut FixtureRunner, file_data: &[u8]) -> Result<LoadedApp, String> {
     let archive =
         SitArchive::parse(file_data).map_err(|e| format!("Failed to parse StuffIt: {:?}", e))?;
+
+    let file_entries: Vec<&SitEntry> = archive
+        .entries
+        .iter()
+        .filter(|entry| !entry.is_folder)
+        .collect();
+    let mut decoded = decompress_file_entries(&file_entries).into_iter();
 
     let mut executable_entry: Option<ExecutableCandidate> = None;
     let mut skipped_disk_image_errors = Vec::new();
@@ -283,8 +345,9 @@ fn load_stuffit(runner: &mut FixtureRunner, file_data: &[u8]) -> Result<LoadedAp
             continue;
         }
 
-        let (data, rsrc) = entry
-            .decompressed_forks()
+        let (data, rsrc) = decoded
+            .next()
+            .expect("one decoded fork pair per file entry")
             .map_err(|e| format!("Decompress error: {:?}", e))?;
 
         let payload = payload_from_forks(
@@ -2724,6 +2787,61 @@ fn read_u32_be(buf: &[u8], offset: &mut usize) -> Result<u32, String> {
 mod tests {
     use super::*;
     use std::io::Write;
+
+    #[test]
+    fn parallel_fork_decode_matches_the_sequential_loop() {
+        // Build a real SIT-5 archive whose forks exercise compressed and
+        // stored entries of assorted sizes; the parallel decode must return
+        // exactly what per-entry sequential decompression returns, in entry
+        // order, for every worker count the machine picks.
+        let mut archive = SitArchive::new();
+        for index in 0..17u32 {
+            let data: Vec<u8> = (0..(index * 977))
+                .map(|byte| (byte * 31 + index) as u8)
+                .collect();
+            let rsrc: Vec<u8> = (0..(index * 61)).map(|byte| (byte ^ index) as u8).collect();
+            archive.add_entry(SitEntry {
+                name: format!("file-{index}"),
+                data_fork: data,
+                resource_fork: rsrc,
+                file_type: *b"TEXT",
+                creator: *b"ttxt",
+                is_folder: false,
+                data_method: 0,
+                rsrc_method: 0,
+                data_ulen: 0,
+                rsrc_ulen: 0,
+                finder_flags: 0,
+                is_compressed: false,
+                format: stuffit::ArchiveFormat::Sit5,
+            });
+        }
+        let bytes = archive
+            .serialize_compressed()
+            .expect("serialize SIT-13 test archive");
+        let parsed = SitArchive::parse(&bytes).expect("re-parse test archive");
+        let entries: Vec<&SitEntry> = parsed
+            .entries
+            .iter()
+            .filter(|entry| !entry.is_folder)
+            .collect();
+        assert_eq!(entries.len(), 17);
+        assert!(
+            entries.iter().any(|entry| entry.is_compressed),
+            "test archive must exercise real decompression"
+        );
+
+        let parallel = decompress_file_entries(&entries);
+        for (entry, decoded) in entries.iter().zip(parallel) {
+            let sequential = entry.decompressed_forks().expect("sequential decode");
+            assert_eq!(
+                decoded.expect("parallel decode"),
+                sequential,
+                "entry {} must decode identically",
+                entry.name
+            );
+        }
+    }
 
     #[test]
     fn disk_image_payload_registers_a_read_only_file_manager_volume() {


### PR DESCRIPTION
From Claude Fable 5, working with @rlanday. One of three independent startup PRs (with #662 and #664); each stands alone.

## What

Fork decompression dominates a desktop launch: EV Override's 10.8 MB SIT-5 archive costs ~1.5 s of arithmetic decoding on one core — 29 % of the whole 5 s boot window in an Instruments trace taken from the first instruction — all of it serial, inside `load_stuffit`'s entry loop.

Every entry is independent (`SitEntry::decompressed_forks` takes `&self` and its doc comment says "designed to be called from parallel contexts"), so this PR decodes file entries with one scoped worker per available core. Workers pull entries through a shared atomic counter — so a few large forks cannot strand the other workers — and the results are consumed by the existing loop in archive order, first error included: callers observe exactly the sequential behavior. wasm32 (no threads) and single-entry archives keep the plain sequential path. Only `load_stuffit` changes; nested archives, BinHex payloads and web packs are untouched.

## Evidence

**Fixed-work headless load** (`--headless --max-instructions 1000 grand9.sit`: parse + decode + VFS insert + a bounded sliver of emulation), three runs per arm, binaries differing only in this change:

| arm | wall | user CPU |
|---|---|---|
| serial (v0.16.0) | 2.14–2.21 s | 2.05–2.10 s |
| parallel (this PR) | **1.04–1.10 s** | 2.14–2.34 s |

Wall −51 %. The user-CPU column is the honest cost: ~+8 % total cycles for coordination, spread across cores instead of serialized on the main thread. The floor is the largest single fork (one fork is one decode stream). Boot output is byte-identical: the headless boot screenshot at the same instruction count has the same MD5 on both binaries.

**Whole boot, GUI, all three startup PRs together** (this + #662 + #664 on one binary vs v0.16.0; launch to a fixed 25 s wall time — both arms are idle at the registration dialog well before that; `time -l` instructions retired, which is insensitive to machine load; interleaved pairs):

| | v0.16.0 | combined |
|---|---|---|
| instructions retired | 37.6–37.7 G | **25.2–25.3 G (−33 %)** |
| cycles | 21.1–21.2 G | 15.4–17.9 G |
| CPU (user) | 5.95–5.97 s | 4.24–5.33 s |

Three further pairs of total CPU at 25 s (`ps time`): 6.04→5.32, 6.70→6.03, 8.69→6.01 s. Ryan's Instruments run of an earlier combined build showed the decode leaving the main thread's critical path (main-thread decode 800 ms → 0; workers 2.2 s total).

Decoding itself is being made cheaper upstream in benletchford/stuffit-rs#21 (−16 % instructions on this archive); that lands here through a dependency bump and composes with this change.

## Tests

The equivalence test builds a real SIT-13 archive (17 entries of assorted sizes, exercising genuine decompression), re-parses it, and requires the parallel decode to match per-entry sequential decompression byte for byte, in order. Full lib suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M3pHH4jDhVuFn8ZeWwkKmA

