### PR TITLE
refactor(menu): make process context own tracking

### DIFF
--- a/src/loader/ppc.rs
+++ b/src/loader/ppc.rs
@@ -56,7 +56,7 @@ use crate::menu_manager::{
     MenuDefinitionTracking, MenuItem as PpcMenuItemDefinition, MenuItems, MenuKeyItem, MenuKeyMenu,
     MenuKeySelection, MenuList as PpcMenuListDefinition, MenuListInstallRequest, MenuRow, MenuRows,
     MenuSnapshotRecord, MenuTrackingKind, MenuTrackingPane, MenuTrackingSurface,
-    MonochromeMenuIconLayout, ProcessMenuTrackingState, ProcessTrackedMenuPane, SharedMenuTracking,
+    MonochromeMenuIconLayout, ProcessMenuTrackingState, ProcessTrackedMenuPane,
     SharedNativeMenuSelection, StandardMenuChrome, StandardMenuIconKind, StandardMenuItemWidth,
     StandardMenuPaneKind, SubmenuReconciliation, SubmenuRequest,
     TrackedMenuIcon as PpcTrackedMenuIcon,
@@ -2922,7 +2922,7 @@ pub struct PpcToolboxStartupState {
     pub cursor_hot_v: i16,
     pub cursor_hot_h: i16,
     pub(crate) pending_native_menu_selection: SharedNativeMenuSelection,
-    pub(crate) menu_tracking: SharedMenuTracking,
+    pub(crate) menu_tracking: Option<ProcessMenuTrackingState>,
     /// Custom popup MDEF state before its returned rectangle creates a pane.
     menu_definition_tracking: Option<MenuDefinitionTracking>,
     /// GetNewMBar result and remaining menus while custom mSizeMsg callbacks run.
@@ -2993,7 +2993,7 @@ impl Default for PpcToolboxStartupState {
             cursor_hot_v: 0,
             cursor_hot_h: 0,
             pending_native_menu_selection: SharedNativeMenuSelection::default(),
-            menu_tracking: SharedMenuTracking::default(),
+            menu_tracking: None,
             menu_definition_tracking: None,
             pending_menu_bar_build: None,
             menu_select_call: None,
@@ -5119,17 +5119,10 @@ impl PpcLoadedApp {
         &self.event_queue
     }
 
-    /// # Safety
-    ///
-    /// The caller must keep this adapter and the context under one process
-    /// owner that serializes all access to their shared handles.
-    pub(crate) unsafe fn attach_process_context(&mut self, context: &ProcessContext) {
-        unsafe {
-            context.attach_menu_tracking(&mut self.toolbox_startup.menu_tracking);
-        }
-        context.attach_native_menu_selection(
-            &mut self.toolbox_startup.pending_native_menu_selection,
-        );
+    pub(crate) fn attach_process_context(&mut self, context: &mut ProcessContext) {
+        context.adopt_menu_tracking(&mut self.toolbox_startup.menu_tracking);
+        context
+            .attach_native_menu_selection(&mut self.toolbox_startup.pending_native_menu_selection);
         context.attach_guest_calls(&mut self.guest_calls);
         context.attach_guest_calls(&mut self.toolbox_startup.guest_calls);
     }
@@ -5149,6 +5142,33 @@ impl PpcLoadedApp {
             Ok(result) => result,
             Err(payload) => std::panic::resume_unwind(payload),
         }
+    }
+
+    /// Temporarily install the canonical retained Menu Manager continuation in
+    /// this adapter, restoring it to the process owner on return or unwind.
+    pub(crate) fn with_menu_tracking<R>(
+        &mut self,
+        menu_tracking: &mut Option<ProcessMenuTrackingState>,
+        f: impl FnOnce(&mut Self) -> R,
+    ) -> R {
+        std::mem::swap(&mut self.toolbox_startup.menu_tracking, menu_tracking);
+        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(self)));
+        std::mem::swap(&mut self.toolbox_startup.menu_tracking, menu_tracking);
+        match outcome {
+            Ok(result) => result,
+            Err(payload) => std::panic::resume_unwind(payload),
+        }
+    }
+
+    /// Install all directly owned process state needed by one native
+    /// execution slice, returning it before the scheduler changes CPU.
+    pub(crate) fn with_process_state<R>(
+        &mut self,
+        event_queue: &mut EventQueue,
+        menu_tracking: &mut Option<ProcessMenuTrackingState>,
+        f: impl FnOnce(&mut Self) -> R,
+    ) -> R {
+        self.with_event_queue(event_queue, |app| app.with_menu_tracking(menu_tracking, f))
     }
 
     /// Park the current native context and enter a PowerPC routine selected by
@@ -16856,14 +16876,14 @@ fn dispatch_supported_import(
                 let mut state = toolbox_startup.menu_tracking.take().unwrap();
                 if state.flash_delay > 0 {
                     state.flash_delay -= 1;
-                    *toolbox_startup.menu_tracking = Some(state);
+                    toolbox_startup.menu_tracking = Some(state);
                     return Some(PpcImportAction::Yield(u64::MAX));
                 }
                 state.flash_remaining -= 1;
                 state.flash_delay = STANDARD_MENU_FLASH_PHASE_DELAY;
                 let result = state.flash_result;
                 if state.flash_remaining == 0 {
-                    *toolbox_startup.menu_tracking = Some(state);
+                    toolbox_startup.menu_tracking = Some(state);
                     let result = ppc_complete_menu_bar_tracking_with_colors(
                         memory,
                         gworlds,
@@ -16886,7 +16906,7 @@ fn dispatch_supported_import(
                         state.flash_remaining & 1 == 0,
                     );
                 }
-                *toolbox_startup.menu_tracking = Some(state);
+                toolbox_startup.menu_tracking = Some(state);
                 Some(PpcImportAction::Yield(u64::MAX))
             } else if toolbox_startup
                 .menu_tracking
@@ -17039,7 +17059,7 @@ fn dispatch_supported_import(
                             vfs_resources,
                             *current_resource_refnum,
                         );
-                        *toolbox_startup.menu_tracking = Some(state);
+                        toolbox_startup.menu_tracking = Some(state);
                     }
                 }
                 if let Some(state) = toolbox_startup.menu_tracking.as_ref() {
@@ -54017,7 +54037,7 @@ fn ppc_set_depth(
         .menu_tracking
         .as_ref()
         .is_some_and(|state| state.kind == MenuTrackingKind::MenuBar);
-    *toolbox_startup.menu_tracking = None;
+    toolbox_startup.menu_tracking = None;
     toolbox_startup.popup_menu_call = None;
     toolbox_startup.go_away_tracking = None;
     toolbox_startup.drag_window_tracking = None;
@@ -67790,7 +67810,7 @@ fn ppc_continue_custom_popup_menu_tracking(
             return PpcImportAction::Return(0);
         }
         state.definition = startup.menu_definition_tracking.take();
-        *startup.menu_tracking = Some(state);
+        startup.menu_tracking = Some(state);
         startup.active_menu_definition_mut().unwrap().draw();
         let invocation = startup
             .active_menu_definition()
@@ -67933,7 +67953,7 @@ fn ppc_dispatch_pop_up_menu_select(
         if live_front.map(MenuTrackingSurface::from) != state.front_buffer {
             // A changed PixMap/depth makes the saved coordinates unsafe to
             // write. Abandon the overlay without touching either buffer.
-            *startup.menu_tracking = None;
+            startup.menu_tracking = None;
             startup.popup_menu_call = None;
             return PpcImportAction::Return(0);
         }
@@ -67952,7 +67972,7 @@ fn ppc_dispatch_pop_up_menu_select(
             };
             if state.flash_delay > 0 {
                 state.flash_delay -= 1;
-                *startup.menu_tracking = Some(state);
+                startup.menu_tracking = Some(state);
                 return PpcImportAction::Yield(u64::MAX);
             }
             state.flash_remaining -= 1;
@@ -67976,7 +67996,7 @@ fn ppc_dispatch_pop_up_menu_select(
                 &state,
                 visible_item,
             );
-            *startup.menu_tracking = Some(state);
+            startup.menu_tracking = Some(state);
             return PpcImportAction::Yield(u64::MAX);
         }
 
@@ -68016,7 +68036,7 @@ fn ppc_dispatch_pop_up_menu_select(
                 &state,
                 highlighted_item,
             );
-            *startup.menu_tracking = Some(state);
+            startup.menu_tracking = Some(state);
             return PpcImportAction::Yield(u64::MAX);
         }
 
@@ -68028,7 +68048,7 @@ fn ppc_dispatch_pop_up_menu_select(
             &state,
             highlighted_item,
         );
-        *startup.menu_tracking = Some(state);
+        startup.menu_tracking = Some(state);
         return PpcImportAction::Yield(u64::MAX);
     }
 
@@ -68083,7 +68103,7 @@ fn ppc_dispatch_pop_up_menu_select(
         &state,
         highlighted_item,
     );
-    *startup.menu_tracking = Some(state);
+    startup.menu_tracking = Some(state);
     startup.popup_menu_call = Some(call);
     PpcImportAction::Yield(u64::MAX)
 }
@@ -69334,7 +69354,7 @@ fn ppc_begin_custom_menu_bar_tracking(
         StandardMenuPaneKind::PullDown,
         &state,
     )?;
