### PR TITLE
refactor(apple-events): share handler dispatch across CPU adapters

### DIFF
--- a/src/guest_procedure.rs
+++ b/src/guest_procedure.rs
@@ -60,7 +60,7 @@ pub(crate) struct GuestProcedure {
 }
 
 impl GuestProcedure {
-    fn raw_m68k(pointer: u32) -> Self {
+    pub(crate) fn raw_m68k(pointer: u32) -> Self {
         Self {
             original_pointer: pointer,
             representation: GuestProcedureRepresentation::RawCode,

--- a/src/loader/ppc.rs
+++ b/src/loader/ppc.rs
@@ -70,9 +70,9 @@ use crate::menu_manager::{
 };
 use crate::menu_model::GuestMenuSnapshot;
 use crate::process_context::{
-    ProcessContext, ProcessHandleRecord, ProcessHandleStateRecord, ProcessMemoryManager,
-    ProcessNativeAllocatorState, ProcessNativeHeapState, ProcessPtrRecord,
-    SharedProcessMemoryManager,
+    ProcessAppleEventHandler, ProcessContext, ProcessHandleRecord, ProcessHandleStateRecord,
+    ProcessMemoryManager, ProcessNativeAllocatorState, ProcessNativeHeapState, ProcessPtrRecord,
+    SharedProcessAppleEventHandlers, SharedProcessMemoryManager,
 };
 use crate::quickdraw::fonts::heuristics::get_italic_slant;
 use crate::quickdraw::fonts::{
@@ -195,6 +195,7 @@ const PPC_HIGH_LEVEL_EVENT_MASK: u16 = 0x0400;
 const PPC_HIGH_LEVEL_EVENT: u16 = 23;
 const PPC_CORE_EVENT_CLASS: u32 = u32::from_be_bytes(*b"aevt");
 const PPC_OPEN_APPLICATION_EVENT: u32 = u32::from_be_bytes(*b"oapp");
+const PPC_TYPE_WILDCARD: u32 = u32::from_be_bytes(*b"****");
 pub const PPC_BAD_FORMAT: i16 = -206;
 pub const PPC_CHANNEL_NOT_BUSY: i16 = -211;
 pub const PPC_GESTALT_UNDEF_SELECTOR_ERR: i16 = -5551;
@@ -2834,15 +2835,6 @@ pub(crate) struct PpcNativeExceptionContext {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct PpcAppleEventHandlerRecord {
-    event_class: u32,
-    event_id: u32,
-    callback: PpcCallbackTarget,
-    refcon: u32,
-    is_system_handler: bool,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct PpcAppleEventDispatchAllocation {
     resume_guest_call_depth: usize,
     descriptors: u32,
@@ -2854,7 +2846,7 @@ struct PpcAppleEventDispatchAllocation {
 pub(crate) struct PpcAppleEventState {
     application_high_level_event_aware: bool,
     sent_open_application_event: bool,
-    handlers: Vec<PpcAppleEventHandlerRecord>,
+    handlers: SharedProcessAppleEventHandlers,
     pending_dispatches: Vec<PpcAppleEventDispatchAllocation>,
 }
 
@@ -5669,6 +5661,7 @@ impl PpcLoadedApp {
             .attach_native_menu_selection(&mut self.toolbox_startup.pending_native_menu_selection);
         context.attach_guest_calls(&mut self.guest_calls);
         context.attach_guest_calls(&mut self.toolbox_startup.guest_calls);
+        context.attach_apple_event_handlers(&mut self.apple_events.handlers);
     }
 
     /// Temporarily borrow the canonical event queue from [`ProcessContext`] into this
@@ -23329,21 +23322,25 @@ fn dispatch_supported_import(
         PpcImportDispatcherTarget::AEInstallEventHandler => {
             Some(ppc_install_apple_event_handler(cpu, memory, apple_events))
         }
-        PpcImportDispatcherTarget::AEProcessAppleEvent => Some(ppc_process_apple_event(
-            cpu,
-            process_memory_manager,
-            memory,
-            heap_cursor,
-            heap_limit,
-            last_mem_error,
-            ptrs,
-            free_ptr_blocks,
-            handles,
-            free_handle_blocks,
-            handle_states,
-            apple_events,
-            toolbox_startup.guest_calls.depth(),
-        )),
+        PpcImportDispatcherTarget::AEProcessAppleEvent => {
+            let guest_call_depth = toolbox_startup.guest_calls.depth();
+            Some(ppc_process_apple_event(
+                cpu,
+                process_memory_manager,
+                memory,
+                heap_cursor,
+                heap_limit,
+                last_mem_error,
+                ptrs,
+                free_ptr_blocks,
+                handles,
+                free_handle_blocks,
+                handle_states,
+                apple_events,
+                toolbox_startup,
+                guest_call_depth,
+            ))
+        }
         PpcImportDispatcherTarget::LNew => {
             // Inside Macintosh: More Macintosh Toolbox (1993), pp. 4-70--4-72:
             // construct the public ListRec, cell-data handle, bounds, default
@@ -61733,25 +61730,32 @@ fn ppc_install_apple_event_handler(
     // Inside Macintosh: Interapplication Communication (1993),
     // pp. 4-62--4-64. PowerPC UPPs can be routine descriptors or TVectors;
     // resolve them when installed so dispatch preserves their TOC value.
-    let Some(callback) = ppc_resolve_callback_target(memory, cpu.gpr[5], cpu.gpr[2], None) else {
+    let Some(procedure) = resolve_guest_procedure(
+        memory,
+        cpu.gpr[5],
+        cpu.gpr[2],
+        None,
+        GuestIsa::PowerPc,
+        GuestIsa::PowerPc,
+    ) else {
         return PpcImportAction::Return(ppc_i16_result(PPC_PARAM_ERR));
     };
-    if memory.read_u32_be(callback.entry).is_none() {
+    let mapped = match procedure.isa {
+        GuestIsa::PowerPc => memory.read_u32_be(procedure.entry).is_some(),
+        GuestIsa::M68k => memory.read_u16_be(procedure.entry).is_some(),
+    };
+    if cpu.gpr[5] & 1 != 0 || !mapped {
         return PpcImportAction::Return(ppc_i16_result(PPC_PARAM_ERR));
     }
-    let record = PpcAppleEventHandlerRecord {
-        event_class: cpu.gpr[3],
-        event_id: cpu.gpr[4],
-        callback,
-        refcon: cpu.gpr[6],
-        is_system_handler: cpu.gpr[7] & 0xff != 0,
-    };
-    apple_events.handlers.retain(|existing| {
-        existing.event_class != record.event_class
-            || existing.event_id != record.event_id
-            || existing.is_system_handler != record.is_system_handler
-    });
-    apple_events.handlers.push(record);
+    apple_events.handlers.install(
+        cpu.gpr[7] & 0xff != 0,
+        cpu.gpr[3],
+        cpu.gpr[4],
+        ProcessAppleEventHandler {
+            procedure,
+            refcon: cpu.gpr[6],
+        },
+    );
     PpcImportAction::Return(ppc_i16_result(PPC_NO_ERR))
 }
 
@@ -61769,6 +61773,7 @@ fn ppc_process_apple_event(
     free_handle_blocks: &mut Vec<PpcHandleRecord>,
     handle_states: &mut Vec<PpcHandleStateRecord>,
     apple_events: &mut PpcAppleEventState,
+    toolbox_startup: &mut PpcToolboxStartupState,
     resume_guest_call_depth: usize,
 ) -> PpcImportAction {
     // AEProcessAppleEvent receives the EventRecord returned by the Event
@@ -61789,19 +61794,7 @@ fn ppc_process_apple_event(
     let Some(handler) =
         apple_events
             .handlers
-            .iter()
-            .rev()
-            .find(|handler| {
-                handler.event_class == event_class
-                    && handler.event_id == event_id
-                    && !handler.is_system_handler
-            })
-            .or_else(|| {
-                apple_events.handlers.iter().rev().find(|handler| {
-                    handler.event_class == event_class && handler.event_id == event_id
-                })
-            })
-            .copied()
+            .handler_for(event_class, event_id, PPC_TYPE_WILDCARD)
     else {
         return PpcImportAction::Return(ppc_i16_result(PPC_ERR_AE_EVENT_NOT_HANDLED));
     };
@@ -61890,13 +61883,77 @@ fn ppc_process_apple_event(
             event_handle,
             reply_handle,
         });
-    PpcImportAction::CallNative {
-        entry: handler.callback.entry,
-        rtoc: handler.callback.rtoc,
-        return_pc: PPC_GUEST_CALL_RETURN_PC,
-        final_pc: cpu.lr,
-        restore_rtoc: cpu.gpr[2],
-        return_gpr3: PpcNativeReturnGpr3::Preserve,
+    match handler.procedure.isa {
+        GuestIsa::PowerPc => PpcImportAction::CallNative {
+            entry: handler.procedure.entry,
+            rtoc: handler.procedure.rtoc,
+            return_pc: PPC_GUEST_CALL_RETURN_PC,
+            final_pc: cpu.lr,
+            restore_rtoc: cpu.gpr[2],
+            return_gpr3: PpcNativeReturnGpr3::Preserve,
+        },
+        GuestIsa::M68k => {
+            // AEEventHandlerProc is a Pascal function returning a two-byte
+            // OSErr with three four-byte arguments. Interapplication
+            // Communication (1993), pp. 4-12 and 4-66--4-68; PowerPC System
+            // Software (1994), pp. 2-12--2-16.
+            let proc_info = if handler.procedure.proc_info == 0 {
+                0x0000_0fe0
+            } else {
+                handler.procedure.proc_info
+            };
+            let saved_gateway = toolbox_startup.mixed_mode_m68k_gateway;
+            let saved_stack_top = toolbox_startup.mixed_mode_m68k_stack_top;
+            let action = ppc_begin_m68k_universal_proc(
+                cpu,
+                memory,
+                heap_cursor,
+                heap_limit,
+                toolbox_startup,
+                handler.procedure,
+                proc_info,
+                None,
+                vec![descriptors, descriptors + 8, handler.refcon],
+                cpu.lr,
+                PpcNativeReturnGpr3::Preserve,
+            );
+            ppc_synchronize_process_native_allocator(
+                process_memory_manager,
+                *heap_cursor,
+                heap_limit,
+                *last_mem_error,
+                ptrs,
+                free_ptr_blocks,
+                free_handle_blocks,
+            );
+            if let Some(action) = action {
+                action
+            } else {
+                apple_events.pending_dispatches.pop();
+                toolbox_startup.mixed_mode_m68k_gateway = saved_gateway;
+                toolbox_startup.mixed_mode_m68k_stack_top = saved_stack_top;
+                for handle in [event_handle, reply_handle] {
+                    let _ = memory.write_u32_be(handle, 0);
+                }
+                process_memory_manager.restore_native_snapshot(snapshot);
+                process_memory_manager.set_native_mem_error(PPC_MEM_FULL_ERR);
+                ppc_apply_process_native_allocator(
+                    process_memory_manager,
+                    memory,
+                    heap_cursor,
+                    last_mem_error,
+                    ptrs,
+                    free_ptr_blocks,
+                    free_handle_blocks,
+                );
+                handles.retain(|record| {
+                    record.handle != event_handle && record.handle != reply_handle
+                });
+                ppc_forget_handle_state(event_handle, handle_states);
+                ppc_forget_handle_state(reply_handle, handle_states);
+                PpcImportAction::Return(ppc_i16_result(PPC_MEM_FULL_ERR))
+            }
+        }
     }
 }
 
@@ -150743,19 +150800,26 @@ pub(crate) mod tests {
             .memory
             .write_u16_be(event_record + 12, PPC_OPEN_APPLICATION_EVENT as u16)
             .unwrap();
-        let mut apple_events = PpcAppleEventState {
-            handlers: vec![PpcAppleEventHandlerRecord {
-                event_class: PPC_CORE_EVENT_CLASS,
-                event_id: PPC_OPEN_APPLICATION_EVENT,
-                callback: PpcCallbackTarget {
-                    entry: PPC_CODE_BASE,
-                    rtoc: PPC_DATA_BASE,
-                    proc_info: 0,
-                    routine_flags: 0,
-                },
+        let handlers = SharedProcessAppleEventHandlers::default();
+        handlers.install(
+            false,
+            PPC_CORE_EVENT_CLASS,
+            PPC_OPEN_APPLICATION_EVENT,
+            ProcessAppleEventHandler {
+                procedure: resolve_guest_procedure(
+                    &mut native.memory,
+                    PPC_CODE_BASE,
+                    PPC_DATA_BASE,
+                    None,
+                    GuestIsa::PowerPc,
+                    GuestIsa::PowerPc,
+                )
+                .unwrap(),
                 refcon: 0xfeed_beef,
-                is_system_handler: false,
-            }],
+            },
+        );
+        let mut apple_events = PpcAppleEventState {
+            handlers,
             ..PpcAppleEventState::default()
         };
         let mut heap_cursor = native.heap_cursor();
@@ -150782,6 +150846,7 @@ pub(crate) mod tests {
                 &mut free_handle_blocks,
                 &mut handle_states,
                 &mut apple_events,
+                &mut native.toolbox_startup,
                 0,
             )
         };
@@ -150919,6 +150984,41 @@ pub(crate) mod tests {
             .dispatch_toolbox(true, 0x016, &mut classic_cpu, &mut classic_bus)
             .unwrap()
             .is_ok());
+        assert_eq!(
+            native
+                .apple_events
+                .handlers
+                .get(false, event_class, event_id)
+                .map(|registered| (
+                    registered.procedure.isa,
+                    registered.procedure.original_pointer,
+                    registered.refcon,
+                )),
+            Some((GuestIsa::M68k, handler, 0xfeed_beef))
+        );
+
+        let native_event_class = u32::from_be_bytes(*b"misc");
+        let native_event_id = u32::from_be_bytes(*b"slct");
+        native.cpu.gpr[3] = native_event_class;
+        native.cpu.gpr[4] = native_event_id;
+        native.cpu.gpr[5] = PPC_CODE_BASE;
+        native.cpu.gpr[6] = 0x1234_5678;
+        native.cpu.gpr[7] = 1;
+        assert_eq!(
+            ppc_install_apple_event_handler(
+                &native.cpu,
+                &mut native.memory,
+                &mut native.apple_events,
+            ),
+            PpcImportAction::Return(ppc_i16_result(PPC_NO_ERR))
+        );
+        assert_eq!(
+            classic
+                .ae_handlers
+                .get(true, native_event_class, native_event_id)
+                .map(|registered| (registered.procedure.isa, registered.refcon)),
+            Some((GuestIsa::PowerPc, 0x1234_5678))
+        );
 
         classic_cpu.write_reg(Register::A7, sp);
         classic_cpu.write_reg(Register::PC, 0x00f0_1234);
@@ -150959,6 +151059,33 @@ pub(crate) mod tests {
         assert_eq!(classic_bus.get_alloc_size(event_handle), None);
         assert_eq!(classic_bus.get_alloc_size(event_data), None);
         assert!(classic.ae_call_state.is_none());
+
+        native.cpu.gpr[3] = event_class;
+        native.cpu.gpr[4] = event_id;
+        native.cpu.gpr[5] = PPC_CODE_BASE;
+        native.cpu.gpr[6] = 0xcafe_babe;
+        native.cpu.gpr[7] = 0;
+        assert_eq!(
+            ppc_install_apple_event_handler(
+                &native.cpu,
+                &mut native.memory,
+                &mut native.apple_events,
+            ),
+            PpcImportAction::Return(ppc_i16_result(PPC_NO_ERR))
+        );
+        classic_cpu.write_reg(Register::A7, sp);
+        classic_cpu.write_reg(Register::PC, 0x00f0_5678);
+        classic_cpu.write_reg(Register::D0, 0x021B);
+        classic_bus.write_long(sp, 0x0032_0000);
+        classic_bus.write_word(sp + 4, 0);
+        assert!(classic
+            .dispatch_toolbox(true, 0x016, &mut classic_cpu, &mut classic_bus)
+            .unwrap()
+            .is_ok());
+        let pending = classic.guest_calls.pending_powerpc_from_m68k().unwrap();
+        assert_eq!(pending.target.isa, GuestIsa::PowerPc);
+        assert_eq!(pending.target.entry, PPC_CODE_BASE);
+        assert_eq!(pending.arguments.as_slice()[2], 0xcafe_babe);
     }
 
     #[test]
@@ -150985,19 +151112,26 @@ pub(crate) mod tests {
             .memory
             .write_u16_be(event_record + 12, PPC_OPEN_APPLICATION_EVENT as u16)
             .unwrap();
-        let mut apple_events = PpcAppleEventState {
-            handlers: vec![PpcAppleEventHandlerRecord {
-                event_class: PPC_CORE_EVENT_CLASS,
-                event_id: PPC_OPEN_APPLICATION_EVENT,
-                callback: PpcCallbackTarget {
-                    entry: PPC_CODE_BASE,
-                    rtoc: PPC_DATA_BASE,
-                    proc_info: 0,
-                    routine_flags: 0,
-                },
+        let handlers = SharedProcessAppleEventHandlers::default();
+        handlers.install(
+            false,
+            PPC_CORE_EVENT_CLASS,
+            PPC_OPEN_APPLICATION_EVENT,
+            ProcessAppleEventHandler {
+                procedure: resolve_guest_procedure(
+                    &mut native.memory,
+                    PPC_CODE_BASE,
+                    PPC_DATA_BASE,
+                    None,
+                    GuestIsa::PowerPc,
+                    GuestIsa::PowerPc,
+                )
+                .unwrap(),
                 refcon: 0,
-                is_system_handler: false,
-            }],
+            },
+        );
+        let mut apple_events = PpcAppleEventState {
+            handlers,
             ..PpcAppleEventState::default()
         };
         let before_allocator = context
@@ -151033,6 +151167,7 @@ pub(crate) mod tests {
                 &mut free_handle_blocks,
                 &mut handle_states,
                 &mut apple_events,
+                &mut native.toolbox_startup,
                 0,
             )
         };
@@ -151056,6 +151191,76 @@ pub(crate) mod tests {
             before_allocator.free_handle_blocks
         );
         assert_eq!(manager.native_handle_records(), before_handles);
+    }
+
+    #[test]
+    fn native_apple_event_dispatch_enters_registered_classic_handler() {
+        let mut native = load_pef_application(&synthetic_pef_with_import(b"TestImport")).unwrap();
+        let mut context = ProcessContext::default();
+        native.attach_process_context(&mut context);
+        let event_record = PPC_DATA_BASE + 0x2800;
+        native.memory.add_region(event_record, vec![0; 16]);
+        native
+            .memory
+            .write_u16_be(event_record, PPC_HIGH_LEVEL_EVENT)
+            .unwrap();
+        native
+            .memory
+            .write_u32_be(event_record + 2, PPC_CORE_EVENT_CLASS)
+            .unwrap();
+        native
+            .memory
+            .write_u16_be(event_record + 10, (PPC_OPEN_APPLICATION_EVENT >> 16) as u16)
+            .unwrap();
+        native
+            .memory
+            .write_u16_be(event_record + 12, PPC_OPEN_APPLICATION_EVENT as u16)
+            .unwrap();
+        let classic_handler = 0x0000_4000;
+        native.apple_events.handlers.install(
+            false,
+            PPC_CORE_EVENT_CLASS,
+            PPC_OPEN_APPLICATION_EVENT,
+            ProcessAppleEventHandler {
+                procedure: crate::guest_procedure::GuestProcedure::raw_m68k(classic_handler),
+                refcon: 0xfeed_beef,
+            },
+        );
+        let mut heap_cursor = native.heap_cursor();
+        let heap_limit = native.heap_limit();
+        let mut last_mem_error = native.last_mem_error();
+        let mut ptrs = native.ptrs();
+        let mut free_ptr_blocks = native.free_ptr_blocks();
+        let mut handles = native.handles();
+        let mut free_handle_blocks = native.free_handle_blocks();
+        let mut handle_states = native.handle_states();
+        native.cpu.gpr[3] = event_record;
+
+        let action = {
+            let mut manager = context.memory_manager_mut();
+            ppc_process_apple_event(
+                &mut native.cpu,
+                &mut manager,
+                &mut native.memory,
+                &mut heap_cursor,
+                heap_limit,
+                &mut last_mem_error,
+                &mut ptrs,
+                &mut free_ptr_blocks,
+                &mut handles,
+                &mut free_handle_blocks,
+                &mut handle_states,
+                &mut native.apple_events,
+                &mut native.toolbox_startup,
+                0,
+            )
+        };
+
+        assert_eq!(action, PpcImportAction::Halt);
+        assert!(native.guest_calls.has_m68k_execution());
+        let pending = native.guest_calls.activate_m68k().unwrap();
+        assert_eq!(pending.entry, classic_handler);
+        assert_eq!(native.apple_events.pending_dispatches.len(), 1);
     }
 
     #[test]

--- a/src/loader/ppc.rs
+++ b/src/loader/ppc.rs
@@ -150881,6 +150881,87 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn classic_apple_event_handler_bundle_is_process_owned_cross_isa_and_disposed() {
+        let (mut classic, mut classic_cpu, mut classic_bus) = setup_with_port();
+        let mut native = load_pef_application(&synthetic_pef_with_import(b"TestImport")).unwrap();
+        let mut context = ProcessContext::default();
+        classic.attach_process_context(&mut context);
+        native.attach_process_context(&mut context);
+
+        let ram_end = classic_bus.ram_size();
+        let low_memory_end = 0x0010_0000.min(ram_end);
+        let low_memory = classic_bus
+            .shared_ram_region(0, low_memory_end)
+            .expect("classic adapter owns low memory");
+        context.attach_memory(0, low_memory, &mut native.memory);
+        for (base, end) in native
+            .memory
+            .ordinary_mapping_holes(low_memory_end, ram_end)
+        {
+            let memory = classic_bus
+                .shared_ram_region(base, end - base)
+                .expect("classic adapter owns the native mapping hole");
+            context.attach_memory(base, memory, &mut native.memory);
+        }
+
+        let sp = TEST_SP;
+        let event_class = u32::from_be_bytes(*b"aevt");
+        let event_id = u32::from_be_bytes(*b"oapp");
+        let handler = 0x0040_8000;
+        classic_cpu.write_reg(Register::D0, 0x091F);
+        classic_bus.write_word(sp, 0);
+        classic_bus.write_long(sp + 2, 0xfeed_beef);
+        classic_bus.write_long(sp + 6, handler);
+        classic_bus.write_long(sp + 10, event_id);
+        classic_bus.write_long(sp + 14, event_class);
+        classic_bus.write_word(sp + 18, 0);
+        assert!(classic
+            .dispatch_toolbox(true, 0x016, &mut classic_cpu, &mut classic_bus)
+            .unwrap()
+            .is_ok());
+
+        classic_cpu.write_reg(Register::A7, sp);
+        classic_cpu.write_reg(Register::PC, 0x00f0_1234);
+        classic_cpu.write_reg(Register::D0, 0x021B);
+        classic_bus.write_long(sp, 0x0032_0000);
+        classic_bus.write_word(sp + 4, 0);
+        assert!(classic
+            .dispatch_toolbox(true, 0x016, &mut classic_cpu, &mut classic_bus)
+            .unwrap()
+            .is_ok());
+
+        let state = classic
+            .ae_call_state
+            .clone()
+            .expect("classic AppleEvent handler is in flight");
+        let (event_desc, reply_desc) = state
+            .owned_descriptors
+            .expect("classic AppleEvent callback descriptors are process-owned");
+        let event_handle = classic_bus.read_long(event_desc + 4);
+        let event_data = classic_bus.read_long(event_handle);
+        assert_eq!(native.memory.read_u32_be(event_desc), Some(event_class));
+        assert_eq!(native.memory.read_u32_be(event_desc + 4), Some(event_handle));
+        assert_eq!(native.memory.read_u32_be(event_handle), Some(event_data));
+        classic_bus.write_byte(event_data, b'C');
+        assert_eq!(native.memory.read_u8(event_data), Some(b'C'));
+        native.memory.write_u8(event_data + 7, b'!').unwrap();
+        assert_eq!(classic_bus.read_byte(event_data + 7), b'!');
+
+        classic_bus.write_word(state.expected_sp_after_rtd, 0);
+        classic_cpu.write_reg(Register::A7, state.expected_sp_after_rtd);
+        classic_cpu.write_reg(Register::D0, 0xFEFE);
+        assert!(classic
+            .dispatch_toolbox(true, 0x016, &mut classic_cpu, &mut classic_bus)
+            .unwrap()
+            .is_ok());
+        assert_eq!(classic_bus.get_alloc_size(event_desc), None);
+        assert_eq!(classic_bus.get_alloc_size(reply_desc), None);
+        assert_eq!(classic_bus.get_alloc_size(event_handle), None);
+        assert_eq!(classic_bus.get_alloc_size(event_data), None);
+        assert!(classic.ae_call_state.is_none());
+    }
+
+    #[test]
     fn apple_event_handler_bundle_allocation_failure_is_atomic() {
         let mut native = load_pef_application(&synthetic_pef_with_import(b"TestImport")).unwrap();
         native.set_heap_cursor(native.heap_limit().saturating_sub(8));

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -2,6 +2,7 @@
 
 use crate::event_queue::EventQueue;
 use crate::guest_call::SharedGuestCallStack;
+use crate::guest_procedure::GuestProcedure;
 use crate::memory::bus::{SharedClassicHeapAllocator, SharedRamRegion};
 use crate::memory::{GuestAddressSpace, MacMemoryBus, MemoryBus};
 use crate::menu_manager::{ProcessMenuTrackingState, SharedNativeMenuSelection};
@@ -37,6 +38,121 @@ pub struct ProcessHandleStateRecord {
     pub high_locked: bool,
     pub no_purge: bool,
     pub resource: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct ProcessAppleEventHandler {
+    pub(crate) procedure: GuestProcedure,
+    pub(crate) refcon: u32,
+}
+
+/// One process's application and system AppleEvent dispatch tables.
+///
+/// Get and remove use the exact key supplied by the caller, while dispatch
+/// searches the application table before the system table and considers the
+/// exact, class-wildcard, ID-wildcard, and double-wildcard keys in that order.
+/// Inside Macintosh: Interapplication Communication (1993), pp. 4-62--4-68.
+#[derive(Debug, Default)]
+pub(crate) struct SharedProcessAppleEventHandlers(
+    Rc<RefCell<HashMap<(bool, u32, u32), ProcessAppleEventHandler>>>,
+);
+
+impl Clone for SharedProcessAppleEventHandlers {
+    fn clone(&self) -> Self {
+        Self(Rc::new(RefCell::new(self.0.borrow().clone())))
+    }
+}
+
+impl PartialEq for SharedProcessAppleEventHandlers {
+    fn eq(&self, other: &Self) -> bool {
+        *self.0.borrow() == *other.0.borrow()
+    }
+}
+
+impl Eq for SharedProcessAppleEventHandlers {}
+
+impl SharedProcessAppleEventHandlers {
+    pub(crate) fn attach_to(&mut self, process_handlers: &Self) {
+        if Rc::ptr_eq(&self.0, &process_handlers.0) {
+            return;
+        }
+        assert!(
+            self.0.borrow().is_empty() || process_handlers.0.borrow().is_empty(),
+            "cannot attach two populated AppleEvent dispatch tables"
+        );
+        let handlers = std::mem::take(&mut *self.0.borrow_mut());
+        self.0 = Rc::clone(&process_handlers.0);
+        self.0.borrow_mut().extend(handlers);
+    }
+
+    pub(crate) fn install(
+        &self,
+        is_system_handler: bool,
+        event_class: u32,
+        event_id: u32,
+        handler: ProcessAppleEventHandler,
+    ) {
+        self.0
+            .borrow_mut()
+            .insert((is_system_handler, event_class, event_id), handler);
+    }
+
+    pub(crate) fn get(
+        &self,
+        is_system_handler: bool,
+        event_class: u32,
+        event_id: u32,
+    ) -> Option<ProcessAppleEventHandler> {
+        self.0
+            .borrow()
+            .get(&(is_system_handler, event_class, event_id))
+            .copied()
+    }
+
+    pub(crate) fn remove(
+        &self,
+        is_system_handler: bool,
+        event_class: u32,
+        event_id: u32,
+        procedure: u32,
+    ) -> bool {
+        let key = (is_system_handler, event_class, event_id);
+        let mut handlers = self.0.borrow_mut();
+        let matches = handlers.get(&key).is_some_and(|handler| {
+            procedure == 0 || handler.procedure.original_pointer == procedure
+        });
+        if matches {
+            handlers.remove(&key);
+        }
+        matches
+    }
+
+    pub(crate) fn handler_for(
+        &self,
+        event_class: u32,
+        event_id: u32,
+        wildcard: u32,
+    ) -> Option<ProcessAppleEventHandler> {
+        let handlers = self.0.borrow();
+        for is_system_handler in [false, true] {
+            for key in [
+                (is_system_handler, event_class, event_id),
+                (is_system_handler, event_class, wildcard),
+                (is_system_handler, wildcard, event_id),
+                (is_system_handler, wildcard, wildcard),
+            ] {
+                if let Some(handler) = handlers.get(&key) {
+                    return Some(*handler);
+                }
+            }
+        }
+        None
+    }
+
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
+        self.0.borrow().len()
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2466,6 +2582,7 @@ pub(crate) struct ProcessContext {
     menu_tracking: Option<ProcessMenuTrackingState>,
     pending_native_menu_selection: SharedNativeMenuSelection,
     guest_calls: SharedGuestCallStack,
+    apple_event_handlers: SharedProcessAppleEventHandlers,
 }
 
 impl ProcessContext {
@@ -2616,6 +2733,13 @@ impl ProcessContext {
 
     pub(crate) fn attach_guest_calls(&self, adapter: &mut SharedGuestCallStack) {
         adapter.attach_to(&self.guest_calls);
+    }
+
+    pub(crate) fn attach_apple_event_handlers(
+        &self,
+        adapter: &mut SharedProcessAppleEventHandlers,
+    ) {
+        adapter.attach_to(&self.apple_event_handlers);
     }
 }
 
@@ -3738,5 +3862,82 @@ mod tests {
         assert_eq!(manager.handle_state(0x5500), 0);
         assert_eq!(manager.native_allocation(0x3300).unwrap().size, 80);
         assert_eq!(manager.native_allocation(0x5500), None);
+    }
+
+    #[test]
+    fn apple_event_dispatch_prefers_application_exact_and_wildcard_entries() {
+        let handlers = SharedProcessAppleEventHandlers::default();
+        let wildcard = u32::from_be_bytes(*b"****");
+        let event_class = u32::from_be_bytes(*b"aevt");
+        let event_id = u32::from_be_bytes(*b"oapp");
+        for (is_system, class, id, pointer, refcon) in [
+            (true, event_class, event_id, 0x1000, 1),
+            (false, wildcard, wildcard, 0x2000, 2),
+            (false, event_class, wildcard, 0x3000, 3),
+            (false, event_class, event_id, 0x4000, 4),
+        ] {
+            handlers.install(
+                is_system,
+                class,
+                id,
+                ProcessAppleEventHandler {
+                    procedure: GuestProcedure::raw_m68k(pointer),
+                    refcon,
+                },
+            );
+        }
+
+        assert_eq!(
+            handlers
+                .handler_for(event_class, event_id, wildcard)
+                .map(|handler| (handler.procedure.original_pointer, handler.refcon)),
+            Some((0x4000, 4))
+        );
+        assert!(handlers.remove(false, event_class, event_id, 0));
+        assert_eq!(
+            handlers
+                .handler_for(event_class, event_id, wildcard)
+                .map(|handler| (handler.procedure.original_pointer, handler.refcon)),
+            Some((0x3000, 3))
+        );
+        assert!(handlers.remove(false, event_class, wildcard, 0x3000));
+        assert!(!handlers.remove(false, wildcard, wildcard, 0x9998));
+        assert_eq!(
+            handlers
+                .handler_for(event_class, event_id, wildcard)
+                .map(|handler| (handler.procedure.original_pointer, handler.refcon)),
+            Some((0x2000, 2))
+        );
+    }
+
+    #[test]
+    fn attached_apple_event_tables_share_mutations_while_clones_detach() {
+        let context = ProcessContext::default();
+        let mut classic = SharedProcessAppleEventHandlers::default();
+        let mut native = SharedProcessAppleEventHandlers::default();
+        context.attach_apple_event_handlers(&mut classic);
+        context.attach_apple_event_handlers(&mut native);
+        let detached = native.clone();
+        let event_class = u32::from_be_bytes(*b"misc");
+        let event_id = u32::from_be_bytes(*b"slct");
+
+        classic.install(
+            false,
+            event_class,
+            event_id,
+            ProcessAppleEventHandler {
+                procedure: GuestProcedure::raw_m68k(0x4000),
+                refcon: 0x1234_5678,
+            },
+        );
+
+        assert_eq!(
+            native.get(false, event_class, event_id),
+            classic.get(false, event_class, event_id)
+        );
+        assert_eq!(detached.get(false, event_class, event_id), None);
+        assert_eq!(classic.len(), 1);
+        assert_eq!(native.len(), 1);
+        assert_eq!(detached.len(), 0);
     }
 }

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -971,6 +971,11 @@ pub(crate) struct AeCallState {
     /// OSErr; AESend reports delivery status, so same-process sends use
     /// noErr here while the handler result remains a reply-event concern.
     pub result_override: Option<i16>,
+    /// Descriptor records created by the Apple Event Manager solely for this
+    /// handler invocation. The manager disposes these application-heap
+    /// objects after the handler returns. Interapplication Communication
+    /// (1993), pp. 4-33 and 4-39.
+    pub(crate) owned_descriptors: Option<(u32, u32)>,
     /// Optional Object Support Library continuation. When AEResolve calls a
     /// guest object accessor, the accessor returns through the same Pack8
     /// trampoline as AE handlers; this state tells the trampoline whether to

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -13,7 +13,9 @@ use crate::machine_profile::reference_machine_profile;
 use crate::managers::resource::ResourceFork;
 use crate::memory::{MacMemoryBus, MemoryBus};
 use crate::menu_manager::{ProcessMenuTrackingState, SharedNativeMenuSelection};
-use crate::process_context::{ProcessContext, SharedProcessMemoryManager};
+use crate::process_context::{
+    ProcessContext, SharedProcessAppleEventHandlers, SharedProcessMemoryManager,
+};
 use crate::trace::{TraceEvent, TraceSink, TraceSource};
 use crate::ui_theme::{UiTheme, UiThemeId};
 use crate::{Error, Result};
@@ -1832,11 +1834,8 @@ pub struct TrapDispatcher {
     pub(crate) dialogs_drawn_by_app: std::collections::HashSet<u32>,
     /// Map of Segment ID -> Loaded Address (for LoadSeg)
     pub(crate) segment_map: HashMap<i16, u32>,
-    /// AppleEvent handlers registered by the guest via Pack8 routine 31
-    /// (AEInstallEventHandler). Key is `(eventClass, eventID)` packed
-    /// as 4-char-codes; value is `(handler_proc_ptr, handler_refcon)`.
-    /// Inside Macintosh Volume VI, 6-43.
-    pub ae_handlers: HashMap<(u32, u32), (u32, u32)>,
+    /// Process-owned application and system AppleEvent dispatch tables.
+    pub(crate) ae_handlers: SharedProcessAppleEventHandlers,
     /// Synthetic AppleEvent descriptors currently visible to guest
     /// handlers. Key is the guest address of the AEDesc record.
     pub(crate) ae_events: HashMap<u32, SyntheticAppleEvent>,
@@ -2950,6 +2949,7 @@ impl TrapDispatcher {
         );
         context.attach_native_menu_selection(&mut self.pending_native_menu_selection);
         context.attach_guest_calls(&mut self.guest_calls);
+        context.attach_apple_event_handlers(&mut self.ae_handlers);
     }
 
     pub(crate) fn process_memory_manager(&self) -> SharedProcessMemoryManager {
@@ -3904,7 +3904,7 @@ impl TrapDispatcher {
             movie_sticky_error: 0,
             dialogs_drawn_by_app: std::collections::HashSet::new(),
             segment_map: HashMap::new(),
-            ae_handlers: HashMap::new(),
+            ae_handlers: SharedProcessAppleEventHandlers::default(),
             ae_events: HashMap::new(),
             ae_descriptors: HashMap::new(),
             ae_descriptor_backing: HashMap::new(),

--- a/src/trap/memory.rs
+++ b/src/trap/memory.rs
@@ -670,21 +670,21 @@ impl super::TrapDispatcher {
         0
     }
 
-    fn new_process_classic_ptr(&mut self, bus: &mut MacMemoryBus, size: u32) -> u32 {
+    pub(super) fn new_process_classic_ptr(&mut self, bus: &mut MacMemoryBus, size: u32) -> u32 {
         let memory_manager = self.process_memory_manager();
         let mut memory_manager = memory_manager.borrow_mut();
         memory_manager.attach_classic_memory_bus(bus);
         memory_manager.new_classic_ptr(bus, size)
     }
 
-    fn dispose_process_ptr(&mut self, bus: &mut MacMemoryBus, ptr: u32) {
+    pub(super) fn dispose_process_ptr(&mut self, bus: &mut MacMemoryBus, ptr: u32) {
         let memory_manager = self.process_memory_manager();
         let mut memory_manager = memory_manager.borrow_mut();
         memory_manager.attach_classic_memory_bus(bus);
         memory_manager.dispose_process_ptr(bus, ptr);
     }
 
-    fn new_process_classic_handle(
+    pub(super) fn new_process_classic_handle(
         &mut self,
         bus: &mut MacMemoryBus,
         size: u32,
@@ -697,7 +697,7 @@ impl super::TrapDispatcher {
             .map_err(|error| error as i32 as u32)
     }
 
-    fn new_empty_process_classic_handle(
+    pub(super) fn new_empty_process_classic_handle(
         &mut self,
         bus: &mut MacMemoryBus,
     ) -> std::result::Result<u32, u32> {
@@ -709,7 +709,7 @@ impl super::TrapDispatcher {
             .map_err(|error| error as i32 as u32)
     }
 
-    fn dispose_process_handle(
+    pub(super) fn dispose_process_handle(
         &mut self,
         bus: &mut MacMemoryBus,
         handle: u32,

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -1392,18 +1392,13 @@ impl super::TrapDispatcher {
         (base, base.wrapping_add(stack_size))
     }
 
-    fn apple_event_handler_for(&self, event_class: u32, event_id: u32) -> Option<(u32, u32)> {
-        // Inside Macintosh Volume VI, 6-28 to 6-29: AEInstallEventHandler
-        // entries may use typeWildCard ('****') for event class, event ID,
-        // or both; wildcard entries match all possible values.
-        [
-            (event_class, event_id),
-            (event_class, AE_TYPE_WILDCARD),
-            (AE_TYPE_WILDCARD, event_id),
-            (AE_TYPE_WILDCARD, AE_TYPE_WILDCARD),
-        ]
-        .into_iter()
-        .find_map(|key| self.ae_handlers.get(&key).copied())
+    fn apple_event_handler_for(
+        &self,
+        event_class: u32,
+        event_id: u32,
+    ) -> Option<crate::process_context::ProcessAppleEventHandler> {
+        self.ae_handlers
+            .handler_for(event_class, event_id, AE_TYPE_WILDCARD)
     }
 
     fn ae_object_accessor_for(
@@ -6908,12 +6903,37 @@ impl super::TrapDispatcher {
                 //   SP+18  result OSErr slot (2 bytes; pre-pushed)
                 // Inside Macintosh Volume VI, 6-43.
                 if routine == 31 && param_bytes == 18 {
+                    let is_sys_handler = Self::stack_bool_slot(bus, sp);
                     let handler_refcon = bus.read_long(sp + 2);
                     let handler_ptr = bus.read_long(sp + 6);
                     let event_id = bus.read_long(sp + 10);
                     let event_class = bus.read_long(sp + 14);
-                    self.ae_handlers
-                        .insert((event_class, event_id), (handler_ptr, handler_refcon));
+                    let procedure = (handler_ptr != 0 && handler_ptr & 1 == 0)
+                        .then(|| {
+                            crate::guest_procedure::resolve_guest_procedure(
+                                bus,
+                                handler_ptr,
+                                0,
+                                None,
+                                crate::guest_procedure::GuestIsa::M68k,
+                                crate::guest_procedure::GuestIsa::M68k,
+                            )
+                        })
+                        .flatten();
+                    let err = if let Some(procedure) = procedure {
+                        self.ae_handlers.install(
+                            is_sys_handler,
+                            event_class,
+                            event_id,
+                            crate::process_context::ProcessAppleEventHandler {
+                                procedure,
+                                refcon: handler_refcon,
+                            },
+                        );
+                        0
+                    } else {
+                        -50i16
+                    };
                     eprintln!(
                         "[AE] InstallEventHandler class='{}' id='{}' handler=${:08X} refcon=${:08X}",
                         format_fourcc(event_class),
@@ -6921,19 +6941,25 @@ impl super::TrapDispatcher {
                         handler_ptr,
                         handler_refcon,
                     );
+                    let new_sp = sp + param_bytes;
+                    bus.write_word(new_sp, err as u16);
+                    cpu.write_reg(Register::A7, new_sp);
+                    cpu.write_reg(Register::D0, err as i32 as u32);
+                    return Some(Ok(()));
                 }
                 if routine == 33 && param_bytes == 18 {
+                    let is_sys_handler = Self::stack_bool_slot(bus, sp);
                     let handler_refcon_ptr = bus.read_long(sp + 2);
                     let handler_ptr = bus.read_long(sp + 6);
                     let event_id = bus.read_long(sp + 10);
                     let event_class = bus.read_long(sp + 14);
-                    let found = self.ae_handlers.get(&(event_class, event_id)).copied();
-                    let err = if let Some((handler, refcon)) = found {
+                    let found = self.ae_handlers.get(is_sys_handler, event_class, event_id);
+                    let err = if let Some(handler) = found {
                         if handler_ptr != 0 {
-                            bus.write_long(handler_ptr, handler);
+                            bus.write_long(handler_ptr, handler.procedure.original_pointer);
                         }
                         if handler_refcon_ptr != 0 {
-                            bus.write_long(handler_refcon_ptr, refcon);
+                            bus.write_long(handler_refcon_ptr, handler.refcon);
                         }
                         0
                     } else {
@@ -6943,6 +6969,27 @@ impl super::TrapDispatcher {
                         if handler_refcon_ptr != 0 {
                             bus.write_long(handler_refcon_ptr, 0);
                         }
+                        AE_ERR_HANDLER_NOT_FOUND
+                    };
+                    let new_sp = sp + param_bytes;
+                    bus.write_word(new_sp, err as u16);
+                    cpu.write_reg(Register::A7, new_sp);
+                    cpu.write_reg(Register::D0, err as i32 as u32);
+                    return Some(Ok(()));
+                }
+                if routine == 32 && param_bytes == 14 {
+                    let is_sys_handler = Self::stack_bool_slot(bus, sp);
+                    let handler_ptr = bus.read_long(sp + 2);
+                    let event_id = bus.read_long(sp + 6);
+                    let event_class = bus.read_long(sp + 10);
+                    let err = if self.ae_handlers.remove(
+                        is_sys_handler,
+                        event_class,
+                        event_id,
+                        handler_ptr,
+                    ) {
+                        0
+                    } else {
                         AE_ERR_HANDLER_NOT_FOUND
                     };
                     let new_sp = sp + param_bytes;
@@ -8183,9 +8230,11 @@ impl super::TrapDispatcher {
                             bus.read_word(event_record + 14)
                         );
                     }
-                    if let Some((handler_ptr, refcon)) =
+                    if let Some(handler) =
                         self.apple_event_handler_for(oapp_class, oapp_id)
                     {
+                        let handler_ptr = handler.procedure.original_pointer;
+                        let refcon = handler.refcon;
                         // Lazily allocate the trampoline on first use.
                         // Six bytes encode `MOVE.W #$FEFE, D0; _Pack8`,
                         // pad to 8 for alignment.
@@ -8270,7 +8319,39 @@ impl super::TrapDispatcher {
                             handler_ptr, trampoline,
                         );
 
-                        cpu.write_reg(Register::PC, handler_ptr);
+                        match handler.procedure.isa {
+                            crate::guest_procedure::GuestIsa::M68k => {
+                                cpu.write_reg(Register::PC, handler.procedure.entry);
+                            }
+                            crate::guest_procedure::GuestIsa::PowerPc => {
+                                let arguments = crate::guest_call::PowerPcArguments::from_slice(&[
+                                    event_desc,
+                                    reply_desc,
+                                    refcon,
+                                ])
+                                .expect("AppleEvent handler has three arguments");
+                                let started = self.guest_calls.begin_m68k_to_powerpc(
+                                    crate::guest_call::GuestCallTarget {
+                                        isa: handler.procedure.isa,
+                                        entry: handler.procedure.entry,
+                                        rtoc: handler.procedure.rtoc,
+                                    },
+                                    arguments,
+                                    trampoline,
+                                    sp + 4,
+                                    Some(crate::guest_call::M68kResultTarget::Memory {
+                                        address: sp + 4,
+                                        size: 2,
+                                    }),
+                                );
+                                if !started {
+                                    self.ae_call_state = self.ae_call_state_stack.pop();
+                                    self.dispose_owned_ae_callback_descriptor(bus, event_desc);
+                                    self.dispose_owned_ae_callback_descriptor(bus, reply_desc);
+                                    return return_allocation_failure(cpu, bus);
+                                }
+                            }
+                        }
                         return Some(Ok(()));
                     }
                 }
@@ -8307,9 +8388,11 @@ impl super::TrapDispatcher {
                         }
                     }
                     if let Some(event) = self.ae_events.get(&event_desc).cloned() {
-                        if let Some((handler_ptr, refcon)) =
+                        if let Some(handler) =
                             self.apple_event_handler_for(event.event_class, event.event_id)
                         {
+                            let handler_ptr = handler.procedure.original_pointer;
+                            let refcon = handler.refcon;
                             let trampoline = match self.ae_trampoline_addr {
                                 Some(addr) => addr,
                                 None => {
@@ -8354,7 +8437,41 @@ impl super::TrapDispatcher {
                                 );
                             }
 
-                            cpu.write_reg(Register::PC, handler_ptr);
+                            match handler.procedure.isa {
+                                crate::guest_procedure::GuestIsa::M68k => {
+                                    cpu.write_reg(Register::PC, handler.procedure.entry);
+                                }
+                                crate::guest_procedure::GuestIsa::PowerPc => {
+                                    let arguments =
+                                        crate::guest_call::PowerPcArguments::from_slice(&[
+                                            event_desc,
+                                            reply_desc,
+                                            refcon,
+                                        ])
+                                        .expect("AppleEvent handler has three arguments");
+                                    if !self.guest_calls.begin_m68k_to_powerpc(
+                                        crate::guest_call::GuestCallTarget {
+                                            isa: handler.procedure.isa,
+                                            entry: handler.procedure.entry,
+                                            rtoc: handler.procedure.rtoc,
+                                        },
+                                        arguments,
+                                        trampoline,
+                                        sp + param_bytes,
+                                        Some(crate::guest_call::M68kResultTarget::Memory {
+                                            address: sp + param_bytes,
+                                            size: 2,
+                                        }),
+                                    ) {
+                                        self.ae_call_state = self.ae_call_state_stack.pop();
+                                        let new_sp = sp + param_bytes;
+                                        bus.write_word(new_sp, (-108i16) as u16);
+                                        cpu.write_reg(Register::A7, new_sp);
+                                        cpu.write_reg(Register::D0, -108i32 as u32);
+                                        return Some(Ok(()));
+                                    }
+                                }
+                            }
                             return Some(Ok(()));
                         }
                     }
@@ -29708,7 +29825,7 @@ mod tests {
         let (mut disp, mut cpu, mut bus) = setup();
         let sp = TEST_SP;
 
-        cpu.write_reg(Register::D0, 0x0720); // 7 words params, routine $20
+        cpu.write_reg(Register::D0, 0x07FF); // 7 words params, unimplemented routine $FF
         for i in 0..14 {
             bus.write_byte(sp + i, 0);
         }
@@ -29757,7 +29874,7 @@ mod tests {
         let sp = TEST_SP;
         let event_class = u32::from_be_bytes(*b"aevt");
         let event_id = u32::from_be_bytes(*b"oapp");
-        let handler_ptr = 0x00AB_CDEFu32;
+        let handler_ptr = 0x00AB_CDEEu32;
         let handler_refcon = 0x0102_0304u32;
 
         // Selector $091F => AEInstallEventHandler.
@@ -29776,8 +29893,10 @@ mod tests {
         assert_eq!(bus.read_word(sp + 18), 0); // noErr
         assert_eq!(cpu.read_reg(Register::A7), sp + 18);
         assert_eq!(
-            disp.ae_handlers.get(&(event_class, event_id)),
-            Some(&(handler_ptr, handler_refcon))
+            disp.ae_handlers
+                .get(false, event_class, event_id)
+                .map(|handler| (handler.procedure.original_pointer, handler.refcon)),
+            Some((handler_ptr, handler_refcon))
         );
     }
 
@@ -29793,7 +29912,7 @@ mod tests {
         cpu.write_reg(Register::D0, 0x091F);
         bus.write_word(sp, 0); // isSysHandler
         bus.write_long(sp + 2, 0x1111_2222); // refcon #1
-        bus.write_long(sp + 6, 0x00AA_0001); // handler #1
+        bus.write_long(sp + 6, 0x00AA_0000); // handler #1
         bus.write_long(sp + 10, event_id);
         bus.write_long(sp + 14, event_class);
         bus.write_word(sp + 18, 0xBEEF);
@@ -29814,8 +29933,10 @@ mod tests {
         assert!(second.unwrap().is_ok());
 
         assert_eq!(
-            disp.ae_handlers.get(&(event_class, event_id)),
-            Some(&(0x00BB_0002u32, 0x3333_4444u32))
+            disp.ae_handlers
+                .get(false, event_class, event_id)
+                .map(|handler| (handler.procedure.original_pointer, handler.refcon)),
+            Some((0x00BB_0002u32, 0x3333_4444u32))
         );
     }
 
@@ -30588,8 +30709,15 @@ mod tests {
             resolve_state: None,
         };
 
-        disp.ae_handlers
-            .insert((event_class, event_id), (handler_ptr, handler_refcon));
+        disp.ae_handlers.install(
+            false,
+            event_class,
+            event_id,
+            crate::process_context::ProcessAppleEventHandler {
+                procedure: crate::guest_procedure::GuestProcedure::raw_m68k(handler_ptr),
+                refcon: handler_refcon,
+            },
+        );
         disp.ae_events.insert(
             event_desc,
             crate::trap::dispatch::SyntheticAppleEvent {

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -1618,18 +1618,18 @@ impl super::TrapDispatcher {
                 if existing != 0 {
                     existing
                 } else {
-                    let handle = bus.alloc(4);
-                    bus.write_long(handle, 0);
-                    handle
+                    self.new_empty_process_classic_handle(bus).unwrap_or(0)
                 }
             } else {
                 0
             }
         } else {
-            let handle = bus.alloc(4);
-            bus.write_long(handle, 0);
-            self.write_bytes_to_handle(bus, handle, &desc.data);
-            handle
+            self.new_process_classic_handle(bus, desc.data.len() as u32)
+                .map(|(handle, ptr)| {
+                    bus.write_bytes(ptr, &desc.data);
+                    handle
+                })
+                .unwrap_or(0)
         };
         bus.write_long(desc_ptr, desc.desc_type);
         bus.write_long(desc_ptr + 4, data_handle);
@@ -1687,8 +1687,22 @@ impl super::TrapDispatcher {
         write_null_aedesc(bus, desc_ptr);
     }
 
+    fn dispose_owned_ae_callback_descriptor(&mut self, bus: &mut MacMemoryBus, desc_ptr: u32) {
+        if desc_ptr == 0 {
+            return;
+        }
+        let data_handle = bus.read_long(desc_ptr + 4);
+        self.ae_events.remove(&desc_ptr);
+        self.ae_descriptors.remove(&desc_ptr);
+        if data_handle != 0 {
+            self.ae_descriptor_backing.remove(&data_handle);
+            let _ = self.dispose_process_handle(bus, data_handle, true);
+        }
+        self.dispose_process_ptr(bus, desc_ptr);
+    }
+
     fn ae_descriptor_record(&mut self, bus: &mut MacMemoryBus, desc: AeDescriptor) -> u32 {
-        let desc_ptr = bus.alloc(8);
+        let desc_ptr = self.new_process_classic_ptr(bus, 8);
         self.write_ae_descriptor_value(bus, desc_ptr, desc);
         desc_ptr
     }
@@ -1896,6 +1910,7 @@ impl super::TrapDispatcher {
             return_pc: resolve_state.return_pc,
             expected_sp_after_rtd: resolve_state.result_slot,
             result_override: None,
+            owned_descriptors: None,
             resolve_state: Some(resolve_state),
         });
 
@@ -6720,6 +6735,10 @@ impl super::TrapDispatcher {
                     let result = state
                         .result_override
                         .unwrap_or_else(|| bus.read_word(sp) as i16);
+                    if let Some((event_desc, reply_desc)) = state.owned_descriptors {
+                        self.dispose_owned_ae_callback_descriptor(bus, event_desc);
+                        self.dispose_owned_ae_callback_descriptor(bus, reply_desc);
+                    }
                     if let Some(resolve_state) = state.resolve_state {
                         self.ae_continue_resolve_after_accessor(bus, cpu, resolve_state, result);
                         return Some(Ok(()));
@@ -7990,6 +8009,7 @@ impl super::TrapDispatcher {
                             return_pc,
                             expected_sp_after_rtd: result_slot,
                             result_override: None,
+                            owned_descriptors: None,
                             resolve_state: None,
                         });
                         cpu.write_reg(Register::PC, handler_ptr);
@@ -8188,11 +8208,30 @@ impl super::TrapDispatcher {
                         // AEGetAttribute* exposes to the handler. The
                         // null reply descriptor matches the no-reply
                         // path for a synthetic open-application event.
-                        let event_desc = bus.alloc(8);
+                        let return_allocation_failure =
+                            |cpu: &mut dyn CpuOps, bus: &mut MacMemoryBus| {
+                                let new_sp = sp + param_bytes;
+                                bus.write_word(new_sp, (-108i16) as u16);
+                                cpu.write_reg(Register::A7, new_sp);
+                                cpu.write_reg(Register::D0, -108i32 as u32);
+                                Some(Ok(()))
+                            };
+                        let event_desc = self.new_process_classic_ptr(bus, 8);
+                        if event_desc == 0 {
+                            return return_allocation_failure(cpu, bus);
+                        }
                         self.write_synthetic_apple_event_descriptor(
                             bus, event_desc, oapp_class, oapp_id,
                         );
-                        let reply_desc = bus.alloc(8);
+                        if bus.read_long(event_desc + 4) == 0 {
+                            self.dispose_owned_ae_callback_descriptor(bus, event_desc);
+                            return return_allocation_failure(cpu, bus);
+                        }
+                        let reply_desc = self.new_process_classic_ptr(bus, 8);
+                        if reply_desc == 0 {
+                            self.dispose_owned_ae_callback_descriptor(bus, event_desc);
+                            return return_allocation_failure(cpu, bus);
+                        }
                         bus.write_long(reply_desc, AE_TYPE_NULL);
                         bus.write_long(reply_desc + 4, 0);
 
@@ -8221,6 +8260,7 @@ impl super::TrapDispatcher {
                             return_pc,
                             expected_sp_after_rtd: sp + 4,
                             result_override: None,
+                            owned_descriptors: Some((event_desc, reply_desc)),
                             resolve_state: None,
                         });
                         self.fired_oapp_handler = true;
@@ -8301,6 +8341,7 @@ impl super::TrapDispatcher {
                                 return_pc,
                                 expected_sp_after_rtd: sp + param_bytes,
                                 result_override: Some(0),
+                                owned_descriptors: None,
                                 resolve_state: None,
                             });
                             if trace_ae_enabled() {
@@ -30227,6 +30268,13 @@ mod tests {
         assert_ne!(bus.read_long(sp - 4), 0, "reply AEDesc pointer");
 
         let passed_event_desc = bus.read_long(sp);
+        let passed_reply_desc = bus.read_long(sp - 4);
+        assert_eq!(
+            state.owned_descriptors,
+            Some((passed_event_desc, passed_reply_desc))
+        );
+        assert_eq!(bus.get_alloc_size(passed_event_desc), Some(8));
+        assert_eq!(bus.get_alloc_size(passed_reply_desc), Some(8));
         assert_ne!(
             passed_event_desc, event_record_ptr,
             "handler must receive an AppleEvent AEDesc, not the source EventRecord"
@@ -30274,6 +30322,15 @@ mod tests {
             .ae_call_state
             .clone()
             .expect("expected in-flight AE call state");
+        let (event_desc, reply_desc) = state
+            .owned_descriptors
+            .expect("AEProcessAppleEvent owns its callback descriptors");
+        let event_handle = bus.read_long(event_desc + 4);
+        let event_data = bus.read_long(event_handle);
+        assert_eq!(bus.get_alloc_size(event_desc), Some(8));
+        assert_eq!(bus.get_alloc_size(reply_desc), Some(8));
+        assert_eq!(bus.get_alloc_size(event_handle), Some(4));
+        assert_eq!(bus.get_alloc_size(event_data), Some(8));
         assert_eq!(state.return_pc, return_pc);
         assert_eq!(state.expected_sp_after_rtd, sp + 4);
     }
@@ -30519,10 +30576,15 @@ mod tests {
         let handler_refcon = 0x0000_0FA2u32;
         let event_desc = 0x0030_0000u32;
         let reply_desc = 0x0030_0100u32;
+        let outer_event_desc = disp.new_process_classic_ptr(&mut bus, 8);
+        let outer_reply_desc = disp.new_process_classic_ptr(&mut bus, 8);
+        super::write_null_aedesc(&mut bus, outer_event_desc);
+        super::write_null_aedesc(&mut bus, outer_reply_desc);
         let outer_state = crate::trap::dispatch::AeCallState {
             return_pc: 0x00F0_9999,
             expected_sp_after_rtd: 0x0010_0100,
             result_override: None,
+            owned_descriptors: Some((outer_event_desc, outer_reply_desc)),
             resolve_state: None,
         };
 
@@ -30578,7 +30640,18 @@ mod tests {
             restored.expected_sp_after_rtd,
             outer_state.expected_sp_after_rtd
         );
+        assert_eq!(bus.get_alloc_size(outer_event_desc), Some(8));
+        assert_eq!(bus.get_alloc_size(outer_reply_desc), Some(8));
         assert!(disp.ae_call_state_stack.is_empty());
+
+        bus.write_word(outer_state.expected_sp_after_rtd, 0);
+        cpu.write_reg(Register::A7, outer_state.expected_sp_after_rtd);
+        cpu.write_reg(Register::D0, 0xFEFE);
+        let outer_trampoline = disp.dispatch_toolbox(true, 0x016, &mut cpu, &mut bus);
+        assert!(outer_trampoline.unwrap().is_ok());
+        assert_eq!(bus.get_alloc_size(outer_event_desc), None);
+        assert_eq!(bus.get_alloc_size(outer_reply_desc), None);
+        assert!(disp.ae_call_state.is_none());
     }
 
     #[test]
@@ -31363,6 +31436,16 @@ mod tests {
             .clone()
             .expect("expected in-flight AE call state");
 
+        let (event_desc, reply_desc) = state
+            .owned_descriptors
+            .expect("AEProcessAppleEvent owns its callback descriptors");
+        let event_handle = bus.read_long(event_desc + 4);
+        let event_data = bus.read_long(event_handle);
+        assert_eq!(bus.get_alloc_size(event_desc), Some(8));
+        assert_eq!(bus.get_alloc_size(reply_desc), Some(8));
+        assert_eq!(bus.get_alloc_size(event_handle), Some(4));
+        assert_eq!(bus.get_alloc_size(event_data), Some(8));
+
         // Simulate handler writing function result then returning through
         // trampoline (`MOVE.W #$FEFE, D0; _Pack8`).
         bus.write_word(state.expected_sp_after_rtd, handler_result);
@@ -31379,6 +31462,54 @@ mod tests {
             cpu.read_reg(Register::D0),
             handler_result as i16 as i32 as u32
         );
+        assert!(disp.ae_call_state.is_none());
+        assert_eq!(bus.get_alloc_size(event_desc), None);
+        assert_eq!(bus.get_alloc_size(reply_desc), None);
+        assert_eq!(bus.get_alloc_size(event_handle), None);
+        assert_eq!(bus.get_alloc_size(event_data), None);
+        assert!(!disp.ae_events.contains_key(&event_desc));
+        assert!(!disp.ae_descriptors.contains_key(&event_desc));
+    }
+
+    #[test]
+    fn pack8_aeprocessappleevent_callback_allocation_failure_is_atomic() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let sp = TEST_SP;
+        let event_class = u32::from_be_bytes(*b"aevt");
+        let event_id = u32::from_be_bytes(*b"oapp");
+
+        cpu.write_reg(Register::D0, 0x091F);
+        bus.write_word(sp, 0);
+        bus.write_long(sp + 2, 0x1111_2222);
+        bus.write_long(sp + 6, 0x0040_9000);
+        bus.write_long(sp + 10, event_id);
+        bus.write_long(sp + 14, event_class);
+        bus.write_word(sp + 18, 0);
+        assert!(disp
+            .dispatch_toolbox(true, 0x016, &mut cpu, &mut bus)
+            .unwrap()
+            .is_ok());
+
+        disp.ae_trampoline_addr = Some(0x0012_3456);
+        let heap_limit = bus.application_memory_limit();
+        let transient_descriptor = heap_limit - 12;
+        bus.reserve_heap_until(transient_descriptor);
+        cpu.write_reg(Register::A7, sp);
+        cpu.write_reg(Register::PC, 0x00f0_5678);
+        cpu.write_reg(Register::D0, 0x021B);
+        bus.write_long(sp, 0x0032_1000);
+        bus.write_word(sp + 4, 0);
+        assert!(disp
+            .dispatch_toolbox(true, 0x016, &mut cpu, &mut bus)
+            .unwrap()
+            .is_ok());
+
+        assert_eq!(cpu.read_reg(Register::A7), sp + 4);
+        assert_eq!(cpu.read_reg(Register::D0), -108i32 as u32);
+        assert_eq!(bus.read_word(sp + 4), (-108i16) as u16);
+        assert_eq!(bus.get_alloc_size(transient_descriptor), None);
+        assert!(disp.ae_events.is_empty());
+        assert!(disp.ae_descriptors.is_empty());
         assert!(disp.ae_call_state.is_none());
     }
 


### PR DESCRIPTION
## Summary

- own AppleEvent handler registration in the Macintosh process instead of separate 68K and PowerPC tables
- preserve application-before-system and exact/wildcard dispatch semantics
- dispatch handlers across ISA boundaries through the process Mixed Mode continuation stack
- keep callback descriptor allocation and cleanup process-owned and transactional

## Evidence

- `cargo test --locked --lib` (4,717 passed; 0 failed; 3 ignored)
- `RUSTDOCFLAGS="-D warnings -D rustdoc::private_intra_doc_links" cargo doc --all-features --locked --no-deps --document-private-items`
- `cargo test --locked --test toolbox_showcase`
- `SYSTEMLESS_PREFER_POWERPC=1 cargo test --locked --test toolbox_showcase`

Follow-up toward #1076; the issue remains open until the complete process/runtime unification criteria are satisfied.