### PR TITLE
fix(event): share the event queue across CPU backends

### DIFF
--- a/src/event_queue.rs
+++ b/src/event_queue.rs
@@ -1,0 +1,110 @@
+//! Architecture-neutral ownership for the Operating System event queue.
+
+use std::cell::UnsafeCell;
+use std::collections::VecDeque;
+use std::ops::{Deref, DerefMut};
+use std::rc::Rc;
+
+/// A queued Mac event (mouseDown, mouseUp, keyDown, etc.).
+///
+/// The Operating System Event Manager owns one queue, and `EventRecord.where`
+/// uses global coordinates. Inside Macintosh Volume I, I-244 and I-259.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct QueuedEvent {
+    /// Event type (1=mouseDown, 2=mouseUp, 3=keyDown, etc.).
+    pub what: u16,
+    /// Event message (key code for key events, window ptr for activate, etc.).
+    pub message: u32,
+    /// Mouse location at event time, in global Macintosh coordinates.
+    pub where_v: i16,
+    pub where_h: i16,
+    /// Modifier flags.
+    pub modifiers: u16,
+}
+
+/// One serialized event queue that can be attached to both CPU adapters.
+///
+/// Ordinary construction owns a private queue. The runner may explicitly
+/// attach a second adapter to the same allocation once both adapters are its
+/// private children and all access is serialized through a mutable runner
+/// borrow.
+#[derive(Debug, Default)]
+pub(crate) struct SharedEventQueue(Rc<UnsafeCell<VecDeque<QueuedEvent>>>);
+
+impl Clone for SharedEventQueue {
+    fn clone(&self) -> Self {
+        // A cloned runtime is a snapshot, not another live CPU adapter.
+        Self(Rc::new(UnsafeCell::new(self.deref().clone())))
+    }
+}
+
+impl SharedEventQueue {
+    /// Attach another CPU adapter to this queue without copying it.
+    ///
+    /// # Safety
+    ///
+    /// Every handle sharing this allocation must remain under one owner that
+    /// serializes access. No queue reference may remain live while another
+    /// handle reads or mutates the allocation.
+    pub(crate) unsafe fn shared_handle(&self) -> Self {
+        Self(Rc::clone(&self.0))
+    }
+}
+
+impl Deref for SharedEventQueue {
+    type Target = VecDeque<QueuedEvent>;
+
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: shared handles can only be created under the serialized
+        // ownership contract documented by `shared_handle`.
+        unsafe { &*self.0.get() }
+    }
+}
+
+impl DerefMut for SharedEventQueue {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        // SAFETY: shared handles can only be created under the serialized
+        // ownership contract documented by `shared_handle`.
+        unsafe { &mut *self.0.get() }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn attached_handles_have_immediate_bidirectional_visibility() {
+        let mut first = SharedEventQueue::default();
+        // SAFETY: this test accesses the handles strictly in sequence.
+        let mut second = unsafe { first.shared_handle() };
+        first.push_back(QueuedEvent {
+            what: 3,
+            message: 0x1122_3344,
+            where_v: 10,
+            where_h: 20,
+            modifiers: 0x0100,
+        });
+        assert_eq!(second.front().map(|event| event.message), Some(0x1122_3344));
+        second.pop_front();
+        assert!(first.is_empty());
+    }
+
+    #[test]
+    fn clone_is_a_detached_snapshot() {
+        let mut live = SharedEventQueue::default();
+        live.push_back(QueuedEvent {
+            what: 3,
+            message: 0x1122_3344,
+            where_v: 10,
+            where_h: 20,
+            modifiers: 0x0100,
+        });
+
+        let mut snapshot = live.clone();
+        snapshot.front_mut().unwrap().message = 0x5566_7788;
+
+        assert_eq!(live.front().unwrap().message, 0x1122_3344);
+        assert_eq!(snapshot.front().unwrap().message, 0x5566_7788);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@ pub mod debug_overlay;
 pub mod disk_image;
 pub mod display;
 mod error;
+mod event_queue;
 pub mod game;
 pub mod loader;
 mod mac_roman;

--- a/src/loader/ppc.rs
+++ b/src/loader/ppc.rs
@@ -14,6 +14,7 @@ use super::pef::{
     SECTION_KIND_PATTERN_DATA, SECTION_KIND_UNPACKED_DATA,
 };
 use super::ApplicationSizeResource;
+use crate::event_queue::{QueuedEvent, SharedEventQueue};
 use crate::machine_profile::REFERENCE_MACHINE_PROFILE;
 use crate::managers::resource::{
     serialize_resource_fork_with_attrs, ResourceFork, ResourceForkEntry,
@@ -1741,14 +1742,8 @@ pub struct PpcHleImportTraceEntry {
     pub repeat_count: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PpcQueuedEvent {
-    pub what: u16,
-    pub message: u32,
-    pub where_v: i16,
-    pub where_h: i16,
-    pub modifiers: u16,
-}
+/// Backward-compatible native-loader name for the shared event record.
+pub type PpcQueuedEvent = QueuedEvent;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PpcInputSprocketSimpleStateTraceEntry {
@@ -4909,7 +4904,7 @@ pub struct PpcLoadedApp {
     pub imports: Vec<PpcImportBinding>,
     pub section_bases: Vec<Option<u32>>,
     pub input: PpcInputSnapshot,
-    pub event_queue: VecDeque<PpcQueuedEvent>,
+    pub(crate) event_queue: SharedEventQueue,
     pub draw_sprocket: PpcDrawSprocketState,
 }
 
@@ -5014,11 +5009,20 @@ impl PpcLoadedApp {
     where
         I: IntoIterator<Item = PpcQueuedEvent>,
     {
-        self.event_queue = events.into_iter().collect();
+        self.event_queue.clear();
+        self.event_queue.extend(events);
     }
 
     pub fn event_queue(&self) -> &VecDeque<PpcQueuedEvent> {
         &self.event_queue
+    }
+
+    pub(crate) fn share_event_queue(&mut self, event_queue: &SharedEventQueue) {
+        let pending = std::mem::take(&mut *self.event_queue);
+        // SAFETY: the runner owns both adapters and serializes all queue access
+        // through its mutable borrow, including native callback execution.
+        self.event_queue = unsafe { event_queue.shared_handle() };
+        self.event_queue.extend(pending);
     }
 
     /// Copy the live PowerPC Menu Manager list into the same frontend-neutral
@@ -13381,7 +13385,7 @@ pub fn load_pef_application_with_config(
         imports,
         section_bases,
         input: PpcInputSnapshot::default(),
-        event_queue: VecDeque::new(),
+        event_queue: SharedEventQueue::default(),
         draw_sprocket: PpcDrawSprocketState::default(),
     })
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -7,9 +7,8 @@ use crate::loader::ppc::{
     PpcDecodedAiffPlaybackRecord, PpcDecodedBufferCommandRecord, PpcDrawSprocketTraceEntry,
     PpcFrontBuffer, PpcGWorldRecord, PpcHleImportTraceEntry, PpcImportBinding,
     PpcImportDispatcherTarget, PpcInputSnapshot, PpcInputSprocketSimpleStateTraceEntry,
-    PpcLoadedApp, PpcQ3GpuFrame, PpcQ3SceneReplay, PpcQ3SoftwareRenderStats, PpcQueuedEvent,
-    PpcRgbColor, PpcSoundCompletionRecord, PpcSoundDoubleBackRecord,
-    PpcSoundDoubleBufferPlaybackRecord,
+    PpcLoadedApp, PpcQ3GpuFrame, PpcQ3SceneReplay, PpcQ3SoftwareRenderStats, PpcRgbColor,
+    PpcSoundCompletionRecord, PpcSoundDoubleBackRecord, PpcSoundDoubleBufferPlaybackRecord,
 };
 use crate::loader::{
     decode_retro68_relocations, ApplicationSizeResource, Code0Header, CodeSegmentHeader,
@@ -2690,12 +2689,15 @@ impl FixtureRunner {
         )
     }
 
-    /// Move the mouse without changing the button state. Updates the
-    /// dispatcher's tracked position and the six mouse-position
+    /// Move the mouse without changing the button state. Coordinates are in
+    /// the runner's presented framebuffer; a centered native framebuffer is
+    /// translated to Macintosh global coordinates at this host-input boundary.
+    /// Updates the dispatcher's tracked position and the six mouse-position
     /// low-memory globals (MTemp / RawMouse / Mouse) so guest code that
     /// reads them directly sees the new coordinates immediately. Leaves
     /// MBState ($0172) untouched. Inside Macintosh Volume II, II-371.
     pub fn set_mouse_position(&mut self, v: i16, h: i16) {
+        let (v, h) = self.canonical_mouse_position(v, h);
         self.dispatcher.set_mouse_position(v, h);
         self.sync_mouse_position_lowmem();
         self.wake_pending_wait_next_event_if_input_available();
@@ -2724,8 +2726,8 @@ impl FixtureRunner {
             // A native command still enters the guest through its ordinary
             // mouseDown event loop; MenuSelect consumes the staged item after
             // the application recognizes the menu-bar click.
-            self.push_mouse_down(10, 15);
-            self.push_mouse_up(10, 15);
+            self.push_canonical_mouse_down(10, 15);
+            self.push_canonical_mouse_up(10, 15);
             return true;
         }
         let Some((_v, _h)) =
@@ -2739,7 +2741,9 @@ impl FixtureRunner {
         true
     }
 
-    /// Inject a mouse-down event and sync low-memory globals.
+    /// Inject a mouse-down event and sync low-memory globals. Coordinates are
+    /// in the runner's presented framebuffer and are normalized to Macintosh
+    /// global coordinates before the event enters the shared queue.
     ///
     /// On real hardware the VBL interrupt handler updates MBState ($0172)
     /// and the mouse-position globals whenever the button state changes.
@@ -2747,6 +2751,11 @@ impl FixtureRunner {
     /// globals here so that code polling the low-memory locations directly
     /// (instead of calling Button or GetNextEvent) sees the correct state.
     pub fn push_mouse_down(&mut self, v: i16, h: i16) {
+        let (v, h) = self.canonical_mouse_position(v, h);
+        self.push_canonical_mouse_down(v, h);
+    }
+
+    fn push_canonical_mouse_down(&mut self, v: i16, h: i16) {
         self.dispatcher.push_mouse_down(v, h);
         self.sync_mouse_lowmem();
         self.wake_pending_wait_next_event_if_input_available();
@@ -2766,7 +2775,9 @@ impl FixtureRunner {
             .count()
     }
 
-    /// Inject a mouse-up event.
+    /// Inject a mouse-up event. Coordinates are in the runner's presented
+    /// framebuffer and are normalized to Macintosh global coordinates before
+    /// the event enters the shared queue.
     ///
     /// Sync MBState ($0172) immediately so code that polls the low-memory
     /// byte directly (rather than calling Button or GetNextEvent) sees the
@@ -2780,6 +2791,11 @@ impl FixtureRunner {
     /// many loop iterations after a click-up.
     /// Inside Macintosh Volume II, II-371
     pub fn push_mouse_up(&mut self, v: i16, h: i16) {
+        let (v, h) = self.canonical_mouse_position(v, h);
+        self.push_canonical_mouse_up(v, h);
+    }
+
+    fn push_canonical_mouse_up(&mut self, v: i16, h: i16) {
         self.dispatcher.push_mouse_up(v, h);
         self.sync_mouse_lowmem();
         self.wake_pending_wait_next_event_if_input_available();
@@ -3937,6 +3953,7 @@ impl FixtureRunner {
         let rnd_seed = self.launch_rnd_seed_override.unwrap_or(time);
         self.bus.write_long(addr::RND_SEED, rnd_seed);
         self.share_ppc_runtime_globals(&mut ppc_app);
+        ppc_app.share_event_queue(&self.dispatcher.event_queue);
         if let Some(time_base) = self.launch_ppc_time_base_override {
             ppc_app.cpu.set_time_base(time_base);
         }
@@ -6085,15 +6102,14 @@ impl FixtureRunner {
         }
 
         self.dispatcher.instruction_count = self.total_instructions;
-        let (input_offset_v, input_offset_h) = self.ppc_viewport_offset();
-        let input = self.ppc_input_snapshot(input_offset_v, input_offset_h);
+        let input = self.ppc_input_snapshot();
         let Some(mut ppc_app) = self.ppc_app.take() else {
             return (0, !self.halted);
         };
 
         ppc_app.toolbox_startup.host_menu_bar_hidden = self.dispatcher.menu_bar_hidden;
         ppc_app.set_input_snapshot(input);
-        self.sync_ppc_event_queue_before_execution(&mut ppc_app, input_offset_v, input_offset_h);
+        self.sync_ppc_event_state_before_execution(&mut ppc_app);
         self.prepare_ppc_execution_clock(&mut ppc_app);
         let cycles_per_tick = self.instructions_per_tick.max(1);
         let remaining_cycles =
@@ -6136,16 +6152,12 @@ impl FixtureRunner {
 
         self.total_instructions = self.total_instructions.saturating_add(cycles);
         self.dispatcher.instruction_count = self.total_instructions;
-        self.sync_ppc_event_state_after_execution(&ppc_app, input_offset_v, input_offset_h);
+        self.sync_ppc_event_state_after_execution(&ppc_app);
         let (vbl_probes, timer_probes) = if exited_via_ppc_exit_to_shell {
             (Vec::new(), Vec::new())
         } else {
             self.advance_ticks_for_ppc_cycles(cycles, tick_cap);
-            self.sync_ppc_event_queue_before_execution(
-                &mut ppc_app,
-                input_offset_v,
-                input_offset_h,
-            );
+            self.sync_ppc_event_state_before_execution(&mut ppc_app);
             let elapsed_ticks = self.dispatcher.tick_count.wrapping_sub(ppc_start_tick);
             self.fire_ppc_tick_callbacks(
                 &mut ppc_app,
@@ -6247,7 +6259,7 @@ impl FixtureRunner {
             self.sync_ppc_vfs_to_dispatcher(&mut ppc_app);
         }
         self.sync_ppc_sound_to_dispatcher(&mut ppc_app);
-        self.sync_ppc_event_state_after_execution(&ppc_app, input_offset_v, input_offset_h);
+        self.sync_ppc_event_state_after_execution(&ppc_app);
         sync_ppc_cursor_state(
             &mut self.dispatcher,
             ppc_app.quickdraw_cursor_level,
@@ -6423,51 +6435,14 @@ impl FixtureRunner {
         (vbl_probes, timer_probes)
     }
 
-    fn sync_ppc_event_state_after_execution(
-        &mut self,
-        ppc_app: &PpcLoadedApp,
-        input_offset_v: i16,
-        input_offset_h: i16,
-    ) {
-        // Establish a queue ownership boundary before runner callbacks run.
-        // Their mutations are synchronized back into PPC memory before any
-        // subsequent PPC callback, so a consumed event and a newly posted
-        // value-identical event never need to be inferred from value equality.
-        self.dispatcher.event_queue = ppc_app
-            .event_queue()
-            .iter()
-            .map(|event| crate::trap::dispatch::QueuedEvent {
-                what: event.what,
-                message: event.message,
-                where_v: event.where_v.saturating_add(input_offset_v),
-                where_h: event.where_h.saturating_add(input_offset_h),
-                modifiers: event.modifiers,
-            })
-            .collect();
+    fn sync_ppc_event_state_after_execution(&mut self, ppc_app: &PpcLoadedApp) {
         sync_ppc_system_event_mask(
             &mut self.dispatcher,
             ppc_app.toolbox_startup.system_event_mask,
         );
     }
 
-    fn sync_ppc_event_queue_before_execution(
-        &self,
-        ppc_app: &mut PpcLoadedApp,
-        input_offset_v: i16,
-        input_offset_h: i16,
-    ) {
-        ppc_app.set_event_queue(
-            self.dispatcher
-                .event_queue
-                .iter()
-                .map(|event| PpcQueuedEvent {
-                    what: event.what,
-                    message: event.message,
-                    where_v: event.where_v.saturating_sub(input_offset_v),
-                    where_h: event.where_h.saturating_sub(input_offset_h),
-                    modifiers: event.modifiers,
-                }),
-        );
+    fn sync_ppc_event_state_before_execution(&self, ppc_app: &mut PpcLoadedApp) {
         ppc_app.toolbox_startup.system_event_mask = self.dispatcher.system_event_mask;
     }
 
@@ -6832,13 +6807,21 @@ impl FixtureRunner {
         }
     }
 
-    fn ppc_input_snapshot(&self, offset_v: i16, offset_h: i16) -> PpcInputSnapshot {
+    fn ppc_input_snapshot(&self) -> PpcInputSnapshot {
         PpcInputSnapshot {
             key_map: self.dispatcher.key_map,
             mouse_button: self.dispatcher.mouse_button,
-            mouse_v: self.dispatcher.mouse_pos.0.saturating_sub(offset_v),
-            mouse_h: self.dispatcher.mouse_pos.1.saturating_sub(offset_h),
+            mouse_v: self.dispatcher.mouse_pos.0,
+            mouse_h: self.dispatcher.mouse_pos.1,
         }
+    }
+
+    fn canonical_mouse_position(&self, v: i16, h: i16) -> (i16, i16) {
+        // EventRecord.where is always in Macintosh global coordinates; the
+        // centered matte is host presentation, not part of that coordinate
+        // system. Inside Macintosh Volume I, I-259.
+        let (offset_v, offset_h) = self.ppc_viewport_offset();
+        (v.saturating_sub(offset_v), h.saturating_sub(offset_h))
     }
 
     fn ppc_viewport_offset(&self) -> (i16, i16) {
@@ -7499,11 +7482,10 @@ impl FixtureRunner {
         let trace_ppc_import_hist = ppc_import_hist_enabled();
         let trace_ppc_imports = record_ppc_imports || trace_ppc_import_hist;
         let trace_ppc_fetches = trace_ppc_fetch_counts_enabled();
-        let (input_offset_v, input_offset_h) = self.ppc_viewport_offset();
         let Some(mut ppc_app) = self.ppc_app.take() else {
             return;
         };
-        self.sync_ppc_event_queue_before_execution(&mut ppc_app, input_offset_v, input_offset_h);
+        self.sync_ppc_event_state_before_execution(&mut ppc_app);
         self.prepare_ppc_execution_clock(&mut ppc_app);
         let mut fired_count = 0usize;
         while !ppc_app.sound.pending_doublebacks.is_empty() && fired_count < 16 {
@@ -7547,13 +7529,9 @@ impl FixtureRunner {
             }
             self.total_instructions = self.total_instructions.saturating_add(invocation.cycles);
             self.dispatcher.instruction_count = self.total_instructions;
-            self.sync_ppc_event_state_after_execution(&ppc_app, input_offset_v, input_offset_h);
+            self.sync_ppc_event_state_after_execution(&ppc_app);
             self.advance_ticks_for_ppc_cycles(invocation.cycles, None);
-            self.sync_ppc_event_queue_before_execution(
-                &mut ppc_app,
-                input_offset_v,
-                input_offset_h,
-            );
+            self.sync_ppc_event_state_before_execution(&mut ppc_app);
             self.prepare_ppc_execution_clock(&mut ppc_app);
 
             let buffer_bit = 1u8 << (doubleback.exhausted_buffer_index.min(1) as u8);
@@ -7595,7 +7573,7 @@ impl FixtureRunner {
                 break;
             }
         }
-        self.sync_ppc_event_state_after_execution(&ppc_app, input_offset_v, input_offset_h);
+        self.sync_ppc_event_state_after_execution(&ppc_app);
         self.sync_ppc_vfs_to_dispatcher(&mut ppc_app);
         self.sync_ppc_sound_to_dispatcher(&mut ppc_app);
         self.ppc_app = Some(ppc_app);
@@ -7613,11 +7591,10 @@ impl FixtureRunner {
         let trace_ppc_import_hist = ppc_import_hist_enabled();
         let trace_ppc_imports = record_ppc_imports || trace_ppc_import_hist;
         let trace_ppc_fetches = trace_ppc_fetch_counts_enabled();
-        let (input_offset_v, input_offset_h) = self.ppc_viewport_offset();
         let Some(mut ppc_app) = self.ppc_app.take() else {
             return;
         };
-        self.sync_ppc_event_queue_before_execution(&mut ppc_app, input_offset_v, input_offset_h);
+        self.sync_ppc_event_state_before_execution(&mut ppc_app);
         self.prepare_ppc_execution_clock(&mut ppc_app);
         let mut fired_count = 0usize;
         while !ppc_app.sound.pending_completions.is_empty() && fired_count < 16 {
@@ -7647,13 +7624,9 @@ impl FixtureRunner {
             }
             self.total_instructions = self.total_instructions.saturating_add(invocation.cycles);
             self.dispatcher.instruction_count = self.total_instructions;
-            self.sync_ppc_event_state_after_execution(&ppc_app, input_offset_v, input_offset_h);
+            self.sync_ppc_event_state_after_execution(&ppc_app);
             self.advance_ticks_for_ppc_cycles(invocation.cycles, None);
-            self.sync_ppc_event_queue_before_execution(
-                &mut ppc_app,
-                input_offset_v,
-                input_offset_h,
-            );
+            self.sync_ppc_event_state_before_execution(&mut ppc_app);
             self.prepare_ppc_execution_clock(&mut ppc_app);
 
             let callback_failed = invocation.unsupported_import_index.is_some()
@@ -7680,7 +7653,7 @@ impl FixtureRunner {
                 break;
             }
         }
-        self.sync_ppc_event_state_after_execution(&ppc_app, input_offset_v, input_offset_h);
+        self.sync_ppc_event_state_after_execution(&ppc_app);
         self.sync_ppc_vfs_to_dispatcher(&mut ppc_app);
         self.sync_ppc_sound_to_dispatcher(&mut ppc_app);
         self.ppc_app = Some(ppc_app);
@@ -8488,13 +8461,12 @@ impl FixtureRunner {
         let mb_state: u8 = if pressed { 0x00 } else { 0x80 };
         self.bus.write_byte(0x0172, mb_state);
         if input_tick_trace_enabled() {
-            let (offset_v, offset_h) = self.ppc_viewport_offset();
             eprintln!(
                 "{}",
                 format_input_tick_trace(
                     new_tick,
                     self.total_instructions,
-                    self.ppc_input_snapshot(offset_v, offset_h),
+                    self.ppc_input_snapshot(),
                     self.dispatcher.event_queue.len(),
                     mb_state,
                 )
@@ -11971,115 +11943,31 @@ mod tests {
     }
 
     #[test]
-    fn ppc_event_merge_keeps_callback_and_tick_posted_events() {
+    fn ppc_event_queue_has_immediate_bidirectional_visibility() {
         let mut app = halted_ppc_app_with_sound(PpcSoundState::default());
-        app.ppc
-            .as_mut()
-            .expect("synthetic PPC app")
-            .memory
-            .add_region(PPC_HALT_PC, vec![0; 64 * 1024]);
-        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
-        runner.init_app(&app);
-        runner
-            .dispatcher
-            .event_queue
-            .push_back(crate::trap::dispatch::QueuedEvent {
-                what: 3,
-                message: 0x1111,
-                where_v: 10,
-                where_h: 20,
-                modifiers: 0,
-            });
-        let mut ppc_app = runner.ppc_app.take().expect("PPC app installed");
-        runner.sync_ppc_event_queue_before_execution(&mut ppc_app, 0, 0);
-
-        // Model the callback consuming the old event and posting a new one,
-        // while tick advancement independently posts an event on the runner.
-        ppc_app.set_event_queue([PpcQueuedEvent {
+        let app_ppc = app.ppc.as_mut().expect("synthetic PPC app");
+        app_ppc.memory.add_region(PPC_HALT_PC, vec![0; 64 * 1024]);
+        app_ppc.event_queue.push_back(QueuedEvent {
             what: 23,
-            message: 0x2222,
-            where_v: 30,
-            where_h: 40,
+            message: 0xaabb_ccdd,
+            where_v: 1,
+            where_h: 2,
             modifiers: 0,
-        }]);
-        ppc_app.toolbox_startup.system_event_mask = 0x1234;
-        runner.sync_ppc_event_state_after_execution(&ppc_app, 0, 0);
-        runner
-            .dispatcher
-            .event_queue
-            .push_back(crate::trap::dispatch::QueuedEvent {
-                what: 5,
-                message: 0x3333,
-                where_v: 50,
-                where_h: 60,
-                modifiers: 0,
-            });
-        runner.sync_ppc_event_queue_before_execution(&mut ppc_app, 0, 0);
-
-        runner.sync_ppc_event_state_after_execution(&ppc_app, 0, 0);
-
-        assert_eq!(runner.dispatcher.event_queue.len(), 2);
-        assert_eq!(runner.dispatcher.event_queue[0].message, 0x2222);
-        assert_eq!(runner.dispatcher.event_queue[1].message, 0x3333);
-        assert_eq!(runner.dispatcher.system_event_mask, 0x1234);
-    }
-
-    #[test]
-    fn ppc_event_merge_keeps_posted_event_after_original_queue_mutation() {
-        let mut app = halted_ppc_app_with_sound(PpcSoundState::default());
-        app.ppc
-            .as_mut()
-            .expect("synthetic PPC app")
-            .memory
-            .add_region(PPC_HALT_PC, vec![0; 64 * 1024]);
+        });
         let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
         runner.init_app(&app);
-        for message in [0x1111, 0x2222] {
+        assert_eq!(
             runner
                 .dispatcher
                 .event_queue
-                .push_back(crate::trap::dispatch::QueuedEvent {
-                    what: 3,
-                    message,
-                    where_v: 10,
-                    where_h: 20,
-                    modifiers: 0,
-                });
-        }
+                .front()
+                .map(|event| event.message),
+            Some(0xaabb_ccdd)
+        );
         let mut ppc_app = runner.ppc_app.take().expect("PPC app installed");
-        runner.sync_ppc_event_queue_before_execution(&mut ppc_app, 0, 0);
-        ppc_app.set_event_queue([]);
+        ppc_app.event_queue.pop_front();
+        assert!(runner.dispatcher.event_queue.is_empty());
 
-        runner.sync_ppc_event_state_after_execution(&ppc_app, 0, 0);
-        runner.dispatcher.event_queue.pop_front();
-        runner
-            .dispatcher
-            .event_queue
-            .push_back(crate::trap::dispatch::QueuedEvent {
-                what: 5,
-                message: 0x3333,
-                where_v: 30,
-                where_h: 40,
-                modifiers: 0,
-            });
-        runner.sync_ppc_event_queue_before_execution(&mut ppc_app, 0, 0);
-
-        runner.sync_ppc_event_state_after_execution(&ppc_app, 0, 0);
-
-        assert_eq!(runner.dispatcher.event_queue.len(), 1);
-        assert_eq!(runner.dispatcher.event_queue[0].message, 0x3333);
-    }
-
-    #[test]
-    fn ppc_event_sync_preserves_callback_repost_identical_to_consumed_event() {
-        let mut app = halted_ppc_app_with_sound(PpcSoundState::default());
-        app.ppc
-            .as_mut()
-            .expect("synthetic PPC app")
-            .memory
-            .add_region(PPC_HALT_PC, vec![0; 64 * 1024]);
-        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
-        runner.init_app(&app);
         let original = crate::trap::dispatch::QueuedEvent {
             what: 3,
             message: 0x1111,
@@ -12088,26 +11976,28 @@ mod tests {
             modifiers: 0x0200,
         };
         runner.dispatcher.event_queue.push_back(original.clone());
-        let mut ppc_app = runner.ppc_app.take().expect("PPC app installed");
-        runner.sync_ppc_event_queue_before_execution(&mut ppc_app, 0, 0);
 
-        // Establish the post-PPC boundary, then model a runner callback that
-        // consumes the original and posts a byte-identical replacement.
-        runner.sync_ppc_event_state_after_execution(&ppc_app, 0, 0);
-        let consumed = runner.dispatcher.event_queue.pop_front().unwrap();
+        let consumed = ppc_app.event_queue.pop_front().unwrap();
         assert_eq!(consumed.message, original.message);
+        assert!(runner.dispatcher.event_queue.is_empty());
+
+        ppc_app.event_queue.push_back(original.clone());
+        assert_eq!(runner.dispatcher.event_queue.front(), Some(&original));
+        runner.dispatcher.event_queue.pop_front();
+        assert!(ppc_app.event_queue.is_empty());
+
+        // A byte-identical repost is a distinct queue mutation and requires
+        // no value-based reconciliation at a callback boundary.
         runner.dispatcher.event_queue.push_back(original);
-        runner.sync_ppc_event_queue_before_execution(&mut ppc_app, 0, 0);
-        runner.dispatcher.event_queue.clear();
-
-        runner.sync_ppc_event_state_after_execution(&ppc_app, 0, 0);
-
-        assert_eq!(runner.dispatcher.event_queue.len(), 1);
-        let reposted = &runner.dispatcher.event_queue[0];
+        let reposted = ppc_app.event_queue.front().unwrap();
         assert_eq!(reposted.what, 3);
         assert_eq!(reposted.message, 0x1111);
         assert_eq!((reposted.where_v, reposted.where_h), (10, 20));
         assert_eq!(reposted.modifiers, 0x0200);
+
+        ppc_app.toolbox_startup.system_event_mask = 0x1234;
+        runner.sync_ppc_event_state_after_execution(&ppc_app);
+        assert_eq!(runner.dispatcher.system_event_mask, 0x1234);
     }
 
     #[test]
@@ -13252,7 +13142,7 @@ mod tests {
             imports: Vec::new(),
             section_bases: Vec::new(),
             input: PpcInputSnapshot::default(),
-            event_queue: VecDeque::new(),
+            event_queue: Default::default(),
             draw_sprocket: PpcDrawSprocketState::default(),
         })
     }
@@ -13439,22 +13329,16 @@ mod tests {
         let ppc_app = runner.ppc_app.as_mut().expect("PPC app");
         assert_eq!(
             ppc_app.memory.read_u16_be(PPC_SOUND_EVENT_RECORD + 10),
-            Some(120i16.saturating_sub(offset_v) as u16)
+            Some(120)
         );
         assert_eq!(
             ppc_app.memory.read_u16_be(PPC_SOUND_EVENT_RECORD + 12),
-            Some(180i16.saturating_sub(offset_h) as u16)
+            Some(180)
         );
         assert_eq!(runner.dispatcher.event_queue.len(), 1);
         let posted = &runner.dispatcher.event_queue[0];
         assert_eq!((posted.what, posted.message), (5, 0x5566_7788));
-        assert_eq!(
-            (posted.where_v, posted.where_h),
-            (
-                17i16.saturating_add(offset_v),
-                19i16.saturating_add(offset_h)
-            )
-        );
+        assert_eq!((posted.where_v, posted.where_h), (17, 19));
         assert_eq!(runner.dispatcher.system_event_mask, 0x1234);
     }
 
@@ -13503,6 +13387,28 @@ mod tests {
         });
 
         assert_ppc_sound_event_boundary(app, FixtureRunner::fire_pending_ppc_sound_completions);
+    }
+
+    #[test]
+    fn ppc_host_mouse_input_enters_the_shared_queue_in_global_coordinates() {
+        use crate::memory::globals::addr;
+
+        let mut app = halted_ppc_app_with_sound(PpcSoundState::default());
+        install_ppc_sound_event_boundary_fixture(&mut app);
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        runner.init_app(&app);
+        let (offset_v, offset_h) = runner.ppc_viewport_offset();
+        assert!(offset_v > 0 && offset_h > 0);
+
+        runner.push_mouse_down(offset_v.saturating_add(12), offset_h.saturating_add(34));
+
+        let event = runner.dispatcher.event_queue.back().expect("mouseDown");
+        assert_eq!((event.where_v, event.where_h), (12, 34));
+        let ppc_app = runner.ppc_app.as_ref().expect("PPC app");
+        let native_event = ppc_app.event_queue.back().expect("shared mouseDown");
+        assert_eq!((native_event.where_v, native_event.where_h), (12, 34));
+        assert_eq!(runner.bus.read_word(addr::M_TEMP), 12);
+        assert_eq!(runner.bus.read_word(addr::M_TEMP + 2), 34);
     }
 
     #[test]
@@ -13895,7 +13801,7 @@ mod tests {
             imports: Vec::new(),
             section_bases: Vec::new(),
             input: PpcInputSnapshot::default(),
-            event_queue: VecDeque::new(),
+            event_queue: Default::default(),
             draw_sprocket: PpcDrawSprocketState::default(),
         });
         let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
@@ -14776,7 +14682,7 @@ mod tests {
             }],
             section_bases: Vec::new(),
             input: PpcInputSnapshot::default(),
-            event_queue: VecDeque::new(),
+            event_queue: Default::default(),
             draw_sprocket: PpcDrawSprocketState::default(),
         });
         let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
@@ -14939,7 +14845,7 @@ mod tests {
             }],
             section_bases: Vec::new(),
             input: PpcInputSnapshot::default(),
-            event_queue: VecDeque::new(),
+            event_queue: Default::default(),
             draw_sprocket: PpcDrawSprocketState::default(),
         });
         let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
@@ -15350,7 +15256,7 @@ mod tests {
             imports: Vec::new(),
             section_bases: Vec::new(),
             input: PpcInputSnapshot::default(),
-            event_queue: VecDeque::new(),
+            event_queue: Default::default(),
             draw_sprocket: PpcDrawSprocketState {
                 front_buffer_gworld: PPC_DSP_BACK_GWORLD,
                 back_buffer_gworld: PPC_MAIN_GWORLD,
@@ -15672,7 +15578,7 @@ mod tests {
             imports: Vec::new(),
             section_bases: Vec::new(),
             input: PpcInputSnapshot::default(),
-            event_queue: VecDeque::new(),
+            event_queue: Default::default(),
             draw_sprocket: PpcDrawSprocketState::default(),
         });
         let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -7,6 +7,7 @@
 use super::types::UnderlineInfo;
 use crate::cpu::{CpuOps, Register};
 use crate::display::CursorImage;
+use crate::event_queue::SharedEventQueue;
 use crate::machine_profile::reference_machine_profile;
 use crate::managers::resource::ResourceFork;
 use crate::memory::{MacMemoryBus, MemoryBus};
@@ -19,6 +20,8 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::collections::VecDeque;
 use std::path::PathBuf;
+
+pub use crate::event_queue::QueuedEvent;
 
 pub(crate) const BOOT_VOLUME_NAME: &str = "MacintoshHD";
 pub(crate) const BOOT_VOLUME_REF_NUM: i16 = -1;
@@ -945,20 +948,6 @@ pub(crate) struct AeCoercionHandler {
     pub from_type_is_desc: bool,
 }
 
-/// A queued Mac event (mouseDown, mouseUp, keyDown, etc.)
-#[derive(Clone, Debug)]
-pub struct QueuedEvent {
-    /// Event type (1=mouseDown, 2=mouseUp, 3=keyDown, etc.)
-    pub what: u16,
-    /// Event message (key code for key events, window ptr for activate, etc.)
-    pub message: u32,
-    /// Mouse location at time of event (v, h)
-    pub where_v: i16,
-    pub where_h: i16,
-    /// Modifier flags
-    pub modifiers: u16,
-}
-
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct KeyRepeatState {
     pub key_code: u8,
@@ -1786,7 +1775,7 @@ pub struct TrapDispatcher {
     pub(crate) input_trace_enabled: bool,
     pub(crate) input_trace_log: Vec<String>,
     /// Queued events (mouseDown, mouseUp, etc.) to deliver via GetNextEvent
-    pub(crate) event_queue: VecDeque<QueuedEvent>,
+    pub(crate) event_queue: SharedEventQueue,
     /// A mouseDown consumed by ModalDialog can return to the application
     /// before the physical release arrives. Keep ownership of that release
     /// even if the application disposes the dialog in the meantime.
@@ -3271,7 +3260,7 @@ impl TrapDispatcher {
             debug_scroll_rect_last_is_color: false,
             input_trace_enabled: false,
             input_trace_log: Vec::new(),
-            event_queue: VecDeque::new(),
+            event_queue: SharedEventQueue::default(),
             pending_modal_dialog_mouse_up: false,
             pending_modal_dialog_mouse_down: None,
             flushed_update_events: VecDeque::new(),

--- a/src/trap/event.rs
+++ b/src/trap/event.rs
@@ -250,7 +250,7 @@ impl super::TrapDispatcher {
             remaining.push_back(event);
         }
 
-        self.event_queue = remaining;
+        *self.event_queue = remaining;
         result
     }
 
@@ -324,12 +324,13 @@ impl super::TrapDispatcher {
         }
 
         let message = ((repeat.key_code as u32) << 8) | (repeat.char_code as u32);
+        let modifiers = self.current_event_modifiers();
         self.event_queue.push_back(super::dispatch::QueuedEvent {
             what: Self::AUTO_KEY_EVENT,
             message,
             where_v: self.mouse_pos.0,
             where_h: self.mouse_pos.1,
-            modifiers: self.current_event_modifiers(),
+            modifiers,
         });
     }
 


### PR DESCRIPTION
## Root cause

The 68k trap dispatcher and native PowerPC loader owned separate event record types and `VecDeque` allocations. Runner execution and callback boundaries rebuilt one queue from the other, translated coordinates in both directions, and relied on reconciliation logic to preserve events posted between slices. That made visibility depend on the active CPU adapter rather than the Event Manager.

## Change

- Introduce one architecture-neutral queued-event type and serialized queue allocation.
- Attach the 68k and native PowerPC adapters to that allocation when the runner loads a native application.
- Preserve standalone native-loader queues and detached runtime cloning.
- Keep event coordinates in Macintosh global space and translate centered host presentation coordinates only at the input boundary.
- Delete the before/after queue-copy and merge paths; retain the still-separate process event-mask synchronization.

Inside Macintosh Volume I, I-244 and I-259 define one OS event queue and global `EventRecord.where` coordinates.

## Validation

- `cargo test --lib` — 4,238 passed, 3 ignored
- `cargo test --lib --features test-support` — 4,244 passed, 3 ignored
- `cargo build --all-targets --all-features`
- `cargo check --no-default-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- `cargo publish --dry-run --allow-dirty`
- `cargo deny check licenses`
- changed-file `rustfmt --check` and `git diff --check`

Closes #927