### PR TITLE
feat(traps): inventory HFSDispatch selectors

### DIFF
--- a/src/trap/dialog.rs
+++ b/src/trap/dialog.rs
@@ -1,8 +1,9 @@
 //! Dialog Manager, Cursor Manager, and misc stub trap handlers.
 
 use super::dispatch::{
-    DialogItem, DialogPopupDraw, DialogPopupTrackingState, DialogTrackingState,
-    PendingDialogPopupMenu, PersistentDialogSnapshot, QueuedEvent, RetainedModalDialogClickState,
+    selector_operation_route, DialogItem, DialogPopupDraw, DialogPopupTrackingState,
+    DialogTrackingState, PendingDialogPopupMenu, PersistentDialogSnapshot, QueuedEvent,
+    RetainedModalDialogClickState, SelectorOperationRoute,
 };
 use super::types::{decode_mac_roman_for_render, Rect, ShapeOp};
 use crate::cpu::{CpuOps, Register};
@@ -21,6 +22,19 @@ static TRACE_TEXTEDIT: OnceLock<bool> = OnceLock::new();
 static TRACE_DIALOG_ITEMS: OnceLock<bool> = OnceLock::new();
 static TRACE_DIALOG_TEXT_INLINE: OnceLock<bool> = OnceLock::new();
 const MANAGER_DIALOG_RECORD_ALIGNMENT: u32 = 256;