-    *startup.menu_tracking = Some(state);
+    startup.menu_tracking = Some(state);
     startup.menu_select_call = Some(PpcMenuSelectCall {
         initial_point,
         return_address: cpu.lr,
@@ -69442,7 +69462,7 @@ fn ppc_continue_custom_menu_bar_tracking(
                         resources,
                         current_resource_refnum,
                     );
-                    *startup.menu_tracking = Some(state);
+                    startup.menu_tracking = Some(state);
                 }
                 if startup.active_menu_definition().is_none() {
                     startup.menu_select_call = None;
@@ -69733,7 +69753,7 @@ fn ppc_track_menu_while_held_with_resources(
             .filter(|(menu_handle, _)| *menu_handle != previous.menu_handle);
         if let Some((menu_handle, title_left)) = switched {
             ppc_restore_menu_tracking(memory, Some(front.into()), &previous);
-            *startup.menu_tracking = ppc_begin_menu_bar_tracking_with_resources(
+            startup.menu_tracking = ppc_begin_menu_bar_tracking_with_resources(
                 memory,
                 front,
                 menu_handle,
@@ -69743,7 +69763,7 @@ fn ppc_track_menu_while_held_with_resources(
             );
             startup.popup_menu_call = None;
         } else {
-            *startup.menu_tracking = Some(previous);
+            startup.menu_tracking = Some(previous);
         }
     } else {
         let Some((menu_handle, title_left)) =
@@ -69761,7 +69781,7 @@ fn ppc_track_menu_while_held_with_resources(
         ) else {
             return;
         };
-        *startup.menu_tracking = Some(state);
+        startup.menu_tracking = Some(state);
         startup.popup_menu_call = None;
     }
     let active_menu_id = startup.menu_tracking.as_ref().and_then(|state| {
@@ -69799,7 +69819,7 @@ fn ppc_track_menu_while_held_with_resources(
             resources,
             current_resource_refnum,
         );
-        *startup.menu_tracking = Some(state);
+        startup.menu_tracking = Some(state);
     }
 }
 
@@ -69904,7 +69924,7 @@ fn ppc_finish_menu_bar_tracking(
             &[],
             0,
         );
-        *startup.menu_tracking = Some(state);
+        startup.menu_tracking = Some(state);
     }
     ppc_finish_menu_bar_tracking_with_colors(
         memory,
@@ -81669,7 +81689,7 @@ pub(crate) mod tests {
                 ..PpcInputSnapshot::default()
             },
         );
-        let tracking = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
+        let tracking = loaded.toolbox_startup.menu_tracking.clone().unwrap();
         let command_text_advance = ppc_text_bytes_advance_for_font(
             b"Command",
             PPC_QD_TEXT_FONT_DEFAULT,
@@ -82402,7 +82422,7 @@ pub(crate) mod tests {
             ppc_memory_read_bytes(&mut loaded.memory, front.base_addr, framebuffer_len),
             Some(before.clone())
         );
-        let tracking = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
+        let tracking = loaded.toolbox_startup.menu_tracking.clone().unwrap();
 
         loaded.set_input_snapshot(PpcInputSnapshot {
             mouse_button: false,
@@ -82884,7 +82904,7 @@ pub(crate) mod tests {
                 &loaded.vfs_resources,
                 loaded.current_resource_refnum,
             );
-            let tracking = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
+            let tracking = loaded.toolbox_startup.menu_tracking.clone().unwrap();
             assert_eq!(
                 tracking
                     .item_appearances
@@ -83074,7 +83094,7 @@ pub(crate) mod tests {
             &loaded.vfs_resources,
             loaded.current_resource_refnum,
         );
-        let root = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
+        let root = loaded.toolbox_startup.menu_tracking.clone().unwrap();
         assert_eq!(root.item_appearances[0].height, 34);
         let parent_top = root.popup_top + root.item_appearances[0].height;
         ppc_track_menu_while_held_with_resources(
@@ -83177,7 +83197,7 @@ pub(crate) mod tests {
                     ..PpcInputSnapshot::default()
                 },
             );
-            let tracking = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
+            let tracking = loaded.toolbox_startup.menu_tracking.clone().unwrap();
             assert_eq!(tracking.front_buffer, Some(front.into()));
             assert_eq!(tracking.popup_left, STANDARD_MENU_BAR_FIRST_TITLE_LEFT);
             assert_eq!(tracking.saved_width, tracking.popup_width + 1);
@@ -83423,7 +83443,7 @@ pub(crate) mod tests {
                     ..PpcInputSnapshot::default()
                 },
             );
-            let root = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
+            let root = loaded.toolbox_startup.menu_tracking.clone().unwrap();
             let parent_hover = PpcInputSnapshot {
                 mouse_button: true,
                 mouse_v: root.popup_top + 8,
@@ -83438,7 +83458,7 @@ pub(crate) mod tests {
                 12,
                 parent_hover,
             );
-            let tracking = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
+            let tracking = loaded.toolbox_startup.menu_tracking.clone().unwrap();
             let child = tracking.submenus.first().expect("submenu did not open");
             assert_eq!(tracking.highlighted_item, 1);
             assert_eq!(child.menu_handle, submenu);
@@ -83738,9 +83758,9 @@ pub(crate) mod tests {
                 );
             };
             track(&mut loaded, (10, 12));
-            let root = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
+            let root = loaded.toolbox_startup.menu_tracking.clone().unwrap();
             track(&mut loaded, (root.popup_top + 8, root.popup_left + 20));
-            let first = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
+            let first = loaded.toolbox_startup.menu_tracking.clone().unwrap();
             assert_eq!(first.submenus.len(), 1);
             assert_eq!(first.submenus[0].menu_handle, options);
             let options_pane = first.submenus[0].clone();
@@ -83748,7 +83768,7 @@ pub(crate) mod tests {
                 &mut loaded,
                 (options_pane.popup_top + 8, options_pane.popup_left + 20),
             );
-            let nested = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
+            let nested = loaded.toolbox_startup.menu_tracking.clone().unwrap();
             assert_eq!(nested.submenus.len(), 2);
             assert_eq!(nested.submenus[0].highlighted_item, 1);
             assert_eq!(nested.submenus[1].menu_handle, speed);
@@ -83760,14 +83780,14 @@ pub(crate) mod tests {
                     options_pane.popup_left + 20,
                 ),
             );
-            let switched = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
+            let switched = loaded.toolbox_startup.menu_tracking.clone().unwrap();
             assert_eq!(switched.submenus.len(), 1);
             assert_eq!(switched.submenus[0].highlighted_item, 2);
             track(
                 &mut loaded,
                 (options_pane.popup_top + 8, options_pane.popup_left + 20),
             );
-            let reopened = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
+            let reopened = loaded.toolbox_startup.menu_tracking.clone().unwrap();
             assert_eq!(reopened.submenus.len(), 2);
             let speed_pane = reopened.submenus[1].clone();
 
@@ -83775,7 +83795,7 @@ pub(crate) mod tests {
                 &mut loaded,
                 (speed_pane.popup_top + 8, speed_pane.popup_left + 20),
             );
-            let cycle = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
+            let cycle = loaded.toolbox_startup.menu_tracking.clone().unwrap();
             assert_eq!(cycle.submenus.len(), 2, "circular submenu grew the chain");
             assert_eq!(cycle.submenus[1].highlighted_item, 1);
             assert_eq!(
@@ -84002,7 +84022,7 @@ pub(crate) mod tests {
                 ..PpcInputSnapshot::default()
             },
         );
-        let tracking = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
+        let tracking = loaded.toolbox_startup.menu_tracking.clone().unwrap();
         assert_eq!(tracking.front_buffer, Some(live.into()));
         let selected = PpcInputSnapshot {
             mouse_button: true,
@@ -84587,81 +84607,71 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn attached_68k_and_powerpc_adapters_share_one_retained_menu_continuation() {
+    fn process_owner_hands_one_retained_menu_continuation_between_adapters() {
         let (mut classic, mut classic_cpu, mut classic_bus) = setup_with_port();
         let pef = synthetic_pef_with_import(b"MenuSelect");
         let mut native = load_pef_application(&pef).unwrap();
-        let context = ProcessContext::default();
-        // SAFETY: the test owns both adapters and accesses them sequentially.
-        unsafe {
-            classic.attach_process_context(&context);
-            native.attach_process_context(&context);
-        }
+        let mut context = ProcessContext::default();
+        classic.attach_process_context(&mut context);
+        native.attach_process_context(&mut context);
 
         let mut tracking = crate::menu_manager::test_process_menu_tracking(0x0012_3456);
         tracking.highlighted_item = 2;
-        *classic.menu_tracking = Some(tracking);
+        context.set_menu_tracking(Some(tracking));
+        classic.with_menu_tracking(context.menu_tracking_slot_mut(), |classic| {
+            assert_eq!(
+                classic
+                    .menu_tracking
+                    .as_ref()
+                    .map(|tracking| (tracking.menu_handle, tracking.highlighted_item)),
+                Some((0x0012_3456, 2))
+            );
+        });
         assert_eq!(
-            native
-                .toolbox_startup
-                .menu_tracking
-                .as_ref()
+            context
+                .menu_tracking()
                 .map(|tracking| (tracking.menu_handle, tracking.highlighted_item)),
             Some((0x0012_3456, 2))
         );
 
-        native.cpu.gpr[3] = 0;
-        run_test_import(&mut native, PpcImportDispatcherTarget::MenuSelect);
-        assert_eq!(
-            classic
+        native.with_menu_tracking(context.menu_tracking_slot_mut(), |native| {
+            native.cpu.gpr[3] = 0;
+            run_test_import(native, PpcImportDispatcherTarget::MenuSelect);
+            native
+                .toolbox_startup
                 .menu_tracking
-                .as_ref()
-                .map(|tracking| tracking.menu_handle),
-            Some(0x0012_3456),
-            "a nested native call consumed the classic continuation"
-        );
-
-        native
-            .toolbox_startup
-            .menu_tracking
-            .as_mut()
-            .unwrap()
-            .highlighted_item = 4;
+                .as_mut()
+                .unwrap()
+                .highlighted_item = 4;
+        });
         assert_eq!(
-            classic
-                .menu_tracking
-                .as_ref()
+            context
+                .menu_tracking()
                 .map(|tracking| tracking.highlighted_item),
             Some(4)
         );
 
         let native_front = native.current_front_buffer().unwrap();
-        native
-            .toolbox_startup
-            .menu_tracking
-            .as_mut()
-            .unwrap()
-            .front_buffer = Some(native_front.into());
+        context.menu_tracking_mut().unwrap().front_buffer = Some(native_front.into());
         classic_cpu.write_reg(Register::A7, TEST_SP);
         classic_bus.write_long(TEST_SP, 0);
         classic_bus.write_long(TEST_SP + 4, u32::MAX);
-        assert!(classic
-            .dispatch_menu(true, 0x13D, &mut classic_cpu, &mut classic_bus)
-            .unwrap()
-            .is_ok());
+        classic.with_menu_tracking(context.menu_tracking_slot_mut(), |classic| {
+            assert!(classic
+                .dispatch_menu(true, 0x13D, &mut classic_cpu, &mut classic_bus)
+                .unwrap()
+                .is_ok());
+        });
         assert_eq!(classic_bus.read_long(TEST_SP + 4), 0);
         assert_eq!(
-            native
-                .toolbox_startup
-                .menu_tracking
-                .as_ref()
-                .map(|tracking| tracking.menu_handle),
+            context.menu_tracking().map(|tracking| tracking.menu_handle),
             Some(0x0012_3456),
-            "a nested classic call consumed the native continuation"
+            "the classic slice must return the continuation to its process owner"
         );
 
-        native.toolbox_startup.menu_tracking.take();
+        context.take_menu_tracking();
         assert!(classic.menu_tracking.is_none());
+        assert!(native.toolbox_startup.menu_tracking.is_none());
     }
 
     #[test]
@@ -84723,6 +84733,58 @@ pub(crate) mod tests {
         assert!(context_queue.menu_bar_is_invalid());
         assert!(native.event_queue.is_empty());
         assert!(!native.event_queue.menu_bar_is_invalid());
+    }
+
+    #[test]
+    fn ppc_with_menu_tracking_returns_mutations_to_process_context() {
+        let pef = synthetic_pef_with_import(b"MenuSelect");
+        let mut native = load_pef_application(&pef).unwrap();
+        let mut context_tracking =
+            Some(crate::menu_manager::test_process_menu_tracking(0x0012_3456));
+
+        native.with_menu_tracking(&mut context_tracking, |app| {
+            app.toolbox_startup
+                .menu_tracking
+                .as_mut()
+                .unwrap()
+                .highlighted_item = 3;
+        });
+
+        assert_eq!(
+            context_tracking
+                .as_ref()
+                .map(|tracking| tracking.highlighted_item),
+            Some(3)
+        );
+        assert!(native.toolbox_startup.menu_tracking.is_none());
+    }
+
+    #[test]
+    fn ppc_with_menu_tracking_restores_process_context_on_panic() {
+        let pef = synthetic_pef_with_import(b"MenuSelect");
+        let mut native = load_pef_application(&pef).unwrap();
+        let mut context_tracking =
+            Some(crate::menu_manager::test_process_menu_tracking(0x0012_3456));
+
+        let panic_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            native.with_menu_tracking(&mut context_tracking, |app| {
+                app.toolbox_startup
+                    .menu_tracking
+                    .as_mut()
+                    .unwrap()
+                    .highlighted_item = 5;
+                panic!("simulated panic inside PPC guest execution");
+            });
+        }));
+
+        assert!(panic_result.is_err());
+        assert_eq!(
+            context_tracking
+                .as_ref()
+                .map(|tracking| tracking.highlighted_item),
+            Some(5)
+        );
+        assert!(native.toolbox_startup.menu_tracking.is_none());
     }
 
     #[test]
@@ -84970,7 +85032,7 @@ pub(crate) mod tests {
             loaded.run_with_hle_imports(64).result,
             PpcRunResult::CycleLimit { .. }
         ));
-        let tracking = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
+        let tracking = loaded.toolbox_startup.menu_tracking.clone().unwrap();
 
         loaded.set_input_snapshot(PpcInputSnapshot {
             mouse_button: false,
@@ -139457,7 +139519,7 @@ pub(crate) mod tests {
             [loaded.cpu.gpr[4], loaded.cpu.gpr[5], loaded.cpu.gpr[6]],
             original_args
         );
-        let tracking = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
+        let tracking = loaded.toolbox_startup.menu_tracking.clone().unwrap();
         let parked_lr = loaded.cpu.lr;
         assert_eq!(tracking.kind, MenuTrackingKind::PopUp);
         assert_eq!(
@@ -139692,7 +139754,7 @@ pub(crate) mod tests {
             });
             let probe = loaded.run_with_hle_imports(64);
             assert!(matches!(probe.result, PpcRunResult::CycleLimit { .. }));
-            let tracking = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
+            let tracking = loaded.toolbox_startup.menu_tracking.clone().unwrap();
             loaded.set_input_snapshot(PpcInputSnapshot {
                 mouse_button: false,
                 mouse_v: tracking.popup_top + 16 + 4,
@@ -139773,7 +139835,7 @@ pub(crate) mod tests {
             let probe = loaded.run_with_hle_imports(64);
 
             assert!(matches!(probe.result, PpcRunResult::CycleLimit { .. }));
-            let tracking = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
+            let tracking = loaded.toolbox_startup.menu_tracking.clone().unwrap();
             assert_eq!(tracking.kind, MenuTrackingKind::PopUp);
             assert_eq!(
                 loaded.toolbox_startup.popup_menu_call,
@@ -139924,7 +139986,7 @@ pub(crate) mod tests {
                 Some(expected_bottom),
             );
         }
-        *loaded.toolbox_startup.menu_tracking = Some(tracking);
+        loaded.toolbox_startup.menu_tracking = Some(tracking);
     }
 
     #[test]
@@ -140119,7 +140181,7 @@ pub(crate) mod tests {
                 "{depth}bpp disabled title did not open",
             );
             assert_eq!(loaded.memory.read_u16_be(PPC_THE_MENU_ADDR), Some(130));
-            let disabled_tracking = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
+            let disabled_tracking = loaded.toolbox_startup.menu_tracking.clone().unwrap();
             assert_eq!(
                 disabled_tracking.highlighted_item, 0,
                 "{depth}bpp disabled menu item became highlighted",
@@ -140182,7 +140244,7 @@ pub(crate) mod tests {
             loaded.run_with_hle_imports(64).result,
             PpcRunResult::CycleLimit { .. }
         ));
-        let switched = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
+        let switched = loaded.toolbox_startup.menu_tracking.clone().unwrap();
         loaded
             .memory
             .write_u16_be(crate::memory::globals::addr::MENU_FLASH, 1)
@@ -140248,7 +140310,7 @@ pub(crate) mod tests {
             loaded.run_with_hle_imports(64).result,
             PpcRunResult::CycleLimit { .. }
         ));
-        let tracking = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
+        let tracking = loaded.toolbox_startup.menu_tracking.clone().unwrap();
         loaded.set_input_snapshot(PpcInputSnapshot {
             mouse_button: false,
             mouse_v: tracking.popup_top + 6,
@@ -146540,7 +146602,7 @@ pub(crate) mod tests {
             item_appearances: Vec::new(),
             submenus: Vec::new(),
         };
-        *loaded.toolbox_startup.menu_tracking = Some(tracking.clone());
+        loaded.toolbox_startup.menu_tracking = Some(tracking.clone());
         loaded.memory.write_u16_be(PPC_THE_MENU_ADDR, 128).unwrap();
 
         loaded.cpu.gpr[3] = PPC_MAIN_GDEVICE;
@@ -146572,7 +146634,7 @@ pub(crate) mod tests {
             stack_pointer: loaded.cpu.gpr[1],
             return_address: loaded.cpu.lr,
         });
-        *loaded.toolbox_startup.menu_tracking = Some(popup_tracking);
+        loaded.toolbox_startup.menu_tracking = Some(popup_tracking);
         loaded
             .memory
             .write_u16_be(PPC_THE_MENU_ADDR, 0x2468)

--- a/src/menu_manager.rs
+++ b/src/menu_manager.rs
@@ -3,8 +3,7 @@
 use crate::mac_roman::decode_mac_roman;
 use crate::menu_model::{GuestMenu, GuestMenuItem, GuestMenuSnapshot};
 use crate::quickdraw::text::{get_glyph, QuickDrawTextStyle};
-use std::cell::{RefCell, UnsafeCell};
-use std::ops::{Deref, DerefMut};
+use std::cell::RefCell;
 use std::rc::Rc;
 
 /// Largest entry count representable by a menu-list partition byte length.
@@ -743,103 +742,6 @@ pub(crate) fn test_process_menu_tracking(menu_handle: u32) -> ProcessMenuTrackin
         saved_pixels: Vec::new(),
         item_appearances: Vec::new(),
         submenus: Vec::new(),
-    }
-}
-
-/// One process-scoped retained Menu Manager owner.
-///
-/// `MenuSelect` manages the complete mouse-down-through-release interaction,
-/// including hierarchical menus, while the menu list stores MenuHandles to
-/// the live MenuRecords. Macintosh Toolbox Essentials (1992), pp. 3-95--3-97
-/// and 3-114--3-119. Both CPU gateways therefore attach to this same retained
-/// continuation instead of owning parallel interaction state.
-#[derive(Debug, Default)]
-pub(crate) struct SharedMenuTracking(Rc<UnsafeCell<Option<ProcessMenuTrackingState>>>);
-
-impl Clone for SharedMenuTracking {
-    fn clone(&self) -> Self {
-        // A cloned runtime is a snapshot, not another live CPU adapter.
-        Self(Rc::new(UnsafeCell::new(self.state().clone())))
-    }
-}
-
-impl PartialEq for SharedMenuTracking {
-    fn eq(&self, other: &Self) -> bool {
-        self.state() == other.state()
-    }
-}
-
-impl Eq for SharedMenuTracking {}
-
-impl PartialEq<Option<ProcessMenuTrackingState>> for SharedMenuTracking {
-    fn eq(&self, other: &Option<ProcessMenuTrackingState>) -> bool {
-        self.state() == other
-    }
-}
-
-impl SharedMenuTracking {
-    fn state(&self) -> &Option<ProcessMenuTrackingState> {
-        // SAFETY: shared handles can only be created under the serialized
-        // ownership contract documented by `shared_handle`.
-        unsafe { &*self.0.get() }
-    }
-
-    fn state_mut(&mut self) -> &mut Option<ProcessMenuTrackingState> {
-        // SAFETY: shared handles can only be created under the serialized
-        // ownership contract documented by `shared_handle`.
-        unsafe { &mut *self.0.get() }
-    }
-
-    /// Attach another CPU adapter without copying the retained continuation.
-    ///
-    /// # Safety
-    ///
-    /// Every handle sharing this allocation must remain under one owner that
-    /// serializes access. No continuation reference may remain live while
-    /// another handle reads or mutates the allocation.
-    pub(crate) unsafe fn shared_handle(&self) -> Self {
-        Self(Rc::clone(&self.0))
-    }
-
-    /// Attach adapter-local tracking to the process continuation.
-    ///
-    /// # Safety
-    ///
-    /// The process owner must serialize all access to every attached handle.
-    pub(crate) unsafe fn attach_to(&mut self, process_tracking: &Self) {
-        if Rc::ptr_eq(&self.0, &process_tracking.0) {
-            return;
-        }
-        assert!(
-            self.is_none() || process_tracking.is_none(),
-            "cannot attach two active Menu Manager continuations"
-        );
-        let pending = self.take();
-        // SAFETY: ProcessContext is owned by FixtureRunner, which serializes
-        // access to every attached CPU adapter through its mutable borrow.
-        self.0 = unsafe { process_tracking.shared_handle() }.0;
-        if self.is_none() {
-            **self = pending;
-        }
-    }
-
-    #[cfg(test)]
-    pub(crate) fn snapshot(&self) -> Option<ProcessMenuTrackingState> {
-        self.state().clone()
-    }
-}
-
-impl Deref for SharedMenuTracking {
-    type Target = Option<ProcessMenuTrackingState>;
-
-    fn deref(&self) -> &Self::Target {
-        self.state()
-    }
-}
-
-impl DerefMut for SharedMenuTracking {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.state_mut()
     }
 }
 
@@ -3649,9 +3551,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn cloned_menu_tracking_owner_is_a_detached_runtime_snapshot() {
-        let mut live = SharedMenuTracking::default();
-        *live = Some(test_process_menu_tracking(0x0012_3456));
+    fn cloned_menu_tracking_state_is_a_detached_runtime_snapshot() {
+        let live = Some(test_process_menu_tracking(0x0012_3456));
 
         let mut snapshot = live.clone();
         snapshot.as_mut().unwrap().highlighted_item = 4;
@@ -4477,7 +4378,7 @@ mod tests {
             standard_menu_icon_kind(7, 0x1D, Some((24, 20))),
             StandardMenuIconKind::Color {
                 width: 24,
-                height: 20,
+                height: 20
             },
             "a valid cicn takes priority over monochrome selectors"
         );
@@ -4503,7 +4404,7 @@ mod tests {
         assert_eq!(
             StandardMenuIconKind::Color {
                 width: 12,
-                height: 24,
+                height: 24
             }
             .width(),
             16
@@ -4519,7 +4420,7 @@ mod tests {
         assert_eq!(
             StandardMenuIconKind::Color {
                 width: 16,
-                height: 24,
+                height: 24
             }
             .row_height(QuickDrawTextStyle::plain()),
             24

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -2,7 +2,7 @@
 
 use crate::event_queue::EventQueue;
 use crate::guest_call::SharedGuestCallStack;
-use crate::menu_manager::{SharedMenuTracking, SharedNativeMenuSelection};
+use crate::menu_manager::{ProcessMenuTrackingState, SharedNativeMenuSelection};
 
 /// Canonical owner for state that belongs to one emulated process rather than
 /// to either of its CPU ABI adapters.
@@ -12,7 +12,7 @@ use crate::menu_manager::{SharedMenuTracking, SharedNativeMenuSelection};
 #[derive(Debug, Default)]
 pub(crate) struct ProcessContext {
     event_queue: EventQueue,
-    menu_tracking: SharedMenuTracking,
+    menu_tracking: Option<ProcessMenuTrackingState>,
     pending_native_menu_selection: SharedNativeMenuSelection,
     guest_calls: SharedGuestCallStack,
 }
@@ -26,18 +26,49 @@ impl ProcessContext {
         &mut self.event_queue
     }
 
-    /// # Safety
-    ///
-    /// The caller must keep the context and adapter under one owner that
-    /// serializes all access to the attached handles.
-    pub(crate) unsafe fn attach_menu_tracking(&self, adapter: &mut SharedMenuTracking) {
-        unsafe { adapter.attach_to(&self.menu_tracking) };
+    pub(crate) fn menu_tracking(&self) -> Option<&ProcessMenuTrackingState> {
+        self.menu_tracking.as_ref()
     }
 
-    pub(crate) fn attach_native_menu_selection(
-        &self,
-        adapter: &mut SharedNativeMenuSelection,
-    ) {
+    #[cfg(test)]
+    pub(crate) fn menu_tracking_mut(&mut self) -> Option<&mut ProcessMenuTrackingState> {
+        self.menu_tracking.as_mut()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn take_menu_tracking(&mut self) -> Option<ProcessMenuTrackingState> {
+        self.menu_tracking.take()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_menu_tracking(&mut self, state: Option<ProcessMenuTrackingState>) {
+        self.menu_tracking = state;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn menu_tracking_slot_mut(&mut self) -> &mut Option<ProcessMenuTrackingState> {
+        &mut self.menu_tracking
+    }
+
+    /// Transfer detached adapter state into the canonical process owner.
+    pub(crate) fn adopt_menu_tracking(&mut self, adapter: &mut Option<ProcessMenuTrackingState>) {
+        assert!(
+            adapter.is_none() || self.menu_tracking.is_none(),
+            "cannot attach two active Menu Manager continuations"
+        );
+        if self.menu_tracking.is_none() {
+            self.menu_tracking = adapter.take();
+        }
+    }
+
+    /// Borrow the process state temporarily installed in an active CPU adapter.
+    pub(crate) fn event_queue_and_menu_tracking_mut(
+        &mut self,
+    ) -> (&mut EventQueue, &mut Option<ProcessMenuTrackingState>) {
+        (&mut self.event_queue, &mut self.menu_tracking)
+    }
+
+    pub(crate) fn attach_native_menu_selection(&self, adapter: &mut SharedNativeMenuSelection) {
         adapter.attach_to(&self.pending_native_menu_selection);
     }
 
@@ -69,24 +100,50 @@ mod tests {
     }
 
     #[test]
+    fn process_context_owns_canonical_menu_tracking() {
+        let mut context = ProcessContext::default();
+        assert!(context.menu_tracking().is_none());
+
+        let tracking = crate::menu_manager::test_process_menu_tracking(0x0012_3456);
+        context.set_menu_tracking(Some(tracking));
+        assert_eq!(
+            context.menu_tracking().map(|t| t.menu_handle),
+            Some(0x0012_3456)
+        );
+
+        if let Some(t) = context.menu_tracking_mut() {
+            t.highlighted_item = 3;
+        }
+        assert_eq!(
+            context
+                .menu_tracking()
+                .map(|t| (t.menu_handle, t.highlighted_item)),
+            Some((0x0012_3456, 3))
+        );
+
+        let taken = context.take_menu_tracking();
+        assert_eq!(taken.map(|t| t.menu_handle), Some(0x0012_3456));
+        assert!(context.menu_tracking().is_none());
+
+        let (queue, menu) = context.event_queue_and_menu_tracking_mut();
+        queue.push_back(QueuedEvent {
+            what: 2,
+            message: 0x5678,
+            where_v: 0,
+            where_h: 0,
+            modifiers: 0,
+        });
+        *menu = Some(crate::menu_manager::test_process_menu_tracking(0x0065_4321));
+        assert_eq!(context.event_queue().len(), 1);
+        assert_eq!(
+            context.menu_tracking().map(|t| t.menu_handle),
+            Some(0x0065_4321)
+        );
+    }
+
+    #[test]
     fn adapters_transfer_pending_state_and_share_one_process_owner() {
         let context = ProcessContext::default();
-
-        let mut classic_tracking = SharedMenuTracking::default();
-        *classic_tracking = Some(crate::menu_manager::test_process_menu_tracking(0x0012_3456));
-        let mut native_tracking = SharedMenuTracking::default();
-        // SAFETY: the test accesses both adapters strictly in sequence.
-        unsafe {
-            context.attach_menu_tracking(&mut classic_tracking);
-            context.attach_menu_tracking(&mut native_tracking);
-        }
-        native_tracking.as_mut().unwrap().highlighted_item = 4;
-        assert_eq!(
-            classic_tracking
-                .as_ref()
-                .map(|tracking| (tracking.menu_handle, tracking.highlighted_item)),
-            Some((0x0012_3456, 4))
-        );
 
         let mut classic_selection = SharedNativeMenuSelection::default();
         assert!(classic_selection.stage((128, 2)));
@@ -116,17 +173,13 @@ mod tests {
 
     #[test]
     #[should_panic(expected = "cannot attach two active Menu Manager continuations")]
-    fn attaching_two_active_menu_continuations_is_always_rejected() {
-        let context = ProcessContext::default();
-        let mut first = SharedMenuTracking::default();
-        *first = Some(crate::menu_manager::test_process_menu_tracking(0x1000));
-        let mut second = SharedMenuTracking::default();
-        *second = Some(crate::menu_manager::test_process_menu_tracking(0x2000));
-        // SAFETY: the test accesses attached handles strictly in sequence.
-        unsafe {
-            context.attach_menu_tracking(&mut first);
-            context.attach_menu_tracking(&mut second);
-        }
+    fn adopting_two_active_menu_continuations_is_always_rejected() {
+        let mut context = ProcessContext::default();
+        context.set_menu_tracking(Some(crate::menu_manager::test_process_menu_tracking(
+            0x1000,
+        )));
+        let mut second = Some(crate::menu_manager::test_process_menu_tracking(0x2000));
+        context.adopt_menu_tracking(&mut second);
     }
 
     #[test]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1898,11 +1898,9 @@ impl FixtureRunner {
             matches!(config.screen_depth, 1 | 2 | 4 | 8),
             "screen_depth must be 1, 2, 4, or 8"
         );
-        let process_context = ProcessContext::default();
+        let mut process_context = ProcessContext::default();
         let mut dispatcher = TrapDispatcher::new();
-        // SAFETY: FixtureRunner owns the context and every attached adapter,
-        // and serializes their access through its mutable borrow.
-        unsafe { dispatcher.attach_process_context(&process_context) };
+        dispatcher.attach_process_context(&mut process_context);
         dispatcher.set_menu_bar_policy(config.menu_bar_policy);
         dispatcher.mmu_mode = u8::from(config.addressing_32_bit);
         dispatcher.set_ui_theme_id(config.ui_theme);
@@ -2603,7 +2601,16 @@ impl FixtureRunner {
     /// Call before reading raw pixels for screenshots.
     pub fn composite_frame(&mut self) {
         self.sync_ppc_deferred_host_state();
-        self.dispatcher.redraw_chrome(&mut self.bus);
+        self.redraw_chrome();
+    }
+
+    fn redraw_chrome(&mut self) {
+        let (event_queue, menu_tracking) =
+            self.process_context.event_queue_and_menu_tracking_mut();
+        self.dispatcher
+            .with_process_state(event_queue, menu_tracking, |dispatcher| {
+                dispatcher.redraw_chrome(&mut self.bus);
+            });
     }
 
     /// Enable or disable arrow-key-to-numpad remapping.
@@ -2723,10 +2730,9 @@ impl FixtureRunner {
     }
 
     fn push_canonical_mouse_down(&mut self, v: i16, h: i16) {
+        let (event_queue, menu_tracking) = self.process_context.event_queue_and_menu_tracking_mut();
         self.dispatcher
-            .with_event_queue(self.process_context.event_queue_mut(), |d| {
-                d.push_mouse_down(v, h);
-            });
+            .with_process_state(event_queue, menu_tracking, |d| d.push_mouse_down(v, h));
         self.sync_mouse_lowmem();
         self.wake_pending_wait_next_event_if_input_available();
         self.wake_foreground_after_input();
@@ -2766,10 +2772,9 @@ impl FixtureRunner {
     }
 
     fn push_canonical_mouse_up(&mut self, v: i16, h: i16) {
+        let (event_queue, menu_tracking) = self.process_context.event_queue_and_menu_tracking_mut();
         self.dispatcher
-            .with_event_queue(self.process_context.event_queue_mut(), |d| {
-                d.push_mouse_up(v, h);
-            });
+            .with_process_state(event_queue, menu_tracking, |d| d.push_mouse_up(v, h));
         self.sync_mouse_lowmem();
         self.wake_pending_wait_next_event_if_input_available();
         self.wake_foreground_after_input();
@@ -2817,8 +2822,9 @@ impl FixtureRunner {
     /// Inject a key-down event, applying arrow→numpad remapping if configured.
     pub fn push_key_down(&mut self, mac_key: u8, char_code: u8) {
         let (key, char_code) = self.remap_key(mac_key, char_code);
+        let (event_queue, menu_tracking) = self.process_context.event_queue_and_menu_tracking_mut();
         self.dispatcher
-            .with_event_queue(self.process_context.event_queue_mut(), |d| {
+            .with_process_state(event_queue, menu_tracking, |d| {
                 d.push_key_down(key, char_code);
             });
         self.sync_key_map_lowmem();
@@ -2832,8 +2838,9 @@ impl FixtureRunner {
         let sys_evt_mask = self
             .bus
             .read_word(crate::memory::globals::addr::SYS_EVT_MASK);
+        let (event_queue, menu_tracking) = self.process_context.event_queue_and_menu_tracking_mut();
         self.dispatcher
-            .with_event_queue(self.process_context.event_queue_mut(), |d| {
+            .with_process_state(event_queue, menu_tracking, |d| {
                 d.push_key_up_with_system_event_mask(sys_evt_mask, key, char_code);
             });
         self.sync_key_map_lowmem();
@@ -2939,7 +2946,7 @@ impl FixtureRunner {
 
     pub fn is_ui_tracking_active(&self) -> bool {
         self.frozen_ticks.is_some()
-            || self.dispatcher.is_menu_tracking()
+            || self.process_context.menu_tracking().is_some()
             || self.dispatcher.is_dialog_tracking()
             || self.dispatcher.is_control_tracking()
             || self.dispatcher.is_window_tracking()
@@ -3950,9 +3957,7 @@ impl FixtureRunner {
         self.dispatcher
             .materialize_trap_tables(&mut self.bus, TrapTableProfile::PowerPc604);
         self.share_ppc_runtime_globals(&mut ppc_app);
-        // SAFETY: FixtureRunner owns the context and every attached adapter,
-        // and serializes their access through its mutable borrow.
-        unsafe { ppc_app.attach_process_context(&self.process_context) };
+        ppc_app.attach_process_context(&mut self.process_context);
         if let Some(time_base) = self.launch_ppc_time_base_override {
             ppc_app.cpu.set_time_base(time_base);
         }
@@ -4156,7 +4161,7 @@ impl FixtureRunner {
         // On a real Mac the Window Manager maintains these as
         // separate layers; here they are raw framebuffer pixels
         // that game drawing (explosions, etc.) can overwrite.
-        self.dispatcher.redraw_chrome(&mut self.bus);
+        self.redraw_chrome();
         self.finish_audio_frame(audio_samples, sound_interrupt_dispatched);
     }
 
@@ -5156,7 +5161,7 @@ impl FixtureRunner {
             if finish_frame {
                 self.sync_ppc_deferred_host_state();
                 if self.halted_by_exit_to_shell() {
-                    self.dispatcher.redraw_chrome(&mut self.bus);
+                    self.redraw_chrome();
                 } else {
                     self.finish_host_frame(audio_samples, false);
                 }
@@ -5685,8 +5690,11 @@ impl FixtureRunner {
                     }
 
                     self.dispatcher.yield_for_ui = yield_for_ui;
-                    let dispatch_result = self.dispatcher.with_event_queue(
-                        self.process_context.event_queue_mut(),
+                    let (event_queue, menu_tracking) =
+                        self.process_context.event_queue_and_menu_tracking_mut();
+                    let dispatch_result = self.dispatcher.with_process_state(
+                        event_queue,
+                        menu_tracking,
                         |dispatcher| dispatcher.dispatch(opcode, &mut self.cpu, &mut self.bus),
                     );
                     match dispatch_result {
@@ -5729,7 +5737,11 @@ impl FixtureRunner {
                             // they can never diverge. Strips auto-pop
                             // bit so `$AD3D` / `$AC0B` / `$AD91`
                             // match too.
-                            let is_tracking_refire = self.dispatcher.is_tracking_refire(opcode);
+                            let is_tracking_refire =
+                                self.dispatcher.is_tracking_refire_with_menu_tracking(
+                                    opcode,
+                                    self.process_context.menu_tracking().is_some(),
+                                );
                             if is_tracking_refire {
                                 // An asynchronous callback may have been
                                 // injected while this tracking trap was
@@ -5748,7 +5760,12 @@ impl FixtureRunner {
                                 if self.dispatcher.is_control_action_callback_pending() {
                                     continue;
                                 }
-                                if self.dispatcher.is_menu_definition_callback_pending() {
+                                if self
+                                    .dispatcher
+                                    .is_menu_definition_callback_pending_with_tracking(
+                                        self.process_context.menu_tracking(),
+                                    )
+                                {
                                     continue;
                                 }
                                 // In GUI mode, freeze ticks so the game clock doesn't
@@ -6026,7 +6043,8 @@ impl FixtureRunner {
         let trace_ppc_imports = record_ppc_imports || trace_ppc_import_hist;
         let trace_ppc_fetches = trace_ppc_fetch_counts_enabled();
         let profile_run_start = profile_ppc.then(Instant::now);
-        let probe = ppc_app.with_event_queue(self.process_context.event_queue_mut(), |app| {
+        let (event_queue, menu_tracking) = self.process_context.event_queue_and_menu_tracking_mut();
+        let probe = ppc_app.with_process_state(event_queue, menu_tracking, |app| {
             match (trace_ppc_imports, trace_ppc_fetches) {
                 (true, true) => {
                     app.run_with_hle_import_trace_and_fetch_histogram(ppc_max_steps as u64)
@@ -6074,7 +6092,9 @@ impl FixtureRunner {
         } else {
             self.advance_ticks_for_ppc_cycles(cycles, tick_cap);
             let elapsed_ticks = self.dispatcher.tick_count.wrapping_sub(ppc_start_tick);
-            let probes = ppc_app.with_event_queue(self.process_context.event_queue_mut(), |app| {
+            let (event_queue, menu_tracking) =
+                self.process_context.event_queue_and_menu_tracking_mut();
+            let probes = ppc_app.with_process_state(event_queue, menu_tracking, |app| {
                 Self::fire_ppc_tick_callbacks(
                     app,
                     ppc_start_tick,
@@ -6278,7 +6298,7 @@ impl FixtureRunner {
         self.ppc_app = Some(ppc_app);
         if exited_via_ppc_exit_to_shell {
             if finish_frame {
-                self.dispatcher.redraw_chrome(&mut self.bus);
+                self.redraw_chrome();
             }
         } else {
             self.queue_due_ppc_sound_completions();
@@ -6389,8 +6409,11 @@ impl FixtureRunner {
                         self.cpu.core.take_aline_exception(&mut self.bus);
                         continue;
                     }
-                    let dispatch_err = self.dispatcher.with_event_queue(
-                        self.process_context.event_queue_mut(),
+                    let (event_queue, menu_tracking) =
+                        self.process_context.event_queue_and_menu_tracking_mut();
+                    let dispatch_err = self.dispatcher.with_process_state(
+                        event_queue,
+                        menu_tracking,
                         |dispatcher| {
                             dispatcher
                                 .dispatch(opcode, &mut self.cpu, &mut self.bus)
@@ -7821,7 +7844,9 @@ impl FixtureRunner {
         while !ppc_app.sound.pending_doublebacks.is_empty() && fired_count < 16 {
             let doubleback = ppc_app.sound.pending_doublebacks.remove(0);
             let resume_pc = ppc_app.cpu.pc;
-            let probe = ppc_app.with_event_queue(self.process_context.event_queue_mut(), |app| {
+            let (event_queue, menu_tracking) =
+                self.process_context.event_queue_and_menu_tracking_mut();
+            let probe = ppc_app.with_process_state(event_queue, menu_tracking, |app| {
                 app.run_sound_doubleback_callback(
                     doubleback,
                     PPC_SOUND_COMPLETION_CALLBACK_MAX_CYCLES,
@@ -7927,7 +7952,9 @@ impl FixtureRunner {
         let mut fired_count = 0usize;
         while !ppc_app.sound.pending_completions.is_empty() && fired_count < 16 {
             let completion = ppc_app.sound.pending_completions.remove(0);
-            let probe = ppc_app.with_event_queue(self.process_context.event_queue_mut(), |app| {
+            let (event_queue, menu_tracking) =
+                self.process_context.event_queue_and_menu_tracking_mut();
+            let probe = ppc_app.with_process_state(event_queue, menu_tracking, |app| {
                 app.run_sound_completion_callback(
                     completion,
                     PPC_SOUND_COMPLETION_CALLBACK_MAX_CYCLES,
@@ -8760,8 +8787,9 @@ impl FixtureRunner {
         let sys_evt_mask = self
             .bus
             .read_word(crate::memory::globals::addr::SYS_EVT_MASK);
+        let (event_queue, menu_tracking) = self.process_context.event_queue_and_menu_tracking_mut();
         self.dispatcher
-            .with_event_queue(self.process_context.event_queue_mut(), |d| {
+            .with_process_state(event_queue, menu_tracking, |d| {
                 d.post_auto_key_if_due(sys_evt_mask);
             });
 
@@ -8778,10 +8806,12 @@ impl FixtureRunner {
         // to 0x80 even when no GetNextEvent ever drains the queue —
         // critical for polling-only games (Bonkheads-Deluxe class titles)
         // that would otherwise see the button as "held forever".
-        let has_pending_unmatched_down = self.dispatcher.with_event_queue(
-            self.process_context.event_queue_mut(),
-            |d| d.has_unmatched_queued_mouse_down(),
-        );
+        let (event_queue, menu_tracking) = self.process_context.event_queue_and_menu_tracking_mut();
+        let has_pending_unmatched_down =
+            self.dispatcher
+                .with_process_state(event_queue, menu_tracking, |d| {
+                    d.has_unmatched_queued_mouse_down()
+                });
         let pressed = self.dispatcher.mouse_button || has_pending_unmatched_down;
         let mb_state: u8 = if pressed { 0x00 } else { 0x80 };
         self.bus.write_byte(0x0172, mb_state);
@@ -8845,9 +8875,10 @@ impl FixtureRunner {
             }
         }
 
+        let (event_queue, menu_tracking) = self.process_context.event_queue_and_menu_tracking_mut();
         let (mut what, mut message, mut where_v, mut where_h, mut modifiers, mut has_event) = self
             .dispatcher
-            .with_event_queue(self.process_context.event_queue_mut(), |dispatcher| {
+            .with_process_state(event_queue, menu_tracking, |dispatcher| {
                 dispatcher.dequeue_toolbox_event(&mut self.cpu, &mut self.bus, pending.event_mask)
             });
         if !has_event {
@@ -10137,7 +10168,7 @@ impl FixtureRunner {
         if self.active_interrupt_callback.is_some() || (opcode & !0x0400) != 0xA93D {
             return false;
         }
-        if self.dispatcher.menu_tracking.is_none() || self.bus.read_byte(0x0172) != 0x00 {
+        if self.process_context.menu_tracking().is_none() || self.bus.read_byte(0x0172) != 0x00 {
             return false;
         }
 
@@ -10667,8 +10698,11 @@ impl FixtureRunner {
                         count += 1;
                         continue;
                     }
-                    let dispatch_result = self.dispatcher.with_event_queue(
-                        self.process_context.event_queue_mut(),
+                    let (event_queue, menu_tracking) =
+                        self.process_context.event_queue_and_menu_tracking_mut();
+                    let dispatch_result = self.dispatcher.with_process_state(
+                        event_queue,
+                        menu_tracking,
                         |dispatcher| dispatcher.dispatch(opcode, &mut self.cpu, &mut self.bus),
                     );
                     match dispatch_result {
@@ -13887,9 +13921,8 @@ mod tests {
                     "native MenuSelect halted before opening the root menu"
                 );
                 runner
-                    .dispatcher
-                    .menu_tracking
-                    .as_ref()
+                    .process_context
+                    .menu_tracking()
                     .filter(|tracking| tracking.menu_handle == root_menu)
                     .map(|tracking| tracking.dropdown_rect())
             })
@@ -13919,9 +13952,8 @@ mod tests {
             "the real 68k MDEF callback did not return"
         );
         let tracking = runner
-            .dispatcher
-            .menu_tracking
-            .as_ref()
+            .process_context
+            .menu_tracking()
             .expect("native interaction should remain retained");
         assert_eq!(tracking.menu_handle, root_menu);
         assert_eq!(
@@ -13957,9 +13989,8 @@ mod tests {
             assert!(running, "native MenuSelect halted before the mouse release");
             runner.bus.read_long(addr::MENU_DISABLE) == raw_choice
                 && runner
-                    .dispatcher
-                    .menu_tracking
-                    .as_ref()
+                    .process_context
+                    .menu_tracking()
                     .is_some_and(|tracking| {
                         tracking.menu_handle == root_menu && tracking.highlighted_item == 0
                     })
@@ -13977,7 +14008,7 @@ mod tests {
             }
         }
         assert!(runner.is_halted());
-        assert!(runner.dispatcher.menu_tracking.is_none());
+        assert!(runner.process_context.menu_tracking().is_none());
         assert!(runner.dispatcher.guest_calls.is_empty());
 
         let native = runner.ppc_app.as_mut().expect("native app retained");

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -12,7 +12,7 @@ use crate::guest_call::SharedGuestCallStack;
 use crate::machine_profile::reference_machine_profile;
 use crate::managers::resource::ResourceFork;
 use crate::memory::{MacMemoryBus, MemoryBus};
-use crate::menu_manager::{SharedMenuTracking, SharedNativeMenuSelection};
+use crate::menu_manager::{ProcessMenuTrackingState, SharedNativeMenuSelection};
 use crate::process_context::ProcessContext;
 use crate::trace::{TraceEvent, TraceSink, TraceSource};
 use crate::ui_theme::{UiTheme, UiThemeId};
@@ -2290,7 +2290,7 @@ pub struct TrapDispatcher {
     /// Menus loaded from MENU resources, in order of insertion
     pub(crate) menus: Vec<super::menu::Menu>,
     /// Active menu tracking state (non-None while MenuSelect is tracking the mouse)
-    pub(crate) menu_tracking: SharedMenuTracking,
+    pub(crate) menu_tracking: Option<ProcessMenuTrackingState>,
     /// Process-owned nested guest-procedure continuations shared by both CPUs.
     pub(crate) guest_calls: SharedGuestCallStack,
     /// Custom popup MDEF state before its returned rectangle creates a pane.
@@ -2927,14 +2927,9 @@ pub(crate) struct LoadedResources {
 }
 
 impl TrapDispatcher {
-    /// # Safety
-    ///
-    /// The caller must keep this adapter and the context under one process
-    /// owner that serializes all access to their shared handles.
-    pub(crate) unsafe fn attach_process_context(&mut self, context: &ProcessContext) {
-        unsafe {
-            context.attach_menu_tracking(&mut self.menu_tracking);
-        }
+    /// Attach shared process resources to this dispatcher.
+    pub(crate) fn attach_process_context(&mut self, context: &mut ProcessContext) {
+        context.adopt_menu_tracking(&mut self.menu_tracking);
         context.attach_native_menu_selection(&mut self.pending_native_menu_selection);
         context.attach_guest_calls(&mut self.guest_calls);
     }
@@ -2954,6 +2949,36 @@ impl TrapDispatcher {
             Ok(result) => result,
             Err(payload) => std::panic::resume_unwind(payload),
         }
+    }
+
+    /// Temporarily borrow the canonical menu tracking state from [`ProcessContext`]
+    /// into this adapter's local tracking for the duration of `f`, and guarantee
+    /// it is swapped back on normal exit, early return, or unwind.
+    pub(crate) fn with_menu_tracking<R>(
+        &mut self,
+        menu_tracking: &mut Option<ProcessMenuTrackingState>,
+        f: impl FnOnce(&mut Self) -> R,
+    ) -> R {
+        std::mem::swap(&mut self.menu_tracking, menu_tracking);
+        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(self)));
+        std::mem::swap(&mut self.menu_tracking, menu_tracking);
+        match outcome {
+            Ok(result) => result,
+            Err(payload) => std::panic::resume_unwind(payload),
+        }
+    }
+
+    /// Install all directly owned process state needed by one 68k execution
+    /// slice, returning it to [`ProcessContext`] before another CPU can run.
+    pub(crate) fn with_process_state<R>(
+        &mut self,
+        event_queue: &mut EventQueue,
+        menu_tracking: &mut Option<ProcessMenuTrackingState>,
+        f: impl FnOnce(&mut Self) -> R,
+    ) -> R {
+        self.with_event_queue(event_queue, |dispatcher| {
+            dispatcher.with_menu_tracking(menu_tracking, f)
+        })
     }
 
     pub(crate) const AUTO_KEY_THRESHOLD_TICKS: u32 = 16;
@@ -3877,7 +3902,7 @@ impl TrapDispatcher {
             menu_bar_hidden: false,
             sound_manager: crate::sound::SoundManager::new(),
             menus: Vec::new(),
-            menu_tracking: SharedMenuTracking::default(),
+            menu_tracking: None,
             guest_calls: SharedGuestCallStack::default(),
             menu_definition_tracking: None,
             pending_menu_bar_build: None,
@@ -4138,11 +4163,20 @@ impl TrapDispatcher {
 
     /// Whether retained menu tracking has entered an application MDEF and
     /// must let that guest callback return to the original menu trap.
+    #[cfg(test)]
     pub(crate) fn is_menu_definition_callback_pending(&self) -> bool {
+        self.is_menu_definition_callback_pending_with_tracking(self.menu_tracking.as_ref())
+    }
+
+    pub(crate) fn is_menu_definition_callback_pending_with_tracking(
+        &self,
+        menu_tracking: Option<&ProcessMenuTrackingState>,
+    ) -> bool {
         self.pending_menu_bar_build.is_some()
             || self
                 .menu_tracking
                 .as_ref()
+                .or(menu_tracking)
                 .and_then(crate::menu_manager::MenuTrackingState::active_definition)
                 .or(self.menu_definition_tracking.as_ref())
                 .is_some_and(|tracking| tracking.pending_invocation().is_some())
@@ -4154,6 +4188,14 @@ impl TrapDispatcher {
     /// tracking loops is active and the trap is the matching routine. Strips
     /// the auto-pop bit (0x0400) so auto-pop variants match too.
     pub fn is_tracking_refire(&self, opcode: u16) -> bool {
+        self.is_tracking_refire_with_menu_tracking(opcode, self.is_menu_tracking())
+    }
+
+    pub(crate) fn is_tracking_refire_with_menu_tracking(
+        &self,
+        opcode: u16,
+        is_menu_tracking: bool,
+    ) -> bool {
         let trap_no_autopop = opcode & !0x0400;
         let is_menu_refire = trap_no_autopop == 0xA93D || trap_no_autopop == 0xA80B;
         let is_menu_bar_build_refire = trap_no_autopop == 0xA9C0;
@@ -4165,7 +4207,7 @@ impl TrapDispatcher {
         let is_go_away_refire = trap_no_autopop == 0xA91E;
         let is_grow_window_refire = trap_no_autopop == 0xA92B;
         let is_region_refire = matches!(trap_no_autopop, 0xA905 | 0xA926);
-        (is_menu_refire && self.is_menu_tracking())
+        (is_menu_refire && is_menu_tracking)
             || (is_menu_bar_build_refire && self.pending_menu_bar_build.is_some())
             || (is_dialog_refire && self.is_dialog_tracking())
             || (is_standard_file_refire
@@ -10299,7 +10341,7 @@ mod tests {
     }
 
     fn install_menu_tracking(disp: &mut TrapDispatcher) {
-        *disp.menu_tracking = Some(test_tracked_menu_state(0, (0, 0, 0, 0), 0));
+        disp.menu_tracking = Some(test_tracked_menu_state(0, (0, 0, 0, 0), 0));
     }
 
     fn install_dialog_tracking(disp: &mut TrapDispatcher) {
@@ -11075,5 +11117,87 @@ mod tests {
         assert!(context_queue.menu_bar_is_invalid());
         assert!(dispatcher.event_queue.is_empty());
         assert!(!dispatcher.event_queue.menu_bar_is_invalid());
+    }
+
+    #[test]
+    fn with_menu_tracking_restores_context_and_adapter_state_on_normal_exit() {
+        let mut dispatcher = TrapDispatcher::new();
+        let mut context_tracking = Some(crate::menu_manager::test_process_menu_tracking(0x1234));
+
+        let ran = dispatcher.with_menu_tracking(&mut context_tracking, |disp| {
+            assert_eq!(
+                disp.menu_tracking.as_ref().map(|t| t.menu_handle),
+                Some(0x1234)
+            );
+            disp.menu_tracking.as_mut().unwrap().highlighted_item = 5;
+            true
+        });
+
+        assert!(ran);
+        assert!(dispatcher.menu_tracking.is_none());
+        assert_eq!(
+            context_tracking
+                .as_ref()
+                .map(|t| (t.menu_handle, t.highlighted_item)),
+            Some((0x1234, 5))
+        );
+    }
+
+    #[test]
+    fn with_menu_tracking_restores_context_and_adapter_state_on_panic() {
+        let mut dispatcher = TrapDispatcher::new();
+        let mut context_tracking = Some(crate::menu_manager::test_process_menu_tracking(0x5678));
+
+        let panic_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            dispatcher.with_menu_tracking(&mut context_tracking, |disp| {
+                disp.menu_tracking.as_mut().unwrap().highlighted_item = 9;
+                panic!("simulated panic inside menu trap execution");
+            })
+        }));
+
+        assert!(panic_result.is_err());
+        assert!(dispatcher.menu_tracking.is_none());
+        assert_eq!(
+            context_tracking
+                .as_ref()
+                .map(|t| (t.menu_handle, t.highlighted_item)),
+            Some((0x5678, 9))
+        );
+    }
+
+    #[test]
+    fn with_process_state_restores_both_canonical_slots_on_panic() {
+        let mut dispatcher = TrapDispatcher::new();
+        let mut context_queue = EventQueue::default();
+        let mut context_tracking = Some(crate::menu_manager::test_process_menu_tracking(0x9abc));
+
+        let panic_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            dispatcher.with_process_state(
+                &mut context_queue,
+                &mut context_tracking,
+                |disp| {
+                    disp.event_queue.push_back(QueuedEvent {
+                        what: 1,
+                        message: 0x3333,
+                        where_v: 1,
+                        where_h: 2,
+                        modifiers: 0,
+                    });
+                    disp.menu_tracking.as_mut().unwrap().highlighted_item = 7;
+                    panic!("simulated panic inside a complete guest execution slice");
+                },
+            );
+        }));
+
+        assert!(panic_result.is_err());
+        assert_eq!(context_queue.front().map(|event| event.message), Some(0x3333));
+        assert_eq!(
+            context_tracking
+                .as_ref()
+                .map(|tracking| (tracking.menu_handle, tracking.highlighted_item)),
+            Some((0x9abc, 7))
+        );
+        assert!(dispatcher.event_queue.is_empty());
+        assert!(dispatcher.menu_tracking.is_none());
     }
 }

--- a/src/trap/framebuffer.rs
+++ b/src/trap/framebuffer.rs
@@ -5132,7 +5132,7 @@ mod redraw_chrome_tests {
         tracking.submenus.push(child);
         tracking.flash_remaining = 5;
         tracking.flash_result = (701u32 << 16) | 1;
-        *disp.menu_tracking = Some(tracking);
+        disp.menu_tracking = Some(tracking);
 
         disp.redraw_chrome(&mut bus);
 

--- a/src/trap/menu.rs
+++ b/src/trap/menu.rs
@@ -2583,7 +2583,7 @@ impl super::TrapDispatcher {
                                 saved,
                             );
                             tracking.definition = self.menu_definition_tracking.take();
-                            *self.menu_tracking = Some(tracking);
+                            self.menu_tracking = Some(tracking);
                             self.draw_menu_dropdown_chrome(bus, menu_idx, rect);
                             self.active_menu_definition_mut().unwrap().draw();
                             if !self.arm_pending_menu_definition(
@@ -2745,7 +2745,7 @@ impl super::TrapDispatcher {
                         .position(|m| m.handle == menu_handle || m.id == menu_id)
                     {
                         if !self.menu_uses_standard_definition(bus, menu_ptr) {
-                            *self.menu_tracking = Some(tracked_menu_state(
+                            self.menu_tracking = Some(tracked_menu_state(
                                 MenuTrackingKind::PopUp,
                                 menu_handle,
                                 (0, 0, 0, 0),
@@ -2785,7 +2785,7 @@ impl super::TrapDispatcher {
 
                         self.restore_visible_dialog_snapshots(bus);
                         let saved = self.save_dropdown_pixels(bus, dd_rect);
-                        *self.menu_tracking = Some(tracked_menu_state_with_content_top(
+                        self.menu_tracking = Some(tracked_menu_state_with_content_top(
                             MenuTrackingKind::PopUp,
                             menu_handle,
                             dd_rect,
@@ -4449,7 +4449,7 @@ impl super::TrapDispatcher {
             tracked_menu_state(MenuTrackingKind::MenuBar, menu.handle, dropdown_rect, saved);
         tracking.definition = custom_definition
             .then(|| SharedMenuDefinitionTracking::begin_draw(menu.handle, dropdown_rect));
-        *self.menu_tracking = Some(tracking);
+        self.menu_tracking = Some(tracking);
         if !custom_definition {
             let rows = self.menu_rows(bus, &self.menus[menu_idx].items);
             Self::write_menu_scrolling_globals(bus, &rows, dropdown_rect.0);
@@ -4830,7 +4830,7 @@ impl super::TrapDispatcher {
     /// Determine which item (1-based) is at the given screen point, or 0.
     #[cfg(test)]
     fn dropdown_item_at_point(&self, bus: &MacMemoryBus, mouse_x: i16, mouse_y: i16) -> i16 {
-        if let Some(ref tracking) = *self.menu_tracking {
+        if let Some(ref tracking) = self.menu_tracking {
             let Some(menu_idx) = self.menu_index_for_handle(tracking.menu_handle) else {
                 return 0;
             };
@@ -11508,7 +11508,7 @@ mod tests {
         );
         classic.menus[0].items[0].mark = 0x12;
         classic.menus[0].items[1].icon = 7;
-        *classic.menu_tracking = Some(test_tracked_menu_state(classic_menu, rect, 1));
+        classic.menu_tracking = Some(test_tracked_menu_state(classic_menu, rect, 1));
         classic.draw_menu_dropdown(&mut classic_bus, 0, rect);
 
         let (mut themed, mut themed_cpu, mut themed_bus) = setup_with_port();
@@ -11535,7 +11535,7 @@ mod tests {
         );
         themed.menus[0].items[0].mark = 0x12;
         themed.menus[0].items[1].icon = 7;
-        *themed.menu_tracking = Some(test_tracked_menu_state(themed_menu, rect, 1));
+        themed.menu_tracking = Some(test_tracked_menu_state(themed_menu, rect, 1));
         themed.draw_menu_dropdown(&mut themed_bus, 0, rect);
 
         assert!(
@@ -11707,7 +11707,7 @@ mod tests {
         );
 
         clear_1bpp_screen(&mut themed_bus, themed_base, themed_row_bytes, 342);
-        *themed.menu_tracking = Some(test_tracked_menu_state(themed_menu, rect, 1));
+        themed.menu_tracking = Some(test_tracked_menu_state(themed_menu, rect, 1));
         themed.draw_menu_dropdown(&mut themed_bus, 0, rect);
 
         assert!(
@@ -11756,7 +11756,7 @@ mod tests {
         }
 
         clear_1bpp_screen(&mut themed_bus, themed_base, themed_row_bytes, 342);
-        *themed.menu_tracking = None;
+        themed.menu_tracking = None;
         themed.dialog_tracking = Some(super::super::dispatch::DialogTrackingState {
             active_popup: Some(super::super::dispatch::DialogPopupTrackingState {
                 item_no: 1,
@@ -12317,7 +12317,7 @@ mod tests {
             "4bpp cicn color should map through MainDevice instead of the foreign 8bpp TheGDevice"
         );
 
-        *disp.menu_tracking = Some(test_tracked_menu_state(menu, rect, 1));
+        disp.menu_tracking = Some(test_tracked_menu_state(menu, rect, 1));
         disp.draw_menu_dropdown(&mut bus, 0, rect);
         assert_eq!(
             packed_4bpp_screen_pixel_index(&bus, base, row_bytes, icon_pixel.0, icon_pixel.1,),
@@ -12587,7 +12587,7 @@ mod tests {
             screen_pixel_is_set(&bus, base, row_bytes, outside_edge.0, outside_edge.1);
         let before = bus.read_bytes(base, (row_bytes * 96) as usize);
 
-        *disp.menu_tracking = Some(test_tracked_menu_state(menu, rect, 1));
+        disp.menu_tracking = Some(test_tracked_menu_state(menu, rect, 1));
         disp.draw_menu_dropdown(&mut bus, 0, rect);
 
         for (component, pixel) in [
@@ -12698,7 +12698,7 @@ mod tests {
             .expect("precondition: item RGB3 black command key should draw");
         let before = bus.read_bytes(base, (row_bytes * 96) as usize);
 
-        *disp.menu_tracking = Some(test_tracked_menu_state(menu, rect, 1));
+        disp.menu_tracking = Some(test_tracked_menu_state(menu, rect, 1));
         disp.draw_menu_dropdown(&mut bus, 0, rect);
 
         assert_eq!(
@@ -12797,7 +12797,7 @@ mod tests {
             .expect("precondition: item RGB3 black command key should draw");
         let before = bus.read_bytes(base, (row_bytes * 96) as usize);
 
-        *disp.menu_tracking = Some(test_tracked_menu_state(menu, rect, 1));
+        disp.menu_tracking = Some(test_tracked_menu_state(menu, rect, 1));
         disp.draw_menu_dropdown(&mut bus, 0, rect);
 
         assert_eq!(
@@ -13483,7 +13483,7 @@ mod tests {
             new_menu_with_title(&mut disp, &mut cpu, &mut bus, 702, 0x302700, "Retained");
         append_menu_data(&mut disp, &mut cpu, &mut bus, retained, 0x302740, "Right");
 
-        *disp.menu_tracking = Some(test_tracked_menu_state(retained, (20, 10, 38, 100), 1));
+        disp.menu_tracking = Some(test_tracked_menu_state(retained, (20, 10, 38, 100), 1));
         disp.menus.swap(0, 1);
 
         assert_eq!(


### PR DESCRIPTION
Closes #1013.

Moves the retained Menu Manager continuation into direct `ProcessContext` ownership. The 68k and PowerPC adapters borrow it only for one scheduler execution or host-compositing slice, with unwind-safe restoration, removing the menu-specific `Rc<UnsafeCell<_>>` contract.

Tests:
- `cargo check --all-targets`
- `cargo test --lib` (4,542 passed; 3 ignored)
- targeted Miri coverage for combined process-state unwind and 68k/PowerPC handoff
- real native `MenuSelect` → 68k MDEF → `DisableItem` regression