### PR TITLE
fix: preserve modal alerts and absent screen saver state

### DIFF
--- a/src/trap/dialog.rs
+++ b/src/trap/dialog.rs
@@ -4096,13 +4096,6 @@ impl super::TrapDispatcher {
         (stage_idx, nibble, box_drawn.then_some(default_item))
     }
 
-    fn enabled_button_count(items: &[DialogItem]) -> usize {
-        items
-            .iter()
-            .filter(|item| (item.item_type & 0x7F) == 4 && (item.item_type & 0x80) == 0)
-            .count()
-    }
-
     fn begin_interactive_alert<C: CpuOps>(
         &mut self,
         cpu: &mut C,
@@ -4120,9 +4113,6 @@ impl super::TrapDispatcher {
         };
         let ditl_len = bus.get_alloc_size(ditl_data).unwrap_or(0);
         let items = Self::parse_ditl(bus, ditl_data, ditl_len);
-        if Self::enabled_button_count(&items) <= 1 {
-            return false;
-        }
 
         let items_handle = {
             let handle = bus.alloc(4);
@@ -4323,7 +4313,15 @@ impl super::TrapDispatcher {
                 let item = &items[(hit - 1) as usize];
                 let base_type = item.item_type & 0x7F;
                 let is_disabled = (item.item_type & 0x80) != 0;
-                if base_type != 4 || is_disabled {
+                if is_disabled {
+                    return;
+                }
+                // Alert returns the number of any enabled item selected by
+                // the user. Push buttons use the standard pressed-button
+                // tracking affordance; other enabled items terminate the
+                // alert directly (Inside Macintosh Volume I, I-418).
+                if base_type != 4 {
+                    self.finish_interactive_alert(cpu, bus, hit);
                     return;
                 }
                 let rect = Self::dialog_item_screen_rect(bounds, item.rect);
@@ -10902,11 +10900,10 @@ impl super::TrapDispatcher {
             // The four alert variants differ only in the ICON they
             // display (none / Stop hand / Note speaker / Caution
             // triangle); their dispatch into the ALRT template +
-            // ALRT stages logic is identical. OK-only alerts collapse
-            // to "return the bold/default item for the current stage,
-            // increment AlertStage." Multi-button alerts enter the
-            // normal dialog tracking loop so a script or user can
-            // choose a non-default button before the trap returns.
+            // ALRT stages logic is identical. Every visible alert enters
+            // the normal dialog tracking loop until the user selects an
+            // enabled item. This includes one-button informational
+            // alerts; Alert is modal and must not silently accept them.
             //
             // ALRT template per IM:I I-422:
             //   +0  boundsRect:   Rect (8 bytes)
@@ -10945,7 +10942,7 @@ impl super::TrapDispatcher {
             // Inside Macintosh Volume I, I-417..I-422 (Alert
             // family + ALRT template); Macintosh Toolbox Essentials
             // 1992, 6-105..6-119 (System 7 alert dispatch).
-            // Alert ($A985): Looks up ALRT, parses stages word at +10 per IM:I I-422, returns bold item (1 or 2) for current visible AlertStage ($0A9A) or -1 if ALRT missing / boxDrwn is clear; multi-button alerts track user/script button hits before returning; increments AlertStage capped at 3; filterProc NOT invoked
+            // Alert ($A985): Looks up ALRT, parses stages word at +10 per IM:I I-422, tracks user/script item hits for a visible alert and returns that item, or returns -1 if ALRT is missing / boxDrwn is clear; increments AlertStage capped at 3; filterProc NOT invoked
             // StopAlert ($A986): Same as Alert with Stop icon; identical dispatch path
             // NoteAlert ($A987): Same as Alert with Note icon; identical dispatch path
             // CautionAlert ($A988): Same as Alert with Caution icon; identical dispatch path
@@ -11014,7 +11011,7 @@ impl super::TrapDispatcher {
 
                     if let Some(default_item) = default_item {
                         // A filter procedure customizes event handling; it does
-                        // not make a multi-button alert non-modal. Until guest
+                        // not make a visible alert non-modal. Until guest
                         // filter callbacks are supported, preserve the visible
                         // alert and standard button/Return handling instead of
                         // silently choosing the default item.
@@ -17662,6 +17659,93 @@ mod tests {
         assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 6);
     }
 
+    #[test]
+    fn one_button_alert_remains_modal_until_default_button_is_accepted() {
+        // Inside Macintosh Volume I, I-417: Alert displays the alert and
+        // returns after the user clicks a button. An informational alert with
+        // only an OK button is still modal and must not be auto-accepted.
+        let (mut disp, mut cpu, mut bus) = setup();
+        let alert_id = 3302;
+        let ditl_id = 3303;
+        let alrt = build_test_alrt((100, 100, 210, 400), ditl_id, 0x5555);
+        let ditl = build_test_ditl_items(&[
+            (4, (70, 230, 90, 290), b"OK"),
+            (8, (16, 20, 56, 280), b"Read this notice before continuing."),
+        ]);
+        disp.install_test_resource(&mut bus, *b"ALRT", alert_id, &alrt);
+        disp.install_test_resource(&mut bus, *b"DITL", ditl_id, &ditl);
+
+        bus.write_long(TEST_SP, 0); // filterProc
+        bus.write_word(TEST_SP + 4, alert_id as u16);
+        bus.write_word(TEST_SP + 6, 0xCAFE);
+        let result = disp.dispatch_dialog(true, 0x185, &mut cpu, &mut bus);
+
+        assert!(result.unwrap().is_ok());
+        assert_eq!(cpu.read_reg(Register::A7), TEST_SP);
+        assert_eq!(bus.read_word(TEST_SP + 6), 0);
+        assert!(disp.dialog_tracking.is_some());
+        assert!(disp.is_tracking_refire(0xA985));
+
+        for _ in 0..4 {
+            let result = disp.dispatch_dialog(true, 0x185, &mut cpu, &mut bus);
+            assert!(result.unwrap().is_ok());
+            assert!(disp.dialog_tracking.is_some());
+            assert_eq!(cpu.read_reg(Register::A7), TEST_SP);
+            assert_eq!(bus.read_word(TEST_SP + 6), 0);
+        }
+
+        disp.push_key_down(0x24, b'\r');
+        for _ in 0..4 {
+            let result = disp.dispatch_dialog(true, 0x185, &mut cpu, &mut bus);
+            assert!(result.unwrap().is_ok());
+            if disp.dialog_tracking.is_none() {
+                break;
+            }
+        }
+
+        assert!(disp.dialog_tracking.is_none());
+        assert_eq!(bus.read_word(TEST_SP + 6), 1);
+        assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 6);
+    }
+
+    #[test]
+    fn alert_returns_enabled_non_button_item_selected_by_mouse() {
+        // Alert returns the item number for any enabled item. TrackControl is
+        // reserved for controls; selecting another enabled item returns it
+        // directly (Inside Macintosh Volume I, I-418).
+        let (mut disp, mut cpu, mut bus) = setup();
+        let alert_id = 3304;
+        let ditl_id = 3305;
+        let alrt = build_test_alrt((100, 100, 210, 400), ditl_id, 0x5555);
+        let ditl = build_test_ditl_items(&[
+            (4, (70, 230, 90, 290), b"OK"),
+            (8, (16, 20, 56, 280), b"Select this enabled text item."),
+        ]);
+        disp.install_test_resource(&mut bus, *b"ALRT", alert_id, &alrt);
+        disp.install_test_resource(&mut bus, *b"DITL", ditl_id, &ditl);
+
+        bus.write_long(TEST_SP, 0); // filterProc
+        bus.write_word(TEST_SP + 4, alert_id as u16);
+        bus.write_word(TEST_SP + 6, 0xCAFE);
+        let result = disp.dispatch_dialog(true, 0x185, &mut cpu, &mut bus);
+
+        assert!(result.unwrap().is_ok());
+        assert!(disp.dialog_tracking.is_some());
+
+        disp.push_mouse_down(130, 140);
+        for _ in 0..4 {
+            let result = disp.dispatch_dialog(true, 0x185, &mut cpu, &mut bus);
+            assert!(result.unwrap().is_ok());
+            if disp.dialog_tracking.is_none() {
+                break;
+            }
+        }
+
+        assert!(disp.dialog_tracking.is_none());
+        assert_eq!(bus.read_word(TEST_SP + 6), 2);
+        assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 6);
+    }
+
     fn loaded_resource_handle_for_test(
         disp: &TrapDispatcher,
         res_type: [u8; 4],
@@ -23669,9 +23753,7 @@ mod tests {
 
         let ditl = build_test_ditl_items(&[
             (4, (48, 70, 70, 132), b"OK".as_slice()),
-            // Keep this fixture on the auto-return path while still verifying
-            // that stage defaults can report item 2.
-            (0x84, (48, 144, 70, 212), b"Cancel".as_slice()),
+            (4, (48, 144, 70, 212), b"Cancel".as_slice()),
         ]);
         let alrt = build_alrt_template(2100, 0xC4C4);
         disp.install_test_resource(&mut bus, *b"DITL", 2100, &ditl);
@@ -23686,6 +23768,17 @@ mod tests {
             disp.dispatch_dialog(true, trap_word, &mut cpu, &mut bus)
                 .unwrap()
                 .unwrap();
+            disp.push_key_down(0x24, b'\r');
+            for _ in 0..4 {
+                disp.dispatch_dialog(true, trap_word, &mut cpu, &mut bus)
+                    .unwrap()
+                    .unwrap();
+                if disp.dialog_tracking.is_none() {
+                    break;
+                }
+            }
+            assert!(disp.dialog_tracking.is_none());
+            disp.push_key_up(0x24, b'\r');
             staged_calls.push(AlertTrapCallSnapshot {
                 trap_word,
                 result: bus.read_word(TEST_SP + 6) as i16,

--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -3433,13 +3433,6 @@ impl super::TrapDispatcher {
                     // handler below.
                     _ => {}
                 }
-                let s = std::str::from_utf8(&sel).unwrap_or("????");
-                eprintln!(
-                    "[GESTALT] selector='{}' (${:08X}) PC=${:08X}",
-                    s,
-                    selector,
-                    cpu.read_reg(Register::PC)
-                );
                 match &sel {
                     // gestaltVersion ('vers') -> Gestalt Manager version.
                     // Inside Macintosh: Operating System Utilities 1994,
@@ -3603,6 +3596,17 @@ impl super::TrapDispatcher {
                     b"snd " => {
                         cpu.write_reg(Register::A0, 0x1CFB);
                         cpu.write_reg(Register::D0, 0);
+                    }
+                    // gestaltScreenSaverAttr ('SAVR') -> After Dark absent.
+                    // AfterDarkGestalt.h (Berkeley Systems, 1993) defines
+                    // this selector for its optional extension. Operating
+                    // System Utilities 1994, pp. 1-31 to 1-32 specifies that
+                    // undefined selectors return gestaltUndefSelectorErr.
+                    // Clear A0 so callers cannot mistake a stale response for
+                    // the extension's enabled or asleep attribute bits.
+                    b"SAVR" => {
+                        cpu.write_reg(Register::A0, 0);
+                        cpu.write_reg(Register::D0, GESTALT_UNDEF_SELECTOR_ERR);
                     }
                     // gestaltSpeechAttr ('ttsc') -> Speech Manager absent.
                     // Sound 1994, 1-11..1-12 defines bit 0 as
@@ -14045,6 +14049,19 @@ mod tests {
         assert_eq!(cpu.read_reg(Register::D0), 0);
     }
 
+    #[test]
+    fn gestalt_absent_screen_saver_extension_clears_response_register() {
+        let (mut disp, mut cpu, mut bus) = setup();
+
+        cpu.write_reg(Register::A0, 0xFFFF_FFFF);
+        cpu.write_reg(Register::D0, u32::from_be_bytes(*b"SAVR"));
+
+        call(&mut disp, false, 0xAD, &mut cpu, &mut bus).unwrap();
+
+        assert_eq!(cpu.read_reg(Register::A0), 0);
+        assert_eq!(cpu.read_reg(Register::D0), 0xFFFF_EA51);
+    }
+
     // ================================================================
     // 14c. Gestalt (0xAD) — unknown selector
     // ================================================================
@@ -14082,6 +14099,18 @@ mod tests {
         call_trap_word(&mut disp, 0xA3AD, &mut cpu, &mut bus).unwrap();
 
         assert_eq!(cpu.read_reg(Register::D0), 0xFFFF_EA50);
+    }
+
+    #[test]
+    fn newgestalt_accepts_unregistered_screen_saver_selector() {
+        let (mut disp, mut cpu, mut bus) = setup();
+
+        cpu.write_reg(Register::A0, 0x0040_0000);
+        cpu.write_reg(Register::D0, u32::from_be_bytes(*b"SAVR"));
+
+        call_trap_word(&mut disp, 0xA3AD, &mut cpu, &mut bus).unwrap();
+
+        assert_eq!(cpu.read_reg(Register::D0), 0);
     }
 
     /// Dispatches _NewGestalt with five distinct fictional selectors via


### PR DESCRIPTION
## Summary

- keep every visible `Alert` modal until the user selects an enabled item, including one-button informational notices
- report the optional After Dark `SAVR` selector as absent with a cleared response register while preserving `NewGestalt` registration semantics
- remove unconditional diagnostic output from recognized Gestalt queries

## Root causes

Systemless previously entered its interactive Alert path only when a DITL contained more than one enabled push button. A one-button notice therefore bypassed event handling and returned its default item immediately. Inside Macintosh Volume I, pp. I-417 to I-418 specifies that Alert handles events until the user selects an enabled item. The updated path keeps all visible alerts pending, preserves standard button tracking and Return handling, and returns other enabled DITL item selections.

`SAVR` is the optional screen-saver selector defined by Berkeley Systems' 1993 `AfterDarkGestalt.h`. With no extension registered, Operating System Utilities 1994, pp. 1-31 to 1-32 requires `gestaltUndefSelectorErr`. The query now also clears A0 so stale attribute bits cannot be mistaken for an enabled or sleeping screen saver. `SAVR` is not treated as a built-in selector, so `NewGestalt('SAVR')` remains valid.

## Compatibility evidence

The checksum-pinned public demo from [Classic Macintosh Game Demos](https://classicmacdemos.com/spaceway-2000) has SHA-256 `7faf4874335f0099086d321cfae5e29a153487c387de1bf03f3261ab6b444728`. The selected `Spaceway 2000™` application is an `APPL` with a parseable resource fork and 68K `CODE` resource ID 0.

Fresh deterministic Systemless and System 7.5.3/BasiliskII runs exercised:

- modal demo notice, title/File availability, Game Options, Memory, Configure Keys, Sound, High Scores, and all four Help routes
- New Game, steering, gear shift, calibrated fore/aft weapons, non-silent weapon audio, pause, continued simulation, End Game/high scores, and restart
- a natural `TIME EXPIRED` wave boundary with the timer restarting and both ships retained
- genuine Route 01 completion, its equipment dialog, and continued execution in active Route 02
- demo-disabled Start at Level, Open Game, and saving were recorded as unavailable rather than treated as accessible routes

Comparison results:

- canonical gameplay: 98.97% strict / 99.76% perceptual overall; every frame at or above 95% strict
- End Game/restart: 99.64% strict / 99.70% perceptual overall
- timed-wave transition: 99.63% strict / 99.66% perceptual overall
- Route 01 to Route 02: 98.35% strict / 99.32% perceptual overall
- menus/options/help, excluding the host desktop around the first notice: 98.28% to 99.85% strict per frame
- the first notice's complete 340x200 application window: 98.77% strict; the preserved full-screen comparison is 16.99% because the two host desktops differ outside the identically positioned application window

Two clean Systemless executions of every final route produced byte-identical screenshots. Input remained responsive, time advanced, audio was non-silent during weapon fire, and execution continued after every terminal checkpoint without unknown traps, unsupported CPU stops, fatal dialogs, or panics.

## Tests

- `cargo test --lib`: baseline 3,874 passed / 3 ignored; post-change 3,878 passed / 3 ignored
- `cargo test --lib --features test-support`: baseline 3,880 passed / 3 ignored; post-change 3,884 passed / 3 ignored
- `cargo check --no-default-features`
- `cargo check --target wasm32-unknown-unknown --no-default-features`
- `cargo package`
- compatibility corpus unchanged: 25 available goldens passed, 282 unavailable-golden cases, 1 ignored
- `cargo fmt --all -- --check` remains at the pre-existing `menu.rs` and `quickdraw.rs` diffs; neither changed file adds formatting output

Closes #766
