### PR TITLE
fix(palette): explicit-tolerant palette entries install their colors

### DIFF
--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -16675,11 +16675,26 @@ impl super::TrapDispatcher {
         for (index, rgb) in updated_clut.iter_mut().enumerate().take(palette_entries) {
             let color_info = Self::palette_color_info_ptr(palette_ptr, index as u32);
             let usage = bus.read_word(color_info + 6) as i16;
-            // pmExplicit makes ciRGB an index into the device ColorTable, so
-            // it does not modify that index's current RGB value. Additional
-            // usage flags do not change the entry's explicit classification.
-            // Inside Macintosh: Advanced Color Imaging (1995), pp. 1-12--1-13.
-            if usage & PM_EXPLICIT != 0 {
+            // Usage decides how a palette entry claims its device slot
+            // (IM: Advanced Color Imaging 1995, pp. 1-12..1-14):
+            //
+            // - PURE pmExplicit names device slot `index` WITHOUT
+            //   requesting a color: the entry means "whatever that slot
+            //   currently holds", so activation must leave the slot's RGB
+            //   alone.
+            // - pmExplicit combined with pmTolerant (or pmAnimated) pins
+            //   the palette's color AT that exact slot: "slot `index`,
+            //   holding this RGB". Full-screen applications install a
+            //   complete custom palette this way -- 256 explicit-tolerant
+            //   entries, entry i claiming slot i -- so their pre-indexed
+            //   artwork displays through their own table. Skipping those
+            //   entries leaves the device on the standard table, and
+            //   every pixel drawn with the application's indices shows
+            //   the wrong colors.
+            //
+            // Only the pure-explicit case keeps the device value; the
+            // combined cases fall through to the ordinary install below.
+            if usage & PM_EXPLICIT != 0 && usage & (PM_TOLERANT | PM_ANIMATED) == 0 {
                 *rgb = current_clut[index];
                 continue;
             }
@@ -36247,10 +36262,16 @@ mod tests {
     }
 
     #[test]
-    fn activatepalette_preserves_device_rgb_for_mixed_explicit_entries() {
-        // pmExplicit identifies a device ColorTable index rather than an RGB
-        // request, even when another usage flag is also present.
-        // Inside Macintosh: Advanced Color Imaging (1995), pp. 1-12--1-13.
+    fn activatepalette_installs_explicit_tolerant_entries_at_their_index() {
+        // PURE pmExplicit identifies a device ColorTable slot without an
+        // RGB request, but pmExplicit COMBINED with pmTolerant pins the
+        // palette's color AT that exact slot -- the combination
+        // full-screen applications use to install a whole custom palette
+        // in known positions (verified against real system software:
+        // the 256 explicit-tolerant entries land on the device; skipping
+        // them leaves the standard table and pre-indexed artwork
+        // displays through the wrong colors).
+        // Inside Macintosh: Advanced Color Imaging (1995), pp. 1-12--1-14.
         let (mut d, mut cpu, mut bus) = setup();
         let window = 0x0020_4160u32;
         let usage = super::PM_TOLERANT | super::PM_EXPLICIT;
@@ -36272,8 +36293,9 @@ mod tests {
 
         let result = d.dispatch_quickdraw(true, 0x294, &mut cpu, &mut bus);
         assert!(result.unwrap().is_ok());
-        assert_eq!(d.device_clut, before);
-        assert_eq!(d.color_manager_clut, before);
+        assert_eq!(d.device_clut[0], [0x1234, 0x5678, 0x9ABC]);
+        assert_eq!(d.color_manager_clut[0], [0x1234, 0x5678, 0x9ABC]);
+        assert_eq!(d.device_clut[1..], before[1..]);
     }
 
     #[test]
@@ -36351,8 +36373,16 @@ mod tests {
         assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 10);
         assert_eq!(d.device_clut[1], animated_rgb);
         assert_eq!(d.color_manager_clut[1], animated_rgb);
-        assert_eq!(d.device_clut[0], before[0]);
-        assert_eq!(d.device_clut[2], before[2]);
+        // Un-animated explicit-animated entries reactivate to their OWN
+        // palette colors (explicit+animated installs at the exact index,
+        // IM:ACI 1995 pp. 1-12..1-14), not the animated value.
+        let (rgb0, _, _) = TrapDispatcher::read_palette_color_info(&bus, palette, 0).unwrap();
+        let (rgb2, _, _) = TrapDispatcher::read_palette_color_info(&bus, palette, 2).unwrap();
+        assert_eq!(d.device_clut[0], rgb0);
+        assert_eq!(d.device_clut[2], rgb2);
+        assert_ne!(d.device_clut[0], animated_rgb);
+        assert_ne!(d.device_clut[2], animated_rgb);
+        let _ = before;
     }
 
     // ==================== ScrollRect ====================
@@ -37616,8 +37646,16 @@ mod tests {
         assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 14);
         assert_eq!(d.device_clut[1], animated_rgb);
         assert_eq!(d.color_manager_clut[1], animated_rgb);
-        assert_eq!(d.device_clut[0], before[0]);
-        assert_eq!(d.device_clut[2], before[2]);
+        // Un-animated explicit-animated entries reactivate to their OWN
+        // palette colors (explicit+animated installs at the exact index,
+        // IM:ACI 1995 pp. 1-12..1-14), not the animated value.
+        let (rgb0, _, _) = TrapDispatcher::read_palette_color_info(&bus, palette, 0).unwrap();
+        let (rgb2, _, _) = TrapDispatcher::read_palette_color_info(&bus, palette, 2).unwrap();
+        assert_eq!(d.device_clut[0], rgb0);
+        assert_eq!(d.device_clut[2], rgb2);
+        assert_ne!(d.device_clut[0], animated_rgb);
+        assert_ne!(d.device_clut[2], animated_rgb);
+        let _ = before;
         assert_eq!(
             TrapDispatcher::read_palette_color_info(&bus, palette, 1),
             Some((animated_rgb, usage, 0))


### PR DESCRIPTION
Fixes #695. **Interacts with #610 — see the compatibility section below.**

## The Palette Manager model (why this one condition matters)

On an 8-bit indexed screen there is one device color table: 256 slots, each an RGB; every framebuffer pixel is an index into it. A window's *palette* is a list of entries `(ciRGB, ciUsage, ciTolerance)`, and activation (window comes to front) walks the entries deciding what happens to the device slots. The usage flags are the request language (IM: Advanced Color Imaging 1995, 1-12…1-14; IM:V V-157…V-160):

| usage | request | activation effect on the device slot |
|---|---|---|
| `pmCourteous` | "roughly this color" | none — drawing nearest-matches |
| `pmTolerant` | "this color within `ciTolerance`" | installs the RGB if nothing close enough exists |
| `pmAnimated` | "a private slot I'll rewrite" | reserves the slot, installs the color |
| `pmExplicit` *(pure)* | "entry *i* means slot *i*, whatever it holds" | **none, deliberately** |
| `pmExplicit + pmTolerant` | "slot *i*, holding this RGB" | **installs the RGB at exactly slot *i*** |

The combined form is how a full-screen application takes over the whole table in a known layout — 256 explicit-tolerant entries, entry *i* claiming slot *i* — so its pre-indexed artwork displays through its own palette.

## The bug (#695)

Since #610, activation keeps the device value for **any** entry with `pmExplicit` set, regardless of the other bits. An application whose entire palette is explicit-tolerant gets a 256-iteration no-op: its palette never lands, the device stays on the boot-time standard table, and every pixel drawn with the application's own indices displays the wrong colors (the #695 symptom: index 104 = khaki in the app's palette, magenta in the standard table; corruption spreads with each repaint as more app-indexed pixels land).

The forensic trail in #695 pinned each step: device table proven byte-perfect standard, framebuffer indices proven to be correct app-palette indices (ground-truthed against the app's tile-PICT clut), and the fix verified headless against the same install running on real system software (SheepShaver/OS 9) — terrain, water, cliffs, and surround all match the reference frame.

## The fix

Keep-device now applies only to *pure* explicit: `usage & PM_EXPLICIT != 0 && usage & (PM_TOLERANT | PM_ANIMATED) == 0`. Combined entries fall through to the ordinary install-at-index path. This restores the pre-#610 condition (which handled explicit+tolerant, IM:V V-157…V-160) and extends it to explicit+animated.

## Compatibility with #610 (Civilization II)

#610 introduced keep-device-for-any-explicit to recover Civilization II's colors (#600). This PR restores installs for combined usages, so **Civ II needs re-verification** — I don't have that fixture. Two observations for that review:

1. If Civ II regresses, the IM-faithful middle ground is **tolerance-aware installation**: explicit-tolerant installs only when the device color differs from `ciRGB` by more than `ciTolerance` (per the tolerant contract). That serves both cases — a custom palette far from the standard table installs; entries already within tolerance are preserved. Happy to implement that variant if Civ II shows it's needed.
2. #610 predates #693 (lazy resource seeding was introduced the following day, and #692 shows palette resources being reported missing/NULL in related paths). If Civ II's original symptom involved bogus `ciRGB` values from a resource-loading path, #693 may have fixed the underlying cause, leaving #610's keep-device as a workaround that can now be narrowed.

## Tests

- `activatepalette_installs_explicit_tolerant_entries_at_their_index` (reworked from #610's `..._preserves_device_rgb_for_mixed_explicit_entries` — under keep-device-for-any-explicit, explicit+tolerant is indistinguishable from pure explicit, and the real-hardware ground truth contradicts that).
- The two animate-entry tests now expect un-animated explicit-animated entries to reactivate to their own palette colors.
- **Pure-explicit preservation stays pinned** by the untouched `activatepalette_does_not_render_explicit_palette_entries`.
- Full suite: 3,779 pass.

---

*From Claude Fable 5, working with @rlanday. Fourth of the bring-up series (#692/#693, #694, #695/this).*
