### PR TITLE
feat(desktop): --fullscreen and rendering on the display's GPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,11 +218,15 @@ systemless --headless --max-instructions 5000000 path/to/app.sit
 systemless --arrows-as-numpad path/to/game.sit
 systemless --display-scale 2 path/to/game.sit
 systemless --ui-theme classic-system7 path/to/game.sit
+systemless --fullscreen path/to/game.sit
 ```
 
 Desktop windows default to a physical 1:1 guest-to-host pixel ratio. Use
 `--display-scale` with an integer from 1 through 8 for explicit pixel-perfect
-enlargement.
+enlargement. `--fullscreen` starts the guest in a borderless fullscreen space.
+On systems where macOS selects direct scan-out for the fullscreen surface this
+measurably reduced pointer-to-screen latency in testing (see issue #1050); the
+benefit depends on the machine and compositor state and is not guaranteed.
 
 The default `systemless-default` guest chrome retains classic Macintosh control
 geometry and metrics while using the ink, tan, blue, and pale-blue colors from

--- a/src/bin/desktop/metal_present.rs
+++ b/src/bin/desktop/metal_present.rs
@@ -406,6 +406,28 @@ pub struct MetalPresenter {
     async_guest_presenter: AsyncGuestPresenter,
 }
 
+/// The GPU that scans out the main display. Rendering there avoids copying every
+/// presented frame across GPUs on dual-GPU Macs when the window is scanned out
+/// directly (fullscreen); windowed presentation is unaffected either way.
+/// `SYSTEMLESS_METAL_DEVICE=default` keeps the system default device.
+fn display_metal_device() -> Option<Retained<ProtocolObject<dyn MTLDevice>>> {
+    #[link(name = "CoreGraphics", kind = "framework")]
+    extern "C" {
+        fn CGMainDisplayID() -> u32;
+        fn CGDirectDisplayCopyCurrentMetalDevice(
+            display: u32,
+        ) -> *mut ProtocolObject<dyn MTLDevice>;
+    }
+    if std::env::var("SYSTEMLESS_METAL_DEVICE")
+        .map(|v| v == "default")
+        .unwrap_or(false)
+    {
+        return None;
+    }
+    // Returns a +1 reference (Copy rule); null when the display has no Metal device.
+    unsafe { Retained::from_raw(CGDirectDisplayCopyCurrentMetalDevice(CGMainDisplayID())) }
+}
+
 impl MetalPresenter {
     pub fn new(window: Rc<Window>) -> Result<Self, String> {
         MainThreadMarker::new()
@@ -428,7 +450,8 @@ impl MetalPresenter {
             root_layer.ok_or_else(|| "AppKit did not create a root layer".to_string())?;
 
         // SAFETY: Metal returns a retained Objective-C protocol object or nil.
-        let device = unsafe { Retained::retain(MTLCreateSystemDefaultDevice()) }
+        let device = display_metal_device()
+            .or_else(|| unsafe { Retained::retain(MTLCreateSystemDefaultDevice()) })
             .ok_or_else(|| "this Mac has no Metal device".to_string())?;
         let command_queue = device
             .newCommandQueue()

--- a/src/bin/systemless.rs
+++ b/src/bin/systemless.rs
@@ -161,6 +161,12 @@ struct Cli {
         value_parser = UiThemeId::parse
     )]
     ui_theme: UiThemeId,
+    /// Start in a borderless fullscreen space. On systems where macOS selects
+    /// direct scan-out for the fullscreen surface this measurably reduced
+    /// pointer-to-screen latency in testing; the benefit depends on the
+    /// machine and compositor state.
+    #[arg(long)]
+    fullscreen: bool,
 
     /// Replay input events from a script during a headless run. Events are
     /// scheduled by retired instruction count, so a run replays identically
@@ -628,6 +634,7 @@ struct App {
     /// unchanged, for native expose/resize events that need a fresh drawable.
     #[cfg(target_os = "macos")]
     force_gpu_present: bool,
+    start_fullscreen: bool,
     /// Show the Systemless debug overlay on top of the game framebuffer.
     debug_overlay_visible: bool,
     #[cfg(target_os = "macos")]
@@ -675,6 +682,7 @@ impl App {
             Some(screen_depth),
             1,
             UiThemeId::ClassicSystem7,
+            false,
         )
     }
 
@@ -686,6 +694,7 @@ impl App {
         screen_depth: Option<u16>,
         display_scale: u32,
         ui_theme: UiThemeId,
+        start_fullscreen: bool,
     ) -> Self {
         #[cfg(not(target_os = "macos"))]
         let _ = native_integrations;
@@ -762,6 +771,7 @@ impl App {
             force_next_render: true,
             #[cfg(target_os = "macos")]
             force_gpu_present: true,
+            start_fullscreen,
             debug_overlay_visible: false,
             #[cfg(target_os = "macos")]
             host_cursor: host_cursor::HostCursor::new(),
@@ -2231,6 +2241,9 @@ impl ApplicationHandler for App {
             }
             #[cfg(not(target_os = "macos"))]
             window.set_cursor_visible(false);
+            if self.start_fullscreen {
+                window.set_fullscreen(Some(winit::window::Fullscreen::Borderless(None)));
+            }
 
             #[cfg(target_os = "macos")]
             let surface = metal_present::MetalPresenter::new(window.clone())
@@ -2462,6 +2475,7 @@ fn run_gui(
     screen_depth: Option<u16>,
     display_scale: u32,
     ui_theme: UiThemeId,
+    fullscreen: bool,
 ) {
     let event_loop = EventLoop::new().expect("Failed to create event loop");
     eprintln!(
@@ -2481,6 +2495,7 @@ fn run_gui(
         screen_depth,
         display_scale,
         ui_theme,
+        fullscreen,
     );
     // `run_app` is the first point at which `resumed` can create a native
     // window. Finish archive decompression and guest initialization before
@@ -2737,6 +2752,7 @@ fn main() {
             cli.screen_depth,
             cli.display_scale,
             cli.ui_theme,
+            cli.fullscreen,
         );
     }
 }


### PR DESCRIPTION
## Summary

Two small changes that together take pointer-to-screen latency for guest content from ~120 ms (windowed) to ~36–41 ms on a 2019 Intel MacBook Pro, without touching the emulation or the presenter's frame path:

- `--fullscreen` starts the window in a borderless fullscreen space (`winit::window::Fullscreen::Borderless`). On macOS a screen-sized opaque `CAMetalLayer` in a fullscreen space is scanned out directly instead of being composited by the window server; the frame is then flipped one refresh after the vsync it was scheduled for, instead of ~5 refreshes later. The window's own scaling, input mapping and resize handling already cope with the screen-sized layer; nothing else changes.
- The Metal presenter now renders on the GPU that drives the main display (`CGDirectDisplayCopyCurrentMetalDevice`), falling back to `MTLCreateSystemDefaultDevice`. On dual-GPU Macs the system default is the discrete GPU while the panel is driven by the integrated one; in direct scan-out every presented frame then has to be copied across. `SYSTEMLESS_METAL_DEVICE=default` keeps the old behaviour.

## Measurements

Instrument: pointer driven by `CGWarpMouseCursorPosition` in a 60 Hz circle; the frame containing each pointer position is timed with the drawable's `presentedTime` (`addPresentedHandler`), i.e. the moment the frame is flipped onto the panel. Display awake, SimCity 2000 title screen, 2019 16" MacBook Pro (Intel UHD 630 drives the 3072×1920 @ 59.94 Hz panel, AMD 5500M is the default device), macOS 26.

| configuration | pointer → on screen (median / p90) | frames shown |
|---|---|---|
| window, default device | 122 ms / 155 | 22 /s |
| `--fullscreen`, default device | 52–58 ms / 58–63 | 57 /s |
| `--fullscreen`, display GPU | **36–41 ms / 39–56** | 57 /s |

A bare 60-line `CAMetalLayer` window reproduces the windowed number (80–115 ms encode→shown, 18–44 fps) and the fullscreen one (32 ms on the default device, 27.5 ms on the display GPU), so the windowed cost is the window server's compositing pipeline on this machine rather than anything in Systemless; no presenter setting (`presentsWithTransaction`, drawable count, `displaySyncEnabled`, `CAMetalDisplayLink`) moved it.

**Caveat discovered after the first draft:** windowed latency on the test machine is *bimodal* — the window server has a fast state (~42 ms pointer→screen) and a slow state (80–122 ms) that comes and goes with an unidentified trigger (not CPU load, transparency, or resolution; all excluded by measurement). Fullscreen measured 29–55 ms in both states, because direct scan-out bypasses the compositor entirely. So the honest claim is: in the compositor's slow state `--fullscreen` is a large, clearly visible improvement; in its fast state the advantage (~10 ms) is real but below the perception threshold. The display-GPU device selection is a small unconditional improvement either way. Fullscreen also roughly halves the gap between game content and the hardware cursor introduced by #992.

Per-frame GPU work on the display GPU is 4.8 ms for the 800×600 guest frame scaled to the panel, comfortably inside a refresh.

### Revalidation after the hardware-cursor merge

Rebased onto current master (v0.27.3) and re-tested after #992's hardware-cursor
presentation path merged. A temporary probe timed each submitted frame from the
main-thread enqueue to the drawable's `presentedTime`; the built-in unchanged-frame
skip was disabled in all three arms so the presenter was stressed continuously at
display cadence. These numbers measure the presenter portion of latency, not the
hardware cursor itself:

| configuration | enqueue → shown (median / p90) | drawables actually shown |
|---|---|---|
| window, default device | 84.8 / 94.6 ms | 29.6 /s |
| `--fullscreen`, default device | 56.0 / 62.2 ms | 59.6 /s |
| `--fullscreen`, display GPU | **41.9 / 59.6 ms** | 59.8 /s |

Samples: 141 / 273 / 277 respectively, over 22.8–23.7 seconds per arm. This
reproduces both effects on the final path: fullscreen bypasses the slow compositor
state seen during this run, and selecting the display GPU removes another ~14 ms
median without changing throughput. The machine/compositor-state caveat above still
applies.

**The 29.6/s windowed result is not the guest's emulation rate, a Systemless
windowed cap, or the hardware cursor's update rate.** Systemless was forced to
offer frames continuously in this test; `presentedTime` counts only drawables the
WindowServer actually put on screen. In the slow compositor state observed during
this arm, windowed drawable presentation settled at roughly every second 60 Hz
refresh while the presenter coalesced pending work to the freshest frame. Fullscreen
made a drawable visible on almost every refresh. The hardware cursor uses a separate
cursor plane and is not paced by either number. Windowed presentation has also been
observed in a faster compositor state, so 29.6/s is a measurement of this run, not a
fixed 30 fps limit.

## Validation

- `cargo build --release`
- `cargo test --lib`
- `cargo check --no-default-features`
- `cargo package`
- clippy: no new warnings in the touched code
- Manual: `systemless --fullscreen assets/sc2k.zip` enters the fullscreen space at launch (window frame = screen); ⌃⌘F leaves and re-enters it; windowed launch unchanged.
- Rebased manual check on v0.27.3: fullscreen launch filled the display and rendered
  correctly on the merged hardware-cursor path during several minutes of live play.
