### PR TITLE
fix(runner): wait-identity proofs compare architectural state only

### DIFF
--- a/src/bin/systemless.rs
+++ b/src/bin/systemless.rs
@@ -2551,8 +2551,16 @@ fn run_headless(
         let screenshot_num = total / 500_000;
         if screenshot_num > last_screenshot {
             last_screenshot = screenshot_num;
-            runner.composite_frame();
-            save_screenshot(&runner, screenshot_num);
+            // Measurement-only switch: timing A/Bs suppress the periodic
+            // PNG encodes (a constant ~7s of host work per census run)
+            // while keeping the final screenshot and its tick check.
+            if std::env::var("SYSTEMLESS_HEADLESS_PERIODIC_SCREENSHOTS")
+                .map(|v| v != "0")
+                .unwrap_or(true)
+            {
+                runner.composite_frame();
+                save_screenshot(&runner, screenshot_num);
+            }
         }
 
         if !running {
@@ -2564,6 +2572,8 @@ fn run_headless(
     eprintln!("[HEADLESS] Completed {} instructions", total);
     save_store.sync_save_files_now(&mut runner);
     save_screenshot(&runner, 9999);
+    // Measurement-only: prints nothing unless SYSTEMLESS_WAIT_STATS is set.
+    systemless::runner::dump_wait_stats();
 }
 
 fn main() {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1315,7 +1315,16 @@ impl CpuArchitecturalSnapshot {
             pmmu_enabled: cpu.pmmu_enabled,
             int_level: cpu.int_level,
             stopped: cpu.stopped,
-            change_of_flow: cpu.change_of_flow,
+            // Deliberately normalized: `change_of_flow` is the m68k core's
+            // internal did-the-last-instruction-branch bookkeeping (a trace
+            // and loop-mode heuristic input), not architectural state. Its
+            // value at a trap site depends on whether execution arrived via
+            // the interpreter or a compiled trace, so comparing it makes
+            // wait-identity proofs fail whenever the JIT compiles part of a
+            // wait loop: measured on the SC2K boot census, the flag was the
+            // sole differing field in every sampled proof failure, and each
+            // lost proof is a lost tick fast-forward.
+            change_of_flow: false,
             loop_mode: cpu.loop_mode,
             loop_body_word: cpu.loop_body_word,
             loop_dbcc_word: cpu.loop_dbcc_word,
@@ -4621,18 +4630,52 @@ impl FixtureRunner {
                     WS_FAIL_TICK.fetch_add(1, AtomicOrdering::Relaxed);
                 } else if same_site_tick {
                     let n = WS_FAIL_CPU.fetch_add(1, AtomicOrdering::Relaxed);
-                    if n < 8 {
+                    if n < 40 {
+                        let a = &probe.cpu;
+                        let b = &cpu;
+                        let mut diffs: Vec<String> = Vec::new();
                         for i in 0..16 {
-                            if probe.cpu.dar[i] != cpu.dar[i] {
-                                eprintln!(
-                                    "[WAIT-STATS] cpu-diff sample {n} pc={trap_pc:08X}: {}{} {:08X} -> {:08X}",
+                            if a.dar[i] != b.dar[i] {
+                                diffs.push(format!(
+                                    "{}{}:{:08X}->{:08X}",
                                     if i < 8 { "D" } else { "A" },
                                     i & 7,
-                                    probe.cpu.dar[i],
-                                    cpu.dar[i]
-                                );
+                                    a.dar[i],
+                                    b.dar[i]
+                                ));
                             }
                         }
+                        if a.ppc != b.ppc {
+                            diffs.push(format!("ppc:{:08X}->{:08X}", a.ppc, b.ppc));
+                        }
+                        if a.pc != b.pc {
+                            diffs.push(format!("pc:{:08X}->{:08X}", a.pc, b.pc));
+                        }
+                        if a.ir != b.ir {
+                            diffs.push(format!("ir:{:04X}->{:04X}", a.ir, b.ir));
+                        }
+                        if a.sr != b.sr {
+                            diffs.push(format!("sr:{:04X}->{:04X}", a.sr, b.sr));
+                        }
+                        if a.prefetch_count != b.prefetch_count {
+                            diffs.push(format!("pfn:{}->{}", a.prefetch_count, b.prefetch_count));
+                        }
+                        if a.prefetch != b.prefetch {
+                            diffs.push(format!("pf:{:04X?}->{:04X?}", a.prefetch, b.prefetch));
+                        }
+                        if a.change_of_flow != b.change_of_flow {
+                            diffs.push(format!("cof:{}->{}", a.change_of_flow, b.change_of_flow));
+                        }
+                        if a.stack_pointers != b.stack_pointers {
+                            diffs.push("sp".to_owned());
+                        }
+                        if diffs.is_empty() {
+                            diffs.push("other-field".to_owned());
+                        }
+                        eprintln!(
+                            "[WAIT-STATS] cpu-diff sample {n} pc={trap_pc:08X}: {}",
+                            diffs.join(" ")
+                        );
                     }
                 }
             }
@@ -18486,6 +18529,13 @@ mod tests {
         let mut cpu = m68k::CpuCore::new();
         cpu.fpr[0] = m68k::fpu::FloatX80::from_extended(0x3FFF, 0x8000_0000_0000_0000);
         let baseline = CpuArchitecturalSnapshot::capture(&cpu);
+
+        cpu.change_of_flow = !cpu.change_of_flow;
+        assert_eq!(
+            baseline,
+            CpuArchitecturalSnapshot::capture(&cpu),
+            "internal flow bookkeeping must not participate in an idle-cycle proof"
+        );
 
         cpu.fpr[0].mantissa ^= 1;
         assert_ne!(


### PR DESCRIPTION
From Claude Fable 5, working with @rlanday. The fix was written in a 2026-08-24 session (Claude, directed by @rlanday); the evidence below is new.

## What

The exact-idle-cycle prover (#644 and earlier) parks a guest wait loop when two same-tick arrivals at a poll site show an identical CPU snapshot and a write journal proving guest RAM was restored. The snapshot included `change_of_flow` — the m68k core's internal "did the last instruction branch" bookkeeping, an input to its trace and loop-mode heuristics, not architectural state. Its value at a trap site depends on whether execution arrived through the interpreter or through a compiled trace, so whenever the JIT had compiled part of a wait loop the two arrivals compared unequal, the proof failed, and the loop executed instead of parking. Each lost proof is a lost tick fast-forward.

The snapshot now normalises that field at capture; it is only ever compared, never restored, so nothing else changes. The commit also carries three measurement aids used to find and verify this: the wait-stats failure sampler reports which snapshot field differed, the headless runner prints the wait-stats counters at exit (no-op unless `SYSTEMLESS_WAIT_STATS` is set), and `SYSTEMLESS_HEADLESS_PERIODIC_SCREENSHOTS=0` suppresses the periodic PNG encodes for timing runs.

## History

Found on 2026-08-24 as a "guest clock drift" between two m68k trees whose only difference was which loops the JIT compiled: field-level sampling showed `change_of_flow` was the sole differing field in every sampled proof failure, and normalising it made the trees bit-identical (SC2K 40M boot: ticks 69,459/64,464 → 84,328 in both, CPU-state failures 43,888 → 1,458, exact repeats 60,645 → 75,906). It has been carried as a local fix in every measurement since; the numbers below are on current upstream master, which shows the same failure with the released m68k 0.7.1 JIT.

## Evidence

**Instrument.** Headless SimCity 2000 (`--headless --max-instructions N --input-script`, the #824 input replay into a running city). Because the fix changes how many wait cycles park, guest ticks per instruction differ between arms by design, so the comparison is **host instructions per guest tick** (guest ticks from the count printed at exit), alongside the raw totals. Six interleaved, order-alternated pairs per run length; both arms are deterministic in ticks (two sanity runs each). Arms: base = master 17fb5af; candidate = 17fb5af + this commit.

| SimCity 2000 (master 17fb5af) | base | this PR | Δ | pairs won |
|---|---|---|---|---|
| 400M instructions, host instructions | 189.41 G | 130.49 G | **−31.1 %** (ratios 0.670–0.701) | 6/6 |
| 400M, host instructions per guest tick | 1,695 k | 1,016 k | **−40.1 %** (0.583–0.610) | 6/6 |
| 2B instructions, host instructions | 859.92 G | 584.34 G | **−32.0 %** (0.642–0.697) | 6/6 |
| 2B, host instructions per guest tick | 3,232 k | 2,065 k | **−36.1 %** (0.603–0.655) | 6/6 |

Guest ticks: 111,771 → 128,460 at 400M (+14.9 %) and 266,066 → 283,023 at 2B (+6.4 %), identical across the six runs of each arm. The fixed arm's raw totals vary by ±0.1 % between runs; the base arm's by ±2.5 % — the failing-probe path is where the run-to-run noise lives.

**Wait-stats** (`SYSTEMLESS_WAIT_STATS=1`, one 400M run): `anchor_calls=2,805,521 probe_starts=228,072 probe_overflows=0 exact_repeats=94,672 fail_cpu=1,485 fail_mem=0 cancel_trap=129,832` for the fixed arm (the base binary has no counter dump — that printout is part of this commit). The remaining `fail_cpu` samples are genuine register differences between the two arrivals (D0/D3/A2), not the normalised flag. In that run the fixed arm reached 128,460 guest ticks against the base's 111,771 for the same 400M instructions.

Screenshots are not compared: the arms reach different guest times per instruction, so their frames differ by construction.

## Tests

- `cargo test --lib --features test-support` on master 17fb5af + this commit: 4,209 passed, 0 failed, 3 ignored (the prover's existing tests, including `aperiodic_state_walk_never_proves` and the period-cap tests, are unchanged: a snapshot that differs in any architectural field still rejects). `cargo clippy --all-targets --all-features`: no finding inside the changed lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ng5oTbT6MzdjV92Fd1qoE
