### PR TITLE
fix(deps): update m68k to 0.11.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1200,9 +1200,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "m68k"
-version = "0.11.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8d8e9024dc018db9d5609d22d9e58261bc04982e8e7483c9aca220f8e457e75"
+checksum = "ffe495fd0fcac358c99e5e13b4f3c9a8f7f64b5a9744ff0cd40c7a66877e58a2"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ default-run = "systemless"
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
-m68k = { version = "0.11.4" }
+m68k = { version = "0.11.5" }
 ppc = "0.4.1"
 thiserror = "2"
 tracing = "0.1"


### PR DESCRIPTION
Closes #950

Updates the published `m68k` dependency from 0.11.4 to 0.11.5. That release includes the guarded stack-frame trace admission fix from benletchford/m68k-rs#154 and benletchford/m68k-rs#155, preventing guest RAM from depending on host `run_batch` boundaries for affected portable traces.

Validation:
- `cargo test --lib` (4,250 passed, 3 ignored)
- `cargo test --lib --features test-support` (4,256 passed, 3 ignored)
- `cargo check --no-default-features`
- `cargo package --allow-dirty --no-verify`
- deterministic 500-tick workload probe completed 190,221,123 instructions with production-sized batches