### PR TITLE
fix: improve Spaceward Ho compatibility

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -5026,6 +5026,29 @@ impl FixtureRunner {
                         continue;
                     }
                     if completed_modal_dialog_draw_proc {
+                        let dialog_ptr = self
+                            .dispatcher
+                            .dialog_tracking
+                            .as_ref()
+                            .map(|tracking| tracking.dialog_ptr)
+                            .unwrap_or(0);
+                        let after_trap_pc = self.cpu.read_reg(Register::PC);
+                        self.cpu
+                            .write_reg(Register::PC, after_trap_pc.wrapping_sub(2));
+                        if self.dispatcher.arm_dialog_control_def_draws(
+                            &mut self.cpu,
+                            &mut self.bus,
+                            dialog_ptr,
+                        ) {
+                            self.dispatcher
+                                .dialog_cdef_draw_pending_snapshot
+                                .insert(dialog_ptr);
+                            if let Some(tracking) = self.dispatcher.dialog_tracking.as_mut() {
+                                tracking.rendered_pixels_final = false;
+                            }
+                            continue;
+                        }
+                        self.cpu.write_reg(Register::PC, after_trap_pc);
                         // The callback completion check already proved that
                         // PC/SP are ModalDialog's exact resume boundary. Do
                         // not let an older deferred tracking address redirect
@@ -8951,7 +8974,7 @@ impl FixtureRunner {
             return false;
         }
         let entry = self.bus.read_word(addr);
-        entry == 0x4E56 || entry == 0x48E7 || entry == 0x4EF9 || entry == 0x4EFA
+        entry == 0x4E56 || entry == 0x48E7 || entry == 0x4EF9 || entry == 0x4EFA || entry == 0x4FEF
     }
 
     fn resolve_dialog_draw_proc_addr(&self, proc_addr: u32) -> Option<u32> {
@@ -19182,6 +19205,16 @@ mod tests {
         );
         assert_eq!(runner.cpu.read_reg(Register::PC), interrupted_pc);
         assert_eq!(runner.cpu.read_reg(Register::A7), interrupted_sp);
+    }
+
+    #[test]
+    fn dialog_draw_proc_accepts_stack_adjust_entry() {
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        let proc_addr = 0x0004_2000u32;
+        runner.bus.write_word(proc_addr, 0x4FEF); // LEA d16(SP),SP
+        runner.bus.write_word(proc_addr + 2, 0xFFF0);
+
+        assert!(runner.looks_like_dialog_proc_entry(proc_addr));
     }
 
     #[test]

