### PR TITLE
feat(memory): share runtime globals across CPU backends

### DIFF
--- a/src/memory/address_space.rs
+++ b/src/memory/address_space.rs
@@ -9,14 +9,39 @@ use m68k::core::memory::{BusFault, BusFaultKind};
 use m68k::AddressBus;
 use ppc::{PpcMemory, PpcSectionMem, PpcSectionMemSpan};
 
+use super::bus::SharedRamRegion;
+
+#[derive(Debug, Clone)]
+struct SharedRegionMapping {
+    base: u32,
+    region: SharedRamRegion,
+}
+
 /// A sparse guest address space that can be executed by either CPU backend.
 ///
 /// The region implementation remains private so loaders and runtime services
 /// depend on the architecture-neutral ownership boundary rather than a CPU
 /// crate's concrete memory type.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Default)]
 pub struct GuestAddressSpace {
     regions: PpcSectionMem,
+    shared_regions: Vec<SharedRegionMapping>,
+}
+
+impl Clone for GuestAddressSpace {
+    fn clone(&self) -> Self {
+        Self {
+            regions: self.regions.clone(),
+            shared_regions: self
+                .shared_regions
+                .iter()
+                .map(|mapping| SharedRegionMapping {
+                    base: mapping.base,
+                    region: mapping.region.detached_clone(),
+                })
+                .collect(),
+        }
+    }
 }
 
 impl GuestAddressSpace {
@@ -35,23 +60,86 @@ impl GuestAddressSpace {
         self.regions.add_readonly_region(base, bytes);
     }
 
+    /// Overlay a runner-owned RAM range without copying it.
+    ///
+    /// Shared mappings remain authoritative over ordinary sparse mappings so
+    /// both CPU adapters observe the same system-scoped bytes immediately.
+    ///
+    /// # Safety
+    ///
+    /// The address space and source bus must remain under one owner that
+    /// serializes all access. No source-bus slice or fast-memory window may be
+    /// used while this address space mutates the shared allocation.
+    pub(crate) unsafe fn add_shared_region(&mut self, base: u32, region: SharedRamRegion) {
+        self.shared_regions
+            .push(SharedRegionMapping { base, region });
+    }
+
     /// Return the number of mapped regions.
     pub fn region_count(&self) -> usize {
-        self.regions.region_count()
+        self.regions.region_count() + self.shared_regions.len()
     }
 
     /// Copy a fully mapped range into `dst`.
     pub fn read_bytes_into(&mut self, addr: u32, dst: &mut [u8]) -> Option<()> {
-        self.regions.read_bytes_into(addr, dst)
+        if !self.shared_overlaps(addr, dst.len()) {
+            return self.regions.read_bytes_into(addr, dst);
+        }
+        for (offset, byte) in dst.iter_mut().enumerate() {
+            *byte = self.read_u8(addr.wrapping_add(offset as u32))?;
+        }
+        Some(())
     }
 
     /// Copy `src` into a fully mapped, writable range.
     pub fn write_bytes(&mut self, addr: u32, src: &[u8]) -> Option<()> {
-        self.regions.write_bytes(addr, src)
+        if !self.shared_overlaps(addr, src.len()) {
+            return self.regions.write_bytes(addr, src);
+        }
+        if (0..src.len()).all(|offset| {
+            self.locate_shared(addr.wrapping_add(offset as u32))
+                .is_some()
+        }) {
+            for (offset, byte) in src.iter().copied().enumerate() {
+                self.write_u8(addr.wrapping_add(offset as u32), byte)
+                    .expect("located shared byte remains mapped");
+            }
+            return Some(());
+        }
+
+        let mut ordinary = Vec::new();
+        let mut shared = Vec::new();
+        for (offset, byte) in src.iter().copied().enumerate() {
+            let address = addr.wrapping_add(offset as u32);
+            if self.locate_shared(address).is_some() {
+                shared.push((address, byte));
+            } else {
+                ordinary.push((address, self.regions.read_u8(address)?, byte));
+            }
+        }
+
+        for (committed, &(address, _, byte)) in ordinary.iter().enumerate() {
+            if self.regions.write_u8(address, byte).is_none() {
+                for &(rollback_address, original, _) in ordinary[..committed].iter().rev() {
+                    self.regions
+                        .write_u8(rollback_address, original)
+                        .expect("a previously writable sparse byte remains writable");
+                }
+                return None;
+            }
+        }
+        for (address, byte) in shared {
+            self.write_u8(address, byte)
+                .expect("located shared byte remains mapped");
+        }
+        Some(())
     }
 
     /// Return a cached writable span contained in one mapped region.
     pub fn writable_span(&mut self, addr: u32, len: usize) -> Option<PpcSectionMemSpan> {
+        if self.shared_overlaps(addr, len) {
+            return None;
+        }
         self.regions.writable_span(addr, len)
     }
 
@@ -82,57 +170,131 @@ impl GuestAddressSpace {
             address,
         }
     }
