### PR TITLE
fix: support UpperText in PowerPC Text Utilities

### DIFF
--- a/src/loader/ppc.rs
+++ b/src/loader/ppc.rs
@@ -1404,6 +1404,7 @@ pub enum PpcImportDispatcherTarget {
     StdRand,
     P2CStr,
     C2PStr,
+    UpperText,
     GetCurrentProcess,
     WakeUpProcess,
     SameProcess,
@@ -15081,6 +15082,7 @@ fn dispatcher_target_for_import(
         ("InterfaceLib", "c2pstr") | ("InterfaceLib", "C2PStr") => {
             PpcImportDispatcherTarget::C2PStr
         }
+        ("InterfaceLib", "UpperText") => PpcImportDispatcherTarget::UpperText,
         ("InterfaceLib", "GetCurrentProcess" | "GetFrontProcess") => {
             PpcImportDispatcherTarget::GetCurrentProcess
         }
@@ -21551,6 +21553,25 @@ fn dispatch_supported_import(
         PpcImportDispatcherTarget::C2PStr => {
             ppc_c2pstr(cpu, memory);
             Some(PpcImportAction::Return(cpu.gpr[3]))
+        }
+        PpcImportDispatcherTarget::UpperText => {
+            // UpperText
+            // Converts a byte range to localized uppercase in place.
+            // PROCEDURE UpperText (textPtr: Ptr; len: Integer);
+            // Inside Macintosh Volume VI (1991), 14-63
+            let text_ptr = cpu.gpr[3];
+            let length = u32::from(cpu.gpr[4] as u16);
+            if ppc_memory_can_write_bytes(memory, text_ptr, length) {
+                for offset in 0..length {
+                    if let Some(byte) = memory.read_u8(text_ptr + offset) {
+                        let _ = memory.write_u8(
+                            text_ptr + offset,
+                            crate::trap::mac_roman_to_upper(byte, false),
+                        );
+                    }
+                }
+            }
+            Some(PpcImportAction::ReturnPreserve)
         }
         PpcImportDispatcherTarget::GetCurrentProcess => Some(PpcImportAction::Return(
             ppc_i16_result(ppc_get_current_process(cpu, memory)),
@@ -138253,6 +138274,28 @@ mod tests {
         assert_eq!(
             ppc_read_pstring_bytes(&mut loaded.memory, string_ptr).as_deref(),
             Some(b"Gridz".as_slice())
+        );
+    }
+
+    #[test]
+    fn hle_import_runner_upper_text_converts_only_the_requested_bytes() {
+        let pef = synthetic_pef_with_import(b"UpperText");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let text_ptr = PPC_DATA_BASE + 0x1000;
+        loaded
+            .memory
+            .add_region(text_ptr, vec![b'a', b'z', 0x8e, b'!', b'q']);
+        loaded.cpu.gpr[3] = text_ptr;
+        loaded.cpu.gpr[4] = 3;
+
+        let probe = loaded.run_with_hle_imports(64);
+
+        assert_eq!(probe.handled_import_count, 1);
+        assert_eq!(probe.unsupported_import_index, None);
+        assert_eq!(loaded.cpu.gpr[3], text_ptr);
+        assert_eq!(
+            ppc_memory_read_bytes(&mut loaded.memory, text_ptr, 5),
+            Some(vec![b'A', b'Z', 0x83, b'!', b'q'])
         );
     }
 

--- a/src/trap/memory.rs
+++ b/src/trap/memory.rs
@@ -4380,7 +4380,7 @@ impl super::TrapDispatcher {
 ///   æ(0xBE)→Æ(0xAE), ç(0x8D)→Ç(0x82), é(0x8E)→É(0x83), ñ(0x96)→Ñ(0x84),
 ///   ö(0x9A)→Ö(0x85), õ(0x9B)→Õ(0xCD), ø(0xBF)→Ø(0xAF), œ(0xCF)→Œ(0xCE),
 ///   ü(0x9F)→Ü(0x86)
-fn mac_roman_to_upper(ch: u8, strip_marks: bool) -> u8 {
+pub(crate) fn mac_roman_to_upper(ch: u8, strip_marks: bool) -> u8 {
     if strip_marks {
         // Strip diacriticals first, then uppercase the base letter
         let stripped = mac_roman_strip_diacriticals(ch);

--- a/src/trap/mod.rs
+++ b/src/trap/mod.rs
@@ -37,6 +37,7 @@ pub(crate) mod types;
 mod window;
 
 pub use dispatch::TrapDispatcher;
+pub(crate) use memory::mac_roman_to_upper;
 pub(crate) use sound::{
     decode_interleaved_stereo_samples, decode_mace3_mono_to_u8, decode_mace6_mono_to_u8,
     parse_aiff_samples,


### PR DESCRIPTION
Closes #980.

## Summary
- dispatch the PowerPC InterfaceLib `UpperText` import
- reuse the existing Mac Roman uppercase conversion used by the 68k Text Utilities trap
- preserve the procedure-style return registers and add a focused regression test

## Validation
- `cargo test`
- Gridz 1.4 reaches its animated title screen and play menu through the PowerPC slice without an unsupported import