### PR TITLE
fix(quickdraw): never hand out SysZone as a GrafPtr when no port is current

### DIFF
--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -1056,7 +1056,7 @@ impl super::TrapDispatcher {
                     if global_ptr != 0 {
                         bus.read_long(global_ptr)
                     } else {
-                        bus.read_long(0x2A6)
+                        bus.read_long(crate::memory::globals::addr::THE_PORT)
                     }
                 };
                 let dst_handle = if port_ptr != 0 {
@@ -1113,7 +1113,7 @@ impl super::TrapDispatcher {
                     if global_ptr != 0 {
                         bus.read_long(global_ptr)
                     } else {
-                        bus.read_long(0x2A6)
+                        bus.read_long(crate::memory::globals::addr::THE_PORT)
                     }
                 };
                 let clip_rgn = if port_ptr != 0 {
@@ -1164,7 +1164,7 @@ impl super::TrapDispatcher {
                     if global_ptr != 0 {
                         bus.read_long(global_ptr)
                     } else {
-                        bus.read_long(0x2A6)
+                        bus.read_long(crate::memory::globals::addr::THE_PORT)
                     }
                 };
                 let clip_rgn_handle = if port_ptr != 0 {
@@ -23910,7 +23910,7 @@ impl super::TrapDispatcher {
         if self.current_port != 0 {
             self.current_port
         } else {
-            bus.read_long(0x2A6)
+            bus.read_long(crate::memory::globals::addr::THE_PORT)
         }
     }
 


### PR DESCRIPTION
## Summary

SimCity 2000 (1.2) stops at the founding newspaper on master (0.19.0)
and never starts its simulation. The cause is a four-line fallback
added in #760: when QuickDraw has no current port, four handlers hand
the application the **system heap zone pointer** as if it were a
**GrafPort pointer**. SC2K saves that value with `GetPort` and later
restores it with `SetPort`, and the SetPort handler then writes a
GrafPort's fields over the zone — which, since #658/#659, is where the
game's own copy of its main code segment lives. This PR makes the four
fallbacks return the real "current port" value (NIL when there is
none), as they did before #760.

## Background — the terms used below

- **GrafPort / GrafPtr.** A GrafPort is QuickDraw's 108-byte drawing
  environment record: which bitmap to draw into (`portBits`), the
  drawable rectangle (`portRect`), the visible and clip regions
  (`visRgn`, `clipRgn`), pen and text state (`pnLoc`, `pnSize`,
  `pnMode`, `pnPat`, `txFont`, `txMode` …) and the foreground/background
  colours (`fgColor` at offset 80, `bkColor` at offset 84) — the record
  is given in *Inside Macintosh* Volume I, p. I-148. A GrafPtr is a
  pointer to one. Every window owns one; drawing calls act on
  whichever port is *current*.
- **The current port.** QuickDraw keeps one global "current port". On a
  real Mac it is the `thePort` field of the application's QuickDraw
  globals; the ROM also mirrors it in the **low-memory global**
  `thePort` at address `$09DA`. `SetPort(port)` makes a port current;
  `GetPort(VAR port)` writes the current port pointer into the caller's
  variable — "GetPort returns a pointer to the current grafPort. This
  pointer is also available through the global variable thePort" (IM I,
  p. I-165; *Imaging With QuickDraw*, p. 2-41, which also shows the
  `GetPort(savePort) … SetPort(savePort)` save/restore idiom SC2K uses).
  `SetClip`, `GetClip` and `ClipRect` read or replace the *current
  port's* clip region, so they too must first resolve which port is
  current. **Before an application makes any port current, `thePort` is
  NIL: `InitGraf` "initializes the global variables listed below …
  thePort GrafPtr NIL" (IM I, p. I-162).** `InitWindows` creates the
  Window Manager port but does not make it current (IM I, p. I-281), so
  NIL is the documented answer until the first `SetPort`.
- **Low-memory globals.** The 68K Mac OS keeps its system variables at
  fixed addresses in the first few kilobytes of RAM. Systemless
  maintains the ones applications read: `thePort` (`$09DA`),
  `WMgrPort` (`$09DE`), `SysZone` (`$02A6`), `ApplZone` (`$02AA`), and
  so on (`src/memory/globals.rs`).
- **`SysZone`, zones and zone pointers.** The Memory Manager's heaps
  are *zones*: a 52-byte zone header followed by the allocated blocks.
  `SysZone` is the low-memory pointer to the system heap zone,
  `ApplZone` to the application heap zone: "the Memory Manager always
  maintains at least two heap zones: a system heap zone that's used by
  the Operating System and an application heap zone that's used by the
  Toolbox and your application program" (IM II, pp. II-9–II-10; the
  `SysZone`/`ApplZone` globals appear in the memory map on p. II-19).
  Systemless places both at `$200000`, the application heap floor; the
  first allocated block starts at `$200040`. A zone pointer therefore
  points at heap bookkeeping followed by whatever the application
  allocated first — it is never a GrafPort.
- **The A5 QuickDraw globals and how they name a port.** A 68K
  application's globals live relative to register A5. The QuickDraw
  globals (`qd`) sit just below A5, and by convention the long word *at*
  A5 (`0(A5)`) holds the address of `qd.thePort`; `InitGraf(&qd.thePort)`
  establishes this. So "the application's current port" can be read as
  `read_long(read_long(A5))`: follow A5 to the address of `qd.thePort`,
  then read the port pointer stored there. This is the documented
  convention: "The InitGraf procedure stores this pointer to thePort in
  the location pointed to by A5. This value is used as a base address
  when accessing the other QuickDraw global variables" (*Imaging With
  QuickDraw*, p. 2-37; the `globalPtr` parameter is "a pointer to the
  global variable thePort", p. 2-36). Systemless's `InitGraf` handler
  writes that pointer at `0(A5)`, and its `SetPort` handler mirrors every
  new current port into `qd.thePort` so the application's view stays in
  sync.
- **The dispatcher's current port.** Systemless's trap dispatcher also
  keeps its own Rust-side copy, `current_port`, set by `SetPort` and
  used by the drawing code.
- **`bus.read_long(addr)`.** Reads a 32-bit big-endian value from guest
  memory at `addr` through the emulated memory bus (`read_word`,
  `write_long` etc. are the same family). `bus.read_long(0x2A6)` is
  therefore "the value of the low-memory global at `$02A6`" — `SysZone`.
- **`effective_the_port`.** A helper introduced by #760 that answers
  "what is the current port?" for `GetPort` and four other handlers.
  It tries, in order: the application's `qd.thePort` via A5; the
  dispatcher's `current_port`; and, if both are zero, a fallback.
- **CODE 1 and CODE 2.** A 68K Macintosh application's code is stored
  in its resource fork as numbered `CODE` resources ("segments"). `CODE
  0` holds the jump table; `CODE 1`, `CODE 2`, … are the segments
  themselves, which the Segment Loader (`_LoadSeg`) brings into memory
  on demand when a jump-table entry is first called. SimCity 2000 has
  four: a 24-byte `CODE 0`, a 1,520-byte `CODE 1` (its start-up and
  segment-management code), a 280,089-byte `CODE 2` (essentially the
  whole game, including the main loop discussed below) and a
  15,478-byte `CODE 3`. Systemless loads all of them into the
  application image at launch; SC2K then also allocates a heap block of
  exactly `CODE 2`'s size, copies the segment into it, and has `CODE 1`
  patch the absolute addresses inside the copy so it can run from
  there. It is this heap copy that the game executes and that the bug
  overwrites.

## What #760 did, and why the fallback is wrong

#760 ("resolve clip port fallbacks and prevent TEUpdate background
erasure") made `SetClip`, `GetClip` and `ClipRect` resolve the current
port through the chain above instead of only the dispatcher's
`current_port`, and factored the same chain into `effective_the_port`
for `GetPort` and others. That part is fine. The final step of the
chain, taken when no port has ever been made current, is
`bus.read_long(0x2A6)` — `SysZone`. Presumably a non-NIL pointer was
wanted so the clip handlers had *something* to operate on, but
`SysZone` is a heap zone, not a port: reading it as a GrafPort yields
garbage, and any handler that *writes* port fields through it corrupts
the heap. Before #760 these handlers used the low-memory `thePort`
(zero when nothing is current), and applications are written to handle
a NIL `GetPort` result before their first `SetPort`.

The four sites (all blamed to `da0aacf`): `SetClip` (`$A879`),
`GetClip` (`$A87A`), `ClipRect` (`$A87B`) and `effective_the_port`,
`src/trap/quickdraw.rs` lines 1059, 1116, 1167 and 23913 on master.

## How it breaks SimCity 2000

Traced end to end on master with a deterministic headless run driven
by the instruction-count input replay from #824 (the same script —
boot → new city → live simulation — was used for every measurement
and every bisect step below):

