### PR TITLE
feat(cli): add --prefer-ppc alias

### DIFF
--- a/src/bin/systemless.rs
+++ b/src/bin/systemless.rs
@@ -135,7 +135,7 @@ struct Cli {
     max_instructions: Option<usize>,
 
     /// Prefer a native PowerPC slice when a classic 68K slice is also available
-    #[arg(long)]
+    #[arg(long, visible_alias = "prefer-ppc")]
     prefer_powerpc: bool,
 
     /// Start with classic 24-bit guest address translation
@@ -2629,6 +2629,14 @@ mod tests {
     }
 
     #[test]
+    fn cli_accepts_prefer_ppc_alias() {
+        let cli = Cli::try_parse_from(["systemless", "--prefer-ppc", "game.sit"])
+            .expect("PowerPC preference alias should parse");
+
+        assert!(cli.prefer_powerpc);
+    }
+
+    #[test]
     fn cli_generates_help_and_version() {
         let help =
             Cli::try_parse_from(["systemless", "--help"]).expect_err("--help should stop parsing");
@@ -2636,6 +2644,7 @@ mod tests {
             .expect_err("--version should stop parsing");
 
         assert_eq!(help.kind(), ErrorKind::DisplayHelp);
+        assert!(help.to_string().contains("[aliases: --prefer-ppc]"));
         assert_eq!(version.kind(), ErrorKind::DisplayVersion);
     }
 


### PR DESCRIPTION
## Summary

- expose `--prefer-ppc` as a visible alias for `--prefer-powerpc`
- verify the alias selects the existing PowerPC preference field
- verify generated help documents the alias

## Root cause

The CLI field only declared its automatically derived `--prefer-powerpc` long option, so Clap correctly rejected the common PPC abbreviation before the runner could launch.

## Validation

- `cargo test --bin systemless` (62 passed)
- `cargo test --bin systemless cli_` (6 passed)
- `cargo check --all-targets --all-features`
- generated `--help` includes `[aliases: --prefer-ppc]`
- `git diff --check`

The repository-wide `cargo fmt --all -- --check` currently reports pre-existing formatting drift in unrelated files under the local Rust 1.95 formatter; this PR does not modify those files.

Closes #670