### PR TITLE
fix: resolve dialog picture items against logical palette during hardware fades

### DIFF
--- a/src/trap/control.rs
+++ b/src/trap/control.rs
@@ -1448,7 +1448,7 @@ impl super::TrapDispatcher {
             abs_bottom,
             abs_right,
             self.screen_mode,
-            &self.device_clut,
+            &self.color_manager_clut,
             device_ct_seed,
             None,
         );

--- a/src/trap/dialog.rs
+++ b/src/trap/dialog.rs
@@ -6512,7 +6512,34 @@ impl super::TrapDispatcher {
                         if let Some((_, pic_ptr)) =
                             self.find_or_load_resource_any(bus, *b"PICT", item.resource_id)
                         {
-                            // Draw PICT into the item's display rectangle
+                            // Draw PICT into the item's display rectangle.
+                            // DrawPicture must map against the port's logical
+                            // ColorTable (or stable color_manager_clut), NOT
+                            // the transient hardware CLUT state (device_clut),
+                            // which may be faded down to black mid-transition.
+                            // Imaging With QuickDraw 1994, p. 7-11, 7-14.
+                            let dialog_clut = if dialog_ptr != 0 {
+                                let port_version = bus.read_word(dialog_ptr + 6);
+                                let is_cgraf_port = (port_version & 0xC000) == 0xC000;
+                                let ctab_handle = if is_cgraf_port {
+                                    let pm_handle = bus.read_long(dialog_ptr + 2);
+                                    if pm_handle != 0 {
+                                        let pm_ptr = bus.read_long(pm_handle);
+                                        if pm_ptr != 0 {
+                                            bus.read_long(pm_ptr + 42)
+                                        } else {
+                                            0
+                                        }
+                                    } else {
+                                        0
+                                    }
+                                } else {
+                                    0
+                                };
+                                self.read_port_clut(bus, ctab_handle)
+                            } else {
+                                self.color_manager_clut
+                            };
                             let device_ct_seed =
                                 Self::ctab_seed(bus, self.current_gdevice_ctab_handle(bus))
                                     .unwrap_or(0);
@@ -6524,7 +6551,7 @@ impl super::TrapDispatcher {
                                 abs_bottom,
                                 abs_right,
                                 self.screen_mode,
-                                &self.device_clut,
+                                &dialog_clut,
                                 device_ct_seed,
                                 None,
                             );
@@ -24851,6 +24878,69 @@ mod tests {
         assert_eq!(
             themed, classic,
             "systemless-default must not change DrawDialog PICT item pixels"
+        );
+    }
+
+    #[test]
+    fn drawdialog_picture_item_maps_against_logical_port_palette_during_hardware_fade() {
+        // Imaging With QuickDraw 1994, pp. 7-11..7-14: DrawPicture maps against
+        // the destination port's logical ColorTable (or stable Color Manager
+        // baseline), not the transient video DAC CLUT (device_clut), which
+        // games may fade down to black before opening a dialog.
+        let (mut disp, mut cpu, mut bus) = setup();
+        let dialog_ptr = bus.alloc(170);
+        let (screen_base, row_bytes, _w, _h, pixel_size) = disp.screen_mode;
+        assert_eq!(pixel_size, 8);
+
+        // Hardware CLUT is faded completely black
+        disp.device_clut = [[0u16; 3]; 256];
+
+        bus.write_word(dialog_ptr + 8, 0);
+        bus.write_word(dialog_ptr + 10, 0);
+        bus.write_word(dialog_ptr + 16, 0);
+        bus.write_word(dialog_ptr + 18, 0);
+        bus.write_word(dialog_ptr + 20, 48);
+        bus.write_word(dialog_ptr + 22, 80);
+        disp.install_test_resource(&mut bus, *b"PICT", 420, &solid_fill_pict_resource(16, 16));
+        disp.dialog_items.insert(
+            dialog_ptr,
+            vec![
+                DialogItem {
+                    item_type: 64, // picture item
+                    rect: (8, 8, 24, 24),
+                    text: String::new(),
+                    resource_id: 420,
+                    proc_ptr: 0,
+                    sel_start: 0,
+                    sel_end: 0,
+                },
+                DialogItem {
+                    item_type: 4,
+                    rect: (30, 8, 42, 40),
+                    text: "OK".to_string(),
+                    resource_id: 0,
+                    proc_ptr: 0,
+                    sel_start: 0,
+                    sel_end: 0,
+                },
+            ],
+        );
+
+        cpu.write_reg(Register::A7, TEST_SP);
+        bus.write_long(TEST_SP, dialog_ptr);
+        bus.write_long(TEST_SP + 4, 0xCAFE_BABE);
+
+        disp.dispatch_dialog(true, 0x181, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+
+        // 0xFF is black in the standard system palette, which solid_fill_pict_resource
+        // filled the rectangle with. If DrawPicture mapped against the all-zero device_clut,
+        // it would have collapsed to index 0 (white).
+        assert_eq!(
+            bus.read_byte(screen_base + 16 * row_bytes + 16),
+            0xFF,
+            "DrawDialog PICT item must map against logical palette even when device_clut is dark"
         );
     }
 

--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -22489,38 +22489,6 @@ impl super::TrapDispatcher {
         // substitutes a scaled `color_manager_clut`.
         //
         self.apply_set_entries_to_device_clut_unchecked(bus, table_ptr, start, count);
-        // Uniform sequence-mode ColorSpec.value fields are client IDs after
-        // Color Manager processing, not physical CLUT indices. Preserve the
-        // independently valid physical mapping while updating the logical
-        // GDevice table; treating the latter as a physical palette
-        // reinterprets already indexed artwork through unrelated colors.
-        // Inside Macintosh Volume V (1986), pp. V-142..V-143.
-        if target_is_screen && sequence_uses_client_ids {
-            if previous_frame_was_dimmed {
-                self.device_clut = self.color_manager_clut;
-            } else {
-                let gdh = self.set_entries_target_gdevice_handle(bus);
-                let ctab = Self::color_table_ptr(bus, Self::gdevice_ctab_handle(bus, gdh));
-                if ctab != 0 {
-                    for index in 0..256u32 {
-                        let value = bus.read_word(ctab + 8 + index * 8);
-                        if (value & ((PM_EXPLICIT as u16) << 8)) != 0 {
-                            self.device_clut[index as usize] =
-                                physical_clut_before_update[index as usize];
-                        }
-                    }
-                }
-            }
-            for index in 0..256u32 {
-                let entry = table_ptr + index * 8;
-                self.color_manager_clut[index as usize] = [
-                    bus.read_word(entry + 2),
-                    bus.read_word(entry + 4),
-                    bus.read_word(entry + 6),
-                ];
-            }
-        }
-
         // Publish `device_clut → color_manager_clut` only on a full-replace
         // SetEntries (start=0, count=255) that represents a fresh palette
         // install. Static dark scene palettes still need to publish so
@@ -22552,6 +22520,38 @@ impl super::TrapDispatcher {
                         table_ptr,
                         &self.color_manager_clut,
                     )));
+
+        // Uniform sequence-mode ColorSpec.value fields are client IDs after
+        // Color Manager processing, not physical CLUT indices. Preserve the
+        // independently valid physical mapping while updating the logical
+        // GDevice table; treating the latter as a physical palette
+        // reinterprets already indexed artwork through unrelated colors.
+        // Inside Macintosh Volume V (1986), pp. V-142..V-143.
+        if target_is_screen && sequence_uses_client_ids && !transient_fade_table {
+            if previous_frame_was_dimmed {
+                self.device_clut = self.color_manager_clut;
+            } else {
+                let gdh = self.set_entries_target_gdevice_handle(bus);
+                let ctab = Self::color_table_ptr(bus, Self::gdevice_ctab_handle(bus, gdh));
+                if ctab != 0 {
+                    for index in 0..256u32 {
+                        let value = bus.read_word(ctab + 8 + index * 8);
+                        if (value & ((PM_EXPLICIT as u16) << 8)) != 0 {
+                            self.device_clut[index as usize] =
+                                physical_clut_before_update[index as usize];
+                        }
+                    }
+                }
+            }
+            for index in 0..256u32 {
+                let entry = table_ptr + index * 8;
+                self.color_manager_clut[index as usize] = [
+                    bus.read_word(entry + 2),
+                    bus.read_word(entry + 4),
+                    bus.read_word(entry + 6),
+                ];
+            }
+        }
 
         if target_is_screen && is_full_replace && !transient_fade_table && !sequence_uses_client_ids
         {
@@ -42244,6 +42244,42 @@ mod tests {
         assert_eq!(bus.read_word(entry_42 + 2), 0x2A00);
         assert_eq!(bus.read_word(entry_42 + 4), 0xD500);
         assert_eq!(bus.read_word(entry_42 + 6), 0x5500);
+    }
+
+    #[test]
+    fn test_setentries_sequence_mode_fade_down_does_not_collapse_color_manager_clut() {
+        // When games perform a smooth fade-down to black using SetEntries sequence mode
+        // (start=0, count=255, with uninitialized/zero ColorSpec.value fields), each
+        // step must dim the physical DAC (device_clut) without overwriting or collapsing
+        // the stable Color Manager baseline (color_manager_clut).
+        let (mut d, _cpu, mut bus) = setup_with_port();
+        d.ensure_main_gdevice(&mut bus);
+        let baseline = TrapDispatcher::standard_mac_8bpp_clut();
+        d.color_manager_clut = baseline;
+        d.device_clut = baseline;
+        let table_ptr = 0x336E00u32;
+
+        // Perform a 4-step fade down to 0%
+        for scale in [0.75, 0.50, 0.25, 0.0] {
+            for index in 0..256u32 {
+                let entry = table_ptr + index * 8;
+                bus.write_word(entry, 0); // zero value field in sequence mode
+                for (ch, &val) in baseline[index as usize].iter().enumerate() {
+                    let scaled = (f64::from(val) * scale).round() as u16;
+                    bus.write_word(entry + 2 + (ch as u32) * 2, scaled);
+                }
+            }
+            d.apply_set_entries_with_gdevice(&mut bus, table_ptr, 0, 255);
+        }
+
+        // Hardware CLUT is now black (0)
+        assert_eq!(d.device_clut[0], [0, 0, 0]);
+        assert_eq!(d.device_clut[128], [0, 0, 0]);
+        // Color Manager CLUT remains the full baseline palette
+        assert_eq!(
+            d.color_manager_clut, baseline,
+            "color_manager_clut must remain the baseline palette during hardware fade-down"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #739

## Summary

- gate `SetEntries` sequence-mode updates behind `!transient_fade_table` so that hardware fade frames update the physical video DAC (`device_clut`) without collapsing the stable logical `color_manager_clut` to black
- resolve type 64 (`Picture`) dialog items in `draw_dialog` against the dialog port's logical `ColorTable` (via `read_port_clut`) or `color_manager_clut` rather than the transient hardware video DAC CLUT (`device_clut`)
- route picture-title custom controls in `control.rs` through `color_manager_clut`
- add unit tests verifying sequence-mode fade-downs preserve `color_manager_clut` and `DrawDialog` picture items map against the logical palette during hardware fades

## Validation

- `cargo fmt --check`
- `cargo test --lib` (3,823 tests pass)
- deterministic play probe for Bonkheads Deluxe world select dialog (`DLOG 10700`) resolves all 12 level banners and the wizard portrait in full color, matching BasiliskII at 91.71% strict pixel agreement