### PR TITLE
refactor(event): make process context own the event queue

### DIFF
--- a/src/event_queue.rs
+++ b/src/event_queue.rs
@@ -1,9 +1,7 @@
 //! Architecture-neutral ownership for Event Manager queue and redraw state.
 
-use std::cell::UnsafeCell;
 use std::collections::VecDeque;
 use std::ops::{Deref, DerefMut};
-use std::rc::Rc;
 
 /// A queued Mac event (mouseDown, mouseUp, keyDown, etc.).
 ///
@@ -22,102 +20,67 @@ pub struct QueuedEvent {
     pub modifiers: u16,
 }
 
-/// One serialized Event Manager state that can be attached to both CPU
-/// adapters. It owns the OS event queue and the menu-bar-invalid bit consumed
-/// during Toolbox event scans.
-///
-/// Ordinary construction owns a private queue. The runner may explicitly
-/// attach a second adapter to the same allocation once both adapters are its
-/// private children and all access is serialized through a mutable runner
-/// borrow.
-#[derive(Clone, Debug, Default)]
-struct SharedEventState {
+/// Architecture-neutral Event Manager state. It owns the OS event queue and the
+/// menu-bar-invalid bit consumed during Toolbox event scans.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct EventQueue {
     events: VecDeque<QueuedEvent>,
     menu_bar_invalid: bool,
 }
 