+
+    #[inline]
+    fn locate_shared(&self, addr: u32) -> Option<(&SharedRamRegion, usize)> {
+        self.shared_regions.iter().rev().find_map(|mapping| {
+            let offset = usize::try_from(addr.checked_sub(mapping.base)?).ok()?;
+            (offset < mapping.region.len()).then_some((&mapping.region, offset))
+        })
+    }
+
+    fn shared_overlaps(&self, addr: u32, len: usize) -> bool {
+        if len == 0 {
+            return false;
+        }
+        const ADDRESS_SPACE_SIZE: u64 = 1u64 << 32;
+        let start = u64::from(addr);
+        let len = len as u64;
+        if len >= ADDRESS_SPACE_SIZE {
+            return !self.shared_regions.is_empty();
+        }
+        let end = start + len;
+        self.shared_regions.iter().any(|mapping| {
+            let mapping_start = u64::from(mapping.base);
+            let mapping_end = mapping_start.saturating_add(mapping.region.len() as u64);
+            if end <= ADDRESS_SPACE_SIZE {
+                start < mapping_end && mapping_start < end
+            } else {
+                start < mapping_end || mapping_start < end - ADDRESS_SPACE_SIZE
+            }
+        })
+    }
 }
 
 impl PpcMemory for GuestAddressSpace {
     #[inline]
     fn read_u8(&mut self, addr: u32) -> Option<u8> {
-        self.regions.read_u8(addr)
+        if let Some((region, offset)) = self.locate_shared(addr) {
+            // SAFETY: `add_shared_region` requires the enclosing runtime to
+            // serialize both adapters for the mapping's complete lifetime.
+            unsafe { region.read(offset) }
+        } else {
+            self.regions.read_u8(addr)
+        }
     }
 
     #[inline]
     fn read_u16_be(&mut self, addr: u32) -> Option<u16> {
-        self.regions.read_u16_be(addr)
+        if !self.shared_overlaps(addr, 2) {
+            return self.regions.read_u16_be(addr);
+        }
+        let mut bytes = [0; 2];
+        self.read_bytes_into(addr, &mut bytes)?;
+        Some(u16::from_be_bytes(bytes))
     }
 
     #[inline]
     fn read_u32_be(&mut self, addr: u32) -> Option<u32> {
-        self.regions.read_u32_be(addr)
+        if !self.shared_overlaps(addr, 4) {
+            return self.regions.read_u32_be(addr);
+        }
+        let mut bytes = [0; 4];
+        self.read_bytes_into(addr, &mut bytes)?;
+        Some(u32::from_be_bytes(bytes))
     }
 
     #[inline]
     fn read_u64_be(&mut self, addr: u32) -> Option<u64> {
-        self.regions.read_u64_be(addr)
+        if !self.shared_overlaps(addr, 8) {
+            return self.regions.read_u64_be(addr);
+        }
+        let mut bytes = [0; 8];
+        self.read_bytes_into(addr, &mut bytes)?;
+        Some(u64::from_be_bytes(bytes))
     }
 
     #[inline]
     fn read_instruction_u32_be(&mut self, addr: u32) -> Option<u32> {
-        self.regions.read_instruction_u32_be(addr)
+        if self.shared_overlaps(addr, 4) {
+            self.read_u32_be(addr)
+        } else {
+            self.regions.read_instruction_u32_be(addr)
+        }
     }
 
     #[inline]
     fn instruction_cache_token(&mut self, addr: u32) -> Option<u64> {
-        self.regions.instruction_cache_token(addr)
+        if self.shared_overlaps(addr, 4) {
+            None
+        } else {
+            self.regions.instruction_cache_token(addr)
+        }
     }
 
     #[inline]
     fn write_u8(&mut self, addr: u32, value: u8) -> Option<()> {
-        self.regions.write_u8(addr, value)
+        if let Some((region, offset)) = self.locate_shared(addr) {
+            // SAFETY: `add_shared_region` requires the enclosing runtime to
+            // serialize both adapters for the mapping's complete lifetime.
+            unsafe { region.write(offset, value) }
+        } else {
+            self.regions.write_u8(addr, value)
+        }
     }
 
     #[inline]
     fn write_u16_be(&mut self, addr: u32, value: u16) -> Option<()> {
-        self.regions.write_u16_be(addr, value)
+        if !self.shared_overlaps(addr, 2) {
+            return self.regions.write_u16_be(addr, value);
+        }
+        self.write_bytes(addr, &value.to_be_bytes())
     }
 
     #[inline]
     fn write_u32_be(&mut self, addr: u32, value: u32) -> Option<()> {
-        self.regions.write_u32_be(addr, value)
+        if !self.shared_overlaps(addr, 4) {
+            return self.regions.write_u32_be(addr, value);
+        }
+        self.write_bytes(addr, &value.to_be_bytes())
     }
 
     #[inline]
     fn write_u64_be(&mut self, addr: u32, value: u64) -> Option<()> {
-        self.regions.write_u64_be(addr, value)
+        if !self.shared_overlaps(addr, 8) {
+            return self.regions.write_u64_be(addr, value);
+        }
+        self.write_bytes(addr, &value.to_be_bytes())
     }
 }
 
