### PR TITLE
fix(game): honor explicit PowerPC executable preference

### DIFF
--- a/src/game/launch.rs
+++ b/src/game/launch.rs
@@ -603,7 +603,7 @@ impl<'a> WebPackLoader<'a> {
                 .is_some_and(WebPackPendingEntry::is_complete)
             {
                 let pending = self.pending.take().expect("complete web-pack entry");
-                maybe_select_executable(
+                maybe_select_executable_with_preference(
                     &mut self.executable_entry,
                     &pending.name,
                     &pending.data,
@@ -612,6 +612,7 @@ impl<'a> WebPackLoader<'a> {
                     pending.data_len,
                     pending.creator_code,
                     1,
+                    runner.prefers_powerpc_executables() || prefer_powerpc(),
                 );
                 insert_forks_into_vfs(
                     runner,
@@ -2062,7 +2063,7 @@ fn insert_payload_into_vfs(
     for file in payload.files {
         let data_len = file.data.len();
         let is_appl = file.file_type == *b"APPL";
-        maybe_select_executable(
+        maybe_select_executable_with_preference(
             executable_entry,
             &file.name,
             &file.data,
@@ -2071,6 +2072,7 @@ fn insert_payload_into_vfs(
             data_len,
             file.creator,
             file.executable_priority,
+            runner.prefers_powerpc_executables() || prefer_powerpc(),
         );
         insert_forks_into_vfs(
             runner,
@@ -2261,6 +2263,7 @@ fn creator_matches(executable: [u8; 4], companion: [u8; 4]) -> bool {
     executable == companion || executable == *b"????" || companion == *b"????"
 }
 
+#[cfg(test)]
 fn maybe_select_executable(
     executable_entry: &mut Option<ExecutableCandidate>,
     name: &str,
@@ -2271,8 +2274,32 @@ fn maybe_select_executable(
     creator: [u8; 4],
     executable_priority: u8,
 ) {
+    maybe_select_executable_with_preference(
+        executable_entry,
+        name,
+        data,
+        rsrc,
+        is_appl,
+        data_len,
+        creator,
+        executable_priority,
+        prefer_powerpc(),
+    );
+}
+
+fn maybe_select_executable_with_preference(
+    executable_entry: &mut Option<ExecutableCandidate>,
+    name: &str,
+    data: &[u8],
+    rsrc: &[u8],
+    is_appl: bool,
+    data_len: usize,
+    creator: [u8; 4],
+    executable_priority: u8,
+    prefer_powerpc: bool,
+) {
     let executable_override = executable_name_override();
-    maybe_select_executable_with_override(
+    maybe_select_executable_with_override_and_preference(
         executable_entry,
         name,
         data,
@@ -2282,9 +2309,11 @@ fn maybe_select_executable(
         creator,
         executable_priority,
         executable_override.as_deref(),
+        prefer_powerpc,
     );
 }
 
+#[cfg(test)]
 fn maybe_select_executable_with_override(
     executable_entry: &mut Option<ExecutableCandidate>,
     name: &str,
@@ -2296,11 +2325,38 @@ fn maybe_select_executable_with_override(
     executable_priority: u8,
     executable_override: Option<&str>,
 ) {
+    maybe_select_executable_with_override_and_preference(
+        executable_entry,
+        name,
+        data,
+        rsrc,
+        is_appl,
+        data_len,
+        creator,
+        executable_priority,
+        executable_override,
+        prefer_powerpc(),
+    );
+}
+
+fn maybe_select_executable_with_override_and_preference(
+    executable_entry: &mut Option<ExecutableCandidate>,
+    name: &str,
+    data: &[u8],
+    rsrc: &[u8],
+    is_appl: bool,
+    data_len: usize,
+    creator: [u8; 4],
+    executable_priority: u8,
+    executable_override: Option<&str>,
+    prefer_powerpc: bool,
+) {
     if rsrc.is_empty() {
         return;
     }
 
-    let Some(kind) = classify_executable(data, rsrc, is_appl) else {
+    let Some(kind) = classify_executable_with_preference(data, rsrc, is_appl, prefer_powerpc)
+    else {
         return;
     };
 
@@ -2643,6 +2699,7 @@ impl ExecutableKind {
     }
 }
 
+#[cfg(test)]
 fn classify_executable(data: &[u8], rsrc: &[u8], is_appl: bool) -> Option<ExecutableKind> {
     classify_executable_with_preference(data, rsrc, is_appl, prefer_powerpc())
 }
@@ -4295,6 +4352,30 @@ mod tests {
                 app_stack_size: 0,
             })
         );
+    }
+
+    #[test]
+    fn executable_candidate_selection_honors_powerpc_preference() {
+        let rsrc = make_fat_application_resource_fork(make_cfrg(0, 0));
+        let ppc_data = make_minimal_pef(*b"pwpc");
+        let mut selected = None;
+
+        maybe_select_executable_with_preference(
+            &mut selected,
+            "Fat Application",
+            &ppc_data,
+            &rsrc,
+            true,
+            ppc_data.len(),
+            *b"TEST",
+            1,
+            true,
+        );
+
+        assert!(matches!(
+            selected.map(|candidate| candidate.kind),
+            Some(ExecutableKind::PowerPcPef { .. })
+        ));
     }
 
     #[test]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1702,6 +1702,7 @@ pub struct FixtureRunner {
     bus: MacMemoryBus,
     dispatcher: TrapDispatcher,
     config: FixtureRunnerConfig,
+    prefer_powerpc_executables: bool,
     trace_buffer: std::collections::VecDeque<(u32, u16, u32, u32, u32, u32)>, // (PC, Op, A0, SP, A6, A5)
     /// Set to true when the application calls ExitToShell
     halted: bool,
@@ -1926,6 +1927,7 @@ impl FixtureRunner {
             bus,
             dispatcher,
             config,
+            prefer_powerpc_executables: false,
             trace_buffer: std::collections::VecDeque::with_capacity(2000),
             halted: false,
             halted_trap: None,
@@ -1972,6 +1974,18 @@ impl FixtureRunner {
             external_q3_renderer_enabled: false,
             pending_q3_gpu_frame: None,
         }
+    }
+
+    /// Prefer a PowerPC application fragment over a classic `CODE` fallback
+    /// when loading a fat application. The default remains classic 68k for
+    /// callers that do not select an architecture explicitly.
+    pub fn set_prefer_powerpc_executables(&mut self, enabled: bool) {
+        self.prefer_powerpc_executables = enabled;
+    }
+
+    /// Returns whether fat applications should prefer a PowerPC fragment.
+    pub fn prefers_powerpc_executables(&self) -> bool {
+        self.prefer_powerpc_executables
     }
 
     pub fn set_external_q3_renderer_enabled(&mut self, enabled: bool) {


### PR DESCRIPTION
## Summary

- add a programmatic runner preference for choosing PowerPC fragments in fat applications
- apply the preference consistently to incremental web packs and other supported archive formats
- retain the existing classic 68k default and environment override
- cover preferred PowerPC candidate selection with a regression test

## Root cause

Browser frontends cannot supply the existing process environment override, so applications containing both classic `CODE` resources and a `pwpc` fragment always selected the classic fallback. Gridz therefore ran a different executable than its declared architecture.

## Validation

- `cargo test --lib` (3928 passed, 3 ignored)
- `cargo check`
- deterministic Gridz PowerPC execution reached gameplay with clean menu and gameplay frames

Closes #798