### PR TITLE
refactor: unify classic text line breaking

### DIFF
--- a/src/loader/ppc.rs
+++ b/src/loader/ppc.rs
@@ -63090,60 +63090,17 @@ fn ppc_frame_front_rect(
     wrote
 }
 
-fn ppc_wrap_dialog_text_paragraph(lines: &mut Vec<Vec<u8>>, paragraph: &[u8], max_width: i16) {
-    let initial_line_count = lines.len();
-    let mut line = Vec::<u8>::new();
-    for word in paragraph.split(|byte| *byte == b' ') {
-        if word.is_empty() {
-            continue;
-        }
-        let mut candidate = line.clone();
-        if !candidate.is_empty() {
-            candidate.push(b' ');
-        }
-        candidate.extend_from_slice(word);
-        if !line.is_empty()
-            && ppc_text_bytes_advance_for_font(
-                &candidate,
-                PPC_QD_TEXT_FONT_DEFAULT,
-                PPC_QD_TEXT_SIZE_SYSTEM,
-            ) > max_width
-        {
-            lines.push(std::mem::take(&mut line));
-            line.extend_from_slice(word);
-        } else {
-            line = candidate;
-        }
-    }
-    if !line.is_empty() {
-        lines.push(line);
-    }
-    if lines.len() == initial_line_count {
-        lines.push(Vec::new());
-    }
-}
-
 fn ppc_dialog_text_lines(bytes: &[u8], max_width: i16) -> Vec<Vec<u8>> {
-    if bytes.is_empty() {
-        return Vec::new();
-    }
-    let mut lines = Vec::<Vec<u8>>::new();
-    let mut paragraph_start = 0usize;
-    let mut index = 0usize;
-    while index < bytes.len() {
-        if matches!(bytes[index], b'\r' | b'\n') {
-            ppc_wrap_dialog_text_paragraph(&mut lines, &bytes[paragraph_start..index], max_width);
-            if bytes[index] == b'\r' && bytes.get(index + 1) == Some(&b'\n') {
-                index += 1;
-            }
-            paragraph_start = index + 1;
-        }
-        index += 1;
-    }
-    if paragraph_start < bytes.len() {
-        ppc_wrap_dialog_text_paragraph(&mut lines, &bytes[paragraph_start..], max_width);
-    }
-    lines
+    crate::quickdraw::text::wrap_classic_text(bytes, max_width, |_, byte| {
+        ppc_text_byte_advance_for_font(
+            byte,
+            PPC_QD_TEXT_FONT_DEFAULT,
+            PPC_QD_TEXT_SIZE_SYSTEM,
+        )
+    })
+    .into_iter()
+    .map(|line| bytes[line.start..line.visible_end].to_vec())
+    .collect()
 }
 
 fn ppc_draw_dialog_text(
@@ -66996,28 +66953,12 @@ fn ppc_te_recalculate_layout(
         ppc_read_rect(memory, te_ptr + PPC_TE_DEST_RECT_OFFSET).unwrap_or((0, 0, 0, i16::MAX));
     let max_width = right.saturating_sub(left).max(1);
     let (font, size) = ppc_te_primary_font_and_size(memory, te_ptr);
-    let mut starts = if text.is_empty() {
-        Vec::new()
-    } else {
-        vec![0u16]
-    };
-    let mut line_width = 0i16;
-    for (index, byte) in text.iter().copied().enumerate() {
-        if byte == b'\r' || byte == b'\n' {
-            if index + 1 < text.len() {
-                starts.push((index + 1).min(u16::MAX as usize) as u16);
-            }
-            line_width = 0;
-            continue;
-        }
-        let advance = ppc_text_byte_advance_for_font(byte, font, size);
-        if line_width > 0 && line_width.saturating_add(advance) > max_width {
-            starts.push(index.min(u16::MAX as usize) as u16);
-            line_width = advance;
-        } else {
-            line_width = line_width.saturating_add(advance);
-        }
-    }
+    let starts = crate::quickdraw::text::wrap_classic_text(&text, max_width, |_, byte| {
+        ppc_text_byte_advance_for_font(byte, font, size)
+    })
+    .into_iter()
+    .map(|line| line.start.min(u16::MAX as usize) as u16)
+    .collect::<Vec<_>>();
     let required_size = PPC_TE_REC_MIN_SIZE.max(
         PPC_TE_LINE_STARTS_OFFSET
             .saturating_add((starts.len() as u32).saturating_add(2).saturating_mul(2)),
@@ -67386,40 +67327,17 @@ fn ppc_te_draw_text_box(
         .saturating_add(face.metrics.leading.saturating_mul(scale))
         .max(1);
     let max_width = right.saturating_sub(left).max(1);
-    let mut lines = Vec::new();
-    let mut start = 0usize;
-    let mut width = 0i16;
-    for (index, byte) in text.iter().copied().enumerate() {
-        if matches!(byte, b'\r' | b'\n') {
-            lines.push((start, index));
-            start = index + 1;
-            width = 0;
-            continue;
-        }
-        let advance = ppc_text_byte_advance_for_font(byte, font, text_size);
-        if width > 0 && width.saturating_add(advance) > max_width {
-            lines.push((start, index));
-            start = index;
-            width = advance;
-        } else {
-            width = width.saturating_add(advance);
-        }
-    }
-    if start < text.len()
-        || text
-            .last()
-            .is_some_and(|byte| matches!(byte, b'\r' | b'\n'))
-    {
-        lines.push((start, text.len()));
-    }
-    for (line, (start, end)) in lines.into_iter().enumerate() {
+    let lines = crate::quickdraw::text::wrap_classic_text(text, max_width, |_, byte| {
+        ppc_text_byte_advance_for_font(byte, font, text_size)
+    });
+    for (line_index, line) in lines.into_iter().enumerate() {
         let baseline = top
             .saturating_add(ascent)
-            .saturating_add((line as i16).saturating_mul(line_height));
+            .saturating_add((line_index as i16).saturating_mul(line_height));
         if baseline.saturating_sub(ascent) >= bottom {
             break;
         }
-        let bytes = &text[start..end];
+        let bytes = &text[line.start..line.visible_end];
         let width = ppc_text_bytes_advance_for_font(bytes, font, text_size);
         let x = ppc_te_aligned_left(left, right, width, alignment);
         let _ = ppc_draw_text_bytes(
@@ -142539,6 +142457,80 @@ pub(crate) mod tests {
             .read_u32_be(te_ptr + PPC_TE_CLICK_TIME_OFFSET)
             .unwrap();
         assert!((100..=164).contains(&click_time));
+    }
+
+    #[test]
+    fn native_textedit_line_starts_follow_shared_word_boundaries() {
+        // Inside Macintosh: Text (1993), pp. 5-24--5-27: prefer a word
+        // boundary over splitting the next word at the overflowing glyph.
+        let pef = synthetic_pef_with_import(b"TECalText");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let rects = PPC_DATA_BASE + 0x1000;
+        loaded.memory.add_region(rects, vec![0; 16]);
+        let font = PPC_QD_TEXT_FONT_DEFAULT;
+        let size = PPC_QD_TEXT_SIZE_SYSTEM;
+        let first_line_width = ppc_text_bytes_advance_for_font(b"one two", font, size);
+        ppc_write_rect(
+            &mut loaded.memory,
+            rects,
+            10,
+            20,
+            80,
+            20 + first_line_width,
+        )
+        .unwrap();
+        ppc_write_rect(
+            &mut loaded.memory,
+            rects + 8,
+            10,
+            20,
+            80,
+            20 + first_line_width,
+        )
+        .unwrap();
+        let te_handle = ppc_te_initialize_record(
+            &mut loaded.memory,
+            &mut loaded.heap_cursor,
+            loaded.heap_limit,
+            &mut loaded.handles,
+            rects,
+            rects + 8,
+            PPC_MAIN_GWORLD,
+            1,
+            PPC_QD_TEXT_MODE_SRC_OR,
+            size,
+            PPC_RGB_BLACK,
+            false,
+        );
+
+        assert_eq!(
+            ppc_te_set_text(
+                &mut loaded.memory,
+                &mut loaded.heap_cursor,
+                loaded.heap_limit,
+                &mut loaded.handles,
+                te_handle,
+                b"one two three",
+            ),
+            PPC_NO_ERR
+        );
+        let te_ptr = loaded.memory.read_u32_be(te_handle).unwrap();
+        assert_eq!(
+            loaded.memory.read_u16_be(te_ptr + PPC_TE_N_LINES_OFFSET),
+            Some(2)
+        );
+        assert_eq!(
+            loaded
+                .memory
+                .read_u16_be(te_ptr + PPC_TE_LINE_STARTS_OFFSET),
+            Some(0)
+        );
+        assert_eq!(
+            loaded
+                .memory
+                .read_u16_be(te_ptr + PPC_TE_LINE_STARTS_OFFSET + 2),
+            Some(8)
+        );
     }
 
     #[test]

--- a/src/quickdraw/text.rs
+++ b/src/quickdraw/text.rs
@@ -256,9 +256,127 @@ pub fn get_underline_thickness(_font_id: i16, _size: i16) -> i16 {
     1
 }
 
+/// One architecture-neutral Classic Mac text line.
+///
+/// `start..visible_end` is the part drawn on screen; `next` is the guest-text
+/// offset at which the following line begins. This keeps hard line endings and
+/// wrap whitespace in the logical text while excluding them from rasterization.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct WrappedTextLine {
+    pub(crate) start: usize,
+    pub(crate) visible_end: usize,
+    pub(crate) next: usize,
+}
+
+/// Break Classic Mac text into display lines using caller-supplied glyph widths.
+///
+/// Both guest adapters use this primitive so TextEdit and dialog static text
+/// agree on word wrapping and CR/LF/CRLF hard breaks. The width callback is
+/// indexed so styled TextEdit can resolve the style run for each byte without
+/// coupling this shared semantic layer to either guest's memory representation.
+///
+/// Inside Macintosh: Text (1993), pp. 2-88--2-89 and 5-24--5-27: TextEdit
+/// prefers word-boundary breaks, uses glyph widths when laying out a line, and
+/// treats trailing whitespace as non-visible.
+pub(crate) fn wrap_classic_text<F>(
+    text: &[u8],
+    max_width: i16,
+    mut byte_advance: F,
+) -> Vec<WrappedTextLine>
+where
+    F: FnMut(usize, u8) -> i16,
+{
+    let mut lines = Vec::new();
+    let mut line_start = 0usize;
+    let max_width = max_width.max(1);
+
+    while line_start < text.len() {
+        let mut index = line_start;
+        let mut width = 0i16;
+        let mut last_whitespace = None::<(usize, usize)>;
+        let mut completed = false;
+
+        while index < text.len() {
+            if matches!(text[index], b'\r' | b'\n') {
+                let next = if text[index] == b'\r' && text.get(index + 1) == Some(&b'\n') {
+                    index + 2
+                } else {
+                    index + 1
+                };
+                lines.push(WrappedTextLine {
+                    start: line_start,
+                    visible_end: trim_classic_line_end(text, line_start, index),
+                    next,
+                });
+                line_start = next;
+                completed = true;
+                break;
+            }
+
+            let advance = byte_advance(index, text[index]).max(0);
+            if index > line_start && width.saturating_add(advance) > max_width {
+                let (visible_end, next) = if text[index] <= b' ' {
+                    let mut next = index + 1;
+                    while next < text.len()
+                        && text[next] <= b' '
+                        && !matches!(text[next], b'\r' | b'\n')
+                    {
+                        next += 1;
+                    }
+                    (trim_classic_line_end(text, line_start, index), next)
+                } else if let Some((visible_end, next)) = last_whitespace {
+                    (visible_end, next)
+                } else {
+                    (index, index)
+                };
+                lines.push(WrappedTextLine {
+                    start: line_start,
+                    visible_end,
+                    next,
+                });
+                line_start = next;
+                completed = true;
+                break;
+            }
+
+            width = width.saturating_add(advance);
+            if text[index] <= b' ' {
+                let whitespace_start = index;
+                let mut next = index + 1;
+                while next < text.len()
+                    && text[next] <= b' '
+                    && !matches!(text[next], b'\r' | b'\n')
+                {
+                    next += 1;
+                }
+                last_whitespace = Some((whitespace_start, next));
+            }
+            index += 1;
+        }
+
+        if !completed {
+            lines.push(WrappedTextLine {
+                start: line_start,
+                visible_end: trim_classic_line_end(text, line_start, text.len()),
+                next: text.len(),
+            });
+            break;
+        }
+    }
+
+    lines
+}
+
+fn trim_classic_line_end(text: &[u8], start: usize, mut end: usize) -> usize {
+    while end > start && text[end - 1] <= b' ' {
+        end -= 1;
+    }
+    end
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{get_glyph, QuickDrawTextStyle};
+    use super::{get_glyph, wrap_classic_text, QuickDrawTextStyle, WrappedTextLine};
 
     #[test]
     fn quickdraw_style_plan_combines_all_low_order_face_bits() {
@@ -299,5 +417,86 @@ mod tests {
         assert!(data[glyph.data_offset..glyph.data_offset + glyph_len]
             .iter()
             .any(|pixel| *pixel != 0));
+    }
+
+    #[test]
+    fn classic_text_wrap_prefers_words_and_hides_wrap_whitespace() {
+        let text = b"one two three";
+
+        assert_eq!(
+            wrap_classic_text(text, 6, |_, _| 1),
+            vec![
+                WrappedTextLine {
+                    start: 0,
+                    visible_end: 3,
+                    next: 4,
+                },
+                WrappedTextLine {
+                    start: 4,
+                    visible_end: 7,
+                    next: 8,
+                },
+                WrappedTextLine {
+                    start: 8,
+                    visible_end: 13,
+                    next: 13,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn classic_text_wrap_normalizes_cr_lf_and_crlf_hard_breaks() {
+        let text = b"one\rtwo\nthree\r\nfour";
+
+        assert_eq!(
+            wrap_classic_text(text, 80, |_, _| 1),
+            vec![
+                WrappedTextLine {
+                    start: 0,
+                    visible_end: 3,
+                    next: 4,
+                },
+                WrappedTextLine {
+                    start: 4,
+                    visible_end: 7,
+                    next: 8,
+                },
+                WrappedTextLine {
+                    start: 8,
+                    visible_end: 13,
+                    next: 15,
+                },
+                WrappedTextLine {
+                    start: 15,
+                    visible_end: 19,
+                    next: 19,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn classic_text_wrap_breaks_an_overlong_word_at_a_character() {
+        assert_eq!(
+            wrap_classic_text(b"toolbox", 3, |_, _| 1),
+            vec![
+                WrappedTextLine {
+                    start: 0,
+                    visible_end: 3,
+                    next: 3,
+                },
+                WrappedTextLine {
+                    start: 3,
+                    visible_end: 6,
+                    next: 6,
+                },
+                WrappedTextLine {
+                    start: 6,
+                    visible_end: 7,
+                    next: 7,
+                },
+            ]
+        );
     }
 }

--- a/src/trap/dialog.rs
+++ b/src/trap/dialog.rs
@@ -1901,72 +1901,19 @@ impl super::TrapDispatcher {
         width
     }
 
-    fn te_next_break_styled(
-        &self,
-        runs: &[TeStyleRun],
-        text_bytes: &[u8],
-        offset: usize,
-        max_width: i16,
-    ) -> usize {
-        let len = text_bytes.len();
-        if offset >= len {
-            return len;
-        }
-
-        let mut width = 0i16;
-        let mut index = offset;
-        while width <= max_width && index < len && !matches!(text_bytes[index], b'\r' | b'\n') {
-            let style = Self::te_style_at_offset(runs, index);
-            width =
-                width.saturating_add(self.te_char_width(style.font, style.size, text_bytes[index]));
-            index += 1;
-        }
-
-        let mut next = if width > max_width {
-            let max_index = index.saturating_sub(1);
-            if text_bytes[max_index] == b' ' {
-                let mut scan = index;
-                while scan < len && text_bytes[scan] == b' ' {
-                    scan += 1;
-                }
-                scan
-            } else {
-                let mut scan = max_index;
-                while scan > offset && !Self::te_word_break_byte(text_bytes[scan - 1]) {
-                    scan -= 1;
-                }
-                if scan == offset {
-                    max_index
-                } else {
-                    scan
-                }
-            }
-        } else if index == len {
-            len
-        } else {
-            index + 1
-        };
-
-        if next == offset && offset < len {
-            next += 1;
-        }
-        next
-    }
-
     fn te_wrap_lines_styled(
         &self,
         runs: &[TeStyleRun],
         text_bytes: &[u8],
         box_width: i16,
     ) -> Vec<(usize, usize)> {
-        let mut lines = Vec::new();
-        let mut line_start = 0usize;
-        while line_start < text_bytes.len() {
-            let next = self.te_next_break_styled(runs, text_bytes, line_start, box_width);
-            lines.push((line_start, next.min(text_bytes.len())));
-            line_start = next;
-        }
-        lines
+        crate::quickdraw::text::wrap_classic_text(text_bytes, box_width, |index, byte| {
+            let style = Self::te_style_at_offset(runs, index);
+            self.te_char_width(style.font, style.size, byte)
+        })
+        .into_iter()
+        .map(|line| (line.start, line.next))
+        .collect()
     }
 
     fn te_line_metrics_for_range(runs: &[TeStyleRun], start: usize, end: usize) -> (i16, i16) {
@@ -2781,57 +2728,6 @@ impl super::TrapDispatcher {
         byte <= 0x20
     }
 
-    fn te_next_break(
-        &self,
-        font: i16,
-        size: i16,
-        text_bytes: &[u8],
-        offset: usize,
-        max_width: i16,
-    ) -> usize {
-        let len = text_bytes.len();
-        if offset >= len {
-            return len;
-        }
-
-        let mut width = 0i16;
-        let mut index = offset;
-        while width <= max_width && index < len && !matches!(text_bytes[index], b'\r' | b'\n') {
-            width = width.saturating_add(self.te_char_width(font, size, text_bytes[index]));
-            index += 1;
-        }
-
-        let mut next = if width > max_width {
-            let max_index = index.saturating_sub(1);
-            if text_bytes[max_index] == b' ' {
-                let mut scan = index;
-                while scan < len && text_bytes[scan] == b' ' {
-                    scan += 1;
-                }
-                scan
-            } else {
-                let mut scan = max_index;
-                while scan > offset && !Self::te_word_break_byte(text_bytes[scan - 1]) {
-                    scan -= 1;
-                }
-                if scan == offset {
-                    max_index
-                } else {
-                    scan
-                }
-            }
-        } else if index == len {
-            len
-        } else {
-            index + 1
-        };
-
-        if next == offset && offset < len {
-            next += 1;
-        }
-        next
-    }
-
     fn te_wrap_lines(
         &self,
         font: i16,
@@ -2839,15 +2735,12 @@ impl super::TrapDispatcher {
         text_bytes: &[u8],
         box_width: i16,
     ) -> Vec<(usize, usize)> {
-        let mut lines: Vec<(usize, usize)> = Vec::new();
-        let mut line_start = 0usize;
-        while line_start < text_bytes.len() {
-            let next = self.te_next_break(font, size, text_bytes, line_start, box_width);
-            lines.push((line_start, next.min(text_bytes.len())));
-            line_start = next;
-        }
-
-        lines
+        crate::quickdraw::text::wrap_classic_text(text_bytes, box_width, |_, byte| {
+            self.te_char_width(font, size, byte)
+        })
+        .into_iter()
+        .map(|line| (line.start, line.next))
+        .collect()
     }
 
     fn te_recalculate_layout(&mut self, bus: &mut MacMemoryBus, te_handle: u32) {
@@ -15242,60 +15135,28 @@ impl super::TrapDispatcher {
                             w
                         };
 
-                        // Word-wrap: split into lines that fit within box_width.
-                        // Break on spaces; if a single word exceeds box_width, break mid-word.
-                        let mut lines: Vec<(usize, usize)> = Vec::new();
-                        let mut line_start = 0usize;
-                        let mut last_break = 0usize;
-                        let mut line_width = 0i16;
-
-                        for (i, &b) in text_bytes.iter().enumerate() {
-                            if b == b'\r' || b == b'\n' {
-                                lines.push((line_start, i));
-                                line_start = i + 1;
-                                last_break = line_start;
-                                line_width = 0;
-                                continue;
-                            }
-                            let ch = b as char;
-                            let char_w = if let Some((g, _)) =
-                                crate::quickdraw::text::get_glyph(font_id, font_size, ch)
-                            {
-                                g.advance as i16 + advance_extra
-                            } else {
-                                missing_advance
-                            };
-                            line_width += char_w;
-                            if b == b' ' {
-                                last_break = i + 1;
-                            }
-                            if line_width > box_width && i > line_start {
-                                if last_break > line_start {
-                                    lines.push((line_start, last_break - 1));
-                                    line_start = last_break;
-                                } else {
-                                    lines.push((line_start, i));
-                                    line_start = i;
-                                }
-                                last_break = line_start;
-                                line_width = measure(line_start, i + 1);
-                            }
-                        }
-                        if line_start < text_bytes.len() {
-                            lines.push((line_start, text_bytes.len()));
-                        }
+                        let lines = crate::quickdraw::text::wrap_classic_text(
+                            &text_bytes,
+                            box_width,
+                            |_, byte| {
+                                crate::quickdraw::text::get_glyph(
+                                    font_id,
+                                    font_size,
+                                    byte as char,
+                                )
+                                .map_or(missing_advance, |(glyph, _)| {
+                                    glyph.advance as i16 + advance_extra
+                                })
+                            },
+                        );
 
                         // Draw each line
                         let mut y = box_top + metrics.ascent;
-                        for (start, end) in &lines {
+                        for line in &lines {
                             if y + metrics.descent > box_bottom {
                                 break;
                             }
-                            let mut trimmed_end = *end;
-                            while trimmed_end > *start && text_bytes[trimmed_end - 1] == b' ' {
-                                trimmed_end -= 1;
-                            }
-                            let lw = measure(*start, trimmed_end);
+                            let lw = measure(line.start, line.visible_end);
                             // Per Inside Macintosh: Text 1993, lines 7320-7323:
                             //   teJustLeft   =  0 (flush left — system default)
                             //   teJustCenter =  1 (centered)
@@ -15303,7 +15164,7 @@ impl super::TrapDispatcher {
                             //   teForceLeft  = -2 (force flush left)
                             let x = Self::te_line_origin_x(align, box_left, box_right, lw);
                             self.pn_loc = (y, x);
-                            for &byte in &text_bytes[*start..trimmed_end] {
+                            for &byte in &text_bytes[line.start..line.visible_end] {
                                 self.draw_char(cpu, bus, byte as char);
                             }
                             y += line_height;


### PR DESCRIPTION
## Summary

- add one architecture-neutral Classic Mac line-breaking primitive to the shared text layer
- route 68K monostyled/styled TextEdit and TETextBox through the shared result
- route PowerPC TextEdit, TETextBox, and dialog static text through the same result
- normalize word-boundary wrapping, trailing whitespace, and CR/LF/CRLF hard breaks across guest architectures
- add shared semantic coverage and a PowerPC public lineStarts regression

## Validation

- cargo test --lib
- cargo test --lib --features test-support
- cargo check --no-default-features
- cargo test --test toolbox_showcase
- SYSTEMLESS_PREFER_POWERPC=1 cargo test --test toolbox_showcase

Closes #1113