### PR TITLE
Make The Tinies fully compatible

### DIFF
--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -1356,6 +1356,10 @@ pub struct TrapDispatcher {
     /// U.S. Roman keyboard-layout resource ID 0 is present in every
     /// System file and is used directly by apps that call KeyTranslate.
     pub(crate) system_kchr_cache: HashMap<i16, u32>,
+    /// Cache of the synthetic standard `'KMAP'` ID 0 resource. Classic apps
+    /// may read its 128-byte hardware-to-virtual-key map directly when
+    /// implementing configurable controls.
+    pub(crate) system_kmap_cache: HashMap<i16, u32>,
     /// Cache of synthetic ROM `'WDEF'` resource pointers. WDEF IDs 0 and 1
     /// are the standard document and rounded-window definition functions.
     /// Their behavior is implemented by the Window Manager HLE, but callers
@@ -1896,6 +1900,11 @@ pub struct TrapDispatcher {
     pub(crate) window_palettes: HashMap<u32, (u32, i16)>,
     /// Palette update flags keyed by PaletteHandle.
     pub(crate) palette_updates: HashMap<u32, i16>,
+    /// Device indices assigned to palette entries by the most recent
+    /// activation. Ordinary tolerant entries are not tied to their palette
+    /// positions, so Entry2Index must consult this allocation rather than
+    /// treating the entry number as a pixel value.
+    pub(crate) palette_device_indices: HashMap<(u32, u16), u8>,
     /// Color tables produced from palettes whose entries are all pmExplicit.
     /// Their pixel values are literal device indices, so indexed CopyBits
     /// must preserve those values instead of color-matching duplicate RGBs.
@@ -3035,6 +3044,7 @@ impl TrapDispatcher {
             system_cursor_cache: HashMap::new(),
             system_clut_cache: HashMap::new(),
             system_kchr_cache: HashMap::new(),
+            system_kmap_cache: HashMap::new(),
             system_wdef_cache: HashMap::new(),
             system_mdef_cache: HashMap::new(),
             tool_trap_trampolines: HashMap::new(),
@@ -3230,6 +3240,7 @@ impl TrapDispatcher {
             recent_resource_ctable_fetch: None,
             window_palettes: HashMap::new(),
             palette_updates: HashMap::new(),
+            palette_device_indices: HashMap::new(),
             explicit_palette_ctabs: HashSet::new(),
             icon_transform_override: 0,
             printing_error: 0,
@@ -5620,8 +5631,9 @@ impl TrapDispatcher {
 
     /// Allocate (and cache) the standard U.S. Roman keyboard-layout
     /// resource (`'KCHR'` ID 0). Inside Macintosh: Text 1993, C-18..C-19
-    /// defines the resource as a version byte, a 256-byte table-selection
-    /// index, and 128-byte character-mapping tables keyed by virtual key code.
+    /// defines the resource as a version word, a 256-byte table-selection
+    /// index, a table-count word, 128-byte character-mapping tables keyed by
+    /// virtual key code, and a dead-key-count word.
     pub(crate) fn synthesize_system_kchr(
         &mut self,
         bus: &mut MacMemoryBus,
@@ -5635,12 +5647,16 @@ impl TrapDispatcher {
         }
 
         const TABLES: usize = 2;
-        const TABLE_BASE: usize = 1 + 256;
-        const LEN: usize = TABLE_BASE + TABLES * 128;
+        const TABLE_COUNT_OFFSET: usize = 2 + 256;
+        const TABLE_BASE: usize = TABLE_COUNT_OFFSET + 2;
+        const DEAD_KEY_COUNT_OFFSET: usize = TABLE_BASE + TABLES * 128;
+        const LEN: usize = DEAD_KEY_COUNT_OFFSET + 2;
         let mut body = vec![0u8; LEN];
         for modifier in 0..=255usize {
-            body[1 + modifier] = if (modifier & 0x22) != 0 { 1 } else { 0 };
+            body[2 + modifier] = if (modifier & 0x22) != 0 { 1 } else { 0 };
         }
+        body[TABLE_COUNT_OFFSET..TABLE_COUNT_OFFSET + 2]
+            .copy_from_slice(&(TABLES as u16).to_be_bytes());
 
         let normal = TABLE_BASE;
         let shifted = TABLE_BASE + 128;
@@ -5694,6 +5710,10 @@ impl TrapDispatcher {
             (0x2F, b'.', b'>'),
             (0x31, b' ', b' '),
             (0x32, b'`', b'~'),
+            (0x7B, 0x1C, 0x1C),
+            (0x7C, 0x1D, 0x1D),
+            (0x7D, 0x1F, 0x1F),
+            (0x7E, 0x1E, 0x1E),
         ];
         for &(vk, unshifted, shifted_char) in keys {
             body[normal + vk] = unshifted;
@@ -5706,6 +5726,40 @@ impl TrapDispatcher {
         }
         bus.write_bytes(ptr, &body);
         self.system_kchr_cache.insert(res_id, ptr);
+        Some(ptr)
+    }
+
+    /// Allocate (and cache) the standard keycode-map resource (`'KMAP'` ID
+    /// 0). Its four-byte ID/version header is followed by the 128-entry
+    /// hardware-to-virtual-key map and a zero exception-array count. The
+    /// standard ADB map is identity-valued; exceptional keyboards describe
+    /// their remapping in the optional records. Macintosh Technical Note 160.
+    pub(crate) fn synthesize_system_kmap(
+        &mut self,
+        bus: &mut MacMemoryBus,
+        res_id: i16,
+    ) -> Option<u32> {
+        if let Some(&ptr) = self.system_kmap_cache.get(&res_id) {
+            return Some(ptr);
+        }
+        if res_id != 0 {
+            return None;
+        }
+
+        const HEADER_SIZE: usize = 4;
+        const MAP_SIZE: usize = 128;
+        const LEN: usize = HEADER_SIZE + MAP_SIZE + 2;
+        let mut body = vec![0u8; LEN];
+        for keycode in 0..MAP_SIZE {
+            body[HEADER_SIZE + keycode] = keycode as u8;
+        }
+
+        let ptr = bus.alloc(body.len() as u32);
+        if ptr == 0 {
+            return None;
+        }
+        bus.write_bytes(ptr, &body);
+        self.system_kmap_cache.insert(res_id, ptr);
         Some(ptr)
     }
 

--- a/src/trap/pict.rs
+++ b/src/trap/pict.rs
@@ -4103,6 +4103,17 @@ fn build_src_to_dst_table_uncached(
                 // indices: a lower-index color in the same 4-bit cell must not
                 // replace an exact match.
                 index as u8
+            } else if let Some(index) = device_clut.iter().position(|destination| {
+                destination[0] >> 8 == entry[0] >> 8
+                    && destination[1] >> 8 == entry[1] >> 8
+                    && destination[2] >> 8 == entry[2] >> 8
+            }) {
+                // Indexed 8-bit video exposes the most-significant byte of
+                // each 16-bit RGB component. Some classic PICT generators
+                // leave bookkeeping values in the low bytes, so colors that
+                // are identical on the device must match before the coarser
+                // inverse-table lookup. Imaging With QuickDraw 1994, p. 4-13.
+                index as u8
             } else {
                 let qr = (entry[0] >> 12) as u32;
                 let qg = (entry[1] >> 12) as u32;
@@ -6617,6 +6628,21 @@ mod tests {
         let table = build_src_to_dst_table(&src, &dst);
 
         assert_eq!(table[71], 12);
+    }
+
+    #[test]
+    fn eight_bit_device_matching_ignores_pict_rgb_low_bytes() {
+        let mut src = [[0u16; 3]; 256];
+        let mut dst = [[0u16; 3]; 256];
+        src[14] = [0xFF0E, 0x2D0E, 0x890E];
+        dst[73] = [0xFFFF, 0x2D2D, 0x8989];
+        // A competing entry occupies the same 4-bit inverse-table cell but
+        // does not display the requested 8-bit RGB value.
+        dst[12] = [0xF000, 0x2000, 0x8000];
+
+        let table = build_src_to_dst_table(&src, &dst);
+
+        assert_eq!(table[14], 73);
     }
 
     #[test]

--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -76,6 +76,26 @@ const PM_EXPLICIT: i16 = 0x0008;
 const PM_NO_UPDATES: i16 = -0x8000;
 const PM_BK_UPDATES: i16 = -0x6000;
 const PM_FG_UPDATES: i16 = -0x4000;
+// Classic Color QuickDraw's 8-bit color-arbitration order. The Palette
+// Manager walks this spread when a tolerant request has no in-tolerance
+// match, preserving the protected white/black endpoints while distributing
+// replacements across the device table. This is deliberately not numerical
+// CLUT order or nearest-RGB order.
+const PM_8BPP_ALLOCATION_ORDER: [u8; 256] = [
+    0, 255, 16, 18, 20, 22, 24, 63, 47, 95, 79, 127, 111, 159, 143, 31, 15, 254, 238, 222, 206,
+    190, 174, 62, 46, 94, 78, 126, 110, 158, 142, 26, 14, 253, 237, 221, 205, 189, 173, 61, 45, 93,
+    77, 125, 109, 157, 141, 29, 13, 252, 236, 220, 204, 188, 172, 156, 44, 124, 76, 92, 108, 60,
+    140, 28, 12, 251, 235, 219, 203, 187, 171, 155, 43, 123, 75, 91, 107, 59, 139, 27, 11, 250,
+    234, 218, 202, 186, 170, 154, 42, 122, 74, 90, 106, 58, 138, 30, 10, 249, 233, 217, 201, 185,
+    169, 153, 41, 121, 73, 89, 105, 57, 137, 25, 9, 248, 232, 216, 200, 184, 168, 152, 40, 120, 72,
+    88, 104, 56, 136, 175, 8, 247, 231, 215, 199, 183, 167, 151, 39, 119, 71, 87, 103, 55, 135, 23,
+    7, 246, 230, 214, 198, 182, 166, 150, 38, 118, 70, 86, 102, 54, 134, 191, 6, 245, 229, 213,
+    197, 181, 165, 149, 37, 117, 69, 85, 101, 53, 133, 21, 5, 244, 228, 212, 196, 180, 164, 148,
+    36, 116, 68, 84, 100, 52, 132, 207, 4, 243, 227, 211, 195, 179, 163, 147, 35, 115, 67, 83, 99,
+    51, 131, 19, 3, 242, 226, 210, 194, 178, 162, 146, 34, 114, 66, 82, 98, 50, 130, 223, 2, 241,
+    225, 209, 193, 177, 161, 49, 33, 81, 65, 113, 97, 145, 129, 17, 1, 240, 224, 208, 192, 176,
+    160, 48, 32, 80, 64, 112, 96, 144, 128, 239,
+];
 
 /// `dstWindow` value that addresses the default palette rather than a window.
 /// `SetPalette`/`NSetPalette` take a WindowPtr, and `(WindowPtr)-1` is the
@@ -16708,7 +16728,22 @@ impl super::TrapDispatcher {
         // already drawn by visible background windows, even though their
         // palettes did not request or receive a redraw.
         let mut updated_clut = current_clut;
-        for (index, rgb) in updated_clut.iter_mut().enumerate().take(palette_entries) {
+        self.palette_device_indices
+            .retain(|(palette, _), _| *palette != palette_handle);
+        let mut claimed = [false; 256];
+        // Color QuickDraw keeps the white and black endpoints available for
+        // its standard drawing operations. Tolerant white and black entries
+        // may share those exact cells; other tolerant colors may not consume
+        // them. Inside Macintosh Volume V (1986), V-162.
+        claimed[0] = true;
+        claimed[255] = true;
+
+        // Preserve the existing behavior for explicit and animated entries,
+        // which either name or reserve a device index. Record those claims
+        // before allocating ordinary tolerant colors so a tolerant entry
+        // cannot displace a fixed-index request that appears later in the
+        // palette.
+        for index in 0..palette_entries {
             let color_info = Self::palette_color_info_ptr(palette_ptr, index as u32);
             let usage = bus.read_word(color_info + 6) as i16;
             // Usage decides how a palette entry claims its device slot
@@ -16731,14 +16766,71 @@ impl super::TrapDispatcher {
             // Only the pure-explicit case keeps the device value; the
             // combined cases fall through to the ordinary install below.
             if usage & PM_EXPLICIT != 0 && usage & (PM_TOLERANT | PM_ANIMATED) == 0 {
-                *rgb = current_clut[index];
                 continue;
             }
-            *rgb = [
+            if usage & PM_EXPLICIT == 0 && usage & PM_TOLERANT != 0 {
+                continue;
+            }
+            let device_index = index & 0xFF;
+            updated_clut[device_index] = [
                 bus.read_word(color_info),
                 bus.read_word(color_info + 2),
                 bus.read_word(color_info + 4),
             ];
+            claimed[device_index] = true;
+            self.palette_device_indices
+                .insert((palette_handle, index as u16), device_index as u8);
+        }
+
+        // Tolerant colors are allocated unique device indices in palette
+        // order. Their palette positions are logical entry numbers, not CLUT
+        // indices. The selected cell changes only when its current color is
+        // farther away than the entry tolerance. Inside Macintosh Volume V
+        // (1986), V-160..V-162; Volume VI (1991), 20-9 and 20-15.
+        for index in 0..palette_entries {
+            let color_info = Self::palette_color_info_ptr(palette_ptr, index as u32);
+            let usage = bus.read_word(color_info + 6) as i16;
+            if usage & PM_TOLERANT == 0 || usage & PM_EXPLICIT != 0 {
+                continue;
+            }
+            let requested = [
+                bus.read_word(color_info),
+                bus.read_word(color_info + 2),
+                bus.read_word(color_info + 4),
+            ];
+            let tolerance = bus.read_word(color_info + 8);
+
+            let endpoint = if requested == [0xFFFF; 3] && current_clut[0] == requested {
+                Some(0usize)
+            } else if requested == [0; 3] && current_clut[255] == requested {
+                Some(255usize)
+            } else {
+                None
+            };
+            let device_index = endpoint.or_else(|| {
+                PM_8BPP_ALLOCATION_ORDER
+                    .iter()
+                    .map(|&candidate| usize::from(candidate))
+                    .find(|&candidate| !claimed[candidate])
+            });
+            let Some(device_index) = device_index else {
+                // Unsatisfied requests fall back to courteous matching.
+                continue;
+            };
+            claimed[device_index] = true;
+            self.palette_device_indices
+                .insert((palette_handle, index as u16), device_index as u8);
+
+            let present = current_clut[device_index];
+            let difference = requested
+                .into_iter()
+                .zip(present)
+                .map(|(wanted, have)| wanted.abs_diff(have))
+                .max()
+                .unwrap_or(0);
+            if difference > tolerance {
+                updated_clut[device_index] = requested;
+            }
         }
         let color_environment_changed = updated_clut != current_clut;
         self.device_clut = updated_clut;
@@ -16849,6 +16941,8 @@ impl super::TrapDispatcher {
             return;
         }
         self.palette_updates.remove(&palette);
+        self.palette_device_indices
+            .retain(|(handle, _), _| *handle != palette);
         self.window_palettes
             .retain(|_, (handle, _)| *handle != palette);
     }
@@ -16947,10 +17041,17 @@ impl super::TrapDispatcher {
             return 0;
         }
 
-        if let Some((_palette, rgb, usage)) = self.palette_entry_rgb_for_current_window(bus, entry)
-        {
+        if let Some((palette, rgb, usage)) = self.palette_entry_rgb_for_current_window(bus, entry) {
             if (usage & PM_EXPLICIT) != 0 {
                 return u32::from((entry as u16) & 0x00FF);
+            }
+
+            if let Some(index) = self
+                .palette_device_indices
+                .get(&(palette, entry as u16))
+                .copied()
+            {
+                return u32::from(index);
             }
 
             return u32::from(super::pict::closest_clut_index(
@@ -36630,13 +36731,21 @@ mod tests {
     fn activatepalette_preserves_device_cells_not_claimed_by_the_palette() {
         let (mut d, mut cpu, mut bus) = setup();
         let window = 0x0020_4120u32;
-        let palette = d.create_palette_from_ctab(&mut bus, 1, 0, super::PM_TOLERANT, 0);
+        let palette = d.create_palette_from_ctab(&mut bus, 2, 0, super::PM_TOLERANT, 0);
         let palette_ptr = TrapDispatcher::palette_ptr(&bus, palette);
         TrapDispatcher::write_palette_color_info(
             &mut bus,
             palette_ptr,
             0,
             [0x1234, 0x5678, 0x9ABC],
+            super::PM_TOLERANT,
+            0,
+        );
+        TrapDispatcher::write_palette_color_info(
+            &mut bus,
+            palette_ptr,
+            1,
+            [0x2468, 0xACE0, 0x1357],
             super::PM_TOLERANT,
             0,
         );
@@ -36651,7 +36760,12 @@ mod tests {
         let result = d.dispatch_quickdraw(true, 0x294, &mut cpu, &mut bus);
 
         assert!(result.unwrap().is_ok());
-        assert_eq!(d.device_clut[0], [0x1234, 0x5678, 0x9ABC]);
+        assert_eq!(d.palette_device_indices[&(palette, 0)], 16);
+        assert_eq!(d.palette_device_indices[&(palette, 1)], 18);
+        assert_eq!(d.device_clut[16], [0x1234, 0x5678, 0x9ABC]);
+        assert_eq!(d.device_clut[18], [0x2468, 0xACE0, 0x1357]);
+        assert_eq!(d.device_clut[0], [0xFFFF; 3]);
+        assert_eq!(d.device_clut[255], [0; 3]);
         assert_eq!(d.device_clut[200], background_color);
         assert_eq!(d.color_manager_clut[200], background_color);
     }

--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -1824,6 +1824,18 @@ impl super::TrapDispatcher {
                     }
                 }
 
+                if res_type == *b"KMAP" {
+                    if let Some(ptr) = self.synthesize_system_kmap(bus, res_id) {
+                        let handle = self.get_or_create_resource_handle(bus, res_type, res_id, ptr);
+                        cpu.write_reg(Register::A0, handle);
+                        cpu.write_reg(Register::D0, 0);
+                        bus.write_word(0x0A60, 0); // ResErr = noErr
+                        bus.write_long(sp + 6, handle);
+                        cpu.write_reg(Register::A7, sp + 6);
+                        return Some(Ok(()));
+                    }
+                }
+
                 cpu.write_reg(Register::A0, 0);
                 cpu.write_reg(Register::D0, 0);
                 bus.write_word(0x0A60, 0);
@@ -9136,30 +9148,67 @@ mod tests {
 
         let kchr = bus.read_long(handle);
         assert_ne!(kchr, 0, "synthetic KCHR handle must be loaded");
-        assert_eq!(bus.get_alloc_size(kchr), Some(1 + 256 + 128 * 2));
-        assert_eq!(bus.read_byte(kchr), 0, "KCHR version byte");
+        assert_eq!(bus.get_alloc_size(kchr), Some(2 + 256 + 2 + 128 * 2 + 2));
+        assert_eq!(bus.read_word(kchr), 0, "KCHR version word");
         assert_eq!(
-            bus.read_byte(kchr + 1),
+            bus.read_byte(kchr + 2),
             0,
             "modifier byte 0 should select the unshifted table"
         );
         assert_eq!(
-            bus.read_byte(kchr + 2),
+            bus.read_byte(kchr + 3),
             0,
             "modifier byte 1 is Command-only and should stay unshifted"
         );
         assert_eq!(
-            bus.read_byte(kchr + 3),
+            bus.read_byte(kchr + 4),
             1,
             "modifier byte 2 should select the shifted table"
         );
 
-        let table0 = kchr + 1 + 256;
+        assert_eq!(bus.read_word(kchr + 2 + 256), 2, "KCHR table count");
+        let table0 = kchr + 2 + 256 + 2;
         let table1 = table0 + 128;
         assert_eq!(bus.read_byte(table0), b'a');
         assert_eq!(bus.read_byte(table1), b'A');
         assert_eq!(bus.read_byte(table0 + 0x0C), b'q');
         assert_eq!(bus.read_byte(table1 + 0x0C), b'Q');
+        assert_eq!(bus.read_byte(table0 + 0x7B), 0x1C, "left arrow");
+        assert_eq!(bus.read_byte(table0 + 0x7C), 0x1D, "right arrow");
+        assert_eq!(bus.read_byte(table0 + 0x7D), 0x1F, "down arrow");
+        assert_eq!(bus.read_byte(table0 + 0x7E), 0x1E, "up arrow");
+        assert_eq!(
+            bus.read_bytes(table1 + 0x7B, 4),
+            vec![0x1C, 0x1D, 0x1F, 0x1E],
+            "shifted arrow translations should remain navigation characters"
+        );
+        assert_eq!(bus.read_word(table1 + 128), 0, "KCHR dead-key count");
+    }
+
+    #[test]
+    fn get_resource_synthesizes_standard_identity_kmap_id_zero() {
+        let (mut disp, mut cpu, mut bus) = setup();
+
+        let sp = TEST_SP;
+        bus.write_word(sp, 0);
+        bus.write_long(sp + 2, u32::from_be_bytes(*b"KMAP"));
+
+        call(&mut disp, true, 0x1A0, &mut cpu, &mut bus).unwrap();
+
+        let handle = bus.read_long(TEST_SP + 6);
+        assert_ne!(handle, 0, "synthetic KMAP must return a handle");
+        let kmap = bus.read_long(handle);
+        assert_eq!(bus.get_alloc_size(kmap), Some(4 + 128 + 2));
+        assert_eq!(bus.read_word(kmap), 0, "KMAP identifier");
+        assert_eq!(bus.read_word(kmap + 2), 0, "KMAP version");
+        for keycode in 0..128u32 {
+            assert_eq!(
+                bus.read_byte(kmap + 4 + keycode),
+                keycode as u8,
+                "standard keycode {keycode} should map to itself"
+            );
+        }
+        assert_eq!(bus.read_word(kmap + 4 + 128), 0, "KMAP exception count");
     }
 
     #[test]

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -4509,9 +4509,11 @@ impl super::TrapDispatcher {
     /// The caller supplies a pointer to a `'KCHR'` resource. The
     /// layout used here follows the documented structure from Inside
     /// Macintosh: Macintosh Toolbox Essentials / Text:
-    ///   - byte 0: version
-    ///   - bytes 1..=256: table-selection index keyed by the modifier byte
+    ///   - bytes 0..=1: version
+    ///   - bytes 2..=257: table-selection index keyed by the modifier byte
+    ///   - bytes 258..=259: character-mapping table count
     ///   - character-mapping tables: 128 bytes per table
+    ///   - a trailing dead-key-record count
     ///
     /// The helper only implements the straight-through character
     /// mapping path. If no translation data is supplied, it falls
@@ -4542,8 +4544,12 @@ impl super::TrapDispatcher {
             };
         }
 
-        let table_code = bus.read_byte(trans_data + 1 + modifier_byte) as u32;
-        let table_base = trans_data + 1 + 256 + table_code * 128;
+        let table_code = bus.read_byte(trans_data + 2 + modifier_byte) as u32;
+        let table_count = u32::from(bus.read_word(trans_data + 2 + 256));
+        if table_code >= table_count {
+            return 0;
+        }
+        let table_base = trans_data + 2 + 256 + 2 + table_code * 128;
         let result = bus.read_byte(table_base + vk) as u32;
         if result != 0 {
             return result;
@@ -19849,19 +19855,22 @@ mod tests {
 
     fn seed_synthetic_kchr(bus: &mut super::MacMemoryBus, trans_data: u32) {
         // Minimal KCHR layout:
-        //   byte 0 = version
-        //   bytes 1..=256 = table-selection index
+        //   bytes 0..=1 = version
+        //   bytes 2..=257 = table-selection index
+        //   table-count word
         //   table 0 and table 1 = 128-byte character tables
+        //   dead-key-count word
         //
         // Modifier byte 0 selects table 0; modifier byte 1 selects table 1.
-        bus.write_byte(trans_data, 0);
+        bus.write_word(trans_data, 0);
         for i in 0..256u32 {
-            bus.write_byte(trans_data + 1 + i, 0);
+            bus.write_byte(trans_data + 2 + i, 0);
         }
-        bus.write_byte(trans_data + 1, 0);
-        bus.write_byte(trans_data + 2, 1);
+        bus.write_byte(trans_data + 2, 0);
+        bus.write_byte(trans_data + 3, 1);
 
-        let table0 = trans_data + 1 + 256;
+        bus.write_word(trans_data + 2 + 256, 2);
+        let table0 = trans_data + 2 + 256 + 2;
         let table1 = table0 + 128;
         bus.write_byte(table0 + 2, b'Q');
         bus.write_byte(table0 + 3, b'W');
@@ -19873,6 +19882,7 @@ mod tests {
         bus.write_byte(table1 + 4, b'C');
         bus.write_byte(table1 + 5, b'V');
         bus.write_byte(table1 + 6, b'B');
+        bus.write_word(table1 + 128, 0);
     }
 
     // KeyTrans ($A9C3)


### PR DESCRIPTION
Closes #726

## Summary

- implement classic 8-bit Palette Manager arbitration for tolerant colors and preserve their allocated device indices
- prefer exact displayed 8-bit RGB matches when translating indexed PICT colors
- synthesize complete standard KCHR and KMAP keyboard resources and parse the documented KCHR layout in KeyTrans
- add focused regression coverage for palette allocation, PICT color matching, keyboard translation, and system keyboard resources

## Gameplay validation

Validated the complete playable flow in The Tinies against a classic runtime reference:

- launch the demo and enter Settings
- remap movement to D/A/W/S and action to Space, with every binding displayed correctly
- start level 1 and move the controller to the Tiny
- select the Tiny, move the controller across the room, and command the Tiny to follow
- reach the sleeper and complete the room, including the PERFECT result
- pause and resume during active gameplay

The game now renders with the expected palette throughout and accepts configurable controls during real gameplay.

## Checks

- cargo test --lib
- cargo test --lib --features test-support
- cargo check --no-default-features
- cargo check --lib --target wasm32-unknown-unknown
- cargo package --allow-dirty
- git diff --check