### PR TITLE
perf(quickdraw): no per-pixel region test for rectangular regions in CopyBits

### DIFF
--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -19939,6 +19939,13 @@ impl super::TrapDispatcher {
             Self::build_region_membership_cache(bus, vis_rgn_handle, clip_t, clip_b);
         let clip_membership =
             Self::build_region_membership_cache(bus, clip_rgn_handle, clip_t, clip_b);
+        // The copy rect was clipped to each region's bounding box above, so
+        // only a region with scan-line data can still exclude a pixel; a
+        // rectangular region needs no per-pixel test (and, uncached, that
+        // test re-read the region header for every pixel).
+        let vis_test = Self::region_needs_pixel_test(bus, vis_rgn_handle);
+        let clip_test = Self::region_needs_pixel_test(bus, clip_rgn_handle);
+        let mask_test = Self::region_needs_pixel_test(bus, mask_rgn);
 
         let trace_probes = if trace_menu_redraw_enabled() {
             trace_menu_probe_points()
@@ -20190,31 +20197,37 @@ impl super::TrapDispatcher {
                 {
                     continue;
                 }
-                if !Self::region_contains_point_cached(
-                    bus,
-                    vis_rgn_handle,
-                    vis_membership.as_ref(),
-                    dy,
-                    dx,
-                ) {
+                if vis_test
+                    && !Self::region_contains_point_cached(
+                        bus,
+                        vis_rgn_handle,
+                        vis_membership.as_ref(),
+                        dy,
+                        dx,
+                    )
+                {
                     continue;
                 }
-                if !Self::region_contains_point_cached(
-                    bus,
-                    clip_rgn_handle,
-                    clip_membership.as_ref(),
-                    dy,
-                    dx,
-                ) {
+                if clip_test
+                    && !Self::region_contains_point_cached(
+                        bus,
+                        clip_rgn_handle,
+                        clip_membership.as_ref(),
+                        dy,
+                        dx,
+                    )
+                {
                     continue;
                 }
-                if !Self::region_contains_point_cached(
-                    bus,
-                    mask_rgn,
-                    mask_membership.as_ref(),
-                    dy,
-                    dx,
-                ) {
+                if mask_test
+                    && !Self::region_contains_point_cached(
+                        bus,
+                        mask_rgn,
+                        mask_membership.as_ref(),
+                        dy,
+                        dx,
+                    )
+                {
                     continue;
                 }
 
@@ -21181,6 +21194,22 @@ impl super::TrapDispatcher {
         *clip_b = (*clip_b).min(bottom);
         *clip_r = (*clip_r).min(right);
         *clip_b > *clip_t && *clip_r > *clip_l
+    }
+
+    /// Whether a region can exclude pixels that lie inside its bounding
+    /// box. A region whose data is only the 10-byte header is exactly its
+    /// bounding rectangle (Inside Macintosh Volume I, I-141), so a caller
+    /// that already clipped to that rectangle can skip the per-pixel
+    /// membership test. An unreadable region keeps the test, which then
+    /// rejects every pixel as before.
+    fn region_needs_pixel_test(bus: &MacMemoryBus, rgn_handle: u32) -> bool {
+        if rgn_handle == 0 {
+            return false;
+        }
+        match Self::region_ptr_and_size(bus, rgn_handle) {
+            Some((_, rgn_size)) => rgn_size > REGION_HEADER_SIZE,
+            None => true,
+        }
     }
 
     pub(super) fn region_is_complex(bus: &MacMemoryBus, rgn_handle: u32) -> bool {


### PR DESCRIPTION
From Claude Fable 5, working with @rlanday. Independent of #853 (measured on top of it).

## What

`copy_bits_common` clips the copy rect to the bounding boxes of the destination port's visRgn and clipRgn and of the mask region, and then still tests every pixel against all three regions with `region_contains_point_cached`. That helper has a cached path only for regions with scan-line data: `build_region_membership_cache` returns `None` for a *rectangular* region (its data is just the 10-byte header), so for those the per-pixel test fell back to the uncached `region_contains_point`, which dereferences the region handle and reads its bounding box again — for every pixel, for each of the three regions.

A rectangular region contains its whole bounding box, and the copy rect is already inside that box, so it cannot exclude anything. `region_needs_pixel_test` now decides once per region whether the per-pixel test can exclude a pixel at all: true only for a region with scan-line data (or one whose handle cannot be read — that case keeps the test, which then rejects every pixel exactly as before). Complex regions keep their cached scan-line test; nothing about *what* is tested changes, only *whether* a test that always says yes is run.

## Why it matters

SimCity 2000's screen blits go through this path with rectangular vis/clip/mask regions. In a steady-state profile of the game on top of #853, `region_contains_point` and the `region_bbox` reads under it were about 5 % of the main thread's samples — roughly 24 bus reads per pixel that always answered "inside".

## Evidence

**Instrument.** Headless SimCity 2000 (`--headless --max-instructions N --input-script`, the #824 input replay into a running city); identical guest work per arm, checked by the guest tick count at exit. Metric: host instructions retired for the whole process (`/usr/bin/time -l`; load-insensitive). Six interleaved, order-alternated pairs per run length; geometric mean of the within-pair ratios, with range and pairs won.

**Arms.** Base = upstream master 0.20.5 (1013a0e) + d2357f7 (a local runner fix carried in both arms: wait-identity proofs compare architectural CPU state only) + #853's row-bulk primitives; candidate = the same plus this commit.

The PR is rebased onto master 17fb5af; upstream's changes since the measured base (the PPC packed-depth work) do not touch `copy_bits_common`'s clipping, the region helpers or the membership cache.

| SimCity 2000 | base | this PR | Δ | pairs won |
|---|---|---|---|---|
| 400M instructions | 115.02 G | 108.17 G | **−5.96 %** (ratios 0.939–0.942) | 6/6 |
| 2B instructions | 504.12 G | 482.85 G | **−4.22 %** (0.957–0.958) | 6/6 |

Guest ticks 128,460 / 283,023 in all 24 runs. The 400M window (boot, the founding dialogs, the first seconds of play) blits more of the screen per instruction than steady play, hence the larger figure there.

**Identity.** The 261 screenshots of a 130M-instruction scripted run (one per 500K instructions) are byte-identical between the arms (ticks 102,146 in both): every pixel a rectangular region's per-pixel test would have passed is still copied, and nothing else is.

## Tests

- `cargo test --lib --features test-support` on this branch (master 17fb5af): 4,209 passed, 0 failed, 3 ignored — the CopyBits suite includes the rectangular- and complex-region clipping cases (`copy_bits_*` / `region_contains_point` tests), all unchanged.
- `cargo fmt --check` clean on the touched file; `cargo clippy --all-targets --all-features`: no finding inside the changed lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ng5oTbT6MzdjV92Fd1qoE
