### PR TITLE
build: restore ppc 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1038,6 +1038,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ieee-apsqrt"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4328941c554aaeea28ca420cd1f10e932fa38874faf8c75e3ed184c64c5c6cec"
+dependencies = [
+ "rustc_apfloat",
+]
+
+[[package]]
 name = "image"
 version = "0.25.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1768,9 +1777,13 @@ dependencies = [
 
 [[package]]
 name = "ppc"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71a947b9def1642a9ac9e1a0827c6574c10512165b2d7f50bf1403f933eb226d"
+checksum = "9e84331783697d955dabfa0f48abb9ca3c278e65dce7e16ba8000feb8a867d94"
+dependencies = [
+ "ieee-apsqrt",
+ "rustc_apfloat",
+]
 
 [[package]]
 name = "prettyplease"
@@ -1949,6 +1962,16 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustc_apfloat"
+version = "0.2.3+llvm-462a31f5a5ab"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "486c2179b4796f65bfe2ee33679acf0927ac83ecf583ad6c91c3b4570911b9ad"
+dependencies = [
+ "bitflags 2.11.0",
+ "smallvec",
+]
 
 [[package]]
 name = "rustix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ default-run = "systemless"
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
 m68k = { version = "0.7.1" }
-ppc = "0.4.0"
+ppc = "0.4.1"
 thiserror = "2"
 tracing = "0.1"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Summary

- restore the `ppc` dependency to 0.4.1
- retain the new deterministic IEEE floating-point dependencies in the lockfile
- keep the PowerPC restoration independent from the m68k regression and release

## Verification

- `cargo test --lib --no-default-features -- --quiet` (4,241 passed, 3 ignored)
- `cargo test --lib --features test-support -- --quiet` (4,256 passed, 3 ignored)
- deterministic Gridz gameplay reaches the same final tick as 0.4.0
- saved execution contexts and framebuffer checkpoints are byte-identical to 0.4.0

Closes #940
