### PR TITLE
fix(release): include refactors in release notes

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,14 @@
     ".": {
       "release-type": "rust",
       "package-name": "systemless",
-      "include-component-in-tag": false
+      "include-component-in-tag": false,
+      "changelog-sections": [
+        { "type": "feat", "section": "Features" },
+        { "type": "fix", "section": "Bug Fixes" },
+        { "type": "perf", "section": "Performance Improvements" },
+        { "type": "revert", "section": "Reverts" },
+        { "type": "refactor", "section": "Code Refactoring" }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary

- preserve the existing feature, bug-fix, performance, and revert release-note sections
- include non-breaking `refactor` commits under **Code Refactoring**
- allow the merged runtime work in #947 to enter the next patch release

Release Please's default policy reported no user-facing commits after #947 merged, so it did not open a release PR even though crate behavior changed.

## Validation

- `release-please-config.json` parses as valid JSON
- the configured fields match the upstream Release Please manifest schema

Closes #995.
