### PR TITLE
fix: restore classic key map bit ordering

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -12619,7 +12619,7 @@ mod tests {
         let ppc_app = runner.ppc_app.as_mut().expect("PPC app should stay loaded");
         let left_key = 0x7bu8;
         let left_byte = key_map_ptr + u32::from(left_key / 8);
-        let left_bit = 0x80u8 >> (left_key % 8);
+        let left_bit = 1u8 << (left_key % 8);
         assert_ne!(ppc_app.memory.read_u8(left_byte).unwrap() & left_bit, 0);
     }
 
@@ -13533,7 +13533,7 @@ mod tests {
 
         assert_eq!(
             runner.bus.read_byte(addr::KEY_MAP_LM + 4),
-            0x02,
+            0x40,
             "J key should be visible to byte/bit KeyMap readers"
         );
         assert_eq!(
@@ -13543,7 +13543,7 @@ mod tests {
         );
         assert_eq!(
             runner.bus.read_byte(addr::KEY_MAP_LM + 15),
-            0x02,
+            0x40,
             "up arrow should be visible to byte/bit KeyMap readers"
         );
         assert_eq!(
@@ -13566,7 +13566,7 @@ mod tests {
         );
         assert_eq!(
             runner.bus.read_byte(addr::KEY_MAP_LM + 15),
-            0x02,
+            0x40,
             "unrelated byte/bit down keys should remain mirrored"
         );
         assert_eq!(
@@ -13584,18 +13584,18 @@ mod tests {
         let caps_lock_byte = addr::KEY_MAP_LM + 7;
 
         runner.push_key_down(0x39, 0);
-        assert_eq!(runner.bus.read_byte(caps_lock_byte) & 0x40, 0x40);
+        assert_eq!(runner.bus.read_byte(caps_lock_byte) & 0x02, 0x02);
         runner.push_key_up(0x39, 0);
         assert_eq!(
-            runner.bus.read_byte(caps_lock_byte) & 0x40,
-            0x40,
+            runner.bus.read_byte(caps_lock_byte) & 0x02,
+            0x02,
             "physical release must keep the low-memory Caps Lock bit latched"
         );
 
         runner.push_key_down(0x39, 0);
-        assert_eq!(runner.bus.read_byte(caps_lock_byte) & 0x40, 0);
+        assert_eq!(runner.bus.read_byte(caps_lock_byte) & 0x02, 0);
         runner.push_key_up(0x39, 0);
-        assert_eq!(runner.bus.read_byte(caps_lock_byte) & 0x40, 0);
+        assert_eq!(runner.bus.read_byte(caps_lock_byte) & 0x02, 0);
     }
 
     #[test]

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -185,10 +185,10 @@ fn key_map_byte_mask(key_code: u8) -> Option<(usize, u8)> {
     if byte_idx >= 16 {
         return None;
     }
-    // `KeyMap` is a Pascal `PACKED ARRAY[0..127] OF Boolean`, whose
-    // elements occupy each byte from its most-significant bit downward.
-    // Inside Macintosh: Macintosh Toolbox Essentials (1992), p. 2-109.
-    let mask = 0x80u8 >> (key_code & 0x07);
+    // The classic C ABI exposes KeyMap as four longs, and games commonly
+    // inspect its bytes directly. Inside Macintosh: Macintosh Toolbox
+    // Essentials (1992), pp. 2-109..2-110.
+    let mask = 1u8 << (key_code & 0x07);
     Some((byte_idx, mask))
 }
 

--- a/src/trap/event.rs
+++ b/src/trap/event.rs
@@ -1262,6 +1262,30 @@ mod tests {
     }
 
     #[test]
+    fn keys_use_classic_keymap_bit_order() {
+        let (mut disp, _, _) = setup();
+
+        for (key_code, expected_byte_index, expected_mask) in [
+            (0x00, 0, 0x01),  // A
+            (0x31, 6, 0x02),  // Space
+            (0x37, 6, 0x80),  // Command
+            (0x7B, 15, 0x08), // Left Arrow
+            (0x7C, 15, 0x10), // Right Arrow
+            (0x7D, 15, 0x20), // Down Arrow
+            (0x7E, 15, 0x40), // Up Arrow
+        ] {
+            disp.push_key_down(key_code, 0);
+            assert_eq!(
+                disp.key_map_bytes()[expected_byte_index],
+                expected_mask,
+                "wrong KeyMap bit for key code {key_code:#04X}"
+            );
+            disp.push_key_up(key_code, 0);
+            assert_eq!(disp.key_map_bytes()[expected_byte_index], 0);
+        }
+    }
+
+    #[test]
     fn repeated_host_keydown_does_not_duplicate_keydown_or_restart_autokey() {
         // Browsers emit repeated keydown callbacks for a held key. Classic
         // Event Manager emits one keyDown followed by timed autoKey records.

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -18004,14 +18004,14 @@ mod tests {
         assert!(disp.key_is_down(0x26));
         assert!(disp.key_is_down(0x7E));
         assert!(!disp.key_is_down(0x2E), "J must not alias the M key");
-        assert_eq!(bus.read_byte(keys_ptr + 4), 0x02, "J key byte");
+        assert_eq!(bus.read_byte(keys_ptr + 4), 0x40, "J key byte");
         assert_eq!(
             bus.read_byte(keys_ptr + 5),
             0,
             "M key byte should stay clear when J is down"
         );
-        assert_eq!(bus.read_byte(keys_ptr + 6), 0x40, "space key byte");
-        assert_eq!(bus.read_byte(keys_ptr + 15), 0x12, "left/up arrow key byte");
+        assert_eq!(bus.read_byte(keys_ptr + 6), 0x02, "space key byte");
+        assert_eq!(bus.read_byte(keys_ptr + 15), 0x48, "left/up arrow key byte");
         assert_eq!(
             bus.read_byte(keys_ptr + 14),
             0,
@@ -18028,7 +18028,7 @@ mod tests {
         assert!(disp.key_is_down(0x31));
         assert!(disp.key_is_down(0x26));
         assert!(disp.key_is_down(0x7E));
-        assert_eq!(bus.read_byte(keys_ptr + 15), 0x02, "only up remains");
+        assert_eq!(bus.read_byte(keys_ptr + 15), 0x40, "only up remains");
 
         // J ($26) and M ($2E) differ only by KeyMap byte. This catches the
         // byte-pair swap that makes EV/Marathon direct pollers invert them.
@@ -18041,7 +18041,7 @@ mod tests {
         assert!(!disp.key_is_down(0x26));
         assert!(disp.key_is_down(0x2E));
         assert_eq!(bus.read_byte(keys_ptr + 4), 0, "J byte should be clear");
-        assert_eq!(bus.read_byte(keys_ptr + 5), 0x02, "M key byte");
+        assert_eq!(bus.read_byte(keys_ptr + 5), 0x40, "M key byte");
     }
 
     // GetMouse ($A972)


### PR DESCRIPTION
## Summary

- restore least-significant-bit-first positions within each byte of the classic 16-byte `KeyMap`
- fix direct keyboard polling for Space, Command, arrows, and every other virtual key
- update 68K, PowerPC, and low-memory mirror coverage and add a focused cross-key regression test

## Root cause

v0.18.8 changed the per-byte mask from `1 << (keyCode & 7)` to `0x80 >> (keyCode & 7)` after interpreting the Pascal `PACKED ARRAY` declaration independently of the classic C ABI. Games inspect the returned `KeyMap` bytes directly, so that change reversed every group of eight key codes. For example, left (`0x7B`) set the right-arrow bit (`0x7C`), while Space (`0x31`) appeared at `0x36` and Command (`0x37`) appeared at Tab (`0x30`).

## Evidence

Inside Macintosh documents `GetKeys` as returning a 16-byte `KeyMap`, with each element indexed by its virtual key code, and exposes the C type as `typedef long KeyMap[4]`. Existing game-compatible byte readers use `keyMap[keyCode >> 3] & (1 << (keyCode & 7))`. The reported arrow behavior exactly matches reversing the bits within the final byte.

## Validation

- `rustfmt --edition 2021 --check src/runner.rs src/trap/dispatch.rs src/trap/event.rs src/trap/toolbox.rs`
- `cargo test --quiet` (3,825 passed, 0 failed, 3 ignored; all binary and integration groups passed)

Closes #746