### PR TITLE
fix: support PPC packed indexed display depths

### DIFF
--- a/src/bin/desktop/metal_present.metal
+++ b/src/bin/desktop/metal_present.metal
@@ -86,10 +86,15 @@ fragment float4 guest_raster_fragment(
         uchar packed = framebuffer[y * frame.row_bytes + x / 2];
         uint index = (x & 1) == 0 ? packed >> 4 : packed & 0x0F;
         argb = palette[index];
+    } else if (frame.pixel_size == 2) {
+        uchar packed = framebuffer[y * frame.row_bytes + x / 4];
+        uint shift = 6 - 2 * (x & 3);
+        uint index = (packed >> shift) & 0x03;
+        argb = palette[index];
     } else {
         uchar packed = framebuffer[y * frame.row_bytes + x / 8];
-        bool black = (packed & (0x80 >> (x & 7))) != 0;
-        argb = black ? 0xFF000000 : 0xFFFFFFFF;
+        uint index = (packed >> (7 - (x & 7))) & 0x01;
+        argb = palette[index];
     }
 
     int cursor_x = int(x) - frame.cursor_left;

--- a/src/bin/desktop/metal_present.rs
+++ b/src/bin/desktop/metal_present.rs
@@ -675,9 +675,9 @@ impl MetalPresenter {
         let screen_height = u32::from(height);
         let (content_left, content_top, width, height) = content_rect;
         let (drawable_width, drawable_height) = drawable_size;
-        if !matches!(pixel_size, 1 | 4 | 8) {
+        let Some(packed_content_left) = guest_packed_content_left(pixel_size, content_left) else {
             return Ok(false);
-        }
+        };
         if content_left.saturating_add(width) > screen_width
             || content_top.saturating_add(height) > screen_height
         {
@@ -704,11 +704,6 @@ impl MetalPresenter {
         let (mut uniforms, cursor_data) = cursor
             .map(|(image, position)| guest_cursor_data(Some(image), position))
             .unwrap_or_else(|| guest_cursor_data(None, (0, 0)));
-        let packed_content_left = match pixel_size {
-            1 => content_left & 7,
-            4 => content_left & 1,
-            _ => 0,
-        };
         let packed_origin_left = content_left - packed_content_left;
         uniforms.row_bytes = u32::try_from(visible_layout.visible_row_bytes)
             .map_err(|_| "visible guest row stride exceeds Metal's limit".to_string())?;
@@ -1081,6 +1076,16 @@ fn guest_frame_byte_len(row_bytes: u32, screen_height: u32) -> Option<usize> {
         .checked_mul(screen_height as usize)
 }
 
+fn guest_packed_content_left(pixel_size: u16, content_left: u32) -> Option<u32> {
+    match pixel_size {
+        1 => Some(content_left & 7),
+        2 => Some(content_left & 3),
+        4 => Some(content_left & 1),
+        8 => Some(0),
+        _ => None,
+    }
+}
+
 #[derive(Clone, Copy)]
 struct GuestVisibleByteLayout {
     first_row_offset: usize,
@@ -1099,7 +1104,7 @@ fn guest_visible_byte_layout(
 ) -> Option<GuestVisibleByteLayout> {
     let row_stride = usize::try_from(row_bytes).ok()?;
     let (first_byte, byte_end) = match pixel_size {
-        1 | 4 => {
+        1 | 2 | 4 => {
             let pixels_per_byte = 8 / u32::from(pixel_size);
             (
                 usize::try_from(left / pixels_per_byte).ok()?,
@@ -1202,8 +1207,9 @@ fn copy_guest_visible_pixels_to_ptr(
 mod tests {
     use super::{
         aspect_fit_viewport, copy_guest_visible_pixels, guest_cursor_data,
-        guest_visible_byte_layout, guest_visible_pixels_equal, replace_pending_guest_frame,
-        GuestCursorData, GuestFrameMailboxState, GuestFrameMetadata, GuestFrameUniforms,
+        guest_packed_content_left, guest_visible_byte_layout, guest_visible_pixels_equal,
+        replace_pending_guest_frame, GuestCursorData, GuestFrameMailboxState, GuestFrameMetadata,
+        GuestFrameUniforms,
     };
     use systemless::display::CursorImage;
 
@@ -1232,6 +1238,35 @@ mod tests {
         assert_eq!(layout.row_stride, 400);
         assert_eq!(layout.visible_row_bytes, 160);
         assert_eq!(layout.row_count, 20);
+    }
+
+    #[test]
+    fn cropped_two_bit_presentation_keeps_msb_aligned_metadata_and_rows() {
+        let layout = guest_visible_byte_layout(200, 2, 5, 10, 319, 20).unwrap();
+        assert_eq!(guest_packed_content_left(2, 5), Some(1));
+        assert_eq!(layout.first_row_offset, 2_001);
+        assert_eq!(layout.row_stride, 200);
+        assert_eq!(layout.visible_row_bytes, 80);
+        assert_eq!(layout.row_count, 20);
+    }
+
+    #[test]
+    fn guest_shader_decodes_two_bit_and_monochrome_pixels_through_the_palette() {
+        let shader = include_str!("metal_present.metal");
+        let (_, after_two_bit_header) = shader
+            .split_once("} else if (frame.pixel_size == 2) {")
+            .expect("guest shader must have an explicit 2bpp branch");
+        let (two_bit_branch, monochrome_branch) = after_two_bit_header
+            .split_once("} else {")
+            .expect("guest shader must retain a final 1bpp branch");
+
+        assert!(two_bit_branch.contains("x / 4"));
+        assert!(two_bit_branch.contains("6 - 2 * (x & 3)"));
+        assert!(two_bit_branch.contains("& 0x03"));
+        assert!(two_bit_branch.contains("argb = palette[index]"));
+        assert!(monochrome_branch.contains("x / 8"));
+        assert!(monochrome_branch.contains("7 - (x & 7)"));
+        assert!(monochrome_branch.contains("argb = palette[index]"));
     }
 
     #[test]

--- a/src/bin/systemless.rs
+++ b/src/bin/systemless.rs
@@ -141,9 +141,9 @@ struct Cli {
     #[arg(long)]
     addressing_24_bit: bool,
 
-    /// Guest indexed display depth
-    #[arg(long, value_name = "BITS", default_value_t = 8, value_parser = parse_screen_depth)]
-    screen_depth: u16,
+    /// Override the guest framebuffer depth (defaults to 8-bit for 68K and 16-bit for PPC)
+    #[arg(long, value_name = "BITS", value_parser = parse_screen_depth)]
+    screen_depth: Option<u16>,
 
     /// Integer host-pixel scale (1 is one host pixel per guest pixel)
     #[arg(long, value_name = "N", default_value_t = 1, value_parser = parse_display_scale)]
@@ -159,9 +159,10 @@ struct Cli {
 fn parse_screen_depth(value: &str) -> Result<u16, String> {
     match value {
         "1" => Ok(1),
+        "2" => Ok(2),
         "4" => Ok(4),
         "8" => Ok(8),
-        _ => Err("screen depth must be 1, 4, or 8".to_string()),
+        _ => Err("screen depth must be 1, 2, 4, or 8".to_string()),
     }
 }
 
@@ -623,8 +624,8 @@ struct App {
     arrows_as_numpad: bool,
     /// Start the guest with 24-bit rather than 32-bit address translation.
     addressing_24_bit: bool,
-    /// Indexed guest framebuffer depth.
-    screen_depth: u16,
+    /// Explicit guest framebuffer depth, or architecture defaults.
+    screen_depth: Option<u16>,
     /// Explicit integer host-pixel scale. Physical sizing keeps compositor
     /// DPI from silently changing the requested guest-to-host ratio.
     display_scale: u32,
@@ -654,7 +655,7 @@ impl App {
             arrows_as_numpad,
             native_integrations,
             addressing_24_bit,
-            screen_depth,
+            Some(screen_depth),
             1,
         )
     }
@@ -664,7 +665,7 @@ impl App {
         arrows_as_numpad: bool,
         native_integrations: bool,
         addressing_24_bit: bool,
-        screen_depth: u16,
+        screen_depth: Option<u16>,
         display_scale: u32,
     ) -> Self {
         #[cfg(not(target_os = "macos"))]
@@ -806,8 +807,12 @@ impl App {
             return;
         }
 
-        let mut runner =
-            game::new_runner_with_configuration(!self.addressing_24_bit, self.screen_depth);
+        let mut runner = match self.screen_depth {
+            Some(screen_depth) => {
+                game::new_runner_with_configuration(!self.addressing_24_bit, screen_depth)
+            }
+            None => game::new_runner_with_addressing(!self.addressing_24_bit),
+        };
         #[cfg(target_os = "macos")]
         if self.native_integrations {
             runner.set_menu_bar_policy(MenuBarPolicy::ForceHidden);
@@ -2362,7 +2367,7 @@ fn run_gui(
     arrows_as_numpad: bool,
     native_integrations: bool,
     addressing_24_bit: bool,
-    screen_depth: u16,
+    screen_depth: Option<u16>,
     display_scale: u32,
 ) {
     let event_loop = EventLoop::new().expect("Failed to create event loop");
@@ -2483,13 +2488,16 @@ fn run_headless(
     game_path: &std::path::Path,
     max_instructions: usize,
     addressing_24_bit: bool,
-    screen_depth: u16,
+    screen_depth: Option<u16>,
     script: &[ScriptedInput],
 ) {
     eprintln!("[HEADLESS] Starting: {}", game_path.display());
     eprintln!("[HEADLESS] Max instructions: {}", max_instructions);
 
-    let mut runner = game::new_runner_with_configuration(!addressing_24_bit, screen_depth);
+    let mut runner = match screen_depth {
+        Some(screen_depth) => game::new_runner_with_configuration(!addressing_24_bit, screen_depth),
+        None => game::new_runner_with_addressing(!addressing_24_bit),
+    };
     let app = game::load_game_from_path(&mut runner, game_path).expect("Failed to load game");
     let mut save_store = DesktopSaveStore::for_loaded_archive(game_path, &mut runner);
     eprintln!(
@@ -3043,7 +3051,7 @@ mod tests {
         assert!(!cli.literal_arrows);
         assert!(cli.prefer_powerpc);
         assert!(cli.addressing_24_bit);
-        assert_eq!(cli.screen_depth, 4);
+        assert_eq!(cli.screen_depth, Some(4));
         assert_eq!(cli.display_scale, 2);
         assert_eq!(cli.max_instructions, Some(1234));
     }
@@ -3053,6 +3061,7 @@ mod tests {
         let cli = Cli::try_parse_from(["systemless", "game.sit"])
             .expect("default display scale should parse");
         assert_eq!(cli.display_scale, 1);
+        assert_eq!(cli.screen_depth, None);
         assert_eq!(
             guest_scaled_physical_size(800, 600, cli.display_scale),
             winit::dpi::PhysicalSize::new(800, 600)
@@ -3068,7 +3077,15 @@ mod tests {
         let cli = Cli::try_parse_from(["systemless", "--screen-depth", "1", "game.sit"])
             .expect("one-bit display depth should parse");
 
-        assert_eq!(cli.screen_depth, 1);
+        assert_eq!(cli.screen_depth, Some(1));
+    }
+
+    #[test]
+    fn cli_accepts_two_bit_screen_depth() {
+        let cli = Cli::try_parse_from(["systemless", "--screen-depth", "2", "game.sit"])
+            .expect("two-bit display depth should parse");
+
+        assert_eq!(cli.screen_depth, Some(2));
     }
 
     #[test]

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,14 +1,12 @@
 //! Shared framebuffer rendering for all Systemless frontends.
 //!
 //! Produces RGBA pixel buffers from guest screen memory, supporting 1bpp
-//! monochrome plus 4bpp and 8bpp indexed-color modes.
+//! monochrome plus 2bpp, 4bpp, and 8bpp indexed-color modes.
 
 use crate::memory::{MacMemoryBus, MemoryBus};
 
 const BLACK_ARGB: u32 = 0xFF000000;
 const WHITE_ARGB: u32 = 0xFFFFFFFF;
-const BLACK_RGBA_WORD: u32 = u32::from_le_bytes([0x00, 0x00, 0x00, 0xFF]);
-const WHITE_RGBA_WORD: u32 = u32::from_le_bytes([0xFF, 0xFF, 0xFF, 0xFF]);
 const COMPACT_MAC_VIEWPORT_WIDTH: usize = 512;
 const COMPACT_MAC_VIEWPORT_HEIGHT: usize = 342;
 const COMPACT_MAC_VIEWPORT_SIDE_PAD: usize = 1;
@@ -23,6 +21,40 @@ pub type RgbaPalette = [u32; 256];
 /// Per-channel display transfer tables applied after truncating a 16-bit
 /// QuickDraw color component to its most-significant byte.
 pub type DisplayGamma = [[u8; 256]; 3];
+
+/// Return the classic video-driver depth-mode token for a pixel size.
+///
+/// Universal Interfaces `Video.h` defines the consecutive `oneBitMode`
+/// through `thirtyTwoBitMode` values. `gdMode`, `VDSwitchInfo.csMode`, and
+/// Display Manager `DepthMode` values use these tokens; PixMap `pixelSize`
+/// remains the literal number of bits per pixel. Imaging With QuickDraw
+/// (1994), pp. 5-33--5-35, requires the mode returned by `HasDepth` to be
+/// accepted by `SetDepth`.
+pub(crate) const fn classic_depth_mode(pixel_size: u16) -> Option<u16> {
+    match pixel_size {
+        1 => Some(0x0080),
+        2 => Some(0x0081),
+        4 => Some(0x0082),
+        8 => Some(0x0083),
+        16 => Some(0x0084),
+        32 => Some(0x0085),
+        _ => None,
+    }
+}
+
+/// Decode either a literal pixel size or a classic video depth-mode token.
+pub(crate) const fn classic_pixel_size(depth_or_mode: u16) -> Option<u16> {
+    match depth_or_mode {
+        1 | 2 | 4 | 8 | 16 | 32 => Some(depth_or_mode),
+        0x0080 => Some(1),
+        0x0081 => Some(2),
+        0x0082 => Some(4),
+        0x0083 => Some(8),
+        0x0084 => Some(16),
+        0x0085 => Some(32),
+        _ => None,
+    }
+}
 
 /// Return the modeled display transfer table used before a guest installs one
 /// through the video driver's `cscSetGamma` control call.
@@ -90,7 +122,8 @@ impl CursorImage {
 
 /// Render the current screen to an RGBA pixel buffer (4 bytes per pixel).
 ///
-/// Uses `ram_slice()` for bulk memory access. Supports 1bpp, 4bpp, and 8bpp modes.
+/// Uses `ram_slice()` for bulk memory access. Supports 1bpp, 2bpp, 4bpp,
+/// 8bpp, and 16bpp modes.
 /// The returned buffer has dimensions `width * height * 4` bytes.
 pub fn render_screen(
     bus: &MacMemoryBus,
@@ -138,7 +171,7 @@ pub fn render_screen_into_with_gamma(
     device_gamma: &DisplayGamma,
     pixels: &mut Vec<u8>,
 ) {
-    if matches!(screen_mode.4, 1 | 4 | 8) {
+    if matches!(screen_mode.4, 1 | 2 | 4 | 8) {
         let palette = rgba_palette_from_clut_with_gamma(device_clut, device_gamma);
         render_screen_with_rgba_palette_into(bus, screen_mode, &palette, pixels);
     } else {
@@ -176,21 +209,52 @@ pub fn render_screen_with_rgba_palette_into(
     let w = scrn_w as u32;
     let h = scrn_h as u32;
     pixels.resize((w * h * 4) as usize, 0);
+    fill_black_rgba(pixels);
 
-    if w == 0 || h == 0 || row_bytes == 0 {
-        pixels.fill(0);
+    let Some(framebuffer_len) = validated_screen_framebuffer_len(bus, screen_mode) else {
+        return;
+    };
+    if w == 0 || h == 0 {
         return;
     }
 
-    let fb = bus.ram_slice(scrn_base, row_bytes * h);
+    let fb = bus.ram_slice(scrn_base, framebuffer_len);
 
     match pixel_size {
         16 => render_16bpp_rgba_rows(fb, row_bytes, w, h, pixels),
         8 => render_8bpp_rgba_rows(fb, row_bytes, w, h, palette, pixels),
         4 => render_4bpp_rgba_rows(fb, row_bytes, w, h, palette, pixels),
-        _ => render_1bpp_rgba_rows(fb, row_bytes, w, h, pixels),
+        2 => render_2bpp_rgba_rows(fb, row_bytes, w, h, palette, pixels),
+        _ => render_1bpp_rgba_rows(fb, row_bytes, w, h, palette, pixels),
     }
     normalize_centered_compact_mac_viewport_margins_rgba(pixels, w as usize, h as usize);
+}
+
+fn validated_screen_framebuffer_len(
+    bus: &MacMemoryBus,
+    screen_mode: (u32, u32, u16, u16, u16),
+) -> Option<u32> {
+    let (base, row_bytes, width, height, pixel_size) = screen_mode;
+    if width == 0 || height == 0 {
+        return Some(0);
+    }
+    let bits_per_row = u32::from(width).checked_mul(u32::from(pixel_size))?;
+    let minimum_row_bytes = match pixel_size {
+        1 | 2 | 4 | 8 | 16 => bits_per_row.checked_add(7)? / 8,
+        _ => return None,
+    };
+    if row_bytes < minimum_row_bytes {
+        return None;
+    }
+    let framebuffer_len = row_bytes.checked_mul(u32::from(height))?;
+    let framebuffer_end = u64::from(base).checked_add(u64::from(framebuffer_len))?;
+    (framebuffer_end <= u64::from(bus.ram_size())).then_some(framebuffer_len)
+}
+
+fn fill_black_rgba(pixels: &mut [u8]) {
+    for pixel in pixels.chunks_exact_mut(4) {
+        pixel.copy_from_slice(&[0, 0, 0, 0xFF]);
+    }
 }
 
 fn normalize_centered_compact_mac_viewport_margins_rgba(
@@ -564,7 +628,40 @@ fn render_4bpp_rgba_rows(
 }
 
 #[inline]
-fn render_1bpp_rgba_rows(fb: &[u8], row_bytes: u32, w: u32, h: u32, pixels: &mut [u8]) {
+fn render_2bpp_rgba_rows(
+    fb: &[u8],
+    row_bytes: u32,
+    w: u32,
+    h: u32,
+    palette: &RgbaPalette,
+    pixels: &mut [u8],
+) {
+    let dst = pixels.as_mut_ptr().cast::<u32>();
+    let w = w as usize;
+    let row_bytes = row_bytes as usize;
+    for gy in 0..h as usize {
+        let src_row = &fb[gy * row_bytes..];
+        let dst_row = unsafe { dst.add(gy * w) };
+        for gx in 0..w {
+            let packed = src_row[gx / 4];
+            let shift = 6 - 2 * (gx & 3);
+            let index = (packed >> shift) & 0x03;
+            unsafe {
+                std::ptr::write_unaligned(dst_row.add(gx), palette[index as usize]);
+            }
+        }
+    }
+}
+
+#[inline]
+fn render_1bpp_rgba_rows(
+    fb: &[u8],
+    row_bytes: u32,
+    w: u32,
+    h: u32,
+    palette: &RgbaPalette,
+    pixels: &mut [u8],
+) {
     let dst = pixels.as_mut_ptr().cast::<u32>();
     let w = w as usize;
     let row_bytes = row_bytes as usize;
@@ -574,13 +671,9 @@ fn render_1bpp_rgba_rows(fb: &[u8], row_bytes: u32, w: u32, h: u32, pixels: &mut
         for gx in 0..w {
             let byte = src_row[gx / 8];
             let bit = 7 - (gx & 7);
-            let rgba = if (byte & (1 << bit)) != 0 {
-                BLACK_RGBA_WORD
-            } else {
-                WHITE_RGBA_WORD
-            };
+            let index = (byte >> bit) & 1;
             unsafe {
-                std::ptr::write_unaligned(dst_row.add(gx), rgba);
+                std::ptr::write_unaligned(dst_row.add(gx), palette[index as usize]);
             }
         }
     }
@@ -622,6 +715,7 @@ pub fn screen_pixel_rgb_with_gamma(
     if x >= w || y >= h || row_bytes == 0 {
         return None;
     }
+    validated_screen_framebuffer_len(bus, screen_mode)?;
 
     match pixel_size {
         16 => {
@@ -643,15 +737,19 @@ pub fn screen_pixel_rgb_with_gamma(
             };
             Some(clut_to_rgba8_with_gamma(device_clut, device_gamma, pixel))
         }
+        2 => {
+            let addr = scrn_base + y * row_bytes + x / 4;
+            let packed = bus.read_byte(addr);
+            let shift = 6 - 2 * (x & 3);
+            let pixel = (packed >> shift) & 0x03;
+            Some(clut_to_rgba8_with_gamma(device_clut, device_gamma, pixel))
+        }
         1 => {
             let addr = scrn_base + y * row_bytes + x / 8;
             let byte = bus.read_byte(addr);
             let bit = 7 - (x % 8);
-            if (byte & (1 << bit)) != 0 {
-                Some([0, 0, 0])
-            } else {
-                Some([255, 255, 255])
-            }
+            let pixel = (byte >> bit) & 1;
+            Some(clut_to_rgba8_with_gamma(device_clut, device_gamma, pixel))
         }
         _ => None,
     }
@@ -690,13 +788,16 @@ pub fn render_screen_argb_with_gamma(
     let len = w.saturating_mul(h);
 
     pixels.resize(len, BLACK_ARGB);
+    pixels.fill(BLACK_ARGB);
 
     if w == 0 || h == 0 || row_bytes == 0 {
-        pixels.fill(BLACK_ARGB);
         return;
     }
 
-    let fb = bus.ram_slice(scrn_base, row_bytes * scrn_h as u32);
+    let Some(framebuffer_len) = validated_screen_framebuffer_len(bus, screen_mode) else {
+        return;
+    };
+    let fb = bus.ram_slice(scrn_base, framebuffer_len);
 
     let palette = argb_palette_from_clut_with_gamma(device_clut, device_gamma);
     match pixel_size {
@@ -736,6 +837,18 @@ pub fn render_screen_argb_with_gamma(
                 }
             }
         }
+        2 => {
+            for gy in 0..h {
+                let row_start = gy * row_bytes as usize;
+                let dst_row = &mut pixels[gy * w..(gy + 1) * w];
+                for gx in 0..w {
+                    let packed = fb[row_start + gx / 4];
+                    let shift = 6 - 2 * (gx & 3);
+                    let index = (packed >> shift) & 0x03;
+                    dst_row[gx] = palette[index as usize];
+                }
+            }
+        }
         _ => {
             for gy in 0..h {
                 let row_start = gy * row_bytes as usize;
@@ -743,11 +856,8 @@ pub fn render_screen_argb_with_gamma(
                 for gx in 0..w {
                     let byte = fb[row_start + (gx / 8)];
                     let bit = 7 - (gx % 8);
-                    dst_row[gx] = if (byte & (1 << bit)) != 0 {
-                        BLACK_ARGB
-                    } else {
-                        WHITE_ARGB
-                    };
+                    let index = (byte >> bit) & 1;
+                    dst_row[gx] = palette[index as usize];
                 }
             }
         }
@@ -1542,13 +1652,31 @@ const MAC_ROM_GAMMA_LUT: [u8; 256] = [
 #[cfg(test)]
 mod tests {
     use super::{
-        argb_palette_from_clut, argb_palette_from_clut_with_gamma, clut_component_to_u8,
-        clut_to_argb, normalize_centered_compact_mac_viewport_margins_rgba, render_cursor,
-        render_cursor_argb, render_screen_argb, render_screen_into,
-        render_screen_with_rgba_palette_into, rgba_palette_from_clut, screen_pixel_rgb,
-        screen_pixel_rgb_with_gamma, CursorImage,
+        argb_palette_from_clut, argb_palette_from_clut_with_gamma, classic_depth_mode,
+        classic_pixel_size, clut_component_to_u8, clut_to_argb,
+        normalize_centered_compact_mac_viewport_margins_rgba, render_cursor, render_cursor_argb,
+        render_screen_argb, render_screen_into, render_screen_with_rgba_palette_into,
+        rgba_palette_from_clut, screen_pixel_rgb, screen_pixel_rgb_with_gamma, CursorImage,
     };
     use crate::memory::{MacMemoryBus, MemoryBus};
+
+    #[test]
+    fn classic_video_depth_modes_round_trip_every_supported_pixel_size() {
+        for (pixel_size, mode) in [
+            (1, 0x0080),
+            (2, 0x0081),
+            (4, 0x0082),
+            (8, 0x0083),
+            (16, 0x0084),
+            (32, 0x0085),
+        ] {
+            assert_eq!(classic_depth_mode(pixel_size), Some(mode));
+            assert_eq!(classic_pixel_size(pixel_size), Some(pixel_size));
+            assert_eq!(classic_pixel_size(mode), Some(pixel_size));
+        }
+        assert_eq!(classic_depth_mode(3), None);
+        assert_eq!(classic_pixel_size(0x0086), None);
+    }
 
     #[test]
     fn clut_component_applies_the_modeled_device_default() {
@@ -1667,6 +1795,75 @@ mod tests {
             screen_pixel_rgb(&bus, (base, 2, 4, 1, 4), &clut, 1, 0),
             Some([0, 255, 0])
         );
+    }
+
+    #[test]
+    fn render_screen_into_2bpp_decodes_high_to_low_fields() {
+        let mut bus = MacMemoryBus::new(1024);
+        let base = 128;
+        bus.write_byte(base, 0b00_01_10_11);
+        bus.write_byte(base + 1, 0xff);
+        let mut clut = [[0u16; 3]; 256];
+        clut[0] = [0xffff, 0xffff, 0xffff];
+        clut[1] = [0xffff, 0x0000, 0x0000];
+        clut[2] = [0x0000, 0xffff, 0x0000];
+        clut[3] = [0x0000, 0x0000, 0xffff];
+
+        let mut rgba = Vec::new();
+        render_screen_into(&bus, (base, 2, 4, 1, 2), &clut, &mut rgba);
+        assert_eq!(
+            rgba,
+            vec![
+                0xff, 0xff, 0xff, 0xff, //
+                0xff, 0x00, 0x00, 0xff, //
+                0x00, 0xff, 0x00, 0xff, //
+                0x00, 0x00, 0xff, 0xff,
+            ]
+        );
+
+        let mut argb = Vec::new();
+        render_screen_argb(&bus, (base, 2, 4, 1, 2), &clut, &mut argb);
+        assert_eq!(
+            argb,
+            vec![0xffff_ffff, 0xffff_0000, 0xff00_ff00, 0xff00_00ff]
+        );
+        for (x, expected) in [
+            [0xff, 0xff, 0xff],
+            [0xff, 0x00, 0x00],
+            [0x00, 0xff, 0x00],
+            [0x00, 0x00, 0xff],
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            assert_eq!(
+                screen_pixel_rgb(&bus, (base, 2, 4, 1, 2), &clut, x as u32, 0),
+                Some(expected)
+            );
+        }
+    }
+
+    #[test]
+    fn malformed_two_bit_screen_modes_render_black_without_reading_past_ram() {
+        let bus = MacMemoryBus::new(64);
+        let mut clut = [[0u16; 3]; 256];
+        clut[0] = [0xFFFF, 0x0000, 0x0000];
+        let malformed_modes = [
+            (60, 1, 5, 1, 2), // Five pixels need two source bytes.
+            (63, 2, 4, 2, 2), // Rows fit, but base + length exceeds RAM.
+        ];
+
+        for screen_mode in malformed_modes {
+            let pixel_count = usize::from(screen_mode.2) * usize::from(screen_mode.3);
+            let mut rgba = vec![0xE7; pixel_count * 4];
+            render_screen_into(&bus, screen_mode, &clut, &mut rgba);
+            assert_eq!(rgba, vec![0, 0, 0, 0xFF].repeat(pixel_count));
+
+            let mut argb = vec![0xFFFF_00FF; pixel_count];
+            render_screen_argb(&bus, screen_mode, &clut, &mut argb);
+            assert_eq!(argb, vec![0xFF00_0000; pixel_count]);
+            assert_eq!(screen_pixel_rgb(&bus, screen_mode, &clut, 0, 0), None);
+        }
     }
 
     #[test]
@@ -1842,11 +2039,13 @@ mod tests {
     }
 
     #[test]
-    fn render_screen_into_1bpp_writes_rgba_bytes() {
+    fn one_bit_host_rendering_uses_swapped_custom_palette() {
         let mut bus = MacMemoryBus::new(1024);
         let base = 128;
         bus.write_byte(base, 0b1010_0000);
-        let clut = [[0u16; 3]; 256];
+        let mut clut = [[0u16; 3]; 256];
+        clut[0] = [0x0000, 0x0000, 0x0000];
+        clut[1] = [0xFFFF, 0x0000, 0x0000];
 
         let mut pixels = Vec::new();
         render_screen_into(&bus, (base, 1, 4, 1, 1), &clut, &mut pixels);
@@ -1854,11 +2053,26 @@ mod tests {
         assert_eq!(
             pixels,
             vec![
-                0x00, 0x00, 0x00, 0xFF, //
-                0xFF, 0xFF, 0xFF, 0xFF, //
-                0x00, 0x00, 0x00, 0xFF, //
-                0xFF, 0xFF, 0xFF, 0xFF,
+                0xFF, 0x00, 0x00, 0xFF, // bit 1 -> custom red
+                0x00, 0x00, 0x00, 0xFF, // bit 0 -> custom black
+                0xFF, 0x00, 0x00, 0xFF, //
+                0x00, 0x00, 0x00, 0xFF,
             ]
+        );
+
+        let mut argb = Vec::new();
+        render_screen_argb(&bus, (base, 1, 4, 1, 1), &clut, &mut argb);
+        assert_eq!(
+            argb,
+            vec![0xFFFF_0000, 0xFF00_0000, 0xFFFF_0000, 0xFF00_0000]
+        );
+        assert_eq!(
+            screen_pixel_rgb(&bus, (base, 1, 4, 1, 1), &clut, 0, 0),
+            Some([255, 0, 0])
+        );
+        assert_eq!(
+            screen_pixel_rgb(&bus, (base, 1, 4, 1, 1), &clut, 1, 0),
+            Some([0, 0, 0])
         );
     }
 
@@ -1900,7 +2114,9 @@ mod tests {
         let mut bus = MacMemoryBus::new(1024);
         let base = 128;
         bus.write_byte(base, 0b1010_0000);
-        let clut = [[0u16; 3]; 256];
+        let mut clut = [[0u16; 3]; 256];
+        clut[0] = [0xFFFF, 0xFFFF, 0xFFFF];
+        clut[1] = [0x0000, 0x0000, 0x0000];
 
         assert_eq!(
             screen_pixel_rgb(&bus, (base, 1, 4, 1, 1), &clut, 0, 0),

--- a/src/game/launch.rs
+++ b/src/game/launch.rs
@@ -48,21 +48,29 @@ pub const MAX_INSTRUCTIONS_PER_FRAME: usize = 2_000_000;
 
 /// Create a new FixtureRunner with standard configuration.
 pub fn new_runner() -> FixtureRunner {
-    new_runner_with_configuration(true, 8)
+    new_runner_with_addressing(true)
 }
 
 /// Create a runner in either the default 32-bit addressing mode or classic
 /// 24-bit mode, where the upper address byte is ignored by memory accesses.
 pub fn new_runner_with_addressing(addressing_32_bit: bool) -> FixtureRunner {
-    new_runner_with_configuration(addressing_32_bit, 8)
+    let config = FixtureRunnerConfig {
+        load_address: 0x10000,
+        max_instructions: MAX_INSTRUCTIONS_PER_FRAME,
+        addressing_32_bit,
+        ..FixtureRunnerConfig::default()
+    };
+    FixtureRunner::new(RAM_SIZE as usize, config)
 }
 
-/// Create a standard runner with the requested indexed screen depth.
+/// Create a standard runner with one explicit indexed depth for both 68K and
+/// native PowerPC launches.
 pub fn new_runner_with_screen_depth(screen_depth: u16) -> FixtureRunner {
     new_runner_with_configuration(true, screen_depth)
 }
 
-/// Create a standard runner with explicit addressing and display modes.
+/// Create a standard runner with explicit addressing and one indexed display
+/// depth applied to both 68K and native PowerPC launches.
 pub fn new_runner_with_configuration(addressing_32_bit: bool, screen_depth: u16) -> FixtureRunner {
     let config = FixtureRunnerConfig {
         load_address: 0x10000,
@@ -72,7 +80,11 @@ pub fn new_runner_with_configuration(addressing_32_bit: bool, screen_depth: u16)
     }
     .with_screen_depth(screen_depth)
     .expect("frontend selected an unsupported screen depth");
-    FixtureRunner::new(RAM_SIZE as usize, config)
+    let mut runner = FixtureRunner::new(RAM_SIZE as usize, config);
+    runner
+        .set_powerpc_screen_depth(screen_depth)
+        .expect("frontend selected an unsupported PowerPC screen depth");
+    runner
 }
 
 /// Load an application from BinHex, MacBinary, StuffIt, web-pack, or raw
@@ -2267,7 +2279,7 @@ fn load_selected_executable(
             }
             let mut ppc_config =
                 crate::loader::ppc::PpcLoadConfig::from_cfrg_app_stack_size(app_stack_size);
-            ppc_config.screen_depth = crate::runner::DEFAULT_POWERPC_SCREEN_DEPTH;
+            ppc_config.screen_depth = runner.configured_powerpc_screen_depth();
             let mut loaded = crate::loader::ppc::load_pef_application_with_config(pef, ppc_config)
                 .map_err(|error| {
                     format!(
@@ -3105,6 +3117,24 @@ fn read_u32_be(buf: &[u8], offset: &mut usize) -> Result<u32, String> {
 mod tests {
     use super::*;
     use std::io::Write;
+
+    #[test]
+    fn frontend_runner_constructors_preserve_defaults_and_explicit_depths() {
+        let default_runner = new_runner();
+        assert_eq!(default_runner.configured_screen_depth(), 8);
+        assert_eq!(default_runner.configured_powerpc_screen_depth(), 16);
+
+        let addressed_default = new_runner_with_addressing(false);
+        assert_eq!(addressed_default.configured_screen_depth(), 8);
+        assert_eq!(addressed_default.configured_powerpc_screen_depth(), 16);
+        assert!(!addressed_default.bus().addressing_32_bit());
+
+        for depth in [1, 2, 4, 8] {
+            let runner = new_runner_with_screen_depth(depth);
+            assert_eq!(runner.configured_screen_depth(), depth);
+            assert_eq!(runner.configured_powerpc_screen_depth(), u32::from(depth));
+        }
+    }
 
     #[test]
     fn parallel_fork_decode_matches_the_sequential_loop() {

--- a/src/loader/ppc.rs
+++ b/src/loader/ppc.rs
@@ -72,6 +72,7 @@ const PPC_MMU_32BIT_ADDR: u32 = 0x0000_0cb2;
 const PPC_CLASSIC_APP_MEMORY_SIZE: usize = 0x000f_0000;
 pub const PPC_MEM_FULL_ERR: i16 = -108;
 const PPC_NIL_HANDLE_ERR: i16 = -109;
+const PPC_C_DEPTH_ERR: i16 = -157;
 pub const PPC_NO_ERR: i16 = 0;
 pub const PPC_EOF_ERR: i16 = -39;
 pub const PPC_FN_OPN_ERR: i16 = -38;
@@ -216,6 +217,9 @@ const PPC_NATIVE_PARAMETER_GPR_COUNT: usize = 8;
 const PPC_MAX_STACK_SIZE: u32 = PPC_STACK_TOP - PPC_HEAP_BASE;
 const PPC_RAND_SEED_ADDR: u32 = 0x0000_0156;
 const PPC_GRAY_RGN_ADDR: u32 = 0x0000_09ee;
+// TheMenu contains the menu ID whose title is currently highlighted.
+// Inside Macintosh Volume V (1986), pp. V-244 and V-571.
+const PPC_THE_MENU_ADDR: u32 = 0x0000_0a26;
 const PPC_MBAR_HEIGHT_ADDR: u32 = 0x0000_0baa;
 const PPC_DEFAULT_DOUBLE_TIME_TICKS: u32 = 20;
 const PPC_RES_CHANGED_ATTR: u16 = 0x0002;
@@ -406,6 +410,10 @@ const PPC_DM_MODE_LIST_DEPTH_BLOCK_OFFSET: u32 = 0x78;
 const PPC_DM_MODE_LIST_DEPTH_INFO_OFFSET: u32 = 0x90;
 const PPC_DM_MODE_LIST_VP_BLOCK_OFFSET: u32 = 0xa8;
 const PPC_DM_MODE_LIST_NAME_OFFSET: u32 = 0xd8;
+const PPC_DM_CURRENT_DISPLAY_MODE_ID: u32 = 0x80;
+const PPC_DM_NO_SWITCH_CONFIRM_MASK: u32 = 1;
+const PPC_DM_DEPTH_NOT_AVAILABLE_MASK: u32 = 1 << 1;
+const PPC_DM_MODE_NOT_FOUND_ERR: i16 = -330;
 const PPC_DSP_CONTEXT_STATE_ACTIVE: u32 = 0;
 const PPC_DSP_CONTEXT_STATE_PAUSED: u32 = 1;
 const PPC_DSP_CONTEXT_STATE_INACTIVE: u32 = 2;
@@ -2682,6 +2690,9 @@ pub struct PpcMenuTrackingState {
     popup_top: i16,
     popup_width: i16,
     popup_height: i16,
+    saved_width: i16,
+    saved_height: i16,
+    front_buffer: PpcFrontBuffer,
     saved_pixels: Vec<u16>,
 }
 
@@ -2767,6 +2778,8 @@ pub struct PpcToolboxStartupState {
     active_device_palettes: HashMap<u32, u32>,
     known_gdevices: Vec<u32>,
     indexed_screen_ctables: HashMap<u32, u32>,
+    indexed_screen_mode: Option<(u32, bool)>,
+    gworld_allocations: HashMap<u32, PpcGWorldAllocationRecord>,
     quickdraw_back_indices: HashMap<u32, u8>,
     pub clut_protected: [bool; 256],
     pub clut_reserved: [bool; 256],
@@ -2820,6 +2833,8 @@ impl Default for PpcToolboxStartupState {
             active_device_palettes: HashMap::new(),
             known_gdevices: vec![PPC_MAIN_GDEVICE],
             indexed_screen_ctables: HashMap::new(),
+            indexed_screen_mode: Some((PPC_MAIN_PIXEL_DEPTH, true)),
+            gworld_allocations: HashMap::new(),
             quickdraw_back_indices: HashMap::new(),
             clut_protected: [false; 256],
             clut_reserved: [false; 256],
@@ -2927,6 +2942,14 @@ pub struct PpcGWorldRecord {
     pub row_bytes: u32,
     pub pixels_locked: bool,
     pub pixels_no_purge: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PpcGWorldAllocationRecord {
+    origin_base: u32,
+    pixel_capacity: u32,
+    ctable_handle: u32,
+    allocation_end: u32,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -10940,12 +10963,49 @@ fn ppc_front_buffer_8bpp_pixel_addr(
         .checked_add(x)
 }
 
+#[cfg(test)]
 fn ppc_rgb_color_to_8bpp_index(color: PpcRgbColor) -> u8 {
     ppc_rgb_color_to_8bpp_index_in_clut(color, &TrapDispatcher::standard_mac_8bpp_clut())
 }
 
+#[cfg(test)]
 fn ppc_rgb_color_to_8bpp_index_in_clut(color: PpcRgbColor, clut: &[[u16; 3]; 256]) -> u8 {
     ppc_rgb555_to_clut_index(ppc_rgb_color_to_rgb555(color), clut)
+}
+
+fn ppc_indexed_depth_entry_count(depth: u32) -> Option<usize> {
+    matches!(depth, 1 | 2 | 4 | 8).then(|| 1usize << depth)
+}
+
+fn ppc_rgb_color_to_index_in_clut(
+    color: PpcRgbColor,
+    clut: &[[u16; 3]; 256],
+    entry_count: usize,
+) -> u8 {
+    ppc_rgb_color_to_valid_index_in_clut(color, clut, &[true; 256], entry_count).unwrap_or(0)
+}
+
+fn ppc_rgb_color_to_valid_index_in_clut(
+    color: PpcRgbColor,
+    clut: &[[u16; 3]; 256],
+    valid: &[bool; 256],
+    entry_count: usize,
+) -> Option<u8> {
+    let target = ppc_rgb_color_to_rgb555(color);
+    let target_r = i64::from((target >> 10) & 0x1f);
+    let target_g = i64::from((target >> 5) & 0x1f);
+    let target_b = i64::from(target & 0x1f);
+    clut.iter()
+        .take(entry_count.min(clut.len()))
+        .enumerate()
+        .filter(|(index, _)| valid[*index])
+        .min_by_key(|(_, [red, green, blue])| {
+            let red = i64::from(*red >> 11);
+            let green = i64::from(*green >> 11);
+            let blue = i64::from(*blue >> 11);
+            (red - target_r).pow(2) + (green - target_g).pow(2) + (blue - target_b).pow(2)
+        })
+        .map(|(index, _)| index as u8)
 }
 
 fn ppc_quickdraw_surface_color_pixel(
@@ -10954,20 +11014,27 @@ fn ppc_quickdraw_surface_color_pixel(
     color: PpcRgbColor,
 ) -> Option<u16> {
     match surface.front_buffer.depth {
-        8 => {
+        depth @ (1 | 2 | 4 | 8) => {
             // Inside Macintosh: Imaging With QuickDraw (1994), pp. 4-81--4-82:
             // Color2Index maps an RGBColor through the destination GDevice's
             // inverse table. For an offscreen PixMap, its own ColorTable is the
             // destination palette, so RGB QuickDraw primitives must not assume
             // the canonical system palette.
-            let fallback = TrapDispatcher::standard_mac_8bpp_clut();
+            // The same volume, pp. 4-14--4-16 and 4-46--4-47, defines indexed
+            // pixel values at 1, 2, 4, and 8 bits. Match only the entries that
+            // the destination pixel can represent; matching all 256 and then
+            // truncating would select a different color and corrupt its index.
+            let fallback = TrapDispatcher::standard_mac_indexed_clut(depth as u16)
+                .map(|(clut, _)| clut)
+                .unwrap_or_else(TrapDispatcher::standard_mac_8bpp_clut);
             let clut = surface
                 .ctable_handle
                 .and_then(|handle| ppc_read_ctable_clut(memory, handle, &fallback))
                 .unwrap_or(fallback);
-            Some(u16::from(ppc_rgb555_to_clut_index(
-                ppc_rgb_color_to_rgb555(color),
+            Some(u16::from(ppc_rgb_color_to_index_in_clut(
+                color,
                 &clut,
+                ppc_indexed_depth_entry_count(depth)?,
             )))
         }
         16 => Some(ppc_rgb_color_to_rgb555(color)),
@@ -10981,9 +11048,9 @@ fn ppc_quickdraw_surface_fore_pixel(
     color: PpcRgbColor,
     explicit_index: Option<u8>,
 ) -> Option<u16> {
-    if surface.front_buffer.depth == 8 {
+    if let Some(entry_count) = ppc_indexed_depth_entry_count(surface.front_buffer.depth) {
         if let Some(index) = explicit_index {
-            return Some(u16::from(index));
+            return Some(u16::from(index) & (entry_count as u16 - 1));
         }
     }
     ppc_quickdraw_surface_color_pixel(memory, surface, color)
@@ -10996,13 +11063,21 @@ fn ppc_quickdraw_write_pixel(
     color: PpcRgbColor,
 ) -> bool {
     match front_buffer.depth {
-        8 => {
-            let Some(addr) = ppc_front_buffer_8bpp_pixel_addr(front_buffer, point) else {
-                return false;
+        depth @ (1 | 2 | 4 | 8) => {
+            let fallback = TrapDispatcher::standard_mac_indexed_clut(depth as u16)
+                .map(|(clut, _)| clut)
+                .unwrap_or_else(TrapDispatcher::standard_mac_8bpp_clut);
+            let clut = if front_buffer.base_addr == PPC_MAIN_SCREEN_BASE {
+                ppc_read_ctable_clut(memory, PPC_MAIN_CTABLE_HANDLE, &fallback).unwrap_or(fallback)
+            } else {
+                fallback
             };
-            memory
-                .write_u8(addr, ppc_rgb_color_to_8bpp_index(color))
-                .is_some()
+            let pixel = ppc_rgb_color_to_index_in_clut(
+                color,
+                &clut,
+                ppc_indexed_depth_entry_count(depth).unwrap_or(1),
+            );
+            ppc_quickdraw_write_raw_pixel(memory, front_buffer, point, u16::from(pixel))
         }
         16 => {
             ppc_q3_write_software_pixel(memory, front_buffer, point, ppc_rgb_color_to_rgb555(color))
@@ -11017,20 +11092,27 @@ fn ppc_quickdraw_read_pixel(
     point: (i32, i32),
 ) -> Option<u16> {
     match front_buffer.depth {
-        1 => {
+        depth @ (1 | 2 | 4) => {
             let (x, y) = point;
             let x = u32::try_from(x).ok()?;
             let y = u32::try_from(y).ok()?;
             if x >= front_buffer.width || y >= front_buffer.height {
                 return None;
             }
+            let pixels_per_byte = 8 / depth;
+            let byte_offset = x / pixels_per_byte;
+            if byte_offset >= front_buffer.row_bytes {
+                return None;
+            }
             let byte = memory.read_u8(
                 front_buffer
                     .base_addr
                     .checked_add(y.checked_mul(front_buffer.row_bytes)?)?
-                    .checked_add(x / 8)?,
+                    .checked_add(byte_offset)?,
             )?;
-            Some(u16::from((byte >> (7 - (x & 7))) & 1))
+            let shift = 8 - depth - (x % pixels_per_byte) * depth;
+            let mask = (1u8 << depth) - 1;
+            Some(u16::from((byte >> shift) & mask))
         }
         8 => memory
             .read_u8(ppc_front_buffer_8bpp_pixel_addr(front_buffer, point)?)
@@ -11047,7 +11129,7 @@ fn ppc_quickdraw_write_raw_pixel(
     value: u16,
 ) -> bool {
     match front_buffer.depth {
-        1 => {
+        depth @ (1 | 2 | 4) => {
             let (x, y) = point;
             let (Ok(x), Ok(y)) = (u32::try_from(x), u32::try_from(y)) else {
                 return false;
@@ -11058,19 +11140,25 @@ fn ppc_quickdraw_write_raw_pixel(
             let Some(row_offset) = y.checked_mul(front_buffer.row_bytes) else {
                 return false;
             };
+            let pixels_per_byte = 8 / depth;
+            let byte_offset = x / pixels_per_byte;
+            if byte_offset >= front_buffer.row_bytes {
+                return false;
+            }
             let Some(addr) = front_buffer
                 .base_addr
                 .checked_add(row_offset)
-                .and_then(|row| row.checked_add(x / 8))
+                .and_then(|row| row.checked_add(byte_offset))
             else {
                 return false;
             };
             let Some(byte) = memory.read_u8(addr) else {
                 return false;
             };
-            let shift = 7 - (x & 7);
-            let pixel_mask = 1 << shift;
-            let packed = ((value as u8) & 1) << shift;
+            let shift = 8 - depth - (x % pixels_per_byte) * depth;
+            let value_mask = (1u8 << depth) - 1;
+            let pixel_mask = value_mask << shift;
+            let packed = ((value as u8) & value_mask) << shift;
             memory
                 .write_u8(addr, (byte & !pixel_mask) | packed)
                 .is_some()
@@ -12507,7 +12595,7 @@ pub fn load_pef_application_with_config(
     data: &[u8],
     config: PpcLoadConfig,
 ) -> Result<PpcLoadedApp, PpcLoadError> {
-    if !matches!(config.screen_depth, 8 | 16) {
+    if !matches!(config.screen_depth, 1 | 2 | 4 | 8 | 16) {
         return Err(PpcLoadError::ScreenDepthOutOfRange {
             requested: config.screen_depth,
         });
@@ -12655,6 +12743,7 @@ pub fn load_pef_application_with_config(
     let mut memory = PpcSectionMem::new();
     memory.add_region(PPC_HALT_PC, vec![0u8; PPC_LOW_MEMORY_SIZE]);
     let _ = memory.write_u16_be(PPC_MBAR_HEIGHT_ADDR, 20);
+    let _ = memory.write_u16_be(PPC_THE_MENU_ADDR, 0);
     // PaintOne normally starts with PaintWhite enabled. Carbon's generated
     // low-memory accessors preserve this flag around window creation.
     let _ = memory.write_u16_be(0x09dc, 1);
@@ -12833,6 +12922,7 @@ pub fn load_pef_application_with_config(
     cpu.gpr[3] = startup.map_or(0, |(_, _, init_block)| init_block);
     cpu.lr = startup.map_or(PPC_HALT_PC, |_| PPC_APPLICATION_INIT_RETURN_PC);
     let mut toolbox_startup = PpcToolboxStartupState::default();
+    let mut handles = Vec::new();
     let mut screen_clut = TrapDispatcher::standard_mac_8bpp_clut();
     let mut color_manager_clut = screen_clut;
     if config.screen_depth != PPC_MAIN_PIXEL_DEPTH {
@@ -12843,6 +12933,9 @@ pub fn load_pef_application_with_config(
         let result = ppc_set_depth(
             &cpu,
             &mut memory,
+            &mut heap_cursor,
+            stack_base,
+            &mut handles,
             &mut gworlds,
             &mut toolbox_startup,
             &mut screen_clut,
@@ -12885,7 +12978,7 @@ pub fn load_pef_application_with_config(
         next_cfm_connection_id,
         ptrs: Vec::new(),
         free_ptr_blocks: Vec::new(),
-        handles: Vec::new(),
+        handles,
         free_handle_blocks: Vec::new(),
         handle_states: Vec::new(),
         controls: Vec::new(),
@@ -15740,6 +15833,9 @@ fn dispatch_supported_import(
                         ..PpcMenuListDefinition::default()
                     },
                 );
+                if *last_mem_error == PPC_NO_ERR {
+                    let _ = memory.write_u16_be(PPC_THE_MENU_ADDR, 0);
+                }
             }
             Some(PpcImportAction::ReturnPreserve)
         }
@@ -15811,23 +15907,31 @@ fn dispatch_supported_import(
             )))
         }
         PpcImportDispatcherTarget::HiliteMenu => {
-            // HiliteMenu(0) removes the selection left by MenuSelect. Redraw
-            // from the live menu list so the saved title pixels and Systemless
-            // mark match DrawMenuBar after tracking ends.
-            // Macintosh Toolbox Essentials (1992), pp. 3-45 and 3-123.
-            if cpu.gpr[3] as u16 == 0 && !toolbox_startup.host_menu_bar_hidden {
-                let _ = ppc_draw_menu_bar(
-                    memory,
-                    gworlds,
-                    toolbox_startup.current_menu_bar,
-                    screen_clut,
-                );
-            }
+            // HiliteMenu first restores the currently highlighted title, then
+            // highlights the requested title; zero or an unknown menu ID
+            // leaves every title normal. Macintosh Toolbox Essentials
+            // (1992), p. 3-119.
+            ppc_set_menu_title_highlight(
+                memory,
+                gworlds,
+                toolbox_startup.current_menu_bar,
+                cpu.gpr[3] as u16 as i16,
+                screen_clut,
+                toolbox_startup.host_menu_bar_hidden,
+            );
             Some(PpcImportAction::ReturnPreserve)
         }
         PpcImportDispatcherTarget::MenuNoop => Some(PpcImportAction::ReturnPreserve),
         PpcImportDispatcherTarget::MenuKey => {
             let result = ppc_menu_key(memory, toolbox_startup.current_menu_bar, cpu.gpr[3] as u8);
+            ppc_set_menu_title_highlight(
+                memory,
+                gworlds,
+                toolbox_startup.current_menu_bar,
+                (result >> 16) as u16 as i16,
+                screen_clut,
+                toolbox_startup.host_menu_bar_hidden,
+            );
             if crate::trap::dispatch::trace_input_enabled() {
                 eprintln!(
                     "[INPUT] PPC MenuKey menu_list=${:08X} key=${:02X} -> ${result:08X}",
@@ -15850,6 +15954,14 @@ fn dispatch_supported_import(
                 } else {
                     0
                 };
+                ppc_set_menu_title_highlight(
+                    memory,
+                    gworlds,
+                    toolbox_startup.current_menu_bar,
+                    (result >> 16) as u16 as i16,
+                    screen_clut,
+                    toolbox_startup.host_menu_bar_hidden,
+                );
                 Some(PpcImportAction::Return(result))
             } else if input.mouse_button {
                 ppc_track_menu_while_held(
@@ -15872,6 +15984,14 @@ fn dispatch_supported_import(
                                 input,
                             )
                         });
+                ppc_set_menu_title_highlight(
+                    memory,
+                    gworlds,
+                    toolbox_startup.current_menu_bar,
+                    (result >> 16) as u16 as i16,
+                    screen_clut,
+                    toolbox_startup.host_menu_bar_hidden,
+                );
                 Some(PpcImportAction::Return(result))
             }
         }
@@ -17805,6 +17925,9 @@ fn dispatch_supported_import(
             Some(PpcImportAction::Return(ppc_i16_result(ppc_set_depth(
                 cpu,
                 memory,
+                heap_cursor,
+                heap_limit,
+                handles,
                 gworlds,
                 toolbox_startup,
                 screen_clut,
@@ -17814,13 +17937,15 @@ fn dispatch_supported_import(
         PpcImportDispatcherTarget::DMGetDisplayIDByGDevice => {
             let gdevice = cpu.gpr[3];
             let display_id_out_ptr = cpu.gpr[4];
+            let fail_to_main = cpu.gpr[5] & 0xff != 0;
             // Apple's "Optimizing Display Modes and Window Buffers" (2007),
             // p. 26: DMGetDisplayIDByGDevice returns the long-lived display ID
-            // associated with a video device. Systemless has one main display.
-            if display_id_out_ptr == 0
-                || !ppc_memory_can_write_bytes(memory, display_id_out_ptr, 4)
-                || gdevice != PPC_MAIN_GDEVICE
+            // associated with a video device. The failToMain Boolean requests
+            // the main display when the supplied GDevice cannot be resolved.
+            if display_id_out_ptr == 0 || !ppc_memory_can_write_bytes(memory, display_id_out_ptr, 4)
             {
+                Some(PpcImportAction::Return(ppc_i16_result(PPC_PARAM_ERR)))
+            } else if gdevice != PPC_MAIN_GDEVICE && !fail_to_main {
                 Some(PpcImportAction::Return(ppc_i16_result(PPC_PARAM_ERR)))
             } else {
                 let _ = memory.write_u32_be(display_id_out_ptr, PPC_DSP_DISPLAY_ID);
@@ -17828,8 +17953,12 @@ fn dispatch_supported_import(
             }
         }
         PpcImportDispatcherTarget::DMGetGDeviceByDisplayID => {
+            let display_id = cpu.gpr[3];
             let gdevice_out_ptr = cpu.gpr[4];
+            let fail_to_main = cpu.gpr[5] & 0xff != 0;
             if gdevice_out_ptr == 0 || !ppc_memory_can_write_bytes(memory, gdevice_out_ptr, 4) {
+                Some(PpcImportAction::Return(ppc_i16_result(PPC_PARAM_ERR)))
+            } else if display_id != PPC_DSP_DISPLAY_ID && !fail_to_main {
                 Some(PpcImportAction::Return(ppc_i16_result(PPC_PARAM_ERR)))
             } else {
                 let _ = memory.write_u32_be(gdevice_out_ptr, PPC_MAIN_GDEVICE);
@@ -17837,7 +17966,7 @@ fn dispatch_supported_import(
             }
         }
         PpcImportDispatcherTarget::NewGWorld => {
-            Some(PpcImportAction::Return(ppc_i16_result(ppc_new_gworld(
+            let result = ppc_new_gworld(
                 cpu,
                 memory,
                 heap_cursor,
@@ -17845,11 +17974,17 @@ fn dispatch_supported_import(
                 last_mem_error,
                 handles,
                 gworlds,
+                &mut toolbox_startup.gworld_allocations,
                 *current_gdevice,
-            ))))
+            );
+            // Imaging With QuickDraw (1994), pp. 6-20 and 6-24: QDError
+            // reports NewGWorld and UpdateGWorld failures, and a successful
+            // call clears the previous QuickDraw error.
+            toolbox_startup.last_quickdraw_error = result;
+            Some(PpcImportAction::Return(ppc_i16_result(result)))
         }
         PpcImportDispatcherTarget::UpdateGWorld => {
-            Some(PpcImportAction::Return(ppc_update_gworld(
+            let result = ppc_update_gworld(
                 cpu,
                 memory,
                 heap_cursor,
@@ -17857,8 +17992,21 @@ fn dispatch_supported_import(
                 last_mem_error,
                 handles,
                 gworlds,
-                *current_gdevice,
-            )))
+                &mut toolbox_startup.gworld_allocations,
+                current_gworld,
+                current_gdevice,
+            );
+            // Imaging With QuickDraw (1994), p. 6-24: after gwFlagErr the
+            // caller uses QDError to obtain the reason UpdateGWorld failed.
+            toolbox_startup.last_quickdraw_error = if result & (1 << 31) != 0 {
+                *last_mem_error
+            } else {
+                PPC_NO_ERR
+            };
+            if result & (1 << 31) == 0 {
+                ppc_register_gdevice(toolbox_startup, *current_gdevice);
+            }
+            Some(PpcImportAction::Return(result))
         }
         PpcImportDispatcherTarget::DisposeGWorld => {
             let port = cpu.gpr[3];
@@ -17869,14 +18017,21 @@ fn dispatch_supported_import(
             gworlds.retain(|gworld| gworld.port == PPC_MAIN_GWORLD || gworld.port != port);
             if let Some(record) = disposed {
                 quickdraw_fore_indices.remove(&port);
+                let allocation = toolbox_startup.gworld_allocations.remove(&port);
                 let saved_ctable = toolbox_startup
                     .indexed_screen_ctables
                     .remove(&record.pixmap_handle)
                     .unwrap_or(0);
-                let ctable_handle = memory
+                let live_ctable = memory
                     .read_u32_be(record.pixmap + 42)
                     .filter(|handle| *handle != 0)
                     .unwrap_or(saved_ctable);
+                let owned_ctable = allocation.map_or(0, |allocation| allocation.ctable_handle);
+                let ctable_handle = if owned_ctable != 0 {
+                    owned_ctable
+                } else {
+                    live_ctable
+                };
                 if ctable_handle != 0 && ctable_handle != PPC_MAIN_CTABLE_HANDLE {
                     let _ =
                         ppc_dispose_tracked_handle(ctable_handle, memory, handles, handle_states);
@@ -17884,11 +18039,18 @@ fn dispatch_supported_import(
                         .indexed_screen_ctables
                         .retain(|_, handle| *handle != ctable_handle);
                 }
-                if ppc_allocation_size(PPC_CGRAF_PORT_SIZE)
-                    .and_then(|size| record.port.checked_add(size))
-                    == Some(*heap_cursor)
-                {
-                    *heap_cursor = record.base_addr;
+                let reclaim_base = allocation
+                    .filter(|allocation| allocation.allocation_end == *heap_cursor)
+                    .map(|allocation| allocation.origin_base)
+                    .or_else(|| {
+                        (ppc_allocation_size(PPC_CGRAF_PORT_SIZE)
+                            .and_then(|size| record.port.checked_add(size))
+                            == Some(*heap_cursor))
+                        .then_some(record.base_addr)
+                    });
+                if let Some(reclaim_base) = reclaim_base {
+                    *heap_cursor = reclaim_base;
+                    ppc_update_zone_free_bytes(memory, heap_limit.saturating_sub(reclaim_base));
                 }
             }
             if *current_gworld == port {
@@ -18409,32 +18571,36 @@ fn dispatch_supported_import(
             Some(PpcImportAction::ReturnPreserve)
         }
         PpcImportDispatcherTarget::FindWindow => {
-            const IN_MENU_BAR: u32 = 1;
-            const IN_CONTENT: u32 = 3;
             let v = (cpu.gpr[3] >> 16) as u16 as i16;
             let h = cpu.gpr[3] as u16 as i16;
             let window_out = cpu.gpr[4];
-            let in_screen = (0..PPC_MAIN_SCREEN_HEIGHT as i16).contains(&v)
-                && (0..PPC_MAIN_SCREEN_WIDTH as i16).contains(&h);
-            let in_menu_bar = in_screen && v < 20;
-            let window = if in_screen && !in_menu_bar && *current_gworld != 0 {
-                *current_gworld
+            let front = ppc_live_front_buffer_for_gworld(memory, gworlds, PPC_MAIN_GWORLD);
+            let screen_width = front
+                .map(|front| ppc_u32_to_i16_saturating(front.width))
+                .unwrap_or(PPC_MAIN_SCREEN_WIDTH as i16);
+            let screen_height = front
+                .map(|front| ppc_u32_to_i16_saturating(front.height))
+                .unwrap_or(PPC_MAIN_SCREEN_HEIGHT as i16);
+            let menu_bar_height = memory.read_u16_be(PPC_MBAR_HEIGHT_ADDR).unwrap_or(20) as i16;
+            let in_screen = (0..screen_height).contains(&v) && (0..screen_width).contains(&h);
+            let in_menu_bar = in_screen && v < menu_bar_height.max(0).min(screen_height);
+            let (part, window) = if in_menu_bar {
+                (1, 0)
+            } else if in_screen {
+                ppc_find_window_at_point(memory, gworlds, v, h, menu_bar_height)
             } else {
-                0
+                (0, 0)
             };
             if window_out != 0 && ppc_memory_can_write_bytes(memory, window_out, 4) {
                 let _ = memory.write_u32_be(window_out, window);
             }
             // FindWindow returns inMenuBar with whichWindow = NIL for points
-            // in the menu bar; applications use that result to call
-            // MenuSelect. Inside Macintosh Volume I (1985), p. I-287.
-            Some(PpcImportAction::Return(if in_menu_bar {
-                IN_MENU_BAR
-            } else if window != 0 {
-                IN_CONTENT
-            } else {
-                0
-            }))
+            // accepted by the menu bar definition procedure's live hit
+            // region. Inside Macintosh Volume V (1986), p. V-207.
+            // Window hits come from the Window Manager's front-to-back list,
+            // not the current GrafPort, which may be the desktop or an
+            // offscreen GWorld. Macintosh Toolbox Essentials (1992), p. 4-91.
+            Some(PpcImportAction::Return(part as u32))
         }
         PpcImportDispatcherTarget::GetGrayRgn => Some(PpcImportAction::Return(
             memory
@@ -18826,42 +18992,35 @@ fn dispatch_supported_import(
         }
         PpcImportDispatcherTarget::DMGetNextScreenDevice => Some(PpcImportAction::Return(0)),
         PpcImportDispatcherTarget::DMGetDisplayMode => {
-            // Display Manager 2.0 / Video.h VDSwitchInfoRec: csMode.w,
-            // csData.l, csPage.w, csBaseAddr.l, and csReserved.l.
-            let gdevice_handle = if cpu.gpr[3] == 0 {
-                PPC_MAIN_GDEVICE
-            } else {
-                cpu.gpr[3]
-            };
             let switch_info = cpu.gpr[4];
-            let gdevice = memory.read_u32_be(gdevice_handle).unwrap_or(0);
-            let mode = memory.read_u32_be(gdevice + 42).unwrap_or(0x85);
-            let base_addr = ppc_front_buffer_for_gworld(gworlds, PPC_MAIN_GWORLD)
-                .map_or(PPC_MAIN_SCREEN_BASE, |front| front.base_addr);
-            let result = if switch_info != 0
-                && memory.write_u16_be(switch_info, mode as u16).is_some()
-                && memory.write_u32_be(switch_info + 2, 0x80).is_some()
-                && memory.write_u16_be(switch_info + 6, 0).is_some()
-                && memory.write_u32_be(switch_info + 8, base_addr).is_some()
-                && memory.write_u32_be(switch_info + 12, 0).is_some()
-            {
-                PPC_NO_ERR
-            } else {
-                PPC_PARAM_ERR
-            };
+            let result = ppc_dm_live_display_mode(memory, cpu.gpr[3])
+                .filter(|_| switch_info != 0 && ppc_memory_can_write_bytes(memory, switch_info, 16))
+                .and_then(|mode| ppc_dm_write_switch_info(memory, switch_info, mode))
+                .map_or(PPC_PARAM_ERR, |_| PPC_NO_ERR);
             Some(PpcImportAction::Return(ppc_i16_result(result)))
         }
         PpcImportDispatcherTarget::DMCheckDisplayMode => {
-            // Universal Interfaces Displays.h: switchFlags and modeOk are
-            // output parameters. The single advertised mode is immediately
-            // switchable and needs no deferred confirmation flags.
             let switch_flags = cpu.gpr[6];
+            let reserved = cpu.gpr[7];
             let mode_ok = cpu.gpr[8];
-            let result = if switch_flags != 0
-                && mode_ok != 0
-                && memory.write_u32_be(switch_flags, 0).is_some()
-                && memory.write_u8(mode_ok, 1).is_some()
+            // Universal Interfaces `Displays.h` defines the intervening
+            // UInt32 as reserved; callers must pass zero.
+            let result = if reserved != 0
+                || switch_flags == 0
+                || mode_ok == 0
+                || !ppc_memory_can_write_bytes(memory, switch_flags, 4)
+                || !ppc_memory_can_write_bytes(memory, mode_ok, 1)
             {
+                PPC_PARAM_ERR
+            } else if let Some(mode) = ppc_dm_live_display_mode(memory, cpu.gpr[3]) {
+                let supported = cpu.gpr[4] == mode.display_mode_id && cpu.gpr[5] == mode.depth_mode;
+                let flags = if supported {
+                    PPC_DM_NO_SWITCH_CONFIRM_MASK
+                } else {
+                    PPC_DM_DEPTH_NOT_AVAILABLE_MASK
+                };
+                let _ = memory.write_u32_be(switch_flags, flags);
+                let _ = memory.write_u8(mode_ok, u8::from(supported));
                 PPC_NO_ERR
             } else {
                 PPC_PARAM_ERR
@@ -18869,21 +19028,24 @@ fn dispatch_supported_import(
             Some(PpcImportAction::Return(ppc_i16_result(result)))
         }
         PpcImportDispatcherTarget::DMSetDisplayMode => {
-            // Displays.h DMSetDisplayMode selects a timing and reports the
-            // resulting depth mode. Systemless exposes one fixed framebuffer,
-            // so selecting its advertised mode updates gdMode in place.
-            let gdevice_handle = if cpu.gpr[3] == 0 {
-                PPC_MAIN_GDEVICE
-            } else {
-                cpu.gpr[3]
-            };
-            let gdevice = memory.read_u32_be(gdevice_handle).unwrap_or(0);
-            let mode = if cpu.gpr[4] == 0 { 0x85 } else { cpu.gpr[4] };
-            let result = if gdevice != 0
-                && memory.write_u32_be(gdevice + 42, mode).is_some()
-                && (cpu.gpr[5] == 0 || memory.write_u32_be(cpu.gpr[5], mode).is_some())
+            let depth_mode = cpu.gpr[5];
+            let reserved = cpu.gpr[6];
+            let result = if reserved != 0
+                || depth_mode == 0
+                || !ppc_memory_can_write_bytes(memory, depth_mode, 4)
             {
-                PPC_NO_ERR
+                PPC_PARAM_ERR
+            } else if let Some(mode) = ppc_dm_live_display_mode(memory, cpu.gpr[3]) {
+                let requested = memory
+                    .read_u32_be(depth_mode)
+                    .map(|depth| (depth, cpu.gpr[4]));
+                if requested != Some((mode.depth_mode, mode.display_mode_id)) {
+                    PPC_DM_MODE_NOT_FOUND_ERR
+                } else if memory.write_u32_be(depth_mode, mode.depth_mode).is_some() {
+                    PPC_NO_ERR
+                } else {
+                    PPC_PARAM_ERR
+                }
             } else {
                 PPC_PARAM_ERR
             };
@@ -19434,6 +19596,7 @@ fn dispatch_supported_import(
         }
         PpcImportDispatcherTarget::InitMenus => {
             toolbox_startup.menus_initialized = true;
+            let _ = memory.write_u16_be(PPC_THE_MENU_ADDR, 0);
             // Inside Macintosh Volume V (1986), pp. V-228--V-230: the first
             // InitMenus call allocates the stable DynamicMenuList whose handle
             // is published in the MenuList low-memory global. Later calls do
@@ -20960,6 +21123,7 @@ fn dispatch_supported_import(
                 last_mem_error,
                 handles,
                 gworlds,
+                &mut toolbox_startup.gworld_allocations,
                 *current_gdevice,
                 draw_sprocket,
             )),
@@ -24200,8 +24364,10 @@ fn ppc_dispatch_quickdraw_compatibility(
                         )),
                     )
                     .map(|pixel| match front.depth {
-                        8 => {
-                            let fallback = TrapDispatcher::standard_mac_8bpp_clut();
+                        depth @ (1 | 2 | 4 | 8) => {
+                            let fallback = TrapDispatcher::standard_mac_indexed_clut(depth as u16)
+                                .map(|(clut, _)| clut)
+                                .unwrap_or_else(TrapDispatcher::standard_mac_8bpp_clut);
                             let clut = surface
                                 .ctable_handle
                                 .and_then(|handle| ppc_read_ctable_clut(memory, handle, &fallback))
@@ -41115,6 +41281,7 @@ fn ppc_rgb555_to_rgb16(pixel: u16) -> [u16; 3] {
     ]
 }
 
+#[cfg(test)]
 fn ppc_rgb555_to_clut_index(pixel: u16, clut: &[[u16; 3]; 256]) -> u8 {
     let [red, green, blue] = ppc_rgb555_to_rgb16(pixel & 0x7fff);
     pict::closest_clut_index(red, green, blue, clut)
@@ -45667,12 +45834,14 @@ fn ppc_seed_main_gworld(memory: &mut PpcSectionMem) -> PpcGWorldRecord {
     let _ = memory.write_u32_be(PPC_GRAY_RGN_HANDLE, PPC_GRAY_RGN);
     let _ = memory.write_u32_be(PPC_GRAY_RGN_ADDR, PPC_GRAY_RGN_HANDLE);
     let _ = memory.write_u16_be(PPC_GRAY_RGN, 10);
-    // Macintosh Toolbox Essentials (1992), p. 4-16: GrayRgn is the desktop
-    // area, which excludes the main screen's menu bar.
+    // Macintosh Toolbox Essentials (1992), pp. 3-112 and 4-16: GrayRgn is
+    // the desktop area below the menu bar, whose live height is MBarHeight.
+    let menu_bar_height = u32::from(memory.read_u16_be(PPC_MBAR_HEIGHT_ADDR).unwrap_or(20))
+        .min(PPC_MAIN_SCREEN_HEIGHT) as i16;
     let _ = ppc_write_rect(
         memory,
         PPC_GRAY_RGN + 2,
-        20,
+        menu_bar_height,
         0,
         PPC_MAIN_SCREEN_HEIGHT as i16,
         PPC_MAIN_SCREEN_WIDTH as i16,
@@ -46997,7 +47166,7 @@ fn ppc_default_color_table_bytes(depth: u32) -> Option<Vec<u8>> {
             [0x5555, 0x5555, 0x5555],
             [0, 0, 0],
         ],
-        4 => TrapDispatcher::standard_mac_4bpp_gworld_clut().to_vec(),
+        4 => TrapDispatcher::standard_mac_4bpp_gworld_clut()[..16].to_vec(),
         8 => TrapDispatcher::standard_mac_8bpp_clut().to_vec(),
         _ => return None,
     };
@@ -47018,11 +47187,18 @@ fn ppc_copy_color_table_bytes(memory: &mut PpcSectionMem, handle: u32) -> Option
     ppc_memory_read_bytes(memory, table, size)
 }
 
-fn ppc_color_table_clut_from_bytes(bytes: &[u8]) -> Option<[[u16; 3]; 256]> {
+#[derive(Clone)]
+struct PpcGWorldClut {
+    colors: [[u16; 3]; 256],
+    valid: [bool; 256],
+}
+
+fn ppc_color_table_clut_from_bytes(bytes: &[u8]) -> Option<PpcGWorldClut> {
     let flags = u16::from_be_bytes(bytes.get(4..6)?.try_into().ok()?);
     let last_entry = usize::from(u16::from_be_bytes(bytes.get(6..8)?.try_into().ok()?));
     let entry_count = last_entry.checked_add(1)?.min(256);
     let mut clut = [[0; 3]; 256];
+    let mut valid = [false; 256];
     for slot in 0..entry_count {
         let offset = 8usize.checked_add(slot.checked_mul(8)?)?;
         let entry = bytes.get(offset..offset.checked_add(8)?)?;
@@ -47031,50 +47207,17 @@ fn ppc_color_table_clut_from_bytes(bytes: &[u8]) -> Option<[[u16; 3]; 256]> {
         if index >= clut.len() {
             continue;
         }
+        valid[index] = true;
         clut[index] = [
             u16::from_be_bytes(entry.get(2..4)?.try_into().ok()?),
             u16::from_be_bytes(entry.get(4..6)?.try_into().ok()?),
             u16::from_be_bytes(entry.get(6..8)?.try_into().ok()?),
         ];
     }
-    Some(clut)
-}
-
-fn ppc_remap_gworld_8bpp_pixels(
-    memory: &mut PpcSectionMem,
-    world: PpcGWorldRecord,
-    old_clut: &[[u16; 3]; 256],
-    new_clut: &[[u16; 3]; 256],
-) -> bool {
-    if world.depth != 8 || world.width > world.row_bytes {
-        return false;
-    }
-    let palette_map = std::array::from_fn::<u8, 256, _>(|index| {
-        let [red, green, blue] = old_clut[index];
-        pict::closest_clut_index(red, green, blue, new_clut)
-    });
-    let Ok(width) = usize::try_from(world.width) else {
-        return false;
-    };
-    let mut row = vec![0; width];
-    for y in 0..world.height {
-        let Some(addr) = world
-            .base_addr
-            .checked_add(y.saturating_mul(world.row_bytes))
-        else {
-            return false;
-        };
-        if memory.read_bytes_into(addr, &mut row).is_none() {
-            return false;
-        }
-        for pixel in &mut row {
-            *pixel = palette_map[usize::from(*pixel)];
-        }
-        if memory.write_bytes(addr, &row).is_none() {
-            return false;
-        }
-    }
-    true
+    Some(PpcGWorldClut {
+        colors: clut,
+        valid,
+    })
 }
 
 fn ppc_new_gworld(
@@ -47085,6 +47228,7 @@ fn ppc_new_gworld(
     last_mem_error: &mut i16,
     handles: &mut Vec<PpcHandleRecord>,
     gworlds: &mut Vec<PpcGWorldRecord>,
+    gworld_allocations: &mut HashMap<u32, PpcGWorldAllocationRecord>,
     current_gdevice: u32,
 ) -> i16 {
     let gworld_out_ptr = cpu.gpr[3];
@@ -47094,12 +47238,14 @@ fn ppc_new_gworld(
     let requested_gdevice = cpu.gpr[7];
     let flags = cpu.gpr[8];
     if gworld_out_ptr == 0 || bounds_ptr == 0 {
+        *last_mem_error = PPC_PARAM_ERR;
         return PPC_PARAM_ERR;
     }
 
     let Some((requested_top, requested_left, requested_bottom, requested_right)) =
         ppc_read_rect(memory, bounds_ptr)
     else {
+        *last_mem_error = PPC_PARAM_ERR;
         return PPC_PARAM_ERR;
     };
     let (width, height) = ppc_rect_dimensions(
@@ -47109,9 +47255,20 @@ fn ppc_new_gworld(
         requested_right,
     );
     const NO_NEW_DEVICE: u32 = 1 << 1;
-    let uses_explicit_gdevice = flags & NO_NEW_DEVICE != 0 && requested_gdevice != 0;
+    // Imaging With QuickDraw (1994), pp. 6-16--6-20: literal depths are
+    // exactly 0, 1, 2, 4, 8, 16, and 32. A zero depth rescans screen devices
+    // even when noNewDevice is present; this single-display runtime selects
+    // the physical main device for both the source PixMap and attachment.
+    let uses_explicit_gdevice =
+        flags & NO_NEW_DEVICE != 0 && requested_gdevice != 0 && requested_depth != 0;
+    if !matches!(requested_depth, 0 | 1 | 2 | 4 | 8 | 16 | 32) {
+        *last_mem_error = PPC_C_DEPTH_ERR;
+        return PPC_C_DEPTH_ERR;
+    }
     let selected_gdevice = if uses_explicit_gdevice {
         requested_gdevice
+    } else if requested_depth == 0 {
+        PPC_MAIN_GDEVICE
     } else {
         current_gdevice
     };
@@ -47128,12 +47285,22 @@ fn ppc_new_gworld(
         .and_then(|pixmap| memory.read_u16_be(pixmap + 32))
         .map(u32::from)
         .filter(|depth| *depth != 0);
-    let depth = if uses_explicit_gdevice || requested_depth <= 0 {
+    if (uses_explicit_gdevice || requested_depth == 0) && device_depth.is_none() {
+        *last_mem_error = PPC_C_DEPTH_ERR;
+        return PPC_C_DEPTH_ERR;
+    }
+    let depth = if uses_explicit_gdevice || requested_depth == 0 {
         device_depth.unwrap_or(PPC_MAIN_PIXEL_DEPTH)
     } else {
         requested_depth as u32
     };
-    let Some(row_bytes) = ppc_row_bytes(width, depth) else {
+    if !matches!(depth, 1 | 2 | 4 | 8 | 16 | 32) {
+        *last_mem_error = PPC_C_DEPTH_ERR;
+        return PPC_C_DEPTH_ERR;
+    }
+    let Some(row_bytes) = ppc_row_bytes(width, depth).filter(|row_bytes| *row_bytes <= 0x3fff)
+    else {
+        *last_mem_error = PPC_PARAM_ERR;
         return PPC_PARAM_ERR;
     };
     let Some(buffer_size) = row_bytes.checked_mul(height) else {
@@ -47147,14 +47314,14 @@ fn ppc_new_gworld(
         return PPC_PARAM_ERR;
     };
     let ctable_bytes = if depth <= 8 {
-        let source_ctable = if requested_depth <= 0 || uses_explicit_gdevice {
+        if requested_depth == 0 || uses_explicit_gdevice {
             ppc_gdevice_ctable_handle(memory, selected_gdevice)
+                .and_then(|handle| ppc_copy_color_table_bytes(memory, handle))
+        } else if requested_ctab != 0 {
+            ppc_copy_color_table_bytes(memory, requested_ctab)
         } else {
-            (requested_ctab != 0).then_some(requested_ctab)
-        };
-        source_ctable
-            .and_then(|handle| ppc_copy_color_table_bytes(memory, handle))
-            .or_else(|| ppc_default_color_table_bytes(depth))
+            ppc_default_color_table_bytes(depth)
+        }
     } else {
         None
     };
@@ -47240,7 +47407,7 @@ fn ppc_new_gworld(
         gdevice: if uses_explicit_gdevice {
             requested_gdevice
         } else {
-            current_gdevice
+            selected_gdevice
         },
         width,
         height,
@@ -47249,6 +47416,16 @@ fn ppc_new_gworld(
         pixels_locked: false,
         pixels_no_purge: false,
     });
+    gworld_allocations.insert(
+        port,
+        PpcGWorldAllocationRecord {
+            origin_base: base_addr,
+            pixel_capacity: ppc_allocation_size(pixel_allocation_size)
+                .unwrap_or(pixel_allocation_size),
+            ctable_handle,
+            allocation_end: *heap_cursor,
+        },
+    );
     if ppc_gworld_trace_enabled() {
         eprintln!(
             "[PPC-GWORLD-TRACE] NewGWorld port=${:08X} out=${:08X} base=${:08X} pixmap=${:08X} handle=${:08X} ctable=${:08X} requested_depth={} requested_ctable=${:08X} requested_gdevice=${:08X} gdevice=${:08X} requested_bounds=({}, {}, {}, {}) bounds=({}, {}, {}, {}) size={}x{}x{} row_bytes={} flags=${:08X}",
@@ -47264,7 +47441,7 @@ fn ppc_new_gworld(
             if uses_explicit_gdevice {
                 requested_gdevice
             } else {
-                current_gdevice
+                selected_gdevice
             },
             requested_top,
             requested_left,
@@ -47293,7 +47470,9 @@ fn ppc_update_gworld(
     last_mem_error: &mut i16,
     handles: &mut Vec<PpcHandleRecord>,
     gworlds: &mut [PpcGWorldRecord],
-    current_gdevice: u32,
+    gworld_allocations: &mut HashMap<u32, PpcGWorldAllocationRecord>,
+    current_gworld: &mut u32,
+    current_gdevice: &mut u32,
 ) -> u32 {
     // Inside Macintosh: Imaging With QuickDraw (1994), pp. 6-23--6-26:
     // UpdateGWorld leaves the old world intact on error, reports structural
@@ -47304,6 +47483,7 @@ fn ppc_update_gworld(
     const ALIGN_PIX: u32 = 1 << 18;
     const NEW_ROW_BYTES: u32 = 1 << 19;
     const REALLOC_PIX: u32 = 1 << 20;
+    const KEEP_LOCAL: u32 = 1 << 3;
     const CLIP_PIX: u32 = 1 << 28;
     const STRETCH_PIX: u32 = 1 << 29;
     const DITHER_PIX: u32 = 1 << 30;
@@ -47315,6 +47495,20 @@ fn ppc_update_gworld(
     let requested_ctab = cpu.gpr[6];
     let requested_gdevice = cpu.gpr[7];
     let requested_flags = cpu.gpr[8];
+    let update_flags = requested_flags & (CLIP_PIX | STRETCH_PIX | DITHER_PIX);
+    let clip_requested = update_flags & CLIP_PIX != 0;
+    let stretch_requested = update_flags & STRETCH_PIX != 0;
+    let dither_requested = update_flags & DITHER_PIX != 0;
+    if requested_flags & !(KEEP_LOCAL | CLIP_PIX | STRETCH_PIX | DITHER_PIX) != 0
+        || (clip_requested && stretch_requested)
+        || (dither_requested && !clip_requested && !stretch_requested)
+    {
+        // Inside Macintosh Volume VI (1991), p. 21-16: the only legal pixel
+        // update sets are none, clip, stretch, clip+dither, and stretch+dither.
+        *last_mem_error = PPC_PARAM_ERR;
+        return GW_FLAG_ERR;
+    }
+    let updates_pixels = clip_requested || stretch_requested;
 
     let Some(port) = (gworld_ptr_ptr != 0 && bounds_ptr != 0)
         .then(|| memory.read_u32_be(gworld_ptr_ptr))
@@ -47351,33 +47545,43 @@ fn ppc_update_gworld(
             .and_then(|pixmap_handle| memory.read_u32_be(pixmap_handle))
             .filter(|pixmap| *pixmap != 0)
     };
-    let device_pixmap = (requested_gdevice != 0)
-        .then(|| device_pixmap_for(memory, requested_gdevice))
-        .flatten();
-    if requested_gdevice != 0 && device_pixmap.is_none() {
-        *last_mem_error = PPC_PARAM_ERR;
+    if requested_gdevice == 0 && !matches!(requested_depth, 0 | 1 | 2 | 4 | 8 | 16 | 32) {
+        *last_mem_error = PPC_C_DEPTH_ERR;
         return GW_FLAG_ERR;
     }
-    let selected_screen_pixmap = if requested_gdevice != 0 {
-        device_pixmap
-    } else if requested_depth <= 0 {
-        device_pixmap_for(memory, current_gdevice)
+    let selected_screen_gdevice = if requested_gdevice != 0 {
+        Some(requested_gdevice)
+    } else if requested_depth == 0 {
+        // Imaging With QuickDraw (1994), pp. 6-23--6-24: depth zero rescans
+        // intersecting screen devices. This single-screen runtime selects the
+        // physical main device for both the source PixMap and attachment.
+        Some(PPC_MAIN_GDEVICE)
     } else {
         None
     };
+    let selected_screen_pixmap =
+        selected_screen_gdevice.and_then(|gdevice| device_pixmap_for(memory, gdevice));
+    if requested_gdevice != 0 && selected_screen_pixmap.is_none() {
+        *last_mem_error = PPC_PARAM_ERR;
+        return GW_FLAG_ERR;
+    }
     let device_depth = selected_screen_pixmap
         .and_then(|pixmap| memory.read_u16_be(pixmap + 32))
         .map(u32::from)
         .filter(|depth| *depth != 0);
+    if (requested_gdevice != 0 || requested_depth == 0) && device_depth.is_none() {
+        *last_mem_error = PPC_C_DEPTH_ERR;
+        return GW_FLAG_ERR;
+    }
     let depth = if requested_gdevice != 0 {
         device_depth.unwrap_or(PPC_MAIN_PIXEL_DEPTH)
-    } else if requested_depth <= 0 {
+    } else if requested_depth == 0 {
         device_depth.unwrap_or(PPC_MAIN_PIXEL_DEPTH)
     } else {
         requested_depth as u32
     };
     if !matches!(depth, 1 | 2 | 4 | 8 | 16 | 32) {
-        *last_mem_error = PPC_PARAM_ERR;
+        *last_mem_error = PPC_C_DEPTH_ERR;
         return GW_FLAG_ERR;
     }
 
@@ -47388,7 +47592,8 @@ fn ppc_update_gworld(
         requested_right,
     );
     let (width, height) = ppc_rect_dimensions(top, left, bottom, right);
-    let Some(row_bytes) = ppc_row_bytes(width, depth) else {
+    let Some(row_bytes) = ppc_row_bytes(width, depth).filter(|row_bytes| *row_bytes <= 0x3fff)
+    else {
         *last_mem_error = PPC_PARAM_ERR;
         return GW_FLAG_ERR;
     };
@@ -47414,19 +47619,17 @@ fn ppc_update_gworld(
         ppc_u32_to_i16_saturating(old.width),
     ));
     let old_ctab = memory.read_u32_be(old.pixmap + 42).unwrap_or(0);
-    let source_ctab = if requested_gdevice != 0 || requested_depth <= 0 {
-        selected_screen_pixmap
-            .and_then(|pixmap| memory.read_u32_be(pixmap + 42))
-            .filter(|handle| *handle != 0)
-    } else if requested_ctab != 0 {
-        Some(requested_ctab)
-    } else {
-        None
-    };
     let desired_ctable_bytes = if depth <= 8 {
-        source_ctab
-            .and_then(|handle| ppc_copy_color_table_bytes(memory, handle))
-            .or_else(|| ppc_default_color_table_bytes(depth))
+        if requested_gdevice != 0 || requested_depth == 0 {
+            selected_screen_pixmap
+                .and_then(|pixmap| memory.read_u32_be(pixmap + 42))
+                .filter(|handle| *handle != 0)
+                .and_then(|handle| ppc_copy_color_table_bytes(memory, handle))
+        } else if requested_ctab != 0 {
+            ppc_copy_color_table_bytes(memory, requested_ctab)
+        } else {
+            ppc_default_color_table_bytes(depth)
+        }
     } else {
         None
     };
@@ -47438,159 +47641,415 @@ fn ppc_update_gworld(
         .then(|| ppc_copy_color_table_bytes(memory, old_ctab))
         .flatten();
     let ctable_changed = old_ctable_bytes != desired_ctable_bytes;
-    let mut new_ctab = old_ctab;
-    let mut reuse_old_ctable = false;
-    if let Some(bytes) = desired_ctable_bytes.as_ref() {
-        if handles.iter().any(|record| record.handle == old_ctab) {
+    let dimensions_changed = width != old.width || height != old.height;
+    let maps_pixels = updates_pixels && depth <= 8 && ctable_changed;
+    let translates_pixels = updates_pixels && (depth != old.depth || maps_pixels);
+    let replaces_pixels = dimensions_changed
+        || depth != old.depth
+        || row_bytes != old.row_bytes
+        || old.base_addr == 0
+        || (ctable_changed && updates_pixels);
+    let preserves_pixels = old.base_addr != 0 && updates_pixels;
+    let dithers_pixels = dither_requested && preserves_pixels && translates_pixels && depth <= 8;
+    let replaces_ctable = depth <= 8 && (ctable_changed || old_ctab == 0);
+
+    let old_clut = if old.depth <= 8 && preserves_pixels && translates_pixels {
+        let Some(bytes) = old_ctable_bytes.as_deref() else {
+            *last_mem_error = PPC_PARAM_ERR;
+            return GW_FLAG_ERR;
+        };
+        let Some(clut) = ppc_color_table_clut_from_bytes(bytes) else {
+            *last_mem_error = PPC_PARAM_ERR;
+            return GW_FLAG_ERR;
+        };
+        Some(clut)
+    } else {
+        None
+    };
+    let new_clut = if depth <= 8 && preserves_pixels && translates_pixels {
+        let Some(bytes) = desired_ctable_bytes.as_deref() else {
+            *last_mem_error = PPC_PARAM_ERR;
+            return GW_FLAG_ERR;
+        };
+        let Some(clut) = ppc_color_table_clut_from_bytes(bytes) else {
+            *last_mem_error = PPC_PARAM_ERR;
+            return GW_FLAG_ERR;
+        };
+        Some(clut)
+    } else {
+        None
+    };
+
+    let allocation_before = gworld_allocations.get(&port).copied();
+    let old_pixel_capacity = allocation_before.map_or_else(
+        || {
+            old.row_bytes
+                .checked_mul(old.height)
+                .and_then(ppc_allocation_size)
+                .unwrap_or(0)
+        },
+        |allocation| allocation.pixel_capacity,
+    );
+    let Some(required_pixel_capacity) = ppc_allocation_size(pixel_allocation_size) else {
+        *last_mem_error = PPC_MEM_FULL_ERR;
+        return GW_FLAG_ERR;
+    };
+    let stable_ctable_handle = allocation_before
+        .map(|allocation| allocation.ctable_handle)
+        .filter(|handle| *handle != 0)
+        .or_else(|| {
+            handles
+                .iter()
+                .any(|record| record.handle == old_ctab && old_ctab != 0)
+                .then_some(old_ctab)
+        });
+    let stable_ctable_record = stable_ctable_handle
+        .and_then(|handle| handles.iter().find(|record| record.handle == handle))
+        .copied();
+    let desired_ctable_size = desired_ctable_bytes
+        .as_ref()
+        .and_then(|bytes| u32::try_from(bytes.len()).ok())
+        .unwrap_or(0);
+    let stable_ctable_resize_allocation = if replaces_ctable {
+        if let Some(record) = stable_ctable_record {
+            let Some(size) =
+                ppc_handle_resize_allocation_size(record, *heap_cursor, desired_ctable_size)
+            else {
+                *last_mem_error = PPC_MEM_FULL_ERR;
+                return GW_FLAG_ERR;
+            };
+            size
+        } else {
+            0
+        }
+    } else {
+        0
+    };
+    let allocates_ctable_handle = replaces_ctable && stable_ctable_record.is_none();
+    let grows_pixel_storage_in_place = replaces_pixels
+        && old.base_addr != 0
+        && required_pixel_capacity > old_pixel_capacity
+        && old.base_addr.checked_add(old_pixel_capacity) == Some(*heap_cursor)
+        && stable_ctable_resize_allocation == 0
+        && !allocates_ctable_handle;
+    let reuses_pixel_storage = replaces_pixels
+        && old.base_addr != 0
+        && (required_pixel_capacity <= old_pixel_capacity || grows_pixel_storage_in_place);
+    let allocates_pixel_storage = replaces_pixels && !reuses_pixel_storage;
+
+    let mut allocation_sizes = Vec::new();
+    if stable_ctable_resize_allocation != 0 {
+        allocation_sizes.push(stable_ctable_resize_allocation);
+    } else if allocates_ctable_handle {
+        allocation_sizes.push(4);
+        allocation_sizes.push(desired_ctable_size);
+    }
+    if grows_pixel_storage_in_place {
+        allocation_sizes.push(required_pixel_capacity - old_pixel_capacity);
+    } else if allocates_pixel_storage {
+        allocation_sizes.push(pixel_allocation_size);
+    }
+    if !allocation_sizes.is_empty()
+        && !ppc_heap_can_alloc_sequence(*heap_cursor, heap_limit, &allocation_sizes)
+    {
+        *last_mem_error = PPC_MEM_FULL_ERR;
+        return GW_FLAG_ERR;
+    }
+
+    let staged_pixels = if replaces_pixels {
+        let Ok(buffer_len) = usize::try_from(buffer_size) else {
+            *last_mem_error = PPC_MEM_FULL_ERR;
+            return GW_FLAG_ERR;
+        };
+        let staged = if preserves_pixels {
+            ppc_stage_update_gworld_pixels(
+                memory,
+                old,
+                row_bytes,
+                width,
+                height,
+                depth,
+                stretch_requested,
+                translates_pixels,
+                dithers_pixels,
+                old_clut.as_ref(),
+                new_clut.as_ref(),
+            )
+        } else {
+            let mut bytes = Vec::new();
+            if bytes.try_reserve_exact(buffer_len).is_err() {
+                None
+            } else {
+                bytes.resize(buffer_len, 0);
+                Some(bytes)
+            }
+        };
+        let Some(staged) = staged else {
+            *last_mem_error = PPC_PARAM_ERR;
+            return GW_FLAG_ERR;
+        };
+        Some(staged)
+    } else {
+        None
+    };
+
+    let Some(old_pixmap_snapshot) = ppc_memory_read_bytes(memory, old.pixmap, PPC_PIXMAP_SIZE)
+    else {
+        *last_mem_error = PPC_PARAM_ERR;
+        return GW_FLAG_ERR;
+    };
+    let Some(old_port_rect_snapshot) = ppc_memory_read_bytes(memory, old.port + 16, 8) else {
+        *last_mem_error = PPC_PARAM_ERR;
+        return GW_FLAG_ERR;
+    };
+    if !ppc_memory_can_write_bytes(memory, old.pixmap, PPC_PIXMAP_SIZE)
+        || !ppc_memory_can_write_bytes(memory, old.port + 16, 8)
+    {
+        *last_mem_error = PPC_PARAM_ERR;
+        return GW_FLAG_ERR;
+    }
+
+    let vis_region_snapshot = memory
+        .read_u32_be(old.port + PPC_CGRAF_PORT_VIS_RGN_OFFSET)
+        .and_then(|handle| ppc_rgn_ptr(memory, handle))
+        .and_then(|ptr| ppc_memory_read_bytes(memory, ptr, 10).map(|bytes| (ptr, bytes)))
+        .filter(|(ptr, _)| ppc_memory_can_write_bytes(memory, *ptr, 10));
+    let new_gdevice = if requested_gdevice != 0 {
+        requested_gdevice
+    } else if requested_depth == 0 {
+        selected_screen_gdevice.unwrap_or(PPC_MAIN_GDEVICE)
+    } else if old.gdevice != 0 {
+        old.gdevice
+    } else {
+        *current_gdevice
+    };
+
+    let reused_pixel_snapshot = if reuses_pixel_storage {
+        let snapshot_size = if grows_pixel_storage_in_place {
+            old_pixel_capacity
+        } else {
+            buffer_size
+        };
+        if !ppc_memory_can_write_bytes(memory, old.base_addr, snapshot_size) {
+            *last_mem_error = PPC_PARAM_ERR;
+            return GW_FLAG_ERR;
+        }
+        let Some(bytes) = ppc_memory_read_bytes(memory, old.base_addr, snapshot_size) else {
+            *last_mem_error = PPC_PARAM_ERR;
+            return GW_FLAG_ERR;
+        };
+        Some(bytes)
+    } else {
+        None
+    };
+    let stable_ctable_snapshot = if replaces_ctable {
+        if let Some(record) = stable_ctable_record {
+            let Some(master) = memory.read_u32_be(record.handle) else {
+                *last_mem_error = PPC_PARAM_ERR;
+                return GW_FLAG_ERR;
+            };
+            if master != record.ptr {
+                *last_mem_error = PPC_PARAM_ERR;
+                return GW_FLAG_ERR;
+            }
+            let Some(bytes) = ppc_memory_read_bytes(memory, record.ptr, record.size) else {
+                *last_mem_error = PPC_PARAM_ERR;
+                return GW_FLAG_ERR;
+            };
+            if desired_ctable_size <= record.capacity
+                && !ppc_memory_can_write_bytes(memory, record.ptr, desired_ctable_size)
+            {
+                *last_mem_error = PPC_PARAM_ERR;
+                return GW_FLAG_ERR;
+            }
+            Some((record, master, bytes))
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    // Allocate only after every source pixel, destination byte, metadata
+    // target, and allocation has been preflighted. Pixel bytes are staged on
+    // the host, and the world's private ColorTable keeps one stable handle;
+    // rollback restores both if an already-preflighted guest write fails.
+    let heap_cursor_before = *heap_cursor;
+    let handles_before = handles.clone();
+    let mut allocation_error = PPC_NO_ERR;
+    let mut owned_ctable_handle = stable_ctable_handle.unwrap_or(0);
+    let new_ctab = if depth > 8 {
+        0
+    } else if replaces_ctable {
+        if let Some(record) = stable_ctable_record {
             let result = ppc_set_handle_size(
                 memory,
                 heap_cursor,
                 heap_limit,
                 handles,
-                old_ctab,
-                u32::try_from(bytes.len()).unwrap_or(u32::MAX),
+                record.handle,
+                desired_ctable_size,
             );
             if result != PPC_NO_ERR {
-                *last_mem_error = result;
-                return GW_FLAG_ERR;
+                allocation_error = result;
+                0
+            } else if let Some(table) = memory
+                .read_u32_be(record.handle)
+                .filter(|table| *table != 0)
+            {
+                if memory
+                    .write_bytes(table, desired_ctable_bytes.as_deref().unwrap_or_default())
+                    .is_none()
+                {
+                    allocation_error = PPC_PARAM_ERR;
+                    0
+                } else {
+                    owned_ctable_handle = record.handle;
+                    record.handle
+                }
+            } else {
+                allocation_error = PPC_PARAM_ERR;
+                0
             }
-            reuse_old_ctable = true;
         } else {
-            new_ctab = ppc_alloc_handle_with_bytes(memory, heap_cursor, heap_limit, handles, bytes);
-            if new_ctab == 0 {
-                *last_mem_error = PPC_MEM_FULL_ERR;
-                return GW_FLAG_ERR;
+            let handle = ppc_alloc_handle_with_bytes(
+                memory,
+                heap_cursor,
+                heap_limit,
+                handles,
+                desired_ctable_bytes.as_deref().unwrap_or_default(),
+            );
+            if handle == 0 {
+                allocation_error = PPC_MEM_FULL_ERR;
+            } else {
+                owned_ctable_handle = handle;
             }
+            handle
         }
     } else {
-        new_ctab = 0;
-    }
-    if ctable_changed && old.depth == 8 && depth == 8 {
-        if let (Some(old_bytes), Some(new_bytes)) =
-            (old_ctable_bytes.as_deref(), desired_ctable_bytes.as_deref())
-        {
-            let Some(old_clut) = ppc_color_table_clut_from_bytes(old_bytes) else {
-                *last_mem_error = PPC_PARAM_ERR;
-                return GW_FLAG_ERR;
-            };
-            let Some(new_clut) = ppc_color_table_clut_from_bytes(new_bytes) else {
-                *last_mem_error = PPC_PARAM_ERR;
-                return GW_FLAG_ERR;
-            };
-            if !ppc_remap_gworld_8bpp_pixels(memory, old, &old_clut, &new_clut) {
-                *last_mem_error = PPC_PARAM_ERR;
-                return GW_FLAG_ERR;
+        old_ctab
+    };
+    let new_base = if allocation_error != PPC_NO_ERR || !replaces_pixels {
+        old.base_addr
+    } else if reuses_pixel_storage {
+        if grows_pixel_storage_in_place {
+            let growth = required_pixel_capacity - old_pixel_capacity;
+            let expected_extension = old.base_addr.checked_add(old_pixel_capacity);
+            let extension = ppc_heap_alloc(memory, heap_cursor, heap_limit, growth, true);
+            if extension == 0 || Some(extension) != expected_extension {
+                allocation_error = PPC_MEM_FULL_ERR;
             }
         }
-    }
-    let needs_reallocation = width != old.width
-        || height != old.height
-        || depth != old.depth
-        || row_bytes != old.row_bytes
-        || old.base_addr == 0;
-    let mut new_base = old.base_addr;
-    if needs_reallocation {
-        if !ppc_heap_can_alloc_sequence(*heap_cursor, heap_limit, &[pixel_allocation_size]) {
-            *last_mem_error = PPC_MEM_FULL_ERR;
-            return GW_FLAG_ERR;
-        }
-        new_base = ppc_heap_alloc(memory, heap_cursor, heap_limit, pixel_allocation_size, true);
-        if new_base == 0 {
-            *last_mem_error = PPC_MEM_FULL_ERR;
-            return GW_FLAG_ERR;
-        }
-        let preserve_flags = requested_flags & (CLIP_PIX | STRETCH_PIX);
-        if preserve_flags != 0
-            && !ppc_update_gworld_pixels(
-                memory,
-                old,
-                new_base,
-                row_bytes,
-                width,
-                height,
-                depth,
-                preserve_flags,
-            )
+        if allocation_error == PPC_NO_ERR
+            && memory
+                .write_bytes(old.base_addr, staged_pixels.as_deref().unwrap_or_default())
+                .is_none()
         {
-            *last_mem_error = PPC_PARAM_ERR;
-            return GW_FLAG_ERR;
+            allocation_error = PPC_PARAM_ERR;
         }
+        old.base_addr
+    } else {
+        let base = ppc_heap_alloc(memory, heap_cursor, heap_limit, pixel_allocation_size, true);
+        if base == 0 {
+            allocation_error = PPC_MEM_FULL_ERR;
+        } else if memory
+            .write_bytes(base, staged_pixels.as_deref().unwrap_or_default())
+            .is_none()
+        {
+            allocation_error = PPC_PARAM_ERR;
+        }
+        base
+    };
+    if allocation_error != PPC_NO_ERR {
+        if let Some(bytes) = reused_pixel_snapshot.as_ref() {
+            let _ = memory.write_bytes(old.base_addr, bytes);
+        }
+        if let Some((record, master, bytes)) = stable_ctable_snapshot.as_ref() {
+            let _ = memory.write_u32_be(record.handle, *master);
+            let _ = memory.write_bytes(record.ptr, bytes);
+        }
+        *heap_cursor = heap_cursor_before;
+        *handles = handles_before;
+        ppc_update_zone_free_bytes(memory, heap_limit.saturating_sub(heap_cursor_before));
+        *last_mem_error = allocation_error;
+        return GW_FLAG_ERR;
     }
 
     let mut result = 0;
-    if ctable_changed {
+    if maps_pixels {
         result |= MAP_PIX;
     }
-    if depth != old.depth {
+    if translates_pixels && depth != old.depth {
         result |= NEW_DEPTH;
     }
-    if width == old.width && height == old.height && old_bounds != (top, left, bottom, right) {
+    if updates_pixels
+        && width == old.width
+        && height == old.height
+        && old_bounds != (top, left, bottom, right)
+    {
         result |= ALIGN_PIX;
     }
     if row_bytes != old.row_bytes {
         result |= NEW_ROW_BYTES;
     }
-    if needs_reallocation {
+    if allocates_pixel_storage {
         result |= REALLOC_PIX;
-        if requested_flags & STRETCH_PIX != 0 {
+    }
+    if dimensions_changed {
+        if stretch_requested {
             result |= STRETCH_PIX;
-        } else if requested_flags & CLIP_PIX != 0 {
+        } else if clip_requested {
             result |= CLIP_PIX;
         }
-        if requested_flags & DITHER_PIX != 0 && result & (CLIP_PIX | STRETCH_PIX) != 0 {
-            result |= DITHER_PIX;
-        }
+    }
+    if dithers_pixels {
+        result |= DITHER_PIX;
     }
 
-    if reuse_old_ctable {
-        let Some(bytes) = desired_ctable_bytes.as_deref() else {
-            *last_mem_error = PPC_PARAM_ERR;
-            return GW_FLAG_ERR;
-        };
-        let Some(table) = memory.read_u32_be(new_ctab).filter(|table| *table != 0) else {
-            *last_mem_error = PPC_PARAM_ERR;
-            return GW_FLAG_ERR;
-        };
-        if memory.write_bytes(table, bytes).is_none() {
-            *last_mem_error = PPC_PARAM_ERR;
-            return GW_FLAG_ERR;
-        }
-    }
-
-    let write_ok = memory.write_u32_be(old.pixmap, new_base).is_some()
+    let (pixel_type, component_count, component_size) = match depth {
+        1 | 2 | 4 | 8 => (0, 1, depth as u16),
+        16 => (16, 3, 5),
+        32 => (16, 3, 8),
+        _ => unreachable!("validated GWorld depth"),
+    };
+    let mut write_ok = memory.write_u32_be(old.pixmap, new_base).is_some()
         && memory
             .write_u16_be(old.pixmap + 4, (row_bytes as u16) | 0x8000)
             .is_some()
         && ppc_write_rect(memory, old.pixmap + 6, top, left, bottom, right).is_some()
+        && memory.write_u16_be(old.pixmap + 30, pixel_type).is_some()
         && memory.write_u16_be(old.pixmap + 32, depth as u16).is_some()
-        && memory.write_u16_be(old.pixmap + 36, depth as u16).is_some()
+        && memory
+            .write_u16_be(old.pixmap + 34, component_count)
+            .is_some()
+        && memory
+            .write_u16_be(old.pixmap + 36, component_size)
+            .is_some()
+        && memory.write_u32_be(old.pixmap + 38, 0).is_some()
         && memory.write_u32_be(old.pixmap + 42, new_ctab).is_some()
         && ppc_write_rect(memory, old.port + 16, top, left, bottom, right).is_some();
+    if let Some((ptr, _)) = vis_region_snapshot.as_ref() {
+        write_ok &= memory.write_u16_be(*ptr, 10).is_some()
+            && ppc_write_rect(memory, *ptr + 2, top, left, bottom, right).is_some();
+    }
     if !write_ok {
+        let _ = memory.write_bytes(old.pixmap, &old_pixmap_snapshot);
+        let _ = memory.write_bytes(old.port + 16, &old_port_rect_snapshot);
+        if let Some((ptr, bytes)) = vis_region_snapshot.as_ref() {
+            let _ = memory.write_bytes(*ptr, bytes);
+        }
+        if let Some(bytes) = reused_pixel_snapshot.as_ref() {
+            let _ = memory.write_bytes(old.base_addr, bytes);
+        }
+        if let Some((record, master, bytes)) = stable_ctable_snapshot.as_ref() {
+            let _ = memory.write_u32_be(record.handle, *master);
+            let _ = memory.write_bytes(record.ptr, bytes);
+        }
+        *heap_cursor = heap_cursor_before;
+        *handles = handles_before;
+        ppc_update_zone_free_bytes(memory, heap_limit.saturating_sub(heap_cursor_before));
         *last_mem_error = PPC_PARAM_ERR;
         return GW_FLAG_ERR;
-    }
-
-    let vis_rgn = memory.read_u32_be(old.port + 24).unwrap_or(0);
-    if vis_rgn != 0 {
-        let _ = ppc_write_rgn_bbox(memory, vis_rgn, top, left, bottom, right);
-    }
-    let new_gdevice = if requested_gdevice != 0 {
-        requested_gdevice
-    } else if requested_depth <= 0 {
-        PPC_MAIN_GDEVICE
-    } else if old.gdevice != 0 {
-        old.gdevice
-    } else {
-        current_gdevice
-    };
-    if new_gdevice != 0 && new_gdevice != PPC_MAIN_GDEVICE {
-        if let Some(device) = memory
-            .read_u32_be(new_gdevice)
-            .filter(|device| *device != 0)
-        {
-            let _ = ppc_write_rect(memory, device + 34, top, left, bottom, right);
-        }
     }
 
     gworlds[record_index] = PpcGWorldRecord {
@@ -47602,6 +48061,44 @@ fn ppc_update_gworld(
         row_bytes,
         ..old
     };
+    let heap_grew = *heap_cursor != heap_cursor_before;
+    let pixel_capacity = if allocates_pixel_storage || grows_pixel_storage_in_place {
+        required_pixel_capacity
+    } else {
+        old_pixel_capacity
+    };
+    let allocation_after = if let Some(previous) = allocation_before {
+        if heap_grew {
+            PpcGWorldAllocationRecord {
+                origin_base: if previous.allocation_end == heap_cursor_before {
+                    previous.origin_base
+                } else {
+                    heap_cursor_before
+                },
+                pixel_capacity,
+                ctable_handle: owned_ctable_handle,
+                allocation_end: *heap_cursor,
+            }
+        } else {
+            PpcGWorldAllocationRecord {
+                pixel_capacity,
+                ctable_handle: owned_ctable_handle,
+                ..previous
+            }
+        }
+    } else {
+        PpcGWorldAllocationRecord {
+            origin_base: if heap_grew { heap_cursor_before } else { 0 },
+            pixel_capacity,
+            ctable_handle: owned_ctable_handle,
+            allocation_end: if heap_grew { *heap_cursor } else { 0 },
+        }
+    };
+    gworld_allocations.insert(port, allocation_after);
+    if *current_gworld == port {
+        *current_gworld = port;
+        *current_gdevice = new_gdevice;
+    }
     *last_mem_error = PPC_NO_ERR;
     if ppc_gworld_trace_enabled() {
         eprintln!(
@@ -47625,92 +48122,281 @@ fn ppc_update_gworld(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn ppc_update_gworld_pixels(
+fn ppc_stage_update_gworld_pixels(
     memory: &mut PpcSectionMem,
     old: PpcGWorldRecord,
-    new_base: u32,
     new_row_bytes: u32,
     new_width: u32,
     new_height: u32,
     new_depth: u32,
-    preserve_flags: u32,
-) -> bool {
-    const STRETCH_PIX: u32 = 1 << 29;
-    let bytes_per_pixel = match (old.depth, new_depth) {
-        (8, 8) => Some(1),
-        (16, 16) => Some(2),
-        (32, 32) => Some(4),
-        _ => None,
-    };
-    if preserve_flags & STRETCH_PIX != 0 {
-        let Some(bytes_per_pixel) = bytes_per_pixel else {
-            return ppc_update_gworld_copy_rows(memory, old, new_base, new_row_bytes, new_height);
-        };
-        for dst_y in 0..new_height {
-            let src_y = u64::from(dst_y)
-                .saturating_mul(u64::from(old.height))
-                .checked_div(u64::from(new_height))
-                .unwrap_or(0) as u32;
-            for dst_x in 0..new_width {
-                let src_x = u64::from(dst_x)
-                    .saturating_mul(u64::from(old.width))
-                    .checked_div(u64::from(new_width))
-                    .unwrap_or(0) as u32;
-                let Some(src_addr) = old
-                    .base_addr
-                    .checked_add(src_y.saturating_mul(old.row_bytes))
-                    .and_then(|addr| addr.checked_add(src_x.saturating_mul(bytes_per_pixel)))
-                else {
-                    return false;
-                };
-                let Some(dst_addr) = new_base
-                    .checked_add(dst_y.saturating_mul(new_row_bytes))
-                    .and_then(|addr| addr.checked_add(dst_x.saturating_mul(bytes_per_pixel)))
-                else {
-                    return false;
-                };
-                for byte_offset in 0..bytes_per_pixel {
-                    let Some(byte) = memory.read_u8(src_addr + byte_offset) else {
-                        return false;
-                    };
-                    if memory.write_u8(dst_addr + byte_offset, byte).is_none() {
-                        return false;
-                    }
-                }
-            }
-        }
-        return true;
+    stretch: bool,
+    translate: bool,
+    dither: bool,
+    old_clut: Option<&PpcGWorldClut>,
+    new_clut: Option<&PpcGWorldClut>,
+) -> Option<Vec<u8>> {
+    let buffer_size = new_row_bytes.checked_mul(new_height)?;
+    let buffer_len = usize::try_from(buffer_size).ok()?;
+    let mut pixels = Vec::new();
+    pixels.try_reserve_exact(buffer_len).ok()?;
+    pixels.resize(buffer_len, 0);
+    let error_width = usize::try_from(new_width).ok()?.checked_add(2)?;
+    let mut current_errors = Vec::new();
+    let mut next_errors = Vec::new();
+    if dither {
+        current_errors.try_reserve_exact(error_width).ok()?;
+        next_errors.try_reserve_exact(error_width).ok()?;
+        current_errors.resize(error_width, [0i32; 3]);
+        next_errors.resize(error_width, [0i32; 3]);
     }
-    ppc_update_gworld_copy_rows(memory, old, new_base, new_row_bytes, new_height)
+    for dst_y in 0..new_height {
+        let src_y = if stretch {
+            u64::from(dst_y)
+                .checked_mul(u64::from(old.height))?
+                .checked_div(u64::from(new_height))? as u32
+        } else {
+            if dst_y >= old.height {
+                continue;
+            }
+            dst_y
+        };
+        for dst_x in 0..new_width {
+            let src_x = if stretch {
+                u64::from(dst_x)
+                    .checked_mul(u64::from(old.width))?
+                    .checked_div(u64::from(new_width))? as u32
+            } else {
+                if dst_x >= old.width {
+                    continue;
+                }
+                dst_x
+            };
+            let raw = ppc_read_gworld_record_raw_pixel(memory, old, src_x, src_y)?;
+            let pixel = if dither {
+                let rgb = ppc_gworld_pixel_to_rgb(raw, old.depth, old_clut)?;
+                let error_index = usize::try_from(dst_x).ok()?.checked_add(1)?;
+                let error = *current_errors.get(error_index)?;
+                let adjusted = PpcRgbColor {
+                    red: u16::try_from((i32::from(rgb.red) + error[0]).clamp(0, 0xffff)).ok()?,
+                    green: u16::try_from((i32::from(rgb.green) + error[1]).clamp(0, 0xffff))
+                        .ok()?,
+                    blue: u16::try_from((i32::from(rgb.blue) + error[2]).clamp(0, 0xffff)).ok()?,
+                };
+                let pixel = ppc_gworld_rgb_to_pixel(adjusted, new_depth, new_clut)?;
+                let palette_index = usize::try_from(pixel).ok()?;
+                let palette = new_clut?;
+                let [red, green, blue] = *palette.colors.get(palette_index)?;
+                let quantization_error = [
+                    i32::from(adjusted.red) - i32::from(red),
+                    i32::from(adjusted.green) - i32::from(green),
+                    i32::from(adjusted.blue) - i32::from(blue),
+                ];
+                for component in 0..3 {
+                    current_errors[error_index + 1][component] +=
+                        quantization_error[component] * 7 / 16;
+                    next_errors[error_index - 1][component] +=
+                        quantization_error[component] * 3 / 16;
+                    next_errors[error_index][component] += quantization_error[component] * 5 / 16;
+                    next_errors[error_index + 1][component] += quantization_error[component] / 16;
+                }
+                pixel
+            } else if translate {
+                let rgb = ppc_gworld_pixel_to_rgb(raw, old.depth, old_clut)?;
+                ppc_gworld_rgb_to_pixel(rgb, new_depth, new_clut)?
+            } else {
+                raw
+            };
+            ppc_write_gworld_staged_pixel(
+                &mut pixels,
+                new_row_bytes,
+                new_width,
+                new_height,
+                new_depth,
+                dst_x,
+                dst_y,
+                pixel,
+            )?;
+        }
+        if dither {
+            std::mem::swap(&mut current_errors, &mut next_errors);
+            next_errors.fill([0; 3]);
+        }
+    }
+    Some(pixels)
 }
 
-fn ppc_update_gworld_copy_rows(
+fn ppc_read_gworld_record_raw_pixel(
     memory: &mut PpcSectionMem,
-    old: PpcGWorldRecord,
-    new_base: u32,
-    new_row_bytes: u32,
-    new_height: u32,
-) -> bool {
-    let copy_rows = old.height.min(new_height);
-    let copy_bytes = old.row_bytes.min(new_row_bytes);
-    let Ok(copy_bytes_usize) = usize::try_from(copy_bytes) else {
-        return false;
-    };
-    let mut row = vec![0; copy_bytes_usize];
-    for y in 0..copy_rows {
-        let Some(src_addr) = old.base_addr.checked_add(y.saturating_mul(old.row_bytes)) else {
-            return false;
-        };
-        let Some(dst_addr) = new_base.checked_add(y.saturating_mul(new_row_bytes)) else {
-            return false;
-        };
-        if memory.read_bytes_into(src_addr, &mut row).is_none()
-            || memory.write_bytes(dst_addr, &row).is_none()
-        {
-            return false;
-        }
+    record: PpcGWorldRecord,
+    x: u32,
+    y: u32,
+) -> Option<u32> {
+    if x >= record.width || y >= record.height {
+        return None;
     }
-    true
+    let row = record
+        .base_addr
+        .checked_add(y.checked_mul(record.row_bytes)?)?;
+    match record.depth {
+        1 | 2 | 4 => {
+            let bit_offset = x.checked_mul(record.depth)?;
+            let byte_offset = bit_offset / 8;
+            if byte_offset >= record.row_bytes {
+                return None;
+            }
+            let shift = 8u32
+                .checked_sub(record.depth)?
+                .checked_sub(bit_offset & 7)?;
+            let mask = (1u8 << record.depth) - 1;
+            memory
+                .read_u8(row.checked_add(byte_offset)?)
+                .map(|byte| u32::from((byte >> shift) & mask))
+        }
+        8 => {
+            if x >= record.row_bytes {
+                return None;
+            }
+            memory.read_u8(row.checked_add(x)?).map(u32::from)
+        }
+        16 => {
+            let byte_offset = x.checked_mul(2)?;
+            if byte_offset.checked_add(2)? > record.row_bytes {
+                return None;
+            }
+            memory
+                .read_u16_be(row.checked_add(byte_offset)?)
+                .map(u32::from)
+        }
+        32 => {
+            let byte_offset = x.checked_mul(4)?;
+            if byte_offset.checked_add(4)? > record.row_bytes {
+                return None;
+            }
+            memory.read_u32_be(row.checked_add(byte_offset)?)
+        }
+        _ => None,
+    }
+}
+
+fn ppc_gworld_pixel_to_rgb(
+    pixel: u32,
+    depth: u32,
+    clut: Option<&PpcGWorldClut>,
+) -> Option<PpcRgbColor> {
+    // Imaging With QuickDraw (1994), pp. 4-13--4-16: indexed pixels name a
+    // ColorTable entry; 16-bit direct pixels use 5:5:5 RGB; 32-bit direct
+    // pixels store the high byte of each RGBColor component in 0x00RRGGBB.
+    match depth {
+        depth @ (1 | 2 | 4 | 8) => {
+            let index = usize::try_from(pixel).ok()?;
+            if index >= ppc_indexed_depth_entry_count(depth)? {
+                return None;
+            }
+            let clut = clut?;
+            if !clut.valid[index] {
+                return None;
+            }
+            let [red, green, blue] = clut.colors[index];
+            Some(PpcRgbColor { red, green, blue })
+        }
+        16 => {
+            let [red, green, blue] = ppc_rgb555_to_rgb16(pixel as u16);
+            Some(PpcRgbColor { red, green, blue })
+        }
+        32 => Some(PpcRgbColor {
+            red: (((pixel >> 16) & 0xff) as u16) * 0x0101,
+            green: (((pixel >> 8) & 0xff) as u16) * 0x0101,
+            blue: ((pixel & 0xff) as u16) * 0x0101,
+        }),
+        _ => None,
+    }
+}
+
+fn ppc_gworld_rgb_to_pixel(
+    color: PpcRgbColor,
+    depth: u32,
+    clut: Option<&PpcGWorldClut>,
+) -> Option<u32> {
+    match depth {
+        depth @ (1 | 2 | 4 | 8) => {
+            let clut = clut?;
+            ppc_rgb_color_to_valid_index_in_clut(
+                color,
+                &clut.colors,
+                &clut.valid,
+                ppc_indexed_depth_entry_count(depth)?,
+            )
+            .map(u32::from)
+        }
+        16 => Some(u32::from(
+            ((color.red >> 11) << 10) | ((color.green >> 11) << 5) | (color.blue >> 11),
+        )),
+        32 => Some(
+            (u32::from(color.red >> 8) << 16)
+                | (u32::from(color.green >> 8) << 8)
+                | u32::from(color.blue >> 8),
+        ),
+        _ => None,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn ppc_write_gworld_staged_pixel(
+    pixels: &mut [u8],
+    row_bytes: u32,
+    width: u32,
+    height: u32,
+    depth: u32,
+    x: u32,
+    y: u32,
+    pixel: u32,
+) -> Option<()> {
+    if x >= width || y >= height {
+        return None;
+    }
+    let row = usize::try_from(y.checked_mul(row_bytes)?).ok()?;
+    match depth {
+        1 | 2 | 4 => {
+            let bit_offset = x.checked_mul(depth)?;
+            let byte_offset = usize::try_from(bit_offset / 8).ok()?;
+            if u32::try_from(byte_offset).ok()? >= row_bytes {
+                return None;
+            }
+            let shift = 8u32.checked_sub(depth)?.checked_sub(bit_offset & 7)?;
+            let value_mask = (1u8 << depth) - 1;
+            let field_mask = value_mask << shift;
+            let byte = pixels.get_mut(row.checked_add(byte_offset)?)?;
+            *byte = (*byte & !field_mask) | (((pixel as u8) & value_mask) << shift);
+        }
+        8 => {
+            if x >= row_bytes {
+                return None;
+            }
+            *pixels.get_mut(row.checked_add(usize::try_from(x).ok()?)?)? = pixel as u8;
+        }
+        16 => {
+            let byte_offset = x.checked_mul(2)?;
+            if byte_offset.checked_add(2)? > row_bytes {
+                return None;
+            }
+            let offset = row.checked_add(usize::try_from(byte_offset).ok()?)?;
+            pixels
+                .get_mut(offset..offset.checked_add(2)?)?
+                .copy_from_slice(&(pixel as u16).to_be_bytes());
+        }
+        32 => {
+            let byte_offset = x.checked_mul(4)?;
+            if byte_offset.checked_add(4)? > row_bytes {
+                return None;
+            }
+            let offset = row.checked_add(usize::try_from(byte_offset).ok()?)?;
+            pixels
+                .get_mut(offset..offset.checked_add(4)?)?
+                .copy_from_slice(&pixel.to_be_bytes());
+        }
+        _ => return None,
+    }
+    Some(())
 }
 
 fn ppc_gworld_device(gworlds: &[PpcGWorldRecord], port: u32) -> Option<u32> {
@@ -47732,6 +48418,59 @@ fn ppc_front_visible_window(
         !matches!(*port, PPC_MAIN_GWORLD | PPC_DSP_BACK_GWORLD)
             && ppc_window_is_visible(memory, *port)
     })
+}
+
+fn ppc_window_global_content_bounds(
+    memory: &mut PpcSectionMem,
+    gworlds: &[PpcGWorldRecord],
+    window: u32,
+) -> Option<(i16, i16, i16, i16)> {
+    let (port_top, port_left, port_bottom, port_right) =
+        ppc_read_rect(memory, window.checked_add(16)?)?;
+    let surface = ppc_live_quickdraw_surface(memory, gworlds, window)?;
+    Some((
+        port_top.saturating_sub(surface.top),
+        port_left.saturating_sub(surface.left),
+        port_bottom.saturating_sub(surface.top),
+        port_right.saturating_sub(surface.left),
+    ))
+}
+
+fn ppc_find_window_at_point(
+    memory: &mut PpcSectionMem,
+    gworlds: &[PpcGWorldRecord],
+    v: i16,
+    h: i16,
+    menu_bar_height: i16,
+) -> (i16, u32) {
+    let front_window = ppc_front_visible_window(memory, gworlds);
+    for window in gworlds.iter().rev().map(|record| record.port) {
+        if matches!(window, PPC_MAIN_GWORLD | PPC_DSP_BACK_GWORLD)
+            || !ppc_window_is_visible(memory, window)
+        {
+            continue;
+        }
+        let Some((top, left, bottom, right)) =
+            ppc_window_global_content_bounds(memory, gworlds, window)
+        else {
+            continue;
+        };
+        if v >= top && v < bottom && h >= left && h < right {
+            return (3, window);
+        }
+        let title_top = top.saturating_sub(18).max(menu_bar_height);
+        if v >= title_top && v < top && h >= left && h < right {
+            let go_away = memory
+                .read_u8(window.wrapping_add(PPC_CWINDOW_GO_AWAY_OFFSET))
+                .unwrap_or(0)
+                != 0;
+            if front_window == Some(window) && go_away && h < left.saturating_add(18) {
+                return (6, window);
+            }
+            return (4, window);
+        }
+    }
+    (0, 0)
 }
 
 fn ppc_set_window_visible(memory: &mut PpcSectionMem, window: u32, visible: bool) -> bool {
@@ -48012,7 +48751,7 @@ fn ppc_line_to(
         return false;
     }
     let front_buffer = surface.front_buffer;
-    if front_buffer.depth != 8 && front_buffer.depth != 16 {
+    if !matches!(front_buffer.depth, 1 | 2 | 4 | 8 | 16) {
         return false;
     }
     let Some(color_pixel) =
@@ -48089,7 +48828,7 @@ fn ppc_draw_oval(
     let (top, left, bottom, right) = surface.local_rect(rect);
     let width = right - left;
     let height = bottom - top;
-    if width <= 0 || height <= 0 || !matches!(front_buffer.depth, 8 | 16) {
+    if width <= 0 || height <= 0 || !matches!(front_buffer.depth, 1 | 2 | 4 | 8 | 16) {
         return false;
     }
     let Some(color_pixel) =
@@ -48199,7 +48938,7 @@ fn ppc_invert_region(
     };
     let front_buffer = surface.front_buffer;
     let mask = match front_buffer.depth {
-        8 => 0x00ff,
+        depth @ (1 | 2 | 4 | 8) => (1u16 << depth) - 1,
         16 => 0x7fff,
         _ => return false,
     };
@@ -48327,7 +49066,7 @@ fn ppc_draw_text_bytes(
         return advance;
     };
     let front_buffer = surface.front_buffer;
-    if front_buffer.depth != 8 && front_buffer.depth != 16 {
+    if !matches!(front_buffer.depth, 1 | 2 | 4 | 8 | 16) {
         return advance;
     }
     let Some(color_pixel) =
@@ -48407,7 +49146,7 @@ fn ppc_paint_rect(
         return false;
     };
     let front_buffer = surface.front_buffer;
-    if !matches!(front_buffer.depth, 8 | 16) {
+    if !matches!(front_buffer.depth, 1 | 2 | 4 | 8 | 16) {
         return false;
     }
     let Some(fore_pixel) =
@@ -48451,7 +49190,7 @@ fn ppc_paint_rect_bounds(
         return false;
     };
     let front_buffer = surface.front_buffer;
-    if front_buffer.depth != 8 && front_buffer.depth != 16 {
+    if !matches!(front_buffer.depth, 1 | 2 | 4 | 8 | 16) {
         return false;
     }
 
@@ -48469,6 +49208,19 @@ fn ppc_paint_rect_bounds(
     else {
         return false;
     };
+    if matches!(front_buffer.depth, 1 | 2 | 4) {
+        // Indexed pixels smaller than a byte share their storage byte with
+        // neighboring pixels. Imaging With QuickDraw (1994), pp. 4-14--4-16,
+        // defines those packed pixel values; update them individually so an
+        // unaligned rectangle never overwrites adjacent fields or row padding.
+        let mut wrote = false;
+        for y in top..bottom {
+            for x in left..right {
+                wrote |= ppc_quickdraw_write_raw_pixel(memory, front_buffer, (x, y), color_pixel);
+            }
+        }
+        return wrote;
+    }
     let pixel_bytes = match front_buffer.depth {
         8 => vec![color_pixel as u8; (right - left) as usize],
         16 => {
@@ -48516,8 +49268,7 @@ fn ppc_invert_rect(
     };
     let front_buffer = surface.front_buffer;
     let mask = match front_buffer.depth {
-        1 => 0x0001,
-        8 => 0x00ff,
+        depth @ (1 | 2 | 4 | 8) => (1u16 << depth) - 1,
         16 => 0x7fff,
         _ => return false,
     };
@@ -48561,7 +49312,7 @@ fn ppc_frame_rect(
         return false;
     };
     let front_buffer = surface.front_buffer;
-    if front_buffer.depth != 8 && front_buffer.depth != 16 {
+    if !matches!(front_buffer.depth, 1 | 2 | 4 | 8 | 16) {
         return false;
     }
 
@@ -48637,7 +49388,7 @@ fn ppc_frame_round_rect(
         return false;
     };
     let front_buffer = surface.front_buffer;
-    if front_buffer.depth != 8 && front_buffer.depth != 16 {
+    if !matches!(front_buffer.depth, 1 | 2 | 4 | 8 | 16) {
         return false;
     }
     let (top, left, bottom, right) = surface.local_rect(rect);
@@ -48807,6 +49558,12 @@ fn ppc_read_pixmap_bits(memory: &mut PpcSectionMem, pixmap: u32) -> Option<PpcPi
     };
     if depth == 0 {
         return None;
+    }
+    if packed_row_bytes & 0x8000 != 0 && matches!(depth, 1 | 2 | 4 | 8 | 16 | 32) {
+        let required_row_bytes = width.checked_mul(depth)?.checked_add(7)? / 8;
+        if row_bytes < required_row_bytes {
+            return None;
+        }
     }
     Some(PpcPixMapBits {
         base_addr,
@@ -49305,18 +50062,16 @@ fn ppc_copy_bits(
             return None;
         };
         let transparent = mode == 36;
-        let compatible_depths = if transparent {
-            (matches!(src_bits.depth, 1 | 8 | 16) && matches!(dst_bits.depth, 8 | 16))
-                || (src_bits.depth == 4 && dst_bits.depth == 4)
-        } else if mode == 0 {
+        let supported_source = matches!(src_bits.depth, 1 | 2 | 4 | 8 | 16);
+        let supported_destination = matches!(dst_bits.depth, 1 | 2 | 4 | 8 | 16);
+        let compatible_depths = if transparent || mode == 0 {
             // Imaging With QuickDraw (1994), p. 3-117 and pp. 4-27--4-28:
             // CopyBits converts source colors into the destination device's
             // pixel format, and expands a BitMap through the foreground and
             // background colors. Source and destination depths need not match.
-            (matches!(src_bits.depth, 1 | 8 | 16) && matches!(dst_bits.depth, 8 | 16))
-                || (src_bits.depth == 4 && dst_bits.depth == 4)
+            supported_source && supported_destination
         } else {
-            src_bits.depth == dst_bits.depth && matches!(src_bits.depth, 8 | 16)
+            src_bits.depth == dst_bits.depth && supported_source
         };
         if !compatible_depths {
             reason = "depth";
@@ -49324,7 +50079,7 @@ fn ppc_copy_bits(
         }
         let src_ctable = ppc_resolve_pixmap_ctable_handle(memory, gworlds, src_bits_ptr);
         let dst_ctable = ppc_resolve_pixmap_ctable_handle(memory, gworlds, dst_bits_ptr);
-        let src_clut = matches!(src_bits.depth, 4 | 8).then(|| {
+        let src_clut = ppc_indexed_depth_entry_count(src_bits.depth).map(|_| {
             let src_ctable = src_ctable.unwrap_or(0);
             ppc_copy_bits_linked_palette_clut(
                 memory,
@@ -49345,7 +50100,7 @@ fn ppc_copy_bits(
         // colors into the current GDevice. The destination PixMap's table is
         // not the inverse-mapping target, even when it differs from that
         // device table.
-        let dst_clut = matches!(dst_bits.depth, 4 | 8).then(|| {
+        let dst_clut = ppc_indexed_depth_entry_count(dst_bits.depth).map(|_| {
             ppc_gdevice_ctable_handle(memory, current_gdevice)
                 .map(|handle| ppc_copy_bits_clut(memory, handle, color_manager_clut))
                 .unwrap_or(*color_manager_clut)
@@ -49356,7 +50111,7 @@ fn ppc_copy_bits(
         // CopyBits preserves the raw indexes even if the handles differ.
         // Imaging With QuickDraw (1994), pp. 4-56--4-57 and 4-97.
         let same_indexed_ctable_identity = src_bits.depth == dst_bits.depth
-            && matches!(src_bits.depth, 4 | 8)
+            && ppc_indexed_depth_entry_count(src_bits.depth).is_some()
             && ppc_color_tables_share_index_space(memory, src_ctable, dst_ctable);
         let palette_map = if src_bits.depth == 8 && dst_bits.depth == 8 {
             let src_ctable = src_ctable.unwrap_or(0);
@@ -49390,7 +50145,7 @@ fn ppc_copy_bits(
                     })
                 })
             }
-        } else if src_bits.depth == 4 && dst_bits.depth == 4 {
+        } else if src_bits.depth == dst_bits.depth && matches!(src_bits.depth, 1 | 2 | 4) {
             let src_ctable = src_ctable.unwrap_or(0);
             let src_clut = src_clut.as_ref().unwrap();
             let dst_clut = dst_clut.as_ref().unwrap();
@@ -49400,25 +50155,20 @@ fn ppc_copy_bits(
                 .is_some_and(|flags| flags & 0x8000 != 0);
             (!same_indexed_ctable_identity && !source_uses_device_indices && src_clut != dst_clut)
                 .then(|| {
+                    let entry_count = ppc_indexed_depth_entry_count(src_bits.depth).unwrap_or(1);
                     std::array::from_fn::<u8, 256, _>(|index| {
                         let [red, green, blue] = src_clut[index];
-                        // CopyBits color-matches through the current GDevice's
-                        // inverse table even when the destination PixMap stores
-                        // fewer bits. The resulting device pixel is then stored
-                        // in the destination field width. Inside Macintosh
-                        // Volume V (1986), pp. V-69 and V-135; Imaging With
-                        // QuickDraw (1994), pp. 4-27--4-28.
-                        if current_gdevice == PPC_MAIN_GDEVICE {
-                            // The synthetic main GDevice models its startup
-                            // system ITable separately from its mutable displayed
-                            // CTable. Match through that startup table, then retain
-                            // the low packed bits. Imaging With QuickDraw (1994),
-                            // pp. 4-81--4-82, describes rebuilding an inverse table
-                            // explicitly with MakeITable after color-table changes.
-                            TrapDispatcher::standard_itable_lookup(red, green, blue)
-                        } else {
-                            pict::closest_clut_index(red, green, blue, dst_clut)
-                        }
+                        // The inverse lookup is constrained to the active
+                        // destination table entries representable at this
+                        // packed depth. Looking up in an 8-bit table and then
+                        // masking the result does not preserve the matched
+                        // color. Imaging With QuickDraw (1994), pp. 4-27--4-28
+                        // and 4-81--4-82.
+                        ppc_rgb_color_to_index_in_clut(
+                            PpcRgbColor { red, green, blue },
+                            dst_clut,
+                            entry_count,
+                        )
                     })
                 })
         } else {
@@ -49528,59 +50278,44 @@ fn ppc_copy_bits(
         let transparent_back_pixel = match src_bits.depth {
             1 => 0,
             8 if back_index.is_some() => u32::from(back_index.unwrap()),
-            4 | 8 => {
+            2 | 4 | 8 => {
                 let clut = src_clut.as_ref()?;
-                let mut packed_clut = *clut;
-                let entry_count = 1usize << src_bits.depth;
-                let terminal = packed_clut[entry_count - 1];
-                packed_clut[entry_count..].fill(terminal);
-                u32::from(pict::closest_clut_index(
-                    back_color.red,
-                    back_color.green,
-                    back_color.blue,
-                    &packed_clut,
+                u32::from(ppc_rgb_color_to_index_in_clut(
+                    back_color,
+                    clut,
+                    ppc_indexed_depth_entry_count(src_bits.depth)?,
                 ))
             }
             16 => u32::from(ppc_rgb_color_to_rgb555(back_color)),
             _ => return None,
         };
         let bitmap_fore_pixel = match dst_bits.depth {
-            4 | 8 if fore_index.is_some() => {
+            1 | 2 | 4 | 8 if fore_index.is_some() => {
                 let pixel_mask = ((1u16 << dst_bits.depth) - 1) as u8;
                 u32::from(fore_index.unwrap() & pixel_mask)
             }
-            4 | 8 => {
+            1 | 2 | 4 | 8 => {
                 let clut = dst_clut.as_ref()?;
-                let mut packed_clut = *clut;
-                let entry_count = 1usize << dst_bits.depth;
-                let terminal = packed_clut[entry_count - 1];
-                packed_clut[entry_count..].fill(terminal);
-                u32::from(pict::closest_clut_index(
-                    fore_color.red,
-                    fore_color.green,
-                    fore_color.blue,
-                    &packed_clut,
+                u32::from(ppc_rgb_color_to_index_in_clut(
+                    fore_color,
+                    clut,
+                    ppc_indexed_depth_entry_count(dst_bits.depth)?,
                 ))
             }
             16 => u32::from(ppc_rgb_color_to_rgb555(fore_color)),
             _ => return None,
         };
         let bitmap_back_pixel = match dst_bits.depth {
-            4 | 8 if back_index.is_some() => {
+            1 | 2 | 4 | 8 if back_index.is_some() => {
                 let pixel_mask = ((1u16 << dst_bits.depth) - 1) as u8;
                 u32::from(back_index.unwrap() & pixel_mask)
             }
-            4 | 8 => {
+            1 | 2 | 4 | 8 => {
                 let clut = dst_clut.as_ref()?;
-                let mut packed_clut = *clut;
-                let entry_count = 1usize << dst_bits.depth;
-                let terminal = packed_clut[entry_count - 1];
-                packed_clut[entry_count..].fill(terminal);
-                u32::from(pict::closest_clut_index(
-                    back_color.red,
-                    back_color.green,
-                    back_color.blue,
-                    &packed_clut,
+                u32::from(ppc_rgb_color_to_index_in_clut(
+                    back_color,
+                    clut,
+                    ppc_indexed_depth_entry_count(dst_bits.depth)?,
                 ))
             }
             16 => u32::from(ppc_rgb_color_to_rgb555(back_color)),
@@ -49614,7 +50349,7 @@ fn ppc_copy_bits(
                 let pixel = if mode == 32 {
                     let dst_pixel = ppc_read_pixmap_raw_pixel(memory, dst_bits, dst_x, dst_y)?;
                     let (source_rgb, destination_rgb) = match src_bits.depth {
-                        8 => (
+                        1 | 2 | 4 | 8 => (
                             src_clut.as_ref()?[src_pixel as usize],
                             dst_clut.as_ref()?[dst_pixel as usize],
                         ),
@@ -49632,11 +50367,14 @@ fn ppc_copy_bits(
                             >> 16) as u16
                     });
                     match dst_bits.depth {
-                        8 => u32::from(pict::closest_clut_index(
-                            blended[0],
-                            blended[1],
-                            blended[2],
+                        depth @ (1 | 2 | 4 | 8) => u32::from(ppc_rgb_color_to_index_in_clut(
+                            PpcRgbColor {
+                                red: blended[0],
+                                green: blended[1],
+                                blue: blended[2],
+                            },
                             dst_clut.as_ref()?,
+                            ppc_indexed_depth_entry_count(depth)?,
                         )),
                         16 => u32::from(ppc_rgb_color_to_rgb555(PpcRgbColor {
                             red: blended[0],
@@ -49653,23 +50391,37 @@ fn ppc_copy_bits(
                     } else {
                         bitmap_fore_pixel
                     }
-                } else if matches!(src_bits.depth, 4 | 8) && src_bits.depth == dst_bits.depth {
+                } else if ppc_indexed_depth_entry_count(src_bits.depth).is_some()
+                    && src_bits.depth == dst_bits.depth
+                {
                     u32::from(
                         palette_map
                             .as_ref()
                             .map(|palette_map| palette_map[src_pixel as usize])
                             .unwrap_or(src_pixel as u8),
                     )
-                } else if src_bits.depth == 8 && dst_bits.depth == 16 {
+                } else if ppc_indexed_depth_entry_count(src_bits.depth).is_some()
+                    && dst_bits.depth == 16
+                {
                     let [red, green, blue] = src_clut.as_ref()?[src_pixel as usize];
                     u32::from(ppc_rgb_color_to_rgb555(PpcRgbColor { red, green, blue }))
-                } else if src_bits.depth == 16 && dst_bits.depth == 8 {
+                } else if src_bits.depth == 16
+                    && ppc_indexed_depth_entry_count(dst_bits.depth).is_some()
+                {
                     let [red, green, blue] = ppc_rgb555_to_rgb16(src_pixel as u16);
-                    u32::from(pict::closest_clut_index(
-                        red,
-                        green,
-                        blue,
+                    u32::from(ppc_rgb_color_to_index_in_clut(
+                        PpcRgbColor { red, green, blue },
                         dst_clut.as_ref()?,
+                        ppc_indexed_depth_entry_count(dst_bits.depth)?,
+                    ))
+                } else if ppc_indexed_depth_entry_count(src_bits.depth).is_some()
+                    && ppc_indexed_depth_entry_count(dst_bits.depth).is_some()
+                {
+                    let [red, green, blue] = src_clut.as_ref()?[src_pixel as usize];
+                    u32::from(ppc_rgb_color_to_index_in_clut(
+                        PpcRgbColor { red, green, blue },
+                        dst_clut.as_ref()?,
+                        ppc_indexed_depth_entry_count(dst_bits.depth)?,
                     ))
                 } else {
                     src_pixel
@@ -49769,7 +50521,7 @@ fn ppc_copy_mask(
             reason = "dst-bits";
             return None;
         };
-        if src_bits.depth != dst_bits.depth || !matches!(src_bits.depth, 8 | 16) {
+        if src_bits.depth != dst_bits.depth || !matches!(src_bits.depth, 1 | 2 | 4 | 8 | 16) {
             reason = "depth";
             return None;
         }
@@ -49799,17 +50551,24 @@ fn ppc_copy_mask(
             return None;
         }
 
-        let palette_map = if src_bits.depth == 8 {
+        let palette_map = if let Some(entry_count) = ppc_indexed_depth_entry_count(src_bits.depth) {
             let src_ctable = ppc_resolve_pixmap_ctable_handle(memory, gworlds, src_bits_ptr);
             let dst_ctable = ppc_resolve_pixmap_ctable_handle(memory, gworlds, dst_bits_ptr);
             match (src_ctable, dst_ctable) {
                 (Some(src_ctable), Some(dst_ctable)) if src_ctable != dst_ctable => {
                     let src_clut = ppc_copy_bits_clut(memory, src_ctable, color_manager_clut);
                     let dst_clut = ppc_copy_bits_clut(memory, dst_ctable, color_manager_clut);
-                    (src_clut != dst_clut).then(|| {
+                    (src_clut[..entry_count] != dst_clut[..entry_count]).then(|| {
                         std::array::from_fn::<u8, 256, _>(|index| {
+                            if index >= entry_count {
+                                return 0;
+                            }
                             let [red, green, blue] = src_clut[index];
-                            pict::closest_clut_index(red, green, blue, &dst_clut)
+                            ppc_rgb_color_to_index_in_clut(
+                                PpcRgbColor { red, green, blue },
+                                &dst_clut,
+                                entry_count,
+                            )
                         })
                     })
                 }
@@ -50007,7 +50766,7 @@ fn ppc_write_gdevice(
         .map(u32::from)
         .unwrap_or(PPC_MAIN_PIXEL_DEPTH);
     let gd_type = if depth <= 8 { 0 } else { 2 };
-    let display_mode = if depth == 8 { 0x85 } else { depth };
+    let depth_mode = crate::display::classic_depth_mode(u16::try_from(depth).ok()?)?;
     memory.write_u16_be(gdevice, 0)?;
     memory.write_u16_be(gdevice + 2, 0)?;
     memory.write_u16_be(gdevice + 4, gd_type)?;
@@ -50015,7 +50774,7 @@ fn ppc_write_gdevice(
     memory.write_u16_be(gdevice + 20, PPC_MAIN_GDEVICE_FLAGS)?;
     memory.write_u32_be(gdevice + 22, pixmap_handle)?;
     ppc_write_rect(memory, gdevice + 34, top, left, bottom, right)?;
-    memory.write_u32_be(gdevice + 42, display_mode)?;
+    memory.write_u32_be(gdevice + 42, u32::from(depth_mode))?;
     Some(())
 }
 
@@ -50084,27 +50843,41 @@ fn ppc_main_gdevice_record_for_depth(
         .then_some(PPC_MAIN_GDEVICE_RECORD)
 }
 
-fn ppc_supported_depth_mode_id(
-    depth: u32,
+fn ppc_supported_depth_mode(
+    depth_or_mode: u32,
     which_flags: u32,
     flags: u32,
     current_flags: u16,
-) -> u32 {
-    let depth = depth & 0xffff;
-    if !matches!(depth, 8 | 16) {
-        return 0;
+) -> Option<(u32, bool)> {
+    let depth = u32::from(crate::display::classic_pixel_size(
+        (depth_or_mode & 0xffff) as u16,
+    )?);
+    if !matches!(depth, 1 | 2 | 4 | 8 | 16) {
+        return None;
     }
-    // HasDepth and SetDepth use whichFlags as a mask over gdFlags. The PPC
-    // display pipeline currently implements color modes only; do not claim a
-    // black-and-white variant merely because its indexed storage would fit.
-    if which_flags & 1 != 0 && flags & 1 == 0 {
-        return 0;
+    // Imaging With QuickDraw (1994), pp. 5-33--5-35: bit gdDevType in
+    // whichFlags selects the black-and-white/grayscale or color personality.
+    // Indexed hardware exposes grayscale at 1/2/4/8 bits and color at 2/4/8
+    // bits; the modeled 16-bit direct mode is color-only. With no gdDevType
+    // constraint, preserve the current indexed personality and use the only
+    // coherent personality at the two endpoint depths.
+    let mode_is_color = if which_flags & 1 != 0 {
+        flags & 1 != 0
+    } else {
+        match depth {
+            1 => false,
+            16 => true,
+            _ => current_flags & 1 != 0,
+        }
+    };
+    if (depth == 1 && mode_is_color) || (depth == 16 && !mode_is_color) {
+        return None;
     }
     let fixed_mask = which_flags as u16 & !1;
     if current_flags & fixed_mask != flags as u16 & fixed_mask {
-        return 0;
+        return None;
     }
-    depth
+    Some((depth, mode_is_color))
 }
 
 fn ppc_has_depth(cpu: &PpcCpu, memory: &mut PpcSectionMem) -> u32 {
@@ -50114,7 +50887,30 @@ fn ppc_has_depth(cpu: &PpcCpu, memory: &mut PpcSectionMem) -> u32 {
     let Some(current_flags) = memory.read_u16_be(gdevice + 20) else {
         return 0;
     };
-    ppc_supported_depth_mode_id(cpu.gpr[4], cpu.gpr[5], cpu.gpr[6], current_flags)
+    ppc_supported_depth_mode(cpu.gpr[4], cpu.gpr[5], cpu.gpr[6], current_flags)
+        .and_then(|(depth, _)| {
+            crate::display::classic_depth_mode(u16::try_from(depth).ok()?).map(u32::from)
+        })
+        .unwrap_or(0)
+}
+
+fn ppc_standard_screen_clut(depth: u32, is_color: bool) -> Option<([[u16; 3]; 256], usize)> {
+    let (mut clut, entry_count) = TrapDispatcher::standard_mac_indexed_clut(depth as u16)?;
+    if !is_color {
+        let last = u32::try_from(entry_count.checked_sub(1)?).ok()?;
+        for (index, color) in clut.iter_mut().take(entry_count).enumerate() {
+            let index = u32::try_from(index).ok()?;
+            let component = ((last - index) * u32::from(u16::MAX) / last) as u16;
+            *color = [component; 3];
+        }
+    } else if depth == 2 {
+        // Inside Macintosh: Volume VI (1991), pp. 17-17--17-18: a color
+        // 2-bit screen uses the enhanced standard table, whose spare entry
+        // carries the current highlight color. PPC currently exposes the
+        // System 7 default highlight green used by the shared 68k Toolbox.
+        (clut, _) = TrapDispatcher::standard_mac_enhanced_clut(2, (0, 0x8000, 0))?;
+    }
+    Some((clut, entry_count))
 }
 
 fn ppc_update_pixmap_depth(
@@ -50125,7 +50921,7 @@ fn ppc_update_pixmap_depth(
     indexed_ctable: u32,
 ) -> Option<()> {
     let (pixel_type, component_count, component_size, color_table) = match depth {
-        8 => (0, 1, 8, indexed_ctable),
+        1 | 2 | 4 | 8 => (0, 1, depth as u16, indexed_ctable),
         16 => (16, 3, 5, 0),
         _ => return None,
     };
@@ -50145,20 +50941,176 @@ fn ppc_main_color_table_is_valid(memory: &mut PpcSectionMem) -> bool {
     else {
         return false;
     };
-    let Some(flags_addr) = table.checked_add(4) else {
-        return false;
-    };
-    let Some(size_addr) = table.checked_add(6) else {
-        return false;
-    };
-    memory.read_u16_be(flags_addr).unwrap_or(0) & 0x8000 != 0
-        && memory.read_u16_be(size_addr) == Some(255)
-        && ppc_memory_read_bytes(memory, table, PPC_MAIN_CTABLE_SIZE).is_some()
+    ppc_memory_can_write_bytes(memory, table, PPC_MAIN_CTABLE_SIZE)
+}
+
+fn ppc_install_standard_indexed_ctable(
+    memory: &mut PpcSectionMem,
+    ctable_handle: u32,
+    seed: u32,
+    clut: &[[u16; 3]; 256],
+    entry_count: usize,
+) -> Option<()> {
+    let table = memory
+        .read_u32_be(ctable_handle)
+        .filter(|table| *table != 0)?;
+    let byte_len = 8u32.checked_add(u32::try_from(entry_count).ok()?.checked_mul(8)?)?;
+    if !ppc_memory_can_write_bytes(memory, table, byte_len) {
+        return None;
+    }
+    let flags = memory.read_u16_be(table + 4)?;
+    memory.write_u32_be(table, seed)?;
+    memory.write_u16_be(
+        table + 4,
+        if ctable_handle == PPC_MAIN_CTABLE_HANDLE {
+            flags | 0x8000
+        } else {
+            flags
+        },
+    )?;
+    memory.write_u16_be(table + 6, u16::try_from(entry_count.checked_sub(1)?).ok()?)?;
+    for (index, [red, green, blue]) in clut.iter().copied().take(entry_count).enumerate() {
+        let entry = table.checked_add(8 + u32::try_from(index).ok()?.checked_mul(8)?)?;
+        memory.write_u16_be(entry, index as u16)?;
+        memory.write_u16_be(entry + 2, red)?;
+        memory.write_u16_be(entry + 4, green)?;
+        memory.write_u16_be(entry + 6, blue)?;
+    }
+    Some(())
+}
+
+fn ppc_preflight_ctable_growth(
+    memory: &mut PpcSectionMem,
+    handles: &[PpcHandleRecord],
+    ctable_handles: &[u32],
+    required_size: u32,
+    heap_cursor: u32,
+    heap_limit: u32,
+) -> Result<(), i16> {
+    let mut simulated_handles = handles.to_vec();
+    let mut simulated_cursor = heap_cursor;
+    for ctable_handle in ctable_handles {
+        if *ctable_handle == PPC_MAIN_CTABLE_HANDLE {
+            let table = memory
+                .read_u32_be(*ctable_handle)
+                .filter(|table| *table != 0)
+                .ok_or(PPC_PARAM_ERR)?;
+            if !ppc_memory_can_write_bytes(memory, table, required_size) {
+                return Err(PPC_PARAM_ERR);
+            }
+            continue;
+        }
+        let table = memory
+            .read_u32_be(*ctable_handle)
+            .filter(|table| *table != 0)
+            .ok_or(PPC_PARAM_ERR)?;
+        let tracked = simulated_handles
+            .iter_mut()
+            .find(|record| record.handle == *ctable_handle);
+        let Some(record) = tracked else {
+            // A mapped address is not evidence that an untracked ColorTable
+            // owns the following bytes: the synthetic heap is one contiguous
+            // region and another object can begin immediately after ctTable.
+            // Without a Memory Manager record we can only use the logical
+            // size declared by ctSize, and cannot relocate the caller's
+            // private Handle on its behalf. Imaging With QuickDraw (1994),
+            // pp. 4-56--4-57.
+            let last_index = memory.read_u16_be(table + 6).ok_or(PPC_PARAM_ERR)?;
+            if (last_index as i16) < 0 || last_index >= 256 {
+                return Err(PPC_PARAM_ERR);
+            }
+            let logical_size = u32::from(last_index)
+                .checked_add(1)
+                .and_then(|entries| entries.checked_mul(8))
+                .and_then(|entries| entries.checked_add(8))
+                .ok_or(PPC_PARAM_ERR)?;
+            if logical_size < required_size
+                || !ppc_memory_can_write_bytes(memory, table, required_size)
+            {
+                return Err(PPC_PARAM_ERR);
+            }
+            continue;
+        };
+        if record.ptr != table {
+            return Err(PPC_PARAM_ERR);
+        }
+        if record.capacity >= required_size {
+            continue;
+        }
+        let old_aligned = ppc_allocation_size(record.size).ok_or(PPC_PARAM_ERR)?;
+        let new_aligned = ppc_allocation_size(required_size).ok_or(PPC_MEM_FULL_ERR)?;
+        let old_end = record
+            .ptr
+            .checked_add(old_aligned)
+            .ok_or(PPC_MEM_FULL_ERR)?;
+        if old_end == simulated_cursor {
+            let new_end = record
+                .ptr
+                .checked_add(new_aligned)
+                .ok_or(PPC_MEM_FULL_ERR)?;
+            if new_end >= heap_limit {
+                return Err(PPC_MEM_FULL_ERR);
+            }
+            simulated_cursor = new_end;
+        } else {
+            let new_ptr =
+                align_up(simulated_cursor, PPC_HEAP_ALIGNMENT).map_err(|_| PPC_MEM_FULL_ERR)?;
+            let new_end = new_ptr.checked_add(new_aligned).ok_or(PPC_MEM_FULL_ERR)?;
+            if new_end >= heap_limit {
+                return Err(PPC_MEM_FULL_ERR);
+            }
+            record.ptr = new_ptr;
+            simulated_cursor = new_end;
+        }
+        record.size = required_size;
+        record.capacity = required_size;
+    }
+    Ok(())
+}
+
+fn ppc_grow_ctables(
+    memory: &mut PpcSectionMem,
+    heap_cursor: &mut u32,
+    heap_limit: u32,
+    handles: &mut [PpcHandleRecord],
+    ctable_handles: &[u32],
+    required_size: u32,
+) -> Result<(), i16> {
+    for ctable_handle in ctable_handles {
+        if *ctable_handle == PPC_MAIN_CTABLE_HANDLE {
+            continue;
+        }
+        let Some(record) = handles
+            .iter()
+            .find(|record| record.handle == *ctable_handle)
+            .copied()
+        else {
+            continue;
+        };
+        if record.capacity >= required_size {
+            continue;
+        }
+        let result = ppc_set_handle_size(
+            memory,
+            heap_cursor,
+            heap_limit,
+            handles,
+            *ctable_handle,
+            required_size,
+        );
+        if result != PPC_NO_ERR {
+            return Err(result);
+        }
+    }
+    Ok(())
 }
 
 fn ppc_set_depth(
     cpu: &PpcCpu,
     memory: &mut PpcSectionMem,
+    heap_cursor: &mut u32,
+    heap_limit: u32,
+    handles: &mut [PpcHandleRecord],
     gworlds: &mut [PpcGWorldRecord],
     toolbox_startup: &mut PpcToolboxStartupState,
     screen_clut: &mut [[u16; 3]; 256],
@@ -50170,10 +51122,11 @@ fn ppc_set_depth(
     let Some(current_gd_flags) = memory.read_u16_be(gdevice + 20) else {
         return PPC_PARAM_ERR;
     };
-    let depth = ppc_supported_depth_mode_id(cpu.gpr[4], cpu.gpr[5], cpu.gpr[6], current_gd_flags);
-    if depth == 0 {
+    let Some((depth, target_is_color)) =
+        ppc_supported_depth_mode(cpu.gpr[4], cpu.gpr[5], cpu.gpr[6], current_gd_flags)
+    else {
         return PPC_PARAM_ERR;
-    }
+    };
 
     let Some(main_record) = gworlds
         .iter()
@@ -50190,6 +51143,9 @@ fn ppc_set_depth(
         .checked_mul(main_record.height)
         .and_then(|len| usize::try_from(len).ok())
     else {
+        return PPC_PARAM_ERR;
+    };
+    let Some(clear_len_u32) = u32::try_from(clear_len).ok() else {
         return PPC_PARAM_ERR;
     };
 
@@ -50253,6 +51209,17 @@ fn ppc_set_depth(
     if memory.read_u32_be(gdevice + 22) != Some(main_pixmap_handle) {
         return PPC_PARAM_ERR;
     }
+    let Some(current_screen_depth) = memory.read_u16_be(main_pixmap + 32).map(u32::from) else {
+        return PPC_PARAM_ERR;
+    };
+    let current_is_color = current_gd_flags & 1 != 0;
+    let preserved_indexed_mode = if current_screen_depth <= 8 {
+        Some((current_screen_depth, current_is_color))
+    } else {
+        toolbox_startup.indexed_screen_mode
+    };
+    let preserve_indexed_tables =
+        depth <= 8 && preserved_indexed_mode == Some((depth, target_is_color));
 
     let screen_bits = if toolbox_startup.init_graf_global_ptr == 0 {
         None
@@ -50268,7 +51235,7 @@ fn ppc_set_depth(
     if !ppc_memory_can_write_bytes(memory, gdevice + 4, 2)
         || !ppc_memory_can_write_bytes(memory, gdevice + 20, 2)
         || !ppc_memory_can_write_bytes(memory, gdevice + 42, 4)
-        || (depth == 8 && !ppc_main_color_table_is_valid(memory))
+        || (depth <= 8 && !ppc_main_color_table_is_valid(memory))
     {
         return PPC_PARAM_ERR;
     }
@@ -50289,7 +51256,7 @@ fn ppc_set_depth(
     let ctable_fallback = TrapDispatcher::standard_mac_8bpp_clut();
     let mut screen_pixmap_updates = Vec::with_capacity(screen_pixmaps.len());
     for pixmap in screen_pixmaps {
-        let indexed_ctable = if depth == 8 {
+        let indexed_ctable = if depth <= 8 {
             let mut selected = (pixmap == main_pixmap).then_some(PPC_MAIN_CTABLE_HANDLE);
             for (_, pixmap_handle, candidate_pixmap) in &screen_records {
                 if *candidate_pixmap != pixmap {
@@ -50319,20 +51286,89 @@ fn ppc_set_depth(
         };
         screen_pixmap_updates.push((pixmap, indexed_ctable));
     }
-    let indexed_device_clut = if depth == 8 {
-        let Some(clut) = ppc_read_ctable_clut(memory, PPC_MAIN_CTABLE_HANDLE, &ctable_fallback)
+    let indexed_device_clut = if depth <= 8 {
+        let Some((standard_clut, entry_count)) = ppc_standard_screen_clut(depth, target_is_color)
         else {
             return PPC_PARAM_ERR;
         };
-        Some(clut)
+        if preserve_indexed_tables {
+            let Some(clut) = ppc_read_ctable_clut(memory, PPC_MAIN_CTABLE_HANDLE, &standard_clut)
+            else {
+                return PPC_PARAM_ERR;
+            };
+            Some((clut, entry_count, Vec::new(), false, 0))
+        } else {
+            let Some(byte_len) = u32::try_from(entry_count)
+                .ok()
+                .and_then(|count| count.checked_mul(8))
+                .and_then(|entries| entries.checked_add(8))
+            else {
+                return PPC_PARAM_ERR;
+            };
+            let mut ctable_handles = screen_pixmap_updates
+                .iter()
+                .map(|(_, ctable_handle)| *ctable_handle)
+                .filter(|ctable_handle| *ctable_handle != 0)
+                .collect::<Vec<_>>();
+            ctable_handles.sort_unstable();
+            ctable_handles.dedup();
+            if let Err(error) = ppc_preflight_ctable_growth(
+                memory,
+                handles,
+                &ctable_handles,
+                byte_len,
+                *heap_cursor,
+                heap_limit,
+            ) {
+                return error;
+            }
+            Some((standard_clut, entry_count, ctable_handles, true, byte_len))
+        }
     } else {
         None
     };
 
-    let clear_byte = if depth == 8 { 0xff } else { 0x00 };
-    let clear = vec![clear_byte; clear_len];
-    if memory.write_bytes(PPC_MAIN_SCREEN_BASE, &clear).is_none() {
+    if !ppc_memory_can_write_bytes(memory, PPC_MAIN_SCREEN_BASE, clear_len_u32) {
         return PPC_PARAM_ERR;
+    }
+
+    if let Some((indexed_device_clut, entry_count, ctable_handles, install_tables, required_size)) =
+        indexed_device_clut.as_ref()
+    {
+        if *install_tables {
+            if let Err(error) = ppc_grow_ctables(
+                memory,
+                heap_cursor,
+                heap_limit,
+                handles,
+                ctable_handles,
+                *required_size,
+            ) {
+                return error;
+            }
+            // Canonical color tables use their depth as the traditional
+            // seed. Grayscale and enhanced 2-bit color tables differ at the
+            // same depth, so give them a fresh seed to keep inverse-table
+            // caches from treating distinct personalities as identical.
+            let seed = if (target_is_color && depth != 2) || depth == 1 {
+                depth
+            } else {
+                ppc_next_ct_seed(toolbox_startup)
+            };
+            for ctable_handle in ctable_handles {
+                if ppc_install_standard_indexed_ctable(
+                    memory,
+                    *ctable_handle,
+                    seed,
+                    indexed_device_clut,
+                    *entry_count,
+                )
+                .is_none()
+                {
+                    return PPC_PARAM_ERR;
+                }
+            }
+        }
     }
 
     // All guest addresses have been preflighted. Patch only the fields that
@@ -50355,11 +51391,23 @@ fn ppc_set_depth(
         }
     }
 
-    let gd_type = if depth == 8 { 0 } else { 2 };
-    let gd_flags = current_gd_flags | 1;
+    let gd_type = if depth <= 8 { 0 } else { 2 };
+    let gd_flags = if target_is_color {
+        current_gd_flags | 1
+    } else {
+        current_gd_flags & !1
+    };
+    let Some(depth_mode) = u16::try_from(depth)
+        .ok()
+        .and_then(crate::display::classic_depth_mode)
+    else {
+        return PPC_PARAM_ERR;
+    };
     if memory.write_u16_be(gdevice + 4, gd_type).is_none()
         || memory.write_u16_be(gdevice + 20, gd_flags).is_none()
-        || memory.write_u32_be(gdevice + 42, depth).is_none()
+        || memory
+            .write_u32_be(gdevice + 42, u32::from(depth_mode))
+            .is_none()
     {
         return PPC_PARAM_ERR;
     }
@@ -50384,11 +51432,28 @@ fn ppc_set_depth(
         }
     }
 
+    let clear_byte = if depth == 8 { 0xff } else { 0x00 };
+    let clear = vec![clear_byte; clear_len];
+    if memory.write_bytes(PPC_MAIN_SCREEN_BASE, &clear).is_none() {
+        return PPC_PARAM_ERR;
+    }
+
     toolbox_startup.indexed_screen_ctables = indexed_screen_ctables;
-    if let Some(indexed_device_clut) = indexed_device_clut {
+    toolbox_startup.indexed_screen_mode = if depth <= 8 {
+        Some((depth, target_is_color))
+    } else {
+        preserved_indexed_mode
+    };
+    if let Some((indexed_device_clut, _, _, _, _)) = indexed_device_clut {
         *screen_clut = indexed_device_clut;
         *color_manager_clut = indexed_device_clut;
     }
+
+    // A depth switch invalidates the saved pixels and front-buffer metadata
+    // owned by an active MenuSelect operation. Drop that operation only after
+    // the mode switch succeeds so it cannot resume against the new PixMap.
+    toolbox_startup.menu_tracking = None;
+    let _ = memory.write_u16_be(PPC_THE_MENU_ADDR, 0);
 
     PPC_NO_ERR
 }
@@ -50780,6 +51845,7 @@ fn ppc_dsp_alt_buffer_new(
     last_mem_error: &mut i16,
     handles: &mut Vec<PpcHandleRecord>,
     gworlds: &mut Vec<PpcGWorldRecord>,
+    gworld_allocations: &mut HashMap<u32, PpcGWorldAllocationRecord>,
     current_gdevice: u32,
     draw_sprocket: &PpcDrawSprocketState,
 ) -> i16 {
@@ -50833,6 +51899,7 @@ fn ppc_dsp_alt_buffer_new(
         last_mem_error,
         handles,
         gworlds,
+        gworld_allocations,
         current_gdevice,
     )
 }
@@ -52951,8 +54018,8 @@ fn ppc_alloc_handle_with_bytes(
     let Some(ptr) = memory.read_u32_be(handle) else {
         return 0;
     };
-    for (offset, byte) in bytes.iter().enumerate() {
-        let _ = memory.write_u8(ptr + offset as u32, *byte);
+    if memory.write_bytes(ptr, bytes).is_none() {
+        return 0;
     }
     handle
 }
@@ -53202,6 +54269,23 @@ fn ppc_set_handle_size(
     record.size = size;
     record.capacity = size;
     PPC_NO_ERR
+}
+
+fn ppc_handle_resize_allocation_size(
+    record: PpcHandleRecord,
+    heap_cursor: u32,
+    size: u32,
+) -> Option<u32> {
+    if size <= record.capacity {
+        return Some(0);
+    }
+    let old_aligned = ppc_allocation_size(record.size)?;
+    let new_aligned = ppc_allocation_size(size)?;
+    if record.ptr.checked_add(old_aligned) == Some(heap_cursor) {
+        new_aligned.checked_sub(old_aligned)
+    } else {
+        Some(new_aligned)
+    }
 }
 
 fn ppc_new_handle(
@@ -53984,7 +55068,7 @@ fn ppc_plot_cicon(
     memory: &mut PpcSectionMem,
     gworlds: &[PpcGWorldRecord],
     current_gworld: u32,
-    screen_clut: &[[u16; 3]; 256],
+    _screen_clut: &[[u16; 3]; 256],
 ) -> bool {
     let rect_ptr = cpu.gpr[3];
     let icon_handle = cpu.gpr[4];
@@ -53999,7 +55083,7 @@ fn ppc_plot_cicon(
     };
     let front_buffer = surface.front_buffer;
     let (dst_top, dst_left, dst_bottom, dst_right) = surface.local_rect_i16(port_dst_rect);
-    if !matches!(front_buffer.depth, 8 | 16) {
+    if !matches!(front_buffer.depth, 1 | 2 | 4 | 8 | 16) {
         return false;
     }
     let Some(pixel_base) = memory.read_u32_be(icon_ptr) else {
@@ -54092,15 +55176,8 @@ fn ppc_plot_cicon(
             let Some(color) = ppc_cicon_color(memory, color_table_handle, index) else {
                 continue;
             };
-            let raw_pixel = if front_buffer.depth == 8 {
-                u16::from(pict::closest_clut_index(
-                    color.red,
-                    color.green,
-                    color.blue,
-                    screen_clut,
-                ))
-            } else {
-                ppc_rgb_color_to_rgb555(color)
+            let Some(raw_pixel) = ppc_quickdraw_surface_color_pixel(memory, surface, color) else {
+                continue;
             };
             drew |= ppc_quickdraw_write_raw_pixel(
                 memory,
@@ -58170,7 +59247,21 @@ fn ppc_fill_front_rect(
         return false;
     }
     let pixel = match front.depth {
-        8 => u16::from(ppc_rgb_color_to_8bpp_index(color)),
+        depth @ (1 | 2 | 4 | 8) => {
+            let fallback = TrapDispatcher::standard_mac_indexed_clut(depth as u16)
+                .map(|(clut, _)| clut)
+                .unwrap_or_else(TrapDispatcher::standard_mac_8bpp_clut);
+            let clut = if front.base_addr == PPC_MAIN_SCREEN_BASE {
+                ppc_read_ctable_clut(memory, PPC_MAIN_CTABLE_HANDLE, &fallback).unwrap_or(fallback)
+            } else {
+                fallback
+            };
+            u16::from(ppc_rgb_color_to_index_in_clut(
+                color,
+                &clut,
+                ppc_indexed_depth_entry_count(depth).unwrap_or(1),
+            ))
+        }
         16 => ppc_rgb_color_to_rgb555(color),
         _ => return false,
     };
@@ -60457,6 +61548,106 @@ fn ppc_font_metrics(memory: &mut PpcSectionMem, metrics_ptr: u32, text_font: i16
     let _ = memory.write_u32_be(metrics_ptr + 16, 0);
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PpcDmLiveDisplayMode {
+    display_mode_id: u32,
+    depth_mode: u32,
+    base_addr: u32,
+    row_bytes: u16,
+    bounds: (i16, i16, i16, i16),
+    width: u32,
+    height: u32,
+    pm_version: u16,
+    pack_type: u16,
+    pack_size: u32,
+    h_res: u32,
+    v_res: u32,
+    pixel_type: u16,
+    pixel_size: u16,
+    component_count: u16,
+    component_size: u16,
+    plane_bytes: u32,
+}
+
+fn ppc_dm_live_display_mode(
+    memory: &mut PpcSectionMem,
+    requested_gdevice: u32,
+) -> Option<PpcDmLiveDisplayMode> {
+    let gdevice = ppc_main_gdevice_record_for_depth(memory, requested_gdevice)?;
+    let pixmap_handle = memory
+        .read_u32_be(gdevice + 22)
+        .filter(|handle| *handle != 0)?;
+    let pixmap = memory
+        .read_u32_be(pixmap_handle)
+        .filter(|pixmap| *pixmap != 0)?;
+    let bounds = ppc_read_rect(memory, pixmap + 6)?;
+    let width = u32::try_from(i32::from(bounds.3) - i32::from(bounds.1)).ok()?;
+    let height = u32::try_from(i32::from(bounds.2) - i32::from(bounds.0)).ok()?;
+    let row_bytes = memory.read_u16_be(pixmap + 4)? & 0x3fff;
+    let pixel_type = memory.read_u16_be(pixmap + 30)?;
+    let pixel_size = memory.read_u16_be(pixmap + 32)?;
+    let component_count = memory.read_u16_be(pixmap + 34)?;
+    let component_size = memory.read_u16_be(pixmap + 36)?;
+    let format_is_supported = match pixel_size {
+        1 | 2 | 4 | 8 => {
+            pixel_type == 0
+                && component_count == 1
+                && component_size == pixel_size
+                && memory
+                    .read_u32_be(pixmap + 42)
+                    .is_some_and(|table| table != 0)
+        }
+        16 => pixel_type == 16 && component_count == 3 && component_size == 5,
+        _ => false,
+    };
+    if width == 0 || height == 0 || row_bytes == 0 || !format_is_supported {
+        return None;
+    }
+    let depth_mode = u32::from(crate::display::classic_depth_mode(pixel_size)?);
+    if memory.read_u32_be(gdevice + 42)? != depth_mode {
+        return None;
+    }
+
+    // Inside Macintosh: Imaging With QuickDraw (1994), pp. 4-46--4-47 and
+    // 5-15--5-18: gdPMap describes the live screen buffer's dimensions,
+    // storage format, and depth, while gdMode is the device's current depth
+    // mode. Keep the Display Manager view derived from those live records.
+    Some(PpcDmLiveDisplayMode {
+        display_mode_id: PPC_DM_CURRENT_DISPLAY_MODE_ID,
+        depth_mode,
+        base_addr: memory.read_u32_be(pixmap)?,
+        row_bytes,
+        bounds,
+        width,
+        height,
+        pm_version: memory.read_u16_be(pixmap + 14)?,
+        pack_type: memory.read_u16_be(pixmap + 16)?,
+        pack_size: memory.read_u32_be(pixmap + 18)?,
+        h_res: memory.read_u32_be(pixmap + 22)?,
+        v_res: memory.read_u32_be(pixmap + 26)?,
+        pixel_type,
+        pixel_size,
+        component_count,
+        component_size,
+        plane_bytes: memory.read_u32_be(pixmap + 38)?,
+    })
+}
+
+fn ppc_dm_write_switch_info(
+    memory: &mut PpcSectionMem,
+    switch_info: u32,
+    mode: PpcDmLiveDisplayMode,
+) -> Option<()> {
+    // Universal Interfaces 3.4.1 Video.h defines VDSwitchInfoRec as the
+    // depth mode, timing mode, page, base address, and a zero reserved field.
+    memory.write_u16_be(switch_info, mode.depth_mode as u16)?;
+    memory.write_u32_be(switch_info + 2, mode.display_mode_id)?;
+    memory.write_u16_be(switch_info + 6, 0)?;
+    memory.write_u32_be(switch_info + 8, mode.base_addr)?;
+    memory.write_u32_be(switch_info + 12, 0)?;
+    Some(())
+}
+
 fn ppc_dm_new_display_mode_list(
     cpu: &PpcCpu,
     memory: &mut PpcSectionMem,
@@ -60489,11 +61680,15 @@ fn ppc_dm_new_display_mode_list_values(
 ) -> i16 {
     if count_out == 0
         || list_out == 0
+        || display_id != PPC_DSP_DISPLAY_ID
         || !ppc_memory_can_write_bytes(memory, count_out, 4)
         || !ppc_memory_can_write_bytes(memory, list_out, 4)
     {
         return PPC_PARAM_ERR;
     }
+    let Some(mode) = ppc_dm_live_display_mode(memory, PPC_MAIN_GDEVICE) else {
+        return PPC_PARAM_ERR;
+    };
     let list = ppc_alloc_ptr(
         memory,
         heap_cursor,
@@ -60515,9 +61710,10 @@ fn ppc_dm_new_display_mode_list_values(
     let vp_block = list + PPC_DM_MODE_LIST_VP_BLOCK_OFFSET;
     let name = list + PPC_DM_MODE_LIST_NAME_OFFSET;
 
-    // Universal Interfaces 3.4.1 Displays.h defines a DMListType plus one
-    // DMDisplayModeListEntryRec for each timing. The single-screen runtime
-    // advertises the configured reference display as one safe indexed mode.
+    // Universal Interfaces 3.4.1 Displays.h defines one
+    // DMDisplayModeListEntryRec per timing and one DMDepthInfoRec per
+    // supported depth. This single-screen list advertises only the active
+    // timing/depth pair reflected by the live GDevice and PixMap above.
     let _ = memory.write_u32_be(list, PPC_DM_MODE_LIST_MAGIC);
     let _ = memory.write_u32_be(list + 4, display_id);
     let _ = memory.write_u32_be(entry, 0);
@@ -60529,26 +61725,22 @@ fn ppc_dm_new_display_mode_list_values(
     let _ = memory.write_u32_be(entry + 24, name);
     let _ = memory.write_u32_be(entry + 28, 0);
 
-    let _ = memory.write_u16_be(switch_info, 0x85);
-    let _ = memory.write_u32_be(switch_info + 2, 0x80);
-    let _ = memory.write_u16_be(switch_info + 6, 0);
-    let _ = memory.write_u32_be(switch_info + 8, PPC_MAIN_SCREEN_BASE);
-    let _ = memory.write_u32_be(switch_info + 12, 0);
+    let _ = ppc_dm_write_switch_info(memory, switch_info, mode);
 
     let _ = memory.write_u32_be(resolution, 0);
-    let _ = memory.write_u32_be(resolution + 4, 0x80);
-    let _ = memory.write_u32_be(resolution + 8, PPC_MAIN_SCREEN_WIDTH);
-    let _ = memory.write_u32_be(resolution + 12, PPC_MAIN_SCREEN_HEIGHT);
+    let _ = memory.write_u32_be(resolution + 4, mode.display_mode_id);
+    let _ = memory.write_u32_be(resolution + 8, mode.width);
+    let _ = memory.write_u32_be(resolution + 12, mode.height);
     let _ = memory.write_u32_be(resolution + 16, 60 << 16);
-    let _ = memory.write_u32_be(resolution + 20, 0x85);
+    let _ = memory.write_u32_be(resolution + 20, mode.depth_mode);
     let _ = memory.write_u32_be(resolution + 24, 0);
     let _ = memory.write_u32_be(resolution + 28, 0);
 
-    let _ = memory.write_u32_be(timing, 0x80);
+    let _ = memory.write_u32_be(timing, mode.display_mode_id);
     let _ = memory.write_u32_be(timing + 4, 0);
     let _ = memory.write_u32_be(timing + 8, 0);
     let _ = memory.write_u32_be(timing + 12, 0);
-    let _ = memory.write_u32_be(timing + 16, 0);
+    let _ = memory.write_u32_be(timing + 16, 0b111);
 
     let _ = memory.write_u32_be(depth_block, 1);
     let _ = memory.write_u32_be(depth_block + 4, depth_info);
@@ -60564,29 +61756,38 @@ fn ppc_dm_new_display_mode_list_values(
     // Video.h VPBlock is 68K-aligned even for CFM clients: long, short,
     // Rect, two shorts, three longs, four shorts, and a final long.
     let _ = memory.write_u32_be(vp_block, 0);
-    let _ = memory.write_u16_be(vp_block + 4, PPC_MAIN_SCREEN_WIDTH as u16);
+    let _ = memory.write_u16_be(vp_block + 4, mode.row_bytes);
     let _ = ppc_write_rect(
         memory,
         vp_block + 6,
-        0,
-        0,
-        PPC_MAIN_SCREEN_HEIGHT as i16,
-        PPC_MAIN_SCREEN_WIDTH as i16,
+        mode.bounds.0,
+        mode.bounds.1,
+        mode.bounds.2,
+        mode.bounds.3,
     );
-    let _ = memory.write_u16_be(vp_block + 14, 0);
-    let _ = memory.write_u16_be(vp_block + 16, 0);
-    let _ = memory.write_u32_be(vp_block + 18, 0);
-    let _ = memory.write_u32_be(vp_block + 22, 72 << 16);
-    let _ = memory.write_u32_be(vp_block + 26, 72 << 16);
-    let _ = memory.write_u16_be(vp_block + 30, 0);
-    let _ = memory.write_u16_be(vp_block + 32, 8);
-    let _ = memory.write_u16_be(vp_block + 34, 1);
-    let _ = memory.write_u16_be(vp_block + 36, 8);
-    let _ = memory.write_u32_be(vp_block + 38, 0);
-    let mode_name = format!(
-        "{} x {}, 256 Colors",
-        PPC_MAIN_SCREEN_WIDTH, PPC_MAIN_SCREEN_HEIGHT
-    );
+    let _ = memory.write_u16_be(vp_block + 14, mode.pm_version);
+    let _ = memory.write_u16_be(vp_block + 16, mode.pack_type);
+    let _ = memory.write_u32_be(vp_block + 18, mode.pack_size);
+    let _ = memory.write_u32_be(vp_block + 22, mode.h_res);
+    let _ = memory.write_u32_be(vp_block + 26, mode.v_res);
+    let _ = memory.write_u16_be(vp_block + 30, mode.pixel_type);
+    let _ = memory.write_u16_be(vp_block + 32, mode.pixel_size);
+    let _ = memory.write_u16_be(vp_block + 34, mode.component_count);
+    let _ = memory.write_u16_be(vp_block + 36, mode.component_size);
+    let _ = memory.write_u32_be(vp_block + 38, mode.plane_bytes);
+    let mode_name = if mode.pixel_size <= 8 {
+        format!(
+            "{} x {}, {} Colors",
+            mode.width,
+            mode.height,
+            1u32 << mode.pixel_size
+        )
+    } else {
+        format!(
+            "{} x {}, {}-bit Color",
+            mode.width, mode.height, mode.pixel_size
+        )
+    };
     let _ = ppc_write_pstring_bytes(memory, name, mode_name.as_bytes());
     let _ = memory.write_u32_be(count_out, 1);
     let _ = memory.write_u32_be(list_out, list);
@@ -62654,6 +63855,16 @@ fn ppc_menu_item_enabled(memory: &mut PpcSectionMem, menu_handle: u32, item: i16
     flags & 1 != 0 && (item > 31 || item > 0 && flags & (1u32 << item) != 0)
 }
 
+fn ppc_menu_item_is_separator(memory: &mut PpcSectionMem, menu_handle: u32, item: i16) -> bool {
+    ppc_menu_item(memory, menu_handle, item)
+        .is_some_and(|(address, len)| len == 1 && memory.read_u8(address + 1) == Some(b'-'))
+}
+
+fn ppc_menu_item_is_selectable(memory: &mut PpcSectionMem, menu_handle: u32, item: i16) -> bool {
+    ppc_menu_item_enabled(memory, menu_handle, item)
+        && !ppc_menu_item_is_separator(memory, menu_handle, item)
+}
+
 fn ppc_guest_menu_snapshot(memory: &mut PpcSectionMem, menu_list_handle: u32) -> GuestMenuSnapshot {
     let menu_list = ppc_menu_list_definition(memory, menu_list_handle).unwrap_or_default();
     let entries = menu_list
@@ -62751,7 +63962,7 @@ fn ppc_pop_up_menu_select(
         return 0;
     }
     let item = i16::try_from(relative_v / row_height + 1).unwrap_or(i16::MAX);
-    if item > count || !ppc_menu_item_enabled(memory, menu_handle, item) {
+    if item > count || !ppc_menu_item_is_selectable(memory, menu_handle, item) {
         return 0;
     }
     let menu_id = memory.read_u16_be(menu).unwrap_or(0);
@@ -62788,7 +63999,12 @@ fn ppc_menu_handle_at_title_point(
     menu_list_handle: u32,
     initial_point: u32,
 ) -> Option<(u32, i16)> {
+    let initial_v = (initial_point >> 16) as u16 as i16;
     let initial_h = initial_point as u16 as i16;
+    let menu_bar_height = memory.read_u16_be(PPC_MBAR_HEIGHT_ADDR).unwrap_or(20) as i16;
+    if initial_v < 0 || initial_v >= menu_bar_height {
+        return None;
+    }
     let mut title_left = PPC_MENU_TITLE_HIT_LEFT;
     for menu_handle in ppc_menu_list_definition(memory, menu_list_handle)?.regular_handles() {
         let menu = memory.read_u32_be(menu_handle).filter(|ptr| *ptr != 0)?;
@@ -62797,7 +64013,8 @@ fn ppc_menu_handle_at_title_point(
             .saturating_add(ppc_menu_title_advance(&title))
             .saturating_add(PPC_MENU_TITLE_SPACING);
         if initial_h >= title_left && initial_h < title_right {
-            return Some((menu_handle, title_left));
+            let menu_enabled = memory.read_u32_be(menu + 10).unwrap_or(0) & 1 != 0;
+            return menu_enabled.then_some((menu_handle, title_left));
         }
         title_left = title_right;
     }
@@ -62817,9 +64034,10 @@ fn ppc_menu_tracking_item(
         return 0;
     }
     let item = i16::try_from(relative_v / 16 + 1).unwrap_or(i16::MAX);
-    (item <= ppc_count_menu_items(memory, state.menu_handle) as i16)
-        .then_some(item)
-        .unwrap_or(0)
+    (item <= ppc_count_menu_items(memory, state.menu_handle) as i16
+        && ppc_menu_item_is_selectable(memory, state.menu_handle, item))
+    .then_some(item)
+    .unwrap_or(0)
 }
 
 fn ppc_restore_tracked_menu(
@@ -62827,9 +64045,12 @@ fn ppc_restore_tracked_menu(
     front: PpcFrontBuffer,
     state: &PpcMenuTrackingState,
 ) {
+    if front != state.front_buffer {
+        return;
+    }
     let mut index = 0usize;
-    for y in 0..i32::from(state.popup_height) {
-        for x in 0..i32::from(state.popup_width) {
+    for y in 0..i32::from(state.saved_height) {
+        for x in 0..i32::from(state.saved_width) {
             if let Some(pixel) = state.saved_pixels.get(index).copied() {
                 let _ = ppc_quickdraw_write_raw_pixel(
                     memory,
@@ -62846,6 +64067,22 @@ fn ppc_restore_tracked_menu(
     }
 }
 
+fn ppc_physical_screen_color_pixel(
+    front: PpcFrontBuffer,
+    color: PpcRgbColor,
+    screen_clut: &[[u16; 3]; 256],
+) -> Option<u16> {
+    match front.depth {
+        depth @ (1 | 2 | 4 | 8) => Some(u16::from(ppc_rgb_color_to_index_in_clut(
+            color,
+            screen_clut,
+            ppc_indexed_depth_entry_count(depth)?,
+        ))),
+        16 => Some(ppc_rgb_color_to_rgb555(color)),
+        _ => None,
+    }
+}
+
 fn ppc_draw_tracked_menu(
     memory: &mut PpcSectionMem,
     gworlds: &[PpcGWorldRecord],
@@ -62853,25 +64090,14 @@ fn ppc_draw_tracked_menu(
     state: &PpcMenuTrackingState,
     input: PpcInputSnapshot,
 ) {
-    let Some(front) = ppc_front_buffer_for_gworld(gworlds, PPC_MAIN_GWORLD) else {
+    let Some(front) = ppc_live_front_buffer_for_gworld(memory, gworlds, PPC_MAIN_GWORLD) else {
         return;
     };
-    let (white, black) = if front.depth == 8 {
-        (
-            u16::from(ppc_rgb_color_to_8bpp_index_in_clut(
-                PPC_RGB_WHITE,
-                screen_clut,
-            )),
-            u16::from(ppc_rgb_color_to_8bpp_index_in_clut(
-                PPC_RGB_BLACK,
-                screen_clut,
-            )),
-        )
-    } else {
-        (
-            ppc_rgb_color_to_rgb555(PPC_RGB_WHITE),
-            ppc_rgb_color_to_rgb555(PPC_RGB_BLACK),
-        )
+    let (Some(white), Some(black)) = (
+        ppc_physical_screen_color_pixel(front, PPC_RGB_WHITE, screen_clut),
+        ppc_physical_screen_color_pixel(front, PPC_RGB_BLACK, screen_clut),
+    ) else {
+        return;
     };
     let selected = ppc_menu_tracking_item(memory, state, input);
     for y in 0..i32::from(state.popup_height) {
@@ -62892,6 +64118,32 @@ fn ppc_draw_tracked_menu(
                 if border || highlighted { black } else { white },
             );
         }
+    }
+    // Macintosh Toolbox Essentials (1992), pp. 3-122--3-123: the standard
+    // menu definition draws a one-pixel shadow below and to the right of the
+    // menu. The saved rectangle includes those pixels so closing the menu is
+    // byte-for-byte reversible even for packed destinations.
+    for y in 1..=i32::from(state.popup_height) {
+        let _ = ppc_quickdraw_write_raw_pixel(
+            memory,
+            front,
+            (
+                i32::from(state.popup_left) + i32::from(state.popup_width),
+                i32::from(state.popup_top) + y,
+            ),
+            black,
+        );
+    }
+    for x in 1..=i32::from(state.popup_width) {
+        let _ = ppc_quickdraw_write_raw_pixel(
+            memory,
+            front,
+            (
+                i32::from(state.popup_left) + x,
+                i32::from(state.popup_top) + i32::from(state.popup_height),
+            ),
+            black,
+        );
     }
     for item in 1..=ppc_count_menu_items(memory, state.menu_handle) as i16 {
         let Some((address, len)) = ppc_menu_item(memory, state.menu_handle, item) else {
@@ -62919,8 +64171,9 @@ fn ppc_draw_tracked_menu(
         } else {
             PPC_RGB_BLACK
         };
-        let explicit_index =
-            (front.depth == 8).then(|| ppc_rgb_color_to_8bpp_index_in_clut(color, screen_clut));
+        let explicit_index = ppc_indexed_depth_entry_count(front.depth)
+            .and_then(|_| ppc_physical_screen_color_pixel(front, color, screen_clut))
+            .and_then(|pixel| u8::try_from(pixel).ok());
         let mode = PPC_QD_TEXT_MODE_SRC_OR;
         let _ = ppc_draw_text_bytes(
             memory,
@@ -62948,10 +64201,25 @@ fn ppc_track_menu_while_held(
     initial_point: u32,
     input: PpcInputSnapshot,
 ) {
-    let Some(front) = ppc_front_buffer_for_gworld(gworlds, PPC_MAIN_GWORLD) else {
+    let Some(front) = ppc_live_front_buffer_for_gworld(memory, gworlds, PPC_MAIN_GWORLD) else {
         return;
     };
+    if startup.host_menu_bar_hidden {
+        if let Some(previous) = startup.menu_tracking.take() {
+            if previous.front_buffer == front {
+                ppc_restore_tracked_menu(memory, front, &previous);
+            }
+        }
+        let _ = memory.write_u16_be(PPC_THE_MENU_ADDR, 0);
+        return;
+    }
     if let Some(previous) = startup.menu_tracking.take() {
+        if previous.front_buffer != front {
+            ppc_restore_tracked_menu(memory, previous.front_buffer, &previous);
+            let _ = memory.write_u16_be(PPC_THE_MENU_ADDR, 0);
+            let _ = ppc_draw_menu_bar(memory, gworlds, startup.current_menu_bar, screen_clut);
+            return;
+        }
         ppc_restore_tracked_menu(memory, front, &previous);
         startup.menu_tracking = Some(previous);
     } else {
@@ -62964,23 +64232,35 @@ fn ppc_track_menu_while_held(
         let Some(menu) = memory.read_u32_be(menu_handle).filter(|ptr| *ptr != 0) else {
             return;
         };
-        let popup_left = title_left;
-        let popup_top = 20;
-        let popup_width = i16::try_from(memory.read_u16_be(menu + 2).unwrap_or(64).max(32))
-            .unwrap_or(i16::MAX)
-            .min(front.width as i16 - popup_left);
-        let popup_height = i16::try_from(
+        let menu_bar_height = memory.read_u16_be(PPC_MBAR_HEIGHT_ADDR).unwrap_or(20) as i16;
+        let front_width = ppc_u32_to_i16_saturating(front.width);
+        let front_height = ppc_u32_to_i16_saturating(front.height);
+        if menu_bar_height <= 0 || menu_bar_height >= front_height || front_width <= 1 {
+            return;
+        }
+        let desired_width =
+            i16::try_from(memory.read_u16_be(menu + 2).unwrap_or(64).max(32)).unwrap_or(i16::MAX);
+        let popup_width = desired_width.min(front_width.saturating_sub(1)).max(1);
+        let popup_left = title_left
+            .max(0)
+            .min(front_width.saturating_sub(popup_width.saturating_add(1)));
+        let popup_top = menu_bar_height;
+        let desired_height = i16::try_from(
             ppc_count_menu_items(memory, menu_handle)
                 .saturating_mul(16)
                 .saturating_add(4),
         )
-        .unwrap_or(i16::MAX)
-        .min(front.height as i16 - popup_top);
+        .unwrap_or(i16::MAX);
+        let popup_height = desired_height
+            .min(front_height.saturating_sub(popup_top).saturating_sub(1))
+            .max(1);
+        let saved_width = popup_width.saturating_add(1);
+        let saved_height = popup_height.saturating_add(1);
         let mut saved_pixels = Vec::with_capacity(
-            usize::try_from(i32::from(popup_width) * i32::from(popup_height)).unwrap_or(0),
+            usize::try_from(i32::from(saved_width) * i32::from(saved_height)).unwrap_or(0),
         );
-        for y in 0..i32::from(popup_height) {
-            for x in 0..i32::from(popup_width) {
+        for y in 0..i32::from(saved_height) {
+            for x in 0..i32::from(saved_width) {
                 saved_pixels.push(
                     ppc_quickdraw_read_pixel(
                         memory,
@@ -62998,14 +64278,33 @@ fn ppc_track_menu_while_held(
             popup_top,
             popup_width,
             popup_height,
+            saved_width,
+            saved_height,
+            front_buffer: front,
             saved_pixels,
         });
+    }
+    let active_menu_id = startup.menu_tracking.as_ref().and_then(|state| {
+        memory
+            .read_u32_be(state.menu_handle)
+            .filter(|menu| *menu != 0)
+            .and_then(|menu| memory.read_u16_be(menu))
+            .map(|menu_id| menu_id as i16)
+    });
+    if let Some(active_menu_id) = active_menu_id {
+        ppc_set_menu_title_highlight(
+            memory,
+            gworlds,
+            startup.current_menu_bar,
+            active_menu_id,
+            screen_clut,
+            startup.host_menu_bar_hidden,
+        );
     }
     if let Some(state) = startup.menu_tracking.as_ref() {
         // MenuSelect highlights the title and tracks the pointer until the
         // button is released, displaying the selected item inversely.
         // Macintosh Toolbox Essentials (1992), pp. 3-43--3-45, 3-122.
-        let _ = state.title_left;
         ppc_draw_tracked_menu(memory, gworlds, screen_clut, state, input);
     }
 }
@@ -63018,19 +64317,42 @@ fn ppc_finish_menu_tracking(
     input: PpcInputSnapshot,
 ) -> Option<u32> {
     let state = startup.menu_tracking.take()?;
-    let item = ppc_menu_tracking_item(memory, &state, input);
-    if let Some(front) = ppc_front_buffer_for_gworld(gworlds, PPC_MAIN_GWORLD) {
-        ppc_restore_tracked_menu(memory, front, &state);
-    }
-    let _ = ppc_draw_menu_bar(memory, gworlds, startup.current_menu_bar, screen_clut);
-    if item <= 0 || !ppc_menu_item_enabled(memory, state.menu_handle, item) {
-        return Some(0);
-    }
-    let menu = memory
+    let item = if startup.host_menu_bar_hidden {
+        0
+    } else {
+        ppc_menu_tracking_item(memory, &state, input)
+    };
+    let menu_id = memory
         .read_u32_be(state.menu_handle)
-        .filter(|ptr| *ptr != 0)?;
-    let menu_id = memory.read_u16_be(menu).unwrap_or(0);
-    Some((u32::from(menu_id) << 16) | u32::from(item as u16))
+        .filter(|ptr| *ptr != 0)
+        .and_then(|menu| memory.read_u16_be(menu))
+        .unwrap_or(0);
+    let result = if item > 0 {
+        (u32::from(menu_id) << 16) | u32::from(item as u16)
+    } else {
+        0
+    };
+    if let Some(front) = ppc_live_front_buffer_for_gworld(memory, gworlds, PPC_MAIN_GWORLD) {
+        if front == state.front_buffer {
+            ppc_restore_tracked_menu(memory, front, &state);
+        }
+    }
+    // Macintosh Toolbox Essentials (1992), pp. 3-89 and 3-115--3-116: a
+    // valid MenuSelect result leaves its title highlighted, while releasing
+    // over a disabled item, divider, the menu bar, or no menu returns zero.
+    // In the latter cases no menu remains current in TheMenu.
+    ppc_set_menu_title_highlight(
+        memory,
+        gworlds,
+        startup.current_menu_bar,
+        (result >> 16) as u16 as i16,
+        screen_clut,
+        startup.host_menu_bar_hidden,
+    );
+    if result == 0 && !startup.host_menu_bar_hidden {
+        let _ = ppc_draw_menu_bar(memory, gworlds, startup.current_menu_bar, screen_clut);
+    }
+    Some(result)
 }
 
 fn ppc_menu_select(
@@ -63039,7 +64361,12 @@ fn ppc_menu_select(
     initial_point: u32,
     input: PpcInputSnapshot,
 ) -> u32 {
+    let initial_v = (initial_point >> 16) as u16 as i16;
     let initial_h = initial_point as u16 as i16;
+    let menu_bar_height = memory.read_u16_be(PPC_MBAR_HEIGHT_ADDR).unwrap_or(20) as i16;
+    if initial_v < 0 || initial_v >= menu_bar_height {
+        return 0;
+    }
     let Some(menu_list) = ppc_menu_list_definition(memory, menu_list_handle) else {
         return 0;
     };
@@ -63053,13 +64380,13 @@ fn ppc_menu_select(
         let title_right = title_left.saturating_add(title_width);
         if initial_h >= title_left && initial_h < title_right {
             let count = ppc_count_menu_items(memory, menu_handle) as i16;
-            let relative_v = i32::from(input.mouse_v) - 20;
+            let relative_v = i32::from(input.mouse_v) - i32::from(menu_bar_height);
             let item = if relative_v >= 0 {
                 i16::try_from(relative_v / 16 + 1).unwrap_or(i16::MAX)
             } else {
                 0
             };
-            if item > 0 && item <= count && ppc_menu_item_enabled(memory, menu_handle, item) {
+            if item > 0 && item <= count && ppc_menu_item_is_selectable(memory, menu_handle, item) {
                 let menu_id = memory.read_u16_be(menu).unwrap_or(0);
                 return (u32::from(menu_id) << 16) | u32::from(item as u16);
             }
@@ -63552,35 +64879,151 @@ fn ppc_get_menu_handle(memory: &mut PpcSectionMem, menu_list_handle: u32, menu_i
     0
 }
 
+fn ppc_regular_menu_contains_id(
+    memory: &mut PpcSectionMem,
+    menu_list_handle: u32,
+    menu_id: i16,
+) -> bool {
+    let Some(menu_list) = ppc_menu_list_definition(memory, menu_list_handle) else {
+        return false;
+    };
+    let contains = menu_list.regular_handles().any(|menu_handle| {
+        memory
+            .read_u32_be(menu_handle)
+            .filter(|menu| *menu != 0)
+            .and_then(|menu| memory.read_u16_be(menu))
+            .map(|id| id as i16)
+            == Some(menu_id)
+    });
+    contains
+}
+
+fn ppc_set_menu_title_highlight(
+    memory: &mut PpcSectionMem,
+    gworlds: &[PpcGWorldRecord],
+    menu_list_handle: u32,
+    requested_menu_id: i16,
+    screen_clut: &[[u16; 3]; 256],
+    menu_bar_hidden: bool,
+) {
+    let target_menu_id = if requested_menu_id != 0
+        && ppc_regular_menu_contains_id(memory, menu_list_handle, requested_menu_id)
+    {
+        requested_menu_id
+    } else {
+        0
+    };
+    let previous_menu_id = memory.read_u16_be(PPC_THE_MENU_ADDR).unwrap_or(0) as i16;
+    if previous_menu_id == target_menu_id {
+        return;
+    }
+    let _ = memory.write_u16_be(PPC_THE_MENU_ADDR, target_menu_id as u16);
+    if !menu_bar_hidden {
+        let _ = ppc_draw_menu_bar(memory, gworlds, menu_list_handle, screen_clut);
+    }
+}
+
+fn ppc_reverse_menu_title_cell(
+    memory: &mut PpcSectionMem,
+    front_buffer: PpcFrontBuffer,
+    screen_clut: &[[u16; 3]; 256],
+    left: i16,
+    right: i16,
+    menu_bar_height: i16,
+) {
+    if menu_bar_height <= 1 {
+        return;
+    }
+    let (Some(white), Some(black)) = (
+        ppc_physical_screen_color_pixel(front_buffer, PPC_RGB_WHITE, screen_clut),
+        ppc_physical_screen_color_pixel(front_buffer, PPC_RGB_BLACK, screen_clut),
+    ) else {
+        return;
+    };
+    let screen_width = ppc_u32_to_i16_saturating(front_buffer.width);
+    let screen_height = ppc_u32_to_i16_saturating(front_buffer.height);
+    // The standard MBDF's highlighted title rectangle extends beyond the
+    // logical hit cell and excludes the menu bar's outer border. Inside
+    // Macintosh Volume I (1985), p. I-356.
+    let left = left.saturating_sub(2).max(0).min(screen_width);
+    let right = right.saturating_add(3).max(0).min(screen_width);
+    let bottom = menu_bar_height.min(screen_height).saturating_sub(1);
+    for y in 1..bottom {
+        for x in left..right {
+            let Some(pixel) =
+                ppc_quickdraw_read_pixel(memory, front_buffer, (i32::from(x), i32::from(y)))
+            else {
+                continue;
+            };
+            let reversed = if pixel == white {
+                black
+            } else if pixel == black {
+                white
+            } else {
+                pixel
+            };
+            let _ = ppc_quickdraw_write_raw_pixel(
+                memory,
+                front_buffer,
+                (i32::from(x), i32::from(y)),
+                reversed,
+            );
+        }
+    }
+}
+
+fn ppc_menu_bar_title_baseline(menu_bar_height: i16) -> i16 {
+    let (menu_font, numerator, denominator) =
+        get_font_face_scale_ratio(PPC_QD_TEXT_FONT_DEFAULT, PPC_QD_TEXT_SIZE_SYSTEM);
+    let menu_ascent =
+        ppc_scale_font_value(i32::from(menu_font.metrics.ascent), numerator, denominator);
+    let menu_descent =
+        ppc_scale_font_value(i32::from(menu_font.metrics.descent), numerator, denominator);
+    // Keep the PowerPC menu title baseline identical to the 68k Menu
+    // Manager when an application changes MBarHeight: center the live system
+    // font metrics inside the bar instead of assuming the default 20 pixels.
+    menu_bar_height
+        .saturating_sub(menu_ascent)
+        .saturating_sub(menu_descent)
+        / 2
+        + menu_ascent
+}
+
+fn ppc_menu_bar_system_mark_top(menu_bar_height: i16) -> i16 {
+    let (menu_font, numerator, denominator) =
+        get_font_face_scale_ratio(PPC_QD_TEXT_FONT_DEFAULT, PPC_QD_TEXT_SIZE_SYSTEM);
+    let menu_ascent =
+        ppc_scale_font_value(i32::from(menu_font.metrics.ascent), numerator, denominator);
+    ppc_menu_bar_title_baseline(menu_bar_height)
+        .saturating_sub(menu_ascent)
+        .saturating_add(1)
+}
+
 fn ppc_draw_menu_bar(
     memory: &mut PpcSectionMem,
     gworlds: &[PpcGWorldRecord],
     menu_list_handle: u32,
     screen_clut: &[[u16; 3]; 256],
 ) -> bool {
-    let Some(front_buffer) = ppc_front_buffer_for_gworld(gworlds, PPC_MAIN_GWORLD) else {
+    let Some(front_buffer) = ppc_live_front_buffer_for_gworld(memory, gworlds, PPC_MAIN_GWORLD)
+    else {
         return false;
     };
-    if !matches!(front_buffer.depth, 8 | 16) {
+    if !matches!(front_buffer.depth, 1 | 2 | 4 | 8 | 16) {
         return false;
     }
-    let white = match front_buffer.depth {
-        8 => u16::from(ppc_rgb_color_to_8bpp_index_in_clut(
-            PPC_RGB_WHITE,
-            screen_clut,
-        )),
-        16 => ppc_rgb_color_to_rgb555(PPC_RGB_WHITE),
-        _ => return false,
+    let (Some(white), Some(black)) = (
+        ppc_physical_screen_color_pixel(front_buffer, PPC_RGB_WHITE, screen_clut),
+        ppc_physical_screen_color_pixel(front_buffer, PPC_RGB_BLACK, screen_clut),
+    ) else {
+        return false;
     };
-    let black = match front_buffer.depth {
-        8 => u16::from(ppc_rgb_color_to_8bpp_index_in_clut(
-            PPC_RGB_BLACK,
-            screen_clut,
-        )),
-        16 => ppc_rgb_color_to_rgb555(PPC_RGB_BLACK),
-        _ => return false,
-    };
-    let height = front_buffer.height.min(20) as i32;
+    let height = front_buffer.height.min(u32::from(
+        memory.read_u16_be(PPC_MBAR_HEIGHT_ADDR).unwrap_or(20),
+    )) as i32;
+    if height == 0 {
+        return true;
+    }
     for y in 0..height {
         let pixel = if y == height - 1 { black } else { white };
         for x in 0..front_buffer.width as i32 {
@@ -63591,7 +65034,13 @@ fn ppc_draw_menu_bar(
     let Some(menu_list) = ppc_menu_list_definition(memory, menu_list_handle) else {
         return true;
     };
+    // DrawMenuBar redraws the title recorded in TheMenu as highlighted after
+    // drawing the remaining titles. Inside Macintosh Volume V (1986), p. V-250.
+    let highlighted_menu_id = memory.read_u16_be(PPC_THE_MENU_ADDR).unwrap_or(0) as i16;
+    let mut highlighted_title_drawn = false;
     let mut title_h = PPC_MENU_TITLE_ORIGIN_H;
+    let menu_bar_height = i16::try_from(height).unwrap_or(i16::MAX);
+    let title_v = ppc_menu_bar_title_baseline(menu_bar_height);
     for menu_handle in menu_list.regular_handles().take(64) {
         if menu_handle == 0 {
             continue;
@@ -63603,17 +65052,18 @@ fn ppc_draw_menu_bar(
         let Some(title) = ppc_read_pascal_string(memory, title_ptr) else {
             continue;
         };
-        let advance = if ppc_is_system_menu_mark(&title) {
+        let system_menu_mark = ppc_is_system_menu_mark(&title);
+        let advance = if system_menu_mark {
             ppc_draw_system_menu_mark(memory, front_buffer, screen_clut, title_h);
             PPC_SYSTEM_MENU_MARK_ADVANCE
         } else {
-            let explicit_index =
-                (front_buffer.depth == 8).then_some(u8::try_from(black).unwrap_or_default());
+            let explicit_index = ppc_indexed_depth_entry_count(front_buffer.depth)
+                .and_then(|_| u8::try_from(black).ok());
             ppc_draw_text_bytes(
                 memory,
                 gworlds,
                 PPC_MAIN_GWORLD,
-                (title_h, 15),
+                (title_h, title_v),
                 PPC_QD_TEXT_FONT_DEFAULT,
                 PPC_QD_TEXT_SIZE_SYSTEM,
                 PPC_QD_TEXT_MODE_SRC_OR,
@@ -63622,6 +65072,29 @@ fn ppc_draw_menu_bar(
                 &title,
             )
         };
+        let menu_id = memory.read_u16_be(menu).unwrap_or(0) as i16;
+        if !highlighted_title_drawn && highlighted_menu_id != 0 && menu_id == highlighted_menu_id {
+            let title_left = title_h
+                .saturating_sub(PPC_MENU_TITLE_ORIGIN_H.saturating_sub(PPC_MENU_TITLE_HIT_LEFT));
+            let title_right = title_left
+                .saturating_add(advance)
+                .saturating_add(PPC_MENU_TITLE_SPACING);
+            ppc_reverse_menu_title_cell(
+                memory,
+                front_buffer,
+                screen_clut,
+                title_left,
+                title_right,
+                menu_bar_height,
+            );
+            // Color title artwork is replotted after reversing its cell so
+            // only the transparent background participates in highlighting.
+            // Inside Macintosh Volume V (1986), pp. V-235 and V-244.
+            if system_menu_mark && front_buffer.depth != 1 {
+                ppc_draw_system_menu_mark(memory, front_buffer, screen_clut, title_h);
+            }
+            highlighted_title_drawn = true;
+        }
         title_h = title_h
             .saturating_add(advance)
             .saturating_add(PPC_MENU_TITLE_SPACING);
@@ -63649,21 +65122,20 @@ fn ppc_draw_system_menu_mark(
     left: i16,
 ) {
     let palette = crate::ui_art::RETRO_COMPUTER_MENU_MARK_PALETTE.map(|rgb| {
-        if front_buffer.depth == 8 {
-            u16::from(pict::closest_clut_index(
-                rgb[0],
-                rgb[1],
-                rgb[2],
-                screen_clut,
-            ))
-        } else {
-            ppc_q3_rgb555((
-                f32::from(rgb[0]) / 65_535.0,
-                f32::from(rgb[1]) / 65_535.0,
-                f32::from(rgb[2]) / 65_535.0,
-            ))
-        }
+        ppc_physical_screen_color_pixel(
+            front_buffer,
+            PpcRgbColor {
+                red: rgb[0],
+                green: rgb[1],
+                blue: rgb[2],
+            },
+            screen_clut,
+        )
+        .unwrap_or(0)
     });
+    let menu_bar_height = memory.read_u16_be(PPC_MBAR_HEIGHT_ADDR).unwrap_or(20) as i16;
+    let top = ppc_menu_bar_system_mark_top(menu_bar_height);
+    let menu_bar_bottom = menu_bar_height.saturating_sub(1).max(0);
     for (dy, row) in crate::ui_art::RETRO_COMPUTER_MENU_MARK_PIXELS
         .iter()
         .enumerate()
@@ -63672,10 +65144,14 @@ fn ppc_draw_system_menu_mark(
             if palette_index == 0 {
                 continue;
             }
+            let y = top.saturating_add(dy as i16);
+            if y < 0 || y >= menu_bar_bottom {
+                continue;
+            }
             let _ = ppc_quickdraw_write_raw_pixel(
                 memory,
                 front_buffer,
-                (i32::from(left) + dx as i32, 3 + dy as i32),
+                (i32::from(left) + dx as i32, i32::from(y)),
                 palette[usize::from(palette_index - 1)],
             );
         }
@@ -71832,6 +73308,60 @@ mod tests {
         assert_eq!(probe.unsupported_import_index, None);
     }
 
+    fn install_test_menu(
+        loaded: &mut PpcLoadedApp,
+        scratch: u32,
+        menu_id: i16,
+        title: &[u8],
+        item_specs: &[u8],
+    ) -> u32 {
+        loaded.memory.add_region(scratch, vec![0; 0x200]);
+        assert!(ppc_write_pstring_bytes(&mut loaded.memory, scratch, title));
+        assert!(ppc_write_pstring_bytes(
+            &mut loaded.memory,
+            scratch + 0x80,
+            item_specs,
+        ));
+        let menu = ppc_new_menu(
+            &mut loaded.memory,
+            &mut loaded.heap_cursor,
+            loaded.heap_limit,
+            &mut loaded.handles,
+            &mut loaded.free_handle_blocks,
+            menu_id,
+            scratch,
+        );
+        assert_ne!(menu, 0);
+        if !item_specs.is_empty() {
+            assert_eq!(
+                ppc_insert_menu_items(
+                    &mut loaded.memory,
+                    &mut loaded.heap_cursor,
+                    loaded.heap_limit,
+                    &mut loaded.handles,
+                    menu,
+                    scratch + 0x80,
+                    i16::MAX,
+                ),
+                PPC_NO_ERR,
+            );
+        }
+        assert_eq!(
+            ppc_insert_menu(
+                &mut loaded.memory,
+                &mut loaded.heap_cursor,
+                loaded.heap_limit,
+                &mut loaded.handles,
+                &mut loaded.free_handle_blocks,
+                &mut loaded.toolbox_startup.current_menu_bar,
+                menu,
+                0,
+            ),
+            PPC_NO_ERR,
+        );
+        menu
+    }
+
     #[test]
     fn ppc_watch_parser_accepts_hex_address_and_optional_length() {
         assert_eq!(
@@ -72580,13 +74110,17 @@ mod tests {
     }
 
     #[test]
-    fn find_window_distinguishes_the_menu_bar_from_window_content() {
+    fn find_window_distinguishes_the_menu_bar_from_the_desktop() {
         let pef = synthetic_pef_with_import(b"FindWindow");
         let mut loaded = load_pef_application(&pef).unwrap();
         let window_out = PPC_DATA_BASE + 0x1000;
         loaded.memory.add_region(window_out, vec![0xff; 4]);
         loaded.current_gworld = PPC_MAIN_GWORLD;
-        loaded.cpu.gpr[3] = (10 << 16) | 72;
+        loaded
+            .memory
+            .write_u16_be(PPC_MBAR_HEIGHT_ADDR, 12)
+            .unwrap();
+        loaded.cpu.gpr[3] = (11 << 16) | 72;
         loaded.cpu.gpr[4] = window_out;
 
         let probe = loaded.run_with_hle_imports(64);
@@ -72597,13 +74131,643 @@ mod tests {
 
         loaded.cpu.pc = loaded.entry_pc;
         loaded.cpu.lr = PPC_HALT_PC;
-        loaded.cpu.gpr[3] = (30 << 16) | 72;
+        loaded.cpu.gpr[3] = (12 << 16) | 72;
         loaded.cpu.gpr[4] = window_out;
         let probe = loaded.run_with_hle_imports(64);
 
         assert_eq!(probe.handled_import_count, 1);
+        assert_eq!(loaded.cpu.gpr[3], 0);
+        assert_eq!(loaded.memory.read_u32_be(window_out), Some(0));
+    }
+
+    #[test]
+    fn find_window_uses_visible_front_to_back_window_geometry_not_the_current_port() {
+        let pef = synthetic_pef_with_import(b"FindWindow");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let scratch = PPC_DATA_BASE + 0x1100;
+        let bounds = scratch;
+        let window_out = scratch + 16;
+        loaded.memory.add_region(scratch, vec![0; 32]);
+
+        ppc_write_rect(&mut loaded.memory, bounds, 40, 40, 140, 180).unwrap();
+        loaded.cpu.gpr[3] = 0;
+        loaded.cpu.gpr[4] = bounds;
+        loaded.cpu.gpr[5] = 0;
+        loaded.cpu.gpr[6] = 1;
+        loaded.cpu.gpr[7] = 0;
+        loaded.cpu.gpr[8] = u32::MAX;
+        loaded.cpu.gpr[9] = 1;
+        loaded.cpu.gpr[10] = 0;
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::NewCWindow);
+        let back_window = loaded.cpu.gpr[3];
+        assert_ne!(back_window, 0);
+
+        ppc_write_rect(&mut loaded.memory, bounds, 60, 60, 160, 200).unwrap();
+        loaded.cpu.gpr[3] = 0;
+        loaded.cpu.gpr[4] = bounds;
+        loaded.cpu.gpr[5] = 0;
+        loaded.cpu.gpr[6] = 1;
+        loaded.cpu.gpr[7] = 0;
+        loaded.cpu.gpr[8] = u32::MAX;
+        loaded.cpu.gpr[9] = 1;
+        loaded.cpu.gpr[10] = 0;
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::NewCWindow);
+        let front_window = loaded.cpu.gpr[3];
+        assert_ne!(front_window, 0);
+
+        // The current graphics port is not the Window Manager's z-order.
+        loaded.current_gworld = PPC_MAIN_GWORLD;
+        loaded.cpu.gpr[3] = (80 << 16) | 80;
+        loaded.cpu.gpr[4] = window_out;
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::FindWindow);
         assert_eq!(loaded.cpu.gpr[3], 3);
-        assert_eq!(loaded.memory.read_u32_be(window_out), Some(PPC_MAIN_GWORLD));
+        assert_eq!(loaded.memory.read_u32_be(window_out), Some(front_window));
+
+        loaded.cpu.gpr[3] = (50 << 16) | 50;
+        loaded.cpu.gpr[4] = window_out;
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::FindWindow);
+        assert_eq!(loaded.cpu.gpr[3], 3);
+        assert_eq!(loaded.memory.read_u32_be(window_out), Some(back_window));
+
+        loaded.cpu.gpr[3] = (300 << 16) | 300;
+        loaded.cpu.gpr[4] = window_out;
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::FindWindow);
+        assert_eq!(loaded.cpu.gpr[3], 0);
+        assert_eq!(loaded.memory.read_u32_be(window_out), Some(0));
+    }
+
+    #[test]
+    fn menu_bar_title_baseline_tracks_the_live_menu_bar_height() {
+        assert_eq!(ppc_menu_bar_title_baseline(12), 11);
+        assert_eq!(ppc_menu_bar_title_baseline(20), 14);
+        assert_eq!(ppc_menu_bar_title_baseline(30), 19);
+        assert_eq!(ppc_menu_bar_system_mark_top(12), 0);
+        assert_eq!(ppc_menu_bar_system_mark_top(20), 3);
+        assert_eq!(ppc_menu_bar_system_mark_top(30), 8);
+    }
+
+    #[test]
+    fn hilite_menu_selects_one_title_and_zero_restores_the_bar_at_supported_depths() {
+        let pef = synthetic_pef_with_import(b"HiliteMenu");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let title = PPC_DATA_BASE + 0x1000;
+        loaded.memory.add_region(title, vec![0; 16]);
+        assert!(ppc_write_pstring_bytes(&mut loaded.memory, title, b"File"));
+        let menu = ppc_new_menu(
+            &mut loaded.memory,
+            &mut loaded.heap_cursor,
+            loaded.heap_limit,
+            &mut loaded.handles,
+            &mut loaded.free_handle_blocks,
+            128,
+            title,
+        );
+        assert_ne!(menu, 0);
+        assert_eq!(
+            ppc_insert_menu(
+                &mut loaded.memory,
+                &mut loaded.heap_cursor,
+                loaded.heap_limit,
+                &mut loaded.handles,
+                &mut loaded.free_handle_blocks,
+                &mut loaded.toolbox_startup.current_menu_bar,
+                menu,
+                0,
+            ),
+            PPC_NO_ERR
+        );
+        let title_glyph_pixels = {
+            let (glyph, data) = get_glyph(PPC_QD_TEXT_FONT_DEFAULT, 12, 'F').unwrap();
+            let mut pixels = Vec::new();
+            for row in 0..glyph.height as usize {
+                for col in 0..glyph.width as usize {
+                    let index = glyph.data_offset + row * glyph.width as usize + col;
+                    if index < data.len() && data[index] >= 128 {
+                        pixels.push((
+                            i32::from(glyph.origin_x) + col as i32,
+                            i32::from(glyph.origin_y) + row as i32,
+                        ));
+                    }
+                }
+            }
+            assert!(!pixels.is_empty());
+            pixels
+        };
+        for depth in [1, 2, 4, 8, 16] {
+            loaded.cpu.gpr[3] = PPC_MAIN_GDEVICE;
+            loaded.cpu.gpr[4] = depth;
+            loaded.cpu.gpr[5] = 1;
+            loaded.cpu.gpr[6] = u32::from(depth != 1);
+            run_test_import(&mut loaded, PpcImportDispatcherTarget::SetDepth);
+            assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_NO_ERR));
+            loaded.memory.write_u16_be(PPC_THE_MENU_ADDR, 0).unwrap();
+            assert!(ppc_draw_menu_bar(
+                &mut loaded.memory,
+                &loaded.gworlds,
+                loaded.toolbox_startup.current_menu_bar,
+                &loaded.screen_clut,
+            ));
+            let front = ppc_live_front_buffer_for_gworld(
+                &mut loaded.memory,
+                &loaded.gworlds,
+                PPC_MAIN_GWORLD,
+            )
+            .unwrap();
+            assert_eq!(front.depth, depth);
+            let menu_bar_bytes = front.row_bytes * 20;
+            let normal =
+                ppc_memory_read_bytes(&mut loaded.memory, front.base_addr, menu_bar_bytes).unwrap();
+            let black =
+                ppc_physical_screen_color_pixel(front, PPC_RGB_BLACK, &loaded.screen_clut).unwrap();
+            let white =
+                ppc_physical_screen_color_pixel(front, PPC_RGB_WHITE, &loaded.screen_clut).unwrap();
+            let title_origin = (
+                i32::from(PPC_MENU_TITLE_ORIGIN_H),
+                i32::from(ppc_menu_bar_title_baseline(20)),
+            );
+            let normal_title_ink = title_glyph_pixels
+                .iter()
+                .filter(|&&(dx, dy)| {
+                    ppc_quickdraw_read_pixel(
+                        &mut loaded.memory,
+                        front,
+                        (title_origin.0 + dx, title_origin.1 + dy),
+                    ) == Some(black)
+                })
+                .count();
+            assert_eq!(
+                normal_title_ink,
+                title_glyph_pixels.len(),
+                "{depth}bpp menu title glyph did not draw in black",
+            );
+
+            loaded.cpu.gpr[3] = 128;
+            run_test_import(&mut loaded, PpcImportDispatcherTarget::HiliteMenu);
+
+            assert_eq!(loaded.memory.read_u16_be(PPC_THE_MENU_ADDR), Some(128));
+            let highlighted =
+                ppc_memory_read_bytes(&mut loaded.memory, front.base_addr, menu_bar_bytes).unwrap();
+            assert_ne!(highlighted, normal, "{depth}bpp title did not highlight");
+            let highlighted_title_ink = title_glyph_pixels
+                .iter()
+                .filter(|&&(dx, dy)| {
+                    ppc_quickdraw_read_pixel(
+                        &mut loaded.memory,
+                        front,
+                        (title_origin.0 + dx, title_origin.1 + dy),
+                    ) == Some(white)
+                })
+                .count();
+            assert_eq!(
+                highlighted_title_ink,
+                title_glyph_pixels.len(),
+                "{depth}bpp highlighted menu title glyph did not reverse to white",
+            );
+
+            loaded.cpu.gpr[3] = 128;
+            run_test_import(&mut loaded, PpcImportDispatcherTarget::HiliteMenu);
+            assert_eq!(
+                ppc_memory_read_bytes(&mut loaded.memory, front.base_addr, menu_bar_bytes),
+                Some(highlighted),
+                "{depth}bpp repeated HiliteMenu changed the title"
+            );
+
+            loaded.cpu.gpr[3] = 0;
+            run_test_import(&mut loaded, PpcImportDispatcherTarget::HiliteMenu);
+            assert_eq!(loaded.memory.read_u16_be(PPC_THE_MENU_ADDR), Some(0));
+            assert_eq!(
+                ppc_memory_read_bytes(&mut loaded.memory, front.base_addr, menu_bar_bytes),
+                Some(normal),
+                "{depth}bpp HiliteMenu(0) did not restore the menu bar"
+            );
+        }
+    }
+
+    #[test]
+    fn menu_tracking_round_trips_unaligned_popup_boundaries_at_supported_depths() {
+        let pef = synthetic_pef_with_import(b"NewMenu");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        install_test_menu(&mut loaded, PPC_DATA_BASE + 0x1000, 128, b"File", b"Open");
+        let item_glyph_pixels = {
+            let (glyph, data) = get_glyph(PPC_QD_TEXT_FONT_DEFAULT, 12, 'O').unwrap();
+            let mut pixels = Vec::new();
+            for row in 0..glyph.height as usize {
+                for col in 0..glyph.width as usize {
+                    let index = glyph.data_offset + row * glyph.width as usize + col;
+                    if index < data.len() && data[index] >= 128 {
+                        pixels.push((
+                            i32::from(glyph.origin_x) + col as i32,
+                            i32::from(glyph.origin_y) + row as i32,
+                        ));
+                    }
+                }
+            }
+            assert!(!pixels.is_empty());
+            pixels
+        };
+
+        for depth in [1, 2, 4, 8, 16] {
+            loaded.cpu.gpr[3] = PPC_MAIN_GDEVICE;
+            loaded.cpu.gpr[4] = depth;
+            loaded.cpu.gpr[5] = 1;
+            loaded.cpu.gpr[6] = u32::from(depth != 1);
+            run_test_import(&mut loaded, PpcImportDispatcherTarget::SetDepth);
+            assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_NO_ERR));
+
+            let front = ppc_live_front_buffer_for_gworld(
+                &mut loaded.memory,
+                &loaded.gworlds,
+                PPC_MAIN_GWORLD,
+            )
+            .unwrap();
+            assert_eq!(front.depth, depth);
+            let active_len = usize::try_from(front.row_bytes * front.height).unwrap();
+            let pattern = (0..active_len)
+                .map(|index| {
+                    (index as u8)
+                        .wrapping_mul(37)
+                        .wrapping_add((depth as u8).wrapping_mul(11))
+                        ^ 0xa5
+                })
+                .collect::<Vec<_>>();
+            loaded
+                .memory
+                .write_bytes(front.base_addr, &pattern)
+                .unwrap();
+            assert!(ppc_draw_menu_bar(
+                &mut loaded.memory,
+                &loaded.gworlds,
+                loaded.toolbox_startup.current_menu_bar,
+                &loaded.screen_clut,
+            ));
+            let before = ppc_memory_read_bytes(
+                &mut loaded.memory,
+                front.base_addr,
+                u32::try_from(active_len).unwrap(),
+            )
+            .unwrap();
+
+            ppc_track_menu_while_held(
+                &mut loaded.memory,
+                &loaded.gworlds,
+                &loaded.screen_clut,
+                &mut loaded.toolbox_startup,
+                12,
+                PpcInputSnapshot {
+                    mouse_button: true,
+                    mouse_v: 10,
+                    mouse_h: 12,
+                    ..PpcInputSnapshot::default()
+                },
+            );
+            let tracking = loaded.toolbox_startup.menu_tracking.clone().unwrap();
+            assert_eq!(tracking.front_buffer, front);
+            assert_eq!(tracking.popup_left, PPC_MENU_TITLE_HIT_LEFT);
+            assert_eq!(tracking.saved_width, tracking.popup_width + 1);
+            assert_eq!(tracking.saved_height, tracking.popup_height + 1);
+            assert_eq!(
+                tracking.saved_pixels.len(),
+                usize::try_from(i32::from(tracking.saved_width) * i32::from(tracking.saved_height))
+                    .unwrap(),
+            );
+            if depth < 8 {
+                let pixels_per_byte = 8 / depth;
+                assert_ne!(
+                    u32::try_from(tracking.popup_left).unwrap() % pixels_per_byte,
+                    0,
+                    "{depth}bpp popup did not exercise an unaligned packed boundary",
+                );
+            }
+            let opened = ppc_memory_read_bytes(
+                &mut loaded.memory,
+                front.base_addr,
+                u32::try_from(active_len).unwrap(),
+            )
+            .unwrap();
+            assert_ne!(opened, before, "{depth}bpp popup did not draw");
+            let black =
+                ppc_physical_screen_color_pixel(front, PPC_RGB_BLACK, &loaded.screen_clut).unwrap();
+            let white =
+                ppc_physical_screen_color_pixel(front, PPC_RGB_WHITE, &loaded.screen_clut).unwrap();
+            let item_origin = (
+                i32::from(tracking.popup_left.saturating_add(18)),
+                i32::from(tracking.popup_top.saturating_add(2 + 12)),
+            );
+            let normal_item_ink = item_glyph_pixels
+                .iter()
+                .filter(|&&(dx, dy)| {
+                    ppc_quickdraw_read_pixel(
+                        &mut loaded.memory,
+                        front,
+                        (item_origin.0 + dx, item_origin.1 + dy),
+                    ) == Some(black)
+                })
+                .count();
+            assert_eq!(
+                normal_item_ink,
+                item_glyph_pixels.len(),
+                "{depth}bpp popup item glyph did not draw in black",
+            );
+
+            let selected = PpcInputSnapshot {
+                mouse_button: true,
+                mouse_v: tracking.popup_top + 8,
+                mouse_h: tracking.popup_left + 20,
+                ..PpcInputSnapshot::default()
+            };
+            assert_eq!(
+                ppc_menu_tracking_item(&mut loaded.memory, &tracking, selected),
+                1,
+            );
+            ppc_track_menu_while_held(
+                &mut loaded.memory,
+                &loaded.gworlds,
+                &loaded.screen_clut,
+                &mut loaded.toolbox_startup,
+                12,
+                selected,
+            );
+            let highlighted = ppc_memory_read_bytes(
+                &mut loaded.memory,
+                front.base_addr,
+                u32::try_from(active_len).unwrap(),
+            )
+            .unwrap();
+            assert_ne!(
+                highlighted, opened,
+                "{depth}bpp item highlight did not draw",
+            );
+            let highlighted_item_ink = item_glyph_pixels
+                .iter()
+                .filter(|&&(dx, dy)| {
+                    ppc_quickdraw_read_pixel(
+                        &mut loaded.memory,
+                        front,
+                        (item_origin.0 + dx, item_origin.1 + dy),
+                    ) == Some(white)
+                })
+                .count();
+            assert_eq!(
+                highlighted_item_ink,
+                item_glyph_pixels.len(),
+                "{depth}bpp highlighted popup item glyph did not reverse to white",
+            );
+
+            let cancelled = PpcInputSnapshot {
+                mouse_v: tracking.popup_top + 8,
+                mouse_h: tracking.popup_left - 1,
+                ..PpcInputSnapshot::default()
+            };
+            assert_eq!(
+                ppc_finish_menu_tracking(
+                    &mut loaded.memory,
+                    &loaded.gworlds,
+                    &loaded.screen_clut,
+                    &mut loaded.toolbox_startup,
+                    cancelled,
+                ),
+                Some(0),
+            );
+            assert_eq!(loaded.toolbox_startup.menu_tracking, None);
+            assert_eq!(loaded.memory.read_u16_be(PPC_THE_MENU_ADDR), Some(0));
+            assert_eq!(
+                ppc_memory_read_bytes(
+                    &mut loaded.memory,
+                    front.base_addr,
+                    u32::try_from(active_len).unwrap(),
+                ),
+                Some(before),
+                "{depth}bpp cancellation did not round-trip the full framebuffer",
+            );
+        }
+    }
+
+    #[test]
+    fn short_menu_bar_system_mark_does_not_bleed_below_the_bar() {
+        let pef = synthetic_pef_with_import(b"DrawMenuBar");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        install_test_menu(&mut loaded, PPC_DATA_BASE + 0x1000, 128, &[0x14], b"");
+
+        for depth in [1, 2, 4, 8, 16] {
+            loaded.cpu.gpr[3] = PPC_MAIN_GDEVICE;
+            loaded.cpu.gpr[4] = depth;
+            loaded.cpu.gpr[5] = 1;
+            loaded.cpu.gpr[6] = u32::from(depth != 1);
+            run_test_import(&mut loaded, PpcImportDispatcherTarget::SetDepth);
+            assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_NO_ERR));
+            loaded
+                .memory
+                .write_u16_be(PPC_MBAR_HEIGHT_ADDR, 12)
+                .unwrap();
+
+            let front = ppc_live_front_buffer_for_gworld(
+                &mut loaded.memory,
+                &loaded.gworlds,
+                PPC_MAIN_GWORLD,
+            )
+            .unwrap();
+            let active_len = usize::try_from(front.row_bytes * front.height).unwrap();
+            let sentinel = (0..active_len)
+                .map(|index| (index as u8).wrapping_mul(13) ^ 0x5a)
+                .collect::<Vec<_>>();
+            loaded
+                .memory
+                .write_bytes(front.base_addr, &sentinel)
+                .unwrap();
+            let below_bar = front.base_addr + front.row_bytes * 12;
+            let below_bar_len = front.row_bytes * front.height.saturating_sub(12);
+            let below_bar_before =
+                ppc_memory_read_bytes(&mut loaded.memory, below_bar, below_bar_len).unwrap();
+
+            assert!(ppc_draw_menu_bar(
+                &mut loaded.memory,
+                &loaded.gworlds,
+                loaded.toolbox_startup.current_menu_bar,
+                &loaded.screen_clut,
+            ));
+
+            assert_eq!(
+                ppc_memory_read_bytes(&mut loaded.memory, below_bar, below_bar_len),
+                Some(below_bar_before),
+                "{depth}bpp system mark painted below MBarHeight=12",
+            );
+            let [red, green, blue] = crate::ui_art::RETRO_COMPUTER_MENU_MARK_PALETTE[0];
+            let outline = ppc_physical_screen_color_pixel(
+                front,
+                PpcRgbColor { red, green, blue },
+                &loaded.screen_clut,
+            )
+            .unwrap();
+            assert_eq!(
+                ppc_quickdraw_read_pixel(
+                    &mut loaded.memory,
+                    front,
+                    (i32::from(PPC_MENU_TITLE_ORIGIN_H + 1), 0),
+                ),
+                Some(outline),
+                "{depth}bpp system mark did not draw at its clipped top",
+            );
+            let black =
+                ppc_physical_screen_color_pixel(front, PPC_RGB_BLACK, &loaded.screen_clut).unwrap();
+            assert_eq!(
+                ppc_quickdraw_read_pixel(&mut loaded.memory, front, (0, 11)),
+                Some(black),
+                "{depth}bpp short menu bar lost its bottom border",
+            );
+        }
+    }
+
+    #[test]
+    fn menu_tracking_uses_the_live_main_set_port_pix_destination() {
+        let pef = synthetic_pef_with_import(b"NewMenu");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        install_test_menu(&mut loaded, PPC_DATA_BASE + 0x1000, 128, b"File", b"Open");
+
+        let scratch = PPC_DATA_BASE + 0x20_000;
+        let live_pixmap_handle = scratch;
+        let live_pixmap = scratch + 0x10;
+        let live_pixels = scratch + 0x100;
+        let live_width = 128u32;
+        let live_height = 96u32;
+        let live_row_bytes = live_width;
+        loaded.memory.add_region(scratch, vec![0; 0x4000]);
+        loaded
+            .memory
+            .write_u32_be(live_pixmap_handle, live_pixmap)
+            .unwrap();
+        ppc_write_pixmap(
+            &mut loaded.memory,
+            live_pixmap,
+            live_pixels,
+            live_row_bytes,
+            0,
+            0,
+            live_height as i16,
+            live_width as i16,
+            8,
+        )
+        .unwrap();
+        loaded
+            .memory
+            .write_u32_be(live_pixmap + 42, PPC_MAIN_CTABLE_HANDLE)
+            .unwrap();
+
+        let cached = ppc_front_buffer_for_gworld(&loaded.gworlds, PPC_MAIN_GWORLD).unwrap();
+        assert_eq!(cached.base_addr, PPC_MAIN_SCREEN_BASE);
+        let cached_len = cached.row_bytes * cached.height;
+        loaded
+            .memory
+            .write_bytes(cached.base_addr, &vec![0x3c; cached_len as usize])
+            .unwrap();
+        let cached_before =
+            ppc_memory_read_bytes(&mut loaded.memory, cached.base_addr, cached_len).unwrap();
+        let live_len = live_row_bytes * live_height;
+        let live_pattern = (0..live_len as usize)
+            .map(|index| (index as u8).wrapping_mul(29) ^ 0x96)
+            .collect::<Vec<_>>();
+        loaded
+            .memory
+            .write_bytes(live_pixels, &live_pattern)
+            .unwrap();
+        ppc_set_port_bits(
+            &mut loaded.memory,
+            PPC_MAIN_GWORLD,
+            live_pixmap_handle,
+            true,
+        );
+
+        let live =
+            ppc_live_front_buffer_for_gworld(&mut loaded.memory, &loaded.gworlds, PPC_MAIN_GWORLD)
+                .unwrap();
+        assert_eq!(
+            live,
+            PpcFrontBuffer {
+                base_addr: live_pixels,
+                row_bytes: live_row_bytes,
+                width: live_width,
+                height: live_height,
+                depth: 8,
+            },
+        );
+        assert!(ppc_draw_menu_bar(
+            &mut loaded.memory,
+            &loaded.gworlds,
+            loaded.toolbox_startup.current_menu_bar,
+            &loaded.screen_clut,
+        ));
+        assert_eq!(
+            ppc_memory_read_bytes(&mut loaded.memory, cached.base_addr, cached_len),
+            Some(cached_before.clone()),
+            "DrawMenuBar touched the stale cached main framebuffer",
+        );
+        let live_before =
+            ppc_memory_read_bytes(&mut loaded.memory, live.base_addr, live_len).unwrap();
+
+        ppc_track_menu_while_held(
+            &mut loaded.memory,
+            &loaded.gworlds,
+            &loaded.screen_clut,
+            &mut loaded.toolbox_startup,
+            12,
+            PpcInputSnapshot {
+                mouse_button: true,
+                mouse_v: 10,
+                mouse_h: 12,
+                ..PpcInputSnapshot::default()
+            },
+        );
+        let tracking = loaded.toolbox_startup.menu_tracking.clone().unwrap();
+        assert_eq!(tracking.front_buffer, live);
+        let selected = PpcInputSnapshot {
+            mouse_button: true,
+            mouse_v: tracking.popup_top + 8,
+            mouse_h: tracking.popup_left + 20,
+            ..PpcInputSnapshot::default()
+        };
+        ppc_track_menu_while_held(
+            &mut loaded.memory,
+            &loaded.gworlds,
+            &loaded.screen_clut,
+            &mut loaded.toolbox_startup,
+            12,
+            selected,
+        );
+        assert_ne!(
+            ppc_memory_read_bytes(&mut loaded.memory, live.base_addr, live_len),
+            Some(live_before.clone()),
+            "tracked popup did not draw into the live main PixMap",
+        );
+        assert_eq!(
+            ppc_memory_read_bytes(&mut loaded.memory, cached.base_addr, cached_len),
+            Some(cached_before.clone()),
+            "tracked popup touched the stale cached main framebuffer",
+        );
+
+        assert_eq!(
+            ppc_finish_menu_tracking(
+                &mut loaded.memory,
+                &loaded.gworlds,
+                &loaded.screen_clut,
+                &mut loaded.toolbox_startup,
+                PpcInputSnapshot {
+                    mouse_v: tracking.popup_top + 8,
+                    mouse_h: tracking.popup_left - 1,
+                    ..PpcInputSnapshot::default()
+                },
+            ),
+            Some(0),
+        );
+        assert_eq!(
+            ppc_memory_read_bytes(&mut loaded.memory, live.base_addr, live_len),
+            Some(live_before),
+            "live main PixMap did not round-trip after cancellation",
+        );
+        assert_eq!(
+            ppc_memory_read_bytes(&mut loaded.memory, cached.base_addr, cached_len),
+            Some(cached_before),
+            "cancellation touched the stale cached main framebuffer",
+        );
+        assert_eq!(loaded.memory.read_u16_be(PPC_THE_MENU_ADDR), Some(0));
     }
 
     #[test]
@@ -72774,6 +74938,223 @@ mod tests {
             })
         }));
         assert_eq!(loaded.last_resource_error, PPC_NO_ERR);
+    }
+
+    #[test]
+    fn menu_tracking_rejects_disabled_items_and_dividers_and_clears_cancellation() {
+        let pef = synthetic_pef_with_import(b"NewMenu");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let scratch = PPC_DATA_BASE + 0x1000;
+        loaded.memory.add_region(scratch, vec![0; 0x100]);
+        assert!(ppc_write_pstring_bytes(
+            &mut loaded.memory,
+            scratch,
+            b"File"
+        ));
+        assert!(ppc_write_pstring_bytes(
+            &mut loaded.memory,
+            scratch + 0x20,
+            b"Open;Disabled(;\x2d"
+        ));
+        let menu_handle = ppc_new_menu(
+            &mut loaded.memory,
+            &mut loaded.heap_cursor,
+            loaded.heap_limit,
+            &mut loaded.handles,
+            &mut loaded.free_handle_blocks,
+            128,
+            scratch,
+        );
+        assert_ne!(menu_handle, 0);
+        assert_eq!(
+            ppc_insert_menu_items(
+                &mut loaded.memory,
+                &mut loaded.heap_cursor,
+                loaded.heap_limit,
+                &mut loaded.handles,
+                menu_handle,
+                scratch + 0x20,
+                i16::MAX,
+            ),
+            PPC_NO_ERR
+        );
+        assert_eq!(
+            ppc_insert_menu(
+                &mut loaded.memory,
+                &mut loaded.heap_cursor,
+                loaded.heap_limit,
+                &mut loaded.handles,
+                &mut loaded.free_handle_blocks,
+                &mut loaded.toolbox_startup.current_menu_bar,
+                menu_handle,
+                0,
+            ),
+            PPC_NO_ERR
+        );
+        let menu_list_handle = loaded.toolbox_startup.current_menu_bar;
+        assert!(ppc_draw_menu_bar(
+            &mut loaded.memory,
+            &loaded.gworlds,
+            menu_list_handle,
+            &loaded.screen_clut,
+        ));
+        let menu_bar_len = u32::from(loaded.memory.read_u16_be(PPC_MBAR_HEIGHT_ADDR).unwrap())
+            * ppc_main_screen_row_bytes();
+        let unhighlighted_bar =
+            ppc_memory_read_bytes(&mut loaded.memory, PPC_MAIN_SCREEN_BASE, menu_bar_len).unwrap();
+        let white = ppc_physical_screen_color_pixel(
+            ppc_front_buffer_for_gworld(&loaded.gworlds, PPC_MAIN_GWORLD).unwrap(),
+            PPC_RGB_WHITE,
+            &loaded.screen_clut,
+        )
+        .unwrap();
+
+        for (label, item) in [("disabled item", 2i16), ("divider", 3i16)] {
+            ppc_track_menu_while_held(
+                &mut loaded.memory,
+                &loaded.gworlds,
+                &loaded.screen_clut,
+                &mut loaded.toolbox_startup,
+                12,
+                PpcInputSnapshot {
+                    mouse_button: true,
+                    mouse_v: 10,
+                    mouse_h: 12,
+                    ..PpcInputSnapshot::default()
+                },
+            );
+            let tracking = loaded.toolbox_startup.menu_tracking.as_ref().unwrap();
+            let input = PpcInputSnapshot {
+                mouse_button: true,
+                mouse_v: tracking.popup_top + 2 + (item - 1) * 16 + 4,
+                mouse_h: tracking.popup_left + 4,
+                ..PpcInputSnapshot::default()
+            };
+            let background_point = (i32::from(input.mouse_h), i32::from(input.mouse_v));
+            assert_eq!(
+                ppc_menu_tracking_item(&mut loaded.memory, tracking, input),
+                0,
+                "{label} became the tracked selection"
+            );
+            ppc_track_menu_while_held(
+                &mut loaded.memory,
+                &loaded.gworlds,
+                &loaded.screen_clut,
+                &mut loaded.toolbox_startup,
+                12,
+                input,
+            );
+            let front = ppc_front_buffer_for_gworld(&loaded.gworlds, PPC_MAIN_GWORLD).unwrap();
+            assert_eq!(
+                ppc_quickdraw_read_pixel(&mut loaded.memory, front, background_point),
+                Some(white),
+                "{label} was drawn highlighted"
+            );
+            assert_eq!(loaded.memory.read_u16_be(PPC_THE_MENU_ADDR), Some(128));
+            assert_eq!(
+                ppc_finish_menu_tracking(
+                    &mut loaded.memory,
+                    &loaded.gworlds,
+                    &loaded.screen_clut,
+                    &mut loaded.toolbox_startup,
+                    input,
+                ),
+                Some(0),
+                "{label} was returned as a menu choice"
+            );
+            assert_eq!(loaded.memory.read_u16_be(PPC_THE_MENU_ADDR), Some(0));
+            assert_eq!(
+                ppc_memory_read_bytes(&mut loaded.memory, PPC_MAIN_SCREEN_BASE, menu_bar_len),
+                Some(unhighlighted_bar.clone()),
+                "{label} cancellation left the title highlighted"
+            );
+        }
+
+        ppc_track_menu_while_held(
+            &mut loaded.memory,
+            &loaded.gworlds,
+            &loaded.screen_clut,
+            &mut loaded.toolbox_startup,
+            12,
+            PpcInputSnapshot {
+                mouse_button: true,
+                mouse_v: 10,
+                mouse_h: 12,
+                ..PpcInputSnapshot::default()
+            },
+        );
+        let tracking = loaded.toolbox_startup.menu_tracking.as_ref().unwrap();
+        let outside = PpcInputSnapshot {
+            mouse_v: tracking.popup_top + 8,
+            mouse_h: tracking.popup_left - 1,
+            ..PpcInputSnapshot::default()
+        };
+        assert_eq!(
+            ppc_finish_menu_tracking(
+                &mut loaded.memory,
+                &loaded.gworlds,
+                &loaded.screen_clut,
+                &mut loaded.toolbox_startup,
+                outside,
+            ),
+            Some(0)
+        );
+        assert_eq!(loaded.memory.read_u16_be(PPC_THE_MENU_ADDR), Some(0));
+        assert_eq!(
+            ppc_memory_read_bytes(&mut loaded.memory, PPC_MAIN_SCREEN_BASE, menu_bar_len),
+            Some(unhighlighted_bar.clone())
+        );
+
+        assert_eq!(
+            ppc_menu_select(
+                &mut loaded.memory,
+                menu_list_handle,
+                12,
+                PpcInputSnapshot {
+                    mouse_v: 60,
+                    mouse_h: 12,
+                    ..PpcInputSnapshot::default()
+                },
+            ),
+            0,
+            "the synchronous MenuSelect path returned a divider"
+        );
+
+        ppc_track_menu_while_held(
+            &mut loaded.memory,
+            &loaded.gworlds,
+            &loaded.screen_clut,
+            &mut loaded.toolbox_startup,
+            12,
+            PpcInputSnapshot {
+                mouse_button: true,
+                mouse_v: 10,
+                mouse_h: 12,
+                ..PpcInputSnapshot::default()
+            },
+        );
+        let tracking = loaded.toolbox_startup.menu_tracking.as_ref().unwrap();
+        let enabled = PpcInputSnapshot {
+            mouse_v: tracking.popup_top + 6,
+            mouse_h: tracking.popup_left + 4,
+            ..PpcInputSnapshot::default()
+        };
+        assert_eq!(
+            ppc_finish_menu_tracking(
+                &mut loaded.memory,
+                &loaded.gworlds,
+                &loaded.screen_clut,
+                &mut loaded.toolbox_startup,
+                enabled,
+            ),
+            Some((128u32 << 16) | 1)
+        );
+        assert_eq!(loaded.memory.read_u16_be(PPC_THE_MENU_ADDR), Some(128));
+        assert_ne!(
+            ppc_memory_read_bytes(&mut loaded.memory, PPC_MAIN_SCREEN_BASE, menu_bar_len),
+            Some(unhighlighted_bar),
+            "a valid choice did not retain its documented title highlight"
+        );
     }
 
     #[test]
@@ -74164,7 +76545,8 @@ mod tests {
         );
         assert_eq!(
             loaded.memory.read_u32_be(PPC_MAIN_GDEVICE_RECORD + 42),
-            Some(0x85)
+            Some(0x83),
+            "the default 8-bit display publishes the classic eightBitMode token"
         );
         assert_eq!(loaded.gworlds[1].port, PPC_DSP_BACK_GWORLD);
         assert_eq!(loaded.gworlds[1].pixmap_handle, PPC_DSP_BACK_PIXMAP_HANDLE);
@@ -108731,6 +111113,9 @@ mod tests {
             ppc_set_depth(
                 &depth_cpu,
                 &mut loaded.memory,
+                &mut loaded.heap_cursor,
+                loaded.heap_limit,
+                &mut loaded.handles,
                 &mut loaded.gworlds,
                 &mut loaded.toolbox_startup,
                 &mut loaded.screen_clut,
@@ -112719,7 +115104,7 @@ mod tests {
     }
 
     #[test]
-    fn hle_import_runner_new_gworld_copies_the_current_device_color_table() {
+    fn hle_import_runner_new_gworld_depth_zero_copies_main_screen_color_table() {
         let pef = synthetic_pef_with_import(b"NewGWorld");
         let mut loaded = load_pef_application(&pef).unwrap();
         let scratch = PPC_DATA_BASE + 0x1000;
@@ -112729,6 +115114,9 @@ mod tests {
         ppc_write_rect(&mut loaded.memory, bounds_ptr, 0, 0, 16, 16).unwrap();
         let main_table = ppc_copy_color_table_bytes(&mut loaded.memory, PPC_MAIN_CTABLE_HANDLE)
             .expect("main device ColorTable");
+        // Depth zero rescans physical screen devices, not an arbitrary
+        // offscreen/custom device that happens to be current.
+        loaded.current_gdevice = 0x0bad_cafe;
         let handle_count = loaded.handles.len();
         loaded.cpu.gpr[3] = gworld_out_ptr;
         loaded.cpu.gpr[4] = 0;
@@ -112747,6 +115135,8 @@ mod tests {
             .iter()
             .find(|record| record.port == gworld)
             .unwrap();
+        assert_eq!(record.depth, PPC_MAIN_PIXEL_DEPTH);
+        assert_eq!(record.gdevice, PPC_MAIN_GDEVICE);
         let private_handle = loaded.memory.read_u32_be(record.pixmap + 42).unwrap();
         assert_ne!(private_handle, 0);
         assert_ne!(private_handle, PPC_MAIN_CTABLE_HANDLE);
@@ -112778,9 +115168,13 @@ mod tests {
         let main_table = ppc_copy_color_table_bytes(&mut loaded.memory, PPC_MAIN_CTABLE_HANDLE)
             .expect("main device ColorTable");
         loaded.cpu.gpr[3] = scratch + 8;
-        loaded.cpu.gpr[4] = 8;
+        // Imaging With QuickDraw (1994), p. 6-18: noNewDevice uses the
+        // supplied device's depth and ColorTable after validating the literal
+        // pixelDepth argument. The otherwise-valid 16-bit depth and invalid
+        // caller ColorTable must therefore both be ignored here.
+        loaded.cpu.gpr[4] = 16;
         loaded.cpu.gpr[5] = scratch;
-        loaded.cpu.gpr[6] = 0;
+        loaded.cpu.gpr[6] = 0x0bad_cafe;
         loaded.cpu.gpr[7] = PPC_MAIN_GDEVICE;
         loaded.cpu.gpr[8] = 1 << 1;
 
@@ -112794,6 +115188,8 @@ mod tests {
             .iter()
             .find(|record| record.port == port)
             .unwrap();
+        assert_eq!(record.depth, PPC_MAIN_PIXEL_DEPTH);
+        assert_eq!(record.gdevice, PPC_MAIN_GDEVICE);
         let ctable = loaded.memory.read_u32_be(record.pixmap + 42).unwrap();
         assert_ne!(ctable, PPC_MAIN_CTABLE_HANDLE);
         assert_eq!(
@@ -112807,6 +115203,51 @@ mod tests {
             loaded.memory.read_u16_be(private_ptr + 10),
             loaded.memory.read_u16_be(main_ptr + 10)
         );
+    }
+
+    #[test]
+    fn hle_import_runner_new_gworld_rejects_invalid_literal_depth_with_explicit_device() {
+        let pef = synthetic_pef_with_import(b"NewGWorld");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let scratch = PPC_DATA_BASE + 0x1000;
+        let bounds_ptr = scratch;
+        let gworld_out_ptr = scratch + 8;
+        loaded.memory.add_region(scratch, vec![0; 16]);
+        ppc_write_rect(&mut loaded.memory, bounds_ptr, 0, 0, 2, 2).unwrap();
+        loaded
+            .memory
+            .write_u32_be(gworld_out_ptr, 0xdead_beef)
+            .unwrap();
+        let heap_cursor_before = loaded.heap_cursor;
+        let handles_before = loaded.handles.clone();
+        let gworlds_before = loaded.gworlds.clone();
+        let allocations_before = loaded.toolbox_startup.gworld_allocations.clone();
+        let region_count_before = loaded.memory.region_count();
+
+        for requested_depth in [u32::from(u16::MAX), 3] {
+            loaded.cpu.gpr[3] = gworld_out_ptr;
+            loaded.cpu.gpr[4] = requested_depth;
+            loaded.cpu.gpr[5] = bounds_ptr;
+            loaded.cpu.gpr[6] = 0;
+            loaded.cpu.gpr[7] = PPC_MAIN_GDEVICE;
+            loaded.cpu.gpr[8] = 1 << 1; // noNewDevice
+            run_test_import(&mut loaded, PpcImportDispatcherTarget::NewGWorld);
+
+            assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_C_DEPTH_ERR));
+            assert_eq!(loaded.last_mem_error, PPC_C_DEPTH_ERR);
+            assert_eq!(loaded.toolbox_startup.last_quickdraw_error, PPC_C_DEPTH_ERR);
+            run_test_import(&mut loaded, PpcImportDispatcherTarget::QDError);
+            assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_C_DEPTH_ERR));
+            assert_eq!(loaded.memory.read_u32_be(gworld_out_ptr), Some(0xdead_beef));
+            assert_eq!(loaded.heap_cursor, heap_cursor_before);
+            assert_eq!(loaded.handles, handles_before);
+            assert_eq!(loaded.gworlds, gworlds_before);
+            assert_eq!(
+                loaded.toolbox_startup.gworld_allocations,
+                allocations_before
+            );
+            assert_eq!(loaded.memory.region_count(), region_count_before);
+        }
     }
 
     #[test]
@@ -112833,7 +115274,7 @@ mod tests {
     }
 
     #[test]
-    fn hle_import_runner_update_gworld_remaps_to_the_current_device_color_table() {
+    fn hle_import_runner_update_gworld_flags_control_color_table_pixel_mapping() {
         let pef = synthetic_pef_with_import(b"NewGWorld");
         let mut loaded = load_pef_application(&pef).unwrap();
         let scratch = PPC_DATA_BASE + 0x1000;
@@ -112898,13 +115339,951 @@ mod tests {
         let probe = loaded.run_with_hle_imports(64);
 
         assert_eq!(probe.unsupported_import_index, None);
-        assert_ne!(loaded.cpu.gpr[3] & (1 << 16), 0, "mapPix");
-        assert_eq!(loaded.memory.read_u8(record.base_addr), Some(77));
-        let private_handle = loaded.memory.read_u32_be(record.pixmap + 42).unwrap();
+        assert_eq!(loaded.cpu.gpr[3] & (1 << 16), 0, "mapPix without clipPix");
+        assert_eq!(loaded.cpu.gpr[3] & (1 << 20), 0, "reallocPix");
+        let updated = *loaded
+            .gworlds
+            .iter()
+            .find(|updated| updated.port == gworld)
+            .unwrap();
+        assert_eq!(updated.base_addr, record.base_addr);
+        assert_eq!(loaded.memory.read_u8(updated.base_addr), Some(42));
+        let private_handle = loaded.memory.read_u32_be(updated.pixmap + 42).unwrap();
         assert_eq!(
             ppc_copy_color_table_bytes(&mut loaded.memory, private_handle),
             ppc_copy_color_table_bytes(&mut loaded.memory, PPC_MAIN_CTABLE_HANDLE)
         );
+
+        // With clipPix, preserve the same pixel bytes through an RGB mapping.
+        // The existing allocation has enough capacity, so this updates in
+        // place and must not falsely report reallocPix.
+        for channel in 0..3u32 {
+            loaded
+                .memory
+                .write_u16_be(
+                    main_table + 8 + 42 * 8 + 2 + channel * 2,
+                    old_color[channel as usize],
+                )
+                .unwrap();
+            loaded
+                .memory
+                .write_u16_be(main_table + 8 + 77 * 8 + 2 + channel * 2, 0)
+                .unwrap();
+        }
+        loaded.cpu.gpr[3] = gworld_out_ptr;
+        loaded.cpu.gpr[4] = 0;
+        loaded.cpu.gpr[5] = bounds_ptr;
+        loaded.cpu.gpr[6] = 0;
+        loaded.cpu.gpr[7] = 0;
+        loaded.cpu.gpr[8] = 1 << 28;
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::UpdateGWorld);
+
+        assert_ne!(loaded.cpu.gpr[3] & (1 << 16), 0, "mapPix");
+        assert_eq!(loaded.cpu.gpr[3] & (1 << 20), 0, "reallocPix");
+        let remapped = *loaded
+            .gworlds
+            .iter()
+            .find(|updated| updated.port == gworld)
+            .unwrap();
+        assert_eq!(remapped.base_addr, record.base_addr);
+        assert_eq!(loaded.memory.read_u8(remapped.base_addr), Some(77));
+        assert_eq!(
+            loaded.memory.read_u32_be(remapped.pixmap + 42),
+            Some(private_handle)
+        );
+    }
+
+    #[test]
+    fn hle_import_runner_update_gworld_writes_coherent_metadata_at_every_depth() {
+        let pef = synthetic_pef_with_import(b"NewGWorld");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let scratch = PPC_DATA_BASE + 0x1000;
+        let bounds_ptr = scratch;
+        let gworld_out_ptr = scratch + 8;
+        loaded.memory.add_region(scratch, vec![0; 16]);
+        ppc_write_rect(&mut loaded.memory, bounds_ptr, 2, 3, 5, 8).unwrap();
+        loaded.cpu.gpr[3] = gworld_out_ptr;
+        loaded.cpu.gpr[4] = 8;
+        loaded.cpu.gpr[5] = bounds_ptr;
+        loaded.cpu.gpr[6] = 0;
+        loaded.cpu.gpr[7] = 0;
+        loaded.cpu.gpr[8] = 0;
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::NewGWorld);
+        assert_eq!(loaded.cpu.gpr[3] as u16 as i16, PPC_NO_ERR);
+        let gworld = loaded.memory.read_u32_be(gworld_out_ptr).unwrap();
+
+        for depth in [1u32, 2, 4, 8, 16, 32] {
+            loaded.cpu.gpr[3] = gworld_out_ptr;
+            loaded.cpu.gpr[4] = depth;
+            loaded.cpu.gpr[5] = bounds_ptr;
+            loaded.cpu.gpr[6] = 0;
+            loaded.cpu.gpr[7] = 0;
+            loaded.cpu.gpr[8] = 1 << 28;
+            run_test_import(&mut loaded, PpcImportDispatcherTarget::UpdateGWorld);
+            assert_eq!(loaded.cpu.gpr[3] & (1 << 31), 0, "{depth}bpp failed");
+            assert_eq!(loaded.last_mem_error, PPC_NO_ERR);
+
+            let record = loaded
+                .gworlds
+                .iter()
+                .find(|record| record.port == gworld)
+                .unwrap();
+            let pixmap = record.pixmap;
+            let (pixel_type, component_count, component_size) = match depth {
+                1 | 2 | 4 | 8 => (0, 1, depth as u16),
+                16 => (16, 3, 5),
+                32 => (16, 3, 8),
+                _ => unreachable!(),
+            };
+            assert_eq!(record.depth, depth);
+            assert_eq!(record.row_bytes, ppc_row_bytes(5, depth).unwrap());
+            assert_eq!(loaded.memory.read_u16_be(pixmap + 30), Some(pixel_type));
+            assert_eq!(loaded.memory.read_u16_be(pixmap + 32), Some(depth as u16));
+            assert_eq!(
+                loaded.memory.read_u16_be(pixmap + 34),
+                Some(component_count)
+            );
+            assert_eq!(loaded.memory.read_u16_be(pixmap + 36), Some(component_size));
+            assert_eq!(loaded.memory.read_u32_be(pixmap + 38), Some(0));
+            let ctable = loaded.memory.read_u32_be(pixmap + 42).unwrap();
+            if depth <= 8 {
+                assert_ne!(ctable, 0, "{depth}bpp indexed PixMap has no pmTable");
+                assert_eq!(
+                    ppc_copy_color_table_bytes(&mut loaded.memory, ctable),
+                    ppc_default_color_table_bytes(depth)
+                );
+            } else {
+                assert_eq!(ctable, 0, "{depth}bpp direct PixMap retained a pmTable");
+            }
+        }
+    }
+
+    #[test]
+    fn hle_import_runner_update_gworld_does_not_mutate_caller_owned_gdevice() {
+        let pef = synthetic_pef_with_import(b"NewGWorld");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let scratch = PPC_DATA_BASE + 0x1000;
+        let bounds_ptr = scratch;
+        let gworld_out_ptr = scratch + 8;
+        loaded.memory.add_region(scratch, vec![0; 16]);
+        ppc_write_rect(&mut loaded.memory, bounds_ptr, 0, 0, 2, 2).unwrap();
+        loaded.cpu.gpr[3] = gworld_out_ptr;
+        loaded.cpu.gpr[4] = 8;
+        loaded.cpu.gpr[5] = bounds_ptr;
+        loaded.cpu.gpr[6] = 0;
+        loaded.cpu.gpr[7] = 0;
+        loaded.cpu.gpr[8] = 0;
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::NewGWorld);
+        let gworld = loaded.memory.read_u32_be(gworld_out_ptr).unwrap();
+
+        let gdevice_handle = PPC_DATA_BASE + 0x5000;
+        let gdevice = PPC_DATA_BASE + 0x5100;
+        let pixmap_handle = PPC_DATA_BASE + 0x5200;
+        let pixmap = PPC_DATA_BASE + 0x5300;
+        loaded.memory.add_region(gdevice_handle, vec![0; 4]);
+        loaded.memory.add_region(gdevice, vec![0; 64]);
+        loaded.memory.add_region(pixmap_handle, vec![0; 4]);
+        loaded
+            .memory
+            .add_region(pixmap, vec![0; PPC_PIXMAP_SIZE as usize]);
+        loaded.memory.write_u32_be(gdevice_handle, gdevice).unwrap();
+        loaded
+            .memory
+            .write_u32_be(gdevice + 22, pixmap_handle)
+            .unwrap();
+        loaded.memory.write_u32_be(pixmap_handle, pixmap).unwrap();
+        ppc_write_pixmap(
+            &mut loaded.memory,
+            pixmap,
+            0x0600_0000,
+            ppc_row_bytes(40, 16).unwrap(),
+            -10,
+            -20,
+            10,
+            20,
+            16,
+        )
+        .unwrap();
+        ppc_write_rect(&mut loaded.memory, gdevice + 34, -10, -20, 10, 20).unwrap();
+        let gdevice_before = ppc_memory_read_bytes(&mut loaded.memory, gdevice, 64).unwrap();
+        let device_pixmap_before =
+            ppc_memory_read_bytes(&mut loaded.memory, pixmap, PPC_PIXMAP_SIZE).unwrap();
+
+        ppc_write_rect(&mut loaded.memory, bounds_ptr, 5, 6, 8, 10).unwrap();
+        loaded.current_gworld = gworld;
+        loaded.current_gdevice = PPC_MAIN_GDEVICE;
+        loaded.toolbox_startup.last_quickdraw_error = PPC_PARAM_ERR;
+        loaded.cpu.gpr[3] = gworld_out_ptr;
+        loaded.cpu.gpr[4] = u32::from(u16::MAX); // ignored when aGDevice is non-NIL
+        loaded.cpu.gpr[5] = bounds_ptr;
+        loaded.cpu.gpr[6] = 0;
+        loaded.cpu.gpr[7] = gdevice_handle;
+        loaded.cpu.gpr[8] = 1 << 28;
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::UpdateGWorld);
+
+        assert_eq!(loaded.cpu.gpr[3] & (1 << 31), 0);
+        assert_eq!(loaded.toolbox_startup.last_quickdraw_error, PPC_NO_ERR);
+        let updated = loaded
+            .gworlds
+            .iter()
+            .find(|record| record.port == gworld)
+            .unwrap();
+        assert_eq!(updated.gdevice, gdevice_handle);
+        assert_eq!(updated.depth, 16);
+        assert_eq!(loaded.current_gworld, gworld);
+        assert_eq!(loaded.current_gdevice, gdevice_handle);
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::GetGDevice);
+        assert_eq!(loaded.cpu.gpr[3], gdevice_handle);
+        assert_eq!(
+            ppc_memory_read_bytes(&mut loaded.memory, gdevice, 64),
+            Some(gdevice_before.clone())
+        );
+        assert_eq!(
+            ppc_memory_read_bytes(&mut loaded.memory, pixmap, PPC_PIXMAP_SIZE),
+            Some(device_pixmap_before)
+        );
+
+        loaded.memory.write_u16_be(pixmap + 32, 0).unwrap();
+        let invalid_device_pixmap =
+            ppc_memory_read_bytes(&mut loaded.memory, pixmap, PPC_PIXMAP_SIZE).unwrap();
+        let world_before = *loaded
+            .gworlds
+            .iter()
+            .find(|record| record.port == gworld)
+            .unwrap();
+        let world_pixmap_before =
+            ppc_memory_read_bytes(&mut loaded.memory, world_before.pixmap, PPC_PIXMAP_SIZE)
+                .unwrap();
+        let world_pixels_before = ppc_memory_read_bytes(
+            &mut loaded.memory,
+            world_before.base_addr,
+            world_before.row_bytes * world_before.height,
+        )
+        .unwrap();
+        let handles_before = loaded.handles.clone();
+        let allocations_before = loaded.toolbox_startup.gworld_allocations.clone();
+        let heap_cursor_before = loaded.heap_cursor;
+        ppc_write_rect(&mut loaded.memory, bounds_ptr, 0, 0, 1, 1).unwrap();
+        loaded.cpu.gpr[3] = gworld_out_ptr;
+        loaded.cpu.gpr[4] = 8;
+        loaded.cpu.gpr[5] = bounds_ptr;
+        loaded.cpu.gpr[6] = 0;
+        loaded.cpu.gpr[7] = gdevice_handle;
+        loaded.cpu.gpr[8] = 1 << 28;
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::UpdateGWorld);
+
+        assert_eq!(loaded.cpu.gpr[3], 1 << 31);
+        assert_eq!(loaded.last_mem_error, PPC_C_DEPTH_ERR);
+        assert_eq!(
+            loaded.gworlds.iter().find(|record| record.port == gworld),
+            Some(&world_before)
+        );
+        assert_eq!(loaded.handles, handles_before);
+        assert_eq!(
+            loaded.toolbox_startup.gworld_allocations,
+            allocations_before
+        );
+        assert_eq!(loaded.heap_cursor, heap_cursor_before);
+        assert_eq!(
+            ppc_memory_read_bytes(&mut loaded.memory, world_before.pixmap, PPC_PIXMAP_SIZE),
+            Some(world_pixmap_before)
+        );
+        assert_eq!(
+            ppc_memory_read_bytes(
+                &mut loaded.memory,
+                world_before.base_addr,
+                world_before.row_bytes * world_before.height,
+            ),
+            Some(world_pixels_before)
+        );
+        assert_eq!(
+            ppc_memory_read_bytes(&mut loaded.memory, gdevice, 64),
+            Some(gdevice_before)
+        );
+        assert_eq!(
+            ppc_memory_read_bytes(&mut loaded.memory, pixmap, PPC_PIXMAP_SIZE),
+            Some(invalid_device_pixmap)
+        );
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::QDError);
+        assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_C_DEPTH_ERR));
+    }
+
+    #[test]
+    fn hle_import_runner_update_gworld_translates_cross_depth_clip_and_stretch_pixels() {
+        const CLIP_PIX: u32 = 1 << 28;
+        const STRETCH_PIX: u32 = 1 << 29;
+
+        assert_eq!(
+            ppc_gworld_rgb_to_pixel(
+                PpcRgbColor {
+                    red: 0x07ff,
+                    green: 0,
+                    blue: 0,
+                },
+                16,
+                None,
+            ),
+            Some(0),
+            "16-bit direct conversion truncates to the most significant 5 bits"
+        );
+
+        let pef = synthetic_pef_with_import(b"NewGWorld");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let scratch = PPC_DATA_BASE + 0x1000;
+        let bounds_ptr = scratch;
+        let gworld_out_ptr = scratch + 8;
+        loaded.memory.add_region(scratch, vec![0; 16]);
+        let source_colors = [
+            [0xffff, 0, 0],
+            [0, 0xffff, 0],
+            [0, 0, 0xffff],
+            [0xffff, 0xffff, 0xffff],
+        ];
+        let source_ctable = ppc_alloc_handle_with_bytes(
+            &mut loaded.memory,
+            &mut loaded.heap_cursor,
+            loaded.heap_limit,
+            &mut loaded.handles,
+            &ppc_color_table_bytes(0x1234_5678, &source_colors).unwrap(),
+        );
+        assert_ne!(source_ctable, 0);
+        ppc_write_rect(&mut loaded.memory, bounds_ptr, 0, 0, 2, 2).unwrap();
+        loaded.cpu.gpr[3] = gworld_out_ptr;
+        loaded.cpu.gpr[4] = 8;
+        loaded.cpu.gpr[5] = bounds_ptr;
+        loaded.cpu.gpr[6] = source_ctable;
+        loaded.cpu.gpr[7] = 0;
+        loaded.cpu.gpr[8] = 0;
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::NewGWorld);
+        let gworld = loaded.memory.read_u32_be(gworld_out_ptr).unwrap();
+        let source = *loaded
+            .gworlds
+            .iter()
+            .find(|record| record.port == gworld)
+            .unwrap();
+        let source_bits = ppc_pixmap_bits_from_record(source).unwrap();
+        for (x, y, pixel) in [(0, 0, 0), (1, 0, 1), (0, 1, 2), (1, 1, 3)] {
+            ppc_write_pixmap_raw_pixel(&mut loaded.memory, source_bits, x, y, pixel).unwrap();
+        }
+
+        // clipPix keeps the top-left portion and performs the indexed-to-555
+        // translation before clipping the bottom row.
+        ppc_write_rect(&mut loaded.memory, bounds_ptr, 0, 0, 1, 2).unwrap();
+        loaded.cpu.gpr[3] = gworld_out_ptr;
+        loaded.cpu.gpr[4] = 16;
+        loaded.cpu.gpr[5] = bounds_ptr;
+        loaded.cpu.gpr[6] = 0;
+        loaded.cpu.gpr[7] = 0;
+        loaded.cpu.gpr[8] = CLIP_PIX;
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::UpdateGWorld);
+        assert_ne!(loaded.cpu.gpr[3] & CLIP_PIX, 0);
+        assert_eq!(
+            loaded.cpu.gpr[3] & (1 << 16),
+            0,
+            "no destination ColorTable"
+        );
+        assert_ne!(loaded.cpu.gpr[3] & (1 << 17), 0, "newDepth");
+        let direct16 = *loaded
+            .gworlds
+            .iter()
+            .find(|record| record.port == gworld)
+            .unwrap();
+        let direct16_bits = ppc_pixmap_bits_from_record(direct16).unwrap();
+        assert_eq!(
+            ppc_read_pixmap_raw_pixel(&mut loaded.memory, direct16_bits, 0, 0),
+            Some(0x7c00)
+        );
+        assert_eq!(
+            ppc_read_pixmap_raw_pixel(&mut loaded.memory, direct16_bits, 1, 0),
+            Some(0x03e0)
+        );
+
+        // stretchPix scales the translated direct image in both axes. The
+        // high byte of every 32-bit direct pixel remains the documented zero.
+        ppc_write_rect(&mut loaded.memory, bounds_ptr, 0, 0, 2, 4).unwrap();
+        loaded.cpu.gpr[3] = gworld_out_ptr;
+        loaded.cpu.gpr[4] = 32;
+        loaded.cpu.gpr[5] = bounds_ptr;
+        loaded.cpu.gpr[6] = 0;
+        loaded.cpu.gpr[7] = 0;
+        loaded.cpu.gpr[8] = STRETCH_PIX;
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::UpdateGWorld);
+        assert_ne!(loaded.cpu.gpr[3] & STRETCH_PIX, 0);
+        let direct32 = *loaded
+            .gworlds
+            .iter()
+            .find(|record| record.port == gworld)
+            .unwrap();
+        let direct32_bits = ppc_pixmap_bits_from_record(direct32).unwrap();
+        for y in 0..2 {
+            assert_eq!(
+                ppc_read_pixmap_raw_pixel(&mut loaded.memory, direct32_bits, 0, y),
+                Some(0x00ff_0000)
+            );
+            assert_eq!(
+                ppc_read_pixmap_raw_pixel(&mut loaded.memory, direct32_bits, 1, y),
+                Some(0x00ff_0000)
+            );
+            assert_eq!(
+                ppc_read_pixmap_raw_pixel(&mut loaded.memory, direct32_bits, 2, y),
+                Some(0x0000_ff00)
+            );
+            assert_eq!(
+                ppc_read_pixmap_raw_pixel(&mut loaded.memory, direct32_bits, 3, y),
+                Some(0x0000_ff00)
+            );
+        }
+
+        let mut target_colors = vec![[0; 3]; 16];
+        target_colors[1] = [0xffff, 0, 0];
+        target_colors[2] = [0, 0xffff, 0];
+        target_colors[3] = [0, 0, 0xffff];
+        target_colors[4] = [0xffff, 0xffff, 0xffff];
+        let target_ctable = ppc_alloc_handle_with_bytes(
+            &mut loaded.memory,
+            &mut loaded.heap_cursor,
+            loaded.heap_limit,
+            &mut loaded.handles,
+            &ppc_color_table_bytes(0x8765_4321, &target_colors).unwrap(),
+        );
+        assert_ne!(target_ctable, 0);
+        ppc_write_rect(&mut loaded.memory, bounds_ptr, 0, 0, 2, 3).unwrap();
+        loaded.cpu.gpr[3] = gworld_out_ptr;
+        loaded.cpu.gpr[4] = 4;
+        loaded.cpu.gpr[5] = bounds_ptr;
+        loaded.cpu.gpr[6] = target_ctable;
+        loaded.cpu.gpr[7] = 0;
+        loaded.cpu.gpr[8] = CLIP_PIX;
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::UpdateGWorld);
+        assert_ne!(loaded.cpu.gpr[3] & (1 << 16), 0, "mapPix");
+        let indexed4 = *loaded
+            .gworlds
+            .iter()
+            .find(|record| record.port == gworld)
+            .unwrap();
+        let indexed4_bits = ppc_pixmap_bits_from_record(indexed4).unwrap();
+        for y in 0..2 {
+            assert_eq!(
+                ppc_read_pixmap_raw_pixel(&mut loaded.memory, indexed4_bits, 0, y),
+                Some(1)
+            );
+            assert_eq!(
+                ppc_read_pixmap_raw_pixel(&mut loaded.memory, indexed4_bits, 1, y),
+                Some(1)
+            );
+            assert_eq!(
+                ppc_read_pixmap_raw_pixel(&mut loaded.memory, indexed4_bits, 2, y),
+                Some(2)
+            );
+        }
+    }
+
+    #[test]
+    fn hle_import_runner_update_gworld_maps_to_sparse_color_table_values() {
+        const CLIP_PIX: u32 = 1 << 28;
+
+        let pef = synthetic_pef_with_import(b"NewGWorld");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let scratch = PPC_DATA_BASE + 0x1000;
+        let bounds_ptr = scratch;
+        let gworld_out_ptr = scratch + 8;
+        loaded.memory.add_region(scratch, vec![0; 16]);
+        ppc_write_rect(&mut loaded.memory, bounds_ptr, 0, 0, 1, 1).unwrap();
+        loaded.cpu.gpr[3] = gworld_out_ptr;
+        loaded.cpu.gpr[4] = 16;
+        loaded.cpu.gpr[5] = bounds_ptr;
+        loaded.cpu.gpr[6] = 0;
+        loaded.cpu.gpr[7] = 0;
+        loaded.cpu.gpr[8] = 0;
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::NewGWorld);
+        let gworld = loaded.memory.read_u32_be(gworld_out_ptr).unwrap();
+        let source = *loaded
+            .gworlds
+            .iter()
+            .find(|record| record.port == gworld)
+            .unwrap();
+        loaded.memory.write_u16_be(source.base_addr, 0).unwrap();
+
+        let mut sparse_bytes = ppc_color_table_bytes(0x1234_5678, &[[0, 0, 0]]).unwrap();
+        sparse_bytes[8..10].copy_from_slice(&9u16.to_be_bytes());
+        let sparse_ctable = ppc_alloc_handle_with_bytes(
+            &mut loaded.memory,
+            &mut loaded.heap_cursor,
+            loaded.heap_limit,
+            &mut loaded.handles,
+            &sparse_bytes,
+        );
+        assert_ne!(sparse_ctable, 0);
+
+        loaded.cpu.gpr[3] = gworld_out_ptr;
+        loaded.cpu.gpr[4] = 8;
+        loaded.cpu.gpr[5] = bounds_ptr;
+        loaded.cpu.gpr[6] = sparse_ctable;
+        loaded.cpu.gpr[7] = 0;
+        loaded.cpu.gpr[8] = CLIP_PIX;
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::UpdateGWorld);
+
+        assert_ne!(loaded.cpu.gpr[3] & (1 << 16), 0, "mapPix");
+        assert_ne!(loaded.cpu.gpr[3] & (1 << 17), 0, "newDepth");
+        let indexed = *loaded
+            .gworlds
+            .iter()
+            .find(|record| record.port == gworld)
+            .unwrap();
+        assert_eq!(loaded.memory.read_u8(indexed.base_addr), Some(9));
+    }
+
+    #[test]
+    fn hle_import_runner_update_gworld_preserves_rect_span_beyond_i16_max() {
+        const CLIP_PIX: u32 = 1 << 28;
+
+        let pef = synthetic_pef_with_import(b"NewGWorld");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let scratch = PPC_DATA_BASE + 0x1000;
+        let bounds_ptr = scratch;
+        let gworld_out_ptr = scratch + 8;
+        loaded.memory.add_region(scratch, vec![0; 16]);
+        ppc_write_rect(&mut loaded.memory, bounds_ptr, 0, i16::MIN, 1, 0).unwrap();
+        loaded.cpu.gpr[3] = gworld_out_ptr;
+        loaded.cpu.gpr[4] = 1;
+        loaded.cpu.gpr[5] = bounds_ptr;
+        loaded.cpu.gpr[6] = 0;
+        loaded.cpu.gpr[7] = 0;
+        loaded.cpu.gpr[8] = 0;
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::NewGWorld);
+        let gworld = loaded.memory.read_u32_be(gworld_out_ptr).unwrap();
+        let source = *loaded
+            .gworlds
+            .iter()
+            .find(|record| record.port == gworld)
+            .unwrap();
+        assert_eq!(source.width, 32_768);
+        let last_byte = source.base_addr + 32_767 / 8;
+        loaded.memory.write_u8(last_byte, 1).unwrap();
+
+        let reversed_ctable = ppc_alloc_handle_with_bytes(
+            &mut loaded.memory,
+            &mut loaded.heap_cursor,
+            loaded.heap_limit,
+            &mut loaded.handles,
+            &ppc_color_table_bytes(0x1234_5678, &[[0, 0, 0], [0xffff; 3]]).unwrap(),
+        );
+        assert_ne!(reversed_ctable, 0);
+        loaded.cpu.gpr[3] = gworld_out_ptr;
+        loaded.cpu.gpr[4] = 1;
+        loaded.cpu.gpr[5] = bounds_ptr;
+        loaded.cpu.gpr[6] = reversed_ctable;
+        loaded.cpu.gpr[7] = 0;
+        loaded.cpu.gpr[8] = CLIP_PIX;
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::UpdateGWorld);
+
+        assert_eq!(loaded.cpu.gpr[3] & (1 << 31), 0);
+        let updated = *loaded
+            .gworlds
+            .iter()
+            .find(|record| record.port == gworld)
+            .unwrap();
+        assert_eq!(
+            ppc_read_gworld_record_raw_pixel(&mut loaded.memory, updated, 32_767, 0),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn hle_import_runner_update_gworld_dithers_direct_gradient_to_indexed_pixels() {
+        const CLIP_PIX: u32 = 1 << 28;
+        const DITHER_PIX: u32 = 1 << 30;
+
+        let pef = synthetic_pef_with_import(b"NewGWorld");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let scratch = PPC_DATA_BASE + 0x1000;
+        let bounds_ptr = scratch;
+        let gworld_out_ptr = scratch + 8;
+        loaded.memory.add_region(scratch, vec![0; 16]);
+        ppc_write_rect(&mut loaded.memory, bounds_ptr, 0, 0, 1, 16).unwrap();
+        loaded.cpu.gpr[3] = gworld_out_ptr;
+        loaded.cpu.gpr[4] = 16;
+        loaded.cpu.gpr[5] = bounds_ptr;
+        loaded.cpu.gpr[6] = 0;
+        loaded.cpu.gpr[7] = 0;
+        loaded.cpu.gpr[8] = 0;
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::NewGWorld);
+        let gworld = loaded.memory.read_u32_be(gworld_out_ptr).unwrap();
+        let source = *loaded
+            .gworlds
+            .iter()
+            .find(|record| record.port == gworld)
+            .unwrap();
+        let source_base = source.base_addr;
+        let mut source_pixels = Vec::new();
+        for x in 0..16u32 {
+            let level = 12 + x / 2;
+            let pixel = (level << 10) | (level << 5) | level;
+            source_pixels.push(pixel);
+            loaded
+                .memory
+                .write_u16_be(source.base_addr + x * 2, pixel as u16)
+                .unwrap();
+        }
+        let destination_clut =
+            ppc_color_table_clut_from_bytes(&ppc_default_color_table_bytes(1).unwrap()).unwrap();
+        let nearest = source_pixels
+            .iter()
+            .copied()
+            .map(|pixel| {
+                let rgb = ppc_gworld_pixel_to_rgb(pixel, 16, None).unwrap();
+                ppc_gworld_rgb_to_pixel(rgb, 1, Some(&destination_clut)).unwrap() as u8
+            })
+            .collect::<Vec<_>>();
+
+        loaded.cpu.gpr[3] = gworld_out_ptr;
+        loaded.cpu.gpr[4] = 1;
+        loaded.cpu.gpr[5] = bounds_ptr;
+        loaded.cpu.gpr[6] = 0;
+        loaded.cpu.gpr[7] = 0;
+        loaded.cpu.gpr[8] = CLIP_PIX | DITHER_PIX;
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::UpdateGWorld);
+
+        assert_ne!(loaded.cpu.gpr[3] & DITHER_PIX, 0);
+        assert_ne!(loaded.cpu.gpr[3] & (1 << 17), 0, "newDepth");
+        assert_eq!(loaded.cpu.gpr[3] & (1 << 20), 0, "reallocPix");
+        let indexed = *loaded
+            .gworlds
+            .iter()
+            .find(|record| record.port == gworld)
+            .unwrap();
+        assert_eq!(indexed.base_addr, source_base);
+        let bits = ppc_pixmap_bits_from_record(indexed).unwrap();
+        let dithered = (0..16)
+            .map(|x| ppc_read_pixmap_raw_pixel(&mut loaded.memory, bits, x, 0).unwrap() as u8)
+            .collect::<Vec<_>>();
+        assert_ne!(dithered, nearest);
+        assert!(dithered.contains(&0));
+        assert!(dithered.contains(&1));
+    }
+
+    #[test]
+    fn hle_import_runner_update_gworld_allocation_preflight_failure_is_atomic() {
+        const GW_FLAG_ERR: u32 = 1 << 31;
+        const CLIP_PIX: u32 = 1 << 28;
+
+        let pef = synthetic_pef_with_import(b"NewGWorld");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let scratch = PPC_DATA_BASE + 0x1000;
+        let bounds_ptr = scratch;
+        let gworld_out_ptr = scratch + 8;
+        loaded.memory.add_region(scratch, vec![0; 16]);
+        ppc_write_rect(&mut loaded.memory, bounds_ptr, 0, 0, 4, 4).unwrap();
+        loaded.cpu.gpr[3] = gworld_out_ptr;
+        loaded.cpu.gpr[4] = 1;
+        loaded.cpu.gpr[5] = bounds_ptr;
+        loaded.cpu.gpr[6] = 0;
+        loaded.cpu.gpr[7] = 0;
+        loaded.cpu.gpr[8] = 0;
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::NewGWorld);
+        let gworld = loaded.memory.read_u32_be(gworld_out_ptr).unwrap();
+        let old = *loaded
+            .gworlds
+            .iter()
+            .find(|record| record.port == gworld)
+            .unwrap();
+        loaded.memory.write_u8(old.base_addr, 0xa5).unwrap();
+
+        let old_pixel_size = old.row_bytes * old.height + old.row_bytes.max(64);
+        let pixmap_before =
+            ppc_memory_read_bytes(&mut loaded.memory, old.pixmap, PPC_PIXMAP_SIZE).unwrap();
+        let pixels_before =
+            ppc_memory_read_bytes(&mut loaded.memory, old.base_addr, old_pixel_size).unwrap();
+        let ctable_handle = loaded.memory.read_u32_be(old.pixmap + 42).unwrap();
+        let ctable_master_before = loaded.memory.read_u32_be(ctable_handle);
+        let ctable_before = ppc_copy_color_table_bytes(&mut loaded.memory, ctable_handle).unwrap();
+        let port_rect_before = ppc_memory_read_bytes(&mut loaded.memory, old.port + 16, 8).unwrap();
+        let handles_before = loaded.handles.clone();
+        let gworlds_before = loaded.gworlds.clone();
+        let allocations_before = loaded.toolbox_startup.gworld_allocations.clone();
+        let heap_cursor_before = loaded.heap_cursor;
+        let region_count_before = loaded.memory.region_count();
+
+        ppc_write_rect(&mut loaded.memory, bounds_ptr, 0, 0, 64, 64).unwrap();
+        let new_row_bytes = ppc_row_bytes(64, 8).unwrap();
+        let pixel_allocation_size = new_row_bytes * 64 + new_row_bytes.max(64);
+        let table_size = u32::try_from(ppc_default_color_table_bytes(8).unwrap().len()).unwrap();
+        // Set the limit exactly at the end of the requested allocation
+        // sequence. The allocator requires the final cursor to remain below
+        // the limit, so UpdateGWorld must reject the request before mutating
+        // the live world.
+        let allocation_limit = heap_cursor_before
+            + ppc_allocation_size(table_size).unwrap()
+            + ppc_allocation_size(pixel_allocation_size).unwrap();
+        loaded.heap_limit = allocation_limit;
+        loaded.cpu.gpr[3] = gworld_out_ptr;
+        loaded.cpu.gpr[4] = 8;
+        loaded.cpu.gpr[5] = bounds_ptr;
+        loaded.cpu.gpr[6] = 0;
+        loaded.cpu.gpr[7] = 0;
+        loaded.cpu.gpr[8] = CLIP_PIX;
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::UpdateGWorld);
+
+        assert_eq!(loaded.cpu.gpr[3], GW_FLAG_ERR);
+        assert_eq!(loaded.last_mem_error, PPC_MEM_FULL_ERR);
+        assert_eq!(loaded.heap_cursor, heap_cursor_before);
+        assert_eq!(loaded.handles, handles_before);
+        assert_eq!(loaded.gworlds, gworlds_before);
+        assert_eq!(
+            loaded.toolbox_startup.gworld_allocations,
+            allocations_before
+        );
+        assert_eq!(loaded.memory.region_count(), region_count_before);
+        assert_eq!(loaded.memory.read_u32_be(gworld_out_ptr), Some(gworld));
+        assert_eq!(
+            ppc_memory_read_bytes(&mut loaded.memory, old.pixmap, PPC_PIXMAP_SIZE),
+            Some(pixmap_before)
+        );
+        assert_eq!(
+            ppc_memory_read_bytes(&mut loaded.memory, old.base_addr, old_pixel_size),
+            Some(pixels_before)
+        );
+        assert_eq!(
+            loaded.memory.read_u32_be(ctable_handle),
+            ctable_master_before
+        );
+        assert_eq!(
+            ppc_copy_color_table_bytes(&mut loaded.memory, ctable_handle),
+            Some(ctable_before)
+        );
+        assert_eq!(
+            ppc_memory_read_bytes(&mut loaded.memory, old.port + 16, 8),
+            Some(port_rect_before)
+        );
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::QDError);
+        assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_MEM_FULL_ERR));
+    }
+
+    #[test]
+    fn hle_import_runner_update_gworld_rejects_invalid_inputs_atomically() {
+        const GW_FLAG_ERR: u32 = 1 << 31;
+
+        let pef = synthetic_pef_with_import(b"NewGWorld");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let scratch = PPC_DATA_BASE + 0x1000;
+        let bounds_ptr = scratch;
+        let gworld_out_ptr = scratch + 8;
+        loaded.memory.add_region(scratch, vec![0; 16]);
+        ppc_write_rect(&mut loaded.memory, bounds_ptr, 0, 0, 2, 2).unwrap();
+        loaded.cpu.gpr[3] = gworld_out_ptr;
+        loaded.cpu.gpr[4] = 8;
+        loaded.cpu.gpr[5] = bounds_ptr;
+        loaded.cpu.gpr[6] = 0;
+        loaded.cpu.gpr[7] = 0;
+        loaded.cpu.gpr[8] = 0;
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::NewGWorld);
+        let gworld = loaded.memory.read_u32_be(gworld_out_ptr).unwrap();
+        let old = *loaded
+            .gworlds
+            .iter()
+            .find(|record| record.port == gworld)
+            .unwrap();
+        loaded.memory.write_u8(old.base_addr, 0x5a).unwrap();
+
+        let invalid_ctable = ppc_alloc_handle(
+            &mut loaded.memory,
+            &mut loaded.heap_cursor,
+            loaded.heap_limit,
+            &mut loaded.handles,
+            8,
+            true,
+        );
+        assert_ne!(invalid_ctable, 0);
+        loaded.memory.write_u32_be(invalid_ctable, 0).unwrap();
+
+        let pixel_size = old.row_bytes * old.height + old.row_bytes.max(64);
+        let pixmap_before =
+            ppc_memory_read_bytes(&mut loaded.memory, old.pixmap, PPC_PIXMAP_SIZE).unwrap();
+        let pixels_before =
+            ppc_memory_read_bytes(&mut loaded.memory, old.base_addr, pixel_size).unwrap();
+        let old_ctable = loaded.memory.read_u32_be(old.pixmap + 42).unwrap();
+        let ctable_before = ppc_copy_color_table_bytes(&mut loaded.memory, old_ctable).unwrap();
+        let handles_before = loaded.handles.clone();
+        let gworlds_before = loaded.gworlds.clone();
+        let allocations_before = loaded.toolbox_startup.gworld_allocations.clone();
+        let heap_cursor_before = loaded.heap_cursor;
+        let region_count_before = loaded.memory.region_count();
+
+        // A non-NIL cTable must be used as supplied. Falling back to the
+        // default table for an invalid explicit handle would silently accept
+        // a different request than the caller made.
+        loaded.cpu.gpr[3] = gworld_out_ptr;
+        loaded.cpu.gpr[4] = 8;
+        loaded.cpu.gpr[5] = bounds_ptr;
+        loaded.cpu.gpr[6] = invalid_ctable;
+        loaded.cpu.gpr[7] = 0;
+        loaded.cpu.gpr[8] = 1 << 28;
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::UpdateGWorld);
+        assert_eq!(loaded.cpu.gpr[3], GW_FLAG_ERR);
+        assert_eq!(loaded.last_mem_error, PPC_PARAM_ERR);
+        assert_eq!(loaded.toolbox_startup.last_quickdraw_error, PPC_PARAM_ERR);
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::QDError);
+        assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_PARAM_ERR));
+
+        // PixMap.rowBytes has only a 14-bit byte-count payload. Reject a
+        // direct image whose scanline cannot be represented instead of
+        // truncating the live record while retaining a larger host rowBytes.
+        ppc_write_rect(&mut loaded.memory, bounds_ptr, 0, i16::MIN, 1, i16::MAX).unwrap();
+        loaded.cpu.gpr[3] = gworld_out_ptr;
+        loaded.cpu.gpr[4] = 32;
+        loaded.cpu.gpr[5] = bounds_ptr;
+        loaded.cpu.gpr[6] = 0;
+        loaded.cpu.gpr[7] = 0;
+        loaded.cpu.gpr[8] = 1 << 28;
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::UpdateGWorld);
+        assert_eq!(loaded.cpu.gpr[3], GW_FLAG_ERR);
+        assert_eq!(loaded.last_mem_error, PPC_PARAM_ERR);
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::QDError);
+        assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_PARAM_ERR));
+
+        ppc_write_rect(&mut loaded.memory, bounds_ptr, 0, 0, 2, 2).unwrap();
+        for flags in [(1 << 28) | (1 << 29), 1 << 30, 1 << 1, 1 << 16] {
+            loaded.cpu.gpr[3] = gworld_out_ptr;
+            loaded.cpu.gpr[4] = 8;
+            loaded.cpu.gpr[5] = bounds_ptr;
+            loaded.cpu.gpr[6] = 0;
+            loaded.cpu.gpr[7] = 0;
+            loaded.cpu.gpr[8] = flags;
+            run_test_import(&mut loaded, PpcImportDispatcherTarget::UpdateGWorld);
+            assert_eq!(loaded.cpu.gpr[3], GW_FLAG_ERR, "flags={flags:#010x}");
+            assert_eq!(loaded.last_mem_error, PPC_PARAM_ERR);
+            run_test_import(&mut loaded, PpcImportDispatcherTarget::QDError);
+            assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_PARAM_ERR));
+        }
+
+        loaded.cpu.gpr[3] = gworld_out_ptr;
+        loaded.cpu.gpr[4] = u32::from(u16::MAX);
+        loaded.cpu.gpr[5] = bounds_ptr;
+        loaded.cpu.gpr[6] = 0;
+        loaded.cpu.gpr[7] = 0;
+        loaded.cpu.gpr[8] = 0;
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::UpdateGWorld);
+        assert_eq!(loaded.cpu.gpr[3], GW_FLAG_ERR);
+        assert_eq!(loaded.last_mem_error, PPC_C_DEPTH_ERR);
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::QDError);
+        assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_C_DEPTH_ERR));
+
+        loaded.cpu.gpr[3] = gworld_out_ptr;
+        loaded.cpu.gpr[4] = 8;
+        loaded.cpu.gpr[5] = bounds_ptr;
+        loaded.cpu.gpr[6] = 0;
+        loaded.cpu.gpr[7] = 0;
+        loaded.cpu.gpr[8] = (1 << 3) | (1 << 28); // keepLocal + clipPix
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::UpdateGWorld);
+        assert_eq!(loaded.cpu.gpr[3] & GW_FLAG_ERR, 0);
+        assert_eq!(loaded.toolbox_startup.last_quickdraw_error, PPC_NO_ERR);
+
+        assert_eq!(loaded.heap_cursor, heap_cursor_before);
+        assert_eq!(loaded.handles, handles_before);
+        assert_eq!(loaded.gworlds, gworlds_before);
+        assert_eq!(
+            loaded.toolbox_startup.gworld_allocations,
+            allocations_before
+        );
+        assert_eq!(loaded.memory.region_count(), region_count_before);
+        assert_eq!(loaded.memory.read_u32_be(gworld_out_ptr), Some(gworld));
+        assert_eq!(
+            ppc_memory_read_bytes(&mut loaded.memory, old.pixmap, PPC_PIXMAP_SIZE),
+            Some(pixmap_before)
+        );
+        assert_eq!(
+            ppc_memory_read_bytes(&mut loaded.memory, old.base_addr, pixel_size),
+            Some(pixels_before)
+        );
+        assert_eq!(
+            ppc_copy_color_table_bytes(&mut loaded.memory, old_ctable),
+            Some(ctable_before)
+        );
+        assert_eq!(loaded.memory.read_u32_be(invalid_ctable), Some(0));
+    }
+
+    #[test]
+    fn hle_import_runner_update_gworld_reuse_preflight_is_atomic() {
+        const GW_FLAG_ERR: u32 = 1 << 31;
+
+        let pef = synthetic_pef_with_import(b"NewGWorld");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let scratch = PPC_DATA_BASE + 0x1000;
+        let bounds_ptr = scratch;
+        let gworld_out_ptr = scratch + 8;
+        loaded.memory.add_region(scratch, vec![0; 16]);
+        ppc_write_rect(&mut loaded.memory, bounds_ptr, 0, 0, 2, 2).unwrap();
+        loaded.cpu.gpr[3] = gworld_out_ptr;
+        loaded.cpu.gpr[4] = 8;
+        loaded.cpu.gpr[5] = bounds_ptr;
+        loaded.cpu.gpr[6] = 0;
+        loaded.cpu.gpr[7] = 0;
+        loaded.cpu.gpr[8] = 0;
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::NewGWorld);
+        let gworld = loaded.memory.read_u32_be(gworld_out_ptr).unwrap();
+        let old = *loaded
+            .gworlds
+            .iter()
+            .find(|record| record.port == gworld)
+            .unwrap();
+        loaded.memory.write_u8(old.base_addr, 0x5a).unwrap();
+        let private_ctable = loaded.memory.read_u32_be(old.pixmap + 42).unwrap();
+        loaded.memory.write_u32_be(private_ctable, 0).unwrap();
+
+        let replacement_colors = vec![[0x1111, 0x2222, 0x3333]; 256];
+        let replacement = ppc_alloc_handle_with_bytes(
+            &mut loaded.memory,
+            &mut loaded.heap_cursor,
+            loaded.heap_limit,
+            &mut loaded.handles,
+            &ppc_color_table_bytes(0x9876_5432, &replacement_colors).unwrap(),
+        );
+        assert_ne!(replacement, 0);
+        let pixmap_before =
+            ppc_memory_read_bytes(&mut loaded.memory, old.pixmap, PPC_PIXMAP_SIZE).unwrap();
+        let pixels_before = ppc_memory_read_bytes(
+            &mut loaded.memory,
+            old.base_addr,
+            old.row_bytes * old.height + old.row_bytes.max(64),
+        )
+        .unwrap();
+        let handles_before = loaded.handles.clone();
+        let gworlds_before = loaded.gworlds.clone();
+        let allocations_before = loaded.toolbox_startup.gworld_allocations.clone();
+        let heap_cursor_before = loaded.heap_cursor;
+
+        loaded.cpu.gpr[3] = gworld_out_ptr;
+        loaded.cpu.gpr[4] = 8;
+        loaded.cpu.gpr[5] = bounds_ptr;
+        loaded.cpu.gpr[6] = replacement;
+        loaded.cpu.gpr[7] = 0;
+        loaded.cpu.gpr[8] = 0;
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::UpdateGWorld);
+
+        assert_eq!(loaded.cpu.gpr[3], GW_FLAG_ERR);
+        assert_eq!(loaded.last_mem_error, PPC_PARAM_ERR);
+        assert_eq!(loaded.memory.read_u32_be(private_ctable), Some(0));
+        assert_eq!(loaded.heap_cursor, heap_cursor_before);
+        assert_eq!(loaded.handles, handles_before);
+        assert_eq!(loaded.gworlds, gworlds_before);
+        assert_eq!(
+            loaded.toolbox_startup.gworld_allocations,
+            allocations_before
+        );
+        assert_eq!(
+            ppc_memory_read_bytes(&mut loaded.memory, old.pixmap, PPC_PIXMAP_SIZE),
+            Some(pixmap_before)
+        );
+        assert_eq!(
+            ppc_memory_read_bytes(
+                &mut loaded.memory,
+                old.base_addr,
+                old.row_bytes * old.height + old.row_bytes.max(64),
+            ),
+            Some(pixels_before)
+        );
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::QDError);
+        assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_PARAM_ERR));
     }
 
     #[test]
@@ -112940,6 +116319,148 @@ mod tests {
         assert_eq!(probe.unsupported_import_index, None);
         assert_eq!(loaded.heap_cursor, heap_cursor);
         assert!(!loaded.gworlds.iter().any(|record| record.port == gworld));
+    }
+
+    #[test]
+    fn hle_import_runner_update_then_dispose_preserves_unrelated_heap_tail() {
+        const CLIP_PIX: u32 = 1 << 28;
+
+        let pef = synthetic_pef_with_import(b"NewGWorld");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let scratch = PPC_DATA_BASE + 0x1000;
+        let bounds_ptr = scratch;
+        let gworld_out_ptr = scratch + 8;
+        loaded.memory.add_region(scratch, vec![0; 16]);
+        ppc_write_rect(&mut loaded.memory, bounds_ptr, 0, 0, 2, 2).unwrap();
+        let initial_handle_count = loaded.handles.len();
+        loaded.cpu.gpr[3] = gworld_out_ptr;
+        loaded.cpu.gpr[4] = 1;
+        loaded.cpu.gpr[5] = bounds_ptr;
+        loaded.cpu.gpr[6] = 0;
+        loaded.cpu.gpr[7] = 0;
+        loaded.cpu.gpr[8] = 0;
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::NewGWorld);
+        let gworld = loaded.memory.read_u32_be(gworld_out_ptr).unwrap();
+        let private_ctable = loaded
+            .toolbox_startup
+            .gworld_allocations
+            .get(&gworld)
+            .unwrap()
+            .ctable_handle;
+        assert_ne!(private_ctable, 0);
+        assert_eq!(loaded.handles.len(), initial_handle_count + 1);
+
+        let sentinel_bytes = b"unrelated allocation";
+        let sentinel = ppc_alloc_handle_with_bytes(
+            &mut loaded.memory,
+            &mut loaded.heap_cursor,
+            loaded.heap_limit,
+            &mut loaded.handles,
+            sentinel_bytes,
+        );
+        assert_ne!(sentinel, 0);
+        let sentinel_ptr = loaded.memory.read_u32_be(sentinel).unwrap();
+        let cursor_before_update = loaded.heap_cursor;
+        let handle_count_with_sentinel = loaded.handles.len();
+
+        for (depth, width, height) in [
+            (8u32, 64i16, 64i16),
+            (16, 80, 80),
+            (4, 32, 32),
+            (32, 96, 96),
+            (8, 8, 8),
+        ] {
+            let before = *loaded
+                .gworlds
+                .iter()
+                .find(|record| record.port == gworld)
+                .unwrap();
+            let allocation_before = *loaded
+                .toolbox_startup
+                .gworld_allocations
+                .get(&gworld)
+                .unwrap();
+            let heap_cursor_before = loaded.heap_cursor;
+            ppc_write_rect(&mut loaded.memory, bounds_ptr, 0, 0, height, width).unwrap();
+            loaded.cpu.gpr[3] = gworld_out_ptr;
+            loaded.cpu.gpr[4] = depth;
+            loaded.cpu.gpr[5] = bounds_ptr;
+            loaded.cpu.gpr[6] = 0;
+            loaded.cpu.gpr[7] = 0;
+            loaded.cpu.gpr[8] = CLIP_PIX;
+            run_test_import(&mut loaded, PpcImportDispatcherTarget::UpdateGWorld);
+            assert_eq!(loaded.cpu.gpr[3] & (1 << 31), 0, "depth={depth}");
+            assert_eq!(loaded.handles.len(), handle_count_with_sentinel);
+            let result = loaded.cpu.gpr[3];
+            let updated = *loaded
+                .gworlds
+                .iter()
+                .find(|record| record.port == gworld)
+                .unwrap();
+            let new_row_bytes = ppc_row_bytes(width as u32, depth).unwrap();
+            let required_capacity =
+                ppc_allocation_size(new_row_bytes * height as u32 + new_row_bytes.max(64)).unwrap();
+            if depth > 8
+                && before
+                    .base_addr
+                    .checked_add(allocation_before.pixel_capacity)
+                    == Some(heap_cursor_before)
+                && required_capacity > allocation_before.pixel_capacity
+            {
+                assert_eq!(updated.base_addr, before.base_addr);
+                assert_eq!(result & (1 << 20), 0, "reallocPix");
+                assert_eq!(
+                    loaded.heap_cursor - heap_cursor_before,
+                    required_capacity - allocation_before.pixel_capacity
+                );
+            }
+            let allocation = loaded
+                .toolbox_startup
+                .gworld_allocations
+                .get(&gworld)
+                .unwrap();
+            assert_eq!(allocation.ctable_handle, private_ctable);
+            assert_eq!(allocation.origin_base, cursor_before_update);
+            let pixmap = loaded
+                .gworlds
+                .iter()
+                .find(|record| record.port == gworld)
+                .unwrap()
+                .pixmap;
+            if depth <= 8 {
+                assert_eq!(loaded.memory.read_u32_be(pixmap + 42), Some(private_ctable));
+            } else {
+                assert_eq!(loaded.memory.read_u32_be(pixmap + 42), Some(0));
+            }
+        }
+
+        loaded.cpu.gpr[3] = gworld;
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::DisposeGWorld);
+
+        assert_eq!(loaded.heap_cursor, cursor_before_update);
+        assert_eq!(loaded.memory.read_u32_be(sentinel), Some(sentinel_ptr));
+        assert_eq!(
+            ppc_memory_read_bytes(
+                &mut loaded.memory,
+                sentinel_ptr,
+                u32::try_from(sentinel_bytes.len()).unwrap(),
+            ),
+            Some(sentinel_bytes.to_vec())
+        );
+        assert!(loaded
+            .handles
+            .iter()
+            .any(|record| record.handle == sentinel));
+        assert!(!loaded
+            .handles
+            .iter()
+            .any(|record| record.handle == private_ctable));
+        assert_eq!(loaded.handles.len(), initial_handle_count + 1);
+        assert!(!loaded.gworlds.iter().any(|record| record.port == gworld));
+        assert!(!loaded
+            .toolbox_startup
+            .gworld_allocations
+            .contains_key(&gworld));
     }
 
     #[test]
@@ -113127,6 +116648,75 @@ mod tests {
         assert_eq!(loaded.memory.region_count(), region_count);
         assert_eq!(loaded.memory.read_u8(heap_cursor), Some(0));
         assert_eq!(loaded.gworlds.len(), gworld_count);
+    }
+
+    #[test]
+    fn hle_import_runner_new_gworld_rejects_explicit_device_without_depth_atomically() {
+        let pef = synthetic_pef_with_import(b"NewGWorld");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let scratch = PPC_DATA_BASE + 0x1000;
+        let bounds_ptr = scratch;
+        let gworld_out_ptr = scratch + 8;
+        let gdevice_handle = PPC_DATA_BASE + 0x5000;
+        let gdevice = PPC_DATA_BASE + 0x5100;
+        let pixmap_handle = PPC_DATA_BASE + 0x5200;
+        let pixmap = PPC_DATA_BASE + 0x5300;
+        loaded.memory.add_region(scratch, vec![0; 16]);
+        loaded.memory.add_region(gdevice_handle, vec![0; 4]);
+        loaded.memory.add_region(gdevice, vec![0; 64]);
+        loaded.memory.add_region(pixmap_handle, vec![0; 4]);
+        loaded
+            .memory
+            .add_region(pixmap, vec![0; PPC_PIXMAP_SIZE as usize]);
+        ppc_write_rect(&mut loaded.memory, bounds_ptr, 0, 0, 2, 2).unwrap();
+        loaded
+            .memory
+            .write_u32_be(gworld_out_ptr, 0xdead_beef)
+            .unwrap();
+        loaded.memory.write_u32_be(gdevice_handle, gdevice).unwrap();
+        loaded
+            .memory
+            .write_u32_be(gdevice + 22, pixmap_handle)
+            .unwrap();
+        loaded.memory.write_u32_be(pixmap_handle, pixmap).unwrap();
+        assert_eq!(loaded.memory.read_u16_be(pixmap + 32), Some(0));
+        let heap_cursor_before = loaded.heap_cursor;
+        let handles_before = loaded.handles.clone();
+        let gworlds_before = loaded.gworlds.clone();
+        let region_count_before = loaded.memory.region_count();
+
+        loaded.cpu.gpr[3] = gworld_out_ptr;
+        loaded.cpu.gpr[4] = 8;
+        loaded.cpu.gpr[5] = bounds_ptr;
+        loaded.cpu.gpr[6] = 0;
+        loaded.cpu.gpr[7] = gdevice_handle;
+        loaded.cpu.gpr[8] = 1 << 1; // noNewDevice
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::NewGWorld);
+
+        assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_C_DEPTH_ERR));
+        assert_eq!(loaded.last_mem_error, PPC_C_DEPTH_ERR);
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::QDError);
+        assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_C_DEPTH_ERR));
+        assert_eq!(loaded.memory.read_u32_be(gworld_out_ptr), Some(0xdead_beef));
+        assert_eq!(loaded.heap_cursor, heap_cursor_before);
+        assert_eq!(loaded.handles, handles_before);
+        assert_eq!(loaded.gworlds, gworlds_before);
+        assert_eq!(loaded.memory.region_count(), region_count_before);
+        assert_eq!(loaded.memory.read_u16_be(pixmap + 32), Some(0));
+
+        loaded.cpu.gpr[3] = gworld_out_ptr;
+        loaded.cpu.gpr[4] = u32::from(u16::MAX); // -1 is not depth zero
+        loaded.cpu.gpr[5] = bounds_ptr;
+        loaded.cpu.gpr[6] = 0;
+        loaded.cpu.gpr[7] = 0;
+        loaded.cpu.gpr[8] = 0;
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::NewGWorld);
+        assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_C_DEPTH_ERR));
+        assert_eq!(loaded.toolbox_startup.last_quickdraw_error, PPC_C_DEPTH_ERR);
+        assert_eq!(loaded.memory.read_u32_be(gworld_out_ptr), Some(0xdead_beef));
+        assert_eq!(loaded.heap_cursor, heap_cursor_before);
+        assert_eq!(loaded.handles, handles_before);
+        assert_eq!(loaded.gworlds, gworlds_before);
     }
 
     #[test]
@@ -113854,6 +117444,163 @@ mod tests {
     }
 
     #[test]
+    fn packed_indexed_pixel_helpers_are_msb_first_and_preserve_row_padding() {
+        let cases: &[(u32, &[u16], [u8; 2])] = &[
+            (
+                1,
+                &[1, 0, 1, 0, 0, 1, 0, 1, 0, 1, 0, 1, 1, 0, 1, 0],
+                [0xa5, 0x5a],
+            ),
+            (2, &[0, 1, 2, 3, 3, 2, 1, 0], [0x1b, 0xe4]),
+            (4, &[10, 5, 1, 14], [0xa5, 0x1e]),
+        ];
+        for &(depth, pixels, expected) in cases {
+            let mut memory = PpcSectionMem::new();
+            let base_addr = 0x1000;
+            memory.add_region(base_addr, vec![0xcc; 3]);
+            let front = PpcFrontBuffer {
+                base_addr,
+                row_bytes: 3,
+                width: pixels.len() as u32,
+                height: 1,
+                depth,
+            };
+            for (x, pixel) in pixels.iter().copied().enumerate() {
+                assert!(ppc_quickdraw_write_raw_pixel(
+                    &mut memory,
+                    front,
+                    (x as i32, 0),
+                    pixel,
+                ));
+            }
+            assert_eq!(memory.read_u8(base_addr), Some(expected[0]));
+            assert_eq!(memory.read_u8(base_addr + 1), Some(expected[1]));
+            assert_eq!(memory.read_u8(base_addr + 2), Some(0xcc));
+            for (x, pixel) in pixels.iter().copied().enumerate() {
+                assert_eq!(
+                    ppc_quickdraw_read_pixel(&mut memory, front, (x as i32, 0)),
+                    Some(pixel)
+                );
+            }
+            assert!(!ppc_quickdraw_write_raw_pixel(
+                &mut memory,
+                front,
+                (-1, 0),
+                0,
+            ));
+            assert!(!ppc_quickdraw_write_raw_pixel(
+                &mut memory,
+                front,
+                (pixels.len() as i32, 0),
+                0,
+            ));
+            assert_eq!(memory.read_u8(base_addr + 2), Some(0xcc));
+        }
+    }
+
+    #[test]
+    fn short_two_bit_pixmap_rows_are_rejected_before_cross_row_access() {
+        let mut memory = PpcSectionMem::new();
+        let pixmap = 0x1000;
+        let pixels = 0x1100;
+        memory.add_region(pixmap, vec![0; 0x200]);
+        ppc_write_pixmap(&mut memory, pixmap, pixels, 1, 0, 0, 2, 8, 2).unwrap();
+        memory.write_bytes(pixels, &[0x55, 0xa5]).unwrap();
+
+        assert!(ppc_read_pixmap_bits(&mut memory, pixmap).is_none());
+
+        let front = PpcFrontBuffer {
+            base_addr: pixels,
+            row_bytes: 1,
+            width: 8,
+            height: 2,
+            depth: 2,
+        };
+        assert_eq!(
+            ppc_quickdraw_read_pixel(&mut memory, front, (3, 0)),
+            Some(1)
+        );
+        assert_eq!(ppc_quickdraw_read_pixel(&mut memory, front, (4, 0)), None);
+        assert!(!ppc_quickdraw_write_raw_pixel(
+            &mut memory,
+            front,
+            (4, 0),
+            2,
+        ));
+        assert_eq!(memory.read_u8(pixels), Some(0x55));
+        assert_eq!(memory.read_u8(pixels + 1), Some(0xa5));
+    }
+
+    #[test]
+    fn hle_import_runner_copybits_copies_one_two_and_four_bit_rows_without_touching_padding() {
+        let pef = synthetic_pef_with_import(b"CopyBits");
+        for (depth, width, packed) in [
+            (1, 16, [0xa5, 0x5a]),
+            (2, 8, [0x1b, 0xe4]),
+            (4, 4, [0xa5, 0x1e]),
+        ] {
+            let mut loaded = load_pef_application(&pef).unwrap();
+            let scratch = PPC_HEAP_BASE + 0x12780;
+            let src_pixels = scratch;
+            let dst_pixels = scratch + 0x10;
+            let src_pixmap = scratch + 0x20;
+            let dst_pixmap = scratch + 0x60;
+            let rect = scratch + 0xa0;
+            loaded.memory.add_region(scratch, vec![0; 0xb0]);
+            ppc_write_pixmap(
+                &mut loaded.memory,
+                src_pixmap,
+                src_pixels,
+                3,
+                0,
+                0,
+                1,
+                width,
+                depth,
+            )
+            .unwrap();
+            ppc_write_pixmap(
+                &mut loaded.memory,
+                dst_pixmap,
+                dst_pixels,
+                3,
+                0,
+                0,
+                1,
+                width,
+                depth,
+            )
+            .unwrap();
+            loaded
+                .memory
+                .write_bytes(src_pixels, &[packed[0], packed[1], 0x99])
+                .unwrap();
+            loaded
+                .memory
+                .write_bytes(dst_pixels, &[0xcc, 0xcc, 0x77])
+                .unwrap();
+            ppc_write_rect(&mut loaded.memory, rect, 0, 0, 1, width).unwrap();
+            loaded.cpu.gpr[3] = src_pixmap;
+            loaded.cpu.gpr[4] = dst_pixmap;
+            loaded.cpu.gpr[5] = rect;
+            loaded.cpu.gpr[6] = rect;
+            loaded.cpu.gpr[7] = 0;
+            loaded.cpu.gpr[8] = 0;
+
+            let probe = loaded.run_with_hle_imports(64);
+
+            assert_eq!(probe.handled_import_count, 1);
+            assert_eq!(probe.unsupported_import_index, None);
+            let mut copied = [0; 3];
+            loaded
+                .memory
+                .read_bytes_into(dst_pixels, &mut copied)
+                .unwrap();
+            assert_eq!(copied, [packed[0], packed[1], 0x77]);
+        }
+    }
+
+    #[test]
     fn hle_import_runner_copybits_copies_4bpp_odd_and_even_nibbles() {
         let pef = synthetic_pef_with_import(b"CopyBits");
         let mut loaded = load_pef_application(&pef).unwrap();
@@ -113903,7 +117650,7 @@ mod tests {
     }
 
     #[test]
-    fn hle_import_runner_copybits_4bpp_uses_main_device_inverse_table() {
+    fn hle_import_runner_copybits_4bpp_matches_within_active_destination_table() {
         let pef = synthetic_pef_with_import(b"CopyBits");
         let mut loaded = load_pef_application(&pef).unwrap();
         let scratch = PPC_HEAP_BASE + 0x12880;
@@ -113943,6 +117690,13 @@ mod tests {
             loaded.memory.write_u16_be(spec + 4, color[1]).unwrap();
             loaded.memory.write_u16_be(spec + 6, color[2]).unwrap();
         }
+        let main_ctable = loaded.memory.read_u32_be(PPC_MAIN_CTABLE_HANDLE).unwrap();
+        for index in [5u32, 252] {
+            let spec = main_ctable + 8 + index * 8;
+            loaded.memory.write_u16_be(spec + 2, 0x4000).unwrap();
+            loaded.memory.write_u16_be(spec + 4, 0x4000).unwrap();
+            loaded.memory.write_u16_be(spec + 6, 0x4000).unwrap();
+        }
         loaded.memory.write_u8(src_pixels, 0xe0).unwrap();
         loaded.memory.write_u8(dst_pixels, 0x0a).unwrap();
         ppc_write_rect(&mut loaded.memory, rect, 0, 0, 1, 1).unwrap();
@@ -113956,14 +117710,10 @@ mod tests {
 
         assert_eq!(probe.handled_import_count, 1);
         assert_eq!(probe.unsupported_import_index, None);
-        assert_eq!(
-            TrapDispatcher::standard_itable_lookup(0x4000, 0x4000, 0x4000),
-            252
-        );
-        // The main device's cached 8-bit inverse table returns pixel 252.
-        // Storing that device pixel in a 4-bit destination retains nibble 12
-        // and preserves the neighboring destination nibble.
-        assert_eq!(loaded.memory.read_u8(dst_pixels), Some(0xca));
+        // Both index 5 and the misleading 8-bit index 252 are exact matches.
+        // A 4-bit destination can represent only the first 16 active entries,
+        // so CopyBits must choose 5 rather than choose 252 and mask it to 12.
+        assert_eq!(loaded.memory.read_u8(dst_pixels), Some(0x5a));
     }
 
     #[test]
@@ -114083,7 +117833,13 @@ mod tests {
         assert_eq!(probe.handled_import_count, 1);
         assert_eq!(probe.unsupported_import_index, None);
         let [red, green, blue] = standard_4bpp[13];
-        let mapped = TrapDispatcher::standard_itable_lookup(red, green, blue) & 0x0f;
+        let active_clut = ppc_copy_bits_clut(
+            &mut loaded.memory,
+            PPC_MAIN_CTABLE_HANDLE,
+            &loaded.color_manager_clut,
+        );
+        let mapped =
+            ppc_rgb_color_to_index_in_clut(PpcRgbColor { red, green, blue }, &active_clut, 16);
         assert_ne!(mapped, 13);
         assert_eq!(loaded.memory.read_u8(dst_pixels), Some(0xa0 | mapped));
 
@@ -114998,6 +118754,81 @@ mod tests {
             .read_bytes_into(dst_pixels, &mut result)
             .unwrap();
         assert_eq!(result, [1, 42, 3, 42, 42, 6, 42, 8]);
+    }
+
+    #[test]
+    fn hle_import_runner_copymask_preserves_unaligned_2bpp_fields_and_padding() {
+        let pef = synthetic_pef_with_import(b"CopyMask");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let scratch = PPC_HEAP_BASE + 0x13900;
+        let src_pixels = scratch;
+        let mask_pixels = scratch + 0x10;
+        let dst_pixels = scratch + 0x20;
+        let src_pixmap = scratch + 0x40;
+        let mask_bitmap = scratch + 0x80;
+        let dst_pixmap = scratch + 0xa0;
+        let rects = scratch + 0xe0;
+        loaded.memory.add_region(scratch, vec![0; 0x120]);
+        ppc_write_pixmap(&mut loaded.memory, src_pixmap, src_pixels, 4, 0, 0, 1, 9, 2).unwrap();
+        ppc_write_pixmap(&mut loaded.memory, dst_pixmap, dst_pixels, 4, 0, 0, 1, 9, 2).unwrap();
+        loaded
+            .memory
+            .write_u32_be(mask_bitmap, mask_pixels)
+            .unwrap();
+        loaded.memory.write_u16_be(mask_bitmap + 4, 3).unwrap();
+        ppc_write_rect(&mut loaded.memory, mask_bitmap + 6, 0, 0, 1, 9).unwrap();
+
+        // Source indexes are [0,2,3,0,3,2,0,2,3]. The destination begins
+        // entirely at index 1, including the two visible boundary pixels.
+        // Both rows reserve a fourth byte as scanline padding.
+        loaded
+            .memory
+            .write_bytes(src_pixels, &[0x2c, 0xe2, 0xc0, 0x9a])
+            .unwrap();
+        loaded
+            .memory
+            .write_bytes(dst_pixels, &[0x55, 0x55, 0x55, 0xcc])
+            .unwrap();
+        // Copy x=1,3,4,7. x=0 and x=8 are outside the unaligned rectangles;
+        // the low seven bits of the second mask byte are deliberately nonzero
+        // tail bits and the third byte is mask-row padding.
+        loaded
+            .memory
+            .write_bytes(mask_pixels, &[0b0101_1001, 0b0010_1101, 0xee])
+            .unwrap();
+        for offset in [0, 8, 16] {
+            ppc_write_rect(&mut loaded.memory, rects + offset, 0, 1, 1, 8).unwrap();
+        }
+        loaded.cpu.gpr[3] = src_pixmap;
+        loaded.cpu.gpr[4] = mask_bitmap;
+        loaded.cpu.gpr[5] = dst_pixmap;
+        loaded.cpu.gpr[6] = rects;
+        loaded.cpu.gpr[7] = rects + 8;
+        loaded.cpu.gpr[8] = rects + 16;
+
+        let probe = loaded.run_with_hle_imports(64);
+
+        assert_eq!(probe.handled_import_count, 1);
+        assert_eq!(probe.unsupported_import_index, None);
+        let mut result = [0; 4];
+        loaded
+            .memory
+            .read_bytes_into(dst_pixels, &mut result)
+            .unwrap();
+        assert_eq!(result, [0x64, 0xd6, 0x55, 0xcc]);
+        let dst_bits = ppc_resolve_pixmap_bits(&mut loaded.memory, &loaded.gworlds, dst_pixmap)
+            .expect("destination PixMap should remain live");
+        assert_eq!(
+            ppc_read_pixmap_raw_pixel(&mut loaded.memory, dst_bits, 0, 0),
+            Some(1),
+            "left neighbour must survive the packed read-modify-write"
+        );
+        assert_eq!(
+            loaded.memory.read_u8(dst_pixels + 2).unwrap() & 0x3f,
+            0x15,
+            "unused tail fields must survive the packed read-modify-write"
+        );
+        assert_eq!(loaded.memory.read_u8(dst_pixels + 3), Some(0xcc));
     }
 
     #[test]
@@ -122188,6 +126019,36 @@ mod tests {
     }
 
     #[test]
+    fn popup_menu_select_rejects_an_enabled_separator() {
+        let pef = synthetic_pef_with_import(b"PopUpMenuSelect");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let menu_handle = install_test_menu(
+            &mut loaded,
+            PPC_DATA_BASE + 0x1000,
+            300,
+            b"Popup",
+            b"First;-",
+        );
+        assert!(ppc_menu_item_enabled(&mut loaded.memory, menu_handle, 2));
+
+        assert_eq!(
+            ppc_pop_up_menu_select(
+                &mut loaded.memory,
+                menu_handle,
+                100,
+                50,
+                2,
+                PpcInputSnapshot {
+                    mouse_v: 100,
+                    mouse_h: 50,
+                    ..PpcInputSnapshot::default()
+                },
+            ),
+            0,
+        );
+    }
+
+    #[test]
     fn hle_import_runner_handles_get_dialog_item_outputs() {
         let pef = synthetic_pef_with_import(b"GetDialogItem");
         let mut loaded = load_pef_application(&pef).unwrap();
@@ -125058,6 +128919,188 @@ mod tests {
     }
 
     #[test]
+    fn hle_import_runner_does_not_cross_short_two_bit_pixmap_rows() {
+        let pef = synthetic_pef_with_import(b"FillRect");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let scratch = PPC_DATA_BASE + 0x1c00;
+        let port = scratch;
+        let pixmap_handle = scratch + 0x100;
+        let pixmap = scratch + 0x120;
+        let rect = scratch + 0x180;
+        let pixels = scratch + 0x200;
+        loaded.memory.add_region(scratch, vec![0; 0x300]);
+        ppc_write_gworld_port(&mut loaded.memory, port, pixmap_handle, 0, 0, 2, 8).unwrap();
+        loaded.memory.write_u32_be(pixmap_handle, pixmap).unwrap();
+        ppc_write_pixmap(&mut loaded.memory, pixmap, pixels, 1, 0, 0, 2, 8, 2).unwrap();
+        loaded.memory.write_bytes(pixels, &[0x55, 0xa5]).unwrap();
+        loaded.gworlds.push(PpcGWorldRecord {
+            port,
+            pixmap_handle,
+            pixmap,
+            base_addr: pixels,
+            gdevice: PPC_MAIN_GDEVICE,
+            width: 8,
+            height: 2,
+            depth: 2,
+            row_bytes: 1,
+            pixels_locked: false,
+            pixels_no_purge: false,
+        });
+        loaded.current_gworld = port;
+        loaded.quickdraw_fore_indices.insert(port, 2);
+        ppc_write_rect(&mut loaded.memory, rect, 0, 0, 1, 8).unwrap();
+        loaded.cpu.gpr[3] = rect;
+
+        assert!(ppc_read_pixmap_bits(&mut loaded.memory, pixmap).is_none());
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::FillRect);
+
+        assert_eq!(loaded.memory.read_u8(pixels), Some(0xaa));
+        assert_eq!(loaded.memory.read_u8(pixels + 1), Some(0xa5));
+    }
+
+    #[test]
+    fn hle_import_runner_draws_representative_quickdraw_primitives_into_2bpp_gworld() {
+        const WIDTH: u32 = 9;
+        const HEIGHT: u32 = 32;
+        const ROW_BYTES: u32 = 4;
+
+        let pef = synthetic_pef_with_import(b"PaintRect");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let scratch = PPC_DATA_BASE + 0x1800;
+        let port = scratch;
+        let rect_ptr = scratch + 0x100;
+        let string_ptr = scratch + 0x120;
+        let pixels = scratch + 0x200;
+        loaded.memory.add_region(scratch, vec![0; 0x400]);
+        loaded
+            .memory
+            .write_bytes(pixels, &vec![0x55; (ROW_BYTES * HEIGHT) as usize])
+            .unwrap();
+        loaded.gworlds.push(PpcGWorldRecord {
+            port,
+            pixmap_handle: 0,
+            pixmap: 0,
+            base_addr: pixels,
+            gdevice: PPC_MAIN_GDEVICE,
+            width: WIDTH,
+            height: HEIGHT,
+            depth: 2,
+            row_bytes: ROW_BYTES,
+            pixels_locked: false,
+            pixels_no_purge: false,
+        });
+        loaded.current_gworld = port;
+        loaded
+            .memory
+            .write_u16_be(port + PPC_CGRAF_PORT_PN_SIZE_OFFSET, 1)
+            .unwrap();
+        loaded
+            .memory
+            .write_u16_be(port + PPC_CGRAF_PORT_PN_SIZE_OFFSET + 2, 1)
+            .unwrap();
+        loaded.quickdraw_fore_color = PpcRgbColor {
+            red: 0xffff,
+            green: 0,
+            blue: 0,
+        };
+        loaded.quickdraw_fore_indices.insert(port, 2);
+        loaded.quickdraw_text_size = 12;
+        loaded.quickdraw_text_mode = PPC_QD_TEXT_MODE_SRC_OR;
+        let front = ppc_front_buffer_for_gworld(&loaded.gworlds, port).unwrap();
+
+        // Start each field at index 1. PaintRect begins at odd x=1 and must
+        // replace only x=1..2 within the first packed byte.
+        ppc_write_rect(&mut loaded.memory, rect_ptr, 0, 1, 1, 3).unwrap();
+        loaded.cpu.gpr[3] = rect_ptr;
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::PaintRect);
+        assert_eq!(loaded.memory.read_u8(pixels), Some(0x69));
+        assert_eq!(loaded.memory.read_u8(pixels + 1), Some(0x55));
+
+        // FillRect begins at odd x=5 and spans the remaining fields of its
+        // byte without changing the adjacent x=4 field.
+        ppc_write_rect(&mut loaded.memory, rect_ptr, 1, 5, 2, 8).unwrap();
+        loaded.cpu.gpr[3] = rect_ptr;
+        loaded.cpu.gpr[4] = 0;
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::FillRect);
+        assert_eq!(loaded.memory.read_u8(pixels + ROW_BYTES), Some(0x55));
+        assert_eq!(loaded.memory.read_u8(pixels + ROW_BYTES + 1), Some(0x6a));
+
+        // Inverting index 1 at odd x=1..2 produces index 2 while retaining
+        // both neighbouring fields.
+        ppc_write_rect(&mut loaded.memory, rect_ptr, 2, 1, 3, 3).unwrap();
+        loaded.cpu.gpr[3] = rect_ptr;
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::InvertRect);
+        assert_eq!(loaded.memory.read_u8(pixels + 2 * ROW_BYTES), Some(0x69));
+
+        loaded.cpu.gpr[3] = 1;
+        loaded.cpu.gpr[4] = 3;
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::MoveTo);
+        loaded.cpu.gpr[3] = 6;
+        loaded.cpu.gpr[4] = 3;
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::LineTo);
+        assert_eq!(loaded.memory.read_u8(pixels + 3 * ROW_BYTES), Some(0x6a));
+        assert_eq!(
+            loaded.memory.read_u8(pixels + 3 * ROW_BYTES + 1),
+            Some(0xa9)
+        );
+
+        let first_covered_glyph_pixel = |ch: char| {
+            let (glyph, data) = get_glyph(PPC_QD_TEXT_FONT_DEFAULT, 12, ch).unwrap();
+            for row in 0..glyph.height as usize {
+                for col in 0..glyph.width as usize {
+                    let index = glyph.data_offset + row * glyph.width as usize + col;
+                    if index < data.len() && data[index] >= 128 {
+                        return (
+                            i32::from(glyph.origin_x) + col as i32,
+                            i32::from(glyph.origin_y) + row as i32,
+                        );
+                    }
+                }
+            }
+            panic!("glyph should contain at least one covered pixel");
+        };
+        let (glyph_dx, glyph_dy) = first_covered_glyph_pixel('H');
+
+        loaded.cpu.gpr[3] = 1;
+        loaded.cpu.gpr[4] = 16;
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::MoveTo);
+        loaded.cpu.gpr[3] = b'H' as u32;
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::DrawChar);
+        assert_eq!(
+            ppc_quickdraw_read_pixel(&mut loaded.memory, front, (1 + glyph_dx, 16 + glyph_dy)),
+            Some(2),
+            "DrawChar must reach the packed 2bpp destination"
+        );
+
+        loaded.memory.write_u8(string_ptr, 1).unwrap();
+        loaded.memory.write_u8(string_ptr + 1, b'H').unwrap();
+        loaded.cpu.gpr[3] = 1;
+        loaded.cpu.gpr[4] = 30;
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::MoveTo);
+        loaded.cpu.gpr[3] = string_ptr;
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::DrawString);
+        assert_eq!(
+            ppc_quickdraw_read_pixel(&mut loaded.memory, front, (1 + glyph_dx, 30 + glyph_dy)),
+            Some(2),
+            "DrawString must reach the packed 2bpp destination"
+        );
+
+        // Width 9 consumes only the high field of byte 2. Every operation
+        // above must preserve its low six tail bits, the fourth padding byte,
+        // and the x=0 neighbour on each touched scanline.
+        for y in 0..HEIGHT {
+            let row = pixels + y * ROW_BYTES;
+            assert_eq!(loaded.memory.read_u8(row + 2).unwrap() & 0x3f, 0x15);
+            assert_eq!(loaded.memory.read_u8(row + 3), Some(0x55));
+            assert_eq!(
+                ppc_quickdraw_read_pixel(&mut loaded.memory, front, (0, y as i32)),
+                Some(1),
+                "left neighbour changed on row {y}"
+            );
+        }
+    }
+
+    #[test]
     fn hle_import_runner_round_trips_quickdraw_pen_state() {
         let pef = synthetic_pef_with_import(b"GetPenState");
         let mut loaded = load_pef_application(&pef).unwrap();
@@ -127086,6 +131129,77 @@ mod tests {
             loaded.memory.read_u32_be(gdevice_out_ptr),
             Some(PPC_MAIN_GDEVICE)
         );
+
+        loaded.cpu.pc = loaded.entry_pc;
+        loaded.cpu.lr = PPC_HALT_PC;
+        loaded
+            .memory
+            .write_u32_be(gdevice_out_ptr, 0xa5a5_5a5a)
+            .unwrap();
+        loaded.cpu.gpr[3] = PPC_DSP_DISPLAY_ID + 1;
+        loaded.cpu.gpr[4] = gdevice_out_ptr;
+        loaded.cpu.gpr[5] = 0;
+        run_test_import(
+            &mut loaded,
+            PpcImportDispatcherTarget::DMGetGDeviceByDisplayID,
+        );
+        assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_PARAM_ERR));
+        assert_eq!(
+            loaded.memory.read_u32_be(gdevice_out_ptr),
+            Some(0xa5a5_5a5a),
+            "failed lookup must leave the output untouched"
+        );
+
+        loaded.cpu.gpr[3] = PPC_DSP_DISPLAY_ID + 1;
+        loaded.cpu.gpr[4] = gdevice_out_ptr;
+        loaded.cpu.gpr[5] = 1;
+        run_test_import(
+            &mut loaded,
+            PpcImportDispatcherTarget::DMGetGDeviceByDisplayID,
+        );
+        assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_NO_ERR));
+        assert_eq!(
+            loaded.memory.read_u32_be(gdevice_out_ptr),
+            Some(PPC_MAIN_GDEVICE),
+            "failToMain must resolve an unknown display ID to the main device"
+        );
+    }
+
+    #[test]
+    fn display_manager_display_id_lookup_honors_fail_to_main() {
+        let pef = synthetic_pef_with_import(b"DMGetDisplayIDByGDevice");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let display_id_out = PPC_DATA_BASE + 0x1000;
+        loaded.memory.add_region(display_id_out, vec![0xa5; 4]);
+        loaded.cpu.gpr[3] = 0x06ff_0000;
+        loaded.cpu.gpr[4] = display_id_out;
+        loaded.cpu.gpr[5] = 0;
+
+        run_test_import(
+            &mut loaded,
+            PpcImportDispatcherTarget::DMGetDisplayIDByGDevice,
+        );
+
+        assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_PARAM_ERR));
+        assert_eq!(
+            loaded.memory.read_u32_be(display_id_out),
+            Some(0xa5a5_a5a5),
+            "failed lookup must leave the output untouched"
+        );
+
+        loaded.cpu.gpr[3] = 0x06ff_0000;
+        loaded.cpu.gpr[4] = display_id_out;
+        loaded.cpu.gpr[5] = 1;
+        run_test_import(
+            &mut loaded,
+            PpcImportDispatcherTarget::DMGetDisplayIDByGDevice,
+        );
+        assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_NO_ERR));
+        assert_eq!(
+            loaded.memory.read_u32_be(display_id_out),
+            Some(PPC_DSP_DISPLAY_ID),
+            "failToMain must resolve an unknown GDevice to the main display"
+        );
     }
 
     #[test]
@@ -127324,22 +131438,33 @@ mod tests {
     fn hle_import_runner_has_depth_only_advertises_settable_modes() {
         let pef = synthetic_pef_with_import(b"HasDepth");
         let cases = [
-            (1, 0, 1, 0),
-            (2, 0, 1, 0),
-            (4, 0, 1, 0),
-            (8, 0, 0, 8),
-            (16, 0, 0, 16),
-            (32, 0, 1, 0),
-            (99, 0, 1, 0),
-            (8, 1, 1, 8),
-            (16, 1, 1, 16),
-            (8, 1, 0, 0),
-            (16, 1, 0, 0),
-            (8, 1 << 11, 1 << 11, 8),
-            (8, 1 << 11, 0, 0),
+            (1, 0, 1, 1, false),
+            (2, 0, 1, 2, true),
+            (4, 0, 1, 4, true),
+            (8, 0, 0, 8, true),
+            (16, 0, 0, 16, true),
+            (32, 0, 1, 0, false),
+            (99, 0, 1, 0, false),
+            (1, 1, 0, 1, false),
+            (1, 1, 1, 0, false),
+            (2, 1, 0, 2, false),
+            (2, 1, 1, 2, true),
+            (4, 1, 0, 4, false),
+            (4, 1, 1, 4, true),
+            (8, 1, 0, 8, false),
+            (8, 1, 1, 8, true),
+            (16, 1, 0, 0, false),
+            (16, 1, 1, 16, true),
+            (8, 1 << 11, 1 << 11, 8, true),
+            (8, 1 << 11, 0, 0, false),
         ];
 
-        for (depth, which_flags, flags, expected_mode) in cases {
+        for (depth, which_flags, flags, expected_depth, expected_color) in cases {
+            let expected_mode = if expected_depth == 0 {
+                0
+            } else {
+                u32::from(crate::display::classic_depth_mode(expected_depth).unwrap())
+            };
             let mut loaded = load_pef_application(&pef).unwrap();
             loaded.cpu.gpr[3] = PPC_MAIN_GDEVICE;
             loaded.cpu.gpr[4] = depth;
@@ -127358,28 +131483,45 @@ mod tests {
                 loaded.cpu.gpr[6] = flags;
                 run_test_import(&mut loaded, PpcImportDispatcherTarget::SetDepth);
                 assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_NO_ERR));
+                assert_eq!(
+                    loaded.memory.read_u32_be(PPC_MAIN_GDEVICE_RECORD + 42),
+                    Some(expected_mode)
+                );
+                assert_eq!(
+                    loaded
+                        .memory
+                        .read_u16_be(PPC_MAIN_GDEVICE_RECORD + 20)
+                        .unwrap()
+                        & 1
+                        != 0,
+                    expected_color
+                );
             }
         }
 
         for gdevice in [0, 0x06ff_0000] {
-            for depth in [8, 16] {
+            for depth in [1, 2, 4, 8, 16] {
                 let mut loaded = load_pef_application(&pef).unwrap();
                 loaded.cpu.gpr[3] = gdevice;
                 loaded.cpu.gpr[4] = depth;
                 loaded.cpu.gpr[5] = 1;
-                loaded.cpu.gpr[6] = 1;
+                loaded.cpu.gpr[6] = u32::from(depth != 1);
                 run_test_import(&mut loaded, PpcImportDispatcherTarget::HasDepth);
                 let mode = loaded.cpu.gpr[3];
                 assert_eq!(
                     mode,
-                    if gdevice == 0 { depth } else { 0 },
+                    if gdevice == 0 {
+                        u32::from(crate::display::classic_depth_mode(depth as u16).unwrap())
+                    } else {
+                        0
+                    },
                     "NIL aliases the main device; other invalid handles do not"
                 );
                 if mode != 0 {
                     loaded.cpu.gpr[3] = gdevice;
                     loaded.cpu.gpr[4] = mode;
                     loaded.cpu.gpr[5] = 1;
-                    loaded.cpu.gpr[6] = 1;
+                    loaded.cpu.gpr[6] = u32::from(depth != 1);
                     run_test_import(&mut loaded, PpcImportDispatcherTarget::SetDepth);
                     assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_NO_ERR));
                 }
@@ -127388,16 +131530,512 @@ mod tests {
     }
 
     #[test]
+    fn hle_import_runner_set_depth_installs_each_advertised_screen_personality() {
+        let pef = synthetic_pef_with_import(b"SetDepth");
+        for (depth, is_color) in [
+            (1, false),
+            (2, false),
+            (2, true),
+            (4, false),
+            (4, true),
+            (8, false),
+            (8, true),
+            (16, true),
+        ] {
+            let mut loaded = load_pef_application(&pef).unwrap();
+            loaded.cpu.gpr[3] = PPC_MAIN_GDEVICE;
+            loaded.cpu.gpr[4] = depth;
+            loaded.cpu.gpr[5] = 1;
+            loaded.cpu.gpr[6] = u32::from(is_color);
+            run_test_import(&mut loaded, PpcImportDispatcherTarget::SetDepth);
+
+            assert_eq!(
+                loaded.cpu.gpr[3],
+                ppc_i16_result(PPC_NO_ERR),
+                "SetDepth rejected {depth}-bit {}",
+                if is_color { "color" } else { "grayscale" }
+            );
+            let row_bytes = ppc_row_bytes(PPC_MAIN_SCREEN_WIDTH, depth).unwrap();
+            assert_eq!(loaded.gworlds[0].depth, depth);
+            assert_eq!(loaded.gworlds[0].row_bytes, row_bytes);
+            assert_eq!(
+                loaded.memory.read_u16_be(PPC_MAIN_PIXMAP + 4),
+                Some(0x8000 | row_bytes as u16)
+            );
+            assert_eq!(
+                loaded.memory.read_u16_be(PPC_MAIN_PIXMAP + 32),
+                Some(depth as u16)
+            );
+            assert_eq!(
+                loaded
+                    .memory
+                    .read_u16_be(PPC_MAIN_GDEVICE_RECORD + 20)
+                    .unwrap()
+                    & 1
+                    != 0,
+                is_color
+            );
+            assert_eq!(
+                loaded.memory.read_u16_be(PPC_MAIN_GDEVICE_RECORD + 4),
+                Some(if depth <= 8 { 0 } else { 2 })
+            );
+            assert_eq!(
+                loaded.memory.read_u32_be(PPC_MAIN_GDEVICE_RECORD + 42),
+                Some(u32::from(
+                    crate::display::classic_depth_mode(depth as u16).unwrap()
+                )),
+                "gdMode for depth {depth}"
+            );
+            if depth <= 8 {
+                let (expected_clut, entry_count) =
+                    ppc_standard_screen_clut(depth, is_color).unwrap();
+                assert_eq!(
+                    loaded.memory.read_u32_be(PPC_MAIN_PIXMAP + 42),
+                    Some(PPC_MAIN_CTABLE_HANDLE)
+                );
+                assert_eq!(loaded.memory.read_u16_be(PPC_MAIN_PIXMAP + 30), Some(0));
+                assert_eq!(loaded.memory.read_u16_be(PPC_MAIN_PIXMAP + 34), Some(1));
+                assert_eq!(
+                    loaded.memory.read_u16_be(PPC_MAIN_PIXMAP + 36),
+                    Some(depth as u16)
+                );
+                assert_eq!(
+                    loaded.memory.read_u16_be(PPC_MAIN_CTABLE + 6),
+                    Some((entry_count - 1) as u16)
+                );
+                assert_eq!(
+                    loaded.memory.read_u16_be(PPC_MAIN_CTABLE + 4).unwrap() & 0x8000,
+                    0x8000
+                );
+                for (index, expected) in expected_clut.into_iter().take(entry_count).enumerate() {
+                    let entry = PPC_MAIN_CTABLE + 8 + index as u32 * 8;
+                    assert_eq!(loaded.memory.read_u16_be(entry), Some(index as u16));
+                    assert_eq!(loaded.memory.read_u16_be(entry + 2), Some(expected[0]));
+                    assert_eq!(loaded.memory.read_u16_be(entry + 4), Some(expected[1]));
+                    assert_eq!(loaded.memory.read_u16_be(entry + 6), Some(expected[2]));
+                }
+                assert_eq!(loaded.screen_clut, expected_clut);
+                assert_eq!(loaded.color_manager_clut, expected_clut);
+            } else {
+                assert_eq!(loaded.memory.read_u32_be(PPC_MAIN_PIXMAP + 42), Some(0));
+                assert_eq!(loaded.memory.read_u16_be(PPC_MAIN_PIXMAP + 30), Some(16));
+                assert_eq!(loaded.memory.read_u16_be(PPC_MAIN_PIXMAP + 34), Some(3));
+                assert_eq!(loaded.memory.read_u16_be(PPC_MAIN_PIXMAP + 36), Some(5));
+            }
+        }
+    }
+
+    #[test]
+    fn hle_import_runner_set_depth_grows_private_screen_ctable_without_replacing_handle() {
+        let pef = synthetic_pef_with_import(b"SetDepth");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let private_ctable_handle = ppc_alloc_handle_with_bytes(
+            &mut loaded.memory,
+            &mut loaded.heap_cursor,
+            loaded.heap_limit,
+            &mut loaded.handles,
+            &ppc_default_color_table_bytes(1).unwrap(),
+        );
+        assert_ne!(private_ctable_handle, 0);
+        let original_ptr = loaded.memory.read_u32_be(private_ctable_handle).unwrap();
+        loaded
+            .memory
+            .write_u16_be(original_ptr + 4, 0x1234)
+            .unwrap();
+        let blocker = ppc_alloc_handle(
+            &mut loaded.memory,
+            &mut loaded.heap_cursor,
+            loaded.heap_limit,
+            &mut loaded.handles,
+            32,
+            true,
+        );
+        assert_ne!(blocker, 0);
+
+        let scratch = PPC_DATA_BASE + 0xb000;
+        let port = scratch;
+        let pixmap_handle = scratch + 0x100;
+        let pixmap = scratch + 0x110;
+        loaded.memory.add_region(scratch, vec![0; 0x160]);
+        loaded.memory.write_u32_be(pixmap_handle, pixmap).unwrap();
+        ppc_write_pixmap(
+            &mut loaded.memory,
+            pixmap,
+            PPC_MAIN_SCREEN_BASE,
+            ppc_main_screen_row_bytes(),
+            0,
+            0,
+            PPC_MAIN_SCREEN_HEIGHT as i16,
+            PPC_MAIN_SCREEN_WIDTH as i16,
+            8,
+        )
+        .unwrap();
+        loaded
+            .memory
+            .write_u32_be(pixmap + 42, private_ctable_handle)
+            .unwrap();
+        ppc_write_gworld_port(
+            &mut loaded.memory,
+            port,
+            pixmap_handle,
+            0,
+            0,
+            PPC_MAIN_SCREEN_HEIGHT as i16,
+            PPC_MAIN_SCREEN_WIDTH as i16,
+        )
+        .unwrap();
+        loaded.gworlds.push(PpcGWorldRecord {
+            port,
+            pixmap_handle,
+            pixmap,
+            base_addr: PPC_MAIN_SCREEN_BASE,
+            gdevice: PPC_MAIN_GDEVICE,
+            width: PPC_MAIN_SCREEN_WIDTH,
+            height: PPC_MAIN_SCREEN_HEIGHT,
+            depth: 8,
+            row_bytes: ppc_main_screen_row_bytes(),
+            pixels_locked: false,
+            pixels_no_purge: false,
+        });
+
+        for depth in [4, 8, 1] {
+            loaded.cpu.gpr[3] = PPC_MAIN_GDEVICE;
+            loaded.cpu.gpr[4] = depth;
+            loaded.cpu.gpr[5] = 1;
+            loaded.cpu.gpr[6] = u32::from(depth != 1);
+            run_test_import(&mut loaded, PpcImportDispatcherTarget::SetDepth);
+            assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_NO_ERR));
+            assert_eq!(
+                loaded.memory.read_u32_be(pixmap + 42),
+                Some(private_ctable_handle)
+            );
+            let table = loaded.memory.read_u32_be(private_ctable_handle).unwrap();
+            assert_eq!(loaded.memory.read_u16_be(table + 4), Some(0x1234));
+            assert_eq!(
+                loaded.memory.read_u16_be(table + 6),
+                Some(((1u32 << depth) - 1) as u16)
+            );
+        }
+
+        let grown = loaded
+            .handles
+            .iter()
+            .find(|record| record.handle == private_ctable_handle)
+            .copied()
+            .unwrap();
+        assert_ne!(grown.ptr, original_ptr);
+        assert_eq!(
+            grown.ptr,
+            loaded.memory.read_u32_be(private_ctable_handle).unwrap()
+        );
+        assert_eq!(grown.size, PPC_MAIN_CTABLE_SIZE);
+        assert_eq!(grown.capacity, PPC_MAIN_CTABLE_SIZE);
+    }
+
+    #[test]
+    fn hle_import_runner_set_depth_private_ctable_growth_failure_is_atomic() {
+        let pef = synthetic_pef_with_import(b"SetDepth");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let private_ctable_handle = ppc_alloc_handle_with_bytes(
+            &mut loaded.memory,
+            &mut loaded.heap_cursor,
+            loaded.heap_limit,
+            &mut loaded.handles,
+            &ppc_default_color_table_bytes(1).unwrap(),
+        );
+        assert_ne!(private_ctable_handle, 0);
+        let scratch = PPC_DATA_BASE + 0xb200;
+        let port = scratch;
+        let pixmap_handle = scratch + 0x100;
+        let pixmap = scratch + 0x110;
+        loaded.memory.add_region(scratch, vec![0; 0x160]);
+        loaded.memory.write_u32_be(pixmap_handle, pixmap).unwrap();
+        ppc_write_pixmap(
+            &mut loaded.memory,
+            pixmap,
+            PPC_MAIN_SCREEN_BASE,
+            ppc_main_screen_row_bytes(),
+            0,
+            0,
+            PPC_MAIN_SCREEN_HEIGHT as i16,
+            PPC_MAIN_SCREEN_WIDTH as i16,
+            8,
+        )
+        .unwrap();
+        loaded
+            .memory
+            .write_u32_be(pixmap + 42, private_ctable_handle)
+            .unwrap();
+        ppc_write_gworld_port(
+            &mut loaded.memory,
+            port,
+            pixmap_handle,
+            0,
+            0,
+            PPC_MAIN_SCREEN_HEIGHT as i16,
+            PPC_MAIN_SCREEN_WIDTH as i16,
+        )
+        .unwrap();
+        loaded.gworlds.push(PpcGWorldRecord {
+            port,
+            pixmap_handle,
+            pixmap,
+            base_addr: PPC_MAIN_SCREEN_BASE,
+            gdevice: PPC_MAIN_GDEVICE,
+            width: PPC_MAIN_SCREEN_WIDTH,
+            height: PPC_MAIN_SCREEN_HEIGHT,
+            depth: 8,
+            row_bytes: ppc_main_screen_row_bytes(),
+            pixels_locked: false,
+            pixels_no_purge: false,
+        });
+        loaded
+            .memory
+            .write_bytes(
+                PPC_MAIN_SCREEN_BASE,
+                &vec![0x5a; ppc_main_screen_buffer_size() as usize],
+            )
+            .unwrap();
+
+        let before_heap_cursor = loaded.heap_cursor;
+        let before_handles = loaded.handles.clone();
+        let before_gworlds = loaded.gworlds.clone();
+        let before_main_pixmap =
+            ppc_memory_read_bytes(&mut loaded.memory, PPC_MAIN_PIXMAP, PPC_PIXMAP_SIZE).unwrap();
+        let before_private_pixmap =
+            ppc_memory_read_bytes(&mut loaded.memory, pixmap, PPC_PIXMAP_SIZE).unwrap();
+        let before_gdevice = ppc_memory_read_bytes(
+            &mut loaded.memory,
+            PPC_MAIN_GDEVICE_RECORD,
+            PPC_GDEVICE_SIZE,
+        )
+        .unwrap();
+        let before_main_ctable =
+            ppc_memory_read_bytes(&mut loaded.memory, PPC_MAIN_CTABLE, PPC_MAIN_CTABLE_SIZE)
+                .unwrap();
+        let private_ptr = loaded.memory.read_u32_be(private_ctable_handle).unwrap();
+        let before_private_ctable =
+            ppc_memory_read_bytes(&mut loaded.memory, private_ptr, 24).unwrap();
+        let before_framebuffer = ppc_memory_read_bytes(
+            &mut loaded.memory,
+            PPC_MAIN_SCREEN_BASE,
+            ppc_main_screen_buffer_size(),
+        )
+        .unwrap();
+        let before_startup = loaded.toolbox_startup.clone();
+        let before_screen_clut = loaded.screen_clut;
+        let before_color_manager_clut = loaded.color_manager_clut;
+        loaded.heap_limit = loaded.heap_cursor + 32;
+
+        loaded.cpu.gpr[3] = PPC_MAIN_GDEVICE;
+        loaded.cpu.gpr[4] = 4;
+        loaded.cpu.gpr[5] = 1;
+        loaded.cpu.gpr[6] = 1;
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::SetDepth);
+
+        assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_MEM_FULL_ERR));
+        assert_eq!(loaded.heap_cursor, before_heap_cursor);
+        assert_eq!(loaded.handles, before_handles);
+        assert_eq!(loaded.gworlds, before_gworlds);
+        assert_eq!(
+            ppc_memory_read_bytes(&mut loaded.memory, PPC_MAIN_PIXMAP, PPC_PIXMAP_SIZE),
+            Some(before_main_pixmap)
+        );
+        assert_eq!(
+            ppc_memory_read_bytes(&mut loaded.memory, pixmap, PPC_PIXMAP_SIZE),
+            Some(before_private_pixmap)
+        );
+        assert_eq!(
+            ppc_memory_read_bytes(
+                &mut loaded.memory,
+                PPC_MAIN_GDEVICE_RECORD,
+                PPC_GDEVICE_SIZE,
+            ),
+            Some(before_gdevice)
+        );
+        assert_eq!(
+            ppc_memory_read_bytes(&mut loaded.memory, PPC_MAIN_CTABLE, PPC_MAIN_CTABLE_SIZE),
+            Some(before_main_ctable)
+        );
+        assert_eq!(
+            ppc_memory_read_bytes(&mut loaded.memory, private_ptr, 24),
+            Some(before_private_ctable)
+        );
+        assert_eq!(
+            ppc_memory_read_bytes(
+                &mut loaded.memory,
+                PPC_MAIN_SCREEN_BASE,
+                ppc_main_screen_buffer_size(),
+            ),
+            Some(before_framebuffer)
+        );
+        assert_eq!(loaded.toolbox_startup, before_startup);
+        assert_eq!(loaded.screen_clut, before_screen_clut);
+        assert_eq!(loaded.color_manager_clut, before_color_manager_clut);
+    }
+
+    #[test]
+    fn hle_import_runner_set_depth_rejects_undersized_untracked_ctable_without_overwrite() {
+        let pef = synthetic_pef_with_import(b"SetDepth");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let scratch = PPC_DATA_BASE + 0xb600;
+        let private_ctable_handle = scratch;
+        let private_ctable = scratch + 0x20;
+        let private_ctable_bytes = ppc_default_color_table_bytes(1).unwrap();
+        let canary = private_ctable + private_ctable_bytes.len() as u32;
+        let port = scratch + 0x200;
+        let pixmap_handle = scratch + 0x300;
+        let pixmap = scratch + 0x310;
+        loaded.memory.add_region(scratch, vec![0; 0x380]);
+        loaded
+            .memory
+            .write_u32_be(private_ctable_handle, private_ctable)
+            .unwrap();
+        loaded
+            .memory
+            .write_bytes(private_ctable, &private_ctable_bytes)
+            .unwrap();
+        loaded.memory.write_bytes(canary, &[0xa5; 64]).unwrap();
+        loaded.memory.write_u32_be(pixmap_handle, pixmap).unwrap();
+        ppc_write_pixmap(
+            &mut loaded.memory,
+            pixmap,
+            PPC_MAIN_SCREEN_BASE,
+            ppc_main_screen_row_bytes(),
+            0,
+            0,
+            PPC_MAIN_SCREEN_HEIGHT as i16,
+            PPC_MAIN_SCREEN_WIDTH as i16,
+            8,
+        )
+        .unwrap();
+        loaded
+            .memory
+            .write_u32_be(pixmap + 42, private_ctable_handle)
+            .unwrap();
+        ppc_write_gworld_port(
+            &mut loaded.memory,
+            port,
+            pixmap_handle,
+            0,
+            0,
+            PPC_MAIN_SCREEN_HEIGHT as i16,
+            PPC_MAIN_SCREEN_WIDTH as i16,
+        )
+        .unwrap();
+        loaded.gworlds.push(PpcGWorldRecord {
+            port,
+            pixmap_handle,
+            pixmap,
+            base_addr: PPC_MAIN_SCREEN_BASE,
+            gdevice: PPC_MAIN_GDEVICE,
+            width: PPC_MAIN_SCREEN_WIDTH,
+            height: PPC_MAIN_SCREEN_HEIGHT,
+            depth: 8,
+            row_bytes: ppc_main_screen_row_bytes(),
+            pixels_locked: false,
+            pixels_no_purge: false,
+        });
+
+        let before_heap_cursor = loaded.heap_cursor;
+        let before_handles = loaded.handles.clone();
+        let before_gworlds = loaded.gworlds.clone();
+        let before_private_table = ppc_memory_read_bytes(
+            &mut loaded.memory,
+            private_ctable,
+            private_ctable_bytes.len() as u32,
+        )
+        .unwrap();
+        let before_canary = ppc_memory_read_bytes(&mut loaded.memory, canary, 64).unwrap();
+        let before_main_pixmap =
+            ppc_memory_read_bytes(&mut loaded.memory, PPC_MAIN_PIXMAP, PPC_PIXMAP_SIZE).unwrap();
+        let before_private_pixmap =
+            ppc_memory_read_bytes(&mut loaded.memory, pixmap, PPC_PIXMAP_SIZE).unwrap();
+        let before_gdevice = ppc_memory_read_bytes(
+            &mut loaded.memory,
+            PPC_MAIN_GDEVICE_RECORD,
+            PPC_GDEVICE_SIZE,
+        )
+        .unwrap();
+
+        loaded.cpu.gpr[3] = PPC_MAIN_GDEVICE;
+        loaded.cpu.gpr[4] = 4;
+        loaded.cpu.gpr[5] = 1;
+        loaded.cpu.gpr[6] = 1;
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::SetDepth);
+
+        assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_PARAM_ERR));
+        assert_eq!(loaded.heap_cursor, before_heap_cursor);
+        assert_eq!(loaded.handles, before_handles);
+        assert_eq!(loaded.gworlds, before_gworlds);
+        assert_eq!(
+            ppc_memory_read_bytes(
+                &mut loaded.memory,
+                private_ctable,
+                private_ctable_bytes.len() as u32,
+            ),
+            Some(before_private_table)
+        );
+        assert_eq!(
+            ppc_memory_read_bytes(&mut loaded.memory, canary, 64),
+            Some(before_canary)
+        );
+        assert_eq!(
+            ppc_memory_read_bytes(&mut loaded.memory, PPC_MAIN_PIXMAP, PPC_PIXMAP_SIZE),
+            Some(before_main_pixmap)
+        );
+        assert_eq!(
+            ppc_memory_read_bytes(&mut loaded.memory, pixmap, PPC_PIXMAP_SIZE),
+            Some(before_private_pixmap)
+        );
+        assert_eq!(
+            ppc_memory_read_bytes(
+                &mut loaded.memory,
+                PPC_MAIN_GDEVICE_RECORD,
+                PPC_GDEVICE_SIZE,
+            ),
+            Some(before_gdevice)
+        );
+    }
+
+    #[test]
+    fn ppc_preflight_ctable_growth_rejects_invalid_untracked_ctsize() {
+        for ct_size in [256, u16::MAX] {
+            let pef = synthetic_pef();
+            let mut loaded = load_pef_application(&pef).unwrap();
+            let scratch = PPC_DATA_BASE + 0xb800;
+            let ctable_handle = scratch;
+            let ctable = scratch + 0x20;
+            loaded.memory.add_region(scratch, vec![0; 0x1000]);
+            loaded.memory.write_u32_be(ctable_handle, ctable).unwrap();
+            loaded.memory.write_u16_be(ctable + 6, ct_size).unwrap();
+            let heap_cursor = loaded.heap_cursor;
+            let heap_limit = loaded.heap_limit;
+
+            assert_eq!(
+                ppc_preflight_ctable_growth(
+                    &mut loaded.memory,
+                    &[],
+                    &[ctable_handle],
+                    PPC_MAIN_CTABLE_SIZE,
+                    heap_cursor,
+                    heap_limit,
+                ),
+                Err(PPC_PARAM_ERR),
+                "ctSize={ct_size:#06x}"
+            );
+        }
+    }
+
+    #[test]
     fn hle_import_runner_set_depth_rejections_are_atomic() {
         let pef = synthetic_pef_with_import(b"SetDepth");
         let rejected = [
-            (PPC_MAIN_GDEVICE, 1, 0, 1),
-            (PPC_MAIN_GDEVICE, 2, 0, 1),
-            (PPC_MAIN_GDEVICE, 4, 0, 1),
+            (PPC_MAIN_GDEVICE, 1, 1, 1),
+            (PPC_MAIN_GDEVICE, 16, 1, 0),
             (PPC_MAIN_GDEVICE, 32, 0, 1),
             (PPC_MAIN_GDEVICE, 99, 0, 1),
-            (PPC_MAIN_GDEVICE, 8, 1, 0),
-            (PPC_MAIN_GDEVICE, 16, 1, 0),
+            (PPC_MAIN_GDEVICE, 8, 1 << 11, 0),
             (0x06ff_0000, 16, 0, 1),
         ];
 
@@ -127518,6 +132156,46 @@ mod tests {
     }
 
     #[test]
+    fn hle_import_runner_set_depth_cancels_tracking_only_after_success() {
+        let pef = synthetic_pef_with_import(b"SetDepth");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let tracking = PpcMenuTrackingState {
+            menu_handle: 0x1234,
+            title_left: 11,
+            popup_left: 11,
+            popup_top: 20,
+            popup_width: 32,
+            popup_height: 20,
+            saved_width: 33,
+            saved_height: 21,
+            front_buffer: ppc_front_buffer_for_gworld(&loaded.gworlds, PPC_MAIN_GWORLD).unwrap(),
+            saved_pixels: vec![0; 33 * 21],
+        };
+        loaded.toolbox_startup.menu_tracking = Some(tracking.clone());
+        loaded.memory.write_u16_be(PPC_THE_MENU_ADDR, 128).unwrap();
+
+        loaded.cpu.gpr[3] = PPC_MAIN_GDEVICE;
+        loaded.cpu.gpr[4] = 32;
+        loaded.cpu.gpr[5] = 0;
+        loaded.cpu.gpr[6] = 1;
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::SetDepth);
+
+        assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_PARAM_ERR));
+        assert_eq!(loaded.toolbox_startup.menu_tracking, Some(tracking));
+        assert_eq!(loaded.memory.read_u16_be(PPC_THE_MENU_ADDR), Some(128));
+
+        loaded.cpu.gpr[3] = PPC_MAIN_GDEVICE;
+        loaded.cpu.gpr[4] = 16;
+        loaded.cpu.gpr[5] = 0;
+        loaded.cpu.gpr[6] = 1;
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::SetDepth);
+
+        assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_NO_ERR));
+        assert_eq!(loaded.toolbox_startup.menu_tracking, None);
+        assert_eq!(loaded.memory.read_u16_be(PPC_THE_MENU_ADDR), Some(0));
+    }
+
+    #[test]
     fn hle_import_runner_set_depth_preserves_device_state_and_clear_bounds() {
         let pef = synthetic_pef_with_import(b"SetDepth");
         let mut loaded = load_pef_application(&pef).unwrap();
@@ -127583,7 +132261,7 @@ mod tests {
             ppc_memory_read_bytes(&mut loaded.memory, PPC_MAIN_CTABLE, PPC_MAIN_CTABLE_SIZE)
                 .unwrap();
 
-        for depth in [16, 8] {
+        for depth in [16, 8, 4, 2, 1] {
             let storage_size = ppc_main_screen_buffer_size() as usize;
             loaded
                 .memory
@@ -127592,7 +132270,7 @@ mod tests {
             loaded.cpu.gpr[3] = PPC_MAIN_GDEVICE;
             loaded.cpu.gpr[4] = depth;
             loaded.cpu.gpr[5] = 1;
-            loaded.cpu.gpr[6] = 1;
+            loaded.cpu.gpr[6] = u32::from(depth != 1);
             run_test_import(&mut loaded, PpcImportDispatcherTarget::SetDepth);
             assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_NO_ERR));
 
@@ -127626,12 +132304,12 @@ mod tests {
                     loaded.memory.read_u16_be(PPC_MAIN_PIXMAP + 36),
                     loaded.memory.read_u32_be(PPC_MAIN_PIXMAP + 42),
                 ),
-                if depth == 8 {
+                if depth <= 8 {
                     (
                         Some(0),
-                        Some(8),
+                        Some(depth as u16),
                         Some(1),
-                        Some(8),
+                        Some(depth as u16),
                         Some(PPC_MAIN_CTABLE_HANDLE),
                     )
                 } else {
@@ -127640,14 +132318,23 @@ mod tests {
             );
             assert_eq!(
                 loaded.memory.read_u16_be(gdevice + 4),
-                Some(if depth == 8 { 0 } else { 2 })
+                Some(if depth <= 8 { 0 } else { 2 })
             );
             assert_eq!(
                 loaded.memory.read_u16_be(gdevice + 20),
-                Some(custom_flags | 1)
+                Some(if depth == 1 {
+                    custom_flags & !1
+                } else {
+                    custom_flags | 1
+                })
             );
             assert_eq!(loaded.memory.read_u32_be(gdevice + 22), Some(gd_pmap));
-            assert_eq!(loaded.memory.read_u32_be(gdevice + 42), Some(depth));
+            assert_eq!(
+                loaded.memory.read_u32_be(gdevice + 42),
+                Some(u32::from(
+                    crate::display::classic_depth_mode(depth as u16).unwrap()
+                ))
+            );
             assert_eq!(loaded.memory.read_u16_be(gdevice), Some(0x1234));
             assert_eq!(loaded.memory.read_u16_be(gdevice + 2), Some(0x2345));
             assert_eq!(loaded.memory.read_u32_be(gdevice + 6), Some(0x3456_789a));
@@ -127668,10 +132355,21 @@ mod tests {
                 loaded.memory.read_u32_be(PPC_MAIN_CTABLE_HANDLE),
                 Some(ctable_handle_before)
             );
-            assert_eq!(
-                ppc_memory_read_bytes(&mut loaded.memory, PPC_MAIN_CTABLE, PPC_MAIN_CTABLE_SIZE,),
-                Some(ctable_before.clone())
-            );
+            if depth >= 8 {
+                assert_eq!(
+                    ppc_memory_read_bytes(
+                        &mut loaded.memory,
+                        PPC_MAIN_CTABLE,
+                        PPC_MAIN_CTABLE_SIZE,
+                    ),
+                    Some(ctable_before.clone())
+                );
+            } else {
+                assert_eq!(
+                    loaded.memory.read_u16_be(PPC_MAIN_CTABLE + 6),
+                    Some((1u16 << depth) - 1)
+                );
+            }
             assert_eq!(
                 ppc_memory_read_bytes(&mut loaded.memory, ctable_before_canary, 32),
                 Some(vec![0xb1; 32])
@@ -127816,11 +132514,11 @@ mod tests {
         let dsp_pixmap_before =
             ppc_memory_read_bytes(&mut loaded.memory, dsp_before.pixmap, PPC_PIXMAP_SIZE).unwrap();
 
-        for depth in [16, 8] {
+        for depth in [16, 8, 4, 2, 1] {
             loaded.cpu.gpr[3] = PPC_MAIN_GDEVICE;
             loaded.cpu.gpr[4] = depth;
             loaded.cpu.gpr[5] = 1;
-            loaded.cpu.gpr[6] = 1;
+            loaded.cpu.gpr[6] = u32::from(depth != 1);
             run_test_import(&mut loaded, PpcImportDispatcherTarget::SetDepth);
             assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_NO_ERR));
             let row_bytes = ppc_row_bytes(PPC_MAIN_SCREEN_WIDTH, depth).unwrap();
@@ -127872,13 +132570,13 @@ mod tests {
                         loaded.memory.read_u16_be(*live_pixmap + 36),
                         loaded.memory.read_u32_be(*live_pixmap + 42),
                     ),
-                    if depth == 8 {
+                    if depth <= 8 {
                         (
                             Some(0x8000 | row_bytes as u16),
                             Some(0),
-                            Some(8),
+                            Some(depth as u16),
                             Some(1),
-                            Some(8),
+                            Some(depth as u16),
                             Some(PPC_MAIN_CTABLE_HANDLE),
                         )
                     } else {
@@ -128114,11 +132812,11 @@ mod tests {
                 .unwrap()
         });
 
-        for depth in [16, 8] {
+        for depth in [16, 8, 4, 2, 1] {
             loaded.cpu.gpr[3] = PPC_MAIN_GDEVICE;
             loaded.cpu.gpr[4] = depth;
             loaded.cpu.gpr[5] = 1;
-            loaded.cpu.gpr[6] = 1;
+            loaded.cpu.gpr[6] = u32::from(depth != 1);
             run_test_import(&mut loaded, PpcImportDispatcherTarget::SetDepth);
             assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_NO_ERR));
             let row_bytes = ppc_row_bytes(PPC_MAIN_SCREEN_WIDTH, depth).unwrap();
@@ -128147,13 +132845,13 @@ mod tests {
                     loaded.memory.read_u16_be(live_pixmap + 36),
                     loaded.memory.read_u32_be(live_pixmap + 42),
                 ),
-                if depth == 8 {
+                if depth <= 8 {
                     (
                         Some(0x8000 | row_bytes as u16),
                         Some(0),
-                        Some(8),
+                        Some(depth as u16),
                         Some(1),
-                        Some(8),
+                        Some(depth as u16),
                         Some(private_ctable_handle),
                     )
                 } else {
@@ -128175,10 +132873,17 @@ mod tests {
                 loaded.memory.read_u32_be(private_ctable_handle),
                 Some(private_handle_before)
             );
-            assert_eq!(
-                ppc_memory_read_bytes(&mut loaded.memory, private_ctable, PPC_MAIN_CTABLE_SIZE,),
-                Some(private_table_before.clone())
-            );
+            if depth >= 8 {
+                assert_eq!(
+                    ppc_memory_read_bytes(&mut loaded.memory, private_ctable, PPC_MAIN_CTABLE_SIZE,),
+                    Some(private_table_before.clone())
+                );
+            } else {
+                assert_eq!(
+                    loaded.memory.read_u16_be(private_ctable + 6),
+                    Some((1u16 << depth) - 1)
+                );
+            }
             for (pixmap, pixmap_bytes, pixels, pixel_bytes) in &owned_before {
                 assert_eq!(
                     ppc_memory_read_bytes(&mut loaded.memory, *pixmap, PPC_PIXMAP_SIZE),
@@ -128191,6 +132896,20 @@ mod tests {
             }
         }
 
+        loaded
+            .memory
+            .write_bytes(private_ctable, &private_table_before)
+            .unwrap();
+        loaded.cpu.gpr[3] = PPC_MAIN_GDEVICE;
+        loaded.cpu.gpr[4] = 8;
+        loaded.cpu.gpr[5] = 1;
+        loaded.cpu.gpr[6] = 1;
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::SetDepth);
+        assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_NO_ERR));
+        loaded
+            .memory
+            .write_bytes(private_ctable, &private_table_before)
+            .unwrap();
         assert_eq!(
             loaded
                 .toolbox_startup
@@ -132854,24 +137573,62 @@ mod tests {
     }
 
     #[test]
-    fn load_pef_application_configures_a_16_bit_main_display() {
+    fn load_pef_application_configures_every_supported_main_display_depth() {
         let pef = synthetic_pef();
-        let mut loaded = load_pef_application_with_config(
-            &pef,
-            PpcLoadConfig {
-                screen_depth: 16,
-                ..PpcLoadConfig::default()
-            },
-        )
-        .unwrap();
+        for depth in [1, 2, 4, 8, 16] {
+            let mut loaded = load_pef_application_with_config(
+                &pef,
+                PpcLoadConfig {
+                    screen_depth: depth,
+                    ..PpcLoadConfig::default()
+                },
+            )
+            .unwrap();
+            let row_bytes = ppc_row_bytes(PPC_MAIN_SCREEN_WIDTH, depth).unwrap();
 
-        assert_eq!(loaded.gworlds[0].depth, 16);
-        assert_eq!(loaded.gworlds[0].row_bytes, PPC_MAIN_SCREEN_WIDTH * 2 + 16);
-        assert_eq!(loaded.current_front_buffer().unwrap().depth, 16);
-        assert_eq!(loaded.memory.read_u16_be(PPC_MAIN_PIXMAP + 32), Some(16));
-        assert_eq!(loaded.memory.read_u32_be(PPC_MAIN_PIXMAP + 42), Some(0));
-        assert_eq!(loaded.cpu.gpr[3], 0);
-        assert_eq!(loaded.cpu.gpr[4], 0);
+            assert_eq!(loaded.gworlds[0].depth, depth);
+            assert_eq!(loaded.gworlds[0].row_bytes, row_bytes);
+            assert_eq!(loaded.current_front_buffer().unwrap().depth, depth);
+            assert_eq!(loaded.current_front_buffer().unwrap().row_bytes, row_bytes);
+            assert_eq!(
+                loaded.memory.read_u16_be(PPC_MAIN_PIXMAP + 4),
+                Some(0x8000 | row_bytes as u16)
+            );
+            assert_eq!(
+                loaded.memory.read_u16_be(PPC_MAIN_PIXMAP + 32),
+                Some(depth as u16)
+            );
+            assert_eq!(
+                loaded.memory.read_u32_be(PPC_MAIN_PIXMAP + 42),
+                Some(if depth <= 8 {
+                    PPC_MAIN_CTABLE_HANDLE
+                } else {
+                    0
+                })
+            );
+            assert_eq!(
+                loaded.memory.read_u16_be(PPC_MAIN_GDEVICE_RECORD + 4),
+                Some(if depth <= 8 { 0 } else { 2 })
+            );
+            assert_eq!(
+                loaded.memory.read_u32_be(PPC_MAIN_GDEVICE_RECORD + 42),
+                Some(u32::from(
+                    crate::display::classic_depth_mode(depth as u16).unwrap()
+                )),
+                "gdMode for depth {depth}"
+            );
+            assert_eq!(
+                loaded
+                    .memory
+                    .read_u16_be(PPC_MAIN_GDEVICE_RECORD + 20)
+                    .unwrap()
+                    & 1
+                    != 0,
+                depth != 1
+            );
+            assert_eq!(loaded.cpu.gpr[3], 0);
+            assert_eq!(loaded.cpu.gpr[4], 0);
+        }
     }
 
     #[test]
@@ -132887,6 +137644,355 @@ mod tests {
         .unwrap_err();
 
         assert_eq!(error, PpcLoadError::ScreenDepthOutOfRange { requested: 32 });
+    }
+
+    #[test]
+    fn display_manager_get_and_mode_list_follow_every_live_screen_depth() {
+        for depth in [1, 2, 4, 8, 16] {
+            let get_pef = synthetic_pef_with_import(b"DMGetDisplayMode");
+            let mut loaded = load_pef_application_with_config(
+                &get_pef,
+                PpcLoadConfig {
+                    screen_depth: depth,
+                    ..PpcLoadConfig::default()
+                },
+            )
+            .unwrap();
+            let switch_info = PPC_DATA_BASE + 0x1000;
+            loaded.memory.add_region(switch_info, vec![0xa5; 16]);
+            loaded.cpu.gpr[3] = PPC_MAIN_GDEVICE;
+            loaded.cpu.gpr[4] = switch_info;
+
+            let probe = loaded.run_with_hle_imports(64);
+
+            assert_eq!(probe.handled_import_count, 1, "depth {depth}");
+            assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_NO_ERR));
+            let depth_mode = loaded
+                .memory
+                .read_u32_be(PPC_MAIN_GDEVICE_RECORD + 42)
+                .unwrap();
+            assert_eq!(
+                loaded.memory.read_u16_be(switch_info),
+                Some(depth_mode as u16),
+                "depth {depth}"
+            );
+            assert_eq!(
+                loaded.memory.read_u32_be(switch_info + 2),
+                Some(PPC_DM_CURRENT_DISPLAY_MODE_ID)
+            );
+            assert_eq!(
+                loaded.memory.read_u32_be(switch_info + 8),
+                loaded.memory.read_u32_be(PPC_MAIN_PIXMAP)
+            );
+
+            let list_pef = synthetic_pef_with_import(b"DMNewDisplayModeList");
+            let mut loaded = load_pef_application_with_config(
+                &list_pef,
+                PpcLoadConfig {
+                    screen_depth: depth,
+                    ..PpcLoadConfig::default()
+                },
+            )
+            .unwrap();
+            let outputs = PPC_DATA_BASE + 0x1200;
+            loaded.memory.add_region(outputs, vec![0; 8]);
+            loaded.cpu.gpr[3] = PPC_DSP_DISPLAY_ID;
+            loaded.cpu.gpr[4] = 0;
+            loaded.cpu.gpr[5] = 0;
+            loaded.cpu.gpr[6] = outputs;
+            loaded.cpu.gpr[7] = outputs + 4;
+
+            let probe = loaded.run_with_hle_imports(64);
+
+            assert_eq!(probe.handled_import_count, 1, "depth {depth}");
+            assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_NO_ERR));
+            assert_eq!(loaded.memory.read_u32_be(outputs), Some(1));
+            let list = loaded.memory.read_u32_be(outputs + 4).unwrap();
+            assert_eq!(
+                loaded.memory.read_u32_be(list),
+                Some(PPC_DM_MODE_LIST_MAGIC)
+            );
+            let mode = ppc_dm_live_display_mode(&mut loaded.memory, PPC_MAIN_GDEVICE).unwrap();
+            let listed_switch = list + PPC_DM_MODE_LIST_SWITCH_INFO_OFFSET;
+            let resolution = list + PPC_DM_MODE_LIST_RESOLUTION_INFO_OFFSET;
+            let timing = list + PPC_DM_MODE_LIST_TIMING_INFO_OFFSET;
+            let vp_block = list + PPC_DM_MODE_LIST_VP_BLOCK_OFFSET;
+            assert_eq!(
+                loaded.memory.read_u16_be(listed_switch),
+                Some(mode.depth_mode as u16)
+            );
+            assert_eq!(
+                loaded.memory.read_u32_be(listed_switch + 2),
+                Some(mode.display_mode_id)
+            );
+            assert_eq!(
+                loaded.memory.read_u32_be(listed_switch + 8),
+                Some(mode.base_addr)
+            );
+            assert_eq!(loaded.memory.read_u32_be(resolution + 8), Some(mode.width));
+            assert_eq!(
+                loaded.memory.read_u32_be(resolution + 12),
+                Some(mode.height)
+            );
+            assert_eq!(
+                loaded.memory.read_u32_be(resolution + 20),
+                Some(mode.depth_mode)
+            );
+            assert_eq!(
+                loaded.memory.read_u32_be(timing),
+                Some(mode.display_mode_id)
+            );
+            assert_eq!(
+                loaded.memory.read_u16_be(vp_block + 4),
+                Some(mode.row_bytes)
+            );
+            assert_eq!(
+                ppc_read_rect(&mut loaded.memory, vp_block + 6),
+                Some(mode.bounds)
+            );
+            assert_eq!(loaded.memory.read_u16_be(vp_block + 14), Some(0));
+            assert_eq!(loaded.memory.read_u16_be(vp_block + 16), Some(0));
+            assert_eq!(loaded.memory.read_u32_be(vp_block + 18), Some(0));
+            assert_eq!(loaded.memory.read_u32_be(vp_block + 22), Some(72 << 16));
+            assert_eq!(loaded.memory.read_u32_be(vp_block + 26), Some(72 << 16));
+            assert_eq!(
+                loaded.memory.read_u16_be(vp_block + 30),
+                Some(mode.pixel_type)
+            );
+            assert_eq!(
+                loaded.memory.read_u16_be(vp_block + 32),
+                Some(mode.pixel_size)
+            );
+            assert_eq!(
+                loaded.memory.read_u16_be(vp_block + 34),
+                Some(mode.component_count)
+            );
+            assert_eq!(
+                loaded.memory.read_u16_be(vp_block + 36),
+                Some(mode.component_size)
+            );
+        }
+    }
+
+    #[test]
+    fn display_manager_check_accepts_only_the_live_timing_and_depth_mode() {
+        let pef = synthetic_pef_with_import(b"DMCheckDisplayMode");
+        let mut loaded = load_pef_application_with_config(
+            &pef,
+            PpcLoadConfig {
+                screen_depth: 4,
+                ..PpcLoadConfig::default()
+            },
+        )
+        .unwrap();
+        let outputs = PPC_DATA_BASE + 0x1000;
+        loaded.memory.add_region(outputs, vec![0xa5; 8]);
+        let depth_mode = loaded
+            .memory
+            .read_u32_be(PPC_MAIN_GDEVICE_RECORD + 42)
+            .unwrap();
+        loaded.cpu.gpr[3] = PPC_MAIN_GDEVICE;
+        loaded.cpu.gpr[4] = PPC_DM_CURRENT_DISPLAY_MODE_ID;
+        loaded.cpu.gpr[5] = depth_mode;
+        loaded.cpu.gpr[6] = outputs;
+        loaded.cpu.gpr[7] = 0;
+        loaded.cpu.gpr[8] = outputs + 4;
+
+        let probe = loaded.run_with_hle_imports(64);
+
+        assert_eq!(probe.handled_import_count, 1);
+        assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_NO_ERR));
+        assert_eq!(
+            loaded.memory.read_u32_be(outputs),
+            Some(PPC_DM_NO_SWITCH_CONFIRM_MASK)
+        );
+        assert_eq!(loaded.memory.read_u8(outputs + 4), Some(1));
+
+        loaded.cpu.pc = loaded.entry_pc;
+        loaded.cpu.lr = PPC_HALT_PC;
+        loaded.cpu.gpr[3] = PPC_MAIN_GDEVICE;
+        loaded.cpu.gpr[4] = PPC_DM_CURRENT_DISPLAY_MODE_ID + 1;
+        loaded.cpu.gpr[5] = depth_mode;
+        loaded.cpu.gpr[6] = outputs;
+        loaded.cpu.gpr[7] = 0;
+        loaded.cpu.gpr[8] = outputs + 4;
+
+        let probe = loaded.run_with_hle_imports(64);
+
+        assert_eq!(probe.handled_import_count, 1);
+        assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_NO_ERR));
+        assert_eq!(
+            loaded.memory.read_u32_be(outputs),
+            Some(PPC_DM_DEPTH_NOT_AVAILABLE_MASK)
+        );
+        assert_eq!(loaded.memory.read_u8(outputs + 4), Some(0));
+
+        loaded.cpu.pc = loaded.entry_pc;
+        loaded.cpu.lr = PPC_HALT_PC;
+        loaded.memory.write_u32_be(outputs, 0xa5a5_5a5a).unwrap();
+        loaded.memory.write_u8(outputs + 4, 0xc3).unwrap();
+        loaded.cpu.gpr[3] = PPC_MAIN_GDEVICE;
+        loaded.cpu.gpr[4] = PPC_DM_CURRENT_DISPLAY_MODE_ID;
+        loaded.cpu.gpr[5] = depth_mode;
+        loaded.cpu.gpr[6] = outputs;
+        loaded.cpu.gpr[7] = 1;
+        loaded.cpu.gpr[8] = outputs + 4;
+
+        let probe = loaded.run_with_hle_imports(64);
+
+        assert_eq!(probe.handled_import_count, 1);
+        assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_PARAM_ERR));
+        assert_eq!(loaded.memory.read_u32_be(outputs), Some(0xa5a5_5a5a));
+        assert_eq!(loaded.memory.read_u8(outputs + 4), Some(0xc3));
+    }
+
+    #[test]
+    fn display_manager_set_is_an_atomic_noop_outside_the_live_mode() {
+        let pef = synthetic_pef_with_import(b"DMSetDisplayMode");
+        let mut loaded = load_pef_application_with_config(
+            &pef,
+            PpcLoadConfig {
+                screen_depth: 2,
+                ..PpcLoadConfig::default()
+            },
+        )
+        .unwrap();
+        let depth_mode_ptr = PPC_DATA_BASE + 0x1000;
+        loaded.memory.add_region(depth_mode_ptr, vec![0; 4]);
+        let depth_mode = loaded
+            .memory
+            .read_u32_be(PPC_MAIN_GDEVICE_RECORD + 42)
+            .unwrap();
+        loaded
+            .memory
+            .write_u32_be(depth_mode_ptr, depth_mode)
+            .unwrap();
+        let gdevice_before = ppc_memory_read_bytes(
+            &mut loaded.memory,
+            PPC_MAIN_GDEVICE_RECORD,
+            PPC_GDEVICE_SIZE,
+        )
+        .unwrap();
+        let pixmap_before =
+            ppc_memory_read_bytes(&mut loaded.memory, PPC_MAIN_PIXMAP, PPC_PIXMAP_SIZE).unwrap();
+        let screen_row_bytes =
+            u32::from(loaded.memory.read_u16_be(PPC_MAIN_PIXMAP + 4).unwrap() & 0x3fff);
+        let screen_before =
+            ppc_memory_read_bytes(&mut loaded.memory, PPC_MAIN_SCREEN_BASE, screen_row_bytes)
+                .unwrap();
+        loaded.cpu.gpr[3] = PPC_MAIN_GDEVICE;
+        loaded.cpu.gpr[4] = PPC_DM_CURRENT_DISPLAY_MODE_ID;
+        loaded.cpu.gpr[5] = depth_mode_ptr;
+        loaded.cpu.gpr[6] = 0;
+        loaded.cpu.gpr[7] = 0;
+
+        let probe = loaded.run_with_hle_imports(64);
+
+        assert_eq!(probe.handled_import_count, 1);
+        assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_NO_ERR));
+        assert_eq!(loaded.memory.read_u32_be(depth_mode_ptr), Some(depth_mode));
+
+        loaded.cpu.pc = loaded.entry_pc;
+        loaded.cpu.lr = PPC_HALT_PC;
+        loaded.cpu.gpr[3] = PPC_MAIN_GDEVICE;
+        loaded.cpu.gpr[4] = PPC_DM_CURRENT_DISPLAY_MODE_ID + 1;
+        loaded.cpu.gpr[5] = depth_mode_ptr;
+        loaded.cpu.gpr[6] = 0;
+        loaded.cpu.gpr[7] = 0;
+
+        let probe = loaded.run_with_hle_imports(64);
+
+        assert_eq!(probe.handled_import_count, 1);
+        assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_DM_MODE_NOT_FOUND_ERR));
+        assert_eq!(loaded.memory.read_u32_be(depth_mode_ptr), Some(depth_mode));
+        assert_eq!(
+            ppc_memory_read_bytes(
+                &mut loaded.memory,
+                PPC_MAIN_GDEVICE_RECORD,
+                PPC_GDEVICE_SIZE,
+            )
+            .unwrap(),
+            gdevice_before
+        );
+        assert_eq!(
+            ppc_memory_read_bytes(&mut loaded.memory, PPC_MAIN_PIXMAP, PPC_PIXMAP_SIZE).unwrap(),
+            pixmap_before
+        );
+        assert_eq!(
+            ppc_memory_read_bytes(&mut loaded.memory, PPC_MAIN_SCREEN_BASE, screen_row_bytes,)
+                .unwrap(),
+            screen_before
+        );
+
+        loaded.cpu.pc = loaded.entry_pc;
+        loaded.cpu.lr = PPC_HALT_PC;
+        loaded.memory.write_u32_be(depth_mode_ptr, 16).unwrap();
+        loaded.cpu.gpr[3] = PPC_MAIN_GDEVICE;
+        loaded.cpu.gpr[4] = PPC_DM_CURRENT_DISPLAY_MODE_ID;
+        loaded.cpu.gpr[5] = depth_mode_ptr;
+        loaded.cpu.gpr[6] = 0;
+        loaded.cpu.gpr[7] = 0;
+
+        let probe = loaded.run_with_hle_imports(64);
+
+        assert_eq!(probe.handled_import_count, 1);
+        assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_DM_MODE_NOT_FOUND_ERR));
+        assert_eq!(loaded.memory.read_u32_be(depth_mode_ptr), Some(16));
+        assert_eq!(
+            ppc_memory_read_bytes(
+                &mut loaded.memory,
+                PPC_MAIN_GDEVICE_RECORD,
+                PPC_GDEVICE_SIZE,
+            )
+            .unwrap(),
+            gdevice_before
+        );
+        assert_eq!(
+            ppc_memory_read_bytes(&mut loaded.memory, PPC_MAIN_PIXMAP, PPC_PIXMAP_SIZE).unwrap(),
+            pixmap_before
+        );
+        assert_eq!(
+            ppc_memory_read_bytes(&mut loaded.memory, PPC_MAIN_SCREEN_BASE, screen_row_bytes,)
+                .unwrap(),
+            screen_before
+        );
+
+        loaded
+            .memory
+            .write_u32_be(depth_mode_ptr, depth_mode)
+            .unwrap();
+        loaded.cpu.pc = loaded.entry_pc;
+        loaded.cpu.lr = PPC_HALT_PC;
+        loaded.cpu.gpr[3] = PPC_MAIN_GDEVICE;
+        loaded.cpu.gpr[4] = PPC_DM_CURRENT_DISPLAY_MODE_ID;
+        loaded.cpu.gpr[5] = depth_mode_ptr;
+        loaded.cpu.gpr[6] = PPC_DATA_BASE + 0x2000;
+        loaded.cpu.gpr[7] = 0;
+
+        let probe = loaded.run_with_hle_imports(64);
+
+        assert_eq!(probe.handled_import_count, 1);
+        assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_PARAM_ERR));
+        assert_eq!(loaded.memory.read_u32_be(depth_mode_ptr), Some(depth_mode));
+        assert_eq!(
+            ppc_memory_read_bytes(
+                &mut loaded.memory,
+                PPC_MAIN_GDEVICE_RECORD,
+                PPC_GDEVICE_SIZE,
+            )
+            .unwrap(),
+            gdevice_before,
+            "the scalar reserved parameter must not be dereferenced as VDSwitchInfo"
+        );
+        assert_eq!(
+            ppc_memory_read_bytes(&mut loaded.memory, PPC_MAIN_PIXMAP, PPC_PIXMAP_SIZE).unwrap(),
+            pixmap_before
+        );
+        assert_eq!(
+            ppc_memory_read_bytes(&mut loaded.memory, PPC_MAIN_SCREEN_BASE, screen_row_bytes,)
+                .unwrap(),
+            screen_before
+        );
     }
 
     fn synthetic_pef() -> Vec<u8> {

--- a/src/memory/bus.rs
+++ b/src/memory/bus.rs
@@ -951,10 +951,9 @@ impl MacMemoryBus {
     }
 
     pub(crate) fn configure_screen_depth(&mut self, depth: u16) {
-        debug_assert!(matches!(depth, 1 | 4 | 8));
+        debug_assert!(matches!(depth, 1 | 2 | 4 | 8));
         let profile = crate::machine_profile::reference_machine_profile();
-        let visible_row_bytes =
-            (u32::from(profile.screen_width) * u32::from(depth)).div_ceil(8);
+        let visible_row_bytes = (u32::from(profile.screen_width) * u32::from(depth)).div_ceil(8);
         let row_bytes = (visible_row_bytes / 16 + 1) * 16;
         self.write_word(super::globals::addr::SCREEN_ROW, row_bytes as u16);
         self.write_word(super::globals::addr::SCREEN_BITS + 4, row_bytes as u16);

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1667,8 +1667,10 @@ pub struct FixtureRunnerConfig {
     /// Use the full 32-bit guest address, or mask memory accesses to the low
     /// 24 bits as on classic Macs running in 24-bit addressing mode.
     pub addressing_32_bit: bool,
-    /// Guest-visible indexed screen depth. Supported values are 1, 4, and 8;
-    /// the default remains 8-bit/256-color mode.
+    /// Initial 68K main-framebuffer depth. Supported values are 1, 2, 4, and
+    /// 8; the default remains 8-bit/256-color mode. Native PowerPC launches
+    /// retain their architecture default unless
+    /// [`FixtureRunner::set_powerpc_screen_depth`] is called explicitly.
     pub screen_depth: u16,
 }
 
@@ -1700,12 +1702,13 @@ struct PpcDecodedDoubleBuffer {
 }
 
 impl FixtureRunnerConfig {
-    /// Validate and select one of the indexed display depths supported by the
-    /// main framebuffer.
+    /// Validate and select the initial 68K indexed main-framebuffer depth.
+    /// Use [`FixtureRunner::set_powerpc_screen_depth`] for an explicit native
+    /// PowerPC launch depth.
     pub fn with_screen_depth(mut self, screen_depth: u16) -> std::result::Result<Self, String> {
-        if !matches!(screen_depth, 1 | 4 | 8) {
+        if !matches!(screen_depth, 1 | 2 | 4 | 8) {
             return Err(format!(
-                "unsupported screen depth {screen_depth}; expected 1, 4, or 8"
+                "unsupported screen depth {screen_depth}; expected 1, 2, 4, or 8"
             ));
         }
         self.screen_depth = screen_depth;
@@ -1748,6 +1751,15 @@ pub struct FixtureRunner {
     bus: MacMemoryBus,
     dispatcher: TrapDispatcher,
     config: FixtureRunnerConfig,
+    /// Explicit display depth carried into native PowerPC launches. `None`
+    /// preserves the architecture defaults: 8bpp for 68K and 16bpp for PPC.
+    powerpc_screen_depth_override: Option<u16>,
+    /// Main host PixMap ColorTable retained while a direct-color PowerPC
+    /// framebuffer temporarily requires a NIL `pmTable`.
+    ppc_host_indexed_ctab_handle: u32,
+    /// Owned host-side framebuffer mirror reused across PowerPC depth changes.
+    ppc_host_mirror_base: u32,
+    ppc_host_mirror_capacity: u32,
     prefer_powerpc_executables: bool,
     trace_buffer: std::collections::VecDeque<(u32, u16, u32, u32, u32, u32)>, // (PC, Op, A0, SP, A6, A5)
     /// Set to true when the application calls ExitToShell
@@ -1939,8 +1951,8 @@ impl FixtureRunner {
             ram_size.min(0x0100_0000)
         };
         assert!(
-            matches!(config.screen_depth, 1 | 4 | 8),
-            "screen_depth must be 1, 4, or 8"
+            matches!(config.screen_depth, 1 | 2 | 4 | 8),
+            "screen_depth must be 1, 2, 4, or 8"
         );
         let mut dispatcher = TrapDispatcher::new();
         dispatcher.set_menu_bar_policy(config.menu_bar_policy);
@@ -1978,6 +1990,10 @@ impl FixtureRunner {
             bus,
             dispatcher,
             config,
+            powerpc_screen_depth_override: None,
+            ppc_host_indexed_ctab_handle: 0,
+            ppc_host_mirror_base: 0,
+            ppc_host_mirror_capacity: 0,
             prefer_powerpc_executables: false,
             trace_buffer: std::collections::VecDeque::with_capacity(2000),
             halted: false,
@@ -2640,6 +2656,39 @@ impl FixtureRunner {
         self.config.arrows_as_numpad
     }
 
+    /// Return the configured initial 68K indexed main-framebuffer depth.
+    /// This does not report an explicit or default native PowerPC depth.
+    pub fn configured_screen_depth(&self) -> u16 {
+        self.config.screen_depth
+    }
+
+    /// Explicitly select the display depth used by subsequently loaded native
+    /// PowerPC applications. Leaving this unset preserves the historical
+    /// 16-bit PowerPC architecture default, independently of the configured
+    /// 68K framebuffer depth.
+    pub fn set_powerpc_screen_depth(
+        &mut self,
+        screen_depth: u16,
+    ) -> std::result::Result<(), String> {
+        if !matches!(screen_depth, 1 | 2 | 4 | 8 | 16) {
+            return Err(format!(
+                "unsupported PowerPC screen depth {screen_depth}; expected 1, 2, 4, 8, or 16"
+            ));
+        }
+        self.powerpc_screen_depth_override = Some(screen_depth);
+        Ok(())
+    }
+
+    /// Return the screen depth to use when the selected executable is native
+    /// PowerPC. The architecture default is 16bpp; only an explicit call to
+    /// [`FixtureRunner::set_powerpc_screen_depth`] overrides it.
+    pub(crate) fn configured_powerpc_screen_depth(&self) -> u32 {
+        u32::from(
+            self.powerpc_screen_depth_override
+                .unwrap_or(DEFAULT_POWERPC_SCREEN_DEPTH as u16),
+        )
+    }
+
     /// Move the mouse without changing the button state. Updates the
     /// dispatcher's tracked position and the six mouse-position
     /// low-memory globals (MTemp / RawMouse / Mouse) so guest code that
@@ -3236,6 +3285,8 @@ impl FixtureRunner {
         let launch_rnd_seed_override = self.launch_rnd_seed_override;
         let launch_ppc_time_base_override = self.launch_ppc_time_base_override;
         let application_partition_size = self.application_partition_size;
+        let powerpc_screen_depth_override = self.powerpc_screen_depth_override;
+        let ppc_host_mirror_capacity = self.ppc_host_mirror_capacity;
         let total_instructions = self.total_instructions;
         let launch_tick = self.guest_tick();
         let launch_time = self.bus.read_long(addr::TIME);
@@ -3270,6 +3321,7 @@ impl FixtureRunner {
         replacement.launch_rnd_seed_override = launch_rnd_seed_override;
         replacement.launch_ppc_time_base_override = launch_ppc_time_base_override;
         replacement.application_partition_size = application_partition_size;
+        replacement.powerpc_screen_depth_override = powerpc_screen_depth_override;
         replacement.total_instructions = total_instructions;
 
         replacement.dispatcher.output_dir = output_dir;
@@ -3292,6 +3344,14 @@ impl FixtureRunner {
             .load_app(&fork)
             .ok_or_else(|| format!("failed to load launched application {normalized:?}"))?;
         replacement.init_app(&app);
+        if ppc_host_mirror_capacity != 0 {
+            let base = replacement.bus.alloc(ppc_host_mirror_capacity);
+            if base == 0 {
+                return Err("failed to preserve the PowerPC host framebuffer mirror".to_string());
+            }
+            replacement.ppc_host_mirror_base = base;
+            replacement.ppc_host_mirror_capacity = ppc_host_mirror_capacity;
+        }
         replacement.bus.write_long(addr::TICKS, launch_tick);
         replacement.bus.write_long(addr::TIME, launch_time);
         replacement.bus.write_long(addr::RND_SEED, launch_rnd_seed);
@@ -7713,18 +7773,14 @@ impl FixtureRunner {
         let Some(primary_buffer) = ppc_app.presented_front_buffer() else {
             return;
         };
-        if primary_buffer.depth == 8 {
+        if matches!(primary_buffer.depth, 1 | 2 | 4 | 8) {
             self.dispatcher.device_clut = ppc_app.screen_clut;
             self.dispatcher.color_manager_clut = ppc_app.color_manager_clut;
             self.dispatcher.device_gamma = ppc_app.device_gamma;
         }
         let (canvas_width, canvas_height) = Self::ppc_host_canvas_dimensions(primary_buffer);
-        let bytes_per_pixel = match primary_buffer.depth {
-            8 => 1,
-            16 => 2,
-            _ => return,
-        };
-        let Some(canvas_row_bytes) = canvas_width.checked_mul(bytes_per_pixel) else {
+        let Some(canvas_row_bytes) = Self::ppc_host_row_bytes(canvas_width, primary_buffer.depth)
+        else {
             return;
         };
         let canvas = PpcFrontBuffer {
@@ -7737,18 +7793,16 @@ impl FixtureRunner {
         let Some(host_base) = self.ensure_ppc_host_screen_mode(canvas) else {
             return;
         };
-        let matte_byte = if primary_buffer.depth == 8 {
-            ppc_app
-                .screen_clut
-                .iter()
-                .enumerate()
-                .min_by_key(|(_, color)| {
-                    u32::from(color[0]) + u32::from(color[1]) + u32::from(color[2])
-                })
-                .map_or(0, |(index, _)| index as u8)
-        } else {
-            0
-        };
+        if primary_buffer.depth <= 8
+            && !self.sync_ppc_host_indexed_color_table(
+                primary_buffer.depth as u16,
+                &ppc_app.screen_clut,
+            )
+        {
+            return;
+        }
+        let matte_byte =
+            Self::ppc_indexed_matte_byte(primary_buffer.depth, &ppc_app.screen_clut).unwrap_or(0);
         let Some(canvas_size) = canvas_row_bytes.checked_mul(canvas_height) else {
             return;
         };
@@ -7784,6 +7838,147 @@ impl FixtureRunner {
         }
     }
 
+    fn ppc_host_row_bytes(width: u32, depth: u32) -> Option<u32> {
+        if !matches!(depth, 1 | 2 | 4 | 8 | 16) {
+            return None;
+        }
+        width.checked_mul(depth)?.checked_add(7)?.checked_div(8)
+    }
+
+    fn sync_ppc_host_indexed_color_table(&mut self, depth: u16, clut: &[[u16; 3]; 256]) -> bool {
+        if !matches!(depth, 1 | 2 | 4 | 8) {
+            return false;
+        }
+        let gdevice_handle = self.dispatcher.ensure_main_gdevice(&mut self.bus);
+        let gdevice = self.bus.read_long(gdevice_handle);
+        if gdevice == 0 {
+            return false;
+        }
+        let pixmap_handle = self.bus.read_long(gdevice + 22);
+        if pixmap_handle == 0 {
+            return false;
+        }
+        let pixmap = self.bus.read_long(pixmap_handle);
+        if pixmap == 0 {
+            return false;
+        }
+        let color_table_handle = self.bus.read_long(pixmap + 42);
+        if color_table_handle == 0 {
+            return false;
+        }
+        let entry_count = 1u32 << depth;
+        let color_table = self.dispatcher.ensure_color_table_capacity(
+            &mut self.bus,
+            color_table_handle,
+            entry_count,
+        );
+        if color_table == 0 {
+            return false;
+        }
+        // An indexed screen PixMap's pmTable is the live mapping from pixel
+        // values to RGB colors. Imaging With QuickDraw (1994), pp. 4-10--4-11
+        // and 4-56--4-57.
+        self.bus.write_long(color_table, u32::from(depth));
+        self.bus.write_word(color_table + 4, 0x8000);
+        self.bus.write_word(color_table + 6, entry_count as u16 - 1);
+        for index in 0..entry_count {
+            let entry = color_table + 8 + index * 8;
+            let rgb = clut[index as usize];
+            self.bus.write_word(entry, 0);
+            self.bus.write_word(entry + 2, rgb[0]);
+            self.bus.write_word(entry + 4, rgb[1]);
+            self.bus.write_word(entry + 6, rgb[2]);
+        }
+        true
+    }
+
+    fn ppc_indexed_matte_byte(depth: u32, clut: &[[u16; 3]; 256]) -> Option<u8> {
+        if !matches!(depth, 1 | 2 | 4 | 8) {
+            return None;
+        }
+        let color_count = 1usize.checked_shl(depth)?;
+        let index = clut
+            .iter()
+            .take(color_count)
+            .enumerate()
+            .min_by_key(|(_, color)| {
+                u32::from(color[0]) + u32::from(color[1]) + u32::from(color[2])
+            })?
+            .0 as u8;
+        let field_mask = ((1u16 << depth) - 1) as u8;
+        let mut packed = 0u8;
+        for field in 0..(8 / depth) {
+            let shift = 8 - depth * (field + 1);
+            packed |= (index & field_mask) << shift;
+        }
+        Some(packed)
+    }
+
+    fn copy_ppc_packed_indexed_row(
+        source: &[u8],
+        depth: u32,
+        width: u32,
+        destination: &mut [u8],
+        destination_x: u32,
+    ) -> bool {
+        if !matches!(depth, 1 | 2 | 4) {
+            return false;
+        }
+        let Some(visible_bits) = width.checked_mul(depth) else {
+            return false;
+        };
+        let Some(source_bytes) = visible_bits.checked_add(7).map(|bits| bits / 8) else {
+            return false;
+        };
+        let Some(destination_start_bit) = destination_x.checked_mul(depth) else {
+            return false;
+        };
+        let Some(destination_end_bit) = destination_start_bit.checked_add(visible_bits) else {
+            return false;
+        };
+        if usize::try_from(source_bytes)
+            .ok()
+            .is_none_or(|bytes| bytes > source.len())
+            || usize::try_from(destination_end_bit.div_ceil(8))
+                .ok()
+                .is_none_or(|bytes| bytes > destination.len())
+        {
+            return false;
+        }
+
+        let mut first_scalar_pixel = 0u32;
+        if destination_start_bit & 7 == 0 {
+            let full_bytes = visible_bits / 8;
+            let Some(source_end) = usize::try_from(full_bytes).ok() else {
+                return false;
+            };
+            let Some(destination_start) = usize::try_from(destination_start_bit / 8).ok() else {
+                return false;
+            };
+            let Some(destination_end) = destination_start.checked_add(source_end) else {
+                return false;
+            };
+            destination[destination_start..destination_end].copy_from_slice(&source[..source_end]);
+            first_scalar_pixel = full_bytes * 8 / depth;
+        }
+
+        let field_mask = ((1u16 << depth) - 1) as u8;
+        for x in first_scalar_pixel..width {
+            let source_bit = x * depth;
+            let source_byte = source[(source_bit / 8) as usize];
+            let source_shift = 8 - depth - (source_bit & 7);
+            let pixel = (source_byte >> source_shift) & field_mask;
+
+            let destination_bit = destination_start_bit + x * depth;
+            let destination_byte = &mut destination[(destination_bit / 8) as usize];
+            let destination_shift = 8 - depth - (destination_bit & 7);
+            let mask = field_mask << destination_shift;
+            *destination_byte =
+                (*destination_byte & !mask) | ((pixel & field_mask) << destination_shift);
+        }
+        true
+    }
+
     fn copy_ppc_front_buffer_rows_to_host(
         bus: &mut MacMemoryBus,
         ppc_app: &mut PpcLoadedApp,
@@ -7793,21 +7988,31 @@ impl FixtureRunner {
         destination_x: u32,
         destination_y: u32,
     ) -> bool {
-        let bytes_per_pixel = match front_buffer.depth {
-            8 => 1,
-            16 => 2,
-            _ => return false,
-        };
-        let Some(destination_x_bytes) = destination_x.checked_mul(bytes_per_pixel) else {
-            return false;
-        };
         let Some(visible_row_bytes) = Self::ppc_front_buffer_visible_row_bytes(front_buffer) else {
             return false;
         };
-        if destination_x_bytes.saturating_add(visible_row_bytes) > host_row_bytes {
+        let Some(destination_end_bits) = destination_x
+            .checked_add(front_buffer.width)
+            .and_then(|pixels| pixels.checked_mul(front_buffer.depth))
+        else {
+            return false;
+        };
+        let Some(host_row_bits) = host_row_bytes.checked_mul(8) else {
+            return false;
+        };
+        if destination_end_bits > host_row_bits {
             return false;
         }
-        let mut row = vec![0u8; front_buffer.row_bytes as usize];
+        let Ok(source_row_len) = usize::try_from(front_buffer.row_bytes) else {
+            return false;
+        };
+        let Ok(visible_row_len) = usize::try_from(visible_row_bytes) else {
+            return false;
+        };
+        let Ok(host_row_len) = usize::try_from(host_row_bytes) else {
+            return false;
+        };
+        let mut row = vec![0u8; source_row_len];
         for y in 0..front_buffer.height {
             if ppc_app
                 .read_front_buffer_row(front_buffer, y, &mut row)
@@ -7816,7 +8021,7 @@ impl FixtureRunner {
                 return false;
             }
             Self::apply_ppc_draw_sprocket_gamma_fade(
-                &mut row[..visible_row_bytes as usize],
+                &mut row[..visible_row_len],
                 front_buffer.depth,
                 ppc_app.draw_sprocket.last_fade_percent,
                 ppc_app.draw_sprocket.last_fade_zero_color,
@@ -7824,21 +8029,42 @@ impl FixtureRunner {
             let Some(destination_row) = destination_y.checked_add(y) else {
                 return false;
             };
-            bus.write_bytes(
-                host_base + destination_row.saturating_mul(host_row_bytes) + destination_x_bytes,
-                &row[..visible_row_bytes as usize],
-            );
+            let Some(destination_row_addr) = destination_row
+                .checked_mul(host_row_bytes)
+                .and_then(|offset| host_base.checked_add(offset))
+            else {
+                return false;
+            };
+            if matches!(front_buffer.depth, 1 | 2 | 4) {
+                let mut packed_destination = bus.read_bytes(destination_row_addr, host_row_len);
+                if packed_destination.len() != host_row_len
+                    || !Self::copy_ppc_packed_indexed_row(
+                        &row[..visible_row_len],
+                        front_buffer.depth,
+                        front_buffer.width,
+                        &mut packed_destination,
+                        destination_x,
+                    )
+                {
+                    return false;
+                }
+                bus.write_bytes(destination_row_addr, &packed_destination);
+            } else {
+                let bytes_per_pixel = front_buffer.depth / 8;
+                let Some(destination_x_bytes) = destination_x.checked_mul(bytes_per_pixel) else {
+                    return false;
+                };
+                bus.write_bytes(
+                    destination_row_addr + destination_x_bytes,
+                    &row[..visible_row_len],
+                );
+            }
         }
         true
     }
 
     fn ppc_front_buffer_visible_row_bytes(front_buffer: PpcFrontBuffer) -> Option<u32> {
-        let bytes_per_pixel = match front_buffer.depth {
-            8 => 1,
-            16 => 2,
-            _ => return None,
-        };
-        let visible = front_buffer.width.checked_mul(bytes_per_pixel)?;
+        let visible = Self::ppc_host_row_bytes(front_buffer.width, front_buffer.depth)?;
         (visible <= front_buffer.row_bytes).then_some(visible)
     }
 
@@ -7915,19 +8141,42 @@ impl FixtureRunner {
             && base
                 .checked_add(bytes_needed)
                 .is_some_and(|end| end <= self.bus.ram_size());
+        let owned_base_valid = self.ppc_host_mirror_base != 0
+            && self.ppc_host_mirror_capacity >= bytes_needed
+            && self
+                .bus
+                .get_alloc_size(self.ppc_host_mirror_base)
+                .is_some_and(|size| size >= self.ppc_host_mirror_capacity)
+            && self
+                .ppc_host_mirror_base
+                .checked_add(bytes_needed)
+                .is_some_and(|end| end <= self.bus.ram_size());
         if base_valid
             && row_bytes == front_buffer.row_bytes
             && current_width == width
             && current_height == height
             && current_depth == depth
+            && (self.ppc_host_mirror_base == 0
+                || (owned_base_valid && base == self.ppc_host_mirror_base))
         {
             return Some(base);
         }
 
-        let base = self.bus.alloc(bytes_needed);
-        if base == 0 {
-            return None;
-        }
+        let base = if owned_base_valid {
+            self.ppc_host_mirror_base
+        } else {
+            let new_base = self.bus.alloc(bytes_needed);
+            if new_base == 0 {
+                return None;
+            }
+            let old_base = self.ppc_host_mirror_base;
+            self.ppc_host_mirror_base = new_base;
+            self.ppc_host_mirror_capacity = bytes_needed;
+            if old_base != 0 {
+                self.bus.free(old_base);
+            }
+            new_base
+        };
         self.dispatcher.screen_mode = (base, front_buffer.row_bytes, width, height, depth);
         self.write_ppc_host_screen_lowmem(base, front_buffer.row_bytes, width, height, depth);
         Some(base)
@@ -7944,6 +8193,7 @@ impl FixtureRunner {
         use crate::memory::globals::addr;
 
         self.bus.write_long(addr::SCRN_BASE, base);
+        self.bus.write_word(addr::SCREEN_ROW, row_bytes as u16);
         self.bus.write_long(addr::SCREEN_BITS, base);
         self.bus.write_word(addr::SCREEN_BITS + 4, row_bytes as u16);
         self.bus.write_word(addr::SCREEN_BITS + 6, 0);
@@ -7964,18 +8214,49 @@ impl FixtureRunner {
         if pixmap == 0 {
             return;
         }
+        let current_ctab_handle = self.bus.read_long(pixmap + 42);
+        if current_ctab_handle != 0 {
+            self.ppc_host_indexed_ctab_handle = current_ctab_handle;
+        }
+        let ctab_handle = if depth <= 8 {
+            self.ppc_host_indexed_ctab_handle
+        } else {
+            0
+        };
         self.bus.write_long(pixmap, base);
         self.bus.write_word(pixmap + 4, (row_bytes as u16) | 0x8000);
         self.bus.write_word(pixmap + 6, 0);
         self.bus.write_word(pixmap + 8, 0);
         self.bus.write_word(pixmap + 10, height);
         self.bus.write_word(pixmap + 12, width);
+        // Indexed PixMaps use one component whose size equals pixelSize;
+        // 16bpp direct PixMaps use three 5-bit RGB components. Imaging With
+        // QuickDraw (1994), pp. 4-10--4-11.
+        let (pixel_type, component_count, component_size, gdevice_type) = if depth <= 8 {
+            (0, 1, depth, 0)
+        } else {
+            (16, 3, 5, 2)
+        };
+        self.bus.write_word(pixmap + 30, pixel_type);
         self.bus.write_word(pixmap + 32, depth);
-        self.bus.write_word(pixmap + 36, depth);
+        self.bus.write_word(pixmap + 34, component_count);
+        self.bus.write_word(pixmap + 36, component_size);
+        self.bus.write_long(pixmap + 42, ctab_handle);
+        self.bus.write_word(gdevice + 4, gdevice_type);
+        let mut gdevice_flags = self.bus.read_word(gdevice + 20);
+        if depth == 1 {
+            gdevice_flags &= !1;
+        } else {
+            gdevice_flags |= 1;
+        }
+        self.bus.write_word(gdevice + 20, gdevice_flags);
         self.bus.write_word(gdevice + 34, 0);
         self.bus.write_word(gdevice + 36, 0);
         self.bus.write_word(gdevice + 38, height);
         self.bus.write_word(gdevice + 40, width);
+        let depth_mode = crate::display::classic_depth_mode(depth)
+            .expect("validated PPC host depth has a classic Video.h mode");
+        self.bus.write_long(gdevice + 42, u32::from(depth_mode));
     }
 
     fn advance_ticks_for_ppc_cycles(&mut self, cycles: u64, tick_cap: Option<u32>) -> bool {
@@ -10790,7 +11071,7 @@ mod tests {
         assert_eq!(runner.bus.read_word(pixmap + 32), 4);
         assert_eq!(runner.bus.read_word(pixmap + 36), 4);
         assert_eq!(runner.bus.read_word(ctab + 6), 15);
-        assert_eq!(runner.bus.read_long(gdevice + 42), 4);
+        assert_eq!(runner.bus.read_long(gdevice + 42), 0x0082);
         assert!(!runner.bus.addressing_32_bit());
         assert_eq!(runner.dispatcher.mmu_mode, 0);
     }
@@ -10816,13 +11097,80 @@ mod tests {
         assert_eq!(runner.bus.read_word(pixmap + 32), 1);
         assert_eq!(runner.bus.read_word(pixmap + 36), 1);
         assert_eq!(runner.bus.read_word(ctab + 6), 1);
-        assert_eq!(runner.bus.read_long(gdevice + 42), 1);
+        assert_eq!(runner.bus.read_long(gdevice + 42), 0x0080);
+    }
+
+    #[test]
+    fn two_bit_runner_publishes_consistent_screen_metadata() {
+        use crate::memory::globals::addr;
+
+        let config = FixtureRunnerConfig::default()
+            .with_screen_depth(2)
+            .expect("2-bit indexed mode should be supported");
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, config);
+        let gdevice_handle = runner.dispatcher.ensure_main_gdevice(&mut runner.bus);
+        let gdevice = runner.bus.read_long(gdevice_handle);
+        let pixmap = runner.bus.read_long(runner.bus.read_long(gdevice + 22));
+        let ctab = runner.bus.read_long(runner.bus.read_long(pixmap + 42));
+
+        assert_eq!(runner.configured_screen_depth(), 2);
+        assert_eq!(runner.dispatcher.screen_mode.1, 208);
+        assert_eq!(runner.dispatcher.screen_mode.4, 2);
+        assert_eq!(runner.bus.read_word(addr::SCREEN_ROW), 208);
+        assert_eq!(runner.bus.read_word(addr::SCREEN_BITS + 4), 208);
+        assert_eq!(runner.bus.read_word(pixmap + 4), 0x8000 | 208);
+        assert_eq!(runner.bus.read_word(pixmap + 32), 2);
+        assert_eq!(runner.bus.read_word(pixmap + 36), 2);
+        assert_eq!(runner.bus.read_word(ctab + 6), 3);
+        assert_eq!(runner.bus.read_long(gdevice + 42), 0x0081);
     }
 
     #[test]
     fn runner_config_rejects_nonselectable_screen_depths() {
-        assert!(FixtureRunnerConfig::default().with_screen_depth(2).is_err());
+        assert!(FixtureRunnerConfig::default().with_screen_depth(3).is_err());
         assert!(FixtureRunnerConfig::default().with_screen_depth(5).is_err());
+    }
+
+    #[test]
+    fn runner_config_preserves_architecture_defaults_until_depth_is_explicit() {
+        let default_runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        assert_eq!(default_runner.configured_screen_depth(), 8);
+        assert_eq!(default_runner.configured_powerpc_screen_depth(), 16);
+
+        for depth in [1, 2, 4, 8] {
+            let config = FixtureRunnerConfig::default()
+                .with_screen_depth(depth)
+                .expect("indexed depth should be supported");
+            let mut runner = FixtureRunner::new(8 * 1024 * 1024, config);
+            assert_eq!(
+                runner.configured_powerpc_screen_depth(),
+                16,
+                "68K config depth {depth} must not become an implicit PPC override"
+            );
+            runner
+                .set_powerpc_screen_depth(depth)
+                .expect("PowerPC indexed depth should be supported");
+            assert_eq!(runner.configured_screen_depth(), depth);
+            assert_eq!(runner.configured_powerpc_screen_depth(), u32::from(depth));
+        }
+
+        let direct_nondefault = FixtureRunner::new(
+            8 * 1024 * 1024,
+            FixtureRunnerConfig {
+                screen_depth: 4,
+                ..FixtureRunnerConfig::default()
+            },
+        );
+        assert_eq!(direct_nondefault.configured_powerpc_screen_depth(), 16);
+
+        let mut explicit_eight =
+            FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        explicit_eight.set_powerpc_screen_depth(8).unwrap();
+        assert_eq!(explicit_eight.configured_powerpc_screen_depth(), 8);
+
+        let mut default_runner =
+            FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        assert!(default_runner.set_powerpc_screen_depth(3).is_err());
     }
 
     #[derive(Clone, Default)]
@@ -14946,10 +15294,18 @@ mod tests {
         );
         assert_eq!(runner.bus.read_word(main_pixmap + 10), height);
         assert_eq!(runner.bus.read_word(main_pixmap + 12), width);
+        assert_eq!(runner.bus.read_word(main_pixmap + 30), 16);
         assert_eq!(runner.bus.read_word(main_pixmap + 32), depth);
-        assert_eq!(runner.bus.read_word(main_pixmap + 36), depth);
+        assert_eq!(runner.bus.read_word(main_pixmap + 34), 3);
+        assert_eq!(runner.bus.read_word(main_pixmap + 36), 5);
+        assert_eq!(runner.bus.read_long(main_pixmap + 42), 0);
+        assert_eq!(runner.bus.read_word(main_gdevice + 4), 2);
         assert_eq!(runner.bus.read_word(main_gdevice + 38), height);
         assert_eq!(runner.bus.read_word(main_gdevice + 40), width);
+        assert_eq!(
+            runner.bus.read_long(main_gdevice + 42),
+            u32::from(crate::display::classic_depth_mode(depth).unwrap())
+        );
 
         let mut ppc_app = runner.ppc_app.take().expect("PPC app should stay loaded");
         ppc_app.draw_sprocket.last_fade_percent = Some(0);
@@ -15222,29 +15578,317 @@ mod tests {
 
     #[test]
     fn ppc_host_sync_excludes_scanline_padding_from_visible_rows() {
-        let indexed = PpcFrontBuffer {
-            base_addr: 0x1000,
-            row_bytes: 656,
-            width: 640,
-            height: 480,
-            depth: 8,
-        };
-        let direct = PpcFrontBuffer {
-            base_addr: 0x2000,
-            row_bytes: 1296,
-            width: 640,
-            height: 480,
-            depth: 16,
-        };
+        for (depth, padded_row_bytes, visible_row_bytes) in [
+            (1, 96, 80),
+            (2, 176, 160),
+            (4, 336, 320),
+            (8, 656, 640),
+            (16, 1296, 1280),
+        ] {
+            let front_buffer = PpcFrontBuffer {
+                base_addr: 0x1000,
+                row_bytes: padded_row_bytes,
+                width: 640,
+                height: 480,
+                depth,
+            };
+            assert_eq!(
+                FixtureRunner::ppc_front_buffer_visible_row_bytes(front_buffer),
+                Some(visible_row_bytes),
+                "{depth}bpp visible row"
+            );
+        }
+    }
 
+    #[test]
+    fn ppc_packed_indexed_row_copy_preserves_neighbors_at_non_byte_offsets() {
+        let mut one_bit = [0u8; 2];
+        assert!(FixtureRunner::copy_ppc_packed_indexed_row(
+            &[0b1010_0000],
+            1,
+            4,
+            &mut one_bit,
+            3,
+        ));
+        assert_eq!(one_bit, [0x14, 0x00]);
+
+        let mut two_bit = [0xffu8; 3];
+        assert!(FixtureRunner::copy_ppc_packed_indexed_row(
+            &[0b00_01_10_11, 0b01_00_00_00],
+            2,
+            5,
+            &mut two_bit,
+            1,
+        ));
+        assert_eq!(two_bit, [0xc6, 0xdf, 0xff]);
+
+        let mut four_bit = [0xaau8; 3];
+        assert!(FixtureRunner::copy_ppc_packed_indexed_row(
+            &[0x12, 0x30],
+            4,
+            3,
+            &mut four_bit,
+            1,
+        ));
+        assert_eq!(four_bit, [0xa1, 0x23, 0xaa]);
+    }
+
+    #[test]
+    fn ppc_indexed_matte_repeats_darkest_representable_clut_index() {
+        for depth in [1u16, 2, 4, 8] {
+            let (clut, _) =
+                TrapDispatcher::standard_mac_indexed_clut(depth).expect("standard indexed depth");
+            assert_eq!(
+                FixtureRunner::ppc_indexed_matte_byte(u32::from(depth), &clut),
+                Some(0xff),
+                "{depth}bpp standard black index"
+            );
+        }
+
+        let mut clut = [[0u16; 3]; 256];
+        clut[0] = [0xffff, 0xffff, 0xffff];
+        clut[1] = [0xaaaa, 0xaaaa, 0xaaaa];
+        clut[2] = [0x0000, 0x0000, 0x0000];
+        clut[3] = [0x5555, 0x5555, 0x5555];
+        assert_eq!(FixtureRunner::ppc_indexed_matte_byte(2, &clut), Some(0xaa));
+    }
+
+    #[test]
+    fn ppc_host_clut_sync_grows_a_lower_depth_main_color_table() {
+        let config = FixtureRunnerConfig::default()
+            .with_screen_depth(1)
+            .expect("1bpp mode");
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, config);
+        let gdevice_handle = runner.dispatcher.ensure_main_gdevice(&mut runner.bus);
+        let gdevice = runner.bus.read_long(gdevice_handle);
+        let pixmap = runner.bus.read_long(runner.bus.read_long(gdevice + 22));
+        let color_table_handle = runner.bus.read_long(pixmap + 42);
+        let old_color_table = runner.bus.read_long(color_table_handle);
+        let (mut clut, _) = TrapDispatcher::standard_mac_indexed_clut(4).expect("4bpp CLUT");
+        clut[7] = [0x1234, 0x5678, 0x9abc];
+
+        assert!(runner.sync_ppc_host_indexed_color_table(4, &clut));
+
+        let color_table = runner.bus.read_long(color_table_handle);
+        assert_ne!(color_table, old_color_table);
+        assert_eq!(runner.bus.get_alloc_size(old_color_table), None);
+        assert_eq!(runner.bus.get_alloc_size(color_table), Some(8 + 16 * 8));
+        assert_eq!(runner.bus.read_word(color_table + 6), 15);
         assert_eq!(
-            FixtureRunner::ppc_front_buffer_visible_row_bytes(indexed),
-            Some(640)
+            [
+                runner.bus.read_word(color_table + 8 + 7 * 8 + 2),
+                runner.bus.read_word(color_table + 8 + 7 * 8 + 4),
+                runner.bus.read_word(color_table + 8 + 7 * 8 + 6),
+            ],
+            clut[7]
         );
-        assert_eq!(
-            FixtureRunner::ppc_front_buffer_visible_row_bytes(direct),
-            Some(1280)
-        );
+    }
+
+    #[test]
+    fn ppc_host_sync_restores_indexed_pm_table_across_direct_color_transitions() {
+        const WIDTH: u32 = 8;
+        const HEIGHT: u32 = 1;
+
+        let mut app = halted_ppc_app_with_sound(PpcSoundState::default());
+        let ppc_app = app.ppc.as_mut().expect("PPC app");
+        ppc_app.memory.add_region(PPC_HEAP_BASE, vec![0; 16]);
+        ppc_app.heap_cursor = PPC_HEAP_BASE + 16;
+        ppc_app.gworlds.push(PpcGWorldRecord {
+            port: PPC_MAIN_GWORLD,
+            pixmap_handle: 0,
+            pixmap: 0,
+            base_addr: PPC_HEAP_BASE,
+            gdevice: PPC_MAIN_GDEVICE,
+            width: WIDTH,
+            height: HEIGHT,
+            depth: 16,
+            row_bytes: 16,
+            pixels_locked: false,
+            pixels_no_purge: false,
+        });
+
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        let gdevice_handle = runner.dispatcher.ensure_main_gdevice(&mut runner.bus);
+        let gdevice = runner.bus.read_long(gdevice_handle);
+        let pixmap = runner.bus.read_long(runner.bus.read_long(gdevice + 22));
+        let indexed_ctab_handle = runner.bus.read_long(pixmap + 42);
+        assert_ne!(indexed_ctab_handle, 0);
+
+        runner.sync_ppc_front_buffer_to_host(ppc_app);
+
+        assert_eq!(runner.bus.read_word(pixmap + 30), 16);
+        assert_eq!(runner.bus.read_word(pixmap + 32), 16);
+        assert_eq!(runner.bus.read_word(pixmap + 34), 3);
+        assert_eq!(runner.bus.read_word(pixmap + 36), 5);
+        assert_eq!(runner.bus.read_long(pixmap + 42), 0);
+        assert_eq!(runner.bus.read_long(gdevice + 42), 0x0084);
+        let host_mirror_base = runner.ppc_host_mirror_base;
+        let host_mirror_capacity = runner.ppc_host_mirror_capacity;
+        assert_eq!(runner.dispatcher.screen_mode.0, host_mirror_base);
+        assert_eq!(host_mirror_capacity, 16);
+        assert_eq!(runner.bus.get_alloc_size(host_mirror_base), Some(16));
+        let canary = runner.bus.alloc(8);
+        runner.bus.fill_bytes(canary, 8, 0x5a);
+
+        let (two_bit_clut, _) = TrapDispatcher::standard_mac_indexed_clut(2).expect("2bpp CLUT");
+        ppc_app.screen_clut = two_bit_clut;
+        ppc_app.color_manager_clut = two_bit_clut;
+        ppc_app.gworlds[0].depth = 2;
+        ppc_app.gworlds[0].row_bytes = 2;
+
+        runner.sync_ppc_front_buffer_to_host(ppc_app);
+
+        assert_eq!(runner.bus.read_word(pixmap + 30), 0);
+        assert_eq!(runner.bus.read_word(pixmap + 32), 2);
+        assert_eq!(runner.bus.read_word(pixmap + 34), 1);
+        assert_eq!(runner.bus.read_word(pixmap + 36), 2);
+        assert_eq!(runner.bus.read_long(pixmap + 42), indexed_ctab_handle);
+        let indexed_ctab = runner.bus.read_long(indexed_ctab_handle);
+        assert_ne!(indexed_ctab, 0);
+        assert_eq!(runner.bus.read_word(indexed_ctab + 6), 3);
+        assert_eq!(runner.bus.read_long(gdevice + 42), 0x0081);
+        let heap_after_first_transition = runner.bus.heap_bump_ptr();
+
+        for _ in 0..8 {
+            ppc_app.gworlds[0].depth = 16;
+            ppc_app.gworlds[0].row_bytes = 16;
+            runner.sync_ppc_front_buffer_to_host(ppc_app);
+            assert_eq!(runner.dispatcher.screen_mode.0, host_mirror_base);
+            assert_eq!(runner.ppc_host_mirror_base, host_mirror_base);
+            assert_eq!(runner.ppc_host_mirror_capacity, host_mirror_capacity);
+
+            ppc_app.gworlds[0].depth = 2;
+            ppc_app.gworlds[0].row_bytes = 2;
+            runner.sync_ppc_front_buffer_to_host(ppc_app);
+            assert_eq!(runner.dispatcher.screen_mode.0, host_mirror_base);
+            assert_eq!(runner.ppc_host_mirror_base, host_mirror_base);
+            assert_eq!(runner.ppc_host_mirror_capacity, host_mirror_capacity);
+        }
+
+        ppc_app.gworlds[0].depth = 16;
+        ppc_app.gworlds[0].row_bytes = 16;
+        runner.sync_ppc_front_buffer_to_host(ppc_app);
+
+        assert_eq!(runner.bus.read_word(pixmap + 30), 16);
+        assert_eq!(runner.bus.read_word(pixmap + 32), 16);
+        assert_eq!(runner.bus.read_word(pixmap + 34), 3);
+        assert_eq!(runner.bus.read_word(pixmap + 36), 5);
+        assert_eq!(runner.bus.read_long(pixmap + 42), 0);
+        assert_eq!(runner.ppc_host_indexed_ctab_handle, indexed_ctab_handle);
+        assert_eq!(runner.bus.read_word(indexed_ctab + 6), 3);
+        assert_eq!(runner.bus.read_long(gdevice + 42), 0x0084);
+        assert_eq!(runner.bus.get_alloc_size(host_mirror_base), Some(16));
+        assert_eq!(runner.bus.read_bytes(canary, 8), vec![0x5a; 8]);
+        assert_eq!(runner.bus.heap_bump_ptr(), heap_after_first_transition);
+    }
+
+    #[test]
+    fn ppc_packed_front_buffers_sync_centered_pixels_and_color_state() {
+        const WIDTH: u32 = 513;
+        const HEIGHT: u32 = 342;
+        const CANVAS_WIDTH: u32 = 800;
+        const CANVAS_HEIGHT: u32 = 600;
+        const DESTINATION_X: u32 = (CANVAS_WIDTH - WIDTH) / 2;
+        const DESTINATION_Y: u32 = (CANVAS_HEIGHT - HEIGHT) / 2;
+
+        for (depth, source_pixels) in [
+            (1u16, [1u8, 0, 1, 0]),
+            (2u16, [0u8, 1, 2, 3]),
+            (4u16, [1u8, 2, 3, 0]),
+        ] {
+            let row_bytes = WIDTH.checked_mul(u32::from(depth)).unwrap().div_ceil(8);
+            let mut pixels = vec![0u8; (row_bytes * HEIGHT) as usize];
+            let field_mask = ((1u16 << depth) - 1) as u8;
+            for (x, pixel) in source_pixels.into_iter().enumerate() {
+                let bit = x as u32 * u32::from(depth);
+                let shift = 8 - u32::from(depth) - (bit & 7);
+                pixels[(bit / 8) as usize] |= (pixel & field_mask) << shift;
+            }
+
+            let mut app = halted_ppc_app_with_sound(PpcSoundState::default());
+            let ppc_app = app.ppc.as_mut().expect("PPC app");
+            ppc_app.memory.add_region(PPC_HEAP_BASE, pixels);
+            ppc_app.heap_cursor = PPC_HEAP_BASE + row_bytes * HEIGHT;
+            ppc_app.gworlds.push(PpcGWorldRecord {
+                port: PPC_MAIN_GWORLD,
+                pixmap_handle: 0,
+                pixmap: 0,
+                base_addr: PPC_HEAP_BASE,
+                gdevice: PPC_MAIN_GDEVICE,
+                width: WIDTH,
+                height: HEIGHT,
+                depth: u32::from(depth),
+                row_bytes,
+                pixels_locked: false,
+                pixels_no_purge: false,
+            });
+            let (mut device_clut, _) =
+                TrapDispatcher::standard_mac_indexed_clut(depth).expect("standard indexed depth");
+            device_clut[0][0] = 0xfffe;
+            let mut color_manager_clut = device_clut;
+            color_manager_clut[0][1] = 0xfffd;
+            ppc_app.screen_clut = device_clut;
+            ppc_app.color_manager_clut = color_manager_clut;
+            ppc_app.device_gamma = crate::display::linear_display_gamma();
+
+            let config = FixtureRunnerConfig::default()
+                .with_screen_depth(depth)
+                .expect("packed indexed mode");
+            let mut runner = FixtureRunner::new(8 * 1024 * 1024, config);
+            let mut ppc_app = app.ppc.take().expect("PPC app");
+            runner.sync_ppc_front_buffer_to_host(&mut ppc_app);
+
+            let (base, host_row_bytes, width, height, host_depth) = runner.dispatcher.screen_mode;
+            assert_eq!(
+                (width, height, host_depth),
+                (CANVAS_WIDTH as u16, CANVAS_HEIGHT as u16, depth)
+            );
+            assert_eq!(
+                host_row_bytes,
+                CANVAS_WIDTH * u32::from(depth) / 8,
+                "{depth}bpp packed canvas stride"
+            );
+            assert_eq!(runner.dispatcher.device_clut, device_clut);
+            assert_eq!(runner.dispatcher.color_manager_clut, color_manager_clut);
+            assert_eq!(
+                runner.dispatcher.device_gamma,
+                crate::display::linear_display_gamma()
+            );
+            let gdevice = runner.bus.read_long(runner.dispatcher.main_gdevice_handle);
+            let pixmap = runner.bus.read_long(runner.bus.read_long(gdevice + 22));
+            let color_table = runner.bus.read_long(runner.bus.read_long(pixmap + 42));
+            assert_eq!(runner.bus.read_word(color_table + 6), (1u16 << depth) - 1);
+            for index in [0u32, (1u32 << depth) - 1] {
+                let entry = color_table + 8 + index * 8;
+                assert_eq!(
+                    [
+                        runner.bus.read_word(entry + 2),
+                        runner.bus.read_word(entry + 4),
+                        runner.bus.read_word(entry + 6),
+                    ],
+                    device_clut[index as usize],
+                    "{depth}bpp host GDevice CLUT entry {index}"
+                );
+            }
+
+            let pixel_at = |x: u32| {
+                let bit = x * u32::from(depth);
+                let packed = runner
+                    .bus
+                    .read_byte(base + DESTINATION_Y * host_row_bytes + bit / 8);
+                let shift = 8 - u32::from(depth) - (bit & 7);
+                (packed >> shift) & field_mask
+            };
+            assert_eq!(pixel_at(DESTINATION_X - 1), field_mask);
+            for (offset, expected) in source_pixels.into_iter().enumerate() {
+                assert_eq!(
+                    pixel_at(DESTINATION_X + offset as u32),
+                    expected,
+                    "{depth}bpp source pixel {offset}"
+                );
+            }
+            assert_eq!(pixel_at(DESTINATION_X + WIDTH), field_mask);
+        }
     }
 
     #[test]

--- a/src/trap/dialog.rs
+++ b/src/trap/dialog.rs
@@ -9945,7 +9945,14 @@ impl super::TrapDispatcher {
             && !skip_canonical_to_screen
             && !hardware_palette_active
         {
-            Some(self.build_palette_translation(bus, &src_clut, &dst_clut, screen_ctab_handle, 8))
+            Some(self.build_palette_translation(
+                bus,
+                &src_clut,
+                &dst_clut,
+                screen_ctab_handle,
+                8,
+                8,
+            ))
         } else {
             None
         };

--- a/src/trap/framebuffer.rs
+++ b/src/trap/framebuffer.rs
@@ -706,8 +706,14 @@ impl super::TrapDispatcher {
         found.then_some(best_index)
     }
 
-    fn fb_pixel_index_for_rgb_in_ctab(bus: &MacMemoryBus, ctab: u32, rgb: [u16; 3]) -> Option<u8> {
-        let count = u32::from(bus.read_word(ctab + 6)).min(255) + 1;
+    fn fb_pixel_index_for_rgb_in_ctab_with_entry_count(
+        bus: &MacMemoryBus,
+        ctab: u32,
+        rgb: [u16; 3],
+        entry_count: usize,
+    ) -> Option<u8> {
+        let entry_count = entry_count.clamp(1, 256);
+        let count = (u32::from(bus.read_word(ctab + 6)).min(255) + 1).min(entry_count as u32);
         let device_table = (bus.read_word(ctab + 4) & 0x8000) != 0;
 
         // Imaging With QuickDraw 1994 p. 4-82 describes inverse-table
@@ -715,8 +721,9 @@ impl super::TrapDispatcher {
         // values. Keep canonical endpoints pinned when the active table has
         // the standard white/black entries, then prefer exact matches before
         // falling back to nearest Euclidean distance in 16-bit RGB space.
-        if rgb == [0, 0, 0] && Self::ctab_value_luma(bus, ctab, 255) == Some(0) {
-            return Some(255);
+        let terminal_index = (entry_count - 1) as u8;
+        if rgb == [0, 0, 0] && Self::ctab_value_luma(bus, ctab, terminal_index) == Some(0) {
+            return Some(terminal_index);
         }
         if rgb == [0xFFFF, 0xFFFF, 0xFFFF]
             && Self::ctab_value_luma(bus, ctab, 0) == Some(0xFFFF * 3)
@@ -733,7 +740,7 @@ impl super::TrapDispatcher {
             } else {
                 bus.read_word(entry)
             };
-            if value > 255 {
+            if usize::from(value) >= entry_count {
                 continue;
             }
             let entry_rgb = [
@@ -760,6 +767,10 @@ impl super::TrapDispatcher {
         best_index
     }
 
+    fn fb_pixel_index_for_rgb_in_ctab(bus: &MacMemoryBus, ctab: u32, rgb: [u16; 3]) -> Option<u8> {
+        Self::fb_pixel_index_for_rgb_in_ctab_with_entry_count(bus, ctab, rgb, 256)
+    }
+
     pub(crate) fn fb_pixel_index_for_rgb(bus: &MacMemoryBus, rgb: [u16; 3]) -> Option<u8> {
         let ctab = Self::active_gdevice_ctab(bus)?;
         Self::fb_pixel_index_for_rgb_in_ctab(bus, ctab, rgb)
@@ -771,6 +782,15 @@ impl super::TrapDispatcher {
     ) -> Option<u8> {
         let ctab = Self::main_gdevice_ctab(bus)?;
         Self::fb_pixel_index_for_rgb_in_ctab(bus, ctab, rgb)
+    }
+
+    fn fb_main_screen_pixel_index_for_rgb_with_entry_count(
+        bus: &MacMemoryBus,
+        rgb: [u16; 3],
+        entry_count: usize,
+    ) -> Option<u8> {
+        let ctab = Self::main_gdevice_ctab(bus)?;
+        Self::fb_pixel_index_for_rgb_in_ctab_with_entry_count(bus, ctab, rgb, entry_count)
     }
 
     /// Read back the RGB a pixel value resolves to through a device colour
@@ -892,15 +912,38 @@ impl super::TrapDispatcher {
         Self::best_luma_pixel_index(bus, ctab, false).unwrap_or(255)
     }
 
-    fn logical_mono_pixel_indexes(bus: &MacMemoryBus) -> (u8, u8) {
-        (
-            Self::logical_white_pixel_index(bus),
-            Self::logical_black_pixel_index(bus),
-        )
+    pub(crate) fn fb_get_pixel_index(
+        bus: &MacMemoryBus,
+        screen_base: u32,
+        row_bytes: u32,
+        pixel_size: u16,
+        screen_width: i16,
+        screen_height: i16,
+        x: i16,
+        y: i16,
+    ) -> Option<u8> {
+        if x < 0 || y < 0 || x >= screen_width || y >= screen_height {
+            return None;
+        }
+        match pixel_size {
+            8 => Some(bus.read_byte(screen_base + y as u32 * row_bytes + x as u32)),
+            bits @ (1 | 2 | 4) => {
+                // QuickDraw lays the leftmost image bits into the high-order
+                // positions of each word; packed indexed pixels follow that
+                // same left-to-right ordering. Imaging With QuickDraw (1994),
+                // pp. 2-8 and 4-10--4-11.
+                let bits = u32::from(bits);
+                let pixels_per_byte = 8 / bits;
+                let byte_offset = y as u32 * row_bytes + x as u32 / pixels_per_byte;
+                let shift = 8 - bits - (x as u32 % pixels_per_byte) * bits;
+                Some((bus.read_byte(screen_base + byte_offset) >> shift) & ((1u8 << bits) - 1))
+            }
+            _ => None,
+        }
     }
 
     /// Set a single pixel in the framebuffer (screen coordinates).
-    /// Works for 1bpp, 4bpp, and 8bpp screen modes.
+    /// Works for 1bpp, 2bpp, 4bpp, and 8bpp screen modes.
     pub(crate) fn fb_set_pixel(
         bus: &mut MacMemoryBus,
         screen_base: u32,
@@ -912,41 +955,22 @@ impl super::TrapDispatcher {
         y: i16,
         black: bool,
     ) {
-        if x < 0 || y < 0 || x >= screen_width || y >= screen_height {
-            return;
-        }
-        if pixel_size == 8 {
-            let addr = screen_base + (y as u32) * row_bytes + (x as u32);
-            bus.write_byte(
-                addr,
-                if black {
-                    Self::logical_black_pixel_index(bus)
-                } else {
-                    Self::logical_white_pixel_index(bus)
-                },
-            );
-        } else if pixel_size == 4 {
-            let addr = screen_base + (y as u32) * row_bytes + (x as u32 / 2);
-            let shift = if x & 1 == 0 { 4 } else { 0 };
-            let mask = 0x0F << shift;
-            let index = if black {
-                Self::logical_black_pixel_index(bus)
-            } else {
-                Self::logical_white_pixel_index(bus)
-            } & 0x0F;
-            let byte = bus.read_byte(addr);
-            bus.write_byte(addr, (byte & !mask) | (index << shift));
+        let pixel_index = if black {
+            Self::logical_black_pixel_index(bus)
         } else {
-            let byte_offset = (y as u32) * row_bytes + (x as u32 / 8);
-            let bit = 7 - (x as u32 % 8);
-            let addr = screen_base + byte_offset;
-            let b = bus.read_byte(addr);
-            if black {
-                bus.write_byte(addr, b | (1 << bit));
-            } else {
-                bus.write_byte(addr, b & !(1 << bit));
-            }
-        }
+            Self::logical_white_pixel_index(bus)
+        };
+        Self::fb_set_pixel_index(
+            bus,
+            screen_base,
+            row_bytes,
+            pixel_size,
+            screen_width,
+            screen_height,
+            x,
+            y,
+            pixel_index,
+        );
     }
 
     pub(crate) fn fb_set_pixel_index(
@@ -960,36 +984,26 @@ impl super::TrapDispatcher {
         y: i16,
         pixel_index: u8,
     ) {
-        if pixel_size == 4 {
-            if x < 0 || y < 0 || x >= screen_width || y >= screen_height {
-                return;
-            }
-            let addr = screen_base + (y as u32) * row_bytes + (x as u32 / 2);
-            let shift = if x & 1 == 0 { 4 } else { 0 };
-            let mask = 0x0F << shift;
-            let byte = bus.read_byte(addr);
-            bus.write_byte(addr, (byte & !mask) | ((pixel_index & 0x0F) << shift));
-            return;
-        }
-        if pixel_size != 8 {
-            Self::fb_set_pixel(
-                bus,
-                screen_base,
-                row_bytes,
-                pixel_size,
-                screen_width,
-                screen_height,
-                x,
-                y,
-                pixel_index != 0,
-            );
-            return;
-        }
         if x < 0 || y < 0 || x >= screen_width || y >= screen_height {
             return;
         }
-        let addr = screen_base + (y as u32) * row_bytes + (x as u32);
-        bus.write_byte(addr, pixel_index);
+        match pixel_size {
+            8 => {
+                let addr = screen_base + y as u32 * row_bytes + x as u32;
+                bus.write_byte(addr, pixel_index);
+            }
+            bits @ (1 | 2 | 4) => {
+                let bits = u32::from(bits);
+                let pixels_per_byte = 8 / bits;
+                let addr = screen_base + y as u32 * row_bytes + x as u32 / pixels_per_byte;
+                let shift = 8 - bits - (x as u32 % pixels_per_byte) * bits;
+                let field_mask = ((1u16 << bits) - 1) as u8;
+                let mask = field_mask << shift;
+                let byte = bus.read_byte(addr);
+                bus.write_byte(addr, (byte & !mask) | ((pixel_index & field_mask) << shift));
+            }
+            _ => {}
+        }
     }
 
     pub(crate) fn fb_fill_rect_index(
@@ -1005,7 +1019,7 @@ impl super::TrapDispatcher {
         right: i16,
         pixel_index: u8,
     ) {
-        if pixel_size == 4 {
+        if matches!(pixel_size, 2 | 4) {
             for y in top..bottom {
                 for x in left..right {
                     Self::fb_set_pixel_index(
@@ -1337,19 +1351,21 @@ impl super::TrapDispatcher {
         if x < 0 || y < 0 || x >= screen_width || y >= screen_height {
             return false;
         }
-        if pixel_size == 8 {
-            let addr = screen_base + (y as u32) * row_bytes + (x as u32);
-            bus.read_byte(addr) == Self::logical_black_pixel_index(bus)
-        } else if pixel_size == 4 {
-            let addr = screen_base + (y as u32) * row_bytes + (x as u32 / 2);
-            let shift = if x & 1 == 0 { 4 } else { 0 };
-            ((bus.read_byte(addr) >> shift) & 0x0F) == (Self::logical_black_pixel_index(bus) & 0x0F)
-        } else {
-            let byte_offset = (y as u32) * row_bytes + (x as u32 / 8);
-            let bit = 7 - (x as u32 % 8);
-            let addr = screen_base + byte_offset;
-            (bus.read_byte(addr) & (1 << bit)) != 0
-        }
+        let field_mask = match pixel_size {
+            1 | 2 | 4 => ((1u16 << pixel_size) - 1) as u8,
+            8 => u8::MAX,
+            _ => return false,
+        };
+        Self::fb_get_pixel_index(
+            bus,
+            screen_base,
+            row_bytes,
+            pixel_size,
+            screen_width,
+            screen_height,
+            x,
+            y,
+        ) == Some(Self::logical_black_pixel_index(bus) & field_mask)
     }
 
     fn visible_window_count(&self, bus: &MacMemoryBus) -> usize {
@@ -1689,7 +1705,7 @@ impl super::TrapDispatcher {
         let gh = glyph.height as usize;
         let metrics = synthetic_italic
             .map(|(font_id, font_size)| (font_id, font_size, get_font_metrics(font_id, font_size)));
-        let text_index = if matches!(pixel_size, 4 | 8) {
+        let text_index = if matches!(pixel_size, 2 | 4 | 8) {
             Some(pixel_index_override.unwrap_or_else(|| {
                 if black {
                     Self::logical_black_pixel_index(bus)
@@ -1729,10 +1745,17 @@ impl super::TrapDispatcher {
                     for dst_col in dst_start..dst_end {
                         let px = gx + dst_col + slant;
                         if let Some(text_index) = text_index {
-                            if px >= 0 && py >= 0 && px < screen_width && py < screen_height {
-                                let addr = screen_base + (py as u32) * row_bytes + (px as u32);
-                                bus.write_byte(addr, text_index);
-                            }
+                            Self::fb_set_pixel_index(
+                                bus,
+                                screen_base,
+                                row_bytes,
+                                pixel_size,
+                                screen_width,
+                                screen_height,
+                                px,
+                                py,
+                                text_index,
+                            );
                         } else {
                             Self::fb_set_pixel(
                                 bus,
@@ -2370,9 +2393,7 @@ impl super::TrapDispatcher {
         let font_id: i16 = 0;
         let font_size: i16 = 12;
         let metrics = get_font_metrics(font_id, font_size);
-        // Vertically center text: baseline = top_margin + ascent
-        let text_height = metrics.ascent + metrics.descent;
-        let text_y = (menu_bar_height - text_height) / 2 + metrics.ascent;
+        let text_y = Self::menu_bar_title_baseline(menu_bar_height);
 
         // Draw visible menu titles from the current menu list. InsertMenu
         // with beforeID=-1 installs a submenu/popup in the current menu
@@ -2538,6 +2559,13 @@ impl super::TrapDispatcher {
         }
     }
 
+    fn menu_bar_title_baseline(menu_bar_height: i16) -> i16 {
+        let metrics = get_font_metrics(0, 12);
+        // Vertically center text: baseline = top margin + ascent.
+        let text_height = metrics.ascent + metrics.descent;
+        (menu_bar_height - text_height) / 2 + metrics.ascent
+    }
+
     pub(super) fn fb_draw_retro_computer_menu_mark(
         &self,
         bus: &mut MacMemoryBus,
@@ -2558,7 +2586,16 @@ impl super::TrapDispatcher {
         });
 
         let left = x;
-        let top = 3;
+        let metrics = get_font_metrics(0, 12);
+        // Align the artwork to the same centered system-font baseline as an
+        // ordinary title. This preserves the reference y=3 placement for a
+        // 20-pixel bar while following a live MBarHeight. Clip to the menu
+        // bar interior so a short bar cannot paint the window/desktop below.
+        let menu_bar_height = bus.read_word(crate::memory::globals::addr::MBAR_HEIGHT) as i16;
+        let top = Self::menu_bar_title_baseline(menu_bar_height)
+            .saturating_sub(metrics.ascent)
+            .saturating_add(1);
+        let menu_bar_bottom = menu_bar_height.saturating_sub(1).max(0);
         for (dy, row) in crate::ui_art::RETRO_COMPUTER_MENU_MARK_PIXELS
             .into_iter()
             .enumerate()
@@ -2569,7 +2606,10 @@ impl super::TrapDispatcher {
                 }
                 let dst_x = left + dx as i16;
                 let dst_y = top + dy as i16;
-                if matches!(pixel_size, 4 | 8) {
+                if dst_y < 0 || dst_y >= menu_bar_bottom {
+                    continue;
+                }
+                if matches!(pixel_size, 2 | 4 | 8) {
                     Self::fb_set_pixel_index(
                         bus,
                         screen_base,
@@ -2734,7 +2774,7 @@ impl super::TrapDispatcher {
             }
             return;
         }
-        if !matches!(pixel_size, 4 | 8) || screen_w == 0 || screen_h == 0 {
+        if !matches!(pixel_size, 1 | 2 | 4 | 8) || screen_w == 0 || screen_h == 0 {
             if trace {
                 eprintln!(
                     "[BLIT] skip: screen mode mismatch (pixel_size={}, w={}, h={})",
@@ -2834,63 +2874,54 @@ impl super::TrapDispatcher {
         };
 
         // Read window content bounds (portRect in GrafPort at offset +16)
-        let wr_top = bus.read_word(port + 16) as i16;
-        let wr_left = bus.read_word(port + 18) as i16;
-        let wr_bottom = bus.read_word(port + 20) as i16;
-        let wr_right = bus.read_word(port + 22) as i16;
+        let wr_top = i32::from(bus.read_word(port + 16) as i16);
+        let wr_left = i32::from(bus.read_word(port + 18) as i16);
+        let wr_bottom = i32::from(bus.read_word(port + 20) as i16);
+        let wr_right = i32::from(bus.read_word(port + 22) as i16);
 
-        let w = (wr_right - wr_left) as u32;
-        let h = (wr_bottom - wr_top) as u32;
-        if w == 0 || h == 0 {
+        let w = wr_right - wr_left;
+        let h = wr_bottom - wr_top;
+        if w <= 0 || h <= 0 {
             return;
         }
+        let w = w as u32;
+        let h = h as u32;
 
         let (global_top, global_left, _, _) = self.window_global_port_rect(bus, port);
         let (pb_top, pb_left, pb_bottom, pb_right) = self.port_bounds_rect(bus, port);
+        let pb_top = i32::from(pb_top);
+        let pb_left = i32::from(pb_left);
+        let pb_bottom = i32::from(pb_bottom);
+        let pb_right = i32::from(pb_right);
 
-        let src_y_offset = (wr_top.wrapping_sub(pb_top)).max(0) as u32;
-        let src_x_offset = (wr_left.wrapping_sub(pb_left)).max(0) as u32;
-        let dst_y = global_top.max(0) as u32;
-        let dst_x = global_left.max(0) as u32;
-
-        // 1bpp source → 8bpp screen via per-pixel bit extraction.
-        // For each source bit, resolve logical white/black through the
-        // active GDevice ColorTable. Applications can repurpose 0xFF away
-        // from black while still expecting mono source bits to scan out black.
-        if port_pixel_size == 1 && pixel_size == 8 {
-            let (white_index, black_index) = Self::logical_mono_pixel_indexes(bus);
-            // Games may set portRect MUCH larger than the actual BitMap
-            // bounds (e.g. StuntCopter: portRect=(0,0..567,791) but
-            // BitMap=(0,0..261,426)). Clamp source reads to the BitMap
-            // bounds so we don't walk past valid source data into adjacent
-            // rows. Without this, the per-row stride bug produces
-            // horizontally-doubled or tiled content.
-            let bitmap_w = (pb_right - pb_left).max(0) as u32;
-            let bitmap_h = (pb_bottom - pb_top).max(0) as u32;
-            let row_count = h.min((screen_h as u32).saturating_sub(dst_y)).min(bitmap_h);
-            let col_count = w.min((screen_w as u32).saturating_sub(dst_x)).min(bitmap_w);
-            for row in 0..row_count {
-                let src_row_addr = port_base + (src_y_offset + row) * port_rb;
-                let dst_row_addr = screen_base + (dst_y + row) * screen_rb + dst_x;
-                for col in 0..col_count {
-                    let src_bit_x = src_x_offset + col;
-                    let src_byte = bus.read_byte(src_row_addr + src_bit_x / 8);
-                    let bit = (src_byte >> (7 - (src_bit_x & 7))) & 1;
-                    let dst_idx = if bit == 0 { white_index } else { black_index };
-                    bus.write_byte(dst_row_addr + col, dst_idx);
-                }
-            }
-            return;
-        }
-
-        // Same-depth fast path. Anything that's neither matched-depth nor
-        // 1bpp→8bpp falls through to a no-op.
-        if port_pixel_size != pixel_size as u32 {
-            return;
-        }
+        let src_y_offset = (wr_top - pb_top).max(0) as u32;
+        let src_x_offset = (wr_left - pb_left).max(0) as u32;
+        let dst_y = i32::from(global_top).max(0) as u32;
+        let dst_x = i32::from(global_left).max(0) as u32;
 
         let row_count = h.min((screen_h as u32).saturating_sub(dst_y));
         let col_count = w.min((screen_w as u32).saturating_sub(dst_x));
+        let bitmap_w = (pb_right - pb_left).max(0) as u32;
+        let bitmap_h = (pb_bottom - pb_top).max(0) as u32;
+        let (bounded_row_count, mut bounded_col_count) = if bitmap_w != 0 && bitmap_h != 0 {
+            (
+                row_count.min(bitmap_h.saturating_sub(src_y_offset)),
+                col_count.min(bitmap_w.saturating_sub(src_x_offset)),
+            )
+        } else {
+            // A few legacy HLE fixtures and malformed ports omit PixMap
+            // bounds while still providing a valid base, stride, and
+            // portRect. Retain their portRect fallback without weakening the
+            // bounds guard for well-formed guest PixMaps.
+            (row_count, col_count)
+        };
+        if matches!(port_pixel_size, 1 | 2 | 4 | 8) {
+            let source_row_pixels = port_rb.saturating_mul(8) / port_pixel_size;
+            bounded_col_count =
+                bounded_col_count.min(source_row_pixels.saturating_sub(src_x_offset));
+        }
+        let destination_row_pixels = screen_rb.saturating_mul(8) / u32::from(pixel_size);
+        bounded_col_count = bounded_col_count.min(destination_row_pixels.saturating_sub(dst_x));
 
         // Color QuickDraw treats PixMap pixels through their pmTable. When
         // HLE composites a front-window offscreen CGrafPort to the screen,
@@ -2916,11 +2947,12 @@ impl super::TrapDispatcher {
                     &dst_clut,
                     screen_ctab_handle,
                     8,
+                    8,
                 );
-                for row in 0..row_count {
+                for row in 0..bounded_row_count {
                     let src_addr = port_base + (src_y_offset + row) * port_rb + src_x_offset;
                     let dst_addr = screen_base + (dst_y + row) * screen_rb + dst_x;
-                    for col in 0..col_count {
+                    for col in 0..bounded_col_count {
                         let src_idx = bus.read_byte(src_addr + col);
                         bus.write_byte(dst_addr + col, translation[src_idx as usize]);
                     }
@@ -2929,26 +2961,111 @@ impl super::TrapDispatcher {
             }
         }
 
-        if port_pixel_size == 4 {
+        // Indexed windows can remain at their original PixMap depth while
+        // SetDepth changes the screen. Read and write each side using its own
+        // packing geometry, and translate colors through the active screen
+        // table whenever their depths differ. Imaging With QuickDraw (1994),
+        // pp. 4-27--4-28 and 4-81--4-82.
+        if matches!(port_pixel_size, 1 | 2 | 4 | 8) && matches!(pixel_size, 1 | 2 | 4 | 8) {
+            let row_count = bounded_row_count;
+            let col_count = bounded_col_count;
+            let screen_ctab_handle = Self::gdevice_ctab_handle(bus, self.main_gdevice_handle);
+            let packed_translation = {
+                let needs_mono_translation = port_pixel_size == 1 || pixel_size == 1;
+                let needs_depth_translation = port_pixel_size != u32::from(pixel_size);
+                let different_color_spaces = if is_cgraf_port {
+                    let src_ctab_seed = Self::ctab_seed(bus, port_ctab_handle);
+                    let dst_ctab_seed = Self::ctab_seed(bus, screen_ctab_handle);
+                    port_ctab_handle != 0
+                        && screen_ctab_handle != 0
+                        && port_ctab_handle != screen_ctab_handle
+                        && matches!((src_ctab_seed, dst_ctab_seed), (Some(src), Some(dst)) if src != 0 && src != dst)
+                        && self.device_clut == self.color_manager_clut
+                } else {
+                    false
+                };
+                if needs_mono_translation || needs_depth_translation || different_color_spaces {
+                    let src_clut = if port_pixel_size == 1 && !is_cgraf_port {
+                        let mut clut = [[0u16; 3]; 256];
+                        clut[0] = [0xffff, 0xffff, 0xffff];
+                        clut
+                    } else {
+                        self.read_port_clut(bus, port_ctab_handle)
+                    };
+                    let dst_clut = self.read_port_clut(bus, screen_ctab_handle);
+                    let mut translation = self.build_palette_translation(
+                        bus,
+                        &src_clut,
+                        &dst_clut,
+                        screen_ctab_handle,
+                        port_pixel_size,
+                        u32::from(pixel_size),
+                    );
+                    if port_pixel_size == 1 || pixel_size == 1 {
+                        let src_entry_count = 1usize << port_pixel_size;
+                        let dst_entry_count = 1usize << pixel_size;
+                        for (index, rgb) in src_clut.iter().take(src_entry_count).enumerate() {
+                            if let Some(pixel) =
+                                Self::fb_main_screen_pixel_index_for_rgb_with_entry_count(
+                                    bus,
+                                    *rgb,
+                                    dst_entry_count,
+                                )
+                            {
+                                translation[index] = pixel;
+                            }
+                        }
+                    }
+                    Some(translation)
+                } else {
+                    None
+                }
+            };
+            let src_pixels_per_byte = 8 / port_pixel_size;
+            let src_field_mask = ((1u16 << port_pixel_size) - 1) as u8;
+            let dst_pixel_size = u32::from(pixel_size);
+            let dst_pixels_per_byte = 8 / dst_pixel_size;
+            let dst_field_mask = ((1u16 << dst_pixel_size) - 1) as u8;
             for row in 0..row_count {
                 let src_row = port_base + (src_y_offset + row) * port_rb;
                 let dst_row = screen_base + (dst_y + row) * screen_rb;
                 for col in 0..col_count {
                     let src_x = src_x_offset + col;
-                    let src_byte = bus.read_byte(src_row + src_x / 2);
-                    let src_index = if src_x & 1 == 0 {
-                        src_byte >> 4
+                    let src_index = if port_pixel_size == 8 {
+                        bus.read_byte(src_row + src_x)
                     } else {
-                        src_byte & 0x0F
+                        let src_byte = bus.read_byte(src_row + src_x / src_pixels_per_byte);
+                        let src_shift =
+                            8 - port_pixel_size - (src_x % src_pixels_per_byte) * port_pixel_size;
+                        (src_byte >> src_shift) & src_field_mask
                     };
+                    // Window Manager compositing observes each PixMap's
+                    // pmTable just like indexed CopyBits. Restrict inverse
+                    // matching to the entries representable at the packed
+                    // destination depth; raw index copying is valid only when
+                    // the two tables identify the same color space. Imaging
+                    // With QuickDraw (1994), pp. 4-27--4-28 and 4-81--4-82.
+                    let dst_index = packed_translation
+                        .as_ref()
+                        .map_or(src_index, |translation| translation[src_index as usize]);
                     let dst_x = dst_x + col;
-                    let dst_addr = dst_row + dst_x / 2;
-                    let dst_shift = if dst_x & 1 == 0 { 4 } else { 0 };
-                    let dst_mask = 0x0F << dst_shift;
-                    let dst_byte = bus.read_byte(dst_addr);
-                    bus.write_byte(dst_addr, (dst_byte & !dst_mask) | (src_index << dst_shift));
+                    if dst_pixel_size == 8 {
+                        bus.write_byte(dst_row + dst_x, dst_index);
+                    } else {
+                        debug_assert!(dst_index <= dst_field_mask);
+                        let dst_addr = dst_row + dst_x / dst_pixels_per_byte;
+                        let dst_shift =
+                            8 - dst_pixel_size - (dst_x % dst_pixels_per_byte) * dst_pixel_size;
+                        let dst_mask = dst_field_mask << dst_shift;
+                        let dst_byte = bus.read_byte(dst_addr);
+                        bus.write_byte(dst_addr, (dst_byte & !dst_mask) | (dst_index << dst_shift));
+                    }
                 }
             }
+            return;
+        }
+
+        if port_pixel_size != pixel_size as u32 {
             return;
         }
 
@@ -3440,7 +3557,7 @@ impl super::TrapDispatcher {
             && !hardware_palette_active
         {
             let translation =
-                self.build_palette_translation(bus, &src_clut, &dst_clut, screen_ctab_handle, 8);
+                self.build_palette_translation(bus, &src_clut, &dst_clut, screen_ctab_handle, 8, 8);
             for row in 0..row_count {
                 let src_addr = candidate.base + row * candidate.row_bytes;
                 let dst_addr = screen_base + (dst_y + row) * screen_rb + dst_x;
@@ -4894,6 +5011,13 @@ mod redraw_chrome_tests {
     const CLIP_RGN: u32 = 0x182200;
     const WINDOW_VISIBLE_OFFSET: u32 = 110;
 
+    #[test]
+    fn menu_bar_title_baseline_tracks_live_height() {
+        assert_eq!(TrapDispatcher::menu_bar_title_baseline(12), 11);
+        assert_eq!(TrapDispatcher::menu_bar_title_baseline(20), 14);
+        assert_eq!(TrapDispatcher::menu_bar_title_baseline(30), 19);
+    }
+
     fn set_window_structure_rect(
         bus: &mut crate::memory::MacMemoryBus,
         window_ptr: u32,
@@ -5200,6 +5324,60 @@ mod redraw_chrome_tests {
         disp.restore_screen_rect_pixels(&mut bus, saved.0, saved.1, saved.2, saved.3, &saved.4);
         assert_eq!(bus.read_byte(screen_base), 0xA5);
         assert_eq!(bus.read_byte(screen_base + 1), 0x5A);
+    }
+
+    #[test]
+    fn indexed_framebuffer_helpers_preserve_adjacent_two_bit_pixels() {
+        let (_disp, _cpu, mut bus) = setup_with_port();
+        let screen_base = bus.alloc(1);
+        bus.write_byte(screen_base, 0b11_10_01_00);
+
+        TrapDispatcher::fb_set_pixel_index(&mut bus, screen_base, 1, 2, 4, 1, 1, 0, 1);
+        assert_eq!(bus.read_byte(screen_base), 0b11_01_01_00);
+
+        TrapDispatcher::fb_fill_rect_index(&mut bus, screen_base, 1, 2, 4, 1, 0, 2, 1, 4, 2);
+        assert_eq!(bus.read_byte(screen_base), 0b11_01_10_10);
+        assert_eq!(
+            (0..4)
+                .map(|x| TrapDispatcher::fb_get_pixel_index(&bus, screen_base, 1, 2, 4, 1, x, 0,))
+                .collect::<Vec<_>>(),
+            vec![Some(3), Some(1), Some(2), Some(2)]
+        );
+    }
+
+    #[test]
+    fn two_bit_indexed_glyph_draw_writes_fields_not_whole_bytes() {
+        let (_disp, _cpu, mut bus) = setup_with_port();
+        let screen_base = bus.alloc(2);
+        bus.write_byte(screen_base, 0b01_01_01_01);
+        let glyph = super::Glyph {
+            width: 2,
+            height: 1,
+            advance: 2,
+            origin_x: 0,
+            origin_y: 0,
+            data_offset: 0,
+        };
+
+        TrapDispatcher::fb_draw_glyph_bitmap_with_slant(
+            &mut bus,
+            screen_base,
+            2,
+            2,
+            8,
+            1,
+            1,
+            0,
+            &glyph,
+            &[0xff, 0xff],
+            None,
+            0,
+            Some(3),
+            true,
+        );
+
+        assert_eq!(bus.read_byte(screen_base), 0b01_11_11_01);
+        assert_eq!(bus.read_byte(screen_base + 1), 0x00);
     }
 
     #[test]
@@ -6859,11 +7037,146 @@ mod redraw_chrome_tests {
     }
 
     #[test]
+    fn redraw_chrome_blit_1bpp_to_1bpp_preserves_odd_edges_and_padding() {
+        let (mut disp, _cpu, mut bus) = setup_with_port();
+        let screen_base = bus.alloc(8);
+        disp.screen_mode = (screen_base, 4, 16, 1, 1);
+        let (screen_clut, _) = TrapDispatcher::standard_mac_indexed_clut(1).unwrap();
+        disp.color_manager_clut = screen_clut;
+        disp.device_clut = screen_clut;
+        bus.write_long(0x0824, screen_base);
+        let gdevice_handle = disp.ensure_main_gdevice(&mut bus);
+        bus.write_long(0x08A4, gdevice_handle);
+        bus.write_long(0x0CC8, gdevice_handle);
+
+        let offscreen_base = bus.alloc(8);
+        bus.write_long(PORT_PTR + 2, offscreen_base);
+        bus.write_word(PORT_PTR + 6, 3);
+        bus.write_word(PORT_PTR + 8, 0);
+        bus.write_word(PORT_PTR + 10, (-1i16) as u16);
+        bus.write_word(PORT_PTR + 12, 1);
+        bus.write_word(PORT_PTR + 14, 9);
+        bus.write_word(PORT_PTR + 16, 0);
+        bus.write_word(PORT_PTR + 18, 0);
+        bus.write_word(PORT_PTR + 20, 1);
+        bus.write_word(PORT_PTR + 22, 8);
+        let source = [0xad, 0x7f, 0xcd];
+        bus.write_bytes(offscreen_base, &source);
+        bus.fill_bytes(screen_base, 8, 0xaa);
+        disp.front_window = PORT_PTR;
+
+        disp.blit_window_to_screen(&mut bus);
+
+        assert_eq!(bus.read_bytes(screen_base, 4), vec![0xad, 0x2a, 0xaa, 0xaa]);
+        assert_eq!(bus.read_bytes(screen_base + 4, 4), vec![0xaa; 4]);
+        assert_eq!(bus.read_bytes(offscreen_base, 3), source);
+    }
+
+    #[test]
+    fn redraw_chrome_blit_1bpp_to_2bpp_uses_destination_packing_and_palette() {
+        let (mut disp, _cpu, mut bus) = setup_with_port();
+        let screen_base = bus.alloc(8);
+        disp.screen_mode = (screen_base, 4, 12, 1, 2);
+        let (screen_clut, _) = TrapDispatcher::standard_mac_indexed_clut(2).unwrap();
+        disp.color_manager_clut = screen_clut;
+        disp.device_clut = screen_clut;
+        bus.write_long(0x0824, screen_base);
+        let gdevice_handle = disp.ensure_main_gdevice(&mut bus);
+        bus.write_long(0x08A4, gdevice_handle);
+        bus.write_long(0x0CC8, gdevice_handle);
+
+        let offscreen_base = bus.alloc(8);
+        bus.write_long(PORT_PTR + 2, offscreen_base);
+        bus.write_word(PORT_PTR + 6, 3);
+        bus.write_word(PORT_PTR + 8, 0);
+        bus.write_word(PORT_PTR + 10, (-1i16) as u16);
+        bus.write_word(PORT_PTR + 12, 1);
+        bus.write_word(PORT_PTR + 14, 9);
+        bus.write_word(PORT_PTR + 16, 0);
+        bus.write_word(PORT_PTR + 18, 0);
+        bus.write_word(PORT_PTR + 20, 1);
+        bus.write_word(PORT_PTR + 22, 8);
+        let source = [0xad, 0x7f, 0xcd];
+        bus.write_bytes(offscreen_base, &source);
+        bus.fill_bytes(screen_base, 8, 0xaa);
+        disp.front_window = PORT_PTR;
+
+        disp.blit_window_to_screen(&mut bus);
+
+        let expected = [0u8, 3, 0, 3, 3, 0, 3, 0];
+        assert_eq!(
+            TrapDispatcher::fb_get_pixel_index(&bus, screen_base, 4, 2, 12, 1, 0, 0),
+            Some(2)
+        );
+        for (offset, expected) in expected.into_iter().enumerate() {
+            assert_eq!(
+                TrapDispatcher::fb_get_pixel_index(
+                    &bus,
+                    screen_base,
+                    4,
+                    2,
+                    12,
+                    1,
+                    offset as i16 + 1,
+                    0,
+                ),
+                Some(expected)
+            );
+        }
+        for x in 9..12 {
+            assert_eq!(
+                TrapDispatcher::fb_get_pixel_index(&bus, screen_base, 4, 2, 12, 1, x, 0),
+                Some(2)
+            );
+        }
+        assert_eq!(bus.read_byte(screen_base + 3), 0xaa);
+        assert_eq!(bus.read_bytes(screen_base + 4, 4), vec![0xaa; 4]);
+        assert_eq!(bus.read_bytes(offscreen_base, 3), source);
+    }
+
+    #[test]
+    fn redraw_chrome_blit_2bpp_to_1bpp_translates_colors_and_preserves_canaries() {
+        let (mut disp, _cpu, mut bus) = setup_with_port();
+        let screen_base = bus.alloc(8);
+        disp.screen_mode = (screen_base, 4, 16, 1, 1);
+        let (screen_clut, _) = TrapDispatcher::standard_mac_indexed_clut(1).unwrap();
+        disp.color_manager_clut = screen_clut;
+        disp.device_clut = screen_clut;
+        bus.write_long(0x0824, screen_base);
+        let gdevice_handle = disp.ensure_main_gdevice(&mut bus);
+        bus.write_long(0x08A4, gdevice_handle);
+        bus.write_long(0x0CC8, gdevice_handle);
+
+        let (src_clut, _) = TrapDispatcher::standard_mac_indexed_clut(2).unwrap();
+        let src_ctab_handle = make_ctab_handle(&mut bus, &src_clut, 0x2000_0002);
+        let offscreen_base = bus.alloc(8);
+        let pixmap_handle =
+            install_8bpp_cgrafport(&mut bus, offscreen_base, 4, 10, 1, src_ctab_handle);
+        let pixmap = bus.read_long(pixmap_handle);
+        bus.write_word(pixmap + 8, (-1i16) as u16);
+        bus.write_word(pixmap + 12, 9);
+        bus.write_word(pixmap + 32, 2);
+        bus.write_word(pixmap + 36, 2);
+        bus.write_word(PORT_PTR + 18, 0);
+        bus.write_word(PORT_PTR + 22, 8);
+        let source = [0x8c, 0xf3, 0x2a, 0xcd];
+        bus.write_bytes(offscreen_base, &source);
+        bus.fill_bytes(screen_base, 8, 0xaa);
+        disp.front_window = PORT_PTR;
+
+        disp.blit_window_to_screen(&mut bus);
+
+        assert_eq!(bus.read_bytes(screen_base, 4), vec![0xad, 0x2a, 0xaa, 0xaa]);
+        assert_eq!(bus.read_bytes(screen_base + 4, 4), vec![0xaa; 4]);
+        assert_eq!(bus.read_bytes(offscreen_base, 4), source);
+    }
+
+    #[test]
     fn redraw_chrome_blit_8bpp_to_8bpp_translates_port_ctab_to_screen() {
         let (mut disp, _cpu, mut bus) = setup_with_port();
 
-        let screen_base = bus.alloc(64 * 64);
-        disp.screen_mode = (screen_base, 64, 64, 64, 8);
+        let screen_base = bus.alloc(70 * 64);
+        disp.screen_mode = (screen_base, 70, 70, 64, 8);
         bus.write_long(0x0824, screen_base);
 
         let gdevice_handle = disp.ensure_main_gdevice(&mut bus);
@@ -6877,11 +7190,13 @@ mod redraw_chrome_tests {
 
         let offscreen_base = bus.alloc(64 * 64);
         install_8bpp_cgrafport(&mut bus, offscreen_base, 64, 64, 64, src_ctab_handle);
+        bus.write_word(PORT_PTR + 22, 70);
 
         bus.write_byte(offscreen_base + 5 * 64 + 10, 42);
         bus.write_byte(offscreen_base + 5 * 64 + 11, 8);
-        bus.write_byte(screen_base + 5 * 64 + 10, 0xAA);
-        bus.write_byte(screen_base + 5 * 64 + 11, 0xAA);
+        bus.write_byte(screen_base + 5 * 70 + 10, 0xAA);
+        bus.write_byte(screen_base + 5 * 70 + 11, 0xAA);
+        bus.fill_bytes(screen_base + 5 * 70 + 64, 6, 0xA5);
 
         disp.front_window = PORT_PTR;
         disp.window_bounds = (0, 0, 64, 64);
@@ -6890,14 +7205,19 @@ mod redraw_chrome_tests {
         disp.blit_window_to_screen(&mut bus);
 
         assert_eq!(
-            bus.read_byte(screen_base + 5 * 64 + 10),
+            bus.read_byte(screen_base + 5 * 70 + 10),
             7,
             "8bpp window blit must translate source CTab index 42 to the screen index for its RGB"
         );
         assert_eq!(
-            bus.read_byte(screen_base + 5 * 64 + 11),
+            bus.read_byte(screen_base + 5 * 70 + 11),
             8,
             "same-RGB entries should remain stable through the translation table"
+        );
+        assert_eq!(
+            bus.read_bytes(screen_base + 5 * 70 + 64, 6),
+            vec![0xA5; 6],
+            "an oversized portRect must not read past the source PixMap bounds"
         );
     }
 
@@ -6930,6 +7250,283 @@ mod redraw_chrome_tests {
             bus.read_bytes(screen_base + 4, 4),
             vec![0x00, 0x00, 0x00, 0x00]
         );
+    }
+
+    #[test]
+    fn redraw_chrome_blit_2bpp_to_2bpp_copies_packed_pixels() {
+        let (mut disp, _cpu, mut bus) = setup_with_port();
+
+        let screen_base = bus.alloc(2 * 2);
+        disp.screen_mode = (screen_base, 2, 8, 2, 2);
+        bus.write_long(0x0824, screen_base);
+
+        let (clut, _) = TrapDispatcher::standard_mac_indexed_clut(2).unwrap();
+        let ctab_handle = make_ctab_handle(&mut bus, &clut, 2);
+        // Reserve more than the four visible bytes: a four-byte allocation is
+        // the in-memory shape of a classic Handle and the PixMap base resolver
+        // intentionally treats it as one.  The extra guard bytes keep this
+        // fixture focused on packed-pixel copying.
+        let offscreen_base = bus.alloc(2 * 2 + 4);
+        let pixmap_handle = install_8bpp_cgrafport(&mut bus, offscreen_base, 2, 8, 2, ctab_handle);
+        let pixmap = bus.read_long(pixmap_handle);
+        bus.write_word(pixmap + 32, 2);
+        bus.write_word(pixmap + 36, 2);
+
+        bus.write_bytes(offscreen_base, &[0b00_01_10_11, 0b11_10_01_00]);
+        bus.fill_bytes(screen_base, 2 * 2, 0xaa);
+        disp.front_window = PORT_PTR;
+        disp.window_bounds = (0, 0, 2, 8);
+        disp.window_proc_id = 1;
+
+        disp.blit_window_to_screen(&mut bus);
+
+        assert_eq!(
+            bus.read_bytes(screen_base, 2),
+            vec![0b00_01_10_11, 0b11_10_01_00]
+        );
+        assert_eq!(bus.read_bytes(screen_base + 2, 2), vec![0x00, 0x00]);
+    }
+
+    #[test]
+    fn redraw_chrome_blit_2bpp_clamps_oversized_port_rect_to_pixmap_bounds() {
+        let (mut disp, _cpu, mut bus) = setup_with_port();
+
+        let screen_base = bus.alloc(8);
+        disp.screen_mode = (screen_base, 4, 12, 1, 2);
+        bus.write_long(0x0824, screen_base);
+        let (clut, _) = TrapDispatcher::standard_mac_indexed_clut(2).unwrap();
+        disp.color_manager_clut = clut;
+        disp.device_clut = clut;
+        let gdevice_handle = disp.ensure_main_gdevice(&mut bus);
+        bus.write_long(0x08A4, gdevice_handle);
+        bus.write_long(0x0CC8, gdevice_handle);
+
+        let ctab_handle = make_ctab_handle(&mut bus, &clut, 2);
+        let offscreen_base = bus.alloc(8);
+        let pixmap_handle = install_8bpp_cgrafport(&mut bus, offscreen_base, 3, 8, 1, ctab_handle);
+        let pixmap = bus.read_long(pixmap_handle);
+        bus.write_word(pixmap + 32, 2);
+        bus.write_word(pixmap + 36, 2);
+        bus.write_word(PORT_PTR + 22, 12);
+        let source = [0b00_01_10_11, 0b11_10_01_00, 0xcd];
+        bus.write_bytes(offscreen_base, &source);
+        bus.fill_bytes(screen_base, 8, 0xaa);
+        disp.front_window = PORT_PTR;
+
+        disp.blit_window_to_screen(&mut bus);
+
+        assert_eq!(
+            bus.read_bytes(screen_base, 4),
+            vec![source[0], source[1], 0xaa, 0xaa]
+        );
+        assert_eq!(bus.read_bytes(screen_base + 4, 4), vec![0xaa; 4]);
+        assert_eq!(bus.read_bytes(offscreen_base, 3), source);
+    }
+
+    #[test]
+    fn window_blit_clamps_extreme_bounds_to_indexed_source_and_destination_rows() {
+        for depth in [1u16, 2, 4, 8] {
+            let (mut disp, _cpu, mut bus) = setup_with_port();
+            let screen_base = bus.alloc(8);
+            disp.screen_mode = (screen_base, 1, 16, 1, depth);
+            bus.write_long(0x0824, screen_base);
+            let (screen_clut, _) = TrapDispatcher::standard_mac_indexed_clut(depth).unwrap();
+            disp.color_manager_clut = screen_clut;
+            disp.device_clut = screen_clut;
+            let gdevice_handle = disp.ensure_main_gdevice(&mut bus);
+            bus.write_long(0x08A4, gdevice_handle);
+            bus.write_long(0x0CC8, gdevice_handle);
+            let screen_ctab_handle = TrapDispatcher::gdevice_ctab_handle(&bus, gdevice_handle);
+
+            let (source_ctab_handle, source_pixel, expected_first) = if depth == 8 {
+                let mut source_clut = screen_clut;
+                source_clut[42] = screen_clut[7];
+                (make_ctab_handle(&mut bus, &source_clut, 0x1234_5678), 42, 7)
+            } else {
+                (screen_ctab_handle, 0, 0)
+            };
+            let offscreen_base = bus.alloc(8);
+            let pixmap_handle =
+                install_8bpp_cgrafport(&mut bus, offscreen_base, 1, 16, 1, source_ctab_handle);
+            let pixmap = bus.read_long(pixmap_handle);
+            bus.write_word(pixmap + 32, depth);
+            bus.write_word(pixmap + 36, depth);
+            if depth == 1 {
+                // Exercise the full signed QuickDraw coordinate span. The
+                // declared geometry is deliberately much wider than either
+                // one-byte row and must not overflow i16 arithmetic.
+                bus.write_word(pixmap + 8, i16::MIN as u16);
+                bus.write_word(pixmap + 12, i16::MAX as u16);
+                bus.write_word(PORT_PTR + 18, i16::MIN as u16);
+                bus.write_word(PORT_PTR + 22, i16::MAX as u16);
+            }
+            let source = [source_pixel, 0xCD, 0xCD, 0xCD];
+            bus.write_bytes(offscreen_base, &source);
+            bus.fill_bytes(screen_base, 8, 0xAA);
+            disp.front_window = PORT_PTR;
+
+            disp.blit_window_to_screen(&mut bus);
+
+            assert_eq!(
+                bus.read_byte(screen_base),
+                expected_first,
+                "{depth}bpp blit should still copy the representable first row byte"
+            );
+            assert_eq!(
+                bus.read_bytes(screen_base + 1, 7),
+                vec![0xAA; 7],
+                "{depth}bpp destination padding must remain untouched"
+            );
+            assert_eq!(bus.read_bytes(offscreen_base, 4), source);
+        }
+    }
+
+    #[test]
+    fn redraw_chrome_blit_2bpp_translates_different_pixmap_tables() {
+        let (mut disp, _cpu, mut bus) = setup_with_port();
+
+        let screen_base = bus.alloc(2);
+        disp.screen_mode = (screen_base, 2, 8, 1, 2);
+        bus.write_long(0x0824, screen_base);
+        let gdevice_handle = disp.ensure_main_gdevice(&mut bus);
+        bus.write_long(0x08A4, gdevice_handle);
+        bus.write_long(0x0CC8, gdevice_handle);
+        let screen_ctab_handle = TrapDispatcher::gdevice_ctab_handle(&bus, gdevice_handle);
+        let screen_ctab = bus.read_long(screen_ctab_handle);
+        bus.write_long(screen_ctab, 0x2222_0002);
+
+        let mut dst_clut = TrapDispatcher::standard_mac_8bpp_clut();
+        dst_clut[1] = [0x1234, 0x5678, 0x9abc];
+        disp.color_manager_clut = dst_clut;
+        disp.device_clut = dst_clut;
+        let mut src_clut = dst_clut;
+        src_clut[3] = dst_clut[1];
+        src_clut[1] = [0xffff, 0, 0];
+        let src_ctab_handle = make_ctab_handle(&mut bus, &src_clut, 0x1111_0002);
+
+        let offscreen_base = bus.alloc(2);
+        let pixmap_handle =
+            install_8bpp_cgrafport(&mut bus, offscreen_base, 2, 8, 1, src_ctab_handle);
+        let pixmap = bus.read_long(pixmap_handle);
+        bus.write_word(pixmap + 32, 2);
+        bus.write_word(pixmap + 36, 2);
+        bus.write_bytes(offscreen_base, &[0xff, 0xff]);
+        bus.fill_bytes(screen_base, 2, 0xaa);
+        disp.front_window = PORT_PTR;
+        disp.window_bounds = (0, 0, 1, 8);
+        disp.window_proc_id = 1;
+
+        disp.blit_window_to_screen(&mut bus);
+
+        assert_eq!(
+            bus.read_bytes(screen_base, 2),
+            vec![0x55, 0x55],
+            "source index 3 must map to the active 2bpp destination's exact color at index 1"
+        );
+    }
+
+    #[test]
+    fn redraw_chrome_blit_2bpp_to_8bpp_translates_pixels_without_touching_padding() {
+        let (mut disp, _cpu, mut bus) = setup_with_port();
+
+        let screen_base = bus.alloc(16);
+        disp.screen_mode = (screen_base, 16, 12, 1, 8);
+        bus.write_long(0x0824, screen_base);
+        let gdevice_handle = disp.ensure_main_gdevice(&mut bus);
+        bus.write_long(0x08A4, gdevice_handle);
+        bus.write_long(0x0CC8, gdevice_handle);
+
+        let mut dst_clut = TrapDispatcher::standard_mac_8bpp_clut();
+        let destination_indices = [10u8, 20, 30, 40];
+        let colors = [
+            [0x1111, 0x2222, 0x3333],
+            [0x4444, 0x5555, 0x6666],
+            [0x7777, 0x8888, 0x9999],
+            [0xaaaa, 0xbbbb, 0xcccc],
+        ];
+        for (index, color) in destination_indices.into_iter().zip(colors) {
+            dst_clut[index as usize] = color;
+        }
+        disp.color_manager_clut = dst_clut;
+        disp.device_clut = dst_clut;
+
+        let mut src_clut = [[0u16; 3]; 256];
+        src_clut[..4].copy_from_slice(&colors);
+        let src_ctab_handle = make_ctab_handle(&mut bus, &src_clut, 0x2000_0002);
+        let offscreen_base = bus.alloc(8);
+        let pixmap_handle =
+            install_8bpp_cgrafport(&mut bus, offscreen_base, 3, 6, 1, src_ctab_handle);
+        let pixmap = bus.read_long(pixmap_handle);
+        bus.write_word(pixmap + 8, (-1i16) as u16);
+        bus.write_word(pixmap + 12, 5);
+        bus.write_word(pixmap + 32, 2);
+        bus.write_word(pixmap + 36, 2);
+        bus.write_word(PORT_PTR + 18, 0);
+        bus.write_word(PORT_PTR + 22, 5);
+
+        let source = [0b11_00_01_10, 0b11_01_00_00, 0xcc];
+        bus.write_bytes(offscreen_base, &source);
+        bus.fill_bytes(screen_base, 16, 0xa5);
+        disp.front_window = PORT_PTR;
+        disp.window_proc_id = 1;
+
+        disp.blit_window_to_screen(&mut bus);
+
+        assert_eq!(bus.read_byte(screen_base), 0xa5);
+        assert_eq!(bus.read_bytes(screen_base + 1, 5), vec![10, 20, 30, 40, 20]);
+        assert_eq!(bus.read_bytes(screen_base + 6, 10), vec![0xa5; 10]);
+        assert_eq!(bus.read_bytes(offscreen_base, 3), source);
+    }
+
+    #[test]
+    fn redraw_chrome_blit_4bpp_to_2bpp_preserves_odd_edges_and_row_padding() {
+        let (mut disp, _cpu, mut bus) = setup_with_port();
+
+        let screen_base = bus.alloc(8);
+        disp.screen_mode = (screen_base, 4, 12, 1, 2);
+        bus.write_long(0x0824, screen_base);
+        let gdevice_handle = disp.ensure_main_gdevice(&mut bus);
+        bus.write_long(0x08A4, gdevice_handle);
+        bus.write_long(0x0CC8, gdevice_handle);
+
+        let colors = [
+            [0xffff, 0xffff, 0xffff],
+            [0xffff, 0, 0],
+            [0, 0xffff, 0],
+            [0, 0, 0],
+        ];
+        let mut dst_clut = [[0u16; 3]; 256];
+        dst_clut[..4].copy_from_slice(&colors);
+        disp.color_manager_clut = dst_clut;
+        disp.device_clut = dst_clut;
+
+        let mut src_clut = [[0u16; 3]; 256];
+        for (index, color) in src_clut[..16].iter_mut().enumerate() {
+            *color = colors[index % colors.len()];
+        }
+        let src_ctab_handle = make_ctab_handle(&mut bus, &src_clut, 0x4000_0004);
+        let offscreen_base = bus.alloc(10);
+        let pixmap_handle =
+            install_8bpp_cgrafport(&mut bus, offscreen_base, 6, 10, 1, src_ctab_handle);
+        let pixmap = bus.read_long(pixmap_handle);
+        bus.write_word(pixmap + 8, (-1i16) as u16);
+        bus.write_word(pixmap + 12, 9);
+        bus.write_word(pixmap + 32, 4);
+        bus.write_word(pixmap + 36, 4);
+        bus.write_word(PORT_PTR + 18, 0);
+        bus.write_word(PORT_PTR + 22, 8);
+
+        let source = [0xf0, 0x12, 0x31, 0x23, 0x0f, 0xcd];
+        bus.write_bytes(offscreen_base, &source);
+        bus.fill_bytes(screen_base, 8, 0xaa);
+        disp.front_window = PORT_PTR;
+        disp.window_proc_id = 1;
+
+        disp.blit_window_to_screen(&mut bus);
+
+        assert_eq!(bus.read_bytes(screen_base, 4), vec![0x86, 0xdb, 0x2a, 0xaa]);
+        assert_eq!(bus.read_bytes(screen_base + 4, 4), vec![0xaa; 4]);
+        assert_eq!(bus.read_bytes(offscreen_base, 6), source);
     }
 
     #[test]

--- a/src/trap/menu.rs
+++ b/src/trap/menu.rs
@@ -821,7 +821,7 @@ impl super::TrapDispatcher {
         pixel_size: u16,
         black: bool,
     ) -> Option<u8> {
-        if !matches!(pixel_size, 4 | 8) {
+        if !matches!(pixel_size, 2 | 4 | 8) {
             return None;
         }
         Self::menu_color_rgb_pixel_index(bus, if black { [0; 3] } else { [0xFFFF; 3] })
@@ -905,7 +905,7 @@ impl super::TrapDispatcher {
         bus: &MacMemoryBus,
         pixel_size: u16,
     ) -> Option<u8> {
-        if !matches!(pixel_size, 4 | 8) {
+        if !matches!(pixel_size, 2 | 4 | 8) {
             return None;
         }
 
@@ -926,7 +926,7 @@ impl super::TrapDispatcher {
         menu_id: i16,
         pixel_size: u16,
     ) -> Option<u8> {
-        if !matches!(pixel_size, 4 | 8) {
+        if !matches!(pixel_size, 2 | 4 | 8) {
             return None;
         }
 
@@ -949,7 +949,7 @@ impl super::TrapDispatcher {
         menu_id: i16,
         pixel_size: u16,
     ) -> Option<u8> {
-        if !matches!(pixel_size, 4 | 8) {
+        if !matches!(pixel_size, 2 | 4 | 8) {
             return None;
         }
 
@@ -969,7 +969,7 @@ impl super::TrapDispatcher {
         menu_id: i16,
         pixel_size: u16,
     ) -> Option<u8> {
-        if !matches!(pixel_size, 4 | 8) {
+        if !matches!(pixel_size, 2 | 4 | 8) {
             return None;
         }
 
@@ -993,7 +993,7 @@ impl super::TrapDispatcher {
         pixel_size: u16,
         item_rgb_offset: u32,
     ) -> Option<u8> {
-        if !matches!(pixel_size, 4 | 8) {
+        if !matches!(pixel_size, 2 | 4 | 8) {
             return None;
         }
 
@@ -1019,7 +1019,7 @@ impl super::TrapDispatcher {
         menu_item: i16,
         pixel_size: u16,
     ) -> Option<u8> {
-        if !matches!(pixel_size, 4 | 8) {
+        if !matches!(pixel_size, 2 | 4 | 8) {
             return None;
         }
 
@@ -1070,7 +1070,7 @@ impl super::TrapDispatcher {
         foreground_index: Option<u8>,
         pixel_size: u16,
     ) -> Option<(u8, u8)> {
-        if !matches!(pixel_size, 4 | 8) {
+        if !matches!(pixel_size, 2 | 4 | 8) {
             return None;
         }
 
@@ -1095,9 +1095,10 @@ impl super::TrapDispatcher {
         }
     }
 
-    fn hilite_packed_4bpp_menu_pixel(
+    fn hilite_packed_menu_pixel(
         bus: &mut MacMemoryBus,
         screen: (u32, u32, i16, i16),
+        pixel_size: u16,
         x: i16,
         y: i16,
         hilite_indexes: (u8, u8),
@@ -1107,21 +1108,24 @@ impl super::TrapDispatcher {
             return;
         }
 
-        // Imaging With QuickDraw 1994 pp. 4-88 to 4-89: 4-bit indexed
-        // pixels are packed high-nibble first. Read only the target pixel,
-        // then use the packed-aware setter so its neighbour survives.
-        let packed = bus.read_byte(screen_base + (y as u32) * row_bytes + (x as u32 / 2));
-        let pixel = if x & 1 == 0 {
-            packed >> 4
-        } else {
-            packed & 0x0F
+        let Some(pixel) = Self::fb_get_pixel_index(
+            bus,
+            screen_base,
+            row_bytes,
+            pixel_size,
+            screen_width,
+            screen_height,
+            x,
+            y,
+        ) else {
+            return;
         };
         let highlighted = Self::menu_hilited_pixel_index(pixel, hilite_indexes.0, hilite_indexes.1);
         Self::fb_set_pixel_index(
             bus,
             screen_base,
             row_bytes,
-            4,
+            pixel_size,
             screen_width,
             screen_height,
             x,
@@ -4389,7 +4393,7 @@ impl super::TrapDispatcher {
                     continue;
                 }
 
-                if matches!(screen_pixel_size, 4 | 8) && layout.pixel_size >= 2 {
+                if matches!(screen_pixel_size, 2 | 4 | 8) && layout.pixel_size >= 2 {
                     let Some(pixel_index) = Self::menu_cicn_pixel_index(
                         bus,
                         layout.pixel_data_ptr,
@@ -5101,20 +5105,21 @@ impl super::TrapDispatcher {
                 && item.enabled
                 && !is_separator;
             let selected_mono = classic_selected && pixel_size == 1;
-            let selected_colors = (classic_selected && matches!(pixel_size, 4 | 8)).then(|| {
-                // IM:V 1986 pp. V-233 and V-249: the standard color MDEF
-                // redraws a selected row with its item/name color (RGB2, or
-                // the default item color) as the background and its menu
-                // background (RGB4) as the foreground for every component.
-                let selected_background = name_pixel_index
-                    .or_else(|| Self::menu_color_rgb_pixel_index(bus, [0; 3]))
-                    .unwrap_or(255);
-                let selected_foreground =
-                    Self::menu_item_background_pixel_index(bus, menu.id, item_no, pixel_size)
-                        .or_else(|| Self::menu_color_rgb_pixel_index(bus, [0xFFFF; 3]))
-                        .unwrap_or(0);
-                (selected_background, selected_foreground)
-            });
+            let selected_colors =
+                (classic_selected && matches!(pixel_size, 2 | 4 | 8)).then(|| {
+                    // IM:V 1986 pp. V-233 and V-249: the standard color MDEF
+                    // redraws a selected row with its item/name color (RGB2, or
+                    // the default item color) as the background and its menu
+                    // background (RGB4) as the foreground for every component.
+                    let selected_background = name_pixel_index
+                        .or_else(|| Self::menu_color_rgb_pixel_index(bus, [0; 3]))
+                        .unwrap_or(255);
+                    let selected_foreground =
+                        Self::menu_item_background_pixel_index(bus, menu.id, item_no, pixel_size)
+                            .or_else(|| Self::menu_color_rgb_pixel_index(bus, [0xFFFF; 3]))
+                            .unwrap_or(0);
+                    (selected_background, selected_foreground)
+                });
             if let Some((selected_background, _)) = selected_colors {
                 Self::fb_fill_rect_index(
                     bus,
@@ -5542,19 +5547,15 @@ impl super::TrapDispatcher {
             }
             let row_start = screen_base + (y as u32) * row_bytes;
             let (byte_left, byte_right) = match pixel_size {
-                1 => {
-                    // 1bpp: pixels packed 8 per byte
+                bits @ (1 | 2 | 4) => {
+                    // Packed indexed pixels occupy each byte from its high
+                    // field downward. Save whole boundary bytes so rectangles
+                    // with non-byte-aligned edges round-trip their neighbours.
+                    // Imaging With QuickDraw (1994), pp. 4-10--4-11.
+                    let pixels_per_byte = 8 / u32::from(bits);
                     (
-                        (left.max(0) as u32) / 8,
-                        (save_right.max(0) as u32).div_ceil(8),
-                    )
-                }
-                4 => {
-                    // 4bpp: pixels packed two per byte, high nibble first.
-                    // Save whole boundary bytes so odd edges round-trip.
-                    (
-                        (left.max(0) as u32) / 2,
-                        (save_right.max(0) as u32).div_ceil(2),
+                        (left.max(0) as u32) / pixels_per_byte,
+                        (save_right.max(0) as u32).div_ceil(pixels_per_byte),
                     )
                 }
                 _ => {
@@ -5583,14 +5584,13 @@ impl super::TrapDispatcher {
         let save_bottom = bottom + 1;
         let save_right = right + 1;
         let (byte_left, byte_right) = match pixel_size {
-            1 => (
-                (left.max(0) as u32) / 8,
-                (save_right.max(0) as u32).div_ceil(8),
-            ),
-            4 => (
-                (left.max(0) as u32) / 2,
-                (save_right.max(0) as u32).div_ceil(2),
-            ),
+            bits @ (1 | 2 | 4) => {
+                let pixels_per_byte = 8 / u32::from(bits);
+                (
+                    (left.max(0) as u32) / pixels_per_byte,
+                    (save_right.max(0) as u32).div_ceil(pixels_per_byte),
+                )
+            }
             _ => (left.max(0) as u32, save_right.max(0) as u32),
         };
         let bx_end = byte_right.min(row_bytes);
@@ -5638,14 +5638,18 @@ impl super::TrapDispatcher {
                     let addr = screen_base + byte_offset;
                     let b = bus.read_byte(addr);
                     bus.write_byte(addr, b ^ (1 << bit));
-                } else if pixel_size == 4 {
+                } else if matches!(pixel_size, 2 | 4) {
                     let indexes = hilite_indexes.unwrap_or((0, 15));
-                    Self::hilite_packed_4bpp_menu_pixel(
+                    Self::hilite_packed_menu_pixel(
                         bus,
                         (screen_base, row_bytes, screen_width, screen_height),
+                        pixel_size,
                         x,
                         y,
-                        indexes,
+                        (
+                            indexes.0 & ((1u16 << pixel_size) - 1) as u8,
+                            indexes.1 & ((1u16 << pixel_size) - 1) as u8,
+                        ),
                     );
                 } else if pixel_size == 8 {
                     let addr = screen_base + (y as u32) * row_bytes + (x as u32);
@@ -5670,7 +5674,7 @@ impl super::TrapDispatcher {
         if menu_bar_height <= 0 {
             return;
         }
-        if !matches!(pixel_size, 1 | 4 | 8) {
+        if !matches!(pixel_size, 1 | 2 | 4 | 8) {
             return;
         }
 
@@ -5838,13 +5842,14 @@ impl super::TrapDispatcher {
                         let addr = screen_base + byte_offset;
                         let b = bus.read_byte(addr);
                         bus.write_byte(addr, b ^ (1 << bit));
-                    } else if pixel_size == 4 {
-                        Self::hilite_packed_4bpp_menu_pixel(
+                    } else if matches!(pixel_size, 2 | 4) {
+                        Self::hilite_packed_menu_pixel(
                             bus,
                             (screen_base, row_bytes, screen_width, screen_height),
+                            pixel_size,
                             x,
                             y,
-                            hilite_indexes.unwrap_or((0, 15)),
+                            hilite_indexes.unwrap_or((0, ((1u16 << pixel_size) - 1) as u8)),
                         );
                     } else if let Some((background, foreground)) = hilite_indexes {
                         let addr = screen_base + (y as u32) * row_bytes + (x as u32);
@@ -5885,7 +5890,7 @@ impl super::TrapDispatcher {
         else {
             return;
         };
-        if !matches!(pixel_size, 4 | 8) {
+        if !matches!(pixel_size, 2 | 4 | 8) {
             return;
         }
         self.fb_draw_retro_computer_menu_mark(
@@ -5904,17 +5909,17 @@ impl super::TrapDispatcher {
             // disabled mark's checkerboard dimming involutive across both
             // HiliteMenu and nonzero FlashMenuBar calls.
             let background_x = title_x - 9;
-            let background_addr = screen_base + row_bytes + (background_x as u32 / 2);
-            let background_index = if pixel_size == 4 {
-                let packed = bus.read_byte(background_addr);
-                if background_x & 1 == 0 {
-                    packed >> 4
-                } else {
-                    packed & 0x0F
-                }
-            } else {
-                bus.read_byte(screen_base + row_bytes + background_x as u32)
-            };
+            let background_index = Self::fb_get_pixel_index(
+                bus,
+                screen_base,
+                row_bytes,
+                pixel_size,
+                screen_width,
+                screen_height,
+                background_x,
+                1,
+            )
+            .unwrap_or(0);
             self.fb_apply_menu_title_dim_pattern(
                 bus,
                 (
@@ -6715,6 +6720,33 @@ mod tests {
             "GetItemCmd should succeed"
         );
         (bus.read_word(out_ptr) & 0xFF) as u8
+    }
+
+    #[test]
+    fn packed_two_bit_menu_highlight_preserves_neighboring_pixels() {
+        let mut bus = MacMemoryBus::new(8 * 1024 * 1024);
+        let base = bus.alloc(1);
+        bus.write_byte(base, 0b00_01_10_11);
+
+        super::super::TrapDispatcher::hilite_packed_menu_pixel(
+            &mut bus,
+            (base, 1, 4, 1),
+            2,
+            0,
+            0,
+            (0, 3),
+        );
+        assert_eq!(bus.read_byte(base), 0b11_01_10_11);
+
+        super::super::TrapDispatcher::hilite_packed_menu_pixel(
+            &mut bus,
+            (base, 1, 4, 1),
+            2,
+            3,
+            0,
+            (0, 3),
+        );
+        assert_eq!(bus.read_byte(base), 0b11_01_10_00);
     }
 
     // IM:I I-353: AddResMenu appends named resources of the requested type
@@ -14817,6 +14849,43 @@ mod tests {
             bus.read_bytes(base, byte_len as usize),
             before,
             "4bpp save/restore should preserve both boundary nibbles byte-for-byte"
+        );
+    }
+
+    #[test]
+    fn save_and_restore_dropdown_pixels_2bpp_round_trip_odd_field_bounds() {
+        let (mut disp, _cpu, mut bus) = setup();
+        let row_bytes = 4u32;
+        let height = 4u32;
+        let base = bus.alloc(row_bytes * height);
+        disp.screen_mode = (base, row_bytes, 12, height as u16, 2);
+        for offset in 0..row_bytes * height {
+            bus.write_byte(
+                base + offset,
+                (offset as u8).wrapping_mul(11).wrapping_add(5),
+            );
+        }
+        let before = bus.read_bytes(base, (row_bytes * height) as usize);
+
+        // The rectangle plus its one-pixel shadow spans x=3 through x=8.
+        // At 2bpp that occupies the first three bytes of each included row;
+        // the fourth byte is scanline padding and must remain outside the
+        // snapshot.
+        let rect = (0, 3, 1, 8);
+        let saved = disp.save_dropdown_pixels(&bus, rect);
+        assert_eq!(saved.len(), 2 * 3);
+
+        for y in 0..2u32 {
+            for byte_x in 0..3u32 {
+                bus.write_byte(base + y * row_bytes + byte_x, 0xAA);
+            }
+        }
+        disp.restore_dropdown_pixels(&mut bus, rect, &saved);
+
+        assert_eq!(
+            bus.read_bytes(base, (row_bytes * height) as usize),
+            before,
+            "2bpp save/restore should preserve boundary fields without touching row padding"
         );
     }
 

--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -3443,6 +3443,7 @@ impl super::TrapDispatcher {
                             dst_clut,
                             dst_ctab_handle,
                             src_info.pixel_size,
+                            dst_info.pixel_size,
                         )),
                         _ => None,
                     }
@@ -3635,11 +3636,25 @@ impl super::TrapDispatcher {
                         palette_translation.is_some(),
                     );
                 }
+                let destination_entry_count =
+                    Self::indexed_ctab_entry_count(dst_info.pixel_size) as usize;
                 let fg_index = dst_clut.as_ref().map(|clut| {
-                    self.palette_index_for_rgb(bus, dst_ctab_handle, clut, copy_fg_rgb)
+                    self.palette_index_for_rgb_with_entry_count(
+                        bus,
+                        dst_ctab_handle,
+                        clut,
+                        copy_fg_rgb,
+                        destination_entry_count,
+                    )
                 });
                 let bg_index = dst_clut.as_ref().map(|clut| {
-                    self.palette_index_for_rgb(bus, dst_ctab_handle, clut, copy_bg_rgb)
+                    self.palette_index_for_rgb_with_entry_count(
+                        bus,
+                        dst_ctab_handle,
+                        clut,
+                        copy_bg_rgb,
+                        destination_entry_count,
+                    )
                 });
                 let transparent_src_indices = if mode_base == 36 {
                     self.copy_bits_transparent_source_indices(
@@ -3829,12 +3844,13 @@ impl super::TrapDispatcher {
                                 ) else {
                                     continue;
                                 };
-                                let mapped = self.palette_index_for_rgb(
+                                let mapped = self.palette_index_for_rgb_with_entry_count(
                                     bus,
                                     dst_ctab_handle,
                                     dst_clut,
                                     result_rgb,
-                                ) & pixel_mask;
+                                    1usize << dst_bits,
+                                );
                                 let shifted_mask = pixel_mask << dst_shift;
                                 bus.write_byte(
                                     dst_addr,
@@ -3870,6 +3886,7 @@ impl super::TrapDispatcher {
                                     dst_ctab_handle,
                                     src_clut,
                                     dst_clut,
+                                    1usize << dst_bits,
                                     palette_translation,
                                     shared_indexed_pixel_mask,
                                     mode_base,
@@ -3915,6 +3932,7 @@ impl super::TrapDispatcher {
                                     dst_ctab_handle,
                                     src_clut,
                                     dst_clut,
+                                    256,
                                     palette_translation,
                                     None,
                                     mode_base,
@@ -3972,6 +3990,7 @@ impl super::TrapDispatcher {
                                     dst_ctab_handle,
                                     src_clut,
                                     dst_clut,
+                                    256,
                                     palette_translation,
                                     shared_indexed_pixel_mask,
                                     mode_base,
@@ -6361,7 +6380,8 @@ impl super::TrapDispatcher {
                     let flags = bus.read_word(sp);
                     let which_flags = bus.read_word(sp + 2);
                     let depth = bus.read_word(sp + 4);
-                    let mode_id = Self::has_depth_mode_id(depth, which_flags, flags);
+                    let gd = bus.read_long(sp + 6);
+                    let mode_id = self.has_depth_mode_id(bus, gd, depth, which_flags, flags);
                     bus.write_word(sp + 10, mode_id);
                     cpu.write_reg(Register::A7, sp + 10);
                     return Some(Ok(()));
@@ -6371,9 +6391,11 @@ impl super::TrapDispatcher {
                     // FUNCTION SetDepth(gd: GDHandle; depth, whichFlags,
                     //                   flags: Integer): OSErr;
                     // IM:VI VI-21-12
+                    let flags = bus.read_word(sp);
+                    let which_flags = bus.read_word(sp + 2);
                     let depth = bus.read_word(sp + 4);
                     let gd = bus.read_long(sp + 6);
-                    let result = self.set_depth_or_mode(cpu, bus, gd, depth);
+                    let result = self.set_depth_or_mode(cpu, bus, gd, depth, which_flags, flags);
                     bus.write_word(sp + 10, result);
                     cpu.write_reg(Register::A7, sp + 10);
                     cpu.write_reg(Register::D0, result as i32 as u32);
@@ -6628,7 +6650,7 @@ impl super::TrapDispatcher {
                     // nonzero mode ID when supported.
                     //
                     // Systemless exposes the common classic Mac display
-                    // depths as device capabilities. 1bpp, 4bpp, and 8bpp are
+                    // depths as device capabilities. 1bpp, 2bpp, 4bpp, and 8bpp are
                     // wired to screenBits/screen_mode; other supported depths
                     // are recorded at the GDevice level without changing the
                     // backing framebuffer.
@@ -6636,8 +6658,8 @@ impl super::TrapDispatcher {
                         let flags = bus.read_word(sp + 2);
                         let which_flags = bus.read_word(sp + 4);
                         let depth = bus.read_word(sp + 6);
-                        let _gd = bus.read_long(sp + 8);
-                        let mode_id = Self::has_depth_mode_id(depth, which_flags, flags);
+                        let gd = bus.read_long(sp + 8);
+                        let mode_id = self.has_depth_mode_id(bus, gd, depth, which_flags, flags);
                         bus.write_word(sp + 12, mode_id);
                         cpu.write_reg(Register::A7, sp + 12);
                     }
@@ -6648,16 +6670,17 @@ impl super::TrapDispatcher {
                     //
                     // Stack: same layout as HasDepth (10-byte arg block).
                     // Result is OSErr (Integer). Systemless updates screenBits
-                    // and screen_mode for the wired 1bpp/4bpp/8bpp paths, and
+                    // and screen_mode for the wired 1bpp/2bpp/4bpp/8bpp paths, and
                     // records other supported depth requests on the GDevice
                     // without changing the backing framebuffer.
                     //
                     0x0A13 => {
-                        let _flags = bus.read_word(sp + 2);
-                        let _which = bus.read_word(sp + 4);
+                        let flags = bus.read_word(sp + 2);
+                        let which_flags = bus.read_word(sp + 4);
                         let depth = bus.read_word(sp + 6);
                         let gd = bus.read_long(sp + 8);
-                        let result = self.set_depth_or_mode(cpu, bus, gd, depth);
+                        let result =
+                            self.set_depth_or_mode(cpu, bus, gd, depth, which_flags, flags);
                         bus.write_word(sp + 12, result);
                         cpu.write_reg(Register::A7, sp + 12);
                         cpu.write_reg(Register::D0, result as i32 as u32);
@@ -14009,6 +14032,7 @@ impl super::TrapDispatcher {
                             dst_clut,
                             dst_ctab_handle,
                             src_info.pixel_size,
+                            dst_info.pixel_size,
                         ))
                     }
                     _ => None,
@@ -14971,6 +14995,8 @@ impl super::TrapDispatcher {
                                 let vp_block = list + VP_BLOCK_OFFSET;
                                 let name = list + NAME_OFFSET;
                                 let (_, row_bytes, width, height, pixel_size) = self.screen_mode;
+                                let depth_mode =
+                                    crate::display::classic_depth_mode(pixel_size).unwrap_or(0);
 
                                 bus.write_long(list, u32::from_be_bytes(*b"DML1"));
                                 bus.write_long(list + 4, display_id);
@@ -14981,7 +15007,7 @@ impl super::TrapDispatcher {
                                 bus.write_long(entry + 20, 1);
                                 bus.write_long(entry + 24, name);
 
-                                bus.write_word(switch_info, 0x85);
+                                bus.write_word(switch_info, depth_mode);
                                 bus.write_long(switch_info + 2, 0x80);
                                 bus.write_long(switch_info + 8, self.screen_mode.0);
 
@@ -14989,7 +15015,7 @@ impl super::TrapDispatcher {
                                 bus.write_long(resolution + 8, u32::from(width));
                                 bus.write_long(resolution + 12, u32::from(height));
                                 bus.write_long(resolution + 16, 60 << 16);
-                                bus.write_long(resolution + 20, 0x85);
+                                bus.write_long(resolution + 20, u32::from(depth_mode));
                                 bus.write_long(timing, 0x80);
 
                                 bus.write_long(depth_block, 1);
@@ -15115,7 +15141,7 @@ impl super::TrapDispatcher {
                     //                  UInt32 reserved, Handle displayState) -> OSErr.
                     // Abuse uses this after accepting the 640x480/256-colour
                     // switch dialog. The single-screen HLE keeps the active
-                    // framebuffer, writes the current device mode to depthMode
+                    // framebuffer, writes the selected device mode to depthMode
                     // for nonzero requests, and routes mode 0 through the
                     // BasiliskII rejection path that leaves depthMode alone,
                     // keeps the main GDevice gdMode unchanged, and does not
@@ -15125,18 +15151,19 @@ impl super::TrapDispatcher {
                         let mode = bus.read_long(sp + 12);
                         let gdh = bus.read_long(sp + 16);
                         let gd = if gdh != 0 { bus.read_long(gdh) } else { 0 };
-                        let current_mode = if gd != 0 { bus.read_long(gd + 42) } else { 0 };
                         let result = if mode == 0 {
                             DM_SET_DISPLAY_MODE_REJECT_ERR
                         } else {
                             let (width, height) = Self::display_mode_geometry(mode)
                                 .unwrap_or_else(|| self.current_screen_geometry());
                             if self.do_setdepth_with_geometry(cpu, bus, 8, width, height) {
+                                let depth_mode = crate::display::classic_depth_mode(8)
+                                    .expect("8-bit display mode is defined by Video.h");
                                 if depth_mode_ptr != 0 {
-                                    bus.write_long(depth_mode_ptr, current_mode);
+                                    bus.write_long(depth_mode_ptr, u32::from(depth_mode));
                                 }
                                 if gd != 0 {
-                                    bus.write_long(gd + 42, mode);
+                                    bus.write_long(gd + 42, u32::from(depth_mode));
                                 }
                                 0
                             } else {
@@ -15166,11 +15193,10 @@ impl super::TrapDispatcher {
                     // DMGetDisplayMode(GDHandle theDevice, VDSwitchInfoPtr switchInfo)
                     // -> OSErr. VDSwitchInfoRec layout from Video.h:
                     //   csMode.w, csData.l, csPage.w, csBaseAddr.l, csReserved.l.
-                    // BasiliskII/System 7.5.3 reports csMode=$0085 and
-                    // csData=$00000080 for the main 8bpp display. Systemless
-                    // returns its guest framebuffer base instead of Basilisk's
-                    // physical `$A0000000` so callers that use the returned
-                    // pointer stay inside emulated RAM.
+                    // Video.h defines csMode as the active depth-mode token;
+                    // csData is the separate timing/display-mode ID. Systemless
+                    // returns its guest framebuffer base so callers that use
+                    // the returned pointer stay inside emulated RAM.
                     0x043E => {
                         let switch_info = bus.read_long(sp);
                         let device_gdh = bus.read_long(sp + 4);
@@ -15180,10 +15206,12 @@ impl super::TrapDispatcher {
                             self.ensure_main_gdevice(bus)
                         };
                         let gd = if gdh != 0 { bus.read_long(gdh) } else { 0 };
-                        let current_mode = if gd != 0 {
+                        let current_depth_mode = if gd != 0 {
                             bus.read_long(gd + 42)
                         } else {
-                            0x0000_0085
+                            crate::display::classic_depth_mode(self.screen_mode.4)
+                                .map(u32::from)
+                                .unwrap_or(0)
                         };
                         if switch_info != 0 {
                             let mut screen_base = self.screen_mode.0;
@@ -15200,7 +15228,7 @@ impl super::TrapDispatcher {
                                     REFERENCE_MACHINE_PROFILE.screen_depth,
                                 );
                             }
-                            bus.write_word(switch_info, current_mode as u16);
+                            bus.write_word(switch_info, current_depth_mode as u16);
                             bus.write_long(switch_info + 2, 0x0000_0080);
                             bus.write_word(switch_info + 6, 0);
                             bus.write_long(switch_info + 8, screen_base);
@@ -16129,15 +16157,12 @@ impl super::TrapDispatcher {
         bus.write_word(gd + 36, 0); // gdRect.left
         bus.write_word(gd + 38, screen_height);
         bus.write_word(gd + 40, screen_width);
-        // Keep the legacy 800x600 token for the default 8-bit mode. For a
-        // frontend-selected packed depth, expose that depth as the active
-        // Graphics Devices mode identifier so gdMode agrees with pixelSize.
-        let display_mode = if screen_depth == 8 {
-            0x0000_0085
-        } else {
-            u32::from(screen_depth)
-        };
-        bus.write_long(gd + 42, display_mode);
+        // Video.h depth-mode tokens are distinct from PixMap pixelSize and
+        // Display Manager timing IDs. Imaging With QuickDraw (1994),
+        // pp. 5-33--5-35, permits the HasDepth mode to be passed to SetDepth.
+        let depth_mode = crate::display::classic_depth_mode(screen_depth)
+            .expect("validated screen depth has a classic Video.h mode");
+        bus.write_long(gd + 42, u32::from(depth_mode));
 
         let gd_handle = bus.alloc(4);
         bus.write_long(gd_handle, gd);
@@ -16217,32 +16242,60 @@ impl super::TrapDispatcher {
         bus.write_word(gd + 20, flags);
     }
 
-    fn has_depth_mode_id(depth: u16, which_flags: u16, flags: u16) -> u16 {
-        // HasDepth's flags bit 0 is the color-device constraint. Classic
-        // color hardware can also advertise indexed grayscale monitor modes
-        // such as 4-bit "16 grays" and 8-bit "256 grays"; Glider PRO checks
-        // those modes before showing its color-depth dialog.
-        if which_flags & 1 != 0 && flags & 1 == 0 {
-            return match depth {
-                1 | 2 | 4 | 8 => depth,
-                _ => 0,
-            };
-        }
-
-        if Self::supported_depth_from_mode(depth).is_some() {
-            depth
+    fn gdevice_depth_flags(&mut self, bus: &mut MacMemoryBus, gdh: u32) -> Option<(u32, u16)> {
+        let gdh = if gdh == 0 {
+            self.ensure_main_gdevice(bus)
         } else {
-            0
+            gdh
+        };
+        let gd = bus.read_long(gdh);
+        (gd != 0).then(|| (gdh, bus.read_word(gd + 20)))
+    }
+
+    fn supported_depth_personality(
+        depth_or_mode: u16,
+        which_flags: u16,
+        flags: u16,
+        current_flags: u16,
+    ) -> Option<(u16, bool)> {
+        let depth = Self::supported_depth_from_mode(depth_or_mode)?;
+        let is_color = if which_flags & 1 != 0 {
+            flags & 1 != 0
+        } else {
+            match depth {
+                1 => false,
+                16 | 32 => true,
+                _ => current_flags & 1 != 0,
+            }
+        };
+        if (depth == 1 && is_color) || (matches!(depth, 16 | 32) && !is_color) {
+            return None;
         }
+        let fixed_mask = which_flags & !1;
+        if current_flags & fixed_mask != flags & fixed_mask {
+            return None;
+        }
+        Some((depth, is_color))
+    }
+
+    fn has_depth_mode_id(
+        &mut self,
+        bus: &mut MacMemoryBus,
+        gdh: u32,
+        depth_or_mode: u16,
+        which_flags: u16,
+        flags: u16,
+    ) -> u16 {
+        let Some((_, current_flags)) = self.gdevice_depth_flags(bus, gdh) else {
+            return 0;
+        };
+        Self::supported_depth_personality(depth_or_mode, which_flags, flags, current_flags)
+            .and_then(|(depth, _)| crate::display::classic_depth_mode(depth))
+            .unwrap_or(0)
     }
 
     fn supported_depth_from_mode(depth_or_mode: u16) -> Option<u16> {
-        match depth_or_mode {
-            1 | 2 | 4 | 8 | 16 | 32 => Some(depth_or_mode),
-            // Display Manager mode tokens already used by the HLE paths.
-            0x0080 | 0x0085 => Some(8),
-            _ => None,
-        }
+        crate::display::classic_pixel_size(depth_or_mode)
     }
 
     fn palette_dispatch_selector(d0: u32) -> u16 {
@@ -16403,8 +16456,8 @@ impl super::TrapDispatcher {
         &mut self,
         bus: &mut MacMemoryBus,
         gdh: u32,
-        mode: u16,
         depth: u16,
+        is_color: bool,
     ) {
         let gdh = if gdh != 0 {
             gdh
@@ -16416,10 +16469,13 @@ impl super::TrapDispatcher {
             return;
         }
 
+        let Some(mode) = crate::display::classic_depth_mode(depth) else {
+            return;
+        };
         bus.write_long(gd + 42, u32::from(mode));
         let mut flags = bus.read_word(gd + 20);
         flags &= !1;
-        if depth > 1 {
+        if is_color {
             flags |= 1;
         }
         bus.write_word(gd + 20, flags);
@@ -16431,21 +16487,30 @@ impl super::TrapDispatcher {
         bus: &mut MacMemoryBus,
         gdh: u32,
         depth_or_mode: u16,
+        which_flags: u16,
+        flags: u16,
     ) -> u16 {
-        let Some(depth) = Self::supported_depth_from_mode(depth_or_mode) else {
+        let Some((gdh, current_flags)) = self.gdevice_depth_flags(bus, gdh) else {
+            return (-50i16) as u16; // paramErr
+        };
+        let Some((depth, is_color)) =
+            Self::supported_depth_personality(depth_or_mode, which_flags, flags, current_flags)
+        else {
             return (-50i16) as u16; // paramErr
         };
 
-        let applied = if matches!(depth, 1 | 4 | 8) {
+        let applied = if matches!(depth, 1 | 2 | 4 | 8) {
             if depth == 8 {
                 if let Some((width, height)) = Self::display_mode_geometry(u32::from(depth_or_mode))
                 {
-                    self.do_setdepth_with_geometry(cpu, bus, depth, width, height)
+                    self.do_setdepth_with_geometry_and_personality(
+                        cpu, bus, depth, width, height, is_color,
+                    )
                 } else {
-                    self.do_setdepth(cpu, bus, depth)
+                    self.do_setdepth_with_personality(cpu, bus, depth, is_color)
                 }
             } else {
-                self.do_setdepth(cpu, bus, depth)
+                self.do_setdepth_with_personality(cpu, bus, depth, is_color)
             }
         } else {
             true
@@ -16454,7 +16519,7 @@ impl super::TrapDispatcher {
             return (-108i16) as u16; // memFullErr
         }
 
-        self.record_gdevice_depth_mode(bus, gdh, depth_or_mode, depth);
+        self.record_gdevice_depth_mode(bus, gdh, depth, is_color);
         0
     }
 
@@ -16689,7 +16754,7 @@ impl super::TrapDispatcher {
         self.resize_handle_allocation(bus, ctab_handle, 8 + entries.saturating_mul(8))
     }
 
-    fn ensure_color_table_capacity(
+    pub(crate) fn ensure_color_table_capacity(
         &mut self,
         bus: &mut MacMemoryBus,
         ctab_handle: u32,
@@ -19026,27 +19091,135 @@ impl super::TrapDispatcher {
     /// Imaging With QuickDraw 1994 pp. 5-34..5-35: SetDepth changes
     /// the pixel depth and color/B&W mode of the requested device.
     /// Systemless currently wires this for the depths its screen renderer
-    /// supports directly: 1bpp B&W plus 4bpp and 8bpp indexed color.
+    /// supports directly: 1bpp B&W plus 2bpp, 4bpp, and 8bpp indexed color.
     /// Returns false without changing the display mode when the target color
     /// tables cannot be grown safely.
+    #[cfg(test)]
     pub(crate) fn do_setdepth<C: CpuOps>(
         &mut self,
         cpu: &mut C,
         bus: &mut MacMemoryBus,
         depth: u16,
     ) -> bool {
-        self.do_setdepth_with_geometry(
+        self.do_setdepth_with_personality(cpu, bus, depth, depth > 1)
+    }
+
+    fn do_setdepth_with_personality<C: CpuOps>(
+        &mut self,
+        cpu: &mut C,
+        bus: &mut MacMemoryBus,
+        depth: u16,
+        is_color: bool,
+    ) -> bool {
+        self.do_setdepth_with_geometry_and_personality(
             cpu,
             bus,
             depth,
             REFERENCE_MACHINE_PROFILE.screen_width,
             REFERENCE_MACHINE_PROFILE.screen_height,
+            is_color,
         )
+    }
+
+    fn standard_screen_depth_clut(depth: u16, is_color: bool) -> Option<([[u16; 3]; 256], usize)> {
+        let (mut clut, entry_count) = Self::standard_mac_indexed_clut(depth)?;
+        if !is_color {
+            let last = u32::try_from(entry_count.checked_sub(1)?).ok()?;
+            for (index, color) in clut.iter_mut().take(entry_count).enumerate() {
+                let index = u32::try_from(index).ok()?;
+                let component = ((last - index) * u32::from(u16::MAX) / last) as u16;
+                *color = [component; 3];
+            }
+        } else if depth == 2 {
+            // The standard 2-bit color screen table uses its spare entry for
+            // the System 7 highlight green; the grayscale personality keeps
+            // all four entries on the white-to-black ramp. Inside Macintosh:
+            // Volume VI (1991), pp. 17-17--17-18.
+            (clut, _) = Self::standard_mac_enhanced_clut(2, (0, 0x8000, 0))?;
+        }
+        Some((clut, entry_count))
+    }
+
+    fn do_setdepth_with_geometry<C: CpuOps>(
+        &mut self,
+        cpu: &mut C,
+        bus: &mut MacMemoryBus,
+        depth: u16,
+        width: u16,
+        height: u16,
+    ) -> bool {
+        self.do_setdepth_with_geometry_and_personality(cpu, bus, depth, width, height, depth > 1)
+    }
+
+    fn do_setdepth_with_geometry_and_personality<C: CpuOps>(
+        &mut self,
+        cpu: &mut C,
+        bus: &mut MacMemoryBus,
+        depth: u16,
+        width: u16,
+        height: u16,
+        is_color: bool,
+    ) -> bool {
+        let Some(row_bytes) = Self::row_bytes_for_depth(width, depth) else {
+            return false;
+        };
+        let ram_size = bus.ram_size();
+        let color_screen_base = ram_size - 0x80000;
+        let Some((_, entry_count)) = Self::standard_screen_depth_clut(depth, is_color) else {
+            return false;
+        };
+        if !self.preflight_setdepth_color_tables(bus, color_screen_base, entry_count) {
+            return false;
+        }
+        bus.write_long(0x0824, color_screen_base); // ScrnBase
+        bus.write_word(crate::memory::globals::addr::SCREEN_ROW, row_bytes as u16);
+
+        let sb = crate::memory::globals::addr::SCREEN_BITS;
+        bus.write_long(sb, color_screen_base);
+        bus.write_word(sb + 4, row_bytes as u16);
+        bus.write_word(sb + 6, 0);
+        bus.write_word(sb + 8, 0);
+        bus.write_word(sb + 10, height);
+        bus.write_word(sb + 12, width);
+
+        // Also update the QD globals copy of screenBits.
+        let a5 = cpu.read_reg(Register::A5);
+        let global_ptr = bus.read_long(a5);
+        if global_ptr != 0 {
+            let sb = global_ptr.wrapping_sub(122);
+            bus.write_long(sb, color_screen_base);
+            bus.write_word(sb + 4, row_bytes as u16);
+            bus.write_word(sb + 6, 0);
+            bus.write_word(sb + 8, 0);
+            bus.write_word(sb + 10, height);
+            bus.write_word(sb + 12, width);
+        }
+
+        self.sync_main_gdevice_geometry(bus, width, height, row_bytes, depth, is_color);
+        self.install_standard_depth_clut(bus, depth, is_color);
+        self.sync_screen_backed_cgrafports_depth(
+            bus,
+            color_screen_base,
+            row_bytes,
+            depth,
+            is_color,
+        );
+
+        // System 7.5.3 clears an 8bpp mode to 0xFF, as covered by the strict
+        // SetDepth oracle. Packed 1/2/4bpp modes clear to index 0; in the
+        // standard low-depth tables that is white.
+        let clear_byte = if depth == 8 { 0xFF } else { 0x00 };
+        for i in 0..(row_bytes * u32::from(height)) {
+            bus.write_byte(color_screen_base + i, clear_byte);
+        }
+        self.screen_mode = (color_screen_base, row_bytes, width, height, depth);
+        true
     }
 
     fn row_bytes_for_depth(width: u16, depth: u16) -> Option<u32> {
         match depth {
             1 => Some(u32::from(width).div_ceil(8)),
+            2 => Some(u32::from(width).div_ceil(4).next_multiple_of(2)),
             4 => Some(u32::from(width).div_ceil(2).next_multiple_of(2)),
             8 => Some(u32::from(width)),
             _ => None,
@@ -19055,10 +19228,11 @@ impl super::TrapDispatcher {
 
     fn display_mode_geometry(mode: u32) -> Option<(u16, u16)> {
         match mode {
-            // Video.h / Display Manager mode token observed from BasiliskII
-            // when games request the 640x480 8bpp switch.
+            // Display Manager timing/display-mode ID observed from BasiliskII
+            // when games request the 640x480 switch. This occupies `csData`,
+            // separate from the Video.h depth token in `csMode`.
             0x0000_0080 => Some((640, 480)),
-            // Default 800x600 8bpp mode token used by the single-screen HLE.
+            // Default 800x600 timing/display-mode ID used by the single-screen HLE.
             0x0000_0085 => Some((
                 REFERENCE_MACHINE_PROFILE.screen_width,
                 REFERENCE_MACHINE_PROFILE.screen_height,
@@ -19086,6 +19260,7 @@ impl super::TrapDispatcher {
         height: u16,
         row_bytes: u32,
         depth: u16,
+        is_color: bool,
     ) {
         let gdh = self.ensure_main_gdevice(bus);
         let gd = bus.read_long(gdh);
@@ -19121,9 +19296,8 @@ impl super::TrapDispatcher {
             }
         }
         let mut flags = bus.read_word(gd + 20);
-        if depth == 1 {
-            flags &= !0x0001;
-        } else {
+        flags &= !0x0001;
+        if is_color {
             flags |= 0x0001;
         }
         bus.write_word(gd + 20, flags);
@@ -19133,8 +19307,8 @@ impl super::TrapDispatcher {
         bus.write_word(gd + 40, width);
     }
 
-    fn install_standard_depth_clut(&mut self, bus: &mut MacMemoryBus, depth: u16) {
-        let Some((clut, entry_count)) = Self::standard_mac_indexed_clut(depth) else {
+    fn install_standard_depth_clut(&mut self, bus: &mut MacMemoryBus, depth: u16, is_color: bool) {
+        let Some((clut, entry_count)) = Self::standard_screen_depth_clut(depth, is_color) else {
             return;
         };
         self.device_clut = clut;
@@ -19163,8 +19337,9 @@ impl super::TrapDispatcher {
         screen_base: u32,
         row_bytes: u32,
         depth: u16,
+        is_color: bool,
     ) {
-        let Some((clut, entry_count)) = Self::standard_mac_indexed_clut(depth) else {
+        let Some((clut, entry_count)) = Self::standard_screen_depth_clut(depth, is_color) else {
             return;
         };
         let mut ports = self.cport_ports.iter().copied().collect::<Vec<_>>();
@@ -19246,64 +19421,6 @@ impl super::TrapDispatcher {
         ctab_handles.into_iter().all(|ctab_handle| {
             self.ensure_color_table_capacity(bus, ctab_handle, entry_count as u32) != 0
         })
-    }
-
-    fn do_setdepth_with_geometry<C: CpuOps>(
-        &mut self,
-        cpu: &mut C,
-        bus: &mut MacMemoryBus,
-        depth: u16,
-        width: u16,
-        height: u16,
-    ) -> bool {
-        let Some(row_bytes) = Self::row_bytes_for_depth(width, depth) else {
-            return false;
-        };
-        let ram_size = bus.ram_size();
-        let color_screen_base = ram_size - 0x80000;
-        let Some((_, entry_count)) = Self::standard_mac_indexed_clut(depth) else {
-            return false;
-        };
-        if !self.preflight_setdepth_color_tables(bus, color_screen_base, entry_count) {
-            return false;
-        }
-        bus.write_long(0x0824, color_screen_base); // ScrnBase
-        bus.write_word(crate::memory::globals::addr::SCREEN_ROW, row_bytes as u16);
-
-        let sb = crate::memory::globals::addr::SCREEN_BITS;
-        bus.write_long(sb, color_screen_base);
-        bus.write_word(sb + 4, row_bytes as u16);
-        bus.write_word(sb + 6, 0);
-        bus.write_word(sb + 8, 0);
-        bus.write_word(sb + 10, height);
-        bus.write_word(sb + 12, width);
-
-        // Also update the QD globals copy of screenBits.
-        let a5 = cpu.read_reg(Register::A5);
-        let global_ptr = bus.read_long(a5);
-        if global_ptr != 0 {
-            let sb = global_ptr.wrapping_sub(122);
-            bus.write_long(sb, color_screen_base);
-            bus.write_word(sb + 4, row_bytes as u16);
-            bus.write_word(sb + 6, 0);
-            bus.write_word(sb + 8, 0);
-            bus.write_word(sb + 10, height);
-            bus.write_word(sb + 12, width);
-        }
-
-        self.sync_main_gdevice_geometry(bus, width, height, row_bytes, depth);
-        self.install_standard_depth_clut(bus, depth);
-        self.sync_screen_backed_cgrafports_depth(bus, color_screen_base, row_bytes, depth);
-
-        // System 7.5.3 clears an 8bpp mode to 0xFF, as covered by the strict
-        // SetDepth oracle. Packed 1/2/4bpp modes clear to index 0; in the
-        // standard low-depth tables that is white.
-        let clear_byte = if depth == 8 { 0xFF } else { 0x00 };
-        for i in 0..(row_bytes * u32::from(height)) {
-            bus.write_byte(color_screen_base + i, clear_byte);
-        }
-        self.screen_mode = (color_screen_base, row_bytes, width, height, depth);
-        true
     }
 
     pub(super) fn sync_current_port_draw_state(&mut self, bus: &mut MacMemoryBus) {
@@ -19877,6 +19994,7 @@ impl super::TrapDispatcher {
                     dst_clut,
                     dst_ctab_handle,
                     src_info.pixel_size,
+                    dst_info.pixel_size,
                 )),
                 _ => None,
             }
@@ -19921,12 +20039,25 @@ impl super::TrapDispatcher {
                 dst_ctab_seed,
             );
         }
-        let fg_index = dst_clut
-            .as_ref()
-            .map(|clut| self.palette_index_for_rgb(bus, dst_ctab_handle, clut, copy_fg_rgb));
-        let bg_index = dst_clut
-            .as_ref()
-            .map(|clut| self.palette_index_for_rgb(bus, dst_ctab_handle, clut, copy_bg_rgb));
+        let destination_entry_count = Self::indexed_ctab_entry_count(dst_info.pixel_size) as usize;
+        let fg_index = dst_clut.as_ref().map(|clut| {
+            self.palette_index_for_rgb_with_entry_count(
+                bus,
+                dst_ctab_handle,
+                clut,
+                copy_fg_rgb,
+                destination_entry_count,
+            )
+        });
+        let bg_index = dst_clut.as_ref().map(|clut| {
+            self.palette_index_for_rgb_with_entry_count(
+                bus,
+                dst_ctab_handle,
+                clut,
+                copy_bg_rgb,
+                destination_entry_count,
+            )
+        });
         let transparent_src_indices = if mode_base == 36 {
             self.copy_bits_transparent_source_indices(
                 bus,
@@ -20129,9 +20260,13 @@ impl super::TrapDispatcher {
                         ) else {
                             continue;
                         };
-                        let mapped =
-                            self.palette_index_for_rgb(bus, dst_ctab_handle, dst_clut, result_rgb)
-                                & pixel_mask;
+                        let mapped = self.palette_index_for_rgb_with_entry_count(
+                            bus,
+                            dst_ctab_handle,
+                            dst_clut,
+                            result_rgb,
+                            1usize << dst_bits,
+                        );
                         let shifted_mask = pixel_mask << dst_shift;
                         bus.write_byte(
                             dst_addr,
@@ -20164,6 +20299,7 @@ impl super::TrapDispatcher {
                             dst_ctab_handle,
                             src_clut,
                             dst_clut,
+                            1usize << dst_bits,
                             palette_translation,
                             shared_indexed_pixel_mask,
                             mode_base,
@@ -20201,6 +20337,7 @@ impl super::TrapDispatcher {
                             dst_ctab_handle,
                             src_clut,
                             dst_clut,
+                            256,
                             palette_translation,
                             None,
                             mode_base,
@@ -20229,6 +20366,7 @@ impl super::TrapDispatcher {
                             dst_ctab_handle,
                             src_clut,
                             dst_clut,
+                            256,
                             palette_translation,
                             shared_indexed_pixel_mask,
                             mode_base,
@@ -22136,6 +22274,16 @@ impl super::TrapDispatcher {
     }
 
     pub(crate) fn nearest_palette_index(clut: &[[u16; 3]; 256], rgb: [u16; 3]) -> u8 {
+        Self::nearest_palette_index_with_entry_count(clut, rgb, 256)
+    }
+
+    fn nearest_palette_index_with_entry_count(
+        clut: &[[u16; 3]; 256],
+        rgb: [u16; 3],
+        entry_count: usize,
+    ) -> u8 {
+        let entry_count = entry_count.clamp(1, 256);
+        let terminal_index = entry_count - 1;
         // QuickDraw's inverse tables reserve exact white/black for the first
         // and last CLUT entries when the endpoints are white/black, rather
         // than returning an arbitrary duplicate color-cube entry. During
@@ -22143,26 +22291,30 @@ impl super::TrapDispatcher {
         // canonical black drawing pinned to entry 255 in that collapsed case.
         // Imaging With QuickDraw 1994, p. 4-82
         // references/executor/src/quickdraw/qColorMgr.cpp (MakeITable)
-        if rgb == [0, 0, 0] && clut[255] == [0, 0, 0] {
-            return 255;
+        if rgb == [0, 0, 0] && clut[terminal_index] == [0, 0, 0] {
+            return terminal_index as u8;
         }
         if rgb == [0xFFFF, 0xFFFF, 0xFFFF] && clut[0] == [0xFFFF, 0xFFFF, 0xFFFF] {
             return 0;
         }
-        if rgb == clut[255] {
-            return 255;
+        if rgb == clut[terminal_index] {
+            return terminal_index as u8;
         }
         if rgb == clut[0] {
             return 0;
         }
 
-        if let Some((index, _)) = clut.iter().enumerate().find(|(_, entry)| **entry == rgb) {
+        if let Some((index, _)) = clut[..entry_count]
+            .iter()
+            .enumerate()
+            .find(|(_, entry)| **entry == rgb)
+        {
             return index as u8;
         }
 
         let mut best_index = 0u8;
         let mut best_distance = u64::MAX;
-        for (index, entry) in clut.iter().enumerate() {
+        for (index, entry) in clut[..entry_count].iter().enumerate() {
             let dr = i64::from(entry[0]) - i64::from(rgb[0]);
             let dg = i64::from(entry[1]) - i64::from(rgb[1]);
             let db = i64::from(entry[2]) - i64::from(rgb[2]);
@@ -22182,9 +22334,12 @@ impl super::TrapDispatcher {
         dst_clut: &[[u16; 3]; 256],
         dst_ctab_handle: u32,
         src_pixel_size: u32,
+        dst_pixel_size: u32,
     ) -> [u8; 256] {
         let mut translation = [0u8; 256];
+        let dst_entry_count = Self::indexed_ctab_entry_count(dst_pixel_size) as usize;
         if src_pixel_size == 4
+            && dst_pixel_size == 8
             && Self::uses_standard_mac_4bpp_gworld_clut(src_clut)
             && Self::uses_canonical_system_8bpp_clut(dst_clut)
         {
@@ -22202,10 +22357,16 @@ impl super::TrapDispatcher {
             return translation;
         }
         for (index, rgb) in src_clut.iter().enumerate() {
-            translation[index] = if dst_clut[index] == *rgb {
+            translation[index] = if index < dst_entry_count && dst_clut[index] == *rgb {
                 index as u8
             } else {
-                self.palette_index_for_rgb(bus, dst_ctab_handle, dst_clut, *rgb)
+                self.palette_index_for_rgb_with_entry_count(
+                    bus,
+                    dst_ctab_handle,
+                    dst_clut,
+                    *rgb,
+                    dst_entry_count,
+                )
             };
         }
         translation
@@ -22242,6 +22403,7 @@ impl super::TrapDispatcher {
         dst_ctab_handle: u32,
         src_clut: Option<&[[u16; 3]; 256]>,
         dst_clut: Option<&[[u16; 3]; 256]>,
+        dst_entry_count: usize,
         palette_translation: Option<&[u8; 256]>,
         shared_indexed_pixel_mask: Option<u8>,
         mode_base: u16,
@@ -22275,7 +22437,15 @@ impl super::TrapDispatcher {
         let dst_rgb = dst_clut[dst_pixel as usize];
         let is_black = src_rgb == [0, 0, 0];
         let is_white = src_rgb == [0xFFFF, 0xFFFF, 0xFFFF];
-        let map_rgb = |rgb| self.palette_index_for_rgb(bus, dst_ctab_handle, dst_clut, rgb);
+        let map_rgb = |rgb| {
+            self.palette_index_for_rgb_with_entry_count(
+                bus,
+                dst_ctab_handle,
+                dst_clut,
+                rgb,
+                dst_entry_count,
+            )
+        };
 
         match mode_base {
             0 => Some(raw_source()),
@@ -23051,6 +23221,7 @@ impl super::TrapDispatcher {
         bus: &MacMemoryBus,
         ctab_handle: u32,
         rgb: [u16; 3],
+        entry_count: usize,
     ) -> Option<u8> {
         if ctab_handle == 0 {
             return None;
@@ -23060,17 +23231,26 @@ impl super::TrapDispatcher {
             return None;
         }
 
+        let entry_count = entry_count.clamp(1, 256) as u32;
         let ct_size = bus.read_word(ctab_ptr + 6) as u32;
-        for i in 0..=ct_size.min(255) {
+        let device_table = bus.read_word(ctab_ptr + 4) & 0x8000 != 0;
+        for i in 0..=ct_size.min(entry_count - 1) {
             let entry = ctab_ptr + 8 + i * 8;
-            let value = bus.read_word(entry) as u8;
+            // Device ColorTables are positional: the entry ordinal is the
+            // pixel value, while image tables use ColorSpec.value. Inside
+            // Macintosh Volume V (1986), pp. V-57--V-58.
+            let value = if device_table {
+                i as u16
+            } else {
+                bus.read_word(entry)
+            };
             let entry_rgb = [
                 bus.read_word(entry + 2),
                 bus.read_word(entry + 4),
                 bus.read_word(entry + 6),
             ];
-            if entry_rgb == rgb {
-                return Some(value);
+            if entry_rgb == rgb && u32::from(value) < entry_count {
+                return Some(value as u8);
             }
         }
         None
@@ -23083,16 +23263,28 @@ impl super::TrapDispatcher {
         clut: &[[u16; 3]; 256],
         rgb: [u16; 3],
     ) -> u8 {
+        self.palette_index_for_rgb_with_entry_count(bus, ctab_handle, clut, rgb, 256)
+    }
+
+    fn palette_index_for_rgb_with_entry_count(
+        &self,
+        bus: &MacMemoryBus,
+        ctab_handle: u32,
+        clut: &[[u16; 3]; 256],
+        rgb: [u16; 3],
+        entry_count: usize,
+    ) -> u8 {
         let screen_ctab_handle = if self.main_gdevice_handle != 0 {
             Self::gdevice_ctab_handle(bus, self.main_gdevice_handle)
         } else {
             0
         };
         if ctab_handle != 0 && ctab_handle != screen_ctab_handle {
-            Self::palette_exact_match_index(bus, ctab_handle, rgb)
-                .unwrap_or_else(|| Self::nearest_palette_index(clut, rgb))
+            Self::palette_exact_match_index(bus, ctab_handle, rgb, entry_count).unwrap_or_else(
+                || Self::nearest_palette_index_with_entry_count(clut, rgb, entry_count),
+            )
         } else {
-            Self::nearest_palette_index(clut, rgb)
+            Self::nearest_palette_index_with_entry_count(clut, rgb, entry_count)
         }
     }
 
@@ -34854,12 +35046,161 @@ mod tests {
         let src = TrapDispatcher::standard_mac_4bpp_gworld_clut();
         let dst = TrapDispatcher::standard_mac_8bpp_clut();
 
-        let translation = d.build_palette_translation(&bus, &src, &dst, 0, 4);
+        let translation = d.build_palette_translation(&bus, &src, &dst, 0, 4, 8);
 
         assert_eq!(
             &translation[..16],
             &[0, 5, 23, 216, 32, 176, 236, 192, 227, 203, 137, 94, 43, 249, 252, 255]
         );
+    }
+
+    #[test]
+    fn copy_bits_four_bit_destination_ignores_exact_matches_outside_active_table() {
+        let (mut d, mut cpu, mut bus) = setup_with_port();
+        let src_pixmap = 0x31E000u32;
+        let dst_pixmap = 0x31E100u32;
+        let src_base = 0x31F000u32;
+        let dst_base = 0x31F100u32;
+        let src_ctab_handle = 0x320000u32;
+        let dst_ctab_handle = 0x321000u32;
+        let src_rect = 0x322000u32;
+        let dst_rect = 0x322010u32;
+        let target = (0x4000, 0x4000, 0x4000);
+
+        let source_entries = (0..16u16)
+            .map(|index| {
+                if index == 3 {
+                    (index, target.0, target.1, target.2)
+                } else {
+                    (index, 0xFFFF, 0, 0)
+                }
+            })
+            .collect::<Vec<_>>();
+        write_color_table(&mut bus, src_ctab_handle, 0x1111_1111, &source_entries);
+
+        let destination_entries = (0..=252u16)
+            .map(|index| match index {
+                5 => (index, 0x4100, 0x4100, 0x4100),
+                252 => (index, target.0, target.1, target.2),
+                _ => (index, 0xFFFF, 0, 0),
+            })
+            .collect::<Vec<_>>();
+        write_color_table(&mut bus, dst_ctab_handle, 0x2222_2222, &destination_entries);
+
+        write_pixmap_indexed(&mut bus, src_pixmap, src_base, 1, 1, 1, 4, src_ctab_handle);
+        write_pixmap_indexed(&mut bus, dst_pixmap, dst_base, 1, 1, 1, 4, dst_ctab_handle);
+        bus.write_byte(src_base, 0x30);
+        bus.write_byte(dst_base, 0x0A);
+        write_rect(&mut bus, src_rect, 0, 0, 1, 1);
+        write_rect(&mut bus, dst_rect, 0, 0, 1, 1);
+
+        bus.write_long(TEST_SP, 0);
+        bus.write_word(TEST_SP + 4, 0); // srcCopy
+        bus.write_long(TEST_SP + 6, dst_rect);
+        bus.write_long(TEST_SP + 10, src_rect);
+        bus.write_long(TEST_SP + 14, dst_pixmap);
+        bus.write_long(TEST_SP + 18, src_pixmap);
+
+        let result = d.dispatch_quickdraw(true, 0x0EC, &mut cpu, &mut bus);
+
+        assert!(result.unwrap().is_ok());
+        assert_eq!(bus.read_byte(dst_base), 0x5A);
+    }
+
+    #[test]
+    fn copy_bits_packed_device_ctable_uses_entry_ordinals_with_zero_values() {
+        let (mut d, mut cpu, mut bus) = setup_with_port();
+        let target = (0x4000, 0x4000, 0x4000);
+
+        for (case, depth, target_index) in [(0u32, 2u16, 2u8), (1, 4, 5)] {
+            let root = 0x330000 + case * 0x4000;
+            let src_pixmap = root + 0x100;
+            let dst_pixmap = root + 0x200;
+            let src_base = root + 0x300;
+            let dst_base = root + 0x310;
+            let src_ctab_handle = root + 0x1000;
+            let dst_ctab_handle = root + 0x2000;
+            let rect = root + 0x3000;
+            let entry_count = 1u16 << depth;
+            let source_index = 1u8;
+
+            let source_entries = (0..entry_count)
+                .map(|index| {
+                    if index == u16::from(source_index) {
+                        (index, target.0, target.1, target.2)
+                    } else {
+                        (index, 0xFFFF, 0, 0)
+                    }
+                })
+                .collect::<Vec<_>>();
+            write_color_table(
+                &mut bus,
+                src_ctab_handle,
+                0x1111_1111 + case,
+                &source_entries,
+            );
+
+            let destination_entries = (0..entry_count)
+                .map(|index| {
+                    if index == u16::from(target_index) {
+                        (0, target.0, target.1, target.2)
+                    } else {
+                        (0, 0xFFFF, 0, 0)
+                    }
+                })
+                .collect::<Vec<_>>();
+            write_color_table(
+                &mut bus,
+                dst_ctab_handle,
+                0x2222_2222 + case,
+                &destination_entries,
+            );
+            let dst_ctab = bus.read_long(dst_ctab_handle);
+            bus.write_word(dst_ctab + 4, 0x8000);
+
+            write_pixmap_indexed(
+                &mut bus,
+                src_pixmap,
+                src_base,
+                1,
+                1,
+                1,
+                depth,
+                src_ctab_handle,
+            );
+            write_pixmap_indexed(
+                &mut bus,
+                dst_pixmap,
+                dst_base,
+                1,
+                1,
+                1,
+                depth,
+                dst_ctab_handle,
+            );
+            let shift = 8 - depth;
+            let trailing_canary = ((1u16 << shift) - 1) as u8;
+            bus.write_byte(src_base, source_index << shift);
+            bus.write_byte(dst_base, trailing_canary);
+            write_rect(&mut bus, rect, 0, 0, 1, 1);
+
+            cpu.write_reg(Register::A7, TEST_SP);
+            bus.write_long(TEST_SP, 0);
+            bus.write_word(TEST_SP + 4, 0); // srcCopy
+            bus.write_long(TEST_SP + 6, rect);
+            bus.write_long(TEST_SP + 10, rect);
+            bus.write_long(TEST_SP + 14, dst_pixmap);
+            bus.write_long(TEST_SP + 18, src_pixmap);
+
+            let result = d.dispatch_quickdraw(true, 0x0EC, &mut cpu, &mut bus);
+
+            assert!(result.unwrap().is_ok());
+            assert_eq!(
+                bus.read_byte(dst_base),
+                (target_index << shift) | trailing_canary,
+                "{depth}bpp device ColorTable"
+            );
+        }
     }
 
     #[test]
@@ -37828,7 +38169,7 @@ mod tests {
         assert!(result.unwrap().is_ok());
         assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 8);
         assert_eq!(bus.read_word(TEST_SP + 8), 0);
-        assert_eq!(bus.read_word(switch_info), 0x0085);
+        assert_eq!(bus.read_word(switch_info), 0x0083);
         assert_eq!(bus.read_long(switch_info + 2), 0x0000_0080);
         assert_eq!(bus.read_word(switch_info + 6), 0);
         assert_eq!(bus.read_long(switch_info + 8), d.screen_mode.0);
@@ -37858,8 +38199,8 @@ mod tests {
         assert!(result.unwrap().is_ok());
         assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 20);
         assert_eq!(bus.read_word(TEST_SP + 20), 0);
-        assert_eq!(bus.read_long(depth_mode), 0x0000_0085);
-        assert_eq!(bus.read_long(gd + 42), 0x0000_0080);
+        assert_eq!(bus.read_long(depth_mode), 0x0000_0083);
+        assert_eq!(bus.read_long(gd + 42), 0x0000_0083);
         assert_eq!(d.screen_mode.2, 640);
         assert_eq!(d.screen_mode.3, 480);
         assert_eq!(d.screen_mode.4, 8);
@@ -37898,8 +38239,8 @@ mod tests {
 
         assert!(result.unwrap().is_ok());
         assert_eq!(bus.read_word(TEST_SP + 20), 0);
-        assert_eq!(bus.read_long(depth_mode), 1);
-        assert_eq!(bus.read_long(gd + 42), 0x0000_0080);
+        assert_eq!(bus.read_long(depth_mode), 0x0000_0083);
+        assert_eq!(bus.read_long(gd + 42), 0x0000_0083);
         let new_ctab = bus.read_long(ctab_handle);
         assert_ne!(new_ctab, old_ctab);
         assert_eq!(bus.get_alloc_size(old_ctab), None);
@@ -37937,7 +38278,7 @@ mod tests {
         assert!(get_result.unwrap().is_ok());
         assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 8);
         assert_eq!(bus.read_word(TEST_SP + 8), 0);
-        assert_eq!(bus.read_word(switch_info), 0x0080);
+        assert_eq!(bus.read_word(switch_info), 0x0083);
     }
 
     #[test]
@@ -37987,7 +38328,7 @@ mod tests {
         assert_eq!(bus.read_word(TEST_SP + 20), (-330i16) as u16);
         assert_eq!(cpu.read_reg(Register::D0), (-330i32) as u32);
         assert_eq!(bus.read_long(depth_mode), 0xCAFEBABEu32);
-        assert_eq!(bus.read_long(gd + 42), 0x0000_0085);
+        assert_eq!(bus.read_long(gd + 42), 0x0000_0083);
         assert_eq!(
             bus.read_long(screen_bits_ptr),
             screen_base_before,
@@ -38229,7 +38570,7 @@ mod tests {
         // a nonzero mode ID when the requested depth is supported.
         // Stack: SP+0=selector, SP+2=flags, SP+4=whichFlags, SP+6=depth,
         //        SP+8=gd, SP+12=result. Pops 12 bytes.
-        for depth in [1, 2, 4, 8] {
+        for depth in [1, 2, 4, 8, 16, 32] {
             let (mut d, mut cpu, mut bus) = setup();
             bus.write_word(TEST_SP, 0x0A14); // selector
             bus.write_word(TEST_SP + 2, 1); // flags (color)
@@ -38239,7 +38580,26 @@ mod tests {
             let result = d.dispatch_quickdraw(true, 0x2A2, &mut cpu, &mut bus);
             assert!(result.unwrap().is_ok());
             assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 12);
-            assert_ne!(bus.read_word(TEST_SP + 12), 0);
+            let mode = bus.read_word(TEST_SP + 12);
+            assert_eq!(mode, crate::display::classic_depth_mode(depth).unwrap());
+
+            cpu.write_reg(Register::A7, TEST_SP);
+            bus.write_word(TEST_SP, 0x0A13); // SetDepth selector
+            bus.write_word(TEST_SP + 2, 1); // flags (color)
+            bus.write_word(TEST_SP + 4, 0); // whichFlags
+            bus.write_word(TEST_SP + 6, mode); // feed HasDepth's mode back
+            bus.write_long(TEST_SP + 8, 0); // main gd
+            let result = d.dispatch_quickdraw(true, 0x2A2, &mut cpu, &mut bus);
+            assert!(result.unwrap().is_ok());
+            assert_eq!(bus.read_word(TEST_SP + 12), 0, "SetDepth mode {mode:#06x}");
+            let gdevice_handle = d.ensure_main_gdevice(&mut bus);
+            let gdevice = bus.read_long(gdevice_handle);
+            assert_eq!(bus.read_long(gdevice + 42), u32::from(mode));
+            if depth <= 8 {
+                let pixmap = bus.read_long(bus.read_long(gdevice + 22));
+                assert_eq!(bus.read_word(pixmap + 32), depth);
+                assert_eq!(d.screen_mode.4, depth);
+            }
         }
     }
 
@@ -38257,7 +38617,7 @@ mod tests {
         let result = d.dispatch_quickdraw(true, 0x2A2, &mut cpu, &mut bus);
         assert!(result.unwrap().is_ok());
         assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 10);
-        assert_eq!(bus.read_word(TEST_SP + 10), 32);
+        assert_eq!(bus.read_word(TEST_SP + 10), 0x0085);
     }
 
     #[test]
@@ -38276,7 +38636,10 @@ mod tests {
             let result = d.dispatch_quickdraw(true, 0x2A2, &mut cpu, &mut bus);
             assert!(result.unwrap().is_ok());
             assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 10);
-            assert_eq!(bus.read_word(TEST_SP + 10), depth);
+            assert_eq!(
+                bus.read_word(TEST_SP + 10),
+                crate::display::classic_depth_mode(depth).unwrap()
+            );
         }
     }
 
@@ -38293,7 +38656,10 @@ mod tests {
             let result = d.dispatch_quickdraw(true, 0x2A2, &mut cpu, &mut bus);
             assert!(result.unwrap().is_ok());
             assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 12);
-            assert_eq!(bus.read_word(TEST_SP + 12), depth);
+            assert_eq!(
+                bus.read_word(TEST_SP + 12),
+                crate::display::classic_depth_mode(depth).unwrap()
+            );
         }
     }
 
@@ -38313,7 +38679,7 @@ mod tests {
         let result = d.dispatch_quickdraw(true, 0x2A2, &mut cpu, &mut bus);
         assert!(result.unwrap().is_ok());
         assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 10);
-        assert_eq!(bus.read_word(TEST_SP + 10), 4);
+        assert_eq!(bus.read_word(TEST_SP + 10), 0x0082);
     }
 
     #[test]
@@ -38331,7 +38697,7 @@ mod tests {
         let result = d.dispatch_quickdraw(true, 0x2A2, &mut cpu, &mut bus);
         assert!(result.unwrap().is_ok());
         assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 10);
-        assert_eq!(bus.read_word(TEST_SP + 10), 8);
+        assert_eq!(bus.read_word(TEST_SP + 10), 0x0083);
     }
 
     #[test]
@@ -38412,6 +38778,100 @@ mod tests {
     }
 
     #[test]
+    fn set_depth_two_wires_packed_screen_and_color_table() {
+        // Imaging With QuickDraw (1994), pp. 4-10--4-11 and 5-34--5-35:
+        // 2bpp is an indexed device depth, and SetDepth imposes the selected
+        // depth on the device rather than merely recording its mode token.
+        let (mut d, mut cpu, mut bus) = setup();
+        let main_gdh = d.ensure_main_gdevice(&mut bus);
+        let main_gd = bus.read_long(main_gdh);
+        let main_pm = bus.read_long(bus.read_long(main_gd + 22));
+
+        bus.write_word(TEST_SP, 0x0A13); // selector
+        bus.write_word(TEST_SP + 2, 1); // flags: color
+        bus.write_word(TEST_SP + 4, 1); // whichFlags: gdDevType
+        bus.write_word(TEST_SP + 6, 2); // depth: 2bpp indexed
+        bus.write_long(TEST_SP + 8, main_gdh);
+        let result = d.dispatch_quickdraw(true, 0x2A2, &mut cpu, &mut bus);
+
+        assert!(result.unwrap().is_ok());
+        assert_eq!(bus.read_word(TEST_SP + 12), 0);
+        assert_eq!(d.screen_mode.1, 200);
+        assert_eq!(d.screen_mode.4, 2);
+        assert_eq!(
+            bus.read_word(crate::memory::globals::addr::SCREEN_BITS + 4),
+            200
+        );
+        assert_eq!(bus.read_word(main_pm + 4), 0x8000 | 200);
+        assert_eq!(bus.read_word(main_pm + 32), 2);
+        assert_eq!(bus.read_word(main_pm + 36), 2);
+        let ctab = bus.read_long(bus.read_long(main_pm + 42));
+        assert_eq!(bus.read_word(ctab + 6), 3);
+        assert_eq!(d.device_clut[0], [0xffff, 0xffff, 0xffff]);
+        assert_eq!(d.device_clut[3], [0x0000, 0x0000, 0x0000]);
+        assert_ne!(bus.read_word(main_gd + 20) & 1, 0);
+    }
+
+    #[test]
+    fn two_bit_has_depth_mode_round_trips_grayscale_and_color_personalities() {
+        for is_color in [false, true] {
+            let (mut d, mut cpu, mut bus) = setup();
+            let main_gdh = d.ensure_main_gdevice(&mut bus);
+            let main_gd = bus.read_long(main_gdh);
+            let main_pm = bus.read_long(bus.read_long(main_gd + 22));
+
+            cpu.write_reg(Register::D0, 0x0A14);
+            bus.write_word(TEST_SP, u16::from(is_color));
+            bus.write_word(TEST_SP + 2, 1); // whichFlags: gdDevType
+            bus.write_word(TEST_SP + 4, 2);
+            bus.write_long(TEST_SP + 6, main_gdh);
+            let result = d.dispatch_quickdraw(true, 0x2A2, &mut cpu, &mut bus);
+            assert!(result.unwrap().is_ok());
+            let mode = bus.read_word(TEST_SP + 10);
+            assert_eq!(mode, 0x0081);
+
+            cpu.write_reg(Register::A7, TEST_SP);
+            cpu.write_reg(Register::D0, 0x0A13);
+            bus.write_word(TEST_SP, u16::from(is_color));
+            bus.write_word(TEST_SP + 2, 1);
+            bus.write_word(TEST_SP + 4, mode);
+            bus.write_long(TEST_SP + 6, main_gdh);
+            let result = d.dispatch_quickdraw(true, 0x2A2, &mut cpu, &mut bus);
+            assert!(result.unwrap().is_ok());
+            assert_eq!(bus.read_word(TEST_SP + 10), 0);
+
+            assert_eq!(bus.read_long(main_gd + 42), u32::from(mode));
+            assert_eq!(bus.read_word(main_gd + 20) & 1 != 0, is_color);
+            assert_eq!(bus.read_word(main_pm + 32), 2);
+            let (expected, entry_count) =
+                TrapDispatcher::standard_screen_depth_clut(2, is_color).unwrap();
+            let ctab = bus.read_long(bus.read_long(main_pm + 42));
+            assert_eq!(bus.read_word(ctab + 6), entry_count as u16 - 1);
+            for (index, color) in expected.iter().enumerate().take(entry_count) {
+                let entry = ctab + 8 + index as u32 * 8;
+                assert_eq!(
+                    [
+                        bus.read_word(entry + 2),
+                        bus.read_word(entry + 4),
+                        bus.read_word(entry + 6),
+                    ],
+                    *color
+                );
+            }
+            assert_eq!(d.device_clut, expected);
+            assert_eq!(d.color_manager_clut, expected);
+            assert_eq!(
+                expected[2],
+                if is_color {
+                    [0x0000, 0x8000, 0x0000]
+                } else {
+                    [0x5555, 0x5555, 0x5555]
+                }
+            );
+        }
+    }
+
+    #[test]
     fn set_depth_accepts_packed_long_d0_selector() {
         // IM:VI Table C-3 lists SetDepth as selector $0A13. Normalize the
         // longword D0 form ($000A0013) before falling back to the legacy
@@ -38471,7 +38931,7 @@ mod tests {
             bus.read_byte(d.screen_mode.0 + d.screen_mode.1 * 600 - 1),
             0x00
         );
-        assert_eq!(bus.read_long(gd + 42), 4);
+        assert_eq!(bus.read_long(gd + 42), 0x0082);
         assert_ne!(bus.read_word(gd + 20) & 1, 0);
     }
 
@@ -38907,23 +39367,35 @@ mod tests {
     fn set_depth_accepts_has_depth_mode_id_without_rewiring_unrendered_framebuffer() {
         // HasDepth's result can be passed back to SetDepth. Systemless records
         // the requested display mode on the GDevice but keeps the real
-        // framebuffer in its wired shape for non-1/4/8bpp requests.
+        // framebuffer in its wired shape for non-1/2/4/8bpp requests.
         let (mut d, mut cpu, mut bus) = setup();
         let gdh = d.ensure_main_gdevice(&mut bus);
         let before_screen_mode = d.screen_mode;
-        bus.write_word(TEST_SP, 0x0A13); // selector
+
+        bus.write_word(TEST_SP, 0x0A14); // HasDepth selector
         bus.write_word(TEST_SP + 2, 1); // flags (color)
         bus.write_word(TEST_SP + 4, 1); // whichFlags: color flag matters
-        bus.write_word(TEST_SP + 6, 32); // HasDepth mode ID for 32bpp
+        bus.write_word(TEST_SP + 6, 32); // requested pixel depth
         bus.write_long(TEST_SP + 8, gdh); // gd
-        let result = d.dispatch_quickdraw(true, 0x2A2, &mut cpu, &mut bus);
-        assert!(result.unwrap().is_ok());
+        let has_depth = d.dispatch_quickdraw(true, 0x2A2, &mut cpu, &mut bus);
+        assert!(has_depth.unwrap().is_ok());
         assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 12);
+        let mode = bus.read_word(TEST_SP + 12);
+        assert_eq!(mode, 0x0085);
+
+        cpu.write_reg(Register::A7, TEST_SP);
+        bus.write_word(TEST_SP, 0x0A13); // SetDepth selector
+        bus.write_word(TEST_SP + 2, 1);
+        bus.write_word(TEST_SP + 4, 1);
+        bus.write_word(TEST_SP + 6, mode);
+        bus.write_long(TEST_SP + 8, gdh);
+        let set_depth = d.dispatch_quickdraw(true, 0x2A2, &mut cpu, &mut bus);
+        assert!(set_depth.unwrap().is_ok());
         assert_eq!(bus.read_word(TEST_SP + 12), 0); // noErr
         assert_eq!(d.screen_mode, before_screen_mode);
 
         let gd = bus.read_long(gdh);
-        assert_eq!(bus.read_long(gd + 42), 32);
+        assert_eq!(bus.read_long(gd + 42), 0x0085);
         assert_ne!(bus.read_word(gd + 20) & 1, 0);
     }
 


### PR DESCRIPTION
## Summary

- add coherent 1, 2, 4, 8, and 16-bit PPC display startup and depth transitions
- support packed indexed QuickDraw, menu, window-compositing, CopyBits, CopyMask, and GWorld paths
- present packed framebuffers through software and Metal hosts with active palettes and bounded row geometry
- preserve screen-backed port metadata, indexed color tables, and host mirror allocations across transitions

## Verification

- cargo test --lib --features test-support
- cargo test --bin systemless
- cargo build --all-targets --all-features
- cargo check --no-default-features
- cargo check --lib --target wasm32-unknown-unknown
- strict rustdoc build
- cargo publish --locked --dry-run

Closes #852