### PR TITLE
fix: complete Dynasty League Baseball compatibility

### DIFF
--- a/src/trap/dialog.rs
+++ b/src/trap/dialog.rs
@@ -36,6 +36,16 @@ struct DialogCIconLayout {
     pixel_data_ptr: u32,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct DialogItemTextStyle {
+    font: i16,
+    face: u8,
+    size: i16,
+    foreground: Option<[u16; 3]>,
+    background: Option<[u16; 3]>,
+    mode: i16,
+}
+
 #[derive(Clone, Copy)]
 struct FullscreenOffscreenDialogRestoreCandidate {
     base: u32,
@@ -3977,7 +3987,18 @@ impl super::TrapDispatcher {
         proc_id: i16,
     ) -> (i16, i16, i16, i16) {
         let (_, _, screen_w, screen_h, _) = self.get_screen_params();
-        let main_screen = (0, 0, screen_h, screen_w);
+        let menu_bar_height = if self.menu_bar_hidden {
+            0
+        } else {
+            bus.read_word(crate::memory::globals::addr::MBAR_HEIGHT) as i16
+        };
+        // The main-screen positioning area is the desktop below the menu bar.
+        // Position the complete window structure within it, then translate
+        // back to the content bounds consumed by NewWindow. The WIND bounds
+        // themselves describe only the content region.
+        // Macintosh Toolbox Essentials (1992), pp. 4-29, 4-31, 4-55,
+        // and 4-124 to 4-126.
+        let main_screen = (menu_bar_height, 0, screen_h, screen_w);
         let place_at_alert_position = |target: (i16, i16, i16, i16)| -> (i16, i16, i16, i16) {
             let dialog_w = bounds.3 - bounds.1;
             let dialog_h = bounds.2 - bounds.0;
@@ -4008,6 +4029,23 @@ impl super::TrapDispatcher {
                     new_left + (bounds.3 - bounds.1),
                 )
             };
+        let center_structure = |target: (i16, i16, i16, i16)| -> (i16, i16, i16, i16) {
+            let structure = self.window_structure_global_rect_for_proc(bus, bounds, proc_id);
+            let structure_w = structure.3 - structure.1;
+            let structure_h = structure.2 - structure.0;
+            let target_w = target.3 - target.1;
+            let target_h = target.2 - target.0;
+            let new_structure_left = target.1 + (target_w - structure_w) / 2;
+            let new_structure_top = target.0 + (target_h - structure_h) / 2;
+            let new_left = new_structure_left + (bounds.1 - structure.1);
+            let new_top = new_structure_top + (bounds.0 - structure.0);
+            (
+                new_top,
+                new_left,
+                new_top + (bounds.2 - bounds.0),
+                new_left + (bounds.3 - bounds.1),
+            )
+        };
         match position {
             // alertPositionMainScreen / ParentWindowScreen
             // Macintosh Toolbox Essentials 1992, pp. 4-125 to 4-126
@@ -4025,15 +4063,25 @@ impl super::TrapDispatcher {
                     .unwrap_or(main_screen);
                 bounds = place_structure_at_alert_position(target);
             }
-            // centerMainScreen / centerParentWindow: true vertical center
-            // Macintosh Toolbox Essentials 1992, p. 4-126
-            0x280A | 0x680A | 0xA80A | 0x380A => {
-                let (_, _, screen_w, screen_h, _) = self.get_screen_params();
-                let dialog_w = bounds.3 - bounds.1;
-                let dialog_h = bounds.2 - bounds.0;
-                let new_left = (screen_w - dialog_w) / 2;
-                let new_top = (screen_h - dialog_h) / 2;
-                bounds = (new_top, new_left, new_top + dialog_h, new_left + dialog_w);
+            // centerMainScreen / centerParentWindowScreen. Systemless models a
+            // single screen, so both use the main-screen desktop rectangle.
+            0x280A | 0x680A => {
+                bounds = center_structure(main_screen);
+            }
+            // centerParentWindow uses the content rectangle of the window in
+            // which the user was last working.
+            0xA80A => {
+                let parent = self.front_window_for_trap(bus);
+                let target = (parent != 0)
+                    .then(|| self.window_content_global_rect(bus, parent))
+                    .flatten()
+                    .unwrap_or(main_screen);
+                bounds = center_structure(target);
+            }
+            // Staggering is retained as the existing single-window fallback
+            // until the Window Manager tracks per-screen stagger slots.
+            0x380A => {
+                bounds = center_structure(main_screen);
             }
             _ => {} // noAutoCenter (0x0000) or unknown: use raw bounds
         }
@@ -4095,6 +4143,7 @@ impl super::TrapDispatcher {
             alert_id as u32,
             items_handle,
             items.clone(),
+            None,
             None,
         );
         if dialog_ptr == 0 {
@@ -4438,9 +4487,11 @@ impl super::TrapDispatcher {
 
     fn ditl_item_payload_len(base_type: u8, data_len_byte: u8, remaining: u32) -> Option<u32> {
         let payload_len = match base_type {
-            // userItem has only the byte after itmtype (reserved/empty),
-            // not a following payload.
-            0 => 0,
+            // The compiled item record stores a length byte for every item
+            // type. User items do not interpret their payload, but the Dialog
+            // Manager must still skip it to locate the next record.
+            // Inside Macintosh Volume I, I-404 to I-405 and I-427.
+            0 => u32::from(data_len_byte),
             // Help items use the byte after itmtype as a sized payload.
             // Macintosh Toolbox Essentials 1992, p. 6-154
             1 => u32::from(data_len_byte),
@@ -5114,6 +5165,108 @@ impl super::TrapDispatcher {
         }
     }
 
+    fn copy_dialog_item_color_table_resource(
+        &mut self,
+        bus: &mut MacMemoryBus,
+        table_id: i16,
+    ) -> Option<u32> {
+        let (_, resource_ptr) = self.find_or_load_resource_any(bus, *b"ictb", table_id)?;
+        let byte_size = bus.get_alloc_size(resource_ptr)?;
+        if byte_size == 0 {
+            return None;
+        }
+        let table_ptr = bus.alloc(byte_size);
+        for offset in 0..byte_size {
+            bus.write_byte(table_ptr + offset, bus.read_byte(resource_ptr + offset));
+        }
+        let table_handle = bus.alloc(4);
+        bus.write_long(table_handle, table_ptr);
+        Some(table_handle)
+    }
+
+    fn dialog_item_text_style(
+        &self,
+        bus: &MacMemoryBus,
+        dialog_ptr: u32,
+        item_index: usize,
+    ) -> Option<DialogItemTextStyle> {
+        let table_handle = self.window_dialog_item_color_table(bus, dialog_ptr);
+        if table_handle == 0 {
+            return None;
+        }
+        let table_ptr = bus.read_long(table_handle);
+        if table_ptr == 0 {
+            return None;
+        }
+        let table_size = bus.get_alloc_size(table_ptr)?;
+        let entry_offset = u32::try_from(item_index).ok()?.checked_mul(4)?;
+        if entry_offset.checked_add(4)? > table_size {
+            return None;
+        }
+
+        let flags = bus.read_word(table_ptr + entry_offset);
+        let style_offset = u32::from(bus.read_word(table_ptr + entry_offset + 2));
+        if flags == 0 && style_offset == 0 {
+            return None;
+        }
+        if style_offset.checked_add(20)? > table_size {
+            return None;
+        }
+
+        let style_ptr = table_ptr + style_offset;
+        let stored_font = bus.read_word(style_ptr) as i16;
+        let stored_face = bus.read_word(style_ptr + 2) as u8;
+        let stored_size = bus.read_word(style_ptr + 4) as i16;
+        let mut size = self.tx_size;
+        if flags & 0x0004 != 0 {
+            size = stored_size;
+        }
+        if flags & 0x0010 != 0 {
+            size = size.saturating_add(stored_size);
+        }
+
+        // A set doFontName bit makes diFont an offset to a Pascal font name.
+        // Font-number lookup remains the safe fallback when that optional
+        // name cannot be resolved by the HLE Font Manager.
+        let font = if flags & 0x0001 != 0 && flags & 0x8000 == 0 {
+            stored_font
+        } else {
+            self.tx_font
+        };
+        let face = if flags & 0x0002 != 0 {
+            stored_face
+        } else {
+            self.tx_face as u8
+        };
+        let foreground = (flags & 0x0008 != 0).then(|| {
+            [
+                bus.read_word(style_ptr + 6),
+                bus.read_word(style_ptr + 8),
+                bus.read_word(style_ptr + 10),
+            ]
+        });
+        let background = (flags & 0x2000 != 0).then(|| {
+            [
+                bus.read_word(style_ptr + 12),
+                bus.read_word(style_ptr + 14),
+                bus.read_word(style_ptr + 16),
+            ]
+        });
+        let mode = if flags & 0x4000 != 0 {
+            bus.read_word(style_ptr + 18) as i16
+        } else {
+            self.tx_mode
+        };
+        Some(DialogItemTextStyle {
+            font,
+            face,
+            size,
+            foreground,
+            background,
+            mode,
+        })
+    }
+
     fn finish_dialog_creation<C: CpuOps>(
         &mut self,
         bus: &mut MacMemoryBus,
@@ -5128,6 +5281,7 @@ impl super::TrapDispatcher {
         items_handle: u32,
         items: Vec<DialogItem>,
         dialog_color_table: Option<u32>,
+        dialog_item_color_table: Option<u32>,
     ) -> u32 {
         let previous_port = self.current_port;
         let previous_gdevice = self.current_gdevice;
@@ -5175,6 +5329,9 @@ impl super::TrapDispatcher {
         if let Some(color_table) = dialog_color_table {
             self.ensure_window_aux_record(bus, dlg_ptr, color_table);
             self.apply_window_color_table(bus, dlg_ptr, color_table);
+        }
+        if let Some(item_color_table) = dialog_item_color_table {
+            self.set_window_dialog_item_color_table(bus, dlg_ptr, item_color_table);
         }
 
         // DialogRecord starts with a WindowRecord; +108 is windowKind,
@@ -5852,7 +6009,7 @@ impl super::TrapDispatcher {
         if let Some((red, green, blue)) = self.window_semantic_color(bus, dialog_ptr, 0) {
             let (screen_base, row_bytes, screen_width, screen_height, pixel_size) =
                 self.get_screen_params();
-            let pixel_index = super::pict::closest_clut_index(red, green, blue, &self.device_clut);
+            let pixel_index = Self::nearest_palette_index(&self.device_clut, [red, green, blue]);
             Self::fb_fill_rect_index(
                 bus,
                 screen_base,
@@ -5869,6 +6026,38 @@ impl super::TrapDispatcher {
         } else {
             self.fill_rect_clipped_to_dialog(bus, bounds, rect, false);
         }
+    }
+
+    fn fill_dialog_item_background(
+        &self,
+        bus: &mut MacMemoryBus,
+        bounds: (i16, i16, i16, i16),
+        rect: (i16, i16, i16, i16),
+        rgb: [u16; 3],
+    ) {
+        let top = rect.0.max(bounds.0);
+        let left = rect.1.max(bounds.1);
+        let bottom = rect.2.min(bounds.2);
+        let right = rect.3.min(bounds.3);
+        if top >= bottom || left >= right {
+            return;
+        }
+        let (screen_base, row_bytes, screen_width, screen_height, pixel_size) =
+            self.get_screen_params();
+        let pixel_index = Self::nearest_palette_index(&self.device_clut, rgb);
+        Self::fb_fill_rect_index(
+            bus,
+            screen_base,
+            row_bytes,
+            pixel_size,
+            screen_width,
+            screen_height,
+            top,
+            left,
+            bottom,
+            right,
+            pixel_index,
+        );
     }
 
     fn dialog_item_enclosing_local_rect(
@@ -6005,7 +6194,7 @@ impl super::TrapDispatcher {
         if !game_managed {
             if let Some((red, green, blue)) = content_color {
                 let pixel_index =
-                    super::pict::closest_clut_index(red, green, blue, &self.device_clut);
+                    Self::nearest_palette_index(&self.device_clut, [red, green, blue]);
                 Self::fb_fill_rect_index(
                     bus,
                     screen_base,
@@ -6088,7 +6277,7 @@ impl super::TrapDispatcher {
                     self.draw_rect_border(bus, top - 1, left - 1, bottom + 1, right + 1);
                     self.draw_shadow(bus, top - 1, left - 1, bottom + 1, right + 1);
                 }
-                0 | 4 => {
+                0 | 4 | 5 => {
                     // documentProc/noGrowDocProc use the Window Manager's
                     // document WDEF title-bar chrome. DrawDialog is allowed
                     // on modeless dialogs too (IM:I I-417; MTE 1992 p. 6-142),
@@ -6106,7 +6295,13 @@ impl super::TrapDispatcher {
                         title.to_string()
                     };
                     self.go_away_flag = dialog_ptr != 0 && bus.read_byte(dialog_ptr + 112) != 0;
-                    self.draw_window_frame(bus);
+                    // DrawDialog has already painted the dialog content. The
+                    // full WDEF draw path erases its structure region before
+                    // drawing document/movable chrome, so use the chrome-only
+                    // path here. This also gives movableDBoxProc its striped
+                    // title bar without clearing dialog-manager-owned items.
+                    // MTE 1992 p. 6-142; HIG 1992 pp. 185-186.
+                    self.draw_window_chrome(bus, true);
                     self.window_bounds = saved_bounds;
                     self.window_proc_id = saved_proc_id;
                     self.window_title = saved_title;
@@ -6243,8 +6438,17 @@ impl super::TrapDispatcher {
                 }
                 // Static text (8)
                 8 => {
+                    let style = self.dialog_item_text_style(bus, dialog_ptr, i);
+                    if let Some(rgb) = style.and_then(|value| value.background) {
+                        self.fill_dialog_item_background(
+                            bus,
+                            bounds,
+                            (abs_top, abs_left, abs_bottom, abs_right),
+                            rgb,
+                        );
+                    }
                     self.draw_static_text(
-                        bus, abs_top, abs_left, abs_bottom, abs_right, &item.text,
+                        bus, abs_top, abs_left, abs_bottom, abs_right, &item.text, style,
                     );
                 }
                 // Edit text (16)
@@ -6860,13 +7064,25 @@ impl super::TrapDispatcher {
                     }
                 }
                 8 => {
-                    self.fill_dialog_content_rect(
-                        bus,
-                        dialog_ptr,
-                        bounds,
-                        (abs_top, abs_left, abs_bottom, abs_right),
-                    );
-                    self.draw_static_text(bus, abs_top, abs_left, abs_bottom, abs_right, &item.text)
+                    let style = self.dialog_item_text_style(bus, dialog_ptr, i);
+                    if let Some(rgb) = style.and_then(|value| value.background) {
+                        self.fill_dialog_item_background(
+                            bus,
+                            bounds,
+                            (abs_top, abs_left, abs_bottom, abs_right),
+                            rgb,
+                        );
+                    } else {
+                        self.fill_dialog_content_rect(
+                            bus,
+                            dialog_ptr,
+                            bounds,
+                            (abs_top, abs_left, abs_bottom, abs_right),
+                        );
+                    }
+                    self.draw_static_text(
+                        bus, abs_top, abs_left, abs_bottom, abs_right, &item.text, style,
+                    )
                 }
                 16 => {
                     let display_text = if item_num == edit_item {
@@ -8512,13 +8728,18 @@ impl super::TrapDispatcher {
         bottom: i16,
         right: i16,
         text: &str,
+        style: Option<DialogItemTextStyle>,
     ) {
         let (screen_base, row_bytes, screen_width, screen_height, pixel_size) =
             self.get_screen_params();
         // SetDialogFont/SetDAFont affects statText and editText items but
         // not control titles (IM:I I-412; MTE 1992 p. 6-105).
-        let font_id = self.tx_font;
-        let font_size = Self::font_lookup_size(self.tx_size);
+        let font_id = style.map(|value| value.font).unwrap_or(self.tx_font);
+        let raw_font_size = style.map(|value| value.size).unwrap_or(self.tx_size);
+        let font_size = Self::font_lookup_size(raw_font_size);
+        let face = style.map(|value| value.face).unwrap_or(self.tx_face as u8);
+        let foreground = style.and_then(|value| value.foreground);
+        let _mode = style.map(|value| value.mode).unwrap_or(self.tx_mode);
         let metrics = get_font_metrics(font_id, font_size);
         let line_height = metrics.ascent + metrics.descent + metrics.leading;
         let max_width = (right - left).saturating_sub(Self::TE_LINE_LEFT_INSET);
@@ -8529,7 +8750,7 @@ impl super::TrapDispatcher {
 
         let substituted = self.apply_param_text(text);
         let text_bytes = substituted.as_bytes();
-        let lines = self.te_wrap_lines(font_id, self.tx_size, text_bytes, max_width);
+        let lines = self.te_wrap_lines(font_id, raw_font_size, text_bytes, max_width);
 
         for (start, end) in lines {
             let mut trimmed_end = end;
@@ -8545,19 +8766,39 @@ impl super::TrapDispatcher {
                     .iter()
                     .map(|&byte| byte as char)
                     .collect();
-                Self::fb_draw_string(
-                    bus,
-                    screen_base,
-                    row_bytes,
-                    pixel_size,
-                    screen_width,
-                    screen_height,
-                    left + Self::TE_LINE_LEFT_INSET,
-                    y,
-                    &line,
-                    font_id,
-                    font_size,
-                );
+                if let Some(rgb) = foreground {
+                    let pixel_index = Self::nearest_palette_index(&self.device_clut, rgb);
+                    Self::fb_draw_string_styled_index(
+                        bus,
+                        screen_base,
+                        row_bytes,
+                        pixel_size,
+                        screen_width,
+                        screen_height,
+                        left + Self::TE_LINE_LEFT_INSET,
+                        y,
+                        &line,
+                        font_id,
+                        font_size,
+                        face,
+                        pixel_index,
+                    );
+                } else {
+                    Self::fb_draw_string_styled(
+                        bus,
+                        screen_base,
+                        row_bytes,
+                        pixel_size,
+                        screen_width,
+                        screen_height,
+                        left + Self::TE_LINE_LEFT_INSET,
+                        y,
+                        &line,
+                        font_id,
+                        font_size,
+                        face,
+                    );
+                }
             }
             y += line_height;
             if y > bottom {
@@ -9430,7 +9671,15 @@ impl super::TrapDispatcher {
         } else {
             self.window_bounds
         };
-        let exposed_rect = retained_visible_bounds.unwrap_or(dialog_record_bounds);
+        // A movable modal dialog's structure includes its title bar above the
+        // DialogRecord content bounds. CloseDialog has CloseWindow semantics,
+        // so PaintBehind must expose the entire structure, not only the port;
+        // otherwise the window behind can never repaint the former title-bar
+        // strip. Macintosh Toolbox Essentials (1992), pp. 4-89, 6-119..6-120.
+        let exposed_rect = self
+            .window_structure_rect(bus, dialog_ptr)
+            .or(retained_visible_bounds)
+            .unwrap_or(dialog_record_bounds);
         let initial_draw_deferred = self.dialog_initial_draw_deferred.remove(&dialog_ptr);
         let retained_stale_saved_under = self
             .dialog_saved_pixels
@@ -10557,9 +10806,15 @@ impl super::TrapDispatcher {
                     } else {
                         0
                     };
-                    // A matching DCTab is copied and associated before the
-                    // dialog's initial visible shell is drawn.
+                    // Matching DCTab and item color table resources are copied
+                    // and associated before the initial visible shell is drawn.
+                    // The ictb ID follows the DITL ID, not the DLOG ID.
+                    // Macintosh Toolbox Essentials 1992, pp. 6-158 to 6-164.
                     let dialog_color_table = self.copy_dialog_color_table_resource(bus, dialog_id);
+                    let dialog_item_color_table = dialog_color_table
+                        .is_some()
+                        .then(|| self.copy_dialog_item_color_table_resource(bus, items_id))
+                        .flatten();
                     // Honor the DLOG resource's visible flag per IM:I I-424.
                     let dlg_ptr = self.finish_dialog_creation(
                         bus,
@@ -10574,6 +10829,7 @@ impl super::TrapDispatcher {
                         items_handle,
                         items,
                         dialog_color_table,
+                        dialog_item_color_table,
                     );
                     // Install any 'pltt' resource whose id matches the
                     // dialog id onto the freshly-created window. This
@@ -15932,6 +16188,7 @@ impl super::TrapDispatcher {
                     items_handle,
                     items,
                     None,
+                    None,
                 );
                 // Honor Pascal `behind` param at SP+10 per IM:I I-412.
                 self.apply_behind_parameter(bus, dlg_ptr, behind);
@@ -16499,6 +16756,7 @@ impl super::TrapDispatcher {
                             items_handle,
                             items,
                             None,
+                            None,
                         );
                         self.apply_behind_parameter(bus, dlg_ptr, behind);
                         bus.write_long(sp + param_bytes, dlg_ptr);
@@ -16665,6 +16923,7 @@ impl super::TrapDispatcher {
 #[cfg(test)]
 mod tests {
     use super::super::test_helpers::{setup, setup_with_port, MockCpu, TEST_SP};
+    use super::DialogItemTextStyle;
     use crate::cpu::{CpuOps, Register};
     use crate::memory::{MacMemoryBus, MemoryBus};
     use crate::trap::dispatch::{
@@ -17116,6 +17375,31 @@ mod tests {
         assert_eq!(items[0].item_type, 0);
         assert_eq!(items[0].rect, (10, 20, 30, 40));
         assert_eq!(items[0].proc_ptr, 0x12345678);
+    }
+
+    #[test]
+    fn ditl_iter_skips_user_item_payload_before_following_items() {
+        let (_disp, _cpu, mut bus) = setup();
+        let mut ditl = Vec::new();
+        push_ditl_count(&mut ditl, 1);
+        push_ditl_item(
+            &mut ditl,
+            0,
+            (10, 20, 30, 140),
+            0,
+            4,
+            &[0x00, 0x05, 0x00, 0x09],
+        );
+        push_ditl_item(&mut ditl, 0, (40, 50, 52, 150), 6, 4, b"Home");
+
+        let items = parse_ditl_bytes(&mut bus, &ditl);
+
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].item_type, 0);
+        assert_eq!(items[0].rect, (10, 20, 30, 140));
+        assert_eq!(items[1].item_type, 6);
+        assert_eq!(items[1].rect, (40, 50, 52, 150));
+        assert_eq!(items[1].text, "Home");
     }
 
     #[test]
@@ -17879,6 +18163,7 @@ mod tests {
         let (mut disp, mut cpu, mut bus) = setup();
         let screen_base = bus.alloc((800 * 600) as u32);
         bus.write_long(0x0824, screen_base);
+        bus.write_word(crate::memory::globals::addr::MBAR_HEIGHT, 20);
         disp.screen_mode = (screen_base, 800, 800, 600, 8);
 
         let dlog = build_test_dlog((10, 20, 110, 220), 1503, 0x280A);
@@ -17894,7 +18179,7 @@ mod tests {
 
         let dlg_ptr = bus.read_long(TEST_SP + 10);
         assert_ne!(dlg_ptr, 0);
-        assert_eq!(disp.window_bounds, (250, 300, 350, 500));
+        assert_eq!(disp.window_bounds, (260, 300, 360, 500));
     }
 
     #[test]
@@ -18173,6 +18458,96 @@ mod tests {
             42,
             "retained statText redraws must erase with the DCTab content color"
         );
+    }
+
+    #[test]
+    fn get_new_dialog_applies_matching_ictb_text_style_on_initial_draw() {
+        // An ictb follows the matching DITL ID. Each four-byte item entry
+        // selects a 20-byte text style record by resource-relative offset.
+        // MTE 1992, pp. 6-158 to 6-164; Inside Macintosh V, pp. V-279–V-282.
+        let (mut disp, mut cpu, mut bus) = setup();
+        let screen_base = bus.alloc((320 * 240) as u32);
+        bus.write_bytes(screen_base, &vec![0xEE; 320 * 240]);
+        bus.write_long(0x0824, screen_base);
+        disp.screen_mode = (screen_base, 320, 320, 240, 8);
+        disp.device_clut.fill([0, 0, 0]);
+        disp.device_clut[0] = [0xFFFF, 0xFFFF, 0xFFFF];
+        disp.device_clut[20] = [0xFFFF, 0xFFFF, 0];
+        disp.device_clut[42] = [0, 0x4000, 0];
+        disp.device_clut[255] = [0, 0, 0];
+
+        let mut dlog = build_test_dlog((40, 50, 120, 250), 1931, 0);
+        dlog[8..10].copy_from_slice(&4i16.to_be_bytes()); // noGrowDocProc
+        dlog[10] = 1;
+        let ditl = build_test_ditl_item(8, (8, 8, 30, 90), b"Styled");
+
+        let mut dctb = Vec::with_capacity(16);
+        dctb.extend_from_slice(&0u32.to_be_bytes());
+        dctb.extend_from_slice(&0u16.to_be_bytes());
+        dctb.extend_from_slice(&0u16.to_be_bytes());
+        dctb.extend_from_slice(&0u16.to_be_bytes());
+        dctb.extend_from_slice(&0u16.to_be_bytes());
+        dctb.extend_from_slice(&0x4000u16.to_be_bytes());
+        dctb.extend_from_slice(&0u16.to_be_bytes());
+
+        let mut ictb = Vec::with_capacity(24);
+        ictb.extend_from_slice(&0x200Fu16.to_be_bytes()); // font, face, size, fg, bg
+        ictb.extend_from_slice(&4u16.to_be_bytes());
+        ictb.extend_from_slice(&0u16.to_be_bytes()); // Chicago
+        ictb.extend_from_slice(&1u16.to_be_bytes()); // bold
+        ictb.extend_from_slice(&12u16.to_be_bytes());
+        ictb.extend_from_slice(&0xFFFFu16.to_be_bytes());
+        ictb.extend_from_slice(&0xFFFFu16.to_be_bytes());
+        ictb.extend_from_slice(&0u16.to_be_bytes());
+        ictb.extend_from_slice(&0u16.to_be_bytes());
+        ictb.extend_from_slice(&0u16.to_be_bytes());
+        ictb.extend_from_slice(&0u16.to_be_bytes());
+        ictb.extend_from_slice(&1u16.to_be_bytes()); // srcCopy
+
+        disp.install_test_resource(&mut bus, *b"DLOG", 1930, &dlog);
+        disp.install_test_resource(&mut bus, *b"DITL", 1931, &ditl);
+        disp.install_test_resource(&mut bus, *b"dctb", 1930, &dctb);
+        let ictb_resource = disp.install_test_resource(&mut bus, *b"ictb", 1931, &ictb);
+        bus.write_long(TEST_SP, 0xFFFF_FFFF);
+        bus.write_long(TEST_SP + 4, 0);
+        bus.write_word(TEST_SP + 8, 1930);
+
+        disp.dispatch_dialog(true, 0x17C, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+
+        let dialog_ptr = bus.read_long(TEST_SP + 10);
+        let ictb_handle = disp.window_dialog_item_color_table(&bus, dialog_ptr);
+        assert_ne!(ictb_handle, 0);
+        assert_ne!(bus.read_long(ictb_handle), ictb_resource);
+        assert_eq!(
+            disp.window_semantic_color(&bus, dialog_ptr, 0),
+            Some((0, 0x4000, 0)),
+            "associating the ictb must not replace the dialog's DCTab"
+        );
+        assert_eq!(
+            bus.read_byte(screen_base + 100 * 320 + 200),
+            42,
+            "the DCTab must still color content outside styled item rectangles"
+        );
+        assert_eq!(
+            disp.dialog_item_text_style(&bus, dialog_ptr, 0),
+            Some(DialogItemTextStyle {
+                font: 0,
+                face: 1,
+                size: 12,
+                foreground: Some([0xFFFF, 0xFFFF, 0]),
+                background: Some([0, 0, 0]),
+                mode: 1,
+            })
+        );
+
+        let mut pixels = Vec::new();
+        for y in 48..70 {
+            pixels.extend(bus.read_bytes(screen_base + y * 320 + 58, 82));
+        }
+        assert!(pixels.contains(&20), "styled text must use ictb foreground");
+        assert!(pixels.contains(&255), "item must use ictb background");
     }
 
     #[test]
@@ -25798,6 +26173,28 @@ mod tests {
     }
 
     #[test]
+    fn movable_dialog_draws_its_title_bar_above_the_content() {
+        // movableDBoxProc adds a striped title bar without a close box.
+        // Macintosh Human Interface Guidelines (1992), pp. 185-186.
+        let (mut disp, _cpu, mut bus) = setup();
+        let screen_base = 0x300000u32;
+        let row_bytes = 64u32;
+        let bounds = (40, 40, 100, 140);
+        disp.set_screen_mode_for_test(screen_base, row_bytes, 512, 342, 1);
+
+        disp.draw_dialog(&mut bus, bounds, 5, "Options", &[], 0, "", 0, false, 0x2000);
+
+        assert!(
+            screen_pixel_is_set(&bus, screen_base, row_bytes, 39, 21),
+            "movableDBoxProc must paint the title-frame top above portRect"
+        );
+        assert!(
+            screen_pixel_is_set(&bus, screen_base, row_bytes, 42, 22),
+            "an active movable title bar must contain racing stripes"
+        );
+    }
+
+    #[test]
     fn draw_window_frame_systemless_theme_routes_border_through_provider() {
         let screen_base = 0x300000u32;
         let row_bytes = 64u32;
@@ -26857,6 +27254,14 @@ mod tests {
         let dialog_ptr = 0x200000u32;
         let prev_window = 0x181000u32;
         seed_window_regions(&mut bus, prev_window, (0, 0, 342, 512));
+        seed_window_regions(&mut bus, dialog_ptr, (100, 120, 220, 320));
+        // WindowRecord.strucRgn is the handle at offset 114 (IM:I I-278).
+        let dialog_structure = bus.read_long(dialog_ptr + 114);
+        let dialog_structure_ptr = bus.read_long(dialog_structure);
+        bus.write_word(dialog_structure_ptr + 2, 81);
+        bus.write_word(dialog_structure_ptr + 4, 119);
+        bus.write_word(dialog_structure_ptr + 6, 222);
+        bus.write_word(dialog_structure_ptr + 8, 322);
 
         disp.front_window = dialog_ptr;
         disp.current_port = dialog_ptr;
@@ -26881,8 +27286,8 @@ mod tests {
         assert_eq!(bus.read_long(global_ptr), prev_window);
         assert_eq!(
             TrapDispatcher::region_handle_rect(&bus, bus.read_long(prev_window + 122)),
-            Some((100, 120, 220, 320)),
-            "CloseDialog should invalidate the dialog-exposed area on the promoted window"
+            Some((81, 119, 222, 322)),
+            "CloseDialog should invalidate the complete structure, including a movable title bar"
         );
         assert!(
             disp.event_queue.iter().any(|event| {

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -5475,7 +5475,11 @@ impl TrapDispatcher {
         })
     }
 
-    pub(crate) fn find_loaded_resource_any(&self, res_type: [u8; 4], res_id: i16) -> Option<(u16, u32)> {
+    pub(crate) fn find_loaded_resource_any(
+        &self,
+        res_type: [u8; 4],
+        res_id: i16,
+    ) -> Option<(u16, u32)> {
         let res_type = Self::normalize_ostype(res_type);
         let resources = self.resources.as_ref()?;
         for refnum in self.resource_search_order() {

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -1900,6 +1900,9 @@ pub struct TrapDispatcher {
     /// Their pixel values are literal device indices, so indexed CopyBits
     /// must preserve those values instead of color-matching duplicate RGBs.
     pub(crate) explicit_palette_ctabs: HashSet<u32>,
+    /// Transform supplied by an Icon Utilities handle call while it routes
+    /// through the legacy icon renderer. Zero for ordinary PlotCIcon calls.
+    pub(crate) icon_transform_override: i16,
     /// Printing Manager error code surfaced by `PrError` and set by
     /// `PrSetError`. Inside Macintosh Volume II 1985, p. II-161;
     /// Inside Macintosh Volume V 1986, p. V-408.
@@ -3228,6 +3231,7 @@ impl TrapDispatcher {
             window_palettes: HashMap::new(),
             palette_updates: HashMap::new(),
             explicit_palette_ctabs: HashSet::new(),
+            icon_transform_override: 0,
             printing_error: 0,
             next_ct_seed: 1,
             fill_black_override: None,
@@ -6794,7 +6798,7 @@ mod tests {
             highlighted_item: 0,
             saved_pixels: Vec::new(),
             dropdown_rect: (0, 0, 0, 0),
-            submenu: None,
+            submenus: Vec::new(),
             stack_ptr: 0,
             flash_remaining: 0,
             flash_delay: 0,

--- a/src/trap/menu.rs
+++ b/src/trap/menu.rs
@@ -53,7 +53,10 @@ pub struct MenuTrackingState {
     pub highlighted_item: i16,
     pub saved_pixels: Vec<u8>,
     pub dropdown_rect: (i16, i16, i16, i16),
-    pub submenu: Option<SubmenuTrackingState>,
+    /// Open hierarchical menus ordered from the root menu's child to the
+    /// deepest descendant. Menu Manager hierarchies may contain more than
+    /// one level (Macintosh Toolbox Essentials 1992, pp. 3-137 to 3-141).
+    pub submenus: Vec<SubmenuTrackingState>,
     pub stack_ptr: u32,
     /// Remaining flash toggles (6 = 3 flashes: off, on, off, on, off, on).
     /// 0 means not flashing.
@@ -1955,13 +1958,13 @@ impl super::TrapDispatcher {
                             let sp = self.menu_tracking.as_ref().unwrap().stack_ptr;
                             let saved = self.menu_tracking.take().unwrap();
                             let active_menu = saved
-                                .submenu
-                                .as_ref()
+                                .submenus
+                                .last()
                                 .map(|submenu| submenu.menu)
                                 .unwrap_or(saved.active_menu);
                             let highlighted_item = saved
-                                .submenu
-                                .as_ref()
+                                .submenus
+                                .last()
                                 .map(|submenu| submenu.highlighted_item)
                                 .unwrap_or(saved.highlighted_item);
                             self.restore_menu_tracking_pixels(bus, saved);
@@ -1994,8 +1997,8 @@ impl super::TrapDispatcher {
                                 .as_ref()
                                 .and_then(|tracking| {
                                     tracking
-                                        .submenu
-                                        .as_ref()
+                                        .submenus
+                                        .last()
                                         .filter(|submenu| submenu.highlighted_item > 0)
                                         .map(|submenu| (submenu.menu, submenu.highlighted_item))
                                         .or_else(|| {
@@ -2070,16 +2073,16 @@ impl super::TrapDispatcher {
 
                         let old_trace = self.menu_tracking.as_ref().map(|tracking| {
                             tracking
-                                .submenu
-                                .as_ref()
+                                .submenus
+                                .last()
                                 .map(|submenu| (submenu.menu, submenu.highlighted_item))
                                 .unwrap_or((tracking.active_menu, tracking.highlighted_item))
                         });
                         self.update_menu_tracking_for_point(bus, mh, mv);
                         let new_trace = self.menu_tracking.as_ref().map(|tracking| {
                             tracking
-                                .submenu
-                                .as_ref()
+                                .submenus
+                                .last()
                                 .map(|submenu| (submenu.menu, submenu.highlighted_item))
                                 .unwrap_or((tracking.active_menu, tracking.highlighted_item))
                         });
@@ -2234,7 +2237,7 @@ impl super::TrapDispatcher {
                             highlighted_item: 0,
                             saved_pixels: saved,
                             dropdown_rect: dd_rect,
-                            submenu: None,
+                            submenus: Vec::new(),
                             stack_ptr: sp,
                             flash_remaining: 0,
                             flash_delay: 0,
@@ -2410,10 +2413,24 @@ impl super::TrapDispatcher {
                 let menu_handle = bus.read_long(sp + 4);
                 cpu.write_reg(Register::A7, sp + 8);
 
-                if let Some(menu) = self.menus.iter_mut().find(|m| m.handle == menu_handle) {
+                let touched = if let Some(menu) =
+                    self.menus.iter_mut().find(|m| m.handle == menu_handle)
+                {
                     if let Some(mi) = menu.items.get_mut((item - 1) as usize) {
                         mi.mark = if checked { 0x12 } else { 0 }; // 0x12 = checkmark char
+                        Some(menu.clone())
+                    } else {
+                        None
                     }
+                } else {
+                    None
+                };
+                // The Menu Manager record is public guest state. Preserve the
+                // mark in its item record so a later mutation that refreshes
+                // the cached menu cannot resurrect the previous value.
+                // Inside Macintosh Volume I, I-355 and I-358.
+                if let Some(menu) = touched {
+                    self.serialise_menu_items_to_memory(bus, &menu);
                 }
                 Ok(())
             }
@@ -4388,7 +4405,7 @@ impl super::TrapDispatcher {
             highlighted_item: 0,
             saved_pixels: saved,
             dropdown_rect,
-            submenu: None,
+            submenus: Vec::new(),
             stack_ptr,
             flash_remaining: 0,
             flash_delay: 0,
@@ -4409,7 +4426,7 @@ impl super::TrapDispatcher {
     }
 
     fn restore_menu_tracking_pixels(&self, bus: &mut MacMemoryBus, saved: MenuTrackingState) {
-        if let Some(submenu) = saved.submenu {
+        for submenu in saved.submenus.into_iter().rev() {
             self.restore_dropdown_pixels(bus, submenu.dropdown_rect, &submenu.saved_pixels);
         }
         self.restore_dropdown_pixels(bus, saved.dropdown_rect, &saved.saved_pixels);
@@ -4419,9 +4436,13 @@ impl super::TrapDispatcher {
         let Some(tracking) = self.menu_tracking.as_ref() else {
             return 0;
         };
-        if let Some(submenu) = tracking.submenu.as_ref() {
+        if let Some(submenu) = tracking.submenus.last() {
             if submenu.highlighted_item > 0 {
                 let menu = &self.menus[submenu.menu];
+                let item = &menu.items[submenu.highlighted_item as usize - 1];
+                if Self::is_hierarchical_item(item) {
+                    return 0;
+                }
                 return ((menu.id as u32) << 16) | (submenu.highlighted_item as u32 & 0xFFFF);
             }
         }
@@ -4440,12 +4461,15 @@ impl super::TrapDispatcher {
         ((menu.id as u32) << 16) | (tracking.highlighted_item as u32 & 0xFFFF)
     }
 
-    fn submenu_menu_index_for_parent_item(&self, parent_item: i16) -> Option<usize> {
-        let tracking = self.menu_tracking.as_ref()?;
+    fn submenu_menu_index_for_parent_item(
+        &self,
+        parent_menu_idx: usize,
+        parent_item: i16,
+    ) -> Option<usize> {
         if parent_item <= 0 {
             return None;
         }
-        let parent_menu = self.menus.get(tracking.active_menu)?;
+        let parent_menu = self.menus.get(parent_menu_idx)?;
         let item = parent_menu.items.get(parent_item as usize - 1)?;
         if !Self::is_hierarchical_item(item) {
             return None;
@@ -4457,14 +4481,15 @@ impl super::TrapDispatcher {
     fn submenu_rect_for_parent_item(
         &self,
         bus: &MacMemoryBus,
+        parent_menu_idx: usize,
+        parent_rect: (i16, i16, i16, i16),
         submenu_idx: usize,
         parent_item: i16,
     ) -> Option<(i16, i16, i16, i16)> {
-        let tracking = self.menu_tracking.as_ref()?;
         let (_screen_base, _row_bytes, screen_width, screen_height, _pixel_size) =
             self.get_screen_params();
-        let (parent_top, parent_left, _parent_bottom, parent_right) = tracking.dropdown_rect;
-        let parent_menu = self.menus.get(tracking.active_menu)?;
+        let (parent_top, parent_left, _parent_bottom, parent_right) = parent_rect;
+        let parent_menu = self.menus.get(parent_menu_idx)?;
         let parent_offset = parent_menu
             .items
             .iter()
@@ -4486,25 +4511,43 @@ impl super::TrapDispatcher {
         Some((submenu_top, submenu_left, submenu_bottom, submenu_right))
     }
 
-    fn close_submenu(&mut self, bus: &mut MacMemoryBus) {
-        let submenu = self
+    fn close_submenus_from(&mut self, bus: &mut MacMemoryBus, depth: usize) {
+        let submenus = self
             .menu_tracking
             .as_mut()
-            .and_then(|tracking| tracking.submenu.take());
-        if let Some(submenu) = submenu {
+            .map(|tracking| tracking.submenus.split_off(depth))
+            .unwrap_or_default();
+        for submenu in submenus.into_iter().rev() {
             self.restore_dropdown_pixels(bus, submenu.dropdown_rect, &submenu.saved_pixels);
         }
     }
 
-    fn ensure_submenu_for_parent_item(&mut self, bus: &mut MacMemoryBus, parent_item: i16) {
-        let Some(submenu_idx) = self.submenu_menu_index_for_parent_item(parent_item) else {
-            self.close_submenu(bus);
+    fn ensure_submenu_for_parent_item(
+        &mut self,
+        bus: &mut MacMemoryBus,
+        parent_depth: Option<usize>,
+        parent_item: i16,
+    ) {
+        let Some((parent_menu_idx, parent_rect, child_depth)) = self.menu_tracking.as_ref().and_then(|tracking| {
+            parent_depth.map_or_else(
+                || Some((tracking.active_menu, tracking.dropdown_rect, 0)),
+                |depth| tracking.submenus.get(depth).map(|submenu| {
+                    (submenu.menu, submenu.dropdown_rect, depth + 1)
+                }),
+            )
+        }) else {
+            return;
+        };
+        let Some(submenu_idx) =
+            self.submenu_menu_index_for_parent_item(parent_menu_idx, parent_item)
+        else {
+            self.close_submenus_from(bus, child_depth);
             return;
         };
         let already_open = self
             .menu_tracking
             .as_ref()
-            .and_then(|tracking| tracking.submenu.as_ref())
+            .and_then(|tracking| tracking.submenus.get(child_depth))
             .is_some_and(|submenu| {
                 submenu.menu == submenu_idx && submenu.parent_item == parent_item
             });
@@ -4512,16 +4555,22 @@ impl super::TrapDispatcher {
             return;
         }
 
-        let Some(dropdown_rect) = self.submenu_rect_for_parent_item(bus, submenu_idx, parent_item)
+        let Some(dropdown_rect) = self.submenu_rect_for_parent_item(
+            bus,
+            parent_menu_idx,
+            parent_rect,
+            submenu_idx,
+            parent_item,
+        )
         else {
-            self.close_submenu(bus);
+            self.close_submenus_from(bus, child_depth);
             return;
         };
-        self.close_submenu(bus);
+        self.close_submenus_from(bus, child_depth);
         let saved_pixels = self.save_dropdown_pixels(bus, dropdown_rect);
         self.draw_menu_dropdown(bus, submenu_idx, dropdown_rect);
         if let Some(tracking) = self.menu_tracking.as_mut() {
-            tracking.submenu = Some(SubmenuTrackingState {
+            tracking.submenus.push(SubmenuTrackingState {
                 menu: submenu_idx,
                 parent_item,
                 highlighted_item: 0,
@@ -4531,31 +4580,44 @@ impl super::TrapDispatcher {
         }
     }
 
-    fn submenu_item_at_point(&self, mouse_x: i16, mouse_y: i16) -> Option<i16> {
+    fn submenu_item_at_point(
+        &self,
+        bus: &MacMemoryBus,
+        depth: usize,
+        mouse_x: i16,
+        mouse_y: i16,
+    ) -> Option<i16> {
         let tracking = self.menu_tracking.as_ref()?;
-        let submenu = tracking.submenu.as_ref()?;
+        let submenu = tracking.submenus.get(depth)?;
         let (top, left, bottom, right) = submenu.dropdown_rect;
         if mouse_x < left || mouse_x >= right || mouse_y < top || mouse_y >= bottom {
             return None;
         }
-        let item_height: i16 = 16;
-        let item_idx = (mouse_y - top - 1) / item_height;
         let menu = self.menus.get(submenu.menu)?;
-        if item_idx < 0 || item_idx as usize >= menu.items.len() {
-            return Some(0);
+        let mut item_top = top + 1;
+        for (item_idx, item) in menu.items.iter().enumerate() {
+            let item_bottom = item_top + self.menu_item_height(bus, item);
+            if mouse_y >= item_top && mouse_y < item_bottom {
+                if item.text == "-" || !item.enabled {
+                    return Some(0);
+                }
+                return Some(item_idx as i16 + 1);
+            }
+            item_top = item_bottom;
         }
-        let item = &menu.items[item_idx as usize];
-        if item.text == "-" || !item.enabled {
-            return Some(0);
-        }
-        Some(item_idx + 1)
+        Some(0)
     }
 
-    fn update_submenu_highlight(&mut self, bus: &mut MacMemoryBus, new_item: i16) {
+    fn update_submenu_highlight(
+        &mut self,
+        bus: &mut MacMemoryBus,
+        depth: usize,
+        new_item: i16,
+    ) {
         let Some((menu_idx, old_item, rect)) = self
             .menu_tracking
             .as_ref()
-            .and_then(|tracking| tracking.submenu.as_ref())
+            .and_then(|tracking| tracking.submenus.get(depth))
             .map(|submenu| {
                 (
                     submenu.menu,
@@ -4567,8 +4629,12 @@ impl super::TrapDispatcher {
             return;
         };
         if old_item == new_item {
+            if new_item > 0 {
+                self.ensure_submenu_for_parent_item(bus, Some(depth), new_item);
+            }
             return;
         }
+        self.close_submenus_from(bus, depth + 1);
         let classic_highlight = self.ui_theme_id() == UiThemeId::ClassicSystem7;
         if classic_highlight && old_item > 0 {
             self.invert_dropdown_item_rect(bus, menu_idx, rect, old_item);
@@ -4576,7 +4642,7 @@ impl super::TrapDispatcher {
         if let Some(submenu) = self
             .menu_tracking
             .as_mut()
-            .and_then(|tracking| tracking.submenu.as_mut())
+            .and_then(|tracking| tracking.submenus.get_mut(depth))
         {
             submenu.highlighted_item = new_item;
         }
@@ -4584,6 +4650,9 @@ impl super::TrapDispatcher {
             self.invert_dropdown_item_rect(bus, menu_idx, rect, new_item);
         } else if !classic_highlight {
             self.draw_menu_dropdown(bus, menu_idx, rect);
+        }
+        if new_item > 0 {
+            self.ensure_submenu_for_parent_item(bus, Some(depth), new_item);
         }
     }
 
@@ -4597,7 +4666,7 @@ impl super::TrapDispatcher {
         };
 
         if old_item != new_item {
-            self.close_submenu(bus);
+            self.close_submenus_from(bus, 0);
             let classic_highlight = self.ui_theme_id() == UiThemeId::ClassicSystem7;
             if classic_highlight && old_item > 0 {
                 self.invert_menu_item(bus, old_item);
@@ -4620,9 +4689,9 @@ impl super::TrapDispatcher {
         }
 
         if new_item > 0 {
-            self.ensure_submenu_for_parent_item(bus, new_item);
+            self.ensure_submenu_for_parent_item(bus, None, new_item);
         } else {
-            self.close_submenu(bus);
+            self.close_submenus_from(bus, 0);
         }
     }
 
@@ -4632,9 +4701,18 @@ impl super::TrapDispatcher {
         mouse_x: i16,
         mouse_y: i16,
     ) {
-        if let Some(submenu_item) = self.submenu_item_at_point(mouse_x, mouse_y) {
-            self.update_submenu_highlight(bus, submenu_item);
-            return;
+        let submenu_count = self
+            .menu_tracking
+            .as_ref()
+            .map(|tracking| tracking.submenus.len())
+            .unwrap_or(0);
+        for depth in (0..submenu_count).rev() {
+            if let Some(submenu_item) =
+                self.submenu_item_at_point(bus, depth, mouse_x, mouse_y)
+            {
+                self.update_submenu_highlight(bus, depth, submenu_item);
+                return;
+            }
         }
         let new_item = self.dropdown_item_at_point(bus, mouse_x, mouse_y);
         self.update_parent_menu_highlight(bus, new_item);
@@ -4855,9 +4933,9 @@ impl super::TrapDispatcher {
                     Some(tracking.highlighted_item)
                 } else {
                     tracking
-                        .submenu
-                        .as_ref()
-                        .filter(|submenu| {
+                        .submenus
+                        .iter()
+                        .find(|submenu| {
                             submenu.menu == menu_idx && submenu.dropdown_rect == rect
                         })
                         .map(|submenu| submenu.highlighted_item)
@@ -7937,6 +8015,32 @@ mod tests {
         );
     }
 
+    #[test]
+    fn checkitem_persists_mark_across_later_menu_mutations() {
+        // IM:I I-355 and I-358: CheckItem changes the mark stored in the
+        // guest MenuInfo item record, not merely transient drawing state.
+        let (mut disp, mut cpu, mut bus) = setup();
+        let menu = new_menu_with_title(&mut disp, &mut cpu, &mut bus, 223, 0x306770, "Speed");
+        append_menu_data(&mut disp, &mut cpu, &mut bus, menu, 0x306780, "Moderate");
+        cpu.write_reg(Register::A7, TEST_SP);
+        bus.write_word(TEST_SP, 0x0100);
+        bus.write_word(TEST_SP + 2, 1);
+        bus.write_long(TEST_SP + 4, menu);
+
+        disp.dispatch_menu(true, 0x145, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+        set_item_cmd(&mut disp, &mut cpu, &mut bus, menu, 1, b'M');
+
+        let item = disp
+            .menus
+            .iter()
+            .find(|candidate| candidate.handle == menu)
+            .and_then(|candidate| candidate.items.first())
+            .unwrap();
+        assert_eq!(item.mark, 0x12);
+    }
+
     // 0x133 — AppendMenu: pops 8 bytes.
     #[test]
     fn test_append_menu() {
@@ -9843,7 +9947,7 @@ mod tests {
             flash_remaining: 0,
             flash_delay: 0,
             flash_result: 0,
-            submenu: None,
+            submenus: Vec::new(),
         });
         classic.draw_menu_dropdown(&mut classic_bus, 0, rect);
 
@@ -9880,7 +9984,7 @@ mod tests {
             flash_remaining: 0,
             flash_delay: 0,
             flash_result: 0,
-            submenu: None,
+            submenus: Vec::new(),
         });
         themed.draw_menu_dropdown(&mut themed_bus, 0, rect);
 
@@ -10054,7 +10158,7 @@ mod tests {
             flash_remaining: 0,
             flash_delay: 0,
             flash_result: 0,
-            submenu: None,
+            submenus: Vec::new(),
         });
         themed.draw_menu_dropdown(&mut themed_bus, 0, rect);
 
@@ -13063,6 +13167,84 @@ mod tests {
             TEST_SP + 4,
             "MenuSelect should pop the Point argument after submenu selection"
         );
+    }
+
+    #[test]
+    fn menuselect_tracks_nested_hierarchical_submenu_item() {
+        // MTE 1992, pp. 3-137 to 3-141: hierarchical menus may themselves
+        // contain hierarchical items. Tracking must retain every open level
+        // and return the deepest selected menu ID and item number.
+        let (mut disp, mut cpu, mut bus) = setup_with_port();
+        disp.menu_bar_hidden = false;
+        bus.write_word(crate::memory::globals::addr::MBAR_HEIGHT, 20);
+
+        let game = new_menu_with_title(&mut disp, &mut cpu, &mut bus, 129, 0x310000, "Game");
+        append_menu_data(&mut disp, &mut cpu, &mut bus, game, 0x310040, "Options");
+        let options =
+            new_menu_with_title(&mut disp, &mut cpu, &mut bus, 138, 0x310200, "Options");
+        append_menu_data(&mut disp, &mut cpu, &mut bus, options, 0x310240, "Speed");
+        let speed =
+            new_menu_with_title(&mut disp, &mut cpu, &mut bus, 139, 0x310400, "Speed");
+        append_menu_data(
+            &mut disp,
+            &mut cpu,
+            &mut bus,
+            speed,
+            0x310440,
+            "Very fast;Fast;Moderate;Slow",
+        );
+        set_item_cmd(&mut disp, &mut cpu, &mut bus, game, 1, 0x1B);
+        set_item_mark(&mut disp, &mut cpu, &mut bus, game, 1, 138);
+        set_item_cmd(&mut disp, &mut cpu, &mut bus, options, 1, 0x1B);
+        set_item_mark(&mut disp, &mut cpu, &mut bus, options, 1, 139);
+        insert_menu(&mut disp, &mut cpu, &mut bus, game);
+        insert_menu_before(&mut disp, &mut cpu, &mut bus, options, -1);
+        insert_menu_before(&mut disp, &mut cpu, &mut bus, speed, -1);
+        cpu.write_reg(Register::A7, TEST_SP);
+        disp.dispatch_menu(true, 0x137, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+
+        let regions = disp.menu_title_regions();
+        let game_mid_h = (regions[0].0 + regions[0].1) / 2;
+        disp.mouse_pos = (10, game_mid_h);
+        disp.mouse_button = true;
+        cpu.write_reg(Register::A7, TEST_SP);
+        bus.write_word(TEST_SP, 10);
+        bus.write_word(TEST_SP + 2, game_mid_h as u16);
+        bus.write_long(TEST_SP + 4, 0xFFFF_FFFF);
+        disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+
+        let root_rect = disp.menu_tracking.as_ref().unwrap().dropdown_rect;
+        disp.mouse_pos = (root_rect.0 + 9, root_rect.1 + 24);
+        disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+        let options_rect = disp.menu_tracking.as_ref().unwrap().submenus[0].dropdown_rect;
+        disp.mouse_pos = (options_rect.0 + 9, options_rect.1 + 24);
+        disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+        let speed_rect = disp.menu_tracking.as_ref().unwrap().submenus[1].dropdown_rect;
+        disp.mouse_pos = (speed_rect.0 + 9, speed_rect.1 + 24);
+        disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+
+        disp.mouse_button = false;
+        for _ in 0..40 {
+            disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+                .unwrap()
+                .unwrap();
+            if disp.menu_tracking.is_none() {
+                break;
+            }
+        }
+
+        assert_eq!(bus.read_long(TEST_SP + 4), (139u32 << 16) | 1);
+        assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 4);
     }
 
     // IM:V V-239: InsertMenu(beforeID=-1) places a menu in the hierarchical

--- a/src/trap/menu.rs
+++ b/src/trap/menu.rs
@@ -1034,31 +1034,32 @@ impl super::TrapDispatcher {
         bus.write_long(handle, menu_ptr);
         self.ptr_to_handle.insert(menu_ptr, handle);
 
-        let menu = if let Some((_, res_ptr)) = self.find_or_load_resource_any(bus, *b"MENU", menu_id) {
-            let res_size = menu_resource_size(bus, res_ptr);
-            for i in 0..res_size.min(256) {
-                bus.write_byte(menu_ptr + i as u32, bus.read_byte(res_ptr + i as u32));
-            }
-            parse_menu_resource(bus, menu_ptr, handle)
-        } else {
-            bus.write_word(menu_ptr, menu_id as u16);
-            bus.write_word(menu_ptr + 2, 0);
-            bus.write_word(menu_ptr + 4, 0);
-            bus.write_long(menu_ptr + 6, 0);
-            bus.write_long(menu_ptr + 10, 0xFFFF_FFFF);
-            bus.write_byte(menu_ptr + 14, 0);
-            bus.write_byte(menu_ptr + 15, 0);
-            Menu {
-                id: menu_id,
-                title: String::new(),
-                items: Vec::new(),
-                enabled: true,
-                handle,
-                in_menu_bar: false,
-                hierarchical: false,
-                visible_in_menu_bar: false,
-            }
-        };
+        let menu =
+            if let Some((_, res_ptr)) = self.find_or_load_resource_any(bus, *b"MENU", menu_id) {
+                let res_size = menu_resource_size(bus, res_ptr);
+                for i in 0..res_size.min(256) {
+                    bus.write_byte(menu_ptr + i as u32, bus.read_byte(res_ptr + i as u32));
+                }
+                parse_menu_resource(bus, menu_ptr, handle)
+            } else {
+                bus.write_word(menu_ptr, menu_id as u16);
+                bus.write_word(menu_ptr + 2, 0);
+                bus.write_word(menu_ptr + 4, 0);
+                bus.write_long(menu_ptr + 6, 0);
+                bus.write_long(menu_ptr + 10, 0xFFFF_FFFF);
+                bus.write_byte(menu_ptr + 14, 0);
+                bus.write_byte(menu_ptr + 15, 0);
+                Menu {
+                    id: menu_id,
+                    title: String::new(),
+                    items: Vec::new(),
+                    enabled: true,
+                    handle,
+                    in_menu_bar: false,
+                    hierarchical: false,
+                    visible_in_menu_bar: false,
+                }
+            };
 
         self.menus.push(menu);
         self.load_menu_color_resource(bus, menu_id);
@@ -1521,18 +1522,17 @@ impl super::TrapDispatcher {
                             .push(parse_menu_resource(bus, menu_ptr, menu_handle));
                     }
                 }
-                let menu_copy = if let Some(menu) =
-                    self.menus.iter_mut().find(|m| m.handle == menu_handle)
-                {
-                    refresh_menu_from_memory(bus, menu);
-                    for item in parsed {
-                        menu.items.push(item);
-                    }
-                    sync_enable_flags(bus, menu);
-                    Some(menu.clone())
-                } else {
-                    None
-                };
+                let menu_copy =
+                    if let Some(menu) = self.menus.iter_mut().find(|m| m.handle == menu_handle) {
+                        refresh_menu_from_memory(bus, menu);
+                        for item in parsed {
+                            menu.items.push(item);
+                        }
+                        sync_enable_flags(bus, menu);
+                        Some(menu.clone())
+                    } else {
+                        None
+                    };
                 // Also serialise items into the guest-memory MENU record so
                 // CountMItems / CalcMenuSize (which parse guest memory to stay
                 // compatible with GetMenu-loaded menus) see the AppendMenu'd
@@ -1569,7 +1569,9 @@ impl super::TrapDispatcher {
                             // raw guest MENU handle). Parse any MENU resource
                             // by menu ID, else fall back to title-only memory.
                             let menu_id = bus.read_word(menu_ptr) as i16;
-                            if let Some((_, res_ptr)) = self.find_or_load_resource_any(bus, *b"MENU", menu_id) {
+                            if let Some((_, res_ptr)) =
+                                self.find_or_load_resource_any(bus, *b"MENU", menu_id)
+                            {
                                 let mut menu = parse_menu_resource(bus, res_ptr, menu_handle);
                                 eprintln!(
                                     "[MENU] InsertMenu: ID={} title=\"{}\" items={}",
@@ -1711,7 +1713,8 @@ impl super::TrapDispatcher {
             (true, 0x1C0) => {
                 let sp = cpu.read_reg(Register::A7);
                 let mbar_id = bus.read_word(sp) as i16;
-                let handle = if let Some((_, mbar_ptr)) = self.find_or_load_resource_any(bus, *b"MBAR", mbar_id)
+                let handle = if let Some((_, mbar_ptr)) =
+                    self.find_or_load_resource_any(bus, *b"MBAR", mbar_id)
                 {
                     let menu_count = bus.read_word(mbar_ptr) as usize;
                     let mut snapshot = Vec::new();
@@ -1719,7 +1722,8 @@ impl super::TrapDispatcher {
 
                     for i in 0..menu_count {
                         let menu_id = bus.read_word(mbar_ptr + 2 + (i as u32) * 2) as i16;
-                        let Some((_, menu_res_ptr)) = self.find_or_load_resource_any(bus, *b"MENU", menu_id)
+                        let Some((_, menu_res_ptr)) =
+                            self.find_or_load_resource_any(bus, *b"MENU", menu_id)
                         else {
                             continue;
                         };
@@ -2413,18 +2417,17 @@ impl super::TrapDispatcher {
                 let menu_handle = bus.read_long(sp + 4);
                 cpu.write_reg(Register::A7, sp + 8);
 
-                let touched = if let Some(menu) =
-                    self.menus.iter_mut().find(|m| m.handle == menu_handle)
-                {
-                    if let Some(mi) = menu.items.get_mut((item - 1) as usize) {
-                        mi.mark = if checked { 0x12 } else { 0 }; // 0x12 = checkmark char
-                        Some(menu.clone())
+                let touched =
+                    if let Some(menu) = self.menus.iter_mut().find(|m| m.handle == menu_handle) {
+                        if let Some(mi) = menu.items.get_mut((item - 1) as usize) {
+                            mi.mark = if checked { 0x12 } else { 0 }; // 0x12 = checkmark char
+                            Some(menu.clone())
+                        } else {
+                            None
+                        }
                     } else {
                         None
-                    }
-                } else {
-                    None
-                };
+                    };
                 // The Menu Manager record is public guest state. Preserve the
                 // mark in its item record so a later mutation that refreshes
                 // the cached menu cannot resurrect the previous value.
@@ -2614,19 +2617,18 @@ impl super::TrapDispatcher {
                 let icon = (bus.read_word(sp) & 0xFF) as u8;
                 let item = bus.read_word(sp + 2) as i16;
                 let menu_handle = bus.read_long(sp + 4);
-                let touched = if let Some(menu) =
-                    self.menus.iter_mut().find(|m| m.handle == menu_handle)
-                {
-                    refresh_menu_from_memory(bus, menu);
-                    if let Some(mi) = menu.items.get_mut((item - 1) as usize) {
-                        mi.icon = icon;
-                        Some(menu.clone())
+                let touched =
+                    if let Some(menu) = self.menus.iter_mut().find(|m| m.handle == menu_handle) {
+                        refresh_menu_from_memory(bus, menu);
+                        if let Some(mi) = menu.items.get_mut((item - 1) as usize) {
+                            mi.icon = icon;
+                            Some(menu.clone())
+                        } else {
+                            None
+                        }
                     } else {
                         None
-                    }
-                } else {
-                    None
-                };
+                    };
                 if let Some(menu) = touched {
                     self.serialise_menu_items_to_memory(bus, &menu);
                 }
@@ -2671,19 +2673,18 @@ impl super::TrapDispatcher {
                 let style = (bus.read_word(sp) & 0xFF) as u8;
                 let item = bus.read_word(sp + 2) as i16;
                 let menu_handle = bus.read_long(sp + 4);
-                let touched = if let Some(menu) =
-                    self.menus.iter_mut().find(|m| m.handle == menu_handle)
-                {
-                    refresh_menu_from_memory(bus, menu);
-                    if let Some(mi) = menu.items.get_mut((item - 1) as usize) {
-                        mi.style = style;
-                        Some(menu.clone())
+                let touched =
+                    if let Some(menu) = self.menus.iter_mut().find(|m| m.handle == menu_handle) {
+                        refresh_menu_from_memory(bus, menu);
+                        if let Some(mi) = menu.items.get_mut((item - 1) as usize) {
+                            mi.style = style;
+                            Some(menu.clone())
+                        } else {
+                            None
+                        }
                     } else {
                         None
-                    }
-                } else {
-                    None
-                };
+                    };
                 if let Some(menu) = touched {
                     self.serialise_menu_items_to_memory(bus, &menu);
                 }
@@ -2725,19 +2726,18 @@ impl super::TrapDispatcher {
                 let mark_char = (bus.read_word(sp) & 0xFF) as u8;
                 let item = bus.read_word(sp + 2) as i16;
                 let menu_handle = bus.read_long(sp + 4);
-                let touched = if let Some(menu) =
-                    self.menus.iter_mut().find(|m| m.handle == menu_handle)
-                {
-                    refresh_menu_from_memory(bus, menu);
-                    if let Some(mi) = menu.items.get_mut((item - 1) as usize) {
-                        mi.mark = mark_char;
-                        Some(menu.clone())
+                let touched =
+                    if let Some(menu) = self.menus.iter_mut().find(|m| m.handle == menu_handle) {
+                        refresh_menu_from_memory(bus, menu);
+                        if let Some(mi) = menu.items.get_mut((item - 1) as usize) {
+                            mi.mark = mark_char;
+                            Some(menu.clone())
+                        } else {
+                            None
+                        }
                     } else {
                         None
-                    }
-                } else {
-                    None
-                };
+                    };
                 if let Some(menu) = touched {
                     self.serialise_menu_items_to_memory(bus, &menu);
                 }
@@ -4528,14 +4528,19 @@ impl super::TrapDispatcher {
         parent_depth: Option<usize>,
         parent_item: i16,
     ) {
-        let Some((parent_menu_idx, parent_rect, child_depth)) = self.menu_tracking.as_ref().and_then(|tracking| {
-            parent_depth.map_or_else(
-                || Some((tracking.active_menu, tracking.dropdown_rect, 0)),
-                |depth| tracking.submenus.get(depth).map(|submenu| {
-                    (submenu.menu, submenu.dropdown_rect, depth + 1)
-                }),
-            )
-        }) else {
+        let Some((parent_menu_idx, parent_rect, child_depth)) =
+            self.menu_tracking.as_ref().and_then(|tracking| {
+                parent_depth.map_or_else(
+                    || Some((tracking.active_menu, tracking.dropdown_rect, 0)),
+                    |depth| {
+                        tracking
+                            .submenus
+                            .get(depth)
+                            .map(|submenu| (submenu.menu, submenu.dropdown_rect, depth + 1))
+                    },
+                )
+            })
+        else {
             return;
         };
         let Some(submenu_idx) =
@@ -4561,8 +4566,7 @@ impl super::TrapDispatcher {
             parent_rect,
             submenu_idx,
             parent_item,
-        )
-        else {
+        ) else {
             self.close_submenus_from(bus, child_depth);
             return;
         };
@@ -4608,12 +4612,7 @@ impl super::TrapDispatcher {
         Some(0)
     }
 
-    fn update_submenu_highlight(
-        &mut self,
-        bus: &mut MacMemoryBus,
-        depth: usize,
-        new_item: i16,
-    ) {
+    fn update_submenu_highlight(&mut self, bus: &mut MacMemoryBus, depth: usize, new_item: i16) {
         let Some((menu_idx, old_item, rect)) = self
             .menu_tracking
             .as_ref()
@@ -4707,9 +4706,7 @@ impl super::TrapDispatcher {
             .map(|tracking| tracking.submenus.len())
             .unwrap_or(0);
         for depth in (0..submenu_count).rev() {
-            if let Some(submenu_item) =
-                self.submenu_item_at_point(bus, depth, mouse_x, mouse_y)
-            {
+            if let Some(submenu_item) = self.submenu_item_at_point(bus, depth, mouse_x, mouse_y) {
                 self.update_submenu_highlight(bus, depth, submenu_item);
                 return;
             }
@@ -4935,9 +4932,7 @@ impl super::TrapDispatcher {
                     tracking
                         .submenus
                         .iter()
-                        .find(|submenu| {
-                            submenu.menu == menu_idx && submenu.dropdown_rect == rect
-                        })
+                        .find(|submenu| submenu.menu == menu_idx && submenu.dropdown_rect == rect)
                         .map(|submenu| submenu.highlighted_item)
                 }
             })
@@ -4953,9 +4948,7 @@ impl super::TrapDispatcher {
                 self.dialog_tracking
                     .as_ref()
                     .and_then(|tracking| tracking.active_popup.as_ref())
-                    .filter(|popup| {
-                        popup.active_menu == menu_idx && popup.dropdown_rect == rect
-                    })
+                    .filter(|popup| popup.active_menu == menu_idx && popup.dropdown_rect == rect)
                     .map(|popup| popup.highlighted_item)
             })
             .unwrap_or(0);
@@ -5674,8 +5667,8 @@ mod tests {
     use super::super::test_helpers::{setup, setup_with_port, MockCpu, TEST_SP};
     use super::{
         count_menu_items_from_memory, parse_appendmenu_items, parse_menu_resource, Menu, MenuItem,
-        MenuTrackingState, MC_ENTRY_SIZE, MENU_KEY_REDUCED_ICON,
-        MENU_KEY_SMALL_ICON, MENU_ROW_HEIGHT,
+        MenuTrackingState, MC_ENTRY_SIZE, MENU_KEY_REDUCED_ICON, MENU_KEY_SMALL_ICON,
+        MENU_ROW_HEIGHT,
     };
     use crate::cpu::{CpuOps, Register};
     use crate::memory::{MacMemoryBus, MemoryBus};
@@ -8113,14 +8106,7 @@ mod tests {
     fn long_menu_mutations_preserve_trailing_item_and_refresh_guest_edits() {
         let (mut disp, mut cpu, mut bus) = setup();
         let menu_id = 447;
-        let handle = new_menu_with_title(
-            &mut disp,
-            &mut cpu,
-            &mut bus,
-            menu_id,
-            0x303800,
-            "Long",
-        );
+        let handle = new_menu_with_title(&mut disp, &mut cpu, &mut bus, menu_id, 0x303800, "Long");
 
         let mut data = vec!["A/A"; 39];
         data.push("Tail/Z");
@@ -8140,7 +8126,10 @@ mod tests {
             "AppendMenu must grow MENU records beyond the legacy 256-byte buffer"
         );
         assert_eq!(count_menu_items_from_memory(&bus, handle), 40);
-        assert_eq!(get_item_cmd(&mut disp, &mut cpu, &mut bus, handle, 40), b'Z');
+        assert_eq!(
+            get_item_cmd(&mut disp, &mut cpu, &mut bus, handle, 40),
+            b'Z'
+        );
 
         let replacement = "Expanded first item that forces another complete record resize";
         write_pstring(&mut bus, 0x303A00, replacement);
@@ -8158,7 +8147,10 @@ mod tests {
             cpu.write_reg(Register::A7, TEST_SP);
             bus.write_word(TEST_SP, 1);
             bus.write_long(TEST_SP + 2, handle);
-            assert!(disp.dispatch_menu(true, trap, &mut cpu, &mut bus).unwrap().is_ok());
+            assert!(disp
+                .dispatch_menu(true, trap, &mut cpu, &mut bus)
+                .unwrap()
+                .is_ok());
         }
         let (height, width) = calc_menu_size_for_test(&mut disp, &mut cpu, &mut bus, handle);
         assert!(height > 0 && width > 0);
@@ -10202,13 +10194,7 @@ mod tests {
             (command_pixel, "command key"),
         ] {
             assert!(
-                screen_pixel_is_set(
-                    &themed_bus,
-                    themed_base,
-                    themed_row_bytes,
-                    pixel.0,
-                    pixel.1
-                ),
+                screen_pixel_is_set(&themed_bus, themed_base, themed_row_bytes, pixel.0, pixel.1),
                 "final themed chrome composition should preserve the highlighted {label}"
             );
         }
@@ -10249,13 +10235,7 @@ mod tests {
             (command_pixel, "popup command key"),
         ] {
             assert!(
-                screen_pixel_is_set(
-                    &themed_bus,
-                    themed_base,
-                    themed_row_bytes,
-                    pixel.0,
-                    pixel.1
-                ),
+                screen_pixel_is_set(&themed_bus, themed_base, themed_row_bytes, pixel.0, pixel.1),
                 "final themed popup composition should preserve the highlighted {label}"
             );
         }
@@ -13180,11 +13160,9 @@ mod tests {
 
         let game = new_menu_with_title(&mut disp, &mut cpu, &mut bus, 129, 0x310000, "Game");
         append_menu_data(&mut disp, &mut cpu, &mut bus, game, 0x310040, "Options");
-        let options =
-            new_menu_with_title(&mut disp, &mut cpu, &mut bus, 138, 0x310200, "Options");
+        let options = new_menu_with_title(&mut disp, &mut cpu, &mut bus, 138, 0x310200, "Options");
         append_menu_data(&mut disp, &mut cpu, &mut bus, options, 0x310240, "Speed");
-        let speed =
-            new_menu_with_title(&mut disp, &mut cpu, &mut bus, 139, 0x310400, "Speed");
+        let speed = new_menu_with_title(&mut disp, &mut cpu, &mut bus, 139, 0x310400, "Speed");
         append_menu_data(
             &mut disp,
             &mut cpu,

--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -9325,12 +9325,23 @@ impl super::TrapDispatcher {
                     ];
                 }
 
-                let dst_clut = if dst_ctab_handle != 0 {
-                    self.read_port_clut(bus, dst_ctab_handle)
+                // Screen-backed color ports retain their own PixMap color
+                // table, but the pixels are interpreted by the live screen
+                // device table. Palette activation can therefore make the
+                // port's table stale. Use the same screen-destination rule as
+                // CopyBits so PlotCIcon maps colors through the live device.
+                // Imaging With QuickDraw (1994), pp. 4-55 to 4-59 and 5-28.
+                let effective_dst_ctab = self.effective_destination_ctab_handle(
+                    dst_base,
+                    dst_row_bytes,
+                    dst_pixel_size,
+                    dst_ctab_handle,
+                );
+                let dst_clut = if effective_dst_ctab != 0 {
+                    self.read_port_clut(bus, effective_dst_ctab)
                 } else {
                     self.device_clut
                 };
-
                 for dst_y_local in dst_top..dst_bottom {
                     let Some(sy) =
                         Self::scale_coord(pm_top, pm_bottom, dst_top, dst_bottom, dst_y_local)
@@ -9403,13 +9414,29 @@ impl super::TrapDispatcher {
                                 ) else {
                                     continue;
                                 };
-                                let rgb = icon_clut
+                                let mut rgb = icon_clut
                                     .get(src_index as usize)
                                     .copied()
                                     .unwrap_or(self.device_clut[src_index as usize]);
-                                let dst_index = super::pict::closest_clut_index(
-                                    rgb[0], rgb[1], rgb[2], &dst_clut,
-                                );
+                                if (self.icon_transform_override & 0x4000) != 0 {
+                                    // ttSelected darkens the standard color
+                                    // icon before mapping it to the active
+                                    // device. This is the selection mechanism
+                                    // used by Finder-style icon controls.
+                                    // More Macintosh Toolbox (1993), pp. 5-20
+                                    // to 5-21 and 5-37; Macintosh Human
+                                    // Interface Guidelines (1992), p. 241.
+                                    for component in &mut rgb {
+                                        *component /= 2;
+                                    }
+                                }
+                                // PlotCIcon performs ordinary Color Manager
+                                // inverse mapping. Do not apply the PICT-only
+                                // grayscale-ramp preference here: a standard
+                                // icon table drawn under an application
+                                // palette must be allowed to select the
+                                // nearest tinted device color.
+                                let dst_index = Self::nearest_palette_index(&dst_clut, rgb);
                                 bus.write_byte(dst_base + dst_y * dst_row_bytes + dst_x, dst_index);
                             }
                             1 => {
@@ -21691,7 +21718,7 @@ impl super::TrapDispatcher {
         Some(i32::from(src_start) + (rel * src_span) / dst_span)
     }
 
-    fn nearest_palette_index(clut: &[[u16; 3]; 256], rgb: [u16; 3]) -> u8 {
+    pub(crate) fn nearest_palette_index(clut: &[[u16; 3]; 256], rgb: [u16; 3]) -> u8 {
         // QuickDraw's inverse tables reserve exact white/black for the first
         // and last CLUT entries when the endpoints are white/black, rather
         // than returning an arbitrary duplicate color-cube entry. During
@@ -35430,6 +35457,104 @@ mod tests {
             vec![7, 9, 42, 255],
             "packed 4bpp source nibbles should decode and remap through the icon ColorTable"
         );
+    }
+
+    #[test]
+    fn plotcicon_screen_backed_port_uses_live_device_clut() {
+        // A screen-backed CGrafPort's private PixMap table can predate a
+        // Palette Manager activation. The screen device's live table must
+        // control inverse mapping, just as it does for other screen drawing.
+        // Imaging With QuickDraw (1994), pp. 4-55 to 4-59 and 5-28.
+        let (mut d, mut cpu, mut bus) = setup();
+        d.device_clut = [[0, 0, 0]; 256];
+        d.device_clut[0] = [0xFFFF, 0xFFFF, 0xFFFF];
+        d.device_clut[1] = [0x1010, 0x1010, 0x1010];
+        d.device_clut[7] = [0x4040, 0x4545, 0x4545];
+
+        let (screen_base, screen_row_bytes, screen_w, screen_h, _) = d.screen_mode;
+        let stale_ctab = make_test_ctab_handle(&mut bus, &[[0x4444, 0x4444, 0x4444]], 1, 0);
+        let pm_handle = bus.alloc(4);
+        let pm_ptr = bus.alloc(64);
+        bus.fill_zeros(pm_ptr, 64);
+        bus.write_long(pm_handle, pm_ptr);
+        bus.write_long(pm_ptr, screen_base);
+        bus.write_word(pm_ptr + 4, 0x8000 | screen_row_bytes as u16);
+        write_rect(&mut bus, pm_ptr + 6, 0, 0, screen_h as i16, screen_w as i16);
+        bus.write_word(pm_ptr + 32, 8);
+        bus.write_long(pm_ptr + 42, stale_ctab);
+
+        let port_ptr = bus.alloc(128);
+        bus.fill_zeros(port_ptr, 128);
+        bus.write_long(port_ptr + 2, pm_handle);
+        bus.write_word(port_ptr + 6, 0xC000);
+        let a5 = cpu.read_reg(Register::A5);
+        let globals_ptr = bus.read_long(a5);
+        bus.write_long(globals_ptr, port_ptr);
+
+        let mut icon_entries = [[0, 0, 0]; 16];
+        icon_entries[1] = [0x4444, 0x4444, 0x4444];
+        let cicn_data = make_test_cicn_resource_4bpp([0x11, 0x11], &icon_entries);
+        d.install_test_resource(&mut bus, *b"cicn", 130, &cicn_data);
+
+        bus.write_word(TEST_SP, 130);
+        let get_icon = d.dispatch_quickdraw(true, 0x21E, &mut cpu, &mut bus);
+        assert!(get_icon.unwrap().is_ok());
+        let icon_handle = bus.read_long(TEST_SP + 2);
+        let rect_ptr = 0x300180u32;
+        write_rect(&mut bus, rect_ptr, 0, 0, 1, 4);
+        cpu.write_reg(Register::A7, TEST_SP);
+        bus.write_long(TEST_SP, icon_handle);
+        bus.write_long(TEST_SP + 4, rect_ptr);
+
+        let plot = d.dispatch_quickdraw(true, 0x21F, &mut cpu, &mut bus);
+
+        assert!(plot.unwrap().is_ok());
+        assert_eq!(bus.read_bytes(screen_base, 4), vec![7, 7, 7, 7]);
+    }
+
+    #[test]
+    fn plotcicon_selected_transform_reduces_icon_brightness() {
+        // ttSelected makes the Apple icon colors darker before inverse
+        // mapping them to the destination device. Macintosh Human Interface
+        // Guidelines (1992), p. 241; More Macintosh Toolbox (1993), p. 5-37.
+        let (mut d, mut cpu, mut bus) = setup();
+        d.device_clut = [[0, 0, 0]; 256];
+        d.device_clut[8] = [0x2222, 0x2222, 0x2222];
+
+        let dst_base = bus.alloc(8);
+        let pm_handle = bus.alloc(4);
+        let pm_ptr = bus.alloc(64);
+        bus.fill_zeros(pm_ptr, 64);
+        bus.write_long(pm_handle, pm_ptr);
+        write_pixmap_8(&mut bus, pm_ptr, dst_base, 4, 1, 0);
+        let port_ptr = bus.alloc(128);
+        bus.fill_zeros(port_ptr, 128);
+        bus.write_long(port_ptr + 2, pm_handle);
+        bus.write_word(port_ptr + 6, 0xC000);
+        let globals_ptr = bus.read_long(cpu.read_reg(Register::A5));
+        bus.write_long(globals_ptr, port_ptr);
+
+        let mut icon_entries = [[0, 0, 0]; 16];
+        icon_entries[1] = [0x4444, 0x4444, 0x4444];
+        let cicn_data = make_test_cicn_resource_4bpp([0x11, 0x11], &icon_entries);
+        d.install_test_resource(&mut bus, *b"cicn", 131, &cicn_data);
+        bus.write_word(TEST_SP, 131);
+        d.dispatch_quickdraw(true, 0x21E, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+        let icon_handle = bus.read_long(TEST_SP + 2);
+        let rect_ptr = 0x3001A0u32;
+        write_rect(&mut bus, rect_ptr, 0, 0, 1, 4);
+        cpu.write_reg(Register::A7, TEST_SP);
+        bus.write_long(TEST_SP, icon_handle);
+        bus.write_long(TEST_SP + 4, rect_ptr);
+        d.icon_transform_override = 0x4000;
+
+        d.dispatch_quickdraw(true, 0x21F, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(bus.read_bytes(dst_base, 4), vec![8, 8, 8, 8]);
     }
 
     #[test]

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -4259,9 +4259,8 @@ impl super::TrapDispatcher {
 
         self.set_current_port_state(bus, cpu, state.port, None);
         let list_port_state = self.qd_state_snapshot();
-        let list_port_color_state = ((bus.read_word(state.port.wrapping_add(6)) & 0xC000)
-            == 0xC000)
-            .then(|| {
+        let list_port_color_state =
+            ((bus.read_word(state.port.wrapping_add(6)) & 0xC000) == 0xC000).then(|| {
                 (
                     bus.read_long(state.port.wrapping_add(80)),
                     bus.read_long(state.port.wrapping_add(84)),
@@ -5512,31 +5511,32 @@ impl super::TrapDispatcher {
 
                 let res_type = *b"STR#";
                 let mut res_found = false;
-                let found_str: Option<Vec<u8>> =
-                    if let Some((_, data_ptr)) = self.find_or_load_resource_any(bus, res_type, str_list_id) {
-                        res_found = true;
-                        // STR# format: 2-byte count, then Pascal strings (1-byte len + chars)
-                        // Inside Macintosh Volume I, I-476
-                        let count = bus.read_word(data_ptr) as usize;
-                        if index >= 1 && index <= count {
-                            let mut offset = 2u32;
-                            let mut found = None;
-                            for i in 1..=count {
-                                let len = bus.read_byte(data_ptr + offset) as usize;
-                                offset += 1;
-                                if i == index {
-                                    found = Some(bus.read_bytes(data_ptr + offset, len));
-                                    break;
-                                }
-                                offset += len as u32;
+                let found_str: Option<Vec<u8>> = if let Some((_, data_ptr)) =
+                    self.find_or_load_resource_any(bus, res_type, str_list_id)
+                {
+                    res_found = true;
+                    // STR# format: 2-byte count, then Pascal strings (1-byte len + chars)
+                    // Inside Macintosh Volume I, I-476
+                    let count = bus.read_word(data_ptr) as usize;
+                    if index >= 1 && index <= count {
+                        let mut offset = 2u32;
+                        let mut found = None;
+                        for i in 1..=count {
+                            let len = bus.read_byte(data_ptr + offset) as usize;
+                            offset += 1;
+                            if i == index {
+                                found = Some(bus.read_bytes(data_ptr + offset, len));
+                                break;
                             }
-                            found
-                        } else {
-                            None
+                            offset += len as u32;
                         }
+                        found
                     } else {
                         None
-                    };
+                    }
+                } else {
+                    None
+                };
 
                 // IM:I I-468 documents GetIndString as calling
                 // GetResource('STR#', strListID) "if necessary". On
@@ -24123,11 +24123,7 @@ mod tests {
                 view_rect_ptr,
                 (10, 10, 48, 100),
             );
-            super::super::TrapDispatcher::write_rect_words(
-                &mut bus,
-                data_bounds_ptr,
-                (0, 0, 4, 1),
-            );
+            super::super::TrapDispatcher::write_rect_words(&mut bus, data_bounds_ptr, (0, 0, 4, 1));
             cpu.write_reg(Register::A7, sp);
             bus.write_word(sp, 0x0044); // LNew
             bus.write_word(sp + 2, 0);
@@ -24203,14 +24199,17 @@ mod tests {
             // The owner starts at global (20,30), so local rView (10,10)
             // begins at screen (30,40). Every row must retain its own text
             // witness instead of collapsing at the view's lower edge.
-            for (row, (top, bottom)) in
-                [(30u32, 42u32), (42, 54), (54, 66)].into_iter().enumerate()
+            for (row, (top, bottom)) in [(30u32, 42u32), (42, 54), (54, 66)].into_iter().enumerate()
             {
                 let witness_pixels = (top..bottom)
                     .flat_map(|y| (40u32..130).map(move |x| (y, x)))
                     .filter(|&(y, x)| {
                         let pixel = bus.read_byte(screen_base + y * row_bytes + x);
-                        if row == 0 { pixel != 255 } else { pixel == 0 }
+                        if row == 0 {
+                            pixel != 255
+                        } else {
+                            pixel == 0
+                        }
                     })
                     .count();
                 assert!(witness_pixels > 0, "trap ${trap:03X} lost row at y={top}");
@@ -24228,8 +24227,9 @@ mod tests {
                 disp.resolved_port_color_fields.get(&owner_port),
                 Some(&0x03)
             );
-            assert!((68u32..72).all(|y| (40u32..130)
-                .all(|x| bus.read_byte(screen_base + y * row_bytes + x) == 255)));
+            assert!((68u32..72).all(
+                |y| (40u32..130).all(|x| bus.read_byte(screen_base + y * row_bytes + x) == 255)
+            ));
 
             // LClick receives the same owner-local coordinate basis as rView.
             cpu.write_reg(Register::A7, sp);
@@ -24244,11 +24244,7 @@ mod tests {
                 .unwrap();
             assert_eq!(bus.read_word(sp + 12), 0);
 
-            super::super::TrapDispatcher::write_point_words(
-                &mut bus,
-                query_cell_ptr,
-                (1, 0),
-            );
+            super::super::TrapDispatcher::write_point_words(&mut bus, query_cell_ptr, (1, 0));
             cpu.write_reg(Register::A7, sp);
             bus.write_word(sp, 0x003C); // LGetSelect(FALSE, row 1)
             bus.write_long(sp + 2, list_handle);
@@ -29810,17 +29806,10 @@ mod tests {
         let (mut disp, mut cpu, mut bus) = setup();
         let sp = TEST_SP;
         let key_ptr = bus.alloc(16);
-        let (base_handle, substitution_handle) =
-            replace_text_handles(&mut bus, b"A^0B^0", b"LONG");
+        let (base_handle, substitution_handle) = replace_text_handles(&mut bus, b"A^0B^0", b"LONG");
         let original_ptr = bus.read_long(base_handle);
         bus.write_pstring(key_ptr, b"^0");
-        write_replace_text_frame(
-            &mut bus,
-            sp,
-            base_handle,
-            substitution_handle,
-            key_ptr,
-        );
+        write_replace_text_frame(&mut bus, sp, base_handle, substitution_handle, key_ptr);
 
         disp.dispatch_toolbox(true, 0x0B5, &mut cpu, &mut bus)
             .expect("ScriptUtil dispatch")
@@ -29842,17 +29831,10 @@ mod tests {
         let (mut disp, mut cpu, mut bus) = setup();
         let sp = TEST_SP;
         let key_ptr = bus.alloc(16);
-        let (base_handle, substitution_handle) =
-            replace_text_handles(&mut bus, b"aaaa", b"a");
+        let (base_handle, substitution_handle) = replace_text_handles(&mut bus, b"aaaa", b"a");
         let original_ptr = bus.read_long(base_handle);
         bus.write_pstring(key_ptr, b"aa");
-        write_replace_text_frame(
-            &mut bus,
-            sp,
-            base_handle,
-            substitution_handle,
-            key_ptr,
-        );
+        write_replace_text_frame(&mut bus, sp, base_handle, substitution_handle, key_ptr);
 
         disp.dispatch_toolbox(true, 0x0B5, &mut cpu, &mut bus)
             .expect("ScriptUtil dispatch")
@@ -29875,13 +29857,7 @@ mod tests {
             replace_text_handles(&mut bus, b"unchanged", b"replacement");
         let original_ptr = bus.read_long(base_handle);
         bus.write_pstring(key_ptr, b"missing");
-        write_replace_text_frame(
-            &mut bus,
-            sp,
-            base_handle,
-            substitution_handle,
-            key_ptr,
-        );
+        write_replace_text_frame(&mut bus, sp, base_handle, substitution_handle, key_ptr);
 
         disp.dispatch_toolbox(true, 0x0B5, &mut cpu, &mut bus)
             .expect("ScriptUtil dispatch")
@@ -29901,13 +29877,7 @@ mod tests {
             replace_text_handles(&mut bus, &[0x81, 0x40, 0x40], b"X");
         disp.tx_font = 0x4000; // first Japanese font-family ID
         bus.write_pstring(key_ptr, &[0x40]);
-        write_replace_text_frame(
-            &mut bus,
-            sp,
-            base_handle,
-            substitution_handle,
-            key_ptr,
-        );
+        write_replace_text_frame(&mut bus, sp, base_handle, substitution_handle, key_ptr);
 
         disp.dispatch_toolbox(true, 0x0B5, &mut cpu, &mut bus)
             .expect("ScriptUtil dispatch")

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -15906,7 +15906,28 @@ impl super::TrapDispatcher {
                 } else {
                     8
                 };
-                match raw_selector {
+                match selector {
+                    // PlotCIconHandle. The Icon Utilities glue passes, in
+                    // reverse Pascal order, the CIconHandle, transform and
+                    // alignment words, and destination Rect pointer. PlotCIcon
+                    // supplies the shared color-icon decode and masked blit;
+                    // an icon-sized destination with atNone requires no
+                    // additional alignment.
+                    // More Macintosh Toolbox (1993), pp. 5-26 to 5-27 and
+                    // 5-72; selector table p. A-34 ($1F06).
+                    0x1F06 => {
+                        let sp = cpu.read_reg(Register::A7);
+                        let transform = bus.read_word(sp + 4) as i16;
+                        let rect_ptr = bus.read_long(sp + 8);
+                        bus.write_long(sp + 4, rect_ptr);
+                        let previous_transform = self.icon_transform_override;
+                        self.icon_transform_override = transform;
+                        let result = self.dispatch_quickdraw(true, 0x21F, cpu, bus);
+                        self.icon_transform_override = previous_transform;
+                        bus.write_word(sp + pop_bytes, 0);
+                        cpu.write_reg(Register::A7, sp + pop_bytes);
+                        result.unwrap_or(Ok(()))
+                    }
                     0 => return_noerr_and_pop(cpu, pop_bytes),
                     _ => return_error_and_pop(cpu, pop_bytes, -50),
                 }
@@ -25196,6 +25217,25 @@ mod tests {
             assert_eq!(cpu.read_reg(Register::D0) as i16, -50);
             assert_eq!(cpu.read_reg(Register::A7), TEST_SP + pop_bytes);
         }
+    }
+
+    #[test]
+    fn icondispatch_plotciconhandle_routes_to_legacy_renderer_and_returns_noerr() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let sp = TEST_SP;
+        cpu.write_reg(Register::A7, sp);
+        cpu.write_reg(Register::D0, 0x0000_061F); // byte-swapped $1F06 selector
+        bus.write_long(sp, 0); // NIL CIconHandle is a safe no-op
+        bus.write_word(sp + 4, 0x4000); // transform
+        bus.write_word(sp + 6, 0); // alignment
+        bus.write_long(sp + 8, 0); // destination Rect pointer
+        bus.write_word(sp + 12, 0x7FFF); // reserved Pascal function result
+
+        let result = disp.dispatch_toolbox(true, 0x3C9, &mut cpu, &mut bus);
+
+        assert!(result.unwrap().is_ok());
+        assert_eq!(cpu.read_reg(Register::A7), sp + 12);
+        assert_eq!(bus.read_word(sp + 12), 0);
     }
 
     #[test]

--- a/src/trap/window.rs
+++ b/src/trap/window.rs
@@ -384,6 +384,39 @@ impl super::TrapDispatcher {
         aux_handle
     }
 
+    pub(crate) fn set_window_dialog_item_color_table(
+        &mut self,
+        bus: &mut MacMemoryBus,
+        window_ptr: u32,
+        item_color_table: u32,
+    ) {
+        let aux_handle = self
+            .window_aux_records
+            .get(&window_ptr)
+            .copied()
+            .unwrap_or_else(|| self.ensure_window_aux_record(bus, window_ptr, 0));
+        let aux_ptr = bus.read_long(aux_handle);
+        if aux_ptr != 0 {
+            bus.write_long(
+                aux_ptr + Self::AUX_WIN_DIALOG_CITEM_OFFSET,
+                item_color_table,
+            );
+        }
+    }
+
+    pub(crate) fn window_dialog_item_color_table(
+        &self,
+        bus: &MacMemoryBus,
+        window_ptr: u32,
+    ) -> u32 {
+        self.window_aux_records
+            .get(&window_ptr)
+            .map(|handle| bus.read_long(*handle))
+            .filter(|ptr| *ptr != 0)
+            .map(|ptr| bus.read_long(ptr + Self::AUX_WIN_DIALOG_CITEM_OFFSET))
+            .unwrap_or(0)
+    }
+
     pub(crate) fn rect_intersection(
         a: (i16, i16, i16, i16),
         b: (i16, i16, i16, i16),
@@ -6976,6 +7009,7 @@ mod tests {
             let (mut disp, mut cpu, mut bus) = setup();
             let screen_base = bus.alloc((800 * 600) as u32);
             bus.write_long(0x0824, screen_base);
+            bus.write_word(crate::memory::globals::addr::MBAR_HEIGHT, 20);
             disp.screen_mode = (screen_base, 800, 800, 600, 8);
             install_positioned_wind_resource(
                 &mut disp,
@@ -7003,8 +7037,8 @@ mod tests {
             assert_ne!(window_ptr, 0);
             assert_eq!(
                 disp.window_global_port_rect(&bus, window_ptr),
-                (103, 152, 497, 647),
-                "trap ${trap_num:03X} should center the WIND content bounds"
+                (121, 152, 515, 647),
+                "trap ${trap_num:03X} should center the complete WIND structure below the menu bar"
             );
         }
     }

--- a/src/trap/window.rs
+++ b/src/trap/window.rs
@@ -10856,9 +10856,8 @@ mod tests {
             super::super::TrapDispatcher::region_contains_point(&bus, back_vis, 80, 100),
             "the back visRgn must expose the front window's former location"
         );
-        let back_update = bus.read_long(
-            back + super::super::TrapDispatcher::WINDOW_UPDATE_RGN_OFFSET,
-        );
+        let back_update =
+            bus.read_long(back + super::super::TrapDispatcher::WINDOW_UPDATE_RGN_OFFSET);
         assert!(
             super::super::TrapDispatcher::region_contains_point(&bus, back_update, 80, 100),
             "the newly exposed back content must be invalidated"


### PR DESCRIPTION
Closes #723

## Summary

- walk compiled user-item payloads correctly and position complete dialog/window structures below the menu bar
- support arbitrary-depth hierarchical menu tracking and persist `CheckItem` changes in guest menu records
- route `PlotCIconHandle` through color-icon rendering with the live device palette and selected transforms
- associate matching `dctb`/`ictb` resources, apply static-text color styles, and preserve dialog content while drawing document and movable-dialog chrome
- invalidate complete movable-dialog structures when closing them

## Gameplay validation

Validated the genuine 68K demo through complete, meaningful gameplay and compared the same interactions with Basilisk II:

- dismissed the information dialog and exercised schedule, Home/Visitor, Day/Night, navigation, Play, and Cancel controls
- entered the stadium and generated and continued real plays with live scoreboard and field state
- navigated Game → Options → Speed through a third-level submenu, changed the speed, and confirmed the new checkmark persisted after reopening
- opened player splits and command-clicked a player to render the complete scouting report with portrait, live player identity, actual statistics, and ratings
- canceled an idle game and confirmed controls disabled and the presentation returned to the suspended/pre-game state
- repeated visual checkpoints produced identical output

## Regression checks

- `cargo test --lib` — 3,815 passed, 3 ignored
- `cargo test --lib --features test-support` — 3,821 passed, 3 ignored
- `cargo check --no-default-features`
- `cargo check --lib --target wasm32-unknown-unknown`
- `cargo package --allow-dirty`
- `git diff --check`

This PR is stacked on #722 and should be rebased onto `master` after that PR lands.