### PR TITLE
fix: restore authentic classic window and menu behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,12 @@ Common runner options:
 ```sh
 systemless --headless --max-instructions 5000000 path/to/app.sit
 systemless --arrows-as-numpad path/to/game.sit
+systemless --display-scale 2 path/to/game.sit
 ```
+
+Desktop windows default to a physical 1:1 guest-to-host pixel ratio. Use
+`--display-scale` with an integer from 1 through 8 for explicit pixel-perfect
+enlargement.
 
 The desktop runner uses the canonical machine profile automatically. On macOS,
 guest menus are mirrored into the native menu bar and the guest's application

--- a/src/bin/systemless.rs
+++ b/src/bin/systemless.rs
@@ -65,7 +65,6 @@ use winit::window::WindowId;
 /// Initial screen dimensions: 800x600 8bpp color mode by default.
 const INITIAL_SCREEN_WIDTH: u32 = 800;
 const INITIAL_SCREEN_HEIGHT: u32 = 600;
-const SCALE: u32 = 1;
 /// Frame duration at 60.15 Hz (Compact Mac VBL rate).
 const FRAME_DURATION: std::time::Duration = std::time::Duration::from_micros(16_625);
 const MIN_RENDER_HEADROOM: std::time::Duration = std::time::Duration::from_micros(1_500);
@@ -146,6 +145,10 @@ struct Cli {
     #[arg(long, value_name = "BITS", default_value_t = 8, value_parser = parse_screen_depth)]
     screen_depth: u16,
 
+    /// Integer host-pixel scale (1 is one host pixel per guest pixel)
+    #[arg(long, value_name = "N", default_value_t = 1, value_parser = parse_display_scale)]
+    display_scale: u32,
+
     /// Replay input events from a script during a headless run. Events are
     /// scheduled by retired instruction count, so a run replays identically
     /// every time and two builds can be compared on matched work.
@@ -160,6 +163,28 @@ fn parse_screen_depth(value: &str) -> Result<u16, String> {
         "8" => Ok(8),
         _ => Err("screen depth must be 1, 4, or 8".to_string()),
     }
+}
+
+fn parse_display_scale(value: &str) -> Result<u32, String> {
+    let scale = value
+        .parse::<u32>()
+        .map_err(|_| "display scale must be an integer from 1 through 8".to_string())?;
+    if (1..=8).contains(&scale) {
+        Ok(scale)
+    } else {
+        Err("display scale must be an integer from 1 through 8".to_string())
+    }
+}
+
+fn guest_scaled_physical_size(
+    width: u32,
+    height: u32,
+    display_scale: u32,
+) -> winit::dpi::PhysicalSize<u32> {
+    winit::dpi::PhysicalSize::new(
+        width.saturating_mul(display_scale),
+        height.saturating_mul(display_scale),
+    )
 }
 
 /// One scripted input, delivered once the run has retired `at`
