### PR TITLE
fix(menu): preserve native handle growth across 68k callbacks

### DIFF
--- a/src/loader/ppc.rs
+++ b/src/loader/ppc.rs
@@ -5004,6 +5004,58 @@ fn push_ppc_hle_import_trace_entry(
 }
 
 impl PpcLoadedApp {
+    /// Replace bytes of a relocatable handle within the native process heap.
+    ///
+    /// If `expected_ptr` is nonzero, verifies that the master pointer currently
+    /// points to `expected_ptr`. Resizes the handle via [`ppc_set_handle_size`],
+    /// writes the replacement bytes, and updates [`Self::last_mem_error`].
+    /// On failure, leaves the existing pointer, bytes, and handle metadata intact.
+    /// Inside Macintosh: Memory (1992), pp. 2-40--2-41.
+    pub(crate) fn replace_handle_bytes(
+        &mut self,
+        handle: u32,
+        expected_ptr: u32,
+        bytes: &[u8],
+    ) -> bool {
+        let Some(current_ptr) = self.memory.read_u32_be(handle) else {
+            self.last_mem_error = PPC_NIL_HANDLE_ERR;
+            return false;
+        };
+        let record_matches = self
+            .handles
+            .iter()
+            .any(|record| record.handle == handle && record.ptr == current_ptr);
+        if current_ptr == 0 || current_ptr != expected_ptr || !record_matches {
+            self.last_mem_error = PPC_NIL_HANDLE_ERR;
+            return false;
+        }
+        let Ok(size) = u32::try_from(bytes.len()) else {
+            self.last_mem_error = PPC_MEM_FULL_ERR;
+            return false;
+        };
+        let result = ppc_set_handle_size(
+            &mut self.memory,
+            &mut self.heap_cursor,
+            self.heap_limit,
+            &mut self.handles,
+            handle,
+            size,
+        );
+        self.last_mem_error = result;
+        if result != PPC_NO_ERR {
+            return false;
+        }
+        let Some(ptr) = self.memory.read_u32_be(handle).filter(|ptr| *ptr != 0) else {
+            self.last_mem_error = PPC_NIL_HANDLE_ERR;
+            return false;
+        };
+        if self.memory.write_bytes(ptr, bytes).is_none() {
+            self.last_mem_error = PPC_PARAM_ERR;
+            return false;
+        }
+        true
+    }
+
     pub(crate) fn prepare_shared_system_reservation(&mut self, base: u32, len: u32) -> bool {
         if self
             .memory
@@ -79899,6 +79951,7 @@ pub(crate) mod tests {
         pub(crate) app: PpcLoadedApp,
         pub(crate) root_menu: u32,
         pub(crate) root_record: u32,
+        pub(crate) mdef_entry: u32,
         pub(crate) callback_marker: u32,
         pub(crate) title_h: i16,
     }
@@ -79985,6 +80038,7 @@ pub(crate) mod tests {
             app: loaded,
             root_menu,
             root_record,
+            mdef_entry: MDEF_ENTRY,
             callback_marker: CALLBACK_MARKER,
             title_h,
         }
@@ -94260,6 +94314,48 @@ pub(crate) mod tests {
         assert!(handle < new_ptr || handle >= new_ptr + 48);
         for (offset, byte) in b"abcdefghijkl".iter().copied().enumerate() {
             assert_eq!(loaded.memory.read_u8(new_ptr + offset as u32), Some(byte));
+        }
+    }
+
+    #[test]
+    fn native_owner_handle_replacement_is_atomic_when_growth_exhausts_the_heap() {
+        let pef = synthetic_pef_with_import(b"MemError");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let handle = ppc_alloc_handle_with_bytes(
+            &mut loaded.memory,
+            &mut loaded.heap_cursor,
+            loaded.heap_limit,
+            &mut loaded.handles,
+            b"original",
+        );
+        assert_ne!(handle, 0);
+        let original_record = *loaded
+            .handles
+            .iter()
+            .find(|record| record.handle == handle)
+            .unwrap();
+        let original_ptr = loaded.memory.read_u32_be(handle).unwrap();
+        loaded.heap_limit = loaded.heap_cursor;
+
+        assert!(!loaded.replace_handle_bytes(
+            handle,
+            original_ptr,
+            &[0x5a; 128],
+        ));
+        assert_eq!(loaded.last_mem_error, PPC_MEM_FULL_ERR);
+        assert_eq!(loaded.memory.read_u32_be(handle), Some(original_ptr));
+        assert_eq!(
+            loaded
+                .handles
+                .iter()
+                .find(|record| record.handle == handle),
+            Some(&original_record)
+        );
+        for (offset, byte) in b"original".iter().copied().enumerate() {
+            assert_eq!(
+                loaded.memory.read_u8(original_ptr + offset as u32),
+                Some(byte)
+            );
         }
     }
 

--- a/src/memory/address_space.rs
+++ b/src/memory/address_space.rs
@@ -87,6 +87,20 @@ impl SharedGuestAddressSpace {
         // SAFETY: upheld by `new` and the caller's serialized interval.
         unsafe { PpcMemory::write_u32_be(self.0.as_ptr().as_mut()?, address, value) }
     }
+
+    /// Whether an address belongs to an ordinary sparse native mapping rather
+    /// than a runner-owned shared flat-RAM overlay.
+    #[inline]
+    pub(crate) unsafe fn is_ordinary_sparse_mapped(self, address: u32) -> bool {
+        // SAFETY: upheld by `new` and caller's serialized interval.
+        let Some(space) = (unsafe { self.0.as_ptr().as_mut() }) else {
+            return false;
+        };
+        if space.locate_shared_mapping(address).is_some() {
+            return false;
+        }
+        space.regions.read_u8(address).is_some()
+    }
 }
 
 impl Clone for GuestAddressSpace {
@@ -839,5 +853,27 @@ mod tests {
             .unwrap();
         assert_eq!(sparse_tail, [1, 2, 3, 4, 0x11, 0x22, 0x33, 0x44]);
         assert_eq!(MemoryBus::read_long(&bus, SPARSE), 0);
+    }
+
+    #[test]
+    fn shared_view_distinguishes_ordinary_sparse_mappings_from_overlays() {
+        let mut memory = GuestAddressSpace::new();
+        memory.add_region(0x2000, vec![0; 0x100]);
+
+        let mut shared_bus_ram = MacMemoryBus::new(64 * 1024);
+        let shared_region = shared_bus_ram.shared_ram_region(0, 0x1000).unwrap();
+        unsafe {
+            memory.add_shared_region(0x0000, shared_region);
+        }
+
+        let shared = unsafe { memory.shared_view() };
+        unsafe {
+            // Shared overlays are not ordinary sparse mappings.
+            assert!(!shared.is_ordinary_sparse_mapped(0x0500));
+            // Native heap regions are ordinary sparse mappings.
+            assert!(shared.is_ordinary_sparse_mapped(0x2050));
+            // Unmapped addresses belong to neither domain.
+            assert!(!shared.is_ordinary_sparse_mapped(0x9000));
+        }
     }
 }

--- a/src/memory/bus.rs
+++ b/src/memory/bus.rs
@@ -1248,6 +1248,17 @@ impl MacMemoryBus {
         self.foreign_address_space = None;
     }
 
+    /// Whether an address is mapped into a foreign guest address space's
+    /// ordinary sparse regions (and not in a shared flat-RAM overlay).
+    #[inline]
+    pub(crate) fn is_foreign_ordinary_sparse_address(&self, address: u32) -> bool {
+        let Some(foreign) = self.foreign_address_space else {
+            return false;
+        };
+        // SAFETY: see `foreign_read_u8`.
+        unsafe { foreign.is_ordinary_sparse_mapped(address) }
+    }
+
     #[inline]
     fn foreign_read_u8(&self, address: u32) -> Option<u8> {
         let memory = self.foreign_address_space?;
@@ -3328,5 +3339,33 @@ mod tests {
                 "in-RAM tail of straddling fill_zeros"
             );
         }
+    }
+
+    #[test]
+    fn bus_detects_foreign_ordinary_sparse_addresses_only_when_attached() {
+        use crate::memory::GuestAddressSpace;
+
+        let mut bus = MacMemoryBus::new(64 * 1024);
+        assert!(!bus.is_foreign_ordinary_sparse_address(0x2000));
+
+        let mut memory = GuestAddressSpace::new();
+        memory.add_region(0x2000, vec![0; 0x100]);
+
+        let shared_region = bus.shared_ram_region(0, 0x1000).unwrap();
+        unsafe {
+            memory.add_shared_region(0x0000, shared_region);
+        }
+
+        let shared = unsafe { memory.shared_view() };
+        unsafe {
+            bus.attach_guest_address_space(shared);
+        }
+
+        assert!(!bus.is_foreign_ordinary_sparse_address(0x0500));
+        assert!(bus.is_foreign_ordinary_sparse_address(0x2050));
+        assert!(!bus.is_foreign_ordinary_sparse_address(0x9000));
+
+        bus.detach_guest_address_space();
+        assert!(!bus.is_foreign_ordinary_sparse_address(0x2050));
     }
 }

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -4,6 +4,19 @@ use crate::event_queue::EventQueue;
 use crate::guest_call::SharedGuestCallStack;
 use crate::menu_manager::{ProcessMenuTrackingState, SharedNativeMenuSelection};
 
