### PR TITLE
fix(quickdraw): resolve clip port fallbacks and prevent TEUpdate background erasure

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -125,6 +125,7 @@ fn trace_buffer_enabled() -> bool {
     *TRACE_BUFFER_ENABLED.get_or_init(|| std::env::var_os("SYSTEMLESS_TRACE_BUFFER").is_some())
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 static TRACE_PC_RANGE: OnceLock<Option<(u32, u32)>> = OnceLock::new();
 #[cfg(not(target_arch = "wasm32"))]
 static TRACE_PC_RANGE_TICKS: OnceLock<Option<(Option<u32>, Option<u32>)>> = OnceLock::new();

--- a/src/trap/cinepak.rs
+++ b/src/trap/cinepak.rs
@@ -47,10 +47,12 @@ impl CinepakDecoder {
         }
     }
 
+    #[allow(dead_code)]
     pub(crate) fn width(&self) -> usize {
         self.width
     }
 
+    #[allow(dead_code)]
     pub(crate) fn height(&self) -> usize {
         self.height
     }
@@ -122,8 +124,8 @@ impl CinepakDecoder {
         right: usize,
     ) -> Result<(), &'static str> {
         // Current 4×4 block cursor.
-        let mut x = left;
-        let mut y = s_top;
+        let mut x;
+        let mut y;
 
         while pos + 4 <= strip_end {
             let chunk_id = ((data[pos] as usize) << 8) | data[pos + 1] as usize;

--- a/src/trap/dialog.rs
+++ b/src/trap/dialog.rs
@@ -1392,7 +1392,7 @@ impl super::TrapDispatcher {
         dest_rect.2 = dest_rect.2.saturating_add(dv);
         dest_rect.3 = dest_rect.3.saturating_add(dh);
         Self::te_write_rect_words(bus, te_ptr + Self::TE_DEST_RECT_OFFSET, dest_rect);
-        self.draw_te_contents(cpu, bus, te_handle);
+        self.draw_te_contents(cpu, bus, te_handle, true);
         // Refresh rendered_pixels so redraw_chrome restores the scrolled state rather
         // than the pre-scroll snapshot captured at dialog creation.
         // Text 1993, 2-89 (TEScroll/TEPinScroll modify destRect and redraw).
@@ -2701,7 +2701,7 @@ impl super::TrapDispatcher {
             if caret_state == 0 { 1 } else { 0 },
         );
         bus.write_long(te_ptr + Self::TE_CARET_TIME_OFFSET, self.tick_count);
-        self.draw_te_contents(cpu, bus, te_handle);
+        self.draw_te_contents(cpu, bus, te_handle, true);
     }
 
     fn te_insert_text(&mut self, bus: &mut MacMemoryBus, te_handle: u32, text: &[u8]) {
@@ -2988,7 +2988,13 @@ impl super::TrapDispatcher {
         base != 0 && row_bytes != 0 && top < bottom && left < right
     }
 
-    fn draw_te_contents(&mut self, cpu: &mut impl CpuOps, bus: &mut MacMemoryBus, te_handle: u32) {
+    fn draw_te_contents(
+        &mut self,
+        cpu: &mut impl CpuOps,
+        bus: &mut MacMemoryBus,
+        te_handle: u32,
+        erase_background: bool,
+    ) {
         let te_ptr = Self::te_record_ptr(bus, te_handle);
         if te_ptr == 0 {
             return;
@@ -3161,17 +3167,19 @@ impl super::TrapDispatcher {
         let clip_right = view_rect.3;
         let box_width = (dest_rect.3 - dest_rect.1).max(0);
 
-        self.draw_rect(
-            cpu,
-            bus,
-            &Rect {
-                top: clip_top,
-                left: clip_left,
-                bottom: clip_bottom,
-                right: clip_right,
-            },
-            ShapeOp::Erase,
-        );
+        if erase_background {
+            self.draw_rect(
+                cpu,
+                bus,
+                &Rect {
+                    top: clip_top,
+                    left: clip_left,
+                    bottom: clip_bottom,
+                    right: clip_right,
+                },
+                ShapeOp::Erase,
+            );
+        }
         let lines = if text_bytes.is_empty() {
             vec![(0usize, 0usize)]
         } else if uses_styled_runs {
@@ -5052,7 +5060,7 @@ impl super::TrapDispatcher {
         bus.write_word(te_ptr + Self::TE_ACTIVE_OFFSET, 1);
         bus.write_long(te_ptr + Self::TE_CARET_TIME_OFFSET, self.tick_count);
         bus.write_word(te_ptr + Self::TE_CARET_STATE_OFFSET, 0);
-        self.draw_te_contents(cpu, bus, text_handle);
+        self.draw_te_contents(cpu, bus, text_handle, true);
         true
     }
 
@@ -14169,7 +14177,7 @@ impl super::TrapDispatcher {
                                     ) && redraw
                                     {
                                         self.te_recalculate_layout(bus, te_handle);
-                                        self.draw_te_contents(cpu, bus, te_handle);
+                                        self.draw_te_contents(cpu, bus, te_handle, true);
                                     }
                                 } else {
                                     let style_handle = Self::te_style_handle(bus, te_handle);
@@ -14546,7 +14554,7 @@ impl super::TrapDispatcher {
                             ) {
                                 self.te_recalculate_layout(bus, te_handle);
                             }
-                            self.draw_te_contents(cpu, bus, te_handle);
+                            self.draw_te_contents(cpu, bus, te_handle, true);
                         } else if text_ptr != 0 && bus.read_byte(text_ptr) == 0 {
                             // The ROM styled-TextEdit path leaves an exhausted
                             // NUL-terminated insertion with no continuation.
@@ -14916,7 +14924,7 @@ impl super::TrapDispatcher {
                         ) {
                             self.te_recalculate_layout(bus, te_handle);
                             if redraw {
-                                self.draw_te_contents(cpu, bus, te_handle);
+                                self.draw_te_contents(cpu, bus, te_handle, true);
                             }
                         }
                         cpu.write_reg(Register::A7, sp + 20);
@@ -15534,7 +15542,7 @@ impl super::TrapDispatcher {
                             view_rect.3
                         );
                     }
-                    self.draw_te_contents(cpu, bus, te_handle);
+                    self.draw_te_contents(cpu, bus, te_handle, false);
                     let te_port = bus.read_long(te_ptr + Self::TE_IN_PORT_OFFSET);
                     self.refresh_visible_dialog_snapshot_for_port(bus, te_port);
                 }
@@ -15790,7 +15798,7 @@ impl super::TrapDispatcher {
                     bus.write_word(te_ptr + Self::TE_ACTIVE_OFFSET, 1);
                     bus.write_long(te_ptr + Self::TE_CARET_TIME_OFFSET, self.tick_count);
                     bus.write_word(te_ptr + Self::TE_CARET_STATE_OFFSET, 0);
-                    self.draw_te_contents(cpu, bus, te_handle);
+                    self.draw_te_contents(cpu, bus, te_handle, true);
                 }
                 cpu.write_reg(Register::A7, sp + 4);
                 Ok(())
@@ -15814,7 +15822,7 @@ impl super::TrapDispatcher {
                 let te_ptr = Self::te_record_ptr(bus, te_handle);
                 if te_ptr != 0 {
                     bus.write_word(te_ptr + Self::TE_ACTIVE_OFFSET, 0);
-                    self.draw_te_contents(cpu, bus, te_handle);
+                    self.draw_te_contents(cpu, bus, te_handle, true);
                 }
                 cpu.write_reg(Register::A7, sp + 4);
                 Ok(())

--- a/src/trap/framebuffer.rs
+++ b/src/trap/framebuffer.rs
@@ -2674,10 +2674,13 @@ impl super::TrapDispatcher {
             return;
         }
 
-        let src_y_offset = wr_top.max(0) as u32;
-        let src_x_offset = wr_left.max(0) as u32;
-        let dst_y = src_y_offset;
-        let dst_x = src_x_offset;
+        let (global_top, global_left, _, _) = self.window_global_port_rect(bus, port);
+        let (pb_top, pb_left, pb_bottom, pb_right) = self.port_bounds_rect(bus, port);
+
+        let src_y_offset = (wr_top.wrapping_sub(pb_top)).max(0) as u32;
+        let src_x_offset = (wr_left.wrapping_sub(pb_left)).max(0) as u32;
+        let dst_y = global_top.max(0) as u32;
+        let dst_x = global_left.max(0) as u32;
 
         // 1bpp source → 8bpp screen via per-pixel bit extraction.
         // For each source bit, resolve logical white/black through the
@@ -2688,14 +2691,9 @@ impl super::TrapDispatcher {
             // Games may set portRect MUCH larger than the actual BitMap
             // bounds (e.g. StuntCopter: portRect=(0,0..567,791) but
             // BitMap=(0,0..261,426)). Clamp source reads to the BitMap
-            // bounds (portBits.bounds at port + 8..15) so we don't walk
-            // past valid source data into adjacent rows. Without this,
-            // the per-row stride bug produces horizontally-doubled or
-            // tiled content.
-            let pb_top = bus.read_word(port + 8) as i16;
-            let pb_left = bus.read_word(port + 10) as i16;
-            let pb_bottom = bus.read_word(port + 12) as i16;
-            let pb_right = bus.read_word(port + 14) as i16;
+            // bounds so we don't walk past valid source data into adjacent
+            // rows. Without this, the per-row stride bug produces
+            // horizontally-doubled or tiled content.
             let bitmap_w = (pb_right - pb_left).max(0) as u32;
             let bitmap_h = (pb_bottom - pb_top).max(0) as u32;
             let row_count = h.min((screen_h as u32).saturating_sub(dst_y)).min(bitmap_h);
@@ -4118,30 +4116,9 @@ impl super::TrapDispatcher {
         // no title bar; dispatch to draw_window_frame rather than
         // draw_window_chrome (which paints title-bar chrome).
         let proc_id = self.window_proc_ids.get(&window_ptr).copied().unwrap_or(0);
-        let port_version = bus.read_word(window_ptr + 6);
-        let (pmap_top, pmap_left) = if (port_version & 0xC000) == 0xC000 {
-            let pm_handle = bus.read_long(window_ptr + 2);
-            let pm_ptr = bus.read_long(pm_handle);
-            (
-                bus.read_word(pm_ptr + 6) as i16,
-                bus.read_word(pm_ptr + 8) as i16,
-            )
-        } else {
-            (
-                bus.read_word(window_ptr + 8) as i16,
-                bus.read_word(window_ptr + 10) as i16,
-            )
-        };
-        // wrapping_neg / wrapping_add match 68k Mac OS i16 wrap-
-        // around — guards against debug-build panics on windows
-        // whose pixmap.bounds.topLeft is i16::MIN or whose total
-        // width/height exceeds i16 range.
-        let wind_top = pmap_top.wrapping_neg();
-        let wind_left = pmap_left.wrapping_neg();
-        let port_bottom = bus.read_word(window_ptr + 20) as i16;
-        let port_right = bus.read_word(window_ptr + 22) as i16;
-        let wind_bottom = wind_top.wrapping_add(port_bottom);
-        let wind_right = wind_left.wrapping_add(port_right);
+        let (wind_top, wind_left, wind_bottom, wind_right) = self
+            .window_content_global_rect(bus, window_ptr)
+            .unwrap_or_else(|| self.window_global_port_rect(bus, window_ptr));
         if wind_bottom <= wind_top || wind_right <= wind_left {
             return;
         }

--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -731,9 +731,7 @@ impl super::TrapDispatcher {
                 let sp = cpu.read_reg(Register::A7);
                 let port_ptr = bus.read_long(sp);
                 cpu.write_reg(Register::A7, sp + 4);
-                let a5 = cpu.read_reg(Register::A5);
-                let global_ptr = bus.read_long(a5);
-                let port = bus.read_long(global_ptr);
+                let port = self.effective_the_port(bus, cpu.read_reg(Register::A5));
                 if port_ptr != port {
                     bus.write_long(port_ptr, port);
                 }
@@ -782,9 +780,7 @@ impl super::TrapDispatcher {
                 let sp = cpu.read_reg(Register::A7);
                 let bits_ptr = bus.read_long(sp);
                 cpu.write_reg(Register::A7, sp + 4);
-                let a5 = cpu.read_reg(Register::A5);
-                let global_ptr = bus.read_long(a5);
-                let port_ptr = bus.read_long(global_ptr);
+                let port_ptr = self.effective_the_port(bus, cpu.read_reg(Register::A5));
                 let is_cgraf_port = (bus.read_word(port_ptr + 6) & 0xC000) == 0xC000;
                 if is_cgraf_port {
                     bus.write_long(port_ptr + 2, bits_ptr);
@@ -801,14 +797,9 @@ impl super::TrapDispatcher {
                             port_ptr, bits_ptr
                         );
                     } else {
-                        let row_bytes = bus.read_word(bits_ptr + 4);
-                        let top = bus.read_word(bits_ptr + 6) as i16;
-                        let left = bus.read_word(bits_ptr + 8) as i16;
-                        let bottom = bus.read_word(bits_ptr + 10) as i16;
-                        let right = bus.read_word(bits_ptr + 12) as i16;
                         eprintln!(
-                            "[DIALOG-PORT] SetPortBits port=${:08X} bits=${:08X} rowBytes=${:04X} bounds=({},{},{},{})",
-                            port_ptr, bits_ptr, row_bytes, top, left, bottom, right
+                            "[DIALOG-PORT] SetPortBits port=${:08X} bits_ptr=${:08X}",
+                            port_ptr, bits_ptr
                         );
                     }
                 }
@@ -816,7 +807,7 @@ impl super::TrapDispatcher {
             }
 
             // PortSize ($A876)
-            // Sets portRect width and height; top-left corner unchanged.
+            // Changes the size of the current grafPort's portRect.
             // PROCEDURE PortSize (width,height: INTEGER);
             // Inside Macintosh Volume I, I-165
             //
@@ -828,9 +819,7 @@ impl super::TrapDispatcher {
                 let height = bus.read_word(sp) as i16;
                 let width = bus.read_word(sp + 2) as i16;
                 cpu.write_reg(Register::A7, sp + 4);
-                let a5 = cpu.read_reg(Register::A5);
-                let global_ptr = bus.read_long(a5);
-                let port_ptr = bus.read_long(global_ptr);
+                let port_ptr = self.effective_the_port(bus, cpu.read_reg(Register::A5));
                 let top = bus.read_word(port_ptr + 16) as i16;
                 let left = bus.read_word(port_ptr + 18) as i16;
                 bus.write_word(port_ptr + 20, (top + height) as u16);
@@ -902,9 +891,7 @@ impl super::TrapDispatcher {
                 let top_global = bus.read_word(sp) as i16;
                 let left_global = bus.read_word(sp + 2) as i16;
                 cpu.write_reg(Register::A7, sp + 4);
-                let a5 = cpu.read_reg(Register::A5);
-                let global_ptr = bus.read_long(a5);
-                let port_ptr = bus.read_long(global_ptr);
+                let port_ptr = self.effective_the_port(bus, cpu.read_reg(Register::A5));
 
                 // IM:I I-166: shift portBits.bounds so that
                 //   portRect.topLeft - bits.bounds.topLeft = (leftGlobal, topGlobal).
@@ -968,9 +955,7 @@ impl super::TrapDispatcher {
                 let v = bus.read_word(sp) as i16;
                 let h = bus.read_word(sp + 2) as i16;
                 cpu.write_reg(Register::A7, sp + 4);
-                let a5 = cpu.read_reg(Register::A5);
-                let global_ptr = bus.read_long(a5);
-                let port_ptr = bus.read_long(global_ptr);
+                let port_ptr = self.effective_the_port(bus, cpu.read_reg(Register::A5));
                 let hidden_window_regions =
                     self.hidden_window_local_regions_for_origin_change(bus, port_ptr);
                 let top = bus.read_word(port_ptr + 16) as i16;
@@ -1063,10 +1048,22 @@ impl super::TrapDispatcher {
                 let sp = cpu.read_reg(Register::A7);
                 let src_handle = bus.read_long(sp);
                 cpu.write_reg(Register::A7, sp + 4);
-                let a5 = cpu.read_reg(Register::A5);
-                let global_ptr = bus.read_long(a5);
-                let port_ptr = bus.read_long(global_ptr);
-                let dst_handle = bus.read_long(port_ptr + 28);
+                let port_ptr = if self.current_port != 0 {
+                    self.current_port
+                } else {
+                    let a5 = cpu.read_reg(Register::A5);
+                    let global_ptr = if a5 != 0 { bus.read_long(a5) } else { 0 };
+                    if global_ptr != 0 {
+                        bus.read_long(global_ptr)
+                    } else {
+                        bus.read_long(0x2A6)
+                    }
+                };
+                let dst_handle = if port_ptr != 0 {
+                    bus.read_long(port_ptr + 28)
+                } else {
+                    0
+                };
                 if src_handle != 0 && dst_handle != 0 {
                     let src_ptr = bus.read_long(src_handle);
                     if src_ptr != 0 {
@@ -1108,10 +1105,22 @@ impl super::TrapDispatcher {
                 let sp = cpu.read_reg(Register::A7);
                 let rgn_handle = bus.read_long(sp);
                 cpu.write_reg(Register::A7, sp + 4);
-                let a5 = cpu.read_reg(Register::A5);
-                let global_ptr = bus.read_long(a5);
-                let port_ptr = bus.read_long(global_ptr);
-                let clip_rgn = bus.read_long(port_ptr + 28);
+                let port_ptr = if self.current_port != 0 {
+                    self.current_port
+                } else {
+                    let a5 = cpu.read_reg(Register::A5);
+                    let global_ptr = if a5 != 0 { bus.read_long(a5) } else { 0 };
+                    if global_ptr != 0 {
+                        bus.read_long(global_ptr)
+                    } else {
+                        bus.read_long(0x2A6)
+                    }
+                };
+                let clip_rgn = if port_ptr != 0 {
+                    bus.read_long(port_ptr + 28)
+                } else {
+                    0
+                };
                 if rgn_handle != 0 && clip_rgn != 0 {
                     let clip_rgn_ptr = bus.read_long(clip_rgn);
                     if clip_rgn_ptr != 0 {
@@ -1147,24 +1156,40 @@ impl super::TrapDispatcher {
                 let sp = cpu.read_reg(Register::A7);
                 let rect_ptr = bus.read_long(sp);
                 cpu.write_reg(Register::A7, sp + 4);
-                let a5 = cpu.read_reg(Register::A5);
-                let global_ptr = bus.read_long(a5);
-                let port_ptr = bus.read_long(global_ptr);
-                let clip_rgn_handle = bus.read_long(port_ptr + 28);
-                let clip_rgn_ptr = bus.read_long(clip_rgn_handle);
-                bus.write_word(clip_rgn_ptr, 10);
-                for i in 0..8u32 {
-                    bus.write_byte(clip_rgn_ptr + 2 + i, bus.read_byte(rect_ptr + i));
-                }
-                if trace_dialog_ports_enabled() {
-                    let top = bus.read_word(rect_ptr) as i16;
-                    let left = bus.read_word(rect_ptr + 2) as i16;
-                    let bottom = bus.read_word(rect_ptr + 4) as i16;
-                    let right = bus.read_word(rect_ptr + 6) as i16;
-                    eprintln!(
-                        "[DIALOG-PORT] ClipRect port=${:08X} rect=({},{},{},{})",
-                        port_ptr, top, left, bottom, right
-                    );
+                let port_ptr = if self.current_port != 0 {
+                    self.current_port
+                } else {
+                    let a5 = cpu.read_reg(Register::A5);
+                    let global_ptr = if a5 != 0 { bus.read_long(a5) } else { 0 };
+                    if global_ptr != 0 {
+                        bus.read_long(global_ptr)
+                    } else {
+                        bus.read_long(0x2A6)
+                    }
+                };
+                let clip_rgn_handle = if port_ptr != 0 {
+                    bus.read_long(port_ptr + 28)
+                } else {
+                    0
+                };
+                if clip_rgn_handle != 0 {
+                    let clip_rgn_ptr = bus.read_long(clip_rgn_handle);
+                    if clip_rgn_ptr != 0 {
+                        bus.write_word(clip_rgn_ptr, 10);
+                        for i in 0..8u32 {
+                            bus.write_byte(clip_rgn_ptr + 2 + i, bus.read_byte(rect_ptr + i));
+                        }
+                        if trace_dialog_ports_enabled() {
+                            let top = bus.read_word(rect_ptr) as i16;
+                            let left = bus.read_word(rect_ptr + 2) as i16;
+                            let bottom = bus.read_word(rect_ptr + 4) as i16;
+                            let right = bus.read_word(rect_ptr + 6) as i16;
+                            eprintln!(
+                                "[DIALOG-PORT] ClipRect port=${:08X} rect=({},{},{},{})",
+                                port_ptr, top, left, bottom, right
+                            );
+                        }
+                    }
                 }
                 Ok(())
             }
@@ -20329,20 +20354,27 @@ impl super::TrapDispatcher {
         // screen.  Treat it as the actual screen pixel depth so CopyBits
         // reads the pixel data correctly instead of interpreting 8bpp bytes
         // as 1bpp packed bits.
-        let pixel_size = if base == screen_base && screen_ps > 1 {
-            screen_ps as u32
+        let raw_row_bytes = (raw_word & 0x3FFF) as u32;
+        let (pixel_size, ctab_handle) = if base == screen_base
+            && raw_row_bytes == self.screen_mode.1
+            && screen_ps > 1
+        {
+            (
+                screen_ps as u32,
+                Self::gdevice_ctab_handle(bus, self.main_gdevice_handle),
+            )
         } else {
-            1
+            (1, 0)
         };
         CopyBitmapInfo {
             base,
-            row_bytes: (raw_word & 0x3FFF) as u32,
+            row_bytes: raw_row_bytes,
             bounds_top: bus.read_word(bits_ptr + 6) as i16,
             bounds_left: bus.read_word(bits_ptr + 8) as i16,
             bounds_bottom: bus.read_word(bits_ptr + 10) as i16,
             bounds_right: bus.read_word(bits_ptr + 12) as i16,
             pixel_size,
-            ctab_handle: 0,
+            ctab_handle,
         }
     }
 
@@ -23682,6 +23714,53 @@ impl super::TrapDispatcher {
                 bus.read_word(port + 8) as i16,
                 bus.read_word(port + 10) as i16,
             )
+        }
+    }
+
+    pub(crate) fn port_bounds_rect(&self, bus: &MacMemoryBus, port: u32) -> (i16, i16, i16, i16) {
+        if port == 0 {
+            return (0, 0, 0, 0);
+        }
+        let port_version = bus.read_word(port + 6);
+        let is_color = (port_version & 0xC000) != 0;
+        if is_color {
+            let pm_handle = bus.read_long(port + 2);
+            if pm_handle != 0 {
+                let pm_ptr = bus.read_long(pm_handle);
+                if pm_ptr != 0 {
+                    return (
+                        bus.read_word(pm_ptr + 6) as i16,
+                        bus.read_word(pm_ptr + 8) as i16,
+                        bus.read_word(pm_ptr + 10) as i16,
+                        bus.read_word(pm_ptr + 12) as i16,
+                    );
+                }
+            }
+            (0, 0, 0, 0)
+        } else {
+            (
+                bus.read_word(port + 8) as i16,
+                bus.read_word(port + 10) as i16,
+                bus.read_word(port + 12) as i16,
+                bus.read_word(port + 14) as i16,
+            )
+        }
+    }
+
+    pub(crate) fn effective_the_port(&self, bus: &MacMemoryBus, a5: u32) -> u32 {
+        if a5 != 0 {
+            let global_ptr = bus.read_long(a5);
+            if global_ptr != 0 {
+                let app_port = bus.read_long(global_ptr);
+                if app_port != 0 {
+                    return app_port;
+                }
+            }
+        }
+        if self.current_port != 0 {
+            self.current_port
+        } else {
+            bus.read_long(0x2A6)
         }
     }
 

--- a/src/trap/shapes.rs
+++ b/src/trap/shapes.rs
@@ -144,6 +144,7 @@ fn indexed_shape_color_index(
 /// tables), then the table is scanned (device tables carry client IDs in
 /// `value`). The table is fetched into a local buffer with one bulk read;
 /// the scan used to issue a bus read per entry, and it runs for every shape.
+#[allow(dead_code)]
 fn ctab_rgb_for_value(bus: &MacMemoryBus, ctab_handle: u32, wanted_value: u8) -> Option<[u16; 3]> {
     let entries = ctab_entries(bus, ctab_handle)?;
     ctab_entries_rgb_for_value(&entries, wanted_value)

--- a/src/trap/window.rs
+++ b/src/trap/window.rs
@@ -998,7 +998,11 @@ impl super::TrapDispatcher {
         )
     }
 
-    fn window_global_port_rect(&self, bus: &MacMemoryBus, window_ptr: u32) -> (i16, i16, i16, i16) {
+    pub(crate) fn window_global_port_rect(
+        &self,
+        bus: &MacMemoryBus,
+        window_ptr: u32,
+    ) -> (i16, i16, i16, i16) {
         let (top, left, bottom, right) = self.window_port_rect(bus, window_ptr);
         let (bounds_top, bounds_left) = self.port_bounds_top_left(bus, window_ptr);
         (


### PR DESCRIPTION
### Root Cause

1. QuickDraw `SetClip` ($A879) and `ClipRect` ($A87B) accessed port pointers from low-memory globals without robust multi-tier fallback to the dispatcher's active port state, causing nil pointer dereferences or stale clip state when guest software altered port pointers directly.
2. In `parse_bits_copy_info` (`CopyBits`), 1bpp vs multi-bit BitMap detection only checked `base == screen_base` without verifying `row_bytes == screen_mode.1`, erroneously promoting non-screen 1bpp BitMaps sharing base pointers.
3. In `draw_te_contents` (`TEUpdate`), the update rectangle was unconditionally erased with `ShapeOp::Erase` using the port's background pattern. This directly violated *Inside Macintosh Volume I*, p. I-387 ("*TEUpdate does not erase the update rectangle; if the background needs to be erased, you must call EraseRect before calling TEUpdate*") and wiped out background art and PICTs drawn before `TEUpdate`.

### Changes

- Extended `SetClip` and `ClipRect` to resolve target ports falling back from `current_port` to A5 globals and low-memory $02A6.
- Verified both `baseAddr` and `rowBytes` in `parse_bits_copy_info` before treating a BitMap as the multi-bit screen surface.
- Added `erase_background: bool` to `draw_te_contents`, passing `false` from `TEUpdate` to preserve pre-rendered content while retaining `true` for active editing and caret blinks.
- Cleaned up unused compiler warnings across native and wasm targets.

### Validation

- All 3,874 library unit tests pass cleanly (`cargo test --lib`).
- Validated on 68K runtime titles and verified zero compiler warnings across native and `wasm32-unknown-unknown` builds.

Closes #759