### PR TITLE
fix: return 0x0100 for pascal boolean true in testdeviceattribute

### DIFF
--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -5781,7 +5781,7 @@ impl super::TrapDispatcher {
                             );
                         }
                         if matched {
-                            0xFFFFu16
+                            0x0100u16
                         } else {
                             0u16
                         }
@@ -37458,7 +37458,7 @@ mod tests {
         assert!(result.unwrap().is_ok());
         assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 6);
         // bit 13 (screenDevice) should be set
-        assert_eq!(bus.read_word(TEST_SP + 6), 0xFFFF);
+        assert_eq!(bus.read_word(TEST_SP + 6), 0x0100);
     }
 
     #[test]
@@ -37531,7 +37531,7 @@ mod tests {
         let set_check_result = d.dispatch_quickdraw(true, 0x22C, &mut cpu, &mut bus);
         assert!(set_check_result.unwrap().is_ok());
         assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 6);
-        assert_eq!(bus.read_word(TEST_SP + 6), 0xFFFF);
+        assert_eq!(bus.read_word(TEST_SP + 6), 0x0100);
 
         cpu.write_reg(Register::A7, TEST_SP);
         bus.write_word(TEST_SP, 31u16);
@@ -37555,7 +37555,7 @@ mod tests {
         let screen_active_result = d.dispatch_quickdraw(true, 0x22C, &mut cpu, &mut bus);
         assert!(screen_active_result.unwrap().is_ok());
         assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 6);
-        assert_eq!(bus.read_word(TEST_SP + 6), 0xFFFF);
+        assert_eq!(bus.read_word(TEST_SP + 6), 0x0100);
     }
 
     #[test]


### PR DESCRIPTION
### Summary

Fix `TestDeviceAttribute` ($AA2C) to return `0x0100` (`0x01` in the high byte) for Pascal `BOOLEAN` `TRUE` instead of `0xFFFF`.

### Rationale

`TestDeviceAttribute` is a Pascal function declared as:
```pascal
FUNCTION TestDeviceAttribute(gdh: GDHandle; attribute: INTEGER): BOOLEAN;
```
Per *Inside Macintosh Volume V* (1986), p. V-124 and *Imaging With QuickDraw* (1994), p. 5-22, Pascal functions returning `BOOLEAN` write `0x0100` (`0x01` in the high byte) for `TRUE` and `0x0000` for `FALSE` into the 2-byte result slot on the stack.

When guest 68k software (such as LittleWing's *Crystal Caliburn*) consumes the result with `MOVE.B (SP)+, D0` or compares the returned value against `1` (`CMPI.W #1, D0`), returning `0xFFFF` left `0xFF` in `D0`, failing the comparison and triggering an unexpected 256-color alert.

### Validation

- `cargo test --lib` in `systemless` passed with updated assertions for `TestDeviceAttribute`.
- Validated with 68k *Crystal Caliburn* execution, confirming the 256-color warning dialog is bypassed and the full color table renders.

Closes #761