### PR TITLE
fix(loader): apply Retro68 RELA relocations

### DIFF
--- a/src/loader/mod.rs
+++ b/src/loader/mod.rs
@@ -328,9 +328,104 @@ fn decode_relocation_offsets(data: &[u8], start: usize, end: usize) -> Option<Ve
     Some(offsets)
 }
 
+/// One relocation decoded from Retro68's compressed `RELA` resource format.
+///
+/// Retro68's `Elf2Mac/Reloc.cc::SerializeRelocs` writes absolute and
+/// PC-relative relocations as two separately terminated ULEB128-delta streams;
+/// `libretro/relocate.c::Retro68ApplyRelocations` consumes the same format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Retro68Relocation {
+    pub offset: u32,
+    pub base_index: usize,
+    pub pc_relative: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Retro68RelocationError {
+    MissingPassTerminator,
+    TruncatedUleb128,
+    Uleb128Overflow,
+    TargetOutOfBounds { offset: i64, target_size: usize },
+    GuestAddressOverflow { base: u32, offset: u32 },
+}
+
+fn decode_retro68_uleb128(data: &[u8], cursor: &mut usize) -> Result<u32, Retro68RelocationError> {
+    let mut value = 0u32;
+
+    for shift in [0, 7, 14, 21, 28] {
+        let byte = *data
+            .get(*cursor)
+            .ok_or(Retro68RelocationError::TruncatedUleb128)?;
+        *cursor += 1;
+
+        let payload = u32::from(byte & 0x7F);
+        if shift == 28 && payload > 0x0F {
+            return Err(Retro68RelocationError::Uleb128Overflow);
+        }
+        value |= payload << shift;
+
+        if byte & 0x80 == 0 {
+            return Ok(value);
+        }
+    }
+
+    Err(Retro68RelocationError::Uleb128Overflow)
+}
+
+pub(crate) fn decode_retro68_relocations(
+    data: &[u8],
+    target_size: usize,
+) -> Result<Vec<Retro68Relocation>, Retro68RelocationError> {
+    let mut relocations = Vec::new();
+    let mut cursor = 0usize;
+
+    for pc_relative in [false, true] {
+        // Retro68 starts each pass one byte before the relocation target so
+        // the first delta can encode an offset of zero without colliding with
+        // the zero-byte pass terminator.
+        let mut offset = -1i64;
+
+        loop {
+            let first = *data
+                .get(cursor)
+                .ok_or(Retro68RelocationError::MissingPassTerminator)?;
+            if first == 0 {
+                cursor += 1;
+                break;
+            }
+
+            let encoded = decode_retro68_uleb128(data, &mut cursor)?;
+            offset += i64::from(encoded >> 2);
+            let end = offset
+                .checked_add(4)
+                .ok_or(Retro68RelocationError::TargetOutOfBounds {
+                    offset,
+                    target_size,
+                })?;
+            if offset < 0 || end > target_size as i64 {
+                return Err(Retro68RelocationError::TargetOutOfBounds {
+                    offset,
+                    target_size,
+                });
+            }
+
+            relocations.push(Retro68Relocation {
+                offset: offset as u32,
+                base_index: (encoded & 3) as usize,
+                pc_relative,
+            });
+        }
+    }
+
+    Ok(relocations)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{ApplicationSizeResource, CodeSegmentHeader, MpwFarSegmentHeader};
+    use super::{
+        decode_retro68_relocations, ApplicationSizeResource, CodeSegmentHeader,
+        MpwFarSegmentHeader, Retro68Relocation, Retro68RelocationError,
+    };
 
     #[test]
     fn parses_application_size_resource_flags_and_partition_sizes() {
@@ -420,6 +515,77 @@ mod tests {
 
         assert_eq!(header.a5_relocation_offsets(&data), Some(vec![0x1428]));
         assert_eq!(header.pc_relocation_offsets(&data), Some(vec![0x2A]));
+    }
+
+    #[test]
+    fn decodes_both_retro68_relocation_passes_and_base_kinds() {
+        let relocations = decode_retro68_relocations(
+            &[
+                0x04, // absolute offset 0, code base
+                0x11, // absolute offset 4, data base
+                0x12, // absolute offset 8, bss base
+                0x13, // absolute offset 12, jump-table base
+                0x00, // absolute pass terminator
+                0xC4, 0x02, // PC-relative offset 80, code base
+                0x00, // PC-relative pass terminator
+            ],
+            84,
+        )
+        .expect("decode Retro68 RELA resource");
+
+        assert_eq!(
+            relocations,
+            vec![
+                Retro68Relocation {
+                    offset: 0,
+                    base_index: 0,
+                    pc_relative: false,
+                },
+                Retro68Relocation {
+                    offset: 4,
+                    base_index: 1,
+                    pc_relative: false,
+                },
+                Retro68Relocation {
+                    offset: 8,
+                    base_index: 2,
+                    pc_relative: false,
+                },
+                Retro68Relocation {
+                    offset: 12,
+                    base_index: 3,
+                    pc_relative: false,
+                },
+                Retro68Relocation {
+                    offset: 80,
+                    base_index: 0,
+                    pc_relative: true,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_retro68_relocation_streams() {
+        assert_eq!(
+            decode_retro68_relocations(&[0x00], 4),
+            Err(Retro68RelocationError::MissingPassTerminator)
+        );
+        assert_eq!(
+            decode_retro68_relocations(&[0x84], 4),
+            Err(Retro68RelocationError::TruncatedUleb128)
+        );
+        assert_eq!(
+            decode_retro68_relocations(&[0xFF, 0xFF, 0xFF, 0xFF, 0x10], 4),
+            Err(Retro68RelocationError::Uleb128Overflow)
+        );
+        assert_eq!(
+            decode_retro68_relocations(&[0x08, 0x00, 0x00], 4),
+            Err(Retro68RelocationError::TargetOutOfBounds {
+                offset: 1,
+                target_size: 4,
+            })
+        );
     }
 }
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -12,8 +12,8 @@ use crate::loader::ppc::{
     PpcSoundDoubleBufferPlaybackRecord,
 };
 use crate::loader::{
-    ApplicationSizeResource, Code0Header, CodeSegmentHeader, JumpTableEntry, LoadedApp,
-    MpwFarSegmentHeader,
+    decode_retro68_relocations, ApplicationSizeResource, Code0Header, CodeSegmentHeader,
+    JumpTableEntry, LoadedApp, MpwFarSegmentHeader, Retro68RelocationError,
 };
 use crate::managers::resource::ResourceFork;
 use crate::memory::{MacMemoryBus, MemoryBus};
@@ -10178,6 +10178,54 @@ impl Drop for FixtureRunner {
 // Loader Implementation
 // =============================================================================
 
+fn apply_retro68_rela_relocations<M: MemoryBus>(
+    bus: &mut M,
+    target_base: u32,
+    target_size: usize,
+    rela: &[u8],
+    displacements: [u32; 4],
+) -> std::result::Result<usize, Retro68RelocationError> {
+    let relocations = decode_retro68_relocations(rela, target_size)?;
+    let addresses = relocations
+        .iter()
+        .map(|relocation| {
+            target_base.checked_add(relocation.offset).ok_or(
+                Retro68RelocationError::GuestAddressOverflow {
+                    base: target_base,
+                    offset: relocation.offset,
+                },
+            )
+        })
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+
+    for (relocation, address) in relocations.iter().zip(addresses) {
+        let mut value = bus
+            .read_long(address)
+            .wrapping_add(displacements[relocation.base_index]);
+        if relocation.pc_relative {
+            value = value.wrapping_sub(address);
+        }
+        bus.write_long(address, value);
+    }
+
+    Ok(relocations.len())
+}
+
+fn update_far_segment_runtime_addresses<M: MemoryBus>(
+    bus: &mut M,
+    segment_addr: u32,
+    a5_base: u32,
+) {
+    bus.write_long(
+        segment_addr + MpwFarSegmentHeader::CURRENT_A5_OFFSET,
+        a5_base,
+    );
+    bus.write_long(
+        segment_addr + MpwFarSegmentHeader::LOAD_ADDRESS_OFFSET,
+        segment_addr,
+    );
+}
+
 fn apply_mpw_far_segment_relocations<M: MemoryBus>(
     bus: &mut M,
     segment_id: i16,
@@ -10229,14 +10277,7 @@ fn apply_mpw_far_segment_relocations<M: MemoryBus>(
         }
     }
 
-    bus.write_long(
-        segment_addr + MpwFarSegmentHeader::CURRENT_A5_OFFSET,
-        a5_base,
-    );
-    bus.write_long(
-        segment_addr + MpwFarSegmentHeader::LOAD_ADDRESS_OFFSET,
-        segment_addr,
-    );
+    update_far_segment_runtime_addresses(bus, segment_addr, a5_base);
 
     if trace_load_enabled() {
         eprintln!(
@@ -10298,6 +10339,16 @@ fn load_app_generic<M: MemoryBus>(
     }
 
     let a5_base = load_address + header.below_a5;
+    let mut all_codes = fork.get_all_code();
+    all_codes.sort_by_key(|code| code.id);
+    let is_retro68_multisegment = all_codes.iter().any(|code| {
+        code.id != 0
+            && matches!(
+                CodeSegmentHeader::parse(&code.data),
+                Some(CodeSegmentHeader::MpwFar)
+            )
+            && fork.get(*b"RELA", code.id).is_some()
+    });
     // For classic Mac apps, above_a5 defines the space needed above A5.
     // However, some apps place QuickDraw globals at higher offsets (e.g., A5+39KB).
     // Add 48KB reserve to accommodate most classic apps.
@@ -10391,6 +10442,31 @@ fn load_app_generic<M: MemoryBus>(
             );
         }
         bus.write_bytes(data_dest, &data.data);
+
+        if is_retro68_multisegment {
+            if let Some(rela) = fork.get(*b"RELA", 0) {
+                // Retro68 MultiSegApp.c relocates initialized globals with
+                // {code, data, bss, jump table} displacements of
+                // {0, A5, A5, A5}.
+                match apply_retro68_rela_relocations(
+                    bus,
+                    data_dest,
+                    data.data.len(),
+                    &rela.data,
+                    [0, a5_base, a5_base, a5_base],
+                ) {
+                    Ok(count) => {
+                        if trace_load_enabled() {
+                            eprintln!("[LOAD] Applied Retro68 RELA 0: count={count}");
+                        }
+                    }
+                    Err(error) => {
+                        tracing::warn!("invalid Retro68 RELA 0 resource: {error:?}");
+                        return None;
+                    }
+                }
+            }
+        }
     }
 
     // 2. Parse Jump Table from CODE 0
@@ -10475,9 +10551,6 @@ fn load_app_generic<M: MemoryBus>(
     // Reserve space: scan CODE headers to find max JT extent so CODE segments
     // are placed above the JT area.
     let mut max_jt_end: u32 = jt_base + (jump_table.len() as u32 * 8);
-    let mut all_codes = fork.get_all_code();
-    all_codes.sort_by_key(|c| c.id);
-
     for code_res in &all_codes {
         if code_res.id == 0 || code_res.data.len() < 4 {
             continue;
@@ -10583,7 +10656,47 @@ fn load_app_generic<M: MemoryBus>(
         // original CODE 0 parse). Near-model segments get their JT entries
         // populated by the app's startup code and patched by LoadSeg.
         if matches!(segment_header, Some(CodeSegmentHeader::MpwFar)) {
-            apply_mpw_far_segment_relocations(bus, code_res.id, user_addr, &code_res.data, a5_base);
+            if let Some(rela) = fork.get(*b"RELA", code_res.id) {
+                // Retro68 MultiSegApp.c relocates the body after the 40-byte
+                // far header with {segment, A5, A5, A5} displacements.
+                let target_base = match user_addr.checked_add(MpwFarSegmentHeader::SIZE as u32) {
+                    Some(address) => address,
+                    None => {
+                        tracing::warn!(
+                            "Retro68 CODE {} relocation target address overflowed",
+                            code_res.id
+                        );
+                        return None;
+                    }
+                };
+                let target_size = code_res.data.len() - MpwFarSegmentHeader::SIZE;
+                match apply_retro68_rela_relocations(
+                    bus,
+                    target_base,
+                    target_size,
+                    &rela.data,
+                    [user_addr, a5_base, a5_base, a5_base],
+                ) {
+                    Ok(count) => {
+                        update_far_segment_runtime_addresses(bus, user_addr, a5_base);
+                        if trace_load_enabled() {
+                            eprintln!("[LOAD] Applied Retro68 RELA {}: count={count}", code_res.id);
+                        }
+                    }
+                    Err(error) => {
+                        tracing::warn!("invalid Retro68 RELA {} resource: {error:?}", code_res.id);
+                        return None;
+                    }
+                }
+            } else {
+                apply_mpw_far_segment_relocations(
+                    bus,
+                    code_res.id,
+                    user_addr,
+                    &code_res.data,
+                    a5_base,
+                );
+            }
 
             for (i, entry) in jump_table.iter_mut().enumerate() {
                 if entry.segment == code_res.id {
@@ -11965,6 +12078,115 @@ mod tests {
                 .read_long(code1_base + MpwFarSegmentHeader::LOAD_ADDRESS_OFFSET),
             code1_base
         );
+    }
+
+    #[test]
+    fn load_app_applies_retro68_code_and_data_relocations() {
+        let mut code0 = minimal_code0(40, 0x2000, 8, 32);
+        code0[16..24].copy_from_slice(&[
+            0x00, 0x01, // segment 1
+            0xA9, 0xF0, // far-model unloaded LoadSeg trap
+            0x00, 0x00, 0x00, 0x28,
+        ]);
+
+        let mut code1 = vec![0u8; 0x60];
+        code1[0..2].copy_from_slice(&0xFFFFu16.to_be_bytes());
+        for (offset, value) in [0x20u32, 0x30, 0x40, 0x50, 0x60].into_iter().enumerate() {
+            let start = MpwFarSegmentHeader::SIZE + offset * 4;
+            code1[start..start + 4].copy_from_slice(&value.to_be_bytes());
+        }
+        let rela1 = [
+            0x04, // absolute offset 0, code base
+            0x11, // absolute offset 4, data base
+            0x12, // absolute offset 8, bss base
+            0x13, // absolute offset 12, jump-table base
+            0x00, // absolute pass terminator
+            0x44, // PC-relative offset 16, code base
+            0x00, // PC-relative pass terminator
+        ];
+
+        let mut data = Vec::new();
+        for value in [0x10u32, 0x20, 0x30, 0x40] {
+            data.extend_from_slice(&value.to_be_bytes());
+        }
+        let rela0 = [
+            0x04, // absolute offset 0, code base
+            0x11, // absolute offset 4, data base
+            0x12, // absolute offset 8, bss base
+            0x13, // absolute offset 12, jump-table base
+            0x00, // absolute pass terminator
+            0x00, // empty PC-relative pass
+        ];
+
+        let fork_bytes = make_resource_fork_bytes(&[
+            (*b"CODE", 0, &code0),
+            (*b"CODE", 1, &code1),
+            (*b"DATA", 0, &data),
+            (*b"RELA", 0, &rela0),
+            (*b"RELA", 1, &rela1),
+        ]);
+        let fork = ResourceFork::parse(&fork_bytes).expect("parse synthetic Retro68 app fork");
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+
+        let app = runner.load_app(&fork).expect("load Retro68 app");
+        let code1_base = app.segment_bases[&1];
+        let code_body = code1_base + MpwFarSegmentHeader::SIZE as u32;
+        let data_base = app.a5_base - app.code0_header.below_a5;
+
+        assert_eq!(runner.bus.read_long(code_body), code1_base + 0x20);
+        assert_eq!(runner.bus.read_long(code_body + 4), app.a5_base + 0x30);
+        assert_eq!(runner.bus.read_long(code_body + 8), app.a5_base + 0x40);
+        assert_eq!(runner.bus.read_long(code_body + 12), app.a5_base + 0x50);
+        assert_eq!(
+            runner.bus.read_long(code_body + 16),
+            0x28,
+            "the first PC-relative record must immediately follow the first terminator"
+        );
+        assert_eq!(runner.bus.read_long(data_base), 0x10);
+        assert_eq!(runner.bus.read_long(data_base + 4), app.a5_base + 0x20);
+        assert_eq!(runner.bus.read_long(data_base + 8), app.a5_base + 0x30);
+        assert_eq!(runner.bus.read_long(data_base + 12), app.a5_base + 0x40);
+        assert_eq!(
+            runner
+                .bus
+                .read_long(code1_base + MpwFarSegmentHeader::CURRENT_A5_OFFSET),
+            app.a5_base
+        );
+        assert_eq!(
+            runner
+                .bus
+                .read_long(code1_base + MpwFarSegmentHeader::LOAD_ADDRESS_OFFSET),
+            code1_base
+        );
+    }
+
+    #[test]
+    fn invalid_retro68_relocations_do_not_partially_modify_memory() {
+        let mut runner = FixtureRunner::new(1024 * 1024, FixtureRunnerConfig::default());
+        let target = 0x1000;
+        runner.bus.write_long(target, 0x20);
+
+        let result = apply_retro68_rela_relocations(
+            &mut runner.bus,
+            target,
+            4,
+            &[
+                0x04, // valid absolute relocation at offset 0
+                0x00, // absolute pass terminator
+                0x08, // invalid PC-relative relocation at offset 1
+                0x00,
+            ],
+            [0x100, 0, 0, 0],
+        );
+
+        assert_eq!(
+            result,
+            Err(Retro68RelocationError::TargetOutOfBounds {
+                offset: 1,
+                target_size: 4,
+            })
+        );
+        assert_eq!(runner.bus.read_long(target), 0x20);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- decode both absolute and PC-relative Retro68 RELA passes with validated ULEB128 deltas and relocation bounds
- relocate far CODE bodies with segment/A5 displacement bases and DATA 0 with the matching A5 model
- preserve the existing MPW far-segment relocation path when no matching RELA resource exists
- reject malformed streams before mutating guest memory

## Root cause

Systemless preloads far CODE resources and marks their runtime headers resident, so the Retro68 segment loader does not apply the matching RELA resources later. The existing MPW-only path therefore left Retro68 data-, BSS-, jump-table-, and PC-relative references unresolved. DATA 0 relocations were also never applied.

The decoder and displacement model follow Retro68 Elf2Mac/Reloc.cc, libretro/relocate.c, and libretro/MultiSegApp.c. The loader updates the far-segment runtime addresses only after relocation succeeds, preventing a later double relocation.

## Validation

- cargo build --all-targets --all-features
- cargo test --lib --features test-support: 4082 passed, 3 ignored
- cargo check --no-default-features
- focused coverage for both RELA passes, all four bases, malformed streams, transactional failure, and the existing MPW fallback
- attached Retro68 C and C++ Raytracers complete 12,000,000-instruction headless runs without faults; a longer C++ run visibly renders the scene
- attached WDEFShell completes 12,000,000 instructions and reaches InitGraf with the corrected A5-relative QuickDraw globals pointer

Closes #826