### PR TITLE
fix(menu): return zero from PopUpMenuSelect when mouse button is up

### DIFF
--- a/src/trap/menu.rs
+++ b/src/trap/menu.rs
@@ -2212,6 +2212,12 @@ impl super::TrapDispatcher {
                 } else {
                     // First call: read params and open popup dropdown
                     let sp = cpu.read_reg(Register::A7);
+                    // If the mouse button is not down when PopUpMenuSelect is called,
+                    // return 0 immediately without tracking or drawing dropdown per IM:Toolbox Essentials 3-120.
+                    if !self.menu_tracking_button_down(bus) {
+                        self.finish_menu_no_hit(bus, cpu, sp, 10);
+                        return Some(Ok(()));
+                    }
                     let popup_item = bus.read_word(sp) as i16;
                     let left = bus.read_word(sp + 2) as i16;
                     let top = bus.read_word(sp + 4) as i16;
@@ -2229,7 +2235,7 @@ impl super::TrapDispatcher {
                     if let Some(menu_idx) = self
                         .menus
                         .iter()
-                        .position(|m| m.id == menu_id && m.in_menu_bar)
+                        .position(|m| m.handle == menu_handle || m.id == menu_id)
                     {
                         let (dd_rect, highlighted_item) =
                             self.popup_menu_dropdown_rect(bus, menu_idx, top, left, popup_item);
@@ -11452,6 +11458,49 @@ mod tests {
         assert!(
             disp.menu_tracking.is_none(),
             "uninserted pop-up menus should not seed tracking"
+        );
+    }
+
+    #[test]
+    fn popupmenuselect_with_mouse_button_up_returns_zero_immediately() {
+        // IM: Toolbox Essentials 1992, p. 3-120:
+        // "If the user releases the mouse button without choosing an item,
+        // or if the mouse button was not down when PopUpMenuSelect was called,
+        // PopUpMenuSelect returns 0."
+        let (mut disp, mut cpu, mut bus) = setup_with_port();
+        disp.menu_bar_hidden = false;
+        disp.mouse_button = false;
+        bus.write_byte(crate::memory::globals::addr::MB_STATE, 0x80); // button up
+        bus.write_word(crate::memory::globals::addr::MBAR_HEIGHT, 20);
+
+        let menu = new_menu_with_title(&mut disp, &mut cpu, &mut bus, 402, 0x302000, "Pop");
+        append_menu_data(&mut disp, &mut cpu, &mut bus, menu, 0x302040, "First;Second;Third");
+        insert_menu_before_id(&mut disp, &mut cpu, &mut bus, menu, -1);
+
+        let sp = TEST_SP;
+        cpu.write_reg(Register::A7, sp);
+        bus.write_word(sp, 1); // popUpItem
+        bus.write_word(sp + 2, 100); // left
+        bus.write_word(sp + 4, 50); // top
+        bus.write_long(sp + 6, menu);
+        bus.write_long(sp + 10, 0xDEAD_BEEF); // result placeholder
+
+        let result = disp.dispatch_menu(true, 0x00B, &mut cpu, &mut bus);
+        assert!(result.is_some(), "PopUpMenuSelect should be handled");
+        assert!(result.unwrap().is_ok(), "PopUpMenuSelect should return");
+        assert_eq!(
+            cpu.read_reg(Register::A7),
+            sp + 10,
+            "PopUpMenuSelect should consume the 10-byte argument frame"
+        );
+        assert_eq!(
+            bus.read_long(sp + 10),
+            0,
+            "PopUpMenuSelect must return 0 when called with mouse button up"
+        );
+        assert!(
+            disp.menu_tracking.is_none(),
+            "PopUpMenuSelect must not start menu tracking when button is up"
         );
     }
 


### PR DESCRIPTION
Closes #743

### Root Cause
When an application invokes `PopUpMenuSelect` ($A80B) while the mouse button is up, `systemless` did not check `menu_tracking_button_down` before opening menu tracking. Instead, it opened a dropdown for the menu (or matched an unrelated menu requiring `in_menu_bar`) and evaluated the mouse position on button-release, returning a synthetic non-zero `(menu_id << 16) | selected_item` value.

In games such as *Castles: Siege and Conquest*, a single user item procedure handles both drawing the popup box and responding to clicks by calling `PopUpMenuSelect`. If `PopUpMenuSelect` returns a non-zero item, the application updates its internal selection state. Because `systemless` returned a synthetic non-zero value during standard dialog drawing passes (when no mouse button was down), this:
1. Drew popup dropdown menus directly across the dialog window surface.
2. Corrupted the application's selected item index with the high/low word mismatch, causing subsequent redraws of the popup text box to be blank or display incorrect menu items.

### Fix
1. Per *Inside Macintosh: Toolbox Essentials* (1992) page 3-120 ("If the user releases the mouse button without choosing an item, or if the mouse button was not down when `PopUpMenuSelect` was called, `PopUpMenuSelect` returns 0"), verify `menu_tracking_button_down` on entry; if the button is up, finish with 0 immediately and consume the 10-byte Pascal stack frame without starting menu tracking or rendering dropdowns.
2. Match popup menus by `m.handle == menu_handle || m.id == menu_id` without requiring `m.in_menu_bar`.
3. Add a unit test verifying `PopUpMenuSelect` immediately returns 0 and cleans up the stack when called with the mouse button up.

### Verification
- `cargo test` passed across all 3,823 unit and integration tests in `systemless`.
- Verified *Castles: Siege and Conquest* "New Game" configuration dialog renders cleanly with all popup menu boxes ("Valois", "Easy", "Balanced") positioned correctly without spurious dropdown overlays.