1. SC2K runs its main loop from its **heap-resident, self-relocated
   copy of `CODE 2`**: it allocates 280,089 bytes (the segment's exact
   size) and its `CODE 1` applies the fixups (for example the absolute
   `JSR $00000316` at `CODE 2` + `$10` is rewritten to `JSR $00200356`).
   Since #658/#659 (`650536c`) the application zone allocates from the
   heap floor below the relocated image, so that copy is the zone's
   very first block, at `$200040`.
2. Early on, before any port is current, the game calls
   `GetPort(&save)`. On master `effective_the_port` finds
   `qd.thePort == 0`, `current_port == 0`, and returns `SysZone` =
   `$200000`. Later the game calls `SetPort(save)`.
3. Systemless's `SetPort` handler (`set_current_port_state`) records
   the port, writes it to `thePort` and `qd.thePort`, and calls
   `restore_port_draw_state` → `sync_port_draw_state`, which writes the
   current pen/text/colour state into the GrafPort record at that
   address so applications that inspect the record see consistent
   fields: `bkPat` at +32, `pnLoc/pnSize/pnMode` at +48..+57, `pnPat`
   at +58, `pnVis/txFont/txFace/txMode/txSize` at +66..+75, and for a
   classic GrafPort the legacy `fgColor = 33` (blackColor) at +80 and
   `bkColor = 30` (whiteColor) at +84 (the OpenPort defaults of *Imaging
   With QuickDraw* Table 2-2, p. 2-38, laid out per IM I, p. I-148). With the "port" at `$200000`,
   +80 and +84 are `$200050` and `$200054` — the first four bytes of the
   relocated `JSR` and the instruction after it. A memory-write trace
   shows exactly these writes landing on the code.
