### PR TITLE
build: update m68k to 0.11.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1200,9 +1200,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "m68k"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe495fd0fcac358c99e5e13b4f3c9a8f7f64b5a9744ff0cd40c7a66877e58a2"
+checksum = "5aaedc7710ba71202eb3f539c1be37f171083c17253c26a9eba5f96d24137095"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ default-run = "systemless"
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
-m68k = { version = "0.11.5" }
+m68k = { version = "0.11.6" }
 ppc = "0.4.1"
 thiserror = "2"
 tracing = "0.1"


### PR DESCRIPTION
## Summary

- update the published `m68k` dependency from 0.11.5 to 0.11.6
- refresh the crates.io checksum in `Cargo.lock`
- pick up architectural MC68040-family format-$2 address-error frames

Release: https://github.com/benletchford/m68k-rs/releases/tag/m68k-v0.11.6

## Validation

- `cargo test --lib --no-default-features --locked` (4,241 passed; 3 ignored)
- `cargo test --lib --features test-support --locked` (4,256 passed; 3 ignored)
- `cargo build --all-targets --all-features --locked`
- `cargo check --no-default-features --locked`
- strict all-feature documentation
- `cargo publish --locked --dry-run --allow-dirty`
- `cargo deny check licenses`

Closes #953
