### PR TITLE
fix: preserve classic HFS media metadata

### DIFF
--- a/src/disk_image.rs
+++ b/src/disk_image.rs
@@ -119,8 +119,7 @@ pub fn extract_dc42_or_hfs(bytes: &[u8]) -> Result<Option<DiskImageContents>, St
             rsrc,
             file_type: file.file_type,
             creator: file.creator,
-            // The classic-HFS path does not currently expose fdFlags.
-            finder_flags: 0,
+            finder_flags: file.finder_flags,
         });
     }
 

--- a/src/disk_image/hfs.rs
+++ b/src/disk_image/hfs.rs
@@ -42,6 +42,7 @@ pub(crate) struct HfsFileEntry {
     pub(crate) rel_path: PathBuf,
     pub(crate) file_type: [u8; 4],
     pub(crate) creator: [u8; 4],
+    pub(crate) finder_flags: u16,
     cnid: u32,
     data_fork: Fork,
     resource_fork: Fork,
@@ -84,6 +85,7 @@ struct RawFile {
     cnid: u32,
     file_type: [u8; 4],
     creator: [u8; 4],
+    finder_flags: u16,
     data_fork: Fork,
     resource_fork: Fork,
 }
@@ -181,6 +183,7 @@ impl<'a> HfsVolume<'a> {
                     rel_path,
                     file_type: file.file_type,
                     creator: file.creator,
+                    finder_flags: file.finder_flags,
                     cnid: file.cnid,
                     data_fork: file.data_fork,
                     resource_fork: file.resource_fork,
@@ -460,6 +463,10 @@ fn parse_catalog_btree(bytes: &[u8]) -> Result<(HashMap<u32, RawDir>, Vec<RawFil
                     cnid,
                     file_type: array_4(data, 4)?,
                     creator: array_4(data, 8)?,
+                    // Finder Interface, Inside Macintosh: Macintosh Toolbox
+                    // Essentials, pp. 7-32 and 7-47: fdFlags follows the
+                    // four-byte type and creator fields in FInfo.
+                    finder_flags: be_u16(data, 12)?,
                     data_fork: Fork {
                         logical_size: be_u32(data, 26)?,
                         extents: parse_extent_record(data, 74)?,
@@ -704,6 +711,7 @@ mod tests {
                 20,
                 *b"APPL",
                 *b"TEST",
+                0x4000,
                 5,
                 [extent(2, 1), Extent::default(), Extent::default()],
                 4,
@@ -730,6 +738,7 @@ mod tests {
         assert_eq!(file.rel_path, PathBuf::from("Games/Café/Demo"));
         assert_eq!(file.file_type, *b"APPL");
         assert_eq!(file.creator, *b"TEST");
+        assert_eq!(file.finder_flags, 0x4000);
         assert_eq!(volume.read_data_fork(file).unwrap(), b"hello");
         assert_eq!(volume.read_rsrc_fork(file).unwrap(), b"rsrc");
 
@@ -747,7 +756,9 @@ mod tests {
         assert_eq!(extracted.rsrc, b"rsrc");
         assert_eq!(extracted.file_type, *b"APPL");
         assert_eq!(extracted.creator, *b"TEST");
-        assert_eq!(extracted.finder_flags, 0);
+        // Inside Macintosh: Macintosh Toolbox Essentials, p. 7-47 defines
+        // isInvisible as Finder flag bit 14 (0x4000).
+        assert_eq!(extracted.finder_flags, 0x4000);
     }
 
     #[test]
@@ -781,6 +792,7 @@ mod tests {
                 20,
                 *b"TEXT",
                 *b"ttxt",
+                0,
                 1,
                 [extent(7, 2), Extent::default(), Extent::default()],
                 0,
@@ -846,6 +858,7 @@ mod tests {
                 20,
                 *b"DATA",
                 *b"TEST",
+                0,
                 3 * BLOCK_SIZE as u32 + 4,
                 [extent(4, 1), extent(5, 1), extent(6, 1)],
                 0,
@@ -978,6 +991,7 @@ mod tests {
         cnid: u32,
         file_type: [u8; 4],
         creator: [u8; 4],
+        finder_flags: u16,
         data_size: u32,
         data_extents: ExtentRecord,
         resource_size: u32,
@@ -988,6 +1002,7 @@ mod tests {
         data[0] = 2;
         data[4..8].copy_from_slice(&file_type);
         data[8..12].copy_from_slice(&creator);
+        put_u16(data, 12, finder_flags);
         put_u32(data, 20, cnid);
         put_u32(data, 26, data_size);
         put_u32(data, 36, resource_size);

--- a/src/game/launch.rs
+++ b/src/game/launch.rs
@@ -3192,13 +3192,14 @@ mod tests {
     }
 
     #[test]
-    fn disk_image_payload_registers_a_read_only_file_manager_volume() {
+    fn disk_image_payload_registers_a_hardware_locked_file_manager_volume() {
         let mut builder = hfsplus::testutil::HfsPlusImageBuilder::new();
         builder.add_file("Data File", b"contents", 0o100644);
         let image_bytes = builder.build();
         let image = crate::disk_image::extract_dc42_or_hfs(&image_bytes)
             .unwrap()
             .expect("HFS+ image");
+        assert_eq!(image.volume_info.attributes & 0x0080, 0);
         let volume_name = image.volume_name.clone();
         let mut runner = new_runner();
         let mut executable = None;
@@ -3214,7 +3215,12 @@ mod tests {
             .vfs_volume_by_name(&volume_name)
             .expect("mounted File Manager volume");
         assert_eq!(volume.ref_num, -2);
-        assert_ne!(volume.attributes & 0x8000, 0, "software-locked volume");
+        assert_ne!(volume.attributes & 0x0080, 0, "hardware-locked volume");
+        assert_eq!(
+            volume.attributes & 0x8000,
+            0,
+            "software lock must retain the source state"
+        );
         assert!(runner
             .dispatcher()
             .vfs_path_is_read_only(&format!("{volume_name}/Data File")));

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -3905,9 +3905,11 @@ impl TrapDispatcher {
                 ref_num,
                 name: normalized,
                 root_dir_id,
-                // Extracted images are immutable even when their on-disk
-                // volume header was not locked at creation time.
-                attributes: attributes | 0x8000,
+                // Extracted images are immutable media. Report the VCB's
+                // hardware-lock bit so PBHGetVInfo agrees with mutations,
+                // which return wPrErr (hardware volume lock). Inside
+                // Macintosh: Files, pp. 2-127, 2-144, and 2-329.
+                attributes: attributes | 0x0080,
                 file_count,
                 allocation_block_count,
                 allocation_block_size,
@@ -3945,7 +3947,7 @@ impl TrapDispatcher {
     /// Return whether a VFS path belongs to an extracted disk-image volume.
     /// Resource-fork mirrors use a `__rsrc__` prefix, so strip it before
     /// resolving the volume root. The synthetic boot volume remains writable;
-    /// extracted image volumes are read-only by construction.
+    /// extracted image volumes are immutable by construction.
     pub(crate) fn vfs_path_is_read_only(&self, path: &str) -> bool {
         let path = path.strip_prefix("__rsrc__").unwrap_or(path);
         self.vfs_volume_for_path(path).is_some()

--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -15240,7 +15240,7 @@ mod tests {
         assert_eq!(cpu.read_reg(Register::D0), 0);
         assert_eq!(bus.read_word(pb + 22), volume_ref as u16);
         assert_eq!(bus.read_pstring(name_buf), b"Legend CD");
-        assert_eq!(bus.read_word(pb + 38), 0x8080, "ioVAtrb");
+        assert_eq!(bus.read_word(pb + 38), 0x0080, "ioVAtrb");
     }
 
     #[test]


### PR DESCRIPTION
Preserve Finder flags from classic HFS file catalog records and propagate them into mounted VFS metadata. Also report immutable extracted disk images with the hardware-lock volume attribute, matching the existing `wPrErr` mutation behavior instead of falsely adding a software lock.

Tests:
- `cargo test --lib` (4253 passed, 3 ignored)
- deterministic archive boot through registration, title screen, and new-game setup

Closes #964.
Closes #965.