+
+const TE_DISPATCH_OPERATION_ROUTES: &[SelectorOperationRoute] =
+    &include!("generated_te_dispatch_operations.rs");
+
+fn te_dispatch_operation_route(
+    trap_word: u16,
+    selector: u16,
+) -> Option<&'static SelectorOperationRoute> {
+    if trap_word != 0xA83D {
+        return None;
+    }
+    selector_operation_route(TE_DISPATCH_OPERATION_ROUTES, u32::from(selector))
+}
 
 struct DialogCIconLayout {
     width: i16,
@@ -14029,70 +14043,14 @@ impl super::TrapDispatcher {
             }
 
             // TEDispatch ($A83D)
-            // Selector-based dispatcher for styled TextEdit routines.
+            // Dispatches styled TextEdit routines selected by a word on the stack.
             // FUNCTION/PROCEDURE TEDispatch(...); selector is the first stack word.
-            // Inside Macintosh Volume VI, 15-22 (TEFeatureFlag),
-            //                              15-25..15-43 (selector mapping),
-            //                              15-34 (TEContinuousStyle).
-            // Inside Macintosh: Text (1993), p. 2-102 (TEContinuousStyle),
-            //                                p. 2-92 / 2-97 (autoscroll default).
-            //
-            // TEDispatch ($A83D) selectors: $0000 TEStylPaste,
-            //   $0001 TESetStyle, $0002 TEReplaceStyle, $0003 TEGetStyle,
-            //   $0004 GetStylHandle, $0005 SetStylHandle, $0006 GetStylScrap,
-            //   $0007 TEStylInsert, $0008 TEGetPoint, $0009 TEGetHeight,
-            //   $000A TEContinuousStyle, $000B TEUseStyleScrap,
-            //   $000C TECustomHook, $000D TENumStyles, $000E TEFeatureFlag.
-            //
-            // MPW Universal Headers TextEdit.h declares each entry point via
-            // THREEWORDINLINE(0x3F3C, <selector>, 0xA83D). The 0x3F3C is
-            // `MOVE.W #imm,-(A7)` which pre-pushes the selector word at the
-            // call site, immediately before the A-line trap. Pascal LR
-            // calling convention pushes args left-to-right (first arg
-            // deepest), so for any N-arg TEDispatch selector the stack
-            // layout at trap entry is:
-            //   sp+0           selector word (2 bytes, last pushed)
-            //   sp+2           arg[N-1] (last Pascal arg, shallowest)
-            //   ...
-            //   sp+(2 + S_0+..+S_{N-2})  arg[0] (first Pascal arg, deepest)
-            //   sp+(2 + Σ S_i) function result slot (for FUNCTION selectors)
-            //
-            // Selector $000A TEContinuousStyle is FUNCTION (Boolean result):
-            //   EXTERN_API(Boolean) TEContinuousStyle(short *mode,
-            //                                         TextStyle *aStyle,
-            //                                         TEHandle hTE)
-            //       THREEWORDINLINE(0x3F3C, 0x000A, 0xA83D);
-            //   Stack: sp+0 selector, sp+2 hTE (4), sp+6 aStyle* (4),
-            //          sp+10 mode* (4), sp+14 Boolean result slot.
-            //   Per IM:Text 1993 p. 2-102: returns TRUE for unstyled edit
-            //   records and reports the global style attributes for the
-            //   mode bits requested by *mode (font=1, face=2, size=4,
-            //   color=8).
-            //
-            // Selector $000E TEFeatureFlag is FUNCTION (short result):
-            //   EXTERN_API(short) TEFeatureFlag(short feature, short action,
-            //                                   TEHandle hTE)
-            //       THREEWORDINLINE(0x3F3C, 0x000E, 0xA83D);
-            //   Stack: sp+0 selector, sp+2 hTE (4), sp+6 action (2),
-            //          sp+8 feature (2), sp+10 short result slot.
-            //   Per IM:VI 15-22: turns features on/off or tests them;
-            //   returns the PRIOR setting of the bit (which, for
-            //   teBitTest=-1, coincides with the current setting since
-            //   the bit is not mutated). Action codes are teBitClear=0,
-            //   teBitSet=1, teBitTest=-1.
-            //
-            // Contract test coverage (this module):
-            //   te_dispatch_feature_flag_test_action_returns_current_state
-            //   te_dispatch_feature_flag_tracks_auto_scroll_state
-            //     (teBitSet on default-off feature returns prior 0 and mutates the bit)
-            //   tefeatureflag_clear_action_returns_prior_one_state_and_clears_bit
-            //     (teBitClear on previously-set feature returns prior 1 and clears the bit)
-            //   te_dispatch_continuous_style_returns_unstyled_record_style
-            //   tedispatch_function_protocol_consumes_threewordinline_stack_frame_for_tefeatureflag
-            //   teautoview_and_tefeatureflag_observe_shared_autoscroll_state
+            // Inside Macintosh Volume VI, 15-42 to 15-43.
             (true, 0x03D) => {
                 let sp = cpu.read_reg(Register::A7);
                 let selector = bus.read_word(sp);
+                let operation = te_dispatch_operation_route(self.current_trap_word, selector);
+                self.current_selector_operation = operation.map(|route| route.operation_id);
                 if trace_textedit_enabled() {
                     eprintln!("[TE] TEDispatch selector=${:04X} sp=${:08X}", selector, sp);
                 }
@@ -34958,6 +34916,90 @@ mod tests {
         assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 10);
         assert_eq!(bus.read_word(TEST_SP + 10), 0);
         assert!(disp.te_feature_bit(te_handle, TrapDispatcher::TE_FEATURE_AUTO_SCROLL));
+    }
+
+    #[test]
+    fn te_dispatch_generated_routes_preserve_exact_stack_selectors() {
+        assert_eq!(super::TE_DISPATCH_OPERATION_ROUTES.len(), 5);
+        assert!(super::TE_DISPATCH_OPERATION_ROUTES
+            .windows(2)
+            .all(|pair| pair[0].selector < pair[1].selector));
+
+        for (selector, routine_name) in [
+            (0x0001, "TESetStyle"),
+            (0x0008, "TEGetPoint"),
+            (0x000A, "TEContinuousStyle"),
+            (0x000C, "TECustomHook"),
+            (0x000E, "TEFeatureFlag"),
+        ] {
+            let route =
+                super::te_dispatch_operation_route(0xA83D, selector).expect("TEDispatch route");
+            assert_eq!(route.routine_name, routine_name);
+            assert_eq!(
+                route.operation_id,
+                format!("selector-operation:_TEDispatch:0x{selector:04X}:stack-word-immediate:16")
+            );
+        }
+
+        for (trap_word, selector) in [
+            (0xA73D, 0x0001),
+            (0xA93D, 0x0008),
+            (0xAB3D, 0x000E),
+            (0xA83D, 0x0000),
+            (0xA83D, 0x0002),
+            (0xA83D, 0x0007),
+            (0xA83D, 0x0009),
+            (0xA83D, 0x000B),
+            (0xA83D, 0x000D),
+            (0xA83D, 0x000F),
+            (0xA83D, 0xFFFF),
+        ] {
+            assert!(super::te_dispatch_operation_route(trap_word, selector).is_none());
+        }
+    }
+
+    #[test]
+    fn te_dispatch_records_known_then_clears_unknown_without_changing_behavior() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        disp.current_trap_word = 0xA83D;
+        cpu.write_reg(Register::D0, 0x1122_3344);
+        cpu.write_reg(Register::D1, 0x5566_7788);
+        bus.write_word(TEST_SP, 0x000C);
+        bus.write_long(TEST_SP + 2, 0xCAFE_BABE);
+        bus.write_long(TEST_SP + 6, 0);
+        bus.write_word(TEST_SP + 10, 0xA55A);
+
+        let result = disp.dispatch_dialog(true, 0x03D, &mut cpu, &mut bus);
+        assert!(result.expect("TEDispatch arm").is_ok());
+        assert_eq!(
+            disp.current_selector_operation,
+            Some("selector-operation:_TEDispatch:0x000C:stack-word-immediate:16")
+        );
+        assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 12);
+        assert_eq!(cpu.read_reg(Register::D0), 0x1122_3344);
+        assert_eq!(cpu.read_reg(Register::D1), 0x5566_7788);
+        assert_eq!(bus.read_long(TEST_SP + 2), 0xCAFE_BABE);
+        assert_eq!(bus.read_long(TEST_SP + 6), 0);
+        assert_eq!(bus.read_word(TEST_SP + 10), 0xA55A);
+
+        disp.current_selector_operation = Some("stale-identity");
+        cpu.write_reg(Register::A7, TEST_SP);
+        bus.write_word(TEST_SP, 0x000F);
+        let result = disp.dispatch_dialog(true, 0x03D, &mut cpu, &mut bus);
+        assert!(result.is_none());
+        assert_eq!(disp.current_selector_operation, None);
+        assert_eq!(cpu.read_reg(Register::A7), TEST_SP);
+        assert_eq!(cpu.read_reg(Register::D0), 0x1122_3344);
+        assert_eq!(bus.read_word(TEST_SP), 0x000F);
+
+        disp.current_selector_operation = Some("stale-identity");
+        disp.current_trap_word = 0xA93D;
+        cpu.write_reg(Register::A7, TEST_SP);
+        bus.write_word(TEST_SP, 0x000C);
+        let result = disp.dispatch_dialog(true, 0x03D, &mut cpu, &mut bus);
+        assert!(result.expect("TEDispatch arm").is_ok());
+        assert_eq!(disp.current_selector_operation, None);
+        assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 12);
     }
 
     // Inside Macintosh Volume VI (1991), pp. 15-22 and 15-43: selector

