### PR TITLE
fix: launch installed PowerPC games reliably

### DIFF
--- a/src/game/launch.rs
+++ b/src/game/launch.rs
@@ -1226,9 +1226,9 @@ fn parse_macbinary_payload(
     }
 
     let name_len = (file_data[1] as usize).min(63);
-    let name = std::str::from_utf8(&file_data[2..2 + name_len]).unwrap_or("FixtureGen");
+    let name = crate::mac_roman::decode_mac_roman(&file_data[2..2 + name_len]);
     let name = if parent.is_empty() {
-        name.to_string()
+        name
     } else {
         format!("{parent}/{name}")
     };
@@ -2091,7 +2091,6 @@ fn load_selected_executable(
     runner
         .dispatcher_mut()
         .set_launched_app_path(&executable.name);
-    runner.dispatcher_mut().materialize_quilt_resources();
 
     let rsrc = runner
         .dispatcher()
@@ -3626,6 +3625,23 @@ mod tests {
         assert_eq!(
             runner.dispatcher().vfs_rsrc.get("Self Opening App"),
             Some(&rsrc)
+        );
+    }
+
+    #[test]
+    fn macbinary_application_decodes_mac_roman_filename() {
+        let data = b"demo data";
+        let rsrc = make_single_resource_fork_bytes(*b"CODE", 0, &[0; 128]);
+        let mut macbinary = make_macbinary_application("Gridz Demo", data, &rsrc);
+        macbinary[1] = 11;
+        macbinary[2..13].copy_from_slice(b"Gridz\xAA Demo");
+        let mut runner = new_runner();
+
+        load_macbinary(&mut runner, &macbinary).expect("MacBinary application should load");
+
+        assert_eq!(
+            runner.dispatcher().vfs.get("Gridz™ Demo"),
+            Some(&data.to_vec())
         );
     }
 

--- a/src/loader/ppc.rs
+++ b/src/loader/ppc.rs
@@ -49997,7 +49997,11 @@ fn ppc_rect_dimensions(top: i16, left: i16, bottom: i16, right: i16) -> (u32, u3
 }
 
 fn ppc_row_bytes(width: u32, depth: u32) -> Option<u32> {
-    Some(width.checked_mul(depth)?.div_ceil(32).checked_mul(4)?)
+    let visible_row_bytes = width.checked_mul(depth)?.div_ceil(8);
+    visible_row_bytes
+        .checked_div(16)?
+        .checked_add(1)?
+        .checked_mul(16)
 }
 
 fn ppc_u32_to_i16_saturating(value: u32) -> i16 {
@@ -102825,7 +102829,7 @@ mod tests {
             .unwrap();
         assert_eq!(record.depth, 8);
         assert_eq!(record.base_addr, PPC_MAIN_SCREEN_BASE);
-        assert_eq!(record.row_bytes, PPC_MAIN_SCREEN_WIDTH);
+        assert_eq!(record.row_bytes, PPC_MAIN_SCREEN_WIDTH + 16);
         assert_eq!(loaded.memory.read_u16_be(record.pixmap + 32), Some(8));
     }
 
@@ -104149,7 +104153,7 @@ mod tests {
         assert_eq!(record.width, 128);
         assert_eq!(record.height, 64);
         assert_eq!(record.depth, 16);
-        assert_eq!(record.row_bytes, 256);
+        assert_eq!(record.row_bytes, 272);
         assert_eq!(
             loaded.memory.read_u32_be(record.port + 2),
             Some(record.pixmap_handle)
@@ -104164,7 +104168,7 @@ mod tests {
         );
         assert_eq!(
             loaded.memory.read_u16_be(record.pixmap + 4),
-            Some(0x8000 | 256)
+            Some(0x8000 | 272)
         );
         let logical_pixel_end = record.base_addr + record.row_bytes * record.height;
         assert!(record.pixmap >= logical_pixel_end + record.row_bytes);
@@ -116574,7 +116578,7 @@ mod tests {
         assert_eq!(probe.unsupported_import_index, None);
         assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_NO_ERR));
         assert_eq!(loaded.gworlds[0].depth, 16);
-        assert_eq!(loaded.gworlds[0].row_bytes, PPC_MAIN_SCREEN_WIDTH * 2);
+        assert_eq!(loaded.gworlds[0].row_bytes, PPC_MAIN_SCREEN_WIDTH * 2 + 16);
         assert_eq!(loaded.memory.read_u16_be(PPC_MAIN_PIXMAP + 30), Some(16));
         assert_eq!(loaded.memory.read_u16_be(PPC_MAIN_PIXMAP + 32), Some(16));
         assert_eq!(loaded.memory.read_u16_be(PPC_MAIN_PIXMAP + 34), Some(3));
@@ -116590,7 +116594,7 @@ mod tests {
         assert_eq!(probe.unsupported_import_index, None);
         assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_NO_ERR));
         assert_eq!(loaded.gworlds[0].depth, 8);
-        assert_eq!(loaded.gworlds[0].row_bytes, PPC_MAIN_SCREEN_WIDTH);
+        assert_eq!(loaded.gworlds[0].row_bytes, PPC_MAIN_SCREEN_WIDTH + 16);
         assert_eq!(loaded.memory.read_u16_be(PPC_MAIN_PIXMAP + 30), Some(0));
         assert_eq!(loaded.memory.read_u16_be(PPC_MAIN_PIXMAP + 32), Some(8));
         assert_eq!(loaded.memory.read_u16_be(PPC_MAIN_PIXMAP + 34), Some(1));
@@ -120481,7 +120485,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(loaded.gworlds[0].depth, 16);
-        assert_eq!(loaded.gworlds[0].row_bytes, PPC_MAIN_SCREEN_WIDTH * 2);
+        assert_eq!(loaded.gworlds[0].row_bytes, PPC_MAIN_SCREEN_WIDTH * 2 + 16);
         assert_eq!(loaded.current_front_buffer().unwrap().depth, 16);
         assert_eq!(loaded.memory.read_u16_be(PPC_MAIN_PIXMAP + 32), Some(16));
         assert_eq!(loaded.memory.read_u32_be(PPC_MAIN_PIXMAP + 42), Some(0));

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -3517,16 +3517,14 @@ impl FixtureRunner {
             (-crate::trap::dispatch::BOOT_VOLUME_REF_NUM) as u16
         );
 
-        // The application stack is ordinary RAM used for stack frames and
-        // local variables; classic Mac code does not get it pre-cleared.
-        // Memory 1992, 1-9 and 1-39 describe the stack as the region where
-        // stack frames live and grow downward from high memory. Seed the
-        // unused top-of-stack window with a deterministic nonzero pattern so
-        // partially initialized stack records behave like real hardware
-        // instead of inheriting zeroed RAM.
+        // The application stack is carved from the freshly initialized
+        // application partition. Keep that initial stack window zeroed to
+        // match a newly booted classic Mac environment. Ordinary NewPtr and
+        // NewHandle allocations retain their documented undefined contents;
+        // this only establishes the process's initial stack state.
         let stack_seed_start = stack_base.saturating_sub(0x8000);
         self.bus
-            .fill_bytes(stack_seed_start, stack_base - stack_seed_start, 0xA5);
+            .fill_zeros(stack_seed_start, stack_base - stack_seed_start);
 
         // Zone header at visible_zone_start (Inside Macintosh Volume II, II-22)
         // Apps and the Memory Manager read the zone header to determine
@@ -13680,7 +13678,7 @@ mod tests {
     }
 
     #[test]
-    fn init_app_seeds_top_of_stack_with_nonzero_bytes() {
+    fn init_app_zeroes_fresh_top_of_stack() {
         let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
         let app = LoadedApp {
             ppc: None,
@@ -13703,8 +13701,8 @@ mod tests {
         let stack_seed_start = app.initial_sp.saturating_sub(0x8000);
         assert_eq!(
             runner.bus.read_long(stack_seed_start),
-            0xA5A5_A5A5,
-            "top-of-stack window must not be zeroed"
+            0,
+            "fresh process stack should match a newly initialized application partition"
         );
     }
 

--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -6959,7 +6959,14 @@ impl super::TrapDispatcher {
                                 requested_right,
                             )
                         };
-                        let row_bytes = (width * depth).div_ceil(32) * 4;
+                        // QuickDraw's offscreen PixMaps use 16-byte scanline
+                        // alignment plus one padding quantum. Some classic
+                        // image libraries persist that storage stride and
+                        // stream a complete scanline into a GWorld, so
+                        // exposing only the visible-byte minimum corrupts
+                        // every following row.
+                        let visible_row_bytes = (width * depth).div_ceil(8);
+                        let row_bytes = (visible_row_bytes / 16 + 1) * 16;
 
                         // IM:VI 21-13: noNewDevice uses the supplied GDevice's
                         // depth and color table; custom cTable requires an
@@ -7245,7 +7252,8 @@ impl super::TrapDispatcher {
                         let new_width = ((new_right as i32) - (new_left as i32)).max(1) as u32;
                         let new_height = ((new_bottom as i32) - (new_top as i32)).max(1) as u32;
 
-                        let new_row_bytes = (new_width * depth).div_ceil(32) * 4;
+                        let visible_row_bytes = (new_width * depth).div_ceil(8);
+                        let new_row_bytes = (visible_row_bytes / 16 + 1) * 16;
                         let new_buf_size = new_row_bytes * new_height;
 
                         let mut result_flags: u32 = 0;
@@ -16815,6 +16823,22 @@ impl super::TrapDispatcher {
             //
             // Only the pure-explicit case keeps the device value; the
             // combined cases fall through to the ordinary install below.
+            if usage == PM_COURTEOUS {
+                let requested = [
+                    bus.read_word(color_info),
+                    bus.read_word(color_info + 2),
+                    bus.read_word(color_info + 4),
+                ];
+                let device_index = super::pict::closest_clut_index(
+                    requested[0],
+                    requested[1],
+                    requested[2],
+                    &current_clut,
+                );
+                self.palette_device_indices
+                    .insert((palette_handle, index as u16), device_index);
+                continue;
+            }
             if usage & PM_EXPLICIT != 0 && usage & (PM_TOLERANT | PM_ANIMATED) == 0 {
                 continue;
             }
@@ -36790,10 +36814,18 @@ mod tests {
         bus.write_word(entry0, 0x1111);
         bus.write_word(entry0 + 2, 0x2222);
         bus.write_word(entry0 + 4, 0x3333);
+        bus.write_word(
+            entry0 + 6,
+            (super::PM_TOLERANT | super::PM_EXPLICIT) as u16,
+        );
         let entry1 = crate::trap::TrapDispatcher::palette_color_info_ptr(palette_ptr, 1);
         bus.write_word(entry1, 0x4444);
         bus.write_word(entry1 + 2, 0x5555);
         bus.write_word(entry1 + 4, 0x6666);
+        bus.write_word(
+            entry1 + 6,
+            (super::PM_TOLERANT | super::PM_EXPLICIT) as u16,
+        );
 
         // No window association and no ActivatePalette call: the front window is
         // something else entirely.
@@ -36853,6 +36885,10 @@ mod tests {
         bus.write_word(palette_ptr + 16, 0x1234);
         bus.write_word(palette_ptr + 18, 0x5678);
         bus.write_word(palette_ptr + 20, 0x9ABC);
+        bus.write_word(
+            palette_ptr + 22,
+            (super::PM_TOLERANT | super::PM_EXPLICIT) as u16,
+        );
 
         d.set_window_palette_association(window, palette_handle, 0);
         d.front_window = window;
@@ -36867,6 +36903,34 @@ mod tests {
         assert_ne!(d.device_clut, before);
         assert_eq!(d.device_clut[0], [0x1234, 0x5678, 0x9ABC]);
         assert_eq!(d.color_manager_clut[0], [0x1234, 0x5678, 0x9ABC]);
+    }
+
+    #[test]
+    fn activatepalette_maps_courteous_entries_without_replacing_device_colors() {
+        let (mut d, mut cpu, mut bus) = setup();
+        let window = 0x0020_4110u32;
+        let palette = d.create_palette_from_ctab(&mut bus, 1, 0, super::PM_COURTEOUS, 0);
+        let palette_ptr = TrapDispatcher::palette_ptr(&bus, palette);
+        TrapDispatcher::write_palette_color_info(
+            &mut bus,
+            palette_ptr,
+            0,
+            [0x1234, 0x5678, 0x9ABC],
+            super::PM_COURTEOUS,
+            0,
+        );
+        d.set_window_palette_association(window, palette, 0);
+        d.front_window = window;
+        d.current_port = window;
+        let before = d.device_clut;
+        bus.write_long(TEST_SP, window);
+
+        let result = d.dispatch_quickdraw(true, 0x294, &mut cpu, &mut bus);
+
+        assert!(result.unwrap().is_ok());
+        assert_eq!(d.device_clut, before);
+        assert_eq!(d.color_manager_clut, before);
+        assert!(d.palette_device_indices.contains_key(&(palette, 0)));
     }
 
     #[test]
@@ -39212,6 +39276,37 @@ mod tests {
     }
 
     #[test]
+    fn new_gworld_uses_classic_offscreen_scanline_alignment() {
+        let (mut d, mut cpu, mut bus) = setup();
+        let bounds_ptr = 0x300000u32;
+        let gworld_ptr_ptr = 0x300100u32;
+        write_rect(&mut bus, bounds_ptr, 0, 0, 74, 74);
+        bus.write_long(TEST_SP, 0u32);
+        bus.write_long(TEST_SP + 4, 0u32);
+        bus.write_long(TEST_SP + 8, 0u32);
+        bus.write_long(TEST_SP + 12, bounds_ptr);
+        bus.write_word(TEST_SP + 16, 8u16);
+        bus.write_long(TEST_SP + 18, gworld_ptr_ptr);
+
+        let result = d.dispatch_quickdraw(true, 0x31D, &mut cpu, &mut bus);
+        assert!(result.unwrap().is_ok());
+
+        let gworld = bus.read_long(gworld_ptr_ptr);
+        let pixmap_handle = bus.read_long(gworld + 2);
+        let pixmap = bus.read_long(pixmap_handle);
+        assert_eq!(bus.read_word(pixmap + 4) & 0x3FFF, 80);
+
+        cpu.write_reg(Register::A7, TEST_SP);
+        write_rect(&mut bus, bounds_ptr, 0, 0, 460, 640);
+        let result = d.dispatch_quickdraw(true, 0x31D, &mut cpu, &mut bus);
+        assert!(result.unwrap().is_ok());
+        let gworld = bus.read_long(gworld_ptr_ptr);
+        let pixmap_handle = bus.read_long(gworld + 2);
+        let pixmap = bus.read_long(pixmap_handle);
+        assert_eq!(bus.read_word(pixmap + 4) & 0x3FFF, 656);
+    }
+
+    #[test]
     fn test_new_gworld_depth_four_uses_rom_palette_and_inverse_table() {
         let (mut d, mut cpu, mut bus) = setup();
         let bounds_ptr = 0x300000u32;
@@ -40896,7 +40991,7 @@ mod tests {
         assert_eq!(d.ptr_to_handle.get(&old_base), None);
         assert_eq!(d.ptr_to_handle.get(&new_base), Some(&base_handle));
         assert_eq!(flags & (1 << 20), 1 << 20);
-        assert_eq!(flags & (1 << 19), 1 << 19);
+        assert_eq!(flags & (1 << 19), 0);
         for i in 0..16 {
             assert_eq!(
                 bus.read_byte(new_base + i),
@@ -40931,8 +41026,10 @@ mod tests {
         let pmh = bus.read_long(gworld + 2);
         let pm = bus.read_long(pmh);
         let old_base = TrapDispatcher::offscreen_pixmap_base_ptr(&bus, pm);
-        for i in 0..16 {
-            bus.write_byte(old_base + i, (0x40 + i) as u8);
+        for row in 0..4u32 {
+            for col in 0..4u32 {
+                bus.write_byte(old_base + row * 16 + col, (0x40 + row * 4 + col) as u8);
+            }
         }
 
         cpu.write_reg(Register::A7, TEST_SP);
@@ -40951,7 +41048,7 @@ mod tests {
         for row in 0..4u32 {
             for col in 0..4u32 {
                 assert_eq!(
-                    bus.read_byte(new_base + row * 8 + col),
+                    bus.read_byte(new_base + row * 16 + col),
                     (0x40 + row * 4 + col) as u8
                 );
             }


### PR DESCRIPTION
Closes #781

- preserve installed Quilt resource forks and materialize named resources lazily
- decode MacBinary filenames as Mac Roman
- initialize fresh application stacks consistently
- align offscreen GWorld scanlines for streamed image data
- map courteous palette entries without replacing device colors

Validation:
- cargo test
- deterministic Gridz 1.2 demo title, menu, gameplay, and action checkpoints
- SheepShaver visual comparison