### PR TITLE
perf(memory): reuse the write-probe journal and hash it by address

### DIFF
--- a/src/memory/bus.rs
+++ b/src/memory/bus.rs
@@ -4,6 +4,7 @@
 
 use std::cell::{RefCell, UnsafeCell};
 use std::collections::HashMap;
+use std::hash::{BuildHasherDefault, Hasher};
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 #[cfg(not(target_arch = "wasm32"))]
@@ -493,7 +494,11 @@ pub struct MacMemoryBus {
     /// journal with final RAM proves whether a candidate execution cycle left
     /// guest memory unchanged, while still allowing temporary stack writes
     /// that are restored before the cycle closes.
-    write_probe_original: Option<HashMap<u32, u8>>,
+    write_probe_original: Option<WriteProbeJournal>,
+    /// The journal's allocation between probes. Probes start more than a
+    /// million times in a long SimCity 2000 session; reusing one map keeps
+    /// the table's capacity instead of regrowing it from empty each time.
+    write_probe_spare: WriteProbeJournal,
     /// An out-of-range write makes the probe unverifiable even though the
     /// normal bus retains its legacy warn-and-ignore behavior.
     write_probe_invalid: bool,
@@ -619,6 +624,38 @@ impl SharedRamRegion {
         }
     }
 }
