### PR TITLE
fix(quickdraw): support enhanced standard color tables

### DIFF
--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -3456,6 +3456,53 @@ impl TrapDispatcher {
         Some((clut, entries))
     }
 
+    /// Return a standard color-device table (the depth plus 64 CTable IDs)
+    /// with the current highlight color represented in the table.
+    ///
+    /// Inside Macintosh: Volume VI (1991), pp. 17-17..17-18 and 20-7,
+    /// describes IDs 66, 68, and 72 as the standard 2-, 4-, and 8-bit
+    /// color tables with the highlight color added. The 2-bit table reserves
+    /// index 2 for that color. The 4-bit table replaces the standard entry
+    /// nearest to it. The 8-bit table already has 254 color entries; the
+    /// System 7.5.3 ROM's GetCTable(72) oracle returns that canonical table
+    /// unchanged, so there is no spare entry to replace in that case.
+    pub(crate) fn standard_mac_enhanced_clut(
+        depth: u16,
+        hilite: (u16, u16, u16),
+    ) -> Option<([[u16; 3]; 256], usize)> {
+        let (mut clut, entries) = Self::standard_mac_indexed_clut(depth)?;
+        let hilite = [hilite.0, hilite.1, hilite.2];
+        match depth {
+            2 => clut[2] = hilite,
+            4 => {
+                // Index 0 is white and the last entry is black; both are
+                // fixed endpoints of the standard table. Select the closest
+                // interior entry using the Color Manager's RGB distance.
+                let mut closest = 1;
+                let mut closest_distance = u64::MAX;
+                for index in 1..entries - 1 {
+                    let color = clut[index];
+                    let distance = color
+                        .iter()
+                        .zip(hilite.iter())
+                        .map(|(&a, &b)| {
+                            let delta = i64::from(a) - i64::from(b);
+                            (delta * delta) as u64
+                        })
+                        .sum();
+                    if distance < closest_distance {
+                        closest = index;
+                        closest_distance = distance;
+                    }
+                }
+                clut[closest] = hilite;
+            }
+            8 => {}
+            _ => return None,
+        }
+        Some((clut, entries))
+    }
+
     /// Return the default 4-bit CTable installed by `NewGWorld` on
     /// System 7.5.3. This differs from the `GetCTable(4)` resource at
     /// dark-green entry 9.

--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -6682,10 +6682,24 @@ impl super::TrapDispatcher {
                     );
                 }
 
