### PR TITLE
fix(quickdraw): measure text width proportionally to the requested size

### DIFF
--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -28067,6 +28067,56 @@ mod tests {
     }
 
     #[test]
+    fn stringwidth_scales_monotonically_with_textsize() {
+        // A guest text-fitting loop (`TextSize(n); StringWidth(s)` until
+        // the string fits a target width) only converges if measured
+        // width makes progress as the size steps. The baked font table
+        // has faces at a few exact sizes; every other size must
+        // interpolate rather than plateau at the base face's width --
+        // a text-fitting loop hangs the application
+        // forever on a plateau (the newspaper becomes an unclickable
+        // modal because the app never returns to its event loop).
+        let (mut d, mut cpu, mut bus) = setup();
+        let str_ptr = 0x300000u32;
+        let text = b"New City Founded";
+        bus.write_byte(str_ptr, text.len() as u8);
+        for (i, byte) in text.iter().enumerate() {
+            bus.write_byte(str_ptr + 1 + i as u32, *byte);
+        }
+        let mut widths = Vec::new();
+        for size in 9i16..=36 {
+            d.tx_size = size;
+            cpu.write_reg(Register::A7, TEST_SP);
+            bus.write_long(TEST_SP, str_ptr);
+            let result = d.dispatch_quickdraw(true, 0x08C, &mut cpu, &mut bus);
+            assert!(result.unwrap().is_ok());
+            widths.push(bus.read_word(TEST_SP + 4) as i16);
+        }
+        // Strict growth across every 3-point span: a fitting loop
+        // stepping the size by 1-3 points always sees the width move.
+        // (Plain per-step monotonicity is not asserted so a resolved-face
+        // switch may round differently at a boundary.)
+        for (i, window) in widths.windows(4).enumerate() {
+            assert!(
+                window[3] > window[0],
+                "width must grow across sizes {}..{}: {:?}",
+                9 + i as i16,
+                9 + i as i16 + 3,
+                widths
+            );
+        }
+        // Exact 2x-face parity: the doubled size doubles the width
+        // (within a rounding pixel), pinning the previously-correct
+        // integer-scale answers.
+        let w12 = widths[(12 - 9) as usize] as i32;
+        let w24 = widths[(24 - 9) as usize] as i32;
+        assert!(
+            (w24 - 2 * w12).abs() <= 1,
+            "24pt width {w24} must be twice the 12pt width {w12}"
+        );
+    }
+
+    #[test]
     fn test_char_width() {
         let (mut d, mut cpu, mut bus) = setup();
         bus.write_word(TEST_SP, b'A' as u16);

--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -1813,19 +1813,19 @@ impl super::TrapDispatcher {
             (true, 0x08C) => {
                 let sp = cpu.read_reg(Register::A7);
                 let str_ptr = bus.read_long(sp);
-                let (_face, scale) = get_font_face_scaled(self.tx_font, self.tx_size);
-                let mut total_width = 0i16;
+                let mut total_base = 0i32;
                 let len = bus.read_byte(str_ptr) as u16;
                 let start_addr = str_ptr + 1;
                 for i in 0..len {
                     let ch = bus.read_byte(start_addr + i as u32) as char;
                     let advance = if let Some((g, _)) = get_glyph(self.tx_font, self.tx_size, ch) {
-                        self.glyph_advance(g) * scale
+                        i32::from(self.glyph_advance(g))
                     } else {
-                        self.missing_glyph_advance() * scale
+                        i32::from(self.missing_glyph_advance())
                     };
-                    total_width += advance;
+                    total_base += advance;
                 }
+                let total_width = self.proportional_text_width(total_base);
                 let new_sp = sp + 4;
                 bus.write_word(new_sp, total_width as u16);
                 cpu.write_reg(Register::A7, new_sp);
@@ -1840,12 +1840,12 @@ impl super::TrapDispatcher {
             (true, 0x08D) => {
                 let sp = cpu.read_reg(Register::A7);
                 let ch = (bus.read_word(sp) & 0xFF) as u8 as char;
-                let (_face, cw_scale) = get_font_face_scaled(self.tx_font, self.tx_size);
                 let advance = if let Some((g, _)) = get_glyph(self.tx_font, self.tx_size, ch) {
-                    self.glyph_advance(g) * cw_scale
+                    i32::from(self.glyph_advance(g))
                 } else {
-                    self.missing_glyph_advance() * cw_scale
+                    i32::from(self.missing_glyph_advance())
                 };
+                let advance = self.proportional_text_width(advance);
                 bus.write_word(sp + 2, advance as u16);
                 cpu.write_reg(Register::A7, sp + 2);
                 Ok(())
@@ -1861,18 +1861,18 @@ impl super::TrapDispatcher {
                 let byte_count = bus.read_word(sp) as i16;
                 let first_byte = bus.read_word(sp + 2) as i16;
                 let text_buf = bus.read_long(sp + 4);
-                let (_face, tw_scale) = get_font_face_scaled(self.tx_font, self.tx_size);
-                let mut total_width = 0i16;
+                let mut total_base = 0i32;
                 let start_addr = text_buf + first_byte as u32;
                 for i in 0..byte_count {
                     let ch = bus.read_byte(start_addr + i as u32) as char;
                     let advance = if let Some((g, _)) = get_glyph(self.tx_font, self.tx_size, ch) {
-                        self.glyph_advance(g) * tw_scale
+                        i32::from(self.glyph_advance(g))
                     } else {
-                        self.missing_glyph_advance() * tw_scale
+                        i32::from(self.missing_glyph_advance())
                     };
-                    total_width += advance;
+                    total_base += advance;
                 }
+                let total_width = self.proportional_text_width(total_base);
                 let new_sp = sp + 8;
                 bus.write_word(new_sp, total_width as u16);
                 cpu.write_reg(Register::A7, new_sp);

--- a/src/trap/text_render.rs
+++ b/src/trap/text_render.rs
@@ -1152,8 +1152,8 @@ impl super::TrapDispatcher {
     /// multiples; `get_font_face_scaled` reports scale 1 for every
     /// OTHER size, so integer-scaled measurement PLATEAUS across size
     /// changes. Guest text-fitting loops (`TextSize`; `StringWidth`
-    /// until it fits — SimCity 2000's founding-newspaper headline is
-    /// the canonical case) never converge on a plateau. Measurement
+    /// until it fits — a newspaper-headline fit loop in a commercial
+    /// game was the reproducer) never converge on a plateau. Measurement
     /// therefore scales linearly with the requested size:
     /// `base_total * tx_size / face_size` — monotone in `tx_size` and
     /// identical to the integer-scale answer at exact and 2x/3x sizes.
@@ -1161,8 +1161,7 @@ impl super::TrapDispatcher {
     /// differ slightly from its measured width at in-between sizes,
     /// which is the standard bitmap-font compromise.
     pub(super) fn proportional_text_width(&self, base_total: i32) -> i16 {
-        let face =
-            crate::quickdraw::fonts::get_font_face_or_default(self.tx_font, self.tx_size);
+        let face = crate::quickdraw::fonts::get_font_face_or_default(self.tx_font, self.tx_size);
         let denom = i32::from(face.size.max(1));
         let size = i32::from(self.tx_size.max(1));
         ((base_total * size + denom / 2) / denom) as i16

--- a/src/trap/text_render.rs
+++ b/src/trap/text_render.rs
@@ -1144,4 +1144,27 @@ impl super::TrapDispatcher {
     pub(super) fn missing_glyph_advance(&self) -> i16 {
         6 + self.advance_extra()
     }
+
+    /// Scale a base-face advance total to the port's `tx_size` for the
+    /// measuring traps (StringWidth / TextWidth / CharWidth).
+    ///
+    /// The baked font table has exact faces plus integer 2x/3x
+    /// multiples; `get_font_face_scaled` reports scale 1 for every
+    /// OTHER size, so integer-scaled measurement PLATEAUS across size
+    /// changes. Guest text-fitting loops (`TextSize`; `StringWidth`
+    /// until it fits — SimCity 2000's founding-newspaper headline is
+    /// the canonical case) never converge on a plateau. Measurement
+    /// therefore scales linearly with the requested size:
+    /// `base_total * tx_size / face_size` — monotone in `tx_size` and
+    /// identical to the integer-scale answer at exact and 2x/3x sizes.
+    /// Rendering keeps the integer-scale glyphs; a drawn string can
+    /// differ slightly from its measured width at in-between sizes,
+    /// which is the standard bitmap-font compromise.
+    pub(super) fn proportional_text_width(&self, base_total: i32) -> i16 {
+        let face =
+            crate::quickdraw::fonts::get_font_face_or_default(self.tx_font, self.tx_size);
+        let denom = i32::from(face.size.max(1));
+        let size = i32::from(self.tx_size.max(1));
+        ((base_total * size + denom / 2) / denom) as i16
+    }
 }


### PR DESCRIPTION
## Summary

`StringWidth` / `TextWidth` / `CharWidth` answer any point size that is not an exact baked face (or an exact 2×/3× multiple of one) with the base face's width at scale 1. Measured width as a function of `TextSize` is therefore a step function with wide plateaus — ask for 13, 14, 15, 16, or 17pt and every answer is the 12pt width.

Guest text-fitting loops never converge on a plateau. The reproducer is **SimCity 2000's founding newspaper**: its headline runs the classic `TextSize(n); StringWidth(s); adjust n; repeat` fit loop, the width never changes as the size steps, and the game never returns to its event loop — the newspaper is an unclickable modal, the date freezes at Jan 1900, and no input (mouse or key) can ever dismiss it.

## Fix

Scoped to the three measuring traps only: the width is the resolved base face's advance total scaled linearly, `base_total × tx_size / face_size` (rounded), which is

- **monotone** in the requested size, so fitting loops always converge, and
- **integer-exact identical** to the previous answer at every size that was previously correct (exact faces and 2×/3× multiples) — no behaviour change for well-measured sizes.

Rendering is untouched: glyphs still draw from the baked faces at integer scales. At in-between sizes a drawn string can differ slightly from its measured width — the standard bitmap-font compromise, and the reason the change is limited to measurement.

## Note on verification base

SC2K only reaches the newspaper once #693 (resource load-on-demand) is in — before that it exits at launch in PrepareColors (#692). The end-to-end verification below therefore ran with both fixes applied; this PR's diff is independent of #693 and each merges standalone.

## Verification

- **SC2K end-to-end (headless)**: before — the game spins forever in the `TextSize`/`StringWidth` pair at the newspaper (trap trace shows the two traps alternating with no event calls); after — the newspaper dismisses on a click and the simulation runs (date advances past Jan 1900).
- New regression test: `stringwidth_scales_monotonically_with_textsize` — strict width growth across every 3-point size span from 9 to 36pt (fails on the plateau behaviour), plus 2× parity pinning the exact-scale answers.
- All existing width/layout tests pass unchanged (they pin exact-size behaviour, which this change preserves).

Before:
<img width="800" height="600" alt="2-newspaper-hang-pre-fontfix" src="https://github.com/user-attachments/assets/9940082c-535b-480f-8530-a70b37fa9f56" />

After:
<img width="912" height="744" alt="Screenshot 2026-08-19 at 1 26 51 PM" src="https://github.com/user-attachments/assets/b453f9c5-618c-4de4-9710-9ab21580abb5" />

Reference image from SheepShaver running OS 9:
<img width="752" height="620" alt="Screenshot 2026-08-19 at 1 22 48 PM" src="https://github.com/user-attachments/assets/d297a64b-2894-4d65-b4d2-f582ffb80e6c" />


---

*From Claude Fable 5, working with @rlanday. Found while bringing SimCity 2000 up as a second m68k perf-census workload.*
