### PR TITLE
perf(render): row-bulk the 8bpp draw primitives

### DIFF
--- a/src/trap/framebuffer.rs
+++ b/src/trap/framebuffer.rs
@@ -1573,9 +1573,7 @@ impl super::TrapDispatcher {
                 Self::logical_white_pixel_index(bus)
             };
             let row_addr = screen_base + (y as u32) * row_bytes;
-            for x in left..right {
-                bus.write_byte(row_addr + x, fill);
-            }
+            bus.fill_bytes(row_addr + left, right - left, fill);
             return;
         }
         for x in x1..x2 {
@@ -2949,13 +2947,18 @@ impl super::TrapDispatcher {
                     8,
                     8,
                 );
+                // Row-buffered: one bulk read, a host-side table pass and
+                // one bulk write per row instead of two bus calls per pixel.
+                let mut src_row = vec![0u8; bounded_col_count as usize];
+                let mut dst_row = vec![0u8; bounded_col_count as usize];
                 for row in 0..bounded_row_count {
                     let src_addr = port_base + (src_y_offset + row) * port_rb + src_x_offset;
                     let dst_addr = screen_base + (dst_y + row) * screen_rb + dst_x;
-                    for col in 0..bounded_col_count {
-                        let src_idx = bus.read_byte(src_addr + col);
-                        bus.write_byte(dst_addr + col, translation[src_idx as usize]);
+                    bus.read_bytes_into(src_addr, &mut src_row);
+                    for (dst, src) in dst_row.iter_mut().zip(src_row.iter()) {
+                        *dst = translation[*src as usize];
                     }
+                    bus.write_bytes(dst_addr, &dst_row);
                 }
                 return;
             }
@@ -3026,15 +3029,32 @@ impl super::TrapDispatcher {
             let dst_pixel_size = u32::from(pixel_size);
             let dst_pixels_per_byte = 8 / dst_pixel_size;
             let dst_field_mask = ((1u16 << dst_pixel_size) - 1) as u8;
+            if row_count == 0 || col_count == 0 {
+                return;
+            }
+            // Row-buffered: bulk-read the source span (and, for a packed
+            // destination, the destination span the pixels merge into),
+            // repack against host buffers, one bulk write per row — instead
+            // of one or two bus calls per pixel.
+            let src_first = (src_x_offset / src_pixels_per_byte) as usize;
+            let src_last = ((src_x_offset + col_count - 1) / src_pixels_per_byte) as usize;
+            let dst_first = (dst_x / dst_pixels_per_byte) as usize;
+            let dst_last = ((dst_x + col_count - 1) / dst_pixels_per_byte) as usize;
+            let mut src_buf = vec![0u8; src_last - src_first + 1];
+            let mut dst_buf = vec![0u8; dst_last - dst_first + 1];
             for row in 0..row_count {
                 let src_row = port_base + (src_y_offset + row) * port_rb;
                 let dst_row = screen_base + (dst_y + row) * screen_rb;
+                bus.read_bytes_into(src_row + src_first as u32, &mut src_buf);
+                if dst_pixel_size != 8 {
+                    bus.read_bytes_into(dst_row + dst_first as u32, &mut dst_buf);
+                }
                 for col in 0..col_count {
                     let src_x = src_x_offset + col;
                     let src_index = if port_pixel_size == 8 {
-                        bus.read_byte(src_row + src_x)
+                        src_buf[src_x as usize - src_first]
                     } else {
-                        let src_byte = bus.read_byte(src_row + src_x / src_pixels_per_byte);
+                        let src_byte = src_buf[(src_x / src_pixels_per_byte) as usize - src_first];
                         let src_shift =
                             8 - port_pixel_size - (src_x % src_pixels_per_byte) * port_pixel_size;
                         (src_byte >> src_shift) & src_field_mask
@@ -3050,17 +3070,17 @@ impl super::TrapDispatcher {
                         .map_or(src_index, |translation| translation[src_index as usize]);
                     let dst_x = dst_x + col;
                     if dst_pixel_size == 8 {
-                        bus.write_byte(dst_row + dst_x, dst_index);
+                        dst_buf[dst_x as usize - dst_first] = dst_index;
                     } else {
                         debug_assert!(dst_index <= dst_field_mask);
-                        let dst_addr = dst_row + dst_x / dst_pixels_per_byte;
+                        let index = (dst_x / dst_pixels_per_byte) as usize - dst_first;
                         let dst_shift =
                             8 - dst_pixel_size - (dst_x % dst_pixels_per_byte) * dst_pixel_size;
                         let dst_mask = dst_field_mask << dst_shift;
-                        let dst_byte = bus.read_byte(dst_addr);
-                        bus.write_byte(dst_addr, (dst_byte & !dst_mask) | (dst_index << dst_shift));
+                        dst_buf[index] = (dst_buf[index] & !dst_mask) | (dst_index << dst_shift);
                     }
                 }
+                bus.write_bytes(dst_row + dst_first as u32, &dst_buf);
             }
             return;
         }

--- a/src/trap/window.rs
+++ b/src/trap/window.rs
@@ -1431,27 +1431,39 @@ impl super::TrapDispatcher {
 
         let width = right - left;
         let height = bottom - top;
-        let mut pixels = Vec::with_capacity(width as usize * height as usize);
-        for y in top..bottom {
-            for x in left..right {
-                match pixel_size {
-                    8 => {
-                        pixels.push(bus.read_byte(screen_base + y as u32 * row_bytes + x as u32));
-                    }
-                    bits @ (2 | 4) => {
-                        let pixels_per_byte = 8 / u32::from(bits);
+        let width_u = width as usize;
+        let mut pixels = vec![0u8; width_u * height as usize];
+        match pixel_size {
+            8 => {
+                // One bulk read per row instead of one bus call per
+                // pixel; `pixels` is already row-major over the rect.
+                for (row, y) in (top..bottom).enumerate() {
+                    let start = screen_base + y as u32 * row_bytes + left as u32;
+                    bus.read_bytes_into(start, &mut pixels[row * width_u..(row + 1) * width_u]);
+                }
+            }
+            bits @ (2 | 4) => {
+                let pixels_per_byte = 8 / u32::from(bits);
+                let mut idx = 0usize;
+                for y in top..bottom {
+                    for x in left..right {
                         let byte_offset = y as u32 * row_bytes + x as u32 / pixels_per_byte;
                         let shift =
                             8 - u32::from(bits) - (x as u32 % pixels_per_byte) * u32::from(bits);
-                        pixels.push(
-                            (bus.read_byte(screen_base + byte_offset) >> shift)
-                                & ((1u8 << bits) - 1),
-                        );
+                        pixels[idx] = (bus.read_byte(screen_base + byte_offset) >> shift)
+                            & ((1u8 << bits) - 1);
+                        idx += 1;
                     }
-                    _ => {
+                }
+            }
+            _ => {
+                let mut idx = 0usize;
+                for y in top..bottom {
+                    for x in left..right {
                         let byte_offset = y as u32 * row_bytes + x as u32 / 8;
                         let bit = 7 - (x as u32 % 8);
-                        pixels.push((bus.read_byte(screen_base + byte_offset) >> bit) & 1);
+                        pixels[idx] = (bus.read_byte(screen_base + byte_offset) >> bit) & 1;
+                        idx += 1;
                     }
                 }
             }
@@ -1471,6 +1483,36 @@ impl super::TrapDispatcher {
     ) {
         let (screen_base, row_bytes, screen_width, screen_height, pixel_size) =
             self.get_screen_params();
+        if pixel_size == 8 && width > 0 && height > 0 {
+            // One bulk write per on-screen row instead of one bus call
+            // per pixel. `pixels` is row-major over the rect; off-screen
+            // columns are clipped while the index still advances, and a
+            // truncated buffer stops the writes exactly where the
+            // per-pixel loop below would.
+            let x0 = dst_left.max(0).min(screen_width);
+            let x1 = dst_left.saturating_add(width).min(screen_width);
+            if x1 <= x0 {
+                return;
+            }
+            let width_u = width as usize;
+            for dy in 0..height {
+                let y = dst_top + dy;
+                if y < 0 || y >= screen_height {
+                    continue;
+                }
+                let row_base = dy as usize * width_u;
+                if row_base >= pixels.len() {
+                    return;
+                }
+                let s = row_base + (x0 - dst_left) as usize;
+                let e = (row_base + (x1 - dst_left) as usize).min(pixels.len());
+                if s < e {
+                    let addr = screen_base + y as u32 * row_bytes + x0 as u32;
+                    bus.write_bytes(addr, &pixels[s..e]);
+                }
+            }
+            return;
+        }
         let mut idx = 0usize;
         for dy in 0..height {
             let y = dst_top + dy;


### PR DESCRIPTION
From Claude Fable 5, working with @rlanday.

## What

Five 8-bit framebuffer primitives made one bus call per pixel; they now make one bulk call per row through the slice fast paths the bus already has (`read_bytes_into`, `write_bytes`, `fill_bytes` — one address translation and one `memcpy`/`memset` per call, the same paths `BlockMove` and the same-depth window blit already use):

- `save_screen_rect_pixels` (8bpp): one `read_bytes_into` per row instead of a `read_byte` per pixel. The packed 2/4bpp path keeps its per-pixel unpacking.
- `restore_screen_rect_pixels` (8bpp): one `write_bytes` per on-screen row; off-screen columns are clipped and a truncated pixel buffer stops exactly where the per-pixel loop stopped.
- `fb_hline` (8bpp): one `fill_bytes`.
- `blit_window_to_screen`: the 8bpp palette-translation loop and the generalised packed-depth loop (any 1/2/4/8-bit port to any 1/2/4/8-bit screen, from 17fb5af) each read the source row's span once — and, for a packed destination, the destination span the pixels merge into — repack against host buffers, and write the row once.

Every bus call pays address translation, the read-only-code check and the idle-probe journal check, so a 560-pixel title-bar border was 560 full-cost calls to store one constant. `fb_fill_rect`, `fb_fill_pattern_rect` and `restore_dialog_pixels` were already row-bulk; this brings the rest of the 8bpp family in line. No caller changes, no behavioural change: the conversions write the same guest bytes in the same order per row.

## Why it matters

`redraw_chrome` runs after every host frame. SimCity 2000 plays with the menu bar visible (MBarHeight stays 20, its main window sits at left=40, so the fullscreen gates never fire), which means the menu-bar repaint and the per-window save/paint/restore pass run every frame, all through these primitives. In a steady-state profile of the game (below) `save_screen_rect_pixels` and `redraw_chrome` (with `restore_screen_rect_pixels` inlined into it) were 2.9% and 3.3% of the main thread's self time, and `MacMemoryBus::write_byte` — mostly their per-pixel stores — 8.7%. Guest `CopyBits` into an offscreen window port, dialog restores and drag outlines go through the same primitives.

## Evidence

**Instrument.** Headless SimCity 2000 (`--headless --max-instructions N --input-script`, the input replay from #824 clicks through the founding dialogs into a running city), so both arms execute identical guest work; the check is the guest tick count printed at exit, identical in every run below. Metric: host **instructions retired** for the whole process from `/usr/bin/time -l` — unlike wall or CPU time it does not move with machine load. Six pairs per run length, arms interleaved and order alternated per pair (A B, B A, …); the figure quoted is the geometric mean of the within-pair ratios, with the pair range and the number of pairs the change won.

**Arms.** Base = upstream master at 0.20.5 (1013a0e) plus one local runner fix carried in *both* arms (d2357f7, wait-identity proofs compare architectural CPU state only — it only affects which idle cycles the prover accepts and is unrelated to drawing); candidate = the same plus this commit. The PR is rebased onto 0.20.6, whose only other change is in the PowerPC loader.

| SimCity 2000 | base | this PR | Δ | pairs won |
|---|---|---|---|---|
| 400M instructions (boot + into the game) | 127.45 G | 114.97 G | **−9.8 %** (ratios 0.901–0.903) | 6/6 |
| 2B instructions | 569.18 G | 504.51 G | **−11.4 %** (0.886–0.888) | 6/6 |
| warm window (2B − 400M, 1.6 B guest instr) | 441.7 G ≈ 276 host/guest | 389.5 G ≈ 243 host/guest | **−11.8 %** | |

Guest ticks: 128,460 at 400M and 283,023 at 2B in all 24 runs.

**EV Override** (same instrument, the #824 click path into flight, 4 pairs per length): headless EV is not tick-deterministic on this base (its default pilot name is clock-seeded; base tick counts spread 2.6 % run to run), so the comparison is host instructions **per guest tick**: 204.3k vs 204.6k at 400M and 354.6k vs 355.3k at 2B — **neutral** (+0.2 %, inside the run-to-run noise). Expected: EV's play windows are created with MBarHeight = 0 (its `[WINDOW-INIT]` lines in the run log show the 800×600 game window followed by windows opened at `MBarHeight=0`), and `redraw_chrome` skips the menu-bar and window-chrome passes whenever MBarHeight is 0, so the converted paths barely run there.

**Re-measured after the rebase onto master 17fb5af** (which rewrote `blit_window_to_screen` into the generalised loop above; this PR's blit change was re-ported onto it). Same instrument, both arms *pure* master with no local fixes: base = 17fb5af, candidate = 17fb5af + this commit.

| SimCity 2000 (master 17fb5af) | base | this PR | Δ | pairs won |
|---|---|---|---|---|
| 400M instructions | 180.12 G | 165.22 G | **−8.27 %** (ratios 0.915–0.920) | 6/6 |
| 2B instructions | 838.00 G | 764.19 G | **−8.82 %** (0.903–0.926) | 6/6 |

Guest ticks 111,771 / 266,066 in all 24 runs. (Pure master does far more host work per guest instruction than the base above — its idle-cycle prover fails on JIT-touched wait loops without the local runner fix — so the same saving is a smaller share here; the absolute saving per run is larger.)

**Identity.** Both binaries run the same 130M-instruction SC2K script with a screenshot every 500K instructions: all 261 screenshots are byte-identical between base and this PR — on the measurement base (ticks 102,146 in both) and again on pure master 17fb5af after the rebase (ticks 85,511 in both) — the conversions write exactly the guest bytes the per-pixel loops wrote.

**Profile.** `/usr/bin/sample` at 1 ms for 5 s, attached 45 s into a 2B run (steady city play), main thread, share of self-time samples ("Sort by top of stack"; the process is unpaced and never idle in headless mode, so no blocking-wait filter is needed). Base, 3,530 samples: `run_steps_internal` 34.7 % (m68k's interpreter inlined into it), `execute_mem_op` 13.2 %, `MacMemoryBus::write_byte` **8.7 %**, `read_word` 5.3 %, `redraw_chrome` **3.3 %** (with `restore_screen_rect_pixels` inlined), `save_screen_rect_pixels` **2.9 %**. This PR, 3,431 samples: `write_byte` **2.7 %**, and neither `redraw_chrome` nor `save_screen_rect_pixels` appears in the top-of-stack list any more; grouped, the memory-bus accessors go 18.5 → 14.4 %, trap dispatch 7.3 → 4.7 %, QuickDraw/blit 5.9 → 3.2 %. What remains of the chrome pass is the title text (`fb_draw_string` through per-pixel `fb_set_pixel`) and the one-pixel-wide vertical borders, which are not row work.

## Tests

- `cargo test --lib --features test-support` on this branch (master 17fb5af): 4,209 passed, 0 failed, 3 ignored (4,144 on 0.20.6 before the rebase). The suite covers every converted path pixel-exactly, including 17fb5af's new packed-depth blit tests (1→2, 2→1, 2→2, 2→8, 4→2 bpp, odd edges, row padding): `save`/`restore_screen_rect_pixels` through the window-chrome and dialog tests, `fb_hline` through the frame tests, and `blit_window_to_screen`'s translation and packed-depth paths through the `redraw_chrome_blit_*` tests.
- `cargo fmt --check` clean on the touched files. `cargo clippy --all-targets --all-features`: no finding inside the changed lines; the only errors it reports are five pre-existing `erasing_op` hits in `src/loader/ppc.rs` from 0.20.6, identical on master.
- `cargo check --no-default-features`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ng5oTbT6MzdjV92Fd1qoE
