### PR TITLE
build: update m68k to 0.11.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1200,9 +1200,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "m68k"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "763f274df69d3cb1f3433a3b801dafbc2d67301d7ad98d75baffdf48be38a317"
+checksum = "d8d8e9024dc018db9d5609d22d9e58261bc04982e8e7483c9aca220f8e457e75"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ default-run = "systemless"
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
-m68k = { version = "0.11.3" }
+m68k = { version = "0.11.4" }
 ppc = "0.4.1"
 thiserror = "2"
 tracing = "0.1"


### PR DESCRIPTION
## Summary

- update the published `m68k` dependency from 0.11.3 to 0.11.4
- refresh the crates.io checksum in `Cargo.lock`
- consume model-correct immediate-register bit-operation trace timing

## Validation

- `cargo test --lib --no-default-features --locked` (4,241 passed, 3 ignored)
- `cargo test --lib --features test-support --locked` (4,256 passed, 3 ignored)
- `cargo check --all-targets --all-features --locked`
- `cargo package --locked`

Closes #948