### PR TITLE
fix(cpu): restore corrected m68k and ppc releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1200,9 +1200,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "m68k"
-version = "0.7.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45baba053cfe6f658103530b33f6dbf7e48389b76614b968c260cabe91873539"
+checksum = "763f274df69d3cb1f3433a3b801dafbc2d67301d7ad98d75baffdf48be38a317"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ default-run = "systemless"
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
-m68k = { version = "0.7.1" }
+m68k = { version = "0.11.3" }
 ppc = "0.4.1"
 thiserror = "2"
 tracing = "0.1"


### PR DESCRIPTION
Closes #942.

Restores the current published CPU crates after the 0.23.5 containment rollback:

- m68k 0.11.3 includes the portable-trace fix for register-indirect `TST (An)`
- ppc 0.4.1 restores enforced 32-bit architectural semantics

Validation:

- `cargo test --quiet` (4,250 passed, 3 ignored; auxiliary suites 73 + 4 + 1 passed)
- `cargo check --target wasm32-unknown-unknown --lib`
- m68k: 184 default-feature tests and 257 JIT-feature tests
- ppc: full suite (500 tests)
- Marathon HUD-visible gate passed (the 0.11.2 failure timed out at tick 5888; 0.11.3 rendered at tick 2859)
- Marathon 2 menu, New Game gameplay, palette, automap, and movement probes passed
- EV Override new-pilot, live-space, targeting/fire-input, movement, and UI/font probes passed

Known pre-existing repository checks outside this dependency diff: `cargo fmt --check` reports existing resource/quilt formatting drift, and the GUI binary fails an all-target wasm check because its `std::time::Instant` differs from winit’s wasm `web_time::Instant`; the browser-consumed library wasm check passes.