### PR TITLE
refactor(runtime): introduce process-owned context

### DIFF
--- a/src/event_queue.rs
+++ b/src/event_queue.rs
@@ -70,6 +70,25 @@ impl SharedEventQueue {
         Self(Rc::clone(&self.0))
     }
 
+    /// Attach an adapter-local queue to the process queue, preserving work
+    /// that the adapter staged before it joined the process.
+    ///
+    /// # Safety
+    ///
+    /// The process owner must serialize all access to every attached handle.
+    pub(crate) unsafe fn attach_to(&mut self, process_queue: &Self) {
+        if Rc::ptr_eq(&self.0, &process_queue.0) {
+            return;
+        }
+        let pending = std::mem::take(self.state_mut());
+        // SAFETY: ProcessContext is owned by FixtureRunner, which serializes
+        // access to every attached CPU adapter through its mutable borrow.
+        self.0 = unsafe { process_queue.shared_handle() }.0;
+        let state = self.state_mut();
+        state.events.extend(pending.events);
+        state.menu_bar_invalid |= pending.menu_bar_invalid;
+    }
+
     /// Mark the menu bar for one deferred redraw by the Toolbox Event
     /// Manager. Repeated invalidations coalesce until the next event scan.
     /// Macintosh Toolbox Essentials (1992), pp. 3-93 and 3-114.

--- a/src/guest_call.rs
+++ b/src/guest_call.rs
@@ -175,9 +175,9 @@ impl Eq for GuestCallFrame {}
 
 /// One process's nested guest-procedure continuation stack.
 ///
-/// Ordinary `Clone` creates an independent process snapshot. The runner uses
-/// [`Self::shared_handle`] explicitly when it attaches two CPU adapters to the
-/// same live process.
+/// Ordinary `Clone` creates an independent process snapshot. The runner's
+/// process context explicitly attaches both CPU adapters to the same live
+/// allocation.
 #[derive(Debug, Default)]
 pub(crate) struct SharedGuestCallStack(Rc<RefCell<Vec<GuestCallFrame>>>);
 