@@ -207,6 +369,7 @@ impl AddressBus for GuestAddressSpace {
 #[cfg(test)]
 mod tests {
     use super::GuestAddressSpace;
+    use crate::memory::{MacMemoryBus, MemoryBus};
     use m68k::{AddressBus, CpuCore, StepResult};
     use ppc::{PpcCpu, PpcMemory, PpcRunResult};
 
@@ -277,5 +440,68 @@ mod tests {
         assert!(AddressBus::try_write_byte(&mut memory, 0x1000, 0xff).is_err());
         assert!(AddressBus::try_read_byte(&mut memory, 0x2000).is_err());
         assert_eq!(AddressBus::read_byte(&mut memory, 0x2000), 0);
+    }
+
+    #[test]
+    fn runner_ram_mapping_is_authoritative_and_clones_as_a_snapshot() {
+        const SHARED: u32 = 0x156;
+
+        let mut runner_bus = MacMemoryBus::new(64 * 1024);
+        MemoryBus::write_long(&mut runner_bus, SHARED, 0x1122_3344);
+
+        let mut memory = GuestAddressSpace::new();
+        memory.add_region(0, vec![0; 64 * 1024]);
+        assert!(runner_bus.fast_mem_window().is_some());
+        let shared = runner_bus
+            .shared_ram_region(SHARED, 4)
+            .expect("owned runner RAM");
+        assert!(runner_bus.fast_mem_window().is_none());
+        // SAFETY: the test accesses the bus and address space sequentially and
+        // does not retain a RAM slice or fast-memory window across a mutation.
+        unsafe {
+            memory.add_shared_region(SHARED, shared);
+        }
+
+        assert_eq!(
+            PpcMemory::read_u32_be(&mut memory, SHARED),
+            Some(0x1122_3344)
+        );
+        assert_eq!(
+            PpcMemory::instruction_cache_token(&mut memory, SHARED),
+            None
+        );
+
+        PpcMemory::write_u32_be(&mut memory, SHARED, 0x5566_7788).unwrap();
+        assert_eq!(MemoryBus::read_long(&runner_bus, SHARED), 0x5566_7788);
+        assert_eq!(runner_bus.ram_slice(SHARED, 4), &[0x55, 0x66, 0x77, 0x88]);
+
+        memory
+            .write_bytes(SHARED - 1, &[0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff])
+            .unwrap();
+        let mut crossed = [0; 6];
+        memory.read_bytes_into(SHARED - 1, &mut crossed).unwrap();
+        assert_eq!(crossed, [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
+        assert_eq!(MemoryBus::read_long(&runner_bus, SHARED), 0xbbcc_ddee);
+
+        memory.add_readonly_region(SHARED + 4, vec![0x7f]);
+        assert_eq!(memory.write_bytes(SHARED - 1, &[1, 2, 3, 4, 5, 6]), None);
+        assert_eq!(PpcMemory::read_u8(&mut memory, SHARED - 1), Some(0xaa));
+        assert_eq!(MemoryBus::read_long(&runner_bus, SHARED), 0xbbcc_ddee);
+        assert_eq!(PpcMemory::read_u8(&mut memory, SHARED + 4), Some(0x7f));
+
+        AddressBus::write_long(&mut memory, SHARED, 0x99aa_bbcc);
+        assert_eq!(MemoryBus::read_long(&runner_bus, SHARED), 0x99aa_bbcc);
+
+        let mut snapshot = memory.clone();
+        PpcMemory::write_u32_be(&mut snapshot, SHARED, 0xddee_ff00).unwrap();
+        assert_eq!(MemoryBus::read_long(&runner_bus, SHARED), 0x99aa_bbcc);
+        assert_eq!(
+            PpcMemory::read_u32_be(&mut memory, SHARED),
+            Some(0x99aa_bbcc)
+        );
+        assert_eq!(
+            PpcMemory::read_u32_be(&mut snapshot, SHARED),
+            Some(0xddee_ff00)
+        );
     }
 }

--- a/src/memory/bus.rs
+++ b/src/memory/bus.rs
@@ -2,8 +2,9 @@
 //!
 //! Provides Big-Endian memory access compatible with 68k Mac architecture.
 
-use std::cell::RefCell;
+use std::cell::{RefCell, UnsafeCell};
 use std::collections::HashMap;
+use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 #[cfg(not(target_arch = "wasm32"))]
 use std::sync::OnceLock;
@@ -512,9 +513,117 @@ pub struct MacMemoryBus {
 /// of the tick.
 pub(crate) const WRITE_PROBE_MAX_ENTRIES: usize = 4096;
 
-/// RAM storage - either owned vector or borrowed slice
+/// Stable shared ownership of the runner's flat RAM allocation.
+///
+/// `FixtureRunner` serializes access to its 68k bus and native application
+/// behind `&mut self`. A mapped [`SharedRamRegion`] can therefore expose the
+/// same allocation to the PowerPC address-space adapter without concurrent
+/// access or a dangling pointer when the runner is moved.
+#[derive(Clone)]
+struct SharedRam(Rc<UnsafeCell<Box<[u8]>>>);
+
+impl SharedRam {
+    #[inline]
+    fn len(&self) -> usize {
+        // SAFETY: the boxed allocation is fixed for every shared handle.
+        unsafe { (&*self.0.get()).len() }
+    }
+
+    #[inline]
+    fn as_ptr(&self) -> *const u8 {
+        // SAFETY: the boxed allocation is fixed for every shared handle.
+        unsafe { (&*self.0.get()).as_ptr() }
+    }
+
+    #[inline]
+    fn as_mut_ptr(&self) -> *mut u8 {
+        // SAFETY: dereferencing this pointer remains subject to the serialized
+        // access contract on `SharedRamRegion`.
+        unsafe { (&mut *self.0.get()).as_mut_ptr() }
+    }
+}
+
+/// A stable subrange of runner RAM mapped into another CPU bus.
+#[derive(Clone)]
+pub(crate) struct SharedRamRegion {
+    ram: SharedRam,
+    offset: usize,
+    len: usize,
+}
+
+impl std::fmt::Debug for SharedRamRegion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SharedRamRegion")
+            .field("offset", &self.offset)
+            .field("len", &self.len)
+            .finish_non_exhaustive()
+    }
+}
+
+impl SharedRamRegion {
+    pub(crate) fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Read a byte from the shared subrange.
+    ///
+    /// # Safety
+    ///
+    /// The caller must serialize access with the source [`MacMemoryBus`] and
+    /// must not retain a source RAM slice or fast-memory window.
+    #[inline]
+    pub(crate) unsafe fn read(&self, offset: usize) -> Option<u8> {
+        (offset < self.len).then(|| {
+            // SAFETY: the caller upholds serialization and the offset was
+            // checked against the shared subrange.
+            unsafe { *self.ram.as_ptr().add(self.offset + offset) }
+        })
+    }
+
+    /// Write a byte into the shared subrange.
+    ///
+    /// # Safety
+    ///
+    /// The caller must serialize access with the source [`MacMemoryBus`] and
+    /// must not retain a source RAM slice or fast-memory window.
+    #[inline]
+    pub(crate) unsafe fn write(&self, offset: usize, value: u8) -> Option<()> {
+        if offset >= self.len {
+            return None;
+        }
+        // SAFETY: the caller upholds serialization and the offset was checked
+        // against the shared subrange.
+        unsafe {
+            *self.ram.as_mut_ptr().add(self.offset + offset) = value;
+        }
+        Some(())
+    }
+
+    pub(crate) fn snapshot(&self) -> Vec<u8> {
+        (0..self.len)
+            .map(|offset| {
+                // SAFETY: snapshotting occurs while the address-space clone
+                // has exclusive access to its runtime-owned mapping.
+                unsafe { self.read(offset).expect("bounded shared RAM read") }
+            })
+            .collect()
+    }
+
+    pub(crate) fn detached_clone(&self) -> Self {
+        let bytes = self.snapshot();
+        let ram = SharedRam(Rc::new(UnsafeCell::new(bytes.into_boxed_slice())));
+        Self {
+            len: ram.len(),
+            ram,
+            offset: 0,
+        }
+    }
+}
+
+/// RAM storage - either a stable owned allocation or borrowed slice.
 enum RamStorage {
     Owned(Vec<u8>),
+    Shared(SharedRam),
     /// Borrowed raw pointer + length (used for wrapping r68k memory)
     /// Safety: The lifetime is managed externally
     External(*mut u8, usize),
@@ -525,6 +634,13 @@ impl RamStorage {
     fn get(&self, index: usize) -> u8 {
         match self {
             RamStorage::Owned(v) => v.get(index).copied().unwrap_or(0),
+            RamStorage::Shared(v) => {
+                if index < v.len() {
+                    unsafe { *v.as_ptr().add(index) }
+                } else {
+                    0
+                }
+            }
             RamStorage::External(ptr, len) => {
                 if index < *len {
                     unsafe { *ptr.add(index) }
@@ -541,6 +657,7 @@ impl RamStorage {
         // avoid repeating slice bounds checks on the instruction hot path.
         match self {
             RamStorage::Owned(v) => unsafe { *v.as_ptr().add(index) },
+            RamStorage::Shared(v) => unsafe { *v.as_ptr().add(index) },
             RamStorage::External(ptr, _) => unsafe { *ptr.add(index) },
         }
     }
@@ -549,6 +666,10 @@ impl RamStorage {
     fn read_word_in_bounds(&self, index: usize) -> u16 {
         match self {
             RamStorage::Owned(v) => unsafe {
+                let ptr = v.as_ptr().add(index);
+                u16::from_be_bytes([*ptr, *ptr.add(1)])
+            },
+            RamStorage::Shared(v) => unsafe {
                 let ptr = v.as_ptr().add(index);
                 u16::from_be_bytes([*ptr, *ptr.add(1)])
             },
@@ -566,6 +687,10 @@ impl RamStorage {
                 let ptr = v.as_ptr().add(index);
                 u32::from_be_bytes([*ptr, *ptr.add(1), *ptr.add(2), *ptr.add(3)])
             },
+            RamStorage::Shared(v) => unsafe {
+                let ptr = v.as_ptr().add(index);
+                u32::from_be_bytes([*ptr, *ptr.add(1), *ptr.add(2), *ptr.add(3)])
+            },
             RamStorage::External(ptr, _) => unsafe {
                 let ptr = ptr.add(index);
                 u32::from_be_bytes([*ptr, *ptr.add(1), *ptr.add(2), *ptr.add(3)])
@@ -579,6 +704,7 @@ impl RamStorage {
             RamStorage::Owned(v) => unsafe {
                 *v.as_mut_ptr().add(index) = value;
             },
+            RamStorage::Shared(v) => unsafe { *v.as_mut_ptr().add(index) = value },
             RamStorage::External(ptr, _) => unsafe {
                 *ptr.add(index) = value;
             },
@@ -593,6 +719,9 @@ impl RamStorage {
                 let ptr = v.as_mut_ptr().add(index);
                 *ptr = bytes[0];
                 *ptr.add(1) = bytes[1];
+            },
+            RamStorage::Shared(v) => unsafe {
+                std::ptr::copy_nonoverlapping(bytes.as_ptr(), v.as_mut_ptr().add(index), 2);
             },
             RamStorage::External(ptr, _) => unsafe {
                 let ptr = ptr.add(index);
@@ -613,6 +742,9 @@ impl RamStorage {
                 *ptr.add(2) = bytes[2];
                 *ptr.add(3) = bytes[3];
             },
+            RamStorage::Shared(v) => unsafe {
+                std::ptr::copy_nonoverlapping(bytes.as_ptr(), v.as_mut_ptr().add(index), 4);
+            },
             RamStorage::External(ptr, _) => unsafe {
                 let ptr = ptr.add(index);
                 *ptr = bytes[0];
@@ -629,6 +761,9 @@ impl RamStorage {
             RamStorage::Owned(v) => unsafe {
                 std::ptr::copy_nonoverlapping(data.as_ptr(), v.as_mut_ptr().add(index), data.len());
             },
+            RamStorage::Shared(v) => unsafe {
+                std::ptr::copy_nonoverlapping(data.as_ptr(), v.as_mut_ptr().add(index), data.len());
+            },
             RamStorage::External(ptr, _) => unsafe {
                 std::ptr::copy_nonoverlapping(data.as_ptr(), ptr.add(index), data.len());
             },
@@ -639,6 +774,13 @@ impl RamStorage {
     fn copy_bytes_in_bounds(&mut self, src_index: usize, dst_index: usize, len: usize) {
         match self {
             RamStorage::Owned(v) => unsafe {
+                std::ptr::copy(
+                    v.as_ptr().add(src_index),
+                    v.as_mut_ptr().add(dst_index),
+                    len,
+                );
+            },
+            RamStorage::Shared(v) => unsafe {
                 std::ptr::copy(
                     v.as_ptr().add(src_index),
                     v.as_mut_ptr().add(dst_index),
@@ -667,6 +809,13 @@ impl RamStorage {
                     *dst.add(offset) = map[*src.add(offset) as usize];
                 }
             },
+            RamStorage::Shared(v) => unsafe {
+                let src = v.as_ptr().add(src_index);
+                let dst = v.as_mut_ptr().add(dst_index);
+                for offset in 0..len {
+                    *dst.add(offset) = map[*src.add(offset) as usize];
+                }
+            },
             RamStorage::External(ptr, _) => unsafe {
                 let src = ptr.add(src_index);
                 let dst = ptr.add(dst_index);
@@ -683,6 +832,9 @@ impl RamStorage {
             RamStorage::Owned(v) => unsafe {
                 std::ptr::write_bytes(v.as_mut_ptr().add(index), 0, len);
             },
+            RamStorage::Shared(v) => unsafe {
+                std::ptr::write_bytes(v.as_mut_ptr().add(index), 0, len);
+            },
             RamStorage::External(ptr, _) => unsafe {
                 std::ptr::write_bytes(ptr.add(index), 0, len);
             },
@@ -693,6 +845,9 @@ impl RamStorage {
     fn fill_bytes_in_bounds(&mut self, index: usize, len: usize, value: u8) {
         match self {
             RamStorage::Owned(v) => unsafe {
+                std::ptr::write_bytes(v.as_mut_ptr().add(index), value, len);
+            },
+            RamStorage::Shared(v) => unsafe {
                 std::ptr::write_bytes(v.as_mut_ptr().add(index), value, len);
             },
             RamStorage::External(ptr, _) => unsafe {
@@ -710,6 +865,11 @@ impl RamStorage {
     fn slice_at(&self, index: usize, len: usize) -> Option<&[u8]> {
         match self {
             RamStorage::Owned(v) => v.get(index..index + len),
+            RamStorage::Shared(v) => {
+                let end = index.checked_add(len)?;
+                (end <= v.len())
+                    .then(|| unsafe { std::slice::from_raw_parts(v.as_ptr().add(index), len) })
+            }
             RamStorage::External(ptr, total_len) => {
                 if index
                     .checked_add(len)
@@ -733,6 +893,12 @@ impl RamStorage {
     fn slice_at_mut(&mut self, index: usize, len: usize) -> Option<&mut [u8]> {
         match self {
             RamStorage::Owned(v) => v.get_mut(index..index + len),
+            RamStorage::Shared(v) => {
+                let end = index.checked_add(len)?;
+                (end <= v.len()).then(|| unsafe {
+                    std::slice::from_raw_parts_mut(v.as_mut_ptr().add(index), len)
+                })
+            }
             RamStorage::External(ptr, total_len) => {
                 if index
                     .checked_add(len)
@@ -752,6 +918,13 @@ impl RamStorage {
             RamStorage::Owned(v) => {
                 if index < v.len() {
                     v[index] = value;
+                }
+            }
+            RamStorage::Shared(v) => {
+                if index < v.len() {
+                    unsafe {
+                        *v.as_mut_ptr().add(index) = value;
+                    }
                 }
             }
             RamStorage::External(ptr, len) => {
@@ -1334,7 +1507,14 @@ impl MacMemoryBus {
         let s = start as usize;
         let e = s + len as usize;
         match &self.ram {
-            RamStorage::Owned(v) => &v[s..e],
+            RamStorage::Owned(v) => {
+                assert!(e <= v.len());
+                &v[s..e]
+            }
+            RamStorage::Shared(v) => {
+                assert!(e <= v.len());
+                unsafe { std::slice::from_raw_parts(v.as_ptr().add(s), len as usize) }
+            }
             RamStorage::External(ptr, max_len) => {
                 assert!(e <= *max_len);
                 unsafe { std::slice::from_raw_parts(ptr.add(s), len as usize) }
@@ -1439,6 +1619,34 @@ impl MacMemoryBus {
         self.ram_size
     }
 
+    /// Return a stable shared view over an owned RAM subrange.
+    ///
+    /// The runner uses this to map selected system-scoped bytes into another
+    /// CPU adapter without copying them. Externally wrapped RAM cannot safely
+    /// extend its caller-provided lifetime and therefore returns `None`.
+    pub(crate) fn shared_ram_region(&mut self, address: u32, len: u32) -> Option<SharedRamRegion> {
+        let end = address.checked_add(len)?;
+        if end > self.ram_size {
+            return None;
+        }
+        let ram = match &mut self.ram {
+            RamStorage::Owned(bytes) => {
+                let shared = SharedRam(Rc::new(UnsafeCell::new(
+                    std::mem::take(bytes).into_boxed_slice(),
+                )));
+                self.ram = RamStorage::Shared(shared.clone());
+                shared
+            }
+            RamStorage::Shared(ram) => ram.clone(),
+            RamStorage::External(_, _) => return None,
+        };
+        Some(SharedRamRegion {
+            ram,
+            offset: address as usize,
+            len: len as usize,
+        })
+    }
+
     /// Select the guest MMU address width. The default is 32-bit addressing.
     pub fn set_addressing_32_bit(&mut self, enabled: bool) {
         self.addressing_32_bit = enabled;
@@ -1485,6 +1693,7 @@ impl MacMemoryBus {
         }
         let ptr = match &mut self.ram {
             RamStorage::Owned(v) => v.as_mut_ptr(),
+            RamStorage::Shared(_) => return None,
             RamStorage::External(ptr, _) => *ptr,
         };
         Some((ptr, self.ram_size))

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -3360,9 +3360,6 @@ impl FixtureRunner {
         replacement.dispatcher.tick_count = launch_tick;
         if let Some(ppc_app) = replacement.ppc_app.as_mut() {
             ppc_app.set_tick_count(launch_tick);
-            let _ = ppc_app.memory.write_u32_be(addr::TICKS, launch_tick);
-            let _ = ppc_app.memory.write_u32_be(addr::TIME, launch_time);
-            let _ = ppc_app.memory.write_u32_be(addr::RND_SEED, launch_rnd_seed);
         }
         replacement.dispatcher.mouse_pos = mouse_pos;
         replacement.dispatcher.mouse_button = mouse_button;
@@ -3933,15 +3930,13 @@ impl FixtureRunner {
         self.bus.write_long(addr::TICKS, launch_ticks);
         self.dispatcher.tick_count = launch_ticks;
         ppc_app.set_tick_count(launch_ticks);
-        let _ = ppc_app.memory.write_u32_be(addr::TICKS, launch_ticks);
         let time = self
             .app_start_time
             .unwrap_or_else(current_mac_epoch_seconds);
         self.bus.write_long(addr::TIME, time);
-        let _ = ppc_app.memory.write_u32_be(addr::TIME, time);
         let rnd_seed = self.launch_rnd_seed_override.unwrap_or(time);
         self.bus.write_long(addr::RND_SEED, rnd_seed);
-        let _ = ppc_app.memory.write_u32_be(addr::RND_SEED, rnd_seed);
+        self.share_ppc_runtime_globals(&mut ppc_app);
         if let Some(time_base) = self.launch_ppc_time_base_override {
             ppc_app.cpu.set_time_base(time_base);
         }
@@ -3987,6 +3982,29 @@ impl FixtureRunner {
         self.ppc_sound_synced_file_playback_count = 0;
         self.ppc_sound_host_playbacks.clear();
         self.ppc_app = Some(ppc_app);
+    }
+
+    fn share_ppc_runtime_globals(&mut self, ppc_app: &mut PpcLoadedApp) {
+        use crate::memory::globals::addr;
+
+        // RndSeed is the system random-number seed (Inside Macintosh Volume I,
+        // I-195). The Vertical Retrace Manager updates Ticks and the one-second
+        // interrupt updates Time (Inside Macintosh Volume II, II-202 and
+        // II-378). These bytes describe one running Macintosh, so native and
+        // 68k callers must observe one backing allocation rather than values
+        // copied at CPU-slice boundaries.
+        for address in [addr::RND_SEED, addr::TICKS, addr::TIME] {
+            let region = self
+                .bus
+                .shared_ram_region(address, 4)
+                .expect("FixtureRunner owns stable guest RAM");
+            // SAFETY: both adapters remain private children of this runner;
+            // every execution and presentation entry point requires a mutable
+            // runner borrow, so their access cannot overlap.
+            unsafe {
+                ppc_app.memory.add_shared_region(address, region);
+            }
+        }
     }
 
     /// Mix and queue audio samples without full frame finalization.
@@ -6067,7 +6085,7 @@ impl FixtureRunner {
         ppc_app.toolbox_startup.host_menu_bar_hidden = self.dispatcher.menu_bar_hidden;
         ppc_app.set_input_snapshot(input);
         self.sync_ppc_event_queue_before_execution(&mut ppc_app, input_offset_v, input_offset_h);
-        self.sync_ppc_low_memory_before_execution(&mut ppc_app);
+        self.prepare_ppc_execution_clock(&mut ppc_app);
         let cycles_per_tick = self.instructions_per_tick.max(1);
         let remaining_cycles =
             (i64::from(self.tick_budget).clamp(0, i64::from(cycles_per_tick))) as u32;
@@ -6109,7 +6127,6 @@ impl FixtureRunner {
 
         self.total_instructions = self.total_instructions.saturating_add(cycles);
         self.dispatcher.instruction_count = self.total_instructions;
-        self.sync_ppc_rnd_seed_to_bus(&mut ppc_app);
         self.sync_ppc_event_state_after_execution(&ppc_app, input_offset_v, input_offset_h);
         let (vbl_probes, timer_probes) = if exited_via_ppc_exit_to_shell {
             (Vec::new(), Vec::new())
@@ -6167,7 +6184,7 @@ impl FixtureRunner {
             .iter()
             .map(|probe| probe.invocation.cycles)
             .sum::<u64>();
-        self.sync_ppc_low_memory_after_execution(&mut ppc_app);
+        self.prepare_ppc_execution_clock(&mut ppc_app);
         self.total_instructions = self
             .total_instructions
             .saturating_add(vbl_cycles)
@@ -6342,27 +6359,12 @@ impl FixtureRunner {
         )
     }
 
-    fn sync_ppc_low_memory_before_execution(&self, ppc_app: &mut PpcLoadedApp) {
+    fn prepare_ppc_execution_clock(&self, ppc_app: &mut PpcLoadedApp) {
         use crate::memory::globals::addr;
 
-        let ticks = self.bus.read_long(addr::TICKS);
-        let time = self.bus.read_long(addr::TIME);
-        let rnd_seed = self.bus.read_long(addr::RND_SEED);
-        ppc_app.set_tick_count(ticks);
-        let _ = ppc_app.memory.write_u32_be(addr::TICKS, ticks);
-        let _ = ppc_app.memory.write_u32_be(addr::TIME, time);
-        let _ = ppc_app.memory.write_u32_be(addr::RND_SEED, rnd_seed);
-    }
-
-    fn sync_ppc_low_memory_after_execution(&mut self, ppc_app: &mut PpcLoadedApp) {
-        use crate::memory::globals::addr;
-
-        let ticks = self.dispatcher.tick_count;
-        let time = self.bus.read_long(addr::TIME);
-        ppc_app.set_tick_count(ticks);
-        let _ = ppc_app.memory.write_u32_be(addr::TICKS, ticks);
-        let _ = ppc_app.memory.write_u32_be(addr::TIME, time);
-        self.sync_ppc_rnd_seed_to_bus(ppc_app);
+        // The guest-visible clock bytes are shared memory. Keep only the
+        // CPU-local HLE timing base aligned with that canonical TickCount.
+        ppc_app.set_tick_count(self.bus.read_long(addr::TICKS));
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -6410,14 +6412,6 @@ impl FixtureRunner {
             ));
         }
         (vbl_probes, timer_probes)
-    }
-
-    fn sync_ppc_rnd_seed_to_bus(&mut self, ppc_app: &mut PpcLoadedApp) {
-        use crate::memory::globals::addr;
-
-        if let Some(rnd_seed) = ppc_app.memory.read_u32_be(addr::RND_SEED) {
-            self.bus.write_long(addr::RND_SEED, rnd_seed);
-        }
     }
 
     fn sync_ppc_event_state_after_execution(
@@ -7501,7 +7495,7 @@ impl FixtureRunner {
             return;
         };
         self.sync_ppc_event_queue_before_execution(&mut ppc_app, input_offset_v, input_offset_h);
-        self.sync_ppc_low_memory_before_execution(&mut ppc_app);
+        self.prepare_ppc_execution_clock(&mut ppc_app);
         let mut fired_count = 0usize;
         while !ppc_app.sound.pending_doublebacks.is_empty() && fired_count < 16 {
             let doubleback = ppc_app.sound.pending_doublebacks.remove(0);
@@ -7544,7 +7538,6 @@ impl FixtureRunner {
             }
             self.total_instructions = self.total_instructions.saturating_add(invocation.cycles);
             self.dispatcher.instruction_count = self.total_instructions;
-            self.sync_ppc_rnd_seed_to_bus(&mut ppc_app);
             self.sync_ppc_event_state_after_execution(&ppc_app, input_offset_v, input_offset_h);
             self.advance_ticks_for_ppc_cycles(invocation.cycles, None);
             self.sync_ppc_event_queue_before_execution(
@@ -7552,7 +7545,7 @@ impl FixtureRunner {
                 input_offset_v,
                 input_offset_h,
             );
-            self.sync_ppc_low_memory_before_execution(&mut ppc_app);
+            self.prepare_ppc_execution_clock(&mut ppc_app);
 
             let buffer_bit = 1u8 << (doubleback.exhausted_buffer_index.min(1) as u8);
             if let Some(playback) =
@@ -7616,7 +7609,7 @@ impl FixtureRunner {
             return;
         };
         self.sync_ppc_event_queue_before_execution(&mut ppc_app, input_offset_v, input_offset_h);
-        self.sync_ppc_low_memory_before_execution(&mut ppc_app);
+        self.prepare_ppc_execution_clock(&mut ppc_app);
         let mut fired_count = 0usize;
         while !ppc_app.sound.pending_completions.is_empty() && fired_count < 16 {
             let completion = ppc_app.sound.pending_completions.remove(0);
@@ -7645,7 +7638,6 @@ impl FixtureRunner {
             }
             self.total_instructions = self.total_instructions.saturating_add(invocation.cycles);
             self.dispatcher.instruction_count = self.total_instructions;
-            self.sync_ppc_rnd_seed_to_bus(&mut ppc_app);
             self.sync_ppc_event_state_after_execution(&ppc_app, input_offset_v, input_offset_h);
             self.advance_ticks_for_ppc_cycles(invocation.cycles, None);
             self.sync_ppc_event_queue_before_execution(
@@ -7653,7 +7645,7 @@ impl FixtureRunner {
                 input_offset_v,
                 input_offset_h,
             );
-            self.sync_ppc_low_memory_before_execution(&mut ppc_app);
+            self.prepare_ppc_execution_clock(&mut ppc_app);
 
             let callback_failed = invocation.unsupported_import_index.is_some()
                 || !matches!(invocation.result, PpcRunResult::Halted { .. });
@@ -11646,7 +11638,7 @@ mod tests {
     }
 
     #[test]
-    fn ppc_slice_synchronizes_low_memory_time_after_sixtieth_tick() {
+    fn ppc_slice_shares_low_memory_time_after_sixtieth_tick() {
         use crate::memory::globals::addr;
 
         let mut app = halted_ppc_app_with_sound(PpcSoundState::default());
@@ -11791,7 +11783,7 @@ mod tests {
     }
 
     #[test]
-    fn ppc_slice_synchronizes_rnd_seed_in_both_directions() {
+    fn ppc_slice_shares_rnd_seed_in_both_directions() {
         use crate::memory::globals::addr;
 
         let mut app = halted_ppc_app_with_sound(PpcSoundState::default());
@@ -11838,7 +11830,7 @@ mod tests {
     }
 
     #[test]
-    fn ppc_rnd_seed_phase_preserves_intervening_runner_mutation() {
+    fn ppc_runtime_globals_have_immediate_bidirectional_visibility() {
         use crate::memory::globals::addr;
 
         let mut app = halted_ppc_app_with_sound(PpcSoundState::default());
@@ -11852,21 +11844,17 @@ mod tests {
         runner.init_app(&app);
         let mut ppc_app = runner.ppc_app.take().expect("PPC app installed");
 
-        ppc_app
-            .memory
-            .write_u32_be(addr::RND_SEED, 0x1234_5678)
-            .unwrap();
-        runner.sync_ppc_rnd_seed_to_bus(&mut ppc_app);
-        assert_eq!(runner.bus.read_long(addr::RND_SEED), 0x1234_5678);
+        for (address, ppc_value, runner_value) in [
+            (addr::RND_SEED, 0x1234_5678, 0x89ab_cdef),
+            (addr::TICKS, 0x1122_3344, 0x5566_7788),
+            (addr::TIME, 0x1020_3040, 0x5060_7080),
+        ] {
+            ppc_app.memory.write_u32_be(address, ppc_value).unwrap();
+            assert_eq!(runner.bus.read_long(address), ppc_value);
 
-        // Model a runner-side tick callback changing Random's authoritative
-        // low-memory seed between PPC execution phases.
-        runner.bus.write_long(addr::RND_SEED, 0x89ab_cdef);
-        runner.sync_ppc_low_memory_before_execution(&mut ppc_app);
-        assert_eq!(
-            ppc_app.memory.read_u32_be(addr::RND_SEED),
-            Some(0x89ab_cdef)
-        );
+            runner.bus.write_long(address, runner_value);
+            assert_eq!(ppc_app.memory.read_u32_be(address), Some(runner_value));
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #921.

## Summary

- promote runner-owned RAM to stable shared backing when PPC runtime globals are mapped
- make `RndSeed`, `Ticks`, and `Time` immediately visible through both CPU memory adapters
- remove the PPC slice-boundary copies for those globals while preserving the CPU-local HLE tick base
- preserve sparse-overlay, bulk-write atomicity, instruction-cache, fast-memory, and clone snapshot semantics

## References

- *Inside Macintosh*, Volume I, I-195 (`RndSeed`)
- *Inside Macintosh*, Volume II, II-202 and II-378 (`Ticks` and `Time`)

## Validation

- `cargo test --lib` (4,236 passed, 3 ignored)
- `cargo test --lib --features test-support` (4,242 passed, 3 ignored)
- `cargo check --all-targets --all-features`
- `cargo check --target wasm32-unknown-unknown --no-default-features`
- strict rustdoc with all features and private items
- `cargo publish --locked --dry-run --allow-dirty`
- focused immediate-visibility and PPC-slice tests