### PR TITLE
docs: establish contributor licensing policy

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+## Summary
+
+<!-- Describe the change and why it is needed. -->
+
+## Validation
+
+<!-- List the checks you ran and any relevant manual testing. -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  licenses:
+    name: dependency licenses
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          rust-version: "1.93"
+          command: check licenses
+
   test:
     name: build & test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,85 @@
+# Systemless Contributor Agreement
+
+Version 1.0
+
+Effective: 21 August 2026
+
+Thanks for contributing to Systemless.
+
+Systemless is an open-source project maintained by Ben Letchford. The public
+project is GPL-licensed and is intended to remain open source.
+
+## Why are these terms needed?
+
+Ben may also publish polished, paid versions of Systemless, such as a Mac App
+Store app, to help support the ongoing development and maintenance of the
+open-source project.
+
+Because contributors keep copyright in the work they contribute, Ben needs
+permission to include those contributions in separately licensed releases as
+well.
+
+These terms do not transfer ownership of your work and do not remove or reduce
+any GPL rights.
+
+### Example
+
+Suppose you contribute a fix that improves compatibility with a classic Mac
+application.
+
+That fix remains part of the public GPL-licensed Systemless project.
+
+It may also be included in a paid Systemless app on the Mac App Store. Revenue
+from that app can help support continued development, testing, compatibility
+work, hosting, and maintenance of Systemless.
+
+You still own your contribution, and the open-source Systemless project remains
+GPL-licensed. This is one example; the terms below also cover other separately
+licensed Systemless distributions.
+
+## Terms
+
+By contributing to Systemless and accepting this agreement, you agree to the
+following:
+
+1. You keep ownership of your contribution.
+
+2. You grant Ben Letchford a perpetual, worldwide, non-exclusive, irrevocable,
+   and royalty-free licence to use, reproduce, modify, distribute, sublicense,
+   and relicense your contribution.
+
+3. This permission includes distributing your contribution as part of
+   open-source, commercial, or proprietary versions of Systemless.
+
+4. Your contribution to the public Systemless project remains available under
+   the project's open-source licence. This agreement does not remove or reduce
+   any GPL rights already granted to anyone.
+
+5. You confirm that you have the right to submit the contribution and grant
+   these permissions.
+
+6. To the extent you can grant such rights, you grant Ben Letchford a
+   perpetual, worldwide, non-exclusive, irrevocable, royalty-free patent
+   licence to make, use, sell, offer for sale, import, and otherwise distribute
+   Systemless where doing so would otherwise infringe patent claims you control
+   that are necessarily practised by your contribution.
+
+7. Ben Letchford may assign or transfer his rights under this agreement in
+   connection with a transfer of his ownership or stewardship of Systemless,
+   including to a company established to own or operate Systemless or to a
+   successor that acquires the project. Any such assignment or transfer does
+   not reduce your ownership of your contribution or any GPL rights already
+   granted.
+
+Unless explicitly agreed otherwise, this agreement applies to your past,
+present, and future contributions to Systemless once you accept it.
+
+This agreement does not transfer your copyright to Ben Letchford. Placing this
+agreement in the repository does not by itself make an existing contributor
+subject to it; each contributor must accept it separately.
+
+## In short
+
+**You keep ownership of your contributions. Systemless stays open source. These
+terms simply allow your work to also be included in paid Systemless releases
+that can help support continued development of the project.**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,21 @@
 Thanks for helping improve Systemless. These guidelines apply to every
 contribution, whether it is prepared manually or with automated tools.
 
+## Contributor terms
+
+Systemless has some short [contributor terms](./CLA.md).
+
+You keep ownership of your work and Systemless remains GPL-licensed. The terms
+also allow contributions to be included in separately licensed paid releases,
+such as a Mac App Store app, which can help support continued development of
+the project.
+
+Existing GPL rights remain unaffected.
+
+If you are not comfortable with those terms, that's completely fine. Please
+open an issue instead and we can discuss the change without accepting
+contributed code.
+
 ## Before making changes
 
 - Read the project context and build instructions in `README.md`.

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,0 +1,50 @@
+# Systemless Licensing
+
+Copyright © 2026 Ben Letchford and Systemless contributors.
+
+## Open-source distribution
+
+The Systemless emulator and runtime code in this public repository is
+distributed under GPL-3.0-or-later. See [LICENSE](./LICENSE) for the full licence
+text.
+
+Some components have additional component-specific licences. In particular,
+the original bitmap font sources in `src/quickdraw/fonts/pixel_font/` are also
+available under the SIL Open Font License 1.1, with "Systemless" as the Reserved
+Font Name. See [OFL.txt](./OFL.txt).
+
+## Separate commercial licensing
+
+Ben Letchford may make software for which he holds sufficient rights available
+under separate commercial licence terms. Receiving Systemless source from
+GitHub or crates.io under the GPL does not grant a proprietary or separate
+commercial licence.
+
+A separately licensed Systemless distribution does not revoke or diminish any
+GPL rights already granted in the open-source project. This document does not
+change the licence of this GPL repository or offer a commercial licence to the
+public.
+
+## Contributions
+
+Contributions are accepted subject to the current
+[Systemless Contributor Agreement](./CLA.md). Contributors retain copyright in
+their contributions and grant Ben Letchford the additional non-exclusive rights
+described in that agreement.
+
+Adding the agreement to this repository does not make historical contributors
+subject to it. Existing contributors must accept it separately before their
+work can be treated as covered by those additional permissions.
+
+## Third-party components
+
+Dependencies, third-party code, and assets remain governed by their respective
+licences. A separately licensed Systemless distribution does not relicense
+third-party material; every included component must independently permit that
+distribution.
+
+## Game and software content
+
+Systemless does not obtain redistribution rights to classic Macintosh
+applications or games merely because it can run them. Rights to distribute game
+and application content are separate from the licensing of Systemless itself.

