### PR TITLE
refactor: share textedit mutation semantics

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,7 @@ pub mod scripted_traces;
 pub mod sound;
 pub mod trace;
 pub mod trap;
+mod text_edit;
 mod ui_art;
 pub mod ui_theme;
 mod window_manager;

--- a/src/loader/ppc.rs
+++ b/src/loader/ppc.rs
@@ -67060,43 +67060,64 @@ fn ppc_te_replace_selection(
     te_handle: u32,
     inserted: &[u8],
 ) -> i16 {
-    let Some(te_ptr) = ppc_te_record_ptr(memory, te_handle) else {
+    let Some(mut buffer) = ppc_te_edit_buffer(memory, handles, te_handle) else {
         return PPC_NIL_HANDLE_ERR;
     };
-    let Some(existing) = ppc_te_text_bytes(memory, handles, te_handle) else {
-        return PPC_PARAM_ERR;
+    buffer.replace_selection(inserted);
+    ppc_te_commit_edit_buffer(
+        memory,
+        heap_cursor,
+        heap_limit,
+        handles,
+        te_handle,
+        &buffer,
+    )
+}
+
+fn ppc_te_edit_buffer(
+    memory: &mut PpcSectionMem,
+    handles: &[PpcHandleRecord],
+    te_handle: u32,
+) -> Option<crate::text_edit::TextEditBuffer> {
+    let Some(te_ptr) = ppc_te_record_ptr(memory, te_handle) else {
+        return None;
     };
-    let mut start = usize::from(
-        memory
-            .read_u16_be(te_ptr + PPC_TE_SEL_START_OFFSET)
-            .unwrap_or(0),
-    )
-    .min(existing.len());
-    let mut end = usize::from(
-        memory
-            .read_u16_be(te_ptr + PPC_TE_SEL_END_OFFSET)
-            .unwrap_or(0),
-    )
-    .min(existing.len());
-    if end < start {
-        std::mem::swap(&mut start, &mut end);
-    }
-    let mut merged = Vec::with_capacity(
-        start
-            .saturating_add(inserted.len())
-            .saturating_add(existing.len().saturating_sub(end)),
+    Some(crate::text_edit::TextEditBuffer::new(
+        ppc_te_text_bytes(memory, handles, te_handle)?,
+        usize::from(memory.read_u16_be(te_ptr + PPC_TE_SEL_START_OFFSET)?),
+        usize::from(memory.read_u16_be(te_ptr + PPC_TE_SEL_END_OFFSET)?),
+    ))
+}
+
+fn ppc_te_commit_edit_buffer(
+    memory: &mut PpcSectionMem,
+    heap_cursor: &mut u32,
+    heap_limit: u32,
+    handles: &mut Vec<PpcHandleRecord>,
+    te_handle: u32,
+    buffer: &crate::text_edit::TextEditBuffer,
+) -> i16 {
+    let result = ppc_te_set_text(
+        memory,
+        heap_cursor,
+        heap_limit,
+        handles,
+        te_handle,
+        buffer.text(),
     );
-    merged.extend_from_slice(&existing[..start]);
-    merged.extend_from_slice(inserted);
-    merged.extend_from_slice(&existing[end..]);
-    let result = ppc_te_set_text(memory, heap_cursor, heap_limit, handles, te_handle, &merged);
     if result != PPC_NO_ERR {
         return result;
     }
-    let insertion_end = start.saturating_add(inserted.len()).min(i16::MAX as usize) as u16;
     if let Some(te_ptr) = ppc_te_record_ptr(memory, te_handle) {
-        let _ = memory.write_u16_be(te_ptr + PPC_TE_SEL_START_OFFSET, insertion_end);
-        let _ = memory.write_u16_be(te_ptr + PPC_TE_SEL_END_OFFSET, insertion_end);
+        let selection = buffer.selection();
+        let _ = memory.write_u16_be(
+            te_ptr + PPC_TE_SEL_START_OFFSET,
+            selection.start.min(i16::MAX as usize) as u16,
+        );
+        let _ = memory.write_u16_be(
+            te_ptr + PPC_TE_SEL_END_OFFSET,
+            selection.end.min(i16::MAX as usize) as u16,
+        );
     }
     PPC_NO_ERR
 }
@@ -67109,49 +67130,18 @@ fn ppc_te_key(
     te_handle: u32,
     key: u8,
 ) -> i16 {
-    let Some(te_ptr) = ppc_te_record_ptr(memory, te_handle) else {
+    let Some(mut buffer) = ppc_te_edit_buffer(memory, handles, te_handle) else {
         return PPC_NIL_HANDLE_ERR;
     };
-    let length = memory
-        .read_u16_be(te_ptr + PPC_TE_LENGTH_OFFSET)
-        .unwrap_or(0);
-    let start = memory
-        .read_u16_be(te_ptr + PPC_TE_SEL_START_OFFSET)
-        .unwrap_or(0)
-        .min(length);
-    let end = memory
-        .read_u16_be(te_ptr + PPC_TE_SEL_END_OFFSET)
-        .unwrap_or(0)
-        .min(length);
-    match key {
-        0x08 | 0x7f => {
-            if start == end && start != 0 {
-                let _ = memory.write_u16_be(te_ptr + PPC_TE_SEL_START_OFFSET, start - 1);
-            }
-            ppc_te_replace_selection(memory, heap_cursor, heap_limit, handles, te_handle, &[])
-        }
-        0x1c => {
-            let insertion = if start != end {
-                start.min(end)
-            } else {
-                start.saturating_sub(1)
-            };
-            let _ = memory.write_u16_be(te_ptr + PPC_TE_SEL_START_OFFSET, insertion);
-            let _ = memory.write_u16_be(te_ptr + PPC_TE_SEL_END_OFFSET, insertion);
-            PPC_NO_ERR
-        }
-        0x1d => {
-            let insertion = if start != end {
-                start.max(end)
-            } else {
-                start.saturating_add(1).min(length)
-            };
-            let _ = memory.write_u16_be(te_ptr + PPC_TE_SEL_START_OFFSET, insertion);
-            let _ = memory.write_u16_be(te_ptr + PPC_TE_SEL_END_OFFSET, insertion);
-            PPC_NO_ERR
-        }
-        _ => ppc_te_replace_selection(memory, heap_cursor, heap_limit, handles, te_handle, &[key]),
-    }
+    buffer.apply_key(key);
+    ppc_te_commit_edit_buffer(
+        memory,
+        heap_cursor,
+        heap_limit,
+        handles,
+        te_handle,
+        &buffer,
+    )
 }
 
 fn ppc_te_line_range(
@@ -67194,14 +67184,6 @@ fn ppc_te_metrics(memory: &mut PpcSectionMem, te_ptr: u32) -> (i16, i16, i16, i1
     (font, size, line_height.max(1), ascent.max(0))
 }
 
-fn ppc_te_aligned_left(left: i16, right: i16, width: i16, alignment: i16) -> i16 {
-    match alignment {
-        1 => left.saturating_add(right.saturating_sub(left).saturating_sub(width) / 2),
-        -1 => right.saturating_sub(width),
-        _ => left,
-    }
-}
-
 fn ppc_te_click(
     memory: &mut PpcSectionMem,
     handles: &[PpcHandleRecord],
@@ -67240,7 +67222,7 @@ fn ppc_te_click(
         .map_or(start, |index| index + 1);
     let width = ppc_text_bytes_advance_for_font(&text[start..visible_end], font, size);
     let alignment = memory.read_u16_be(te_ptr + PPC_TE_JUST_OFFSET).unwrap_or(0) as i16;
-    let line_left = ppc_te_aligned_left(left.saturating_add(1), right, width, alignment);
+    let line_left = crate::text_edit::aligned_line_left(left, right, width, alignment, 1);
     let target_x = h.saturating_sub(line_left);
     let mut offset = start;
     let mut advance = 0i16;
@@ -67346,7 +67328,7 @@ fn ppc_te_draw_text_box(
         }
         let bytes = &text[line.start..line.visible_end];
         let width = ppc_text_bytes_advance_for_font(bytes, font, text_size);
-        let x = ppc_te_aligned_left(left, right, width, alignment);
+        let x = crate::text_edit::aligned_line_left(left, right, width, alignment, 0);
         let _ = ppc_draw_text_bytes(
             memory,
             gworlds,
@@ -67465,7 +67447,7 @@ fn ppc_te_get_point(
         .map_or(start, |index| index + 1);
     let line_width = ppc_text_bytes_advance_for_font(&text[start..visible_end], font, size);
     let alignment = memory.read_u16_be(te_ptr + PPC_TE_JUST_OFFSET).unwrap_or(0) as i16;
-    let line_left = ppc_te_aligned_left(left.saturating_add(1), right, line_width, alignment);
+    let line_left = crate::text_edit::aligned_line_left(left, right, line_width, alignment, 1);
     let h = line_left.saturating_add(ppc_text_bytes_advance_for_font(
         &text[start..offset.min(visible_end)],
         font,
@@ -67592,15 +67574,11 @@ fn ppc_te_selected_bytes(
     handles: &[PpcHandleRecord],
     te_handle: u32,
 ) -> Option<Vec<u8>> {
-    let te_ptr = ppc_te_record_ptr(memory, te_handle)?;
-    let text = ppc_te_text_bytes(memory, handles, te_handle)?;
-    let mut start =
-        usize::from(memory.read_u16_be(te_ptr + PPC_TE_SEL_START_OFFSET)?).min(text.len());
-    let mut end = usize::from(memory.read_u16_be(te_ptr + PPC_TE_SEL_END_OFFSET)?).min(text.len());
-    if end < start {
-        std::mem::swap(&mut start, &mut end);
-    }
-    Some(text[start..end].to_vec())
+    Some(
+        ppc_te_edit_buffer(memory, handles, te_handle)?
+            .selected_text()
+            .to_vec(),
+    )
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -67616,6 +67594,9 @@ fn ppc_te_copy_or_cut(
     let Some(selected) = ppc_te_selected_bytes(memory, handles, te_handle) else {
         return PPC_NIL_HANDLE_ERR;
     };
+    if selected.is_empty() {
+        return PPC_NO_ERR;
+    }
     let result = ppc_te_set_scrap_bytes(memory, heap_cursor, heap_limit, handles, scrap, &selected);
     if result != PPC_NO_ERR || !cut {
         return result;
@@ -67759,7 +67740,7 @@ fn ppc_te_draw(
         }
         let width = ppc_text_bytes_advance_for_font(&text[start..visible_end], font, size);
         let alignment = memory.read_u16_be(te_ptr + PPC_TE_JUST_OFFSET).unwrap_or(0) as i16;
-        let line_left = ppc_te_aligned_left(left.saturating_add(1), right, width, alignment);
+        let line_left = crate::text_edit::aligned_line_left(left, right, width, alignment, 1);
         let _ = ppc_draw_text_bytes(
             memory,
             gworlds,
@@ -142545,13 +142526,39 @@ pub(crate) mod tests {
 
         loaded.cpu.pc = loaded.entry_pc;
         loaded.cpu.lr = PPC_HALT_PC;
+        loaded.cpu.gpr[3] = 0x1c;
+        loaded.run_with_hle_imports(64);
+        let te_ptr = loaded.memory.read_u32_be(te_handle).unwrap();
+        assert_eq!(
+            loaded.memory.read_u16_be(te_ptr + PPC_TE_SEL_START_OFFSET),
+            Some(2)
+        );
+        assert_eq!(
+            loaded.memory.read_u16_be(te_ptr + PPC_TE_SEL_END_OFFSET),
+            Some(2)
+        );
+
+        loaded.cpu.pc = loaded.entry_pc;
+        loaded.cpu.lr = PPC_HALT_PC;
+        loaded.cpu.gpr[3] = 0x1d;
+        loaded.run_with_hle_imports(64);
+        assert_eq!(
+            loaded.memory.read_u16_be(te_ptr + PPC_TE_SEL_START_OFFSET),
+            Some(3)
+        );
+        assert_eq!(
+            ppc_te_text_bytes(&mut loaded.memory, &loaded.handles, te_handle),
+            Some(b"abZ".to_vec())
+        );
+
+        loaded.cpu.pc = loaded.entry_pc;
+        loaded.cpu.lr = PPC_HALT_PC;
         loaded.imports[0].dispatcher_target = PpcImportDispatcherTarget::TEClick;
         loaded.tick_count = 100;
         loaded.cpu.gpr[3] = (12u32 << 16) | 20;
         loaded.cpu.gpr[4] = 0;
         loaded.cpu.gpr[5] = te_handle;
         loaded.run_with_hle_imports(64);
-        let te_ptr = loaded.memory.read_u32_be(te_handle).unwrap();
         assert_eq!(
             loaded.memory.read_u16_be(te_ptr + PPC_TE_SEL_START_OFFSET),
             Some(0)

--- a/src/text_edit.rs
+++ b/src/text_edit.rs
@@ -1,0 +1,160 @@
+//! Architecture-neutral TextEdit editing semantics.
+//!
+//! The 68K trap and PowerPC import layers translate guest ABI and memory into
+//! this model, then serialize the result back into their respective `TERec`.
+
+use std::ops::Range;
+
+/// Mutable text and normalized selection state for one TextEdit operation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct TextEditBuffer {
+    text: Vec<u8>,
+    selection: Range<usize>,
+}
+
+impl TextEditBuffer {
+    /// Load guest text and clamp its possibly reversed selection.
+    pub(crate) fn new(text: Vec<u8>, selection_start: usize, selection_end: usize) -> Self {
+        let start = selection_start.min(text.len());
+        let end = selection_end.min(text.len());
+        Self {
+            text,
+            selection: start.min(end)..start.max(end),
+        }
+    }
+
+    pub(crate) fn text(&self) -> &[u8] {
+        &self.text
+    }
+
+    pub(crate) fn selection(&self) -> Range<usize> {
+        self.selection.clone()
+    }
+
+    pub(crate) fn selected_text(&self) -> &[u8] {
+        &self.text[self.selection.clone()]
+    }
+
+    /// Replace the selected range and collapse the selection after the insert.
+    ///
+    /// Inside Macintosh: Text (1993), pp. 2-81 and 2-92--2-93.
+    pub(crate) fn replace_selection(&mut self, inserted: &[u8]) {
+        let insertion_start = self.selection.start;
+        self.text
+            .splice(self.selection.clone(), inserted.iter().copied());
+        let insertion_end = insertion_start
+            .saturating_add(inserted.len())
+            .min(self.text.len());
+        self.selection = insertion_end..insertion_end;
+    }
+
+    /// Delete a nonempty selection, leaving an insertion point at its start.
+    ///
+    /// Inside Macintosh: Text (1993), pp. 2-91--2-92.
+    pub(crate) fn delete_selection(&mut self) -> bool {
+        if self.selection.is_empty() {
+            return false;
+        }
+        self.replace_selection(&[]);
+        true
+    }
+
+    /// Apply the byte accepted by `TEKey`.
+    ///
+    /// Backspace deletes the selection or the preceding character. Left and
+    /// right arrows move or collapse the caret rather than becoming text.
+    /// Inside Macintosh: Text (1993), pp. 2-36--2-37 and 2-81--2-82.
+    pub(crate) fn apply_key(&mut self, key: u8) {
+        match key {
+            0x08 | 0x7f => {
+                if self.selection.is_empty() && self.selection.start > 0 {
+                    self.selection.start -= 1;
+                }
+                self.replace_selection(&[]);
+            }
+            0x1c => {
+                let caret = if self.selection.is_empty() {
+                    self.selection.start.saturating_sub(1)
+                } else {
+                    self.selection.start
+                };
+                self.selection = caret..caret;
+            }
+            0x1d => {
+                let caret = if self.selection.is_empty() {
+                    self.selection.end.saturating_add(1).min(self.text.len())
+                } else {
+                    self.selection.end
+                };
+                self.selection = caret..caret;
+            }
+            _ => self.replace_selection(&[key]),
+        }
+    }
+}
+
+/// Horizontal origin for a TextEdit line, including its caller-selected inset.
+///
+/// Inside Macintosh: Text (1993), pp. 2-87--2-88.
+pub(crate) fn aligned_line_left(
+    left: i16,
+    right: i16,
+    width: i16,
+    alignment: i16,
+    left_inset: i16,
+) -> i16 {
+    match alignment {
+        1 => left.saturating_add(right.saturating_sub(left).saturating_sub(width) / 2),
+        -1 => right.saturating_sub(width),
+        _ => left.saturating_add(left_inset),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{aligned_line_left, TextEditBuffer};
+
+    #[test]
+    fn selection_is_clamped_and_normalized_once() {
+        let buffer = TextEditBuffer::new(b"toolbox".to_vec(), 20, 3);
+
+        assert_eq!(buffer.selection(), 3..7);
+        assert_eq!(buffer.selected_text(), b"lbox");
+    }
+
+    #[test]
+    fn replace_and_delete_share_selection_semantics() {
+        let mut buffer = TextEditBuffer::new(b"one three".to_vec(), 4, 4);
+        buffer.replace_selection(b"two ");
+        assert_eq!(buffer.text(), b"one two three");
+        assert_eq!(buffer.selection(), 8..8);
+
+        let mut buffer = TextEditBuffer::new(buffer.text().to_vec(), 8, 4);
+        assert!(buffer.delete_selection());
+        assert_eq!(buffer.text(), b"one three");
+        assert_eq!(buffer.selection(), 4..4);
+        assert!(!buffer.delete_selection());
+    }
+
+    #[test]
+    fn key_editing_handles_backspace_and_caret_arrows() {
+        let mut buffer = TextEditBuffer::new(b"abc".to_vec(), 2, 2);
+        buffer.apply_key(0x08);
+        assert_eq!(buffer.text(), b"ac");
+        assert_eq!(buffer.selection(), 1..1);
+
+        buffer.apply_key(0x1c);
+        assert_eq!(buffer.selection(), 0..0);
+        buffer.apply_key(0x1d);
+        assert_eq!(buffer.selection(), 1..1);
+        assert_eq!(buffer.text(), b"ac");
+    }
+
+    #[test]
+    fn alignment_is_shared_for_every_guest_adapter() {
+        assert_eq!(aligned_line_left(20, 200, 80, 0, 1), 21);
+        assert_eq!(aligned_line_left(20, 200, 80, -2, 1), 21);
+        assert_eq!(aligned_line_left(20, 200, 80, 1, 1), 70);
+        assert_eq!(aligned_line_left(20, 200, 80, -1, 1), 120);
+    }
+}

--- a/src/trap/dialog.rs
+++ b/src/trap/dialog.rs
@@ -2515,6 +2515,57 @@ impl super::TrapDispatcher {
         bus.read_bytes(text_ptr, len)
     }
 
+    fn te_edit_buffer(
+        bus: &MacMemoryBus,
+        te_handle: u32,
+    ) -> Option<crate::text_edit::TextEditBuffer> {
+        let te_ptr = Self::te_record_ptr(bus, te_handle);
+        if te_ptr == 0 {
+            return None;
+        }
+        Some(crate::text_edit::TextEditBuffer::new(
+            Self::te_text_bytes(bus, te_handle),
+            bus.read_word(te_ptr + Self::TE_SEL_START_OFFSET) as usize,
+            bus.read_word(te_ptr + Self::TE_SEL_END_OFFSET) as usize,
+        ))
+    }
+
+    fn te_commit_edit_buffer(
+        &mut self,
+        bus: &mut MacMemoryBus,
+        te_handle: u32,
+        buffer: &crate::text_edit::TextEditBuffer,
+    ) {
+        self.te_set_text_contents(bus, te_handle, buffer.text());
+        let te_ptr = Self::te_record_ptr(bus, te_handle);
+        if te_ptr == 0 {
+            return;
+        }
+        let selection = buffer.selection();
+        let start = selection.start.min(u16::MAX as usize) as u16;
+        let end = selection.end.min(u16::MAX as usize) as u16;
+        bus.write_word(te_ptr + Self::TE_SEL_START_OFFSET, start);
+        bus.write_word(te_ptr + Self::TE_SEL_END_OFFSET, end);
+    }
+
+    fn te_set_scrap_bytes(bus: &mut MacMemoryBus, selected: &[u8]) {
+        use crate::memory::globals::addr;
+
+        let mut scrap_handle = bus.read_long(addr::TE_SCRP_HANDLE);
+        if scrap_handle == 0 {
+            scrap_handle = Self::allocate_handle_with_data(bus, 0);
+            bus.write_long(addr::TE_SCRP_HANDLE, scrap_handle);
+        }
+        let text_ptr = Self::ensure_text_handle_size(bus, scrap_handle, selected.len());
+        if text_ptr != 0 && !selected.is_empty() {
+            bus.write_bytes(text_ptr, selected);
+        }
+        bus.write_word(
+            addr::TE_SCRP_LENGTH,
+            selected.len().min(u16::MAX as usize) as u16,
+        );
+    }
+
     pub(crate) fn te_find_word_bounds(
         &self,
         bus: &MacMemoryBus,
@@ -2671,31 +2722,11 @@ impl super::TrapDispatcher {
     }
 
     fn te_insert_text(&mut self, bus: &mut MacMemoryBus, te_handle: u32, text: &[u8]) {
-        let te_ptr = Self::te_record_ptr(bus, te_handle);
-        if te_ptr == 0 {
+        let Some(mut buffer) = Self::te_edit_buffer(bus, te_handle) else {
             return;
-        }
-
-        let existing = Self::te_text_bytes(bus, te_handle);
-        let mut sel_start = bus.read_word(te_ptr + Self::TE_SEL_START_OFFSET) as usize;
-        let mut sel_end = bus.read_word(te_ptr + Self::TE_SEL_END_OFFSET) as usize;
-        let text_len = existing.len();
-        sel_start = sel_start.min(text_len);
-        sel_end = sel_end.min(text_len);
-        if sel_end < sel_start {
-            std::mem::swap(&mut sel_start, &mut sel_end);
-        }
-
-        let mut merged =
-            Vec::with_capacity(sel_start + text.len() + text_len.saturating_sub(sel_end));
-        merged.extend_from_slice(&existing[..sel_start]);
-        merged.extend_from_slice(text);
-        merged.extend_from_slice(&existing[sel_end..]);
-        self.te_set_text_contents(bus, te_handle, &merged);
-
-        let insertion_end = (sel_start + text.len()).min(u16::MAX as usize) as u16;
-        bus.write_word(te_ptr + Self::TE_SEL_START_OFFSET, insertion_end);
-        bus.write_word(te_ptr + Self::TE_SEL_END_OFFSET, insertion_end);
+        };
+        buffer.replace_selection(text);
+        self.te_commit_edit_buffer(bus, te_handle, &buffer);
     }
 
     fn te_char_width(&self, font: i16, size: i16, byte: u8) -> i16 {
@@ -2845,20 +2876,6 @@ impl super::TrapDispatcher {
 
         if styled {
             Self::te_update_styled_run_sentinel(bus, te_handle, text_len);
-        }
-    }
-
-    fn te_line_origin_x(just: i16, box_left: i16, box_right: i16, line_width: i16) -> i16 {
-        // Per Inside Macintosh: Text 1993, p. 7320-7323 (and MPW
-        // Universal Headers `TextEdit.h`):
-        //   teJustLeft   =  0  (flush left — system default for LTR)
-        //   teJustCenter =  1  (centered)
-        //   teJustRight  = -1  (flush right)
-        //   teForceLeft  = -2  (force flush left, overrides localised right-to-left)
-        match just {
-            1 => box_left + ((box_right - box_left) - line_width) / 2,
-            -1 => box_right - line_width,
-            _ => box_left.saturating_add(Self::TE_LINE_LEFT_INSET), // 0 / -2 / any other → flush left inside destRect
         }
     }
 
@@ -3126,7 +3143,13 @@ impl super::TrapDispatcher {
             } else {
                 self.te_measure_text_width(font, size, &text_bytes, *start, trimmed_end)
             };
-            let x = Self::te_line_origin_x(just, dest_rect.1, dest_rect.3, line_width);
+            let x = crate::text_edit::aligned_line_left(
+                dest_rect.1,
+                dest_rect.3,
+                line_width,
+                just,
+                Self::TE_LINE_LEFT_INSET,
+            );
             visual_lines.push((*start, *end, top, line_bottom, x));
             self.pn_loc = (top.saturating_add(line_ascent), x);
             for (offset, &byte) in text_bytes[*start..trimmed_end].iter().enumerate() {
@@ -15162,7 +15185,13 @@ impl super::TrapDispatcher {
                             //   teJustCenter =  1 (centered)
                             //   teJustRight  = -1 (flush right)
                             //   teForceLeft  = -2 (force flush left)
-                            let x = Self::te_line_origin_x(align, box_left, box_right, lw);
+                            let x = crate::text_edit::aligned_line_left(
+                                box_left,
+                                box_right,
+                                lw,
+                                align,
+                                Self::TE_LINE_LEFT_INSET,
+                            );
                             self.pn_loc = (y, x);
                             for &byte in &text_bytes[line.start..line.visible_end] {
                                 self.draw_char(cpu, bus, byte as char);
@@ -15446,35 +15475,9 @@ impl super::TrapDispatcher {
             (true, 0x1D5) => {
                 let sp = cpu.read_reg(Register::A7);
                 let te_handle = bus.read_long(sp);
-                let te_ptr = Self::te_record_ptr(bus, te_handle);
-                if te_ptr != 0 {
-                    let sel_start = bus.read_word(te_ptr + Self::TE_SEL_START_OFFSET) as usize;
-                    let sel_end = bus.read_word(te_ptr + Self::TE_SEL_END_OFFSET) as usize;
-                    let (s, e) = if sel_start <= sel_end {
-                        (sel_start, sel_end)
-                    } else {
-                        (sel_end, sel_start)
-                    };
-                    if s != e {
-                        use crate::memory::globals::addr;
-                        let existing = Self::te_text_bytes(bus, te_handle);
-                        let s = s.min(existing.len());
-                        let e = e.min(existing.len());
-                        let selected = &existing[s..e];
-                        let mut scrap_handle = bus.read_long(addr::TE_SCRP_HANDLE);
-                        if scrap_handle == 0 {
-                            scrap_handle = Self::allocate_handle_with_data(bus, 0);
-                            bus.write_long(addr::TE_SCRP_HANDLE, scrap_handle);
-                        }
-                        let text_ptr =
-                            Self::ensure_text_handle_size(bus, scrap_handle, selected.len());
-                        if text_ptr != 0 && !selected.is_empty() {
-                            bus.write_bytes(text_ptr, selected);
-                        }
-                        bus.write_word(
-                            addr::TE_SCRP_LENGTH,
-                            selected.len().min(u16::MAX as usize) as u16,
-                        );
+                if let Some(buffer) = Self::te_edit_buffer(bus, te_handle) {
+                    if !buffer.selected_text().is_empty() {
+                        Self::te_set_scrap_bytes(bus, buffer.selected_text());
                     }
                 }
                 cpu.write_reg(Register::A7, sp + 4);
@@ -15492,47 +15495,11 @@ impl super::TrapDispatcher {
             (true, 0x1D6) => {
                 let sp = cpu.read_reg(Register::A7);
                 let te_handle = bus.read_long(sp);
-                let te_ptr = Self::te_record_ptr(bus, te_handle);
-                if te_ptr != 0 {
-                    let sel_start = bus.read_word(te_ptr + Self::TE_SEL_START_OFFSET) as usize;
-                    let sel_end = bus.read_word(te_ptr + Self::TE_SEL_END_OFFSET) as usize;
-                    let (s, e) = if sel_start <= sel_end {
-                        (sel_start, sel_end)
-                    } else {
-                        (sel_end, sel_start)
-                    };
-                    if s != e {
-                        let existing = Self::te_text_bytes(bus, te_handle);
-                        let s = s.min(existing.len());
-                        let e = e.min(existing.len());
-                        // Copy selection into the scrap (replace, not
-                        // append — IM:I I-391).
-                        {
-                            use crate::memory::globals::addr;
-                            let selected = &existing[s..e];
-                            let mut scrap_handle = bus.read_long(addr::TE_SCRP_HANDLE);
-                            if scrap_handle == 0 {
-                                scrap_handle = Self::allocate_handle_with_data(bus, 0);
-                                bus.write_long(addr::TE_SCRP_HANDLE, scrap_handle);
-                            }
-                            let text_ptr =
-                                Self::ensure_text_handle_size(bus, scrap_handle, selected.len());
-                            if text_ptr != 0 && !selected.is_empty() {
-                                bus.write_bytes(text_ptr, selected);
-                            }
-                            bus.write_word(
-                                addr::TE_SCRP_LENGTH,
-                                selected.len().min(u16::MAX as usize) as u16,
-                            );
-                        }
-                        // Delete selection from the TE text.
-                        let mut merged = Vec::with_capacity(existing.len() - (e - s));
-                        merged.extend_from_slice(&existing[..s]);
-                        merged.extend_from_slice(&existing[e..]);
-                        self.te_set_text_contents(bus, te_handle, &merged);
-                        let new_pos = s.min(u16::MAX as usize) as u16;
-                        bus.write_word(te_ptr + Self::TE_SEL_START_OFFSET, new_pos);
-                        bus.write_word(te_ptr + Self::TE_SEL_END_OFFSET, new_pos);
+                if let Some(mut buffer) = Self::te_edit_buffer(bus, te_handle) {
+                    if !buffer.selected_text().is_empty() {
+                        Self::te_set_scrap_bytes(bus, buffer.selected_text());
+                        buffer.delete_selection();
+                        self.te_commit_edit_buffer(bus, te_handle, &buffer);
                     }
                 }
                 cpu.write_reg(Register::A7, sp + 4);
@@ -15556,22 +15523,9 @@ impl super::TrapDispatcher {
                 if trace_textedit_enabled() {
                     eprintln!("[TE] TEDelete hTE=${:08X}", te_handle);
                 }
-                let te_ptr = Self::te_record_ptr(bus, te_handle);
-                if te_ptr != 0 {
-                    let sel_start = bus.read_word(te_ptr + Self::TE_SEL_START_OFFSET) as usize;
-                    let sel_end = bus.read_word(te_ptr + Self::TE_SEL_END_OFFSET) as usize;
-                    if sel_start != sel_end {
-                        let existing = Self::te_text_bytes(bus, te_handle);
-                        let s = sel_start.min(existing.len());
-                        let e = sel_end.min(existing.len());
-                        let (s, e) = if s > e { (e, s) } else { (s, e) };
-                        let mut merged = Vec::with_capacity(existing.len() - (e - s));
-                        merged.extend_from_slice(&existing[..s]);
-                        merged.extend_from_slice(&existing[e..]);
-                        self.te_set_text_contents(bus, te_handle, &merged);
-                        let new_pos = s.min(u16::MAX as usize) as u16;
-                        bus.write_word(te_ptr + Self::TE_SEL_START_OFFSET, new_pos);
-                        bus.write_word(te_ptr + Self::TE_SEL_END_OFFSET, new_pos);
+                if let Some(mut buffer) = Self::te_edit_buffer(bus, te_handle) {
+                    if buffer.delete_selection() {
+                        self.te_commit_edit_buffer(bus, te_handle, &buffer);
                     }
                 }
                 cpu.write_reg(Register::A7, sp + 4);
@@ -15729,42 +15683,9 @@ impl super::TrapDispatcher {
                         char::from(key).escape_default().to_string()
                     );
                 }
-                let te_ptr = Self::te_record_ptr(bus, te_handle);
-                if te_ptr != 0 {
-                    let sel_start = bus.read_word(te_ptr + Self::TE_SEL_START_OFFSET) as usize;
-                    let sel_end = bus.read_word(te_ptr + Self::TE_SEL_END_OFFSET) as usize;
-                    let existing = Self::te_text_bytes(bus, te_handle);
-                    let text_len = existing.len();
-                    let s = sel_start.min(text_len);
-                    let e = sel_end.min(text_len);
-                    let (s, e) = if s > e { (e, s) } else { (s, e) };
-
-                    if key == 0x08 {
-                        // Backspace
-                        if s != e {
-                            // Delete selected text
-                            let mut merged = Vec::with_capacity(text_len - (e - s));
-                            merged.extend_from_slice(&existing[..s]);
-                            merged.extend_from_slice(&existing[e..]);
-                            self.te_set_text_contents(bus, te_handle, &merged);
-                            let new_pos = s.min(u16::MAX as usize) as u16;
-                            bus.write_word(te_ptr + Self::TE_SEL_START_OFFSET, new_pos);
-                            bus.write_word(te_ptr + Self::TE_SEL_END_OFFSET, new_pos);
-                        } else if s > 0 {
-                            // Delete character before insertion point
-                            let mut merged = Vec::with_capacity(text_len - 1);
-                            merged.extend_from_slice(&existing[..s - 1]);
-                            merged.extend_from_slice(&existing[s..]);
-                            self.te_set_text_contents(bus, te_handle, &merged);
-                            let new_pos = (s - 1).min(u16::MAX as usize) as u16;
-                            bus.write_word(te_ptr + Self::TE_SEL_START_OFFSET, new_pos);
-                            bus.write_word(te_ptr + Self::TE_SEL_END_OFFSET, new_pos);
-                        }
-                        // At start with no selection: do nothing
-                    } else {
-                        // Insert printable character (replacing selection if any)
-                        self.te_insert_text(bus, te_handle, &[key]);
-                    }
+                if let Some(mut buffer) = Self::te_edit_buffer(bus, te_handle) {
+                    buffer.apply_key(key);
+                    self.te_commit_edit_buffer(bus, te_handle, &buffer);
 
                     // TEKey is a drawing operation as well as an editing
                     // operation. Applications do not need to follow every
@@ -19254,7 +19175,7 @@ mod tests {
         assert_eq!(bus.read_word(TEST_SP + 6) as i16, -1);
     }
 
-    // ---- te_line_origin_x (TextEdit alignment) ----
+    // ---- shared TextEdit alignment ----
     //
     // Per IM:Text 1993 lines 7320-7323 and the MPW Universal Headers:
     // teJustLeft = 0, teJustCenter = 1, teJustRight = -1, teForceLeft = -2.
@@ -19263,7 +19184,7 @@ mod tests {
     fn te_line_origin_te_just_left_flush_left() {
         // teJustLeft (0): origin = box_left + TextEdit's left inset.
         assert_eq!(
-            TrapDispatcher::te_line_origin_x(0, 20, 200, 80),
+            crate::text_edit::aligned_line_left(20, 200, 80, 0, 1),
             21,
             "teJustLeft (0) must anchor one pixel inside box_left"
         );
@@ -19274,7 +19195,7 @@ mod tests {
         // teJustCenter (1): origin = box_left + (box_w - line_w) / 2.
         // (200-20 - 80) / 2 = 50 → origin = 20 + 50 = 70.
         assert_eq!(
-            TrapDispatcher::te_line_origin_x(1, 20, 200, 80),
+            crate::text_edit::aligned_line_left(20, 200, 80, 1, 1),
             70,
             "teJustCenter must midpoint the slack"
         );
@@ -19285,7 +19206,7 @@ mod tests {
         // teJustRight (-1): origin = box_right - line_width.
         // 200 - 80 = 120.
         assert_eq!(
-            TrapDispatcher::te_line_origin_x(-1, 20, 200, 80),
+            crate::text_edit::aligned_line_left(20, 200, 80, -1, 1),
             120,
             "teJustRight (-1) must anchor at box_right - line_width"
         );
@@ -19297,7 +19218,7 @@ mod tests {
         // (overrides any
         // localised right-to-left default).
         assert_eq!(
-            TrapDispatcher::te_line_origin_x(-2, 20, 200, 80),
+            crate::text_edit::aligned_line_left(20, 200, 80, -2, 1),
             21,
             "teForceLeft (-2) must anchor one pixel inside box_left"
         );
@@ -19308,7 +19229,7 @@ mod tests {
         // teJustSystem (0): localised default = left for LTR, with the
         // same TextEdit left inset.
         assert_eq!(
-            TrapDispatcher::te_line_origin_x(0, 20, 200, 80),
+            crate::text_edit::aligned_line_left(20, 200, 80, 0, 1),
             21,
             "teJustSystem must default to flush left inside box_left"
         );
@@ -27089,11 +27010,16 @@ mod tests {
         let x_right = run_align(-1);
 
         let expected_left =
-            TrapDispatcher::te_line_origin_x(0, box_left, box_right, line_width) + line_width;
+            crate::text_edit::aligned_line_left(box_left, box_right, line_width, 0, 1) + line_width;
         let expected_center =
-            TrapDispatcher::te_line_origin_x(1, box_left, box_right, line_width) + line_width;
-        let expected_right =
-            TrapDispatcher::te_line_origin_x(-1, box_left, box_right, line_width) + line_width;
+            crate::text_edit::aligned_line_left(box_left, box_right, line_width, 1, 1) + line_width;
+        let expected_right = crate::text_edit::aligned_line_left(
+            box_left,
+            box_right,
+            line_width,
+            -1,
+            1,
+        ) + line_width;
 
         assert_eq!(x_left, expected_left);
         assert_eq!(x_center, expected_center);
@@ -35953,6 +35879,42 @@ mod tests {
             1
         );
         assert_eq!(bus.read_word(te_ptr + TrapDispatcher::TE_SEL_END_OFFSET), 1);
+    }
+
+    #[test]
+    fn tekey_arrows_move_the_caret_without_inserting_text() {
+        // Inside Macintosh: Text (1993), pp. 2-36 to 2-37 and 2-81:
+        // arrow key codes move the insertion point; they are not text bytes.
+        let (mut disp, mut cpu, mut bus) = setup();
+        let te_handle = make_te_with_text(&mut disp, &mut bus, b"HELLO");
+        let te_ptr = bus.read_long(te_handle);
+        bus.write_word(te_ptr + TrapDispatcher::TE_SEL_START_OFFSET, 2);
+        bus.write_word(te_ptr + TrapDispatcher::TE_SEL_END_OFFSET, 4);
+
+        bus.write_long(TEST_SP, te_handle);
+        bus.write_word(TEST_SP + 4, 0x001C);
+        let result = disp.dispatch_dialog(true, 0x1DC, &mut cpu, &mut bus);
+        assert!(result.unwrap().is_ok());
+        assert_eq!(
+            bus.read_word(te_ptr + TrapDispatcher::TE_SEL_START_OFFSET),
+            2
+        );
+        assert_eq!(bus.read_word(te_ptr + TrapDispatcher::TE_SEL_END_OFFSET), 2);
+
+        cpu.write_reg(Register::A7, TEST_SP);
+        bus.write_long(TEST_SP, te_handle);
+        bus.write_word(TEST_SP + 4, 0x001D);
+        let result = disp.dispatch_dialog(true, 0x1DC, &mut cpu, &mut bus);
+        assert!(result.unwrap().is_ok());
+        assert_eq!(
+            bus.read_word(te_ptr + TrapDispatcher::TE_SEL_START_OFFSET),
+            3
+        );
+        assert_eq!(bus.read_word(te_ptr + TrapDispatcher::TE_SEL_END_OFFSET), 3);
+        assert_eq!(
+            TrapDispatcher::te_text_bytes(&bus, te_handle),
+            b"HELLO".to_vec()
+        );
     }
 
     // ---- HideDialogItem / ShowDialogItem ($A827 / $A828) ----


### PR DESCRIPTION
## Summary

- introduce one architecture-neutral TextEdit buffer and selection model
- route 68K traps and PowerPC imports through the same replacement, deletion, key, and alignment semantics
- keep each architecture layer responsible only for guest record and ABI translation
- make 68K arrow-key behavior match the documented TextEdit contract and the PowerPC path

## Evidence

Inside Macintosh: Text (1993), pp. 2-36–2-37, 2-81–2-82, and 2-87–2-93 describes arrow-key movement, selection replacement/deletion, and line justification.

## Verification

- `cargo test --lib`
- `cargo test --lib --features test-support`
- `cargo check --no-default-features`
- `cargo test --test toolbox_showcase`
- `SYSTEMLESS_PREFER_POWERPC=1 cargo test --test toolbox_showcase`

Closes #1117