@@ -204,11 +204,11 @@ impl SharedGuestCallStack {
         if Rc::ptr_eq(&self.0, &process_calls.0) {
             return;
         }
-        let pending = std::mem::take(&mut *self.0.borrow_mut());
-        debug_assert!(
-            pending.is_empty() || process_calls.is_empty(),
+        assert!(
+            self.is_empty() || process_calls.is_empty(),
             "cannot attach two active guest-procedure continuation stacks"
         );
+        let pending = std::mem::take(&mut *self.0.borrow_mut());
         self.0 = Rc::clone(&process_calls.0);
         self.0.borrow_mut().extend(pending);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,7 @@ pub mod memory;
 mod menu_manager;
 pub mod menu_model;
 mod mixed_mode;
+mod process_context;
 pub mod quickdraw;
 pub mod runner;
 /// Deterministic trap-interaction replays. This is internal test

--- a/src/loader/ppc.rs
+++ b/src/loader/ppc.rs
@@ -69,6 +69,7 @@ use crate::menu_manager::{
     MenuListEntry as PpcMenuListEntry, MENU_COLOR_ENTRY_SIZE, STANDARD_MENU_BAR_TITLE_ORIGIN_INSET,
 };
 use crate::menu_model::GuestMenuSnapshot;
+use crate::process_context::ProcessContext;
 use crate::quickdraw::fonts::heuristics::get_italic_slant;
 use crate::quickdraw::fonts::{
     font_id_for_name, font_name_for_id, get_font_face_scale_ratio, get_font_face_scaled,
@@ -5118,46 +5119,20 @@ impl PpcLoadedApp {
         &self.event_queue
     }
 
-    pub(crate) fn share_event_queue(&mut self, event_queue: &SharedEventQueue) {
-        let pending = std::mem::take(&mut *self.event_queue);
-        // SAFETY: the runner owns both adapters and serializes all queue access
-        // through its mutable borrow, including native callback execution.
-        self.event_queue = unsafe { event_queue.shared_handle() };
-        self.event_queue.extend(pending);
-    }
-
-    pub(crate) fn share_menu_tracking(&mut self, menu_tracking: &SharedMenuTracking) {
-        let pending = self.toolbox_startup.menu_tracking.take();
-        debug_assert!(
-            pending.is_none() || menu_tracking.is_none(),
-            "cannot attach two active Menu Manager continuations"
-        );
-        // SAFETY: the runner owns both adapters and serializes all retained
-        // Menu Manager access through its mutable borrow, including native
-        // callback execution.
-        self.toolbox_startup.menu_tracking = unsafe { menu_tracking.shared_handle() };
-        if self.toolbox_startup.menu_tracking.is_none() {
-            *self.toolbox_startup.menu_tracking = pending;
+    /// # Safety
+    ///
+    /// The caller must keep this adapter and the context under one process
+    /// owner that serializes all access to their shared handles.
+    pub(crate) unsafe fn attach_process_context(&mut self, context: &ProcessContext) {
+        unsafe {
+            context.attach_event_queue(&mut self.event_queue);
+            context.attach_menu_tracking(&mut self.toolbox_startup.menu_tracking);
         }
-    }
-
-    pub(crate) fn share_native_menu_selection(&mut self, selection: &SharedNativeMenuSelection) {
-        let pending = self.toolbox_startup.pending_native_menu_selection.take();
-        debug_assert!(
-            pending.is_none() || selection.is_none(),
-            "cannot attach two pending native menu selections"
+        context.attach_native_menu_selection(
+            &mut self.toolbox_startup.pending_native_menu_selection,
         );
-        self.toolbox_startup.pending_native_menu_selection = selection.shared_handle();
-        if let Some(pending) = pending {
-            self.toolbox_startup
-                .pending_native_menu_selection
-                .stage(pending);
-        }
-    }
-
-    pub(crate) fn share_guest_calls(&mut self, guest_calls: &SharedGuestCallStack) {
-        self.guest_calls.attach_to(guest_calls);
-        self.toolbox_startup.guest_calls.attach_to(guest_calls);
+        context.attach_guest_calls(&mut self.guest_calls);
+        context.attach_guest_calls(&mut self.toolbox_startup.guest_calls);
     }
 
     /// Park the current native context and enter a PowerPC routine selected by
@@ -84601,7 +84576,12 @@ pub(crate) mod tests {
         classic.sent_open_app_event = true;
         let pef = synthetic_pef_with_import(b"InvalMenuBar");
         let mut native = load_pef_application(&pef).unwrap();
-        native.share_event_queue(&classic.event_queue);
+        let context = ProcessContext::default();
+        // SAFETY: the test owns both adapters and accesses them sequentially.
+        unsafe {
+            classic.attach_process_context(&context);
+            native.attach_process_context(&context);
+        }
 
         assert!(classic
             .dispatch_menu(true, 0x01D, &mut classic_cpu, &mut classic_bus)
@@ -84634,7 +84614,12 @@ pub(crate) mod tests {
         let (mut classic, mut classic_cpu, mut classic_bus) = setup_with_port();
         let pef = synthetic_pef_with_import(b"MenuSelect");
         let mut native = load_pef_application(&pef).unwrap();
-        native.share_menu_tracking(&classic.menu_tracking);
+        let context = ProcessContext::default();
+        // SAFETY: the test owns both adapters and accesses them sequentially.
+        unsafe {
+            classic.attach_process_context(&context);
+            native.attach_process_context(&context);
+        }
 
         let mut tracking = crate::menu_manager::test_process_menu_tracking(0x0012_3456);
         tracking.highlighted_item = 2;

--- a/src/menu_manager.rs
+++ b/src/menu_manager.rs
@@ -801,6 +801,28 @@ impl SharedMenuTracking {
         Self(Rc::clone(&self.0))
     }
 
+    /// Attach adapter-local tracking to the process continuation.
+    ///
+    /// # Safety
+    ///
+    /// The process owner must serialize all access to every attached handle.
+    pub(crate) unsafe fn attach_to(&mut self, process_tracking: &Self) {
+        if Rc::ptr_eq(&self.0, &process_tracking.0) {
+            return;
+        }
+        assert!(
+            self.is_none() || process_tracking.is_none(),
+            "cannot attach two active Menu Manager continuations"
+        );
+        let pending = self.take();
+        // SAFETY: ProcessContext is owned by FixtureRunner, which serializes
+        // access to every attached CPU adapter through its mutable borrow.
+        self.0 = unsafe { process_tracking.shared_handle() }.0;
+        if self.is_none() {
+            **self = pending;
+        }
+    }
+
     #[cfg(test)]
     pub(crate) fn snapshot(&self) -> Option<ProcessMenuTrackingState> {
         self.state().clone()
@@ -852,8 +874,25 @@ impl PartialEq<Option<(i16, i16)>> for SharedNativeMenuSelection {
 
 impl SharedNativeMenuSelection {
     /// Attach another CPU adapter without copying the pending selection.
+    #[cfg(test)]
     pub(crate) fn shared_handle(&self) -> Self {
         Self(Rc::clone(&self.0))
+    }
+
+    /// Attach adapter-local input to the process selection slot.
+    pub(crate) fn attach_to(&mut self, process_selection: &Self) {
+        if Rc::ptr_eq(&self.0, &process_selection.0) {
+            return;
+        }
+        assert!(
+            self.is_none() || process_selection.is_none(),
+            "cannot attach two pending native menu selections"
+        );
+        let pending = self.take();
+        self.0 = Rc::clone(&process_selection.0);
+        if let Some(pending) = pending {
+            self.stage(pending);
+        }
     }
 
     pub(crate) fn is_some(&self) -> bool {

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -1,0 +1,170 @@
+//! Process-scoped state shared by classic and native CPU adapters.
+
+use crate::event_queue::SharedEventQueue;
+use crate::guest_call::SharedGuestCallStack;
+use crate::menu_manager::{SharedMenuTracking, SharedNativeMenuSelection};
+
+/// Canonical owner for state that belongs to one emulated process rather than
+/// to either of its CPU ABI adapters.
+///
+/// `FixtureRunner` owns this context and serializes all adapter access through
+/// its mutable borrow. Adapters may still start detached for focused tests,
+/// then transfer any pending state when they attach here.
+#[derive(Debug, Default)]
+pub(crate) struct ProcessContext {
+    event_queue: SharedEventQueue,
+    menu_tracking: SharedMenuTracking,
+    pending_native_menu_selection: SharedNativeMenuSelection,
+    guest_calls: SharedGuestCallStack,
+}
+
+impl ProcessContext {
+    /// # Safety
+    ///
+    /// The caller must keep the context and adapter under one owner that
+    /// serializes all access to the attached handles.
+    pub(crate) unsafe fn attach_event_queue(&self, adapter: &mut SharedEventQueue) {
+        unsafe { adapter.attach_to(&self.event_queue) };
+    }
+
+    /// # Safety
+    ///
+    /// The caller must keep the context and adapter under one owner that
+    /// serializes all access to the attached handles.
+    pub(crate) unsafe fn attach_menu_tracking(&self, adapter: &mut SharedMenuTracking) {
+        unsafe { adapter.attach_to(&self.menu_tracking) };
+    }
+
+    pub(crate) fn attach_native_menu_selection(
+        &self,
+        adapter: &mut SharedNativeMenuSelection,
+    ) {
+        adapter.attach_to(&self.pending_native_menu_selection);
+    }
+
+    pub(crate) fn attach_guest_calls(&self, adapter: &mut SharedGuestCallStack) {
+        adapter.attach_to(&self.guest_calls);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::event_queue::QueuedEvent;
+    use crate::guest_call::GuestCallTarget;
+    use crate::guest_procedure::GuestIsa;
+
+    #[test]
+    fn adapters_transfer_pending_state_and_share_one_process_owner() {
+        let context = ProcessContext::default();
+        let mut classic_events = SharedEventQueue::default();
+        classic_events.push_back(QueuedEvent {
+            what: 1,
+            message: 0x1122_3344,
+            where_v: 10,
+            where_h: 20,
+            modifiers: 0,
+        });
+        let mut native_events = SharedEventQueue::default();
+        // SAFETY: the test accesses both adapters strictly in sequence.
+        unsafe {
+            context.attach_event_queue(&mut classic_events);
+            context.attach_event_queue(&mut native_events);
+        }
+        assert_eq!(native_events.front().map(|event| event.message), Some(0x1122_3344));
+        native_events.pop_front();
+        assert!(classic_events.is_empty());
+
+        let mut classic_tracking = SharedMenuTracking::default();
+        *classic_tracking = Some(crate::menu_manager::test_process_menu_tracking(0x0012_3456));
+        let mut native_tracking = SharedMenuTracking::default();
+        // SAFETY: the test accesses both adapters strictly in sequence.
+        unsafe {
+            context.attach_menu_tracking(&mut classic_tracking);
+            context.attach_menu_tracking(&mut native_tracking);
+        }
+        native_tracking.as_mut().unwrap().highlighted_item = 4;
+        assert_eq!(
+            classic_tracking
+                .as_ref()
+                .map(|tracking| (tracking.menu_handle, tracking.highlighted_item)),
+            Some((0x0012_3456, 4))
+        );
+
+        let mut classic_selection = SharedNativeMenuSelection::default();
+        assert!(classic_selection.stage((128, 2)));
+        let mut native_selection = SharedNativeMenuSelection::default();
+        context.attach_native_menu_selection(&mut classic_selection);
+        context.attach_native_menu_selection(&mut native_selection);
+        assert_eq!(native_selection.take(), Some((128, 2)));
+        assert!(classic_selection.is_none());
+
+        let mut classic_calls = SharedGuestCallStack::default();
+        classic_calls.begin_m68k(
+            GuestCallTarget {
+                isa: GuestIsa::M68k,
+                entry: 0x1000,
+                rtoc: 0,
+            },
+            0x2000,
+            0x3000,
+        );
+        let mut native_calls = SharedGuestCallStack::default();
+        context.attach_guest_calls(&mut classic_calls);
+        context.attach_guest_calls(&mut native_calls);
+        assert_eq!(native_calls.len(), 1);
+        assert!(native_calls.complete_m68k(0x2002, 0x3000));
+        assert!(classic_calls.is_empty());
+    }
+
+    #[test]
+    #[should_panic(expected = "cannot attach two active Menu Manager continuations")]
+    fn attaching_two_active_menu_continuations_is_always_rejected() {
+        let context = ProcessContext::default();
+        let mut first = SharedMenuTracking::default();
+        *first = Some(crate::menu_manager::test_process_menu_tracking(0x1000));
+        let mut second = SharedMenuTracking::default();
+        *second = Some(crate::menu_manager::test_process_menu_tracking(0x2000));
+        // SAFETY: the test accesses attached handles strictly in sequence.
+        unsafe {
+            context.attach_menu_tracking(&mut first);
+            context.attach_menu_tracking(&mut second);
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "cannot attach two pending native menu selections")]
+    fn attaching_two_pending_native_selections_is_always_rejected() {
+        let context = ProcessContext::default();
+        let mut first = SharedNativeMenuSelection::default();
+        let mut second = SharedNativeMenuSelection::default();
+        first.stage((128, 1));
+        second.stage((129, 2));
+        context.attach_native_menu_selection(&mut first);
+        context.attach_native_menu_selection(&mut second);
+    }
+
+    #[test]
+    #[should_panic(expected = "cannot attach two active guest-procedure continuation stacks")]
+    fn attaching_two_active_guest_call_stacks_is_always_rejected() {
+        fn begin_call(calls: &SharedGuestCallStack, entry: u32) {
+            calls.begin_m68k(
+                GuestCallTarget {
+                    isa: GuestIsa::M68k,
+                    entry,
+                    rtoc: 0,
+                },
+                entry + 2,
+                0x3000,
+            );
+        }
+
+        let context = ProcessContext::default();
+        let mut first = SharedGuestCallStack::default();
+        let mut second = SharedGuestCallStack::default();
+        begin_call(&first, 0x1000);
+        begin_call(&second, 0x2000);
+        context.attach_guest_calls(&mut first);
+        context.attach_guest_calls(&mut second);
+    }
+}

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -18,6 +18,7 @@ use crate::managers::resource::ResourceFork;
 use crate::memory::GuestAddressSpace as PpcSectionMem;
 use crate::memory::{MacMemoryBus, MemoryBus};
 use crate::menu_model::GuestMenuSnapshot;
+use crate::process_context::ProcessContext;
 use crate::trap::dispatch::TrapTableProfile;
 use crate::trap::TrapDispatcher;
 use crate::ui_theme::{ThemeMetricsMode, UiTheme, UiThemeId};
@@ -1688,6 +1689,8 @@ pub struct FixtureRunner {
     ppc_sound_host_playbacks: Vec<PpcHostSoundPlayback>,
     bus: MacMemoryBus,
     dispatcher: TrapDispatcher,
+    /// Canonical owner for state shared by this process's CPU ABI adapters.
+    process_context: ProcessContext,
     config: FixtureRunnerConfig,
     /// Explicit display depth carried into native PowerPC launches. `None`
     /// preserves the architecture defaults: 8bpp for 68K and 16bpp for PPC.
@@ -1895,7 +1898,11 @@ impl FixtureRunner {
             matches!(config.screen_depth, 1 | 2 | 4 | 8),
             "screen_depth must be 1, 2, 4, or 8"
         );
+        let process_context = ProcessContext::default();
         let mut dispatcher = TrapDispatcher::new();
+        // SAFETY: FixtureRunner owns the context and every attached adapter,
+        // and serializes their access through its mutable borrow.
+        unsafe { dispatcher.attach_process_context(&process_context) };
         dispatcher.set_menu_bar_policy(config.menu_bar_policy);
         dispatcher.mmu_mode = u8::from(config.addressing_32_bit);
         dispatcher.set_ui_theme_id(config.ui_theme);
@@ -1940,6 +1947,7 @@ impl FixtureRunner {
             ppc_sound_host_playbacks: Vec::new(),
             bus,
             dispatcher,
+            process_context,
             config,
             powerpc_screen_depth_override: None,
             ppc_host_indexed_ctab_handle: 0,
@@ -3932,10 +3940,9 @@ impl FixtureRunner {
         self.dispatcher
             .materialize_trap_tables(&mut self.bus, TrapTableProfile::PowerPc604);
         self.share_ppc_runtime_globals(&mut ppc_app);
-        ppc_app.share_event_queue(&self.dispatcher.event_queue);
-        ppc_app.share_menu_tracking(&self.dispatcher.menu_tracking);
-        ppc_app.share_native_menu_selection(&self.dispatcher.pending_native_menu_selection);
-        ppc_app.share_guest_calls(&self.dispatcher.guest_calls);
+        // SAFETY: FixtureRunner owns the context and every attached adapter,
+        // and serializes their access through its mutable borrow.
+        unsafe { ppc_app.attach_process_context(&self.process_context) };
         if let Some(time_base) = self.launch_ppc_time_base_override {
             ppc_app.cpu.set_time_base(time_base);
         }

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -13,6 +13,7 @@ use crate::machine_profile::reference_machine_profile;
 use crate::managers::resource::ResourceFork;
 use crate::memory::{MacMemoryBus, MemoryBus};
 use crate::menu_manager::{SharedMenuTracking, SharedNativeMenuSelection};
+use crate::process_context::ProcessContext;
 use crate::trace::{TraceEvent, TraceSink, TraceSource};
 use crate::ui_theme::{UiTheme, UiThemeId};
 use crate::{Error, Result};
@@ -2926,6 +2927,19 @@ pub(crate) struct LoadedResources {
 }
 
 impl TrapDispatcher {
+    /// # Safety
+    ///
+    /// The caller must keep this adapter and the context under one process
+    /// owner that serializes all access to their shared handles.
+    pub(crate) unsafe fn attach_process_context(&mut self, context: &ProcessContext) {
+        unsafe {
+            context.attach_event_queue(&mut self.event_queue);
+            context.attach_menu_tracking(&mut self.menu_tracking);
+        }
+        context.attach_native_menu_selection(&mut self.pending_native_menu_selection);
+        context.attach_guest_calls(&mut self.guest_calls);
+    }
+
     pub(crate) const AUTO_KEY_THRESHOLD_TICKS: u32 = 16;
     pub(crate) const AUTO_KEY_RATE_TICKS: u32 = 4;
     const CAPS_LOCK_KEY_CODE: u8 = 0x39;


### PR DESCRIPTION
## Summary

- make `FixtureRunner` own one process context for state shared by the 68k and PowerPC ABI adapters
- centralize attachment of the event queue, retained menu continuation, native menu selection, and guest-call stack
- preserve staged adapter state and reject dual-active ownership conflicts consistently in debug and release builds
- route cross-adapter event/menu tests through the production context attachment path

## Verification

- `cargo fmt --check`
- `cargo check --features test-support`
- `cargo test --features test-support` (4,537 passed, 3 ignored; all desktop, packer, and doc tests passed)
- optimized process-context conflict tests (4 passed)
- retained native `MenuSelect` → 68k MDEF → 68k `DisableItem` → native continuation regression
- deterministic gameplay to interactive checkpoints in Tomb Raider Gold, Escape Velocity 1.0.5, and Marathon 2: Durandal

Closes #1006