--- a/README.md
+++ b/README.md
@@ -321,9 +321,11 @@ Systemless intentionally diverges from it, and why.
 
 ## License
 
-The emulator code is GPL-3.0-or-later. See [LICENSE](./LICENSE).
+The open-source Systemless emulator/runtime is licensed under
+GPL-3.0-or-later.
 
-The systemless bitmap fonts are original artwork authored for this project and
-are additionally available under the SIL Open Font License 1.1 (see
-[OFL.txt](./OFL.txt)), Reserved Font Name "Systemless" — see
-[Font license](#font-license). No third-party font data is bundled.
+Some components have additional component-specific licensing, including the
+original Systemless bitmap fonts under the SIL Open Font License 1.1.
+
+See [LICENSING.md](./LICENSING.md), [LICENSE](./LICENSE), and
+[OFL.txt](./OFL.txt) for details.

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,26 @@
+[licenses]
+confidence-threshold = 0.8
+unused-allowed-license = "deny"
+unused-license-exception = "deny"
+
+# Permissive licence expressions currently present in the resolved graph.
+# Licences not listed here or in a crate-specific exception are denied.
+allow = [
+    "0BSD",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "MIT",
+    "Unicode-3.0",
+    "Unlicense",
+    "Zlib",
+]
+
+# Keep copyleft and component-specific licences scoped to the reviewed crates
+# that require them. New GPL, LGPL, AGPL, or OFL dependencies will fail.
+exceptions = [
+    { crate = "hfs-reader@0.1.1", allow = ["GPL-3.0-or-later"] },
+    { crate = "systemless", allow = ["GPL-3.0-or-later", "OFL-1.1"] },
+]


### PR DESCRIPTION
## Summary

- add Contributor Agreement version 1.0 while preserving contributor ownership and existing GPL rights
- document the boundary between the public GPL project, separate commercial licensing, component-specific licences, third-party material, and game content
- add a friendly contributor-terms summary while keeping the pull-request template focused on summary and validation
- add a reviewed `cargo-deny` licence policy and a focused dependency-licence CI job

The public project remains GPL-3.0-or-later, the original bitmap fonts retain their OFL-1.1 treatment, and `LICENSE`, `OFL.txt`, `Cargo.toml`, and `Cargo.lock` are unchanged. No public commercial licence option is introduced.

## Dependency audit

The resolved graph uses 0BSD, Apache-2.0, Apache-2.0 WITH LLVM-exception, BSD-2-Clause, BSD-3-Clause, ISC, MIT, Unicode-3.0, Unlicense, and Zlib permissive licences. Systemless itself retains its existing GPL-3.0-or-later AND OFL-1.1 package metadata.

`hfs-reader 0.1.1` is an existing direct GPL-3.0-or-later dependency and receives a version-specific exception; this must be separately cleared or replaced before inclusion in a proprietary distribution. `r-efi` offers MIT or Apache-2.0 alternatives in addition to LGPL-2.1-or-later, so no LGPL allowance is required. New GPL, LGPL, AGPL, OFL, unknown, or unlicensed dependencies fail unless consciously reviewed and narrowly configured.

## Existing contributor scope

Adding the agreement does not bind historical contributors. Their open-source contributions remain GPL, and any retrospective commercial permission must be collected separately.

## Validation

- `git diff --check`
- `cargo deny check licenses`
- `cargo deny -L info --all-features check licenses` (297 crates, 0 errors, 0 warnings)
- `cargo test --lib` (3,803 passed, 3 ignored)
- `cargo check --no-default-features`
- `cargo package --locked --allow-dirty`
- `actionlint .github/workflows/ci.yml`

Closes #717