### PR TITLE
fix(files): keep relative paths on the default volume

### DIFF
--- a/src/loader/ppc.rs
+++ b/src/loader/ppc.rs
@@ -73806,6 +73806,8 @@ fn ppc_pbh_get_v_info(
             .map(|name| decode_mac_roman(&name))
             .unwrap_or_default()
     };
+    let relative_pathname = requested_name.starts_with(':');
+    let absolute_pathname = !relative_pathname && requested_name.contains(':');
 
     // Inside Macintosh: Files (1992), pp. 2-144--2-146: a positive
     // ioVolIndex enumerates the VCB queue, zero selects by name or reference,
@@ -73851,6 +73853,8 @@ fn ppc_pbh_get_v_info(
     let selected = if volume_index == 0 {
         if vref_num != 0 {
             volume_by_ref(vref_num)
+        } else if relative_pathname {
+            Some(boot_volume())
         } else if !requested_name.is_empty() {
             volume_by_name(&requested_name)
         } else {
@@ -73862,10 +73866,12 @@ fn ppc_pbh_get_v_info(
         } else {
             vfs_volumes.get((volume_index - 2) as usize).cloned()
         }
-    } else if requested_name.contains(':') {
+    } else if absolute_pathname {
         volume_by_name(&requested_name)
     } else if vref_num != 0 {
         volume_by_ref(vref_num)
+    } else if relative_pathname {
+        Some(boot_volume())
     } else if !requested_name.is_empty() {
         volume_by_name(&requested_name)
     } else {
@@ -141029,6 +141035,40 @@ mod tests {
         let _ = loaded.run_with_hle_imports(64);
         assert_eq!(loaded.cpu.gpr[3], 0);
         assert_eq!(loaded.memory.read_u16_be(pb + 22), Some((-2i16) as u16));
+    }
+
+    #[test]
+    fn pbh_get_v_info_keeps_relative_paths_on_the_default_volume() {
+        let pef = synthetic_pef_with_import(b"PBHGetVInfoSync");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let pb = PPC_DATA_BASE + 0x1000;
+        let name_ptr = pb + 0x100;
+        loaded.memory.add_region(pb, vec![0; 0x200]);
+        loaded.memory.write_u32_be(pb + 18, name_ptr).unwrap();
+        loaded.memory.write_u16_be(pb + 22, 0).unwrap();
+        loaded
+            .memory
+            .write_u16_be(pb + 28, (-1i16) as u16)
+            .unwrap();
+        assert!(ppc_write_pstring_bytes(
+            &mut loaded.memory,
+            name_ptr,
+            b":data:title.phd",
+        ));
+        loaded.cpu.gpr[3] = pb;
+
+        let probe = loaded.run_with_hle_imports(64);
+
+        assert_eq!(probe.unsupported_import_index, None);
+        assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_NO_ERR));
+        assert_eq!(
+            loaded.memory.read_u16_be(pb + 22),
+            Some(PPC_BOOT_VOLUME_REF_NUM as u16)
+        );
+        assert_eq!(
+            ppc_read_pstring_bytes(&mut loaded.memory, name_ptr).as_deref(),
+            Some(crate::trap::TrapDispatcher::boot_volume_name().as_bytes())
+        );
     }
 
     #[test]

--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -4333,6 +4333,8 @@ impl super::TrapDispatcher {
                 let volume_index = bus.read_word(pb + 28) as i16;
                 let requested_vref = bus.read_word(pb + 22) as i16;
                 let requested_name = Self::read_pb_filename(bus, bus.read_long(pb + 18));
+                let relative_pathname = requested_name.starts_with(':');
+                let absolute_pathname = !relative_pathname && requested_name.contains(':');
                 if super::dispatch::trace_resfile_enabled() {
                     eprintln!(
                         "[TRAP] PBHGetVInfo index={} vref={} name={:?}",
@@ -4382,6 +4384,8 @@ impl super::TrapDispatcher {
                     // boot volume; callers use nsvErr to detect a bad volume.
                     if requested_vref != 0 {
                         volume_by_ref(requested_vref)
+                    } else if relative_pathname {
+                        volume_by_ref(self.app_wd_refnum)
                     } else if !requested_name.is_empty() {
                         volume_by_name(&requested_name)
                     } else {
@@ -4406,10 +4410,12 @@ impl super::TrapDispatcher {
                     // volume by ioNamePtr and ioVRefNum in the standard way.
                     // A full pathname's volume name takes precedence; otherwise
                     // a nonzero volume or working-directory reference is used.
-                    if requested_name.contains(':') {
+                    if absolute_pathname {
                         volume_by_name(&requested_name)
                     } else if requested_vref != 0 {
                         volume_by_ref(requested_vref)
+                    } else if relative_pathname {
+                        volume_by_ref(self.app_wd_refnum)
                     } else if !requested_name.is_empty() {
                         volume_by_name(&requested_name)
                     } else {
@@ -15508,6 +15514,30 @@ mod tests {
         cpu.write_reg(Register::A0, pb);
         bus.write_long(pb + 18, name_buf);
         bus.write_pstring(name_buf, b"MacintoshHD:Games:Demo");
+        bus.write_word(pb + 22, 0);
+        bus.write_word(pb + 28, (-1i16) as u16);
+
+        call(&mut disp, false, 0x07, &mut cpu, &mut bus).unwrap();
+
+        assert_eq!(cpu.read_reg(Register::D0), 0);
+        assert_eq!(bus.read_word(pb + 16), 0, "ioResult");
+        assert_eq!(
+            bus.read_word(pb + 22),
+            super::super::dispatch::BOOT_VOLUME_REF_NUM as u16,
+            "ioVRefNum"
+        );
+        assert_eq!(bus.read_pstring(name_buf), b"MacintoshHD");
+    }
+
+    #[test]
+    fn pb_hget_vinfo_keeps_relative_paths_on_the_default_volume() {
+        let (mut disp, mut cpu, mut bus) = setup();
+
+        let pb = 0x300000u32;
+        let name_buf = 0x300100u32;
+        cpu.write_reg(Register::A0, pb);
+        bus.write_long(pb + 18, name_buf);
+        bus.write_pstring(name_buf, b":data:title.phd");
         bus.write_word(pb + 22, 0);
         bus.write_word(pb + 28, (-1i16) as u16);
 


### PR DESCRIPTION
## Summary

- distinguish leading-colon relative pathnames from volume-qualified absolute paths
- resolve relative `PBHGetVInfo` requests through the default volume in both PowerPC and 68k adapters
- cover the failing `:data:title.phd` parameter block with focused regression tests

## Testing

- `cargo fmt --check`
- `cargo build --all-targets --all-features`
- `cargo test --lib --features test-support`
- `cargo check --no-default-features`
- Tomb Raider Gold: title, passport, responsive 3D gameplay, and forward movement
- Gridz: mounted-volume path through active gameplay
- Escape Velocity: live space, landing, return to space, and acceleration
- Marathon 2: menu audio, gameplay, automap, and forward movement

Closes #998