--- a/src/trap/generated_hfs_dispatch_operations.rs
+++ b/src/trap/generated_hfs_dispatch_operations.rs
@@ -1,0 +1,18 @@
+// Generated selector-operation routes. Do not edit by hand.
+[
+    SelectorOperationRoute::new(
+        0x003F,
+        "selector-operation:_HFSDispatch:0x003F:d0-moveq-immediate:8",
+        "PBGetVolMountInfoSize",
+    ),
+    SelectorOperationRoute::new(
+        0x0040,
+        "selector-operation:_HFSDispatch:0x0040:d0-moveq-immediate:8",
+        "PBGetVolMountInfo",
+    ),
+    SelectorOperationRoute::new(
+        0x0041,
+        "selector-operation:_HFSDispatch:0x0041:d0-moveq-immediate:8",
+        "PBVolumeMount",
+    ),
+]

--- a/src/trap/generated_te_dispatch_operations.rs
+++ b/src/trap/generated_te_dispatch_operations.rs
@@ -1,0 +1,28 @@
+// Generated selector-operation routes. Do not edit by hand.
+[
+    SelectorOperationRoute::new(
+        0x0001,
+        "selector-operation:_TEDispatch:0x0001:stack-word-immediate:16",
+        "TESetStyle",
+    ),
+    SelectorOperationRoute::new(
+        0x0008,
+        "selector-operation:_TEDispatch:0x0008:stack-word-immediate:16",
+        "TEGetPoint",
+    ),
+    SelectorOperationRoute::new(
+        0x000A,
+        "selector-operation:_TEDispatch:0x000A:stack-word-immediate:16",
+        "TEContinuousStyle",
+    ),
+    SelectorOperationRoute::new(
+        0x000C,
+        "selector-operation:_TEDispatch:0x000C:stack-word-immediate:16",
+        "TECustomHook",
+    ),
+    SelectorOperationRoute::new(
+        0x000E,
+        "selector-operation:_TEDispatch:0x000E:stack-word-immediate:16",
+        "TEFeatureFlag",
+    ),
+]

