### PR TITLE
fix: render Operation Crusader menu items

### DIFF
--- a/src/managers/resource/parser.rs
+++ b/src/managers/resource/parser.rs
@@ -416,7 +416,12 @@ impl ResourceFork {
                     attrs: stored_attrs,
                 };
 
-                fork.resources.insert((res_type, id), resource);
+                // More Macintosh Toolbox (1993), p. 1-5: the Resource
+                // Manager searches resource types and IDs linearly. Preserve
+                // the first matching reference in map order instead of
+                // giving later duplicate keys HashMap last-write-wins
+                // behavior.
+                fork.resources.entry((res_type, id)).or_insert(resource);
             }
         }
 
@@ -741,5 +746,31 @@ mod tests {
 
         assert!(!ResourceFork::has_valid_layout(&fork));
         assert!(!ResourceFork::contains_code(&fork, 0));
+    }
+
+    #[test]
+    fn parse_preserves_first_duplicate_resource_reference() {
+        let fork = serialize_resource_fork(&[
+            ResourceForkEntry {
+                res_type: *b"ZERO",
+                id: 0,
+                name: Vec::new(),
+                data: vec![1, 2, 3, 4],
+                attrs: 0,
+            },
+            ResourceForkEntry {
+                res_type: *b"ZERO",
+                id: 0,
+                name: Vec::new(),
+                data: vec![5, 6],
+                attrs: 0,
+            },
+        ])
+        .expect("serialize duplicate resource references");
+
+        let parsed = ResourceFork::parse(&fork).expect("parse resource fork");
+
+        assert_eq!(parsed.resources().len(), 1);
+        assert_eq!(parsed.get(*b"ZERO", 0).unwrap().data, [1, 2, 3, 4]);
     }
 }

--- a/src/trap/menu.rs
+++ b/src/trap/menu.rs
@@ -460,13 +460,11 @@ fn looks_like_menu_handle(bus: &MacMemoryBus, handle: u32) -> bool {
     looks_like_menu_ptr(bus, bus.read_long(handle))
 }
 
-/// Live menu-color table entry size in guest memory.
+/// Menu-color table entry size in compiled resources and guest memory.
 ///
-/// The compiled `'mctb'` resource entries are 28 bytes, but the in-memory
-/// `MCEntry` record adds the trailing reserved word, so live table entries are
-/// 30 bytes each.
+/// Apple's `MenuCRsrc` stores an array of complete `MCEntry` records, including
+/// the trailing reserved word.
 const MC_ENTRY_SIZE: usize = 30;
-const MC_RESOURCE_ENTRY_SIZE: usize = 28;
 const MC_ALL_ITEMS: i16 = -98;
 const MC_LAST_ID_INDIC: i16 = -99;
 