+
+/// Hasher for the write-probe journal, which is keyed by RAM address.
+/// The journal takes one insert per byte written while an idle-cycle probe
+/// is armed, so the default SipHash was most of a probe's cost. A
+/// multiplicative mix of the 32-bit key, folded so the high address bits
+/// reach the low hash bits, is enough for hashbrown, which draws its tag
+/// from the top bits and its bucket from the low ones.
+#[derive(Default, Clone, Copy)]
+struct AddressHasher(u64);
+
+impl Hasher for AddressHasher {
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.0
+    }
+
+    #[inline]
+    fn write(&mut self, bytes: &[u8]) {
+        for &byte in bytes {
+            self.0 = (self.0 ^ u64::from(byte)).wrapping_mul(0x0000_0100_0000_01b3);
+        }
+    }
+
+    #[inline]
+    fn write_u32(&mut self, address: u32) {
+        let mixed = (u64::from(address) ^ self.0).wrapping_mul(0x9E37_79B9_7F4A_7C15);
+        self.0 = mixed ^ (mixed >> 32);
+    }
+}
+
+/// Original bytes of the addresses written during an exact-state probe.
+type WriteProbeJournal = HashMap<u32, u8, BuildHasherDefault<AddressHasher>>;
 
 /// RAM storage - either a stable owned allocation or borrowed slice.
 enum RamStorage {
@@ -1067,6 +1104,7 @@ impl MacMemoryBus {
             reserved_heap_ranges: Vec::new(),
             alloc_bucket_sizes: HashMap::new(),
             write_probe_original: None,
+            write_probe_spare: WriteProbeJournal::default(),
             write_probe_invalid: false,
             write_probe_overflowed: false,
         };
@@ -1161,6 +1199,7 @@ impl MacMemoryBus {
             reserved_heap_ranges: Vec::new(),
             alloc_bucket_sizes: HashMap::new(),
             write_probe_original: None,
+            write_probe_spare: WriteProbeJournal::default(),
             write_probe_invalid: false,
             write_probe_overflowed: false,
         }
@@ -1169,14 +1208,16 @@ impl MacMemoryBus {
     /// Begin journaling original RAM bytes for an exact-state execution
     /// probe. Calling this again discards the previous incomplete probe.
     pub(crate) fn begin_write_probe(&mut self) {
-        self.write_probe_original = Some(HashMap::new());
+        let mut journal = std::mem::take(&mut self.write_probe_spare);
+        journal.clear();
+        self.write_probe_original = Some(journal);
         self.write_probe_invalid = false;
         self.write_probe_overflowed = false;
     }
 
     /// Discard an incomplete write probe and restore normal fast-memory use.
     pub(crate) fn cancel_write_probe(&mut self) {
-        self.write_probe_original = None;
+        self.park_write_probe_journal();
         self.write_probe_invalid = false;
         self.write_probe_overflowed = false;
     }
@@ -1195,11 +1236,19 @@ impl MacMemoryBus {
         };
         let unchanged = !self.write_probe_invalid
             && original
-                .into_iter()
-                .all(|(address, value)| self.ram.get_in_bounds(address as usize) == value);
+                .iter()
+                .all(|(&address, &value)| self.ram.get_in_bounds(address as usize) == value);
+        self.write_probe_spare = original;
         self.write_probe_invalid = false;
         self.write_probe_overflowed = false;
         unchanged
+    }
+
+    /// Close the journal, keeping its allocation for the next probe.
+    fn park_write_probe_journal(&mut self) {
+        if let Some(journal) = self.write_probe_original.take() {
+            self.write_probe_spare = journal;
+        }
     }
 
     #[inline]
@@ -1220,7 +1269,7 @@ impl MacMemoryBus {
         if journal.len() > WRITE_PROBE_MAX_ENTRIES {
             // Too much written for a wait cycle: void the probe now so the
             // fast paths (and fastmem) come back for the work in progress.
-            self.write_probe_original = None;
+            self.park_write_probe_journal();
             self.write_probe_overflowed = true;
         }
     }
@@ -2218,6 +2267,31 @@ mod tests {
         bus.write_byte(0x102, 0xCC);
 
         assert!(!bus.finish_write_probe_unchanged());
+    }
+
+    #[test]
+    fn write_probe_journal_is_reused_without_stale_entries() {
+        let mut bus = MacMemoryBus::new(1024);
+        bus.write_long(0x100, 0x1122_3344);
+
+        // First probe records $102 as changed; its journal is kept as the
+        // spare afterwards.
+        bus.begin_write_probe();
+        bus.write_byte(0x102, 0xCC);
+        assert!(!bus.finish_write_probe_unchanged());
+
+        // The reused journal must start empty: a probe that writes nothing
+        // is unchanged even though $102 now differs from its old original.
+        bus.begin_write_probe();
+        assert!(bus.finish_write_probe_unchanged());
+
+        // And a cancelled probe hands the journal back too.
+        bus.begin_write_probe();
+        bus.write_byte(0x103, 0xDD);
+        bus.cancel_write_probe();
+        bus.begin_write_probe();
+        bus.write_byte(0x103, 0xDD);
+        assert!(bus.finish_write_probe_unchanged());
     }
 
     #[test]


### PR DESCRIPTION
From Claude Fable 5, working with @rlanday. Independent of #853 (measured on top of it).

## What

The idle-cycle write probe journals the original byte of every address written while it is armed — the journal is what proves a candidate wait cycle left guest RAM unchanged. It was a `HashMap<u32, u8>` with the default SipHash, created fresh for every probe.

Two changes, no semantic change:

- **Hash by address.** A `Hasher` for the journal's `u32` keys: a multiplicative mix folded so the high address bits reach the low hash bits (hashbrown takes its tag from the top bits and its bucket from the low ones). SipHash's keyed, DoS-resistant mixing buys nothing for a map keyed by guest addresses that never leaves the process.
- **Keep one map.** The journal is parked when a probe is cancelled, finished or voided, and cleared when the next probe arms, so its table capacity survives instead of regrowing from empty (`reserve_rehash`) every time.

Same distinct-address cap (`WRITE_PROBE_MAX_ENTRIES`), same overflow void, same final byte-for-byte comparison; a new test checks that a reused journal starts empty after a finished and after a cancelled probe.

## Why it matters

On the SimCity 2000 headless run the probe arms about **1.3 million times per 2 billion instructions**, and while it is armed every guest store goes byte-wise through `write_byte` — `write_long` → `write_word` → `write_byte`, each byte a journal insert. In a steady-state profile (below) the journal's `hash_one`, SipHash `write` and `reserve_rehash` were about 4 % of the main thread's samples, all reached from `write_byte`.

## Evidence

**Instrument.** Headless SimCity 2000 (`--headless --max-instructions N --input-script`, the #824 input replay into a running city), identical guest work per arm — checked by the guest tick count printed at exit, identical in every run below. Metric: host **instructions retired** for the whole process from `/usr/bin/time -l` (load-insensitive, unlike wall or CPU time). Six pairs per run length, arms interleaved with alternating order; the figure is the geometric mean of the within-pair ratios, with the pair range and pairs won.

**Arms.** Base = upstream master 0.20.5 (1013a0e) + d2357f7 (a local runner fix carried in *both* arms: wait-identity proofs compare architectural CPU state only) + #853's row-bulk primitives; candidate = the same plus this commit.

The PR is rebased onto master 17fb5af; upstream's changes since the measured base do not touch the probe or the journal (the only `bus.rs` change is in `configure_screen_depth`).

| SimCity 2000 | base | this PR | Δ | pairs won |
|---|---|---|---|---|
| 400M instructions | 114.97 G | 110.08 G | **−4.25 %** (ratios 0.957–0.958) | 6/6 |
| 2B instructions | 504.27 G | 483.63 G | **−4.09 %** (0.958–0.960) | 6/6 |

Guest ticks 128,460 / 283,023 in all 24 runs. Identity: the 261 screenshots of a 130M-instruction scripted run (one per 500K instructions) are byte-identical between the arms — the journal's verdicts, and therefore which cycles the runner parks, are unchanged.

**Profile** (`/usr/bin/sample` 1 ms × 5 s at 45 s of a 2B run, main thread self time, 3,431 samples, base arm): `hash_one` 2.1 %, `reserve_rehash` 1.0 %, SipHash `Hasher::write` 0.9 % — call-graph attribution puts 96 of the 128 `reserve_rehash` samples and all of the SipHash samples under `MacMemoryBus::write_byte`, i.e. the probe journal; the remaining allocator time under `reserve_rehash` (`nanov2_free`, 11 samples) is the per-probe table growth this removes.

## Tests

- `cargo test --lib --features test-support` on this branch (master 17fb5af): 4,210 passed, 0 failed, 3 ignored (the existing `write_probe_*` tests cover accept/reject/overflow; the new `write_probe_journal_is_reused_without_stale_entries` covers reuse after finish and after cancel).
- `cargo fmt --check` clean on the changed lines (the file's one pre-existing diff, in `configure_screen_depth`, is untouched). `cargo clippy --all-targets --all-features`: no finding inside the changed lines (the crate's pre-existing findings are unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ng5oTbT6MzdjV92Fd1qoE