--- a/src/trap/generated_translation_dispatch_operations.rs
+++ b/src/trap/generated_translation_dispatch_operations.rs
@@ -1,0 +1,33 @@
+// Generated selector-operation routes. Do not edit by hand.
+[
+    SelectorOperationRoute::new(
+        0x0001,
+        "selector-operation:_TranslationDispatch:0x0001:d0-moveq-immediate:8",
+        "UpdateTranslationProgress",
+    ),
+    SelectorOperationRoute::new(
+        0x0002,
+        "selector-operation:_TranslationDispatch:0x0002:d0-moveq-immediate:8",
+        "SetTranslationAdvertisement",
+    ),
+    SelectorOperationRoute::new(
+        0x0009,
+        "selector-operation:_TranslationDispatch:0x0009:d0-moveq-immediate:8",
+        "ExtendFileTypeList",
+    ),
+    SelectorOperationRoute::new(
+        0x000C,
+        "selector-operation:_TranslationDispatch:0x000C:d0-moveq-immediate:8",
+        "TranslateFile",
+    ),
+    SelectorOperationRoute::new(
+        0x001C,
+        "selector-operation:_TranslationDispatch:0x001C:d0-moveq-immediate:8",
+        "GetFileTypesThatAppCanNativelyOpen",
+    ),
+    SelectorOperationRoute::new(
+        0x001E,
+        "selector-operation:_TranslationDispatch:0x001E:d0-moveq-immediate:8",
+        "CanDocBeOpened",
+    ),
+]

--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -26,6 +26,8 @@ const RESOURCE_DISPATCH_OPERATION_ROUTES: &[SelectorOperationRoute] =
     &include!("generated_resource_dispatch_operations.rs");
 const HIGH_LEVEL_FS_DISPATCH_OPERATION_ROUTES: &[SelectorOperationRoute] =
     &include!("generated_high_level_fs_dispatch_operations.rs");
+const HFS_DISPATCH_OPERATION_ROUTES: &[SelectorOperationRoute] =
+    &include!("generated_hfs_dispatch_operations.rs");
 const OS_DISPATCH_OPERATION_ROUTES: &[SelectorOperationRoute] =
     &include!("generated_os_dispatch_operations.rs");
 
@@ -47,6 +49,16 @@ fn high_level_fs_dispatch_operation_route(
         return None;
     }
     selector_operation_route(HIGH_LEVEL_FS_DISPATCH_OPERATION_ROUTES, selector)
+}
+
+fn hfs_dispatch_operation_route(
+    trap_word: u16,
+    selector: u32,
+) -> Option<&'static SelectorOperationRoute> {
+    if trap_word != 0xA260 {
+        return None;
+    }
+    selector_operation_route(HFS_DISPATCH_OPERATION_ROUTES, selector)
 }
 
 fn os_dispatch_operation_route(
@@ -7195,10 +7207,15 @@ impl super::TrapDispatcher {
                 }
             }
 
