### PR TITLE
fix: run Blue's ABC Time Activities

### DIFF
--- a/src/trap/dialog.rs
+++ b/src/trap/dialog.rs
@@ -3999,15 +3999,6 @@ impl super::TrapDispatcher {
         // Macintosh Toolbox Essentials (1992), pp. 4-29, 4-31, 4-55,
         // and 4-124 to 4-126.
         let main_screen = (menu_bar_height, 0, screen_h, screen_w);
-        let place_at_alert_position = |target: (i16, i16, i16, i16)| -> (i16, i16, i16, i16) {
-            let dialog_w = bounds.3 - bounds.1;
-            let dialog_h = bounds.2 - bounds.0;
-            let target_w = target.3 - target.1;
-            let target_h = target.2 - target.0;
-            let new_left = target.1 + (target_w - dialog_w) / 2;
-            let new_top = target.0 + (target_h - dialog_h) / 5;
-            (new_top, new_left, new_top + dialog_h, new_left + dialog_w)
-        };
         // Parent-relative placement positions the complete dialog structure,
         // then converts the result back to the content bounds used by NewWindow.
         // Macintosh Toolbox Essentials 1992, pp. 4-125 to 4-126 and 6-62 to 6-63
@@ -4050,7 +4041,7 @@ impl super::TrapDispatcher {
             // alertPositionMainScreen / ParentWindowScreen
             // Macintosh Toolbox Essentials 1992, pp. 4-125 to 4-126
             0x300A | 0x700A => {
-                bounds = place_at_alert_position(main_screen);
+                bounds = place_structure_at_alert_position(main_screen);
             }
             // alertPositionParentWindow uses the content rectangle of the
             // window in which the user was last working.
@@ -11196,6 +11187,13 @@ impl super::TrapDispatcher {
 
                 let target_dialog = self.dialog_from_window_event(what, message);
                 if let Some(dialog_ptr) = target_dialog {
+                    // System 7 leaves the affected dialog in theDialog while
+                    // handling update and activate events even though the
+                    // Boolean result is FALSE. Macintosh Toolbox Essentials
+                    // (1992), pp. 6-139 through 6-141.
+                    if matches!(what, 6 | 8) && dialog_out_ptr != 0 {
+                        bus.write_long(dialog_out_ptr, dialog_ptr);
+                    }
                     let bounds = Self::dialog_screen_bounds(bus, dialog_ptr);
                     trace_detail = format!(
                         "bounds=({},{},{},{}) outcome=no_item",
@@ -18237,6 +18235,18 @@ mod tests {
     }
 
     #[test]
+    fn alert_position_places_the_complete_movable_dialog_structure() {
+        let (mut disp, _cpu, bus) = setup();
+        disp.screen_mode = (0, 800, 800, 600, 8);
+        disp.menu_bar_hidden = true;
+
+        assert_eq!(
+            disp.positioned_window_bounds(&bus, (120, 120, 215, 520), 0x700A, 5),
+            (115, 199, 210, 599)
+        );
+    }
+
+    #[test]
     fn get_new_dialog_uses_parent_window_for_alert_position() {
         // MTE 1992 pp. 4-125 to 4-126: alertPositionParentWindow places the
         // new window in the alert position of the window last used.
@@ -20308,6 +20318,39 @@ mod tests {
         assert!(result.unwrap().is_ok());
         assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 12);
         assert_eq!(bus.read_byte(TEST_SP + 12), 0);
+    }
+
+    #[test]
+    fn dialog_select_update_returns_affected_dialog_while_false() {
+        // MTE 1992 pp. 6-139..6-141: DialogSelect handles an update event
+        // and returns FALSE. System 7 also leaves the affected DialogPtr in
+        // theDialog, which movable-modal event loops may retain afterward.
+        let (mut disp, mut cpu, mut bus) = setup();
+        let dialog_ptr = bus.alloc(170);
+        let event_ptr = 0x300000u32;
+        let dialog_out_ptr = 0x300100u32;
+        let item_hit_ptr = 0x300104u32;
+
+        disp.front_window = dialog_ptr;
+        bus.write_byte(dialog_ptr + 109, 0xFF);
+        bus.write_word(dialog_ptr + 16, 10);
+        bus.write_word(dialog_ptr + 18, 20);
+        bus.write_word(dialog_ptr + 20, 110);
+        bus.write_word(dialog_ptr + 22, 180);
+        disp.dialog_items.insert(dialog_ptr, Vec::new());
+
+        bus.write_word(event_ptr, 6); // updateEvt
+        bus.write_long(event_ptr + 2, dialog_ptr);
+        bus.write_long(TEST_SP, item_hit_ptr);
+        bus.write_long(TEST_SP + 4, dialog_out_ptr);
+        bus.write_long(TEST_SP + 8, event_ptr);
+        bus.write_long(dialog_out_ptr, 0xDEAD_BEEF);
+
+        let result = disp.dispatch_dialog(true, 0x180, &mut cpu, &mut bus);
+        assert!(result.unwrap().is_ok());
+        assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 12);
+        assert_eq!(bus.read_byte(TEST_SP + 12), 0);
+        assert_eq!(bus.read_long(dialog_out_ptr), dialog_ptr);
     }
 
     #[test]
@@ -23966,8 +24009,8 @@ mod tests {
     #[test]
     fn systemless_theme_does_not_change_dialogselect_window_events() {
         // MTE 1992 p. 6-139 and IM:I I-417: activate/update events for a
-        // dialog window are handled by DialogSelect and return FALSE rather
-        // than reporting an enabled item through theDialog/itemHit.
+        // dialog window are handled by DialogSelect and return FALSE while
+        // identifying the affected window through theDialog, without an itemHit.
         // MTE 1992 pp. 6-141 and 6-143 plus IM:I I-291: update handling
         // brackets the redraw with BeginUpdate/EndUpdate, uses the dialog
         // port, redraws the dialog, and leaves app-owned userItem drawing
@@ -23978,7 +24021,7 @@ mod tests {
         let themed = dialog_select_window_event_results_for_theme(UiThemeId::SystemlessDefault);
 
         assert_eq!(classic.update_result, 0);
-        assert_eq!(classic.update_dialog_out, 0xDEAD_BEEF);
+        assert_eq!(classic.update_dialog_out, classic.dialog_ptr);
         assert_eq!(classic.update_item_hit, 0xCAFE);
         assert_eq!(classic.update_stack_after, TEST_SP + 12);
         assert!(!classic.update_deferred_after);
@@ -23996,7 +24039,7 @@ mod tests {
         );
         assert_eq!(classic.update_item_count_after, 3);
         assert_eq!(classic.activate_result, 0);
-        assert_eq!(classic.activate_dialog_out, 0xDEAD_BEEF);
+        assert_eq!(classic.activate_dialog_out, classic.dialog_ptr);
         assert_eq!(classic.activate_item_hit, 0xCAFE);
         assert_eq!(classic.activate_stack_after, TEST_SP + 12);
         assert_eq!(

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -1355,6 +1355,10 @@ pub struct TrapDispatcher {
     /// resource fork, but some installers call `GetResource('clut', depth)`
     /// directly instead of `GetCTable`.
     pub(crate) system_clut_cache: HashMap<i16, u32>,
+    /// Cache of the synthetic System-file `'wctb'` ID 0 resource. The
+    /// Window Manager loads this standard table during initialization, and
+    /// applications may also retrieve and duplicate it directly.
+    pub(crate) system_wctb_cache: HashMap<i16, u32>,
     /// Cache of synthetic System-file `'KCHR'` resource pointers. The
     /// U.S. Roman keyboard-layout resource ID 0 is present in every
     /// System file and is used directly by apps that call KeyTranslate.
@@ -3046,6 +3050,7 @@ impl TrapDispatcher {
             system_str_cache: HashMap::new(),
             system_cursor_cache: HashMap::new(),
             system_clut_cache: HashMap::new(),
+            system_wctb_cache: HashMap::new(),
             system_kchr_cache: HashMap::new(),
             system_kmap_cache: HashMap::new(),
             system_wdef_cache: HashMap::new(),
@@ -5572,6 +5577,54 @@ impl TrapDispatcher {
             bus.write_word(entry + 6, b);
         }
         self.system_clut_cache.insert(res_id, ptr);
+        Some(ptr)
+    }
+
+    /// Allocate (and cache) the standard System 7 window color table.
+    /// `InitWindows` searches the application, System file, and ROM for
+    /// `'wctb'` ID 0, whose `WinCTab` contains the colors for the standard
+    /// window-part identifiers. Inside Macintosh Volume V (1986), pp.
+    /// V-201..V-203; Macintosh Toolbox Essentials (1992), pp. 4-71 and 4-127.
+    pub(crate) fn synthesize_system_wctb(
+        &mut self,
+        bus: &mut MacMemoryBus,
+        res_id: i16,
+    ) -> Option<u32> {
+        if res_id != 0 {
+            return None;
+        }
+        if let Some(&ptr) = self.system_wctb_cache.get(&res_id) {
+            return Some(ptr);
+        }
+
+        const COLORS: [(u16, u16, u16, u16); 13] = [
+            (0, 0xFFFF, 0xFFFF, 0xFFFF),  // wContentColor
+            (1, 0x0000, 0x0000, 0x0000),  // wFrameColor
+            (2, 0x0000, 0x0000, 0x0000),  // wTextColor
+            (3, 0x0000, 0x0000, 0x0000),  // wHiliteColor
+            (4, 0xFFFF, 0xFFFF, 0xFFFF),  // wTitleBarColor
+            (5, 0xFFFF, 0xFFFF, 0xFFFF),  // wHiliteColorLight
+            (6, 0x0000, 0x0000, 0x0000),  // wHiliteColorDark
+            (7, 0xFFFF, 0xFFFF, 0xFFFF),  // wTitleBarLight
+            (8, 0x0000, 0x0000, 0x0000),  // wTitleBarDark
+            (9, 0xCCCC, 0xCCCC, 0xFFFF),  // wDialogLight
+            (10, 0x0000, 0x0000, 0x0000), // wDialogDark
+            (11, 0xCCCC, 0xCCCC, 0xFFFF), // wTingeLight
+            (12, 0x3333, 0x3333, 0x6666), // wTingeDark
+        ];
+
+        let ptr = bus.alloc(8 + COLORS.len() as u32 * 8);
+        bus.write_long(ptr, 0); // wCSeed is reserved.
+        bus.write_word(ptr + 4, 0); // wCReserved is reserved.
+        bus.write_word(ptr + 6, COLORS.len() as u16 - 1);
+        for (index, &(part, red, green, blue)) in COLORS.iter().enumerate() {
+            let entry = ptr + 8 + index as u32 * 8;
+            bus.write_word(entry, part);
+            bus.write_word(entry + 2, red);
+            bus.write_word(entry + 4, green);
+            bus.write_word(entry + 6, blue);
+        }
+        self.system_wctb_cache.insert(res_id, ptr);
         Some(ptr)
     }
 

--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -1774,6 +1774,18 @@ impl super::TrapDispatcher {
                     }
                 }
 
+                if res_type == *b"wctb" {
+                    if let Some(ptr) = self.synthesize_system_wctb(bus, res_id) {
+                        let handle = self.get_or_create_resource_handle(bus, res_type, res_id, ptr);
+                        cpu.write_reg(Register::A0, handle);
+                        cpu.write_reg(Register::D0, 0);
+                        bus.write_word(0x0A60, 0); // ResErr = noErr
+                        bus.write_long(sp + 6, handle);
+                        cpu.write_reg(Register::A7, sp + 6);
+                        return Some(Ok(()));
+                    }
+                }
+
                 if res_type == *b"WDEF" {
                     if let Some(ptr) = self.synthesize_system_wdef(bus, res_id) {
                         let handle = self
@@ -4253,52 +4265,46 @@ impl super::TrapDispatcher {
                         0u16,
                     ))
                 };
+                let volume_by_name = |name: &str| {
+                    // A full pathname names its volume before the first colon.
+                    // Files 1992, 2-6 and 2-145.
+                    let name = name.split(':').next().unwrap_or(name);
+                    if name.eq_ignore_ascii_case(super::TrapDispatcher::boot_volume_name()) {
+                        boot_volume()
+                    } else {
+                        self.vfs_volume_by_name(name)
+                            .map(|volume| (volume.name.clone(), volume.ref_num, volume.attributes))
+                    }
+                };
+                let volume_by_ref = |requested_vref: i16| {
+                    let volume_ref_num = if requested_vref
+                        == super::TrapDispatcher::boot_volume_ref_num()
+                        || self.vfs_volumes.contains_key(&requested_vref)
+                    {
+                        Some(requested_vref)
+                    } else {
+                        self.working_directories
+                            .get(&requested_vref)
+                            .map(|working_directory| working_directory.volume_ref_num)
+                    }?;
+                    if volume_ref_num == super::TrapDispatcher::boot_volume_ref_num() {
+                        boot_volume()
+                    } else {
+                        self.vfs_volume_for_ref_num(volume_ref_num)
+                            .map(|volume| (volume.name.clone(), volume.ref_num, volume.attributes))
+                    }
+                };
                 let volume_info = if volume_index == 0 {
                     // Files 1992, 2-145: ioVolIndex == 0 selects a volume by
                     // ioNamePtr or ioVRefNum instead of enumerating the VCB
                     // queue. Do not silently turn an unknown vRefNum into the
                     // boot volume; callers use nsvErr to detect a bad volume.
                     if requested_vref != 0 {
-                        let volume_ref_num = if requested_vref
-                            == super::TrapDispatcher::boot_volume_ref_num()
-                            || self.vfs_volumes.contains_key(&requested_vref)
-                        {
-                            Some(requested_vref)
-                        } else {
-                            self.working_directories
-                                .get(&requested_vref)
-                                .map(|working_directory| working_directory.volume_ref_num)
-                        };
-                        volume_ref_num.and_then(|volume_ref_num| {
-                            if volume_ref_num == super::TrapDispatcher::boot_volume_ref_num() {
-                                boot_volume()
-                            } else {
-                                self.vfs_volume_for_ref_num(volume_ref_num).map(|volume| {
-                                    (volume.name.clone(), volume.ref_num, volume.attributes)
-                                })
-                            }
-                        })
+                        volume_by_ref(requested_vref)
                     } else if !requested_name.is_empty() {
-                        if requested_name
-                            .eq_ignore_ascii_case(super::TrapDispatcher::boot_volume_name())
-                        {
-                            boot_volume()
-                        } else {
-                            self.vfs_volume_by_name(&requested_name).map(|volume| {
-                                (volume.name.clone(), volume.ref_num, volume.attributes)
-                            })
-                        }
+                        volume_by_name(&requested_name)
                     } else {
-                        let volume_ref_num = Some(self.resolve_volume_ref_num(self.app_wd_refnum));
-                        volume_ref_num.and_then(|volume_ref_num| {
-                            if volume_ref_num == super::TrapDispatcher::boot_volume_ref_num() {
-                                boot_volume()
-                            } else {
-                                self.vfs_volume_for_ref_num(volume_ref_num).map(|volume| {
-                                    (volume.name.clone(), volume.ref_num, volume.attributes)
-                                })
-                            }
-                        })
+                        volume_by_ref(self.app_wd_refnum)
                     }
                 } else if volume_index > 0 {
                     let mut mounted = self
@@ -4315,7 +4321,19 @@ impl super::TrapDispatcher {
                     volumes.extend(mounted);
                     volumes.get((volume_index - 1) as usize).cloned()
                 } else {
-                    None
+                    // Files 1992, 2-145: a negative ioVolIndex selects the
+                    // volume by ioNamePtr and ioVRefNum in the standard way.
+                    // A full pathname's volume name takes precedence; otherwise
+                    // a nonzero volume or working-directory reference is used.
+                    if requested_name.contains(':') {
+                        volume_by_name(&requested_name)
+                    } else if requested_vref != 0 {
+                        volume_by_ref(requested_vref)
+                    } else if !requested_name.is_empty() {
+                        volume_by_name(&requested_name)
+                    } else {
+                        volume_by_ref(self.app_wd_refnum)
+                    }
                 };
                 let Some((volume_name, volume_ref_num, volume_attributes)) = volume_info else {
                     // Files 1992, 2-145: positive ioVolIndex values walk the
@@ -9087,6 +9105,41 @@ mod tests {
         assert_eq!(bus.read_word(black + 2), 0, "entry 255 red");
         assert_eq!(bus.read_word(black + 4), 0, "entry 255 green");
         assert_eq!(bus.read_word(black + 6), 0, "entry 255 blue");
+    }
+
+    #[test]
+    fn get_resource_synthesizes_standard_system_window_color_table() {
+        // IM:V pp. V-201..V-203: InitWindows falls back to the System-file
+        // or ROM `'wctb'` ID 0 when the application does not provide one.
+        let (mut disp, mut cpu, mut bus) = setup();
+
+        bus.write_word(TEST_SP, 0);
+        bus.write_long(TEST_SP + 2, u32::from_be_bytes(*b"wctb"));
+
+        call(&mut disp, true, 0x1A0, &mut cpu, &mut bus).unwrap();
+
+        let handle = bus.read_long(TEST_SP + 6);
+        assert_ne!(handle, 0);
+        assert_eq!(cpu.read_reg(Register::A0), handle);
+        assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 6);
+        assert_eq!(bus.read_word(0x0A60), 0);
+
+        let table = bus.read_long(handle);
+        assert_ne!(table, 0);
+        assert_eq!(bus.get_alloc_size(table), Some(112));
+        assert_eq!(bus.read_long(table), 0);
+        assert_eq!(bus.read_word(table + 4), 0);
+        assert_eq!(bus.read_word(table + 6), 12);
+        assert_eq!(bus.read_word(table + 8), 0); // wContentColor
+        assert_eq!(bus.read_word(table + 10), 0xFFFF);
+        assert_eq!(bus.read_word(table + 12), 0xFFFF);
+        assert_eq!(bus.read_word(table + 14), 0xFFFF);
+        assert_eq!(bus.read_word(table + 16), 1); // wFrameColor
+        assert_eq!(bus.read_word(table + 18), 0);
+        assert_eq!(bus.read_word(table + 104), 12); // wTingeDark
+        assert_eq!(bus.read_word(table + 106), 0x3333);
+        assert_eq!(bus.read_word(table + 108), 0x3333);
+        assert_eq!(bus.read_word(table + 110), 0x6666);
     }
 
     #[test]
@@ -15104,6 +15157,54 @@ mod tests {
         assert_eq!(bus.read_word(pb + 22), volume_ref as u16);
         assert_eq!(bus.read_pstring(name_buf), b"Legend CD");
         assert_eq!(bus.read_word(pb + 38), 0x8080, "ioVAtrb");
+    }
+
+    #[test]
+    fn pb_hget_vinfo_negative_index_selects_volume_from_full_path() {
+        // Inside Macintosh: Files (1992), 2-145: negative ioVolIndex uses
+        // ioNamePtr and ioVRefNum in the standard way. A full pathname names
+        // its volume before the first colon.
+        let (mut disp, mut cpu, mut bus) = setup();
+
+        let pb = 0x300000u32;
+        let name_buf = 0x300100u32;
+        cpu.write_reg(Register::A0, pb);
+        bus.write_long(pb + 18, name_buf);
+        bus.write_pstring(name_buf, b"MacintoshHD:Games:Demo");
+        bus.write_word(pb + 22, 0);
+        bus.write_word(pb + 28, (-1i16) as u16);
+
+        call(&mut disp, false, 0x07, &mut cpu, &mut bus).unwrap();
+
+        assert_eq!(cpu.read_reg(Register::D0), 0);
+        assert_eq!(bus.read_word(pb + 16), 0, "ioResult");
+        assert_eq!(
+            bus.read_word(pb + 22),
+            super::super::dispatch::BOOT_VOLUME_REF_NUM as u16,
+            "ioVRefNum"
+        );
+        assert_eq!(bus.read_pstring(name_buf), b"MacintoshHD");
+    }
+
+    #[test]
+    fn pb_hget_vinfo_negative_index_resolves_working_directory_reference() {
+        let (mut disp, mut cpu, mut bus) = setup();
+
+        let pb = 0x300000u32;
+        cpu.write_reg(Register::A0, pb);
+        bus.write_long(pb + 18, 0);
+        bus.write_word(pb + 22, disp.app_wd_refnum as u16);
+        bus.write_word(pb + 28, (-1i16) as u16);
+
+        call(&mut disp, false, 0x07, &mut cpu, &mut bus).unwrap();
+
+        assert_eq!(cpu.read_reg(Register::D0), 0);
+        assert_eq!(bus.read_word(pb + 16), 0, "ioResult");
+        assert_eq!(
+            bus.read_word(pb + 22),
+            super::super::dispatch::BOOT_VOLUME_REF_NUM as u16,
+            "ioVRefNum"
+        );
     }
 
     #[test]

--- a/src/trap/window.rs
+++ b/src/trap/window.rs
@@ -1949,7 +1949,11 @@ impl super::TrapDispatcher {
             window_ptr + Self::WINDOW_GO_AWAY_FLAG_OFFSET,
             if go_away_flag { 0xFF } else { 0x00 },
         );
-        bus.write_byte(window_ptr + Self::WINDOW_SPARE_FLAG_OFFSET, 0);
+        let standard_zoom_window = matches!(proc_id, 8 | 12);
+        bus.write_byte(
+            window_ptr + Self::WINDOW_SPARE_FLAG_OFFSET,
+            if standard_zoom_window { 0xFF } else { 0 },
+        );
         // WindowRecord strucRgn, contRgn, and updateRgn are maintained in
         // global coordinates. Inside Macintosh Volume I, p. I-278.
         let global_content = self.window_local_rect_to_global(bus, window_ptr, content_rect);
@@ -1962,7 +1966,48 @@ impl super::TrapDispatcher {
         bus.write_long(window_ptr + Self::WINDOW_CONT_RGN_OFFSET, cont_rgn);
         bus.write_long(window_ptr + Self::WINDOW_UPDATE_RGN_OFFSET, update_rgn);
         bus.write_long(window_ptr + Self::WINDOW_DEF_PROC_OFFSET, 0);
-        bus.write_long(window_ptr + Self::WINDOW_DATA_HANDLE_OFFSET, 0);
+        if standard_zoom_window {
+            // The standard WDEF owns a WStateData handle for zoomDocProc and
+            // zoomNoGrow windows. Applications are expressly allowed to
+            // replace either rectangle before calling ZoomWindow, so the
+            // handle must exist as soon as NewWindow/GetNewWindow returns.
+            // Macintosh Toolbox Essentials (1992), pp. 4-53 through 4-54.
+            let state = bus.alloc(16);
+            let state_handle = bus.alloc(4);
+            bus.write_long(state_handle, state);
+
+            // userState begins at the window's requested global content
+            // bounds. The default standard state is the main device's gray
+            // region inset by three pixels; applications commonly replace it
+            // with their own ideal bounds before zooming.
+            for (offset, value) in [
+                (0u32, global_content.0),
+                (2, global_content.1),
+                (4, global_content.2),
+                (6, global_content.3),
+            ] {
+                bus.write_word(state + offset, value as u16);
+            }
+            let (_, _, screen_width, screen_height, _) = self.screen_mode;
+            let menu_bar_height = bus.read_word(crate::memory::globals::addr::MBAR_HEIGHT) as i16;
+            let standard = (
+                menu_bar_height.saturating_add(3),
+                3i16,
+                (screen_height as i16).saturating_sub(3),
+                (screen_width as i16).saturating_sub(3),
+            );
+            for (offset, value) in [
+                (8u32, standard.0),
+                (10, standard.1),
+                (12, standard.2),
+                (14, standard.3),
+            ] {
+                bus.write_word(state + offset, value as u16);
+            }
+            bus.write_long(window_ptr + Self::WINDOW_DATA_HANDLE_OFFSET, state_handle);
+        } else {
+            bus.write_long(window_ptr + Self::WINDOW_DATA_HANDLE_OFFSET, 0);
+        }
         bus.write_long(window_ptr + Self::WINDOW_TITLE_HANDLE_OFFSET, 0);
         bus.write_word(window_ptr + Self::WINDOW_TITLE_WIDTH_OFFSET, 0);
         bus.write_long(window_ptr + Self::WINDOW_CONTROL_LIST_OFFSET, 0);
@@ -11490,6 +11535,64 @@ mod tests {
             bus.read_word(TEST_SP),
             0,
             "TrackBox should write BOOLEAN FALSE to the result slot"
+        );
+    }
+
+    // MTE 1992 pp. 4-53..4-54: the standard zoom WDEF creates WStateData
+    // and marks spareFlag when it initializes the window record.
+    #[test]
+    fn standard_zoom_window_creation_installs_wstate_data() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let window = bus.alloc(256);
+        bus.write_word(crate::memory::globals::addr::MBAR_HEIGHT, 20);
+        let (_, _, screen_width, screen_height, _) = disp.screen_mode;
+
+        disp.init_cgraf_window(
+            &mut bus,
+            &mut cpu,
+            window,
+            disp.screen_mode.0,
+            50,
+            10,
+            530,
+            650,
+            "Zoomable",
+            12,
+            true,
+            false,
+            true,
+            0,
+        );
+
+        assert_eq!(
+            bus.read_byte(window + super::super::TrapDispatcher::WINDOW_SPARE_FLAG_OFFSET),
+            0xFF,
+            "zoomNoGrow must set the WindowRecord zoom flag"
+        );
+        let state_handle =
+            bus.read_long(window + super::super::TrapDispatcher::WINDOW_DATA_HANDLE_OFFSET);
+        assert_ne!(state_handle, 0, "zoomNoGrow must allocate WStateData");
+        let state = bus.read_long(state_handle);
+        assert_ne!(state, 0, "WStateData handle must be dereferenceable");
+        assert_eq!(
+            (
+                bus.read_word(state) as i16,
+                bus.read_word(state + 2) as i16,
+                bus.read_word(state + 4) as i16,
+                bus.read_word(state + 6) as i16,
+            ),
+            (50, 10, 530, 650),
+            "userState must begin at the requested global bounds"
+        );
+        assert_eq!(
+            (
+                bus.read_word(state + 8) as i16,
+                bus.read_word(state + 10) as i16,
+                bus.read_word(state + 12) as i16,
+                bus.read_word(state + 14) as i16,
+            ),
+            (23, 3, screen_height as i16 - 3, screen_width as i16 - 3),
+            "stdState must default to the gray region inset by three pixels"
         );
     }
 


### PR DESCRIPTION
## Summary

- report Component Manager 3.0 through `Gestalt('cpnt')`, matching the implemented dispatch surface
- provide the standard System 7 window color table and resolve negative-index volume queries by full path, volume reference, or working-directory reference
- initialize standard zoom-window state so the game expands its window to the intended 800×600 display
- position the complete window structure for System 7 alert-position constants
- preserve the affected `DialogPtr` from `DialogSelect` update and activate events while retaining its `FALSE` Boolean result
- cover every compatibility correction with focused unit tests

## Generic root causes

The startup color warning was caused by an understated Component Manager capability response. After that gate, the application required the standard `wctb` resource, Finder-compatible volume lookup semantics, and initialized standard zoom-window state to locate its companion data and establish the intended display.

The pause loop exposed two Dialog Manager defects. Alert-position constants were centering only the content rectangle rather than the complete WDEF structure, and `DialogSelect` discarded the affected dialog pointer on handled update/activate events. System 7 preserves that pointer while returning `FALSE`; the application retains it during its movable-modal loop. Both behaviors are implemented generically following *Macintosh Toolbox Essentials* (1992), pp. 4-125–4-126 and 6-139–6-143.

## 68K compatibility result

The checksum-pinned 68K `CODE 0` executable now completes its CD-ROM check and intro, enters the demo’s only playable activity (Bathtime Rhymes), accepts a rhyme-bubble selection, produces non-silent response audio, pauses and resumes, exposes and applies Game-menu music and volume options, plays the Quit outro, and exits normally through `ExitToShell`. The demo offers no save/load, restart, scenario-selection, or ending route. The archive’s incomplete native PowerPC path is outside this explicitly 68K issue.

Fresh Systemless and System 7.5.3 BasiliskII runs used the same archive and deterministic inputs. Canonical before/resume/continued gameplay frames scored 97.37%, 97.97%, and 96.70% strict pixel match (97.35% overall); the menu-options route scored 97.89%; and the Quit route scored 95.70% followed by a pixel-exact outro frame. Two clean Systemless runs of every final route produced byte-identical artifacts. The meaningful bubble action produced 1,516,490 non-silent samples with no callback or runtime error.

## Validation

- `cargo fmt --all -- --check` — compatibility diff clean; current `master` has one pre-existing format-only diff in untouched `src/trap/menu.rs`
- `cargo test --lib` — 3,831 passed, 3 ignored
- `cargo test --lib --features test-support` — 3,837 passed, 3 ignored
- `cargo check --no-default-features`
- `cargo check --target wasm32-unknown-unknown --no-default-features`
- `cargo package` verification
- focused Component Manager, window-color-table, volume-selection, zoom-window, alert-position, and `DialogSelect` tests
- deterministic startup/intro, activity, bubble/audio, pause/resume, Game-menu settings, Quit/outro, and normal-exit routes under both 68K runtimes

Closes #747

