### PR TITLE
fix: complete Dynasty League Baseball compatibility

### DIFF
--- a/src/loader/ppc.rs
+++ b/src/loader/ppc.rs
@@ -2561,7 +2561,7 @@ impl PpcInputSnapshot {
             return false;
         }
         let idx = (key_code / 8) as usize;
-        let bit = 1u8 << (key_code % 8);
+        let bit = 0x80u8 >> (key_code % 8);
         self.key_map[idx] & bit != 0
     }
 
@@ -79842,7 +79842,7 @@ mod tests {
         loaded.set_input_snapshot(PpcInputSnapshot {
             key_map: {
                 let mut key_map = [0; 16];
-                key_map[(PPC_KEY_SPACE / 8) as usize] |= 1u8 << (PPC_KEY_SPACE % 8);
+                key_map[(PPC_KEY_SPACE / 8) as usize] |= 0x80u8 >> (PPC_KEY_SPACE % 8);
                 key_map
             },
             ..PpcInputSnapshot::default()
@@ -107080,7 +107080,7 @@ mod tests {
         let mut loaded = load_pef_application(&pef).unwrap();
         let key_map_ptr = PPC_DATA_BASE + 0x1000;
         let mut input = PpcInputSnapshot::default();
-        input.key_map[(PPC_KEY_LEFT / 8) as usize] |= 1u8 << (PPC_KEY_LEFT % 8);
+        input.key_map[(PPC_KEY_LEFT / 8) as usize] |= 0x80u8 >> (PPC_KEY_LEFT % 8);
         loaded.set_input_snapshot(input);
         loaded
             .memory
@@ -107096,7 +107096,7 @@ mod tests {
                 .memory
                 .read_u8(key_map_ptr + u32::from(PPC_KEY_LEFT / 8))
                 .unwrap()
-                & (1u8 << (PPC_KEY_LEFT % 8)),
+                & (0x80u8 >> (PPC_KEY_LEFT % 8)),
             0
         );
 
@@ -109364,7 +109364,7 @@ mod tests {
         }
 
         let mut input = PpcInputSnapshot::default();
-        input.key_map[(PPC_KEY_LEFT / 8) as usize] |= 1u8 << (PPC_KEY_LEFT % 8);
+        input.key_map[(PPC_KEY_LEFT / 8) as usize] |= 0x80u8 >> (PPC_KEY_LEFT % 8);
         let action =
             dispatch_getkeys_import(&mut cpu, &mut memory, input, Some(&mut idle_poll_counts));
         assert_eq!(action, PpcImportAction::ReturnPreserve);
@@ -109477,7 +109477,7 @@ mod tests {
         let mut loaded = load_pef_application(&pef).unwrap();
         let key_map_ptr = PPC_DATA_BASE + 0x1000;
         let mut input = PpcInputSnapshot::default();
-        input.key_map[(PPC_KEY_LEFT / 8) as usize] |= 1u8 << (PPC_KEY_LEFT % 8);
+        input.key_map[(PPC_KEY_LEFT / 8) as usize] |= 0x80u8 >> (PPC_KEY_LEFT % 8);
         loaded.set_input_snapshot(input);
         loaded.memory.add_region(key_map_ptr, vec![0xcc; 4]);
         loaded.cpu.gpr[3] = key_map_ptr;
@@ -112075,7 +112075,7 @@ mod tests {
             b"Primary Trigger",
         );
         let mut input = PpcInputSnapshot::default();
-        input.key_map[(PPC_KEY_LEFT / 8) as usize] |= 1u8 << (PPC_KEY_LEFT % 8);
+        input.key_map[(PPC_KEY_LEFT / 8) as usize] |= 0x80u8 >> (PPC_KEY_LEFT % 8);
         loaded.set_input_snapshot(input);
         loaded.cpu.pc = loaded.entry_pc;
         loaded.imports[0].dispatcher_target = PpcImportDispatcherTarget::ISpElementGetSimpleState;
@@ -112306,7 +112306,7 @@ mod tests {
         assert_eq!(probe.unsupported_import_index, None);
         let element = loaded.memory.read_u32_be(elements_out_ptr).unwrap();
         let mut input = PpcInputSnapshot::default();
-        input.key_map[(PPC_KEY_LEFT / 8) as usize] |= 1u8 << (PPC_KEY_LEFT % 8);
+        input.key_map[(PPC_KEY_LEFT / 8) as usize] |= 0x80u8 >> (PPC_KEY_LEFT % 8);
         loaded.set_input_snapshot(input);
         loaded.cpu.pc = loaded.entry_pc;
         loaded.imports[0].dispatcher_target = PpcImportDispatcherTarget::ISpElementGetSimpleState;
@@ -112388,7 +112388,7 @@ mod tests {
         };
         let snapshot = |key: u8| {
             let mut input = PpcInputSnapshot::default();
-            input.key_map[(key / 8) as usize] |= 1u8 << (key % 8);
+            input.key_map[(key / 8) as usize] |= 0x80u8 >> (key % 8);
             input
         };
         let walk = ppc_isp_action_binding(PPC_ISP_ELEMENT_KIND_AXIS, Some("Walk"));
@@ -112450,7 +112450,7 @@ mod tests {
         let snapshot = |keys: &[u8]| {
             let mut input = PpcInputSnapshot::default();
             for &key in keys {
-                input.key_map[(key / 8) as usize] |= 1u8 << (key % 8);
+                input.key_map[(key / 8) as usize] |= 0x80u8 >> (key % 8);
             }
             input
         };
@@ -112606,7 +112606,7 @@ mod tests {
             ..PpcInputSprocketState::default()
         };
         let mut space = PpcInputSnapshot::default();
-        space.key_map[(PPC_KEY_SPACE / 8) as usize] |= 1u8 << (PPC_KEY_SPACE % 8);
+        space.key_map[(PPC_KEY_SPACE / 8) as usize] |= 0x80u8 >> (PPC_KEY_SPACE % 8);
         assert_eq!(
             ppc_isp_input_simple_state(
                 PPC_ISP_ELEMENT_KIND_BUTTON,

--- a/src/mac_roman.rs
+++ b/src/mac_roman.rs
@@ -54,16 +54,17 @@ pub(crate) fn decode_mac_roman_for_render(bytes: &[u8]) -> String {
 pub(crate) fn encode_mac_roman_lossy(value: &str) -> Vec<u8> {
     value
         .chars()
-        .map(|ch| {
-            if ch.is_ascii() {
-                ch as u8
-            } else {
-                MAC_ROMAN_HIGH
-                    .iter()
-                    .position(|&candidate| candidate == ch)
-                    .map(|idx| idx as u8 + 0x80)
-                    .unwrap_or(b'?')
-            }
-        })
+        .map(|ch| encode_mac_roman_char(ch).unwrap_or(b'?'))
         .collect()
+}
+
+pub(crate) fn encode_mac_roman_char(ch: char) -> Option<u8> {
+    if ch.is_ascii() {
+        Some(ch as u8)
+    } else {
+        MAC_ROMAN_HIGH
+            .iter()
+            .position(|&candidate| candidate == ch)
+            .map(|idx| idx as u8 + 0x80)
+    }
 }

--- a/src/quickdraw/fonts/pixel_font/menu_symbols.rs
+++ b/src/quickdraw/fonts/pixel_font/menu_symbols.rs
@@ -36,10 +36,20 @@ const CHECKMARK_LEN: usize = data_len(CHECKMARK_SRC);
 static CHECKMARK_GLYPHS: [Glyph; 1] = decode_glyphs(CHECKMARK_SRC);
 static CHECKMARK_DATA: [u8; CHECKMARK_LEN] = decode_data(CHECKMARK_SRC);
 
+const TRADEMARK_SRC: &[GlyphSrc] = &[g!(6, (0, -8),
+    "###.#.#"
+    ".#..###"
+    ".#..#.#"
+)];
+const TRADEMARK_LEN: usize = data_len(TRADEMARK_SRC);
+static TRADEMARK_GLYPHS: [Glyph; 1] = decode_glyphs(TRADEMARK_SRC);
+static TRADEMARK_DATA: [u8; TRADEMARK_LEN] = decode_data(TRADEMARK_SRC);
+
 pub(crate) fn get_glyph(ch: char) -> Option<(&'static Glyph, &'static [u8])> {
     match ch {
         '\u{2318}' => Some((&COMMAND_KEY_GLYPHS[0], &COMMAND_KEY_DATA)),
         '\u{2713}' => Some((&CHECKMARK_GLYPHS[0], &CHECKMARK_DATA)),
+        '\u{2122}' => Some((&TRADEMARK_GLYPHS[0], &TRADEMARK_DATA)),
         _ => None,
     }
 }

--- a/src/quickdraw/text.rs
+++ b/src/quickdraw/text.rs
@@ -79,6 +79,13 @@ pub fn get_glyph(font_id: i16, size: i16, ch: char) -> Option<(&'static Glyph, &
         return get_macroman_glyph(font_id, size, 0x14);
     }
 
+    // HLE chrome stores text as Unicode for layout and logging. Route every
+    // representable extended character back through its Mac Roman glyph slot
+    // so titles and menus use the same bitmap repertoire as guest DrawText.
+    if let Some(mac_code @ 0x80..=0xFF) = crate::mac_roman::encode_mac_roman_char(ch) {
+        return macroman_or_ascii_fallback(font_id, size, mac_code);
+    }
+
     None
 }
 
@@ -102,6 +109,9 @@ fn macroman_or_ascii_fallback(
 ) -> Option<(&'static Glyph, &'static [u8])> {
     if let Some(hit) = get_macroman_glyph(font_id, size, mac_code) {
         return Some(hit);
+    }
+    if mac_code == 0xAA {
+        return crate::quickdraw::fonts::pixel_font::menu_symbols::get_glyph('\u{2122}');
     }
     // ASCII fallback for extended characters that have a close ASCII
     // equivalent. Better to render a slightly-wrong glyph than silently
@@ -148,5 +158,14 @@ mod tests {
                 "{name} symbol should contain visible pixels"
             );
         }
+    }
+
+    #[test]
+    fn unicode_hle_text_uses_mac_roman_extended_glyphs() {
+        let (glyph, data) = get_glyph(0, 12, '™').expect("Mac Roman trademark glyph");
+        let glyph_len = usize::from(glyph.width) * usize::from(glyph.height);
+        assert!(data[glyph.data_offset..glyph.data_offset + glyph_len]
+            .iter()
+            .any(|pixel| *pixel != 0));
     }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -12619,7 +12619,7 @@ mod tests {
         let ppc_app = runner.ppc_app.as_mut().expect("PPC app should stay loaded");
         let left_key = 0x7bu8;
         let left_byte = key_map_ptr + u32::from(left_key / 8);
-        let left_bit = 1u8 << (left_key % 8);
+        let left_bit = 0x80u8 >> (left_key % 8);
         assert_ne!(ppc_app.memory.read_u8(left_byte).unwrap() & left_bit, 0);
     }
 
@@ -13533,7 +13533,7 @@ mod tests {
 
         assert_eq!(
             runner.bus.read_byte(addr::KEY_MAP_LM + 4),
-            0x40,
+            0x02,
             "J key should be visible to byte/bit KeyMap readers"
         );
         assert_eq!(
@@ -13543,7 +13543,7 @@ mod tests {
         );
         assert_eq!(
             runner.bus.read_byte(addr::KEY_MAP_LM + 15),
-            0x40,
+            0x02,
             "up arrow should be visible to byte/bit KeyMap readers"
         );
         assert_eq!(
@@ -13566,7 +13566,7 @@ mod tests {
         );
         assert_eq!(
             runner.bus.read_byte(addr::KEY_MAP_LM + 15),
-            0x40,
+            0x02,
             "unrelated byte/bit down keys should remain mirrored"
         );
         assert_eq!(
@@ -13584,18 +13584,18 @@ mod tests {
         let caps_lock_byte = addr::KEY_MAP_LM + 7;
 
         runner.push_key_down(0x39, 0);
-        assert_eq!(runner.bus.read_byte(caps_lock_byte) & 0x02, 0x02);
+        assert_eq!(runner.bus.read_byte(caps_lock_byte) & 0x40, 0x40);
         runner.push_key_up(0x39, 0);
         assert_eq!(
-            runner.bus.read_byte(caps_lock_byte) & 0x02,
-            0x02,
+            runner.bus.read_byte(caps_lock_byte) & 0x40,
+            0x40,
             "physical release must keep the low-memory Caps Lock bit latched"
         );
 
         runner.push_key_down(0x39, 0);
-        assert_eq!(runner.bus.read_byte(caps_lock_byte) & 0x02, 0);
+        assert_eq!(runner.bus.read_byte(caps_lock_byte) & 0x40, 0);
         runner.push_key_up(0x39, 0);
-        assert_eq!(runner.bus.read_byte(caps_lock_byte) & 0x02, 0);
+        assert_eq!(runner.bus.read_byte(caps_lock_byte) & 0x40, 0);
     }
 
     #[test]

--- a/src/trap/dialog.rs
+++ b/src/trap/dialog.rs
@@ -36,6 +36,16 @@ struct DialogCIconLayout {
     pixel_data_ptr: u32,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct DialogItemTextStyle {
+    font: i16,
+    face: u8,
+    size: i16,
+    foreground: Option<[u16; 3]>,
+    background: Option<[u16; 3]>,
+    mode: i16,
+}
+
 #[derive(Clone, Copy)]
 struct FullscreenOffscreenDialogRestoreCandidate {
     base: u32,
@@ -3977,7 +3987,18 @@ impl super::TrapDispatcher {
         proc_id: i16,
     ) -> (i16, i16, i16, i16) {
         let (_, _, screen_w, screen_h, _) = self.get_screen_params();
-        let main_screen = (0, 0, screen_h, screen_w);
+        let menu_bar_height = if self.menu_bar_hidden {
+            0
+        } else {
+            bus.read_word(crate::memory::globals::addr::MBAR_HEIGHT) as i16
+        };
+        // The main-screen positioning area is the desktop below the menu bar.
+        // Position the complete window structure within it, then translate
+        // back to the content bounds consumed by NewWindow. The WIND bounds
+        // themselves describe only the content region.
+        // Macintosh Toolbox Essentials (1992), pp. 4-29, 4-31, 4-55,
+        // and 4-124 to 4-126.
+        let main_screen = (menu_bar_height, 0, screen_h, screen_w);
         let place_at_alert_position = |target: (i16, i16, i16, i16)| -> (i16, i16, i16, i16) {
             let dialog_w = bounds.3 - bounds.1;
             let dialog_h = bounds.2 - bounds.0;
@@ -4008,6 +4029,23 @@ impl super::TrapDispatcher {
                     new_left + (bounds.3 - bounds.1),
                 )
             };
+        let center_structure = |target: (i16, i16, i16, i16)| -> (i16, i16, i16, i16) {
+            let structure = self.window_structure_global_rect_for_proc(bus, bounds, proc_id);
+            let structure_w = structure.3 - structure.1;
+            let structure_h = structure.2 - structure.0;
+            let target_w = target.3 - target.1;
+            let target_h = target.2 - target.0;
+            let new_structure_left = target.1 + (target_w - structure_w) / 2;
+            let new_structure_top = target.0 + (target_h - structure_h) / 2;
+            let new_left = new_structure_left + (bounds.1 - structure.1);
+            let new_top = new_structure_top + (bounds.0 - structure.0);
+            (
+                new_top,
+                new_left,
+                new_top + (bounds.2 - bounds.0),
+                new_left + (bounds.3 - bounds.1),
+            )
+        };
         match position {
             // alertPositionMainScreen / ParentWindowScreen
             // Macintosh Toolbox Essentials 1992, pp. 4-125 to 4-126
@@ -4025,15 +4063,25 @@ impl super::TrapDispatcher {
                     .unwrap_or(main_screen);
                 bounds = place_structure_at_alert_position(target);
             }
-            // centerMainScreen / centerParentWindow: true vertical center
-            // Macintosh Toolbox Essentials 1992, p. 4-126
-            0x280A | 0x680A | 0xA80A | 0x380A => {
-                let (_, _, screen_w, screen_h, _) = self.get_screen_params();
-                let dialog_w = bounds.3 - bounds.1;
-                let dialog_h = bounds.2 - bounds.0;
-                let new_left = (screen_w - dialog_w) / 2;
-                let new_top = (screen_h - dialog_h) / 2;
-                bounds = (new_top, new_left, new_top + dialog_h, new_left + dialog_w);
+            // centerMainScreen / centerParentWindowScreen. Systemless models a
+            // single screen, so both use the main-screen desktop rectangle.
+            0x280A | 0x680A => {
+                bounds = center_structure(main_screen);
+            }
+            // centerParentWindow uses the content rectangle of the window in
+            // which the user was last working.
+            0xA80A => {
+                let parent = self.front_window_for_trap(bus);
+                let target = (parent != 0)
+                    .then(|| self.window_content_global_rect(bus, parent))
+                    .flatten()
+                    .unwrap_or(main_screen);
+                bounds = center_structure(target);
+            }
+            // Staggering is retained as the existing single-window fallback
+            // until the Window Manager tracks per-screen stagger slots.
+            0x380A => {
+                bounds = center_structure(main_screen);
             }
             _ => {} // noAutoCenter (0x0000) or unknown: use raw bounds
         }
@@ -4095,6 +4143,7 @@ impl super::TrapDispatcher {
             alert_id as u32,
             items_handle,
             items.clone(),
+            None,
             None,
         );
         if dialog_ptr == 0 {
@@ -4438,9 +4487,11 @@ impl super::TrapDispatcher {
 
     fn ditl_item_payload_len(base_type: u8, data_len_byte: u8, remaining: u32) -> Option<u32> {
         let payload_len = match base_type {
-            // userItem has only the byte after itmtype (reserved/empty),
-            // not a following payload.
-            0 => 0,
+            // The compiled item record stores a length byte for every item
+            // type. User items do not interpret their payload, but the Dialog
+            // Manager must still skip it to locate the next record.
+            // Inside Macintosh Volume I, I-404 to I-405 and I-427.
+            0 => u32::from(data_len_byte),
             // Help items use the byte after itmtype as a sized payload.
             // Macintosh Toolbox Essentials 1992, p. 6-154
             1 => u32::from(data_len_byte),
@@ -5114,6 +5165,108 @@ impl super::TrapDispatcher {
         }
     }
 
+    fn copy_dialog_item_color_table_resource(
+        &mut self,
+        bus: &mut MacMemoryBus,
+        table_id: i16,
+    ) -> Option<u32> {
+        let (_, resource_ptr) = self.find_or_load_resource_any(bus, *b"ictb", table_id)?;
+        let byte_size = bus.get_alloc_size(resource_ptr)?;
+        if byte_size == 0 {
+            return None;
+        }
+        let table_ptr = bus.alloc(byte_size);
+        for offset in 0..byte_size {
+            bus.write_byte(table_ptr + offset, bus.read_byte(resource_ptr + offset));
+        }
+        let table_handle = bus.alloc(4);
+        bus.write_long(table_handle, table_ptr);
+        Some(table_handle)
+    }
+
+    fn dialog_item_text_style(
+        &self,
+        bus: &MacMemoryBus,
+        dialog_ptr: u32,
+        item_index: usize,
+    ) -> Option<DialogItemTextStyle> {
+        let table_handle = self.window_dialog_item_color_table(bus, dialog_ptr);
+        if table_handle == 0 {
+            return None;
+        }
+        let table_ptr = bus.read_long(table_handle);
+        if table_ptr == 0 {
+            return None;
+        }
+        let table_size = bus.get_alloc_size(table_ptr)?;
+        let entry_offset = u32::try_from(item_index).ok()?.checked_mul(4)?;
+        if entry_offset.checked_add(4)? > table_size {
+            return None;
+        }
+
+        let flags = bus.read_word(table_ptr + entry_offset);
+        let style_offset = u32::from(bus.read_word(table_ptr + entry_offset + 2));
+        if flags == 0 && style_offset == 0 {
+            return None;
+        }
+        if style_offset.checked_add(20)? > table_size {
+            return None;
+        }
+
+        let style_ptr = table_ptr + style_offset;
+        let stored_font = bus.read_word(style_ptr) as i16;
+        let stored_face = bus.read_word(style_ptr + 2) as u8;
+        let stored_size = bus.read_word(style_ptr + 4) as i16;
+        let mut size = self.tx_size;
+        if flags & 0x0004 != 0 {
+            size = stored_size;
+        }
+        if flags & 0x0010 != 0 {
+            size = size.saturating_add(stored_size);
+        }
+
+        // A set doFontName bit makes diFont an offset to a Pascal font name.
+        // Font-number lookup remains the safe fallback when that optional
+        // name cannot be resolved by the HLE Font Manager.
+        let font = if flags & 0x0001 != 0 && flags & 0x8000 == 0 {
+            stored_font
+        } else {
+            self.tx_font
+        };
+        let face = if flags & 0x0002 != 0 {
+            stored_face
+        } else {
+            self.tx_face as u8
+        };
+        let foreground = (flags & 0x0008 != 0).then(|| {
+            [
+                bus.read_word(style_ptr + 6),
+                bus.read_word(style_ptr + 8),
+                bus.read_word(style_ptr + 10),
+            ]
+        });
+        let background = (flags & 0x2000 != 0).then(|| {
+            [
+                bus.read_word(style_ptr + 12),
+                bus.read_word(style_ptr + 14),
+                bus.read_word(style_ptr + 16),
+            ]
+        });
+        let mode = if flags & 0x4000 != 0 {
+            bus.read_word(style_ptr + 18) as i16
+        } else {
+            self.tx_mode
+        };
+        Some(DialogItemTextStyle {
+            font,
+            face,
+            size,
+            foreground,
+            background,
+            mode,
+        })
+    }
+
     fn finish_dialog_creation<C: CpuOps>(
         &mut self,
         bus: &mut MacMemoryBus,
@@ -5128,6 +5281,7 @@ impl super::TrapDispatcher {
         items_handle: u32,
         items: Vec<DialogItem>,
         dialog_color_table: Option<u32>,
+        dialog_item_color_table: Option<u32>,
     ) -> u32 {
         let previous_port = self.current_port;
         let previous_gdevice = self.current_gdevice;
@@ -5175,6 +5329,9 @@ impl super::TrapDispatcher {
         if let Some(color_table) = dialog_color_table {
             self.ensure_window_aux_record(bus, dlg_ptr, color_table);
             self.apply_window_color_table(bus, dlg_ptr, color_table);
+        }
+        if let Some(item_color_table) = dialog_item_color_table {
+            self.set_window_dialog_item_color_table(bus, dlg_ptr, item_color_table);
         }
 
         // DialogRecord starts with a WindowRecord; +108 is windowKind,
@@ -5852,7 +6009,7 @@ impl super::TrapDispatcher {
         if let Some((red, green, blue)) = self.window_semantic_color(bus, dialog_ptr, 0) {
             let (screen_base, row_bytes, screen_width, screen_height, pixel_size) =
                 self.get_screen_params();
-            let pixel_index = super::pict::closest_clut_index(red, green, blue, &self.device_clut);
+            let pixel_index = Self::nearest_palette_index(&self.device_clut, [red, green, blue]);
             Self::fb_fill_rect_index(
                 bus,
                 screen_base,
@@ -5869,6 +6026,38 @@ impl super::TrapDispatcher {
         } else {
             self.fill_rect_clipped_to_dialog(bus, bounds, rect, false);
         }
+    }
+
+    fn fill_dialog_item_background(
+        &self,
+        bus: &mut MacMemoryBus,
+        bounds: (i16, i16, i16, i16),
+        rect: (i16, i16, i16, i16),
+        rgb: [u16; 3],
+    ) {
+        let top = rect.0.max(bounds.0);
+        let left = rect.1.max(bounds.1);
+        let bottom = rect.2.min(bounds.2);
+        let right = rect.3.min(bounds.3);
+        if top >= bottom || left >= right {
+            return;
+        }
+        let (screen_base, row_bytes, screen_width, screen_height, pixel_size) =
+            self.get_screen_params();
+        let pixel_index = Self::nearest_palette_index(&self.device_clut, rgb);
+        Self::fb_fill_rect_index(
+            bus,
+            screen_base,
+            row_bytes,
+            pixel_size,
+            screen_width,
+            screen_height,
+            top,
+            left,
+            bottom,
+            right,
+            pixel_index,
+        );
     }
 
     fn dialog_item_enclosing_local_rect(
@@ -6005,7 +6194,7 @@ impl super::TrapDispatcher {
         if !game_managed {
             if let Some((red, green, blue)) = content_color {
                 let pixel_index =
-                    super::pict::closest_clut_index(red, green, blue, &self.device_clut);
+                    Self::nearest_palette_index(&self.device_clut, [red, green, blue]);
                 Self::fb_fill_rect_index(
                     bus,
                     screen_base,
@@ -6088,7 +6277,7 @@ impl super::TrapDispatcher {
                     self.draw_rect_border(bus, top - 1, left - 1, bottom + 1, right + 1);
                     self.draw_shadow(bus, top - 1, left - 1, bottom + 1, right + 1);
                 }
-                0 | 4 => {
+                0 | 4 | 5 => {
                     // documentProc/noGrowDocProc use the Window Manager's
                     // document WDEF title-bar chrome. DrawDialog is allowed
                     // on modeless dialogs too (IM:I I-417; MTE 1992 p. 6-142),
@@ -6106,7 +6295,13 @@ impl super::TrapDispatcher {
                         title.to_string()
                     };
                     self.go_away_flag = dialog_ptr != 0 && bus.read_byte(dialog_ptr + 112) != 0;
-                    self.draw_window_frame(bus);
+                    // DrawDialog has already painted the dialog content. The
+                    // full WDEF draw path erases its structure region before
+                    // drawing document/movable chrome, so use the chrome-only
+                    // path here. This also gives movableDBoxProc its striped
+                    // title bar without clearing dialog-manager-owned items.
+                    // MTE 1992 p. 6-142; HIG 1992 pp. 185-186.
+                    self.draw_window_chrome(bus, true);
                     self.window_bounds = saved_bounds;
                     self.window_proc_id = saved_proc_id;
                     self.window_title = saved_title;
@@ -6243,8 +6438,17 @@ impl super::TrapDispatcher {
                 }
                 // Static text (8)
                 8 => {
+                    let style = self.dialog_item_text_style(bus, dialog_ptr, i);
+                    if let Some(rgb) = style.and_then(|value| value.background) {
+                        self.fill_dialog_item_background(
+                            bus,
+                            bounds,
+                            (abs_top, abs_left, abs_bottom, abs_right),
+                            rgb,
+                        );
+                    }
                     self.draw_static_text(
-                        bus, abs_top, abs_left, abs_bottom, abs_right, &item.text,
+                        bus, abs_top, abs_left, abs_bottom, abs_right, &item.text, style,
                     );
                 }
                 // Edit text (16)
@@ -6860,13 +7064,25 @@ impl super::TrapDispatcher {
                     }
                 }
                 8 => {
-                    self.fill_dialog_content_rect(
-                        bus,
-                        dialog_ptr,
-                        bounds,
-                        (abs_top, abs_left, abs_bottom, abs_right),
-                    );
-                    self.draw_static_text(bus, abs_top, abs_left, abs_bottom, abs_right, &item.text)
+                    let style = self.dialog_item_text_style(bus, dialog_ptr, i);
+                    if let Some(rgb) = style.and_then(|value| value.background) {
+                        self.fill_dialog_item_background(
+                            bus,
+                            bounds,
+                            (abs_top, abs_left, abs_bottom, abs_right),
+                            rgb,
+                        );
+                    } else {
+                        self.fill_dialog_content_rect(
+                            bus,
+                            dialog_ptr,
+                            bounds,
+                            (abs_top, abs_left, abs_bottom, abs_right),
+                        );
+                    }
+                    self.draw_static_text(
+                        bus, abs_top, abs_left, abs_bottom, abs_right, &item.text, style,
+                    )
                 }
                 16 => {
                     let display_text = if item_num == edit_item {
@@ -8512,13 +8728,18 @@ impl super::TrapDispatcher {
         bottom: i16,
         right: i16,
         text: &str,
+        style: Option<DialogItemTextStyle>,
     ) {
         let (screen_base, row_bytes, screen_width, screen_height, pixel_size) =
             self.get_screen_params();
         // SetDialogFont/SetDAFont affects statText and editText items but
         // not control titles (IM:I I-412; MTE 1992 p. 6-105).
-        let font_id = self.tx_font;
-        let font_size = Self::font_lookup_size(self.tx_size);
+        let font_id = style.map(|value| value.font).unwrap_or(self.tx_font);
+        let raw_font_size = style.map(|value| value.size).unwrap_or(self.tx_size);
+        let font_size = Self::font_lookup_size(raw_font_size);
+        let face = style.map(|value| value.face).unwrap_or(self.tx_face as u8);
+        let foreground = style.and_then(|value| value.foreground);
+        let _mode = style.map(|value| value.mode).unwrap_or(self.tx_mode);
         let metrics = get_font_metrics(font_id, font_size);
         let line_height = metrics.ascent + metrics.descent + metrics.leading;
         let max_width = (right - left).saturating_sub(Self::TE_LINE_LEFT_INSET);
@@ -8529,7 +8750,7 @@ impl super::TrapDispatcher {
 
         let substituted = self.apply_param_text(text);
         let text_bytes = substituted.as_bytes();
-        let lines = self.te_wrap_lines(font_id, self.tx_size, text_bytes, max_width);
+        let lines = self.te_wrap_lines(font_id, raw_font_size, text_bytes, max_width);
 
         for (start, end) in lines {
             let mut trimmed_end = end;
@@ -8545,19 +8766,39 @@ impl super::TrapDispatcher {
                     .iter()
                     .map(|&byte| byte as char)
                     .collect();
-                Self::fb_draw_string(
-                    bus,
-                    screen_base,
-                    row_bytes,
-                    pixel_size,
-                    screen_width,
-                    screen_height,
-                    left + Self::TE_LINE_LEFT_INSET,
-                    y,
-                    &line,
-                    font_id,
-                    font_size,
-                );
+                if let Some(rgb) = foreground {
+                    let pixel_index = Self::nearest_palette_index(&self.device_clut, rgb);
+                    Self::fb_draw_string_styled_index(
+                        bus,
+                        screen_base,
+                        row_bytes,
+                        pixel_size,
+                        screen_width,
+                        screen_height,
+                        left + Self::TE_LINE_LEFT_INSET,
+                        y,
+                        &line,
+                        font_id,
+                        font_size,
+                        face,
+                        pixel_index,
+                    );
+                } else {
+                    Self::fb_draw_string_styled(
+                        bus,
+                        screen_base,
+                        row_bytes,
+                        pixel_size,
+                        screen_width,
+                        screen_height,
+                        left + Self::TE_LINE_LEFT_INSET,
+                        y,
+                        &line,
+                        font_id,
+                        font_size,
+                        face,
+                    );
+                }
             }
             y += line_height;
             if y > bottom {
@@ -9430,7 +9671,15 @@ impl super::TrapDispatcher {
         } else {
             self.window_bounds
         };
-        let exposed_rect = retained_visible_bounds.unwrap_or(dialog_record_bounds);
+        // A movable modal dialog's structure includes its title bar above the
+        // DialogRecord content bounds. CloseDialog has CloseWindow semantics,
+        // so PaintBehind must expose the entire structure, not only the port;
+        // otherwise the window behind can never repaint the former title-bar
+        // strip. Macintosh Toolbox Essentials (1992), pp. 4-89, 6-119..6-120.
+        let exposed_rect = self
+            .window_structure_rect(bus, dialog_ptr)
+            .or(retained_visible_bounds)
+            .unwrap_or(dialog_record_bounds);
         let initial_draw_deferred = self.dialog_initial_draw_deferred.remove(&dialog_ptr);
         let retained_stale_saved_under = self
             .dialog_saved_pixels
@@ -10557,9 +10806,15 @@ impl super::TrapDispatcher {
                     } else {
                         0
                     };
-                    // A matching DCTab is copied and associated before the
-                    // dialog's initial visible shell is drawn.
+                    // Matching DCTab and item color table resources are copied
+                    // and associated before the initial visible shell is drawn.
+                    // The ictb ID follows the DITL ID, not the DLOG ID.
+                    // Macintosh Toolbox Essentials 1992, pp. 6-158 to 6-164.
                     let dialog_color_table = self.copy_dialog_color_table_resource(bus, dialog_id);
+                    let dialog_item_color_table = dialog_color_table
+                        .is_some()
+                        .then(|| self.copy_dialog_item_color_table_resource(bus, items_id))
+                        .flatten();
                     // Honor the DLOG resource's visible flag per IM:I I-424.
                     let dlg_ptr = self.finish_dialog_creation(
                         bus,
@@ -10574,6 +10829,7 @@ impl super::TrapDispatcher {
                         items_handle,
                         items,
                         dialog_color_table,
+                        dialog_item_color_table,
                     );
                     // Install any 'pltt' resource whose id matches the
                     // dialog id onto the freshly-created window. This
@@ -15932,6 +16188,7 @@ impl super::TrapDispatcher {
                     items_handle,
                     items,
                     None,
+                    None,
                 );
                 // Honor Pascal `behind` param at SP+10 per IM:I I-412.
                 self.apply_behind_parameter(bus, dlg_ptr, behind);
@@ -16499,6 +16756,7 @@ impl super::TrapDispatcher {
                             items_handle,
                             items,
                             None,
+                            None,
                         );
                         self.apply_behind_parameter(bus, dlg_ptr, behind);
                         bus.write_long(sp + param_bytes, dlg_ptr);
@@ -16665,6 +16923,7 @@ impl super::TrapDispatcher {
 #[cfg(test)]
 mod tests {
     use super::super::test_helpers::{setup, setup_with_port, MockCpu, TEST_SP};
+    use super::DialogItemTextStyle;
     use crate::cpu::{CpuOps, Register};
     use crate::memory::{MacMemoryBus, MemoryBus};
     use crate::trap::dispatch::{
@@ -17116,6 +17375,31 @@ mod tests {
         assert_eq!(items[0].item_type, 0);
         assert_eq!(items[0].rect, (10, 20, 30, 40));
         assert_eq!(items[0].proc_ptr, 0x12345678);
+    }
+
+    #[test]
+    fn ditl_iter_skips_user_item_payload_before_following_items() {
+        let (_disp, _cpu, mut bus) = setup();
+        let mut ditl = Vec::new();
+        push_ditl_count(&mut ditl, 1);
+        push_ditl_item(
+            &mut ditl,
+            0,
+            (10, 20, 30, 140),
+            0,
+            4,
+            &[0x00, 0x05, 0x00, 0x09],
+        );
+        push_ditl_item(&mut ditl, 0, (40, 50, 52, 150), 6, 4, b"Home");
+
+        let items = parse_ditl_bytes(&mut bus, &ditl);
+
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].item_type, 0);
+        assert_eq!(items[0].rect, (10, 20, 30, 140));
+        assert_eq!(items[1].item_type, 6);
+        assert_eq!(items[1].rect, (40, 50, 52, 150));
+        assert_eq!(items[1].text, "Home");
     }
 
     #[test]
@@ -17879,6 +18163,7 @@ mod tests {
         let (mut disp, mut cpu, mut bus) = setup();
         let screen_base = bus.alloc((800 * 600) as u32);
         bus.write_long(0x0824, screen_base);
+        bus.write_word(crate::memory::globals::addr::MBAR_HEIGHT, 20);
         disp.screen_mode = (screen_base, 800, 800, 600, 8);
 
         let dlog = build_test_dlog((10, 20, 110, 220), 1503, 0x280A);
@@ -17894,7 +18179,7 @@ mod tests {
 
         let dlg_ptr = bus.read_long(TEST_SP + 10);
         assert_ne!(dlg_ptr, 0);
-        assert_eq!(disp.window_bounds, (250, 300, 350, 500));
+        assert_eq!(disp.window_bounds, (260, 300, 360, 500));
     }
 
     #[test]
@@ -18173,6 +18458,96 @@ mod tests {
             42,
             "retained statText redraws must erase with the DCTab content color"
         );
+    }
+
+    #[test]
+    fn get_new_dialog_applies_matching_ictb_text_style_on_initial_draw() {
+        // An ictb follows the matching DITL ID. Each four-byte item entry
+        // selects a 20-byte text style record by resource-relative offset.
+        // MTE 1992, pp. 6-158 to 6-164; Inside Macintosh V, pp. V-279–V-282.
+        let (mut disp, mut cpu, mut bus) = setup();
+        let screen_base = bus.alloc((320 * 240) as u32);
+        bus.write_bytes(screen_base, &vec![0xEE; 320 * 240]);
+        bus.write_long(0x0824, screen_base);
+        disp.screen_mode = (screen_base, 320, 320, 240, 8);
+        disp.device_clut.fill([0, 0, 0]);
+        disp.device_clut[0] = [0xFFFF, 0xFFFF, 0xFFFF];
+        disp.device_clut[20] = [0xFFFF, 0xFFFF, 0];
+        disp.device_clut[42] = [0, 0x4000, 0];
+        disp.device_clut[255] = [0, 0, 0];
+
+        let mut dlog = build_test_dlog((40, 50, 120, 250), 1931, 0);
+        dlog[8..10].copy_from_slice(&4i16.to_be_bytes()); // noGrowDocProc
+        dlog[10] = 1;
+        let ditl = build_test_ditl_item(8, (8, 8, 30, 90), b"Styled");
+
+        let mut dctb = Vec::with_capacity(16);
+        dctb.extend_from_slice(&0u32.to_be_bytes());
+        dctb.extend_from_slice(&0u16.to_be_bytes());
+        dctb.extend_from_slice(&0u16.to_be_bytes());
+        dctb.extend_from_slice(&0u16.to_be_bytes());
+        dctb.extend_from_slice(&0u16.to_be_bytes());
+        dctb.extend_from_slice(&0x4000u16.to_be_bytes());
+        dctb.extend_from_slice(&0u16.to_be_bytes());
+
+        let mut ictb = Vec::with_capacity(24);
+        ictb.extend_from_slice(&0x200Fu16.to_be_bytes()); // font, face, size, fg, bg
+        ictb.extend_from_slice(&4u16.to_be_bytes());
+        ictb.extend_from_slice(&0u16.to_be_bytes()); // Chicago
+        ictb.extend_from_slice(&1u16.to_be_bytes()); // bold
+        ictb.extend_from_slice(&12u16.to_be_bytes());
+        ictb.extend_from_slice(&0xFFFFu16.to_be_bytes());
+        ictb.extend_from_slice(&0xFFFFu16.to_be_bytes());
+        ictb.extend_from_slice(&0u16.to_be_bytes());
+        ictb.extend_from_slice(&0u16.to_be_bytes());
+        ictb.extend_from_slice(&0u16.to_be_bytes());
+        ictb.extend_from_slice(&0u16.to_be_bytes());
+        ictb.extend_from_slice(&1u16.to_be_bytes()); // srcCopy
+
+        disp.install_test_resource(&mut bus, *b"DLOG", 1930, &dlog);
+        disp.install_test_resource(&mut bus, *b"DITL", 1931, &ditl);
+        disp.install_test_resource(&mut bus, *b"dctb", 1930, &dctb);
+        let ictb_resource = disp.install_test_resource(&mut bus, *b"ictb", 1931, &ictb);
+        bus.write_long(TEST_SP, 0xFFFF_FFFF);
+        bus.write_long(TEST_SP + 4, 0);
+        bus.write_word(TEST_SP + 8, 1930);
+
+        disp.dispatch_dialog(true, 0x17C, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+
+        let dialog_ptr = bus.read_long(TEST_SP + 10);
+        let ictb_handle = disp.window_dialog_item_color_table(&bus, dialog_ptr);
+        assert_ne!(ictb_handle, 0);
+        assert_ne!(bus.read_long(ictb_handle), ictb_resource);
+        assert_eq!(
+            disp.window_semantic_color(&bus, dialog_ptr, 0),
+            Some((0, 0x4000, 0)),
+            "associating the ictb must not replace the dialog's DCTab"
+        );
+        assert_eq!(
+            bus.read_byte(screen_base + 100 * 320 + 200),
+            42,
+            "the DCTab must still color content outside styled item rectangles"
+        );
+        assert_eq!(
+            disp.dialog_item_text_style(&bus, dialog_ptr, 0),
+            Some(DialogItemTextStyle {
+                font: 0,
+                face: 1,
+                size: 12,
+                foreground: Some([0xFFFF, 0xFFFF, 0]),
+                background: Some([0, 0, 0]),
+                mode: 1,
+            })
+        );
+
+        let mut pixels = Vec::new();
+        for y in 48..70 {
+            pixels.extend(bus.read_bytes(screen_base + y * 320 + 58, 82));
+        }
+        assert!(pixels.contains(&20), "styled text must use ictb foreground");
+        assert!(pixels.contains(&255), "item must use ictb background");
     }
 
     #[test]
@@ -25798,6 +26173,28 @@ mod tests {
     }
 
     #[test]
+    fn movable_dialog_draws_its_title_bar_above_the_content() {
+        // movableDBoxProc adds a striped title bar without a close box.
+        // Macintosh Human Interface Guidelines (1992), pp. 185-186.
+        let (mut disp, _cpu, mut bus) = setup();
+        let screen_base = 0x300000u32;
+        let row_bytes = 64u32;
+        let bounds = (40, 40, 100, 140);
+        disp.set_screen_mode_for_test(screen_base, row_bytes, 512, 342, 1);
+
+        disp.draw_dialog(&mut bus, bounds, 5, "Options", &[], 0, "", 0, false, 0x2000);
+
+        assert!(
+            screen_pixel_is_set(&bus, screen_base, row_bytes, 39, 21),
+            "movableDBoxProc must paint the title-frame top above portRect"
+        );
+        assert!(
+            screen_pixel_is_set(&bus, screen_base, row_bytes, 42, 22),
+            "an active movable title bar must contain racing stripes"
+        );
+    }
+
+    #[test]
     fn draw_window_frame_systemless_theme_routes_border_through_provider() {
         let screen_base = 0x300000u32;
         let row_bytes = 64u32;
@@ -26857,6 +27254,14 @@ mod tests {
         let dialog_ptr = 0x200000u32;
         let prev_window = 0x181000u32;
         seed_window_regions(&mut bus, prev_window, (0, 0, 342, 512));
+        seed_window_regions(&mut bus, dialog_ptr, (100, 120, 220, 320));
+        // WindowRecord.strucRgn is the handle at offset 114 (IM:I I-278).
+        let dialog_structure = bus.read_long(dialog_ptr + 114);
+        let dialog_structure_ptr = bus.read_long(dialog_structure);
+        bus.write_word(dialog_structure_ptr + 2, 81);
+        bus.write_word(dialog_structure_ptr + 4, 119);
+        bus.write_word(dialog_structure_ptr + 6, 222);
+        bus.write_word(dialog_structure_ptr + 8, 322);
 
         disp.front_window = dialog_ptr;
         disp.current_port = dialog_ptr;
@@ -26881,8 +27286,8 @@ mod tests {
         assert_eq!(bus.read_long(global_ptr), prev_window);
         assert_eq!(
             TrapDispatcher::region_handle_rect(&bus, bus.read_long(prev_window + 122)),
-            Some((100, 120, 220, 320)),
-            "CloseDialog should invalidate the dialog-exposed area on the promoted window"
+            Some((81, 119, 222, 322)),
+            "CloseDialog should invalidate the complete structure, including a movable title bar"
         );
         assert!(
             disp.event_queue.iter().any(|event| {

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -185,7 +185,10 @@ fn key_map_byte_mask(key_code: u8) -> Option<(usize, u8)> {
     if byte_idx >= 16 {
         return None;
     }
-    let mask = 1u8 << (key_code & 0x07);
+    // `KeyMap` is a Pascal `PACKED ARRAY[0..127] OF Boolean`, whose
+    // elements occupy each byte from its most-significant bit downward.
+    // Inside Macintosh: Macintosh Toolbox Essentials (1992), p. 2-109.
+    let mask = 0x80u8 >> (key_code & 0x07);
     Some((byte_idx, mask))
 }
 
@@ -1356,6 +1359,10 @@ pub struct TrapDispatcher {
     /// U.S. Roman keyboard-layout resource ID 0 is present in every
     /// System file and is used directly by apps that call KeyTranslate.
     pub(crate) system_kchr_cache: HashMap<i16, u32>,
+    /// Cache of the synthetic standard `'KMAP'` ID 0 resource. Classic apps
+    /// may read its 128-byte hardware-to-virtual-key map directly when
+    /// implementing configurable controls.
+    pub(crate) system_kmap_cache: HashMap<i16, u32>,
     /// Cache of synthetic ROM `'WDEF'` resource pointers. WDEF IDs 0 and 1
     /// are the standard document and rounded-window definition functions.
     /// Their behavior is implemented by the Window Manager HLE, but callers
@@ -3040,6 +3047,7 @@ impl TrapDispatcher {
             system_cursor_cache: HashMap::new(),
             system_clut_cache: HashMap::new(),
             system_kchr_cache: HashMap::new(),
+            system_kmap_cache: HashMap::new(),
             system_wdef_cache: HashMap::new(),
             system_mdef_cache: HashMap::new(),
             tool_trap_trampolines: HashMap::new(),
@@ -5626,8 +5634,9 @@ impl TrapDispatcher {
 
     /// Allocate (and cache) the standard U.S. Roman keyboard-layout
     /// resource (`'KCHR'` ID 0). Inside Macintosh: Text 1993, C-18..C-19
-    /// defines the resource as a version byte, a 256-byte table-selection
-    /// index, and 128-byte character-mapping tables keyed by virtual key code.
+    /// defines the resource as a version word, a 256-byte table-selection
+    /// index, a table-count word, 128-byte character-mapping tables keyed by
+    /// virtual key code, and a dead-key-count word.
     pub(crate) fn synthesize_system_kchr(
         &mut self,
         bus: &mut MacMemoryBus,
@@ -5641,12 +5650,16 @@ impl TrapDispatcher {
         }
 
         const TABLES: usize = 2;
-        const TABLE_BASE: usize = 1 + 256;
-        const LEN: usize = TABLE_BASE + TABLES * 128;
+        const TABLE_COUNT_OFFSET: usize = 2 + 256;
+        const TABLE_BASE: usize = TABLE_COUNT_OFFSET + 2;
+        const DEAD_KEY_COUNT_OFFSET: usize = TABLE_BASE + TABLES * 128;
+        const LEN: usize = DEAD_KEY_COUNT_OFFSET + 2;
         let mut body = vec![0u8; LEN];
         for modifier in 0..=255usize {
-            body[1 + modifier] = if (modifier & 0x22) != 0 { 1 } else { 0 };
+            body[2 + modifier] = if (modifier & 0x22) != 0 { 1 } else { 0 };
         }
+        body[TABLE_COUNT_OFFSET..TABLE_COUNT_OFFSET + 2]
+            .copy_from_slice(&(TABLES as u16).to_be_bytes());
 
         let normal = TABLE_BASE;
         let shifted = TABLE_BASE + 128;
@@ -5700,6 +5713,10 @@ impl TrapDispatcher {
             (0x2F, b'.', b'>'),
             (0x31, b' ', b' '),
             (0x32, b'`', b'~'),
+            (0x7B, 0x1C, 0x1C),
+            (0x7C, 0x1D, 0x1D),
+            (0x7D, 0x1F, 0x1F),
+            (0x7E, 0x1E, 0x1E),
         ];
         for &(vk, unshifted, shifted_char) in keys {
             body[normal + vk] = unshifted;
@@ -5712,6 +5729,54 @@ impl TrapDispatcher {
         }
         bus.write_bytes(ptr, &body);
         self.system_kchr_cache.insert(res_id, ptr);
+        Some(ptr)
+    }
+
+    /// Allocate (and cache) the standard keycode-map resource (`'KMAP'` ID
+    /// 0). Its four-byte ID/version header is followed by the 128-entry
+    /// hardware-to-virtual-key map and a zero exception-array count. The
+    /// standard map translates Control and the four cursor keys between the
+    /// original and ADB virtual-key assignments; all other entries are
+    /// identity-valued. Inside Macintosh: Text (1993), pp. C-11..C-15.
+    pub(crate) fn synthesize_system_kmap(
+        &mut self,
+        bus: &mut MacMemoryBus,
+        res_id: i16,
+    ) -> Option<u32> {
+        if let Some(&ptr) = self.system_kmap_cache.get(&res_id) {
+            return Some(ptr);
+        }
+        if res_id != 0 {
+            return None;
+        }
+
+        const HEADER_SIZE: usize = 4;
+        const MAP_SIZE: usize = 128;
+        const LEN: usize = HEADER_SIZE + MAP_SIZE + 2;
+        let mut body = vec![0u8; LEN];
+        for keycode in 0..MAP_SIZE {
+            body[HEADER_SIZE + keycode] = keycode as u8;
+        }
+        for (raw, virtual_key) in [
+            (0x36usize, 0x3Bu8),
+            (0x3B, 0x7B),
+            (0x3C, 0x7C),
+            (0x3D, 0x7D),
+            (0x3E, 0x7E),
+            (0x7B, 0x3C),
+            (0x7C, 0x3D),
+            (0x7D, 0x3E),
+            (0x7E, 0x36),
+        ] {
+            body[HEADER_SIZE + raw] = virtual_key;
+        }
+
+        let ptr = bus.alloc(body.len() as u32);
+        if ptr == 0 {
+            return None;
+        }
+        bus.write_bytes(ptr, &body);
+        self.system_kmap_cache.insert(res_id, ptr);
         Some(ptr)
     }
 

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -5481,7 +5481,11 @@ impl TrapDispatcher {
         })
     }
 
-    pub(crate) fn find_loaded_resource_any(&self, res_type: [u8; 4], res_id: i16) -> Option<(u16, u32)> {
+    pub(crate) fn find_loaded_resource_any(
+        &self,
+        res_type: [u8; 4],
+        res_id: i16,
+    ) -> Option<(u16, u32)> {
         let res_type = Self::normalize_ostype(res_type);
         let resources = self.resources.as_ref()?;
         for refnum in self.resource_search_order() {

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -1896,6 +1896,11 @@ pub struct TrapDispatcher {
     pub(crate) window_palettes: HashMap<u32, (u32, i16)>,
     /// Palette update flags keyed by PaletteHandle.
     pub(crate) palette_updates: HashMap<u32, i16>,
+    /// Device indices assigned to palette entries by the most recent
+    /// activation. Ordinary tolerant entries are not tied to their palette
+    /// positions, so Entry2Index must consult this allocation rather than
+    /// treating the entry number as a pixel value.
+    pub(crate) palette_device_indices: HashMap<(u32, u16), u8>,
     /// Color tables produced from palettes whose entries are all pmExplicit.
     /// Their pixel values are literal device indices, so indexed CopyBits
     /// must preserve those values instead of color-matching duplicate RGBs.
@@ -3230,6 +3235,7 @@ impl TrapDispatcher {
             recent_resource_ctable_fetch: None,
             window_palettes: HashMap::new(),
             palette_updates: HashMap::new(),
+            palette_device_indices: HashMap::new(),
             explicit_palette_ctabs: HashSet::new(),
             icon_transform_override: 0,
             printing_error: 0,

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -1900,6 +1900,9 @@ pub struct TrapDispatcher {
     /// Their pixel values are literal device indices, so indexed CopyBits
     /// must preserve those values instead of color-matching duplicate RGBs.
     pub(crate) explicit_palette_ctabs: HashSet<u32>,
+    /// Transform supplied by an Icon Utilities handle call while it routes
+    /// through the legacy icon renderer. Zero for ordinary PlotCIcon calls.
+    pub(crate) icon_transform_override: i16,
     /// Printing Manager error code surfaced by `PrError` and set by
     /// `PrSetError`. Inside Macintosh Volume II 1985, p. II-161;
     /// Inside Macintosh Volume V 1986, p. V-408.
@@ -3228,6 +3231,7 @@ impl TrapDispatcher {
             window_palettes: HashMap::new(),
             palette_updates: HashMap::new(),
             explicit_palette_ctabs: HashSet::new(),
+            icon_transform_override: 0,
             printing_error: 0,
             next_ct_seed: 1,
             fill_black_override: None,
@@ -6794,7 +6798,7 @@ mod tests {
             highlighted_item: 0,
             saved_pixels: Vec::new(),
             dropdown_rect: (0, 0, 0, 0),
-            submenu: None,
+            submenus: Vec::new(),
             stack_ptr: 0,
             flash_remaining: 0,
             flash_delay: 0,

--- a/src/trap/menu.rs
+++ b/src/trap/menu.rs
@@ -53,7 +53,10 @@ pub struct MenuTrackingState {
     pub highlighted_item: i16,
     pub saved_pixels: Vec<u8>,
     pub dropdown_rect: (i16, i16, i16, i16),
-    pub submenu: Option<SubmenuTrackingState>,
+    /// Open hierarchical menus ordered from the root menu's child to the
+    /// deepest descendant. Menu Manager hierarchies may contain more than
+    /// one level (Macintosh Toolbox Essentials 1992, pp. 3-137 to 3-141).
+    pub submenus: Vec<SubmenuTrackingState>,
     pub stack_ptr: u32,
     /// Remaining flash toggles (6 = 3 flashes: off, on, off, on, off, on).
     /// 0 means not flashing.
@@ -1955,13 +1958,13 @@ impl super::TrapDispatcher {
                             let sp = self.menu_tracking.as_ref().unwrap().stack_ptr;
                             let saved = self.menu_tracking.take().unwrap();
                             let active_menu = saved
-                                .submenu
-                                .as_ref()
+                                .submenus
+                                .last()
                                 .map(|submenu| submenu.menu)
                                 .unwrap_or(saved.active_menu);
                             let highlighted_item = saved
-                                .submenu
-                                .as_ref()
+                                .submenus
+                                .last()
                                 .map(|submenu| submenu.highlighted_item)
                                 .unwrap_or(saved.highlighted_item);
                             self.restore_menu_tracking_pixels(bus, saved);
@@ -1994,8 +1997,8 @@ impl super::TrapDispatcher {
                                 .as_ref()
                                 .and_then(|tracking| {
                                     tracking
-                                        .submenu
-                                        .as_ref()
+                                        .submenus
+                                        .last()
                                         .filter(|submenu| submenu.highlighted_item > 0)
                                         .map(|submenu| (submenu.menu, submenu.highlighted_item))
                                         .or_else(|| {
@@ -2070,16 +2073,16 @@ impl super::TrapDispatcher {
 
                         let old_trace = self.menu_tracking.as_ref().map(|tracking| {
                             tracking
-                                .submenu
-                                .as_ref()
+                                .submenus
+                                .last()
                                 .map(|submenu| (submenu.menu, submenu.highlighted_item))
                                 .unwrap_or((tracking.active_menu, tracking.highlighted_item))
                         });
                         self.update_menu_tracking_for_point(bus, mh, mv);
                         let new_trace = self.menu_tracking.as_ref().map(|tracking| {
                             tracking
-                                .submenu
-                                .as_ref()
+                                .submenus
+                                .last()
                                 .map(|submenu| (submenu.menu, submenu.highlighted_item))
                                 .unwrap_or((tracking.active_menu, tracking.highlighted_item))
                         });
@@ -2234,7 +2237,7 @@ impl super::TrapDispatcher {
                             highlighted_item: 0,
                             saved_pixels: saved,
                             dropdown_rect: dd_rect,
-                            submenu: None,
+                            submenus: Vec::new(),
                             stack_ptr: sp,
                             flash_remaining: 0,
                             flash_delay: 0,
@@ -2410,10 +2413,24 @@ impl super::TrapDispatcher {
                 let menu_handle = bus.read_long(sp + 4);
                 cpu.write_reg(Register::A7, sp + 8);
 
-                if let Some(menu) = self.menus.iter_mut().find(|m| m.handle == menu_handle) {
+                let touched = if let Some(menu) =
+                    self.menus.iter_mut().find(|m| m.handle == menu_handle)
+                {
                     if let Some(mi) = menu.items.get_mut((item - 1) as usize) {
                         mi.mark = if checked { 0x12 } else { 0 }; // 0x12 = checkmark char
+                        Some(menu.clone())
+                    } else {
+                        None
                     }
+                } else {
+                    None
+                };
+                // The Menu Manager record is public guest state. Preserve the
+                // mark in its item record so a later mutation that refreshes
+                // the cached menu cannot resurrect the previous value.
+                // Inside Macintosh Volume I, I-355 and I-358.
+                if let Some(menu) = touched {
+                    self.serialise_menu_items_to_memory(bus, &menu);
                 }
                 Ok(())
             }
@@ -4388,7 +4405,7 @@ impl super::TrapDispatcher {
             highlighted_item: 0,
             saved_pixels: saved,
             dropdown_rect,
-            submenu: None,
+            submenus: Vec::new(),
             stack_ptr,
             flash_remaining: 0,
             flash_delay: 0,
@@ -4409,7 +4426,7 @@ impl super::TrapDispatcher {
     }
 
     fn restore_menu_tracking_pixels(&self, bus: &mut MacMemoryBus, saved: MenuTrackingState) {
-        if let Some(submenu) = saved.submenu {
+        for submenu in saved.submenus.into_iter().rev() {
             self.restore_dropdown_pixels(bus, submenu.dropdown_rect, &submenu.saved_pixels);
         }
         self.restore_dropdown_pixels(bus, saved.dropdown_rect, &saved.saved_pixels);
@@ -4419,9 +4436,13 @@ impl super::TrapDispatcher {
         let Some(tracking) = self.menu_tracking.as_ref() else {
             return 0;
         };
-        if let Some(submenu) = tracking.submenu.as_ref() {
+        if let Some(submenu) = tracking.submenus.last() {
             if submenu.highlighted_item > 0 {
                 let menu = &self.menus[submenu.menu];
+                let item = &menu.items[submenu.highlighted_item as usize - 1];
+                if Self::is_hierarchical_item(item) {
+                    return 0;
+                }
                 return ((menu.id as u32) << 16) | (submenu.highlighted_item as u32 & 0xFFFF);
             }
         }
@@ -4440,12 +4461,15 @@ impl super::TrapDispatcher {
         ((menu.id as u32) << 16) | (tracking.highlighted_item as u32 & 0xFFFF)
     }
 
-    fn submenu_menu_index_for_parent_item(&self, parent_item: i16) -> Option<usize> {
-        let tracking = self.menu_tracking.as_ref()?;
+    fn submenu_menu_index_for_parent_item(
+        &self,
+        parent_menu_idx: usize,
+        parent_item: i16,
+    ) -> Option<usize> {
         if parent_item <= 0 {
             return None;
         }
-        let parent_menu = self.menus.get(tracking.active_menu)?;
+        let parent_menu = self.menus.get(parent_menu_idx)?;
         let item = parent_menu.items.get(parent_item as usize - 1)?;
         if !Self::is_hierarchical_item(item) {
             return None;
@@ -4457,14 +4481,15 @@ impl super::TrapDispatcher {
     fn submenu_rect_for_parent_item(
         &self,
         bus: &MacMemoryBus,
+        parent_menu_idx: usize,
+        parent_rect: (i16, i16, i16, i16),
         submenu_idx: usize,
         parent_item: i16,
     ) -> Option<(i16, i16, i16, i16)> {
-        let tracking = self.menu_tracking.as_ref()?;
         let (_screen_base, _row_bytes, screen_width, screen_height, _pixel_size) =
             self.get_screen_params();
-        let (parent_top, parent_left, _parent_bottom, parent_right) = tracking.dropdown_rect;
-        let parent_menu = self.menus.get(tracking.active_menu)?;
+        let (parent_top, parent_left, _parent_bottom, parent_right) = parent_rect;
+        let parent_menu = self.menus.get(parent_menu_idx)?;
         let parent_offset = parent_menu
             .items
             .iter()
@@ -4486,25 +4511,43 @@ impl super::TrapDispatcher {
         Some((submenu_top, submenu_left, submenu_bottom, submenu_right))
     }
 
-    fn close_submenu(&mut self, bus: &mut MacMemoryBus) {
-        let submenu = self
+    fn close_submenus_from(&mut self, bus: &mut MacMemoryBus, depth: usize) {
+        let submenus = self
             .menu_tracking
             .as_mut()
-            .and_then(|tracking| tracking.submenu.take());
-        if let Some(submenu) = submenu {
+            .map(|tracking| tracking.submenus.split_off(depth))
+            .unwrap_or_default();
+        for submenu in submenus.into_iter().rev() {
             self.restore_dropdown_pixels(bus, submenu.dropdown_rect, &submenu.saved_pixels);
         }
     }
 
-    fn ensure_submenu_for_parent_item(&mut self, bus: &mut MacMemoryBus, parent_item: i16) {
-        let Some(submenu_idx) = self.submenu_menu_index_for_parent_item(parent_item) else {
-            self.close_submenu(bus);
+    fn ensure_submenu_for_parent_item(
+        &mut self,
+        bus: &mut MacMemoryBus,
+        parent_depth: Option<usize>,
+        parent_item: i16,
+    ) {
+        let Some((parent_menu_idx, parent_rect, child_depth)) = self.menu_tracking.as_ref().and_then(|tracking| {
+            parent_depth.map_or_else(
+                || Some((tracking.active_menu, tracking.dropdown_rect, 0)),
+                |depth| tracking.submenus.get(depth).map(|submenu| {
+                    (submenu.menu, submenu.dropdown_rect, depth + 1)
+                }),
+            )
+        }) else {
+            return;
+        };
+        let Some(submenu_idx) =
+            self.submenu_menu_index_for_parent_item(parent_menu_idx, parent_item)
+        else {
+            self.close_submenus_from(bus, child_depth);
             return;
         };
         let already_open = self
             .menu_tracking
             .as_ref()
-            .and_then(|tracking| tracking.submenu.as_ref())
+            .and_then(|tracking| tracking.submenus.get(child_depth))
             .is_some_and(|submenu| {
                 submenu.menu == submenu_idx && submenu.parent_item == parent_item
             });
@@ -4512,16 +4555,22 @@ impl super::TrapDispatcher {
             return;
         }
 
-        let Some(dropdown_rect) = self.submenu_rect_for_parent_item(bus, submenu_idx, parent_item)
+        let Some(dropdown_rect) = self.submenu_rect_for_parent_item(
+            bus,
+            parent_menu_idx,
+            parent_rect,
+            submenu_idx,
+            parent_item,
+        )
         else {
-            self.close_submenu(bus);
+            self.close_submenus_from(bus, child_depth);
             return;
         };
-        self.close_submenu(bus);
+        self.close_submenus_from(bus, child_depth);
         let saved_pixels = self.save_dropdown_pixels(bus, dropdown_rect);
         self.draw_menu_dropdown(bus, submenu_idx, dropdown_rect);
         if let Some(tracking) = self.menu_tracking.as_mut() {
-            tracking.submenu = Some(SubmenuTrackingState {
+            tracking.submenus.push(SubmenuTrackingState {
                 menu: submenu_idx,
                 parent_item,
                 highlighted_item: 0,
@@ -4531,31 +4580,44 @@ impl super::TrapDispatcher {
         }
     }
 
-    fn submenu_item_at_point(&self, mouse_x: i16, mouse_y: i16) -> Option<i16> {
+    fn submenu_item_at_point(
+        &self,
+        bus: &MacMemoryBus,
+        depth: usize,
+        mouse_x: i16,
+        mouse_y: i16,
+    ) -> Option<i16> {
         let tracking = self.menu_tracking.as_ref()?;
-        let submenu = tracking.submenu.as_ref()?;
+        let submenu = tracking.submenus.get(depth)?;
         let (top, left, bottom, right) = submenu.dropdown_rect;
         if mouse_x < left || mouse_x >= right || mouse_y < top || mouse_y >= bottom {
             return None;
         }
-        let item_height: i16 = 16;
-        let item_idx = (mouse_y - top - 1) / item_height;
         let menu = self.menus.get(submenu.menu)?;
-        if item_idx < 0 || item_idx as usize >= menu.items.len() {
-            return Some(0);
+        let mut item_top = top + 1;
+        for (item_idx, item) in menu.items.iter().enumerate() {
+            let item_bottom = item_top + self.menu_item_height(bus, item);
+            if mouse_y >= item_top && mouse_y < item_bottom {
+                if item.text == "-" || !item.enabled {
+                    return Some(0);
+                }
+                return Some(item_idx as i16 + 1);
+            }
+            item_top = item_bottom;
         }
-        let item = &menu.items[item_idx as usize];
-        if item.text == "-" || !item.enabled {
-            return Some(0);
-        }
-        Some(item_idx + 1)
+        Some(0)
     }
 
-    fn update_submenu_highlight(&mut self, bus: &mut MacMemoryBus, new_item: i16) {
+    fn update_submenu_highlight(
+        &mut self,
+        bus: &mut MacMemoryBus,
+        depth: usize,
+        new_item: i16,
+    ) {
         let Some((menu_idx, old_item, rect)) = self
             .menu_tracking
             .as_ref()
-            .and_then(|tracking| tracking.submenu.as_ref())
+            .and_then(|tracking| tracking.submenus.get(depth))
             .map(|submenu| {
                 (
                     submenu.menu,
@@ -4567,8 +4629,12 @@ impl super::TrapDispatcher {
             return;
         };
         if old_item == new_item {
+            if new_item > 0 {
+                self.ensure_submenu_for_parent_item(bus, Some(depth), new_item);
+            }
             return;
         }
+        self.close_submenus_from(bus, depth + 1);
         let classic_highlight = self.ui_theme_id() == UiThemeId::ClassicSystem7;
         if classic_highlight && old_item > 0 {
             self.invert_dropdown_item_rect(bus, menu_idx, rect, old_item);
@@ -4576,7 +4642,7 @@ impl super::TrapDispatcher {
         if let Some(submenu) = self
             .menu_tracking
             .as_mut()
-            .and_then(|tracking| tracking.submenu.as_mut())
+            .and_then(|tracking| tracking.submenus.get_mut(depth))
         {
             submenu.highlighted_item = new_item;
         }
@@ -4584,6 +4650,9 @@ impl super::TrapDispatcher {
             self.invert_dropdown_item_rect(bus, menu_idx, rect, new_item);
         } else if !classic_highlight {
             self.draw_menu_dropdown(bus, menu_idx, rect);
+        }
+        if new_item > 0 {
+            self.ensure_submenu_for_parent_item(bus, Some(depth), new_item);
         }
     }
 
@@ -4597,7 +4666,7 @@ impl super::TrapDispatcher {
         };
 
         if old_item != new_item {
-            self.close_submenu(bus);
+            self.close_submenus_from(bus, 0);
             let classic_highlight = self.ui_theme_id() == UiThemeId::ClassicSystem7;
             if classic_highlight && old_item > 0 {
                 self.invert_menu_item(bus, old_item);
@@ -4620,9 +4689,9 @@ impl super::TrapDispatcher {
         }
 
         if new_item > 0 {
-            self.ensure_submenu_for_parent_item(bus, new_item);
+            self.ensure_submenu_for_parent_item(bus, None, new_item);
         } else {
-            self.close_submenu(bus);
+            self.close_submenus_from(bus, 0);
         }
     }
 
@@ -4632,9 +4701,18 @@ impl super::TrapDispatcher {
         mouse_x: i16,
         mouse_y: i16,
     ) {
-        if let Some(submenu_item) = self.submenu_item_at_point(mouse_x, mouse_y) {
-            self.update_submenu_highlight(bus, submenu_item);
-            return;
+        let submenu_count = self
+            .menu_tracking
+            .as_ref()
+            .map(|tracking| tracking.submenus.len())
+            .unwrap_or(0);
+        for depth in (0..submenu_count).rev() {
+            if let Some(submenu_item) =
+                self.submenu_item_at_point(bus, depth, mouse_x, mouse_y)
+            {
+                self.update_submenu_highlight(bus, depth, submenu_item);
+                return;
+            }
         }
         let new_item = self.dropdown_item_at_point(bus, mouse_x, mouse_y);
         self.update_parent_menu_highlight(bus, new_item);
@@ -4855,9 +4933,9 @@ impl super::TrapDispatcher {
                     Some(tracking.highlighted_item)
                 } else {
                     tracking
-                        .submenu
-                        .as_ref()
-                        .filter(|submenu| {
+                        .submenus
+                        .iter()
+                        .find(|submenu| {
                             submenu.menu == menu_idx && submenu.dropdown_rect == rect
                         })
                         .map(|submenu| submenu.highlighted_item)
@@ -7937,6 +8015,32 @@ mod tests {
         );
     }
 
+    #[test]
+    fn checkitem_persists_mark_across_later_menu_mutations() {
+        // IM:I I-355 and I-358: CheckItem changes the mark stored in the
+        // guest MenuInfo item record, not merely transient drawing state.
+        let (mut disp, mut cpu, mut bus) = setup();
+        let menu = new_menu_with_title(&mut disp, &mut cpu, &mut bus, 223, 0x306770, "Speed");
+        append_menu_data(&mut disp, &mut cpu, &mut bus, menu, 0x306780, "Moderate");
+        cpu.write_reg(Register::A7, TEST_SP);
+        bus.write_word(TEST_SP, 0x0100);
+        bus.write_word(TEST_SP + 2, 1);
+        bus.write_long(TEST_SP + 4, menu);
+
+        disp.dispatch_menu(true, 0x145, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+        set_item_cmd(&mut disp, &mut cpu, &mut bus, menu, 1, b'M');
+
+        let item = disp
+            .menus
+            .iter()
+            .find(|candidate| candidate.handle == menu)
+            .and_then(|candidate| candidate.items.first())
+            .unwrap();
+        assert_eq!(item.mark, 0x12);
+    }
+
     // 0x133 — AppendMenu: pops 8 bytes.
     #[test]
     fn test_append_menu() {
@@ -9843,7 +9947,7 @@ mod tests {
             flash_remaining: 0,
             flash_delay: 0,
             flash_result: 0,
-            submenu: None,
+            submenus: Vec::new(),
         });
         classic.draw_menu_dropdown(&mut classic_bus, 0, rect);
 
@@ -9880,7 +9984,7 @@ mod tests {
             flash_remaining: 0,
             flash_delay: 0,
             flash_result: 0,
-            submenu: None,
+            submenus: Vec::new(),
         });
         themed.draw_menu_dropdown(&mut themed_bus, 0, rect);
 
@@ -10054,7 +10158,7 @@ mod tests {
             flash_remaining: 0,
             flash_delay: 0,
             flash_result: 0,
-            submenu: None,
+            submenus: Vec::new(),
         });
         themed.draw_menu_dropdown(&mut themed_bus, 0, rect);
 
@@ -13063,6 +13167,84 @@ mod tests {
             TEST_SP + 4,
             "MenuSelect should pop the Point argument after submenu selection"
         );
+    }
+
+    #[test]
+    fn menuselect_tracks_nested_hierarchical_submenu_item() {
+        // MTE 1992, pp. 3-137 to 3-141: hierarchical menus may themselves
+        // contain hierarchical items. Tracking must retain every open level
+        // and return the deepest selected menu ID and item number.
+        let (mut disp, mut cpu, mut bus) = setup_with_port();
+        disp.menu_bar_hidden = false;
+        bus.write_word(crate::memory::globals::addr::MBAR_HEIGHT, 20);
+
+        let game = new_menu_with_title(&mut disp, &mut cpu, &mut bus, 129, 0x310000, "Game");
+        append_menu_data(&mut disp, &mut cpu, &mut bus, game, 0x310040, "Options");
+        let options =
+            new_menu_with_title(&mut disp, &mut cpu, &mut bus, 138, 0x310200, "Options");
+        append_menu_data(&mut disp, &mut cpu, &mut bus, options, 0x310240, "Speed");
+        let speed =
+            new_menu_with_title(&mut disp, &mut cpu, &mut bus, 139, 0x310400, "Speed");
+        append_menu_data(
+            &mut disp,
+            &mut cpu,
+            &mut bus,
+            speed,
+            0x310440,
+            "Very fast;Fast;Moderate;Slow",
+        );
+        set_item_cmd(&mut disp, &mut cpu, &mut bus, game, 1, 0x1B);
+        set_item_mark(&mut disp, &mut cpu, &mut bus, game, 1, 138);
+        set_item_cmd(&mut disp, &mut cpu, &mut bus, options, 1, 0x1B);
+        set_item_mark(&mut disp, &mut cpu, &mut bus, options, 1, 139);
+        insert_menu(&mut disp, &mut cpu, &mut bus, game);
+        insert_menu_before(&mut disp, &mut cpu, &mut bus, options, -1);
+        insert_menu_before(&mut disp, &mut cpu, &mut bus, speed, -1);
+        cpu.write_reg(Register::A7, TEST_SP);
+        disp.dispatch_menu(true, 0x137, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+
+        let regions = disp.menu_title_regions();
+        let game_mid_h = (regions[0].0 + regions[0].1) / 2;
+        disp.mouse_pos = (10, game_mid_h);
+        disp.mouse_button = true;
+        cpu.write_reg(Register::A7, TEST_SP);
+        bus.write_word(TEST_SP, 10);
+        bus.write_word(TEST_SP + 2, game_mid_h as u16);
+        bus.write_long(TEST_SP + 4, 0xFFFF_FFFF);
+        disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+
+        let root_rect = disp.menu_tracking.as_ref().unwrap().dropdown_rect;
+        disp.mouse_pos = (root_rect.0 + 9, root_rect.1 + 24);
+        disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+        let options_rect = disp.menu_tracking.as_ref().unwrap().submenus[0].dropdown_rect;
+        disp.mouse_pos = (options_rect.0 + 9, options_rect.1 + 24);
+        disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+        let speed_rect = disp.menu_tracking.as_ref().unwrap().submenus[1].dropdown_rect;
+        disp.mouse_pos = (speed_rect.0 + 9, speed_rect.1 + 24);
+        disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+
+        disp.mouse_button = false;
+        for _ in 0..40 {
+            disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+                .unwrap()
+                .unwrap();
+            if disp.menu_tracking.is_none() {
+                break;
+            }
+        }
+
+        assert_eq!(bus.read_long(TEST_SP + 4), (139u32 << 16) | 1);
+        assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 4);
     }
 
     // IM:V V-239: InsertMenu(beforeID=-1) places a menu in the hierarchical

--- a/src/trap/menu.rs
+++ b/src/trap/menu.rs
@@ -1034,31 +1034,32 @@ impl super::TrapDispatcher {
         bus.write_long(handle, menu_ptr);
         self.ptr_to_handle.insert(menu_ptr, handle);
 
-        let menu = if let Some((_, res_ptr)) = self.find_or_load_resource_any(bus, *b"MENU", menu_id) {
-            let res_size = menu_resource_size(bus, res_ptr);
-            for i in 0..res_size.min(256) {
-                bus.write_byte(menu_ptr + i as u32, bus.read_byte(res_ptr + i as u32));
-            }
-            parse_menu_resource(bus, menu_ptr, handle)
-        } else {
-            bus.write_word(menu_ptr, menu_id as u16);
-            bus.write_word(menu_ptr + 2, 0);
-            bus.write_word(menu_ptr + 4, 0);
-            bus.write_long(menu_ptr + 6, 0);
-            bus.write_long(menu_ptr + 10, 0xFFFF_FFFF);
-            bus.write_byte(menu_ptr + 14, 0);
-            bus.write_byte(menu_ptr + 15, 0);
-            Menu {
-                id: menu_id,
-                title: String::new(),
-                items: Vec::new(),
-                enabled: true,
-                handle,
-                in_menu_bar: false,
-                hierarchical: false,
-                visible_in_menu_bar: false,
-            }
-        };
+        let menu =
+            if let Some((_, res_ptr)) = self.find_or_load_resource_any(bus, *b"MENU", menu_id) {
+                let res_size = menu_resource_size(bus, res_ptr);
+                for i in 0..res_size.min(256) {
+                    bus.write_byte(menu_ptr + i as u32, bus.read_byte(res_ptr + i as u32));
+                }
+                parse_menu_resource(bus, menu_ptr, handle)
+            } else {
+                bus.write_word(menu_ptr, menu_id as u16);
+                bus.write_word(menu_ptr + 2, 0);
+                bus.write_word(menu_ptr + 4, 0);
+                bus.write_long(menu_ptr + 6, 0);
+                bus.write_long(menu_ptr + 10, 0xFFFF_FFFF);
+                bus.write_byte(menu_ptr + 14, 0);
+                bus.write_byte(menu_ptr + 15, 0);
+                Menu {
+                    id: menu_id,
+                    title: String::new(),
+                    items: Vec::new(),
+                    enabled: true,
+                    handle,
+                    in_menu_bar: false,
+                    hierarchical: false,
+                    visible_in_menu_bar: false,
+                }
+            };
 
         self.menus.push(menu);
         self.load_menu_color_resource(bus, menu_id);
@@ -1521,18 +1522,17 @@ impl super::TrapDispatcher {
                             .push(parse_menu_resource(bus, menu_ptr, menu_handle));
                     }
                 }
-                let menu_copy = if let Some(menu) =
-                    self.menus.iter_mut().find(|m| m.handle == menu_handle)
-                {
-                    refresh_menu_from_memory(bus, menu);
-                    for item in parsed {
-                        menu.items.push(item);
-                    }
-                    sync_enable_flags(bus, menu);
-                    Some(menu.clone())
-                } else {
-                    None
-                };
+                let menu_copy =
+                    if let Some(menu) = self.menus.iter_mut().find(|m| m.handle == menu_handle) {
+                        refresh_menu_from_memory(bus, menu);
+                        for item in parsed {
+                            menu.items.push(item);
+                        }
+                        sync_enable_flags(bus, menu);
+                        Some(menu.clone())
+                    } else {
+                        None
+                    };
                 // Also serialise items into the guest-memory MENU record so
                 // CountMItems / CalcMenuSize (which parse guest memory to stay
                 // compatible with GetMenu-loaded menus) see the AppendMenu'd
@@ -1569,7 +1569,9 @@ impl super::TrapDispatcher {
                             // raw guest MENU handle). Parse any MENU resource
                             // by menu ID, else fall back to title-only memory.
                             let menu_id = bus.read_word(menu_ptr) as i16;
-                            if let Some((_, res_ptr)) = self.find_or_load_resource_any(bus, *b"MENU", menu_id) {
+                            if let Some((_, res_ptr)) =
+                                self.find_or_load_resource_any(bus, *b"MENU", menu_id)
+                            {
                                 let mut menu = parse_menu_resource(bus, res_ptr, menu_handle);
                                 eprintln!(
                                     "[MENU] InsertMenu: ID={} title=\"{}\" items={}",
@@ -1711,7 +1713,8 @@ impl super::TrapDispatcher {
             (true, 0x1C0) => {
                 let sp = cpu.read_reg(Register::A7);
                 let mbar_id = bus.read_word(sp) as i16;
-                let handle = if let Some((_, mbar_ptr)) = self.find_or_load_resource_any(bus, *b"MBAR", mbar_id)
+                let handle = if let Some((_, mbar_ptr)) =
+                    self.find_or_load_resource_any(bus, *b"MBAR", mbar_id)
                 {
                     let menu_count = bus.read_word(mbar_ptr) as usize;
                     let mut snapshot = Vec::new();
@@ -1719,7 +1722,8 @@ impl super::TrapDispatcher {
 
                     for i in 0..menu_count {
                         let menu_id = bus.read_word(mbar_ptr + 2 + (i as u32) * 2) as i16;
-                        let Some((_, menu_res_ptr)) = self.find_or_load_resource_any(bus, *b"MENU", menu_id)
+                        let Some((_, menu_res_ptr)) =
+                            self.find_or_load_resource_any(bus, *b"MENU", menu_id)
                         else {
                             continue;
                         };
@@ -2413,18 +2417,17 @@ impl super::TrapDispatcher {
                 let menu_handle = bus.read_long(sp + 4);
                 cpu.write_reg(Register::A7, sp + 8);
 
-                let touched = if let Some(menu) =
-                    self.menus.iter_mut().find(|m| m.handle == menu_handle)
-                {
-                    if let Some(mi) = menu.items.get_mut((item - 1) as usize) {
-                        mi.mark = if checked { 0x12 } else { 0 }; // 0x12 = checkmark char
-                        Some(menu.clone())
+                let touched =
+                    if let Some(menu) = self.menus.iter_mut().find(|m| m.handle == menu_handle) {
+                        if let Some(mi) = menu.items.get_mut((item - 1) as usize) {
+                            mi.mark = if checked { 0x12 } else { 0 }; // 0x12 = checkmark char
+                            Some(menu.clone())
+                        } else {
+                            None
+                        }
                     } else {
                         None
-                    }
-                } else {
-                    None
-                };
+                    };
                 // The Menu Manager record is public guest state. Preserve the
                 // mark in its item record so a later mutation that refreshes
                 // the cached menu cannot resurrect the previous value.
@@ -2614,19 +2617,18 @@ impl super::TrapDispatcher {
                 let icon = (bus.read_word(sp) & 0xFF) as u8;
                 let item = bus.read_word(sp + 2) as i16;
                 let menu_handle = bus.read_long(sp + 4);
-                let touched = if let Some(menu) =
-                    self.menus.iter_mut().find(|m| m.handle == menu_handle)
-                {
-                    refresh_menu_from_memory(bus, menu);
-                    if let Some(mi) = menu.items.get_mut((item - 1) as usize) {
-                        mi.icon = icon;
-                        Some(menu.clone())
+                let touched =
+                    if let Some(menu) = self.menus.iter_mut().find(|m| m.handle == menu_handle) {
+                        refresh_menu_from_memory(bus, menu);
+                        if let Some(mi) = menu.items.get_mut((item - 1) as usize) {
+                            mi.icon = icon;
+                            Some(menu.clone())
+                        } else {
+                            None
+                        }
                     } else {
                         None
-                    }
-                } else {
-                    None
-                };
+                    };
                 if let Some(menu) = touched {
                     self.serialise_menu_items_to_memory(bus, &menu);
                 }
@@ -2671,19 +2673,18 @@ impl super::TrapDispatcher {
                 let style = (bus.read_word(sp) & 0xFF) as u8;
                 let item = bus.read_word(sp + 2) as i16;
                 let menu_handle = bus.read_long(sp + 4);
-                let touched = if let Some(menu) =
-                    self.menus.iter_mut().find(|m| m.handle == menu_handle)
-                {
-                    refresh_menu_from_memory(bus, menu);
-                    if let Some(mi) = menu.items.get_mut((item - 1) as usize) {
-                        mi.style = style;
-                        Some(menu.clone())
+                let touched =
+                    if let Some(menu) = self.menus.iter_mut().find(|m| m.handle == menu_handle) {
+                        refresh_menu_from_memory(bus, menu);
+                        if let Some(mi) = menu.items.get_mut((item - 1) as usize) {
+                            mi.style = style;
+                            Some(menu.clone())
+                        } else {
+                            None
+                        }
                     } else {
                         None
-                    }
-                } else {
-                    None
-                };
+                    };
                 if let Some(menu) = touched {
                     self.serialise_menu_items_to_memory(bus, &menu);
                 }
@@ -2725,19 +2726,18 @@ impl super::TrapDispatcher {
                 let mark_char = (bus.read_word(sp) & 0xFF) as u8;
                 let item = bus.read_word(sp + 2) as i16;
                 let menu_handle = bus.read_long(sp + 4);
-                let touched = if let Some(menu) =
-                    self.menus.iter_mut().find(|m| m.handle == menu_handle)
-                {
-                    refresh_menu_from_memory(bus, menu);
-                    if let Some(mi) = menu.items.get_mut((item - 1) as usize) {
-                        mi.mark = mark_char;
-                        Some(menu.clone())
+                let touched =
+                    if let Some(menu) = self.menus.iter_mut().find(|m| m.handle == menu_handle) {
+                        refresh_menu_from_memory(bus, menu);
+                        if let Some(mi) = menu.items.get_mut((item - 1) as usize) {
+                            mi.mark = mark_char;
+                            Some(menu.clone())
+                        } else {
+                            None
+                        }
                     } else {
                         None
-                    }
-                } else {
-                    None
-                };
+                    };
                 if let Some(menu) = touched {
                     self.serialise_menu_items_to_memory(bus, &menu);
                 }
@@ -4528,14 +4528,19 @@ impl super::TrapDispatcher {
         parent_depth: Option<usize>,
         parent_item: i16,
     ) {
-        let Some((parent_menu_idx, parent_rect, child_depth)) = self.menu_tracking.as_ref().and_then(|tracking| {
-            parent_depth.map_or_else(
-                || Some((tracking.active_menu, tracking.dropdown_rect, 0)),
-                |depth| tracking.submenus.get(depth).map(|submenu| {
-                    (submenu.menu, submenu.dropdown_rect, depth + 1)
-                }),
-            )
-        }) else {
+        let Some((parent_menu_idx, parent_rect, child_depth)) =
+            self.menu_tracking.as_ref().and_then(|tracking| {
+                parent_depth.map_or_else(
+                    || Some((tracking.active_menu, tracking.dropdown_rect, 0)),
+                    |depth| {
+                        tracking
+                            .submenus
+                            .get(depth)
+                            .map(|submenu| (submenu.menu, submenu.dropdown_rect, depth + 1))
+                    },
+                )
+            })
+        else {
             return;
         };
         let Some(submenu_idx) =
@@ -4561,8 +4566,7 @@ impl super::TrapDispatcher {
             parent_rect,
             submenu_idx,
             parent_item,
-        )
-        else {
+        ) else {
             self.close_submenus_from(bus, child_depth);
             return;
         };
@@ -4608,12 +4612,7 @@ impl super::TrapDispatcher {
         Some(0)
     }
 
-    fn update_submenu_highlight(
-        &mut self,
-        bus: &mut MacMemoryBus,
-        depth: usize,
-        new_item: i16,
-    ) {
+    fn update_submenu_highlight(&mut self, bus: &mut MacMemoryBus, depth: usize, new_item: i16) {
         let Some((menu_idx, old_item, rect)) = self
             .menu_tracking
             .as_ref()
@@ -4707,9 +4706,7 @@ impl super::TrapDispatcher {
             .map(|tracking| tracking.submenus.len())
             .unwrap_or(0);
         for depth in (0..submenu_count).rev() {
-            if let Some(submenu_item) =
-                self.submenu_item_at_point(bus, depth, mouse_x, mouse_y)
-            {
+            if let Some(submenu_item) = self.submenu_item_at_point(bus, depth, mouse_x, mouse_y) {
                 self.update_submenu_highlight(bus, depth, submenu_item);
                 return;
             }
@@ -4935,9 +4932,7 @@ impl super::TrapDispatcher {
                     tracking
                         .submenus
                         .iter()
-                        .find(|submenu| {
-                            submenu.menu == menu_idx && submenu.dropdown_rect == rect
-                        })
+                        .find(|submenu| submenu.menu == menu_idx && submenu.dropdown_rect == rect)
                         .map(|submenu| submenu.highlighted_item)
                 }
             })
@@ -4953,9 +4948,7 @@ impl super::TrapDispatcher {
                 self.dialog_tracking
                     .as_ref()
                     .and_then(|tracking| tracking.active_popup.as_ref())
-                    .filter(|popup| {
-                        popup.active_menu == menu_idx && popup.dropdown_rect == rect
-                    })
+                    .filter(|popup| popup.active_menu == menu_idx && popup.dropdown_rect == rect)
                     .map(|popup| popup.highlighted_item)
             })
             .unwrap_or(0);
@@ -5674,8 +5667,8 @@ mod tests {
     use super::super::test_helpers::{setup, setup_with_port, MockCpu, TEST_SP};
     use super::{
         count_menu_items_from_memory, parse_appendmenu_items, parse_menu_resource, Menu, MenuItem,
-        MenuTrackingState, MC_ENTRY_SIZE, MENU_KEY_REDUCED_ICON,
-        MENU_KEY_SMALL_ICON, MENU_ROW_HEIGHT,
+        MenuTrackingState, MC_ENTRY_SIZE, MENU_KEY_REDUCED_ICON, MENU_KEY_SMALL_ICON,
+        MENU_ROW_HEIGHT,
     };
     use crate::cpu::{CpuOps, Register};
     use crate::memory::{MacMemoryBus, MemoryBus};
@@ -8113,14 +8106,7 @@ mod tests {
     fn long_menu_mutations_preserve_trailing_item_and_refresh_guest_edits() {
         let (mut disp, mut cpu, mut bus) = setup();
         let menu_id = 447;
-        let handle = new_menu_with_title(
-            &mut disp,
-            &mut cpu,
-            &mut bus,
-            menu_id,
-            0x303800,
-            "Long",
-        );
+        let handle = new_menu_with_title(&mut disp, &mut cpu, &mut bus, menu_id, 0x303800, "Long");
 
         let mut data = vec!["A/A"; 39];
         data.push("Tail/Z");
@@ -8140,7 +8126,10 @@ mod tests {
             "AppendMenu must grow MENU records beyond the legacy 256-byte buffer"
         );
         assert_eq!(count_menu_items_from_memory(&bus, handle), 40);
-        assert_eq!(get_item_cmd(&mut disp, &mut cpu, &mut bus, handle, 40), b'Z');
+        assert_eq!(
+            get_item_cmd(&mut disp, &mut cpu, &mut bus, handle, 40),
+            b'Z'
+        );
 
         let replacement = "Expanded first item that forces another complete record resize";
         write_pstring(&mut bus, 0x303A00, replacement);
@@ -8158,7 +8147,10 @@ mod tests {
             cpu.write_reg(Register::A7, TEST_SP);
             bus.write_word(TEST_SP, 1);
             bus.write_long(TEST_SP + 2, handle);
-            assert!(disp.dispatch_menu(true, trap, &mut cpu, &mut bus).unwrap().is_ok());
+            assert!(disp
+                .dispatch_menu(true, trap, &mut cpu, &mut bus)
+                .unwrap()
+                .is_ok());
         }
         let (height, width) = calc_menu_size_for_test(&mut disp, &mut cpu, &mut bus, handle);
         assert!(height > 0 && width > 0);
@@ -10202,13 +10194,7 @@ mod tests {
             (command_pixel, "command key"),
         ] {
             assert!(
-                screen_pixel_is_set(
-                    &themed_bus,
-                    themed_base,
-                    themed_row_bytes,
-                    pixel.0,
-                    pixel.1
-                ),
+                screen_pixel_is_set(&themed_bus, themed_base, themed_row_bytes, pixel.0, pixel.1),
                 "final themed chrome composition should preserve the highlighted {label}"
             );
         }
@@ -10249,13 +10235,7 @@ mod tests {
             (command_pixel, "popup command key"),
         ] {
             assert!(
-                screen_pixel_is_set(
-                    &themed_bus,
-                    themed_base,
-                    themed_row_bytes,
-                    pixel.0,
-                    pixel.1
-                ),
+                screen_pixel_is_set(&themed_bus, themed_base, themed_row_bytes, pixel.0, pixel.1),
                 "final themed popup composition should preserve the highlighted {label}"
             );
         }
@@ -13180,11 +13160,9 @@ mod tests {
 
         let game = new_menu_with_title(&mut disp, &mut cpu, &mut bus, 129, 0x310000, "Game");
         append_menu_data(&mut disp, &mut cpu, &mut bus, game, 0x310040, "Options");
-        let options =
-            new_menu_with_title(&mut disp, &mut cpu, &mut bus, 138, 0x310200, "Options");
+        let options = new_menu_with_title(&mut disp, &mut cpu, &mut bus, 138, 0x310200, "Options");
         append_menu_data(&mut disp, &mut cpu, &mut bus, options, 0x310240, "Speed");
-        let speed =
-            new_menu_with_title(&mut disp, &mut cpu, &mut bus, 139, 0x310400, "Speed");
+        let speed = new_menu_with_title(&mut disp, &mut cpu, &mut bus, 139, 0x310400, "Speed");
         append_menu_data(
             &mut disp,
             &mut cpu,

--- a/src/trap/pict.rs
+++ b/src/trap/pict.rs
@@ -4103,6 +4103,17 @@ fn build_src_to_dst_table_uncached(
                 // indices: a lower-index color in the same 4-bit cell must not
                 // replace an exact match.
                 index as u8
+            } else if let Some(index) = device_clut.iter().position(|destination| {
+                destination[0] >> 8 == entry[0] >> 8
+                    && destination[1] >> 8 == entry[1] >> 8
+                    && destination[2] >> 8 == entry[2] >> 8
+            }) {
+                // Indexed 8-bit video exposes the most-significant byte of
+                // each 16-bit RGB component. Some classic PICT generators
+                // leave bookkeeping values in the low bytes, so colors that
+                // are identical on the device must match before the coarser
+                // inverse-table lookup. Imaging With QuickDraw 1994, p. 4-13.
+                index as u8
             } else {
                 let qr = (entry[0] >> 12) as u32;
                 let qg = (entry[1] >> 12) as u32;
@@ -6617,6 +6628,21 @@ mod tests {
         let table = build_src_to_dst_table(&src, &dst);
 
         assert_eq!(table[71], 12);
+    }
+
+    #[test]
+    fn eight_bit_device_matching_ignores_pict_rgb_low_bytes() {
+        let mut src = [[0u16; 3]; 256];
+        let mut dst = [[0u16; 3]; 256];
+        src[14] = [0xFF0E, 0x2D0E, 0x890E];
+        dst[73] = [0xFFFF, 0x2D2D, 0x8989];
+        // A competing entry occupies the same 4-bit inverse-table cell but
+        // does not display the requested 8-bit RGB value.
+        dst[12] = [0xF000, 0x2000, 0x8000];
+
+        let table = build_src_to_dst_table(&src, &dst);
+
+        assert_eq!(table[14], 73);
     }
 
     #[test]

--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -76,6 +76,26 @@ const PM_EXPLICIT: i16 = 0x0008;
 const PM_NO_UPDATES: i16 = -0x8000;
 const PM_BK_UPDATES: i16 = -0x6000;
 const PM_FG_UPDATES: i16 = -0x4000;
+// Classic Color QuickDraw's 8-bit color-arbitration order. The Palette
+// Manager walks this spread when a tolerant request has no in-tolerance
+// match, preserving the protected white/black endpoints while distributing
+// replacements across the device table. This is deliberately not numerical
+// CLUT order or nearest-RGB order.
+const PM_8BPP_ALLOCATION_ORDER: [u8; 256] = [
+    0, 255, 16, 18, 20, 22, 24, 63, 47, 95, 79, 127, 111, 159, 143, 31, 15, 254, 238, 222, 206,
+    190, 174, 62, 46, 94, 78, 126, 110, 158, 142, 26, 14, 253, 237, 221, 205, 189, 173, 61, 45, 93,
+    77, 125, 109, 157, 141, 29, 13, 252, 236, 220, 204, 188, 172, 156, 44, 124, 76, 92, 108, 60,
+    140, 28, 12, 251, 235, 219, 203, 187, 171, 155, 43, 123, 75, 91, 107, 59, 139, 27, 11, 250,
+    234, 218, 202, 186, 170, 154, 42, 122, 74, 90, 106, 58, 138, 30, 10, 249, 233, 217, 201, 185,
+    169, 153, 41, 121, 73, 89, 105, 57, 137, 25, 9, 248, 232, 216, 200, 184, 168, 152, 40, 120, 72,
+    88, 104, 56, 136, 175, 8, 247, 231, 215, 199, 183, 167, 151, 39, 119, 71, 87, 103, 55, 135, 23,
+    7, 246, 230, 214, 198, 182, 166, 150, 38, 118, 70, 86, 102, 54, 134, 191, 6, 245, 229, 213,
+    197, 181, 165, 149, 37, 117, 69, 85, 101, 53, 133, 21, 5, 244, 228, 212, 196, 180, 164, 148,
+    36, 116, 68, 84, 100, 52, 132, 207, 4, 243, 227, 211, 195, 179, 163, 147, 35, 115, 67, 83, 99,
+    51, 131, 19, 3, 242, 226, 210, 194, 178, 162, 146, 34, 114, 66, 82, 98, 50, 130, 223, 2, 241,
+    225, 209, 193, 177, 161, 49, 33, 81, 65, 113, 97, 145, 129, 17, 1, 240, 224, 208, 192, 176,
+    160, 48, 32, 80, 64, 112, 96, 144, 128, 239,
+];
 
 /// `dstWindow` value that addresses the default palette rather than a window.
 /// `SetPalette`/`NSetPalette` take a WindowPtr, and `(WindowPtr)-1` is the
@@ -1655,7 +1675,10 @@ impl super::TrapDispatcher {
             }
 
             // RectRgn ($A8DF)
-            // RectRgn ($A8DF): Sets region to bounding rect
+            // Destroys the previous region structure and replaces it with the
+            // supplied rectangle.
+            // PROCEDURE RectRgn(rgn: RgnHandle; r: Rect);
+            // Imaging With QuickDraw (1994), p. 3-92
             (true, 0x0DF) => {
                 let sp = cpu.read_reg(Register::A7);
                 let rect_ptr = bus.read_long(sp);
@@ -16708,7 +16731,22 @@ impl super::TrapDispatcher {
         // already drawn by visible background windows, even though their
         // palettes did not request or receive a redraw.
         let mut updated_clut = current_clut;
-        for (index, rgb) in updated_clut.iter_mut().enumerate().take(palette_entries) {
+        self.palette_device_indices
+            .retain(|(palette, _), _| *palette != palette_handle);
+        let mut claimed = [false; 256];
+        // Color QuickDraw keeps the white and black endpoints available for
+        // its standard drawing operations. Tolerant white and black entries
+        // may share those exact cells; other tolerant colors may not consume
+        // them. Inside Macintosh Volume V (1986), V-162.
+        claimed[0] = true;
+        claimed[255] = true;
+
+        // Preserve the existing behavior for explicit and animated entries,
+        // which either name or reserve a device index. Record those claims
+        // before allocating ordinary tolerant colors so a tolerant entry
+        // cannot displace a fixed-index request that appears later in the
+        // palette.
+        for index in 0..palette_entries {
             let color_info = Self::palette_color_info_ptr(palette_ptr, index as u32);
             let usage = bus.read_word(color_info + 6) as i16;
             // Usage decides how a palette entry claims its device slot
@@ -16731,14 +16769,71 @@ impl super::TrapDispatcher {
             // Only the pure-explicit case keeps the device value; the
             // combined cases fall through to the ordinary install below.
             if usage & PM_EXPLICIT != 0 && usage & (PM_TOLERANT | PM_ANIMATED) == 0 {
-                *rgb = current_clut[index];
                 continue;
             }
-            *rgb = [
+            if usage & PM_EXPLICIT == 0 && usage & PM_TOLERANT != 0 {
+                continue;
+            }
+            let device_index = index & 0xFF;
+            updated_clut[device_index] = [
                 bus.read_word(color_info),
                 bus.read_word(color_info + 2),
                 bus.read_word(color_info + 4),
             ];
+            claimed[device_index] = true;
+            self.palette_device_indices
+                .insert((palette_handle, index as u16), device_index as u8);
+        }
+
+        // Tolerant colors are allocated unique device indices in palette
+        // order. Their palette positions are logical entry numbers, not CLUT
+        // indices. The selected cell changes only when its current color is
+        // farther away than the entry tolerance. Inside Macintosh Volume V
+        // (1986), V-160..V-162; Volume VI (1991), 20-9 and 20-15.
+        for index in 0..palette_entries {
+            let color_info = Self::palette_color_info_ptr(palette_ptr, index as u32);
+            let usage = bus.read_word(color_info + 6) as i16;
+            if usage & PM_TOLERANT == 0 || usage & PM_EXPLICIT != 0 {
+                continue;
+            }
+            let requested = [
+                bus.read_word(color_info),
+                bus.read_word(color_info + 2),
+                bus.read_word(color_info + 4),
+            ];
+            let tolerance = bus.read_word(color_info + 8);
+
+            let endpoint = if requested == [0xFFFF; 3] && current_clut[0] == requested {
+                Some(0usize)
+            } else if requested == [0; 3] && current_clut[255] == requested {
+                Some(255usize)
+            } else {
+                None
+            };
+            let device_index = endpoint.or_else(|| {
+                PM_8BPP_ALLOCATION_ORDER
+                    .iter()
+                    .map(|&candidate| usize::from(candidate))
+                    .find(|&candidate| !claimed[candidate])
+            });
+            let Some(device_index) = device_index else {
+                // Unsatisfied requests fall back to courteous matching.
+                continue;
+            };
+            claimed[device_index] = true;
+            self.palette_device_indices
+                .insert((palette_handle, index as u16), device_index as u8);
+
+            let present = current_clut[device_index];
+            let difference = requested
+                .into_iter()
+                .zip(present)
+                .map(|(wanted, have)| wanted.abs_diff(have))
+                .max()
+                .unwrap_or(0);
+            if difference > tolerance {
+                updated_clut[device_index] = requested;
+            }
         }
         let color_environment_changed = updated_clut != current_clut;
         self.device_clut = updated_clut;
@@ -16849,6 +16944,8 @@ impl super::TrapDispatcher {
             return;
         }
         self.palette_updates.remove(&palette);
+        self.palette_device_indices
+            .retain(|(handle, _), _| *handle != palette);
         self.window_palettes
             .retain(|_, (handle, _)| *handle != palette);
     }
@@ -16947,10 +17044,17 @@ impl super::TrapDispatcher {
             return 0;
         }
 
-        if let Some((_palette, rgb, usage)) = self.palette_entry_rgb_for_current_window(bus, entry)
-        {
+        if let Some((palette, rgb, usage)) = self.palette_entry_rgb_for_current_window(bus, entry) {
             if (usage & PM_EXPLICIT) != 0 {
                 return u32::from((entry as u16) & 0x00FF);
+            }
+
+            if let Some(index) = self
+                .palette_device_indices
+                .get(&(palette, entry as u16))
+                .copied()
+            {
+                return u32::from(index);
             }
 
             return u32::from(super::pict::closest_clut_index(
@@ -20778,6 +20882,11 @@ impl super::TrapDispatcher {
             return None;
         }
         bus.write_long(rgn_handle, new_ptr);
+        // Regions are relocatable blocks. QuickDraw region operations may
+        // move their backing storage, while the handle remains stable
+        // (Imaging With QuickDraw, 1994, pp. 3-91–3-92). Once the master
+        // pointer names the replacement, release the superseded allocation.
+        bus.free(current_ptr);
         Some(new_ptr)
     }
 
@@ -23832,6 +23941,39 @@ mod tests {
             bus.read_word(addr + 4) as i16,
             bus.read_word(addr + 6) as i16,
         )
+    }
+
+    #[test]
+    fn growing_region_releases_each_superseded_backing_allocation() {
+        let (_d, _cpu, mut bus) = setup();
+        let handle = bus.alloc(4);
+        let initial_ptr = bus.alloc(super::REGION_HEADER_SIZE);
+        bus.write_long(handle, initial_ptr);
+        bus.write_word(initial_ptr, super::REGION_HEADER_SIZE as u16);
+
+        let mut previous_ptr = initial_ptr;
+        for edge_count in 2..64 {
+            let data_words = (0..edge_count).map(|edge| edge as i16).collect::<Vec<_>>();
+            assert!(TrapDispatcher::write_region(
+                &mut bus,
+                handle,
+                Some((0, 0, 1, edge_count as i16)),
+                &data_words,
+            ));
+
+            let current_ptr = bus.read_long(handle);
+            assert_ne!(current_ptr, previous_ptr);
+            assert_eq!(
+                bus.get_alloc_size(previous_ptr),
+                None,
+                "relocating a growing region must release its old storage"
+            );
+            assert_eq!(
+                bus.get_alloc_size(current_ptr),
+                Some(super::REGION_HEADER_SIZE + edge_count * 2)
+            );
+            previous_ptr = current_ptr;
+        }
     }
 
     fn centered_640x480_copybits_rect() -> ScreenCopyBitsRect {
@@ -36630,13 +36772,21 @@ mod tests {
     fn activatepalette_preserves_device_cells_not_claimed_by_the_palette() {
         let (mut d, mut cpu, mut bus) = setup();
         let window = 0x0020_4120u32;
-        let palette = d.create_palette_from_ctab(&mut bus, 1, 0, super::PM_TOLERANT, 0);
+        let palette = d.create_palette_from_ctab(&mut bus, 2, 0, super::PM_TOLERANT, 0);
         let palette_ptr = TrapDispatcher::palette_ptr(&bus, palette);
         TrapDispatcher::write_palette_color_info(
             &mut bus,
             palette_ptr,
             0,
             [0x1234, 0x5678, 0x9ABC],
+            super::PM_TOLERANT,
+            0,
+        );
+        TrapDispatcher::write_palette_color_info(
+            &mut bus,
+            palette_ptr,
+            1,
+            [0x2468, 0xACE0, 0x1357],
             super::PM_TOLERANT,
             0,
         );
@@ -36651,7 +36801,12 @@ mod tests {
         let result = d.dispatch_quickdraw(true, 0x294, &mut cpu, &mut bus);
 
         assert!(result.unwrap().is_ok());
-        assert_eq!(d.device_clut[0], [0x1234, 0x5678, 0x9ABC]);
+        assert_eq!(d.palette_device_indices[&(palette, 0)], 16);
+        assert_eq!(d.palette_device_indices[&(palette, 1)], 18);
+        assert_eq!(d.device_clut[16], [0x1234, 0x5678, 0x9ABC]);
+        assert_eq!(d.device_clut[18], [0x2468, 0xACE0, 0x1357]);
+        assert_eq!(d.device_clut[0], [0xFFFF; 3]);
+        assert_eq!(d.device_clut[255], [0; 3]);
         assert_eq!(d.device_clut[200], background_color);
         assert_eq!(d.color_manager_clut[200], background_color);
     }

--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -9325,12 +9325,23 @@ impl super::TrapDispatcher {
                     ];
                 }
 
-                let dst_clut = if dst_ctab_handle != 0 {
-                    self.read_port_clut(bus, dst_ctab_handle)
+                // Screen-backed color ports retain their own PixMap color
+                // table, but the pixels are interpreted by the live screen
+                // device table. Palette activation can therefore make the
+                // port's table stale. Use the same screen-destination rule as
+                // CopyBits so PlotCIcon maps colors through the live device.
+                // Imaging With QuickDraw (1994), pp. 4-55 to 4-59 and 5-28.
+                let effective_dst_ctab = self.effective_destination_ctab_handle(
+                    dst_base,
+                    dst_row_bytes,
+                    dst_pixel_size,
+                    dst_ctab_handle,
+                );
+                let dst_clut = if effective_dst_ctab != 0 {
+                    self.read_port_clut(bus, effective_dst_ctab)
                 } else {
                     self.device_clut
                 };
-
                 for dst_y_local in dst_top..dst_bottom {
                     let Some(sy) =
                         Self::scale_coord(pm_top, pm_bottom, dst_top, dst_bottom, dst_y_local)
@@ -9403,13 +9414,29 @@ impl super::TrapDispatcher {
                                 ) else {
                                     continue;
                                 };
-                                let rgb = icon_clut
+                                let mut rgb = icon_clut
                                     .get(src_index as usize)
                                     .copied()
                                     .unwrap_or(self.device_clut[src_index as usize]);
-                                let dst_index = super::pict::closest_clut_index(
-                                    rgb[0], rgb[1], rgb[2], &dst_clut,
-                                );
+                                if (self.icon_transform_override & 0x4000) != 0 {
+                                    // ttSelected darkens the standard color
+                                    // icon before mapping it to the active
+                                    // device. This is the selection mechanism
+                                    // used by Finder-style icon controls.
+                                    // More Macintosh Toolbox (1993), pp. 5-20
+                                    // to 5-21 and 5-37; Macintosh Human
+                                    // Interface Guidelines (1992), p. 241.
+                                    for component in &mut rgb {
+                                        *component /= 2;
+                                    }
+                                }
+                                // PlotCIcon performs ordinary Color Manager
+                                // inverse mapping. Do not apply the PICT-only
+                                // grayscale-ramp preference here: a standard
+                                // icon table drawn under an application
+                                // palette must be allowed to select the
+                                // nearest tinted device color.
+                                let dst_index = Self::nearest_palette_index(&dst_clut, rgb);
                                 bus.write_byte(dst_base + dst_y * dst_row_bytes + dst_x, dst_index);
                             }
                             1 => {
@@ -21691,7 +21718,7 @@ impl super::TrapDispatcher {
         Some(i32::from(src_start) + (rel * src_span) / dst_span)
     }
 
-    fn nearest_palette_index(clut: &[[u16; 3]; 256], rgb: [u16; 3]) -> u8 {
+    pub(crate) fn nearest_palette_index(clut: &[[u16; 3]; 256], rgb: [u16; 3]) -> u8 {
         // QuickDraw's inverse tables reserve exact white/black for the first
         // and last CLUT entries when the endpoints are white/black, rather
         // than returning an arbitrary duplicate color-cube entry. During
@@ -35430,6 +35457,104 @@ mod tests {
             vec![7, 9, 42, 255],
             "packed 4bpp source nibbles should decode and remap through the icon ColorTable"
         );
+    }
+
+    #[test]
+    fn plotcicon_screen_backed_port_uses_live_device_clut() {
+        // A screen-backed CGrafPort's private PixMap table can predate a
+        // Palette Manager activation. The screen device's live table must
+        // control inverse mapping, just as it does for other screen drawing.
+        // Imaging With QuickDraw (1994), pp. 4-55 to 4-59 and 5-28.
+        let (mut d, mut cpu, mut bus) = setup();
+        d.device_clut = [[0, 0, 0]; 256];
+        d.device_clut[0] = [0xFFFF, 0xFFFF, 0xFFFF];
+        d.device_clut[1] = [0x1010, 0x1010, 0x1010];
+        d.device_clut[7] = [0x4040, 0x4545, 0x4545];
+
+        let (screen_base, screen_row_bytes, screen_w, screen_h, _) = d.screen_mode;
+        let stale_ctab = make_test_ctab_handle(&mut bus, &[[0x4444, 0x4444, 0x4444]], 1, 0);
+        let pm_handle = bus.alloc(4);
+        let pm_ptr = bus.alloc(64);
+        bus.fill_zeros(pm_ptr, 64);
+        bus.write_long(pm_handle, pm_ptr);
+        bus.write_long(pm_ptr, screen_base);
+        bus.write_word(pm_ptr + 4, 0x8000 | screen_row_bytes as u16);
+        write_rect(&mut bus, pm_ptr + 6, 0, 0, screen_h as i16, screen_w as i16);
+        bus.write_word(pm_ptr + 32, 8);
+        bus.write_long(pm_ptr + 42, stale_ctab);
+
+        let port_ptr = bus.alloc(128);
+        bus.fill_zeros(port_ptr, 128);
+        bus.write_long(port_ptr + 2, pm_handle);
+        bus.write_word(port_ptr + 6, 0xC000);
+        let a5 = cpu.read_reg(Register::A5);
+        let globals_ptr = bus.read_long(a5);
+        bus.write_long(globals_ptr, port_ptr);
+
+        let mut icon_entries = [[0, 0, 0]; 16];
+        icon_entries[1] = [0x4444, 0x4444, 0x4444];
+        let cicn_data = make_test_cicn_resource_4bpp([0x11, 0x11], &icon_entries);
+        d.install_test_resource(&mut bus, *b"cicn", 130, &cicn_data);
+
+        bus.write_word(TEST_SP, 130);
+        let get_icon = d.dispatch_quickdraw(true, 0x21E, &mut cpu, &mut bus);
+        assert!(get_icon.unwrap().is_ok());
+        let icon_handle = bus.read_long(TEST_SP + 2);
+        let rect_ptr = 0x300180u32;
+        write_rect(&mut bus, rect_ptr, 0, 0, 1, 4);
+        cpu.write_reg(Register::A7, TEST_SP);
+        bus.write_long(TEST_SP, icon_handle);
+        bus.write_long(TEST_SP + 4, rect_ptr);
+
+        let plot = d.dispatch_quickdraw(true, 0x21F, &mut cpu, &mut bus);
+
+        assert!(plot.unwrap().is_ok());
+        assert_eq!(bus.read_bytes(screen_base, 4), vec![7, 7, 7, 7]);
+    }
+
+    #[test]
+    fn plotcicon_selected_transform_reduces_icon_brightness() {
+        // ttSelected makes the Apple icon colors darker before inverse
+        // mapping them to the destination device. Macintosh Human Interface
+        // Guidelines (1992), p. 241; More Macintosh Toolbox (1993), p. 5-37.
+        let (mut d, mut cpu, mut bus) = setup();
+        d.device_clut = [[0, 0, 0]; 256];
+        d.device_clut[8] = [0x2222, 0x2222, 0x2222];
+
+        let dst_base = bus.alloc(8);
+        let pm_handle = bus.alloc(4);
+        let pm_ptr = bus.alloc(64);
+        bus.fill_zeros(pm_ptr, 64);
+        bus.write_long(pm_handle, pm_ptr);
+        write_pixmap_8(&mut bus, pm_ptr, dst_base, 4, 1, 0);
+        let port_ptr = bus.alloc(128);
+        bus.fill_zeros(port_ptr, 128);
+        bus.write_long(port_ptr + 2, pm_handle);
+        bus.write_word(port_ptr + 6, 0xC000);
+        let globals_ptr = bus.read_long(cpu.read_reg(Register::A5));
+        bus.write_long(globals_ptr, port_ptr);
+
+        let mut icon_entries = [[0, 0, 0]; 16];
+        icon_entries[1] = [0x4444, 0x4444, 0x4444];
+        let cicn_data = make_test_cicn_resource_4bpp([0x11, 0x11], &icon_entries);
+        d.install_test_resource(&mut bus, *b"cicn", 131, &cicn_data);
+        bus.write_word(TEST_SP, 131);
+        d.dispatch_quickdraw(true, 0x21E, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+        let icon_handle = bus.read_long(TEST_SP + 2);
+        let rect_ptr = 0x3001A0u32;
+        write_rect(&mut bus, rect_ptr, 0, 0, 1, 4);
+        cpu.write_reg(Register::A7, TEST_SP);
+        bus.write_long(TEST_SP, icon_handle);
+        bus.write_long(TEST_SP + 4, rect_ptr);
+        d.icon_transform_override = 0x4000;
+
+        d.dispatch_quickdraw(true, 0x21F, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(bus.read_bytes(dst_base, 4), vec![8, 8, 8, 8]);
     }
 
     #[test]

--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -1824,6 +1824,18 @@ impl super::TrapDispatcher {
                     }
                 }
 
+                if res_type == *b"KMAP" {
+                    if let Some(ptr) = self.synthesize_system_kmap(bus, res_id) {
+                        let handle = self.get_or_create_resource_handle(bus, res_type, res_id, ptr);
+                        cpu.write_reg(Register::A0, handle);
+                        cpu.write_reg(Register::D0, 0);
+                        bus.write_word(0x0A60, 0); // ResErr = noErr
+                        bus.write_long(sp + 6, handle);
+                        cpu.write_reg(Register::A7, sp + 6);
+                        return Some(Ok(()));
+                    }
+                }
+
                 cpu.write_reg(Register::A0, 0);
                 cpu.write_reg(Register::D0, 0);
                 bus.write_word(0x0A60, 0);
@@ -9136,30 +9148,82 @@ mod tests {
 
         let kchr = bus.read_long(handle);
         assert_ne!(kchr, 0, "synthetic KCHR handle must be loaded");
-        assert_eq!(bus.get_alloc_size(kchr), Some(1 + 256 + 128 * 2));
-        assert_eq!(bus.read_byte(kchr), 0, "KCHR version byte");
+        assert_eq!(bus.get_alloc_size(kchr), Some(2 + 256 + 2 + 128 * 2 + 2));
+        assert_eq!(bus.read_word(kchr), 0, "KCHR version word");
         assert_eq!(
-            bus.read_byte(kchr + 1),
+            bus.read_byte(kchr + 2),
             0,
             "modifier byte 0 should select the unshifted table"
         );
         assert_eq!(
-            bus.read_byte(kchr + 2),
+            bus.read_byte(kchr + 3),
             0,
             "modifier byte 1 is Command-only and should stay unshifted"
         );
         assert_eq!(
-            bus.read_byte(kchr + 3),
+            bus.read_byte(kchr + 4),
             1,
             "modifier byte 2 should select the shifted table"
         );
 
-        let table0 = kchr + 1 + 256;
+        assert_eq!(bus.read_word(kchr + 2 + 256), 2, "KCHR table count");
+        let table0 = kchr + 2 + 256 + 2;
         let table1 = table0 + 128;
         assert_eq!(bus.read_byte(table0), b'a');
         assert_eq!(bus.read_byte(table1), b'A');
         assert_eq!(bus.read_byte(table0 + 0x0C), b'q');
         assert_eq!(bus.read_byte(table1 + 0x0C), b'Q');
+        assert_eq!(bus.read_byte(table0 + 0x7B), 0x1C, "left arrow");
+        assert_eq!(bus.read_byte(table0 + 0x7C), 0x1D, "right arrow");
+        assert_eq!(bus.read_byte(table0 + 0x7D), 0x1F, "down arrow");
+        assert_eq!(bus.read_byte(table0 + 0x7E), 0x1E, "up arrow");
+        assert_eq!(
+            bus.read_bytes(table1 + 0x7B, 4),
+            vec![0x1C, 0x1D, 0x1F, 0x1E],
+            "shifted arrow translations should remain navigation characters"
+        );
+        assert_eq!(bus.read_word(table1 + 128), 0, "KCHR dead-key count");
+    }
+
+    #[test]
+    fn get_resource_synthesizes_standard_adb_kmap_id_zero() {
+        let (mut disp, mut cpu, mut bus) = setup();
+
+        let sp = TEST_SP;
+        bus.write_word(sp, 0);
+        bus.write_long(sp + 2, u32::from_be_bytes(*b"KMAP"));
+
+        call(&mut disp, true, 0x1A0, &mut cpu, &mut bus).unwrap();
+
+        let handle = bus.read_long(TEST_SP + 6);
+        assert_ne!(handle, 0, "synthetic KMAP must return a handle");
+        let kmap = bus.read_long(handle);
+        assert_eq!(bus.get_alloc_size(kmap), Some(4 + 128 + 2));
+        assert_eq!(bus.read_word(kmap), 0, "KMAP identifier");
+        assert_eq!(bus.read_word(kmap + 2), 0, "KMAP version");
+        let remapped = [
+            (0x36u32, 0x3Bu8),
+            (0x3B, 0x7B),
+            (0x3C, 0x7C),
+            (0x3D, 0x7D),
+            (0x3E, 0x7E),
+            (0x7B, 0x3C),
+            (0x7C, 0x3D),
+            (0x7D, 0x3E),
+            (0x7E, 0x36),
+        ];
+        for keycode in 0..128u32 {
+            let expected = remapped
+                .iter()
+                .find_map(|&(raw, virtual_key)| (raw == keycode).then_some(virtual_key))
+                .unwrap_or(keycode as u8);
+            assert_eq!(
+                bus.read_byte(kmap + 4 + keycode),
+                expected,
+                "standard raw keycode {keycode:#04X} should use its ADB virtual-key mapping"
+            );
+        }
+        assert_eq!(bus.read_word(kmap + 4 + 128), 0, "KMAP exception count");
     }
 
     #[test]

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -4259,9 +4259,8 @@ impl super::TrapDispatcher {
 
         self.set_current_port_state(bus, cpu, state.port, None);
         let list_port_state = self.qd_state_snapshot();
-        let list_port_color_state = ((bus.read_word(state.port.wrapping_add(6)) & 0xC000)
-            == 0xC000)
-            .then(|| {
+        let list_port_color_state =
+            ((bus.read_word(state.port.wrapping_add(6)) & 0xC000) == 0xC000).then(|| {
                 (
                     bus.read_long(state.port.wrapping_add(80)),
                     bus.read_long(state.port.wrapping_add(84)),
@@ -5512,31 +5511,32 @@ impl super::TrapDispatcher {
 
                 let res_type = *b"STR#";
                 let mut res_found = false;
-                let found_str: Option<Vec<u8>> =
-                    if let Some((_, data_ptr)) = self.find_or_load_resource_any(bus, res_type, str_list_id) {
-                        res_found = true;
-                        // STR# format: 2-byte count, then Pascal strings (1-byte len + chars)
-                        // Inside Macintosh Volume I, I-476
-                        let count = bus.read_word(data_ptr) as usize;
-                        if index >= 1 && index <= count {
-                            let mut offset = 2u32;
-                            let mut found = None;
-                            for i in 1..=count {
-                                let len = bus.read_byte(data_ptr + offset) as usize;
-                                offset += 1;
-                                if i == index {
-                                    found = Some(bus.read_bytes(data_ptr + offset, len));
-                                    break;
-                                }
-                                offset += len as u32;
+                let found_str: Option<Vec<u8>> = if let Some((_, data_ptr)) =
+                    self.find_or_load_resource_any(bus, res_type, str_list_id)
+                {
+                    res_found = true;
+                    // STR# format: 2-byte count, then Pascal strings (1-byte len + chars)
+                    // Inside Macintosh Volume I, I-476
+                    let count = bus.read_word(data_ptr) as usize;
+                    if index >= 1 && index <= count {
+                        let mut offset = 2u32;
+                        let mut found = None;
+                        for i in 1..=count {
+                            let len = bus.read_byte(data_ptr + offset) as usize;
+                            offset += 1;
+                            if i == index {
+                                found = Some(bus.read_bytes(data_ptr + offset, len));
+                                break;
                             }
-                            found
-                        } else {
-                            None
+                            offset += len as u32;
                         }
+                        found
                     } else {
                         None
-                    };
+                    }
+                } else {
+                    None
+                };
 
                 // IM:I I-468 documents GetIndString as calling
                 // GetResource('STR#', strListID) "if necessary". On
@@ -24123,11 +24123,7 @@ mod tests {
                 view_rect_ptr,
                 (10, 10, 48, 100),
             );
-            super::super::TrapDispatcher::write_rect_words(
-                &mut bus,
-                data_bounds_ptr,
-                (0, 0, 4, 1),
-            );
+            super::super::TrapDispatcher::write_rect_words(&mut bus, data_bounds_ptr, (0, 0, 4, 1));
             cpu.write_reg(Register::A7, sp);
             bus.write_word(sp, 0x0044); // LNew
             bus.write_word(sp + 2, 0);
@@ -24203,14 +24199,17 @@ mod tests {
             // The owner starts at global (20,30), so local rView (10,10)
             // begins at screen (30,40). Every row must retain its own text
             // witness instead of collapsing at the view's lower edge.
-            for (row, (top, bottom)) in
-                [(30u32, 42u32), (42, 54), (54, 66)].into_iter().enumerate()
+            for (row, (top, bottom)) in [(30u32, 42u32), (42, 54), (54, 66)].into_iter().enumerate()
             {
                 let witness_pixels = (top..bottom)
                     .flat_map(|y| (40u32..130).map(move |x| (y, x)))
                     .filter(|&(y, x)| {
                         let pixel = bus.read_byte(screen_base + y * row_bytes + x);
-                        if row == 0 { pixel != 255 } else { pixel == 0 }
+                        if row == 0 {
+                            pixel != 255
+                        } else {
+                            pixel == 0
+                        }
                     })
                     .count();
                 assert!(witness_pixels > 0, "trap ${trap:03X} lost row at y={top}");
@@ -24228,8 +24227,9 @@ mod tests {
                 disp.resolved_port_color_fields.get(&owner_port),
                 Some(&0x03)
             );
-            assert!((68u32..72).all(|y| (40u32..130)
-                .all(|x| bus.read_byte(screen_base + y * row_bytes + x) == 255)));
+            assert!((68u32..72).all(
+                |y| (40u32..130).all(|x| bus.read_byte(screen_base + y * row_bytes + x) == 255)
+            ));
 
             // LClick receives the same owner-local coordinate basis as rView.
             cpu.write_reg(Register::A7, sp);
@@ -24244,11 +24244,7 @@ mod tests {
                 .unwrap();
             assert_eq!(bus.read_word(sp + 12), 0);
 
-            super::super::TrapDispatcher::write_point_words(
-                &mut bus,
-                query_cell_ptr,
-                (1, 0),
-            );
+            super::super::TrapDispatcher::write_point_words(&mut bus, query_cell_ptr, (1, 0));
             cpu.write_reg(Register::A7, sp);
             bus.write_word(sp, 0x003C); // LGetSelect(FALSE, row 1)
             bus.write_long(sp + 2, list_handle);
@@ -29810,17 +29806,10 @@ mod tests {
         let (mut disp, mut cpu, mut bus) = setup();
         let sp = TEST_SP;
         let key_ptr = bus.alloc(16);
-        let (base_handle, substitution_handle) =
-            replace_text_handles(&mut bus, b"A^0B^0", b"LONG");
+        let (base_handle, substitution_handle) = replace_text_handles(&mut bus, b"A^0B^0", b"LONG");
         let original_ptr = bus.read_long(base_handle);
         bus.write_pstring(key_ptr, b"^0");
-        write_replace_text_frame(
-            &mut bus,
-            sp,
-            base_handle,
-            substitution_handle,
-            key_ptr,
-        );
+        write_replace_text_frame(&mut bus, sp, base_handle, substitution_handle, key_ptr);
 
         disp.dispatch_toolbox(true, 0x0B5, &mut cpu, &mut bus)
             .expect("ScriptUtil dispatch")
@@ -29842,17 +29831,10 @@ mod tests {
         let (mut disp, mut cpu, mut bus) = setup();
         let sp = TEST_SP;
         let key_ptr = bus.alloc(16);
-        let (base_handle, substitution_handle) =
-            replace_text_handles(&mut bus, b"aaaa", b"a");
+        let (base_handle, substitution_handle) = replace_text_handles(&mut bus, b"aaaa", b"a");
         let original_ptr = bus.read_long(base_handle);
         bus.write_pstring(key_ptr, b"aa");
-        write_replace_text_frame(
-            &mut bus,
-            sp,
-            base_handle,
-            substitution_handle,
-            key_ptr,
-        );
+        write_replace_text_frame(&mut bus, sp, base_handle, substitution_handle, key_ptr);
 
         disp.dispatch_toolbox(true, 0x0B5, &mut cpu, &mut bus)
             .expect("ScriptUtil dispatch")
@@ -29875,13 +29857,7 @@ mod tests {
             replace_text_handles(&mut bus, b"unchanged", b"replacement");
         let original_ptr = bus.read_long(base_handle);
         bus.write_pstring(key_ptr, b"missing");
-        write_replace_text_frame(
-            &mut bus,
-            sp,
-            base_handle,
-            substitution_handle,
-            key_ptr,
-        );
+        write_replace_text_frame(&mut bus, sp, base_handle, substitution_handle, key_ptr);
 
         disp.dispatch_toolbox(true, 0x0B5, &mut cpu, &mut bus)
             .expect("ScriptUtil dispatch")
@@ -29901,13 +29877,7 @@ mod tests {
             replace_text_handles(&mut bus, &[0x81, 0x40, 0x40], b"X");
         disp.tx_font = 0x4000; // first Japanese font-family ID
         bus.write_pstring(key_ptr, &[0x40]);
-        write_replace_text_frame(
-            &mut bus,
-            sp,
-            base_handle,
-            substitution_handle,
-            key_ptr,
-        );
+        write_replace_text_frame(&mut bus, sp, base_handle, substitution_handle, key_ptr);
 
         disp.dispatch_toolbox(true, 0x0B5, &mut cpu, &mut bus)
             .expect("ScriptUtil dispatch")

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -15906,7 +15906,28 @@ impl super::TrapDispatcher {
                 } else {
                     8
                 };
-                match raw_selector {
+                match selector {
+                    // PlotCIconHandle. The Icon Utilities glue passes, in
+                    // reverse Pascal order, the CIconHandle, transform and
+                    // alignment words, and destination Rect pointer. PlotCIcon
+                    // supplies the shared color-icon decode and masked blit;
+                    // an icon-sized destination with atNone requires no
+                    // additional alignment.
+                    // More Macintosh Toolbox (1993), pp. 5-26 to 5-27 and
+                    // 5-72; selector table p. A-34 ($1F06).
+                    0x1F06 => {
+                        let sp = cpu.read_reg(Register::A7);
+                        let transform = bus.read_word(sp + 4) as i16;
+                        let rect_ptr = bus.read_long(sp + 8);
+                        bus.write_long(sp + 4, rect_ptr);
+                        let previous_transform = self.icon_transform_override;
+                        self.icon_transform_override = transform;
+                        let result = self.dispatch_quickdraw(true, 0x21F, cpu, bus);
+                        self.icon_transform_override = previous_transform;
+                        bus.write_word(sp + pop_bytes, 0);
+                        cpu.write_reg(Register::A7, sp + pop_bytes);
+                        result.unwrap_or(Ok(()))
+                    }
                     0 => return_noerr_and_pop(cpu, pop_bytes),
                     _ => return_error_and_pop(cpu, pop_bytes, -50),
                 }
@@ -25196,6 +25217,25 @@ mod tests {
             assert_eq!(cpu.read_reg(Register::D0) as i16, -50);
             assert_eq!(cpu.read_reg(Register::A7), TEST_SP + pop_bytes);
         }
+    }
+
+    #[test]
+    fn icondispatch_plotciconhandle_routes_to_legacy_renderer_and_returns_noerr() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let sp = TEST_SP;
+        cpu.write_reg(Register::A7, sp);
+        cpu.write_reg(Register::D0, 0x0000_061F); // byte-swapped $1F06 selector
+        bus.write_long(sp, 0); // NIL CIconHandle is a safe no-op
+        bus.write_word(sp + 4, 0x4000); // transform
+        bus.write_word(sp + 6, 0); // alignment
+        bus.write_long(sp + 8, 0); // destination Rect pointer
+        bus.write_word(sp + 12, 0x7FFF); // reserved Pascal function result
+
+        let result = disp.dispatch_toolbox(true, 0x3C9, &mut cpu, &mut bus);
+
+        assert!(result.unwrap().is_ok());
+        assert_eq!(cpu.read_reg(Register::A7), sp + 12);
+        assert_eq!(bus.read_word(sp + 12), 0);
     }
 
     #[test]

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -4509,9 +4509,11 @@ impl super::TrapDispatcher {
     /// The caller supplies a pointer to a `'KCHR'` resource. The
     /// layout used here follows the documented structure from Inside
     /// Macintosh: Macintosh Toolbox Essentials / Text:
-    ///   - byte 0: version
-    ///   - bytes 1..=256: table-selection index keyed by the modifier byte
+    ///   - bytes 0..=1: version
+    ///   - bytes 2..=257: table-selection index keyed by the modifier byte
+    ///   - bytes 258..=259: character-mapping table count
     ///   - character-mapping tables: 128 bytes per table
+    ///   - a trailing dead-key-record count
     ///
     /// The helper only implements the straight-through character
     /// mapping path. If no translation data is supplied, it falls
@@ -4542,8 +4544,12 @@ impl super::TrapDispatcher {
             };
         }
 
-        let table_code = bus.read_byte(trans_data + 1 + modifier_byte) as u32;
-        let table_base = trans_data + 1 + 256 + table_code * 128;
+        let table_code = bus.read_byte(trans_data + 2 + modifier_byte) as u32;
+        let table_count = u32::from(bus.read_word(trans_data + 2 + 256));
+        if table_code >= table_count {
+            return 0;
+        }
+        let table_base = trans_data + 2 + 256 + 2 + table_code * 128;
         let result = bus.read_byte(table_base + vk) as u32;
         if result != 0 {
             return result;
@@ -17998,14 +18004,14 @@ mod tests {
         assert!(disp.key_is_down(0x26));
         assert!(disp.key_is_down(0x7E));
         assert!(!disp.key_is_down(0x2E), "J must not alias the M key");
-        assert_eq!(bus.read_byte(keys_ptr + 4), 0x40, "J key byte");
+        assert_eq!(bus.read_byte(keys_ptr + 4), 0x02, "J key byte");
         assert_eq!(
             bus.read_byte(keys_ptr + 5),
             0,
             "M key byte should stay clear when J is down"
         );
-        assert_eq!(bus.read_byte(keys_ptr + 6), 0x02, "space key byte");
-        assert_eq!(bus.read_byte(keys_ptr + 15), 0x48, "left/up arrow key byte");
+        assert_eq!(bus.read_byte(keys_ptr + 6), 0x40, "space key byte");
+        assert_eq!(bus.read_byte(keys_ptr + 15), 0x12, "left/up arrow key byte");
         assert_eq!(
             bus.read_byte(keys_ptr + 14),
             0,
@@ -18022,7 +18028,7 @@ mod tests {
         assert!(disp.key_is_down(0x31));
         assert!(disp.key_is_down(0x26));
         assert!(disp.key_is_down(0x7E));
-        assert_eq!(bus.read_byte(keys_ptr + 15), 0x40, "only up remains");
+        assert_eq!(bus.read_byte(keys_ptr + 15), 0x02, "only up remains");
 
         // J ($26) and M ($2E) differ only by KeyMap byte. This catches the
         // byte-pair swap that makes EV/Marathon direct pollers invert them.
@@ -18035,7 +18041,7 @@ mod tests {
         assert!(!disp.key_is_down(0x26));
         assert!(disp.key_is_down(0x2E));
         assert_eq!(bus.read_byte(keys_ptr + 4), 0, "J byte should be clear");
-        assert_eq!(bus.read_byte(keys_ptr + 5), 0x40, "M key byte");
+        assert_eq!(bus.read_byte(keys_ptr + 5), 0x02, "M key byte");
     }
 
     // GetMouse ($A972)
@@ -19849,19 +19855,22 @@ mod tests {
 
     fn seed_synthetic_kchr(bus: &mut super::MacMemoryBus, trans_data: u32) {
         // Minimal KCHR layout:
-        //   byte 0 = version
-        //   bytes 1..=256 = table-selection index
+        //   bytes 0..=1 = version
+        //   bytes 2..=257 = table-selection index
+        //   table-count word
         //   table 0 and table 1 = 128-byte character tables
+        //   dead-key-count word
         //
         // Modifier byte 0 selects table 0; modifier byte 1 selects table 1.
-        bus.write_byte(trans_data, 0);
+        bus.write_word(trans_data, 0);
         for i in 0..256u32 {
-            bus.write_byte(trans_data + 1 + i, 0);
+            bus.write_byte(trans_data + 2 + i, 0);
         }
-        bus.write_byte(trans_data + 1, 0);
-        bus.write_byte(trans_data + 2, 1);
+        bus.write_byte(trans_data + 2, 0);
+        bus.write_byte(trans_data + 3, 1);
 
-        let table0 = trans_data + 1 + 256;
+        bus.write_word(trans_data + 2 + 256, 2);
+        let table0 = trans_data + 2 + 256 + 2;
         let table1 = table0 + 128;
         bus.write_byte(table0 + 2, b'Q');
         bus.write_byte(table0 + 3, b'W');
@@ -19873,6 +19882,7 @@ mod tests {
         bus.write_byte(table1 + 4, b'C');
         bus.write_byte(table1 + 5, b'V');
         bus.write_byte(table1 + 6, b'B');
+        bus.write_word(table1 + 128, 0);
     }
 
     // KeyTrans ($A9C3)

--- a/src/trap/window.rs
+++ b/src/trap/window.rs
@@ -384,6 +384,39 @@ impl super::TrapDispatcher {
         aux_handle
     }
 
+    pub(crate) fn set_window_dialog_item_color_table(
+        &mut self,
+        bus: &mut MacMemoryBus,
+        window_ptr: u32,
+        item_color_table: u32,
+    ) {
+        let aux_handle = self
+            .window_aux_records
+            .get(&window_ptr)
+            .copied()
+            .unwrap_or_else(|| self.ensure_window_aux_record(bus, window_ptr, 0));
+        let aux_ptr = bus.read_long(aux_handle);
+        if aux_ptr != 0 {
+            bus.write_long(
+                aux_ptr + Self::AUX_WIN_DIALOG_CITEM_OFFSET,
+                item_color_table,
+            );
+        }
+    }
+
+    pub(crate) fn window_dialog_item_color_table(
+        &self,
+        bus: &MacMemoryBus,
+        window_ptr: u32,
+    ) -> u32 {
+        self.window_aux_records
+            .get(&window_ptr)
+            .map(|handle| bus.read_long(*handle))
+            .filter(|ptr| *ptr != 0)
+            .map(|ptr| bus.read_long(ptr + Self::AUX_WIN_DIALOG_CITEM_OFFSET))
+            .unwrap_or(0)
+    }
+
     pub(crate) fn rect_intersection(
         a: (i16, i16, i16, i16),
         b: (i16, i16, i16, i16),
@@ -6976,6 +7009,7 @@ mod tests {
             let (mut disp, mut cpu, mut bus) = setup();
             let screen_base = bus.alloc((800 * 600) as u32);
             bus.write_long(0x0824, screen_base);
+            bus.write_word(crate::memory::globals::addr::MBAR_HEIGHT, 20);
             disp.screen_mode = (screen_base, 800, 800, 600, 8);
             install_positioned_wind_resource(
                 &mut disp,
@@ -7003,8 +7037,8 @@ mod tests {
             assert_ne!(window_ptr, 0);
             assert_eq!(
                 disp.window_global_port_rect(&bus, window_ptr),
-                (103, 152, 497, 647),
-                "trap ${trap_num:03X} should center the WIND content bounds"
+                (121, 152, 515, 647),
+                "trap ${trap_num:03X} should center the complete WIND structure below the menu bar"
             );
         }
     }

--- a/src/trap/window.rs
+++ b/src/trap/window.rs
@@ -10890,9 +10890,8 @@ mod tests {
             super::super::TrapDispatcher::region_contains_point(&bus, back_vis, 80, 100),
             "the back visRgn must expose the front window's former location"
         );
-        let back_update = bus.read_long(
-            back + super::super::TrapDispatcher::WINDOW_UPDATE_RGN_OFFSET,
-        );
+        let back_update =
+            bus.read_long(back + super::super::TrapDispatcher::WINDOW_UPDATE_RGN_OFFSET);
         assert!(
             super::super::TrapDispatcher::region_contains_point(&bus, back_update, 80, 100),
             "the newly exposed back content must be invalidated"

--- a/src/trap/window.rs
+++ b/src/trap/window.rs
@@ -1,6 +1,7 @@
 //! Window Manager trap handlers.
 
 use crate::cpu::{CpuOps, Register};
+use crate::mac_roman::{decode_mac_roman, encode_mac_roman_lossy};
 use crate::memory::{MacMemoryBus, MemoryBus};
 use crate::trap::dispatch::{DrawOldState, PortDrawState, QueuedEvent};
 use crate::trap::quickdraw::RegionBooleanOp;
@@ -93,8 +94,7 @@ impl super::TrapDispatcher {
         } else {
             0
         };
-        let title =
-            String::from_utf8_lossy(&bus.read_bytes(ptr + 19, title_len as usize)).into_owned();
+        let title = decode_mac_roman(&bus.read_bytes(ptr + 19, title_len as usize));
         Some(WindTemplate {
             bounds: Self::read_rect(bus, ptr),
             proc_id: bus.read_word(ptr + 8) as i16,
@@ -2407,7 +2407,7 @@ impl super::TrapDispatcher {
         self.window_title = if title_handle != 0 {
             let title_ptr = bus.read_long(title_handle);
             if title_ptr != 0 {
-                String::from_utf8_lossy(&bus.read_pstring(title_ptr)).into_owned()
+                decode_mac_roman(&bus.read_pstring(title_ptr))
             } else {
                 String::new()
             }
@@ -2810,7 +2810,7 @@ impl super::TrapDispatcher {
 
         // Allocate a StringHandle for the title and store it in the window record.
         // Inside Macintosh Volume I, I-276: titleHandle is a StringHandle.
-        Self::set_title_handle(bus, window_ptr, wind_title.as_bytes());
+        Self::set_title_handle(bus, window_ptr, &encode_mac_roman_lossy(wind_title));
 
         // Window creation initializes the port as the current drawing target.
         // Individual NewWindow/NewCWindow callers restore the previous port
@@ -3078,7 +3078,7 @@ impl super::TrapDispatcher {
 
                 // Read title Pascal string
                 let title = if title_ptr != 0 {
-                    String::from_utf8_lossy(&bus.read_pstring(title_ptr)).into_owned()
+                    decode_mac_roman(&bus.read_pstring(title_ptr))
                 } else {
                     String::new()
                 };
@@ -3290,7 +3290,7 @@ impl super::TrapDispatcher {
                 let storage_ptr = bus.read_long(sp + 22);
 
                 let wind_title = if title_ptr != 0 {
-                    String::from_utf8_lossy(&bus.read_pstring(title_ptr)).into_owned()
+                    decode_mac_roman(&bus.read_pstring(title_ptr))
                 } else {
                     String::new()
                 };
@@ -3795,7 +3795,7 @@ impl super::TrapDispatcher {
                     let bytes = bus.read_pstring(title_ptr);
                     Self::set_title_handle(bus, the_window, &bytes);
                     if the_window == self.front_window {
-                        self.window_title = String::from_utf8_lossy(&bytes).into_owned();
+                        self.window_title = decode_mac_roman(&bytes);
                     }
                     if self.window_visible(bus, the_window) {
                         let hilited = bus.read_byte(the_window + Self::WINDOW_HILITED_OFFSET) != 0;
@@ -7004,6 +7004,18 @@ mod tests {
     }
 
     #[test]
+    fn wind_template_preserves_mac_roman_title_bytes() {
+        let (_disp, _cpu, mut bus) = setup();
+        let wind_ptr = bus.alloc(24);
+        bus.write_byte(wind_ptr + 18, 4);
+        bus.write_bytes(wind_ptr + 19, b"DLB\xAA");
+
+        let template = super::super::TrapDispatcher::parse_wind_template(&bus, wind_ptr, 23)
+            .expect("WIND template with Mac Roman title");
+        assert_eq!(template.title, "DLB™");
+    }
+
+    #[test]
     fn get_new_window_constructors_apply_center_main_screen_positioning() {
         for trap_num in [0x1BD, 0x246] {
             let (mut disp, mut cpu, mut bus) = setup();
@@ -8701,6 +8713,28 @@ mod tests {
         let result = dispatch(&mut disp, 0x11A, &mut cpu, &mut bus);
         assert!(result.unwrap().is_ok());
         assert_eq!(cpu.read_reg(Register::A7), TEST_SP);
+    }
+
+    #[test]
+    fn setwtitle_decodes_mac_roman_for_window_chrome() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let window = bus.alloc(256);
+        disp.front_window = window;
+        let title = bus.alloc(8);
+        bus.write_pstring(title, b"DLB\xAA");
+        let sp = TEST_SP - 8;
+        cpu.write_reg(Register::A7, sp);
+        bus.write_long(sp, title);
+        bus.write_long(sp + 4, window);
+
+        dispatch(&mut disp, 0x11A, &mut cpu, &mut bus)
+            .expect("SetWTitle dispatch")
+            .expect("SetWTitle");
+
+        assert_eq!(disp.window_title, "DLB™");
+        let handle =
+            bus.read_long(window + super::super::TrapDispatcher::WINDOW_TITLE_HANDLE_OFFSET);
+        assert_eq!(bus.read_pstring(bus.read_long(handle)), b"DLB\xAA");
     }
 
     #[test]


### PR DESCRIPTION
Closes #723

## Summary

- complete color-dialog and hierarchical-menu behavior required by the game
- implement classic tolerant palette allocation and exact 8-bit PICT color matching
- release superseded QuickDraw region storage so repeated region growth cannot corrupt the application stack
- preserve Mac Roman window-title bytes and render the trademark character through HLE text

## Validation

- `cargo fmt --check`
- `cargo test` (3,820 library tests, 65 desktop tests, 4 pack tests, and 1 doctest pass)
- deterministic play reaches tick 2796 after 632,170,282 guest instructions without a halt or invalid program counter
- the synchronized live-game content checkpoint matches the BasiliskII oracle at 96.18% strict pixels and 99.29% perceptual pixels over the 440×639 guest content rectangle
- later generated-play checkpoints remain deterministic and progress correctly; their play selection is clock-seeded, so the two runners can choose different valid plays when their launch timing differs