-#[derive(Debug, Default)]
-pub(crate) struct SharedEventQueue(Rc<UnsafeCell<SharedEventState>>);
-
-impl Clone for SharedEventQueue {
-    fn clone(&self) -> Self {
-        // A cloned runtime is a snapshot, not another live CPU adapter.
-        Self(Rc::new(UnsafeCell::new(self.state().clone())))
-    }
-}
-
-impl SharedEventQueue {
-    fn state(&self) -> &SharedEventState {
-        // SAFETY: shared handles can only be created under the serialized
-        // ownership contract documented by `shared_handle`.
-        unsafe { &*self.0.get() }
-    }
-
-    fn state_mut(&mut self) -> &mut SharedEventState {
-        // SAFETY: shared handles can only be created under the serialized
-        // ownership contract documented by `shared_handle`.
-        unsafe { &mut *self.0.get() }
-    }
-
-    /// Attach another CPU adapter to this queue without copying it.
-    ///
-    /// # Safety
-    ///
-    /// Every handle sharing this allocation must remain under one owner that
-    /// serializes access. No queue reference may remain live while another
-    /// handle reads or mutates the allocation.
-    pub(crate) unsafe fn shared_handle(&self) -> Self {
-        Self(Rc::clone(&self.0))
-    }
-
-    /// Attach an adapter-local queue to the process queue, preserving work
-    /// that the adapter staged before it joined the process.
-    ///
-    /// # Safety
-    ///
-    /// The process owner must serialize all access to every attached handle.
-    pub(crate) unsafe fn attach_to(&mut self, process_queue: &Self) {
-        if Rc::ptr_eq(&self.0, &process_queue.0) {
-            return;
-        }
-        let pending = std::mem::take(self.state_mut());
-        // SAFETY: ProcessContext is owned by FixtureRunner, which serializes
-        // access to every attached CPU adapter through its mutable borrow.
-        self.0 = unsafe { process_queue.shared_handle() }.0;
-        let state = self.state_mut();
-        state.events.extend(pending.events);
-        state.menu_bar_invalid |= pending.menu_bar_invalid;
+impl EventQueue {
+    #[allow(dead_code)]
+    pub fn new() -> Self {
+        Self::default()
     }
 
     /// Mark the menu bar for one deferred redraw by the Toolbox Event
     /// Manager. Repeated invalidations coalesce until the next event scan.
     /// Macintosh Toolbox Essentials (1992), pp. 3-93 and 3-114.
-    pub(crate) fn invalidate_menu_bar(&mut self) {
-        self.state_mut().menu_bar_invalid = true;
+    pub fn invalidate_menu_bar(&mut self) {
+        self.menu_bar_invalid = true;
     }
 
     /// Consume the deferred menu-bar redraw request at an event scan.
-    pub(crate) fn take_menu_bar_invalidation(&mut self) -> bool {
-        std::mem::take(&mut self.state_mut().menu_bar_invalid)
+    pub fn take_menu_bar_invalidation(&mut self) -> bool {
+        std::mem::take(&mut self.menu_bar_invalid)
     }
 
     #[cfg(test)]
-    pub(crate) fn menu_bar_is_invalid(&self) -> bool {
-        self.state().menu_bar_invalid
+    pub fn menu_bar_is_invalid(&self) -> bool {
+        self.menu_bar_invalid
+    }
+
+    /// Merge another detached queue into this one by preserving all existing events,
+    /// appending the other queue's events, and OR-ing their menu bar invalidation flags.
+    pub fn merge(&mut self, mut other: Self) {
+        if other.take_menu_bar_invalidation() {
+            self.invalidate_menu_bar();
+        }
+        self.events.append(&mut other.events);
     }
 }
 
-impl Deref for SharedEventQueue {
+impl Deref for EventQueue {
     type Target = VecDeque<QueuedEvent>;
 
     fn deref(&self) -> &Self::Target {
-        &self.state().events
+        &self.events
     }
 }
 
-impl DerefMut for SharedEventQueue {
+impl DerefMut for EventQueue {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.state_mut().events
+        &mut self.events
+    }
+}
+
+impl FromIterator<QueuedEvent> for EventQueue {
+    fn from_iter<T: IntoIterator<Item = QueuedEvent>>(iter: T) -> Self {
+        Self {
+            events: iter.into_iter().collect(),
+            menu_bar_invalid: false,
+        }
     }
 }
 
@@ -126,30 +89,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn attached_handles_have_immediate_bidirectional_visibility() {
-        let mut first = SharedEventQueue::default();
-        // SAFETY: this test accesses the handles strictly in sequence.
-        let mut second = unsafe { first.shared_handle() };
-        first.push_back(QueuedEvent {
-            what: 3,
-            message: 0x1122_3344,
-            where_v: 10,
-            where_h: 20,
-            modifiers: 0x0100,
-        });
-        assert_eq!(second.front().map(|event| event.message), Some(0x1122_3344));
-        second.pop_front();
-        assert!(first.is_empty());
-
-        first.invalidate_menu_bar();
-        assert!(second.menu_bar_is_invalid());
-        assert!(second.take_menu_bar_invalidation());
-        assert!(!first.menu_bar_is_invalid());
-    }
-
-    #[test]
     fn clone_is_a_detached_snapshot() {
-        let mut live = SharedEventQueue::default();
+        let mut live = EventQueue::default();
         live.push_back(QueuedEvent {
             what: 3,
             message: 0x1122_3344,
@@ -170,12 +111,68 @@ mod tests {
 
     #[test]
     fn repeated_menu_bar_invalidations_coalesce_until_consumed() {
-        let mut queue = SharedEventQueue::default();
+        let mut queue = EventQueue::default();
 
         queue.invalidate_menu_bar();
         queue.invalidate_menu_bar();
 
         assert!(queue.take_menu_bar_invalidation());
         assert!(!queue.take_menu_bar_invalidation());
+    }
+
+    #[test]
+    fn queue_ordering_and_mutations_are_preserved() {
+        let mut queue = EventQueue::default();
+        queue.push_back(QueuedEvent {
+            what: 1,
+            message: 0x100,
+            where_v: 1,
+            where_h: 2,
+            modifiers: 0,
+        });
+        queue.push_back(QueuedEvent {
+            what: 2,
+            message: 0x200,
+            where_v: 3,
+            where_h: 4,
+            modifiers: 0,
+        });
+
+        assert_eq!(queue.len(), 2);
+        assert_eq!(queue.pop_front().map(|e| e.message), Some(0x100));
+        assert_eq!(queue.pop_front().map(|e| e.message), Some(0x200));
+        assert!(queue.is_empty());
+    }
+
+    #[test]
+    fn merge_preserves_order_and_combines_invalidation() {
+        let mut target = EventQueue::default();
+        target.push_back(QueuedEvent {
+            what: 1,
+            message: 0x111,
+            where_v: 1,
+            where_h: 2,
+            modifiers: 0,
+        });
+
+        let mut source = EventQueue::default();
+        source.push_back(QueuedEvent {
+            what: 2,
+            message: 0x222,
+            where_v: 3,
+            where_h: 4,
+            modifiers: 0,
+        });
+        source.invalidate_menu_bar();
+
+        assert!(!target.menu_bar_is_invalid());
+        assert!(source.menu_bar_is_invalid());
+
+        target.merge(source);
+
+        assert_eq!(target.len(), 2);
+        assert_eq!(target[0].message, 0x111);
+        assert_eq!(target[1].message, 0x222);
+        assert!(target.menu_bar_is_invalid());
     }
 }

--- a/src/loader/ppc.rs
+++ b/src/loader/ppc.rs
@@ -14,7 +14,7 @@ use super::pef::{
     SECTION_KIND_PATTERN_DATA, SECTION_KIND_UNPACKED_DATA,
 };
 use super::ApplicationSizeResource;
-use crate::event_queue::{QueuedEvent, SharedEventQueue};
+use crate::event_queue::{EventQueue, QueuedEvent};
 use crate::guest_call::SharedGuestCallStack;
 use crate::guest_procedure::{
     resolve_guest_procedure, GuestIsa, GuestProcedure,
@@ -4959,7 +4959,7 @@ pub struct PpcLoadedApp {
     pub imports: Vec<PpcImportBinding>,
     pub section_bases: Vec<Option<u32>>,
     pub input: PpcInputSnapshot,
-    pub(crate) event_queue: SharedEventQueue,
+    pub(crate) event_queue: EventQueue,
     pub(crate) guest_calls: SharedGuestCallStack,
     pub draw_sprocket: PpcDrawSprocketState,
 }
@@ -5125,7 +5125,6 @@ impl PpcLoadedApp {
     /// owner that serializes all access to their shared handles.
     pub(crate) unsafe fn attach_process_context(&mut self, context: &ProcessContext) {
         unsafe {
-            context.attach_event_queue(&mut self.event_queue);
             context.attach_menu_tracking(&mut self.toolbox_startup.menu_tracking);
         }
         context.attach_native_menu_selection(
@@ -5133,6 +5132,23 @@ impl PpcLoadedApp {
         );
         context.attach_guest_calls(&mut self.guest_calls);
         context.attach_guest_calls(&mut self.toolbox_startup.guest_calls);
+    }
+
+    /// Temporarily borrow the canonical event queue from [`ProcessContext`] into this
+    /// adapter's local queue for the duration of `f`, and guarantee it is swapped back
+    /// on normal exit, early return, or unwind.
+    pub(crate) fn with_event_queue<R>(
+        &mut self,
+        event_queue: &mut EventQueue,
+        f: impl FnOnce(&mut Self) -> R,
+    ) -> R {
+        std::mem::swap(&mut self.event_queue, event_queue);
+        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(self)));
+        std::mem::swap(&mut self.event_queue, event_queue);
+        match outcome {
+            Ok(result) => result,
+            Err(payload) => std::panic::resume_unwind(payload),
+        }
     }
 
     /// Park the current native context and enter a PowerPC routine selected by
@@ -13604,7 +13620,7 @@ fn load_pef_application_with_config_and_optional_system_reservation(
         imports,
         section_bases,
         input: PpcInputSnapshot::default(),
-        event_queue: SharedEventQueue::default(),
+        event_queue: EventQueue::default(),
         guest_calls: SharedGuestCallStack::default(),
         draw_sprocket: PpcDrawSprocketState::default(),
     })
@@ -15666,7 +15682,7 @@ fn dispatch_supported_import(
     scrap: &mut PpcScrapState,
     list_manager: &mut PpcListManagerState,
     input: PpcInputSnapshot,
-    event_queue: &mut SharedEventQueue,
+    event_queue: &mut EventQueue,
     draw_sprocket: &mut PpcDrawSprocketState,
 ) -> Option<PpcImportAction> {
     if is_quickdraw_3d_library(&binding.library_name)
@@ -71033,7 +71049,7 @@ fn ppc_draw_menu_bar_with_colors(
 }
 
 fn ppc_service_invalid_menu_bar(
-    event_queue: &mut SharedEventQueue,
+    event_queue: &mut EventQueue,
     memory: &mut PpcSectionMem,
     handles: &[PpcHandleRecord],
     gworlds: &[PpcGWorldRecord],
@@ -84571,45 +84587,6 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn attached_68k_and_powerpc_event_adapters_share_menu_bar_invalidation() {
-        let (mut classic, mut classic_cpu, mut classic_bus) = setup_with_port();
-        classic.sent_open_app_event = true;
-        let pef = synthetic_pef_with_import(b"InvalMenuBar");
-        let mut native = load_pef_application(&pef).unwrap();
-        let context = ProcessContext::default();
-        // SAFETY: the test owns both adapters and accesses them sequentially.
-        unsafe {
-            classic.attach_process_context(&context);
-            native.attach_process_context(&context);
-        }
-
-        assert!(classic
-            .dispatch_menu(true, 0x01D, &mut classic_cpu, &mut classic_bus)
-            .unwrap()
-            .is_ok());
-        assert!(native.event_queue.menu_bar_is_invalid());
-        let native_event = PPC_DATA_BASE + 0x1000;
-        native.memory.add_region(native_event, vec![0; 16]);
-        native.cpu.gpr[3] = 0;
-        native.cpu.gpr[4] = native_event;
-        run_test_import(&mut native, PpcImportDispatcherTarget::GetNextEvent);
-        assert!(!classic.event_queue.menu_bar_is_invalid());
-        assert_eq!(native.toolbox_startup.menu_bar_draw_count, 1);
-
-        run_test_import(&mut native, PpcImportDispatcherTarget::InvalMenuBar);
-        assert!(classic.event_queue.menu_bar_is_invalid());
-        let classic_event = classic_bus.alloc(16);
-        classic_cpu.write_reg(Register::A7, TEST_SP);
-        classic_bus.write_long(TEST_SP, classic_event);
-        classic_bus.write_word(TEST_SP + 4, 0);
-        assert!(classic
-            .dispatch_toolbox(true, 0x171, &mut classic_cpu, &mut classic_bus)
-            .unwrap()
-            .is_ok());
-        assert!(!native.event_queue.menu_bar_is_invalid());
-    }
-
-    #[test]
     fn attached_68k_and_powerpc_adapters_share_one_retained_menu_continuation() {
         let (mut classic, mut classic_cpu, mut classic_bus) = setup_with_port();
         let pef = synthetic_pef_with_import(b"MenuSelect");
@@ -84685,6 +84662,67 @@ pub(crate) mod tests {
 
         native.toolbox_startup.menu_tracking.take();
         assert!(classic.menu_tracking.is_none());
+    }
+
+    #[test]
+    fn attached_68k_and_powerpc_event_adapters_share_menu_bar_invalidation() {
+        let (mut classic, _, _) = setup_with_port();
+        let pef = synthetic_pef_with_import(b"InvalMenuBar");
+        let mut native = load_pef_application(&pef).unwrap();
+        let mut context = ProcessContext::default();
+
+        assert!(!context.event_queue().menu_bar_is_invalid());
+
+        classic.with_event_queue(context.event_queue_mut(), |classic| {
+            classic.event_queue.invalidate_menu_bar();
+            assert!(classic.event_queue.menu_bar_is_invalid());
+        });
+
+        assert!(context.event_queue().menu_bar_is_invalid());
+
+        native.with_event_queue(context.event_queue_mut(), |native| {
+            assert!(native.event_queue.menu_bar_is_invalid());
+            assert!(native.event_queue.take_menu_bar_invalidation());
+            assert!(!native.event_queue.menu_bar_is_invalid());
+        });
+
+        assert!(!context.event_queue().menu_bar_is_invalid());
+    }
+
+    #[test]
+    fn ppc_with_event_queue_restores_context_and_adapter_state_on_panic() {
+        let pef = synthetic_pef_with_import(b"InvalMenuBar");
+        let mut native = load_pef_application(&pef).unwrap();
+        let mut context_queue = EventQueue::default();
+        context_queue.push_back(QueuedEvent {
+            what: 1,
+            message: 0x1111,
+            where_v: 10,
+            where_h: 20,
+            modifiers: 0,
+        });
+
+        let panic_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            native.with_event_queue(&mut context_queue, |app| {
+                app.event_queue.push_back(QueuedEvent {
+                    what: 2,
+                    message: 0x2222,
+                    where_v: 30,
+                    where_h: 40,
+                    modifiers: 0,
+                });
+                app.event_queue.invalidate_menu_bar();
+                panic!("simulated panic inside PPC guest execution");
+            })
+        }));
+
+        assert!(panic_result.is_err());
+        assert_eq!(context_queue.len(), 2);
+        assert_eq!(context_queue[0].message, 0x1111);
+        assert_eq!(context_queue[1].message, 0x2222);
+        assert!(context_queue.menu_bar_is_invalid());
+        assert!(native.event_queue.is_empty());
+        assert!(!native.event_queue.menu_bar_is_invalid());
     }
 
     #[test]

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -1,6 +1,6 @@
 //! Process-scoped state shared by classic and native CPU adapters.
 
-use crate::event_queue::SharedEventQueue;
+use crate::event_queue::EventQueue;
 use crate::guest_call::SharedGuestCallStack;
 use crate::menu_manager::{SharedMenuTracking, SharedNativeMenuSelection};
 
@@ -8,23 +8,22 @@ use crate::menu_manager::{SharedMenuTracking, SharedNativeMenuSelection};
 /// to either of its CPU ABI adapters.
 ///
 /// `FixtureRunner` owns this context and serializes all adapter access through
-/// its mutable borrow. Adapters may still start detached for focused tests,
-/// then transfer any pending state when they attach here.
+/// its mutable borrow.
 #[derive(Debug, Default)]
 pub(crate) struct ProcessContext {
-    event_queue: SharedEventQueue,
+    event_queue: EventQueue,
     menu_tracking: SharedMenuTracking,
     pending_native_menu_selection: SharedNativeMenuSelection,
     guest_calls: SharedGuestCallStack,
 }
 
 impl ProcessContext {
-    /// # Safety
-    ///
-    /// The caller must keep the context and adapter under one owner that
-    /// serializes all access to the attached handles.
-    pub(crate) unsafe fn attach_event_queue(&self, adapter: &mut SharedEventQueue) {
-        unsafe { adapter.attach_to(&self.event_queue) };
+    pub(crate) fn event_queue(&self) -> &EventQueue {
+        &self.event_queue
+    }
+
+    pub(crate) fn event_queue_mut(&mut self) -> &mut EventQueue {
+        &mut self.event_queue
     }
 
     /// # Safety
@@ -55,25 +54,23 @@ mod tests {
     use crate::guest_procedure::GuestIsa;
 
     #[test]
-    fn adapters_transfer_pending_state_and_share_one_process_owner() {
-        let context = ProcessContext::default();
-        let mut classic_events = SharedEventQueue::default();
-        classic_events.push_back(QueuedEvent {
+    fn process_context_owns_canonical_event_queue() {
+        let mut context = ProcessContext::default();
+        assert!(context.event_queue().is_empty());
+        context.event_queue_mut().push_back(QueuedEvent {
             what: 1,
-            message: 0x1122_3344,
+            message: 0x1234,
             where_v: 10,
             where_h: 20,
             modifiers: 0,
         });
-        let mut native_events = SharedEventQueue::default();
-        // SAFETY: the test accesses both adapters strictly in sequence.
-        unsafe {
-            context.attach_event_queue(&mut classic_events);
-            context.attach_event_queue(&mut native_events);
-        }
-        assert_eq!(native_events.front().map(|event| event.message), Some(0x1122_3344));
-        native_events.pop_front();
-        assert!(classic_events.is_empty());
+        assert_eq!(context.event_queue().len(), 1);
+        assert_eq!(context.event_queue().front().unwrap().message, 0x1234);
+    }
+
+    #[test]
+    fn adapters_transfer_pending_state_and_share_one_process_owner() {
+        let context = ProcessContext::default();
 
         let mut classic_tracking = SharedMenuTracking::default();
         *classic_tracking = Some(crate::menu_manager::test_process_menu_tracking(0x0012_3456));

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2723,7 +2723,10 @@ impl FixtureRunner {
     }
 
     fn push_canonical_mouse_down(&mut self, v: i16, h: i16) {
-        self.dispatcher.push_mouse_down(v, h);
+        self.dispatcher
+            .with_event_queue(self.process_context.event_queue_mut(), |d| {
+                d.push_mouse_down(v, h);
+            });
         self.sync_mouse_lowmem();
         self.wake_pending_wait_next_event_if_input_available();
         self.wake_foreground_after_input();
@@ -2735,8 +2738,8 @@ impl FixtureRunner {
     /// consumed a posted mouse-down event; physical button duration is tracked
     /// independently.
     pub fn pending_mouse_down_count(&self) -> usize {
-        self.dispatcher
-            .event_queue
+        self.process_context
+            .event_queue()
             .iter()
             .filter(|event| event.what == 1)
             .count()
@@ -2763,7 +2766,10 @@ impl FixtureRunner {
     }
 
     fn push_canonical_mouse_up(&mut self, v: i16, h: i16) {
-        self.dispatcher.push_mouse_up(v, h);
+        self.dispatcher
+            .with_event_queue(self.process_context.event_queue_mut(), |d| {
+                d.push_mouse_up(v, h);
+            });
         self.sync_mouse_lowmem();
         self.wake_pending_wait_next_event_if_input_available();
         self.wake_foreground_after_input();
@@ -2811,7 +2817,10 @@ impl FixtureRunner {
     /// Inject a key-down event, applying arrow→numpad remapping if configured.
     pub fn push_key_down(&mut self, mac_key: u8, char_code: u8) {
         let (key, char_code) = self.remap_key(mac_key, char_code);
-        self.dispatcher.push_key_down(key, char_code);
+        self.dispatcher
+            .with_event_queue(self.process_context.event_queue_mut(), |d| {
+                d.push_key_down(key, char_code);
+            });
         self.sync_key_map_lowmem();
         self.wake_pending_wait_next_event_if_input_available();
         self.wake_foreground_after_input();
@@ -2820,12 +2829,13 @@ impl FixtureRunner {
     /// Inject a key-up event, applying arrow→numpad remapping if configured.
     pub fn push_key_up(&mut self, mac_key: u8, char_code: u8) {
         let (key, char_code) = self.remap_key(mac_key, char_code);
-        self.dispatcher.push_key_up_with_system_event_mask(
-            self.bus
-                .read_word(crate::memory::globals::addr::SYS_EVT_MASK),
-            key,
-            char_code,
-        );
+        let sys_evt_mask = self
+            .bus
+            .read_word(crate::memory::globals::addr::SYS_EVT_MASK);
+        self.dispatcher
+            .with_event_queue(self.process_context.event_queue_mut(), |d| {
+                d.push_key_up_with_system_event_mask(sys_evt_mask, key, char_code);
+            });
         self.sync_key_map_lowmem();
         self.wake_pending_wait_next_event_if_input_available();
         self.wake_foreground_after_input();
@@ -3987,6 +3997,10 @@ impl FixtureRunner {
         self.cpu.write_reg(Register::PC, 0);
         self.ppc_sound_synced_file_playback_count = 0;
         self.ppc_sound_host_playbacks.clear();
+        let detached_events = std::mem::take(&mut ppc_app.event_queue);
+        self.process_context
+            .event_queue_mut()
+            .merge(detached_events);
         self.ppc_app = Some(ppc_app);
     }
 
@@ -5671,10 +5685,11 @@ impl FixtureRunner {
                     }
 
                     self.dispatcher.yield_for_ui = yield_for_ui;
-                    match self
-                        .dispatcher
-                        .dispatch(opcode, &mut self.cpu, &mut self.bus)
-                    {
+                    let dispatch_result = self.dispatcher.with_event_queue(
+                        self.process_context.event_queue_mut(),
+                        |dispatcher| dispatcher.dispatch(opcode, &mut self.cpu, &mut self.bus),
+                    );
+                    match dispatch_result {
                         Ok(()) => {
                             let null_event = self.note_idle_cycle_trap_result(opcode);
                             // TickCount spin-loop acceleration is a post-dispatch
@@ -6011,14 +6026,16 @@ impl FixtureRunner {
         let trace_ppc_imports = record_ppc_imports || trace_ppc_import_hist;
         let trace_ppc_fetches = trace_ppc_fetch_counts_enabled();
         let profile_run_start = profile_ppc.then(Instant::now);
-        let probe = match (trace_ppc_imports, trace_ppc_fetches) {
-            (true, true) => {
-                ppc_app.run_with_hle_import_trace_and_fetch_histogram(ppc_max_steps as u64)
+        let probe = ppc_app.with_event_queue(self.process_context.event_queue_mut(), |app| {
+            match (trace_ppc_imports, trace_ppc_fetches) {
+                (true, true) => {
+                    app.run_with_hle_import_trace_and_fetch_histogram(ppc_max_steps as u64)
+                }
+                (true, false) => app.run_with_hle_import_trace(ppc_max_steps as u64),
+                (false, true) => app.run_with_hle_import_fetch_histogram(ppc_max_steps as u64),
+                (false, false) => app.run_with_hle_imports(ppc_max_steps as u64),
             }
-            (true, false) => ppc_app.run_with_hle_import_trace(ppc_max_steps as u64),
-            (false, true) => ppc_app.run_with_hle_import_fetch_histogram(ppc_max_steps as u64),
-            (false, false) => ppc_app.run_with_hle_imports(ppc_max_steps as u64),
-        };
+        });
         let profile_run_us = elapsed_profile_micros(profile_run_start);
         let ppc_cycles = ppc_run_result_cycles(probe.result);
         let resumed_m68k = self.resume_m68k_after_powerpc(&mut ppc_app);
@@ -6057,15 +6074,18 @@ impl FixtureRunner {
         } else {
             self.advance_ticks_for_ppc_cycles(cycles, tick_cap);
             let elapsed_ticks = self.dispatcher.tick_count.wrapping_sub(ppc_start_tick);
-            self.fire_ppc_tick_callbacks(
-                &mut ppc_app,
-                ppc_start_tick,
-                ppc_start_time,
-                elapsed_ticks,
-                u64::from(cycles_per_tick),
-                trace_ppc_imports,
-                trace_ppc_fetches,
-            )
+            let probes = ppc_app.with_event_queue(self.process_context.event_queue_mut(), |app| {
+                Self::fire_ppc_tick_callbacks(
+                    app,
+                    ppc_start_tick,
+                    ppc_start_time,
+                    elapsed_ticks,
+                    u64::from(cycles_per_tick),
+                    trace_ppc_imports,
+                    trace_ppc_fetches,
+                )
+            });
+            probes
         };
         if trace_vbl_enabled() {
             for vbl_probe in &vbl_probes {
@@ -6369,11 +6389,15 @@ impl FixtureRunner {
                         self.cpu.core.take_aline_exception(&mut self.bus);
                         continue;
                     }
-                    if self
-                        .dispatcher
-                        .dispatch(opcode, &mut self.cpu, &mut self.bus)
-                        .is_err()
-                    {
+                    let dispatch_err = self.dispatcher.with_event_queue(
+                        self.process_context.event_queue_mut(),
+                        |dispatcher| {
+                            dispatcher
+                                .dispatch(opcode, &mut self.cpu, &mut self.bus)
+                                .is_err()
+                        },
+                    );
+                    if dispatch_err {
                         running = false;
                         break;
                     }
@@ -6709,7 +6733,6 @@ impl FixtureRunner {
 
     #[allow(clippy::too_many_arguments)]
     fn fire_ppc_tick_callbacks(
-        &self,
         ppc_app: &mut PpcLoadedApp,
         start_tick: u32,
         start_time: u32,
@@ -7798,12 +7821,14 @@ impl FixtureRunner {
         while !ppc_app.sound.pending_doublebacks.is_empty() && fired_count < 16 {
             let doubleback = ppc_app.sound.pending_doublebacks.remove(0);
             let resume_pc = ppc_app.cpu.pc;
-            let probe = ppc_app.run_sound_doubleback_callback(
-                doubleback,
-                PPC_SOUND_COMPLETION_CALLBACK_MAX_CYCLES,
-                trace_ppc_imports,
-                trace_ppc_fetches,
-            );
+            let probe = ppc_app.with_event_queue(self.process_context.event_queue_mut(), |app| {
+                app.run_sound_doubleback_callback(
+                    doubleback,
+                    PPC_SOUND_COMPLETION_CALLBACK_MAX_CYCLES,
+                    trace_ppc_imports,
+                    trace_ppc_fetches,
+                )
+            });
             let invocation = probe.invocation;
             if trace_sound_runner_enabled() {
                 eprintln!(
@@ -7902,12 +7927,14 @@ impl FixtureRunner {
         let mut fired_count = 0usize;
         while !ppc_app.sound.pending_completions.is_empty() && fired_count < 16 {
             let completion = ppc_app.sound.pending_completions.remove(0);
-            let probe = ppc_app.run_sound_completion_callback(
-                completion,
-                PPC_SOUND_COMPLETION_CALLBACK_MAX_CYCLES,
-                trace_ppc_imports,
-                trace_ppc_fetches,
-            );
+            let probe = ppc_app.with_event_queue(self.process_context.event_queue_mut(), |app| {
+                app.run_sound_completion_callback(
+                    completion,
+                    PPC_SOUND_COMPLETION_CALLBACK_MAX_CYCLES,
+                    trace_ppc_imports,
+                    trace_ppc_fetches,
+                )
+            });
             let invocation = probe.invocation;
             if record_ppc_imports {
                 self.record_ppc_import_trace(&probe.import_trace);
@@ -8730,10 +8757,13 @@ impl FixtureRunner {
         let new_tick = self.bus.read_long(0x016A).wrapping_add(1);
         self.bus.write_long(0x016A, new_tick);
         self.dispatcher.tick_count = new_tick;
-        self.dispatcher.post_auto_key_if_due(
-            self.bus
-                .read_word(crate::memory::globals::addr::SYS_EVT_MASK),
-        );
+        let sys_evt_mask = self
+            .bus
+            .read_word(crate::memory::globals::addr::SYS_EVT_MASK);
+        self.dispatcher
+            .with_event_queue(self.process_context.event_queue_mut(), |d| {
+                d.post_auto_key_if_due(sys_evt_mask);
+            });
 
         // Sync MBState ($0172) from the internal button state.
         // On real hardware the VBL interrupt handler reads the ADB mouse
@@ -8748,7 +8778,10 @@ impl FixtureRunner {
         // to 0x80 even when no GetNextEvent ever drains the queue —
         // critical for polling-only games (Bonkheads-Deluxe class titles)
         // that would otherwise see the button as "held forever".
-        let has_pending_unmatched_down = self.dispatcher.has_unmatched_queued_mouse_down();
+        let has_pending_unmatched_down = self.dispatcher.with_event_queue(
+            self.process_context.event_queue_mut(),
+            |d| d.has_unmatched_queued_mouse_down(),
+        );
         let pressed = self.dispatcher.mouse_button || has_pending_unmatched_down;
         let mb_state: u8 = if pressed { 0x00 } else { 0x80 };
         self.bus.write_byte(0x0172, mb_state);
@@ -8759,7 +8792,7 @@ impl FixtureRunner {
                     new_tick,
                     self.total_instructions,
                     self.ppc_input_snapshot(),
-                    self.dispatcher.event_queue.len(),
+                    self.process_context.event_queue().len(),
                     mb_state,
                 )
             );
@@ -8788,7 +8821,7 @@ impl FixtureRunner {
 
     fn deliver_pending_wait_next_event_if_available(&mut self) -> bool {
         let Some(pending) = self.dispatcher.pending_wait_next_event_return.take() else {
-            if !self.dispatcher.event_queue.is_empty()
+            if !self.process_context.event_queue().is_empty()
                 || self.dispatcher.has_pending_native_menu_event()
             {
                 self.dispatcher.pending_wait_sleep_ticks = 0;
@@ -8814,7 +8847,9 @@ impl FixtureRunner {
 
         let (mut what, mut message, mut where_v, mut where_h, mut modifiers, mut has_event) = self
             .dispatcher
-            .dequeue_toolbox_event(&mut self.cpu, &mut self.bus, pending.event_mask);
+            .with_event_queue(self.process_context.event_queue_mut(), |dispatcher| {
+                dispatcher.dequeue_toolbox_event(&mut self.cpu, &mut self.bus, pending.event_mask)
+            });
         if !has_event {
             if let Some(event) = self.dispatcher.mouse_moved_event_for_region(
                 &self.bus,
@@ -10183,8 +10218,8 @@ impl FixtureRunner {
     }
 
     fn dialog_filter_has_real_event_pending(&self, dialog_ptr: u32) -> bool {
-        self.dispatcher
-            .event_queue
+        self.process_context
+            .event_queue()
             .iter()
             .any(|event| matches!(event.what, 1 | 2 | 3 | 4 | 6))
             || self
@@ -10335,11 +10370,11 @@ impl FixtureRunner {
         // Mac ModalDialog which calls GetNextEvent before invoking the filter.
         // Inside Macintosh Volume I, I-415
         let idx = self
-            .dispatcher
-            .event_queue
+            .process_context
+            .event_queue()
             .iter()
             .position(|e| matches!(e.what, 1 | 2 | 3 | 4 | 6));
-        let next_event = idx.map(|i| self.dispatcher.event_queue.remove(i).unwrap());
+        let next_event = idx.map(|i| self.process_context.event_queue_mut().remove(i).unwrap());
 
         let filter_event = if let Some(e) = next_event {
             e
@@ -10632,10 +10667,11 @@ impl FixtureRunner {
                         count += 1;
                         continue;
                     }
-                    match self
-                        .dispatcher
-                        .dispatch(opcode, &mut self.cpu, &mut self.bus)
-                    {
+                    let dispatch_result = self.dispatcher.with_event_queue(
+                        self.process_context.event_queue_mut(),
+                        |dispatcher| dispatcher.dispatch(opcode, &mut self.cpu, &mut self.bus),
+                    );
+                    match dispatch_result {
                         Ok(()) => {
                             // Smart PC Advance:
                             // Only advance PC if the trap didn't change it
@@ -12120,6 +12156,75 @@ mod tests {
     }
 
     #[test]
+    fn init_ppc_app_merges_detached_events_and_menu_bar_invalidation() {
+        // Test case 1: Context has event and invalidation=true, detached PPC has event and invalidation=false
+        {
+            let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+            runner.process_context.event_queue_mut().push_back(QueuedEvent {
+                what: 3,
+                message: 0x1111,
+                where_v: 10,
+                where_h: 20,
+                modifiers: 0x0100,
+            });
+            runner.process_context.event_queue_mut().invalidate_menu_bar();
+
+            let mut app = halted_ppc_app_with_sound(PpcSoundState::default());
+            let ppc_app = app.ppc.as_mut().expect("synthetic PPC app");
+            ppc_app.memory.add_region(PPC_HALT_PC, vec![0; 64 * 1024]);
+            ppc_app.event_queue.push_back(QueuedEvent {
+                what: 1,
+                message: 0x2222,
+                where_v: 30,
+                where_h: 40,
+                modifiers: 0x0200,
+            });
+
+            runner.init_app(&app);
+
+            let queue = runner.process_context.event_queue();
+            assert_eq!(queue.len(), 2);
+            assert_eq!(queue[0].message, 0x1111, "canonical event must remain in front");
+            assert_eq!(queue[1].message, 0x2222, "detached PPC event must be appended after canonical events");
+            assert!(queue.menu_bar_is_invalid(), "menu_bar_invalid should be true when context was true");
+            assert!(runner.ppc_app.as_ref().unwrap().event_queue.is_empty());
+        }
+
+        // Test case 2: Context has event and invalidation=false, detached PPC has event and invalidation=true
+        {
+            let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+            runner.process_context.event_queue_mut().push_back(QueuedEvent {
+                what: 3,
+                message: 0x3333,
+                where_v: 10,
+                where_h: 20,
+                modifiers: 0x0100,
+            });
+
+            let mut app = halted_ppc_app_with_sound(PpcSoundState::default());
+            let ppc_app = app.ppc.as_mut().expect("synthetic PPC app");
+            ppc_app.memory.add_region(PPC_HALT_PC, vec![0; 64 * 1024]);
+            ppc_app.event_queue.push_back(QueuedEvent {
+                what: 1,
+                message: 0x4444,
+                where_v: 30,
+                where_h: 40,
+                modifiers: 0x0200,
+            });
+            ppc_app.event_queue.invalidate_menu_bar();
+
+            runner.init_app(&app);
+
+            let queue = runner.process_context.event_queue();
+            assert_eq!(queue.len(), 2);
+            assert_eq!(queue[0].message, 0x3333, "canonical event must remain in front");
+            assert_eq!(queue[1].message, 0x4444, "detached PPC event must be appended after canonical events");
+            assert!(queue.menu_bar_is_invalid(), "menu_bar_invalid should be true when detached PPC was true");
+            assert!(runner.ppc_app.as_ref().unwrap().event_queue.is_empty());
+        }
+    }
+
+    #[test]
     fn ppc_slice_keeps_ticks_coherent_across_runner_and_guest_memory() {
         use crate::memory::globals::addr;
 
@@ -12283,7 +12388,7 @@ mod tests {
         }
 
         let (vbl, timer) =
-            runner.fire_ppc_tick_callbacks(&mut ppc_app, 41, 0x1020_3040, 2, 64, false, false);
+            FixtureRunner::fire_ppc_tick_callbacks(&mut ppc_app, 41, 0x1020_3040, 2, 64, false, false);
 
         assert_eq!(vbl.len(), 2);
         assert!(timer.is_empty());
@@ -12512,60 +12617,6 @@ mod tests {
             ppc_app.memory.read_u32_be(addr::THE_ZONE),
             Some(0x1122_3344)
         );
-    }
-
-    #[test]
-    fn ppc_event_queue_has_immediate_bidirectional_visibility() {
-        let mut app = halted_ppc_app_with_sound(PpcSoundState::default());
-        let app_ppc = app.ppc.as_mut().expect("synthetic PPC app");
-        app_ppc.memory.add_region(PPC_HALT_PC, vec![0; 64 * 1024]);
-        app_ppc.event_queue.push_back(QueuedEvent {
-            what: 23,
-            message: 0xaabb_ccdd,
-            where_v: 1,
-            where_h: 2,
-            modifiers: 0,
-        });
-        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
-        runner.init_app(&app);
-        assert_eq!(
-            runner
-                .dispatcher
-                .event_queue
-                .front()
-                .map(|event| event.message),
-            Some(0xaabb_ccdd)
-        );
-        let mut ppc_app = runner.ppc_app.take().expect("PPC app installed");
-        ppc_app.event_queue.pop_front();
-        assert!(runner.dispatcher.event_queue.is_empty());
-
-        let original = crate::trap::dispatch::QueuedEvent {
-            what: 3,
-            message: 0x1111,
-            where_v: 10,
-            where_h: 20,
-            modifiers: 0x0200,
-        };
-        runner.dispatcher.event_queue.push_back(original.clone());
-
-        let consumed = ppc_app.event_queue.pop_front().unwrap();
-        assert_eq!(consumed.message, original.message);
-        assert!(runner.dispatcher.event_queue.is_empty());
-
-        ppc_app.event_queue.push_back(original.clone());
-        assert_eq!(runner.dispatcher.event_queue.front(), Some(&original));
-        runner.dispatcher.event_queue.pop_front();
-        assert!(ppc_app.event_queue.is_empty());
-
-        // A byte-identical repost is a distinct queue mutation and requires
-        // no value-based reconciliation at a callback boundary.
-        runner.dispatcher.event_queue.push_back(original);
-        let reposted = ppc_app.event_queue.front().unwrap();
-        assert_eq!(reposted.what, 3);
-        assert_eq!(reposted.message, 0x1111);
-        assert_eq!((reposted.where_v, reposted.where_h), (10, 20));
-        assert_eq!(reposted.modifiers, 0x0200);
     }
 
     #[test]
@@ -15171,7 +15222,7 @@ mod tests {
             offset_v > 0 && offset_h > 0,
             "fixture must use a centered viewport"
         );
-        runner.dispatcher.event_queue.push_back(QueuedEvent {
+        runner.process_context.event_queue_mut().push_back(QueuedEvent {
             what: 3,
             message: 0x1122_3344,
             where_v: 120,
@@ -15190,8 +15241,8 @@ mod tests {
             ppc_app.memory.read_u16_be(PPC_SOUND_EVENT_RECORD + 12),
             Some(180)
         );
-        assert_eq!(runner.dispatcher.event_queue.len(), 1);
-        let posted = &runner.dispatcher.event_queue[0];
+        assert_eq!(runner.process_context.event_queue().len(), 1);
+        let posted = &runner.process_context.event_queue()[0];
         assert_eq!((posted.what, posted.message), (5, 0x5566_7788));
         assert_eq!((posted.where_v, posted.where_h), (17, 19));
         assert_eq!(
@@ -15268,13 +15319,63 @@ mod tests {
 
         runner.push_mouse_down(offset_v.saturating_add(12), offset_h.saturating_add(34));
 
-        let event = runner.dispatcher.event_queue.back().expect("mouseDown");
+        let event = runner.process_context.event_queue().back().expect("mouseDown");
         assert_eq!((event.where_v, event.where_h), (12, 34));
-        let ppc_app = runner.ppc_app.as_ref().expect("PPC app");
-        let native_event = ppc_app.event_queue.back().expect("shared mouseDown");
-        assert_eq!((native_event.where_v, native_event.where_h), (12, 34));
+        let mut ppc_app = runner.ppc_app.take().expect("PPC app");
+        ppc_app.with_event_queue(runner.process_context.event_queue_mut(), |ppc_app| {
+            let native_event = ppc_app.event_queue.back().expect("shared mouseDown");
+            assert_eq!((native_event.where_v, native_event.where_h), (12, 34));
+        });
+        runner.ppc_app = Some(ppc_app);
         assert_eq!(runner.bus.read_word(addr::M_TEMP), 12);
         assert_eq!(runner.bus.read_word(addr::M_TEMP + 2), 34);
+    }
+
+    #[test]
+    fn ppc_event_queue_has_immediate_bidirectional_visibility() {
+        let app = halted_ppc_app_with_sound(PpcSoundState::default());
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        runner.init_app(&app);
+
+        // Host input pushes directly into process context canonical queue
+        runner.push_mouse_down(10, 20);
+        assert_eq!(runner.process_context.event_queue().len(), 1);
+        assert_eq!(
+            (
+                runner.process_context.event_queue().front().unwrap().where_v,
+                runner.process_context.event_queue().front().unwrap().where_h
+            ),
+            (10, 20)
+        );
+
+        // PPC adapter receives canonical queue during execution
+        let mut ppc_app = runner.ppc_app.take().unwrap();
+        ppc_app.with_event_queue(runner.process_context.event_queue_mut(), |app| {
+            assert_eq!(app.event_queue.len(), 1);
+            let event = app.event_queue.pop_front().unwrap();
+            assert_eq!((event.where_v, event.where_h), (10, 20));
+            app.event_queue.push_back(QueuedEvent {
+                what: 2, // mouseUp
+                message: 0,
+                where_v: 30,
+                where_h: 40,
+                modifiers: 0,
+            });
+        });
+        runner.ppc_app = Some(ppc_app);
+
+        // Immediately visible in ProcessContext without sync copies
+        assert_eq!(runner.process_context.event_queue().len(), 1);
+        assert_eq!(runner.process_context.event_queue().front().unwrap().what, 2);
+
+        // 68k dispatcher receives canonical queue during execution
+        runner.dispatcher.with_event_queue(runner.process_context.event_queue_mut(), |classic| {
+            assert_eq!(classic.event_queue.len(), 1);
+            let event = classic.event_queue.pop_front().unwrap();
+            assert_eq!((event.where_v, event.where_h), (30, 40));
+        });
+
+        assert!(runner.process_context.event_queue().is_empty());
     }
 
     #[test]
@@ -16359,8 +16460,8 @@ mod tests {
         runner.push_key_up(0x7c, 29);
 
         assert!(runner
-            .dispatcher
-            .event_queue
+            .process_context
+            .event_queue()
             .iter()
             .any(|event| event.what == 4 && event.message == 0x0000_7c1d));
     }
@@ -16415,8 +16516,8 @@ mod tests {
         }
 
         assert!(runner
-            .dispatcher
-            .event_queue
+            .process_context
+            .event_queue()
             .iter()
             .any(|event| { event.what == 5 && event.message == 0x0000_0061 }));
     }
@@ -22019,7 +22120,7 @@ mod tests {
             assert_eq!(runner.cpu.read_reg(Register::PC), base);
 
             runner.dispatcher.modeless_dialog_draw_proc_queue.clear();
-            runner.dispatcher.event_queue.push_back(QueuedEvent {
+            runner.process_context.event_queue_mut().push_back(QueuedEvent {
                 what: 3,
                 message: 0x0000_351B, // Escape
                 where_v: 0,
@@ -22220,7 +22321,7 @@ mod tests {
         runner.cpu.write_reg(Register::A7, 0x0010_0000);
         runner.bus.write_long(0x016A, 0);
         runner.dispatcher.tick_count = 0;
-        runner.dispatcher.event_queue.push_back(QueuedEvent {
+        runner.process_context.event_queue_mut().push_back(QueuedEvent {
             what: 6,
             message: 0,
             where_v: 0,
@@ -22257,7 +22358,7 @@ mod tests {
         runner.cpu.write_reg(Register::A7, 0x0010_0000);
         runner.bus.write_long(0x016A, 0);
         runner.dispatcher.tick_count = 0;
-        runner.dispatcher.event_queue.push_back(QueuedEvent {
+        runner.process_context.event_queue_mut().push_back(QueuedEvent {
             what: 1,
             message: 0,
             where_v: 12,
@@ -22286,7 +22387,7 @@ mod tests {
         assert_eq!(runner.bus.read_word(event_ptr + 10), 12);
         assert_eq!(runner.bus.read_word(event_ptr + 12), 24);
         assert!(
-            runner.dispatcher.event_queue.is_empty(),
+            runner.process_context.event_queue().is_empty(),
             "the filter callback should consume a queued button mouseDown event"
         );
     }
@@ -22327,7 +22428,7 @@ mod tests {
         runner.dispatcher.tick_count = 42;
         runner.bus.write_long(0x016A, 42);
         runner.dialog_filter_last_null_event_tick = Some((dialog_ptr, 42));
-        runner.dispatcher.event_queue.push_back(QueuedEvent {
+        runner.process_context.event_queue_mut().push_back(QueuedEvent {
             what: 1,
             message: 0,
             where_v: 12,
@@ -22340,7 +22441,7 @@ mod tests {
             "mouse/key/update events must still enter the filter immediately"
         );
 
-        runner.dispatcher.event_queue.clear();
+        runner.process_context.event_queue_mut().clear();
         let window_ptr = runner.bus.alloc(170);
         runner.dispatcher.init_cgraf_window(
             &mut runner.bus,
@@ -22569,7 +22670,7 @@ mod tests {
         runner.set_instructions_per_tick(1_000_000);
         runner.bus.write_long(sp, event);
         runner.bus.write_word(sp + 4, 0x0008); // keyDownMask
-        runner.dispatcher.push_key_down(0x31, b' ');
+        runner.push_key_down(0x31, b' ');
 
         let before_traps = runner.dispatcher.trap_count;
         let before_game = runner.dispatcher.game_trap_count;
@@ -22590,7 +22691,7 @@ mod tests {
             (0x31u32 << 8) | u32::from(b' ')
         );
         assert_eq!(
-            runner.dispatcher.event_queue.len(),
+            runner.process_context.event_queue().len(),
             1,
             "EventAvail must not dequeue the matching event"
         );
@@ -22981,8 +23082,8 @@ mod tests {
         assert!(runner.dispatcher.pending_wait_next_event_return.is_some());
         assert!(
             runner
-                .dispatcher
-                .event_queue
+                .process_context
+                .event_queue()
                 .iter()
                 .any(|event| event.what == 1 && event.where_v == 123 && event.where_h == 456),
             "the mouseDown should remain queued for the foreground event loop"
@@ -23015,7 +23116,7 @@ mod tests {
             resume_pc: Some(parked_pc),
             resume_sp: Some(parked_sp),
         });
-        runner.dispatcher.push_mouse_down(123, 456);
+        runner.push_mouse_down(123, 456);
 
         let (steps, running) = runner.run_steps(1, Some(10));
 
@@ -23030,8 +23131,8 @@ mod tests {
         assert!(runner.dispatcher.pending_wait_next_event_return.is_none());
         assert!(
             runner
-                .dispatcher
-                .event_queue
+                .process_context
+                .event_queue()
                 .iter()
                 .any(|event| event.what == 1 && event.where_v == 123 && event.where_h == 456),
             "stale WNE cleanup should not silently consume a queued event"
@@ -23342,7 +23443,7 @@ mod tests {
             false,
             0,
         );
-        runner.dispatcher.event_queue.clear();
+        runner.process_context.event_queue_mut().clear();
         runner.dispatcher.dialog_tracking =
             Some(dialog_tracking_for_test(filter_proc, 0x0030_0000));
         runner
@@ -23386,7 +23487,7 @@ mod tests {
             false,
             0,
         );
-        runner.dispatcher.event_queue.clear();
+        runner.process_context.event_queue_mut().clear();
         runner.dispatcher.dialog_tracking =
             Some(dialog_tracking_for_test(filter_proc, 0x0030_0000));
         runner
@@ -23415,7 +23516,7 @@ mod tests {
             "the same invalid-region update should not refire indefinitely in one guest tick"
         );
 
-        runner.dispatcher.event_queue.push_back(QueuedEvent {
+        runner.process_context.event_queue_mut().push_back(QueuedEvent {
             what: 1,
             message: 0,
             where_v: 123,
@@ -23431,7 +23532,7 @@ mod tests {
         assert_eq!(runner.bus.read_word(event_ptr + 10), 123);
         assert_eq!(runner.bus.read_word(event_ptr + 12), 234);
         assert!(
-            runner.dispatcher.event_queue.is_empty(),
+            runner.process_context.event_queue().is_empty(),
             "the queued mouse event should be consumed by the filter call"
         );
 
@@ -24342,7 +24443,7 @@ mod tests {
         runner.push_mouse_down(10, 20);
         assert_eq!(runner.pending_mouse_down_count(), 1);
 
-        runner.dispatcher.event_queue.pop_front();
+        runner.process_context.event_queue_mut().pop_front();
         assert_eq!(runner.pending_mouse_down_count(), 0);
     }
 
@@ -24397,14 +24498,13 @@ mod tests {
         );
         // Sanity-check the events ARE still in the queue (this test is
         // about MBState despite the unconsumed events, not about queue
-        // state). The dispatcher field is pub(crate); read it through
-        // the same accessor used by the production sync logic.
+        // state). Read it from the canonical process_context queue.
         assert!(
-            runner.dispatcher.event_queue.iter().any(|e| e.what == 1),
+            runner.process_context.event_queue().iter().any(|e| e.what == 1),
             "mouseDown event must remain in the queue (would be drained by GetNextEvent)"
         );
         assert!(
-            runner.dispatcher.event_queue.iter().any(|e| e.what == 2),
+            runner.process_context.event_queue().iter().any(|e| e.what == 2),
             "mouseUp event must remain in the queue"
         );
     }

--- a/src/trap/dialog.rs
+++ b/src/trap/dialog.rs
@@ -4204,7 +4204,11 @@ impl super::TrapDispatcher {
         cpu.write_reg(Register::A7, stack_after);
     }
 
-    fn handle_interactive_alert_refire<C: CpuOps>(&mut self, cpu: &mut C, bus: &mut MacMemoryBus) {
+    fn handle_interactive_alert_refire<C: CpuOps>(
+        &mut self,
+        cpu: &mut C,
+        bus: &mut MacMemoryBus,
+    ) {
         if self.dialog_tracking.is_none() {
             return;
         }

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -7,7 +7,7 @@
 use super::types::UnderlineInfo;
 use crate::cpu::{CpuOps, Register};
 use crate::display::CursorImage;
-use crate::event_queue::SharedEventQueue;
+use crate::event_queue::EventQueue;
 use crate::guest_call::SharedGuestCallStack;
 use crate::machine_profile::reference_machine_profile;
 use crate::managers::resource::ResourceFork;
@@ -2393,7 +2393,7 @@ pub struct TrapDispatcher {
     pub(crate) input_trace_enabled: bool,
     pub(crate) input_trace_log: Vec<String>,
     /// Queued events (mouseDown, mouseUp, etc.) to deliver via GetNextEvent
-    pub(crate) event_queue: SharedEventQueue,
+    pub(crate) event_queue: EventQueue,
     /// A mouseDown consumed by ModalDialog can return to the application
     /// before the physical release arrives. Keep ownership of that release
     /// even if the application disposes the dialog in the meantime.
@@ -2933,11 +2933,27 @@ impl TrapDispatcher {
     /// owner that serializes all access to their shared handles.
     pub(crate) unsafe fn attach_process_context(&mut self, context: &ProcessContext) {
         unsafe {
-            context.attach_event_queue(&mut self.event_queue);
             context.attach_menu_tracking(&mut self.menu_tracking);
         }
         context.attach_native_menu_selection(&mut self.pending_native_menu_selection);
         context.attach_guest_calls(&mut self.guest_calls);
+    }
+
+    /// Temporarily borrow the canonical event queue from [`ProcessContext`] into this
+    /// adapter's local queue for the duration of `f`, and guarantee it is swapped back
+    /// on normal exit, early return, or unwind.
+    pub(crate) fn with_event_queue<R>(
+        &mut self,
+        event_queue: &mut EventQueue,
+        f: impl FnOnce(&mut Self) -> R,
+    ) -> R {
+        std::mem::swap(&mut self.event_queue, event_queue);
+        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(self)));
+        std::mem::swap(&mut self.event_queue, event_queue);
+        match outcome {
+            Ok(result) => result,
+            Err(payload) => std::panic::resume_unwind(payload),
+        }
     }
 
     pub(crate) const AUTO_KEY_THRESHOLD_TICKS: u32 = 16;
@@ -3915,7 +3931,7 @@ impl TrapDispatcher {
             debug_scroll_rect_last_is_color: false,
             input_trace_enabled: false,
             input_trace_log: Vec::new(),
-            event_queue: SharedEventQueue::default(),
+            event_queue: EventQueue::default(),
             pending_modal_dialog_mouse_up: false,
             pending_modal_dialog_mouse_down: None,
             flushed_update_events: VecDeque::new(),
@@ -11024,5 +11040,40 @@ mod tests {
             Some(bounds),
             "synthetic records without Window Manager regions fall back to content bounds"
         );
+    }
+
+    #[test]
+    fn with_event_queue_restores_context_and_adapter_state_on_panic() {
+        let mut dispatcher = TrapDispatcher::new();
+        let mut context_queue = EventQueue::default();
+        context_queue.push_back(QueuedEvent {
+            what: 1,
+            message: 0x1111,
+            where_v: 10,
+            where_h: 20,
+            modifiers: 0,
+        });
+
+        let panic_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            dispatcher.with_event_queue(&mut context_queue, |disp| {
+                disp.event_queue.push_back(QueuedEvent {
+                    what: 2,
+                    message: 0x2222,
+                    where_v: 30,
+                    where_h: 40,
+                    modifiers: 0,
+                });
+                disp.event_queue.invalidate_menu_bar();
+                panic!("simulated panic inside guest execution");
+            })
+        }));
+
+        assert!(panic_result.is_err());
+        assert_eq!(context_queue.len(), 2);
+        assert_eq!(context_queue[0].message, 0x1111);
+        assert_eq!(context_queue[1].message, 0x2222);
+        assert!(context_queue.menu_bar_is_invalid());
+        assert!(dispatcher.event_queue.is_empty());
+        assert!(!dispatcher.event_queue.menu_bar_is_invalid());
     }
 }


### PR DESCRIPTION
## Summary

- make `ProcessContext` the canonical owner of Event Manager queue and deferred menu-bar invalidation state
- replace `SharedEventQueue` and its `Rc<UnsafeCell<_>>` attachment contract with a safe value-owned `EventQueue`
- lend the canonical queue to active 68k and PowerPC adapters at serialized execution boundaries, restoring it on normal return and panic
- preserve detached adapter tests and merge pre-attachment native events without losing FIFO order or invalidation state

## Verification

- `cargo fmt --check`
- `cargo check --all-targets`
- full `cargo test`
- focused cross-adapter visibility, invalidation, panic-restoration, and detached-state merge tests
- focused Miri runs for both adapter wrappers, cross-adapter invalidation, queue invariants, and native initialization merge

Closes #1009