### PR TITLE
build: update CPU dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1038,6 +1038,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ieee-apsqrt"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4328941c554aaeea28ca420cd1f10e932fa38874faf8c75e3ed184c64c5c6cec"
+dependencies = [
+ "rustc_apfloat",
+]
+
+[[package]]
 name = "image"
 version = "0.25.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1191,9 +1200,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "m68k"
-version = "0.7.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad5d9c86aa821297e93fe0d4968c0f3eeef07073a58e8dc1e62b1d58b9fe48a1"
+checksum = "db8c10d469f68c2b7cb110f4a73668f8f523e294be6201baf6cad5b341377da4"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -1768,9 +1777,13 @@ dependencies = [
 
 [[package]]
 name = "ppc"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71a947b9def1642a9ac9e1a0827c6574c10512165b2d7f50bf1403f933eb226d"
+checksum = "9e84331783697d955dabfa0f48abb9ca3c278e65dce7e16ba8000feb8a867d94"
+dependencies = [
+ "ieee-apsqrt",
+ "rustc_apfloat",
+]
 
 [[package]]
 name = "prettyplease"
@@ -1949,6 +1962,16 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustc_apfloat"
+version = "0.2.3+llvm-462a31f5a5ab"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "486c2179b4796f65bfe2ee33679acf0927ac83ecf583ad6c91c3b4570911b9ad"
+dependencies = [
+ "bitflags 2.11.0",
+ "smallvec",
+]
 
 [[package]]
 name = "rustix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ default-run = "systemless"
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
-m68k = { version = "0.7.1" }
-ppc = "0.4.0"
+m68k = { version = "0.11.2" }
+ppc = "0.4.1"
 thiserror = "2"
 tracing = "0.1"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Summary

- update `m68k` from 0.7.1 to 0.11.2
- update `ppc` from 0.4.0 to 0.4.1
- refresh the lockfile for the CPU crates and their new floating-point dependencies

## Root cause and evidence

The manifest remained pinned to older CPU crate releases even though newer versions are published on crates.io. `cargo search m68k` reports 0.11.2 and `cargo search ppc` reports 0.4.1. Cargo resolves both updates without requiring runtime source changes.

## Validation

- `cargo check --all-targets --all-features`
- `cargo test --all-features` (4,324 passed; 3 ignored)
- `cargo check --no-default-features`
- `cargo test --lib --features test-support` (4,246 passed; 3 ignored)
- documentation build with warnings denied
- `cargo publish --locked --dry-run` from a clean standalone checkout

Closes #934