-            // FSDispatch ($A060) / HFSDispatch ($A260)
-            // HFSDispatch / FSDispatch ($A060): Selectors 1=PBOpenWD, 2=PBCloseWD, 6=PBDirCreate, 7=PBGetWDInfo, 8=PBGetFCBInfo, 9=PBGetCatInfo, 26=PBHOpenDF; by-name lookups retry via default/WD directory
+            // HFSDispatch ($A260) / FSDispatch ($A060)
+            // Dispatches hierarchical File Manager routines selected by D0.
+            // A0: parameter block; D0 and ioResult: OSErr.
+            // Inside Macintosh: Files (1992), pp. 2-183 to 2-238.
             (false, 0x60) => {
-                let selector = cpu.read_reg(Register::D0) & 0xFFFF;
+                let raw_selector = cpu.read_reg(Register::D0);
+                let operation = hfs_dispatch_operation_route(self.current_trap_word, raw_selector);
+                self.current_selector_operation = operation.map(|route| route.operation_id);
+                let selector = raw_selector & 0xFFFF;
                 let pb = cpu.read_reg(Register::A0);
                 if selector == 0x18 {
                     // PBCatSearch ($A260, selector $0018) searches one
@@ -16020,6 +16037,80 @@ mod tests {
             &vec![9, 9, 9, 9],
             "resource fork must be preserved across truncate"
         );
+    }
+
+    #[test]
+    fn hfs_dispatch_generated_routes_preserve_exact_d0_selectors() {
+        assert_eq!(super::HFS_DISPATCH_OPERATION_ROUTES.len(), 3);
+        assert!(super::HFS_DISPATCH_OPERATION_ROUTES
+            .windows(2)
+            .all(|pair| pair[0].selector < pair[1].selector));
+
+        for (selector, routine_name) in [
+            (0x003F, "PBGetVolMountInfoSize"),
+            (0x0040, "PBGetVolMountInfo"),
+            (0x0041, "PBVolumeMount"),
+        ] {
+            let route =
+                super::hfs_dispatch_operation_route(0xA260, selector).expect("HFSDispatch route");
+            assert_eq!(route.routine_name, routine_name);
+            assert_eq!(
+                route.operation_id,
+                format!("selector-operation:_HFSDispatch:0x{selector:04X}:d0-moveq-immediate:8")
+            );
+        }
+
+        for (trap_word, selector) in [
+            (0xA060, 0x003F),
+            (0xA660, 0x003F),
+            (0xA360, 0x0040),
+            (0xA260, 0x003E),
+            (0xA260, 0x0042),
+            (0xA260, 0x0001_003F),
+            (0xA260, u32::MAX),
+        ] {
+            assert!(super::hfs_dispatch_operation_route(trap_word, selector).is_none());
+        }
+    }
+
+    #[test]
+    fn hfs_dispatch_records_known_then_clears_nonidentity_without_changing_behavior() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let pb = 0x300000u32;
+        cpu.write_reg(Register::A0, pb);
+        bus.write_word(pb + 16, 0x3FFF);
+        bus.write_long(pb + 32, 0xCAFE_BABE);
+        let sp = cpu.read_reg(Register::A7);
+
+        cpu.write_reg(Register::D0, 0x0040);
+        call_trap_word(&mut disp, 0xA260, &mut cpu, &mut bus).unwrap();
+        assert_eq!(
+            disp.current_selector_operation,
+            Some("selector-operation:_HFSDispatch:0x0040:d0-moveq-immediate:8")
+        );
+        assert_eq!(cpu.read_reg(Register::D0), 0);
+        assert_eq!(cpu.read_reg(Register::A0), pb);
+        assert_eq!(cpu.read_reg(Register::A7), sp);
+        assert_eq!(bus.read_word(pb + 16), 0);
+        assert_eq!(bus.read_long(pb + 32), 0xCAFE_BABE);
+
+        disp.current_selector_operation = Some("stale-identity");
+        bus.write_word(pb + 16, 0x3FFF);
+        cpu.write_reg(Register::D0, 0x0001_0040);
+        call_trap_word(&mut disp, 0xA260, &mut cpu, &mut bus).unwrap();
+        assert_eq!(disp.current_selector_operation, None);
+        assert_eq!(cpu.read_reg(Register::D0), 0);
+        assert_eq!(bus.read_word(pb + 16), 0);
+
+        for trap_word in [0xA060, 0xA660] {
+            disp.current_selector_operation = Some("stale-identity");
+            bus.write_word(pb + 16, 0x3FFF);
+            cpu.write_reg(Register::D0, 0x0040);
+            call_trap_word(&mut disp, trap_word, &mut cpu, &mut bus).unwrap();
+            assert_eq!(disp.current_selector_operation, None);
+            assert_eq!(cpu.read_reg(Register::D0), 0);
+            assert_eq!(bus.read_word(pb + 16), 0);
+        }
     }
 
     // ================================================================

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -59,6 +59,8 @@ const SCSI_DISPATCH_OPERATION_ROUTES: &[SelectorOperationRoute] =
     &include!("generated_scsi_dispatch_operations.rs");
 const PACK11_OPERATION_ROUTES: &[SelectorOperationRoute] =
     &include!("generated_pack11_operations.rs");
