### PR TITLE
fix: support authentic multi-disk game launches

### DIFF
--- a/src/game/launch.rs
+++ b/src/game/launch.rs
@@ -340,12 +340,16 @@ fn load_stuffit(runner: &mut FixtureRunner, file_data: &[u8]) -> Result<LoadedAp
 
     let mut executable_entry: Option<ExecutableCandidate> = None;
     let mut skipped_disk_image_errors = Vec::new();
+    let mut payload = Payload {
+        dirs: Vec::new(),
+        files: Vec::new(),
+        volumes: Vec::new(),
+        skipped_disk_image_errors: Vec::new(),
+    };
 
     for entry in &archive.entries {
         if entry.is_folder {
-            // Register folder in VFS so directory lookups (e.g. Plug-Ins) succeed.
-            let normalized = crate::trap::dispatch::TrapDispatcher::normalize_vfs_path(&entry.name);
-            runner.dispatcher_mut().ensure_vfs_directory(&normalized);
+            payload.dirs.push(entry.name.clone());
             continue;
         }
 
@@ -354,7 +358,7 @@ fn load_stuffit(runner: &mut FixtureRunner, file_data: &[u8]) -> Result<LoadedAp
             .expect("one decoded fork pair per file entry")
             .map_err(|e| format!("Decompress error: {:?}", e))?;
 
-        let payload = payload_from_forks(
+        let entry_payload = payload_from_forks(
             &entry.name,
             data,
             rsrc,
@@ -363,9 +367,16 @@ fn load_stuffit(runner: &mut FixtureRunner, file_data: &[u8]) -> Result<LoadedAp
             entry.finder_flags,
             1,
         )?;
-        skipped_disk_image_errors.extend(payload.skipped_disk_image_errors.iter().cloned());
-        insert_payload_into_vfs(runner, payload, &mut executable_entry);
+        payload.dirs.extend(entry_payload.dirs);
+        payload.files.extend(entry_payload.files);
+        payload.volumes.extend(entry_payload.volumes);
+        payload
+            .skipped_disk_image_errors
+            .extend(entry_payload.skipped_disk_image_errors);
     }
+    let payload = expand_split_vise_payloads(payload)?;
+    skipped_disk_image_errors.extend(payload.skipped_disk_image_errors.iter().cloned());
+    insert_payload_into_vfs(runner, payload, &mut executable_entry);
 
     log_vfs(runner);
 
@@ -1152,7 +1163,7 @@ fn collect_zip_payload(file_data: &[u8]) -> Result<Payload, String> {
             .extend(nested.skipped_disk_image_errors);
     }
 
-    Ok(payload)
+    expand_split_vise_payloads(payload)
 }
 
 fn safe_zip_entry_path<R: std::io::Read>(
@@ -1288,7 +1299,7 @@ fn payload_from_stuffit_archive(
     for entry in archive.entries.iter().filter(|entry| entry.is_folder) {
         payload.dirs.push(entry.name.clone());
     }
-    Ok(payload)
+    expand_split_vise_payloads(payload)
 }
 
 fn payload_from_stuffit_bytes(
@@ -1630,8 +1641,29 @@ fn payload_from_forks(
         return Ok(payload);
     }
 
-    if let Some(payload) = expand_vise_payload(name, &data, executable_priority)? {
-        return Ok(payload);
+    if let Some(parsed) = crate::game::vise::parse_vise(&data) {
+        match parsed {
+            Ok(_) => match expand_vise_payload(name, &data, executable_priority) {
+                Ok(Some(payload)) => return Ok(payload),
+                Ok(None) => {}
+                Err(error) => {
+                    if crate::runner::trace_load_enabled() {
+                        eprintln!(
+                        "[LOAD] Preserving Installer VISE payload \"{}\" for possible continuation: {}",
+                        name, error
+                    );
+                    }
+                }
+            },
+            Err(error) => {
+                if crate::runner::trace_load_enabled() {
+                    eprintln!(
+                        "[LOAD] Preserving unexpanded Installer VISE payload \"{}\": {}",
+                        name, error
+                    );
+                }
+            }
+        }
     }
 
     if let Some(file) = expand_squz_payload_file(
@@ -1963,6 +1995,92 @@ fn expand_vise_payload(
     }
 
     Ok(Some(payload))
+}
+
+fn expand_split_vise_payloads(mut payload: Payload) -> Result<Payload, String> {
+    loop {
+        let mut resolved = None;
+
+        'sources: for source_index in 0..payload.files.len() {
+            let source = &payload.files[source_index];
+            if crate::game::vise::parse_vise(&source.data).is_none()
+                || crate::game::vise::continuation_bytes(&source.data).is_some()
+            {
+                continue;
+            }
+
+            let source_name = source.name.clone();
+            let executable_priority = source.executable_priority;
+            if let Ok(Some(expanded)) =
+                expand_vise_payload(&source_name, &source.data, executable_priority)
+            {
+                resolved = Some((source_index, Vec::new(), expanded, source_name));
+                break;
+            }
+
+            // Multi-disk VISE installers store the catalog in the first file
+            // and continue its logical byte stream in VIS* data files on
+            // later disks. Join those segments in archive order before
+            // parsing so multi-volume installers can be opened directly.
+            let mut continuation_indices = Vec::new();
+            for (index, file) in payload.files.iter().enumerate().skip(source_index + 1) {
+                if (file.file_type[..3] != *b"VIS" && file.creator[..3] != *b"VIS")
+                    || crate::game::vise::continuation_bytes(&file.data).is_none()
+                {
+                    continue;
+                }
+                continuation_indices.push(index);
+                let continuation_data = continuation_indices
+                    .iter()
+                    .map(|&index| payload.files[index].data.as_slice())
+                    .collect::<Vec<_>>();
+                let Ok(joined) = crate::game::vise::join_segments(
+                    &payload.files[source_index].data,
+                    &continuation_data,
+                ) else {
+                    continue;
+                };
+                let Ok(Some(expanded)) =
+                    expand_vise_payload(&source_name, &joined, executable_priority)
+                else {
+                    continue;
+                };
+                resolved = Some((source_index, continuation_indices, expanded, source_name));
+                break 'sources;
+            }
+        }
+
+        let Some((source_index, continuation_indices, expanded, source_name)) = resolved else {
+            break;
+        };
+        if crate::runner::trace_load_enabled() && !continuation_indices.is_empty() {
+            eprintln!(
+                "[LOAD] Joined {} Installer VISE continuation file(s) for \"{}\"",
+                continuation_indices.len(),
+                source_name
+            );
+        }
+
+        let mut remove = vec![false; payload.files.len()];
+        remove[source_index] = true;
+        for index in continuation_indices {
+            remove[index] = true;
+        }
+        payload.files = payload
+            .files
+            .into_iter()
+            .enumerate()
+            .filter_map(|(index, file)| (!remove[index]).then_some(file))
+            .collect();
+        payload.dirs.extend(expanded.dirs);
+        payload.files.extend(expanded.files);
+        payload.volumes.extend(expanded.volumes);
+        payload
+            .skipped_disk_image_errors
+            .extend(expanded.skipped_disk_image_errors);
+    }
+
+    Ok(payload)
 }
 
 fn decode_installer_fork(

--- a/src/game/vise.rs
+++ b/src/game/vise.rs
@@ -15,6 +15,7 @@ const VISE_MAGIC: &[u8; 4] = b"SVCT";
 const VISE_CATALOG_MAGIC: &[u8; 4] = b"CVCT";
 const VISE_HEADER_LEN: usize = 44;
 const VISE_CATALOG_HEADER_LEN: usize = 20;
+const VISE_VERSION_35: u32 = 0x8001_0201;
 const VISE_VERSION_35_LITE: u32 = 0x8001_0202;
 const VISE_VERSION_36_LITE: u32 = 0x8001_0300;
 const VISE_VERSION_EXTENDED_CATALOG: u32 = 0x8001_0307;
@@ -78,12 +79,162 @@ pub fn parse_vise(data: &[u8]) -> Option<Result<ViseArchive<'_>, String>> {
         .then(|| parse_vise_result(data))
 }
 
+pub(crate) fn continuation_bytes(data: &[u8]) -> Option<&[u8]> {
+    let header = data.get(..VISE_HEADER_LEN)?;
+    (header.starts_with(VISE_MAGIC) && read_u32(header, 36, "catalog offset").ok()? == 0)
+        .then(|| &data[VISE_HEADER_LEN..])
+}
+
+pub(crate) fn join_segments(primary: &[u8], continuations: &[&[u8]]) -> Result<Vec<u8>, String> {
+    let header = range(primary, 0, VISE_HEADER_LEN, "primary header")?;
+    if !header.starts_with(VISE_MAGIC) {
+        return Err("primary segment is missing the SVCT signature".to_string());
+    }
+    let version = read_u32(header, 16, "archive version")?;
+    let catalog_offset = read_u32(header, 36, "catalog offset")? as usize;
+    let mut continuation_payloads = Vec::with_capacity(continuations.len());
+    for (index, continuation) in continuations.iter().enumerate() {
+        let payload = continuation_bytes(continuation)
+            .ok_or_else(|| format!("VISE continuation segment {} has a catalog", index + 2))?;
+        continuation_payloads.push(payload);
+    }
+
+    let mut patched = primary.to_vec();
+    let catalog = range(
+        &patched,
+        catalog_offset,
+        VISE_CATALOG_HEADER_LEN,
+        "catalog header",
+    )?;
+    if !catalog.starts_with(VISE_CATALOG_MAGIC) {
+        return Err(format!(
+            "missing CVCT catalog signature at 0x{catalog_offset:X}"
+        ));
+    }
+    let entry_count = read_u16(catalog, 16, "catalog entry count")? as usize;
+    let mut cursor = catalog_offset + VISE_CATALOG_HEADER_LEN;
+    if version == VISE_VERSION_EXTENDED_CATALOG {
+        range(
+            &patched,
+            cursor,
+            VISE_EXTENDED_CATALOG_PREFIX_LEN,
+            "extended catalog prefix",
+        )?;
+        cursor += VISE_EXTENDED_CATALOG_PREFIX_LEN;
+    }
+    for index in 0..entry_count {
+        let magic = range(&patched, cursor, 4, &format!("catalog entry {index} magic"))?;
+        let kind = magic[0];
+        if &magic[1..] != b"VCT" {
+            return Err(format!("catalog entry {index} has invalid magic"));
+        }
+        cursor += 4;
+        match kind {
+            b'D' => {
+                let record = range(
+                    &patched,
+                    cursor,
+                    VISE_DIRECTORY_RECORD_LEN,
+                    &format!("directory {index} record"),
+                )?;
+                let name_len = record[76] as usize;
+                cursor += VISE_DIRECTORY_RECORD_LEN;
+                if version == VISE_VERSION_36_LITE {
+                    cursor += 6;
+                } else if version == VISE_VERSION_EXTENDED_CATALOG {
+                    cursor += VISE_EXTENDED_DIRECTORY_SUFFIX_LEN;
+                }
+                range(&patched, cursor, name_len, "directory name")?;
+                cursor += name_len;
+            }
+            b'F' => {
+                let record_offset = cursor;
+                let record = range(
+                    &patched,
+                    record_offset,
+                    VISE_FILE_RECORD_LEN,
+                    &format!("file {index} record"),
+                )?;
+                let name_len = record[118] as usize;
+                let segment_number = read_u16(record, 94, "file segment number")? as usize;
+                if segment_number > 1 {
+                    let segment_index = segment_number - 2;
+                    let segment = continuation_payloads.get(segment_index).ok_or_else(|| {
+                        format!("file {index} requires missing VISE segment {segment_number}")
+                    })?;
+                    let original_offset = read_u32(record, 96, "file payload offset")? as usize;
+                    let segment_end = segment
+                        .len()
+                        .checked_add(VISE_HEADER_LEN)
+                        .ok_or_else(|| "VISE segment length overflow".to_string())?;
+                    if original_offset < VISE_HEADER_LEN || original_offset > segment_end {
+                        return Err(format!(
+                            "file {index} has invalid segment {segment_number} offset 0x{original_offset:X}"
+                        ));
+                    }
+                    let prior_payload_len = continuation_payloads[..segment_index]
+                        .iter()
+                        .try_fold(0usize, |total, payload| total.checked_add(payload.len()))
+                        .ok_or_else(|| "VISE segment offset overflow".to_string())?;
+                    let normalized_offset = catalog_offset
+                        .checked_add(prior_payload_len)
+                        .and_then(|offset| offset.checked_add(original_offset - VISE_HEADER_LEN))
+                        .ok_or_else(|| "VISE normalized file offset overflow".to_string())?;
+                    let normalized_offset = u32::try_from(normalized_offset)
+                        .map_err(|_| "VISE normalized file offset exceeds 32 bits".to_string())?;
+                    patched[record_offset + 94..record_offset + 96]
+                        .copy_from_slice(&1u16.to_be_bytes());
+                    patched[record_offset + 96..record_offset + 100]
+                        .copy_from_slice(&normalized_offset.to_be_bytes());
+                }
+                cursor += VISE_FILE_RECORD_LEN;
+                if version == VISE_VERSION_EXTENDED_CATALOG {
+                    cursor += VISE_EXTENDED_FILE_SUFFIX_LEN;
+                }
+                range(&patched, cursor, name_len, "file name")?;
+                cursor += name_len;
+            }
+            other => {
+                return Err(format!(
+                    "catalog entry {index} has unsupported kind 0x{other:02X}"
+                ));
+            }
+        }
+    }
+
+    let continuation_len = continuation_payloads
+        .iter()
+        .try_fold(0usize, |total, payload| total.checked_add(payload.len()))
+        .ok_or_else(|| "VISE continuation length overflow".to_string())?;
+    let normalized_catalog_offset = catalog_offset
+        .checked_add(continuation_len)
+        .ok_or_else(|| "VISE normalized catalog offset overflow".to_string())?;
+    let mut joined = Vec::with_capacity(
+        primary
+            .len()
+            .checked_add(continuation_len)
+            .ok_or_else(|| "VISE joined length overflow".to_string())?,
+    );
+    joined.extend_from_slice(&patched[..catalog_offset]);
+    for payload in continuation_payloads {
+        joined.extend_from_slice(payload);
+    }
+    joined.extend_from_slice(&patched[catalog_offset..]);
+    let normalized_catalog_offset = u32::try_from(normalized_catalog_offset)
+        .map_err(|_| "VISE normalized catalog offset exceeds 32 bits".to_string())?;
+    joined[36..40].copy_from_slice(&normalized_catalog_offset.to_be_bytes());
+    Ok(joined)
+}
+
 fn parse_vise_result(data: &[u8]) -> Result<ViseArchive<'_>, String> {
     let header = range(data, 0, VISE_HEADER_LEN, "header")?;
     let version = read_u32(header, 16, "archive version")?;
     if !matches!(
         version,
-        VISE_VERSION_35_LITE | VISE_VERSION_36_LITE | VISE_VERSION_EXTENDED_CATALOG
+        VISE_VERSION_35
+            | VISE_VERSION_35_LITE
+            | VISE_VERSION_36_LITE
+            | VISE_VERSION_EXTENDED_CATALOG
     ) {
         return Err(format!("unsupported archive version 0x{version:08X}"));
     }
@@ -762,6 +913,118 @@ mod tests {
         assert_eq!(
             decode_vise_fork(entry.rsrc_packed, entry.rsrc_unpacked_len).unwrap(),
             resource_fork
+        );
+    }
+
+    #[test]
+    fn parses_full_vise_35_catalog_layout() {
+        let payload = b"VISE 3.5 installed file";
+        let packed = encode_vise_fork(payload);
+        let payload_offset = VISE_HEADER_LEN;
+        let catalog_offset = payload_offset + packed.len();
+        let mut archive = vec![0u8; VISE_HEADER_LEN];
+        archive[0..4].copy_from_slice(VISE_MAGIC);
+        archive[16..20].copy_from_slice(&VISE_VERSION_35.to_be_bytes());
+        archive[36..40].copy_from_slice(&(catalog_offset as u32).to_be_bytes());
+        archive.extend_from_slice(&packed);
+
+        let mut catalog = [0u8; VISE_CATALOG_HEADER_LEN];
+        catalog[0..4].copy_from_slice(VISE_CATALOG_MAGIC);
+        catalog[16..18].copy_from_slice(&1u16.to_be_bytes());
+        archive.extend_from_slice(&catalog);
+        archive.extend_from_slice(b"FVCT");
+        let mut file = [0u8; VISE_FILE_RECORD_LEN];
+        file[40..44].copy_from_slice(b"APPL");
+        file[44..48].copy_from_slice(b"TEST");
+        file[64..68].copy_from_slice(&(packed.len() as u32).to_be_bytes());
+        file[68..72].copy_from_slice(&(payload.len() as u32).to_be_bytes());
+        file[94..96].copy_from_slice(&1u16.to_be_bytes());
+        file[96..100].copy_from_slice(&(payload_offset as u32).to_be_bytes());
+        file[118] = 7;
+        archive.extend_from_slice(&file);
+        archive.extend_from_slice(b"Runtime");
+
+        let parsed = parse_vise(&archive).unwrap().unwrap();
+        assert_eq!(parsed.entries[0].path, "Runtime");
+        assert_eq!(
+            decode_vise_fork(
+                parsed.entries[0].data_packed,
+                parsed.entries[0].data_unpacked_len,
+            )
+            .unwrap(),
+            payload
+        );
+    }
+
+    #[test]
+    fn joins_crossing_and_later_segment_file_streams() {
+        let crossing_data = b"a compressed stream split across installer disks";
+        let later_data = b"a file stored wholly on the second disk";
+        let crossing_packed = encode_vise_fork(crossing_data);
+        let later_packed = encode_vise_fork(later_data);
+        let split = crossing_packed.len() / 2;
+        let payload_offset = VISE_HEADER_LEN;
+        let catalog_offset = payload_offset + split;
+
+        let mut primary = vec![0u8; VISE_HEADER_LEN];
+        primary[0..4].copy_from_slice(VISE_MAGIC);
+        primary[16..20].copy_from_slice(&VISE_VERSION_35.to_be_bytes());
+        primary[36..40].copy_from_slice(&(catalog_offset as u32).to_be_bytes());
+        primary.extend_from_slice(&crossing_packed[..split]);
+        let mut catalog = [0u8; VISE_CATALOG_HEADER_LEN];
+        catalog[0..4].copy_from_slice(VISE_CATALOG_MAGIC);
+        catalog[16..18].copy_from_slice(&2u16.to_be_bytes());
+        primary.extend_from_slice(&catalog);
+
+        primary.extend_from_slice(b"FVCT");
+        let mut crossing_file = [0u8; VISE_FILE_RECORD_LEN];
+        crossing_file[40..44].copy_from_slice(b"TEXT");
+        crossing_file[44..48].copy_from_slice(b"TEST");
+        crossing_file[64..68].copy_from_slice(&(crossing_packed.len() as u32).to_be_bytes());
+        crossing_file[68..72].copy_from_slice(&(crossing_data.len() as u32).to_be_bytes());
+        crossing_file[94..96].copy_from_slice(&1u16.to_be_bytes());
+        crossing_file[96..100].copy_from_slice(&(payload_offset as u32).to_be_bytes());
+        crossing_file[118] = 8;
+        primary.extend_from_slice(&crossing_file);
+        primary.extend_from_slice(b"Crossing");
+
+        primary.extend_from_slice(b"FVCT");
+        let mut later_file = [0u8; VISE_FILE_RECORD_LEN];
+        later_file[40..44].copy_from_slice(b"TEXT");
+        later_file[44..48].copy_from_slice(b"TEST");
+        later_file[64..68].copy_from_slice(&(later_packed.len() as u32).to_be_bytes());
+        later_file[68..72].copy_from_slice(&(later_data.len() as u32).to_be_bytes());
+        later_file[94..96].copy_from_slice(&2u16.to_be_bytes());
+        let later_segment_offset = VISE_HEADER_LEN + crossing_packed.len().saturating_sub(split);
+        later_file[96..100].copy_from_slice(&(later_segment_offset as u32).to_be_bytes());
+        later_file[118] = 5;
+        primary.extend_from_slice(&later_file);
+        primary.extend_from_slice(b"Later");
+
+        let mut continuation = vec![0u8; VISE_HEADER_LEN];
+        continuation[0..4].copy_from_slice(VISE_MAGIC);
+        continuation[16..20].copy_from_slice(&VISE_VERSION_35.to_be_bytes());
+        continuation.extend_from_slice(&crossing_packed[split..]);
+        continuation.extend_from_slice(&later_packed);
+
+        let joined = join_segments(&primary, &[&continuation]).unwrap();
+        let parsed = parse_vise(&joined).unwrap().unwrap();
+        assert_eq!(parsed.entries.len(), 2);
+        assert_eq!(
+            decode_vise_fork(
+                parsed.entries[0].data_packed,
+                parsed.entries[0].data_unpacked_len,
+            )
+            .unwrap(),
+            crossing_data
+        );
+        assert_eq!(
+            decode_vise_fork(
+                parsed.entries[1].data_packed,
+                parsed.entries[1].data_unpacked_len,
+            )
+            .unwrap(),
+            later_data
         );
     }
 

--- a/src/trap/control.rs
+++ b/src/trap/control.rs
@@ -18,7 +18,7 @@ impl super::TrapDispatcher {
     const CDEF_DRAW_CNTL_MSG: i16 = 0;
     const CDEF_TEST_CNTL_MSG: i16 = 1;
     const CDEF_INIT_CNTL_MSG: i16 = 3;
-    const CDEF_TRAMPOLINE_SIZE: u32 = 64;
+    const CDEF_TRAMPOLINE_SIZE: u32 = 80;
     const LOWMEM_AUX_CTL_HEAD: u32 = 0x0CD4;
     const AUX_CTL_NEXT_OFFSET: u32 = 0;
     const AUX_CTL_OWNER_OFFSET: u32 = 4;
@@ -269,6 +269,8 @@ impl super::TrapDispatcher {
         result_addr: u32,
         saved_regs_sp: u32,
         next_trampoline: Option<u32>,
+        restore_port: u32,
+        restore_gdevice: u32,
     ) {
         bus.write_word(tramp, 0x48E7); // MOVEM.L D0-D3/A0-A3,-(SP)
         bus.write_word(tramp + 2, 0xF0F0);
@@ -297,8 +299,17 @@ impl super::TrapDispatcher {
                 bus.write_long(tramp + 56, next);
             }
             None => {
-                bus.write_word(tramp + 54, 0x4E75); // RTS
-                bus.write_long(tramp + 56, 0);
+                // Control Manager calls a CDEF in its owning window's port,
+                // but leaves the caller's current GrafPort and GDevice
+                // unchanged. Restore both after the final callback.
+                // Inside Macintosh Volume I, pp. I-163, I-329 to I-331.
+                bus.write_word(tramp + 54, 0x2F3C); // MOVE.L #port,-(SP)
+                bus.write_long(tramp + 56, restore_port);
+                bus.write_word(tramp + 60, 0xA873); // _SetPort
+                bus.write_word(tramp + 62, 0x2F3C); // MOVE.L #gdh,-(SP)
+                bus.write_long(tramp + 64, restore_gdevice);
+                bus.write_word(tramp + 68, 0xAA31); // _SetGDevice
+                bus.write_word(tramp + 70, 0x4E75); // RTS
             }
         }
     }
@@ -330,6 +341,13 @@ impl super::TrapDispatcher {
         if callable.is_empty() {
             return false;
         }
+        let restore_port = self.current_port;
+        let restore_gdevice = self.current_gdevice;
+        let first_ctrl_ptr = Self::control_record_ptr(bus, callable[0].0);
+        let owner = bus.read_long(first_ctrl_ptr + 4);
+        if owner != 0 && owner != self.current_port {
+            self.set_current_port_state(bus, cpu, owner, None);
+        }
         let final_sp = cpu.read_reg(Register::A7);
         let return_pc = cpu.read_reg(Register::PC);
         let return_slot = final_sp.wrapping_sub(4);
@@ -357,9 +375,11 @@ impl super::TrapDispatcher {
                 message,
                 param,
                 proc_addr,
-                result_addr.unwrap_or(trampolines[idx] + 60),
+                result_addr.unwrap_or(trampolines[idx] + 72),
                 saved_regs_sp,
                 trampolines.get(idx + 1).copied(),
+                restore_port,
+                restore_gdevice,
             );
         }
 
@@ -381,6 +401,48 @@ impl super::TrapDispatcher {
             .map(|&(message, param, result_addr)| (ctrl_handle, message, param, result_addr))
             .collect();
         self.arm_control_def_call_chain(cpu, bus, &calls)
+    }
+
+    fn arm_control_action_proc<C: CpuOps>(
+        &mut self,
+        cpu: &mut C,
+        bus: &mut MacMemoryBus,
+        ctrl_handle: u32,
+        part: u16,
+        action_proc: u32,
+        final_sp: u32,
+    ) -> bool {
+        if action_proc == 0 || action_proc > bus.ram_size().saturating_sub(2) {
+            return false;
+        }
+
+        // ControlActionProcPtr is a Pascal procedure taking the control and
+        // part code. TrackControl calls it while the mouse remains over an
+        // arrow or page region. One callback corresponds to the initial
+        // mouse-down; subsequent host events can enter TrackControl again for
+        // auto-repeat. Macintosh Toolbox Essentials 1992, pp. 5-89 to 5-91.
+        let trampoline = self.get_or_create_control_def_trampoline(bus);
+        let return_pc = cpu.read_reg(Register::PC);
+        let return_slot = final_sp.wrapping_sub(4);
+        let saved_regs_sp = return_slot.wrapping_sub(32);
+        bus.write_word(trampoline, 0x48E7); // MOVEM.L D0-D3/A0-A3,-(SP)
+        bus.write_word(trampoline + 2, 0xF0F0);
+        bus.write_word(trampoline + 4, 0x2F3C); // MOVE.L #control,-(SP)
+        bus.write_long(trampoline + 6, ctrl_handle);
+        bus.write_word(trampoline + 10, 0x3F3C); // MOVE.W #part,-(SP)
+        bus.write_word(trampoline + 12, part);
+        bus.write_word(trampoline + 14, 0x4EB9); // JSR abs.L
+        bus.write_long(trampoline + 16, action_proc);
+        bus.write_word(trampoline + 20, 0x2E7C); // MOVEA.L #savedRegsSP,A7
+        bus.write_long(trampoline + 22, saved_regs_sp);
+        bus.write_word(trampoline + 26, 0x4CDF); // MOVEM.L (SP)+,D0-D3/A0-A3
+        bus.write_word(trampoline + 28, 0x0F0F);
+        bus.write_word(trampoline + 30, 0x4E75); // RTS
+
+        bus.write_long(return_slot, return_pc);
+        cpu.write_reg(Register::A7, return_slot);
+        cpu.write_reg(Register::PC, trampoline);
+        true
     }
 
     pub(crate) fn arm_new_dialog_control_defs<C: CpuOps>(
@@ -414,9 +476,6 @@ impl super::TrapDispatcher {
         if calls.is_empty() {
             return false;
         }
-        // Custom CDEFs use dialog-local contrlRect coordinates for both
-        // OpenPicture and DrawPicture, so dispatch them in the owner port.
-        self.set_current_port_state(bus, cpu, dialog_ptr, None);
         self.arm_control_def_call_chain(cpu, bus, &calls)
     }
 
@@ -457,7 +516,6 @@ impl super::TrapDispatcher {
         if calls.is_empty() {
             return false;
         }
-        self.set_current_port_state(bus, cpu, dialog_ptr, None);
         // Establish the retained-dialog baseline before guest drawing. Each
         // DrawPicture callback then refreshes this snapshot, so frame
         // composition cannot restore the pre-CDEF shell over the artwork.
@@ -1150,6 +1208,18 @@ impl super::TrapDispatcher {
         if !Self::control_vis_is_visible(vis) {
             return;
         }
+        let window_ptr = bus.read_long(ctrl_ptr + 4);
+        if window_ptr != 0 {
+            let vis_rgn = bus.read_long(window_ptr + 24);
+            if vis_rgn != 0 && Self::region_handle_rect(bus, vis_rgn).is_none() {
+                return;
+            }
+        }
+        let saved_port = self.current_port;
+        let saved_gdevice = self.current_gdevice;
+        if window_ptr != 0 && window_ptr != saved_port {
+            self.set_current_port_state(bus, cpu, window_ptr, None);
+        }
 
         let r_top = bus.read_word(ctrl_ptr + 8) as i16;
         let r_left = bus.read_word(ctrl_ptr + 10) as i16;
@@ -1181,7 +1251,6 @@ impl super::TrapDispatcher {
         };
 
         // Screen coordinates for fb_draw_string (text rendering)
-        let window_ptr = bus.read_long(ctrl_ptr + 4);
         let (scr_top, scr_left, _, _) = Self::dialog_screen_bounds(bus, window_ptr);
         let abs_top = scr_top + r_top;
         let abs_left = scr_left + r_left;
@@ -1405,6 +1474,9 @@ impl super::TrapDispatcher {
         self.pn_size = saved_pn_size;
         self.pn_mode = saved_pn_mode;
         self.pn_pat = saved_pn_pat;
+        if self.current_port != saved_port || self.current_gdevice != saved_gdevice {
+            self.set_current_port_state(bus, cpu, saved_port, Some(saved_gdevice));
+        }
     }
 
     fn draw_picture_title_control(
@@ -2563,10 +2635,6 @@ impl super::TrapDispatcher {
                 }
                 cpu.write_reg(Register::A7, sp + 4);
                 if let Some(ctrl_ptr) = newly_visible_control {
-                    let owner = bus.read_long(ctrl_ptr + 4);
-                    if owner != 0 {
-                        self.set_current_port_state(bus, cpu, owner, None);
-                    }
                     if !self.arm_control_def_messages(
                         cpu,
                         bus,
@@ -3175,6 +3243,39 @@ impl super::TrapDispatcher {
                             {
                                 let proc_id =
                                     self.control_proc_ids.get(&ctrl_ptr).copied().unwrap_or(0);
+                                if proc_id == 16 {
+                                    part = self.standard_scrollbar_testcontrol_part_code(
+                                        bus, ctrl_ptr, pt_v, pt_h,
+                                    );
+                                    outcome = if part == 0 {
+                                        "scrollbar_no_part"
+                                    } else {
+                                        "scrollbar_part_hit"
+                                    };
+                                    self.record_trackcontrol_input_trace(
+                                        bus,
+                                        "start",
+                                        ctrl_handle,
+                                        Some((pt_v, pt_h)),
+                                        action_proc,
+                                        Some(part),
+                                        None,
+                                        outcome,
+                                    );
+                                    bus.write_word(sp + 12, part);
+                                    cpu.write_reg(Register::A7, sp + 12);
+                                    if matches!(part, 20..=23) {
+                                        self.arm_control_action_proc(
+                                            cpu,
+                                            bus,
+                                            ctrl_handle,
+                                            part,
+                                            action_proc,
+                                            sp + 12,
+                                        );
+                                    }
+                                    return Some(Ok(()));
+                                }
                                 if Self::is_popup_menu_proc_id(proc_id) {
                                     let menu_id = self.popup_control_menu_id(
                                         bus,
@@ -4407,7 +4508,10 @@ mod tests {
         );
         assert_eq!(bus.read_long(draw_tramp + 26), 0);
         assert_eq!(bus.read_long(draw_tramp + 32), cdef_proc);
-        assert_eq!(bus.read_word(draw_tramp + 54), 0x4E75);
+        assert_eq!(bus.read_word(draw_tramp + 54), 0x2F3C);
+        assert_eq!(bus.read_word(draw_tramp + 60), 0xA873);
+        assert_eq!(bus.read_word(draw_tramp + 68), 0xAA31);
+        assert_eq!(bus.read_word(draw_tramp + 70), 0x4E75);
     }
 
     // IM:I I-332: DisposeControl takes one ControlHandle argument.
@@ -5398,6 +5502,44 @@ mod tests {
     }
 
     #[test]
+    fn track_control_scrollbar_arrow_calls_action_proc_with_part_code() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let sp = 0x300000u32;
+        let return_pc = 0x0012_3456;
+        let action_proc = bus.alloc(2);
+        bus.write_word(action_proc, 0x4E75); // RTS
+        let (ctrl_handle, _) =
+            alloc_scrollbar_control(&mut disp, &mut bus, (60, 240, 220, 256), 255, 0, 40, 0, 100);
+
+        cpu.write_reg(Register::PC, return_pc);
+        cpu.write_reg(Register::A7, sp);
+        bus.write_long(sp, action_proc);
+        bus.write_word(sp + 4, 210);
+        bus.write_word(sp + 6, 248);
+        bus.write_long(sp + 8, ctrl_handle);
+        bus.write_word(sp + 12, 0xBEEF);
+
+        disp.dispatch_control(true, 0x168, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(bus.read_word(sp + 12), 21, "down arrow is inDownButton");
+        let trampoline = disp.control_def_trampoline;
+        assert_ne!(trampoline, 0);
+        assert_eq!(cpu.read_reg(Register::PC), trampoline);
+        assert_eq!(cpu.read_reg(Register::A7), sp + 8);
+        assert_eq!(bus.read_long(sp + 8), return_pc);
+        assert_eq!(bus.read_word(trampoline), 0x48E7);
+        assert_eq!(bus.read_word(trampoline + 4), 0x2F3C);
+        assert_eq!(bus.read_long(trampoline + 6), ctrl_handle);
+        assert_eq!(bus.read_word(trampoline + 10), 0x3F3C);
+        assert_eq!(bus.read_word(trampoline + 12), 21);
+        assert_eq!(bus.read_word(trampoline + 14), 0x4EB9);
+        assert_eq!(bus.read_long(trampoline + 16), action_proc);
+        assert_eq!(bus.read_word(trampoline + 30), 0x4E75);
+    }
+
+    #[test]
     fn track_control_button_systemless_theme_tracks_pressed_state_until_release() {
         let (mut disp, mut cpu, mut bus) = setup_with_port();
         disp.set_ui_theme_id(UiThemeId::SystemlessDefault);
@@ -6042,7 +6184,10 @@ mod tests {
             super::super::TrapDispatcher::CDEF_DRAW_CNTL_MSG as u16
         );
         assert_eq!(bus.read_long(second_tramp + 32), cdef_proc);
-        assert_eq!(bus.read_word(second_tramp + 54), 0x4E75);
+        assert_eq!(bus.read_word(second_tramp + 54), 0x2F3C);
+        assert_eq!(bus.read_word(second_tramp + 60), 0xA873);
+        assert_eq!(bus.read_word(second_tramp + 68), 0xAA31);
+        assert_eq!(bus.read_word(second_tramp + 70), 0x4E75);
     }
 
     // FindControl semantics per IM:I (1985) I-323 and MTE (1992) 5-89.

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -4583,12 +4583,7 @@ impl TrapDispatcher {
                 .find(|path| path.eq_ignore_ascii_case(&normalized))
                 .cloned();
         }
-        sorted_keys
-            .iter()
-            .copied()
-            .filter(|path| !path.is_empty())
-            .find(|path| Self::vfs_basename(path).eq_ignore_ascii_case(&normalized))
-            .cloned()
+        None
     }
 
     pub(crate) fn list_vfs_catalog_entries(&mut self, dir_id: u32) -> Vec<VfsCatalogEntry> {
@@ -7321,6 +7316,20 @@ mod tests {
 
         assert_eq!(
             disp.find_vfs_file_in_directory(pref_dir_id, "Shared Preferences"),
+            None
+        );
+    }
+
+    #[test]
+    fn find_vfs_directory_in_directory_does_not_escape_explicit_parent() {
+        // Files 1992, 2-29: a nonzero parent directory ID suppresses the
+        // poor man's search path. A same-named directory elsewhere on the
+        // volume must not satisfy the lookup.
+        let mut disp = TrapDispatcher::new();
+        let simfarm_dir_id = disp.ensure_vfs_directory("Maxis/SimFarm");
+
+        assert_eq!(
+            disp.find_vfs_directory_in_directory(simfarm_dir_id, "SimFarm"),
             None
         );
     }

--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -2885,6 +2885,20 @@ impl super::TrapDispatcher {
                     return Some(Ok(()));
                 }
 
+                // The QuickDraw bottleneck is downstream of GrafPort
+                // clipping. A replacement bitsProc must not get a chance to
+                // paint through a hidden window (whose visRgn is empty), nor
+                // through an empty clipRgn. Inside Macintosh Volume I,
+                // pp. I-158, I-176, and I-197.
+                if self.copy_bits_fully_clipped_in_current_port(
+                    bus,
+                    dst_bits_ptr,
+                    dst_rect_ptr,
+                    mask_rgn,
+                ) {
+                    return Some(Ok(()));
+                }
+
                 // CopyBits is a bottleneck caller: it hands the transfer to the
                 // current port's grafProcs.bitsProc, which is StdBits unless the
                 // app replaced it (IM:I I-176 and I-197). Applications that
@@ -9320,6 +9334,35 @@ impl super::TrapDispatcher {
                     dst_pixel_size
                 };
 
+                // PlotCIcon is defined in terms of QuickDraw transfers and
+                // therefore observes the current port's visRgn and clipRgn.
+                // Hidden windows have an empty visRgn; drawing their cached
+                // controls must not leak directly into the screen PixMap.
+                // More Macintosh Toolbox 1993, pp. 5-25 to 5-26; Inside
+                // Macintosh Volume I, p. I-158.
+                let vis_rgn = bus.read_long(port + 24);
+                let clip_rgn = bus.read_long(port + 28);
+                let mut clip_top = dst_top;
+                let mut clip_left = dst_left;
+                let mut clip_bottom = dst_bottom;
+                let mut clip_right = dst_right;
+                for region in [vis_rgn, clip_rgn] {
+                    if !Self::clip_rect_to_region_bbox(
+                        bus,
+                        region,
+                        &mut clip_top,
+                        &mut clip_left,
+                        &mut clip_bottom,
+                        &mut clip_right,
+                    ) {
+                        return Some(Ok(()));
+                    }
+                }
+                let vis_membership =
+                    Self::build_region_membership_cache(bus, vis_rgn, clip_top, clip_bottom);
+                let clip_membership =
+                    Self::build_region_membership_cache(bus, clip_rgn, clip_top, clip_bottom);
+
                 if trace_menu_redraw_enabled() {
                     let abs_top = dst_top + dst_bounds_top;
                     let abs_left = dst_left + dst_bounds_left;
@@ -9420,13 +9463,28 @@ impl super::TrapDispatcher {
                 } else {
                     self.device_clut
                 };
-                for dst_y_local in dst_top..dst_bottom {
+                for dst_y_local in clip_top..clip_bottom {
                     let Some(sy) =
                         Self::scale_coord(pm_top, pm_bottom, dst_top, dst_bottom, dst_y_local)
                     else {
                         continue;
                     };
-                    for dst_x_local in dst_left..dst_right {
+                    for dst_x_local in clip_left..clip_right {
+                        if !Self::region_contains_point_cached(
+                            bus,
+                            vis_rgn,
+                            vis_membership.as_ref(),
+                            dst_y_local,
+                            dst_x_local,
+                        ) || !Self::region_contains_point_cached(
+                            bus,
+                            clip_rgn,
+                            clip_membership.as_ref(),
+                            dst_y_local,
+                            dst_x_local,
+                        ) {
+                            continue;
+                        }
                         let Some(sx) =
                             Self::scale_coord(pm_left, pm_right, dst_left, dst_right, dst_x_local)
                         else {
@@ -20295,6 +20353,52 @@ impl super::TrapDispatcher {
         Some(bits_proc)
     }
 
+    fn copy_bits_fully_clipped_in_current_port(
+        &self,
+        bus: &MacMemoryBus,
+        dst_bits_ptr: u32,
+        dst_rect_ptr: u32,
+        mask_rgn: u32,
+    ) -> bool {
+        let port = self.current_port;
+        if port == 0 || !Self::guest_range_in_ram(bus, port, 32) {
+            return false;
+        }
+
+        let port_version = bus.read_word(port + 6);
+        let port_base = if (port_version & 0xC000) == 0xC000 {
+            let pixmap_handle = bus.read_long(port + 2);
+            let pixmap = (pixmap_handle != 0).then(|| bus.read_long(pixmap_handle));
+            pixmap
+                .filter(|&pixmap| pixmap != 0)
+                .map(|pixmap| Self::offscreen_pixmap_base_ptr(bus, pixmap))
+                .unwrap_or(0)
+        } else {
+            bus.read_long(port + 2)
+        };
+        if port_base != self.resolve_copy_bitmap(bus, dst_bits_ptr).base {
+            return false;
+        }
+
+        let mut top = bus.read_word(dst_rect_ptr) as i16;
+        let mut left = bus.read_word(dst_rect_ptr + 2) as i16;
+        let mut bottom = bus.read_word(dst_rect_ptr + 4) as i16;
+        let mut right = bus.read_word(dst_rect_ptr + 6) as i16;
+        for region in [bus.read_long(port + 24), bus.read_long(port + 28), mask_rgn] {
+            if !Self::clip_rect_to_region_bbox(
+                bus,
+                region,
+                &mut top,
+                &mut left,
+                &mut bottom,
+                &mut right,
+            ) {
+                return true;
+            }
+        }
+        false
+    }
+
     pub(super) fn resolve_copy_bitmap(&self, bus: &MacMemoryBus, bits_ptr: u32) -> CopyBitmapInfo {
         if bits_ptr == 0 || !Self::guest_range_in_ram(bus, bits_ptr, 14) {
             return Self::inert_copy_bitmap_info();
@@ -30181,6 +30285,32 @@ mod tests {
     }
 
     #[test]
+    fn copybits_does_not_call_replacement_bitsproc_for_hidden_port() {
+        // A hidden WindowRecord has an empty visRgn. CopyBits is clipped
+        // before the bitsProc bottleneck, so an application replacement proc
+        // cannot draw its screen-backed port while the window is hidden.
+        let (mut d, mut cpu, mut bus) = setup_with_port();
+        const PORT_PTR: u32 = 0x181000;
+        const BITS_PROC: u32 = 0x0006_F123;
+        const RETURN_PC: u32 = 0x0004_5678;
+        d.current_port = PORT_PTR;
+        let _ = setup_copybits_through_port_bottleneck(&mut bus, BITS_PROC);
+
+        let vis_rgn_ptr = bus.alloc(10);
+        bus.write_word(vis_rgn_ptr, 10);
+        let vis_rgn = bus.alloc(4);
+        bus.write_long(vis_rgn, vis_rgn_ptr);
+        bus.write_long(PORT_PTR + 24, vis_rgn);
+        cpu.write_reg(Register::PC, RETURN_PC);
+
+        let result = d.dispatch_quickdraw(true, 0x0EC, &mut cpu, &mut bus);
+        assert!(result.unwrap().is_ok());
+        assert_eq!(cpu.read_reg(Register::PC), RETURN_PC);
+        assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 22);
+        assert_eq!(bus.read_byte(0x300480), 0x00);
+    }
+
+    #[test]
     fn copybits_ignores_the_synthesized_standard_bitsproc_marker() {
         // SetStdProcs writes $00F0A8EB into the bitsProc slot to mean "the
         // standard proc" (IM:I I-197). Calling back into that marker address
@@ -35603,7 +35733,7 @@ mod tests {
     }
 
     #[test]
-    fn plotcicon_draws_into_real_cgrafport_portpixmap_layout() {
+    fn plotcicon_uses_real_cgrafport_layout_and_honors_empty_visrgn() {
         // Systemless CGrafPorts store portPixMap at +2 and portVersion at
         // +6, matching Imaging With QuickDraw's CGrafPort layout. PlotCIcon
         // must resolve that real layout, not only the legacy synthetic test
@@ -35649,6 +35779,20 @@ mod tests {
         assert!(plot.unwrap().is_ok());
         assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 8);
         assert_eq!(bus.read_byte(dst_base), 0x5F);
+
+        let vis_rgn_ptr = bus.alloc(10);
+        bus.write_word(vis_rgn_ptr, 10);
+        let vis_rgn = bus.alloc(4);
+        bus.write_long(vis_rgn, vis_rgn_ptr);
+        bus.write_long(port_ptr + 24, vis_rgn);
+        bus.write_byte(dst_base, 0x0F);
+        cpu.write_reg(Register::A7, TEST_SP);
+        bus.write_long(TEST_SP, icon_handle);
+        bus.write_long(TEST_SP + 4, rect_ptr);
+
+        let hidden_plot = d.dispatch_quickdraw(true, 0x21F, &mut cpu, &mut bus);
+        assert!(hidden_plot.unwrap().is_ok());
+        assert_eq!(bus.read_byte(dst_base), 0x0F);
     }
 
     #[test]

--- a/src/trap/window.rs
+++ b/src/trap/window.rs
@@ -2847,6 +2847,14 @@ impl super::TrapDispatcher {
             go_away_flag,
             ref_con,
         );
+        if !visible {
+            // A hidden window has no pixels visible on the screen. Its
+            // GrafPort remains a valid drawing destination, but QuickDraw's
+            // visRgn must be empty so controls and other drawing cannot paint
+            // through it until ShowWindow makes the window visible.
+            // Inside Macintosh Volume I, pp. I-278, I-283.
+            Self::write_region_handle_rect(bus, bus.read_long(window_ptr + 24), None);
+        }
         let window_def_proc = self.window_def_proc_handle(bus, wind_proc_id);
         bus.write_long(window_ptr + Self::WINDOW_DEF_PROC_OFFSET, window_def_proc);
         // OpenPort/OpenCPort initializes clipRgn to an arbitrarily large
@@ -5739,6 +5747,12 @@ mod tests {
             false,
             false,
             0,
+        );
+
+        assert_eq!(
+            read_window_region_rect(&bus, window_addr, 24),
+            (0, 0, 0, 0),
+            "a newly hidden window must start with an empty visRgn"
         );
 
         disp.move_window_to_global(&mut bus, window_addr, 0, 0, false);


### PR DESCRIPTION
## Summary

- extract multi-segment VISE 3.5 installers across disk images while retaining every mounted volume
- automatically select and launch the extracted application instead of presenting the installer
- honor hidden-window QuickDraw clipping and control ownership so inactive controls cannot leak onto visible windows
- restore classic Control Manager scrollbar action callbacks and authentic menu/control rendering

## Testing

- `cargo test -p systemless`
- `cargo check -p systemless`
- end-to-end two-disk launch, game creation, pull-down menu interaction, and scrollbar interaction

Closes #802