### PR TITLE
fix(resource): guest-visible getters load lazily-seeded resources on demand

### DIFF
--- a/src/trap/control.rs
+++ b/src/trap/control.rs
@@ -198,7 +198,7 @@ impl super::TrapDispatcher {
         }
 
         let cdef_id = proc_id >> 4;
-        self.find_resource_any(*b"CDEF", cdef_id)
+        self.find_or_load_resource_any(bus, *b"CDEF", cdef_id)
             .map(|(_, ptr)| ptr)
             .map(|ptr| self.get_or_create_resource_handle(bus, *b"CDEF", cdef_id, ptr))
             .unwrap_or(0)
@@ -1421,10 +1421,10 @@ impl super::TrapDispatcher {
         let Some((off_id, on_id)) = Self::picture_ids_from_control_title(title_bytes) else {
             return false;
         };
-        let Some((_, off_pic_ptr)) = self.find_resource_any(*b"PICT", off_id) else {
+        let Some((_, off_pic_ptr)) = self.find_or_load_resource_any(bus, *b"PICT", off_id) else {
             return false;
         };
-        let Some((_, on_pic_ptr)) = self.find_resource_any(*b"PICT", on_id) else {
+        let Some((_, on_pic_ptr)) = self.find_or_load_resource_any(bus, *b"PICT", on_id) else {
             return false;
         };
 
@@ -3516,7 +3516,7 @@ impl super::TrapDispatcher {
 
                 // IM:I I-321: if the CNTL template cannot be read, return NIL.
                 let cntl_data = self
-                    .find_resource_any(*b"CNTL", ctrl_id)
+                    .find_or_load_resource_any(bus, *b"CNTL", ctrl_id)
                     .map(|(_, ptr)| ptr);
 
                 let Some(rsrc_addr) = cntl_data else {

--- a/src/trap/dialog.rs
+++ b/src/trap/dialog.rs
@@ -308,7 +308,7 @@ impl super::TrapDispatcher {
     }
 
     fn dialog_template_res_err(&self, dialog_id: i16) -> i16 {
-        if self.find_resource_any(*b"DLOG", dialog_id).is_some() {
+        if self.find_loaded_resource_any(*b"DLOG", dialog_id).is_some() {
             0
         } else {
             0
@@ -363,7 +363,7 @@ impl super::TrapDispatcher {
         let (refnum, ptr) = if load_if_missing {
             self.find_or_load_resource_any(bus, res_type, res_id)?
         } else {
-            self.find_resource_any(res_type, res_id)?
+            self.find_loaded_resource_any(res_type, res_id)?
         };
         let handle = if load_if_missing {
             let handle =

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -5471,7 +5471,7 @@ impl TrapDispatcher {
         })
     }
 
-    pub(crate) fn find_resource_any(&self, res_type: [u8; 4], res_id: i16) -> Option<(u16, u32)> {
+    pub(crate) fn find_loaded_resource_any(&self, res_type: [u8; 4], res_id: i16) -> Option<(u16, u32)> {
         let res_type = Self::normalize_ostype(res_type);
         let resources = self.resources.as_ref()?;
         for refnum in self.resource_search_order() {

--- a/src/trap/memory.rs
+++ b/src/trap/memory.rs
@@ -4770,7 +4770,7 @@ mod tests {
         assert!(!dispatcher.loaded_handles.contains_key(&handle));
         assert!(!dispatcher.resource_handle_files.contains_key(&handle));
         assert_eq!(
-            dispatcher.find_resource_any(*b"RSRC", 7),
+            dispatcher.find_loaded_resource_any(*b"RSRC", 7),
             Some((0, data_ptr)),
             "Resource Manager map should still point at live backing data"
         );

--- a/src/trap/menu.rs
+++ b/src/trap/menu.rs
@@ -708,7 +708,7 @@ impl super::TrapDispatcher {
             .and_then(|menu| menu.items.get(selected - 1))
             .map(|item| item.text.clone())
             .or_else(|| {
-                let (_, menu_ptr) = self.find_resource_any(*b"MENU", menu_id)?;
+                let (_, menu_ptr) = self.find_loaded_resource_any(*b"MENU", menu_id)?;
                 Self::popup_menu_item_title_from_resource(bus, menu_ptr, selected)
             })
     }
@@ -1033,7 +1033,7 @@ impl super::TrapDispatcher {
         bus.write_long(handle, menu_ptr);
         self.ptr_to_handle.insert(menu_ptr, handle);
 
-        let menu = if let Some((_, res_ptr)) = self.find_resource_any(*b"MENU", menu_id) {
+        let menu = if let Some((_, res_ptr)) = self.find_or_load_resource_any(bus, *b"MENU", menu_id) {
             let res_size = menu_resource_size(bus, res_ptr);
             for i in 0..res_size.min(256) {
                 bus.write_byte(menu_ptr + i as u32, bus.read_byte(res_ptr + i as u32));
@@ -1106,7 +1106,7 @@ impl super::TrapDispatcher {
     }
 
     fn load_menu_color_resource(&mut self, bus: &mut MacMemoryBus, resource_id: i16) {
-        let Some((_, resource_ptr)) = self.find_resource_any(*b"mctb", resource_id) else {
+        let Some((_, resource_ptr)) = self.find_or_load_resource_any(bus, *b"mctb", resource_id) else {
             return;
         };
         let resource_size = bus.get_alloc_size(resource_ptr).unwrap_or(0) as usize;
@@ -1568,7 +1568,7 @@ impl super::TrapDispatcher {
                             // raw guest MENU handle). Parse any MENU resource
                             // by menu ID, else fall back to title-only memory.
                             let menu_id = bus.read_word(menu_ptr) as i16;
-                            if let Some((_, res_ptr)) = self.find_resource_any(*b"MENU", menu_id) {
+                            if let Some((_, res_ptr)) = self.find_or_load_resource_any(bus, *b"MENU", menu_id) {
                                 let mut menu = parse_menu_resource(bus, res_ptr, menu_handle);
                                 eprintln!(
                                     "[MENU] InsertMenu: ID={} title=\"{}\" items={}",
@@ -1710,7 +1710,7 @@ impl super::TrapDispatcher {
             (true, 0x1C0) => {
                 let sp = cpu.read_reg(Register::A7);
                 let mbar_id = bus.read_word(sp) as i16;
-                let handle = if let Some((_, mbar_ptr)) = self.find_resource_any(*b"MBAR", mbar_id)
+                let handle = if let Some((_, mbar_ptr)) = self.find_or_load_resource_any(bus, *b"MBAR", mbar_id)
                 {
                     let menu_count = bus.read_word(mbar_ptr) as usize;
                     let mut snapshot = Vec::new();
@@ -1718,7 +1718,7 @@ impl super::TrapDispatcher {
 
                     for i in 0..menu_count {
                         let menu_id = bus.read_word(mbar_ptr + 2 + (i as u32) * 2) as i16;
-                        let Some((_, menu_res_ptr)) = self.find_resource_any(*b"MENU", menu_id)
+                        let Some((_, menu_res_ptr)) = self.find_or_load_resource_any(bus, *b"MENU", menu_id)
                         else {
                             continue;
                         };
@@ -3975,11 +3975,37 @@ impl super::TrapDispatcher {
         self.cicn_menu_icon_resource_ptr(item).is_some()
     }
 
+    /// Materialize a menu's item-icon resources (cicn/ICON/SICN at
+    /// icon-number + 256, MTE 1992 pp. 3-46, 3-137..3-138) before the
+    /// dropdown draws. The draw path reads icons through `&self` helpers
+    /// deep in borrow chains that cannot load on demand, so lazily-seeded
+    /// icon resources (IM-style empty handles) are faulted in here at the
+    /// one mutable moment the flow guarantees -- without this, an
+    /// application whose first icon touch happens at draw time shows
+    /// empty slots for icons that are present in the fork.
+    fn preload_menu_item_icon_resources(&mut self, bus: &mut MacMemoryBus, menu_idx: usize) {
+        let icon_ids: Vec<i16> = self
+            .menus
+            .get(menu_idx)
+            .map(|menu| {
+                menu.items
+                    .iter()
+                    .filter_map(Self::menu_item_icon_resource_id)
+                    .collect()
+            })
+            .unwrap_or_default();
+        for icon_resource_id in icon_ids {
+            for res_type in [*b"cicn", *b"ICON", *b"SICN"] {
+                let _ = self.find_or_load_resource_any(bus, res_type, icon_resource_id);
+            }
+        }
+    }
+
     fn cicn_menu_icon_resource_ptr(&self, item: &MenuItem) -> Option<u32> {
         let Some(icon_resource_id) = Self::menu_item_icon_resource_id(item) else {
             return None;
         };
-        self.find_resource_any(*b"cicn", icon_resource_id)
+        self.find_loaded_resource_any(*b"cicn", icon_resource_id)
             .map(|(_, ptr)| ptr)
     }
 
@@ -3992,7 +4018,7 @@ impl super::TrapDispatcher {
         // 1992 pp. 3-137 to 3-138 specify the Menu Manager adds 256
         // to obtain the ICON resource ID for the reduced-icon case.
         let icon_resource_id = Self::menu_item_icon_resource_id(item)?;
-        self.find_resource_any(*b"ICON", icon_resource_id)
+        self.find_loaded_resource_any(*b"ICON", icon_resource_id)
             .map(|(_, ptr)| ptr)
     }
 
@@ -4005,7 +4031,7 @@ impl super::TrapDispatcher {
         // cicn is used, the Menu Manager looks for an SICN resource at
         // icon-number+256 and plots it in a 16-by-16 rectangle.
         let icon_resource_id = Self::menu_item_icon_resource_id(item)?;
-        self.find_resource_any(*b"SICN", icon_resource_id)
+        self.find_loaded_resource_any(*b"SICN", icon_resource_id)
             .map(|(_, ptr)| ptr)
     }
 
@@ -4018,7 +4044,7 @@ impl super::TrapDispatcher {
         // 256 as an ICON or cicn resource ID; this path implements the
         // monochrome ICON case and leaves cicn-specific drawing open.
         let icon_resource_id = Self::menu_item_icon_resource_id(item)?;
-        self.find_resource_any(*b"ICON", icon_resource_id)
+        self.find_loaded_resource_any(*b"ICON", icon_resource_id)
             .map(|(_, ptr)| ptr)
     }
 
@@ -4315,6 +4341,9 @@ impl super::TrapDispatcher {
 
     /// Open a menu dropdown and start tracking.
     fn open_menu_dropdown(&mut self, bus: &mut MacMemoryBus, menu_idx: usize, stack_ptr: u32) {
+        // Fault in this menu's icon resources while `self` is still
+        // mutable; the draw path below reads them through `&self` only.
+        self.preload_menu_item_icon_resources(bus, menu_idx);
         let (_screen_base, _row_bytes, screen_width, screen_height, _pixel_size) =
             self.get_screen_params();
 

--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -4518,7 +4518,7 @@ impl super::TrapDispatcher {
             (true, 0x20C) => {
                 let sp = cpu.read_reg(Register::A7);
                 let pat_id = bus.read_word(sp) as i16;
-                let handle = match self.find_resource_any(*b"ppat", pat_id) {
+                let handle = match self.find_or_load_resource_any(bus, *b"ppat", pat_id) {
                     Some((_, data_ptr)) => {
                         self.get_or_create_resource_handle(bus, *b"ppat", pat_id, data_ptr)
                     }
@@ -8940,7 +8940,7 @@ impl super::TrapDispatcher {
                 let sp = cpu.read_reg(Register::A7);
                 let icon_id = bus.read_word(sp) as i16;
                 let handle = if let Some((_, resource_ptr)) =
-                    self.find_resource_any(*b"cicn", icon_id)
+                    self.find_or_load_resource_any(bus, *b"cicn", icon_id)
                 {
                     let resource_size = bus.get_alloc_size(resource_ptr).unwrap_or(0);
                     if resource_size == 0 {
@@ -13697,7 +13697,7 @@ impl super::TrapDispatcher {
             (true, 0x21B) => {
                 let sp = cpu.read_reg(Register::A7);
                 let crsr_id = bus.read_word(sp) as i16;
-                let handle = match self.find_resource_any(*b"crsr", crsr_id) {
+                let handle = match self.find_or_load_resource_any(bus, *b"crsr", crsr_id) {
                     Some((_, data_ptr)) => self
                         .promote_compiled_crsr_resource(bus, data_ptr)
                         .unwrap_or_else(|| {
@@ -16613,14 +16613,23 @@ impl super::TrapDispatcher {
     }
 
     pub(crate) fn copy_palette_resource(&mut self, bus: &mut MacMemoryBus, palette_id: i16) -> u32 {
+        // Load-on-demand, not find-only: since lazy resource seeding, a
+        // 'pltt' that no one has touched yet sits in the map with a NULL
+        // pointer (an IM-style empty handle), and the find-only lookup
+        // reports it missing. An application that probes its palette
+        // during launch gets NIL and exits. Same conversion GetCTable
+        // ('clut') and the Sound Manager already received.
         let resource_ptr = self
-            .find_resource_any(*b"pltt", palette_id)
+            .find_or_load_resource_any(bus, *b"pltt", palette_id)
+            .map(|(_, ptr)| ptr)
             .or_else(|| {
                 (palette_id != 0)
-                    .then(|| self.find_resource_any(*b"pltt", 0))
+                    .then(|| {
+                        self.find_or_load_resource_any(bus, *b"pltt", 0)
+                            .map(|(_, ptr)| ptr)
+                    })
                     .flatten()
             })
-            .map(|(_, ptr)| ptr)
             .unwrap_or(0);
         self.copy_palette_resource_from_ptr(bus, palette_id, resource_ptr)
     }
@@ -16631,7 +16640,7 @@ impl super::TrapDispatcher {
         palette_id: i16,
     ) -> u32 {
         let resource_ptr = self
-            .find_resource_any(*b"pltt", palette_id)
+            .find_or_load_resource_any(bus, *b"pltt", palette_id)
             .map(|(_, ptr)| ptr)
             .unwrap_or(0);
         self.copy_palette_resource_from_ptr(bus, palette_id, resource_ptr)
@@ -43556,6 +43565,46 @@ mod tests {
         assert_eq!(bus.read_word(table + 10), 0x1234);
         assert_eq!(bus.read_word(table + 12), 0x5678);
         assert_eq!(bus.read_word(table + 14), 0x9ABC);
+    }
+
+    #[test]
+    fn get_new_palette_reloads_a_lazily_seeded_pltt_resource() {
+        // Lazy resource seeding leaves never-touched resources in the map
+        // as IM-style empty handles: entry present, pointer NULL (IM: More
+        // Macintosh Toolbox 1-84 -- SetResLoad / empty handles). Toolbox
+        // getters emulate GetResource with ResLoad TRUE, which "reads the
+        // resource into memory if it's not already in memory" (IM:MMT
+        // 1-17), so GetNewPalette must fault the data in rather than
+        // report the palette missing. An application that checks its
+        // palette at launch exits when GetNewPalette(0) returns NIL for
+        // its lazily-seeded 'pltt'.
+        let (mut d, mut cpu, mut bus) = setup();
+        let mut resource = vec![0u8; 32];
+        resource[6..8].copy_from_slice(&1u16.to_be_bytes()); // pmEntries = 1
+        resource[16..18].copy_from_slice(&0x1234u16.to_be_bytes());
+        resource[18..20].copy_from_slice(&0x5678u16.to_be_bytes());
+        resource[20..22].copy_from_slice(&0x9ABCu16.to_be_bytes());
+        let original = d.install_test_resource(&mut bus, *b"pltt", 700, &resource);
+        d.resources
+            .as_mut()
+            .unwrap()
+            .files
+            .get_mut(&0)
+            .unwrap()
+            .loaded
+            .insert((*b"pltt", 700), 0);
+        bus.free(original);
+        bus.write_word(TEST_SP, 700);
+
+        let result = d.dispatch_quickdraw(true, 0x292, &mut cpu, &mut bus);
+
+        assert!(result.unwrap().is_ok());
+        assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 2);
+        assert_ne!(
+            bus.read_long(TEST_SP + 2),
+            0,
+            "GetNewPalette must reload an empty-handle 'pltt' resource"
+        );
     }
 
     #[test]

--- a/src/trap/sound.rs
+++ b/src/trap/sound.rs
@@ -3255,7 +3255,7 @@ mod tests {
             vec![0x00, 0x02, 0x00, 0x00, 0x00, 0x00],
         )]);
         disp.load_resources(&fork, &mut bus);
-        assert!(disp.find_resource_any(*b"snd ", 30_000).is_none());
+        assert!(disp.find_loaded_resource_any(*b"snd ", 30_000).is_none());
 
         let chan_ptr = 0x250000;
         disp.sound_manager
@@ -3266,7 +3266,7 @@ mod tests {
             disp.snd_start_file_play(&mut bus, chan_ptr, 0, 30_000, 0, 0, 1),
             0
         );
-        assert!(disp.find_resource_any(*b"snd ", 30_000).is_some());
+        assert!(disp.find_loaded_resource_any(*b"snd ", 30_000).is_some());
         assert_eq!(disp.sound_manager.debug_file_play_count, 1);
     }
 

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -5513,7 +5513,7 @@ impl super::TrapDispatcher {
                 let res_type = *b"STR#";
                 let mut res_found = false;
                 let found_str: Option<Vec<u8>> =
-                    if let Some((_, data_ptr)) = self.find_resource_any(res_type, str_list_id) {
+                    if let Some((_, data_ptr)) = self.find_or_load_resource_any(bus, res_type, str_list_id) {
                         res_found = true;
                         // STR# format: 2-byte count, then Pascal strings (1-byte len + chars)
                         // Inside Macintosh Volume I, I-476
@@ -10684,7 +10684,7 @@ impl super::TrapDispatcher {
                         let cells_handle = bus.alloc(4);
 
                         let list_def_proc_handle = self
-                            .find_resource_any(*b"LDEF", proc_id)
+                            .find_or_load_resource_any(bus, *b"LDEF", proc_id)
                             .map(|(_, ptr)| {
                                 self.get_or_create_resource_handle(bus, *b"LDEF", proc_id, ptr)
                             })
@@ -11746,7 +11746,7 @@ impl super::TrapDispatcher {
                         let cells_handle = bus.alloc(4);
 
                         let list_def_proc_handle = self
-                            .find_resource_any(*b"LDEF", proc_id)
+                            .find_or_load_resource_any(bus, *b"LDEF", proc_id)
                             .map(|(_, ptr)| {
                                 self.get_or_create_resource_handle(bus, *b"LDEF", proc_id, ptr)
                             })

--- a/src/trap/window.rs
+++ b/src/trap/window.rs
@@ -198,7 +198,7 @@ impl super::TrapDispatcher {
         table_id: i16,
     ) -> Option<u32> {
         let resource_ptr = self
-            .find_resource_any(resource_type, table_id)
+            .find_or_load_resource_any(bus, resource_type, table_id)
             .map(|(_, ptr)| ptr)?;
 
         if bus.get_alloc_size(resource_ptr).unwrap_or(0) < 8 {
@@ -487,7 +487,7 @@ impl super::TrapDispatcher {
         let wdef_id = Self::window_def_resource_id(proc_id);
         if Self::is_application_window_def_proc_id(proc_id) {
             return self
-                .find_resource_any(*b"WDEF", wdef_id)
+                .find_or_load_resource_any(bus, *b"WDEF", wdef_id)
                 .map(|(_, ptr)| ptr)
                 .map(|ptr| self.get_or_create_resource_handle(bus, *b"WDEF", wdef_id, ptr))
                 .unwrap_or(0);


### PR DESCRIPTION
Fixes #692.

## Motivating example

SimCity 2000 1.2 exits at launch — its own error dialog:

> Program Failure: Cannot get appPalette in PrepareColors()

<img width="912" height="744" alt="Screenshot 2026-08-19 at 1 29 55 PM" src="https://github.com/user-attachments/assets/faf09bc7-80d2-4571-bd28-22acf29631c0" />

Bisects to `650536c` (#660). SC2K's `PrepareColors` calls `GetNewPalette(0)`; the app's `pltt 0` is present in the resource map but lazily seeded (NULL guest pointer), the find-only lookup filters `ptr != 0` and reports it missing, SC2K gets NIL and quits. Probe at the failure: the map held `pltt` ids `[0, 2, 1000, 1212]`, entry present, pointer NULL.

## The rule (Inside Macintosh)

Lazy seeding matches the real Resource Manager — opening a file reads only the resource **map**; data loads on demand (IM: More Macintosh Toolbox 1-17), and a never-loaded/purged resource is an **empty handle** (IM:MMT 1-84). The defect is that the find-only helper conflated "empty handle" with "absent". `GetResource` with ResLoad TRUE "reads the resource into memory if it's not already in memory" — so every **guest-visible getter** must take the loading path; find-only is correct **only** for introspection that must not fault data in (ResLoad-FALSE semantics, reverse maps, existence checks). GetCTable (`59a8970`) and the Sound Manager (#685) were this same class, fixed one crash at a time; this PR does the whole audit.

## Changes

- **Rename** `find_resource_any` → `find_loaded_resource_any`, so the no-load semantics are explicit at every remaining call site and new getters reach for the loading variant by default.
- **Convert the guest-visible getters** to `find_or_load_resource_any`: `pltt` (GetNewPalette/GetPalette — the SC2K fix), CDEF/CNTL + picture-button PICTs, WDEF + window color tables, `STR#` (GetIndString), LDEF, MENU/MBAR/mctb, `ppat` (GetPixPat), `cicn` (GetCIcon), `crsr` (GetCCursor).
- **Menu item icons** (cicn/ICON/SICN at icon-number+256, MTE 1992 pp. 3-46, 3-137f) draw through deep `&self` chains that cannot load on demand; `preload_menu_item_icon_resources` faults them in at `open_menu_dropdown`, the one mutable moment before drawing.
- **Deliberate find-only survivors**, each with its reason in place: `prepare_dialog_resource_handle`'s `load_if_missing = false` arm (explicit ResLoad-FALSE semantics) and `popup_menu_item_title`'s read-only fallback (its data is materialized by `create_popup_menu_handle`).

## Verification

- New regression test `get_new_palette_reloads_a_lazily_seeded_pltt_resource`: seeds a `pltt` as an IM-style empty handle (map entry, NULL pointer, backing data registered) and asserts `GetNewPalette` faults it in — fails on the find-only behaviour.
- Full suite: 3,780 pass.
- End-to-end: SimCity 2000 boots past `PrepareColors` (verified headless with palette tracing: `GetNewPalette id=0 -> $0039489C`, previously `$00000000` + ExitToShell).

---

*From Claude Fable 5, working with @rlanday. Found while bringing SimCity 2000 up as a second m68k perf-census workload.*
