### PR TITLE
perf(runner): admit journal-complete Window Manager queries and TEIdle to idle-cycle proofs

### DIFF
--- a/src/memory/bus.rs
+++ b/src/memory/bus.rs
@@ -517,6 +517,10 @@ pub struct MacMemoryBus {
     /// probed cycle was doing work, not waiting. Sticky until the runner
     /// takes it, so the verdict survives the journal's disappearance.
     write_probe_overflowed: bool,
+    /// Armed journal has no entry cap (parked-repaint byte-identity check:
+    /// no guest code runs, so unbounded growth is impossible and overflow
+    /// must not void the check).
+    write_probe_uncapped: bool,
     /// Temporary sparse-memory view used only while a parked native process
     /// runs its emulated 68k context. The runner installs and removes this
     /// view around each serialized execution interval.
@@ -1137,6 +1141,7 @@ impl MacMemoryBus {
             write_probe_spare: WriteProbeJournal::default(),
             write_probe_invalid: false,
             write_probe_overflowed: false,
+            write_probe_uncapped: false,
             foreign_address_space: None,
         };
         bus.write_word(super::globals::addr::ROM85, 0x7FFF);
@@ -1233,6 +1238,7 @@ impl MacMemoryBus {
             write_probe_spare: WriteProbeJournal::default(),
             write_probe_invalid: false,
             write_probe_overflowed: false,
+            write_probe_uncapped: false,
             foreign_address_space: None,
         }
     }
@@ -1341,6 +1347,17 @@ impl MacMemoryBus {
         self.write_probe_original = Some(journal);
         self.write_probe_invalid = false;
         self.write_probe_overflowed = false;
+        self.write_probe_uncapped = false;
+    }
+
+    /// Begin a write probe with no entry cap. Only for host-owned drawing
+    /// performed while the guest is parked (no guest code runs, so the
+    /// journal is bounded by what the drawing touches): the byte-identity
+    /// answer from [`Self::finish_write_probe_unchanged`] must never be
+    /// voided by the overflow guard sized for guest wait cycles.
+    pub(crate) fn begin_uncapped_write_probe(&mut self) {
+        self.begin_write_probe();
+        self.write_probe_uncapped = true;
     }
 
     /// Discard an incomplete write probe and restore normal fast-memory use.
@@ -1348,6 +1365,7 @@ impl MacMemoryBus {
         self.park_write_probe_journal();
         self.write_probe_invalid = false;
         self.write_probe_overflowed = false;
+        self.write_probe_uncapped = false;
     }
 
     /// Detach the armed journal so writes made meanwhile -- host-owned
@@ -1382,6 +1400,7 @@ impl MacMemoryBus {
         self.write_probe_spare = original;
         self.write_probe_invalid = false;
         self.write_probe_overflowed = false;
+        self.write_probe_uncapped = false;
         unchanged
     }
 