--- a/src/trap/control.rs
+++ b/src/trap/control.rs
@@ -429,6 +429,7 @@ impl super::TrapDispatcher {
         if dialog_ptr == 0 {
             return false;
         }
+        let dialog_visible = self.window_visible(bus, dialog_ptr);
         let vis_rgn = bus.read_long(dialog_ptr + 24);
         if Self::region_handle_rect(bus, vis_rgn).is_none() {
             return false;
@@ -463,7 +464,7 @@ impl super::TrapDispatcher {
         // composition cannot restore the pre-CDEF shell over the artwork.
         self.refresh_visible_dialog_snapshot_for_port(bus, dialog_ptr);
         let armed = self.arm_control_def_call_chain(cpu, bus, &calls);
-        if armed {
+        if armed && dialog_visible {
             self.dialog_cdefs_initially_drawn.insert(dialog_ptr);
         }
         armed
@@ -4358,6 +4359,7 @@ mod tests {
         let title_ptr = bus.alloc(16);
         let proc_id = (160i16 << 4) | 5;
         let cdef_proc = disp.install_test_resource(&mut bus, *b"CDEF", 160, &[0x4E, 0x56, 0, 0]);
+        bus.write_byte(window_ptr + 110, 0xFF);
 
         for (offset, value) in [10i16, 20, 40, 100].into_iter().enumerate() {
             bus.write_word(bounds_ptr + offset as u32 * 2, value as u16);

--- a/src/trap/dialog.rs
+++ b/src/trap/dialog.rs
@@ -7232,6 +7232,29 @@ impl super::TrapDispatcher {
             self.dialog_visible_snapshots
                 .insert(port, PersistentDialogSnapshot { bounds, pixels });
         }
+
+        // ModalDialog restores `rendered_pixels` between guest callbacks and
+        // UI slices. Fold incremental QuickDraw operations (not only bulk
+        // CopyBits/DrawPicture calls) into that active snapshot, otherwise a
+        // custom CDEF that builds its control from DrawString/FrameRect calls
+        // loses each operation before the callback has finished.
+        let tracking_bounds = self
+            .dialog_tracking
+            .as_ref()
+            .filter(|tracking| tracking.dialog_ptr == port)
+            .map(|tracking| tracking.bounds);
+        if let Some(bounds) = tracking_bounds {
+            let screen_params = self.get_screen_params();
+            if let Some(tracking) = self.dialog_tracking.as_mut() {
+                Self::refresh_saved_pixel_buffer_after_screen_draw(
+                    bus,
+                    screen_params,
+                    bounds,
+                    screen_rect,
+                    &mut tracking.rendered_pixels,
+                );
+            }
+        }
     }
 
     pub(crate) fn refresh_visible_dialog_snapshot_after_bulk_port_draw(
@@ -7345,24 +7368,26 @@ impl super::TrapDispatcher {
         let dialog_ptr = tracking.dialog_ptr;
         let popup_draws = tracking.popup_draws.clone();
         let game_managed = tracking.game_managed;
+        let cdef_draw_pending_snapshot = self.dialog_cdef_draw_pending_snapshot.remove(&dialog_ptr);
 
         if !game_managed {
             if self.front_window == dialog_ptr {
                 self.blit_window_to_screen(bus);
             }
-            self.redraw_standard_dialog_items(
-                bus,
-                bounds,
-                &items,
-                default_item,
-                &edit_text,
-                edit_item,
-                dialog_ptr,
-            );
+            if !cdef_draw_pending_snapshot {
+                self.redraw_standard_dialog_items(
+                    bus,
+                    bounds,
+                    &items,
+                    default_item,
+                    &edit_text,
+                    edit_item,
+                    dialog_ptr,
+                );
+            }
         }
         self.redraw_dialog_popup_controls(bus, &popup_draws);
         let rendered = self.save_dialog_pixels(bus, bounds);
-
         if let Some(tracking) = self.dialog_tracking.as_mut() {
             tracking.rendered_pixels = rendered;
             tracking.rendered_pixels_final = true;
@@ -10232,6 +10257,14 @@ impl super::TrapDispatcher {
         Self::rects_intersect(Self::dialog_item_screen_rect(bounds, item.rect), bounds)
     }
 
+    fn dialog_user_item_proc_is_callable(bus: &MacMemoryBus, proc_ptr: u32) -> bool {
+        proc_ptr != 0
+            && matches!(
+                bus.read_word(proc_ptr),
+                0x4E56 | 0x48E7 | 0x4EF9 | 0x4EFA | 0x4FEF
+            )
+    }
+
     fn dialog_is_game_managed(bounds: (i16, i16, i16, i16), items: &[DialogItem]) -> bool {
         let mut has_visible_item = false;
         for item in items {
@@ -13059,6 +13092,7 @@ impl super::TrapDispatcher {
                             .filter(|(i, item)| {
                                 let item_no = (*i + 1) as i16;
                                 (item.item_type & 0x7F) == 0
+                                    && !Self::dialog_user_item_proc_is_callable(bus, item.proc_ptr)
                                     && !self
                                         .dialog_item_popup_menus
                                         .contains_key(&(dialog_ptr, item_no))
@@ -13091,7 +13125,9 @@ impl super::TrapDispatcher {
                             .enumerate()
                             .filter_map(|(i, item)| {
                                 let item_no = (i + 1) as i16;
-                                if (item.item_type & 0x7F) != 0 {
+                                if (item.item_type & 0x7F) != 0
+                                    || Self::dialog_user_item_proc_is_callable(bus, item.proc_ptr)
+                                {
                                     return None;
                                 }
                                 let key = (dialog_ptr, item_no);
@@ -13206,20 +13242,22 @@ impl super::TrapDispatcher {
                             active_button: None,
                             active_user_item: None,
                         });
-                        // ModalDialog is a re-fire trap. Run application CDEF
-                        // draws after the HLE shell becomes visible, then
-                        // resume at the trap instruction so the next pass can
-                        // snapshot the guest-owned pixels before event
-                        // handling continues.
+                        // ModalDialog is a re-fire trap. Custom userItem draw
+                        // procedures are part of the dialog update pass and
+                        // run before Control Manager CDEF drawing. When there
+                        // are no userItems, run CDEFs immediately; otherwise
+                        // the runner arms them after the final userItem returns.
                         let after_trap_pc = cpu.read_reg(Register::PC);
-                        cpu.write_reg(Register::PC, after_trap_pc.wrapping_sub(2));
-                        if self.arm_dialog_control_def_draws(cpu, bus, dialog_ptr) {
-                            self.dialog_cdef_draw_pending_snapshot.insert(dialog_ptr);
-                            if let Some(tracking) = self.dialog_tracking.as_mut() {
-                                tracking.rendered_pixels_final = false;
+                        if !has_draw_procs {
+                            cpu.write_reg(Register::PC, after_trap_pc.wrapping_sub(2));
+                            if self.arm_dialog_control_def_draws(cpu, bus, dialog_ptr) {
+                                self.dialog_cdef_draw_pending_snapshot.insert(dialog_ptr);
+                                if let Some(tracking) = self.dialog_tracking.as_mut() {
+                                    tracking.rendered_pixels_final = false;
+                                }
+                            } else {
+                                cpu.write_reg(Register::PC, after_trap_pc);
                             }
-                        } else {
-                            cpu.write_reg(Register::PC, after_trap_pc);
                         }
                         self.record_modal_dialog_input_trace(
                             "start",
@@ -16934,6 +16972,18 @@ mod tests {
     use crate::trap::TrapDispatcher;
     use crate::ui_theme::UiThemeId;
     use std::collections::VecDeque;
+
+    #[test]
+    fn callable_user_item_proc_includes_stack_adjust_entry() {
+        let (_, _, mut bus) = setup();
+        let proc_ptr = bus.alloc(4);
+        bus.write_word(proc_ptr, 0x4FEF); // LEA d16(SP),SP
+        bus.write_word(proc_ptr + 2, 0xFFF0);
+
+        assert!(TrapDispatcher::dialog_user_item_proc_is_callable(
+            &bus, proc_ptr
+        ));
+    }
 
     fn screen_pixel_is_set(bus: &MacMemoryBus, base: u32, row_bytes: u32, x: i16, y: i16) -> bool {
         let byte = bus.read_byte(base + (y as u32 * row_bytes) + ((x as u32) / 8));
@@ -26733,6 +26783,14 @@ mod tests {
         let later_probe = screen_base + 16 * 64 + 16;
         bus.write_byte(later_probe, 0x77);
         disp.refresh_visible_dialog_snapshot_region_for_port(&bus, dialog_ptr, (16, 16, 17, 17));
+        let later_index = (16 - bounds.0 + TrapDispatcher::DBOX_FRAME_MARGIN) as usize
+            * snapshot_width
+            + (16 - bounds.1 + TrapDispatcher::DBOX_FRAME_MARGIN) as usize;
+        assert_eq!(
+            disp.dialog_tracking.as_ref().unwrap().rendered_pixels[later_index],
+            0x77,
+            "incremental guest drawing must immediately update the active modal snapshot"
+        );
         disp.dialog_tracking.as_mut().unwrap().last_filter_event = None;
 
         cpu.write_reg(Register::A7, TEST_SP);
@@ -26745,9 +26803,6 @@ mod tests {
         let bulk_index = (15 - bounds.0 + TrapDispatcher::DBOX_FRAME_MARGIN) as usize
             * snapshot_width
             + (15 - bounds.1 + TrapDispatcher::DBOX_FRAME_MARGIN) as usize;
-        let later_index = (16 - bounds.0 + TrapDispatcher::DBOX_FRAME_MARGIN) as usize
-            * snapshot_width
-            + (16 - bounds.1 + TrapDispatcher::DBOX_FRAME_MARGIN) as usize;
         assert_eq!(tracking.rendered_pixels[bulk_index], 0x44);
         assert_eq!(tracking.rendered_pixels[later_index], 0x77);
     }
@@ -31374,9 +31429,11 @@ mod tests {
             active_button: None,
             active_user_item: None,
         });
+        disp.dialog_cdef_draw_pending_snapshot.insert(dialog_ptr);
 
         disp.finalize_dialog_draw_procs_if_idle(&mut bus);
 
+        assert!(!disp.dialog_cdef_draw_pending_snapshot.contains(&dialog_ptr));
         let tracking = disp.dialog_tracking.as_ref().unwrap();
         assert!(tracking.draw_procs_done);
         assert!(tracking.rendered_pixels_final);

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -3089,10 +3089,9 @@ impl TrapDispatcher {
             pm_fg_color: None,
             pm_bg_color: None,
             makergbpat_colors: HashMap::new(),
-            // Default HiliteRGB used before an application calls HiliteColor.
-            // The System 7.5.3 BasiliskII reference resolves this to EV's
-            // darker selected-list green rather than a saturated primary.
-            hilite_color: (0x0000, 0x8000, 0x0000),
+            // Classic default HiliteRGB used before an application calls
+            // HiliteColor. Applications can replace it per color port.
+            hilite_color: (0x0000, 0x0000, 0x0000),
             op_color: (0x0000, 0x0000, 0x0000),
             char_extra: 0,
             bk_pat: [0x00; 8],

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -1272,6 +1272,9 @@ pub struct TrapDispatcher {
     /// Address of the lazily-allocated trampoline template used by the
     /// Window Manager to call a guest WDEF procedure.
     pub(crate) window_def_trampoline: u32,
+    /// Return PCs of the private CalcVis calls inserted between a custom
+    /// WDEF's wCalcRgns and wDraw callbacks.
+    pub(crate) window_def_calcvis_return_pcs: HashSet<u32>,
     /// Address of the lazily-allocated trampoline template used by the
     /// Control Manager to call a guest CDEF procedure.
     pub(crate) control_def_trampoline: u32,
@@ -3024,6 +3027,7 @@ impl TrapDispatcher {
             device_loop_trampoline: 0,
             list_def_trampoline: 0,
             window_def_trampoline: 0,
+            window_def_calcvis_return_pcs: HashSet::new(),
             control_def_trampoline: 0,
             control_def_trampoline_chain: Vec::new(),
             defer_user_fn_trampoline: 0,
@@ -5578,9 +5582,9 @@ impl TrapDispatcher {
     /// window definition functions. The Window Manager HLE implements their
     /// drawing and hit-testing behavior for built-in procIDs. A direct guest
     /// call still has to honor the Pascal WDEF ABI, however: four parameters
-    /// occupy 12 bytes and the caller reserves a 4-byte result. The shim
-    /// discards those parameters, clears the result to the documented default
-    /// of zero, and returns through the saved JSR address. Macintosh Toolbox
+    /// occupy 12 bytes and the caller reserves a 4-byte result. The shim enters
+    /// the HLE through its private Debugger marker, returns D0 through the
+    /// result slot, and resumes through the saved JSR address. Macintosh Toolbox
     /// Essentials (1992), pp. 4-145..4-146; Inside Macintosh Volume V,
     /// V-31..V-32.
     pub(crate) fn synthesize_system_wdef(
@@ -5595,12 +5599,13 @@ impl TrapDispatcher {
             return None;
         }
 
-        let ptr = bus.alloc(10);
-        bus.write_word(ptr, 0x205F); // MOVEA.L (SP)+,A0 — recover JSR return PC.
-        bus.write_word(ptr + 2, 0xDEFC); // ADDA.W #12,SP — discard WDEF parameters.
-        bus.write_word(ptr + 4, 12);
-        bus.write_word(ptr + 6, 0x4297); // CLR.L (SP) — LongInt function result.
-        bus.write_word(ptr + 8, 0x4ED0); // JMP (A0).
+        let ptr = bus.alloc(12);
+        bus.write_word(ptr, 0xA9FF); // _Debugger — private direct-WDEF callback marker.
+        bus.write_word(ptr + 2, 0x205F); // MOVEA.L (SP)+,A0 — recover JSR return PC.
+        bus.write_word(ptr + 4, 0xDEFC); // ADDA.W #12,SP — discard WDEF parameters.
+        bus.write_word(ptr + 6, 12);
+        bus.write_word(ptr + 8, 0x2E80); // MOVE.L D0,(SP) — LongInt function result.
+        bus.write_word(ptr + 10, 0x4ED0); // JMP (A0).
         self.system_wdef_cache.insert(res_id, ptr);
         Some(ptr)
     }

--- a/src/trap/pict.rs
+++ b/src/trap/pict.rs
@@ -347,7 +347,6 @@ pub fn draw_picture(
 
     let scale_x = dst_w / frame_w;
     let scale_y = dst_h / frame_h;
-
     // Start parsing opcodes after the 10-byte header
     let mut pos = pic_ptr + 10;
     let mut opcount = 0;
@@ -487,7 +486,9 @@ pub fn draw_picture(
                 pos += 4;
             }
             0x0C => {
-                // Origin (4 bytes)
+                // Origin(dh,dv). The opcode updates QuickDraw's current port
+                // origin while recording; its coordinate effect is already
+                // baked into the subsequent PICT operands.
                 pos += 4;
             }
             0x0D => {
@@ -1197,6 +1198,8 @@ pub fn draw_picture(
                         dst_left,
                         frame_top,
                         frame_left,
+                        frame_bottom,
+                        frame_right,
                         scale_x,
                         scale_y,
                         screen_mode,
@@ -1243,6 +1246,8 @@ pub fn draw_picture(
                     dst_left,
                     frame_top,
                     frame_left,
+                    frame_bottom,
+                    frame_right,
                     scale_x,
                     scale_y,
                     screen_mode,
@@ -4382,6 +4387,25 @@ fn map_src_pixel_span(
     Some((pic_start, screen_start, screen_end))
 }
 
+/// Some classic screen-capture PICTs retain global CopyBits destination
+/// coordinates even though their picture frame is rebased to `(0, 0)`.
+/// DrawPicture treats a full-frame raster as local to that frame; normalize
+/// the retained coordinate before applying the picture-to-destination scale.
+fn normalize_full_frame_raster_start(
+    frame_start: i16,
+    frame_end: i16,
+    pic_dst_start: i16,
+    pic_dst_end: i16,
+) -> i16 {
+    let raster_span = i32::from(pic_dst_end) - i32::from(pic_dst_start);
+    let frame_span = i32::from(frame_end) - i32::from(frame_start);
+    if frame_start == 0 && pic_dst_start != 0 && raster_span > 0 && raster_span == frame_span {
+        pic_dst_start
+    } else {
+        frame_start
+    }
+}
+
 /// Parse BitsRect / BitsRgn (1bpp bitmap, opcode 0x0090/0x0091)
 fn parse_bits_rect(
     bus: &mut MacMemoryBus,
@@ -4527,6 +4551,8 @@ fn parse_indexed_bits_rect(
     dst_left: i16,
     frame_top: i16,
     frame_left: i16,
+    frame_bottom: i16,
+    frame_right: i16,
     scale_x: f64,
     scale_y: f64,
     screen_mode: (u32, u32, u16, u16, u16),
@@ -4615,6 +4641,11 @@ fn parse_indexed_bits_rect(
     let mode = bus.read_word(pos);
     pos += 2;
     let mode_base = mode & 0x003F;
+
+    let frame_top =
+        normalize_full_frame_raster_start(frame_top, frame_bottom, pic_dst_top, pic_dst_bottom);
+    let frame_left =
+        normalize_full_frame_raster_start(frame_left, frame_right, pic_dst_left, pic_dst_right);
 
     if trace_pict_enabled() {
         let kind = if packed { "PackBits" } else { "Bits" };
@@ -6495,12 +6526,20 @@ mod tests {
     use super::{
         blit_row, build_device_itable, build_pict_indexed_transfer_table, build_src_to_dst_table,
         clear_src_to_dst_table_cache_for_tests, closest_grayscale_luminance_index, draw_picture,
-        dst_clip_row_spans, peek_initial_packbits_clut, picture_stream_len, read_color_table,
-        try_blit_packbits_8bpp_src_copy_fast, try_blit_row_8bpp_src_copy_fast, DstClip,
-        DstClipRegion, PictIndexedTransfer, PictureRegion, PixMapInfo,
+        dst_clip_row_spans, normalize_full_frame_raster_start, peek_initial_packbits_clut,
+        picture_stream_len, read_color_table, try_blit_packbits_8bpp_src_copy_fast,
+        try_blit_row_8bpp_src_copy_fast, DstClip, DstClipRegion, PictIndexedTransfer,
+        PictureRegion, PixMapInfo,
     };
     use crate::memory::{MacMemoryBus, MemoryBus};
     use crate::trap::dispatch::TrapDispatcher;
+
+    #[test]
+    fn full_frame_raster_with_global_coordinates_is_rebased() {
+        assert_eq!(normalize_full_frame_raster_start(0, 74, 381, 455), 381);
+        assert_eq!(normalize_full_frame_raster_start(12, 86, 381, 455), 12);
+        assert_eq!(normalize_full_frame_raster_start(0, 74, 381, 454), 0);
+    }
 
     #[test]
     fn device_itable_matches_rom_propagation_samples() {

--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -1743,6 +1743,10 @@ impl super::TrapDispatcher {
                 self.tx_font = bus.read_word(sp) as i16;
                 cpu.write_reg(Register::A7, sp + 2);
                 self.sync_current_port_draw_state(bus);
+                if let Some((_, _, _, _, _, commands)) = self.recording_picture.as_mut() {
+                    Self::push_pict_word(commands, 0x0003);
+                    Self::push_pict_word(commands, self.tx_font as u16);
+                }
                 Ok(())
             }
 
@@ -1756,6 +1760,10 @@ impl super::TrapDispatcher {
                 self.tx_face = decode_text_face_style(bus.read_word(sp));
                 cpu.write_reg(Register::A7, sp + 2);
                 self.sync_current_port_draw_state(bus);
+                if let Some((_, _, _, _, _, commands)) = self.recording_picture.as_mut() {
+                    Self::push_pict_word(commands, 0x0004);
+                    Self::push_pict_word(commands, self.tx_face as u16);
+                }
                 Ok(())
             }
 
@@ -1769,6 +1777,10 @@ impl super::TrapDispatcher {
                 self.tx_mode = bus.read_word(sp) as i16;
                 cpu.write_reg(Register::A7, sp + 2);
                 self.sync_current_port_draw_state(bus);
+                if let Some((_, _, _, _, _, commands)) = self.recording_picture.as_mut() {
+                    Self::push_pict_word(commands, 0x0005);
+                    Self::push_pict_word(commands, self.tx_mode as u16);
+                }
                 Ok(())
             }
 
@@ -1782,6 +1794,10 @@ impl super::TrapDispatcher {
                 self.tx_size = bus.read_word(sp) as i16;
                 cpu.write_reg(Register::A7, sp + 2);
                 self.sync_current_port_draw_state(bus);
+                if let Some((_, _, _, _, _, commands)) = self.recording_picture.as_mut() {
+                    Self::push_pict_word(commands, 0x000D);
+                    Self::push_pict_word(commands, self.tx_size as u16);
+                }
                 Ok(())
             }
 
@@ -1966,6 +1982,9 @@ impl super::TrapDispatcher {
                         String::from_utf8_lossy(&bytes),
                     );
                 }
+                let len = bus.read_byte(str_ptr) as usize;
+                let text = bus.read_bytes(str_ptr + 1, len);
+                self.record_picture_long_text(self.pn_loc.0, self.pn_loc.1, &text);
                 self.draw_string(cpu, bus, str_ptr);
                 self.refresh_visible_dialog_snapshot_for_port(bus, self.current_port);
                 Ok(())
@@ -2006,6 +2025,9 @@ impl super::TrapDispatcher {
                         String::from_utf8_lossy(&bytes),
                     );
                 }
+                let safe_count = byte_count.max(0) as usize;
+                let text = bus.read_bytes(start, safe_count);
+                self.record_picture_long_text(self.pn_loc.0, self.pn_loc.1, &text);
                 for i in 0..byte_count {
                     let ch = bus.read_byte(start + i as u32) as char;
                     self.draw_char(cpu, bus, ch);
@@ -2580,7 +2602,11 @@ impl super::TrapDispatcher {
                 if self.extend_recording_region(r.top, r.left, r.bottom, r.right) {
                     return Some(Ok(()));
                 }
+                let hilite_mode = bus.read_byte(0x0938);
                 self.draw_rect(cpu, bus, &r, ShapeOp::Invert);
+                if hilite_mode & 1 == 0 {
+                    bus.write_byte(0x0938, hilite_mode | 1);
+                }
                 Ok(())
             }
 
@@ -7596,7 +7622,11 @@ impl super::TrapDispatcher {
                     // QuickDraw Reference (Carbon) p. 307;
                     // QDOffscreen.h declaration.
                     0x0014 => {
-                        let version = 1u32;
+                        // OffscreenVersion uses the classic packed version
+                        // format: $0100 means version 1.0. Returning the
+                        // integer 1 makes clients mistake an available
+                        // Color QuickDraw implementation for a pre-1.0 one.
+                        let version = 0x0100u32;
                         bus.write_long(sp, version);
                         cpu.write_reg(Register::D0, version);
                     }
@@ -20354,6 +20384,21 @@ impl super::TrapDispatcher {
         bytes.extend_from_slice(&value.to_be_bytes());
     }
 
+    fn record_picture_long_text(&mut self, v: i16, h: i16, text: &[u8]) {
+        let Some((_, _, _, _, _, commands)) = self.recording_picture.as_mut() else {
+            return;
+        };
+        let len = text.len().min(255);
+        Self::push_pict_word(commands, 0x0028);
+        Self::push_pict_word(commands, v as u16);
+        Self::push_pict_word(commands, h as u16);
+        commands.push(len as u8);
+        commands.extend_from_slice(&text[..len]);
+        if !(1 + len).is_multiple_of(2) {
+            commands.push(0);
+        }
+    }
+
     fn push_packbits_literal_row(bytes: &mut Vec<u8>, row: &[u8]) {
         let mut packed = Vec::with_capacity(row.len() + row.len().div_ceil(128));
         for chunk in row.chunks(128) {
@@ -26131,6 +26176,7 @@ mod tests {
     /// path). Returns the buffer after the call.
     fn invert_rect_8bpp(notched_clip: bool) -> Vec<u8> {
         let (mut d, mut cpu, mut bus) = setup();
+        bus.write_byte(0x0938, 1);
         let base = bus.alloc(16 * 6);
         for offset in 0..(16 * 6) as u32 {
             bus.write_byte(base + offset, (offset * 7 + 3) as u8);
@@ -30612,10 +30658,12 @@ mod tests {
         let (mut d, mut cpu, mut bus) = setup_with_port();
         let rect_ptr = 0x300000u32;
         write_rect(&mut bus, rect_ptr, 10, 10, 20, 20);
+        bus.write_byte(0x0938, 0);
         bus.write_long(TEST_SP, rect_ptr);
         let result = d.dispatch_quickdraw(true, 0x0A4, &mut cpu, &mut bus);
         assert!(result.unwrap().is_ok());
         assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 4);
+        assert_eq!(bus.read_byte(0x0938), 1, "hilite mode is one-shot");
     }
 
     #[test]
@@ -40486,8 +40534,7 @@ mod tests {
         let result = d.dispatch_quickdraw(true, 0x31D, &mut cpu, &mut bus);
         assert!(result.unwrap().is_ok());
         assert_eq!(cpu.read_reg(Register::A7), TEST_SP);
-        assert_ne!(bus.read_long(TEST_SP), 0);
-        assert_ne!(bus.read_long(TEST_SP), 0xDEAD_BEEFu32);
+        assert_eq!(bus.read_long(TEST_SP), 0x0100);
     }
 
     // $AB1C is not documented as SetGWorld (SetGWorld uses _QDExtensions
@@ -43026,6 +43073,43 @@ mod tests {
         assert_ne!(bus.read_byte(screen_base + 1 + 8), 0);
         assert_ne!(bus.read_byte(screen_base + 2 + 2 * 8), 0);
         assert_eq!(bus.read_byte(screen_base + 4 + 4 * 8), 0);
+    }
+
+    #[test]
+    fn closepicture_replays_recorded_long_text_commands() {
+        let (mut d, _cpu, mut bus) = setup();
+        let screen_base = bus.alloc(64 * 32);
+        bus.fill_zeros(screen_base, 64 * 32);
+        d.screen_mode = (screen_base, 64, 64, 32, 8);
+        d.recording_picture = Some((1, 0, 0, 32, 64, Vec::new()));
+
+        d.record_picture_long_text(16, 4, b"Picture text");
+        let (_, _, _, _, _, commands) = d.recording_picture.take().unwrap();
+        assert_eq!(&commands[..2], &[0x00, 0x28]);
+        let picture = TrapDispatcher::encode_recorded_picture_pict(0, 0, 32, 64, commands);
+        let pic_ptr = bus.alloc(picture.len() as u32);
+        bus.write_bytes(pic_ptr, &picture);
+
+        let (drawn, _) = crate::trap::pict::draw_picture(
+            &mut bus,
+            pic_ptr,
+            0,
+            0,
+            32,
+            64,
+            d.screen_mode,
+            &d.device_clut,
+            0,
+            None,
+        );
+
+        assert!(drawn);
+        assert!(
+            bus.read_bytes(screen_base, 64 * 32)
+                .iter()
+                .any(|&pixel| pixel != 0),
+            "recorded text must render when the generated picture is replayed"
+        );
     }
 
     #[test]

--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -2670,7 +2670,7 @@ impl super::TrapDispatcher {
                 let rect_ptr = bus.read_long(sp);
                 cpu.write_reg(Register::A7, sp + 4);
                 let r = read_rect(bus, rect_ptr);
-                if self.extend_recording_region(r.top, r.left, r.bottom, r.right) {
+                if self.extend_recording_region_oval(r.top, r.left, r.bottom, r.right) {
                     return Some(Ok(()));
                 }
                 self.draw_oval(cpu, bus, &r, ShapeOp::Frame);
@@ -2686,7 +2686,7 @@ impl super::TrapDispatcher {
                 let rect_ptr = bus.read_long(sp);
                 cpu.write_reg(Register::A7, sp + 4);
                 let r = read_rect(bus, rect_ptr);
-                if self.extend_recording_region(r.top, r.left, r.bottom, r.right) {
+                if self.extend_recording_region_oval(r.top, r.left, r.bottom, r.right) {
                     return Some(Ok(()));
                 }
                 self.draw_oval(cpu, bus, &r, ShapeOp::Paint);
@@ -2702,7 +2702,7 @@ impl super::TrapDispatcher {
                 let rect_ptr = bus.read_long(sp);
                 cpu.write_reg(Register::A7, sp + 4);
                 let r = read_rect(bus, rect_ptr);
-                if self.extend_recording_region(r.top, r.left, r.bottom, r.right) {
+                if self.extend_recording_region_oval(r.top, r.left, r.bottom, r.right) {
                     return Some(Ok(()));
                 }
                 self.draw_oval(cpu, bus, &r, ShapeOp::Erase);
@@ -2718,7 +2718,7 @@ impl super::TrapDispatcher {
                 let rect_ptr = bus.read_long(sp);
                 cpu.write_reg(Register::A7, sp + 4);
                 let r = read_rect(bus, rect_ptr);
-                if self.extend_recording_region(r.top, r.left, r.bottom, r.right) {
+                if self.extend_recording_region_oval(r.top, r.left, r.bottom, r.right) {
                     return Some(Ok(()));
                 }
                 self.draw_oval(cpu, bus, &r, ShapeOp::Invert);
@@ -2735,7 +2735,7 @@ impl super::TrapDispatcher {
                 let rect_ptr = bus.read_long(sp + 4);
                 cpu.write_reg(Register::A7, sp + 8);
                 let r = read_rect(bus, rect_ptr);
-                if self.extend_recording_region(r.top, r.left, r.bottom, r.right) {
+                if self.extend_recording_region_oval(r.top, r.left, r.bottom, r.right) {
                     return Some(Ok(()));
                 }
                 let mut pat = [0u8; 8];
@@ -3783,7 +3783,7 @@ impl super::TrapDispatcher {
                                 let dst_clut = dst_clut.as_ref().expect("indexed destination CLUT");
                                 let dst_rgb = dst_clut[usize::from(dst_pixel)];
                                 let effective_mode = if mode_base == 36 { 0 } else { mode_base };
-                                let Some(result_rgb) = Self::copy_bits_direct_source_mode_rgb(
+                                let Some(result_rgb) = self.copy_bits_direct_source_mode_rgb(
                                     src_rgb,
                                     dst_rgb,
                                     effective_mode,
@@ -8203,7 +8203,6 @@ impl super::TrapDispatcher {
                         port_w,
                         port_h,
                     );
-
                     let picture_info = self.loaded_handles.get(&pic_handle).copied();
                     if trace_title_diag_enabled() && self.tick_count >= 80 && self.tick_count <= 110
                     {
@@ -15803,6 +15802,38 @@ impl super::TrapDispatcher {
         }
     }
 
+    pub(crate) fn extend_recording_region_oval(
+        &mut self,
+        top: i16,
+        left: i16,
+        bottom: i16,
+        right: i16,
+    ) -> bool {
+        if self.recording_region.is_none() {
+            return false;
+        }
+        let width = right.saturating_sub(left);
+        let height = bottom.saturating_sub(top);
+        if width <= 0 || height <= 0 {
+            return true;
+        }
+        let rows = self
+            .compute_oval_spans(width, height)
+            .into_iter()
+            .map(|(span_left, span_right)| {
+                let span_left = left.saturating_add(span_left);
+                let span_right = left.saturating_add(span_right);
+                if span_left < span_right {
+                    vec![span_left, span_right]
+                } else {
+                    Vec::new()
+                }
+            })
+            .collect::<Vec<_>>();
+        Self::add_recording_rows(self.recording_region.as_mut().unwrap(), top, &rows);
+        true
+    }
+
     pub(crate) fn record_region_line(&mut self, v0: i16, h0: i16, v1: i16, h1: i16) -> bool {
         if let Some(recording) = self.recording_region.as_mut() {
             recording.outline_segments.push(((v0, h0), (v1, h1)));
@@ -19893,7 +19924,7 @@ impl super::TrapDispatcher {
                         let dst_clut = dst_clut.as_ref().expect("indexed destination CLUT");
                         let dst_rgb = dst_clut[usize::from(dst_pixel)];
                         let effective_mode = if mode_base == 36 { 0 } else { mode_base };
-                        let Some(result_rgb) = Self::copy_bits_direct_source_mode_rgb(
+                        let Some(result_rgb) = self.copy_bits_direct_source_mode_rgb(
                             src_rgb,
                             dst_rgb,
                             effective_mode,
@@ -21973,6 +22004,33 @@ impl super::TrapDispatcher {
         Self::colorize_src_copy_rgb(src_rgb, dst_rgb, fg_rgb)
     }
 
+    fn blend_rgb(src_rgb: [u16; 3], dst_rgb: [u16; 3], weight_rgb: [u16; 3]) -> [u16; 3] {
+        let mut out = [0u16; 3];
+        for component in 0..3 {
+            let source = u64::from(src_rgb[component]);
+            let destination = u64::from(dst_rgb[component]);
+            let weight = u64::from(weight_rgb[component]);
+            out[component] = ((source * weight
+                + destination * (u64::from(u16::MAX) - weight)
+                + u64::from(u16::MAX) / 2)
+                / u64::from(u16::MAX)) as u16;
+        }
+        out
+    }
+
+    fn arithmetic_palette_index(clut: &[[u16; 3]; 256], rgb: [u16; 3]) -> u8 {
+        // Color QuickDraw maps arithmetic-transfer results through the
+        // current GDevice's 4-bit inverse table. A full-precision nearest
+        // search chooses different indices near cell boundaries, which is
+        // especially visible when blend is used to matte indexed sprites.
+        // Imaging With QuickDraw (1994), pp. 4-39 and 4-82.
+        if Self::uses_canonical_system_8bpp_clut(clut) {
+            Self::standard_itable_lookup(rgb[0], rgb[1], rgb[2])
+        } else {
+            Self::nearest_palette_index(clut, rgb)
+        }
+    }
+
     fn copy_bits_color_source_mode_pixel(
         &self,
         bus: &MacMemoryBus,
@@ -22027,6 +22085,14 @@ impl super::TrapDispatcher {
             6 => is_white.then(|| Self::inverted_palette_index(dst_clut, dst_pixel)),
             7 => (!is_black)
                 .then(|| map_rgb(Self::colorize_not_src_or_rgb(src_rgb, bg_rgb, dst_rgb))),
+            32 => Some(Self::arithmetic_palette_index(
+                dst_clut,
+                Self::blend_rgb(
+                    src_rgb,
+                    dst_rgb,
+                    [self.op_color.0, self.op_color.1, self.op_color.2],
+                ),
+            )),
             _ => Some(raw_source()),
         }
     }
@@ -22084,6 +22150,7 @@ impl super::TrapDispatcher {
     }
 
     fn copy_bits_direct_source_mode_rgb(
+        &self,
         src_rgb: [u16; 3],
         dst_rgb: [u16; 3],
         mode_base: u16,
@@ -22113,6 +22180,11 @@ impl super::TrapDispatcher {
                 ]
             }),
             7 => (!is_black).then(|| Self::colorize_not_src_or_rgb(src_rgb, bg_rgb, dst_rgb)),
+            32 => Some(Self::blend_rgb(
+                src_rgb,
+                dst_rgb,
+                [self.op_color.0, self.op_color.1, self.op_color.2],
+            )),
             _ => Some(src_rgb),
         }
     }
@@ -27745,6 +27817,35 @@ mod tests {
             "gap between recorded loops must remain outside the region"
         );
         assert!(TrapDispatcher::region_contains_point(&bus, dst, 1, 9));
+    }
+
+    #[test]
+    fn closergn_preserves_a_recorded_oval_instead_of_its_bounding_box() {
+        let (mut d, mut cpu, mut bus) = setup_with_port();
+        let dst_ptr = bus.alloc(10);
+        let dst = bus.alloc(4);
+        make_rgn(&mut bus, dst_ptr, dst, 0, 0, 0, 0);
+        let oval_rect = bus.alloc(8);
+        write_rect(&mut bus, oval_rect, 10, 20, 66, 76);
+
+        d.dispatch_quickdraw(true, 0x0DA, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+        cpu.write_reg(Register::A7, TEST_SP);
+        bus.write_long(TEST_SP, oval_rect);
+        d.dispatch_quickdraw(true, 0x0B8, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+        cpu.write_reg(Register::A7, TEST_SP);
+        bus.write_long(TEST_SP, dst);
+        d.dispatch_quickdraw(true, 0x0DB, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(read_rgn_bbox(&bus, dst), (10, 20, 66, 76));
+        assert!(bus.read_word(bus.read_long(dst)) > super::REGION_HEADER_SIZE as u16);
+        assert!(TrapDispatcher::region_contains_point(&bus, dst, 38, 48));
+        assert!(!TrapDispatcher::region_contains_point(&bus, dst, 10, 20));
     }
 
     #[test]
@@ -33633,6 +33734,31 @@ mod tests {
                 [0x8000, 0x8000, 0x8000],
             ),
             [0x4000, 0x4000, 0x4000]
+        );
+    }
+
+    #[test]
+    fn blend_rgb_weights_each_component_with_opcolor() {
+        // Imaging With QuickDraw (1994), pp. 4-38..4-40: blend uses each
+        // OpColor component as the source weight and its complement as the
+        // destination weight.
+        assert_eq!(
+            TrapDispatcher::blend_rgb(
+                [0xFFFF, 0xFFFF, 0x0000],
+                [0x0000, 0x8000, 0xFFFF],
+                [0xFFFF, 0x8000, 0x0000],
+            ),
+            [0xFFFF, 0xC000, 0xFFFF]
+        );
+    }
+
+    #[test]
+    fn arithmetic_transfer_uses_the_standard_inverse_table() {
+        let clut = TrapDispatcher::standard_mac_8bpp_clut();
+        let rgb = [0x27FF, 0x37FF, 0x47FF];
+        assert_eq!(
+            TrapDispatcher::arithmetic_palette_index(&clut, rgb),
+            TrapDispatcher::standard_itable_lookup(rgb[0], rgb[1], rgb[2]),
         );
     }
 

--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -9113,16 +9113,21 @@ mod tests {
         assert_ne!(wdef, 0, "synthetic WDEF handle must be loaded");
         assert_eq!(
             bus.read_word(wdef),
+            0xA9FF,
+            "standard WDEF shim should enter the private HLE marker"
+        );
+        assert_eq!(
+            bus.read_word(wdef + 2),
             0x205F,
             "standard WDEF shim should first recover the JSR return address"
         );
         assert_eq!(
-            bus.read_word(wdef + 2),
+            bus.read_word(wdef + 4),
             0xDEFC,
             "standard WDEF shim should discard its 12-byte Pascal parameter block"
         );
         assert_eq!(
-            bus.read_word(wdef + 8),
+            bus.read_word(wdef + 10),
             0x4ED0,
             "standard WDEF shim should return through the recovered address"
         );

--- a/src/trap/shapes.rs
+++ b/src/trap/shapes.rs
@@ -308,6 +308,16 @@ fn invert_indexed_pixel(old: u8) -> u8 {
     255 - old
 }
 
+fn hilite_indexed_pixel(old: u8, background: u8, hilite: u8) -> u8 {
+    if old == background {
+        hilite
+    } else if old == hilite {
+        background
+    } else {
+        old
+    }
+}
+
 fn apply_boolean_transfer_1(old: bool, mode: i16, source_is_black: bool) -> bool {
     match normalize_boolean_transfer_mode(mode) {
         0 => source_is_black,
@@ -1500,6 +1510,30 @@ impl super::TrapDispatcher {
             bg_idx = 0;
         }
 
+        // Clearing pHiliteBit makes the next XOR-style drawing operation use
+        // Color QuickDraw's one-shot hilite mode. Unlike indexed inversion,
+        // highlighting exchanges only the port background and HiliteRGB;
+        // every other color remains unchanged.
+        let hilite_indexes = if pixel_size == 8
+            && is_color
+            && matches!(op, ShapeOp::Invert)
+            && bus.read_byte(0x0938) & 1 == 0
+        {
+            let port_clut = indexed_clut.as_ref().expect("8bpp color port CLUT");
+            let hilite = shape_palette_index_for_rgb(
+                [
+                    self.hilite_color.0,
+                    self.hilite_color.1,
+                    self.hilite_color.2,
+                ],
+                pixel_size,
+                port_clut,
+            );
+            Some((bg_idx, hilite))
+        } else {
+            None
+        };
+
         let installed_raw_pixpat = if pixel_size == 8 && is_color {
             let handle = match op {
                 ShapeOp::Paint | ShapeOp::Frame => bus.read_long(port.wrapping_add(58)),
@@ -1544,7 +1578,11 @@ impl super::TrapDispatcher {
                             if invert_rows {
                                 bus.read_bytes_into(addr, &mut row);
                                 for pixel in row.iter_mut() {
-                                    *pixel = invert_indexed_pixel(*pixel);
+                                    *pixel = if let Some((background, hilite)) = hilite_indexes {
+                                        hilite_indexed_pixel(*pixel, background, hilite)
+                                    } else {
+                                        invert_indexed_pixel(*pixel)
+                                    };
                                 }
                             }
                             bus.write_bytes(addr, &row);
@@ -1766,7 +1804,13 @@ impl super::TrapDispatcher {
                             bus.write_byte(addr, new);
                         }
                         ShapeOp::Invert => {
-                            bus.write_byte(addr, invert_indexed_pixel(bus.read_byte(addr)))
+                            let old = bus.read_byte(addr);
+                            let new = if let Some((background, hilite)) = hilite_indexes {
+                                hilite_indexed_pixel(old, background, hilite)
+                            } else {
+                                invert_indexed_pixel(old)
+                            };
+                            bus.write_byte(addr, new)
                         }
                     }
                 } else if matches!(pixel_size, 2 | 4) {
@@ -1948,8 +1992,9 @@ impl super::TrapDispatcher {
 mod tests {
     use super::{
         apply_boolean_transfer_1, apply_boolean_transfer_8, blend_rgb, ctab_rgb_for_value,
-        ctab_uses_noncanonical_black, fg_bg_low_contrast, indexed_shape_color_index,
-        lighten_stem_alpha, normalize_boolean_transfer_mode, shape_palette_index_for_rgb,
+        ctab_uses_noncanonical_black, fg_bg_low_contrast, hilite_indexed_pixel,
+        indexed_shape_color_index, lighten_stem_alpha, normalize_boolean_transfer_mode,
+        shape_palette_index_for_rgb,
     };
     use crate::memory::{MacMemoryBus, MemoryBus};
 
@@ -2085,6 +2130,13 @@ mod tests {
     fn apply_boolean_transfer_1_src_xor_inverts_only_black_source_pixels() {
         assert!(!apply_boolean_transfer_1(true, 2, true));
         assert!(apply_boolean_transfer_1(true, 2, false));
+    }
+
+    #[test]
+    fn color_hilite_exchanges_only_background_and_hilite_pixels() {
+        assert_eq!(hilite_indexed_pixel(0, 0, 255), 255);
+        assert_eq!(hilite_indexed_pixel(255, 0, 255), 0);
+        assert_eq!(hilite_indexed_pixel(42, 0, 255), 42);
     }
 
     // Lock the anti-aliased glyph blend contract. Partial glyph coverage

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -5888,7 +5888,33 @@ impl super::TrapDispatcher {
             // Inside Macintosh: Memory (1992), p. 3-23.
             // Debugger ($A9FF): No debugger installed on Systemless,
             // so this is a no-op that returns to the caller.
-            (true, 0x1FF) => Ok(()),
+            (true, 0x1FF) => {
+                let pc = cpu.read_reg(Register::PC);
+                let direct_wdef = self
+                    .system_wdef_cache
+                    .iter()
+                    .find_map(|(&resource_id, &ptr)| (pc == ptr + 2).then_some(resource_id));
+                if let Some(resource_id) = direct_wdef {
+                    // A custom WDEF may delegate to a standard System-file
+                    // WDEF by loading and calling its resource directly. The
+                    // synthetic resource enters here before its ABI cleanup.
+                    let sp = cpu.read_reg(Register::A7);
+                    let param = bus.read_long(sp + 4);
+                    let message = bus.read_word(sp + 8) as i16;
+                    let window_ptr = bus.read_long(sp + 10);
+                    let variant = bus.read_word(sp + 14) as i16;
+                    let result = self.dispatch_direct_system_wdef(
+                        bus,
+                        resource_id,
+                        variant,
+                        window_ptr,
+                        message,
+                        param,
+                    );
+                    cpu.write_reg(Register::D0, result);
+                }
+                Ok(())
+            }
 
             // _Shutdown ($A895) — Shutdown Manager dispatch
             // Inside Macintosh Volume V, V-589..V-590.
@@ -20556,6 +20582,52 @@ mod tests {
         assert!(result.is_some(), "Debugger should be handled");
         assert!(result.unwrap().is_ok(), "Debugger should return");
         assert_eq!(cpu.read_reg(Register::A7), sp_before);
+    }
+
+    #[test]
+    fn synthetic_system_wdef_debugger_marker_recalculates_document_frame() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let window = bus.alloc(256);
+        disp.init_cgraf_window(
+            &mut bus,
+            &mut cpu,
+            window,
+            disp.screen_mode.0,
+            40,
+            2,
+            490,
+            798,
+            "Document",
+            8,
+            true,
+            false,
+            false,
+            0,
+        );
+        let wdef = disp.synthesize_system_wdef(&mut bus, 0).unwrap();
+        let structure = bus.read_long(window + 108);
+        let structure_ptr = bus.read_long(structure);
+        bus.write_word(structure_ptr + 2, 40);
+        bus.write_word(structure_ptr + 4, 2);
+        bus.write_word(structure_ptr + 6, 490);
+        bus.write_word(structure_ptr + 8, 798);
+
+        let sp = cpu.read_reg(Register::A7) - 20;
+        cpu.write_reg(Register::A7, sp);
+        cpu.write_reg(Register::PC, wdef + 2);
+        bus.write_long(sp + 4, 0); // param
+        bus.write_word(sp + 8, 2); // wCalcRgns
+        bus.write_long(sp + 10, window);
+        bus.write_word(sp + 14, 8); // zoomDocProc variant
+
+        let result = disp.dispatch_toolbox(true, 0x1FF, &mut cpu, &mut bus);
+        assert!(result.unwrap().is_ok());
+        assert_eq!(cpu.read_reg(Register::D0), 0);
+        assert_eq!(
+            disp.window_structure_rect(&bus, window),
+            Some((21, 1, 492, 800)),
+            "direct standard WDEF delegation should calculate document chrome"
+        );
     }
 
     #[test]

--- a/src/trap/window.rs
+++ b/src/trap/window.rs
@@ -64,7 +64,7 @@ impl super::TrapDispatcher {
     const WDEF_WCALC_RGNS_MSG: i16 = 2;
     const WDEF_WNEW_MSG: i16 = 3;
     const WDEF_FIRST_APPLICATION_RESOURCE_ID: i16 = 128;
-    const WDEF_TRAMPOLINE_SIZE: u32 = 68;
+    const WDEF_TRAMPOLINE_SIZE: u32 = 80;
     const AUX_WIN_NEXT_OFFSET: u32 = 0;
     const AUX_WIN_OWNER_OFFSET: u32 = 4;
     pub(crate) const AUX_WIN_CTABLE_OFFSET: u32 = 8;
@@ -593,6 +593,7 @@ impl super::TrapDispatcher {
         proc_addr: u32,
         return_slot: u32,
         next_trampoline: Option<u32>,
+        restore_port: u32,
         restore_cgraf_fields: Option<(u32, u32)>,
     ) {
         bus.write_word(tramp, 0x48E7);
@@ -615,23 +616,42 @@ impl super::TrapDispatcher {
         bus.write_word(tramp + 44, 0x0F0F);
         match next_trampoline {
             Some(next) => {
-                bus.write_word(tramp + 46, 0x4EF9); // JMP abs.L
-                bus.write_long(tramp + 48, next);
+                if message == Self::WDEF_WCALC_RGNS_MSG {
+                    // The WDEF owns strucRgn and contRgn, but must not alter
+                    // visRgn. Recalculate visibility after wCalcRgns and
+                    // before wDraw so the resized frame and subsequent
+                    // application drawing use the new content geometry.
+                    // Macintosh Toolbox Essentials 1992, pp. 4-122..4-123.
+                    bus.write_word(tramp + 46, 0x2F3C); // MOVE.L #window,-(SP)
+                    bus.write_long(tramp + 48, window_ptr);
+                    bus.write_word(tramp + 52, 0xA909); // _CalcVis
+                    bus.write_word(tramp + 54, 0x4EF9); // JMP abs.L
+                    bus.write_long(tramp + 56, next);
+                } else {
+                    bus.write_word(tramp + 46, 0x4EF9); // JMP abs.L
+                    bus.write_long(tramp + 48, next);
+                }
             }
             None => {
+                // Window Manager callbacks run in WMgrPort, but the Window
+                // Manager preserves the application's current port across the
+                // call. Restore it before returning to guest code so a
+                // following LocalToGlobal still uses the caller's window.
+                bus.write_word(tramp + 46, 0x2F3C); // MOVE.L #savedPort,-(SP)
+                bus.write_long(tramp + 48, restore_port);
+                bus.write_word(tramp + 52, 0xA873); // _SetPort
                 if let Some((graf_vars, color_fields)) = restore_cgraf_fields {
                     // MOVE.L #grafVars,window+8
-                    bus.write_word(tramp + 46, 0x23FC);
-                    bus.write_long(tramp + 48, graf_vars);
-                    bus.write_long(tramp + 52, window_ptr + 8);
+                    bus.write_word(tramp + 54, 0x23FC);
+                    bus.write_long(tramp + 56, graf_vars);
+                    bus.write_long(tramp + 60, window_ptr + 8);
                     // MOVE.L #chExtra/pnLocHFrac,window+12
-                    bus.write_word(tramp + 56, 0x23FC);
-                    bus.write_long(tramp + 58, color_fields);
-                    bus.write_long(tramp + 62, window_ptr + 12);
-                    bus.write_word(tramp + 66, 0x4E75); // RTS
+                    bus.write_word(tramp + 64, 0x23FC);
+                    bus.write_long(tramp + 66, color_fields);
+                    bus.write_long(tramp + 70, window_ptr + 12);
+                    bus.write_word(tramp + 74, 0x4E75); // RTS
                 } else {
-                    bus.write_word(tramp + 46, 0x4E75); // RTS
-                    bus.write_long(tramp + 48, 0);
+                    bus.write_word(tramp + 54, 0x4E75); // RTS
                 }
             }
         }
@@ -655,6 +675,23 @@ impl super::TrapDispatcher {
             return false;
         }
 
+        if messages
+            .iter()
+            .any(|&(message, _)| message == Self::WDEF_WCALC_RGNS_MSG)
+        {
+            // The Window Manager supplies the content rectangle as the seed
+            // structure for wCalcRgns. Custom WDEFs then expand or reshape
+            // strucRgn in place; leaving the previous frame there makes a
+            // resized window retain its old hit-test bounds.
+            // Macintosh Toolbox Essentials 1992, pp. 4-120..4-123.
+            let content = self.window_content_global_rect(bus, window_ptr);
+            Self::write_region_handle_rect(
+                bus,
+                bus.read_long(window_ptr + Self::WINDOW_STRUC_RGN_OFFSET),
+                content,
+            );
+        }
+
         // Window definition functions are Pascal functions:
         // FUNCTION MyWindow(varCode: Integer; theWindow: WindowPtr;
         //                   message: Integer; param: LongInt): LongInt;
@@ -662,6 +699,7 @@ impl super::TrapDispatcher {
         // low four bits of the window definition ID, and draw wDraw in the
         // Window Manager port. Macintosh Toolbox Essentials 1992, pp. 4-120
         // through 4-127; Inside Macintosh Volume I 1985, pp. I-282, I-304.
+        let restore_port = self.current_port;
         let wmgr_port = self.ensure_color_window_manager_port(bus);
         self.set_current_port_state(bus, cpu, wmgr_port, None);
 
@@ -721,8 +759,13 @@ impl super::TrapDispatcher {
                 proc_addr,
                 return_slot,
                 next,
+                restore_port,
                 final_restore,
             );
+            if message == Self::WDEF_WCALC_RGNS_MSG && next.is_some() {
+                self.window_def_calcvis_return_pcs
+                    .insert(trampolines[idx] + 54);
+            }
         }
 
         bus.write_long(return_slot, return_pc);
@@ -1164,6 +1207,66 @@ impl super::TrapDispatcher {
         self.window_structure_global_rect_for_proc(bus, content_rect, proc_id)
     }
 
+    pub(crate) fn dispatch_direct_system_wdef(
+        &mut self,
+        bus: &mut MacMemoryBus,
+        resource_id: i16,
+        variant: i16,
+        window_ptr: u32,
+        message: i16,
+        param: u32,
+    ) -> u32 {
+        if window_ptr == 0 {
+            return 0;
+        }
+        let standard_proc_id = resource_id.saturating_mul(16).saturating_add(variant);
+        match message {
+            0 => {
+                let hilited = bus.read_byte(window_ptr + Self::WINDOW_HILITED_OFFSET) != 0;
+                let custom_proc_id = self.window_proc_ids.insert(window_ptr, standard_proc_id);
+                self.draw_single_window_chrome_inline(bus, window_ptr, hilited);
+                if let Some(custom_proc_id) = custom_proc_id {
+                    self.window_proc_ids.insert(window_ptr, custom_proc_id);
+                }
+                0
+            }
+            1 => {
+                let point_v = (param >> 16) as i16;
+                let point_h = param as i16;
+                if Self::point_in_rect(
+                    point_v,
+                    point_h,
+                    self.window_content_global_rect(bus, window_ptr)
+                        .unwrap_or((0, 0, 0, 0)),
+                ) {
+                    3
+                } else if Self::point_in_rect(
+                    point_v,
+                    point_h,
+                    self.window_structure_rect(bus, window_ptr)
+                        .unwrap_or((0, 0, 0, 0)),
+                ) {
+                    4
+                } else {
+                    0
+                }
+            }
+            2 => {
+                if let Some(content) = self.window_content_global_rect(bus, window_ptr) {
+                    let structure =
+                        self.window_structure_global_rect_for_proc(bus, content, standard_proc_id);
+                    Self::write_region_handle_rect(
+                        bus,
+                        bus.read_long(window_ptr + Self::WINDOW_STRUC_RGN_OFFSET),
+                        Some(structure),
+                    );
+                }
+                0
+            }
+            _ => 0,
+        }
+    }
+
     pub(super) fn window_structure_rect(
         &self,
         bus: &MacMemoryBus,
@@ -1363,7 +1466,14 @@ impl super::TrapDispatcher {
     }
 
     fn window_uses_save_under(&self, proc_id: i16) -> bool {
-        !Self::window_is_document_proc(proc_id)
+        // A custom WDEF ID says nothing about whether the application is
+        // implementing a transient dialog or a persistent document/utility
+        // window. Treating every application WDEF as save-under captures an
+        // arbitrary old framebuffer and later restores stale windows when the
+        // application hides its interface. Restrict this HLE optimization to
+        // the standard dialog-box WDEF variants whose lifetime semantics are
+        // known; custom windows are exposed and invalidated normally.
+        !Self::is_application_window_def_proc_id(proc_id) && !Self::window_is_document_proc(proc_id)
     }
 
     fn save_window_under_pixels_for_proc(
@@ -1471,11 +1581,14 @@ impl super::TrapDispatcher {
 
         let (_, _, screen_w, screen_h, _) = self.screen_mode;
         let old_port_rect = self.window_global_port_rect(bus, the_window);
+        let custom_wdef = self.window_uses_custom_def_proc(bus, the_window);
+        let old_structure_rect = self.window_structure_rect(bus, the_window);
         let old_structure = if self.window_visible(bus, the_window) {
-            self.window_structure_rect(bus, the_window)
+            old_structure_rect
         } else {
             None
         };
+        let old_content_global = self.window_content_global_rect(bus, the_window);
         let local_content_rect = self
             .window_content_rect(bus, the_window)
             .unwrap_or_else(|| self.window_port_rect(bus, the_window));
@@ -1506,19 +1619,44 @@ impl super::TrapDispatcher {
         }
 
         // portRect, visRgn, clipRgn stay in local coords — no update needed.
-        let global_content = self.window_local_rect_to_global(bus, the_window, local_content_rect);
-        let global_structure =
-            self.window_structure_global_rect_for_window(bus, the_window, global_content);
-        Self::write_region_handle_rect(
-            bus,
-            bus.read_long(the_window + Self::WINDOW_CONT_RGN_OFFSET),
-            Some(global_content),
-        );
-        Self::write_region_handle_rect(
-            bus,
-            bus.read_long(the_window + Self::WINDOW_STRUC_RGN_OFFSET),
-            Some(global_structure),
-        );
+        if custom_wdef {
+            // Preserve the WDEF's shapes while translating them to the new
+            // port origin. The trap handler follows this move by asking a
+            // visible custom WDEF to recalculate and draw its frame.
+            let offset_rect = |rect: (i16, i16, i16, i16)| {
+                (
+                    rect.0.wrapping_add(delta_v),
+                    rect.1.wrapping_add(delta_h),
+                    rect.2.wrapping_add(delta_v),
+                    rect.3.wrapping_add(delta_h),
+                )
+            };
+            Self::write_region_handle_rect(
+                bus,
+                bus.read_long(the_window + Self::WINDOW_CONT_RGN_OFFSET),
+                old_content_global.map(offset_rect),
+            );
+            Self::write_region_handle_rect(
+                bus,
+                bus.read_long(the_window + Self::WINDOW_STRUC_RGN_OFFSET),
+                old_structure_rect.map(offset_rect),
+            );
+        } else {
+            let global_content =
+                self.window_local_rect_to_global(bus, the_window, local_content_rect);
+            let global_structure =
+                self.window_structure_global_rect_for_window(bus, the_window, global_content);
+            Self::write_region_handle_rect(
+                bus,
+                bus.read_long(the_window + Self::WINDOW_CONT_RGN_OFFSET),
+                Some(global_content),
+            );
+            Self::write_region_handle_rect(
+                bus,
+                bus.read_long(the_window + Self::WINDOW_STRUC_RGN_OFFSET),
+                Some(global_structure),
+            );
+        }
         if let Some(update_rect) = old_update_rect {
             Self::write_region_handle_rect(
                 bus,
@@ -1587,7 +1725,7 @@ impl super::TrapDispatcher {
             );
         }
 
-        if self.window_visible(bus, the_window) {
+        if self.window_visible(bus, the_window) && !custom_wdef {
             let hilited = bus.read_byte(the_window + Self::WINDOW_HILITED_OFFSET) != 0;
             self.draw_single_window_chrome_inline(bus, the_window, hilited);
         }
@@ -3735,18 +3873,25 @@ impl super::TrapDispatcher {
                     bus.write_byte(the_window + Self::WINDOW_VISIBLE_OFFSET, 0x00);
                     self.set_window_vis_from_content(bus, the_window, false);
                     self.clear_queued_update_events(the_window);
-                    if !self.restore_window_under_pixels(bus, the_window) {
+                    let restored_save_under = self.restore_window_under_pixels(bus, the_window);
+                    if !restored_save_under {
                         // Restore the exposed structure area from the desktop
                         // background. A full Window Manager would also repaint
                         // uncovered windows behind; this keeps desktop exposure
                         // mode-correct when no save-under snapshot exists.
                         let (_, _, screen_width, screen_height, _) = self.get_screen_params();
-                        self.erase_exposed_desktop_rect(
-                            bus,
+                        let erase_rect = exposed_rect.unwrap_or((
                             (wind_top - 19).max(0),
                             (wind_left - 1).max(0),
                             (wind_bottom + 2).min(screen_height),
                             (wind_right + 2).min(screen_width),
+                        ));
+                        self.erase_exposed_desktop_rect(
+                            bus,
+                            erase_rect.0,
+                            erase_rect.1,
+                            erase_rect.2,
+                            erase_rect.3,
                         );
                     }
                     if self.front_window == the_window {
@@ -3769,6 +3914,16 @@ impl super::TrapDispatcher {
                             self.activate_as_front_window(bus, new_front);
                         } else {
                             self.front_window = 0;
+                            self.sync_cached_front_window_render_state(bus);
+                            // Hiding the final visible window exposes the
+                            // Window Manager desktop. Repaint the entire gray
+                            // region so pixels drawn outside an application's
+                            // declared custom strucRgn cannot survive as
+                            // orphaned frame fragments.
+                            if !restored_save_under {
+                                let (top, left, bottom, right) = self.desktop_gray_region_rect(bus);
+                                self.erase_exposed_desktop_rect(bus, top, left, bottom, right);
+                            }
                         }
                         if self.current_port == the_window {
                             self.current_port = new_front;
@@ -3971,9 +4126,14 @@ impl super::TrapDispatcher {
                 let h_global = bus.read_word(sp + 4) as i16;
                 let the_window = bus.read_long(sp + 6);
 
+                let arm_custom_wdef_draw = self.window_visible(bus, the_window)
+                    && self.window_uses_custom_def_proc(bus, the_window);
                 self.move_window_to_global(bus, the_window, h_global, v_global, front_flag);
 
                 cpu.write_reg(Register::A7, sp + 10);
+                if arm_custom_wdef_draw {
+                    self.arm_window_def_draw(cpu, bus, the_window);
+                }
                 Ok(())
             }
 
@@ -3996,6 +4156,7 @@ impl super::TrapDispatcher {
                 let h = bus.read_word(sp + 2) as i16;
                 let w = bus.read_word(sp + 4) as i16;
                 let the_window = bus.read_long(sp + 6);
+                let mut arm_custom_wdef_draw = false;
 
                 if the_window != 0 {
                     // Capture the old content rect before we resize so
@@ -4009,23 +4170,42 @@ impl super::TrapDispatcher {
                     bus.write_word(the_window + 22, w as u16);
                     let content_top = old_content_rect.map(|rect| rect.0).unwrap_or(0);
                     let content_rect = (content_top, 0, h, w);
-                    let global_content =
-                        self.window_local_rect_to_global(bus, the_window, content_rect);
-                    let global_structure = self.window_structure_global_rect_for_window(
-                        bus,
-                        the_window,
-                        global_content,
-                    );
-                    Self::write_region_handle_rect(
-                        bus,
-                        bus.read_long(the_window + Self::WINDOW_CONT_RGN_OFFSET),
-                        Some(global_content),
-                    );
-                    Self::write_region_handle_rect(
-                        bus,
-                        bus.read_long(the_window + Self::WINDOW_STRUC_RGN_OFFSET),
-                        Some(global_structure),
-                    );
+                    let custom_wdef = self.window_uses_custom_def_proc(bus, the_window);
+                    if custom_wdef {
+                        // SizeWindow establishes the rectangular content region
+                        // from the resized port before wCalcRgns. The custom WDEF
+                        // then derives its nonstandard structure from that region;
+                        // replacing the structure with a document frame here
+                        // changes both hit testing and visible geometry.
+                        // Macintosh Toolbox Essentials 1992, pp. 4-100,
+                        // 4-120 through 4-123.
+                        let global_content =
+                            self.window_local_rect_to_global(bus, the_window, (0, 0, h, w));
+                        Self::write_region_handle_rect(
+                            bus,
+                            bus.read_long(the_window + Self::WINDOW_CONT_RGN_OFFSET),
+                            Some(global_content),
+                        );
+                        arm_custom_wdef_draw = self.window_visible(bus, the_window);
+                    } else {
+                        let global_content =
+                            self.window_local_rect_to_global(bus, the_window, content_rect);
+                        let global_structure = self.window_structure_global_rect_for_window(
+                            bus,
+                            the_window,
+                            global_content,
+                        );
+                        Self::write_region_handle_rect(
+                            bus,
+                            bus.read_long(the_window + Self::WINDOW_CONT_RGN_OFFSET),
+                            Some(global_content),
+                        );
+                        Self::write_region_handle_rect(
+                            bus,
+                            bus.read_long(the_window + Self::WINDOW_STRUC_RGN_OFFSET),
+                            Some(global_structure),
+                        );
+                    }
 
                     // Update visRgn in local coords
                     let vis_rgn_handle = bus.read_long(the_window + 24);
@@ -4055,7 +4235,9 @@ impl super::TrapDispatcher {
                     // behind it. Rebuild visRgn data instead of editing only
                     // its bounding words, which leaves stale complex runs.
                     // Inside Macintosh Volume I, I-287 and I-297.
-                    self.recalculate_window_vis_regions(bus);
+                    if !custom_wdef {
+                        self.recalculate_window_vis_regions(bus);
+                    }
 
                     // Derive screen origin from pixmap bounds to update hit-test bounds.
                     if the_window == self.front_window {
@@ -4089,6 +4271,9 @@ impl super::TrapDispatcher {
                 }
 
                 cpu.write_reg(Register::A7, sp + 10);
+                if arm_custom_wdef_draw {
+                    self.arm_window_def_draw(cpu, bus, the_window);
+                }
                 Ok(())
             }
 
@@ -4183,6 +4368,7 @@ impl super::TrapDispatcher {
                 let start_v = bus.read_word(sp + 4) as i16;
                 let start_h = bus.read_word(sp + 6) as i16;
                 let the_window = bus.read_long(sp + 8);
+                let mut arm_custom_wdef_draw = false;
 
                 if the_window != 0 && bounds_rect_ptr != 0 {
                     let bounds_rect = (
@@ -4213,6 +4399,8 @@ impl super::TrapDispatcher {
                         let new_v = top.wrapping_add(release_v.wrapping_sub(start_v));
                         let new_h = left.wrapping_add(release_h.wrapping_sub(start_h));
                         let front_flag = !self.key_is_down(0x37);
+                        arm_custom_wdef_draw = self.window_visible(bus, the_window)
+                            && self.window_uses_custom_def_proc(bus, the_window);
                         self.move_window_to_global(bus, the_window, new_h, new_v, front_flag);
                         if trace_dragwindow_enabled() {
                             eprintln!(
@@ -4225,6 +4413,9 @@ impl super::TrapDispatcher {
                     }
                 }
                 cpu.write_reg(Register::A7, sp + 12);
+                if arm_custom_wdef_draw {
+                    self.arm_window_def_draw(cpu, bus, the_window);
+                }
                 Ok(())
             }
 
@@ -4302,11 +4493,13 @@ impl super::TrapDispatcher {
                 // Pascal BOOLEAN in high byte (MPW C convention).
                 let show_flag = bus.read_byte(sp) != 0;
                 let the_window = bus.read_long(sp + 2);
+                let mut arm_custom_wdef_draw = false;
                 if the_window != 0 {
                     if !show_flag {
                         self.dialog_visible_snapshots.remove(&the_window);
                     }
-                    let exposed_rect = (!show_flag && self.window_visible(bus, the_window))
+                    let was_visible = self.window_visible(bus, the_window);
+                    let exposed_rect = (!show_flag && was_visible)
                         .then(|| self.window_structure_rect(bus, the_window))
                         .flatten();
                     let windows_behind = if exposed_rect.is_some() {
@@ -4314,27 +4507,54 @@ impl super::TrapDispatcher {
                     } else {
                         Vec::new()
                     };
-                    bus.write_byte(
-                        the_window + Self::WINDOW_VISIBLE_OFFSET,
-                        if show_flag { 0xFF } else { 0x00 },
-                    );
-                    self.set_window_vis_from_content(bus, the_window, show_flag);
                     if show_flag {
-                        if let Some(content_rect) = self.window_content_global_rect(bus, the_window)
-                        {
-                            Self::write_region_handle_rect(
-                                bus,
-                                bus.read_long(the_window + Self::WINDOW_UPDATE_RGN_OFFSET),
-                                Some(content_rect),
-                            );
-                            self.queue_window_update_event(the_window);
+                        bus.write_byte(the_window + Self::WINDOW_VISIBLE_OFFSET, 0xFF);
+                        self.set_window_vis_from_content(bus, the_window, true);
+                        if !was_visible {
+                            self.save_window_under_pixels(bus, the_window);
+                            if let Some(content_rect) =
+                                self.window_content_global_rect(bus, the_window)
+                            {
+                                Self::write_region_handle_rect(
+                                    bus,
+                                    bus.read_long(the_window + Self::WINDOW_UPDATE_RGN_OFFSET),
+                                    Some(content_rect),
+                                );
+                                self.queue_window_update_event(the_window);
+                            }
+
+                            // ShowHide differs from ShowWindow only in window-list
+                            // ordering and activation; the Window Manager still
+                            // reveals the structure and asks a custom WDEF to draw
+                            // it. Macintosh Toolbox Essentials (1992), pp. 4-84
+                            // and 4-100.
+                            if self.dialog_items.contains_key(&the_window) {
+                                self.redraw_dialog_window_contents(bus, the_window);
+                                if !self.modeless_dialog_cdef_draw_queue.contains(&the_window) {
+                                    self.modeless_dialog_cdef_draw_queue.push_back(the_window);
+                                }
+                            } else if self.window_uses_custom_def_proc(bus, the_window) {
+                                arm_custom_wdef_draw = true;
+                            } else {
+                                let hilited =
+                                    bus.read_byte(the_window + Self::WINDOW_HILITED_OFFSET) != 0;
+                                self.draw_single_window_chrome_inline(bus, the_window, hilited);
+                            }
                         }
                     } else {
+                        // ShowHide(FALSE) removes the window from the screen even
+                        // though it deliberately leaves the window-list order and
+                        // activation state alone. Merely clearing `visible` leaves
+                        // the old frame and content pixels behind.
+                        self.erase_window_for_removal(bus, the_window);
                         self.clear_queued_update_events(the_window);
                         self.invalidate_exposed_windows(bus, &windows_behind, exposed_rect);
                     }
                 }
                 cpu.write_reg(Register::A7, sp + 6);
+                if arm_custom_wdef_draw {
+                    self.arm_window_def_draw(cpu, bus, the_window);
+                }
                 Ok(())
             }
 
@@ -4348,6 +4568,13 @@ impl super::TrapDispatcher {
             (true, 0x109) => {
                 let sp = cpu.read_reg(Register::A7);
                 let _the_window = bus.read_long(sp);
+
+                if self
+                    .window_def_calcvis_return_pcs
+                    .contains(&cpu.read_reg(Register::PC))
+                {
+                    self.recalculate_window_vis_regions(bus);
+                }
 
                 cpu.write_reg(Register::A7, sp + 4);
                 Ok(())
@@ -5783,6 +6010,10 @@ mod tests {
             disp.window_uses_custom_def_proc(&bus, window_addr),
             "custom WDEF window should be classified from procID + windowDefProc"
         );
+        assert!(
+            !disp.window_saved_under_pixels.contains_key(&window_addr),
+            "an application WDEF must not be guessed to have transient save-under semantics"
+        );
     }
 
     #[test]
@@ -5913,11 +6144,19 @@ mod tests {
         assert_eq!(bus.read_long(calc_tramp + 38), (sp + 6).wrapping_sub(32));
         assert_eq!(
             bus.read_word(calc_tramp + 46),
-            0x4EF9,
-            "wCalcRgns should chain to wDraw"
+            0x2F3C,
+            "wCalcRgns should pass the window to CalcVis"
+        );
+        assert_eq!(bus.read_long(calc_tramp + 48), window_ptr);
+        assert_eq!(bus.read_word(calc_tramp + 52), 0xA909);
+        assert_eq!(bus.read_word(calc_tramp + 54), 0x4EF9);
+        assert!(
+            disp.window_def_calcvis_return_pcs
+                .contains(&(calc_tramp + 54)),
+            "only the WDEF trampoline's private CalcVis return PC should enable recomputation"
         );
 
-        let draw_tramp = bus.read_long(calc_tramp + 48);
+        let draw_tramp = bus.read_long(calc_tramp + 56);
         assert_ne!(draw_tramp, 0);
         assert_eq!(bus.read_word(draw_tramp + 12), 3);
         assert_eq!(bus.read_long(draw_tramp + 16), window_ptr);
@@ -5928,25 +6167,219 @@ mod tests {
         assert_eq!(bus.read_long(draw_tramp + 26), 0);
         assert_eq!(bus.read_long(draw_tramp + 32), wdef_proc);
         assert_eq!(bus.read_long(draw_tramp + 38), (sp + 6).wrapping_sub(32));
-        assert_eq!(bus.read_word(draw_tramp + 46), 0x23FC);
+        assert_eq!(bus.read_word(draw_tramp + 46), 0x2F3C);
+        assert_eq!(bus.read_long(draw_tramp + 48), window_ptr);
+        assert_eq!(bus.read_word(draw_tramp + 52), 0xA873);
+        assert_eq!(bus.read_word(draw_tramp + 54), 0x23FC);
         assert_eq!(
-            bus.read_long(draw_tramp + 48),
+            bus.read_long(draw_tramp + 56),
             0,
             "final callback should restore grafVars"
         );
-        assert_eq!(bus.read_long(draw_tramp + 52), window_ptr + 8);
-        assert_eq!(bus.read_word(draw_tramp + 56), 0x23FC);
+        assert_eq!(bus.read_long(draw_tramp + 60), window_ptr + 8);
+        assert_eq!(bus.read_word(draw_tramp + 64), 0x23FC);
         assert_eq!(
-            bus.read_long(draw_tramp + 58),
+            bus.read_long(draw_tramp + 66),
             0,
             "final callback should restore chExtra and pnLocHFrac"
         );
-        assert_eq!(bus.read_long(draw_tramp + 62), window_ptr + 12);
-        assert_eq!(bus.read_word(draw_tramp + 66), 0x4E75);
+        assert_eq!(bus.read_long(draw_tramp + 70), window_ptr + 12);
+        assert_eq!(bus.read_word(draw_tramp + 74), 0x4E75);
         assert_eq!(
             disp.current_port, disp.window_manager_cport,
             "wDraw should run in the color Window Manager port"
         );
+    }
+
+    #[test]
+    fn sizewindow_asks_visible_custom_wdef_to_recalculate_and_draw() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let wdef_proc = install_wdef_resource(&mut disp, &mut bus, 200);
+        let window_ptr = bus.alloc(256);
+        let proc_id = (200i16 << 4) | 3;
+
+        disp.init_cgraf_window(
+            &mut bus,
+            &mut cpu,
+            window_ptr,
+            disp.screen_mode.0,
+            40,
+            50,
+            120,
+            180,
+            "",
+            proc_id,
+            true,
+            false,
+            false,
+            0,
+        );
+        let old_structure = (31, 41, 129, 189);
+        let old_content = (40, 50, 120, 180);
+        let structure_handle =
+            bus.read_long(window_ptr + super::super::TrapDispatcher::WINDOW_STRUC_RGN_OFFSET);
+        let content_handle =
+            bus.read_long(window_ptr + super::super::TrapDispatcher::WINDOW_CONT_RGN_OFFSET);
+        super::super::TrapDispatcher::write_region_handle_rect(
+            &mut bus,
+            structure_handle,
+            Some(old_structure),
+        );
+        super::super::TrapDispatcher::write_region_handle_rect(
+            &mut bus,
+            content_handle,
+            Some(old_content),
+        );
+
+        let sp = TEST_SP - 10;
+        let return_pc = 0x1234_5678;
+        cpu.write_reg(Register::A7, sp);
+        cpu.write_reg(Register::PC, return_pc);
+        bus.write_byte(sp, 0xFF); // fUpdate
+        bus.write_word(sp + 2, 160); // h
+        bus.write_word(sp + 4, 300); // w
+        bus.write_long(sp + 6, window_ptr);
+
+        let result = dispatch(&mut disp, 0x11D, &mut cpu, &mut bus);
+        assert!(result.is_some());
+        assert!(result.unwrap().is_ok());
+        assert_eq!(bus.read_word(window_ptr + 20), 160);
+        assert_eq!(bus.read_word(window_ptr + 22), 300);
+        assert_eq!(
+            read_window_region_rect(
+                &bus,
+                window_ptr,
+                super::super::TrapDispatcher::WINDOW_STRUC_RGN_OFFSET,
+            ),
+            (40, 50, 200, 350),
+            "wCalcRgns must receive the resized content rectangle as its structure seed"
+        );
+        assert_eq!(
+            read_window_region_rect(
+                &bus,
+                window_ptr,
+                super::super::TrapDispatcher::WINDOW_CONT_RGN_OFFSET,
+            ),
+            (40, 50, 200, 350),
+            "SizeWindow must expose the resized content geometry to the WDEF"
+        );
+
+        let calc_tramp = disp.window_def_trampoline;
+        assert_ne!(calc_tramp, 0);
+        assert_eq!(cpu.read_reg(Register::PC), calc_tramp);
+        assert_eq!(cpu.read_reg(Register::A7), sp + 6);
+        assert_eq!(bus.read_long(sp + 6), return_pc);
+        assert_eq!(bus.read_word(calc_tramp + 12), 3);
+        assert_eq!(bus.read_long(calc_tramp + 16), window_ptr);
+        assert_eq!(
+            bus.read_word(calc_tramp + 22),
+            super::super::TrapDispatcher::WDEF_WCALC_RGNS_MSG as u16,
+        );
+        assert_eq!(bus.read_long(calc_tramp + 32), wdef_proc);
+
+        assert_eq!(bus.read_long(calc_tramp + 48), window_ptr);
+        assert_eq!(bus.read_word(calc_tramp + 52), 0xA909);
+        let draw_tramp = bus.read_long(calc_tramp + 56);
+        assert_ne!(draw_tramp, 0);
+        assert_eq!(bus.read_long(draw_tramp + 16), window_ptr);
+        assert_eq!(
+            bus.read_word(draw_tramp + 22),
+            super::super::TrapDispatcher::WDEF_WDRAW_MSG as u16,
+        );
+        assert_eq!(bus.read_long(draw_tramp + 32), wdef_proc);
+        assert_eq!(
+            disp.current_port, disp.window_manager_cport,
+            "custom resize drawing must run in the color Window Manager port"
+        );
+    }
+
+    #[test]
+    fn movewindow_translates_custom_regions_then_asks_wdef_to_recalculate() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let wdef_proc = install_wdef_resource(&mut disp, &mut bus, 200);
+        let window_ptr = bus.alloc(256);
+        let proc_id = (200i16 << 4) | 3;
+
+        disp.init_cgraf_window(
+            &mut bus,
+            &mut cpu,
+            window_ptr,
+            disp.screen_mode.0,
+            40,
+            50,
+            120,
+            180,
+            "",
+            proc_id,
+            true,
+            false,
+            false,
+            0,
+        );
+        let structure_handle =
+            bus.read_long(window_ptr + super::super::TrapDispatcher::WINDOW_STRUC_RGN_OFFSET);
+        let content_handle =
+            bus.read_long(window_ptr + super::super::TrapDispatcher::WINDOW_CONT_RGN_OFFSET);
+        super::super::TrapDispatcher::write_region_handle_rect(
+            &mut bus,
+            structure_handle,
+            Some((31, 41, 129, 189)),
+        );
+        super::super::TrapDispatcher::write_region_handle_rect(
+            &mut bus,
+            content_handle,
+            Some((40, 50, 120, 180)),
+        );
+
+        let sp = TEST_SP - 10;
+        let return_pc = 0x1234_5678;
+        cpu.write_reg(Register::A7, sp);
+        cpu.write_reg(Register::PC, return_pc);
+        bus.write_byte(sp, 0); // front
+        bus.write_word(sp + 2, 70); // vGlobal
+        bus.write_word(sp + 4, 90); // hGlobal
+        bus.write_long(sp + 6, window_ptr);
+
+        let result = dispatch(&mut disp, 0x11B, &mut cpu, &mut bus);
+        assert!(result.is_some());
+        assert!(result.unwrap().is_ok());
+        assert_eq!(
+            read_window_region_rect(
+                &bus,
+                window_ptr,
+                super::super::TrapDispatcher::WINDOW_STRUC_RGN_OFFSET,
+            ),
+            (70, 90, 150, 220),
+            "wCalcRgns must receive the moved content rectangle as its structure seed"
+        );
+        assert_eq!(
+            read_window_region_rect(
+                &bus,
+                window_ptr,
+                super::super::TrapDispatcher::WINDOW_CONT_RGN_OFFSET,
+            ),
+            (70, 90, 150, 220),
+            "MoveWindow must translate the custom content instead of replacing it"
+        );
+
+        let calc_tramp = disp.window_def_trampoline;
+        assert_ne!(calc_tramp, 0);
+        assert_eq!(cpu.read_reg(Register::PC), calc_tramp);
+        assert_eq!(cpu.read_reg(Register::A7), sp + 6);
+        assert_eq!(bus.read_long(sp + 6), return_pc);
+        assert_eq!(
+            bus.read_word(calc_tramp + 22),
+            super::super::TrapDispatcher::WDEF_WCALC_RGNS_MSG as u16,
+        );
+        assert_eq!(bus.read_long(calc_tramp + 32), wdef_proc);
+        assert_eq!(bus.read_long(calc_tramp + 48), window_ptr);
+        assert_eq!(bus.read_word(calc_tramp + 52), 0xA909);
+        let draw_tramp = bus.read_long(calc_tramp + 56);
+        assert_eq!(
+            bus.read_word(draw_tramp + 22),
+            super::super::TrapDispatcher::WDEF_WDRAW_MSG as u16,
+        );
+        assert_eq!(bus.read_long(draw_tramp + 32), wdef_proc);
     }
 
     // ---------------------------------------------------------------
@@ -8146,6 +8579,58 @@ mod tests {
     }
 
     #[test]
+    fn hide_last_visible_window_repaints_the_entire_desktop() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let screen_base = bus.alloc(800 * 600);
+        bus.write_long(0x0824, screen_base);
+        bus.write_word(crate::memory::globals::addr::MBAR_HEIGHT, 20);
+        disp.menu_bar_hidden = false;
+        disp.set_screen_mode_for_test(screen_base, 800, 800, 600, 8);
+
+        let window = bus.alloc(256);
+        disp.init_cgraf_window(
+            &mut bus,
+            &mut cpu,
+            window,
+            screen_base,
+            80,
+            100,
+            220,
+            420,
+            "Only Window",
+            0,
+            true,
+            true,
+            false,
+            0,
+        );
+        disp.front_window = window;
+        let desktop_probe = screen_base + 550 * 800 + 700;
+        let injected = [0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47];
+        for (offset, value) in injected.iter().copied().enumerate() {
+            bus.write_byte(desktop_probe + offset as u32, value);
+        }
+
+        let sp = TEST_SP - 4;
+        cpu.write_reg(Register::A7, sp);
+        bus.write_long(sp, window);
+        dispatch(&mut disp, 0x116, &mut cpu, &mut bus)
+            .expect("HideWindow dispatch")
+            .expect("HideWindow");
+
+        assert_eq!(disp.front_window, 0);
+        assert_eq!(disp.window_bounds, (0, 0, 0, 0));
+        assert!(
+            injected
+                .iter()
+                .copied()
+                .enumerate()
+                .any(|(offset, value)| { bus.read_byte(desktop_probe + offset as u32) != value }),
+            "hiding the final window must repaint desktop pixels outside that window's strucRgn"
+        );
+    }
+
+    #[test]
     fn hide_window_invalidates_visible_content_behind_it() {
         let (mut disp, mut cpu, mut bus) = setup();
         let screen_base = bus.alloc(800 * 600);
@@ -8328,6 +8813,64 @@ mod tests {
             bus.read_byte(probe),
             0xCC,
             "HideWindow should restore the pixels saved under non-document windows"
+        );
+    }
+
+    #[test]
+    fn hide_window_erases_custom_wdef_structure_outside_port_rect() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let screen_base = bus.alloc(800 * 600);
+        bus.write_long(0x0824, screen_base);
+        disp.set_screen_mode_for_test(screen_base, 800, 800, 600, 8);
+        install_wdef_resource(&mut disp, &mut bus, 200);
+
+        let window = bus.alloc(256);
+        disp.init_cgraf_window(
+            &mut bus,
+            &mut cpu,
+            window,
+            screen_base,
+            40,
+            40,
+            200,
+            300,
+            "",
+            200i16 << 4,
+            true,
+            true,
+            false,
+            0,
+        );
+        let structure = bus.read_long(window + 114);
+        super::super::TrapDispatcher::write_region_handle_rect(
+            &mut bus,
+            structure,
+            Some((20, 30, 220, 320)),
+        );
+        assert_eq!(
+            disp.window_structure_rect(&bus, window),
+            Some((20, 30, 220, 320))
+        );
+        assert!(disp.window_visible(&bus, window));
+        assert!(!disp.window_saved_under_pixels.contains_key(&window));
+        let outside_port = screen_base + 210 * 800 + 304;
+        let injected = [0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47];
+        for (offset, value) in injected.iter().copied().enumerate() {
+            bus.write_byte(outside_port + offset as u32, value);
+        }
+
+        let sp = TEST_SP - 4;
+        cpu.write_reg(Register::A7, sp);
+        bus.write_long(sp, window);
+        dispatch(&mut disp, 0x116, &mut cpu, &mut bus)
+            .expect("HideWindow dispatch")
+            .expect("HideWindow");
+
+        assert!(
+            injected.iter().copied().enumerate().any(|(offset, value)| {
+                bus.read_byte(outside_port + offset as u32) != value
+            }),
+            "HideWindow must erase the full custom strucRgn, including frame pixels outside portRect"
         );
     }
 
@@ -8569,6 +9112,51 @@ mod tests {
         );
     }
 
+    #[test]
+    fn showhide_true_asks_custom_wdef_to_recalculate_and_draw() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let window = bus.alloc(256);
+        let proc_id = 200i16 << 4;
+        install_wdef_resource(&mut disp, &mut bus, 200);
+        disp.init_cgraf_window(
+            &mut bus,
+            &mut cpu,
+            window,
+            disp.screen_mode.0,
+            40,
+            40,
+            200,
+            300,
+            "",
+            proc_id,
+            false,
+            false,
+            false,
+            0,
+        );
+
+        let sp = TEST_SP - 6;
+        let return_pc = 0x1234_5678;
+        cpu.write_reg(Register::A7, sp);
+        cpu.write_reg(Register::PC, return_pc);
+        bus.write_byte(sp, 1);
+        bus.write_long(sp + 2, window);
+
+        dispatch(&mut disp, 0x108, &mut cpu, &mut bus)
+            .expect("ShowHide dispatch")
+            .expect("ShowHide");
+
+        let tramp = disp.window_def_trampoline;
+        assert_ne!(tramp, 0);
+        assert_eq!(cpu.read_reg(Register::PC), tramp);
+        assert_eq!(
+            bus.read_word(tramp + 22) as i16,
+            super::super::TrapDispatcher::WDEF_WCALC_RGNS_MSG,
+            "first message is wCalcRgns"
+        );
+        assert_eq!(bus.read_long(sp + 2), return_pc);
+    }
+
     // IM:I I-285: ShowHide(FALSE) makes the target window invisible but does
     // not reorder windows or generate activate events.
     #[test]
@@ -8681,6 +9269,8 @@ mod tests {
         let update_handle = bus.read_long(back + 122);
         super::super::TrapDispatcher::write_region_handle_rect(&mut bus, update_handle, None);
         disp.clear_queued_update_events(back);
+        let covered_pixel = screen_base + 100 * 800 + 150;
+        bus.write_byte(covered_pixel, 0xEE);
 
         let sp = TEST_SP - 6;
         cpu.write_reg(Register::A7, sp);
@@ -8695,6 +9285,11 @@ mod tests {
             .iter()
             .any(|event| { event.what == 6 && event.message == back }));
         assert!(!disp.dialog_visible_snapshots.contains_key(&target));
+        assert_ne!(
+            bus.read_byte(covered_pixel),
+            0xEE,
+            "ShowHide(FALSE) must remove the hidden window's pixels from the screen"
+        );
     }
 
     // ---------------------------------------------------------------


### PR DESCRIPTION
## Status

Spaceward Ho! 4.0 now completes the accessible demo matrix under deterministic inputs, including game creation, sustained turn progression, sound, preferences, save, close, and reopen. The final 68K oracle comparison and replay validation are complete.

## Changes

- preserve incremental dialog drawing across guest callbacks and custom controls
- report the classic OffscreenVersion value expected by Color QuickDraw clients
- record text state and LongText operations in generated PICTs and normalize rebased raster coordinates
- implement indexed Color QuickDraw highlighting, blend arithmetic, and inverse-table result mapping
- preserve actual oval geometry recorded by OpenRgn so complex CopyBits masks do not collapse to bounding rectangles
- run custom WDEF callbacks in Window Manager context while restoring the caller's port and temporary CGrafPort fields
- recalculate custom window structure, content, and visibility regions before drawing after create, move, resize, and show operations
- support custom WDEF delegation to the standard system WDEF for frame calculation, drawing, and hit testing
- erase, restore, invalidate, and repaint the correct structure regions when custom or save-under windows are hidden
- add focused regression coverage for each generic behavior

## 68K validation

- Source: [Classic Macintosh Game Demos](https://classicmacdemos.com/spaceward-ho)
- Archive SHA-256: `de215b7b02db591bc9e27d2508067d1b53922c80881756e6fb7c9b404cfd97b5`
- Executable: `DemoHo68K`, structurally verified as `APPL` with a parseable resource fork and `CODE` resource ID 0
- Exercised game creation, player naming, joining alone, tutorial dismissal, map selection, first and second turns, Options/Sound, Preferences, save, close, open, and continued execution after reopening
- Meaningful gameplay sound produced 990 non-silent samples in a 1,024-sample assertion window
- Seven stable application-content checkpoints matched the fresh System 7.5.3 reference at 99.44% strict / 99.56% perceptual overall; the lowest individual strict match was 99.23%
- Full-frame screenshots were also inspected; after excluding desktop chrome differences, no material application-owned visual mismatch remains
- Two clean runs produced byte-identical screenshots and checkpoint context artifacts
- Known-good compatibility checks for Absolute Solitaire, EV Override, Welltris, and Marathon 2 remain green

## Verification

- `cargo fmt --all -- --check`
- `cargo test --lib` (3,835 passed, 3 ignored)
- `cargo test --lib --features test-support` (3,841 passed, 3 ignored)
- `cargo check --no-default-features`
- `cargo check --target wasm32-unknown-unknown --no-default-features`
- `cargo package`

Closes #735
