### PR TITLE
fix(menu): preserve native mutations across 68k callbacks

### DIFF
--- a/src/loader/ppc.rs
+++ b/src/loader/ppc.rs
@@ -79658,7 +79658,7 @@ fn read_u32(data: &[u8], offset: usize) -> Option<u32> {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
     use crate::cpu::{CpuOps, Register};
     use crate::managers::resource::serialize_resource_fork;
@@ -79882,6 +79882,101 @@ mod tests {
             &loaded.screen_clut,
             MenuColorTable::new(&menu_color_bytes),
         )
+    }
+
+    pub(crate) struct CrossAbiMenuSelectFixture {
+        pub(crate) app: PpcLoadedApp,
+        pub(crate) root_menu: u32,
+        pub(crate) root_record: u32,
+        pub(crate) callback_marker: u32,
+        pub(crate) title_h: i16,
+    }
+
+    pub(crate) fn cross_abi_menu_select_fixture() -> CrossAbiMenuSelectFixture {
+        const ROOT_MENU_ID: i16 = 140;
+        const CHILD_MENU_ID: i16 = 141;
+        const TARGET_ITEM: i16 = 2;
+        const MDEF_HANDLE: u32 = PPC_DATA_BASE + 0x7000;
+        const MDEF_ENTRY: u32 = PPC_DATA_BASE + 0x7100;
+        const CALLBACK_MARKER: u32 = PPC_DATA_BASE + 0x7200;
+        const CALLBACK_VALUE: u32 = 0x68c0_ab1e;
+
+        let pef = synthetic_pef_with_import(b"MenuSelect");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let root_menu = install_test_menu(
+            &mut loaded,
+            PPC_DATA_BASE + 0x1000,
+            ROOT_MENU_ID,
+            b"File",
+            b"Custom child;Disabled after callback",
+        );
+        let child_menu = install_test_popup_menu(
+            &mut loaded,
+            PPC_DATA_BASE + 0x1400,
+            CHILD_MENU_ID,
+            b"Child",
+            b"Choice",
+        );
+
+        loaded.cpu.gpr[3] = root_menu;
+        loaded.cpu.gpr[4] = 1;
+        loaded.cpu.gpr[5] = 0x1b;
+        ppc_set_item_cmd(&loaded.cpu, &mut loaded.memory, &loaded.handles);
+        loaded.cpu.gpr[5] = CHILD_MENU_ID as u32;
+        ppc_set_item_mark(&loaded.cpu, &mut loaded.memory, &loaded.handles);
+
+        let root_record = loaded.memory.read_u32_be(root_menu).unwrap();
+        let child_record = loaded.memory.read_u32_be(child_menu).unwrap();
+        loaded.memory.write_u16_be(child_record + 2, 72).unwrap();
+        loaded.memory.write_u16_be(child_record + 4, 32).unwrap();
+        loaded.memory.add_region(MDEF_HANDLE, vec![0; 4]);
+        loaded.memory.add_region(CALLBACK_MARKER, vec![0; 4]);
+
+        // The resource-backed MDEF is real 68k guest code. It pushes the
+        // Pascal DisableItem(rootMenu, 2) arguments, executes the A-line, then
+        // leaves a marker only after the trap returns and closes its own
+        // 18-byte MenuDefProc argument frame.
+        let mut mdef = Vec::new();
+        mdef.extend_from_slice(&0x2f3cu16.to_be_bytes()); // MOVE.L #rootMenu,-(SP)
+        mdef.extend_from_slice(&root_menu.to_be_bytes());
+        mdef.extend_from_slice(&0x3f3cu16.to_be_bytes()); // MOVE.W #2,-(SP)
+        mdef.extend_from_slice(&(TARGET_ITEM as u16).to_be_bytes());
+        mdef.extend_from_slice(&0xa93au16.to_be_bytes()); // DisableItem
+        mdef.extend_from_slice(&0x23fcu16.to_be_bytes()); // MOVE.L #value,marker
+        mdef.extend_from_slice(&CALLBACK_VALUE.to_be_bytes());
+        mdef.extend_from_slice(&CALLBACK_MARKER.to_be_bytes());
+        mdef.extend_from_slice(&0x4e74u16.to_be_bytes()); // RTD #18
+        mdef.extend_from_slice(&0x0012u16.to_be_bytes());
+        loaded.memory.add_region(MDEF_ENTRY, mdef.clone());
+        loaded.memory.write_u32_be(MDEF_HANDLE, MDEF_ENTRY).unwrap();
+        loaded
+            .memory
+            .write_u32_be(child_record + 6, MDEF_HANDLE)
+            .unwrap();
+        loaded.vfs_resources.push(PpcVfsResourceRecord {
+            ref_num: loaded.current_resource_refnum,
+            path: "Cross-ABI menu fixture".to_string(),
+            res_type: u32::from_be_bytes(*b"MDEF"),
+            res_id: 512,
+            name: Vec::new(),
+            data: mdef,
+            raw_data: None,
+            raw_attrs: None,
+            attrs: 0,
+            handle: MDEF_HANDLE,
+        });
+
+        assert!(draw_current_test_menu_bar(&mut loaded));
+        let title_h = STANDARD_MENU_BAR_FIRST_TITLE_LEFT + 2;
+        loaded.cpu.gpr[3] = (u32::from(10u16) << 16) | u32::from(title_h as u16);
+
+        CrossAbiMenuSelectFixture {
+            app: loaded,
+            root_menu,
+            root_record,
+            callback_marker: CALLBACK_MARKER,
+            title_h,
+        }
     }
 
     fn test_wind_resource(

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -4001,6 +4001,11 @@ impl FixtureRunner {
         // and 68k callers must observe one backing allocation rather than
         // values copied at CPU-slice boundaries.
         for (address, len) in [
+            // A native-to-68k callback executes in this process's writable
+            // Trap Manager topology. Keep line-A and line-F exception vectors
+            // attached to the same cells as the 68k dispatcher so nested
+            // A-lines do not fall through a detached native low-memory copy.
+            (0x28, 8),
             (
                 crate::trap::dispatch::OS_TRAP_TABLE_BASE,
                 u32::from(crate::trap::dispatch::OS_TRAP_TABLE_SLOTS) * 4,
@@ -11286,6 +11291,7 @@ mod tests {
     use crate::audio::AudioBackend;
     use crate::loader::ppc::*;
     use crate::loader::{ApplicationSizeResource, Code0Header, LoadedApp};
+    use crate::menu_manager::TrackedMenuPaneView;
     use crate::sound::{
         DoubleBufferState, PendingDoubleBackCallback, PendingSoundCallback, PlaybackKind,
         SndChannel, SndCommand, OUTPUT_RATE,
@@ -13768,6 +13774,180 @@ mod tests {
             .toolbox_startup
             .pending_native_menu_selection
             .is_none());
+    }
+
+    #[test]
+    fn native_menu_select_observes_68k_disable_item_after_mdef_returns() {
+        use crate::loader::ppc::tests::cross_abi_menu_select_fixture;
+        use crate::memory::globals::addr;
+
+        const CALLBACK_VALUE: u32 = 0x68c0_ab1e;
+        const ROOT_MENU_ID: i16 = 140;
+        const TARGET_ITEM: i16 = 2;
+
+        let fixture = cross_abi_menu_select_fixture();
+        let root_menu = fixture.root_menu;
+        let root_record = fixture.root_record;
+        let callback_marker = fixture.callback_marker;
+        let title_h = fixture.title_h;
+        let app = LoadedApp::from_ppc(fixture.app);
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        runner.init_app(&app);
+
+        let framebuffer_before = {
+            let native = runner.ppc_app.as_mut().expect("native app");
+            let front = native.current_front_buffer().expect("front buffer");
+            let mut framebuffer = Vec::with_capacity((front.row_bytes * front.height) as usize);
+            let mut row = vec![0; front.row_bytes as usize];
+            for y in 0..front.height {
+                native
+                    .read_front_buffer_row(front, y, &mut row)
+                    .expect("front-buffer row");
+                framebuffer.extend_from_slice(&row);
+            }
+            framebuffer
+        };
+        assert_ne!(
+            runner
+                .ppc_app
+                .as_mut()
+                .unwrap()
+                .memory
+                .read_u32_be(root_record + 10)
+                .unwrap()
+                & (1 << TARGET_ITEM),
+            0,
+            "the target row must begin enabled"
+        );
+
+        runner.push_canonical_mouse_down(10, title_h);
+        let root_rect = (0..16)
+            .find_map(|_| {
+                let (_, running) = runner.run_steps(512, None);
+                assert!(
+                    running,
+                    "native MenuSelect halted before opening the root menu"
+                );
+                runner
+                    .dispatcher
+                    .menu_tracking
+                    .as_ref()
+                    .filter(|tracking| tracking.menu_handle == root_menu)
+                    .map(|tracking| tracking.dropdown_rect())
+            })
+            .expect("native MenuSelect should retain the canonical root handle");
+
+        runner
+            .dispatcher
+            .set_mouse_position(root_rect.0 + 8, root_rect.1 + 16);
+        runner.sync_mouse_position_lowmem();
+        let callback_completed = (0..32).any(|_| {
+            let (_, running) = runner.run_steps(512, None);
+            assert!(
+                running,
+                "native MenuSelect halted during the 68k MDEF callback"
+            );
+            let callback_value = runner
+                .ppc_app
+                .as_mut()
+                .unwrap()
+                .memory
+                .read_u32_be(callback_marker);
+            callback_value == Some(CALLBACK_VALUE)
+                && runner.dispatcher.guest_calls.is_empty()
+        });
+        assert!(
+            callback_completed,
+            "the real 68k MDEF callback did not return"
+        );
+        let tracking = runner
+            .dispatcher
+            .menu_tracking
+            .as_ref()
+            .expect("native interaction should remain retained");
+        assert_eq!(tracking.menu_handle, root_menu);
+        assert_eq!(
+            runner
+                .ppc_app
+                .as_mut()
+                .unwrap()
+                .memory
+                .read_u32_be(root_menu),
+            Some(root_record),
+            "a fixed-size 68k mutation must preserve the native handle allocation"
+        );
+        assert_eq!(
+            runner
+                .ppc_app
+                .as_mut()
+                .unwrap()
+                .memory
+                .read_u32_be(root_record + 10)
+                .unwrap()
+                & (1 << TARGET_ITEM),
+            0,
+            "the 68k DisableItem trap must mutate the live native MenuInfo"
+        );
+
+        let target_v = root_rect.0 + 24;
+        let target_h = root_rect.1 + 16;
+        runner.dispatcher.set_mouse_position(target_v, target_h);
+        runner.sync_mouse_position_lowmem();
+        let raw_choice = (u32::from(ROOT_MENU_ID as u16) << 16) | u32::from(TARGET_ITEM as u16);
+        let native_observed_disabled_row = (0..16).any(|_| {
+            let (_, running) = runner.run_steps(512, None);
+            assert!(running, "native MenuSelect halted before the mouse release");
+            runner.bus.read_long(addr::MENU_DISABLE) == raw_choice
+                && runner
+                    .dispatcher
+                    .menu_tracking
+                    .as_ref()
+                    .is_some_and(|tracking| {
+                        tracking.menu_handle == root_menu && tracking.highlighted_item == 0
+                    })
+        });
+        assert!(
+            native_observed_disabled_row,
+            "native tracking did not reread the live disabled enableFlags"
+        );
+
+        runner.push_canonical_mouse_up(target_v, target_h);
+        for _ in 0..16 {
+            let (_, running) = runner.run_steps(512, None);
+            if !running {
+                break;
+            }
+        }
+        assert!(runner.is_halted());
+        assert!(runner.dispatcher.menu_tracking.is_none());
+        assert!(runner.dispatcher.guest_calls.is_empty());
+
+        let native = runner.ppc_app.as_mut().expect("native app retained");
+        assert_eq!(native.cpu.gpr[3], 0, "disabled rows cannot be selected");
+        let framebuffer_after = {
+            let front = native.current_front_buffer().expect("front buffer");
+            let mut framebuffer = Vec::with_capacity((front.row_bytes * front.height) as usize);
+            let mut row = vec![0; front.row_bytes as usize];
+            for y in 0..front.height {
+                native
+                    .read_front_buffer_row(front, y, &mut row)
+                    .expect("front-buffer row");
+                framebuffer.extend_from_slice(&row);
+            }
+            framebuffer
+        };
+        assert_eq!(
+            framebuffer_after, framebuffer_before,
+            "the retained interaction must restore its saved presentation"
+        );
+
+        native.cpu.pc = native.entry_pc;
+        native.cpu.lr = PPC_HALT_PC;
+        native.imports[0].dispatcher_target = PpcImportDispatcherTarget::MenuChoice;
+        let probe = native.run_with_hle_imports(64);
+        assert_eq!(probe.handled_import_count, 1);
+        assert_eq!(probe.unsupported_import_index, None);
+        assert_eq!(native.cpu.gpr[3], raw_choice);
     }
 
     #[test]

--- a/src/trap/menu.rs
+++ b/src/trap/menu.rs
@@ -1548,12 +1548,14 @@ impl super::TrapDispatcher {
         let Some(bytes) = items.rebuild(&original) else {
             return false;
         };
-        let required_size = bytes.len().max(256);
-        if record_size as usize >= required_size {
+        // A serialized 68k callback can be attached to a native process whose
+        // allocator capacity is not recorded by MacMemoryBus. Non-growing
+        // rebuilds still fit the decoded record and must preserve its handle.
+        if record_size as usize >= bytes.len() {
             bus.write_bytes(menu_ptr, &bytes);
         } else {
             let mut allocation = bytes;
-            allocation.resize(required_size, 0);
+            allocation.resize(allocation.len().max(256), 0);
             if !self.replace_handle_bytes(bus, menu_handle, &allocation) {
                 return false;
             }


### PR DESCRIPTION
## Summary

- share the process line-A and line-F vector cells with serialized native-to-68k callbacks
- keep non-growing 68k menu-record rebuilds in place so native handle allocations remain canonical
- add an end-to-end native `MenuSelect` → real 68k custom MDEF → nested `DisableItem` → native continuation regression

## Verification

- `cargo test --lib --features test-support` (4,533 passed, 3 ignored)
- `cargo build --all-targets --all-features`
- `cargo check --no-default-features`
- documentation build with warnings denied
- `cargo publish --locked --dry-run --allow-dirty`
- `cargo deny check licenses`
- `cargo fmt --all -- --check`
- deterministic gameplay to active input: Tomb Raider Gold Demo, Escape Velocity, Marathon 2: Durandal, and Gridz

Closes #1001