### PR TITLE
fix(event): use SysEvtMask as the posting authority

### DIFF
--- a/src/loader/ppc.rs
+++ b/src/loader/ppc.rs
@@ -79,6 +79,7 @@ pub const PPC_MEM_FULL_ERR: i16 = -108;
 const PPC_NIL_HANDLE_ERR: i16 = -109;
 const PPC_C_DEPTH_ERR: i16 = -157;
 pub const PPC_NO_ERR: i16 = 0;
+const PPC_EVT_NOT_ENB: i16 = 1;
 pub const PPC_EOF_ERR: i16 = -39;
 pub const PPC_FN_OPN_ERR: i16 = -38;
 pub const PPC_POS_ERR: i16 = -40;
@@ -2979,7 +2980,6 @@ pub struct PpcToolboxStartupState {
     pub flush_events_count: u32,
     pub last_flush_event_mask: u16,
     pub last_flush_stop_mask: u16,
-    pub system_event_mask: u16,
     pub dispose_dialog_count: u32,
     pub last_disposed_dialog: u32,
     pub delay_deadline: Option<u32>,
@@ -3035,9 +3035,6 @@ impl Default for PpcToolboxStartupState {
             flush_events_count: 0,
             last_flush_event_mask: 0,
             last_flush_stop_mask: 0,
-            // Macintosh Toolbox Essentials (1992), p. 2-99: the Process
-            // Manager initializes SysEvtMask to everyEvent-keyUpMask.
-            system_event_mask: 0xffef,
             dispose_dialog_count: 0,
             last_disposed_dialog: 0,
             delay_deadline: None,
@@ -13066,6 +13063,10 @@ pub fn load_pef_application_with_config(
 
     let mut memory = PpcSectionMem::new();
     memory.add_region(PPC_HALT_PC, vec![0u8; PPC_LOW_MEMORY_SIZE]);
+    let _ = memory.write_u16_be(
+        crate::memory::globals::addr::SYS_EVT_MASK,
+        crate::memory::globals::DEFAULT_SYS_EVT_MASK,
+    );
     let _ = memory.write_u16_be(PPC_MBAR_HEIGHT_ADDR, 20);
     let _ = memory.write_u16_be(PPC_THE_MENU_ADDR, 0);
     // PaintOne normally starts with PaintWhite enabled. Carbon's generated
@@ -20893,9 +20894,13 @@ fn dispatch_supported_import(
         }
         PpcImportDispatcherTarget::SetEventMask => {
             // Macintosh Toolbox Essentials (1992), pp. 2-99--2-100: this is
-            // per-process OS Event Manager posting state. Host events remain
-            // queued; GetNextEvent still applies the caller's retrieval mask.
-            toolbox_startup.system_event_mask = cpu.gpr[3] as u16;
+            // the current process's OS Event Manager posting state. Universal
+            // Interfaces 3.4 LowMem.h exposes the same word directly at
+            // SysEvtMask ($0144), so the guest-visible bytes are authoritative.
+            let _ = memory.write_u16_be(
+                crate::memory::globals::addr::SYS_EVT_MASK,
+                cpu.gpr[3] as u16,
+            );
             Some(PpcImportAction::ReturnPreserve)
         }
         PpcImportDispatcherTarget::DisposeDialog => {
@@ -20978,14 +20983,24 @@ fn dispatch_supported_import(
             Some(PpcImportAction::Return(u32::from(has_event)))
         }
         PpcImportDispatcherTarget::PostEvent => {
-            event_queue.push_back(PpcQueuedEvent {
-                what: cpu.gpr[3] as u16,
-                message: cpu.gpr[4],
-                where_v: input.mouse_v,
-                where_h: input.mouse_h,
-                modifiers: 0,
-            });
-            Some(PpcImportAction::Return(ppc_i16_result(PPC_NO_ERR)))
+            let what = cpu.gpr[3] as u16;
+            let system_event_mask = memory
+                .read_u16_be(crate::memory::globals::addr::SYS_EVT_MASK)
+                .unwrap_or(crate::memory::globals::DEFAULT_SYS_EVT_MASK);
+            let result =
+                if crate::trap::TrapDispatcher::posted_event_is_enabled(system_event_mask, what) {
+                    event_queue.push_back(PpcQueuedEvent {
+                        what,
+                        message: cpu.gpr[4],
+                        where_v: input.mouse_v,
+                        where_h: input.mouse_h,
+                        modifiers: 0,
+                    });
+                    PPC_NO_ERR
+                } else {
+                    PPC_EVT_NOT_ENB
+                };
+            Some(PpcImportAction::Return(ppc_i16_result(result)))
         }
         PpcImportDispatcherTarget::Button => {
             Some(PpcImportAction::Return(u32::from(input.mouse_button)))
@@ -86771,7 +86786,12 @@ mod tests {
             0x0000_ffdf,
             0,
         );
-        assert_eq!(loaded.toolbox_startup.system_event_mask, 0xffdf);
+        assert_eq!(
+            loaded
+                .memory
+                .read_u16_be(crate::memory::globals::addr::SYS_EVT_MASK),
+            Some(0xffdf)
+        );
 
         run_toolbox_import(
             &mut loaded,
@@ -136016,6 +136036,41 @@ mod tests {
                 where_h: 456,
                 modifiers: 0,
             }])
+        );
+    }
+
+    #[test]
+    fn hle_import_runner_posts_events_through_sys_evt_mask_low_memory() {
+        let pef = synthetic_pef_with_import(b"PostEvent");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let mask_addr = crate::memory::globals::addr::SYS_EVT_MASK;
+        assert_eq!(
+            loaded.memory.read_u16_be(mask_addr),
+            Some(crate::memory::globals::DEFAULT_SYS_EVT_MASK)
+        );
+
+        loaded.cpu.gpr[3] = 4;
+        loaded.cpu.gpr[4] = 0x1234;
+        let probe = loaded.run_with_hle_imports(64);
+        assert_eq!(probe.handled_import_count, 1);
+        assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_EVT_NOT_ENB));
+        assert!(loaded.event_queue().is_empty());
+
+        loaded.memory.write_u16_be(mask_addr, 0xffff).unwrap();
+        loaded.cpu.pc = loaded.entry_pc;
+        loaded.cpu.lr = PPC_HALT_PC;
+        loaded.cpu.gpr[3] = 4;
+        loaded.cpu.gpr[4] = 0x5678;
+        let probe = loaded.run_with_hle_imports(64);
+        assert_eq!(probe.handled_import_count, 1);
+        assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_NO_ERR));
+        assert_eq!(
+            loaded.event_queue().front().map(|event| event.what),
+            Some(4)
+        );
+        assert_eq!(
+            loaded.event_queue().front().map(|event| event.message),
+            Some(0x5678)
         );
     }
 

