### PR TITLE
fix: launch extended VISE PowerPC games

### DIFF
--- a/src/game/launch.rs
+++ b/src/game/launch.rs
@@ -2276,6 +2276,7 @@ fn maybe_select_executable_with_override(
         priority: executable_priority,
         creator,
         is_installer: is_installer_executable(name, creator),
+        is_documentation: is_documentation_executable(name),
         is_demo: executable_name_has_role(name, "demo"),
         version: executable_version(rsrc),
     };
@@ -2326,16 +2327,18 @@ struct ExecutableCandidate {
     priority: u8,
     creator: [u8; 4],
     is_installer: bool,
+    is_documentation: bool,
     is_demo: bool,
     version: Option<u32>,
 }
 
 impl ExecutableCandidate {
-    fn selection_key(&self) -> (u8, bool, bool, bool, bool, bool, bool, usize) {
+    fn selection_key(&self) -> (u8, bool, bool, bool, bool, bool, bool, bool, usize) {
         (
             self.priority,
             self.is_appl,
             !self.is_installer,
+            !self.is_documentation,
             !self.is_demo,
             !is_system_folder_path(&self.name),
             self.kind.is_powerpc(),
@@ -2421,6 +2424,20 @@ fn is_installer_executable(name: &str, creator: [u8; 4]) -> bool {
     ]
     .into_iter()
     .any(|role| executable_name_has_role(name, role))
+}
+
+fn is_documentation_executable(name: &str) -> bool {
+    let file_name = name.rsplit('/').next().unwrap_or(name).to_ascii_lowercase();
+    let words = file_name
+        .split(|character: char| !character.is_ascii_alphanumeric())
+        .filter(|word| !word.is_empty())
+        .collect::<Vec<_>>();
+    words.iter().any(|word| {
+        matches!(
+            *word,
+            "documentation" | "docs" | "help" | "manual" | "readme"
+        )
+    }) || words.windows(2).any(|words| words == ["read", "me"])
 }
 
 fn executable_name_has_role(name: &str, role: &str) -> bool {
@@ -3212,6 +3229,44 @@ mod tests {
     }
 
     #[test]
+    fn executable_selection_prefers_demo_game_over_documentation_app() {
+        let game_rsrc = make_single_resource_fork_bytes(*b"CODE", 0, &[0; 128]);
+        let docs_rsrc = make_single_resource_fork_bytes(*b"CODE", 0, &[0; 256]);
+
+        for docs_first in [false, true] {
+            let mut selected = None;
+            let mut candidates = [
+                ("Game Folder/Game Demo", &game_rsrc, 300_000usize),
+                (
+                    "Game Folder/Game Demo Documentation",
+                    &docs_rsrc,
+                    600_000usize,
+                ),
+            ];
+            if docs_first {
+                candidates.reverse();
+            }
+            for (name, rsrc, data_len) in candidates {
+                maybe_select_executable(
+                    &mut selected,
+                    name,
+                    &[0],
+                    rsrc,
+                    true,
+                    data_len,
+                    *b"GAME",
+                    1,
+                );
+            }
+
+            assert_eq!(
+                selected.expect("expected an executable candidate").name,
+                "Game Folder/Game Demo"
+            );
+        }
+    }
+
+    #[test]
     fn executable_selection_prefers_user_app_over_system_folder_utility() {
         let utility_rsrc = make_single_resource_fork_bytes(*b"CODE", 0, &[0; 256]);
         let game_rsrc = make_single_resource_fork_bytes(*b"CODE", 0, &[0; 128]);
@@ -3517,6 +3572,7 @@ mod tests {
             priority: 1,
             creator: *b"ABCD",
             is_installer: false,
+            is_documentation: false,
             is_demo: false,
             version: None,
         };
@@ -3552,6 +3608,7 @@ mod tests {
             priority: 1,
             creator: *b"ABCD",
             is_installer: false,
+            is_documentation: false,
             is_demo: false,
             version: None,
         };
@@ -3584,6 +3641,7 @@ mod tests {
             priority: 1,
             creator: *b"ABCD",
             is_installer: false,
+            is_documentation: false,
             is_demo: false,
             version: None,
         };

--- a/src/game/vise.rs
+++ b/src/game/vise.rs
@@ -17,8 +17,12 @@ const VISE_HEADER_LEN: usize = 44;
 const VISE_CATALOG_HEADER_LEN: usize = 20;
 const VISE_VERSION_35_LITE: u32 = 0x8001_0202;
 const VISE_VERSION_36_LITE: u32 = 0x8001_0300;
+const VISE_VERSION_EXTENDED_CATALOG: u32 = 0x8001_0307;
 const VISE_DIRECTORY_RECORD_LEN: usize = 78;
 const VISE_FILE_RECORD_LEN: usize = 120;
+const VISE_EXTENDED_CATALOG_PREFIX_LEN: usize = 80;
+const VISE_EXTENDED_DIRECTORY_SUFFIX_LEN: usize = 66;
+const VISE_EXTENDED_FILE_SUFFIX_LEN: usize = 62;
 
 // Installer VISE 3 archive layout and transform reference:
 // ScummVM `common/compression/vise.cpp`, GPL-3.0-or-later, as of
@@ -77,7 +81,10 @@ pub fn parse_vise(data: &[u8]) -> Option<Result<ViseArchive<'_>, String>> {
 fn parse_vise_result(data: &[u8]) -> Result<ViseArchive<'_>, String> {
     let header = range(data, 0, VISE_HEADER_LEN, "header")?;
     let version = read_u32(header, 16, "archive version")?;
-    if !matches!(version, VISE_VERSION_35_LITE | VISE_VERSION_36_LITE) {
+    if !matches!(
+        version,
+        VISE_VERSION_35_LITE | VISE_VERSION_36_LITE | VISE_VERSION_EXTENDED_CATALOG
+    ) {
         return Err(format!("unsupported archive version 0x{version:08X}"));
     }
 
@@ -95,6 +102,18 @@ fn parse_vise_result(data: &[u8]) -> Result<ViseArchive<'_>, String> {
     }
     let entry_count = read_u16(catalog, 16, "catalog entry count")? as usize;
     let mut cursor = catalog_offset + VISE_CATALOG_HEADER_LEN;
+    if version == VISE_VERSION_EXTENDED_CATALOG {
+        let prefix = range(
+            data,
+            cursor,
+            VISE_EXTENDED_CATALOG_PREFIX_LEN,
+            "extended catalog prefix",
+        )?;
+        if !prefix.starts_with(b"PACK") {
+            return Err("extended catalog is missing PACK prefix".to_string());
+        }
+        cursor += VISE_EXTENDED_CATALOG_PREFIX_LEN;
+    }
     let mut dirs = Vec::<ViseDirectory>::new();
     let mut entries = Vec::<ViseEntry<'_>>::new();
 
@@ -122,6 +141,14 @@ fn parse_vise_result(data: &[u8]) -> Result<ViseArchive<'_>, String> {
                 if version == VISE_VERSION_36_LITE {
                     range(data, cursor, 6, "VISE 3.6 directory extension")?;
                     cursor += 6;
+                } else if version == VISE_VERSION_EXTENDED_CATALOG {
+                    range(
+                        data,
+                        cursor,
+                        VISE_EXTENDED_DIRECTORY_SUFFIX_LEN,
+                        "extended directory suffix",
+                    )?;
+                    cursor += VISE_EXTENDED_DIRECTORY_SUFFIX_LEN;
                 }
                 let name = decode_catalog_name(data, &mut cursor, name_len, "directory name")?;
                 let path = child_path(&dirs, parent, &name, "directory")?;
@@ -147,6 +174,15 @@ fn parse_vise_result(data: &[u8]) -> Result<ViseArchive<'_>, String> {
                 file_type.copy_from_slice(&record[40..44]);
                 let mut creator = [0; 4];
                 creator.copy_from_slice(&record[44..48]);
+                if version == VISE_VERSION_EXTENDED_CATALOG {
+                    range(
+                        data,
+                        cursor,
+                        VISE_EXTENDED_FILE_SUFFIX_LEN,
+                        "extended file suffix",
+                    )?;
+                    cursor += VISE_EXTENDED_FILE_SUFFIX_LEN;
+                }
                 let name = decode_catalog_name(data, &mut cursor, name_len, "file name")?;
                 let path = child_path(&dirs, parent, &name, "file")?;
                 let data_packed = range(
@@ -172,7 +208,13 @@ fn parse_vise_result(data: &[u8]) -> Result<ViseArchive<'_>, String> {
                     rsrc_packed,
                     data_packed_offset: packed_offset,
                     rsrc_packed_offset: rsrc_offset,
-                    unpacked_offset,
+                    unpacked_offset: if version == VISE_VERSION_EXTENDED_CATALOG
+                        && unpacked_offset >= data_unpacked_len
+                    {
+                        0
+                    } else {
+                        unpacked_offset
+                    },
                     data_unpacked_len,
                     rsrc_unpacked_len,
                 });
@@ -696,6 +738,59 @@ mod tests {
         assert_eq!(
             decode_vise_fork(entry.rsrc_packed, entry.rsrc_unpacked_len).unwrap(),
             resource_fork
+        );
+    }
+
+    #[test]
+    fn parses_extended_catalog_records() {
+        let data_fork = b"extended catalog payload";
+        let packed_data = encode_vise_fork(data_fork);
+        let payload_offset = VISE_HEADER_LEN;
+        let catalog_offset = payload_offset + packed_data.len();
+        let mut archive = vec![0u8; VISE_HEADER_LEN];
+        archive[0..4].copy_from_slice(VISE_MAGIC);
+        archive[16..20].copy_from_slice(&VISE_VERSION_EXTENDED_CATALOG.to_be_bytes());
+        archive[36..40].copy_from_slice(&(catalog_offset as u32).to_be_bytes());
+        archive.extend_from_slice(&packed_data);
+
+        let mut catalog = [0u8; VISE_CATALOG_HEADER_LEN];
+        catalog[0..4].copy_from_slice(VISE_CATALOG_MAGIC);
+        catalog[16..18].copy_from_slice(&2u16.to_be_bytes());
+        archive.extend_from_slice(&catalog);
+        let mut prefix = [0u8; VISE_EXTENDED_CATALOG_PREFIX_LEN];
+        prefix[0..4].copy_from_slice(b"PACK");
+        archive.extend_from_slice(&prefix);
+
+        archive.extend_from_slice(b"DVCT");
+        let mut directory = [0u8; VISE_DIRECTORY_RECORD_LEN];
+        directory[76] = 4;
+        archive.extend_from_slice(&directory);
+        archive.extend_from_slice(&[0u8; VISE_EXTENDED_DIRECTORY_SUFFIX_LEN]);
+        archive.extend_from_slice(b"Game");
+
+        archive.extend_from_slice(b"FVCT");
+        let mut file = [0u8; VISE_FILE_RECORD_LEN];
+        file[40..44].copy_from_slice(b"APPL");
+        file[44..48].copy_from_slice(b"TEST");
+        file[64..68].copy_from_slice(&(packed_data.len() as u32).to_be_bytes());
+        file[68..72].copy_from_slice(&(data_fork.len() as u32).to_be_bytes());
+        file[92..94].copy_from_slice(&1u16.to_be_bytes());
+        file[96..100].copy_from_slice(&(payload_offset as u32).to_be_bytes());
+        file[100..104].copy_from_slice(&0xfffc_0000u32.to_be_bytes());
+        file[118] = 7;
+        archive.extend_from_slice(&file);
+        archive.extend_from_slice(&[0u8; VISE_EXTENDED_FILE_SUFFIX_LEN]);
+        archive.extend_from_slice(b"Runtime");
+
+        let parsed = parse_vise(&archive).unwrap().unwrap();
+        assert_eq!(parsed.dirs, ["Game"]);
+        assert_eq!(parsed.entries.len(), 1);
+        let entry = &parsed.entries[0];
+        assert_eq!(entry.path, "Game/Runtime");
+        assert_eq!(entry.unpacked_offset, 0);
+        assert_eq!(
+            decode_vise_fork(entry.data_packed, entry.data_unpacked_len).unwrap(),
+            data_fork
         );
     }
 

--- a/src/loader/ppc.rs
+++ b/src/loader/ppc.rs
@@ -262,6 +262,8 @@ const PPC_MAIN_VIS_RGN_HANDLE: u32 = 0x02f0_0b00;
 const PPC_MAIN_VIS_RGN: u32 = 0x02f0_0c00;
 const PPC_MAIN_CLIP_RGN_HANDLE: u32 = 0x02f0_0d00;
 const PPC_MAIN_CLIP_RGN: u32 = 0x02f0_0e00;
+const PPC_MAIN_GAMMA_TABLE: u32 = 0x02f0_1000;
+const PPC_MAIN_GAMMA_TABLE_SIZE: u32 = 12 + 256;
 const PPC_PORT_LIST_HANDLE: u32 = 0x02f0_1300;
 const PPC_PORT_LIST: u32 = 0x02f0_1400;
 const PPC_PORT_LIST_ADDR: u32 = 0x0d66;
@@ -12324,6 +12326,17 @@ pub fn load_pef_application_with_config(
     memory.add_region(PPC_MAIN_VIS_RGN, vec![0u8; 10]);
     memory.add_region(PPC_MAIN_CLIP_RGN_HANDLE, vec![0u8; 4]);
     memory.add_region(PPC_MAIN_CLIP_RGN, vec![0u8; 10]);
+    // Universal Interfaces 3.4 Video.h defines GammaTbl as a six-word
+    // header followed by formula bytes and channel data. The main display's
+    // device-owned table is the standard one-channel, 8-bit linear ramp.
+    let mut gamma_table = vec![0u8; PPC_MAIN_GAMMA_TABLE_SIZE as usize];
+    gamma_table[6..8].copy_from_slice(&1u16.to_be_bytes()); // gChanCnt
+    gamma_table[8..10].copy_from_slice(&256u16.to_be_bytes()); // gDataCnt
+    gamma_table[10..12].copy_from_slice(&8u16.to_be_bytes()); // gDataWidth
+    for (value, output) in gamma_table[12..].iter_mut().enumerate() {
+        *output = value as u8;
+    }
+    memory.add_readonly_region(PPC_MAIN_GAMMA_TABLE, gamma_table);
     memory.add_region(PPC_PORT_LIST_HANDLE, vec![0u8; 4]);
     memory.add_region(PPC_PORT_LIST, vec![0u8; 2]);
     // PortList is a QuickDraw-owned handle whose first word is the number of
@@ -17085,26 +17098,9 @@ fn dispatch_supported_import(
         PpcImportDispatcherTarget::PBControl => Some(PpcImportAction::Return(ppc_i16_result(
             ppc_pb_control(cpu, memory, *current_gdevice, screen_clut, toolbox_startup),
         ))),
-        PpcImportDispatcherTarget::PBStatus => {
-            // Inside Macintosh: Devices (1994), 1-79 through 1-80: PBStatus
-            // mirrors the driver result into CntrlParam.ioResult at offset 16.
-            let pb = cpu.gpr[3];
-            let result = if pb == 0 {
-                PPC_NO_ERR
-            } else if let Some(ref_num) = memory.read_u16_be(pb + 24) {
-                if ref_num == 0 {
-                    PPC_NO_ERR
-                } else {
-                    -21 // badUnitErr: no matching Device Manager driver.
-                }
-            } else {
-                PPC_PARAM_ERR
-            };
-            if pb != 0 {
-                let _ = memory.write_u16_be(pb + 16, result as u16);
-            }
-            Some(PpcImportAction::Return(ppc_i16_result(result)))
-        }
+        PpcImportDispatcherTarget::PBStatus => Some(PpcImportAction::Return(ppc_i16_result(
+            ppc_pb_status(cpu, memory),
+        ))),
         PpcImportDispatcherTarget::Gestalt => Some(PpcImportAction::Return(ppc_i16_result(
             ppc_gestalt(cpu, memory),
         ))),
@@ -51058,6 +51054,49 @@ fn ppc_pb_control(
     result
 }
 
+fn ppc_pb_status(cpu: &PpcCpu, memory: &mut PpcSectionMem) -> i16 {
+    const STATUS_ERR: i16 = -18;
+
+    let parameter_block = cpu.gpr[3];
+    let result = (|| {
+        let ref_num = memory.read_u16_be(parameter_block.checked_add(24)?)? as i16;
+        if ref_num != 0 {
+            return Some(-21); // badUnitErr: no matching Device Manager driver.
+        }
+        let cs_code = memory.read_u16_be(parameter_block.checked_add(26)?)? as i16;
+        let cs_param = parameter_block.checked_add(28)?;
+
+        // Inside Macintosh: Devices (1994), pp. 1-65 and 1-83: PBStatus
+        // uses CntrlParam.csCode/csParam, and selector 1 is handled by the
+        // Device Manager itself by returning the driver's DCE handle.
+        match cs_code {
+            1 => memory
+                .write_u32_be(cs_param, PPC_MAIN_DCE_HANDLE)
+                .map(|()| PPC_NO_ERR),
+            // Universal Interfaces 3.4 Video.h defines cscGetGamma (8) as a
+            // status request whose csParam contains a VDGammaRecord pointer;
+            // the driver stores its device-owned GammaTbl pointer there.
+            8 => {
+                let vd_gamma = memory.read_u32_be(cs_param)?;
+                memory
+                    .write_u32_be(vd_gamma, PPC_MAIN_GAMMA_TABLE)
+                    .map(|()| PPC_NO_ERR)
+            }
+            // Inside Macintosh: Devices (1994), p. 1-47: a driver must
+            // return statusErr for status selectors that it does not support.
+            _ => Some(STATUS_ERR),
+        }
+    })()
+    .unwrap_or(PPC_PARAM_ERR);
+
+    if parameter_block != 0 {
+        if let Some(result_addr) = parameter_block.checked_add(16) {
+            let _ = memory.write_u16_be(result_addr, result as u16);
+        }
+    }
+    result
+}
+
 fn ppc_get_ctable(
     cpu: &PpcCpu,
     memory: &mut PpcSectionMem,
@@ -63704,6 +63743,45 @@ mod tests {
         );
         assert_eq!(screen_clut[7], [0x1111, 0x2222, 0x3333]);
         assert_eq!(memory.read_u16_be(parameter_block + 16), Some(0));
+    }
+
+    #[test]
+    fn video_status_returns_device_owned_linear_gamma_table() {
+        let pef = synthetic_pef_with_import(b"PBStatusSync");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let parameter_block = PPC_DATA_BASE + 0x1000;
+        let vd_gamma = parameter_block + 64;
+        loaded.memory.add_region(parameter_block, vec![0; 128]);
+        loaded.memory.write_u16_be(parameter_block + 24, 0).unwrap();
+        loaded.memory.write_u16_be(parameter_block + 26, 8).unwrap();
+        loaded
+            .memory
+            .write_u32_be(parameter_block + 28, vd_gamma)
+            .unwrap();
+        loaded.cpu.gpr[3] = parameter_block;
+
+        assert_eq!(ppc_pb_status(&loaded.cpu, &mut loaded.memory), PPC_NO_ERR);
+        assert_eq!(loaded.memory.read_u16_be(parameter_block + 16), Some(0));
+        assert_eq!(
+            loaded.memory.read_u32_be(vd_gamma),
+            Some(PPC_MAIN_GAMMA_TABLE)
+        );
+        assert_eq!(loaded.memory.read_u16_be(PPC_MAIN_GAMMA_TABLE), Some(0));
+        assert_eq!(loaded.memory.read_u16_be(PPC_MAIN_GAMMA_TABLE + 6), Some(1));
+        assert_eq!(
+            loaded.memory.read_u16_be(PPC_MAIN_GAMMA_TABLE + 8),
+            Some(256)
+        );
+        assert_eq!(
+            loaded.memory.read_u16_be(PPC_MAIN_GAMMA_TABLE + 10),
+            Some(8)
+        );
+        for value in 0..256u32 {
+            assert_eq!(
+                loaded.memory.read_u8(PPC_MAIN_GAMMA_TABLE + 12 + value),
+                Some(value as u8)
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- parse Installer VISE `0x80010307` extended catalogues and their longer directory/file records
- rank game applications ahead of bundled documentation executables
- implement the PowerPC display driver’s `PBStatus` gamma-table response using device-owned linear gamma state
- return documented Device Manager errors for unsupported status selectors

## Root cause

The archive reader only recognized two older VISE catalogue layouts. Once the extended archive was extracted, executable ranking favored a documentation application over a demo executable, and the PowerPC `PBStatusSync` implementation returned `noErr` for `cscGetGamma` without writing the requested `GammaTbl` pointer. The game consequently dereferenced a null gamma-table source during display initialization and exited.

## Validation

- `cargo test --lib --quiet` — 3,782 passed, 3 ignored
- focused extended-catalogue, executable-ranking, and video gamma tests
- deterministic automatic launch reached the animated title and main menu without an executable override
- `rustfmt --check` and `git diff --check`

A BasiliskII comparison was not available because the local Docker daemon was not running.

Closes #690