### PR TITLE
fix(quickdraw): align main and offscreen scanline storage

### DIFF
--- a/src/machine_profile.rs
+++ b/src/machine_profile.rs
@@ -73,10 +73,13 @@ impl MachineProfile {
         self.gestalt_fpu_type != 0
     }
 
-    /// Bytes per scanline for this profile's packed indexed screen.
+    /// Bytes per scanline for this profile's indexed screen. `rowBytes` is an
+    /// offset and may include storage beyond the visible pixels; matching the
+    /// offscreen 16-byte quantum keeps direct full-row transfers coherent.
+    /// Imaging With QuickDraw 1994, p. 4-5
     pub const fn screen_row_bytes(self) -> u32 {
         let bytes = (self.screen_width as u32 * self.screen_depth as u32).div_ceil(8);
-        (bytes + 1) & !1
+        (bytes / 16 + 1) * 16
     }
 }
 

--- a/src/memory/bus.rs
+++ b/src/memory/bus.rs
@@ -910,7 +910,7 @@ impl MacMemoryBus {
         } else {
             0 // Fallback for unit tests with small RAM
         };
-        let screen_row_bytes: u16 = 800;
+        let screen_row_bytes: u16 = 816;
         let screen_width: u16 = 800;
         let screen_height: u16 = 600;
 
@@ -953,7 +953,9 @@ impl MacMemoryBus {
     pub(crate) fn configure_screen_depth(&mut self, depth: u16) {
         debug_assert!(matches!(depth, 1 | 4 | 8));
         let profile = crate::machine_profile::reference_machine_profile();
-        let row_bytes = ((u32::from(profile.screen_width) * u32::from(depth)).div_ceil(8) + 1) & !1;
+        let visible_row_bytes =
+            (u32::from(profile.screen_width) * u32::from(depth)).div_ceil(8);
+        let row_bytes = (visible_row_bytes / 16 + 1) * 16;
         self.write_word(super::globals::addr::SCREEN_ROW, row_bytes as u16);
         self.write_word(super::globals::addr::SCREEN_BITS + 4, row_bytes as u16);
     }
@@ -1961,7 +1963,7 @@ mod tests {
     #[test]
     fn new_bus_publishes_default_screen_row_bytes() {
         let bus = MacMemoryBus::new(1024);
-        assert_eq!(bus.read_word(crate::memory::globals::addr::SCREEN_ROW), 800);
+        assert_eq!(bus.read_word(crate::memory::globals::addr::SCREEN_ROW), 816);
     }
 
     #[test]
@@ -2259,7 +2261,7 @@ mod tests {
         let sound_base = bus.read_long(crate::memory::globals::addr::SOUND_BASE);
 
         assert_eq!(
-            sound_base, 0x003F_5300,
+            sound_base, 0x003F_7880,
             "SoundBase should sit just past the active framebuffer in the reserved hardware-buffer area"
         );
         assert!(

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1898,9 +1898,9 @@ impl FixtureRunner {
         bus.set_addressing_32_bit(config.addressing_32_bit);
         bus.configure_screen_depth(config.screen_depth);
         let profile = crate::machine_profile::reference_machine_profile();
-        let row_bytes =
-            ((u32::from(profile.screen_width) * u32::from(config.screen_depth)).div_ceil(8) + 1)
-                & !1;
+        let visible_row_bytes =
+            (u32::from(profile.screen_width) * u32::from(config.screen_depth)).div_ceil(8);
+        let row_bytes = (visible_row_bytes / 16 + 1) * 16;
         dispatcher.screen_mode = (
             bus.read_long(crate::memory::globals::addr::SCRN_BASE),
             row_bytes,
@@ -10329,11 +10329,11 @@ mod tests {
         let pixmap = runner.bus.read_long(runner.bus.read_long(gdevice + 22));
         let ctab = runner.bus.read_long(runner.bus.read_long(pixmap + 42));
 
-        assert_eq!(runner.dispatcher.screen_mode.1, 400);
+        assert_eq!(runner.dispatcher.screen_mode.1, 416);
         assert_eq!(runner.dispatcher.screen_mode.4, 4);
-        assert_eq!(runner.bus.read_word(addr::SCREEN_ROW), 400);
-        assert_eq!(runner.bus.read_word(addr::SCREEN_BITS + 4), 400);
-        assert_eq!(runner.bus.read_word(pixmap + 4), 0x8000 | 400);
+        assert_eq!(runner.bus.read_word(addr::SCREEN_ROW), 416);
+        assert_eq!(runner.bus.read_word(addr::SCREEN_BITS + 4), 416);
+        assert_eq!(runner.bus.read_word(pixmap + 4), 0x8000 | 416);
         assert_eq!(runner.bus.read_word(pixmap + 32), 4);
         assert_eq!(runner.bus.read_word(pixmap + 36), 4);
         assert_eq!(runner.bus.read_word(ctab + 6), 15);
@@ -10355,11 +10355,11 @@ mod tests {
         let pixmap = runner.bus.read_long(runner.bus.read_long(gdevice + 22));
         let ctab = runner.bus.read_long(runner.bus.read_long(pixmap + 42));
 
-        assert_eq!(runner.dispatcher.screen_mode.1, 100);
+        assert_eq!(runner.dispatcher.screen_mode.1, 112);
         assert_eq!(runner.dispatcher.screen_mode.4, 1);
-        assert_eq!(runner.bus.read_word(addr::SCREEN_ROW), 100);
-        assert_eq!(runner.bus.read_word(addr::SCREEN_BITS + 4), 100);
-        assert_eq!(runner.bus.read_word(pixmap + 4), 0x8000 | 100);
+        assert_eq!(runner.bus.read_word(addr::SCREEN_ROW), 112);
+        assert_eq!(runner.bus.read_word(addr::SCREEN_BITS + 4), 112);
+        assert_eq!(runner.bus.read_word(pixmap + 4), 0x8000 | 112);
         assert_eq!(runner.bus.read_word(pixmap + 32), 1);
         assert_eq!(runner.bus.read_word(pixmap + 36), 1);
         assert_eq!(runner.bus.read_word(ctab + 6), 1);
@@ -14031,7 +14031,7 @@ mod tests {
             .bus
             .read_long(crate::memory::globals::addr::SOUND_BASE);
         assert_eq!(
-            sound_base, 0x007F_5300,
+            sound_base, 0x007F_7880,
             "SoundBase ($0266) should point at the 370-word legacy sound buffer in reserved display memory"
         );
         assert_eq!(


### PR DESCRIPTION
## Summary

- publish the same padded row stride for the main indexed screen and offscreen GWorlds
- keep screen PixMap, low-memory globals, and legacy sound-buffer placement consistent at every indexed depth
- prevent bulk row transfers from skewing animated and gameplay frames

## Root cause

Offscreen GWorlds use a padded 16-byte storage quantum, while the main 68k screen still advertised a packed row. Games that copy complete scanlines directly between those surfaces advanced source and destination pointers by different amounts, producing periodic horizontal corruption.

## Validation

- `cargo test --lib` (3,927 passed, 3 ignored)
- deterministic Gridz 640×480 title, four spaced menu frames, and gameplay replay
- deterministic Playroom bedroom replay
- deterministic Prince of Destruction startup/menu replay

Closes #790
Closes #791