### PR TITLE
fix: support Space Madness compatibility

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -8216,8 +8216,18 @@ impl FixtureRunner {
             return;
         }
 
-        let mut due_task = None;
-        for task in &self.dispatcher.vbl_tasks {
+        // Decrement every queue element before choosing a callback. A task
+        // earlier in the queue may run every retrace; stopping at that task
+        // would starve all later elements. Preserve tasks that became due
+        // while another callback was delivered and service those first on
+        // the next opportunity.
+        let pending_before: Vec<bool> = self
+            .dispatcher
+            .vbl_tasks
+            .iter()
+            .map(|task| task.pending)
+            .collect();
+        for task in &mut self.dispatcher.vbl_tasks {
             let count = self.bus.read_word(task.task_ptr + 10) as i16;
             if count <= 0 {
                 continue;
@@ -8225,10 +8235,24 @@ impl FixtureRunner {
             let new_count = count - 1;
             self.bus.write_word(task.task_ptr + 10, new_count as u16);
             if new_count == 0 {
-                due_task = Some(task.task_ptr);
-                break;
+                task.pending = true;
             }
         }
+
+        let due_index = pending_before
+            .iter()
+            .position(|pending| *pending)
+            .or_else(|| {
+                self.dispatcher
+                    .vbl_tasks
+                    .iter()
+                    .position(|task| task.pending)
+            });
+        let due_task = due_index.map(|index| {
+            let task = &mut self.dispatcher.vbl_tasks[index];
+            task.pending = false;
+            task.task_ptr
+        });
 
         let Some(task_ptr) = due_task else {
             return;
@@ -8352,11 +8376,7 @@ impl FixtureRunner {
             .dispatcher
             .timer_tasks
             .iter_mut()
-            .filter(|task| {
-                task.active
-                    && current_subtick >= task.fire_at_subtick
-                    && task.last_fired_tick != Some(current_tick)
-            })
+            .filter(|task| task.active && current_subtick >= task.fire_at_subtick)
             .min_by_key(|task| task.fire_at_subtick)
         {
             let task_ptr = task.task_ptr;
@@ -14770,7 +14790,7 @@ mod tests {
     }
 
     #[test]
-    fn self_reprimed_timer_waits_for_the_next_vbl_service() {
+    fn self_reprimed_timer_can_fire_again_within_the_same_vbl() {
         let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
         let interrupted_pc = 0x0001_0000;
         let interrupted_sp = 0x007F_FFC0;
@@ -14801,17 +14821,11 @@ mod tests {
 
         runner.fire_timer_tasks_at(10_300_000);
         assert!(
-            runner.active_interrupt_callback.is_none(),
-            "one queue element must not monopolize the same VBL"
-        );
-        assert!(runner.dispatcher.timer_tasks[0].active);
-
-        runner.fire_timer_tasks_at(11_000_000);
-        assert!(
             runner.active_interrupt_callback.is_some(),
-            "the re-primed element becomes eligible at the next VBL service"
+            "a revised Time Manager task must honor a new sub-VBL deadline"
         );
-        assert_eq!(runner.dispatcher.timer_tasks[0].last_fired_tick, Some(11));
+        assert!(!runner.dispatcher.timer_tasks[0].active);
+        assert_eq!(runner.dispatcher.timer_tasks[0].last_fired_tick, Some(10));
     }
 
     #[test]
@@ -15757,6 +15771,7 @@ mod tests {
         runner.dispatcher.vbl_tasks.push(VblTask {
             task_ptr,
             slot: Some(9),
+            pending: false,
         });
 
         runner.fire_vbl_tasks();
@@ -15785,6 +15800,47 @@ mod tests {
     }
 
     #[test]
+    fn simultaneous_vbl_callbacks_do_not_starve_later_queue_elements() {
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        let interrupted_pc = 0x0002_0000;
+        let interrupted_sp = 0x007F_FFC0;
+        let first_ptr = 0x0020_2000;
+        let second_ptr = 0x0020_2020;
+
+        runner.cpu.write_reg(Register::PC, interrupted_pc);
+        runner.cpu.write_reg(Register::A7, interrupted_sp);
+        runner.cpu.core.set_sr_noint_nosp(0x2000);
+        for (task_ptr, callback) in [(first_ptr, 0x0004_1234), (second_ptr, 0x0004_5678)] {
+            runner.bus.write_word(task_ptr + 4, 1);
+            runner.bus.write_long(task_ptr + 6, callback);
+            runner.bus.write_word(task_ptr + 10, 1);
+            runner.dispatcher.vbl_tasks.push(VblTask {
+                task_ptr,
+                slot: None,
+                pending: false,
+            });
+        }
+
+        runner.fire_vbl_tasks();
+        assert_eq!(runner.bus.read_long(runner.vbl_trampoline + 6), first_ptr);
+        assert!(runner.dispatcher.vbl_tasks[1].pending);
+
+        // Model the first callback rescheduling itself every retrace. The
+        // already-due second element must run before the first one can run
+        // again.
+        runner.bus.write_word(first_ptr + 10, 1);
+        runner.active_interrupt_callback = None;
+        runner.cpu.write_reg(Register::PC, interrupted_pc);
+        runner.cpu.write_reg(Register::A7, interrupted_sp);
+        runner.cpu.core.set_sr_noint_nosp(0x2000);
+        runner.fire_vbl_tasks();
+
+        assert_eq!(runner.bus.read_long(runner.vbl_trampoline + 6), second_ptr);
+        assert!(runner.dispatcher.vbl_tasks[0].pending);
+        assert!(!runner.dispatcher.vbl_tasks[1].pending);
+    }
+
+    #[test]
     fn vbl_callback_defers_while_processor_priority_masks_level_one() {
         let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
         let interrupted_pc = 0x0002_0000;
@@ -15802,6 +15858,7 @@ mod tests {
         runner.dispatcher.vbl_tasks.push(VblTask {
             task_ptr,
             slot: None,
+            pending: false,
         });
 
         runner.fire_vbl_tasks();
@@ -15833,6 +15890,7 @@ mod tests {
         runner.dispatcher.vbl_tasks.push(VblTask {
             task_ptr,
             slot: None,
+            pending: false,
         });
 
         runner.fire_vbl_tasks();
@@ -17361,6 +17419,7 @@ mod tests {
         runner.dispatcher.vbl_tasks.push(VblTask {
             task_ptr,
             slot: None,
+            pending: false,
         });
 
         let mut count = 0usize;
@@ -19624,6 +19683,7 @@ mod tests {
         runner.dispatcher.vbl_tasks.push(VblTask {
             task_ptr,
             slot: None,
+            pending: false,
         });
 
         let (steps, running) = runner.run_steps(1, None);

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -708,12 +708,10 @@ pub struct TimerTask {
     /// Revised Time Manager deadline in millionths of a 60 Hz guest tick.
     /// This preserves negative PrimeTime microsecond delays below one VBL.
     pub fire_at_subtick: u64,
-    /// VBL tick in which this task was most recently dispatched.
-    ///
-    /// BasiliskII's Time Manager services an individual queue element at
-    /// most once per VBL even when its revised/extended delay is shorter.
-    /// Retaining the sub-tick deadline still orders concurrent tasks without
-    /// allowing one self-repriming task to monopolize the interrupt queue.
+    /// VBL tick in which this task was most recently dispatched. The PPC
+    /// runner uses this to prevent repeat delivery within a VBL; the 68K
+    /// runner retains it as callback metadata while honoring revised
+    /// sub-VBL deadlines.
     pub last_fired_tick: Option<u32>,
 }
 
@@ -725,6 +723,8 @@ pub struct VblTask {
     pub task_ptr: u32,
     /// Optional slot number for slot-based VBL tasks.
     pub slot: Option<i16>,
+    /// The task reached a zero count but has not yet received its callback.
+    pub pending: bool,
 }
 
 pub(crate) const LOADSEG_GETRESOURCE_SENTINEL: u16 = 0x51F0;
@@ -1339,6 +1339,12 @@ pub struct TrapDispatcher {
     /// resource fork provides. The pointer is held permanently so
     /// repeat calls return the same handle. Networking 1994, 2-799.
     pub(crate) system_str_cache: HashMap<i16, u32>,
+    /// Cache of synthetic System-file `'INTL'` resource pointers. Classic
+    /// International Utilities expose U.S. numeric/time settings as ID 0 and
+    /// U.S. day/month names as ID 1. Systemless does not mount a System file,
+    /// so these records are synthesized on demand. Inside Macintosh Volume I
+    /// (1985), pp. I-495..I-505.
+    pub(crate) system_intl_cache: HashMap<i16, u32>,
     /// Cache of synthesized built-in system cursor blocks for
     /// GetCursor ($A9B9). On real Mac the standard cursor IDs (1
     /// iBeamCursor, 2 crossCursor, 3 plusCursor, 4 watchCursor per
@@ -3048,6 +3054,7 @@ impl TrapDispatcher {
             saved_draw_old_regions: HashMap::new(),
             fired_oapp_handler: false,
             system_str_cache: HashMap::new(),
+            system_intl_cache: HashMap::new(),
             system_cursor_cache: HashMap::new(),
             system_clut_cache: HashMap::new(),
             system_wctb_cache: HashMap::new(),
@@ -5548,6 +5555,94 @@ impl TrapDispatcher {
         let ptr = bus.alloc(body.len() as u32);
         bus.write_bytes(ptr, body);
         self.system_str_cache.insert(res_id, ptr);
+        Some(ptr)
+    }
+
+    /// Allocate and cache the classic U.S. `'INTL'` resources used by
+    /// `IUGetIntl` and direct Resource Manager lookups. ID 0 is an `Intl0Rec`
+    /// (numeric, currency, short-date, and time settings); ID 1 is an
+    /// `Intl1Rec` (long-date names and separators). Inside Macintosh Volume I
+    /// (1985), pp. I-495..I-501.
+    pub(crate) fn synthesize_system_intl(
+        &mut self,
+        bus: &mut MacMemoryBus,
+        res_id: i16,
+    ) -> Option<u32> {
+        if let Some(&ptr) = self.system_intl_cache.get(&res_id) {
+            return Some(ptr);
+        }
+
+        let body = match res_id {
+            0 => vec![
+                b'.', b',', b';', // decimalPt, thousSep, listSep
+                b'$', 0, 0,    // currSym1..3
+                0xF0, // symbol leads; minus sign; trailing and leading zeroes
+                0,    // dateOrder: month, day, year
+                0,    // shrtDateFmt: no leading zeroes or century
+                b'/', 0xFF, // dateSep, 12-hour timeCycle
+                0x60, // leading zeroes for minutes and seconds
+                b' ', b'A', b'M', 0, // mornStr
+                b' ', b'P', b'M', 0,    // eveStr
+                b':', // timeSep
+                0, 0, 0, 0, 0, 0, 0, 0, // time1Suff..time8Suff
+                0, // non-metric
+                0, 0, // U.S. region, version 0
+            ],
+            1 => {
+                fn push_str15(body: &mut Vec<u8>, value: &[u8]) {
+                    debug_assert!(value.len() <= 15);
+                    body.push(value.len() as u8);
+                    body.extend_from_slice(value);
+                    body.resize(body.len() + 15 - value.len(), 0);
+                }
+
+                let mut body = Vec::with_capacity(332);
+                for day in [
+                    b"Sunday".as_slice(),
+                    b"Monday",
+                    b"Tuesday",
+                    b"Wednesday",
+                    b"Thursday",
+                    b"Friday",
+                    b"Saturday",
+                ] {
+                    push_str15(&mut body, day);
+                }
+                for month in [
+                    b"January".as_slice(),
+                    b"February",
+                    b"March",
+                    b"April",
+                    b"May",
+                    b"June",
+                    b"July",
+                    b"August",
+                    b"September",
+                    b"October",
+                    b"November",
+                    b"December",
+                ] {
+                    push_str15(&mut body, month);
+                }
+                body.extend_from_slice(&[
+                    0, 0xFF, 0, 3, // include day; month/day/year; no leading 0; abbr 3
+                    0, 0, 0, 0, // st0
+                    b',', b' ', 0, 0, // st1
+                    b' ', 0, 0, 0, // st2
+                    b',', b' ', 0, 0, // st3
+                    0, 0, 0, 0, // st4
+                    0, 0, // U.S. region, version 0
+                    0x4E, 0x75, // localRtn: RTS (no localization hook)
+                ]);
+                debug_assert_eq!(body.len(), 332);
+                body
+            }
+            _ => return None,
+        };
+
+        let ptr = bus.alloc(body.len() as u32);
+        bus.write_bytes(ptr, &body);
+        self.system_intl_cache.insert(res_id, ptr);
         Some(ptr)
     }
 

--- a/src/trap/memory.rs
+++ b/src/trap/memory.rs
@@ -563,8 +563,11 @@ impl super::TrapDispatcher {
         bus.write_word(task_ptr + 10, vbl_count.wrapping_add(vbl_phase) as u16);
 
         self.vbl_tasks.retain(|task| task.task_ptr != task_ptr);
-        self.vbl_tasks
-            .push(super::dispatch::VblTask { task_ptr, slot });
+        self.vbl_tasks.push(super::dispatch::VblTask {
+            task_ptr,
+            slot,
+            pending: false,
+        });
         self.sync_vbl_links(bus);
         0
     }
@@ -1870,7 +1873,33 @@ impl super::TrapDispatcher {
             // Processes 1994, 3-19
             (false, 0x59) => {
                 let task_ptr = cpu.read_reg(Register::A0);
+                let current_subtick = self
+                    .timer_current_subtick
+                    .max(bus.read_long(0x016A) as u64 * 1_000_000);
+                let remaining_subticks = self
+                    .timer_tasks
+                    .iter()
+                    .find(|task| task.task_ptr == task_ptr && task.active)
+                    .map(|task| task.fire_at_subtick.saturating_sub(current_subtick))
+                    .unwrap_or(0);
                 self.timer_tasks.retain(|t| t.task_ptr != task_ptr);
+
+                // The revised and extended Time Managers return unused time
+                // through tmCount. Prefer negated microseconds for maximum
+                // accuracy, falling back to positive milliseconds only when
+                // the microsecond magnitude cannot fit in a signed LongInt.
+                // Inside Macintosh: Processes (1994), pp. 3-14 and 3-21.
+                let remaining_count = if remaining_subticks == 0 {
+                    0
+                } else {
+                    let remaining_us = remaining_subticks.div_ceil(60);
+                    if remaining_us <= i32::MAX as u64 {
+                        -(remaining_us as i32)
+                    } else {
+                        remaining_us.div_ceil(1_000).min(i32::MAX as u64) as i32
+                    }
+                };
+                bus.write_long(task_ptr + 10, remaining_count as u32);
                 // RmvTime clears the qType high-order bit (task no longer active).
                 // Processes 1994, 3-20: "RmvTime sets the high-order bit of the qType field to 0."
                 let q = bus.read_word(task_ptr + 4);
@@ -9384,6 +9413,59 @@ mod tests {
             task.fire_at_subtick, 100_199_980,
             "3,333 microseconds should remain below one 60 Hz guest tick"
         );
+    }
+
+    #[test]
+    fn rmv_time_returns_active_task_remaining_time_as_negative_microseconds() {
+        // Processes 1994 pp. 3-14 and 3-21: revised Time Manager RmvTime
+        // reports unused time in tmCount, using negated microseconds when it
+        // fits. This is the standard elapsed-time measurement contract.
+        let (mut dispatcher, mut cpu, mut bus) = setup();
+        let task_ptr = 0x200000;
+        bus.write_long(0x016A, 100);
+
+        cpu.write_reg(Register::A0, task_ptr);
+        dispatcher
+            .dispatch_memory(false, 0x58, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+        cpu.write_reg(Register::A0, task_ptr);
+        cpu.write_reg(Register::D0, (-10_000_i32) as u32);
+        dispatcher
+            .dispatch_memory(false, 0x5A, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+
+        dispatcher.timer_current_subtick = 100_150_000; // 2,500 us elapsed
+        cpu.write_reg(Register::A0, task_ptr);
+        dispatcher
+            .dispatch_memory(false, 0x59, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(bus.read_long(task_ptr + 10) as i32, -7_500);
+        assert_eq!(bus.read_word(task_ptr + 4) & 0x8000, 0);
+        assert_eq!(dispatcher.timer_task_count(), 0);
+    }
+
+    #[test]
+    fn rmv_time_returns_zero_for_inactive_task() {
+        let (mut dispatcher, mut cpu, mut bus) = setup();
+        let task_ptr = 0x200000;
+        bus.write_long(task_ptr + 10, 0xDEAD_BEEF);
+        cpu.write_reg(Register::A0, task_ptr);
+        dispatcher
+            .dispatch_memory(false, 0x58, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+
+        cpu.write_reg(Register::A0, task_ptr);
+        dispatcher
+            .dispatch_memory(false, 0x59, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(bus.read_long(task_ptr + 10), 0);
     }
 
     #[test]

--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -1750,6 +1750,19 @@ impl super::TrapDispatcher {
                     }
                 }
 
+                if res_type == *b"INTL" {
+                    if let Some(ptr) = self.synthesize_system_intl(bus, res_id) {
+                        let handle = self
+                            .get_or_create_resource_handle_in_file(bus, res_type, res_id, ptr, 0);
+                        cpu.write_reg(Register::A0, handle);
+                        cpu.write_reg(Register::D0, 0);
+                        bus.write_word(0x0A60, 0); // ResErr = noErr
+                        bus.write_long(sp + 6, handle);
+                        cpu.write_reg(Register::A7, sp + 6);
+                        return Some(Ok(()));
+                    }
+                }
+
                 if res_type == *b"clut" {
                     if let Some(ptr) = self.synthesize_system_clut(bus, res_id) {
                         if trace_getresource_enabled() {
@@ -9105,6 +9118,30 @@ mod tests {
         assert_eq!(bus.read_word(black + 2), 0, "entry 255 red");
         assert_eq!(bus.read_word(black + 4), 0, "entry 255 green");
         assert_eq!(bus.read_word(black + 6), 0, "entry 255 blue");
+    }
+
+    #[test]
+    fn get_resource_synthesizes_us_system_intl_zero() {
+        // IM:I pp. I-495..I-499: INTL ID 0 contains the active numeric,
+        // currency, short-date, and time conventions.
+        let (mut disp, mut cpu, mut bus) = setup();
+
+        bus.write_word(TEST_SP, 0);
+        bus.write_long(TEST_SP + 2, u32::from_be_bytes(*b"INTL"));
+        call(&mut disp, true, 0x1A0, &mut cpu, &mut bus).unwrap();
+
+        let handle = bus.read_long(TEST_SP + 6);
+        assert_ne!(handle, 0);
+        assert_eq!(disp.resource_handle_files.get(&handle), Some(&0));
+        assert_eq!(bus.read_word(0x0A60), 0);
+
+        let intl = bus.read_long(handle);
+        assert_eq!(bus.get_alloc_size(intl), Some(32));
+        assert_eq!(bus.read_bytes(intl, 12), b".,;$\0\0\xF0\0\0/\xFF\x60");
+        assert_eq!(bus.read_bytes(intl + 12, 4), b" AM\0");
+        assert_eq!(bus.read_bytes(intl + 16, 4), b" PM\0");
+        assert_eq!(bus.read_byte(intl + 20), b':');
+        assert_eq!(bus.read_word(intl + 30), 0);
     }
 
     #[test]

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -12359,22 +12359,19 @@ impl super::TrapDispatcher {
             // convention.
             //
             // HLE compromise: Systemless runs a single-script (Roman /
-            // Latin-1) US-default environment with no localised
-            // 'INTL' / 'itl2' / 'itl4' resources. Date strings
+            // Latin-1) US-default environment. It synthesizes classic
+            // U.S. 'INTL' IDs 0 and 1, but no localised 'itl2' / 'itl4'
+            // resources. Date strings
             // collapse to a "1/1/04" placeholder; time strings to
             // "12:00 AM" / "12:00:00 AM"; metric query returns FALSE;
-            // INTL resource handles return NIL; comparators do byte-
+            // comparators do byte-
             // level compare returning -1/0/+1 (Mag/Comp variants;
             // case-sensitive) or 0/1 (MagID/Equal variants; case-
             // insensitive ASCII fold); script/lang ordering does
             // numeric compare. IUClearCache / IUSetIntl /
             // IUGetIntlTable are no-ops with documented VAR-out NIL
-            // writes. Apps that defensively check (handle != NIL)
-            // before dereffing fall through cleanly; apps that need
-            // locale-specific formatting see Mac-default English
-            // output. The "no INTL" fallback is INTENTIONALLY SAFE
-            // per IM:I I-505 ("if the INTL resource is missing,
-            // IUGetIntl returns NIL").
+            // writes. Apps that need locale-specific formatting see
+            // Mac-default English output.
             //
             // Stack frames assume Pascal arg conventions: LongInt =
             // 4, Integer/Boolean/DateForm = 2 (DateForm = 1 byte at
@@ -12393,7 +12390,7 @@ impl super::TrapDispatcher {
             //
             // Inside Macintosh Volume I (1985), pages I-485..I-510.
             // Inside Macintosh Volume VI (1991), pages 14-1..14-135.
-            // Pack6 / Intl Utilities ($A9ED): Per-selector Pascal frames per IM:I I-487 + IM:VI 14-135: $0000 IUDateString pop 12 result@SP+2, $0002 IUTimeString pop 12 result@SP+2, $0004 IUMetric pop 2 result@SP+2 (FALSE), $0006 IUGetIntl pop 4 result@SP+4 (NIL handle), $0008 IUSetIntl pop 10 (no-op), $000A IUMagString pop 14 result@SP+14 (-1/0/+1 byte cmp), $000C IUMagIDString pop 14 result@SP+14 (0/1 case-insens), $000E IUDatePString pop 16 result@SP+6, $0010 IUTimePString pop 16 result@SP+6, $0014 IULDateString pop 16 result@SP+6, $0016 IULTimeString pop 16 result@SP+6, $0018 IUClearCache pop 2 (no-op), $001A IUMagPString pop 18 result@SP+18 (-1/0/+1), $001C IUMagIDPString pop 18 result@SP+18 (0/1), $001E IUScriptOrder pop 6 result@SP+6 (-1/0/+1), $0020 IULangOrder pop 6 result@SP+6 (-1/0/+1), $0022 IUTextOrder pop 22 result@SP+22 (-1/0/+1), $0024 IUGetIntlTable pop 18 (writes NIL/0/0 to 3 VAR ptrs).
+            // Pack6 / Intl Utilities ($A9ED): Per-selector Pascal frames per IM:I I-487 + IM:VI 14-135: $0000 IUDateString pop 12 result@SP+2, $0002 IUTimeString pop 12 result@SP+2, $0004 IUMetric pop 2 result@SP+2 (FALSE), $0006 IUGetIntl pop 4 result@SP+4 (INTL handle), $0008 IUSetIntl pop 10 (no-op), $000A IUMagString pop 14 result@SP+14 (-1/0/+1 byte cmp), $000C IUMagIDString pop 14 result@SP+14 (0/1 case-insens), $000E IUDatePString pop 16 result@SP+6, $0010 IUTimePString pop 16 result@SP+6, $0014 IULDateString pop 16 result@SP+6, $0016 IULTimeString pop 16 result@SP+6, $0018 IUClearCache pop 2 (no-op), $001A IUMagPString pop 18 result@SP+18 (-1/0/+1), $001C IUMagIDPString pop 18 result@SP+18 (0/1), $001E IUScriptOrder pop 6 result@SP+6 (-1/0/+1), $0020 IULangOrder pop 6 result@SP+6 (-1/0/+1), $0022 IUTextOrder pop 22 result@SP+22 (-1/0/+1), $0024 IUGetIntlTable pop 18 (writes NIL/0/0 to 3 VAR ptrs).
             (true, 0x1ED) => {
                 let sp = cpu.read_reg(Register::A7);
                 let selector = bus.read_word(sp);
@@ -12444,9 +12441,23 @@ impl super::TrapDispatcher {
                     // FUNCTION IUGetIntl(theID: Integer): Handle;
                     // IM:I I-487, I-505. Stack: sel(2) + theID(2)
                     // + result(4) = 8. Pop 4, leave result long at
-                    // new SP+0. Returns NIL — no INTL resources.
+                    // new SP+0. Search loaded resource files first, then use
+                    // the built-in U.S. System-file records for IDs 0 and 1.
                     0x0006 => {
-                        bus.write_long(sp + 4, 0);
+                        let id = bus.read_word(sp + 2) as i16;
+                        let handle = if let Some((refnum, ptr)) =
+                            self.find_or_load_resource_any(bus, *b"INTL", id)
+                        {
+                            self.get_or_create_resource_handle_in_file(
+                                bus, *b"INTL", id, ptr, refnum,
+                            )
+                        } else if let Some(ptr) = self.synthesize_system_intl(bus, id) {
+                            self.get_or_create_resource_handle_in_file(bus, *b"INTL", id, ptr, 0)
+                        } else {
+                            0
+                        };
+                        bus.write_long(sp + 4, handle);
+                        cpu.write_reg(Register::A0, handle);
                         cpu.write_reg(Register::A7, sp + 4);
                         cpu.write_reg(Register::D0, 0);
                         Ok(())
@@ -26796,6 +26807,88 @@ mod tests {
         assert_eq!(bus.read_word(sp + 2), 0);
         assert_eq!(cpu.read_reg(Register::A7), sp + 2);
         assert_eq!(cpu.read_reg(Register::D0), 0);
+    }
+
+    // Pack6 / Intl Utilities ($A9ED) — IUGetIntl selector $0006.
+    // IM:I pp. I-495 and I-505: return the requested INTL resource handle.
+    #[test]
+    fn iugetintl_returns_stable_us_system_resource_handles() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let sp = TEST_SP;
+
+        bus.write_word(sp, 0x0006);
+        bus.write_word(sp + 2, 0);
+        bus.write_long(sp + 4, 0xDEAD_BEEF);
+        disp.dispatch_toolbox(true, 0x1ED, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+
+        let intl0_handle = bus.read_long(sp + 4);
+        assert_ne!(intl0_handle, 0);
+        assert_eq!(cpu.read_reg(Register::A0), intl0_handle);
+        assert_eq!(cpu.read_reg(Register::A7), sp + 4);
+        assert_eq!(disp.resource_handle_files.get(&intl0_handle), Some(&0));
+        assert_eq!(bus.get_alloc_size(bus.read_long(intl0_handle)), Some(32));
+
+        cpu.write_reg(Register::A7, sp);
+        bus.write_word(sp + 2, 1);
+        disp.dispatch_toolbox(true, 0x1ED, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+        let intl1_handle = bus.read_long(sp + 4);
+        let intl1 = bus.read_long(intl1_handle);
+        assert_ne!(intl1_handle, 0);
+        assert_eq!(bus.get_alloc_size(intl1), Some(332));
+        assert_eq!(bus.read_pstring(intl1), b"Sunday");
+        assert_eq!(bus.read_pstring(intl1 + 7 * 16), b"January");
+        assert_eq!(bus.read_word(intl1 + 330), 0x4E75);
+
+        cpu.write_reg(Register::A7, sp);
+        bus.write_word(sp + 2, 0);
+        disp.dispatch_toolbox(true, 0x1ED, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+        assert_eq!(bus.read_long(sp + 4), intl0_handle);
+
+        cpu.write_reg(Register::A7, sp);
+        bus.write_word(sp + 2, 42);
+        disp.dispatch_toolbox(true, 0x1ED, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+        assert_eq!(bus.read_long(sp + 4), 0);
+    }
+
+    #[test]
+    fn iugetintl_prefers_loaded_application_resource() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let override_ptr = bus.alloc(32);
+        bus.fill_bytes(override_ptr, 32, 0xA5);
+        disp.resources = Some(LoadedResources {
+            files: HashMap::from([
+                (0, ResourceFileMap::default()),
+                (
+                    1,
+                    ResourceFileMap {
+                        loaded: HashMap::from([((*b"INTL", 0), override_ptr)]),
+                        ..ResourceFileMap::default()
+                    },
+                ),
+            ]),
+            names: HashMap::new(),
+            search_order: vec![0, 1],
+            current_file: 1,
+        });
+
+        bus.write_word(TEST_SP, 0x0006);
+        bus.write_word(TEST_SP + 2, 0);
+        disp.dispatch_toolbox(true, 0x1ED, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+
+        let handle = bus.read_long(TEST_SP + 4);
+        assert_eq!(bus.read_long(handle), override_ptr);
+        assert_eq!(disp.resource_handle_files.get(&handle), Some(&1));
+        assert!(disp.system_intl_cache.is_empty());
     }
 
     // Pack6 / Intl Utilities ($A9ED) — IUMagIDString selector $000C


### PR DESCRIPTION
## Summary

- synthesize the standard U.S. System-file `INTL` 0 and 1 resources for Resource Manager and International Utilities callers, with stable handles and application-resource precedence
- return revised Time Manager remaining time from `RmvTime` and honor self-reprimed sub-VBL deadlines
- service simultaneous Vertical Retrace Manager queue elements fairly instead of allowing an every-retrace callback to starve later tasks
- add focused regression coverage for every behavior

These are generic Toolbox and interrupt-queue fixes based on Inside Macintosh Volume I and Inside Macintosh: Processes. Together they take the checksum-pinned public Space Madness demo (`58fae30f9b217a5f1792bd0f7bdea7675da012e0cf1c67306181458a63362f23`) from exiting during launch to complete demo compatibility.

## Compatibility evidence

The verified 68K `CODE 0` executable was exercised through:

- optimization notice, title sequence, main menu, preferences/help, mission briefing, ordering information, volume selection, high-score clearing, and normal quit
- gameplay entry, thrust, rotation, pause/resume, shields, pellets, torpedoes, continued simulation, and non-silent action audio
- sustained scoring and resource depletion through fuel exhaustion and the demo's terminal return to its ordering screen

Fresh deterministic BasiliskII comparisons measured:

- canonical menu/input/continued gameplay: 99.93% strict, 99.96% perceptual
- sustained gameplay and terminal transition: 99.49% strict, 99.51% perceptual
- ordering and volume routes: 99.98% strict, 99.99% perceptual
- high-score and quit routes: 100% strict and perceptual

Preferences, help, and briefing content has identical geometry and semantic state on visual inspection. Remaining whole-frame differences are only the demo's continuously cycling magenta palette and animated ship-icon phase. Two clean Systemless executions of every final sequence produced byte-identical artifacts. No unknown traps, unsupported CPU stops, fatal dialogs, panics, silent error bypasses, or material visual/audio/input/timing mismatches remain on the exercised paths.

## Validation

- `cargo test --lib`: 3,880 passed, 3 ignored
- `cargo test --lib --features test-support`: 3,886 passed, 3 ignored
- `cargo check --no-default-features`
- `cargo check --target wasm32-unknown-unknown --no-default-features`
- `cargo package --allow-dirty`
- established gameplay parity corpus: unchanged from baseline at 25 passed, 282 missing-golden failures, 1 ignored
- `cargo fmt --all -- --check`: unchanged baseline-only diffs in two unrelated existing tests

Closes #764
