### PR TITLE
fix: complete The Tinies compatibility

### DIFF
--- a/src/loader/ppc.rs
+++ b/src/loader/ppc.rs
@@ -2561,7 +2561,7 @@ impl PpcInputSnapshot {
             return false;
         }
         let idx = (key_code / 8) as usize;
-        let bit = 1u8 << (key_code % 8);
+        let bit = 0x80u8 >> (key_code % 8);
         self.key_map[idx] & bit != 0
     }
 
@@ -79842,7 +79842,7 @@ mod tests {
         loaded.set_input_snapshot(PpcInputSnapshot {
             key_map: {
                 let mut key_map = [0; 16];
-                key_map[(PPC_KEY_SPACE / 8) as usize] |= 1u8 << (PPC_KEY_SPACE % 8);
+                key_map[(PPC_KEY_SPACE / 8) as usize] |= 0x80u8 >> (PPC_KEY_SPACE % 8);
                 key_map
             },
             ..PpcInputSnapshot::default()
@@ -107080,7 +107080,7 @@ mod tests {
         let mut loaded = load_pef_application(&pef).unwrap();
         let key_map_ptr = PPC_DATA_BASE + 0x1000;
         let mut input = PpcInputSnapshot::default();
-        input.key_map[(PPC_KEY_LEFT / 8) as usize] |= 1u8 << (PPC_KEY_LEFT % 8);
+        input.key_map[(PPC_KEY_LEFT / 8) as usize] |= 0x80u8 >> (PPC_KEY_LEFT % 8);
         loaded.set_input_snapshot(input);
         loaded
             .memory
@@ -107096,7 +107096,7 @@ mod tests {
                 .memory
                 .read_u8(key_map_ptr + u32::from(PPC_KEY_LEFT / 8))
                 .unwrap()
-                & (1u8 << (PPC_KEY_LEFT % 8)),
+                & (0x80u8 >> (PPC_KEY_LEFT % 8)),
             0
         );
 
@@ -109364,7 +109364,7 @@ mod tests {
         }
 
         let mut input = PpcInputSnapshot::default();
-        input.key_map[(PPC_KEY_LEFT / 8) as usize] |= 1u8 << (PPC_KEY_LEFT % 8);
+        input.key_map[(PPC_KEY_LEFT / 8) as usize] |= 0x80u8 >> (PPC_KEY_LEFT % 8);
         let action =
             dispatch_getkeys_import(&mut cpu, &mut memory, input, Some(&mut idle_poll_counts));
         assert_eq!(action, PpcImportAction::ReturnPreserve);
@@ -109477,7 +109477,7 @@ mod tests {
         let mut loaded = load_pef_application(&pef).unwrap();
         let key_map_ptr = PPC_DATA_BASE + 0x1000;
         let mut input = PpcInputSnapshot::default();
-        input.key_map[(PPC_KEY_LEFT / 8) as usize] |= 1u8 << (PPC_KEY_LEFT % 8);
+        input.key_map[(PPC_KEY_LEFT / 8) as usize] |= 0x80u8 >> (PPC_KEY_LEFT % 8);
         loaded.set_input_snapshot(input);
         loaded.memory.add_region(key_map_ptr, vec![0xcc; 4]);
         loaded.cpu.gpr[3] = key_map_ptr;
@@ -112075,7 +112075,7 @@ mod tests {
             b"Primary Trigger",
         );
         let mut input = PpcInputSnapshot::default();
-        input.key_map[(PPC_KEY_LEFT / 8) as usize] |= 1u8 << (PPC_KEY_LEFT % 8);
+        input.key_map[(PPC_KEY_LEFT / 8) as usize] |= 0x80u8 >> (PPC_KEY_LEFT % 8);
         loaded.set_input_snapshot(input);
         loaded.cpu.pc = loaded.entry_pc;
         loaded.imports[0].dispatcher_target = PpcImportDispatcherTarget::ISpElementGetSimpleState;
@@ -112306,7 +112306,7 @@ mod tests {
         assert_eq!(probe.unsupported_import_index, None);
         let element = loaded.memory.read_u32_be(elements_out_ptr).unwrap();
         let mut input = PpcInputSnapshot::default();
-        input.key_map[(PPC_KEY_LEFT / 8) as usize] |= 1u8 << (PPC_KEY_LEFT % 8);
+        input.key_map[(PPC_KEY_LEFT / 8) as usize] |= 0x80u8 >> (PPC_KEY_LEFT % 8);
         loaded.set_input_snapshot(input);
         loaded.cpu.pc = loaded.entry_pc;
         loaded.imports[0].dispatcher_target = PpcImportDispatcherTarget::ISpElementGetSimpleState;
@@ -112388,7 +112388,7 @@ mod tests {
         };
         let snapshot = |key: u8| {
             let mut input = PpcInputSnapshot::default();
-            input.key_map[(key / 8) as usize] |= 1u8 << (key % 8);
+            input.key_map[(key / 8) as usize] |= 0x80u8 >> (key % 8);
             input
         };
         let walk = ppc_isp_action_binding(PPC_ISP_ELEMENT_KIND_AXIS, Some("Walk"));
@@ -112450,7 +112450,7 @@ mod tests {
         let snapshot = |keys: &[u8]| {
             let mut input = PpcInputSnapshot::default();
             for &key in keys {
-                input.key_map[(key / 8) as usize] |= 1u8 << (key % 8);
+                input.key_map[(key / 8) as usize] |= 0x80u8 >> (key % 8);
             }
             input
         };
@@ -112606,7 +112606,7 @@ mod tests {
             ..PpcInputSprocketState::default()
         };
         let mut space = PpcInputSnapshot::default();
-        space.key_map[(PPC_KEY_SPACE / 8) as usize] |= 1u8 << (PPC_KEY_SPACE % 8);
+        space.key_map[(PPC_KEY_SPACE / 8) as usize] |= 0x80u8 >> (PPC_KEY_SPACE % 8);
         assert_eq!(
             ppc_isp_input_simple_state(
                 PPC_ISP_ELEMENT_KIND_BUTTON,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -12619,7 +12619,7 @@ mod tests {
         let ppc_app = runner.ppc_app.as_mut().expect("PPC app should stay loaded");
         let left_key = 0x7bu8;
         let left_byte = key_map_ptr + u32::from(left_key / 8);
-        let left_bit = 1u8 << (left_key % 8);
+        let left_bit = 0x80u8 >> (left_key % 8);
         assert_ne!(ppc_app.memory.read_u8(left_byte).unwrap() & left_bit, 0);
     }
 
@@ -13533,7 +13533,7 @@ mod tests {
 
         assert_eq!(
             runner.bus.read_byte(addr::KEY_MAP_LM + 4),
-            0x40,
+            0x02,
             "J key should be visible to byte/bit KeyMap readers"
         );
         assert_eq!(
@@ -13543,7 +13543,7 @@ mod tests {
         );
         assert_eq!(
             runner.bus.read_byte(addr::KEY_MAP_LM + 15),
-            0x40,
+            0x02,
             "up arrow should be visible to byte/bit KeyMap readers"
         );
         assert_eq!(
@@ -13566,7 +13566,7 @@ mod tests {
         );
         assert_eq!(
             runner.bus.read_byte(addr::KEY_MAP_LM + 15),
-            0x40,
+            0x02,
             "unrelated byte/bit down keys should remain mirrored"
         );
         assert_eq!(
@@ -13584,18 +13584,18 @@ mod tests {
         let caps_lock_byte = addr::KEY_MAP_LM + 7;
 
         runner.push_key_down(0x39, 0);
-        assert_eq!(runner.bus.read_byte(caps_lock_byte) & 0x02, 0x02);
+        assert_eq!(runner.bus.read_byte(caps_lock_byte) & 0x40, 0x40);
         runner.push_key_up(0x39, 0);
         assert_eq!(
-            runner.bus.read_byte(caps_lock_byte) & 0x02,
-            0x02,
+            runner.bus.read_byte(caps_lock_byte) & 0x40,
+            0x40,
             "physical release must keep the low-memory Caps Lock bit latched"
         );
 
         runner.push_key_down(0x39, 0);
-        assert_eq!(runner.bus.read_byte(caps_lock_byte) & 0x02, 0);
+        assert_eq!(runner.bus.read_byte(caps_lock_byte) & 0x40, 0);
         runner.push_key_up(0x39, 0);
-        assert_eq!(runner.bus.read_byte(caps_lock_byte) & 0x02, 0);
+        assert_eq!(runner.bus.read_byte(caps_lock_byte) & 0x40, 0);
     }
 
     #[test]

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -1356,6 +1356,10 @@ pub struct TrapDispatcher {
     /// U.S. Roman keyboard-layout resource ID 0 is present in every
     /// System file and is used directly by apps that call KeyTranslate.
     pub(crate) system_kchr_cache: HashMap<i16, u32>,
+    /// Cache of the synthetic standard `'KMAP'` ID 0 resource. Classic apps
+    /// may read its 128-byte hardware-to-virtual-key map directly when
+    /// implementing configurable controls.
+    pub(crate) system_kmap_cache: HashMap<i16, u32>,
     /// Cache of synthetic ROM `'WDEF'` resource pointers. WDEF IDs 0 and 1
     /// are the standard document and rounded-window definition functions.
     /// Their behavior is implemented by the Window Manager HLE, but callers
@@ -3040,6 +3044,7 @@ impl TrapDispatcher {
             system_cursor_cache: HashMap::new(),
             system_clut_cache: HashMap::new(),
             system_kchr_cache: HashMap::new(),
+            system_kmap_cache: HashMap::new(),
             system_wdef_cache: HashMap::new(),
             system_mdef_cache: HashMap::new(),
             tool_trap_trampolines: HashMap::new(),
@@ -5626,8 +5631,9 @@ impl TrapDispatcher {
 
     /// Allocate (and cache) the standard U.S. Roman keyboard-layout
     /// resource (`'KCHR'` ID 0). Inside Macintosh: Text 1993, C-18..C-19
-    /// defines the resource as a version byte, a 256-byte table-selection
-    /// index, and 128-byte character-mapping tables keyed by virtual key code.
+    /// defines the resource as a version word, a 256-byte table-selection
+    /// index, a table-count word, 128-byte character-mapping tables keyed by
+    /// virtual key code, and a dead-key-count word.
     pub(crate) fn synthesize_system_kchr(
         &mut self,
         bus: &mut MacMemoryBus,
@@ -5641,12 +5647,16 @@ impl TrapDispatcher {
         }
 
         const TABLES: usize = 2;
-        const TABLE_BASE: usize = 1 + 256;
-        const LEN: usize = TABLE_BASE + TABLES * 128;
+        const TABLE_COUNT_OFFSET: usize = 2 + 256;
+        const TABLE_BASE: usize = TABLE_COUNT_OFFSET + 2;
+        const DEAD_KEY_COUNT_OFFSET: usize = TABLE_BASE + TABLES * 128;
+        const LEN: usize = DEAD_KEY_COUNT_OFFSET + 2;
         let mut body = vec![0u8; LEN];
         for modifier in 0..=255usize {
-            body[1 + modifier] = if (modifier & 0x22) != 0 { 1 } else { 0 };
+            body[2 + modifier] = if (modifier & 0x22) != 0 { 1 } else { 0 };
         }
+        body[TABLE_COUNT_OFFSET..TABLE_COUNT_OFFSET + 2]
+            .copy_from_slice(&(TABLES as u16).to_be_bytes());
 
         let normal = TABLE_BASE;
         let shifted = TABLE_BASE + 128;
@@ -5700,6 +5710,10 @@ impl TrapDispatcher {
             (0x2F, b'.', b'>'),
             (0x31, b' ', b' '),
             (0x32, b'`', b'~'),
+            (0x7B, 0x1C, 0x1C),
+            (0x7C, 0x1D, 0x1D),
+            (0x7D, 0x1F, 0x1F),
+            (0x7E, 0x1E, 0x1E),
         ];
         for &(vk, unshifted, shifted_char) in keys {
             body[normal + vk] = unshifted;
@@ -5712,6 +5726,40 @@ impl TrapDispatcher {
         }
         bus.write_bytes(ptr, &body);
         self.system_kchr_cache.insert(res_id, ptr);
+        Some(ptr)
+    }
+
+    /// Allocate (and cache) the standard keycode-map resource (`'KMAP'` ID
+    /// 0). Its four-byte ID/version header is followed by the 128-entry
+    /// hardware-to-virtual-key map and a zero exception-array count. The
+    /// standard ADB map is identity-valued; exceptional keyboards describe
+    /// their remapping in the optional records. Macintosh Technical Note 160.
+    pub(crate) fn synthesize_system_kmap(
+        &mut self,
+        bus: &mut MacMemoryBus,
+        res_id: i16,
+    ) -> Option<u32> {
+        if let Some(&ptr) = self.system_kmap_cache.get(&res_id) {
+            return Some(ptr);
+        }
+        if res_id != 0 {
+            return None;
+        }
+
+        const HEADER_SIZE: usize = 4;
+        const MAP_SIZE: usize = 128;
+        const LEN: usize = HEADER_SIZE + MAP_SIZE + 2;
+        let mut body = vec![0u8; LEN];
+        for keycode in 0..MAP_SIZE {
+            body[HEADER_SIZE + keycode] = keycode as u8;
+        }
+
+        let ptr = bus.alloc(body.len() as u32);
+        if ptr == 0 {
+            return None;
+        }
+        bus.write_bytes(ptr, &body);
+        self.system_kmap_cache.insert(res_id, ptr);
         Some(ptr)
     }
 

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -185,7 +185,10 @@ fn key_map_byte_mask(key_code: u8) -> Option<(usize, u8)> {
     if byte_idx >= 16 {
         return None;
     }
-    let mask = 1u8 << (key_code & 0x07);
+    // `KeyMap` is a Pascal `PACKED ARRAY[0..127] OF Boolean`, whose
+    // elements occupy each byte from its most-significant bit downward.
+    // Inside Macintosh: Macintosh Toolbox Essentials (1992), p. 2-109.
+    let mask = 0x80u8 >> (key_code & 0x07);
     Some((byte_idx, mask))
 }
 
@@ -5732,8 +5735,9 @@ impl TrapDispatcher {
     /// Allocate (and cache) the standard keycode-map resource (`'KMAP'` ID
     /// 0). Its four-byte ID/version header is followed by the 128-entry
     /// hardware-to-virtual-key map and a zero exception-array count. The
-    /// standard ADB map is identity-valued; exceptional keyboards describe
-    /// their remapping in the optional records. Macintosh Technical Note 160.
+    /// standard map translates Control and the four cursor keys between the
+    /// original and ADB virtual-key assignments; all other entries are
+    /// identity-valued. Inside Macintosh: Text (1993), pp. C-11..C-15.
     pub(crate) fn synthesize_system_kmap(
         &mut self,
         bus: &mut MacMemoryBus,
@@ -5752,6 +5756,19 @@ impl TrapDispatcher {
         let mut body = vec![0u8; LEN];
         for keycode in 0..MAP_SIZE {
             body[HEADER_SIZE + keycode] = keycode as u8;
+        }
+        for (raw, virtual_key) in [
+            (0x36usize, 0x3Bu8),
+            (0x3B, 0x7B),
+            (0x3C, 0x7C),
+            (0x3D, 0x7D),
+            (0x3E, 0x7E),
+            (0x7B, 0x3C),
+            (0x7C, 0x3D),
+            (0x7D, 0x3E),
+            (0x7E, 0x36),
+        ] {
+            body[HEADER_SIZE + raw] = virtual_key;
         }
 
         let ptr = bus.alloc(body.len() as u32);

--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -9186,7 +9186,7 @@ mod tests {
     }
 
     #[test]
-    fn get_resource_synthesizes_standard_identity_kmap_id_zero() {
+    fn get_resource_synthesizes_standard_adb_kmap_id_zero() {
         let (mut disp, mut cpu, mut bus) = setup();
 
         let sp = TEST_SP;
@@ -9201,11 +9201,26 @@ mod tests {
         assert_eq!(bus.get_alloc_size(kmap), Some(4 + 128 + 2));
         assert_eq!(bus.read_word(kmap), 0, "KMAP identifier");
         assert_eq!(bus.read_word(kmap + 2), 0, "KMAP version");
+        let remapped = [
+            (0x36u32, 0x3Bu8),
+            (0x3B, 0x7B),
+            (0x3C, 0x7C),
+            (0x3D, 0x7D),
+            (0x3E, 0x7E),
+            (0x7B, 0x3C),
+            (0x7C, 0x3D),
+            (0x7D, 0x3E),
+            (0x7E, 0x36),
+        ];
         for keycode in 0..128u32 {
+            let expected = remapped
+                .iter()
+                .find_map(|&(raw, virtual_key)| (raw == keycode).then_some(virtual_key))
+                .unwrap_or(keycode as u8);
             assert_eq!(
                 bus.read_byte(kmap + 4 + keycode),
-                keycode as u8,
-                "standard keycode {keycode} should map to itself"
+                expected,
+                "standard raw keycode {keycode:#04X} should use its ADB virtual-key mapping"
             );
         }
         assert_eq!(bus.read_word(kmap + 4 + 128), 0, "KMAP exception count");

--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -1824,6 +1824,18 @@ impl super::TrapDispatcher {
                     }
                 }
 
+                if res_type == *b"KMAP" {
+                    if let Some(ptr) = self.synthesize_system_kmap(bus, res_id) {
+                        let handle = self.get_or_create_resource_handle(bus, res_type, res_id, ptr);
+                        cpu.write_reg(Register::A0, handle);
+                        cpu.write_reg(Register::D0, 0);
+                        bus.write_word(0x0A60, 0); // ResErr = noErr
+                        bus.write_long(sp + 6, handle);
+                        cpu.write_reg(Register::A7, sp + 6);
+                        return Some(Ok(()));
+                    }
+                }
+
                 cpu.write_reg(Register::A0, 0);
                 cpu.write_reg(Register::D0, 0);
                 bus.write_word(0x0A60, 0);
@@ -9136,30 +9148,67 @@ mod tests {
 
         let kchr = bus.read_long(handle);
         assert_ne!(kchr, 0, "synthetic KCHR handle must be loaded");
-        assert_eq!(bus.get_alloc_size(kchr), Some(1 + 256 + 128 * 2));
-        assert_eq!(bus.read_byte(kchr), 0, "KCHR version byte");
+        assert_eq!(bus.get_alloc_size(kchr), Some(2 + 256 + 2 + 128 * 2 + 2));
+        assert_eq!(bus.read_word(kchr), 0, "KCHR version word");
         assert_eq!(
-            bus.read_byte(kchr + 1),
+            bus.read_byte(kchr + 2),
             0,
             "modifier byte 0 should select the unshifted table"
         );
         assert_eq!(
-            bus.read_byte(kchr + 2),
+            bus.read_byte(kchr + 3),
             0,
             "modifier byte 1 is Command-only and should stay unshifted"
         );
         assert_eq!(
-            bus.read_byte(kchr + 3),
+            bus.read_byte(kchr + 4),
             1,
             "modifier byte 2 should select the shifted table"
         );
 
-        let table0 = kchr + 1 + 256;
+        assert_eq!(bus.read_word(kchr + 2 + 256), 2, "KCHR table count");
+        let table0 = kchr + 2 + 256 + 2;
         let table1 = table0 + 128;
         assert_eq!(bus.read_byte(table0), b'a');
         assert_eq!(bus.read_byte(table1), b'A');
         assert_eq!(bus.read_byte(table0 + 0x0C), b'q');
         assert_eq!(bus.read_byte(table1 + 0x0C), b'Q');
+        assert_eq!(bus.read_byte(table0 + 0x7B), 0x1C, "left arrow");
+        assert_eq!(bus.read_byte(table0 + 0x7C), 0x1D, "right arrow");
+        assert_eq!(bus.read_byte(table0 + 0x7D), 0x1F, "down arrow");
+        assert_eq!(bus.read_byte(table0 + 0x7E), 0x1E, "up arrow");
+        assert_eq!(
+            bus.read_bytes(table1 + 0x7B, 4),
+            vec![0x1C, 0x1D, 0x1F, 0x1E],
+            "shifted arrow translations should remain navigation characters"
+        );
+        assert_eq!(bus.read_word(table1 + 128), 0, "KCHR dead-key count");
+    }
+
+    #[test]
+    fn get_resource_synthesizes_standard_identity_kmap_id_zero() {
+        let (mut disp, mut cpu, mut bus) = setup();
+
+        let sp = TEST_SP;
+        bus.write_word(sp, 0);
+        bus.write_long(sp + 2, u32::from_be_bytes(*b"KMAP"));
+
+        call(&mut disp, true, 0x1A0, &mut cpu, &mut bus).unwrap();
+
+        let handle = bus.read_long(TEST_SP + 6);
+        assert_ne!(handle, 0, "synthetic KMAP must return a handle");
+        let kmap = bus.read_long(handle);
+        assert_eq!(bus.get_alloc_size(kmap), Some(4 + 128 + 2));
+        assert_eq!(bus.read_word(kmap), 0, "KMAP identifier");
+        assert_eq!(bus.read_word(kmap + 2), 0, "KMAP version");
+        for keycode in 0..128u32 {
+            assert_eq!(
+                bus.read_byte(kmap + 4 + keycode),
+                keycode as u8,
+                "standard keycode {keycode} should map to itself"
+            );
+        }
+        assert_eq!(bus.read_word(kmap + 4 + 128), 0, "KMAP exception count");
     }
 
     #[test]

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -4509,9 +4509,11 @@ impl super::TrapDispatcher {
     /// The caller supplies a pointer to a `'KCHR'` resource. The
     /// layout used here follows the documented structure from Inside
     /// Macintosh: Macintosh Toolbox Essentials / Text:
-    ///   - byte 0: version
-    ///   - bytes 1..=256: table-selection index keyed by the modifier byte
+    ///   - bytes 0..=1: version
+    ///   - bytes 2..=257: table-selection index keyed by the modifier byte
+    ///   - bytes 258..=259: character-mapping table count
     ///   - character-mapping tables: 128 bytes per table
+    ///   - a trailing dead-key-record count
     ///
     /// The helper only implements the straight-through character
     /// mapping path. If no translation data is supplied, it falls
@@ -4542,8 +4544,12 @@ impl super::TrapDispatcher {
             };
         }
 
-        let table_code = bus.read_byte(trans_data + 1 + modifier_byte) as u32;
-        let table_base = trans_data + 1 + 256 + table_code * 128;
+        let table_code = bus.read_byte(trans_data + 2 + modifier_byte) as u32;
+        let table_count = u32::from(bus.read_word(trans_data + 2 + 256));
+        if table_code >= table_count {
+            return 0;
+        }
+        let table_base = trans_data + 2 + 256 + 2 + table_code * 128;
         let result = bus.read_byte(table_base + vk) as u32;
         if result != 0 {
             return result;
@@ -19849,19 +19855,22 @@ mod tests {
 
     fn seed_synthetic_kchr(bus: &mut super::MacMemoryBus, trans_data: u32) {
         // Minimal KCHR layout:
-        //   byte 0 = version
-        //   bytes 1..=256 = table-selection index
+        //   bytes 0..=1 = version
+        //   bytes 2..=257 = table-selection index
+        //   table-count word
         //   table 0 and table 1 = 128-byte character tables
+        //   dead-key-count word
         //
         // Modifier byte 0 selects table 0; modifier byte 1 selects table 1.
-        bus.write_byte(trans_data, 0);
+        bus.write_word(trans_data, 0);
         for i in 0..256u32 {
-            bus.write_byte(trans_data + 1 + i, 0);
+            bus.write_byte(trans_data + 2 + i, 0);
         }
-        bus.write_byte(trans_data + 1, 0);
-        bus.write_byte(trans_data + 2, 1);
+        bus.write_byte(trans_data + 2, 0);
+        bus.write_byte(trans_data + 3, 1);
 
-        let table0 = trans_data + 1 + 256;
+        bus.write_word(trans_data + 2 + 256, 2);
+        let table0 = trans_data + 2 + 256 + 2;
         let table1 = table0 + 128;
         bus.write_byte(table0 + 2, b'Q');
         bus.write_byte(table0 + 3, b'W');
@@ -19873,6 +19882,7 @@ mod tests {
         bus.write_byte(table1 + 4, b'C');
         bus.write_byte(table1 + 5, b'V');
         bus.write_byte(table1 + 6, b'B');
+        bus.write_word(table1 + 128, 0);
     }
 
     // KeyTrans ($A9C3)

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -18004,14 +18004,14 @@ mod tests {
         assert!(disp.key_is_down(0x26));
         assert!(disp.key_is_down(0x7E));
         assert!(!disp.key_is_down(0x2E), "J must not alias the M key");
-        assert_eq!(bus.read_byte(keys_ptr + 4), 0x40, "J key byte");
+        assert_eq!(bus.read_byte(keys_ptr + 4), 0x02, "J key byte");
         assert_eq!(
             bus.read_byte(keys_ptr + 5),
             0,
             "M key byte should stay clear when J is down"
         );
-        assert_eq!(bus.read_byte(keys_ptr + 6), 0x02, "space key byte");
-        assert_eq!(bus.read_byte(keys_ptr + 15), 0x48, "left/up arrow key byte");
+        assert_eq!(bus.read_byte(keys_ptr + 6), 0x40, "space key byte");
+        assert_eq!(bus.read_byte(keys_ptr + 15), 0x12, "left/up arrow key byte");
         assert_eq!(
             bus.read_byte(keys_ptr + 14),
             0,
@@ -18028,7 +18028,7 @@ mod tests {
         assert!(disp.key_is_down(0x31));
         assert!(disp.key_is_down(0x26));
         assert!(disp.key_is_down(0x7E));
-        assert_eq!(bus.read_byte(keys_ptr + 15), 0x40, "only up remains");
+        assert_eq!(bus.read_byte(keys_ptr + 15), 0x02, "only up remains");
 
         // J ($26) and M ($2E) differ only by KeyMap byte. This catches the
         // byte-pair swap that makes EV/Marathon direct pollers invert them.
@@ -18041,7 +18041,7 @@ mod tests {
         assert!(!disp.key_is_down(0x26));
         assert!(disp.key_is_down(0x2E));
         assert_eq!(bus.read_byte(keys_ptr + 4), 0, "J byte should be clear");
-        assert_eq!(bus.read_byte(keys_ptr + 5), 0x40, "M key byte");
+        assert_eq!(bus.read_byte(keys_ptr + 5), 0x02, "M key byte");
     }
 
     // GetMouse ($A972)


### PR DESCRIPTION
Closes #726

## Summary

- synthesize the standard KCHR and KMAP resources with their documented headers, tables, cursor/control remappings, and terminators
- encode the classic `KeyMap` packed Boolean array in Pascal MSB-first bit order across 68K low memory, `GetKeys`, and PowerPC input snapshots
- retain the tolerant palette allocation and exact 8-bit PICT matching supplied by the parent compatibility branch
- add focused coverage for KCHR translation, the standard ADB KMAP, low-memory key state, and PowerPC consumers

## Validation

- `cargo fmt --check`
- `cargo test` (3,821 library tests, 65 desktop tests, 4 pack tests, and 1 doctest pass)
- deterministic play configures D/A/W/S/F controls, starts level 1, selects and moves the Tiny to its sleeper, pauses and resumes, and reaches the level-completion banner after 433,676,381 guest instructions
- the same 118-action script completes under BasiliskII; eight checkpoints match at 98.80% strict pixels and 98.87% perceptual pixels overall (the lowest individual checkpoint is 94.72% strict)