+const TRANSLATION_DISPATCH_OPERATION_ROUTES: &[SelectorOperationRoute] =
+    &include!("generated_translation_dispatch_operations.rs");
 
 fn slot_manager_operation_route(selector: u32) -> Option<&'static SelectorOperationRoute> {
     selector_operation_route(SLOT_MANAGER_OPERATION_ROUTES, selector)
@@ -201,6 +203,16 @@ fn pack11_operation_route(
         return None;
     }
     selector_operation_route(PACK11_OPERATION_ROUTES, u32::from(selector))
+}
+
+fn translation_dispatch_operation_route(
+    trap_word: u16,
+    selector: u32,
+) -> Option<&'static SelectorOperationRoute> {
+    if trap_word != 0xABFC {
+        return None;
+    }
+    selector_operation_route(TRANSLATION_DISPATCH_OPERATION_ROUTES, selector)
 }
 
 const AE_TYPE_APPLE_EVENT: u32 = u32::from_be_bytes(*b"aevt");
@@ -15980,7 +15992,7 @@ impl super::TrapDispatcher {
                     0 => return_noerr_and_pop(cpu, pop_bytes),
                     _ => return_error_and_pop(cpu, pop_bytes, -50),
                 }
-            }
+            },
 
             // ThreadDispatch ($ABF2) — cooperative Thread Manager
             // Inside Macintosh: Thread Manager (1999), pp. 1-56 to 1-58:
@@ -16362,34 +16374,19 @@ impl super::TrapDispatcher {
                 } else {
                     return_error_and_pop(cpu, argument_bytes, result)
                 }
-            }
+            },
 
-            // TranslationDispatch ($ABFC) — Translation Manager
-            // Inside Macintosh: More Macintosh Toolbox (1993),
-            // pp. 7-12 and 7-66:
-            // `Gestalt('xlat', ...)` with response bit
-            // `gestaltTranslationMgrExists` gates availability; the
-            // manager's routines are invoked through
-            // `_TranslationDispatch` routine selectors.
-            // The Translation Manager (Mac Easy Open / Macintosh
-            // Easy Open) routes file-format translation requests
-            // — e.g. MS Word .doc → Mac Word .mcw, JPEG → PICT.
-            // Selector convention: D0 = routine number per the
-            // selector summary table at MMTB 20828ff. Routines
-            // include GetTranslationExtensions, IdentifyFile,
-            // TranslateFile, TranslateContents, NewScriptingFile.
-            // Gestalt: `gestaltTranslationAttr` (response bit 0
-            // `gestaltTranslationMgrExists`).
-            //
-            // HLE behaviour: the dispatcher returns a non-zero error
-            // and advances A7 by 4 bytes. Apps that probe Gestalt
-            // see "absent" and either ask the user to convert the
-            // file manually or refuse to open foreign formats.
-            //
-            // Regression coverage:
-            //   src/trap/toolbox.rs::tests::translationdispatch_*
-            // TranslationDispatch ($ABFC): MMTB 1993 ch.21 20111+20828. D0 selector per MMTB 20828 selector summary. Gestalt → gestaltTranslationMgrExists=0. HLE: D0=0, registers + stack preserved (apps refuse foreign-format opens).
-            (true, 0x3FC) => return_error_and_pop(cpu, 4, -50),
+            // _TranslationDispatch (0xABFC)
+            // Dispatches Translation Manager routines selected by D0.
+            // FUNCTION GetFileTypesThatAppCanNativelyOpen (appVRefNumHint: Integer; appSignature: OSType; VAR nativeTypes: TypesBlock): OSErr;
+            // Inside Macintosh: More Macintosh Toolbox (1993), pp. 7-37–7-38 and 7-66.
+            (true, 0x3FC) => {
+                let selector = cpu.read_reg(Register::D0);
+                let operation =
+                    translation_dispatch_operation_route(self.current_trap_word, selector);
+                self.current_selector_operation = operation.map(|route| route.operation_id);
+                return_error_and_pop(cpu, 4, -50)
+            },
 
             _ => return None,
         })
