### PR TITLE
perf(shapes): fill, erase and invert rectangles a row at a time on 1-bit and 8-bit ports

### DIFF
--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -25775,6 +25775,221 @@ mod tests {
         );
     }
 
+    /// InvertRect on an 8bpp port: a 16x6 buffer of distinct pixels, the
+    /// rect (1,2)-(5,14), and either a rectangular clipRgn (3,4)-(5,10)
+    /// (row path) or the same box notched at row 4, columns 6-7 (per-pixel
+    /// path). Returns the buffer after the call.
+    fn invert_rect_8bpp(notched_clip: bool) -> Vec<u8> {
+        let (mut d, mut cpu, mut bus) = setup();
+        let base = bus.alloc(16 * 6);
+        for offset in 0..(16 * 6) as u32 {
+            bus.write_byte(base + offset, (offset * 7 + 3) as u8);
+        }
+        let ctab = make_test_ctab_handle(
+            &mut bus,
+            &TrapDispatcher::standard_mac_8bpp_clut(),
+            0x1234,
+            0,
+        );
+        let pixmap_handle = bus.alloc(4);
+        let pixmap_ptr = bus.alloc(50);
+        bus.write_long(pixmap_handle, pixmap_ptr);
+        write_pixmap_8(&mut bus, pixmap_ptr, base, 16, 6, ctab);
+
+        let port = bus.alloc(96);
+        bus.write_long(port + 2, pixmap_handle);
+        bus.write_word(port + 6, 0xC000);
+        write_rect(&mut bus, port + 16, 0, 0, 6, 16);
+        let vis = make_complex_rgn(&mut bus, (0, 0, 6, 16), &[]);
+        let clip = if notched_clip {
+            make_complex_rgn(
+                &mut bus,
+                (3, 4, 5, 10),
+                &[
+                    3,
+                    4,
+                    10,
+                    super::REGION_STOP,
+                    4,
+                    6,
+                    8,
+                    super::REGION_STOP,
+                    super::REGION_STOP,
+                ],
+            )
+        } else {
+            make_complex_rgn(&mut bus, (3, 4, 5, 10), &[])
+        };
+        bus.write_long(port + 24, vis);
+        bus.write_long(port + 28, clip);
+        d.set_current_port_state(&mut bus, &mut cpu, port, None);
+
+        let rect = Rect {
+            top: 1,
+            left: 2,
+            bottom: 5,
+            right: 14,
+        };
+        d.draw_rect(&mut cpu, &mut bus, &rect, ShapeOp::Invert);
+        bus.read_bytes(base, 16 * 6)
+    }
+
+    #[test]
+    fn invertrect_8bpp_rows_invert_exactly_inside_the_clip_and_match_the_pixel_path() {
+        let original: Vec<u8> = (0..(16 * 6) as u32).map(|o| (o * 7 + 3) as u8).collect();
+        let rows = invert_rect_8bpp(false);
+        for y in 0..6usize {
+            for x in 0..16usize {
+                let inside = (3..5).contains(&y) && (4..10).contains(&x);
+                let expected = if inside {
+                    255 - original[y * 16 + x]
+                } else {
+                    original[y * 16 + x]
+                };
+                assert_eq!(rows[y * 16 + x], expected, "row path: pixel ({y}, {x})");
+            }
+        }
+        // The notched clip forces the per-pixel path; outside the notch the
+        // two paths must agree, and the notch must be left alone.
+        let pixels = invert_rect_8bpp(true);
+        for y in 0..6usize {
+            for x in 0..16usize {
+                let notch = y == 4 && (6..8).contains(&x);
+                let expected = if notch {
+                    original[y * 16 + x]
+                } else {
+                    rows[y * 16 + x]
+                };
+                assert_eq!(pixels[y * 16 + x], expected, "pixel path: pixel ({y}, {x})");
+            }
+        }
+    }
+
+    /// A basic (1bpp) GrafPort over a 40x6 bitmap (5 bytes per row) filled
+    /// with a distinct pattern; draws `op` on rect (1,3)-(5,29) -- partial
+    /// bytes at both ends and whole bytes between -- under a rectangular
+    /// clipRgn (2,5)-(5,27) (row path) or the same box notched at row 3,
+    /// columns 12-13 (per-pixel path; region rows are XOR deltas, so the
+    /// second [12,14] at row 4 closes the notch again). `pattern` sets
+    /// pnPat/bkPat.
+    fn draw_rect_1bpp(op: ShapeOp, pattern: [u8; 8], notched_clip: bool) -> Vec<u8> {
+        let (mut d, mut cpu, mut bus) = setup();
+        let base = bus.alloc(5 * 6);
+        for offset in 0..30u32 {
+            bus.write_byte(base + offset, (offset * 37 + 11) as u8);
+        }
+        let port = bus.alloc(96);
+        write_bitmap_1bpp(&mut bus, port + 2, base, 5, (0, 0, 6, 40));
+        write_rect(&mut bus, port + 16, 0, 0, 6, 40);
+        let vis = make_complex_rgn(&mut bus, (0, 0, 6, 40), &[]);
+        let clip = if notched_clip {
+            make_complex_rgn(
+                &mut bus,
+                (2, 5, 5, 27),
+                &[
+                    2,
+                    5,
+                    27,
+                    super::REGION_STOP,
+                    3,
+                    12,
+                    14,
+                    super::REGION_STOP,
+                    4,
+                    12,
+                    14,
+                    super::REGION_STOP,
+                    super::REGION_STOP,
+                ],
+            )
+        } else {
+            make_complex_rgn(&mut bus, (2, 5, 5, 27), &[])
+        };
+        bus.write_long(port + 24, vis);
+        bus.write_long(port + 28, clip);
+        d.set_current_port_state(&mut bus, &mut cpu, port, None);
+        d.pn_pat = pattern;
+        d.bk_pat = pattern;
+        d.pn_mode = 8; // srcCopy
+
+        let rect = Rect {
+            top: 1,
+            left: 3,
+            bottom: 5,
+            right: 29,
+        };
+        d.draw_rect(&mut cpu, &mut bus, &rect, op);
+        bus.read_bytes(base, 30)
+    }
+
+    fn bit_at(bits: &[u8], y: usize, x: usize) -> bool {
+        bits[y * 5 + x / 8] & (0x80 >> (x % 8)) != 0
+    }
+
+    #[test]
+    fn one_bit_rect_ops_run_by_row_exactly_inside_the_clip_and_match_the_pixel_path() {
+        let original: Vec<u8> = (0..30u32).map(|o| (o * 37 + 11) as u8).collect();
+        // (op, pattern, expected bit inside the clip as a function of the old bit)
+        type BitRule = fn(bool) -> bool;
+        let cases: [(&str, ShapeOp, [u8; 8], BitRule); 5] = [
+            ("invert", ShapeOp::Invert, [0xAA; 8], |old| !old),
+            ("erase black", ShapeOp::Erase, [0xFF; 8], |_| true),
+            ("erase white", ShapeOp::Erase, [0x00; 8], |_| false),
+            ("paint black", ShapeOp::Paint, [0xFF; 8], |_| true),
+            ("fill white", ShapeOp::Fill([0x00; 8]), [0x00; 8], |_| false),
+        ];
+        for (label, op, pattern, expected_bit) in cases {
+            let rows = draw_rect_1bpp(op, pattern, false);
+            for y in 0..6usize {
+                for x in 0..40usize {
+                    let inside = (2..5).contains(&y) && (5..27).contains(&x);
+                    let old = bit_at(&original, y, x);
+                    let expected = if inside { expected_bit(old) } else { old };
+                    assert_eq!(
+                        bit_at(&rows, y, x),
+                        expected,
+                        "{label} row path: pixel ({y}, {x})"
+                    );
+                }
+            }
+            // The notched clip forces the per-pixel arm; outside the notch
+            // the two paths must agree, and the notch stays as it was.
+            let pixels = draw_rect_1bpp(op, pattern, true);
+            for y in 0..6usize {
+                for x in 0..40usize {
+                    let notch = y == 3 && (12..14).contains(&x);
+                    let expected = if notch {
+                        bit_at(&original, y, x)
+                    } else {
+                        bit_at(&rows, y, x)
+                    };
+                    assert_eq!(
+                        bit_at(&pixels, y, x),
+                        expected,
+                        "{label} pixel path: pixel ({y}, {x})"
+                    );
+                }
+            }
+        }
+        // A dithered pattern is not a row op: erase must leave the row path
+        // and reproduce the pattern per pixel (bit set where the pattern is).
+        let dithered = draw_rect_1bpp(
+            ShapeOp::Erase,
+            [0xAA, 0x55, 0xAA, 0x55, 0xAA, 0x55, 0xAA, 0x55],
+            false,
+        );
+        for y in 2..5usize {
+            for x in 5..27usize {
+                let pattern_bit = [0xAAu8, 0x55][y % 2] & (0x80 >> (x % 8)) != 0;
+                assert_eq!(
+                    bit_at(&dithered, y, x),
+                    pattern_bit,
+                    "dithered erase: pixel ({y}, {x})"
+                );
+            }
+        }
+    }
+
     #[test]
     fn drawrect_honors_complex_current_port_clip_region_on_8bpp_fast_fill() {
         let (mut d, mut cpu, mut bus) = setup();

--- a/src/trap/shapes.rs
+++ b/src/trap/shapes.rs
@@ -218,6 +218,74 @@ fn normalize_boolean_transfer_mode(mode: i16) -> i16 {
     }
 }
 
