### PR TITLE
build: restore m68k 0.11.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1191,9 +1191,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "m68k"
-version = "0.7.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45baba053cfe6f658103530b33f6dbf7e48389b76614b968c260cabe91873539"
+checksum = "763f274df69d3cb1f3433a3b801dafbc2d67301d7ad98d75baffdf48be38a317"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ default-run = "systemless"
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
-m68k = { version = "0.7.1" }
+m68k = { version = "0.11.3" }
 ppc = "0.4.0"
 thiserror = "2"
 tracing = "0.1"


### PR DESCRIPTION
## Summary

- restore the `m68k` dependency to the published 0.11.3 release
- consume the portable-trace fix for extensionless `TST.B/W/L (An)`
- keep the m68k restoration independent from the PowerPC dependency update

## Verification

- `cargo test --lib --no-default-features -- --quiet` (4,241 passed, 3 ignored)
- `cargo test --lib --features test-support -- --quiet` (4,256 passed, 3 ignored)
- repaired Marathon 2 gameplay, automap, and movement checkpoints are byte-identical to m68k 0.10.14
- EV Override completes its deterministic gameplay script

Closes #943
