### PR TITLE
perf(text): stop re-scanning the colour table per glyph; iterate only the glyph box

### DIFF
--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -26171,6 +26171,87 @@ mod tests {
         }
     }
 
+    /// Draw `ch` in srcOr on an 8bpp CGrafPort at pen (30, 20) and return
+    /// the set of pixels that changed from the background, together with the
+    /// pixels the glyph bitmap says must be painted (the per-pixel arm's
+    /// rule: coverage at or above MONO_COVERAGE_THRESHOLD, placed at
+    /// pen + glyph origin).
+    fn plain_glyph_footprint(ch: char) -> (Vec<(i16, i16)>, Vec<(i16, i16)>) {
+        let (mut d, mut cpu, mut bus) = setup();
+        let base = bus.alloc(64 * 40);
+        for offset in 0..(64 * 40) as u32 {
+            bus.write_byte(base + offset, 5);
+        }
+        let ctab = make_test_ctab_handle(
+            &mut bus,
+            &TrapDispatcher::standard_mac_8bpp_clut(),
+            0x1234,
+            0,
+        );
+        let pixmap_handle = bus.alloc(4);
+        let pixmap_ptr = bus.alloc(50);
+        bus.write_long(pixmap_handle, pixmap_ptr);
+        write_pixmap_8(&mut bus, pixmap_ptr, base, 64, 40, ctab);
+        let port = bus.alloc(96);
+        bus.write_long(port + 2, pixmap_handle);
+        bus.write_word(port + 6, 0xC000);
+        write_rect(&mut bus, port + 16, 0, 0, 40, 64);
+        let vis = make_complex_rgn(&mut bus, (0, 0, 40, 64), &[]);
+        bus.write_long(port + 24, vis);
+        bus.write_long(port + 28, vis);
+        d.set_current_port_state(&mut bus, &mut cpu, port, None);
+        d.fg_color = (0, 0, 0);
+        d.tx_font = 0;
+        d.tx_size = 12;
+        d.tx_face = 0;
+        d.tx_mode = 1; // srcOr: only glyph pixels may change
+        d.pn_loc = (20, 30);
+        d.draw_char(&mut cpu, &mut bus, ch);
+
+        let mut changed = Vec::new();
+        for y in 0..40i16 {
+            for x in 0..64i16 {
+                if bus.read_byte(base + (y as u32) * 64 + x as u32) != 5 {
+                    changed.push((y, x));
+                }
+            }
+        }
+        let mut expected = Vec::new();
+        if let Some((glyph, data)) = crate::quickdraw::text::get_glyph(0, 12, ch) {
+            for row in 0..glyph.height as i16 {
+                for col in 0..glyph.width as i16 {
+                    let index =
+                        glyph.data_offset + row as usize * glyph.width as usize + col as usize;
+                    if data[index] >= crate::quickdraw::fonts::MONO_COVERAGE_THRESHOLD {
+                        expected.push((
+                            20 + glyph.origin_y as i16 + row,
+                            30 + glyph.origin_x as i16 + col,
+                        ));
+                    }
+                }
+            }
+        }
+        expected.sort();
+        (changed, expected)
+    }
+
+    #[test]
+    fn plain_glyphs_paint_exactly_their_bitmap_pixels() {
+        // Covers the tightened plain-glyph rect: every bitmap pixel (first
+        // and last rows and columns included) must be painted and nothing
+        // else may change, for an ascender, a descender and a space.
+        for ch in ['A', 'g', 'y', '.', ' '] {
+            let (changed, expected) = plain_glyph_footprint(ch);
+            assert_eq!(
+                changed, expected,
+                "glyph {ch:?}: painted pixels must equal the bitmap"
+            );
+            if ch != ' ' {
+                assert!(!expected.is_empty(), "glyph {ch:?} must have pixels");
+            }
+        }
+    }
+
     #[test]
     fn drawrect_honors_complex_current_port_clip_region_on_8bpp_fast_fill() {
         let (mut d, mut cpu, mut bus) = setup();

--- a/src/trap/shapes.rs
+++ b/src/trap/shapes.rs
@@ -139,7 +139,19 @@ fn indexed_shape_color_index(
     }
 }
 