+/// What a whole-row 1bpp operation does to every bit of the clipped rect.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum BitRowOp {
+    Set,
+    Clear,
+    Toggle,
+}
+
+/// A solid all-black pattern sets every bit and a solid all-white pattern
+/// clears every bit (`apply_boolean_transfer_1` in srcCopy: the result is
+/// the source bit); anything else needs the per-pixel pattern lookup.
+fn solid_bit_row_op(pattern: [u8; 8]) -> Option<BitRowOp> {
+    if pattern == [0xFF; 8] {
+        Some(BitRowOp::Set)
+    } else if pattern == [0x00; 8] {
+        Some(BitRowOp::Clear)
+    } else {
+        None
+    }
+}
+
+/// Apply `op` to bits `first_bit..end_bit` (MSB-first, as QuickDraw packs
+/// them) of the 1bpp row at `row_base`: masked read-modify-write of the two
+/// edge bytes, one bulk write for the whole bytes between.
+fn apply_bit_row_op(
+    bus: &mut MacMemoryBus,
+    row_base: u32,
+    first_bit: u32,
+    end_bit: u32,
+    op: BitRowOp,
+) {
+    debug_assert!(first_bit < end_bit);
+    let first_byte = first_bit / 8;
+    let last_byte = (end_bit - 1) / 8;
+    let head_mask = 0xFFu8 >> (first_bit % 8);
+    let tail_mask = 0xFFu8 << (7 - ((end_bit - 1) % 8));
+    let apply = |old: u8, mask: u8| match op {
+        BitRowOp::Set => old | mask,
+        BitRowOp::Clear => old & !mask,
+        BitRowOp::Toggle => old ^ mask,
+    };
+    if first_byte == last_byte {
+        let addr = row_base + first_byte;
+        bus.write_byte(addr, apply(bus.read_byte(addr), head_mask & tail_mask));
+        return;
+    }
+    let head_addr = row_base + first_byte;
+    bus.write_byte(head_addr, apply(bus.read_byte(head_addr), head_mask));
+    let middle = last_byte - first_byte - 1;
+    if middle > 0 {
+        let middle_addr = head_addr + 1;
+        match op {
+            BitRowOp::Set => bus.fill_bytes(middle_addr, middle, 0xFF),
+            BitRowOp::Clear => bus.fill_bytes(middle_addr, middle, 0x00),
+            BitRowOp::Toggle => {
+                let mut row = vec![0u8; middle as usize];
+                bus.read_bytes_into(middle_addr, &mut row);
+                for byte in row.iter_mut() {
+                    *byte = !*byte;
+                }
+                bus.write_bytes(middle_addr, &row);
+            }
+        }
+    }
+    let tail_addr = row_base + last_byte;
+    bus.write_byte(tail_addr, apply(bus.read_byte(tail_addr), tail_mask));
+}
+
 fn invert_indexed_pixel(old: u8) -> u8 {
     255 - old
 }