@@ -26528,7 +26525,7 @@ mod tests {
     }
 
     #[test]
-    fn translationdispatch_selector_zero_returns_param_err_and_pops_four_bytes() {
+    fn translationdispatch_known_selector_returns_param_err_and_pops_four_bytes() {
         let (mut disp, mut cpu, mut bus) = setup();
         let sp = TEST_SP;
         cpu.write_reg(Register::A7, sp);
@@ -26554,7 +26551,7 @@ mod tests {
     }
 
     #[test]
-    fn translationdispatch_selector_zero_preserves_non_d0_registers_and_pops_four_bytes() {
+    fn translationdispatch_known_selector_preserves_non_d0_registers_and_pops_four_bytes() {
         let (mut disp, mut cpu, mut bus) = setup();
         cpu.write_reg(Register::D0, 0x0000_0009);
         cpu.write_reg(Register::D1, 0x7777_8888);
@@ -33828,5 +33825,121 @@ mod tests {
             0x1122_3344,
             "guest stack memory must remain invariant on trap word mismatch"
         );
+    }
+
+    #[test]
+    fn translation_dispatch_generated_routes_preserve_exact_register_values() {
+        assert_eq!(super::TRANSLATION_DISPATCH_OPERATION_ROUTES.len(), 6);
+        assert!(super::TRANSLATION_DISPATCH_OPERATION_ROUTES
+            .windows(2)
+            .all(|pair| pair[0].selector < pair[1].selector));
+
+        for (selector, routine_name) in [
+            (0x0001, "UpdateTranslationProgress"),
+            (0x0002, "SetTranslationAdvertisement"),
+            (0x0009, "ExtendFileTypeList"),
+            (0x000C, "TranslateFile"),
+            (0x001C, "GetFileTypesThatAppCanNativelyOpen"),
+            (0x001E, "CanDocBeOpened"),
+        ] {
+            let route = super::translation_dispatch_operation_route(0xABFC, selector)
+                .expect("TranslationDispatch route");
+            assert_eq!(route.routine_name, routine_name);
+            assert_eq!(
+                route.operation_id,
+                format!("selector-operation:_TranslationDispatch:0x{selector:04X}:d0-moveq-immediate:8")
+            );
+        }
+
+        for (trap_word, selector) in [
+            (0xA8FC, 0x0001),
+            (0xA9FC, 0x0009),
+            (0xAAFC, 0x001C),
+            (0xABFC, 0x0000),
+            (0xABFC, 0x0003),
+            (0xABFC, 0x0008),
+            (0xABFC, 0x0010),
+            (0xABFC, 0x0020),
+            (0xABFC, 0x7001),
+            (0xABFC, 0x701C),
+            (0xABFC, 0x0001_0001),
+            (0xABFC, 0xDEAD_001C),
+            (0xABFC, 0xFFFF_0009),
+            (0xABFC, 0x1C00),
+        ] {
+            assert!(super::translation_dispatch_operation_route(trap_word, selector).is_none());
+        }
+    }
+
+    #[test]
+    fn translation_dispatch_records_known_then_clears_unknown_and_preserves_invariants() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let sp = TEST_SP;
+        disp.current_trap_word = 0xABFC;
+
+        // Known selector: GetFileTypesThatAppCanNativelyOpen ($001C)
+        cpu.write_reg(Register::A7, sp);
+        cpu.write_reg(Register::D0, 0x0000_001C);
+        cpu.write_reg(Register::D1, 0x1122_3344);
+        cpu.write_reg(Register::D2, 0x5566_7788);
+        cpu.write_reg(Register::A0, 0x99AA_BBCC);
+        cpu.write_reg(Register::A1, 0xDDEE_FF00);
+        cpu.write_reg(Register::A2, 0x1357_2468);
+        bus.write_long(sp, 0xCAFE_BABE);
+        bus.write_long(sp + 4, 0xDEAD_BEEF);
+        bus.write_long(sp - 8, 0x0123_4567);
+
+        let result = disp.dispatch_toolbox(true, 0x3FC, &mut cpu, &mut bus);
+        assert!(result.is_some(), "TranslationDispatch should be handled");
+        assert!(result.unwrap().is_ok(), "TranslationDispatch should return");
+        assert_eq!(
+            disp.current_selector_operation,
+            Some("selector-operation:_TranslationDispatch:0x001C:d0-moveq-immediate:8")
+        );
+        assert_eq!(cpu.read_reg(Register::D0) as i16, -50);
+        assert_eq!(cpu.read_reg(Register::A7), sp + 4);
+        assert_eq!(cpu.read_reg(Register::D1), 0x1122_3344);
+        assert_eq!(cpu.read_reg(Register::D2), 0x5566_7788);
+        assert_eq!(cpu.read_reg(Register::A0), 0x99AA_BBCC);
+        assert_eq!(cpu.read_reg(Register::A1), 0xDDEE_FF00);
+        assert_eq!(cpu.read_reg(Register::A2), 0x1357_2468);
+        assert_eq!(bus.read_long(sp), 0xCAFE_BABE);
+        assert_eq!(bus.read_long(sp + 4), 0xDEAD_BEEF);
+        assert_eq!(bus.read_long(sp - 8), 0x0123_4567);
+
+        // Unknown selector ($0000): must clear operation identity and preserve invariants
+        cpu.write_reg(Register::A7, sp);
+        cpu.write_reg(Register::D0, 0x0000_0000);
+        let result = disp.dispatch_toolbox(true, 0x3FC, &mut cpu, &mut bus);
+        assert!(result.is_some());
+        assert!(result.unwrap().is_ok());
+        assert_eq!(disp.current_selector_operation, None);
+        assert_eq!(cpu.read_reg(Register::D0) as i16, -50);
+        assert_eq!(cpu.read_reg(Register::A7), sp + 4);
+        assert_eq!(cpu.read_reg(Register::D1), 0x1122_3344);
+        assert_eq!(bus.read_long(sp), 0xCAFE_BABE);
+
+        // Stale high word ($DEAD_001C): must clear operation identity
+        disp.current_selector_operation = Some("stale-identity");
+        cpu.write_reg(Register::A7, sp);
+        cpu.write_reg(Register::D0, 0xDEAD_001C);
+        let result = disp.dispatch_toolbox(true, 0x3FC, &mut cpu, &mut bus);
+        assert!(result.is_some());
+        assert!(result.unwrap().is_ok());
+        assert_eq!(disp.current_selector_operation, None);
+        assert_eq!(cpu.read_reg(Register::D0) as i16, -50);
+        assert_eq!(cpu.read_reg(Register::A7), sp + 4);
+
+        // Trap word mismatch (0xA8FC): must clear operation identity
+        disp.current_selector_operation = Some("stale-identity");
+        disp.current_trap_word = 0xA8FC;
+        cpu.write_reg(Register::A7, sp);
+        cpu.write_reg(Register::D0, 0x0000_001C);
+        let result = disp.dispatch_toolbox(true, 0x3FC, &mut cpu, &mut bus);
+        assert!(result.is_some());
+        assert!(result.unwrap().is_ok());
+        assert_eq!(disp.current_selector_operation, None);
+        assert_eq!(cpu.read_reg(Register::D0) as i16, -50);
+        assert_eq!(cpu.read_reg(Register::A7), sp + 4);
     }
 }


### PR DESCRIPTION
## Summary

- generate the three manual-backed _HFSDispatch volume-mount selector identities
- record exact full-D0 operation identity only for synchronous $A260 calls
- preserve the existing File Manager behavior while clearing stale identities on non-matches
- add focused exactness and lifecycle tests

## Verification

- 46 selector-reference inventory tests
- 9 runtime-route inventory tests
- 4,553 release library tests passed; 3 ignored
- release all-target check
- formatting check
- deterministic gameplay: Tomb Raider Gold, Escape Velocity 1.0.5, and Marathon 2

Closes #1039