### PR TITLE
chore: add reproducible runtime route inventory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,11 @@ jobs:
       - name: Headless library build (no default features)
         run: cargo check --no-default-features
 
+      - name: Verify runtime route inventory
+        run: |
+          cargo test --locked --example runtime_route_inventory
+          cargo run --locked --example runtime_route_inventory -- --check audits/runtime-route-baseline.json
+
       - name: Build API documentation
         env:
           RUSTDOCFLAGS: -D warnings -D rustdoc::private_intra_doc_links

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,6 +224,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -504,6 +513,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "cranelift-assembler-x64"
 version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -706,6 +724,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "ctor-lite"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -722,6 +750,16 @@ name = "dasp_sample"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "dispatch"
@@ -930,6 +968,16 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -2060,6 +2108,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2212,8 +2271,10 @@ dependencies = [
  "objc2-metal",
  "objc2-quartz-core 0.2.2",
  "ppc",
+ "regex",
  "serde",
  "serde_json",
+ "sha2",
  "softbuffer",
  "stuffit",
  "tempfile",
@@ -2393,6 +2454,12 @@ name = "typed-path"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,8 @@ required-features = ["gui"]
 
 [dev-dependencies]
 hfsplus = { version = "0.2.4", features = ["testutil"] }
+regex = "1"
+sha2 = "0.10"
 tempfile = "3"
 
 # The 68k interpreter is the dominant hot path; fat LTO + a single

--- a/README.md
+++ b/README.md
@@ -202,6 +202,9 @@ cargo check --no-default-features
 cargo package
 ```
 
+The legacy HLE route baseline is reproducible with the Rust command documented
+in [`docs/runtime-route-inventory.md`](docs/runtime-route-inventory.md).
+
 The off-by-default `test-support` feature exposes `scripted_traces`, the
 deterministic trap-replay test scaffolding. It is kept out of the published
 public API; enable it only when running tests.

--- a/audits/runtime-route-baseline.json
+++ b/audits/runtime-route-baseline.json
@@ -1,0 +1,110 @@
+{
+  "schema_version": 1,
+  "report_kind": "legacy_runtime_route_inventory",
+  "coverage_warning": "Source-route counts are not API catalogue, semantic coverage, or completion evidence.",
+  "source_sha256": {
+    "examples/runtime_route_inventory.rs": "ebecf8f7e5299abe66b2700771cb9f86e723207c3d1a5bbdfd4117633aaa19fe",
+    "src/loader/ppc.rs": "a8c81f6beb7cc86763b68ac599bf0d4fe6e593f88121156fcf2681640cf71a6b",
+    "src/trap/cinepak.rs": "5400e1450016b01e9a9113a2e498bc3a5d23b0106023dd8a589f7e056350f900",
+    "src/trap/control.rs": "2b3be73d55ef213f467a48bc6518c71e9df537841623db2507119d104b840076",
+    "src/trap/dialog.rs": "9bc813c52c3e43a6b2494d0b45174eafbf73670cd8e086ec08faa04e264df14a",
+    "src/trap/dispatch.rs": "464a5cc082fc7295b6c71a39b2bdf80d1bb91a56d49e49f9663b508c45c6943e",
+    "src/trap/event.rs": "cf92db629c8aa3c9183c4a0bc7afec752072b63b35de2350777e6834d0580db9",
+    "src/trap/extended80.rs": "86cddbe4bb7dea055a23970f0ab791bb9ff7ad42fa21e4c4cb0b0ef3dfb026ea",
+    "src/trap/framebuffer.rs": "19c65a73ae10b0492559c2a4a8f5721de32dc7798e12596fdc7a3cb632892785",
+    "src/trap/memory.rs": "e8b953d80d1dcd1016bf98e39609e0d952c9ac4cf63cd64b21517dcd5e6396d9",
+    "src/trap/menu.rs": "7421785c919652b15a6f7360882a9e3178f4a76ad144b3e393745adb0beb7894",
+    "src/trap/mod.rs": "9af67ff27ca8ba817586bf237a8b4f08f95ecf667d70438a1ae331cb93315702",
+    "src/trap/movie_media.rs": "7ed942dd94570d4081ce837d6c9a69fa434f2196ed637e85254c1ab398356579",
+    "src/trap/pict.rs": "1cf9d795920d321d796ce77451c47eab73901a07156f4a5e6b5c48ce60b04ecd",
+    "src/trap/qtrle.rs": "d409f78fba0572c707a104eaec367bcecba10c6029b2db703e7243bd254ddef1",
+    "src/trap/quickdraw.rs": "ce60185dadc426d7cfbfd879afd3e32330919c839e8d399e761dc6b62e9b154e",
+    "src/trap/resource.rs": "f94c08263752a1ba64ec03883f7a13f8bf86c75fc55745480e8d9f836d415e06",
+    "src/trap/sane.rs": "cb92507b759c6993eac35386f19db660769121df98e827d33c9272729ddc6547",
+    "src/trap/shapes.rs": "5db02a8a602f79a2971c748405eac796ea6b108c7d95a3a0c0fbeeb4f3650b2f",
+    "src/trap/smc.rs": "8bba7d53d445063dbf35ce1f651c7102d6d86ce42ef4b4ad2cfaf6e0d7a826be",
+    "src/trap/sound.rs": "87c91a13c25b74a6762464d6a58dc0c3f93f9eef18780d21999a6fea479fefee",
+    "src/trap/test_helpers.rs": "f9640fe2d4731903643213b340f495c486a35b1da357a08dbb270f429bda9017",
+    "src/trap/text_render.rs": "407b1144151e75b752747ea95e0828a641f4d42b8a6c4160dbf360162cbf29b6",
+    "src/trap/toolbox.rs": "b907e88a14b74ab75fbebf72fa5b3ced4b8b70935dd58bb153ab9ed77f7796a8",
+    "src/trap/types.rs": "a14cd7875f2c5766ce78c19447d74d0d2592c821e66c6075a0489c94ce9ce1d4",
+    "src/trap/window.rs": "dffb249b1f5d49a07142e69cfc596676a510bf444d69c3266d1b614b49542af9"
+  },
+  "m68k": {
+    "dispatcher_order": [
+      "dispatch_memory",
+      "dispatch_event",
+      "dispatch_resource",
+      "dispatch_quickdraw",
+      "dispatch_menu",
+      "dispatch_window",
+      "dispatch_control",
+      "dispatch_dialog",
+      "dispatch_sound",
+      "dispatch_toolbox",
+      "dispatch_sane"
+    ],
+    "canonical_claim_count": 792,
+    "unique_canonical_claim_count": 791,
+    "os_unique_claim_count": 149,
+    "toolbox_unique_claim_count": 642,
+    "unmatched_canonical_slot_count": 489,
+    "raw_word_count_routing_to_claimed_slots": 2476,
+    "duplicate_or_unreachable_claims": [
+      {
+        "canonical_word": "0xA070",
+        "claims": [
+          {
+            "dispatcher": "dispatch_memory",
+            "file": "src/trap/memory.rs",
+            "line": 1156,
+            "reachable": true
+          },
+          {
+            "dispatcher": "dispatch_event",
+            "file": "src/trap/event.rs",
+            "line": 810,
+            "reachable": false
+          }
+        ]
+      }
+    ],
+    "fallback_signals": {
+      "unknown_selector_mentions": 18,
+      "return_noerr_calls": 13
+    }
+  },
+  "powerpc": {
+    "source": "src/loader/ppc.rs",
+    "enum_variant_count": 872,
+    "mapping_arm_count_including_wildcard": 890,
+    "exact_library_symbol_tuple_count": 738,
+    "distinct_mapped_target_count_excluding_unsupported": 869,
+    "helper_disabled_arm_count": 1,
+    "fallback_target": "Unsupported",
+    "compatibility_targets": [
+      "StdIoCompatibility",
+      "AppleEventCompatibility",
+      "DialogCompatibility",
+      "QuickDrawCompatibility",
+      "SystemCompatibility",
+      "FileCompatibility",
+      "AppleTalkCompatibility",
+      "PrintingCompatibility",
+      "SlotCompatibility",
+      "StandardFileCompatibility",
+      "SoundInputCompatibility",
+      "SpeechCompatibility",
+      "QuickTimeCompatibility",
+      "InputSprocketCompatibility",
+      "MathCompatibility",
+      "StdCCompatibility",
+      "ObjectSupportCompatibility"
+    ],
+    "production_target_reference_counts": {
+      "NoOpPreserve": 5,
+      "ReturnNoErr": 4,
+      "Unsupported": 4
+    }
+  }
+}

--- a/docs/runtime-route-inventory.md
+++ b/docs/runtime-route-inventory.md
@@ -1,0 +1,21 @@
+# Runtime route inventory
+
+The Rust `runtime_route_inventory` example records reproducible source-level signals
+from the legacy 68K trap and native PowerPC HLE dispatchers:
+
+```sh
+cargo run --example runtime_route_inventory
+cargo run --example runtime_route_inventory -- --check audits/runtime-route-baseline.json
+cargo test --example runtime_route_inventory
+```
+
+The report identifies production trap claims in first-match dispatcher order,
+duplicate or unreachable canonical claims, raw A-line words routed to claimed
+slots, PowerPC import mapper and target counts, and selected fallback signals.
+It hashes every scanned source file so a retained report can be tied to the
+exact implementation it describes.
+
+These are implementation inventory signals only. They are not an API catalog,
+semantic coverage percentage, profile availability proof, or evidence that a
+route is correct. Aliases, selector routines, callback forms, native exports,
+components, and dependencies require independent profile-backed registry rows.

--- a/examples/runtime_route_inventory.rs
+++ b/examples/runtime_route_inventory.rs
@@ -1,0 +1,628 @@
+use regex::Regex;
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, BTreeSet};
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const TRAP_DISPATCHERS: &[&str] = &[
+    "dispatch_memory",
+    "dispatch_event",
+    "dispatch_resource",
+    "dispatch_quickdraw",
+    "dispatch_menu",
+    "dispatch_window",
+    "dispatch_control",
+    "dispatch_dialog",
+    "dispatch_sound",
+    "dispatch_toolbox",
+    "dispatch_sane",
+];
+
+#[derive(Clone, Debug)]
+struct TrapClaim {
+    dispatcher: String,
+    file: String,
+    line: usize,
+    is_toolbox: bool,
+    slot: u16,
+}
+
+impl TrapClaim {
+    fn canonical_word(&self) -> u16 {
+        (if self.is_toolbox { 0xA800 } else { 0xA000 }) | self.slot
+    }
+}
+
+#[derive(Serialize)]
+struct Report {
+    schema_version: u8,
+    report_kind: &'static str,
+    coverage_warning: &'static str,
+    source_sha256: BTreeMap<String, String>,
+    m68k: M68kInventory,
+    powerpc: PpcInventory,
+}
+
+#[derive(Serialize)]
+struct M68kInventory {
+    dispatcher_order: &'static [&'static str],
+    canonical_claim_count: usize,
+    unique_canonical_claim_count: usize,
+    os_unique_claim_count: usize,
+    toolbox_unique_claim_count: usize,
+    unmatched_canonical_slot_count: usize,
+    raw_word_count_routing_to_claimed_slots: usize,
+    duplicate_or_unreachable_claims: Vec<DuplicateClaim>,
+    fallback_signals: M68kFallbackSignals,
+}
+
+#[derive(Serialize)]
+struct DuplicateClaim {
+    canonical_word: String,
+    claims: Vec<ClaimLocation>,
+}
+
+#[derive(Serialize)]
+struct ClaimLocation {
+    dispatcher: String,
+    file: String,
+    line: usize,
+    reachable: bool,
+}
+
+#[derive(Default, Serialize)]
+struct M68kFallbackSignals {
+    unknown_selector_mentions: usize,
+    return_noerr_calls: usize,
+}
+
+#[derive(Serialize)]
+struct PpcInventory {
+    source: String,
+    enum_variant_count: usize,
+    mapping_arm_count_including_wildcard: usize,
+    exact_library_symbol_tuple_count: usize,
+    distinct_mapped_target_count_excluding_unsupported: usize,
+    helper_disabled_arm_count: usize,
+    fallback_target: Option<&'static str>,
+    compatibility_targets: Vec<String>,
+    production_target_reference_counts: BTreeMap<&'static str, usize>,
+}
+
+fn mask_non_code(source: &str, keep_strings: bool) -> String {
+    let mut bytes = source.as_bytes().to_vec();
+    let mut index = 0;
+    let mut block_depth = 0usize;
+    let mut state = State::Code;
+    while index < bytes.len() {
+        let current = bytes[index];
+        let following = bytes.get(index + 1).copied().unwrap_or_default();
+        match state {
+            State::Code => {
+                if current == b'/' && following == b'/' {
+                    bytes[index] = b' ';
+                    bytes[index + 1] = b' ';
+                    index += 2;
+                    state = State::LineComment;
+                    continue;
+                }
+                if current == b'/' && following == b'*' {
+                    bytes[index] = b' ';
+                    bytes[index + 1] = b' ';
+                    index += 2;
+                    block_depth = 1;
+                    state = State::BlockComment;
+                    continue;
+                }
+                if current == b'"' {
+                    if !keep_strings {
+                        bytes[index] = b' ';
+                    }
+                    state = State::String;
+                } else if current == b'\'' && bytes.get(index + 2).copied() == Some(b'\'') {
+                    if !keep_strings {
+                        bytes[index] = b' ';
+                    }
+                    state = State::Character;
+                }
+            }
+            State::LineComment => {
+                if current == b'\n' {
+                    state = State::Code;
+                } else {
+                    bytes[index] = b' ';
+                }
+            }
+            State::BlockComment => {
+                if current == b'/' && following == b'*' {
+                    bytes[index] = b' ';
+                    bytes[index + 1] = b' ';
+                    index += 2;
+                    block_depth += 1;
+                    continue;
+                }
+                if current == b'*' && following == b'/' {
+                    bytes[index] = b' ';
+                    bytes[index + 1] = b' ';
+                    index += 2;
+                    block_depth -= 1;
+                    if block_depth == 0 {
+                        state = State::Code;
+                    }
+                    continue;
+                }
+                if current != b'\n' {
+                    bytes[index] = b' ';
+                }
+            }
+            State::String | State::Character => {
+                if !keep_strings && current != b'\n' {
+                    bytes[index] = b' ';
+                }
+                if current == b'\\' {
+                    if !keep_strings && index + 1 < bytes.len() {
+                        bytes[index + 1] = b' ';
+                    }
+                    index += 2;
+                    continue;
+                }
+                let terminator = if state == State::String { b'"' } else { b'\'' };
+                if current == terminator {
+                    state = State::Code;
+                }
+            }
+        }
+        index += 1;
+    }
+    String::from_utf8(bytes).expect("masking replaces source bytes with ASCII")
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum State {
+    Code,
+    LineComment,
+    BlockComment,
+    String,
+    Character,
+}
+
+fn matching_brace(masked: &str, opening: usize) -> Result<usize, String> {
+    let mut depth = 0usize;
+    for (offset, byte) in masked.as_bytes()[opening..].iter().enumerate() {
+        match byte {
+            b'{' => depth += 1,
+            b'}' => {
+                depth = depth
+                    .checked_sub(1)
+                    .ok_or_else(|| format!("unexpected closing brace at {opening}"))?;
+                if depth == 0 {
+                    return Ok(opening + offset);
+                }
+            }
+            _ => {}
+        }
+    }
+    Err(format!("unclosed brace at {opening}"))
+}
+
+fn depth_at_offsets(masked: &str, offsets: impl Iterator<Item = usize>) -> Vec<usize> {
+    let offsets: Vec<_> = offsets.collect();
+    let mut result = Vec::with_capacity(offsets.len());
+    let mut braces = 0usize;
+    let mut cursor = 0usize;
+    for offset in offsets {
+        for byte in &masked.as_bytes()[cursor..offset] {
+            match byte {
+                b'{' => braces += 1,
+                b'}' => braces = braces.saturating_sub(1),
+                _ => {}
+            }
+        }
+        result.push(braces);
+        cursor = offset;
+    }
+    result
+}
+
+fn top_level_token_count(masked: &str, token: &[u8]) -> usize {
+    let bytes = masked.as_bytes();
+    let mut braces = 0usize;
+    let mut parentheses = 0usize;
+    let mut brackets = 0usize;
+    let mut count = 0usize;
+    let mut index = 0usize;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'{' => braces += 1,
+            b'}' => braces = braces.saturating_sub(1),
+            b'(' => parentheses += 1,
+            b')' => parentheses = parentheses.saturating_sub(1),
+            b'[' => brackets += 1,
+            b']' => brackets = brackets.saturating_sub(1),
+            _ => {}
+        }
+        if braces == 0 && parentheses == 0 && brackets == 0 && bytes[index..].starts_with(token) {
+            count += 1;
+            index += token.len();
+        } else {
+            index += 1;
+        }
+    }
+    count
+}
+
+fn named_body(source: &str, declaration: &Regex) -> Result<(usize, usize), String> {
+    let masked = mask_non_code(source, false);
+    let found = declaration
+        .find(&masked)
+        .ok_or_else(|| format!("declaration not found: {}", declaration.as_str()))?;
+    let opening = masked[found.end()..]
+        .find('{')
+        .map(|relative| found.end() + relative)
+        .ok_or_else(|| format!("body not found: {}", declaration.as_str()))?;
+    Ok((opening + 1, matching_brace(&masked, opening)?))
+}
+
+fn rust_trap_files(root: &Path) -> Result<Vec<PathBuf>, String> {
+    let mut paths = fs::read_dir(root.join("src/trap"))
+        .map_err(|error| error.to_string())?
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().and_then(|value| value.to_str()) == Some("rs"))
+        .collect::<Vec<_>>();
+    paths.sort();
+    Ok(paths)
+}
+
+fn relative(root: &Path, path: &Path) -> Result<String, String> {
+    Ok(path
+        .strip_prefix(root)
+        .map_err(|error| error.to_string())?
+        .to_string_lossy()
+        .replace('\\', "/"))
+}
+
+fn trap_claims(root: &Path) -> Result<Vec<TrapClaim>, String> {
+    let tuple = Regex::new(r"\(\s*(true|false)\s*,\s*(0x[0-9A-Fa-f]+)\s*\)").unwrap();
+    let trap_match = Regex::new(r"\bmatch\s*\(\s*is_tool\s*,\s*trap_num\s*\)\s*\{").unwrap();
+    let mut claims = Vec::new();
+    let mut remaining: BTreeSet<_> = TRAP_DISPATCHERS.iter().copied().collect();
+    for path in rust_trap_files(root)? {
+        let source = fs::read_to_string(&path).map_err(|error| error.to_string())?;
+        let code = mask_non_code(&source, false);
+        for dispatcher in TRAP_DISPATCHERS {
+            let declaration = Regex::new(&format!(
+                r"\bfn\s+{}\s*(?:<[^{{>]*>)?\s*\(",
+                regex::escape(dispatcher)
+            ))
+            .unwrap();
+            let Some(found) = declaration.find(&code) else {
+                continue;
+            };
+            remaining.remove(dispatcher);
+            let function_open = code[found.end()..]
+                .find('{')
+                .map(|relative| found.end() + relative)
+                .ok_or_else(|| format!("body not found for {dispatcher}"))?;
+            let function_close = matching_brace(&code, function_open)?;
+            let function_code = &code[function_open + 1..function_close];
+            let found_match = trap_match
+                .find(function_code)
+                .ok_or_else(|| format!("trap match not found in {dispatcher}"))?;
+            let match_open = function_open + 1 + found_match.end() - 1;
+            let match_close = matching_brace(&code, match_open)?;
+            let match_code = &code[match_open + 1..match_close];
+            let found_claims = tuple.find_iter(match_code).collect::<Vec<_>>();
+            let depths =
+                depth_at_offsets(match_code, found_claims.iter().map(|found| found.start()));
+            for (found_claim, depth) in found_claims.into_iter().zip(depths) {
+                if depth != 0 {
+                    continue;
+                }
+                let captures = tuple.captures(found_claim.as_str()).unwrap();
+                let absolute = match_open + 1 + found_claim.start();
+                claims.push(TrapClaim {
+                    dispatcher: (*dispatcher).to_string(),
+                    file: relative(root, &path)?,
+                    line: source.as_bytes()[..absolute]
+                        .iter()
+                        .filter(|byte| **byte == b'\n')
+                        .count()
+                        + 1,
+                    is_toolbox: &captures[1] == "true",
+                    slot: u16::from_str_radix(&captures[2][2..], 16)
+                        .map_err(|error| error.to_string())?,
+                });
+            }
+        }
+    }
+    if !remaining.is_empty() {
+        return Err(format!("missing trap dispatchers: {remaining:?}"));
+    }
+    claims.sort_by_key(|claim| {
+        (
+            TRAP_DISPATCHERS
+                .iter()
+                .position(|dispatcher| *dispatcher == claim.dispatcher)
+                .expect("claim dispatcher comes from the configured chain"),
+            claim.file.clone(),
+            claim.line,
+        )
+    });
+    Ok(claims)
+}
+
+fn before_tests(source: &str) -> &str {
+    Regex::new(r"(?m)^#\[cfg\(test\)\]\s*\nmod\s+tests\s*\{")
+        .unwrap()
+        .find(source)
+        .map_or(source, |found| &source[..found.start()])
+}
+
+fn ppc_inventory(root: &Path) -> Result<PpcInventory, String> {
+    let path = root.join("src/loader/ppc.rs");
+    let source = fs::read_to_string(&path).map_err(|error| error.to_string())?;
+    let (enum_start, enum_end) = named_body(
+        &source,
+        &Regex::new(r"\bpub\s+enum\s+PpcImportDispatcherTarget\b").unwrap(),
+    )?;
+    let enum_body = mask_non_code(&source[enum_start..enum_end], false);
+    let variant = Regex::new(r"(?m)^\s*([A-Z][A-Za-z0-9_]*)\b").unwrap();
+    let variants = variant
+        .captures_iter(&enum_body)
+        .map(|captures| captures[1].to_string())
+        .collect::<Vec<_>>();
+
+    let (function_start, function_end) = named_body(
+        &source,
+        &Regex::new(r"\bfn\s+dispatcher_target_for_import\s*\(").unwrap(),
+    )?;
+    let function_code = mask_non_code(&source[function_start..function_end], false);
+    let import_match =
+        Regex::new(r"\bmatch\s*\(\s*library_name\s*,\s*symbol_name\s*\)\s*\{").unwrap();
+    let found_match = import_match
+        .find(&function_code)
+        .ok_or_else(|| "PowerPC import mapper match not found".to_string())?;
+    let match_open = function_start + found_match.end() - 1;
+    let source_code = mask_non_code(&source, false);
+    let match_close = matching_brace(&source_code, match_open)?;
+    let match_source = &source[match_open + 1..match_close];
+    let match_code = mask_non_code(match_source, true);
+    let match_structure = mask_non_code(match_source, false);
+
+    let pair =
+        Regex::new(r#"\(\s*"([^"\\]*(?:\\.[^"\\]*)*)"\s*,\s*"([^"\\]*(?:\\.[^"\\]*)*)"\s*\)"#)
+            .unwrap();
+    let found_pairs = pair.find_iter(&match_code).collect::<Vec<_>>();
+    let pair_depths = depth_at_offsets(
+        &match_structure,
+        found_pairs.iter().map(|found| found.start()),
+    );
+    let exact_pair_count = pair_depths.into_iter().filter(|depth| *depth == 0).count();
+
+    let target = Regex::new(r"PpcImportDispatcherTarget::([A-Za-z0-9_]+)").unwrap();
+    let mapped_targets = target
+        .captures_iter(&match_code)
+        .map(|captures| captures[1].to_string())
+        .collect::<BTreeSet<_>>();
+    let compatibility_targets = variants
+        .iter()
+        .filter(|name| name.ends_with("Compatibility"))
+        .cloned()
+        .collect();
+    let production = mask_non_code(before_tests(&source), false);
+    let mut production_target_reference_counts = BTreeMap::new();
+    for name in ["ReturnNoErr", "NoOpPreserve", "Unsupported"] {
+        let expression = Regex::new(&format!(
+            r"PpcImportDispatcherTarget::{}\b",
+            regex::escape(name)
+        ))
+        .unwrap();
+        production_target_reference_counts.insert(name, expression.find_iter(&production).count());
+    }
+    Ok(PpcInventory {
+        source: relative(root, &path)?,
+        enum_variant_count: variants.len(),
+        mapping_arm_count_including_wildcard: top_level_token_count(&match_structure, b"=>"),
+        exact_library_symbol_tuple_count: exact_pair_count,
+        distinct_mapped_target_count_excluding_unsupported: mapped_targets
+            .iter()
+            .filter(|name| name.as_str() != "Unsupported")
+            .count(),
+        helper_disabled_arm_count: Regex::new(r"\bis_quickdraw_3d_status_success_import\s*\(")
+            .unwrap()
+            .find_iter(&match_code)
+            .count(),
+        fallback_target: mapped_targets
+            .contains("Unsupported")
+            .then_some("Unsupported"),
+        compatibility_targets,
+        production_target_reference_counts,
+    })
+}
+
+fn generate(root: &Path) -> Result<Report, String> {
+    let claims = trap_claims(root)?;
+    let mut occurrences: BTreeMap<u16, Vec<&TrapClaim>> = BTreeMap::new();
+    let mut os_claims = BTreeSet::new();
+    let mut toolbox_claims = BTreeSet::new();
+    for claim in &claims {
+        occurrences
+            .entry(claim.canonical_word())
+            .or_default()
+            .push(claim);
+        if claim.is_toolbox {
+            toolbox_claims.insert(claim.slot);
+        } else {
+            os_claims.insert(claim.slot);
+        }
+    }
+    let duplicate_or_unreachable_claims = occurrences
+        .iter()
+        .filter(|(_, claims)| claims.len() > 1)
+        .map(|(word, claims)| DuplicateClaim {
+            canonical_word: format!("0x{word:04X}"),
+            claims: claims
+                .iter()
+                .enumerate()
+                .map(|(index, claim)| ClaimLocation {
+                    dispatcher: claim.dispatcher.clone(),
+                    file: claim.file.clone(),
+                    line: claim.line,
+                    reachable: index == 0,
+                })
+                .collect(),
+        })
+        .collect();
+
+    let mut source_paths = rust_trap_files(root)?;
+    source_paths.push(root.join("src/loader/ppc.rs"));
+    source_paths.push(root.join("examples/runtime_route_inventory.rs"));
+    source_paths.sort();
+    let mut source_sha256 = BTreeMap::new();
+    let mut fallback_signals = M68kFallbackSignals::default();
+    let unknown_selector = Regex::new(r"(?i)unknown[^\n]{0,80}selector").unwrap();
+    let return_noerr = Regex::new(r"\breturn_noerr\s*\(").unwrap();
+    for path in source_paths {
+        let bytes = fs::read(&path).map_err(|error| error.to_string())?;
+        source_sha256.insert(
+            relative(root, &path)?,
+            format!("{:x}", Sha256::digest(&bytes)),
+        );
+        if path.parent() == Some(root.join("src/trap").as_path()) {
+            let source = String::from_utf8(bytes).map_err(|error| error.to_string())?;
+            let production = before_tests(&source);
+            fallback_signals.unknown_selector_mentions +=
+                unknown_selector.find_iter(production).count();
+            fallback_signals.return_noerr_calls += return_noerr
+                .find_iter(&mask_non_code(production, false))
+                .count();
+        }
+    }
+
+    Ok(Report {
+        schema_version: 1,
+        report_kind: "legacy_runtime_route_inventory",
+        coverage_warning:
+            "Source-route counts are not API catalogue, semantic coverage, or completion evidence.",
+        source_sha256,
+        m68k: M68kInventory {
+            dispatcher_order: TRAP_DISPATCHERS,
+            canonical_claim_count: claims.len(),
+            unique_canonical_claim_count: occurrences.len(),
+            os_unique_claim_count: os_claims.len(),
+            toolbox_unique_claim_count: toolbox_claims.len(),
+            unmatched_canonical_slot_count: 1280 - occurrences.len(),
+            raw_word_count_routing_to_claimed_slots: os_claims.len() * 8 + toolbox_claims.len() * 2,
+            duplicate_or_unreachable_claims,
+            fallback_signals,
+        },
+        powerpc: ppc_inventory(root)?,
+    })
+}
+
+fn repository_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).to_path_buf()
+}
+
+fn run() -> Result<(), String> {
+    let mut root = repository_root();
+    let mut output = None;
+    let mut check = None;
+    let mut arguments = env::args().skip(1);
+    while let Some(argument) = arguments.next() {
+        match argument.as_str() {
+            "--root" => root = PathBuf::from(arguments.next().ok_or("--root needs a path")?),
+            "--output" => {
+                output = Some(PathBuf::from(
+                    arguments.next().ok_or("--output needs a path")?,
+                ))
+            }
+            "--check" => {
+                check = Some(PathBuf::from(
+                    arguments.next().ok_or("--check needs a path")?,
+                ))
+            }
+            "--help" | "-h" => {
+                println!("runtime-route-inventory [--root PATH] [--output PATH] [--check PATH]");
+                return Ok(());
+            }
+            _ => return Err(format!("unknown argument: {argument}")),
+        }
+    }
+    let rendered =
+        serde_json::to_string_pretty(&generate(&root)?).map_err(|error| error.to_string())? + "\n";
+    if let Some(path) = check {
+        let expected = fs::read_to_string(&path).map_err(|error| error.to_string())?;
+        if expected != rendered {
+            return Err(format!("inventory differs from {}", path.display()));
+        }
+    }
+    if let Some(path) = output {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+        }
+        fs::write(path, rendered).map_err(|error| error.to_string())?;
+    } else {
+        print!("{rendered}");
+    }
+    Ok(())
+}
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("runtime-route-inventory: {error}");
+        std::process::exit(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn masks_nested_comments_without_changing_offsets() {
+        let source = "fn f() { /* first { /* nested */ } */ \"text\"; }";
+        let masked = mask_non_code(source, false);
+        assert_eq!(source.len(), masked.len());
+        let opening = masked.find('{').unwrap();
+        assert_eq!(matching_brace(&masked, opening), Ok(source.len() - 1));
+    }
+
+    #[test]
+    fn counts_only_top_level_tokens() {
+        let source = "one => value, { nested => value }, two => value";
+        assert_eq!(top_level_token_count(source, b"=>"), 2);
+    }
+
+    #[test]
+    fn preserves_dispatch_order_and_alternative_claims() {
+        let temporary =
+            env::temp_dir().join(format!("systemless-route-inventory-{}", std::process::id()));
+        let trap_directory = temporary.join("src/trap");
+        fs::create_dir_all(&trap_directory).unwrap();
+        let mut source = String::new();
+        for dispatcher in TRAP_DISPATCHERS {
+            let arms = if *dispatcher == TRAP_DISPATCHERS[0] {
+                "(false, 0x70) | (true, 0x001) => {},"
+            } else {
+                "_ => {},"
+            };
+            source.push_str(&format!(
+                "fn {dispatcher}(is_tool: bool, trap_num: u16) {{ match (is_tool, trap_num) {{ {arms} }} }}\n"
+            ));
+        }
+        fs::write(trap_directory.join("dispatch.rs"), source).unwrap();
+        let claims = trap_claims(&temporary).unwrap();
+        fs::remove_dir_all(&temporary).unwrap();
+        assert_eq!(
+            claims
+                .iter()
+                .map(TrapClaim::canonical_word)
+                .collect::<Vec<_>>(),
+            vec![0xA070, 0xA801]
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- add a packaged Rust inventory example for the legacy 68K trap and native PowerPC dispatch routes
- retain a source-hashed JSON baseline with duplicate reachability and fallback signals
- verify the baseline in CI and document how to regenerate it

## Evidence

The retained v0.21.2 inventory reports 792 canonical 68K claims, 791 unique keys, 149 OS slots, 642 Toolbox slots, 2,476 routed raw words, and the unreachable second `$A070` claim. It also reports 872 PowerPC dispatcher targets, 890 mapper arms, 738 exact library/symbol tuples, 869 mapped non-unsupported targets, and one helper-disabled mapper arm. The report explicitly states that these source-route counts are not semantic coverage.

## Validation

- `cargo test --locked --example runtime_route_inventory`
- `cargo run --locked --example runtime_route_inventory -- --check audits/runtime-route-baseline.json`
- `cargo check --locked --no-default-features`
- `cargo package --locked --allow-dirty --no-verify`

Closes #902