@@ -1430,13 +1498,19 @@ impl super::TrapDispatcher {
             && !has_complex_port_clip
             && installed_raw_pixpat.is_none()
         {
-            if let Some(fill_idx) = self.solid_src_copy_fill_index(
+            // Whole-row 8bpp paths: a solid srcCopy fill writes one prepared
+            // row per scanline; InvertRect maps each row through `255 - x`
+            // (exactly `invert_indexed_pixel`, applied per pixel below) --
+            // both instead of one bus round trip per pixel.
+            let solid_fill_idx = self.solid_src_copy_fill_index(
                 &op,
                 fg_idx,
                 bg_idx,
                 effective_pn_pat,
                 effective_bk_pat,
-            ) {
+            );
+            let invert_rows = matches!(op, ShapeOp::Invert);
+            if solid_fill_idx.is_some() || invert_rows {
                 let top = r.top.max(clip_top);
                 let left = r.left.max(clip_left);
                 let bottom = r.bottom.min(clip_bottom);
@@ -1445,10 +1519,17 @@ impl super::TrapDispatcher {
                     let dx = (left - bounds_left) as u32;
                     let width = (right - left) as u32;
                     if dx < pix_row_bytes && width <= pix_row_bytes.saturating_sub(dx) {
-                        let row = vec![fill_idx; width as usize];
+                        let mut row = vec![solid_fill_idx.unwrap_or(0); width as usize];
                         for y in top..bottom {
                             let dy = (y - bounds_top) as u32;
-                            bus.write_bytes(pix_base + dy * pix_row_bytes + dx, &row);
+                            let addr = pix_base + dy * pix_row_bytes + dx;
+                            if invert_rows {
+                                bus.read_bytes_into(addr, &mut row);
+                                for pixel in row.iter_mut() {
+                                    *pixel = invert_indexed_pixel(*pixel);
+                                }
+                            }
+                            bus.write_bytes(addr, &row);
                         }
                         let screen_rect = (
                             top.saturating_sub(bounds_top),
@@ -1465,6 +1546,54 @@ impl super::TrapDispatcher {
                         return;
                     }
                 }
+            }
+        }
+
+        // Whole-row 1bpp paths. On a monochrome port the per-pixel arm
+        // below reads and writes a byte per PIXEL; the ops that reduce to
+        // "set", "clear" or "toggle" every bit of the clipped rect --
+        // Erase with a solid pattern, srcCopy Paint/Fill with a solid
+        // pattern, and Invert (mode 2 with a black source, i.e. `!old`) --
+        // become masked writes at the two edge bytes and one bulk write in
+        // between, exactly what `apply_boolean_transfer_1` yields per pixel.
+        // EV Override clears its 1-bit offscreen buffers at boot with an
+        // EraseRect + InvertRect pair over 8.3 M pixels each.
+        if pixel_size == 1 && full_rect_coverage && !has_complex_port_clip {
+            let bit_op = match op {
+                ShapeOp::Invert => Some(BitRowOp::Toggle),
+                ShapeOp::Erase => solid_bit_row_op(self.bk_pat),
+                ShapeOp::Fill(pattern) => solid_bit_row_op(pattern),
+                ShapeOp::Paint if normalize_boolean_transfer_mode(self.pn_mode) == 0 => {
+                    solid_bit_row_op(self.pn_pat)
+                }
+                _ => None,
+            };
+            if let Some(bit_op) = bit_op {
+                let top = r.top.max(clip_top);
+                let left = r.left.max(clip_left);
+                let bottom = r.bottom.min(clip_bottom);
+                let right = r.right.min(clip_right);
+                if top < bottom && left < right {
+                    let first_bit = (left - bounds_left) as u32;
+                    // Pixels past the row's last byte are skipped, as the
+                    // per-pixel arm does.
+                    let end_bit = ((right - bounds_left) as u32).min(pix_row_bytes * 8);
+                    if first_bit < end_bit {
+                        for y in top..bottom {
+                            let row_base = pix_base + (y - bounds_top) as u32 * pix_row_bytes;
+                            apply_bit_row_op(bus, row_base, first_bit, end_bit, bit_op);
+                        }
+                    }
+                    let screen_rect = (
+                        top.saturating_sub(bounds_top),
+                        left.saturating_sub(bounds_left),
+                        bottom.saturating_sub(bounds_top),
+                        right.saturating_sub(bounds_left),
+                    );
+                    self.refresh_dialog_saved_pixels_after_screen_draw(bus, port, screen_rect);
+                    self.refresh_visible_dialog_snapshot_region_for_port(bus, port, screen_rect);
+                }
+                return;
             }
         }
 


### PR DESCRIPTION
From Claude Fable 5, working with @rlanday. Independent of #662/#663/#664 (same base); measured on top of them.

## What

`draw_generic_shape`'s per-pixel loop pays a coverage test, two clip tests and a bus read plus write per pixel. Two families of rectangle ops reduce to whole-row work but were still taking it:

- **1bpp (basic GrafPort) destinations** — every op did, and the bus is touched once per *pixel* there. Erase with a solid pattern, srcCopy Paint/Fill with a solid pattern, and Invert reduce to setting, clearing or toggling every bit of the clipped rect (exactly what `apply_boolean_transfer_1` yields per pixel), so they now run as masked read-modify-writes of the two edge bytes and one bulk write between (`fill_bytes`, or read-xor-write for Invert).
- **8bpp destinations** — the solid-fill row path already existed; it now also takes Invert (each row read, mapped through `invert_indexed_pixel`, written back — the same pure per-byte map the per-pixel arm applies).

Same guards as the existing row path: full-rect coverage, rectangular vis/clipRgn, no raw PixPat. Complex clips and patterned fills keep the per-pixel loop; pixels past a row's last byte are skipped as before.

**Why it matters for EV Override:** the game clears its 1-bit offscreen buffers at boot with an EraseRect + InvertRect pair — 107 calls each over 8.3 M pixels each (984×1152 and 750×816 ports among them; from a `SYSTEMLESS_TRACE_SHAPES_ALL` tally of one headless boot, cross-checked with a probe of the fast-path guards: all 107 inverts were `pixel_size=1`, full-rect, no complex clip). After #662/#663/#664, `draw_rect` was the largest QuickDraw item left on the boot's main thread in Ryan's Instruments run (309 ms inclusive of a 5 s window: 147 ms self + 84 ms `write_byte`).

## Evidence

Launch → fixed 25 s wall time (both arms idle at the registration dialog long before), `time -l` instructions retired / cycles (insensitive to machine load), three interleaved pairs, native-bundle re-exec suppressed so the launched pid is the process. Arms: `#662+#663+#664` vs the same plus this PR:

| | without | with this PR |
|---|---|---|
| instructions retired | 25.02–25.03 G | **22.35–22.40 G (−10.6 %)** |
| cycles | 14.1–14.9 G | 13.0–13.4 G |
| user CPU | 4.19–4.47 s | 3.70–4.00 s |

Every pair in the same direction. Cumulatively with the other three startup PRs, boot instructions v0.16.0 → here: 37.6 G → 22.4 G (−40 %).

## Tests

- 1bpp: an unaligned rect (partial bytes at both ends, whole bytes between) with each of the five ops under a rectangular clip (row path) and under the same box notched (per-pixel path): every bit inside the clip is the op's result, nothing outside changes, the two paths agree outside the notch, and a dithered pattern still reproduces per pixel. Mutation checks (each applied alone, test must fail — all did): dropped head mask, dropped tail mask, no-op toggle, wrong clear fill, dropped end-of-row clamp.
- 8bpp: InvertRect under a rectangular clip and under a notched one; the two paths agree; mutations (double inversion, ignored clip edge) fail it.
- Full lib suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M3pHH4jDhVuFn8ZeWwkKmA