+/// The RGB of the ColorSpec whose `value` field is `wanted_value`, if the
+/// table has one: the entry at that ordinal is tried first (index-addressed
+/// tables), then the table is scanned (device tables carry client IDs in
+/// `value`). The table is fetched into a local buffer with one bulk read;
+/// the scan used to issue a bus read per entry, and it runs for every shape.
 fn ctab_rgb_for_value(bus: &MacMemoryBus, ctab_handle: u32, wanted_value: u8) -> Option<[u16; 3]> {
+    let entries = ctab_entries(bus, ctab_handle)?;
+    ctab_entries_rgb_for_value(&entries, wanted_value)
+}
+
+/// The ColorSpec entries of a color table (8 bytes each: value, r, g, b),
+/// read in one bulk transfer.
+fn ctab_entries(bus: &MacMemoryBus, ctab_handle: u32) -> Option<Vec<u8>> {
     if ctab_handle == 0 {
         return None;
     }
@@ -147,34 +159,40 @@ fn ctab_rgb_for_value(bus: &MacMemoryBus, ctab_handle: u32, wanted_value: u8) ->
     if ctab == 0 {
         return None;
     }
-    let count = u32::from(bus.read_word(ctab + 6)).min(255) + 1;
-    let ordinal = u32::from(wanted_value);
-    if ordinal < count {
-        let entry = ctab + 8 + ordinal * 8;
-        if bus.read_word(entry) == u16::from(wanted_value) {
-            return Some([
-                bus.read_word(entry + 2),
-                bus.read_word(entry + 4),
-                bus.read_word(entry + 6),
-            ]);
+    let count = usize::from(bus.read_word(ctab + 6).min(255)) + 1;
+    let mut entries = vec![0u8; count * 8];
+    bus.read_bytes_into(ctab + 8, &mut entries);
+    Some(entries)
+}
+
+fn ctab_entries_rgb_for_value(entries: &[u8], wanted_value: u8) -> Option<[u16; 3]> {
+    let rgb = |entry: &[u8]| {
+        [
+            u16::from_be_bytes([entry[2], entry[3]]),
+            u16::from_be_bytes([entry[4], entry[5]]),
+            u16::from_be_bytes([entry[6], entry[7]]),
+        ]
+    };
+    let matches =
+        |entry: &[u8]| u16::from_be_bytes([entry[0], entry[1]]) == u16::from(wanted_value);
+    let ordinal = usize::from(wanted_value);
+    if let Some(entry) = entries.chunks_exact(8).nth(ordinal) {
+        if matches(entry) {
+            return Some(rgb(entry));
         }
     }
-    for ordinal in 0..count {
-        let entry = ctab + 8 + ordinal * 8;
-        if bus.read_word(entry) == u16::from(wanted_value) {
-            return Some([
-                bus.read_word(entry + 2),
-                bus.read_word(entry + 4),
-                bus.read_word(entry + 6),
-            ]);
-        }
-    }
-    None
+    entries
+        .chunks_exact(8)
+        .find(|entry| matches(entry))
+        .map(rgb)
 }
 
 fn ctab_uses_noncanonical_black(bus: &MacMemoryBus, ctab_handle: u32) -> bool {
-    ctab_rgb_for_value(bus, ctab_handle, 1) == Some([0, 0, 0])
-        && ctab_rgb_for_value(bus, ctab_handle, 255) != Some([0, 0, 0])
+    let Some(entries) = ctab_entries(bus, ctab_handle) else {
+        return false;
+    };
+    ctab_entries_rgb_for_value(&entries, 1) == Some([0, 0, 0])
+        && ctab_entries_rgb_for_value(&entries, 255) != Some([0, 0, 0])
 }
 
 fn trace_menu_probe_points() -> [(&'static str, i16, i16); 2] {
@@ -1929,10 +1947,85 @@ impl super::TrapDispatcher {
 #[cfg(test)]
 mod tests {
     use super::{
-        apply_boolean_transfer_1, apply_boolean_transfer_8, blend_rgb, fg_bg_low_contrast,
-        indexed_shape_color_index, lighten_stem_alpha, normalize_boolean_transfer_mode,
-        shape_palette_index_for_rgb,
+        apply_boolean_transfer_1, apply_boolean_transfer_8, blend_rgb, ctab_rgb_for_value,
+        ctab_uses_noncanonical_black, fg_bg_low_contrast, indexed_shape_color_index,
+        lighten_stem_alpha, normalize_boolean_transfer_mode, shape_palette_index_for_rgb,
     };
+    use crate::memory::{MacMemoryBus, MemoryBus};
+
+    /// Write a ColorTable at `ctab` (handle at `handle`) with the given
+    /// (value, rgb) ColorSpecs; `device` sets ctFlags' device bit.
+    fn write_ctab(
+        bus: &mut MacMemoryBus,
+        handle: u32,
+        ctab: u32,
+        device: bool,
+        specs: &[(u16, [u16; 3])],
+    ) {
+        bus.write_long(handle, ctab);
+        bus.write_long(ctab, 0x1234_5678); // ctSeed
+        bus.write_word(ctab + 4, if device { 0x8000 } else { 0 });
+        bus.write_word(ctab + 6, (specs.len() - 1) as u16);
+        for (i, (value, rgb)) in specs.iter().enumerate() {
+            let entry = ctab + 8 + i as u32 * 8;
+            bus.write_word(entry, *value);
+            bus.write_word(entry + 2, rgb[0]);
+            bus.write_word(entry + 4, rgb[1]);
+            bus.write_word(entry + 6, rgb[2]);
+        }
+    }
+
+    #[test]
+    fn ctab_lookups_find_values_by_ordinal_and_by_scan_and_detect_noncanonical_black() {
+        let mut bus = MacMemoryBus::new(64 * 1024);
+        // Index-addressed table: value == position, black at 255 (canonical).
+        let specs: Vec<(u16, [u16; 3])> = (0..=255u16)
+            .map(|v| {
+                (
+                    v,
+                    if v == 255 {
+                        [0, 0, 0]
+                    } else {
+                        [v * 100, 0x1000, 0x2000]
+                    },
+                )
+            })
+            .collect();
+        write_ctab(&mut bus, 0x1000, 0x2000, false, &specs);
+        assert_eq!(
+            ctab_rgb_for_value(&bus, 0x1000, 7),
+            Some([700, 0x1000, 0x2000])
+        );
+        assert_eq!(ctab_rgb_for_value(&bus, 0x1000, 255), Some([0, 0, 0]));
+        assert!(!ctab_uses_noncanonical_black(&bus, 0x1000));
+
+        // Device table with client IDs in `value` (out of order): the ordinal
+        // shortcut misses and the scan must find them; black lives at value 1.
+        let specs = [
+            (5u16, [0x0100u16, 0x0200, 0x0300]),
+            (1, [0, 0, 0]),
+            (255, [0xFFFF, 0xFFFF, 0xFFFF]),
+            (2, [0x0400, 0x0500, 0x0600]),
+        ];
+        write_ctab(&mut bus, 0x3000, 0x4000, true, &specs);
+        assert_eq!(
+            ctab_rgb_for_value(&bus, 0x3000, 2),
+            Some([0x0400, 0x0500, 0x0600])
+        );
+        assert_eq!(ctab_rgb_for_value(&bus, 0x3000, 1), Some([0, 0, 0]));
+        assert_eq!(
+            ctab_rgb_for_value(&bus, 0x3000, 255),
+            Some([0xFFFF, 0xFFFF, 0xFFFF])
+        );
+        assert_eq!(ctab_rgb_for_value(&bus, 0x3000, 9), None);
+        assert!(ctab_uses_noncanonical_black(&bus, 0x3000));
+
+        // Null handle / null table pointer.
+        assert_eq!(ctab_rgb_for_value(&bus, 0, 1), None);
+        bus.write_long(0x5000, 0);
+        assert_eq!(ctab_rgb_for_value(&bus, 0x5000, 1), None);
+        assert!(!ctab_uses_noncanonical_black(&bus, 0x5000));
+    }
 
     #[test]
     fn standard_4bit_gworld_shape_colors_use_the_rom_inverse_table() {

--- a/src/trap/text_render.rs
+++ b/src/trap/text_render.rs
@@ -780,11 +780,26 @@ impl super::TrapDispatcher {
                 bottom + style_pad
             };
 
-            let r = Rect {
-                top: draw_top,
-                left: draw_left,
-                bottom: draw_bottom,
-                right: draw_right,
+            let plain = !is_italic && !is_bold && !is_underline && !is_outline && !is_shadow;
+            let r = if plain {
+                // With no style effects the coverage closure below is
+                // non-zero only inside the glyph's own box; iterating the
+                // conservative advance/ascent rect visits the same painted
+                // pixels through several times as many zero-coverage
+                // evaluations (and a space glyph costs nothing).
+                Rect {
+                    top: glyph_visual_top,
+                    left,
+                    bottom: glyph_visual_bottom,
+                    right,
+                }
+            } else {
+                Rect {
+                    top: draw_top,
+                    left: draw_left,
+                    bottom: draw_bottom,
+                    right: draw_right,
+                }
             };
 
             if trace_dialog_text_enabled()


### PR DESCRIPTION
From Claude Fable 5, working with @rlanday.

## What

Text drawing was 13–18 % of the main thread in EV Override's crawl (and in flight windows that include takeoff/HUD text): in an Instruments run of the current master + the startup PRs, `draw_string` totalled 1.44 s over 65 s; in an 8 s `sample` window of the crawl, 573 of 1,619 main-thread ms. Almost none of it was drawing pixels (`write_byte`: 14 ms). Two things were:

1. **A colour-table scan per glyph.** Every shape's colour setup calls `ctab_uses_noncanonical_black` on the current GDevice's colour table (twice per glyph), and `ctab_rgb_for_value`'s fallback scan issued one bus `read_word` per entry — ~512 bus reads per character on a device table (~120 ms of the 573). It now reads the table into a local buffer once per lookup and scans that: identical semantics (ordinal shortcut, then scan), one bulk read.
2. **The glyph loop iterated the conservative draw rect** (advance × ascent-to-descent plus style padding) and evaluated the coverage closure stack at every pixel. With no style effects the closure is non-zero only inside the glyph's own box, so the plain case now iterates exactly that box (a space costs nothing). Styled text — italic/bold/underline/outline/shadow — keeps the full rect and closure stack unchanged.

## Evidence

Crawl, 8 s `sample` windows, main thread, base = master + #662–#668, three windows (two base sessions bracket the fix in time):

| | main active | `draw_string` incl | CLUT scan | text_render self |
|---|---|---|---|---|
| base | 1,617 / 1,511 ms | 573 / 545 | 119 / 113 | 376 / 338 |
| **this PR** | **1,455 ms** | **384 (−30 %)** | **0** | 248 |

Single windows resolve to about ±3 %; the two base windows differ by 7 % between themselves, so read the main-thread delta as roughly −5 to −10 % of the crawl's CPU and the text-cost delta (−30 %) as the reliable number.

## Tests

- `ctab_rgb_for_value` / `ctab_uses_noncanonical_black`: index-addressed table (ordinal hit), device table with client-ID values (scan), missing value, null handle and null table pointer.
- Glyph footprint: draws an ascender, a descender, punctuation and a space in srcOr on an 8bpp CGrafPort and requires the changed pixels to equal exactly the glyph bitmap's pixels (coverage ≥ threshold) at pen + origin — the suite previously had no test of glyph pixel output (dropping the top row of every glyph passed); mutations dropping the top row or the right column now fail.
- Full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M3pHH4jDhVuFn8ZeWwkKmA