@@ -1431,7 +1450,7 @@ impl MacMemoryBus {
                 .as_mut()
                 .expect("write probe checked above");
             journal.entry(word).or_insert(original);
-            if journal.len() > WRITE_PROBE_MAX_ENTRIES {
+            if !self.write_probe_uncapped && journal.len() > WRITE_PROBE_MAX_ENTRIES {
                 // Too much written for a wait cycle: void the probe now so
                 // the fast paths (and fastmem) come back for the work in
                 // progress.

--- a/src/memory/bus.rs
+++ b/src/memory/bus.rs
@@ -676,6 +676,11 @@ impl Hasher for AddressHasher {
 /// withdrawn), so comparing them at the end is harmless.
 type WriteProbeJournal = HashMap<u32, u32, BuildHasherDefault<AddressHasher>>;
 
+/// An armed write journal temporarily detached from the bus by
+/// [`MacMemoryBus::suspend_write_probe`]; hand it back with
+/// [`MacMemoryBus::resume_write_probe`].
+pub(crate) struct SuspendedWriteProbe(WriteProbeJournal);
+
 /// RAM storage - either a stable owned allocation or borrowed slice.
 enum RamStorage {
     Owned(Vec<u8>),
@@ -1343,6 +1348,19 @@ impl MacMemoryBus {
         self.park_write_probe_journal();
         self.write_probe_invalid = false;
         self.write_probe_overflowed = false;
+    }
+
+    /// Detach the armed journal so writes made meanwhile -- host-owned
+    /// drawing the guest never performed -- are neither recorded nor able
+    /// to overflow it. The bus's fast paths come back while it is detached;
+    /// `resume_write_probe` re-arms the very same journal. `None` when no
+    /// journal is armed.
+    pub(crate) fn suspend_write_probe(&mut self) -> Option<SuspendedWriteProbe> {
+        self.write_probe_original.take().map(SuspendedWriteProbe)
+    }
+
+    pub(crate) fn resume_write_probe(&mut self, suspended: SuspendedWriteProbe) {
+        self.write_probe_original = Some(suspended.0);
     }
 
     /// Report -- and clear -- whether the most recent probe's journal
@@ -2811,6 +2829,39 @@ mod tests {
         bus.begin_write_probe();
         bus.fill_bytes_strided(0x105, 16, 4, 0xEE);
         assert!(bus.finish_write_probe_unchanged(), "same bytes: unchanged");
+    }
+
+    #[test]
+    fn suspended_write_probe_ignores_writes_and_rearms_intact() {
+        // A host-sized burst (more units than WRITE_PROBE_MAX_ENTRIES)
+        // overflows an armed journal; made while the journal is suspended it
+        // is neither recorded nor able to overflow, and the re-armed journal
+        // still catches the next write.
+        let mut bus = MacMemoryBus::new(1024 * 1024);
+        let base = 0x0008_0000u32;
+        let burst = (WRITE_PROBE_MAX_ENTRIES as u32 + 64) * 4;
+
+        bus.begin_write_probe();
+        bus.fill_bytes(base, burst, 0xAA);
+        assert!(bus.take_write_probe_overflow());
+        bus.cancel_write_probe();
+        bus.fill_bytes(base, burst, 0x00);
+
+        bus.begin_write_probe();
+        let suspended = bus.suspend_write_probe().expect("journal armed");
+        assert!(bus.suspend_write_probe().is_none());
+        bus.fill_bytes(base, burst, 0xAA);
+        bus.resume_write_probe(suspended);
+        assert!(!bus.take_write_probe_overflow());
+        bus.write_byte(base + 8, 0x01);
+        assert!(!bus.finish_write_probe_unchanged());
+
+        bus.begin_write_probe();
+        let suspended = bus.suspend_write_probe().expect("journal armed");
+        bus.fill_bytes(base, burst, 0x55);
+        bus.resume_write_probe(suspended);
+        assert!(bus.finish_write_probe_unchanged());
+        assert!(bus.suspend_write_probe().is_none());
     }
 
     #[test]

--- a/src/menu_manager.rs
+++ b/src/menu_manager.rs
@@ -817,7 +817,7 @@ impl SharedNativeMenuSelection {
         self.0.borrow_mut().take()
     }
 
-    #[cfg(test)]
+    /// Current value without consuming it (idle-park host snapshot).
     pub(crate) fn snapshot(&self) -> Option<(i16, i16)> {
         *self.0.borrow()
     }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -935,6 +935,10 @@ static WS_CANCEL_TRAP: AtomicU64 = AtomicU64::new(0);
 static WS_PARKED: AtomicU64 = AtomicU64::new(0);
 static WS_PERIOD_STEPS: AtomicU64 = AtomicU64::new(0);
 static WS_PROBE_OVERFLOWS: AtomicU64 = AtomicU64::new(0);
+static WS_RESUMED: AtomicU64 = AtomicU64::new(0);
+static WS_RESUME_FAIL_MEM: AtomicU64 = AtomicU64::new(0);
+static WS_RESUME_FAIL_HOST: AtomicU64 = AtomicU64::new(0);
+static WS_RESUME_FAIL_OTHER: AtomicU64 = AtomicU64::new(0);
 static WS_CANCEL_TRAP_WORDS: std::sync::Mutex<Option<std::collections::BTreeMap<u16, u64>>> =
     std::sync::Mutex::new(None);
 
@@ -968,6 +972,13 @@ pub fn dump_wait_stats() {
         WS_FAIL_CPU.load(AtomicOrdering::Relaxed),
         WS_FAIL_MEM.load(AtomicOrdering::Relaxed),
         WS_CANCEL_TRAP.load(AtomicOrdering::Relaxed),
+    );
+    eprintln!(
+        "[WAIT-STATS] resumed={} resume_fail_mem={} resume_fail_host={} resume_fail_other={}",
+        WS_RESUMED.load(AtomicOrdering::Relaxed),
+        WS_RESUME_FAIL_MEM.load(AtomicOrdering::Relaxed),
+        WS_RESUME_FAIL_HOST.load(AtomicOrdering::Relaxed),
+        WS_RESUME_FAIL_OTHER.load(AtomicOrdering::Relaxed),
     );
     if let Ok(guard) = WS_CANCEL_TRAP_WORDS.lock() {
         if let Some(map) = guard.as_ref() {
@@ -1314,6 +1325,15 @@ struct IdleCycleHostSnapshot {
     mouse_button: bool,
     key_map: [u8; 16],
     caps_lock_physically_pressed: bool,
+    /// Host mirror of the guest window chain, read by the admitted Window
+    /// Manager queries. Every mutation of it is also written into the guest
+    /// chain (journaled), so this is belt-and-braces: a parked cycle must
+    /// not resume across a reordering the journal somehow missed.
+    window_list: Vec<u32>,
+    /// A native menu selection staged for MenuSelect. It is always paired
+    /// with a pending event the resume gate sees; recorded here so the
+    /// pairing is not the only thing standing between it and a proof.
+    pending_native_menu_selection: Option<(i16, i16)>,
 }
 
 impl IdleCycleHostSnapshot {
@@ -1323,6 +1343,8 @@ impl IdleCycleHostSnapshot {
             mouse_button: dispatcher.mouse_button,
             key_map: *dispatcher.key_map_bytes(),
             caps_lock_physically_pressed: dispatcher.caps_lock_physically_pressed,
+            window_list: dispatcher.window_list.clone(),
+            pending_native_menu_selection: dispatcher.pending_native_menu_selection.snapshot(),
         }
     }
 }
@@ -2601,7 +2623,7 @@ impl FixtureRunner {
     /// Call before reading raw pixels for screenshots.
     pub fn composite_frame(&mut self) {
         self.sync_ppc_deferred_host_state();
-        self.redraw_chrome();
+        self.redraw_chrome_outside_idle_journal();
     }
 
     fn redraw_chrome(&mut self) {
@@ -4156,12 +4178,30 @@ impl FixtureRunner {
         self.sync_ppc_sound_completions_from_dispatcher();
     }
 
+    /// Repaint the host-owned chrome (menu bar, window frames, cursor)
+    /// without it counting against an armed idle-proof journal. The runner
+    /// paints it every frame on the guest's behalf, so it is not a guest
+    /// memory effect, and at 8 bpp the menu bar alone is more journal words
+    /// than `WRITE_PROBE_MAX_ENTRIES`: recorded, it would overflow the
+    /// journal and void a parked cycle on every frame. Its pixels change
+    /// only when dispatcher state does, which happens through guest traps
+    /// (never admitted into a proof) or host input (gated by
+    /// `IdleCycleHostSnapshot` before a park resumes), so leaving them out
+    /// of the journal takes nothing away from the proof.
+    fn redraw_chrome_outside_idle_journal(&mut self) {
+        let suspended = self.bus.suspend_write_probe();
+        self.redraw_chrome();
+        if let Some(journal) = suspended {
+            self.bus.resume_write_probe(journal);
+        }
+    }
+
     fn finish_host_frame(&mut self, audio_samples: usize, sound_interrupt_dispatched: bool) {
         // Redraw menu bar and window chrome after each frame.
         // On a real Mac the Window Manager maintains these as
         // separate layers; here they are raw framebuffer pixels
         // that game drawing (explosions, etc.) can overwrite.
-        self.redraw_chrome();
+        self.redraw_chrome_outside_idle_journal();
         self.finish_audio_frame(audio_samples, sound_interrupt_dispatched);
     }
 
@@ -4517,6 +4557,16 @@ impl FixtureRunner {
             || !host_unchanged
             || !event_stream_empty
         {
+            if wait_stats_enabled() {
+                let counter = if !memory_unchanged {
+                    &WS_RESUME_FAIL_MEM
+                } else if !host_unchanged {
+                    &WS_RESUME_FAIL_HOST
+                } else {
+                    &WS_RESUME_FAIL_OTHER
+                };
+                counter.fetch_add(1, AtomicOrdering::Relaxed);
+            }
             self.cancel_idle_cycle_detector();
             return false;
         }
@@ -4527,6 +4577,9 @@ impl FixtureRunner {
         };
         match self.advance_until_tick(sleep.wake_tick, Some(cap)) {
             AdvanceResult::CapHit => {
+                if wait_stats_enabled() {
+                    WS_RESUMED.fetch_add(1, AtomicOrdering::Relaxed);
+                }
                 self.park_proven_idle_cycle(sleep.trap_pc, sleep.wake_tick);
                 true
             }
@@ -5161,7 +5214,7 @@ impl FixtureRunner {
             if finish_frame {
                 self.sync_ppc_deferred_host_state();
                 if self.halted_by_exit_to_shell() {
-                    self.redraw_chrome();
+                    self.redraw_chrome_outside_idle_journal();
                 } else {
                     self.finish_host_frame(audio_samples, false);
                 }
@@ -6298,7 +6351,7 @@ impl FixtureRunner {
         self.ppc_app = Some(ppc_app);
         if exited_via_ppc_exit_to_shell {
             if finish_frame {
-                self.redraw_chrome();
+                self.redraw_chrome_outside_idle_journal();
             }
         } else {
             self.queue_due_ppc_sound_completions();
@@ -21011,6 +21064,45 @@ mod tests {
         // observe; it must cancel.
         runner.note_idle_cycle_trap_result(0xA893);
         assert!(runner.idle_cycle_probe.is_none());
+    }
+
+    #[test]
+    fn chrome_repaint_stays_out_of_an_armed_idle_journal() {
+        // The runner repaints host-owned chrome every frame. Painted under an
+        // armed idle-proof journal it would be recorded against the proof
+        // (and at 8 bpp overflow it -- see
+        // memory::bus::tests::suspended_write_probe_ignores_writes_and_rearms_intact);
+        // the runner's wrapper must leave the journal armed and untouched.
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        let screen_base = 0x0040_0000u32;
+        runner.dispatcher.screen_mode = (screen_base, 1024, 1024, 768, 8);
+        runner.bus.write_long(0x0824, screen_base);
+        runner.bus.write_word(0x0BAA, 20);
+
+        runner.bus.begin_write_probe();
+        runner.redraw_chrome_outside_idle_journal();
+        assert!(!runner.bus.take_write_probe_overflow());
+        assert!(
+            runner.bus.suspend_write_probe().is_some(),
+            "the journal must still be armed after the repaint"
+        );
+        runner.bus.cancel_write_probe();
+
+        runner.bus.begin_write_probe();
+        runner.redraw_chrome_outside_idle_journal();
+        assert!(runner.bus.finish_write_probe_unchanged());
+    }
+
+    #[test]
+    fn host_snapshot_tracks_window_list_and_pending_native_menu_selection() {
+        let mut runner = FixtureRunner::new(1024 * 1024, FixtureRunnerConfig::default());
+        let before = IdleCycleHostSnapshot::capture(&runner.dispatcher);
+        runner.dispatcher.window_list.push(0x0012_3456);
+        assert_ne!(before, IdleCycleHostSnapshot::capture(&runner.dispatcher));
+        runner.dispatcher.window_list.pop();
+        assert_eq!(before, IdleCycleHostSnapshot::capture(&runner.dispatcher));
+        runner.dispatcher.pending_native_menu_selection = Some((3, 1));
+        assert_ne!(before, IdleCycleHostSnapshot::capture(&runner.dispatcher));
     }
 
     #[test]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -4222,16 +4222,6 @@ impl FixtureRunner {
         self.sync_ppc_sound_completions_from_dispatcher();
     }
 
-    /// Repaint the host-owned chrome (menu bar, window frames, cursor)
-    /// without it counting against an armed idle-proof journal. The runner
-    /// paints it every frame on the guest's behalf, so it is not a guest
-    /// memory effect, and at 8 bpp the menu bar alone is more journal words
-    /// than `WRITE_PROBE_MAX_ENTRIES`: recorded, it would overflow the
-    /// journal and void a parked cycle on every frame. Its pixels change
-    /// only when dispatcher state does, which happens through guest traps
-    /// (never admitted into a proof) or host input (gated by
-    /// `IdleCycleHostSnapshot` before a park resumes), so leaving them out
-    /// of the journal takes nothing away from the proof.
     /// Repaint host chrome without recording it against an armed
     /// idle-proof journal (the per-frame repaint would overflow the
     /// journal's guest-wait-cycle entry cap at 8 bpp and void every proof).

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1074,13 +1074,45 @@ fn canonical_trap_number(opcode: u16) -> (bool, u16) {
     (is_tool, trap_num)
 }
 
-/// Traps an exact idle-cycle proof may observe without cancelling: every
-/// consequence lands in CPU registers or guest RAM, so the exact-state
-/// journal sees any real change. Event polls only qualify when they
-/// returned a null event; SystemTask only without periodic host work --
-/// callers pass those runtime facts in. ONE definition, consulted from
-/// both the inline pre-dispatch check and the post-dispatch quiescence
-/// classification (they were once two hand-synced copies and drifted).
+/// Traps an exact idle-cycle proof may observe without cancelling.
+///
+/// The prover parks a wait loop behind two independent gates, and a trap
+/// is admitted here only if it cannot beat either:
+///
+/// 1. **The proof.** Two arrivals at the same trap site in the same tick
+///    must show an identical `CpuArchitecturalSnapshot` *and* a write
+///    journal in which every guest-RAM byte written during the cycle
+///    still holds its original value (`try_exact_idle_cycle_fastfwd`).
+/// 2. **The park.** A proven cycle is reused only while guest memory, the
+///    CPU snapshot, `IdleCycleHostSnapshot` (mouse, keys, caps lock, the
+///    window list, any staged native menu selection) and the guest tick
+///    are all unchanged and the Event Manager has nothing to deliver
+///    (`try_resume_proven_idle_cycle`). A park is at most one tick.
+///
+/// A trap is *journal-complete* -- admissible -- when every input it acts
+/// on is CPU state, guest RAM or the current tick, and every consequence
+/// of calling it is either nothing at all or a write through the bus into
+/// guest RAM, so that any real difference between two iterations shows
+/// up in one of the two comparisons above. Concretely, before admitting a
+/// trap check all of:
+///
+/// - it reads no host state outside `IdleCycleHostSnapshot` -- or, if it
+///   reads a host mirror (the window list, a staged menu selection), every
+///   mutation of that mirror is also written into journaled guest RAM or
+///   posts an event the park gate sees;
+/// - on any path that writes guest RAM it writes *before* it touches
+///   host-cached state the journal cannot see (TEIdle's caret stamps
+///   precede its draw; MoveTo, which only mirrors pnLoc into dispatcher
+///   state, is the counter-example and stays out);
+/// - its only other effects are diagnostics (trace `eprintln!`s).
+///
+/// Event polls only qualify when they returned a null event; SystemTask
+/// only without periodic host work -- callers pass those runtime facts
+/// in. ONE definition, consulted from both the inline pre-dispatch check
+/// and the post-dispatch quiescence classification (they were once two
+/// hand-synced copies and drifted). The membership test
+/// `journal_complete_traps_do_not_cancel_an_idle_probe` covers both the
+/// plain and the auto-pop encodings.
 fn idle_cycle_trap_is_journal_complete(
     opcode: u16,
     null_event: bool,
@@ -1088,8 +1120,20 @@ fn idle_cycle_trap_is_journal_complete(
 ) -> bool {
     match canonical_trap_number(opcode) {
         (true, 0x0170) | (true, 0x0171) => null_event,
-        // GlobalToLocal: pure register/memory transform.
-        (true, 0x0071) => true,
+        // Pure transforms of a Point on the stack (quickdraw.rs).
+        (true, 0x0070) | (true, 0x0071) => true, // LocalToGlobal, GlobalToLocal
+        // TEIdle (dialog.rs `textedit_idle`) reads the TERec and the tick and
+        // either returns having written nothing, or stamps caretState and
+        // caretTime into guest RAM *before* it paints -- that ordering is
+        // what lets the journal fail a proof a due blink lands in.
+        (true, 0x01DA) => true, // TEIdle
+        // Window Manager queries (window.rs) whose results reach the guest
+        // through RAM and the stack. The host window list they read is
+        // rewritten into the guest chain (journaled) by every mutation
+        // (`sync_window_list_links`), a staged native menu selection is
+        // always paired with a pending event the parked resume sees, and
+        // `IdleCycleHostSnapshot` carries both besides.
+        (true, 0x0117) | (true, 0x0124) | (true, 0x012C) => true, // GetWRefCon, FrontWindow, FindWindow
         // Input-poll family: GetMouse/StillDown/Button/TickCount/GetKeys.
         (true, 0x0172..=0x0176) => true,
         // SANE Pack4/Pack5: pure transforms of stack operands.
@@ -21041,10 +21085,12 @@ mod tests {
     }
 
     #[test]
-    fn poll_traps_and_sane_do_not_cancel_an_idle_probe() {
+    fn journal_complete_traps_do_not_cancel_an_idle_probe() {
         // EV Override's crawl idles in a GetKeys/Button cycle interleaved
-        // with SANE math; the proof must survive every one of those traps
-        // and still cancel on anything with unjournaled consequences.
+        // with SANE math; SimCity 2000's dialog loops poll LocalToGlobal,
+        // the Window Manager queries and TEIdle. The proof must survive every
+        // one of those traps, in the plain and the auto-pop encodings, and
+        // still cancel on anything with unjournaled consequences.
         let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
         let trap_pc = 0x0002_0000u32;
         runner.cpu.write_reg(Register::A7, 0x0010_0000);
@@ -21053,15 +21099,18 @@ mod tests {
         assert!(!runner.try_exact_idle_cycle_fastfwd(trap_pc, 200, Some(105)));
         assert!(runner.idle_cycle_probe.is_some());
 
-        for opcode in [0xA972u16, 0xA973, 0xA974, 0xA975, 0xA976, 0xA9EB, 0xA9EC] {
+        for opcode in [
+            0xA972u16, 0xA973, 0xA974, 0xA975, 0xA976, 0xA9EB, 0xA9EC, 0xA870, 0xA871, 0xA917,
+            0xA924, 0xA92C, 0xA9DA, 0xAC70, 0xAC71, 0xAD17, 0xAD24, 0xAD2C, 0xADDA,
+        ] {
             runner.note_idle_cycle_trap_result(opcode);
             assert!(
                 runner.idle_cycle_probe.is_some(),
-                "poll/SANE trap {opcode:04X} must not cancel the probe"
+                "journal-complete trap {opcode:04X} must not cancel the probe"
             );
         }
-        // A drawing trap has host-visible consequences the journal cannot
-        // observe; it must cancel.
+        // MoveTo mirrors pnLoc into dispatcher state the journal cannot
+        // see; anything with host-cached consequences must cancel.
         runner.note_idle_cycle_trap_result(0xA893);
         assert!(runner.idle_cycle_probe.is_none());
     }
@@ -21103,6 +21152,84 @@ mod tests {
         assert_eq!(before, IdleCycleHostSnapshot::capture(&runner.dispatcher));
         runner.dispatcher.pending_native_menu_selection = Some((3, 1));
         assert_ne!(before, IdleCycleHostSnapshot::capture(&runner.dispatcher));
+    }
+
+    #[test]
+    fn window_and_textedit_mutators_still_cancel_an_idle_probe() {
+        // The admission is a list of specific traps, not a range: the
+        // neighbours that mutate host-mirrored window or TextEdit state
+        // must go on cancelling.
+        for opcode in [0xA918u16, 0xA91F, 0xA928, 0xA929, 0xA9D8, 0xA9D9, 0xA9DC] {
+            let mut runner = FixtureRunner::new(1024 * 1024, FixtureRunnerConfig::default());
+            let trap_pc = 0x0002_0000u32;
+            runner.cpu.write_reg(Register::A7, 0x0008_0000);
+            runner.dispatcher.tick_count = 100;
+            assert!(!runner.try_exact_idle_cycle_fastfwd(trap_pc, 200, Some(105)));
+            assert!(!runner.try_exact_idle_cycle_fastfwd(trap_pc, 200, Some(105)));
+            assert!(runner.idle_cycle_probe.is_some());
+            runner.note_idle_cycle_trap_result(opcode);
+            assert!(
+                runner.idle_cycle_probe.is_none(),
+                "{opcode:04X} must cancel the probe"
+            );
+        }
+    }
+
+    #[test]
+    fn teidle_inside_a_proof_parks_when_idle_and_fails_on_memory_when_it_blinks() {
+        // TEIdle is admitted because it either writes nothing or stamps
+        // caretState/caretTime into guest RAM before it paints. Both halves
+        // of that claim, through the real handler under a real probe.
+        for (blink_due, expect_park) in [(false, true), (true, false)] {
+            let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+            let trap_pc = 0x0002_0000u32;
+            let sp = 0x0010_0000u32;
+            let te_handle = 0x0020_0000u32;
+            let te_rec = 0x0020_0100u32;
+            runner.cpu.write_reg(Register::PC, trap_pc + 2);
+            runner.cpu.core.ppc = trap_pc;
+            runner.cpu.core.ir = 0xA975; // the loop's TickCount anchor
+            runner.bus.write_long(0x016A, 100);
+            runner.dispatcher.tick_count = 100;
+            runner.bus.write_long(te_handle, te_rec);
+            runner.bus.write_word(te_rec + 0x20, 5); // selStart
+            runner.bus.write_word(te_rec + 0x22, 5); // selEnd: an insertion point
+            runner.bus.write_word(te_rec + 0x24, 1); // active
+            runner
+                .bus
+                .write_long(te_rec + 0x34, if blink_due { 60 } else { 100 }); // caretTime
+            runner.bus.write_word(te_rec + 0x38, 0); // caretState
+                                                     // The argument slot holds hTE before the journal opens, so the
+                                                     // loop's push below rewrites the same bytes.
+            runner.bus.write_long(sp - 4, te_handle);
+            runner.cpu.write_reg(Register::A7, sp);
+            assert!(!runner.try_exact_idle_cycle_fastfwd(trap_pc, 200, Some(105)));
+            assert!(!runner.try_exact_idle_cycle_fastfwd(trap_pc, 200, Some(105)));
+            assert!(runner.idle_cycle_probe.is_some());
+
+            let before = CpuArchitecturalSnapshot::capture(&runner.cpu.core);
+            // One loop iteration: push hTE, call TEIdle (which pops it).
+            runner.cpu.write_reg(Register::A7, sp - 4);
+            runner.bus.write_long(sp - 4, te_handle);
+            let result =
+                runner
+                    .dispatcher
+                    .dispatch_dialog(true, 0x1DA, &mut runner.cpu, &mut runner.bus);
+            assert!(result.unwrap().is_ok());
+            assert_eq!(runner.cpu.read_reg(Register::A7), sp);
+            runner.note_idle_cycle_trap_result(0xA9DA);
+            assert!(runner.idle_cycle_probe.is_some(), "TEIdle is admitted");
+            assert_eq!(
+                before,
+                CpuArchitecturalSnapshot::capture(&runner.cpu.core),
+                "TEIdle must leave the architectural state as it found it"
+            );
+            assert_eq!(runner.bus.read_word(te_rec + 0x38), u16::from(blink_due));
+
+            let parked = runner.try_exact_idle_cycle_fastfwd(trap_pc, 200, Some(105));
+            assert_eq!(parked, expect_park, "blink_due={blink_due}");
+            assert_eq!(runner.idle_cycle_sleep.is_some(), expect_park);
+        }
     }
 
     #[test]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -4232,11 +4232,35 @@ impl FixtureRunner {
     /// (never admitted into a proof) or host input (gated by
     /// `IdleCycleHostSnapshot` before a park resumes), so leaving them out
     /// of the journal takes nothing away from the proof.
+    /// Repaint host chrome without recording it against an armed
+    /// idle-proof journal (the per-frame repaint would overflow the
+    /// journal's guest-wait-cycle entry cap at 8 bpp and void every proof).
+    ///
+    /// Correctness boundary (issue #1052): suspending the journal is safe
+    /// only while the repaint cannot change guest RAM relative to a proven
+    /// state. During the probing phase that holds trivially -- proofs
+    /// re-execute the whole cycle, so a changed repaint just fails to
+    /// prove. While PARKED the proof is reused without re-execution, so
+    /// the first repaint after a park (guest code may have overwritten a
+    /// chrome pixel before entering its idle loop) is checked for
+    /// byte-identity with an uncapped journal; a repaint that changed
+    /// anything revokes the park and the site re-proves from scratch.
     fn redraw_chrome_outside_idle_journal(&mut self) {
         let suspended = self.bus.suspend_write_probe();
+        let check_parked_repaint = self.idle_cycle_sleep.is_some() && suspended.is_some();
+        if check_parked_repaint {
+            self.bus.begin_uncapped_write_probe();
+        }
         self.redraw_chrome();
+        let revoke = check_parked_repaint && !self.bus.finish_write_probe_unchanged();
         if let Some(journal) = suspended {
             self.bus.resume_write_probe(journal);
+        }
+        if revoke {
+            if wait_stats_enabled() {
+                WS_RESUME_FAIL_MEM.fetch_add(1, AtomicOrdering::Relaxed);
+            }
+            self.cancel_idle_cycle_detector();
         }
     }
 
@@ -21143,6 +21167,105 @@ mod tests {
     }
 
     #[test]
+    fn first_parked_repaint_revokes_the_park_when_guest_overwrote_a_chrome_pixel() {
+        // Issue #1052: the park reuses its proof without re-execution, so a
+        // suspended repaint that is not byte-identical (guest code scribbled
+        // over chrome before entering the idle loop) would silently change
+        // guest RAM relative to the proven state. It must revoke the park.
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        let screen_base = 0x0040_0000u32;
+        runner.dispatcher.screen_mode = (screen_base, 1024, 1024, 768, 8);
+        runner.bus.write_long(0x0824, screen_base);
+        runner.bus.write_word(0x0BAA, 20);
+
+        runner.dispatcher.menus.push(crate::trap::menu::Menu {
+            id: 1,
+            title: String::from("Apple"),
+            items: Vec::new(),
+            enabled: true,
+            handle: 0,
+            in_menu_bar: true,
+            hierarchical: false,
+            visible_in_menu_bar: true,
+        });
+        runner.dispatcher.front_window = 0;
+        runner.dispatcher.fullscreen_locked = false;
+        runner.dispatcher.menu_bar_hidden = false;
+
+        // Establish the current chrome pixels, then scribble one menu-bar
+        // pixel the way pre-idle guest drawing would.
+        runner.redraw_chrome_outside_idle_journal();
+        let pixel = screen_base + 5 * 1024 + 100;
+        assert_ne!(
+            runner.bus.read_byte(pixel),
+            0xAA,
+            "fixture: a painted menu-bar pixel must differ from the sentinel"
+        );
+        runner.bus.write_byte(pixel, 0xAA);
+
+        runner.park_proven_idle_cycle(0x0002_0000, 205);
+        assert!(runner.idle_cycle_sleep.is_some());
+
+        runner.redraw_chrome_outside_idle_journal();
+        assert_ne!(
+            runner.bus.read_byte(pixel),
+            0xAA,
+            "the repaint repainted the scribbled chrome pixel"
+        );
+        assert!(
+            runner.idle_cycle_sleep.is_none(),
+            "a repaint that changed guest RAM must revoke the park"
+        );
+        assert!(
+            runner.bus.suspend_write_probe().is_none(),
+            "the revoked park's journal must be closed"
+        );
+    }
+
+    #[test]
+    fn byte_identical_parked_repaints_keep_the_park() {
+        // The control for the revocation gate: chrome that is already
+        // current repaints byte-identically, the park survives, and its
+        // journal stays armed and unchanged.
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        let screen_base = 0x0040_0000u32;
+        runner.dispatcher.screen_mode = (screen_base, 1024, 1024, 768, 8);
+        runner.bus.write_long(0x0824, screen_base);
+        runner.bus.write_word(0x0BAA, 20);
+
+        runner.dispatcher.menus.push(crate::trap::menu::Menu {
+            id: 1,
+            title: String::from("Apple"),
+            items: Vec::new(),
+            enabled: true,
+            handle: 0,
+            in_menu_bar: true,
+            hierarchical: false,
+            visible_in_menu_bar: true,
+        });
+        runner.dispatcher.front_window = 0;
+        runner.dispatcher.fullscreen_locked = false;
+        runner.dispatcher.menu_bar_hidden = false;
+
+        runner.redraw_chrome_outside_idle_journal();
+        runner.park_proven_idle_cycle(0x0002_0000, 205);
+        assert!(runner.idle_cycle_sleep.is_some());
+
+        runner.redraw_chrome_outside_idle_journal();
+        runner.redraw_chrome_outside_idle_journal();
+        assert!(
+            runner.idle_cycle_sleep.is_some(),
+            "byte-identical repaints must keep the park"
+        );
+        let journal = runner
+            .bus
+            .suspend_write_probe()
+            .expect("the park's journal must still be armed");
+        runner.bus.resume_write_probe(journal);
+        assert!(runner.bus.finish_write_probe_unchanged());
+    }
+
+    #[test]
     fn host_snapshot_tracks_window_list_and_pending_native_menu_selection() {
         let mut runner = FixtureRunner::new(1024 * 1024, FixtureRunnerConfig::default());
         let before = IdleCycleHostSnapshot::capture(&runner.dispatcher);
@@ -21150,7 +21273,7 @@ mod tests {
         assert_ne!(before, IdleCycleHostSnapshot::capture(&runner.dispatcher));
         runner.dispatcher.window_list.pop();
         assert_eq!(before, IdleCycleHostSnapshot::capture(&runner.dispatcher));
-        runner.dispatcher.pending_native_menu_selection = Some((3, 1));
+        runner.dispatcher.pending_native_menu_selection.stage((3, 1));
         assert_ne!(before, IdleCycleHostSnapshot::capture(&runner.dispatcher));
     }
 

--- a/src/trap/dialog.rs
+++ b/src/trap/dialog.rs
@@ -2709,6 +2709,11 @@ impl super::TrapDispatcher {
             return;
         }
 
+        // Stamp before painting. Idle-cycle proofs admit TEIdle on the
+        // strength of these two guest-RAM writes preceding any draw: the
+        // draw path below mutates host-cached port state the write journal
+        // cannot see, and it is these stamps that make a proof containing a
+        // blink fail on memory (runner.rs, idle_cycle_trap_is_journal_complete).
         let caret_state = bus.read_word(te_ptr + Self::TE_CARET_STATE_OFFSET);
         bus.write_word(
             te_ptr + Self::TE_CARET_STATE_OFFSET,

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -2269,6 +2269,13 @@ pub struct TrapDispatcher {
     pub(crate) go_away_flag: bool,
     /// Window list in front-to-back order.
     /// Macintosh Toolbox Essentials 1992, p. 4-65
+    ///
+    /// Invariant the idle-cycle prover relies on: every mutation of this
+    /// host mirror is also written into the guest window chain
+    /// (`sync_window_list_links`), so a proof's write journal sees it;
+    /// the parked-cycle host snapshot carries a copy besides. FrontWindow
+    /// and FindWindow are admitted to proofs on that basis
+    /// (`runner::idle_cycle_trap_is_journal_complete`).
     pub(crate) window_list: Vec<u32>,
     /// Set once the game has entered fullscreen (window covers entire screen
     /// and MBarHeight was 0). While set, the menu bar is suppressed even if
@@ -2306,6 +2313,12 @@ pub struct TrapDispatcher {
     /// A host-native menu selection waiting for the guest's normal
     /// FindWindow -> MenuSelect event path.  It is consumed only by
     /// MenuSelect and revalidated against the live menu list there.
+    ///
+    /// Invariant the idle-cycle prover relies on: this is only ever staged
+    /// together with `pending_native_menu_event`, so a parked cycle sees a
+    /// deliverable event and resumes instead of reusing a FindWindow
+    /// answer that would now say `inMenuBar`; the parked-cycle host
+    /// snapshot carries a copy besides.
     pub(crate) pending_native_menu_selection: SharedNativeMenuSelection,
     /// Latched menu-bar mouseDown corresponding to
     /// `pending_native_menu_selection`. Unlike an ordinary queued event, this

--- a/src/trap/mod.rs
+++ b/src/trap/mod.rs
@@ -21,7 +21,7 @@ mod event;
 pub(crate) mod extended80;
 mod framebuffer;
 mod memory;
-mod menu;
+pub(crate) mod menu;
 mod movie_media;
 pub(crate) mod pict;
 mod qtrle;


### PR DESCRIPTION
## Summary

SimCity 2000's wait loops call `LocalToGlobal`, `FrontWindow`, `FindWindow`, `GetWRefCon` and `TEIdle` on every iteration. None of them was admitted to the exact idle-cycle prover, so a loop that had nothing to do still executed a full tick's instruction budget to earn each tick. This PR admits those five traps, with the argument for each written out below, and fixes a frame-boundary problem the admissions expose in the GUI. Two commits:

1. `fix(runner): keep host chrome repaints out of an armed idle-proof journal`
2. `perf(runner): admit journal-complete Window Manager queries and TEIdle to idle-cycle proofs`

Headless SimCity 2000 on master 0.23.8 (m68k 0.11.6), 2 billion instructions, three runs per arm:

| | master 298bf2e | + Window Manager queries | + TEIdle (this PR) |
|---|---|---|---|
| host instructions retired | 394.76 G | 358.62 G | 356.82 G |
| guest ticks reached | 283,023 | 304,960 | **355,838 (+25.7 %)** |
| **host instructions per guest tick** | 1,394.8 k | 1,176.0 k (−15.7 %) | **1,002.7 k (−28.1 %)** |

GUI results are in the *Evidence* section.

### How the prover decides a loop is idle

Two independent gates; a bad admission would have to beat both.

**Gate 1 — the proof** (`try_exact_idle_cycle_fastfwd`). Two arrivals at the same trap site in the same guest tick must show an identical `CpuArchitecturalSnapshot` *and* a write journal in which every guest-RAM byte written during the cycle still holds its original value. A trap is *journal-complete* if every consequence of calling it lands in CPU registers or guest RAM, because then any real difference between the two iterations shows up in one of those two comparisons.

**Gate 2 — the park** (`try_resume_proven_idle_cycle`). A proven cycle is not replayed blindly. `park_proven_idle_cycle` arms a second write journal while parked, and the cycle may be reused only while guest memory, the CPU snapshot, the guest tick and `IdleCycleHostSnapshot` are unchanged and the Event Manager has nothing to deliver. A park advances only to the next guest tick, the GUI wall-clock cap, or an interrupt — never further — so every tick still runs the two real iterations a proof needs.

The dangerous shape is therefore narrow: **a trap that reads host-side state which can change while the guest is stopped, is not covered by the host snapshot or the event stream, and whose changed answer the guest would have acted on.** The rustdoc on `idle_cycle_trap_is_journal_complete` now states this as the admission checklist.

### The five traps and where their inputs and outputs live

| trap | reads | writes | why it is journal-complete |
|---|---|---|---|
| `LocalToGlobal` $A870 | A7, the `Point` (RAM), A5 → QuickDraw globals → `thePort` → port bounds (RAM) | the `Point` in place, A7 | Guest RAM and registers only; the mirror image of the already-admitted `GlobalToLocal`. |
| `GetWRefCon` $A917 | A7, `window+152` (RAM) | the result long on the stack, A7 | Guest RAM only. Any writer of `refCon`, guest or HLE, writes through the bus, so the journal sees it. |
| `FrontWindow` $A924 | `dispatcher.window_list` (host mirror), `GhostWindow`, per-window visibility bytes (RAM) | the result on the stack, A7 | The mirror is rewritten into the guest window chain (journaled) by every mutation; see below. |
| `FindWindow` $A92C | A7, the `Point` and VAR pointer (RAM), `MBarHeight` (RAM), `dispatcher.pending_native_menu_selection` (host), `window_list` (host), window records (RAM) | the window through the VAR parameter, the part code as the result, A7 | Both host inputs are covered: see below. |
| `TEIdle` $A9DA | A7, the TERec (RAM), the current tick | either nothing, or `caretState`/`caretTime` (RAM) and then the caret/text pixels (RAM) | Writes nothing, or stamps guest RAM *before* any draw; see below. |

### Why each admission is sound

**LocalToGlobal / GetWRefCon.** Pure functions of guest RAM and registers. Nothing to argue beyond the table.

**FrontWindow / FindWindow.** These read a host-side mirror of the guest window chain, so the honest statement is that their soundness is *transitive*: every mutation of `window_list` in the tree is under `src/trap/` (reachable only from guest trap dispatch — no runner or frontend path touches it), no guest code runs while parked, and every such mutation ends in `sync_window_list_links`, which rewrites the guest chain through the bus, so a proof's journal sees it. `FindWindow` additionally answers `inMenuBar` while a native menu selection is staged; that staging always sets `pending_native_menu_event` in the same branch, which `peek_toolbox_event` merges into the stream, so the park gate revokes the park. Because both of these are invariants rather than local facts, this PR (a) states them at the two field declarations in `dispatch.rs`, and (b) adds `window_list` and `pending_native_menu_selection` to `IdleCycleHostSnapshot`, so a parked cycle cannot resume across a change to either even if a future mutator forgets the chain rewrite or the paired event.

**TEIdle.** `textedit_idle` reads the TERec and the dispatcher tick, and does one of two things: returns having written nothing (record inactive, selection not an insertion point, or the 32-tick blink interval not yet elapsed), or toggles `caretState`, stamps `caretTime` with the current tick, and *then* calls `draw_te_contents`. The draw path mutates host-cached QuickDraw state the journal cannot see (`set_current_port_state`, `last_screen_frame_rect`), so the admission rests on the ordering: the two guest-RAM stamps precede any draw, and a blink that lands inside a proof therefore fails the proof on memory rather than escaping it. That ordering is now called out at the stamp site in `dialog.rs`, and `teidle_inside_a_proof_parks_when_idle_and_fails_on_memory_when_it_blinks` exercises both halves through the real handler under a real probe.

*Blink fidelity.* A park is at most one tick and every tick runs the two real iterations a proof needs, with the real tick count. While the interval has not elapsed TEIdle returns having written nothing — a genuine wait, parked exactly as the unparked loop would have spun; when it has, the stamps fail the proof and the guest runs that iteration for real. A due blink therefore fires in the same tick it fires on the real machine, and no tick is ever skipped, so caret parity is preserved. Two toggles inside one probe window — the only way to leave the final bytes equal after a blink — would need 64 ticks inside a single tick.

### Attacks considered, and what defeats them

1. *The window list changes while a loop is parked, so FrontWindow should have returned a different pointer.* No guest code runs while parked, only trap dispatch mutates the list, and the answer is never cached across a park: on resume the loop runs again and calls the trap afresh.
2. *The user picks something from the native menu bar while parked.* The strongest attack, since `FindWindow` would answer `inMenuBar`. Defeated by the paired `pending_native_menu_event` (the park gate sees a deliverable event) and now also by the host snapshot.
3. *The guest polls for a brief mouse-down inside a parked tick and misses it.* Pre-existing machinery: `mouse_button` and `mouse_pos` are in the host snapshot, so any click or movement revokes the park.
4. *A trap's answer changes but the guest discards it, so state repeats and a loop "making progress" is parked.* Not a soundness problem: if the guest discarded the value no guest-visible state depends on it, and the park ends at the next tick, so the loop is re-run with fresh answers; nothing is skipped, only re-derived.
5. *`refCon` is written between iterations.* Every writer goes through the bus; the journal sees it.
6. *TEIdle skips or desynchronises blinks.* See *Blink fidelity* above — a park never spans more than one tick.
7. *TEIdle's host-side draw effects escape the journal.* They can only occur after the two stamps, which fail the proof; the comment at `textedit_idle` marks that ordering as load-bearing.
8. *`tick_count` (dispatcher) and `Ticks` (guest RAM) diverge across a proof.* The resume gate checks both agree before extending a park, and TEIdle only ever runs in unparked execution.
9. *Diagnostics.* `FindWindow` and `TEIdle` print under trace env vars; parked ticks emit none, as for every admitted trap. Not a correctness matter, but worth knowing before diffing two trace logs.

### The fix this exposes (commit 1)

The runner repaints the host-owned chrome (menu bar, window frames, cursor) every frame after the guest slice returns. When a proven cycle is parked, its journal stays armed across that repaint, so the chrome's writes were recorded against the proof — and at 8 bpp the menu bar alone is about 4,000 journal words against `WRITE_PROBE_MAX_ENTRIES = 4096`. On any 8-bit screen the journal overflowed, the park was cancelled and the cycle re-proved from scratch on every frame. Nothing parked at 8 bpp before these admissions, which is how it went unnoticed; the headless harness never parks at all (it fast-forwards within a slice), so no headless number could have shown it.

The bus can now detach an armed journal (`suspend_write_probe`) and re-arm the same one (`resume_write_probe`), and the runner paints the chrome between the two at all four call sites. This takes nothing from the proof: the chrome's pixels change only when dispatcher state does, which happens through guest traps (never admitted into a proof) or host input (gated before a park resumes). `SYSTEMLESS_WAIT_STATS=1` now also reports `resumed` and `resume_fail_{mem,host,other}`, so park survival is observable in the GUI.

### Residual points, and what is deliberately not admitted

- The transitive invariants behind FrontWindow/FindWindow are now written down where they are enforced and mirrored in the host snapshot; a future mutator that breaks either still cannot make a park resume, only cost a re-proof.
- `find_window_at_point` reads window-record fields and `MBarHeight` — all bus reads, so covered.
- Under-inclusion, not risk: other pure window queries (`GetWTitle`, `GetWVariant`, …) are equally journal-complete by this argument and are *not* admitted; this change is measured on one workload and stops at what that workload needs.
- The neighbours that mutate host-mirrored state — `SetWRefCon`, `SelectWindow`, `ShowWindow`, `HideWindow`, `TEActivate`, `TEDeactivate`, `TEKey` — still cancel, and a test pins that, because the admission is a list of specific traps, not a range.

### Evidence

**Instrument (headless).** `--headless --max-instructions 2000000000 --input-script`, the #824 replay into a running city; host instructions retired from `/usr/bin/time -l`, guest ticks from the run log; three runs per arm, interleaved. Because the change alters how much guest time an instruction budget buys, host instructions *per guest tick* is the figure that matters. Tick counts repeat bit-for-bit across runs on every arm (spreads ≤ 0.16 % on instructions).

**Correctness (headless).** Over the full replay the arms' window/dialog/menu/resource milestone sequences are prefix-identical to master's and only *append* three lines — the window the parking arms get far enough to open. Comparing screenshots at equal guest ticks is *not* a valid check for an arm that changes instructions-per-tick, because `--input-script` schedules events by instruction count, so the arms have seen different input at the matched tick; the milestone-sequence diff over the complete replay is the sound check. `SYSTEMLESS_WAIT_STATS=1` on the arm shows the byte-exact journal still rejecting proofs (`fail_mem` > 0), i.e. gate 1 doing work rather than rubber-stamping. An admit-every-trap probe puts the ceiling near −35 % per tick; it is not what this admits.

**GUI** (hand-driven sessions: boot → new city → map, then idle; `SYSTEMLESS_WAIT_STATS=1`): on master a 232 s session used 106.6 s of CPU with `cancel_trap = 5.56 M` — 2.79 M FrontWindow and 2.78 M LocalToGlobal cancels, i.e. the dialog and menu phases spin. On this branch a **937 s** session used **88.1 s** of CPU with `cancel_trap = 221` and **51,627 parks** (master: 7,157). `probe_overflows = 0` confirms commit 1: the chrome repaint no longer overflows a parked journal. `resumed = 0 / resume_fail_mem = 49,693` over ~56 k frames means parks are re-proved about once per frame, and this is correct behaviour, not overhead to remove: `finish_audio_frame` schedules the guest’s SndDoubleBackProc callbacks (SimCity 2000 streams double-buffered sound), that guest code writes guest RAM, and the journal is right to fail the resume. The re-proof after each callback is bounded (one loop iteration plus two snapshots) and the new counters make it observable. An Instruments Time Profiler capture of a 75.7 s boot-to-map session on this branch plus the CopyBits change shows the main thread using 17.9 s (~24 %), with ~58 % of that in the m68k core and no anomaly attributable to this PR.

## Validation

- New tests: a suspended journal ignores a host-sized burst and re-arms intact (`memory::bus`); the runner's chrome repaint leaves an armed journal armed and unchanged; the host snapshot tracks both new fields; a due `TEIdle` blink inside a proof fails it on memory while an idle `TEIdle` lets the cycle park, through the real handler under a real probe; the window and TextEdit mutators next to the admitted traps still cancel; the journal-complete list is exercised in both the plain and auto-pop encodings. The existing membership test is renamed to say what it checks and its negative case now names the real disqualifier (MoveTo mirrors `pnLoc` into dispatcher state).
- `cargo test --lib` (4,262 passed, 0 failed), `cargo build --release`, `cargo check --no-default-features`, `cargo package`.
- `cargo fmt --check` clean on the touched files; `cargo clippy --all-targets --all-features` adds no diagnostic relative to master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NoS2nQc8CBYWtb9LZgdGVh



Closes #1052