--- a/src/memory/globals.rs
+++ b/src/memory/globals.rs
@@ -9,6 +9,10 @@
 
 use std::collections::HashMap;
 
+/// Initial per-process SysEvtMask: every low-level event except keyUp.
+/// Macintosh Toolbox Essentials (1992), pp. 2-28--2-29 and 2-99.
+pub(crate) const DEFAULT_SYS_EVT_MASK: u16 = 0xFFEF;
+
 /// Low-memory global variable addresses
 pub mod addr {
     // System globals
@@ -19,6 +23,10 @@ pub mod addr {
     pub const BUF_PTR: u32 = 0x010C; // Sound/disk buffer (ptr)
     pub const HEAP_END: u32 = 0x0114; // End of heap zone (ptr)
     pub const THE_ZONE: u32 = 0x0118; // Current heap zone (ptr)
+    /// SysEvtMask: current process's low-level event posting mask (word).
+    /// Macintosh Toolbox Essentials (1992), pp. 2-28--2-29 and 2-99--2-100;
+    /// Inside Macintosh Volume III (1985), low-memory globals table.
+    pub const SYS_EVT_MASK: u32 = 0x0144;
     pub const RND_SEED: u32 = 0x0156; // Random number seed (long) - Inside Macintosh Volume II, II-387
     pub const TICKS: u32 = 0x016A; // Tick count (long) - system timer
     pub const MB_STATE: u32 = 0x0172; // Mouse button state (byte) - 0=down, $80=up

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -411,14 +411,6 @@ fn format_input_key_map(key_map: &[u8; 16]) -> String {
     out
 }
 
-fn sync_ppc_system_event_mask(dispatcher: &mut TrapDispatcher, system_event_mask: u16) {
-    // Macintosh Toolbox Essentials (1992), pp. 2-99--2-100: SetEventMask
-    // changes the current process's OS Event Manager posting mask. Input is
-    // injected through the shared dispatcher, so it must observe the PPC
-    // process's mask before deciding whether to post keyUp events.
-    dispatcher.system_event_mask = system_event_mask;
-}
-
 fn sync_ppc_cursor_state(
     dispatcher: &mut TrapDispatcher,
     cursor_level: i16,
@@ -1961,6 +1953,10 @@ impl FixtureRunner {
         let mut bus = MacMemoryBus::new(ram_size);
         bus.set_addressing_32_bit(config.addressing_32_bit);
         bus.configure_screen_depth(config.screen_depth);
+        bus.write_word(
+            crate::memory::globals::addr::SYS_EVT_MASK,
+            crate::memory::globals::DEFAULT_SYS_EVT_MASK,
+        );
         let profile = crate::machine_profile::reference_machine_profile();
         let visible_row_bytes =
             (u32::from(profile.screen_width) * u32::from(config.screen_depth)).div_ceil(8);
@@ -2853,7 +2849,12 @@ impl FixtureRunner {
     /// Inject a key-up event, applying arrow→numpad remapping if configured.
     pub fn push_key_up(&mut self, mac_key: u8, char_code: u8) {
         let (key, char_code) = self.remap_key(mac_key, char_code);
-        self.dispatcher.push_key_up(key, char_code);
+        self.dispatcher.push_key_up_with_system_event_mask(
+            self.bus
+                .read_word(crate::memory::globals::addr::SYS_EVT_MASK),
+            key,
+            char_code,
+        );
         self.sync_key_map_lowmem();
         self.wake_pending_wait_next_event_if_input_available();
         self.wake_foreground_after_input();
@@ -4004,6 +4005,9 @@ impl FixtureRunner {
     fn share_ppc_runtime_globals(&mut self, ppc_app: &mut PpcLoadedApp) {
         use crate::memory::globals::addr;
 
+        // SysEvtMask is the current process's low-level event posting mask
+        // (Macintosh Toolbox Essentials 1992, pp. 2-28--2-29 and 2-99--2-100;
+        // Inside Macintosh Volume III 1985, low-memory globals table).
         // RndSeed is the system random-number seed (Inside Macintosh Volume I,
         // I-195). The Vertical Retrace Manager updates Ticks and the one-second
         // interrupt updates Time (Inside Macintosh Volume II, II-202 and
@@ -4013,6 +4017,7 @@ impl FixtureRunner {
         // and 68k callers must observe one backing allocation rather than
         // values copied at CPU-slice boundaries.
         for (address, len) in [
+            (addr::SYS_EVT_MASK, 2),
             (addr::RND_SEED, 4),
             (addr::TICKS, 4),
             (addr::TIME, 4),
@@ -6109,7 +6114,6 @@ impl FixtureRunner {
 
         ppc_app.toolbox_startup.host_menu_bar_hidden = self.dispatcher.menu_bar_hidden;
         ppc_app.set_input_snapshot(input);
-        self.sync_ppc_event_state_before_execution(&mut ppc_app);
         self.prepare_ppc_execution_clock(&mut ppc_app);
         let cycles_per_tick = self.instructions_per_tick.max(1);
         let remaining_cycles =
@@ -6152,12 +6156,10 @@ impl FixtureRunner {
 
         self.total_instructions = self.total_instructions.saturating_add(cycles);
         self.dispatcher.instruction_count = self.total_instructions;
-        self.sync_ppc_event_state_after_execution(&ppc_app);
         let (vbl_probes, timer_probes) = if exited_via_ppc_exit_to_shell {
             (Vec::new(), Vec::new())
         } else {
             self.advance_ticks_for_ppc_cycles(cycles, tick_cap);
-            self.sync_ppc_event_state_before_execution(&mut ppc_app);
             let elapsed_ticks = self.dispatcher.tick_count.wrapping_sub(ppc_start_tick);
             self.fire_ppc_tick_callbacks(
                 &mut ppc_app,
@@ -6259,7 +6261,6 @@ impl FixtureRunner {
             self.sync_ppc_vfs_to_dispatcher(&mut ppc_app);
         }
         self.sync_ppc_sound_to_dispatcher(&mut ppc_app);
-        self.sync_ppc_event_state_after_execution(&ppc_app);
         sync_ppc_cursor_state(
             &mut self.dispatcher,
             ppc_app.quickdraw_cursor_level,
@@ -6433,17 +6434,6 @@ impl FixtureRunner {
             ));
         }
         (vbl_probes, timer_probes)
-    }
-
-    fn sync_ppc_event_state_after_execution(&mut self, ppc_app: &PpcLoadedApp) {
-        sync_ppc_system_event_mask(
-            &mut self.dispatcher,
-            ppc_app.toolbox_startup.system_event_mask,
-        );
-    }
-
-    fn sync_ppc_event_state_before_execution(&self, ppc_app: &mut PpcLoadedApp) {
-        ppc_app.toolbox_startup.system_event_mask = self.dispatcher.system_event_mask;
     }
 
     fn render_ppc_completed_frames(
@@ -7485,7 +7475,6 @@ impl FixtureRunner {
         let Some(mut ppc_app) = self.ppc_app.take() else {
             return;
         };
-        self.sync_ppc_event_state_before_execution(&mut ppc_app);
         self.prepare_ppc_execution_clock(&mut ppc_app);
         let mut fired_count = 0usize;
         while !ppc_app.sound.pending_doublebacks.is_empty() && fired_count < 16 {
@@ -7529,9 +7518,7 @@ impl FixtureRunner {
             }
             self.total_instructions = self.total_instructions.saturating_add(invocation.cycles);
             self.dispatcher.instruction_count = self.total_instructions;
-            self.sync_ppc_event_state_after_execution(&ppc_app);
             self.advance_ticks_for_ppc_cycles(invocation.cycles, None);
-            self.sync_ppc_event_state_before_execution(&mut ppc_app);
             self.prepare_ppc_execution_clock(&mut ppc_app);
 
             let buffer_bit = 1u8 << (doubleback.exhausted_buffer_index.min(1) as u8);
@@ -7573,7 +7560,6 @@ impl FixtureRunner {
                 break;
             }
         }
-        self.sync_ppc_event_state_after_execution(&ppc_app);
         self.sync_ppc_vfs_to_dispatcher(&mut ppc_app);
         self.sync_ppc_sound_to_dispatcher(&mut ppc_app);
         self.ppc_app = Some(ppc_app);
@@ -7594,7 +7580,6 @@ impl FixtureRunner {
         let Some(mut ppc_app) = self.ppc_app.take() else {
             return;
         };
-        self.sync_ppc_event_state_before_execution(&mut ppc_app);
         self.prepare_ppc_execution_clock(&mut ppc_app);
         let mut fired_count = 0usize;
         while !ppc_app.sound.pending_completions.is_empty() && fired_count < 16 {
@@ -7624,9 +7609,7 @@ impl FixtureRunner {
             }
             self.total_instructions = self.total_instructions.saturating_add(invocation.cycles);
             self.dispatcher.instruction_count = self.total_instructions;
-            self.sync_ppc_event_state_after_execution(&ppc_app);
             self.advance_ticks_for_ppc_cycles(invocation.cycles, None);
-            self.sync_ppc_event_state_before_execution(&mut ppc_app);
             self.prepare_ppc_execution_clock(&mut ppc_app);
 
             let callback_failed = invocation.unsupported_import_index.is_some()
@@ -7653,7 +7636,6 @@ impl FixtureRunner {
                 break;
             }
         }
-        self.sync_ppc_event_state_after_execution(&ppc_app);
         self.sync_ppc_vfs_to_dispatcher(&mut ppc_app);
         self.sync_ppc_sound_to_dispatcher(&mut ppc_app);
         self.ppc_app = Some(ppc_app);
@@ -8441,7 +8423,10 @@ impl FixtureRunner {
         let new_tick = self.bus.read_long(0x016A).wrapping_add(1);
         self.bus.write_long(0x016A, new_tick);
         self.dispatcher.tick_count = new_tick;
-        self.dispatcher.post_auto_key_if_due();
+        self.dispatcher.post_auto_key_if_due(
+            self.bus
+                .read_word(crate::memory::globals::addr::SYS_EVT_MASK),
+        );
 
         // Sync MBState ($0172) from the internal button state.
         // On real hardware the VBL interrupt handler reads the ADB mouse
@@ -11852,6 +11837,27 @@ mod tests {
         runner.init_app(&app);
         let mut ppc_app = runner.ppc_app.take().expect("PPC app installed");
 
+        assert_eq!(
+            runner.bus.read_word(addr::SYS_EVT_MASK),
+            crate::memory::globals::DEFAULT_SYS_EVT_MASK
+        );
+        assert_eq!(
+            ppc_app.memory.read_u16_be(addr::SYS_EVT_MASK),
+            Some(crate::memory::globals::DEFAULT_SYS_EVT_MASK)
+        );
+        ppc_app
+            .memory
+            .write_u16_be(addr::SYS_EVT_MASK, 0xffdf)
+            .unwrap();
+        assert_eq!(runner.bus.read_word(addr::SYS_EVT_MASK), 0xffdf);
+        runner.bus.write_word(addr::SYS_EVT_MASK, 0x1234);
+        assert_eq!(ppc_app.memory.read_u16_be(addr::SYS_EVT_MASK), Some(0x1234));
+
+        let mut detached = ppc_app.memory.clone();
+        detached.write_u16_be(addr::SYS_EVT_MASK, 0xabcd).unwrap();
+        assert_eq!(runner.bus.read_word(addr::SYS_EVT_MASK), 0x1234);
+        assert_eq!(ppc_app.memory.read_u16_be(addr::SYS_EVT_MASK), Some(0x1234));
+
         ppc_app.memory.write_u8(addr::MB_STATE, 0).unwrap();
         assert_eq!(runner.bus.read_byte(addr::MB_STATE), 0);
         runner.bus.write_byte(addr::MB_STATE, 0x80);
@@ -11994,10 +12000,6 @@ mod tests {
         assert_eq!(reposted.message, 0x1111);
         assert_eq!((reposted.where_v, reposted.where_h), (10, 20));
         assert_eq!(reposted.modifiers, 0x0200);
-
-        ppc_app.toolbox_startup.system_event_mask = 0x1234;
-        runner.sync_ppc_event_state_after_execution(&ppc_app);
-        assert_eq!(runner.dispatcher.system_event_mask, 0x1234);
     }
 
     #[test]
@@ -13339,7 +13341,18 @@ mod tests {
         let posted = &runner.dispatcher.event_queue[0];
         assert_eq!((posted.what, posted.message), (5, 0x5566_7788));
         assert_eq!((posted.where_v, posted.where_h), (17, 19));
-        assert_eq!(runner.dispatcher.system_event_mask, 0x1234);
+        assert_eq!(
+            runner
+                .bus
+                .read_word(crate::memory::globals::addr::SYS_EVT_MASK),
+            0x1234
+        );
+        assert_eq!(
+            ppc_app
+                .memory
+                .read_u16_be(crate::memory::globals::addr::SYS_EVT_MASK),
+            Some(0x1234)
+        );
     }
 
     #[test]
@@ -14470,10 +14483,23 @@ mod tests {
     }
 
     #[test]
-    fn ppc_system_event_mask_enables_injected_key_up_events() {
+    fn ppc_system_event_mask_write_enables_injected_key_up_events() {
+        let mut app = halted_ppc_app_with_sound(PpcSoundState::default());
+        app.ppc
+            .as_mut()
+            .expect("synthetic PPC app")
+            .memory
+            .add_region(PPC_HALT_PC, vec![0; 64 * 1024]);
         let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        runner.init_app(&app);
 
-        sync_ppc_system_event_mask(&mut runner.dispatcher, 0xffdf);
+        runner
+            .ppc_app
+            .as_mut()
+            .expect("PPC app installed")
+            .memory
+            .write_u16_be(crate::memory::globals::addr::SYS_EVT_MASK, 0xffdf)
+            .unwrap();
         runner.push_key_down(0x7c, 29);
         runner.push_key_up(0x7c, 29);
 

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -1788,9 +1788,6 @@ pub struct TrapDispatcher {
     /// One-shot update events recovered after FlushEvents drops queue entries
     /// while the Window Manager update region remains dirty.
     pub(crate) flushed_update_events: VecDeque<QueuedEvent>,
-    /// System event mask used by PostEvent/PPostEvent filtering.
-    /// Inside Macintosh Volume II, II-70.
-    pub(crate) system_event_mask: u16,
     /// Whether the synthetic kAEOpenApplication event has been delivered.
     /// On a real Mac, the Finder sends this Apple Event at launch.
     /// Macintosh Toolbox Essentials 1992, p. 5-90
@@ -3264,7 +3261,6 @@ impl TrapDispatcher {
             pending_modal_dialog_mouse_up: false,
             pending_modal_dialog_mouse_down: None,
             flushed_update_events: VecDeque::new(),
-            system_event_mask: 0xFFEF, // everyEvent - keyUpMask
             sent_open_app_event: false,
             application_high_level_event_aware: false,
             current_trap_word: 0,
@@ -5031,6 +5027,19 @@ impl TrapDispatcher {
 
     /// Push a key-up event into the event queue.
     pub fn push_key_up(&mut self, key_code: u8, char_code: u8) {
+        self.push_key_up_with_system_event_mask(
+            crate::memory::globals::DEFAULT_SYS_EVT_MASK,
+            key_code,
+            char_code,
+        );
+    }
+
+    pub(crate) fn push_key_up_with_system_event_mask(
+        &mut self,
+        system_event_mask: u16,
+        key_code: u8,
+        char_code: u8,
+    ) {
         if key_code == Self::CAPS_LOCK_KEY_CODE {
             self.caps_lock_physically_pressed = false;
         } else {
@@ -5060,7 +5069,7 @@ impl TrapDispatcher {
         // OS event queue only when the application explicitly enables
         // keyUpMask through SetEventMask. Inside Macintosh Volume I, I-254;
         // Macintosh Toolbox Essentials 1992, pp. 2-28..2-29 and 2-99.
-        if self.posted_event_is_enabled(4) {
+        if Self::posted_event_is_enabled(system_event_mask, 4) {
             self.event_queue.push_back(QueuedEvent {
                 what: 4, // keyUp
                 message,

--- a/src/trap/event.rs
+++ b/src/trap/event.rs
@@ -163,7 +163,7 @@ impl super::TrapDispatcher {
         })
     }
 
-    pub(crate) fn posted_event_is_enabled(&self, what: u16) -> bool {
+    pub(crate) fn posted_event_is_enabled(system_event_mask: u16, what: u16) -> bool {
         // The system event mask (SysEvtMask) gates OS-level events.
         // Per IM:II-67 table 2-2, bits 0..15 correspond to specific
         // event types (mDown, keyDown, activate, etc.); bit 10 is
@@ -172,10 +172,10 @@ impl super::TrapDispatcher {
         // 24/25/26 per IM:II-66) and Sound Manager / file-system
         // notification events are NOT gated by SysEvtMask — always postable.
         match what {
-            Self::K_HIGH_LEVEL_EVENT => (self.system_event_mask & Self::HIGH_LEVEL_EVENT_MASK) != 0,
+            Self::K_HIGH_LEVEL_EVENT => (system_event_mask & Self::HIGH_LEVEL_EVENT_MASK) != 0,
             0..=15 => {
                 let bit = 1u16 << what;
-                (self.system_event_mask & bit) != 0
+                (system_event_mask & bit) != 0
             }
             _ => true,
         }
@@ -213,7 +213,10 @@ impl super::TrapDispatcher {
     }
 
     fn post_os_event(&mut self, bus: &mut MacMemoryBus, what: u16, message: u32) -> (u32, u32) {
-        if !self.posted_event_is_enabled(what) {
+        if !Self::posted_event_is_enabled(
+            bus.read_word(crate::memory::globals::addr::SYS_EVT_MASK),
+            what,
+        ) {
             return (Self::EVT_NOT_ENB, 0);
         }
 
@@ -300,12 +303,12 @@ impl super::TrapDispatcher {
         now.wrapping_sub(due) < 0x8000_0000
     }
 
-    pub(crate) fn post_auto_key_if_due(&mut self) {
+    pub(crate) fn post_auto_key_if_due(&mut self, system_event_mask: u16) {
         // Auto-key is a low-level event posted by the Operating System Event
         // Manager once the threshold/rate elapses; it is not synthesized only
         // when an application happens to poll. Macintosh Toolbox Essentials,
         // pp. 2-29 and 2-38.
-        if !self.posted_event_is_enabled(Self::AUTO_KEY_EVENT) {
+        if !Self::posted_event_is_enabled(system_event_mask, Self::AUTO_KEY_EVENT) {
             return;
         }
         let Some(repeat) = self.key_repeat else {
@@ -334,9 +337,9 @@ impl super::TrapDispatcher {
         });
     }
 
-    fn enqueue_auto_key_if_due(&mut self, event_mask: u16) {
+    fn enqueue_auto_key_if_due(&mut self, system_event_mask: u16, event_mask: u16) {
         if Self::event_matches_mask(event_mask, Self::AUTO_KEY_EVENT) {
-            self.post_auto_key_if_due();
+            self.post_auto_key_if_due(system_event_mask);
         }
     }
 
@@ -386,7 +389,10 @@ impl super::TrapDispatcher {
         event_mask: u16,
     ) -> Option<super::dispatch::QueuedEvent> {
         self.enqueue_open_application_event_if_needed(event_mask);
-        self.enqueue_auto_key_if_due(event_mask);
+        self.enqueue_auto_key_if_due(
+            bus.read_word(crate::memory::globals::addr::SYS_EVT_MASK),
+            event_mask,
+        );
         let pending_menu = self.peek_pending_native_menu_event(event_mask);
         let queued = self
             .matching_toolbox_event_index(event_mask)
@@ -424,8 +430,15 @@ impl super::TrapDispatcher {
         }
     }
 
-    fn peek_event(&mut self, event_mask: u16) -> Option<super::dispatch::QueuedEvent> {
-        self.enqueue_auto_key_if_due(event_mask);
+    fn peek_event(
+        &mut self,
+        bus: &MacMemoryBus,
+        event_mask: u16,
+    ) -> Option<super::dispatch::QueuedEvent> {
+        self.enqueue_auto_key_if_due(
+            bus.read_word(crate::memory::globals::addr::SYS_EVT_MASK),
+            event_mask,
+        );
         let pending = self.peek_pending_native_menu_event(event_mask);
         let queued = self
             .event_queue
@@ -448,7 +461,10 @@ impl super::TrapDispatcher {
         event_mask: u16,
     ) -> (u16, u32, i16, i16, u16, bool) {
         self.enqueue_open_application_event_if_needed(event_mask);
-        self.enqueue_auto_key_if_due(event_mask);
+        self.enqueue_auto_key_if_due(
+            bus.read_word(crate::memory::globals::addr::SYS_EVT_MASK),
+            event_mask,
+        );
         if Self::event_matches_mask(event_mask, 6) {
             self.service_window_picture_updates(cpu, bus);
         }
@@ -656,8 +672,15 @@ impl super::TrapDispatcher {
 
     /// Dequeue one event matching the event mask, or return a null event.
     /// Returns (what, message, where_v, where_h, modifiers, has_event).
-    pub(crate) fn dequeue_event(&mut self, event_mask: u16) -> (u16, u32, i16, i16, u16, bool) {
-        self.enqueue_auto_key_if_due(event_mask);
+    pub(crate) fn dequeue_event(
+        &mut self,
+        bus: &MacMemoryBus,
+        event_mask: u16,
+    ) -> (u16, u32, i16, i16, u16, bool) {
+        self.enqueue_auto_key_if_due(
+            bus.read_word(crate::memory::globals::addr::SYS_EVT_MASK),
+            event_mask,
+        );
         let queued_idx = self.event_queue.iter().position(|event| {
             Self::is_low_level_os_event(event.what)
                 && Self::event_matches_mask(event_mask, event.what)
@@ -1165,7 +1188,7 @@ impl super::TrapDispatcher {
             (false, 0x30) => {
                 let event_mask = cpu.read_reg(Register::D0) as u16;
                 let event_ptr = cpu.read_reg(Register::A0);
-                if let Some(event) = self.peek_event(event_mask) {
+                if let Some(event) = self.peek_event(bus, event_mask) {
                     self.write_event_record(
                         bus,
                         event_ptr,
@@ -1201,7 +1224,7 @@ impl super::TrapDispatcher {
                 let event_mask = cpu.read_reg(Register::D0) as u16;
                 let event_ptr = cpu.read_reg(Register::A0);
                 let (what, message, where_v, where_h, modifiers, has_event) =
-                    self.dequeue_event(event_mask);
+                    self.dequeue_event(bus, event_mask);
                 self.write_event_record(bus, event_ptr, what, message, where_v, where_h, modifiers);
                 // D0=0 means event found (TRUE); D0=$FFFF means null (FALSE).
                 // TB Essentials 1992, p. 2-97; confirmed by MPW disassembly (ADDQ+BEQ pattern).
@@ -1225,7 +1248,7 @@ mod tests {
 
     #[test]
     fn native_menu_mouse_down_is_latched_and_rate_limited_until_menuselect() {
-        let (mut disp, _cpu, _bus) = setup();
+        let (mut disp, _cpu, bus) = setup();
         disp.tick_count = 100;
         disp.pending_native_menu_event = Some(QueuedEvent {
             what: 1,
@@ -1235,16 +1258,16 @@ mod tests {
             modifiers: 0,
         });
 
-        let first = disp.dequeue_event(1 << 1);
+        let first = disp.dequeue_event(&bus, 1 << 1);
         assert!(first.5);
         assert_eq!((first.0, first.2, first.3), (1, 10, 42));
         assert!(disp.pending_native_menu_event.is_some());
 
-        let same_tick = disp.dequeue_event(1 << 1);
+        let same_tick = disp.dequeue_event(&bus, 1 << 1);
         assert!(!same_tick.5, "latched click must not spin an event loop");
 
         disp.tick_count += 1;
-        let next_tick = disp.dequeue_event(1 << 1);
+        let next_tick = disp.dequeue_event(&bus, 1 << 1);
         assert!(next_tick.5, "ignored menu click must be presented again");
         assert!(disp.pending_native_menu_event.is_some());
     }
@@ -1268,10 +1291,10 @@ mod tests {
             modifiers: 0,
         });
 
-        assert_eq!(disp.peek_event(u16::MAX).unwrap().what, 3);
+        assert_eq!(disp.peek_event(&bus, u16::MAX).unwrap().what, 3);
         let event = disp.dequeue_toolbox_event(&mut cpu, &mut bus, u16::MAX);
         assert_eq!((event.0, event.1), (3, 0x1234));
-        let event = disp.dequeue_event(u16::MAX);
+        let event = disp.dequeue_event(&bus, u16::MAX);
         assert_eq!((event.0, event.2, event.3), (1, 10, 42));
 
         disp.tick_count += 1;
@@ -1282,8 +1305,8 @@ mod tests {
             where_h: 30,
             modifiers: 0,
         });
-        assert_eq!(disp.peek_event(u16::MAX).unwrap().what, 1);
-        assert_eq!(disp.dequeue_event(u16::MAX).0, 1);
+        assert_eq!(disp.peek_event(&bus, u16::MAX).unwrap().what, 1);
+        assert_eq!(disp.dequeue_event(&bus, u16::MAX).0, 1);
     }
 
     #[test]
@@ -1382,8 +1405,15 @@ mod tests {
         assert_eq!(what, 5);
         assert_eq!(message, 0x0000_7D1F);
 
-        disp.system_event_mask |= 1 << 4;
-        disp.push_key_up(0x7D, 31);
+        bus.write_word(
+            crate::memory::globals::addr::SYS_EVT_MASK,
+            bus.read_word(crate::memory::globals::addr::SYS_EVT_MASK) | (1 << 4),
+        );
+        disp.push_key_up_with_system_event_mask(
+            bus.read_word(crate::memory::globals::addr::SYS_EVT_MASK),
+            0x7D,
+            31,
+        );
         let (what, _, _, _, _, has_event) = disp.dequeue_toolbox_event(&mut cpu, &mut bus, 0x0010);
         assert!(has_event, "keyUp should be delivered");
         assert_eq!(what, 4);
@@ -1403,7 +1433,7 @@ mod tests {
         assert!(has_event, "initial keyDown should be delivered");
 
         disp.tick_count += TrapDispatcher::AUTO_KEY_THRESHOLD_TICKS;
-        disp.post_auto_key_if_due();
+        disp.post_auto_key_if_due(bus.read_word(crate::memory::globals::addr::SYS_EVT_MASK));
 
         disp.push_key_up(0x00, b'a');
         let (what, message, _, _, _, has_event) =
@@ -2389,6 +2419,30 @@ mod tests {
         assert_eq!(cpu.read_reg(Register::D0), 0);
     }
 
+    #[test]
+    fn post_event_observes_direct_sys_evt_mask_writes() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        cpu.write_reg(Register::A0, 4);
+        cpu.write_reg(Register::D0, 0x1234);
+
+        let result = disp.dispatch_event(false, 0x2F, &mut cpu, &mut bus);
+        assert!(result.unwrap().is_ok());
+        assert_eq!(cpu.read_reg(Register::D0), TrapDispatcher::EVT_NOT_ENB);
+        assert!(disp.event_queue.is_empty());
+
+        bus.write_word(crate::memory::globals::addr::SYS_EVT_MASK, 0xffff);
+        cpu.write_reg(Register::A0, 4);
+        cpu.write_reg(Register::D0, 0x5678);
+        let result = disp.dispatch_event(false, 0x2F, &mut cpu, &mut bus);
+        assert!(result.unwrap().is_ok());
+        assert_eq!(cpu.read_reg(Register::D0), 0);
+        assert_eq!(disp.event_queue.front().map(|event| event.what), Some(4));
+        assert_eq!(
+            disp.event_queue.front().map(|event| event.message),
+            Some(0x5678)
+        );
+    }
+
     // ---- OSEventAvail ($A030) ----
 
     #[test]
@@ -2726,7 +2780,7 @@ mod tests {
     fn get_os_event_mouse_up_reports_button_up_modifier() {
         let (mut disp, mut cpu, mut bus) = setup();
         disp.push_mouse_down(75, 150);
-        let _ = disp.dequeue_event(0xFFFF);
+        let _ = disp.dequeue_event(&bus, 0xFFFF);
         disp.push_mouse_up(75, 150);
 
         cpu.write_reg(Register::D0, 0x0004);

--- a/src/trap/test_helpers.rs
+++ b/src/trap/test_helpers.rs
@@ -97,6 +97,10 @@ pub fn setup() -> (TrapDispatcher, MockCpu, MacMemoryBus) {
 
     // Set up TickCount low-memory global
     bus.write_long(0x016A, 100);
+    bus.write_word(
+        crate::memory::globals::addr::SYS_EVT_MASK,
+        crate::memory::globals::DEFAULT_SYS_EVT_MASK,
+    );
     // MBState ($0172) is 0 when the mouse button is down and $80 when it is
     // up. Real startup code initializes it to up; zero-filled test RAM would
     // otherwise look like a held mouse. Inside Macintosh Volume II, II-371.

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -18362,7 +18362,7 @@ mod tests {
         // Simulate: runner wrote $0172=0x00 on mouse-down
         bus.write_byte(0x0172, 0x00);
         disp.push_mouse_down(50, 100);
-        let _ = disp.dequeue_event(0xFFFF);
+        let _ = disp.dequeue_event(&bus, 0xFFFF);
         disp.push_mouse_up(50, 100);
 
         // Internal state is released, but $0172 is still "pressed"


### PR DESCRIPTION
## Root cause

The 68k dispatcher and native PowerPC Toolbox state each retained a separate system-event-mask scalar. Runner execution and callback boundaries copied those values, while the guest-visible `SysEvtMask` word at `$0144` was not authoritative. This made direct low-memory writes and cross-CPU posting visibility dependent on synchronization timing.

## Change

- initialize the documented `everyEvent-keyUpMask` value in guest low memory
- share the `$0144` bytes between the 68k and PowerPC memory adapters
- make native `SetEventMask`, both `PostEvent` paths, auto-key posting, and host key-up injection consult those bytes
- remove both duplicate scalar fields and every event-mask synchronization boundary
- cover default initialization, direct bidirectional writes, native import behavior, callback visibility, host injection, and detached address-space cloning

Macintosh Toolbox Essentials (1992), pp. 2-28–2-29 and 2-99–2-100, defines this as current-process event-posting state exposed through `SysEvtMask`; Universal Interfaces 3.4 maps its low-memory accessors directly to `$0144`.

## Validation

- `cargo test --lib` — 4,240 passed, 3 ignored
- `cargo test --lib --features test-support` — 4,246 passed, 3 ignored
- `cargo build --all-targets --all-features`
- `cargo check --no-default-features`
- strict all-feature private-item documentation build
- `cargo publish --locked --dry-run`
- `cargo deny check licenses`

Closes #930