4. The CPU then executes `ORI.B #$21,D0; ORI.B #$1E,D0; OR.B (A2)+,D1`
   where the call to the tick worker used to be. That worker is what
   compares `TickCount` against the game's next-step target
   (`$2CC2(A5)`), so the target is written once at initialisation and
   never again, the simulation never steps, and the newspaper animation
   never completes. The guest spins in this loop for the rest of the
   run.

Bisect over master, each candidate commit built with the #824 harness
and run through the same script (verdict: share of sampled PCs
inside the corrupted loop, and whether the simulation target is ever
rewritten): 0.16.0 pass, #693 pass, #716 pass, #765's parent fail, and
finally `c31d1ed` (the commit before #760) passes while `da0aacf`
(#760) fails — first bad commit. Ruled out by measurement on the way:
VBL tasks (~100k fires either way), the sound double-buffer callbacks
(identical counts), resource lookups (identical requests), the
TickCount spin fast-forward (disabled: still stuck), trap dispatch
(329k `TickCount` dispatches), and `650536c` on its own (#693, which
includes it, passes — the heap-floor layout only decided *what* the
stray writes hit).

## References

- *Inside Macintosh* Volume I (1985): p. I-148 (the GrafPort record),
  p. I-162 (`InitGraf` initial values — `thePort` NIL), p. I-165
  (`GetPort`/`SetPort`), p. I-204 (`thePort` among the QuickDraw global
  variables), p. I-281 (`InitWindows` creates the Window Manager port).
- *Inside Macintosh* Volume II (1985): pp. II-9–II-10 (system and
  application heap zones), p. II-19 (memory map with `SysZone` and
  `ApplZone`).
- *Inside Macintosh: Imaging With QuickDraw* (1994): pp. 2-36–2-37
  (`InitGraf`, the `thePort` pointer stored at A5), p. 2-38 (Table 2-2,
  initial values of a basic graphics port), p. 2-41 (`GetPort`), p. 4-9
  (`thePort` points to the current port for basic and colour ports).

## The change

At the four sites, replace `bus.read_long(0x2A6)` with
`bus.read_long(crate::memory::globals::addr::THE_PORT)` — the
low-memory `thePort`, NIL when nothing is current. Four lines, no
reformatting.

## Verification

- SC2K on master + this fix, same #824 replay, 130M instructions: the
  simulation runs — the next-step target `$2CC2(A5)` is rewritten 78
  times (once on master), no sampled PC lands in the corrupted loop, and
  the final frame reads "Mar 1900 <New City> — Power Plant Needed",
  matching what 0.16.0 reaches.
- EV Override 1.0.1 is unaffected on master and on this branch (it
  sets a port before its first `GetPort`).
- Full suite on the branch: 3,953 + 65 + 4 + 1 tests pass, 0 failed,
  including the port-fallback tests #760 added. Clippy reports nothing
  new in `quickdraw.rs` (the one hit at line 3913 predates #760).
- Audit for the same class of bug: `read_long(0x2A6)` / `0x02AA`
  used as anything but a zone pointer occurs only at these four sites;
  the remaining zone/heap-global reads (`ApplZone`, `HeapEnd`,
  `ApplLimit` in `trap/memory.rs`) are genuine Memory Manager uses; no
  HLE code uses fixed guest addresses at or above `$200000`. Where
  QuickDraw genuinely needs a non-NIL port with none current, the
  existing pattern is the Window Manager port
  (`ensure_color_window_manager_port`, `quickdraw.rs:18545`) — that,
  not a zone pointer, would be the right choice if a handler must have
  one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019xXVFS9G1t9hEi33kN7MPN

Closes #829