### PR TITLE
fix(pict): preserve exact indexed colors

### DIFF
--- a/src/trap/pict.rs
+++ b/src/trap/pict.rs
@@ -4093,6 +4093,16 @@ fn build_src_to_dst_table_uncached(
             }
             table[i] = if *entry == device_clut[i] {
                 i as u8
+            } else if let Some(index) = device_clut
+                .iter()
+                .position(|destination| destination == entry)
+            {
+                // Color2Index returns an exact CTable entry before consulting
+                // the quantized inverse-table cell. This matters when source
+                // and device palettes contain the same colors at different
+                // indices: a lower-index color in the same 4-bit cell must not
+                // replace an exact match.
+                index as u8
             } else {
                 let qr = (entry[0] >> 12) as u32;
                 let qg = (entry[1] >> 12) as u32;
@@ -6552,6 +6562,19 @@ mod tests {
         let table = build_src_to_dst_table(&src, &dst);
 
         assert_eq!(table[71], 71);
+    }
+
+    #[test]
+    fn exact_palette_entry_at_another_index_wins_over_inverse_cell_seed() {
+        let mut src = [[0u16; 3]; 256];
+        let mut dst = [[0u16; 3]; 256];
+        dst[5] = [0x2000, 0x0000, 0x3000];
+        dst[12] = [0x2E2E, 0x0202, 0x3333];
+        src[71] = dst[12];
+
+        let table = build_src_to_dst_table(&src, &dst);
+
+        assert_eq!(table[71], 12);
     }
 
     #[test]


### PR DESCRIPTION
Closes #698.

Color2Index checks for an exact CTable entry before consulting the quantized inverse-table cell. Indexed PICT translation already preserved a same-index exact match, but missed exact RGB values installed at another device index. In that case an earlier color sharing the same 4-bit inverse cell could replace the authored color.

This preserves exact cross-index matches first and retains inverse-table approximation only when no exact device color exists.

Ferazel validation was performed headlessly across the complete launch sequence. Its title PICT contains all 256 colors in the installed device palette at permuted indices, so they now survive exactly. The settled demo menu already shares 252 authored colors at the same indices; its conspicuous residual dithering is present in that demo PICT rather than introduced by CLUT translation. A one-guest-tick New Game click still advances through the palette fade into the HUD.

Tests: `cargo test`