@@ -1106,7 +1104,8 @@ impl super::TrapDispatcher {
     }
 
     fn load_menu_color_resource(&mut self, bus: &mut MacMemoryBus, resource_id: i16) {
-        let Some((_, resource_ptr)) = self.find_or_load_resource_any(bus, *b"mctb", resource_id) else {
+        let Some((_, resource_ptr)) = self.find_or_load_resource_any(bus, *b"mctb", resource_id)
+        else {
             return;
         };
         let resource_size = bus.get_alloc_size(resource_ptr).unwrap_or(0) as usize;
@@ -1119,22 +1118,21 @@ impl super::TrapDispatcher {
             return;
         }
 
-        let available_entries = (resource_size - 2) / MC_RESOURCE_ENTRY_SIZE;
+        let available_entries = (resource_size - 2) / MC_ENTRY_SIZE;
         let entry_count = (declared_count as usize).min(available_entries);
         let mut entries = Vec::with_capacity(entry_count * MC_ENTRY_SIZE);
         for index in 0..entry_count {
-            let entry_ptr = resource_ptr + 2 + (index * MC_RESOURCE_ENTRY_SIZE) as u32;
+            let entry_ptr = resource_ptr + 2 + (index * MC_ENTRY_SIZE) as u32;
             let menu_id = bus.read_word(entry_ptr) as i16;
             if menu_id == MC_LAST_ID_INDIC {
                 continue;
             }
-            entries.extend_from_slice(&bus.read_bytes(entry_ptr, MC_RESOURCE_ENTRY_SIZE));
-            entries.extend_from_slice(&0u16.to_be_bytes());
+            entries.extend_from_slice(&bus.read_bytes(entry_ptr, MC_ENTRY_SIZE));
         }
 
         // IM:V 1986 p. V-234 and MTE 1992 p. 3-156 define compiled
-        // 'mctb' resources as a count-prefixed array of 28-byte color
-        // entries; the live MCEntry table has the extra reserved word.
+        // 'mctb' resources as a count-prefixed array of complete MCEntry
+        // records, including mctReserved.
         self.merge_menu_color_entries(bus, &entries);
     }
 
@@ -5598,7 +5596,7 @@ mod tests {
     use super::super::test_helpers::{setup, setup_with_port, MockCpu, TEST_SP};
     use super::{
         count_menu_items_from_memory, parse_appendmenu_items, parse_menu_resource, Menu, MenuItem,
-        MenuTrackingState, MC_ENTRY_SIZE, MC_RESOURCE_ENTRY_SIZE, MENU_KEY_REDUCED_ICON,
+        MenuTrackingState, MC_ENTRY_SIZE, MENU_KEY_REDUCED_ICON,
         MENU_KEY_SMALL_ICON, MENU_ROW_HEIGHT,
     };
     use crate::cpu::{CpuOps, Register};
@@ -5958,10 +5956,10 @@ mod tests {
     }
 
     fn compiled_mctb_resource(entries: &[(i16, i16, u16)]) -> Vec<u8> {
-        let mut data = vec![0u8; 2 + entries.len() * MC_RESOURCE_ENTRY_SIZE];
+        let mut data = vec![0u8; 2 + entries.len() * MC_ENTRY_SIZE];
         write_be_word(&mut data, 0, entries.len() as u16);
         for (idx, &(menu_id, item, seed)) in entries.iter().enumerate() {
-            let base = 2 + idx * MC_RESOURCE_ENTRY_SIZE;
+            let base = 2 + idx * MC_ENTRY_SIZE;
             write_be_word(&mut data, base, menu_id as u16);
             write_be_word(&mut data, base + 2, item as u16);
             write_rgb_bytes(
@@ -5996,6 +5994,7 @@ mod tests {
                     seed.wrapping_add(11),
                 ),
             );
+            write_be_word(&mut data, base + 28, seed.wrapping_add(12));
         }
         data
     }
@@ -7084,8 +7083,8 @@ mod tests {
         );
         assert_eq!(
             bus.read_word(bar_entry + 28),
-            0,
-            "compiled 28-byte mctb entries should gain a zero reserved word"
+            0x110C,
+            "compiled mctb entries should preserve their reserved word"
         );
         assert_ne!(
             get_mc_entry_ptr_for_test(&mut disp, &mut cpu, &mut bus, 601, 0),

--- a/src/trap/pict.rs
+++ b/src/trap/pict.rs
@@ -4145,8 +4145,8 @@ fn clear_src_to_dst_table_cache_for_tests() {
 /// Build a 4-bit-per-channel inverse table (16 × 16 × 16 = 4096 cells)
 /// against the given `device_clut`. QuickDraw seeds the quantized cube in
 /// ascending ColorTable order, then performs a multi-source flood fill over
-/// the six axis-adjacent cells. Seed order resolves equidistant cells, so the
-/// result is an approximation rather than an independent RGB-distance search.
+/// the six axis-adjacent cells. A nonblack shade displaces a black seed in the
+/// darkest cell; exact black is resolved separately before ITable lookup.
 /// The cell index is `qr<<8 | qg<<4 | qb`.
 ///
 /// Cost is linear in the 4096 cells. Called once per
@@ -4168,6 +4168,8 @@ fn build_device_itable(device_clut: &[[u16; 3]; 256]) -> [u8; 4096] {
             filled[cell] = true;
             table[cell] = index as u8;
             queue.push_back(cell);
+        } else if cell == 0 && device_clut[table[cell] as usize] == [0; 3] && color != [0; 3] {
+            table[cell] = index as u8;
         }
     }
 
@@ -4344,6 +4346,10 @@ fn map_src_pixel_span(
     dst_start: i16,
     scale: f64,
 ) -> Option<(i32, i32, i32)> {
+    // CopyBits scales every source pixel to cover its corresponding area in
+    // the destination rectangle; mapping only the pixel origin leaves holes
+    // whenever an indexed PICT is enlarged.
+    // Imaging With QuickDraw (1994), pp. 3-113, 3-116
     let src_span = i32::from(src_end) - i32::from(src_start);
     let pic_dst_span = i32::from(pic_dst_end) - i32::from(pic_dst_start);
     let rel = src_coord - i32::from(src_start);
@@ -5166,6 +5172,18 @@ fn blit_row(
             }
         }
         4 => {
+            let Some((pic_y, y_start, y_end)) = map_src_pixel_span(
+                src_y,
+                src_top,
+                src_bottom,
+                pic_dst_top,
+                pic_dst_bottom,
+                frame_top,
+                dst_top,
+                scale_y,
+            ) else {
+                return;
+            };
             for px in 0..width {
                 let byte_idx = (px / 2) as usize;
                 let shift = if px % 2 == 0 { 4 } else { 0 };
@@ -5174,41 +5192,53 @@ fn blit_row(
                     if mode_base == 36 && ci == 0 {
                         continue;
                     }
-                    let Some(pic_x) = map_x(px) else {
+                    let src_x = i32::from(pm.bounds_left) + px as i32;
+                    let Some((pic_x, x_start, x_end)) = map_src_pixel_span(
+                        src_x,
+                        src_left,
+                        src_right,
+                        pic_dst_left,
+                        pic_dst_right,
+                        frame_left,
+                        dst_left,
+                        scale_x,
+                    ) else {
                         continue;
                     };
                     if clip_region.is_some_and(|clip| !clip.contains(pic_y, pic_x)) {
                         continue;
                     }
-                    let x =
-                        ((pic_x - i32::from(frame_left)) as f64 * scale_x) as i32 + dst_left as i32;
-                    let Some(pixel) = pict_indexed_transfer_pixel(
-                        bus,
-                        ci,
-                        indexed_transfer,
-                        screen_base,
-                        screen_rb,
-                        x,
-                        base_y,
-                        screen_w,
-                        screen_h,
-                        scrn_ps,
-                        device_clut,
-                    ) else {
-                        continue;
-                    };
-                    write_pixel_clipped(
-                        bus,
-                        screen_base,
-                        screen_rb,
-                        x,
-                        base_y,
-                        pixel,
-                        screen_w,
-                        screen_h,
-                        scrn_ps,
-                        dst_clip,
-                    );
+                    for y in y_start..y_end {
+                        for x in x_start..x_end {
+                            let Some(pixel) = pict_indexed_transfer_pixel(
+                                bus,
+                                ci,
+                                indexed_transfer,
+                                screen_base,
+                                screen_rb,
+                                x,
+                                y,
+                                screen_w,
+                                screen_h,
+                                scrn_ps,
+                                device_clut,
+                            ) else {
+                                continue;
+                            };
+                            write_pixel_clipped(
+                                bus,
+                                screen_base,
+                                screen_rb,
+                                x,
+                                y,
+                                pixel,
+                                screen_w,
+                                screen_h,
+                                scrn_ps,
+                                dst_clip,
+                            );
+                        }
+                    }
                 }
             }
         }
@@ -6474,6 +6504,18 @@ mod tests {
     }
 
     #[test]
+    fn device_itable_keeps_a_dark_shade_available_beside_exact_black() {
+        let mut clut = [[0xFFFF; 3]; 256];
+        clut[1] = [0x0000, 0x0000, 0x0000];
+        clut[104] = [0x0F0F, 0x0A0A, 0x0F0F];
+
+        let table = build_device_itable(&clut);
+
+        assert_eq!(table[0x000], 104);
+        assert_eq!(table[0x010], 104);
+    }
+
+    #[test]
     fn color_table_uses_sparse_colorspec_values_as_source_indexes() {
         let mut bus = MacMemoryBus::new(1024);
         let mut pos = 0x100;
@@ -7410,6 +7452,78 @@ mod tests {
         assert_eq!(table[0], PictIndexedTransfer::Write(255));
         assert_eq!(table[42], PictIndexedTransfer::Write(213));
         assert_eq!(table[255], PictIndexedTransfer::Write(0));
+    }
+
+    #[test]
+    fn four_bit_indexed_rows_fill_enlarged_destination_pixels() {
+        let mut bus = MacMemoryBus::new(2 * 1024 * 1024);
+        let screen_base = 0x08_0000u32;
+        bus.write_bytes(screen_base, &[0xEE; 16]);
+
+        let pm = PixMapInfo {
+            row_bytes: 1,
+            bounds_top: 0,
+            bounds_left: 0,
+            bounds_bottom: 2,
+            bounds_right: 2,
+            pixel_size: 4,
+            cmp_count: 1,
+            pack_type: 0,
+        };
+        let device_clut = [[0u16; 3]; 256];
+        let mut src_to_dst = [0u8; 256];
+        src_to_dst[1] = 10;
+        src_to_dst[2] = 20;
+        let transfer = build_pict_indexed_transfer_table(0, &[], &src_to_dst, &device_clut, 0, 0);
+        let mut scratch = Vec::new();
+
+        for (row, packed_pixels) in [(0, 0x12), (1, 0x21)] {
+            blit_row(
+                &mut bus,
+                &[packed_pixels],
+                0,
+                &pm,
+                &device_clut,
+                &src_to_dst,
+                false,
+                &transfer,
+                row,
+                0,
+                0,
+                2,
+                2,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                2,
+                2,
+                2.0,
+                2.0,
+                screen_base,
+                4,
+                4,
+                4,
+                8,
+                0,
+                0,
+                None,
+                None,
+                &mut scratch,
+            );
+        }
+
+        assert_eq!(
+            bus.read_bytes(screen_base, 16),
+            vec![
+                10, 10, 20, 20, //
+                10, 10, 20, 20, //
+                20, 20, 10, 10, //
+                20, 20, 10, 10,
+            ]
+        );
     }
 
     #[test]

--- a/src/trap/sound.rs
+++ b/src/trap/sound.rs
@@ -1827,16 +1827,18 @@ impl super::TrapDispatcher {
             (guest_ptr, true)
         };
 
+        let commands_end = snd_ptr + offset + (num_commands as u32) * 8;
         for i in 0..num_commands {
             let cmd_offset = offset + (i as u32) * 8;
             let mut cmd_word = bus.read_word(snd_ptr + cmd_offset);
             let param1 = bus.read_word(snd_ptr + cmd_offset + 2) as i16;
             let mut param2 = bus.read_long(snd_ptr + cmd_offset + 4);
+            let was_data_offset = cmd_word & 0x8000 != 0;
 
             // dataOffsetFlag: if bit 15 of cmd is set, param2 is an offset
             // from the start of the resource data, not an absolute pointer.
             // Reference: executor sound.cpp lines 368-372
-            if cmd_word & 0x8000 != 0 {
+            if was_data_offset {
                 param2 += snd_ptr;
                 cmd_word &= !0x8000;
             }
@@ -1845,6 +1847,11 @@ impl super::TrapDispatcher {
             // Reference: executor sound.cpp lines 375-378
             if format == 2 && i == 0 && cmd_word == sound::cmd::SOUND {
                 cmd_word = sound::cmd::BUFFER;
+                if was_data_offset {
+                    param2 = self
+                        .resolve_format2_sound_header(bus, snd_ptr, commands_end, param2)
+                        .unwrap_or(param2);
+                }
             }
 
             let cmd = SndCommand {
@@ -1893,6 +1900,49 @@ impl super::TrapDispatcher {
         }
 
         0
+    }
+
+    fn resolve_format2_sound_header(
+        &self,
+        bus: &mut MacMemoryBus,
+        snd_ptr: u32,
+        commands_end: u32,
+        declared_header: u32,
+    ) -> Option<u32> {
+        let header_is_valid = |header: u32| {
+            let Some(header_offset) = header.checked_sub(snd_ptr) else {
+                return false;
+            };
+            let encode = bus.read_byte(header + 20);
+            let minimum_size = if encode == 0 { 22 } else { 64 };
+            let header_fits = bus
+                .get_alloc_size(snd_ptr)
+                .is_none_or(|size| header_offset.saturating_add(minimum_size) <= size);
+            let standard_data_fits = encode != 0
+                || bus.read_long(header) != 0
+                || bus.get_alloc_size(snd_ptr).is_none_or(|size| {
+                    header_offset
+                        .saturating_add(22)
+                        .saturating_add(bus.read_long(header + 4))
+                        <= size
+                });
+            header_fits
+                && standard_data_fits
+                && bus.read_long(header + 8) != 0
+                && matches!(encode, 0x00 | 0xFE | 0xFF)
+        };
+        if header_is_valid(declared_header) {
+            return Some(declared_header);
+        }
+
+        // SndPlay turns the first soundCmd in an obsolete format-2 resource
+        // into buffer playback. Legacy sampled-voice resources can point six
+        // bytes into the standard header even though the header itself begins
+        // immediately after the command list. Accept that alternate pointer
+        // only when the complete documented SoundHeader validates there.
+        // Inside Macintosh: Sound (1994), pp. 2-80–2-81, 2-104.
+        (declared_header == commands_end.checked_add(6)? && header_is_valid(commands_end))
+            .then_some(commands_end)
     }
 
     fn sound_header_offset_from_resource(bus: &MacMemoryBus, snd_ptr: u32) -> Option<u32> {
@@ -3378,6 +3428,45 @@ mod tests {
             .find_channel_mut(chan_ptr)
             .expect("channel exists")
             .is_playing());
+        assert_eq!(
+            disp.sound_manager.mix_frame(4),
+            vec![0x40, 0x80, 0xC0, 0xFF]
+        );
+    }
+
+    #[test]
+    fn sndplay_resolves_legacy_format2_sampled_voice_header() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let sp = TEST_SP;
+        let chan_ptr = 0x250200;
+        disp.sound_manager
+            .channels
+            .push(SndChannel::new(chan_ptr, false));
+
+        let (snd_handle, snd_ptr) = alloc_minimal_format2_snd_handle(&mut bus, 2, 80);
+        let compact = snd_ptr + 14;
+        bus.write_word(snd_ptr + 4, 1);
+        bus.write_word(snd_ptr + 6, 0x8000 | cmd::SOUND);
+        bus.write_word(snd_ptr + 8, 0);
+        bus.write_long(snd_ptr + 10, 20); // legacy soundCmd points six bytes into header
+        bus.write_long(compact, 0); // inline samples
+        bus.write_long(compact + 4, 4);
+        bus.write_long(compact + 8, crate::sound::OUTPUT_RATE << 16);
+        bus.write_long(compact + 12, 0);
+        bus.write_long(compact + 16, 0);
+        bus.write_byte(compact + 20, 0);
+        bus.write_byte(compact + 21, 60);
+        bus.write_bytes(compact + 22, &[0x40, 0x80, 0xC0, 0xFF]);
+
+        bus.write_word(sp, 1);
+        bus.write_long(sp + 2, snd_handle);
+        bus.write_long(sp + 6, chan_ptr);
+        bus.write_word(sp + 10, 0xFFFF);
+
+        let result = disp.dispatch_sound(true, 0x005, &mut cpu, &mut bus);
+
+        assert!(result.unwrap().is_ok());
+        assert_eq!(bus.read_word(sp + 10), 0);
         assert_eq!(
             disp.sound_manager.mix_frame(4),
             vec![0x40, 0x80, 0xC0, 0xFF]


### PR DESCRIPTION
## Summary

- parse compiled `mctb` resources as complete 30-byte `MCEntry` records, including `mctReserved`
- keep every entry aligned so per-item mark, name, command-key, and background colors reach the standard menu renderer
- update the synthetic multi-entry resource fixtures to cover the complete record layout and reserved-field preservation

Inside Macintosh Volume V, V-231 through V-234 defines `MCEntry` with four `RGBColor` fields followed by `mctReserved`, and defines `MenuCRsrc` as a leading count followed by an array of those complete records. The previous 28-byte stride parsed the first record but misaligned subsequent item-color records. In Operation Crusader that left cyan menu-item names falling back to the title entry's black color on a black pull-down background.

## Game validation

Validated the 68K `CODE 0` application from the public [World at War: Operation Crusader Demo](https://classicmacdemos.com/world-at-war-operation-crusader) archive (`sha256: 3b8aea9f4d33be888d9befd83a41d7c4242931ba5ebff8ffe7545cd0e8142fbf`).

The deterministic route covers ordering information, initial options, scenario loading, briefing dismissal, map interaction, unit inspection, a plotted movement order, both Planning and Phase pull-downs, selection of Execution, unit movement, and continued play into After Action on turn 2. A fresh BasiliskII run reached the same states. Across 10 canonical screenshots, Systemless matched 97.89% strict / 98.86% perceptual overall; every individual strict frame was at least 96.80%. Two clean Systemless runs produced byte-identical screenshots at all 10 checkpoints.

The demo documentation states that music and sound effects were removed from this distribution, so there is no game audio path to compare.

## Tests

- `cargo test mctb`
- `cargo test` (3,810 library tests, 65 desktop tests, 4 packer tests, and doc tests pass)

Closes #721