+/// A deferred byte replacement for a relocatable guest handle.
+///
+/// This channel lets a serialized 68k execution context request a handle resize
+/// and byte update within the native process address space without giving the
+/// 68k dispatcher direct allocator ownership over the parked PowerPC heap.
+/// Inside Macintosh: Memory (1992), pp. 2-40--2-41.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PendingHandleByteReplacement {
+    pub(crate) handle: u32,
+    pub(crate) expected_ptr: u32,
+    pub(crate) replacement: Vec<u8>,
+}
+
 /// Canonical owner for state that belongs to one emulated process rather than
 /// to either of its CPU ABI adapters.
 ///
@@ -15,6 +28,7 @@ pub(crate) struct ProcessContext {
     menu_tracking: Option<ProcessMenuTrackingState>,
     pending_native_menu_selection: SharedNativeMenuSelection,
     guest_calls: SharedGuestCallStack,
+    pending_memory_effects: Vec<PendingHandleByteReplacement>,
 }
 
 impl ProcessContext {
@@ -50,6 +64,24 @@ impl ProcessContext {
         &mut self.menu_tracking
     }
 
+    #[cfg(test)]
+    pub(crate) fn pending_memory_effects(&self) -> &[PendingHandleByteReplacement] {
+        &self.pending_memory_effects
+    }
+
+    #[cfg(test)]
+    pub(crate) fn pending_memory_effects_mut(&mut self) -> &mut Vec<PendingHandleByteReplacement> {
+        &mut self.pending_memory_effects
+    }
+
+    pub(crate) fn take_pending_memory_effects(&mut self) -> Vec<PendingHandleByteReplacement> {
+        std::mem::take(&mut self.pending_memory_effects)
+    }
+
+    pub(crate) fn has_pending_memory_effects(&self) -> bool {
+        !self.pending_memory_effects.is_empty()
+    }
+
     /// Transfer detached adapter state into the canonical process owner.
     pub(crate) fn adopt_menu_tracking(&mut self, adapter: &mut Option<ProcessMenuTrackingState>) {
         assert!(
@@ -66,6 +98,20 @@ impl ProcessContext {
         &mut self,
     ) -> (&mut EventQueue, &mut Option<ProcessMenuTrackingState>) {
         (&mut self.event_queue, &mut self.menu_tracking)
+    }
+
+    pub(crate) fn event_queue_menu_tracking_and_memory_effects_mut(
+        &mut self,
+    ) -> (
+        &mut EventQueue,
+        &mut Option<ProcessMenuTrackingState>,
+        &mut Vec<PendingHandleByteReplacement>,
+    ) {
+        (
+            &mut self.event_queue,
+            &mut self.menu_tracking,
+            &mut self.pending_memory_effects,
+        )
     }
 
     pub(crate) fn attach_native_menu_selection(&self, adapter: &mut SharedNativeMenuSelection) {
@@ -216,5 +262,46 @@ mod tests {
         begin_call(&second, 0x2000);
         context.attach_guest_calls(&mut first);
         context.attach_guest_calls(&mut second);
+    }
+
+    #[test]
+    fn process_context_owns_canonical_pending_memory_effects() {
+        let mut context = ProcessContext::default();
+        assert!(!context.has_pending_memory_effects());
+        assert!(context.pending_memory_effects().is_empty());
+
+        context.pending_memory_effects_mut().push(PendingHandleByteReplacement {
+            handle: 0x1000,
+            expected_ptr: 0x2000,
+            replacement: vec![1, 2, 3, 4],
+        });
+        assert!(context.has_pending_memory_effects());
+        assert_eq!(context.pending_memory_effects().len(), 1);
+        assert_eq!(context.pending_memory_effects()[0].handle, 0x1000);
+
+        let taken = context.take_pending_memory_effects();
+        assert_eq!(taken.len(), 1);
+        assert_eq!(taken[0].handle, 0x1000);
+        assert_eq!(taken[0].expected_ptr, 0x2000);
+        assert_eq!(taken[0].replacement, vec![1, 2, 3, 4]);
+        assert!(!context.has_pending_memory_effects());
+
+        let (queue, menu, effects) = context.event_queue_menu_tracking_and_memory_effects_mut();
+        queue.push_back(QueuedEvent {
+            what: 1,
+            message: 0x1234,
+            where_v: 0,
+            where_h: 0,
+            modifiers: 0,
+        });
+        *menu = Some(crate::menu_manager::test_process_menu_tracking(0x3000));
+        effects.push(PendingHandleByteReplacement {
+            handle: 0x4000,
+            expected_ptr: 0x5000,
+            replacement: vec![9, 8, 7],
+        });
+        assert_eq!(context.event_queue().len(), 1);
+        assert!(context.menu_tracking().is_some());
+        assert_eq!(context.pending_memory_effects().len(), 1);
     }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -6409,17 +6409,21 @@ impl FixtureRunner {
                         self.cpu.core.take_aline_exception(&mut self.bus);
                         continue;
                     }
-                    let (event_queue, menu_tracking) =
-                        self.process_context.event_queue_and_menu_tracking_mut();
-                    let dispatch_err = self.dispatcher.with_process_state(
+                    let (event_queue, menu_tracking, memory_effects) =
+                        self.process_context.event_queue_menu_tracking_and_memory_effects_mut();
+                    let dispatch_err = self.dispatcher.with_process_state_and_memory_effects(
                         event_queue,
                         menu_tracking,
+                        memory_effects,
                         |dispatcher| {
                             dispatcher
                                 .dispatch(opcode, &mut self.cpu, &mut self.bus)
                                 .is_err()
                         },
                     );
+                    if self.process_context.has_pending_memory_effects() {
+                        self.apply_pending_process_memory_effects(ppc_app);
+                    }
                     if dispatch_err {
                         running = false;
                         break;
@@ -6445,6 +6449,46 @@ impl FixtureRunner {
         }
         self.bus.detach_guest_address_space();
         Some((executed, running))
+    }
+
+    fn apply_pending_process_memory_effects(&mut self, ppc_app: &mut PpcLoadedApp) {
+        let effects = self.process_context.take_pending_memory_effects();
+        if effects.is_empty() {
+            return;
+        }
+        self.bus.detach_guest_address_space();
+        let mut successful_menus = Vec::new();
+        for effect in effects {
+            let success = ppc_app.replace_handle_bytes(
+                effect.handle,
+                effect.expected_ptr,
+                &effect.replacement,
+            );
+            if success {
+                self.bus
+                    .write_word(crate::memory::globals::addr::MEM_ERR, 0);
+                successful_menus.push((effect.handle, effect.expected_ptr));
+            } else {
+                let err = if ppc_app.last_mem_error != 0 {
+                    ppc_app.last_mem_error as u16
+                } else {
+                    (-108i16) as u16 // memFullErr
+                };
+                self.bus
+                    .write_word(crate::memory::globals::addr::MEM_ERR, err);
+            }
+        }
+        // SAFETY: `ppc_app` is parked for this whole interval. The address
+        // space remains in place, and all reads and writes are serialized
+        // through this runner until the bus is detached.
+        let shared_memory = unsafe { ppc_app.memory.shared_view() };
+        unsafe {
+            self.bus.attach_guest_address_space(shared_memory);
+        }
+        for (menu_handle, old_ptr) in successful_menus {
+            self.dispatcher
+                .complete_deferred_menu_replacement(&self.bus, menu_handle, old_ptr);
+        }
     }
 
     fn resume_m68k_after_powerpc(&mut self, ppc_app: &mut PpcLoadedApp) -> bool {
@@ -14037,6 +14081,153 @@ mod tests {
         assert_eq!(probe.handled_import_count, 1);
         assert_eq!(probe.unsupported_import_index, None);
         assert_eq!(native.cpu.gpr[3], raw_choice);
+    }
+
+    #[test]
+    fn native_menu_select_observes_growing_68k_append_menu_after_mdef_returns() {
+        use crate::loader::ppc::tests::cross_abi_menu_select_fixture;
+
+        const APPEND_STRING: u32 = crate::loader::ppc::PPC_DATA_BASE + 0x7300;
+        const CALLBACK_VALUE: u32 = 0x68c0_ab1e;
+        const ROOT_MENU_ID: i16 = 140;
+        const TARGET_ITEM: i16 = 2;
+        const APPENDED_TEXT: &[u8] =
+            b"Cross-ABI growth must remain visible through the original native MenuHandle";
+
+        let mut fixture = cross_abi_menu_select_fixture();
+        let root_menu = fixture.root_menu;
+        let original_record = fixture.root_record;
+        let original_handle_record = fixture
+            .app
+            .handles
+            .iter()
+            .copied()
+            .find(|record| record.handle == root_menu)
+            .expect("native root-menu allocation");
+        let callback_marker = fixture.callback_marker;
+        let title_h = fixture.title_h;
+
+        let mut append_string = Vec::with_capacity(APPENDED_TEXT.len() + 1);
+        append_string.push(APPENDED_TEXT.len() as u8);
+        append_string.extend_from_slice(APPENDED_TEXT);
+        fixture.app.memory.add_region(APPEND_STRING, append_string);
+
+        // The real 68k MDEF grows the native MenuInfo with AppendMenu. A
+        // relocatable block can move during SetHandleSize, but its master
+        // pointer and Handle identity remain authoritative. Inside Macintosh:
+        // Memory (1992), pp. 1-16--1-17 and 2-40--2-41.
+        let mut mdef = Vec::new();
+        mdef.extend_from_slice(&0x4ab9u16.to_be_bytes()); // TST.L marker
+        mdef.extend_from_slice(&callback_marker.to_be_bytes());
+        mdef.extend_from_slice(&0x660eu16.to_be_bytes()); // BNE.S after AppendMenu
+        mdef.extend_from_slice(&0x2f3cu16.to_be_bytes()); // MOVE.L #rootMenu,-(SP)
+        mdef.extend_from_slice(&root_menu.to_be_bytes());
+        mdef.extend_from_slice(&0x2f3cu16.to_be_bytes()); // MOVE.L #appendString,-(SP)
+        mdef.extend_from_slice(&APPEND_STRING.to_be_bytes());
+        mdef.extend_from_slice(&0xa933u16.to_be_bytes()); // AppendMenu
+        mdef.extend_from_slice(&0x23fcu16.to_be_bytes()); // MOVE.L #value,marker
+        mdef.extend_from_slice(&CALLBACK_VALUE.to_be_bytes());
+        mdef.extend_from_slice(&callback_marker.to_be_bytes());
+        mdef.extend_from_slice(&0x4e74u16.to_be_bytes()); // RTD #18
+        mdef.extend_from_slice(&0x0012u16.to_be_bytes());
+        fixture.app.memory.add_region(fixture.mdef_entry, mdef);
+
+        let app = LoadedApp::from_ppc(fixture.app);
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        runner.init_app(&app);
+
+        runner.push_canonical_mouse_down(10, title_h);
+        let root_rect = (0..16)
+            .find_map(|_| {
+                let (_, running) = runner.run_steps(512, None);
+                assert!(running, "native MenuSelect halted before opening the root menu");
+                runner
+                    .process_context
+                    .menu_tracking()
+                    .filter(|tracking| tracking.menu_handle == root_menu)
+                    .map(|tracking| tracking.dropdown_rect())
+            })
+            .expect("native MenuSelect should retain the canonical root handle");
+
+        runner
+            .dispatcher
+            .set_mouse_position(root_rect.0 + 8, root_rect.1 + 16);
+        runner.sync_mouse_position_lowmem();
+        let callback_completed = (0..32).any(|_| {
+            let (_, running) = runner.run_steps(512, None);
+            assert!(running, "native MenuSelect halted during the growing 68k callback");
+            runner
+                .ppc_app
+                .as_mut()
+                .unwrap()
+                .memory
+                .read_u32_be(callback_marker)
+                == Some(CALLBACK_VALUE)
+                && runner.dispatcher.guest_calls.is_empty()
+        });
+        assert!(callback_completed, "the growing real 68k MDEF callback did not return");
+
+        let native = runner.ppc_app.as_mut().expect("native app retained");
+        let relocated_record = native
+            .memory
+            .read_u32_be(root_menu)
+            .expect("live native root-menu master pointer");
+        let handle_record = native
+            .handles
+            .iter()
+            .copied()
+            .find(|record| record.handle == root_menu)
+            .expect("updated native root-menu allocation");
+        assert_eq!(handle_record.ptr, relocated_record);
+        assert_eq!(handle_record.handle, root_menu);
+        assert_eq!(handle_record.size, handle_record.capacity);
+        assert!(handle_record.size > original_handle_record.size);
+        assert_ne!(relocated_record, original_record, "the fixture must force relocation");
+        let mut menu_bytes = vec![0; handle_record.size as usize];
+        native
+            .memory
+            .read_bytes_into(relocated_record, &mut menu_bytes)
+            .expect("complete relocated MenuInfo bytes");
+        let items = crate::menu_manager::MenuItems::decode(&menu_bytes)
+            .expect("relocated native MenuInfo remains decodable");
+        assert!(
+            items.items.iter().any(|item| item.text == APPENDED_TEXT),
+            "native decoding must observe the item appended by the 68k callback"
+        );
+        assert_eq!(native.last_mem_error, 0);
+        assert!(!runner.process_context.has_pending_memory_effects());
+        assert_eq!(runner.bus.read_word(crate::memory::globals::addr::MEM_ERR), 0);
+
+        let target_v = root_rect.0 + 24;
+        let target_h = root_rect.1 + 16;
+        runner.dispatcher.set_mouse_position(target_v, target_h);
+        runner.sync_mouse_position_lowmem();
+        let target_observed = (0..16).any(|_| {
+            let (_, running) = runner.run_steps(512, None);
+            assert!(running, "native MenuSelect halted before the mouse release");
+            runner
+                .process_context
+                .menu_tracking()
+                .is_some_and(|tracking| {
+                    tracking.menu_handle == root_menu && tracking.highlighted_item == TARGET_ITEM
+                })
+        });
+        assert!(target_observed, "native tracking did not reach the live regular row");
+        runner.push_canonical_mouse_up(target_v, target_h);
+        for _ in 0..128 {
+            let (_, running) = runner.run_steps(512, None);
+            if !running {
+                break;
+            }
+        }
+        assert!(runner.is_halted());
+        assert!(runner.process_context.menu_tracking().is_none());
+        assert!(runner.dispatcher.guest_calls.is_empty());
+        assert_eq!(
+            runner.ppc_app.as_ref().unwrap().cpu.gpr[3],
+            (u32::from(ROOT_MENU_ID as u16) << 16) | u32::from(TARGET_ITEM as u16),
+            "native MenuSelect must continue and return the live regular row"
+        );
     }
 
     #[test]

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -2291,6 +2291,8 @@ pub struct TrapDispatcher {
     pub(crate) menus: Vec<super::menu::Menu>,
     /// Active menu tracking state (non-None while MenuSelect is tracking the mouse)
     pub(crate) menu_tracking: Option<ProcessMenuTrackingState>,
+    /// Process-owned pending handle memory replacements staged during cross-ISA dispatch.
+    pub(crate) pending_memory_effects: Vec<crate::process_context::PendingHandleByteReplacement>,
     /// Process-owned nested guest-procedure continuations shared by both CPUs.
     pub(crate) guest_calls: SharedGuestCallStack,
     /// Custom popup MDEF state before its returned rectangle creates a pane.
@@ -2968,6 +2970,27 @@ impl TrapDispatcher {
         }
     }
 
+    /// Temporarily borrow the canonical pending memory effects from [`ProcessContext`]
+    /// into this adapter's local queue for the duration of `f`, and guarantee
+    /// it is swapped back on normal exit, early return, or unwind.
+    pub(crate) fn with_memory_effects<R>(
+        &mut self,
+        memory_effects: &mut Vec<crate::process_context::PendingHandleByteReplacement>,
+        f: impl FnOnce(&mut Self) -> R,
+    ) -> R {
+        assert!(
+            self.pending_memory_effects.is_empty(),
+            "cannot install process memory effects over detached adapter effects"
+        );
+        std::mem::swap(&mut self.pending_memory_effects, memory_effects);
+        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(self)));
+        std::mem::swap(&mut self.pending_memory_effects, memory_effects);
+        match outcome {
+            Ok(result) => result,
+            Err(payload) => std::panic::resume_unwind(payload),
+        }
+    }
+
     /// Install all directly owned process state needed by one 68k execution
     /// slice, returning it to [`ProcessContext`] before another CPU can run.
     pub(crate) fn with_process_state<R>(
@@ -2978,6 +3001,20 @@ impl TrapDispatcher {
     ) -> R {
         self.with_event_queue(event_queue, |dispatcher| {
             dispatcher.with_menu_tracking(menu_tracking, f)
+        })
+    }
+
+    /// Install the process-owned state and effect channel needed by a
+    /// serialized native-to-68k execution slice.
+    pub(crate) fn with_process_state_and_memory_effects<R>(
+        &mut self,
+        event_queue: &mut EventQueue,
+        menu_tracking: &mut Option<ProcessMenuTrackingState>,
+        memory_effects: &mut Vec<crate::process_context::PendingHandleByteReplacement>,
+        f: impl FnOnce(&mut Self) -> R,
+    ) -> R {
+        self.with_process_state(event_queue, menu_tracking, |dispatcher| {
+            dispatcher.with_memory_effects(memory_effects, f)
         })
     }
 
@@ -3903,6 +3940,7 @@ impl TrapDispatcher {
             sound_manager: crate::sound::SoundManager::new(),
             menus: Vec::new(),
             menu_tracking: None,
+            pending_memory_effects: Vec::new(),
             guest_calls: SharedGuestCallStack::default(),
             menu_definition_tracking: None,
             pending_menu_bar_build: None,
@@ -11166,15 +11204,45 @@ mod tests {
     }
 
     #[test]
-    fn with_process_state_restores_both_canonical_slots_on_panic() {
+    fn with_memory_effects_borrows_and_restores_pending_replacements() {
+        let mut dispatcher = TrapDispatcher::new();
+        let mut context_effects = vec![crate::process_context::PendingHandleByteReplacement {
+            handle: 0x1111,
+            expected_ptr: 0x2222,
+            replacement: vec![1, 2, 3],
+        }];
+
+        let ran = dispatcher.with_memory_effects(&mut context_effects, |disp| {
+            assert_eq!(disp.pending_memory_effects.len(), 1);
+            assert_eq!(disp.pending_memory_effects[0].handle, 0x1111);
+            disp.pending_memory_effects.push(
+                crate::process_context::PendingHandleByteReplacement {
+                    handle: 0x3333,
+                    expected_ptr: 0x4444,
+                    replacement: vec![4, 5, 6],
+                },
+            );
+            true
+        });
+
+        assert!(ran);
+        assert!(dispatcher.pending_memory_effects.is_empty());
+        assert_eq!(context_effects.len(), 2);
+        assert_eq!(context_effects[1].handle, 0x3333);
+    }
+
+    #[test]
+    fn with_process_state_restores_all_canonical_slots_on_panic() {
         let mut dispatcher = TrapDispatcher::new();
         let mut context_queue = EventQueue::default();
         let mut context_tracking = Some(crate::menu_manager::test_process_menu_tracking(0x9abc));
+        let mut context_effects = Vec::new();
 
         let panic_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            dispatcher.with_process_state(
+            dispatcher.with_process_state_and_memory_effects(
                 &mut context_queue,
                 &mut context_tracking,
+                &mut context_effects,
                 |disp| {
                     disp.event_queue.push_back(QueuedEvent {
                         what: 1,
@@ -11184,6 +11252,13 @@ mod tests {
                         modifiers: 0,
                     });
                     disp.menu_tracking.as_mut().unwrap().highlighted_item = 7;
+                    disp.pending_memory_effects.push(
+                        crate::process_context::PendingHandleByteReplacement {
+                            handle: 0x5555,
+                            expected_ptr: 0x6666,
+                            replacement: vec![7, 8, 9],
+                        },
+                    );
                     panic!("simulated panic inside a complete guest execution slice");
                 },
             );
@@ -11197,7 +11272,10 @@ mod tests {
                 .map(|tracking| (tracking.menu_handle, tracking.highlighted_item)),
             Some((0x9abc, 7))
         );
+        assert_eq!(context_effects.len(), 1);
+        assert_eq!(context_effects[0].handle, 0x5555);
         assert!(dispatcher.event_queue.is_empty());
         assert!(dispatcher.menu_tracking.is_none());
+        assert!(dispatcher.pending_memory_effects.is_empty());
     }
 }

--- a/src/trap/menu.rs
+++ b/src/trap/menu.rs
@@ -452,6 +452,25 @@ fn mc_entry_matches(bytes: &[u8], menu_id: i16, menu_item: i16) -> bool {
 }
 
 impl super::TrapDispatcher {
+    pub(crate) fn complete_deferred_menu_replacement(
+        &mut self,
+        bus: &MacMemoryBus,
+        menu_handle: u32,
+        old_ptr: u32,
+    ) {
+        let menu_ptr = bus.read_long(menu_handle);
+        self.ptr_to_handle.remove(&old_ptr);
+        if menu_ptr != 0 {
+            self.ptr_to_handle.insert(menu_ptr, menu_handle);
+        }
+        if let Some(menu) = self.menus.iter_mut().find(|m| m.handle == menu_handle) {
+            refresh_menu_from_memory(bus, menu);
+        } else if menu_ptr != 0 {
+            self.menus
+                .push(parse_menu_resource(bus, menu_ptr, menu_handle));
+        }
+    }
+
     fn menu_uses_standard_definition(&self, bus: &MacMemoryBus, menu_ptr: u32) -> bool {
         let handle = bus.read_long(menu_ptr + 6);
         self.loaded_handles
@@ -1553,6 +1572,22 @@ impl super::TrapDispatcher {
         // rebuilds still fit the decoded record and must preserve its handle.
         if record_size as usize >= bytes.len() {
             bus.write_bytes(menu_ptr, &bytes);
+        } else if bus.is_foreign_ordinary_sparse_address(menu_handle)
+            && bus.is_foreign_ordinary_sparse_address(menu_ptr)
+        {
+            // Inside Macintosh: Memory (1992), pp. 2-40--2-41.
+            // When a relocatable block allocated in the native process heap grows,
+            // the replacement cannot be allocated from the 68k flat-RAM heap.
+            // Stage the handle replacement on the process context so the native
+            // memory owner can reallocate within its own address space.
+            self.pending_memory_effects.push(
+                crate::process_context::PendingHandleByteReplacement {
+                    handle: menu_handle,
+                    expected_ptr: menu_ptr,
+                    replacement: bytes,
+                },
+            );
+            return true;
         } else {
             let mut allocation = bytes;
             allocation.resize(allocation.len().max(256), 0);


### PR DESCRIPTION
## Summary

- route growing MenuHandle mutations made by nested 68k callbacks through the native PowerPC heap owner
- keep the guest master pointer, native handle record, and shared menu cache synchronized after relocation
- retain the existing flat-memory path for ordinary 68k-owned handles
- add an end-to-end native MenuSelect → 68k MDEF → AppendMenu regression that forces relocation and continues through selection

## Root cause

A growing 68k Menu Manager mutation could see a PowerPC-owned handle through the shared address space, but it resized the block with the flat 68k allocator. The guest master pointer changed while the native PpcHandleRecord retained the old pointer, so subsequent native Menu Manager work observed stale metadata.

## Implementation

ProcessContext now owns a short-lived queue of handle replacement effects. The 68k adapter stages an effect only when both the handle and data pointer belong to the native ordinary sparse address space. After the callback returns, the runner detaches the borrowed address-space view, asks the native owner to resize and write the handle, recreates the shared view, refreshes menu caches, and propagates MemErr.

## Validation

- cargo test --lib: 4,548 passed, 3 ignored
- cargo check --all-targets
- cargo fmt --all -- --check
- cargo check --no-default-features
- cargo check --target wasm32-unknown-unknown --no-default-features
- cargo test --features test-support: 4,554 passed
- cargo package
- focused Miri coverage for sparse-address classification and canonical-state restoration
- existing fixed-size cross-ABI DisableItem regression
- new forced-relocation cross-ABI AppendMenu/MenuSelect regression
- native owner out-of-memory atomicity regression

Closes #1016