-                let ct_handle = if ct_id == 1 || ct_id == 2 || ct_id == 4 || ct_id == 8 {
+                let standard_ctable = match ct_id {
+                    1 | 2 | 4 | 8 => Some((ct_id as u16, false)),
+                    // Inside Macintosh: Volume VI (1991), pp. 17-17..17-18:
+                    // pixel depth + 64 selects the enhanced standard color
+                    // table, and must be obtained through GetCTable rather
+                    // than GetResource.
+                    66 => Some((2, true)),
+                    68 => Some((4, true)),
+                    72 => Some((8, true)),
+                    _ => None,
+                };
+                let ct_handle = if let Some((depth, enhanced)) = standard_ctable {
                     self.recent_resource_ctable_fetch = None;
-                    let (std_clut, entry_count) =
-                        Self::standard_mac_indexed_clut(ct_id as u16).unwrap();
+                    let (std_clut, entry_count) = if enhanced {
+                        Self::standard_mac_enhanced_clut(depth, self.hilite_color).unwrap()
+                    } else {
+                        Self::standard_mac_indexed_clut(depth).unwrap()
+                    };
                     let ct_size: u32 = 8 + entry_count as u32 * 8;
                     let ct_ptr = bus.alloc(ct_size);
                     // Executor's depth convention (qGWorld.cpp:217,
@@ -6695,7 +6709,15 @@ impl super::TrapDispatcher {
                     // (also stamped ctSeed=depth) identity-copy via the
                     // seed-match gates when the destination
                     // is that same canonical CTab.
-                    bus.write_long(ct_ptr, ct_id as u32); // ctSeed = depth
+                    // Enhanced tables are derived from the standard table and
+                    // depend on HiliteColor, so they need a fresh seed rather
+                    // than colliding with the canonical depth seed.
+                    let seed = if enhanced {
+                        self.next_color_table_seed()
+                    } else {
+                        depth as u32
+                    };
+                    bus.write_long(ct_ptr, seed);
                     bus.write_word(ct_ptr + 4, 0); // ctFlags (0 = pixmap color table)
                     bus.write_word(ct_ptr + 6, entry_count as u16 - 1); // ctSize
                     for i in 0..entry_count as u32 {
@@ -44298,6 +44320,58 @@ mod tests {
             8,
             "GetCTable(8) must return ctSeed=8 (depth convention)"
         );
+    }
+
+    /// GetCTable's depth-plus-64 IDs are standard Color QuickDraw tables,
+    /// not resource lookups. In particular, a missing 'clut' 72 resource
+    /// must not turn the enhanced 8-bit table into NIL (Inside Macintosh:
+    /// Volume VI, pp. 17-17..17-18 and 20-7).
+    #[test]
+    fn test_get_ctable_enhanced_standard_ids() {
+        let (mut d, mut cpu, mut bus) = setup();
+        let hilite = d.hilite_color;
+
+        bus.write_word(TEST_SP, 66u16);
+        d.dispatch_quickdraw(true, 0x218, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+        let ctab_66 = bus.read_long(cpu.read_reg(Register::A7));
+        assert_ne!(ctab_66, 0, "GetCTable(66) must return a non-null handle");
+        let ptr_66 = bus.read_long(ctab_66);
+        assert_eq!(bus.read_word(ptr_66 + 6), 3);
+        assert_eq!(bus.read_word(ptr_66 + 8 + 2 * 8 + 2), hilite.0);
+        assert_eq!(bus.read_word(ptr_66 + 8 + 2 * 8 + 4), hilite.1);
+        assert_eq!(bus.read_word(ptr_66 + 8 + 2 * 8 + 6), hilite.2);
+
+        let sp = cpu.read_reg(Register::A7);
+        bus.write_word(sp, 68u16);
+        d.dispatch_quickdraw(true, 0x218, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+        let ctab_68 = bus.read_long(cpu.read_reg(Register::A7));
+        assert_ne!(ctab_68, 0, "GetCTable(68) must return a non-null handle");
+        let ptr_68 = bus.read_long(ctab_68);
+        assert_eq!(bus.read_word(ptr_68 + 6), 15);
+        assert_eq!(bus.read_word(ptr_68 + 8 + 9 * 8 + 2), hilite.0);
+        assert_eq!(bus.read_word(ptr_68 + 8 + 9 * 8 + 4), hilite.1);
+        assert_eq!(bus.read_word(ptr_68 + 8 + 9 * 8 + 6), hilite.2);
+
+        let sp = cpu.read_reg(Register::A7);
+        bus.write_word(sp, 72u16);
+        d.dispatch_quickdraw(true, 0x218, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+        let ctab_72 = bus.read_long(cpu.read_reg(Register::A7));
+        assert_ne!(ctab_72, 0, "GetCTable(72) must return a non-null handle");
+        let ptr_72 = bus.read_long(ctab_72);
+        assert_eq!(bus.read_word(ptr_72 + 6), 255);
+        let standard_8bpp = TrapDispatcher::standard_mac_8bpp_clut();
+        for index in [0usize, 197, 225, 255] {
+            let entry = ptr_72 + 8 + index as u32 * 8;
+            assert_eq!(bus.read_word(entry + 2), standard_8bpp[index][0]);
+            assert_eq!(bus.read_word(entry + 4), standard_8bpp[index][1]);
+            assert_eq!(bus.read_word(entry + 6), standard_8bpp[index][2]);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- synthesize the documented enhanced standard color tables for `GetCTable` IDs 66, 68, and 72
- preserve canonical 8-bit entries while incorporating `HiliteColor` where the enhanced 2-bit and 4-bit tables provide a replaceable entry
- assign fresh seeds to highlight-dependent tables and add focused regression coverage

## Reference behavior

Inside Macintosh: Volume VI documents the depth-plus-64 IDs as standard Color Manager tables obtained through `GetCTable`, not ordinary application resources. A System 7.5.3 check confirms that ID 72 returns the canonical 256-entry table.

With the public Star Trek: 25th Anniversary demo (`da00d1cd3fa4db2ce5cbd5f8ba57957964f92e709f7081b2646b4d39b3b3bb06`) and the SAVR Gestalt correction in #768, the previously black indexed frame renders the Enterprise scene and narration.

## Verification

- focused enhanced-standard-table regression test
- `cargo test --lib` (3,878 passed)
- `cargo test --lib --features test-support` (3,881 passed)
- `cargo check --no-default-features`
- `cargo check --target wasm32-unknown-unknown --no-default-features`
- `cargo package --allow-dirty`
- `cargo fmt --all -- --check` retains only the same two unrelated pre-existing diffs present on master

Closes #769