@@ -600,6 +625,9 @@ struct App {
     addressing_24_bit: bool,
     /// Indexed guest framebuffer depth.
     screen_depth: u16,
+    /// Explicit integer host-pixel scale. Physical sizing keeps compositor
+    /// DPI from silently changing the requested guest-to-host ratio.
+    display_scale: u32,
     #[cfg(target_os = "macos")]
     native_integrations: bool,
     #[cfg(target_os = "macos")]
@@ -613,12 +641,31 @@ struct App {
 }
 
 impl App {
+    #[cfg(test)]
     fn new(
         game_path: PathBuf,
         arrows_as_numpad: bool,
         native_integrations: bool,
         addressing_24_bit: bool,
         screen_depth: u16,
+    ) -> Self {
+        Self::new_with_display_scale(
+            game_path,
+            arrows_as_numpad,
+            native_integrations,
+            addressing_24_bit,
+            screen_depth,
+            1,
+        )
+    }
+
+    fn new_with_display_scale(
+        game_path: PathBuf,
+        arrows_as_numpad: bool,
+        native_integrations: bool,
+        addressing_24_bit: bool,
+        screen_depth: u16,
+        display_scale: u32,
     ) -> Self {
         #[cfg(not(target_os = "macos"))]
         let _ = native_integrations;
@@ -702,6 +749,7 @@ impl App {
             arrows_as_numpad,
             addressing_24_bit,
             screen_depth,
+            display_scale,
             #[cfg(target_os = "macos")]
             native_integrations,
             #[cfg(target_os = "macos")]
@@ -2091,9 +2139,10 @@ impl ApplicationHandler for App {
             let window_title = "Systemless - Macintosh Emulator";
             let window_attrs = Window::default_attributes()
                 .with_title(window_title)
-                .with_inner_size(winit::dpi::LogicalSize::new(
-                    initial_size.0 * SCALE,
-                    initial_size.1 * SCALE,
+                .with_inner_size(guest_scaled_physical_size(
+                    initial_size.0,
+                    initial_size.1,
+                    self.display_scale,
                 ))
                 .with_resizable(true);
             let window_attrs = platform_window_attrs(window_attrs);
@@ -2291,8 +2340,11 @@ impl ApplicationHandler for App {
                 self.current_screen_width = sw;
                 self.current_screen_height = sh;
                 if let Some(window) = &self.window {
-                    let _ = window
-                        .request_inner_size(winit::dpi::LogicalSize::new(sw * SCALE, sh * SCALE));
+                    let _ = window.request_inner_size(guest_scaled_physical_size(
+                        sw,
+                        sh,
+                        self.display_scale,
+                    ));
                 }
                 self.force_next_render = true;
             }
@@ -2311,6 +2363,7 @@ fn run_gui(
     native_integrations: bool,
     addressing_24_bit: bool,
     screen_depth: u16,
+    display_scale: u32,
 ) {
     let event_loop = EventLoop::new().expect("Failed to create event loop");
     eprintln!(
@@ -2322,12 +2375,13 @@ fn run_gui(
         }
     );
 
-    let mut app = App::new(
+    let mut app = App::new_with_display_scale(
         game_path,
         arrows_as_numpad,
         native_integrations,
         addressing_24_bit,
         screen_depth,
+        display_scale,
     );
     // `run_app` is the first point at which `resumed` can create a native
     // window. Finish archive decompression and guest initialization before
@@ -2566,6 +2620,7 @@ fn main() {
             native_integrations,
             cli.addressing_24_bit,
             cli.screen_depth,
+            cli.display_scale,
         );
     }
 }
@@ -2973,6 +3028,8 @@ mod tests {
             "--addressing-24-bit",
             "--screen-depth",
             "4",
+            "--display-scale",
+            "2",
             "--max-instructions",
             "1234",
             "game.sit",
@@ -2987,7 +3044,23 @@ mod tests {
         assert!(cli.prefer_powerpc);
         assert!(cli.addressing_24_bit);
         assert_eq!(cli.screen_depth, 4);
+        assert_eq!(cli.display_scale, 2);
         assert_eq!(cli.max_instructions, Some(1234));
+    }
+
+    #[test]
+    fn cli_defaults_to_one_physical_host_pixel_per_guest_pixel() {
+        let cli = Cli::try_parse_from(["systemless", "game.sit"])
+            .expect("default display scale should parse");
+        assert_eq!(cli.display_scale, 1);
+        assert_eq!(
+            guest_scaled_physical_size(800, 600, cli.display_scale),
+            winit::dpi::PhysicalSize::new(800, 600)
+        );
+
+        let invalid = Cli::try_parse_from(["systemless", "--display-scale", "0", "game.sit"])
+            .expect_err("zero display scale should be rejected");
+        assert_eq!(invalid.kind(), ErrorKind::ValueValidation);
     }
 
     #[test]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1107,6 +1107,7 @@ fn tracking_refire_should_freeze_ticks(opcode: u16) -> bool {
     trap_no_autopop == 0xA93D // MenuSelect
         || trap_no_autopop == 0xA80B // PopUpMenuSelect / MenuKey tracking
         || trap_no_autopop == 0xA968 // TrackControl
+        || trap_no_autopop == 0xA91E // TrackGoAway
         || trap_no_autopop == 0xA925 // DragWindow
         || trap_no_autopop == 0xA905 // DragGrayRgn
         || trap_no_autopop == 0xA926 // DragTheRgn
@@ -19018,6 +19019,8 @@ mod tests {
         assert!(tracking_refire_should_freeze_ticks(0xAC0B));
         assert!(tracking_refire_should_freeze_ticks(0xA968));
         assert!(tracking_refire_should_freeze_ticks(0xAD68));
+        assert!(tracking_refire_should_freeze_ticks(0xA91E));
+        assert!(tracking_refire_should_freeze_ticks(0xAD1E));
         assert!(tracking_refire_should_freeze_ticks(0xA925));
         assert!(tracking_refire_should_freeze_ticks(0xAD25));
         assert!(tracking_refire_should_freeze_ticks(0xA905));

--- a/src/trap/control.rs
+++ b/src/trap/control.rs
@@ -161,6 +161,69 @@ impl super::TrapDispatcher {
         }
     }
 
+    /// Save portions of a control rectangle that are outside its owner's
+    /// current visible region. Standard CDEFs draw through the owner's
+    /// GrafPort and are clipped by `visRgn`; several HLE control renderers
+    /// write screen pixels directly, so those pixels need the same clipping
+    /// guarantee when a front window overlaps a background control.
+    /// Inside Macintosh Volume I (1985), pp. I-145 and I-326;
+    /// Macintosh Toolbox Essentials (1992), pp. 4-69 to 4-70.
+    fn save_control_pixels_outside_owner_visibility(
+        &self,
+        bus: &MacMemoryBus,
+        owner: u32,
+        rect: (i16, i16, i16, i16),
+    ) -> Vec<(i16, i16, i16, i16, Vec<u8>)> {
+        if owner == 0 {
+            return Vec::new();
+        }
+        let vis_rgn = bus.read_long(owner + 24);
+        if vis_rgn == 0 {
+            return Vec::new();
+        }
+        let Some((top, left, width, height, pixels)) = self.save_screen_rect_pixels(bus, rect)
+        else {
+            return Vec::new();
+        };
+        let (bounds_top, bounds_left) = self.port_bounds_top_left(bus, owner);
+        let visible_at = |bus: &MacMemoryBus, y: i16, x: i16| {
+            Self::region_contains_point(
+                bus,
+                vis_rgn,
+                y.wrapping_add(bounds_top),
+                x.wrapping_add(bounds_left),
+            )
+        };
+
+        let mut saved_runs = Vec::new();
+        for row in 0..height {
+            let y = top + row;
+            let mut column = 0i16;
+            while column < width {
+                let x = left + column;
+                if visible_at(bus, y, x) {
+                    column += 1;
+                    continue;
+                }
+                let run_start = column;
+                column += 1;
+                while column < width && !visible_at(bus, y, left + column) {
+                    column += 1;
+                }
+                let start = row as usize * width as usize + run_start as usize;
+                let end = row as usize * width as usize + column as usize;
+                saved_runs.push((
+                    y,
+                    left + run_start,
+                    column - run_start,
+                    1,
+                    pixels[start..end].to_vec(),
+                ));
+            }
+        }
+        saved_runs
+    }
+
     fn read_pascal_string(bus: &MacMemoryBus, str_ptr: u32) -> Vec<u8> {
         if str_ptr == 0 {
             return Vec::new();
@@ -1319,6 +1382,11 @@ impl super::TrapDispatcher {
         let abs_left = scr_left + r_left;
         let abs_bottom = scr_top + r_bottom;
         let abs_right = scr_left + r_right;
+        let occluded_pixels = self.save_control_pixels_outside_owner_visibility(
+            bus,
+            window_ptr,
+            (abs_top, abs_left, abs_bottom, abs_right),
+        );
 
         match proc_id {
             0 => {
@@ -1537,6 +1605,9 @@ impl super::TrapDispatcher {
         self.pn_size = saved_pn_size;
         self.pn_mode = saved_pn_mode;
         self.pn_pat = saved_pn_pat;
+        for (top, left, width, height, pixels) in occluded_pixels {
+            self.restore_screen_rect_pixels(bus, top, left, width, height, &pixels);
+        }
         if self.current_port != saved_port || self.current_gdevice != saved_gdevice {
             self.set_current_port_state(bus, cpu, saved_port, Some(saved_gdevice));
         }
@@ -7044,6 +7115,90 @@ mod tests {
 
         assert_eq!(cpu.read_reg(Register::A7), sp + 4);
         assert_eq!(disp.current_gdevice, gdevice_before);
+    }
+
+    #[test]
+    fn background_scrollbar_drawing_is_clipped_behind_front_window() {
+        // Standard CDEF drawing is clipped by the owner window's visRgn.
+        // A background window's scrollbar must therefore never paint through
+        // a front window even though the HLE scrollbar renderer writes direct
+        // framebuffer pixels. IM:I I-145 and I-326; MTE 1992 pp. 4-69..4-70.
+        let (mut disp, mut cpu, mut bus) = setup();
+        let screen_base = 0x300000u32;
+        disp.set_screen_mode_for_test(screen_base, 320, 320, 240, 8);
+        bus.write_long(0x0824, screen_base);
+        bus.write_word(crate::memory::globals::addr::MBAR_HEIGHT, 20);
+
+        let back = bus.alloc(256);
+        disp.init_cgraf_window(
+            &mut bus,
+            &mut cpu,
+            back,
+            screen_base,
+            40,
+            40,
+            220,
+            280,
+            "Back",
+            0,
+            true,
+            false,
+            false,
+            0,
+        );
+        let front = bus.alloc(256);
+        disp.init_cgraf_window(
+            &mut bus,
+            &mut cpu,
+            front,
+            screen_base,
+            90,
+            90,
+            200,
+            220,
+            "Front",
+            0,
+            true,
+            false,
+            false,
+            0,
+        );
+        assert_eq!(disp.window_list, vec![front, back]);
+
+        // Back-local (60,40..76,200) maps to global (100,80..116,240),
+        // crossing straight through the front content.
+        let (_handle, ctrl_ptr) =
+            alloc_scrollbar_control(&mut disp, &mut bus, (60, 40, 76, 200), 0xFF, 0, 5, 0, 10);
+        bus.write_long(ctrl_ptr + 4, back);
+
+        for y in 100u32..116 {
+            for x in 90u32..220 {
+                bus.write_byte(screen_base + y * 320 + x, 0x4D);
+            }
+        }
+        // An uncovered portion should still prove the scrollbar was drawn.
+        for y in 100u32..116 {
+            for x in 80u32..90 {
+                bus.write_byte(screen_base + y * 320 + x, 0x4D);
+            }
+        }
+
+        disp.draw_control(&mut cpu, &mut bus, ctrl_ptr);
+
+        for y in 100u32..116 {
+            for x in 90u32..220 {
+                assert_eq!(
+                    bus.read_byte(screen_base + y * 320 + x),
+                    0x4D,
+                    "background scrollbar painted through front window at ({x},{y})"
+                );
+            }
+        }
+        assert!(
+            (100u32..116)
+                .any(|y| { (80u32..90).any(|x| bus.read_byte(screen_base + y * 320 + x) != 0x4D) }),
+            "visible portion of the background scrollbar should still draw"
+        );
     }
 
     #[test]

--- a/src/trap/dialog.rs
+++ b/src/trap/dialog.rs
@@ -15909,7 +15909,9 @@ impl super::TrapDispatcher {
             // the insertion point just past it. Backspace ($08) deletes the
             // selection or the character before the insertion point.
             // PROCEDURE TEKey(key: CHAR; hTE: TEHandle);
-            // Inside Macintosh Volume I, I-385; Text 1993, 2-81
+            // Inside Macintosh Volume I, I-385; Inside Macintosh: Text
+            // (1993), pp. 2-81 to 2-82. In addition to editing the TERec,
+            // TEKey "redraws the text as necessary" before it returns.
             //
             // TEKey ($A9DC): Inserts character at insertion point, replaces selection; backspace deletes. IM:I I-385
             (true, 0x1DC) => {
@@ -15960,6 +15962,12 @@ impl super::TrapDispatcher {
                         // Insert printable character (replacing selection if any)
                         self.te_insert_text(bus, te_handle, &[key]);
                     }
+
+                    // TEKey is a drawing operation as well as an editing
+                    // operation. Applications do not need to follow every
+                    // key with TEUpdate; the TextEdit Manager redraws the
+                    // affected text and insertion point itself.
+                    self.draw_te_contents(cpu, bus, te_handle, true);
                 }
                 cpu.write_reg(Register::A7, sp + 6);
                 Ok(())
@@ -35946,6 +35954,37 @@ mod tests {
             2
         );
         assert_eq!(bus.read_word(te_ptr + TrapDispatcher::TE_SEL_END_OFFSET), 2);
+    }
+
+    #[test]
+    fn tekey_redraws_the_edited_text_before_returning() {
+        // Inside Macintosh: Text (1993), pp. 2-81 to 2-82: TEKey redraws
+        // the text as necessary. A dialog event loop may therefore call
+        // TEKey without a subsequent TEUpdate and still expects the typed
+        // character to become visible immediately.
+        let (mut disp, mut cpu, mut bus) = setup_with_port();
+        let te_handle = make_te_with_text(&mut disp, &mut bus, b"");
+        let (screen_base, row_bytes, width, height, _) = disp.screen_mode;
+        let screen_len = row_bytes * height as u32;
+        let before = bus.read_bytes(screen_base, screen_len as usize);
+
+        bus.write_long(TEST_SP, te_handle);
+        bus.write_word(TEST_SP + 4, u16::from(b'W'));
+        let result = disp.dispatch_dialog(true, 0x1DC, &mut cpu, &mut bus);
+        assert!(result.unwrap().is_ok());
+
+        assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 6);
+        assert_eq!(
+            TrapDispatcher::te_text_bytes(&bus, te_handle),
+            b"W".to_vec()
+        );
+        assert_ne!(
+            bus.read_bytes(screen_base, screen_len as usize),
+            before,
+            "TEKey must paint the changed TextEdit record before returning ({}x{})",
+            width,
+            height
+        );
     }
 
     #[test]

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -630,6 +630,19 @@ pub(crate) struct WindowTrackingState {
     pub command_down: bool,
 }
 
+/// Retained state for TrackGoAway while the mouse button remains down.
+/// The Window Manager keeps control, toggles the close-box highlight as the
+/// cursor crosses its region, and returns only after mouse-up.
+/// Macintosh Toolbox Essentials (1992), pp. 4-103 to 4-104.
+#[derive(Clone, Debug)]
+pub(crate) struct GoAwayTrackingState {
+    pub window_ptr: u32,
+    pub stack_ptr: u32,
+    pub hit_rect: (i16, i16, i16, i16),
+    pub highlight_rect: (i16, i16, i16, i16),
+    pub highlighted: bool,
+}
+
 /// Retained state shared by DragGrayRgn and DragTheRgn while the mouse
 /// button remains down. Both routines own a synchronous tracking loop and
 /// return only after release.
@@ -1684,6 +1697,8 @@ pub struct TrapDispatcher {
     pub(crate) control_tracking: Option<ControlTrackingState>,
     /// Active DragWindow tracking state.
     pub(crate) window_tracking: Option<WindowTrackingState>,
+    /// Active TrackGoAway close-box tracking state.
+    pub(crate) go_away_tracking: Option<GoAwayTrackingState>,
     /// Active DragGrayRgn / DragTheRgn tracking state.
     pub(crate) region_tracking: Option<RegionTrackingState>,
     /// Underline info for continuous underline across a string (set by draw_string)
@@ -3196,6 +3211,7 @@ impl TrapDispatcher {
             pending_native_menu_event_tick: None,
             control_tracking: None,
             window_tracking: None,
+            go_away_tracking: None,
             region_tracking: None,
             underline_info: None,
             mouse_pos: (0, 0),
@@ -3412,6 +3428,11 @@ impl TrapDispatcher {
         self.window_tracking.is_some()
     }
 
+    /// Whether TrackGoAway is actively tracking the close box.
+    pub fn is_go_away_tracking(&self) -> bool {
+        self.go_away_tracking.is_some()
+    }
+
     /// Whether DragGrayRgn or DragTheRgn is actively tracking the mouse.
     pub fn is_region_tracking(&self) -> bool {
         self.region_tracking.is_some()
@@ -3439,6 +3460,7 @@ impl TrapDispatcher {
         let is_standard_file_refire = trap_no_autopop == 0xA9EA;
         let is_control_refire = trap_no_autopop == 0xA968;
         let is_window_refire = trap_no_autopop == 0xA925;
+        let is_go_away_refire = trap_no_autopop == 0xA91E;
         let is_region_refire = matches!(trap_no_autopop, 0xA905 | 0xA926);
         (is_menu_refire && self.is_menu_tracking())
             || (is_dialog_refire && self.is_dialog_tracking())
@@ -3446,6 +3468,7 @@ impl TrapDispatcher {
                 && (self.is_standard_file_put_tracking() || self.is_standard_file_get_tracking()))
             || (is_control_refire && self.is_control_tracking())
             || (is_window_refire && self.is_window_tracking())
+            || (is_go_away_refire && self.is_go_away_tracking())
             || (is_region_refire && self.is_region_tracking())
     }
 
@@ -7279,6 +7302,16 @@ mod tests {
         });
     }
 
+    fn install_go_away_tracking(disp: &mut TrapDispatcher) {
+        disp.go_away_tracking = Some(GoAwayTrackingState {
+            window_ptr: 0,
+            stack_ptr: 0,
+            hit_rect: (0, 0, 18, 18),
+            highlight_rect: (3, 8, 14, 19),
+            highlighted: true,
+        });
+    }
+
     fn install_region_tracking(disp: &mut TrapDispatcher) {
         disp.region_tracking = Some(RegionTrackingState {
             stack_ptr: 0,
@@ -7645,6 +7678,7 @@ mod tests {
         assert!(!disp.is_tracking_refire(0xA987)); // NoteAlert
         assert!(!disp.is_tracking_refire(0xA988)); // CautionAlert
         assert!(!disp.is_tracking_refire(0xA968)); // TrackControl
+        assert!(!disp.is_tracking_refire(0xA91E)); // TrackGoAway
         assert!(!disp.is_tracking_refire(0xA925)); // DragWindow
         assert!(!disp.is_tracking_refire(0xA905)); // DragGrayRgn
         assert!(!disp.is_tracking_refire(0xA926)); // DragTheRgn
@@ -7693,6 +7727,14 @@ mod tests {
         install_window_tracking(&mut disp);
         assert!(disp.is_tracking_refire(0xA925));
         assert!(disp.is_tracking_refire(0xAD25));
+    }
+
+    #[test]
+    fn is_tracking_refire_true_for_trackgoaway_when_close_box_tracking() {
+        let mut disp = TrapDispatcher::new();
+        install_go_away_tracking(&mut disp);
+        assert!(disp.is_tracking_refire(0xA91E));
+        assert!(disp.is_tracking_refire(0xAD1E));
     }
 
     #[test]

--- a/src/trap/framebuffer.rs
+++ b/src/trap/framebuffer.rs
@@ -4639,6 +4639,13 @@ impl super::TrapDispatcher {
         if let Some(tracking) = self.window_tracking.as_ref() {
             self.draw_window_drag_outline(bus, tracking.outline_rect);
         }
+        if let Some(tracking) = self
+            .go_away_tracking
+            .as_ref()
+            .filter(|tracking| tracking.highlighted)
+        {
+            self.toggle_standard_go_away_highlight(bus, tracking.highlight_rect);
+        }
         if let Some((rect, pattern)) = self.region_tracking.as_ref().and_then(|tracking| {
             tracking
                 .outline_rect

--- a/src/trap/menu.rs
+++ b/src/trap/menu.rs
@@ -90,6 +90,8 @@ struct MenuCIconLayout {
     pixel_size: u16,
     mask_data_ptr: u32,
     bmap_data_ptr: u32,
+    ctab_ptr: u32,
+    ctab_entries: u16,
     pixel_data_ptr: u32,
 }
 
@@ -2237,6 +2239,13 @@ impl super::TrapDispatcher {
                         .iter()
                         .position(|m| m.handle == menu_handle || m.id == menu_id)
                     {
+                        // Popup menus bypass `open_menu_dropdown`, so fault
+                        // their item-icon resources in here before sizing and
+                        // drawing. Macintosh Toolbox Essentials (1992),
+                        // pp. 3-46 and 3-137 to 3-138: the standard MDEF
+                        // resolves item icon number + 256, with `cicn`
+                        // taking precedence over the monochrome families.
+                        self.preload_menu_item_icon_resources(bus, menu_idx);
                         let (dd_rect, highlighted_item) =
                             self.popup_menu_dropdown_rect(bus, menu_idx, top, left, popup_item);
 
@@ -3846,8 +3855,34 @@ impl super::TrapDispatcher {
             pixel_size,
             mask_data_ptr,
             bmap_data_ptr,
+            ctab_ptr,
+            ctab_entries: (ct_size + 1) as u16,
             pixel_data_ptr,
         })
+    }
+
+    fn menu_cicn_rgb_for_index(
+        bus: &MacMemoryBus,
+        layout: MenuCIconLayout,
+        pixel_index: u8,
+    ) -> Option<[u16; 3]> {
+        let device_table = (bus.read_word(layout.ctab_ptr + 4) & 0x8000) != 0;
+        for ordinal in 0..u32::from(layout.ctab_entries) {
+            let entry = layout.ctab_ptr + 8 + ordinal * 8;
+            let value = if device_table {
+                ordinal as u16
+            } else {
+                bus.read_word(entry)
+            };
+            if value == u16::from(pixel_index) {
+                return Some([
+                    bus.read_word(entry + 2),
+                    bus.read_word(entry + 4),
+                    bus.read_word(entry + 6),
+                ]);
+            }
+        }
+        None
     }
 
     fn menu_cicn_pixel_index(
@@ -4217,12 +4252,29 @@ impl super::TrapDispatcher {
                     ) else {
                         continue;
                     };
+                    // A `cicn` pixel is an index into the icon's own
+                    // ColorTable, not a destination-device pixel value.
+                    // PlotCIcon remaps those colors to the current depth and
+                    // color table. More Macintosh Toolbox (1993), pp. 5-25
+                    // to 5-26; Imaging With QuickDraw (1994), p. 4-106.
+                    let destination_index = Self::menu_cicn_rgb_for_index(bus, layout, pixel_index)
+                        .map(|rgb| {
+                            Self::fb_pixel_index_for_rgb(bus, rgb).unwrap_or_else(|| {
+                                super::pict::closest_clut_index(
+                                    rgb[0],
+                                    rgb[1],
+                                    rgb[2],
+                                    &self.device_clut,
+                                )
+                            })
+                        })
+                        .unwrap_or(pixel_index);
                     let dst_x = left + dx;
                     let dst_y = top + dy;
                     if dst_x >= 0 && dst_y >= 0 && dst_x < screen_width && dst_y < screen_height {
                         bus.write_byte(
                             screen_base + (dst_y as u32) * row_bytes + dst_x as u32,
-                            pixel_index,
+                            destination_index,
                         );
                     }
                     continue;
@@ -5856,6 +5908,47 @@ mod tests {
             }
             data[bmap_row] = 0x30;
             data[pixel_row] = 0x30;
+        }
+        data
+    }
+
+    fn cicn_source_with_solid_4bpp_color(source_index: u8, rgb: [u16; 3]) -> Vec<u8> {
+        let width = 16u16;
+        let height = 16u16;
+        let pm_row_bytes = 8usize;
+        let mask_row_bytes = 2usize;
+        let mask_size = mask_row_bytes * usize::from(height);
+        let bmap_size = mask_size;
+        let ctab_offset = 82 + mask_size + bmap_size;
+        let pixel_offset = ctab_offset + 16;
+        let mut data = vec![0u8; pixel_offset + pm_row_bytes * usize::from(height)];
+
+        write_be_word(&mut data, 4, 0x8000 | pm_row_bytes as u16);
+        write_be_word(&mut data, 10, height);
+        write_be_word(&mut data, 12, width);
+        write_be_word(&mut data, 32, 4);
+        write_be_word(&mut data, 34, 1);
+        write_be_word(&mut data, 36, 4);
+
+        write_be_word(&mut data, 54, mask_row_bytes as u16);
+        write_be_word(&mut data, 60, height);
+        write_be_word(&mut data, 62, width);
+        write_be_word(&mut data, 68, mask_row_bytes as u16);
+        write_be_word(&mut data, 74, height);
+        write_be_word(&mut data, 76, width);
+
+        write_be_word(&mut data, ctab_offset + 6, 0);
+        write_be_word(&mut data, ctab_offset + 8, u16::from(source_index));
+        write_be_word(&mut data, ctab_offset + 10, rgb[0]);
+        write_be_word(&mut data, ctab_offset + 12, rgb[1]);
+        write_be_word(&mut data, ctab_offset + 14, rgb[2]);
+
+        let packed = (source_index << 4) | source_index;
+        for row in 0..usize::from(height) {
+            data[82 + row * mask_row_bytes] = 0xFF;
+            data[82 + row * mask_row_bytes + 1] = 0xFF;
+            data[pixel_offset + row * pm_row_bytes..pixel_offset + (row + 1) * pm_row_bytes]
+                .fill(packed);
         }
         data
     }
@@ -10657,6 +10750,33 @@ mod tests {
     }
 
     #[test]
+    fn draw_menu_dropdown_remaps_cicn_color_table_to_current_device() {
+        let rect = (20, 20, 38, 110);
+        let (mut disp, mut cpu, mut bus) = setup_with_port();
+        let (base, row_bytes) = setup_8bpp_menu_screen(&mut disp, &mut bus, 128, 96);
+        let menu = new_menu_with_title(&mut disp, &mut cpu, &mut bus, 622, 0x302F00, "Color");
+        append_menu_data(&mut disp, &mut cpu, &mut bus, menu, 0x302F40, "Crop");
+        disp.menus[0].items[0].icon = 7;
+        let icon = cicn_source_with_solid_4bpp_color(3, [0, 0xFFFF, 0]);
+        disp.install_test_resource(&mut bus, *b"cicn", 263, &icon);
+
+        disp.draw_menu_dropdown(&mut bus, 0, rect);
+
+        let mapped_green =
+            super::super::TrapDispatcher::fb_pixel_index_for_rgb(&bus, [0, 0xFFFF, 0])
+                .expect("active device should represent green");
+        assert_ne!(
+            mapped_green, 3,
+            "precondition: source icon index must differ from the device index"
+        );
+        assert_eq!(
+            screen_pixel_index(&bus, base, row_bytes, rect.1 + 4, rect.0 + 2),
+            mapped_green,
+            "cicn pixels should be mapped through their own ColorTable instead of copied as raw indexes"
+        );
+    }
+
+    #[test]
     fn draw_menu_bar_8bpp_uses_menucinfo_bar_and_title_colors() {
         let file_id = 622;
         let edit_id = 623;
@@ -12815,6 +12935,56 @@ mod tests {
         assert!(
             disp.dispatch_menu(true, 0x00B, cpu, bus).unwrap().is_ok(),
             "PopUpMenuSelect should succeed"
+        );
+    }
+
+    #[test]
+    fn popupmenuselect_faults_in_cicn_items_before_sizing_and_drawing() {
+        let (mut disp, mut cpu, mut bus) = setup_with_port();
+        let row_bytes = 64;
+        let base = bus.alloc(row_bytes * 160);
+        disp.set_screen_mode_for_test(base, row_bytes, 512, 160, 1);
+        clear_1bpp_screen(&mut bus, base, row_bytes, 160);
+        disp.menu_bar_hidden = false;
+        disp.mouse_button = true;
+
+        let menu = new_menu_with_title(&mut disp, &mut cpu, &mut bus, 733, 0x30BE00, "Crops");
+        append_menu_data(&mut disp, &mut cpu, &mut bus, menu, 0x30BE40, "Corn;Wheat");
+        // Item icon 19 resolves to resource 275. Leave its key-equivalent
+        // byte at zero; without the color icon this would be mis-sized as a
+        // 34-pixel normal ICON row.
+        disp.menus[0].items[0].icon = 19;
+        let cicn = cicn_source_with_left_stripe(16, 16);
+        disp.install_test_resource(&mut bus, *b"cicn", 275, &cicn);
+        disp.resources
+            .as_mut()
+            .unwrap()
+            .files
+            .get_mut(&0)
+            .unwrap()
+            .loaded
+            .insert((*b"cicn", 275), 0);
+        assert!(
+            disp.find_loaded_resource_any(*b"cicn", 275).is_none(),
+            "precondition: the color icon should be nonresident"
+        );
+        insert_menu_before_id(&mut disp, &mut cpu, &mut bus, menu, -1);
+
+        dispatch_popupmenuselect_start(&mut disp, &mut cpu, &mut bus, menu, 50, 40, 0);
+
+        let rect = disp.menu_tracking.as_ref().unwrap().dropdown_rect;
+        assert_eq!(
+            rect.2 - rect.0,
+            16 + 16 + 2,
+            "popup geometry should use the loaded 16-pixel cicn rows"
+        );
+        assert!(
+            disp.find_loaded_resource_any(*b"cicn", 275).is_some(),
+            "PopUpMenuSelect should materialize a nonresident item icon"
+        );
+        assert!(
+            screen_pixel_is_set(&bus, base, row_bytes, rect.1 + 4, rect.0 + 2),
+            "the popup should draw the application color icon"
         );
     }
 

--- a/src/trap/window.rs
+++ b/src/trap/window.rs
@@ -1662,6 +1662,84 @@ impl super::TrapDispatcher {
         matches!(proc_id, 0 | 4 | 8 | 12 | 16)
     }
 
+    /// Standard document WDEF close-box regions in global coordinates.
+    ///
+    /// The hit region is the 18-by-18 upper-left title-bar cell used by the
+    /// Window Manager. The visible System 7 close-box glyph is the inset
+    /// 11-by-11 shape drawn by `draw_window_chrome`.
+    fn standard_go_away_rects(
+        &self,
+        bus: &MacMemoryBus,
+        window_ptr: u32,
+    ) -> Option<((i16, i16, i16, i16), (i16, i16, i16, i16))> {
+        if window_ptr == 0
+            || !self.window_is_active_for_standard_go_away(bus, window_ptr)
+            || bus.read_byte(window_ptr + Self::WINDOW_HILITED_OFFSET) == 0
+            || bus.read_byte(window_ptr + Self::WINDOW_GO_AWAY_FLAG_OFFSET) == 0
+        {
+            return None;
+        }
+        let proc_id = self.window_proc_ids.get(&window_ptr).copied().unwrap_or(0);
+        if !Self::window_is_document_proc(proc_id) {
+            return None;
+        }
+
+        let (top, left, _, _) = self.window_global_port_rect(bus, window_ptr);
+        let menu_bar_height = bus.read_word(crate::memory::globals::addr::MBAR_HEIGHT) as i16;
+        let title_top = top.saturating_sub(18).max(menu_bar_height);
+        let hit_rect = (title_top, left, top, left.saturating_add(18));
+
+        // Keep this geometry identical to draw_window_chrome's standard
+        // document close box: title top is contentTop-19, followed by one
+        // interior pixel and vertical centering of an 11-pixel glyph.
+        let chrome_top = top.saturating_sub(19).max(menu_bar_height);
+        let chrome_bottom = top.saturating_sub(1);
+        let interior_top = chrome_top.saturating_add(1);
+        let interior_height = chrome_bottom.saturating_sub(interior_top);
+        let glyph_top = interior_top.saturating_add((interior_height - 11) / 2);
+        let glyph_left = left.saturating_add(8);
+        let highlight_rect = (
+            glyph_top,
+            glyph_left,
+            glyph_top.saturating_add(11),
+            glyph_left.saturating_add(11),
+        );
+        Some((hit_rect, highlight_rect))
+    }
+
+    fn window_is_active_for_standard_go_away(&self, bus: &MacMemoryBus, window_ptr: u32) -> bool {
+        let ghost_window = bus.read_long(crate::memory::globals::addr::GHOST_WINDOW);
+        for &candidate in &self.window_list {
+            if candidate == ghost_window || !self.window_visible(bus, candidate) {
+                continue;
+            }
+            if candidate == window_ptr {
+                return true;
+            }
+            if !self.window_is_custom_utility_layer_candidate(bus, candidate) {
+                return false;
+            }
+        }
+        false
+    }
+
+    pub(super) fn toggle_standard_go_away_highlight(
+        &self,
+        bus: &mut MacMemoryBus,
+        rect: (i16, i16, i16, i16),
+    ) {
+        // The standard WDEF toggles the close box with an XOR mask. Expanding
+        // by one feeds the exact glyph bounds through invert_button_rect,
+        // whose edge inset is otherwise intended for dialog buttons.
+        self.invert_button_rect(
+            bus,
+            rect.0.saturating_sub(1),
+            rect.1.saturating_sub(1),
+            rect.2.saturating_add(1),
+            rect.3.saturating_add(1),
+        );
+    }
+
     fn window_uses_save_under(&self, proc_id: i16) -> bool {
         !Self::window_is_document_proc(proc_id)
     }
@@ -1907,6 +1985,18 @@ impl super::TrapDispatcher {
             let (top, left, bottom, right) = self.window_global_port_rect(bus, window_ptr);
             if Self::point_in_rect(pt_v, pt_h, (top, left, bottom, right)) {
                 return (3, window_ptr);
+            }
+
+            // Only the active window exposes an operable go-away region.
+            // FindWindow returns inGoAway (6) for that region; applications
+            // then call TrackGoAway to own the click through mouse-up.
+            // Inside Macintosh Volume I (1985), pp. I-287 to I-288;
+            // Macintosh Toolbox Essentials (1992), pp. 4-43 to 4-46.
+            if self
+                .standard_go_away_rects(bus, window_ptr)
+                .is_some_and(|(hit_rect, _)| Self::point_in_rect(pt_v, pt_h, hit_rect))
+            {
+                return (6, window_ptr);
             }
 
             // The title/drag region sits above the content rect for ordinary
@@ -2725,6 +2815,13 @@ impl super::TrapDispatcher {
         {
             self.dialog_tracking = None;
         }
+        if self
+            .go_away_tracking
+            .as_ref()
+            .is_some_and(|tracking| tracking.window_ptr == window_ptr)
+        {
+            self.go_away_tracking = None;
+        }
         if self.front_window == window_ptr {
             // Promote the first VISIBLE window remaining in the list.
             // CloseWindow and DisposeWindow both route through
@@ -3342,7 +3439,7 @@ impl super::TrapDispatcher {
         window_ptr: u32,
         visible: bool,
     ) {
-        if !visible {
+        if !visible || !self.window_original_pixmaps.contains_key(&window_ptr) {
             return;
         }
 
@@ -3353,6 +3450,9 @@ impl super::TrapDispatcher {
         }
 
         let (top, left, bottom, right) = self.window_port_rect(bus, window_ptr);
+        let old_port = self.current_port;
+        let old_gdevice = self.current_gdevice;
+        self.set_current_port_state(bus, cpu, window_ptr, None);
         self.draw_rect(
             cpu,
             bus,
@@ -3364,6 +3464,7 @@ impl super::TrapDispatcher {
             },
             ShapeOp::Erase,
         );
+        self.set_current_port_state(bus, cpu, old_port, Some(old_gdevice));
     }
 
     pub(crate) fn dispatch_window<C: CpuOps>(
@@ -3935,6 +4036,7 @@ impl super::TrapDispatcher {
                     self.set_window_vis_from_content(bus, the_window, true);
                     if !was_visible {
                         self.save_window_under_pixels(bus, the_window);
+                        self.paint_new_window_content(bus, cpu, the_window, true);
                     }
                     if !was_visible {
                         if was_front {
@@ -3970,34 +4072,6 @@ impl super::TrapDispatcher {
                         if self.window_uses_custom_def_proc(bus, the_window) {
                             arm_custom_wdef_draw = !was_visible;
                         } else {
-                            let proc_id =
-                                self.window_proc_ids.get(&the_window).copied().unwrap_or(0);
-                            if !was_visible && matches!(proc_id, 1..=3) {
-                                if let Some((top, left, bottom, right)) =
-                                    self.window_content_global_rect(bus, the_window)
-                                {
-                                    let (
-                                        screen_base,
-                                        row_bytes,
-                                        screen_width,
-                                        screen_height,
-                                        pixel_size,
-                                    ) = self.get_screen_params();
-                                    Self::fb_fill_rect(
-                                        bus,
-                                        screen_base,
-                                        row_bytes,
-                                        pixel_size,
-                                        screen_width,
-                                        screen_height,
-                                        top,
-                                        left,
-                                        bottom,
-                                        right,
-                                        false,
-                                    );
-                                }
-                            }
                             self.draw_single_window_chrome_inline(bus, the_window, hilited);
                         }
                     }
@@ -4482,18 +4556,10 @@ impl super::TrapDispatcher {
             //     FUNCTION-typed traps; PROCEDUREs (DragWindow) just call
             //     MoveWindow at the final location
             //
-            // HLE compromise: DragWindow, DragGrayRgn, and DragTheRgn retain
-            // their traps across host presentation boundaries and follow the
-            // live mouse with the documented outline. TrackGoAway and
-            // GrowWindow still model only terminal state. Optional DragHook
-            // and region actionProc callbacks are not yet dispatched.
-            //
-            // The current behavior is:
-            //   - TrackGoAway → FALSE (user didn't release inside the
-            //     close box — equivalent to "user pressed close box but
-            //     dragged out before releasing"; correct semantic since
-            //     no click has actually happened yet from Systemless's
-            //     event model)
+            // The retained HLE behavior is:
+            //   - TrackGoAway → retain until release, toggle the standard
+            //     WDEF close-box highlight as the cursor crosses its hit
+            //     region, and return whether release occurred inside
             //   - DragWindow  → retain until release, then move by the
             //     release-start delta via MoveWindow semantics when the
             //     release point is inside boundsRect
@@ -4673,12 +4739,71 @@ impl super::TrapDispatcher {
 
             // TrackGoAway ($A91E)
             // FUNCTION TrackGoAway(theWindow: WindowPtr; thePt: Point): BOOLEAN;
-            // Inside Macintosh Volume I, I-294
-            // TrackGoAway ($A91E): Pops 8 args bytes + writes FALSE to 2-byte BOOLEAN result slot @ sp+8 per IM:I I-294 "TrackGoAway returns TRUE if the mouse is inside the go-away region when the mouse button is released, and FALSE otherwise" — HLE has no go-away-region hit-test / WaitMouseUp loop so FALSE matches "user pressed close box but didn't release inside it"
+            // Retains its Pascal frame through the Window Manager's tracking
+            // loop, toggles the standard WDEF's close-box XOR highlight, and
+            // writes TRUE iff mouse-up occurs inside the go-away region.
+            // Inside Macintosh Volume I (1985), pp. I-288 and I-294;
+            // Macintosh Toolbox Essentials (1992), pp. 4-103 to 4-104.
             (true, 0x11E) => {
+                if let Some(mut tracking) = self.go_away_tracking.take() {
+                    let mouse = self.window_tracking_mouse_pos(bus);
+                    let inside = Self::point_in_rect(mouse.0, mouse.1, tracking.hit_rect);
+                    if self.window_tracking_button_down(bus) {
+                        if inside != tracking.highlighted {
+                            self.toggle_standard_go_away_highlight(bus, tracking.highlight_rect);
+                            tracking.highlighted = inside;
+                        }
+                        cpu.write_reg(Register::A7, tracking.stack_ptr);
+                        self.go_away_tracking = Some(tracking);
+                        return Some(Ok(()));
+                    }
+
+                    if tracking.highlighted {
+                        self.toggle_standard_go_away_highlight(bus, tracking.highlight_rect);
+                    }
+                    // Mouse-up belongs to TrackGoAway's private loop rather
+                    // than the application's next Event Manager call.
+                    if let Some(index) = self.event_queue.iter().position(|event| event.what == 2) {
+                        self.event_queue.remove(index);
+                    }
+                    // Mac Pascal BOOLEAN occupies the high byte of its
+                    // two-byte result slot (TRUE = $0100).
+                    bus.write_word(tracking.stack_ptr + 8, if inside { 0x0100 } else { 0 });
+                    cpu.write_reg(Register::A7, tracking.stack_ptr + 8);
+                    return Some(Ok(()));
+                }
+
                 let sp = cpu.read_reg(Register::A7);
-                bus.write_word(sp + 8, 0);
-                cpu.write_reg(Register::A7, sp + 8);
+                let the_window = bus.read_long(sp + 4);
+                let initial_point = (bus.read_word(sp) as i16, bus.read_word(sp + 2) as i16);
+                let Some((hit_rect, highlight_rect)) = self.standard_go_away_rects(bus, the_window)
+                else {
+                    bus.write_word(sp + 8, 0);
+                    cpu.write_reg(Register::A7, sp + 8);
+                    return Some(Ok(()));
+                };
+
+                if !Self::point_in_rect(initial_point.0, initial_point.1, hit_rect)
+                    || !self.window_tracking_button_down(bus)
+                {
+                    bus.write_word(sp + 8, 0);
+                    cpu.write_reg(Register::A7, sp + 8);
+                    return Some(Ok(()));
+                }
+
+                let mouse = self.window_tracking_mouse_pos(bus);
+                let highlighted = Self::point_in_rect(mouse.0, mouse.1, hit_rect);
+                if highlighted {
+                    self.toggle_standard_go_away_highlight(bus, highlight_rect);
+                }
+                self.go_away_tracking = Some(super::dispatch::GoAwayTrackingState {
+                    window_ptr: the_window,
+                    stack_ptr: sp,
+                    hit_rect,
+                    highlight_rect,
+                    highlighted,
+                });
+                cpu.write_reg(Register::A7, sp);
                 Ok(())
             }
 
@@ -4746,10 +4871,11 @@ impl super::TrapDispatcher {
                 let show_flag = bus.read_byte(sp) != 0;
                 let the_window = bus.read_long(sp + 2);
                 if the_window != 0 {
+                    let was_visible = self.window_visible(bus, the_window);
                     if !show_flag {
                         self.dialog_visible_snapshots.remove(&the_window);
                     }
-                    let exposed_rect = (!show_flag && self.window_visible(bus, the_window))
+                    let exposed_rect = (!show_flag && was_visible)
                         .then(|| self.window_structure_rect(bus, the_window))
                         .flatten();
                     let windows_behind = if exposed_rect.is_some() {
@@ -4763,6 +4889,19 @@ impl super::TrapDispatcher {
                     );
                     self.set_window_vis_from_content(bus, the_window, show_flag);
                     if show_flag {
+                        if !was_visible {
+                            self.save_window_under_pixels(bus, the_window);
+                            self.paint_new_window_content(bus, cpu, the_window, true);
+                        }
+                        if self.front_window == 0 || !self.window_visible(bus, self.front_window) {
+                            // ShowHide deliberately leaves z-order and
+                            // activation events alone (IM:I I-285), but the
+                            // Window Manager's internal active-window cache
+                            // must recover after the last visible window was
+                            // hidden and a window is later revealed.
+                            self.front_window = self.front_window_for_internal_state(bus);
+                            self.sync_cached_front_window_render_state(bus);
+                        }
                         if let Some(content_rect) = self.window_content_global_rect(bus, the_window)
                         {
                             Self::write_region_handle_rect(
@@ -8399,6 +8538,54 @@ mod tests {
     }
 
     #[test]
+    fn showwindow_erases_newly_exposed_content_with_window_background() {
+        // PaintOne erases exposed content before the application receives its
+        // update event. Inside Macintosh Volume I (1985), pp. I-278, I-296.
+        let (mut disp, mut cpu, mut bus) = setup();
+        let screen_base = bus.alloc(800 * 600);
+        bus.write_long(crate::memory::globals::addr::SCREEN_BITS, screen_base);
+        disp.set_screen_mode_for_test(screen_base, 800, 800, 600, 8);
+
+        let window = bus.alloc(256);
+        disp.init_cgraf_window(
+            &mut bus,
+            &mut cpu,
+            window,
+            screen_base,
+            100,
+            200,
+            300,
+            500,
+            "Hidden",
+            4,
+            false,
+            false,
+            true,
+            0,
+        );
+        let probe = screen_base + 150 * 800 + 323;
+        bus.write_byte(probe, 0x42);
+
+        let previous_port = disp.current_port;
+        let sp = TEST_SP - 4;
+        cpu.write_reg(Register::A7, sp);
+        bus.write_long(sp, window);
+        dispatch(&mut disp, 0x115, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+
+        assert_ne!(
+            bus.read_byte(probe),
+            0x42,
+            "ShowWindow must erase stale pixels across the whole revealed content area"
+        );
+        assert_eq!(
+            disp.current_port, previous_port,
+            "Window Manager painting must restore the application's current port"
+        );
+    }
+
+    #[test]
     fn showwindow_hidden_frontmost_window_queues_activate_event() {
         let (mut disp, mut cpu, mut bus) = setup();
         let window = bus.alloc(256);
@@ -9027,6 +9214,59 @@ mod tests {
             disp.window_update_rect(&bus, window),
             Some((100, 200, 300, 500)),
             "ShowHide(TRUE) should invalidate revealed content in global coordinates"
+        );
+    }
+
+    #[test]
+    fn showhide_true_erases_content_and_recovers_stale_front_window_cache() {
+        // ShowHide does not reorder or generate activation events, but showing
+        // a window still runs the Window Manager's PaintOne erase and makes a
+        // visible window available to its internal front-window state.
+        // Inside Macintosh Volume I (1985), pp. I-278, I-285, I-296.
+        let (mut disp, mut cpu, mut bus) = setup();
+        let screen_base = bus.alloc(800 * 600);
+        bus.write_long(crate::memory::globals::addr::SCREEN_BITS, screen_base);
+        disp.set_screen_mode_for_test(screen_base, 800, 800, 600, 8);
+
+        let window = bus.alloc(256);
+        disp.init_cgraf_window(
+            &mut bus,
+            &mut cpu,
+            window,
+            screen_base,
+            100,
+            200,
+            300,
+            500,
+            "Hidden",
+            4,
+            false,
+            false,
+            true,
+            0,
+        );
+        disp.front_window = 0;
+        disp.event_queue.clear();
+        let probe = screen_base + 150 * 800 + 323;
+        bus.write_byte(probe, 0x42);
+
+        let sp = TEST_SP - 6;
+        cpu.write_reg(Register::A7, sp);
+        bus.write_byte(sp, 1);
+        bus.write_long(sp + 2, window);
+        dispatch(&mut disp, 0x108, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+
+        assert_ne!(
+            bus.read_byte(probe),
+            0x42,
+            "ShowHide(TRUE) must erase stale pixels before the application's update"
+        );
+        assert_eq!(disp.front_window, window);
+        assert!(
+            disp.event_queue.iter().all(|event| event.what != 8),
+            "ShowHide must not synthesize activate or deactivate events"
         );
     }
 
@@ -9871,6 +10111,119 @@ mod tests {
         // Verify whichWindow was written
         let which_window = bus.read_long(wnd_ptr_ptr);
         assert_eq!(which_window, window_addr);
+    }
+
+    #[test]
+    fn findwindow_reports_ingoaway_for_active_document_close_box() {
+        // MTE 1992 pp. 4-43 to 4-46: the active document window's close
+        // region is reported as inGoAway (6), not inDrag (4).
+        let (mut disp, mut cpu, mut bus) = setup();
+        bus.write_word(crate::memory::globals::addr::MBAR_HEIGHT, 20);
+        let window = bus.alloc(256);
+        disp.init_cgraf_window(
+            &mut bus,
+            &mut cpu,
+            window,
+            disp.screen_mode.0,
+            100,
+            100,
+            260,
+            360,
+            "Document",
+            0,
+            true,
+            false,
+            true,
+            0,
+        );
+        disp.front_window = window;
+        disp.window_list = vec![window];
+        bus.write_byte(
+            window + super::super::TrapDispatcher::WINDOW_HILITED_OFFSET,
+            0xFF,
+        );
+
+        let which_window = bus.alloc(4);
+        let sp = TEST_SP - 10;
+        cpu.write_reg(Register::A7, sp);
+        bus.write_long(sp, which_window);
+        bus.write_word(sp + 4, 85); // inside [contentTop-18, contentTop)
+        bus.write_word(sp + 6, 105); // inside [contentLeft, contentLeft+18)
+        bus.write_word(sp + 8, 0);
+
+        dispatch(&mut disp, 0x12C, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+        assert_eq!(cpu.read_reg(Register::A7), sp + 8);
+        assert_eq!(bus.read_word(sp + 8), 6);
+        assert_eq!(bus.read_long(which_window), window);
+    }
+
+    #[test]
+    fn findwindow_reports_ingoaway_for_active_document_behind_floating_utility() {
+        // Floating utility windows stay visually above the active document;
+        // they do not disable that document's close box. Macintosh Human
+        // Interface Guidelines (1992), pp. 137, 144.
+        let (mut disp, mut cpu, mut bus) = setup();
+        bus.write_word(crate::memory::globals::addr::MBAR_HEIGHT, 20);
+        install_wdef_resource(&mut disp, &mut bus, 200);
+
+        let utility = bus.alloc(256);
+        disp.init_cgraf_window(
+            &mut bus,
+            &mut cpu,
+            utility,
+            disp.screen_mode.0,
+            300,
+            300,
+            380,
+            500,
+            "",
+            200i16 << 4,
+            true,
+            false,
+            false,
+            0,
+        );
+        let document = bus.alloc(256);
+        disp.init_cgraf_window(
+            &mut bus,
+            &mut cpu,
+            document,
+            disp.screen_mode.0,
+            100,
+            100,
+            260,
+            360,
+            "Document",
+            4,
+            true,
+            false,
+            true,
+            0,
+        );
+        disp.apply_behind_parameter(&mut bus, document, utility);
+
+        assert_eq!(disp.window_list, vec![utility, document]);
+        assert_eq!(disp.front_window, document);
+        assert_eq!(
+            bus.read_byte(document + super::super::TrapDispatcher::WINDOW_HILITED_OFFSET),
+            0xFF
+        );
+
+        let which_window = bus.alloc(4);
+        let sp = TEST_SP - 10;
+        cpu.write_reg(Register::A7, sp);
+        bus.write_long(sp, which_window);
+        bus.write_word(sp + 4, 85);
+        bus.write_word(sp + 6, 105);
+        bus.write_word(sp + 8, 0);
+
+        dispatch(&mut disp, 0x12C, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+        assert_eq!(bus.read_word(sp + 8), 6);
+        assert_eq!(bus.read_long(which_window), document);
     }
 
     #[test]
@@ -12110,7 +12463,7 @@ mod tests {
 
     // IM:I p.I-294 (signature/call-frame summary on p.I-91):
     // TrackGoAway returns TRUE only when mouse-up lands inside the go-away
-    // box; no-tracking path returns FALSE and still consumes its arguments.
+    // box; an invalid/no-tracking call returns FALSE and still consumes args.
     #[test]
     fn trackgoaway_returns_false_and_consumes_window_and_point_arguments() {
         let (mut disp, mut cpu, mut bus) = setup();
@@ -12125,6 +12478,116 @@ mod tests {
         assert!(result.unwrap().is_ok());
         assert_eq!(cpu.read_reg(Register::A7), TEST_SP);
         assert_eq!(bus.read_word(TEST_SP), 0);
+    }
+
+    #[test]
+    fn trackgoaway_retains_until_mouseup_and_returns_true_inside_close_box() {
+        // MTE 1992 pp. 4-103 to 4-104: TrackGoAway keeps control while the
+        // button is held, highlights inside the region, removes highlighting
+        // at release, and returns TRUE for an inside release.
+        let (mut disp, mut cpu, mut bus) = setup();
+        bus.write_word(crate::memory::globals::addr::MBAR_HEIGHT, 20);
+        let window = bus.alloc(256);
+        disp.init_cgraf_window(
+            &mut bus,
+            &mut cpu,
+            window,
+            disp.screen_mode.0,
+            100,
+            100,
+            260,
+            360,
+            "Document",
+            0,
+            true,
+            false,
+            true,
+            0,
+        );
+        disp.front_window = window;
+        disp.window_list = vec![window];
+        bus.write_byte(
+            window + super::super::TrapDispatcher::WINDOW_HILITED_OFFSET,
+            0xFF,
+        );
+
+        let sp = TEST_SP - 8;
+        cpu.write_reg(Register::A7, sp);
+        bus.write_word(sp, 85);
+        bus.write_word(sp + 2, 105);
+        bus.write_long(sp + 4, window);
+        bus.write_word(sp + 8, 0xDEAD);
+        disp.push_mouse_down(85, 105);
+        disp.event_queue.pop_front(); // application already received mouseDown
+
+        dispatch(&mut disp, 0x11E, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+        assert_eq!(cpu.read_reg(Register::A7), sp);
+        assert!(disp.go_away_tracking.is_some());
+        assert!(disp.is_tracking_refire(0xA91E));
+
+        disp.push_mouse_up(85, 105);
+        dispatch(&mut disp, 0x11E, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+        assert_eq!(cpu.read_reg(Register::A7), sp + 8);
+        assert_eq!(bus.read_word(sp + 8), 0x0100);
+        assert!(disp.go_away_tracking.is_none());
+        assert!(disp.event_queue.iter().all(|event| event.what != 2));
+    }
+
+    #[test]
+    fn trackgoaway_unhighlights_and_returns_false_after_dragging_out() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        bus.write_word(crate::memory::globals::addr::MBAR_HEIGHT, 20);
+        let window = bus.alloc(256);
+        disp.init_cgraf_window(
+            &mut bus,
+            &mut cpu,
+            window,
+            disp.screen_mode.0,
+            100,
+            100,
+            260,
+            360,
+            "Document",
+            0,
+            true,
+            false,
+            true,
+            0,
+        );
+        disp.front_window = window;
+        disp.window_list = vec![window];
+        bus.write_byte(
+            window + super::super::TrapDispatcher::WINDOW_HILITED_OFFSET,
+            0xFF,
+        );
+
+        let sp = TEST_SP - 8;
+        cpu.write_reg(Register::A7, sp);
+        bus.write_word(sp, 85);
+        bus.write_word(sp + 2, 105);
+        bus.write_long(sp + 4, window);
+        disp.push_mouse_down(85, 105);
+        disp.event_queue.pop_front();
+        dispatch(&mut disp, 0x11E, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+
+        disp.set_mouse_position(130, 200);
+        dispatch(&mut disp, 0x11E, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+        assert!(!disp.go_away_tracking.as_ref().unwrap().highlighted);
+
+        disp.push_mouse_up(130, 200);
+        dispatch(&mut disp, 0x11E, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+        assert_eq!(cpu.read_reg(Register::A7), sp + 8);
+        assert_eq!(bus.read_word(sp + 8), 0);
     }
 
     // ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

- redraw TextEdit contents synchronously from `TEKey`
- implement retained classic close-box tracking and repair window exposure, visibility, clipping, and active-document behavior
- fault in popup color icons before layout and remap each icon ColorTable through the active display device
- default desktop presentation to a physical 1:1 guest-to-host pixel ratio, with explicit integer scaling via `--display-scale`

## Validation

- `cargo test`
- `cargo check --no-default-features`
- `cargo check --target wasm32-unknown-unknown --lib`
- deterministic registration, About-window close, popup-icon, Map, Buy/Sell, z-order, and drag replays compared with BasiliskII

Human visual validation is requested. This PR intentionally leaves the issue open.

Refs #802