### PR TITLE
fix: preserve working directories for 3-D Ultra Pinball

### DIFF
--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -1609,6 +1609,11 @@ pub struct TrapDispatcher {
     /// Guest-controlled runners default to `false`; explicit frontend policy
     /// may set it while leaving `fullscreen_locked` to model guest state.
     pub menu_bar_hidden: bool,
+    /// Raw framebuffer pixels covered by the host-rendered menu bar. The real
+    /// Window Manager owns a separate visual layer; the HLE renderer restores
+    /// this snapshot when the guest hides the bar so stale chrome does not
+    /// remain in full-screen modes.
+    pub(crate) menu_bar_saved_under_pixels: Option<(u32, u32, u16, Vec<u8>)>,
     /// Sound Manager state (channels, playback buffers).
     pub sound_manager: crate::sound::SoundManager,
     /// Menus loaded from MENU resources, in order of insertion
@@ -3133,6 +3138,7 @@ impl TrapDispatcher {
             menu_bar_policy: crate::runner::MenuBarPolicy::GuestControlled,
             initial_kiosk_guest_hide_observed: false,
             menu_bar_hidden: false,
+            menu_bar_saved_under_pixels: None,
             sound_manager: crate::sound::SoundManager::new(),
             menus: Vec::new(),
             saved_menu_bars: HashMap::new(),

--- a/src/trap/framebuffer.rs
+++ b/src/trap/framebuffer.rs
@@ -1418,6 +1418,35 @@ impl super::TrapDispatcher {
         }
     }
 
+    fn fill_black_outside_rect(&self, bus: &mut MacMemoryBus, excluded_rect: (i16, i16, i16, i16)) {
+        let (screen_base, row_bytes, screen_width, screen_height, pixel_size) =
+            self.get_screen_params();
+        let top = excluded_rect.0.max(0).min(screen_height);
+        let left = excluded_rect.1.max(0).min(screen_width);
+        let bottom = excluded_rect.2.max(0).min(screen_height);
+        let right = excluded_rect.3.max(0).min(screen_width);
+        for (rt, rl, rb, rr) in [
+            (0, 0, top, screen_width),
+            (bottom, 0, screen_height, screen_width),
+            (top, 0, bottom, left),
+            (top, right, bottom, screen_width),
+        ] {
+            Self::fb_fill_rect(
+                bus,
+                screen_base,
+                row_bytes,
+                pixel_size,
+                screen_width,
+                screen_height,
+                rt,
+                rl,
+                rb,
+                rr,
+                true,
+            );
+        }
+    }
+
     fn refresh_saved_under_with_desktop_pattern(&mut self, bus: &MacMemoryBus, window: u32) {
         let (_, _, _, _, pixel_size) = self.get_screen_params();
         let black = Self::logical_black_pixel_index(bus);
@@ -2203,7 +2232,7 @@ impl super::TrapDispatcher {
     /// Draw the menu bar at the top of the screen.
     /// Height is read from the MBarHeight low-memory global ($0BAA).
     /// If MBarHeight is 0, the menu bar is hidden (full-screen mode).
-    pub(crate) fn draw_menu_bar_to_fb(&self, bus: &mut MacMemoryBus) {
+    pub(crate) fn draw_menu_bar_to_fb(&mut self, bus: &mut MacMemoryBus) {
         if self.fullscreen_locked || self.menu_bar_hidden {
             return;
         }
@@ -2212,6 +2241,14 @@ impl super::TrapDispatcher {
         let menu_bar_height = bus.read_word(crate::memory::globals::addr::MBAR_HEIGHT) as i16;
         if menu_bar_height <= 0 {
             return;
+        }
+        if self.menu_bar_saved_under_pixels.is_none() {
+            let saved_height = (menu_bar_height as u16).min(screen_height as u16);
+            let byte_len = row_bytes.saturating_mul(u32::from(saved_height));
+            let pixels = (0..byte_len)
+                .map(|offset| bus.read_byte(screen_base + offset))
+                .collect();
+            self.menu_bar_saved_under_pixels = Some((screen_base, row_bytes, saved_height, pixels));
         }
         let menu_bar_bg_index = self.menu_bar_background_pixel_index(bus, pixel_size);
 
@@ -4405,6 +4442,26 @@ impl super::TrapDispatcher {
         }
     }
 
+    fn restore_hidden_menu_bar_pixels(&mut self, bus: &mut MacMemoryBus) {
+        let menu_bar_height = bus.read_word(crate::memory::globals::addr::MBAR_HEIGHT) as i16;
+        if menu_bar_height > 0 && !self.fullscreen_locked && !self.menu_bar_hidden {
+            return;
+        }
+        let Some((saved_base, saved_row_bytes, saved_height, pixels)) =
+            self.menu_bar_saved_under_pixels.take()
+        else {
+            return;
+        };
+        let (screen_base, row_bytes, _, screen_height, _) = self.get_screen_params();
+        if saved_base != screen_base
+            || saved_row_bytes != row_bytes
+            || saved_height > screen_height as u16
+        {
+            return;
+        }
+        bus.write_bytes(screen_base, &pixels);
+    }
+
     /// Redraw the menu bar and window chrome into the framebuffer.
     ///
     /// On a real Mac, the Window Manager maintains these UI elements and redraws
@@ -4413,6 +4470,7 @@ impl super::TrapDispatcher {
     /// the chrome and should be called after each frame of emulation.
     pub fn redraw_chrome(&mut self, bus: &mut MacMemoryBus) {
         self.refresh_menu_bar_policy_from_guest(bus);
+        self.restore_hidden_menu_bar_pixels(bus);
 
         // Blit front window's port pixels to screen framebuffer if they differ.
         // On real Mac OS the Window Manager composites windows to the screen.
@@ -4455,6 +4513,17 @@ impl super::TrapDispatcher {
             && menu_bar_height <= 0
         {
             self.fullscreen_locked = true;
+        }
+
+        // A full-screen presentation can place a smaller game window over a
+        // screen-sized backdrop. Once the guest has hidden the menu bar and
+        // entered that mode, the exposed area is a black matte rather than
+        // stale desktop or host-rendered menu pixels.
+        if self.fullscreen_locked && self.front_window != 0 {
+            let presentation_rect = self
+                .window_structure_rect(bus, self.front_window)
+                .unwrap_or(self.window_bounds);
+            self.fill_black_outside_rect(bus, presentation_rect);
         }
 
         self.restore_kiosk_dialog_desktop_background(bus);
@@ -5647,6 +5716,69 @@ mod redraw_chrome_tests {
     }
 
     /// Counterpart to the kiosk-mode test above: when `menu_bar_hidden
+    #[test]
+    fn hidden_menu_bar_restores_pixels_saved_before_host_chrome() {
+        let (mut disp, _cpu, mut bus) = setup_with_port();
+
+        let screen_base = bus.alloc(64 * 64);
+        disp.screen_mode = (screen_base, 64, 64, 64, 8);
+        bus.write_long(0x0824, screen_base);
+        bus.fill_bytes(screen_base, 64 * 64, 0xE1);
+        bus.write_word(crate::memory::globals::addr::MBAR_HEIGHT, 20);
+        disp.menus.push(super::super::menu::Menu {
+            id: 1,
+            title: String::from("Apple"),
+            items: Vec::new(),
+            enabled: true,
+            handle: 0,
+            in_menu_bar: true,
+            hierarchical: false,
+            visible_in_menu_bar: true,
+        });
+
+        disp.draw_menu_bar_to_fb(&mut bus);
+        assert_ne!(bus.read_byte(screen_base + 10 * 64 + 32), 0xE1);
+
+        // Repainting while visible must retain the original saved-under
+        // pixels, not snapshot the already-rendered menu bar.
+        disp.draw_menu_bar_to_fb(&mut bus);
+        bus.write_word(crate::memory::globals::addr::MBAR_HEIGHT, 0);
+        disp.redraw_chrome(&mut bus);
+
+        for y in 0..20u32 {
+            for x in 0..64u32 {
+                assert_eq!(
+                    bus.read_byte(screen_base + y * 64 + x),
+                    0xE1,
+                    "hidden menu bar should reveal saved pixel at ({x},{y})"
+                );
+            }
+        }
+        assert!(disp.menu_bar_saved_under_pixels.is_none());
+    }
+
+    #[test]
+    fn fullscreen_matte_clears_exposed_pixels_around_centered_window() {
+        let (mut disp, _cpu, mut bus) = setup_with_port();
+
+        let screen_base = bus.alloc(64 * 64);
+        disp.screen_mode = (screen_base, 64, 64, 64, 8);
+        bus.write_long(0x0824, screen_base);
+        bus.fill_bytes(screen_base, 64 * 64, 0x7E);
+        disp.fill_black_outside_rect(&mut bus, (10, 12, 50, 52));
+
+        let black = TrapDispatcher::logical_black_pixel_index(&bus);
+        assert_eq!(bus.read_byte(screen_base + 5 * 64 + 32), black);
+        assert_eq!(bus.read_byte(screen_base + 30 * 64 + 5), black);
+        assert_eq!(bus.read_byte(screen_base + 30 * 64 + 58), black);
+        assert_eq!(bus.read_byte(screen_base + 58 * 64 + 32), black);
+        assert_eq!(
+            bus.read_byte(screen_base + 30 * 64 + 32),
+            0x7E,
+            "the centered presentation rectangle must remain untouched"
+        );
+    }
+
     /// = false` (guest-controlled hosting), `redraw_chrome` MUST paint
     /// the menu bar so menus are reachable.
     #[test]

--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -5729,16 +5729,21 @@ impl super::TrapDispatcher {
                     cpu.write_reg(Register::D0, nsverr as u32);
                     return Some(Ok(()));
                 }
-                let mut target_volume_ref_num = named_volume
-                    .map(|(volume_ref_num, _)| volume_ref_num)
+                // PBSetVol makes the encoded directory and its containing volume
+                // the defaults when ioVRefNum is a working-directory refnum.
+                // Inside Macintosh: Files (1992), p. 2-151.
+                let requested_working_directory =
+                    self.working_directories.get(&requested_vref).copied();
+                let mut target_volume_ref_num = requested_working_directory
+                    .map(|working_directory| working_directory.volume_ref_num)
+                    .or_else(|| named_volume.map(|(volume_ref_num, _)| volume_ref_num))
                     .unwrap_or_else(|| self.resolve_volume_ref_num(requested_vref));
-                let mut target_dir_id = if let Some((_, root_dir_id)) = named_volume {
-                    root_dir_id
-                } else if let Some(working_directory) =
-                    self.working_directories.get(&requested_vref)
+                let mut target_dir_id = if let Some(working_directory) = requested_working_directory
                 {
                     target_volume_ref_num = working_directory.volume_ref_num;
                     working_directory.dir_id
+                } else if let Some((_, root_dir_id)) = named_volume {
+                    root_dir_id
                 } else if is_hfs_set_vol
                     && requested_dir_id != 0
                     && self.directory_entry_for_id(requested_dir_id).is_some()
@@ -16651,6 +16656,30 @@ mod tests {
             super::super::dispatch::BOOT_VOLUME_REF_NUM
         );
         assert_eq!(bus.read_long(addr::CUR_DIR_STORE), 2);
+    }
+
+    #[test]
+    fn pbsetvol_named_volume_preserves_working_directory_refnum() {
+        let (mut disp, mut cpu, mut bus) = setup();
+
+        let app_dir_id = disp.ensure_vfs_directory("Applications/Example Game");
+        let wd_ref_num = disp
+            .open_working_directory(super::super::dispatch::BOOT_VOLUME_REF_NUM, app_dir_id, 0)
+            .expect("working-directory refnum");
+
+        let pb = 0x300000u32;
+        let name_buf = 0x300100u32;
+        cpu.write_reg(Register::A0, pb);
+        bus.write_long(pb + 18, name_buf);
+        write_pstring(&mut bus, name_buf, b"MacintoshHD");
+        bus.write_word(pb + 22, wd_ref_num as u16);
+
+        call_trap_word(&mut disp, 0xA015, &mut cpu, &mut bus).unwrap();
+
+        assert_eq!(cpu.read_reg(Register::D0), 0);
+        assert_eq!(disp.default_dir_id, app_dir_id);
+        assert_eq!(disp.app_wd_refnum, wd_ref_num);
+        assert_eq!(bus.read_long(addr::CUR_DIR_STORE), app_dir_id);
     }
 
     #[test]


### PR DESCRIPTION
Closes #741.

Depends on #738; this PR is intentionally stacked on its public branch and contains only the additional compatibility changes.

3-D Ultra Pinball saves a default-directory working-directory reference with PBGetVol and later restores it with PBSetVol while also supplying the volume name. The File Manager implementation selected the named volume root first, so later relative opens searched the root and the demo stopped before loading its table data. Inside Macintosh: Files (1992), p. 2-151 specifies that PBSetVol given a working-directory reference makes that directory and its containing volume the defaults. PBSetVol now preserves that encoded directory while still validating the named volume.

The demo also enters a guest-controlled fullscreen presentation after host-rendered menu chrome has appeared. The framebuffer compositor now restores pixels covered by a hidden menu bar and clears exposed pixels around a centered fullscreen window to a black matte, preventing stale desktop and menu pixels from leaking into the presentation.

Focused coverage:

- PBSetVol preserves a working-directory reference when the matching volume name is also supplied.
- Hiding a host-rendered menu bar restores its saved-under pixels.
- Fullscreen matte composition clears only the area outside the centered presentation rectangle.

Public crate gates:

- cargo fmt --all -- --check
- cargo test --lib: 3,838 passed, 3 ignored
- cargo test --lib --features test-support: 3,844 passed, 3 ignored
- cargo check --no-default-features
- cargo check --target wasm32-unknown-unknown --no-default-features
- cargo package --allow-dirty

Fresh 68K validation used the public demo archive from Classic Macintosh Game Demos (SHA-256 becae8fd53da4d7287505a0507440214ddc3cb26e0dbb23c2d3a88c7f03a8f2d). The deterministic matrix covers startup, the live Outpost table, both flippers, Options/Windows/Help routes, plunger launch, nudge, continued simulation, and gameplay audio. Two clean Systemless runs produced identical artifacts. All ten canonical frames exceeded the unchanged 95% strict threshold against a fresh BasiliskII run: 97.57% strict and 98.15% perceptual overall. Gameplay audio produced 344 non-silent buffers out of 367 sampled after launch.

Known-good compatibility checks for Absolute Solitaire and Welltris pass. The aggregate local corpus retains its existing missing-reference failures. Marathon 2 also retains three existing below-floor golden comparisons; disabling the new fullscreen matte reproduced the same percentages, ruling out this change as their cause. EV Override gameplay comparison remains unavailable because its expected BasiliskII frames are absent.