### PR TITLE
refactor(memory): unify process memory management

### DIFF
--- a/src/loader/ppc.rs
+++ b/src/loader/ppc.rs
@@ -9890,6 +9890,21 @@ impl PpcLoadedApp {
         self.list_manager = list_manager;
         self.event_queue = event_queue;
         self.draw_sprocket = draw_sprocket;
+        ppc_synchronize_process_native_allocator(
+            process_memory_manager,
+            heap_cursor,
+            heap_limit,
+            last_mem_error,
+            &ptrs,
+            &free_ptr_blocks,
+            &free_handle_blocks,
+        );
+        ppc_synchronize_process_native_handles(
+            process_memory_manager,
+            &handles,
+            &handle_states,
+        );
+
         if trace_recent_on_halt && !matches!(result, PpcRunResult::CycleLimit { .. }) {
             let indirect = self.cpu.gpr[12];
             eprintln!(

--- a/src/loader/ppc.rs
+++ b/src/loader/ppc.rs
@@ -4989,7 +4989,9 @@ impl Drop for PpcTestHandles {
             .map(|record| {
                 (
                     *record,
-                    memory_manager.state_for_handle(record.handle).unwrap_or(0x40),
+                    memory_manager
+                        .state_for_handle(record.handle)
+                        .unwrap_or(0x40),
                 )
             })
             .collect();
@@ -5526,10 +5528,7 @@ impl PpcLoadedApp {
     }
 
     pub(crate) fn prepare_shared_system_reservation(&mut self, base: u32, len: u32) -> bool {
-        if self
-            .memory
-            .has_readonly_allocation_exclusion(base, len)
-        {
+        if self.memory.has_readonly_allocation_exclusion(base, len) {
             return true;
         }
         let start = u64::from(base);
@@ -5540,11 +5539,7 @@ impl PpcLoadedApp {
             return false;
         }
 
-        fn ordinary_overlaps(
-            memory: &mut PpcSectionMem,
-            start: u64,
-            end: u64,
-        ) -> bool {
+        fn ordinary_overlaps(memory: &mut PpcSectionMem, start: u64, end: u64) -> bool {
             if start >= end {
                 return false;
             }
@@ -9899,11 +9894,7 @@ impl PpcLoadedApp {
             &free_ptr_blocks,
             &free_handle_blocks,
         );
-        ppc_synchronize_process_native_handles(
-            process_memory_manager,
-            &handles,
-            &handle_states,
-        );
+        ppc_synchronize_process_native_handles(process_memory_manager, &handles, &handle_states);
 
         if trace_recent_on_halt && !matches!(result, PpcRunResult::CycleLimit { .. }) {
             let indirect = self.cpu.gpr[12];
@@ -14280,8 +14271,8 @@ fn load_pef_application_with_config_and_optional_system_reservation(
     if let Some((base, len)) = system_reservation {
         let reservation_start = u64::from(base);
         let reservation_end = reservation_start + u64::from(len);
-        let overlaps_stack = reservation_start < u64::from(PPC_STACK_TOP)
-            && u64::from(stack_base) < reservation_end;
+        let overlaps_stack =
+            reservation_start < u64::from(PPC_STACK_TOP) && u64::from(stack_base) < reservation_end;
         if overlaps_stack || memory.ordinary_mapping_overlaps(base, len) {
             return Err(PpcLoadError::AddressOverflow);
         }
@@ -14356,11 +14347,14 @@ fn load_pef_application_with_config_and_optional_system_reservation(
         let saved_r4 = cpu.gpr[4];
         cpu.gpr[3] = PPC_MAIN_GDEVICE;
         cpu.gpr[4] = config.screen_depth;
+        let mut last_mem_error = PPC_NO_ERR;
         let result = ppc_set_depth(
             &cpu,
+            None,
             &mut memory,
             &mut heap_cursor,
             stack_base,
+            &mut last_mem_error,
             &mut handles,
             &mut gworlds,
             &mut toolbox_startup,
@@ -16414,9 +16408,8 @@ fn dispatcher_target_for_import(
             | "CopyPalette" | "CTab2Palette" | "DisposeGDevice" | "DisposePalette" | "Exp1to3"
             | "Exp1to6" | "GetCPixel" | "GetEntryUsage" | "GetItemIcon" | "GetItemStyle"
             | "ClosePicture" | "GetNewPalette" | "NewGDevice" | "NewPalette" | "OpenPicture"
-            | "PenPat" | "PlotIcon"
-            | "Palette2CTab" | "ScrollRect" | "SetEntryColor" | "SetEntryUsage" | "SetItemIcon"
-            | "SetItemStyle" | "SetStdCProcs" | "SetStdProcs",
+            | "PenPat" | "PlotIcon" | "Palette2CTab" | "ScrollRect" | "SetEntryColor"
+            | "SetEntryUsage" | "SetItemIcon" | "SetItemStyle" | "SetStdCProcs" | "SetStdProcs",
         ) => PpcImportDispatcherTarget::QuickDrawCompatibility,
         (
             "InterfaceLib",
@@ -16571,13 +16564,8 @@ fn ppc_synchronize_process_native_handles(
     }));
 }
 
-fn ppc_process_handle_state_bits(
-    handle_states: &[PpcHandleStateRecord],
-    handle: u32,
-) -> u8 {
-    let state = handle_states
-        .iter()
-        .find(|state| state.handle == handle);
+fn ppc_process_handle_state_bits(handle_states: &[PpcHandleStateRecord], handle: u32) -> u8 {
+    let state = handle_states.iter().find(|state| state.handle == handle);
     let mut bits = 0u8;
     if state.is_some_and(|state| state.locked) {
         bits |= 0x80;
@@ -16635,7 +16623,9 @@ fn ppc_dispose_process_native_handle(
         free_handle_blocks,
     );
     ppc_synchronize_process_native_handles(memory_manager, handles, handle_states);
-    let disposed = memory_manager.dispose_native_handle(memory, handle).is_some();
+    let disposed = memory_manager
+        .dispose_native_handle(memory, handle)
+        .is_some();
     ppc_apply_process_native_allocator(
         memory_manager,
         memory,
@@ -16661,10 +16651,7 @@ fn ppc_apply_process_native_handle(
     let Some(updated) = memory_manager.native_allocation(handle) else {
         return;
     };
-    if let Some(record) = handles
-        .iter_mut()
-        .find(|record| record.handle == handle)
-    {
+    if let Some(record) = handles.iter_mut().find(|record| record.handle == handle) {
         *record = updated;
     } else {
         handles.push(updated);
@@ -16928,11 +16915,8 @@ fn dispatch_supported_import(
                 free_ptr_blocks,
                 free_handle_blocks,
             );
-            *last_mem_error = process_memory_manager.set_native_ptr_size(
-                memory,
-                cpu.gpr[3],
-                cpu.gpr[4],
-            );
+            *last_mem_error =
+                process_memory_manager.set_native_ptr_size(memory, cpu.gpr[3], cpu.gpr[4]);
             ppc_apply_process_native_allocator(
                 process_memory_manager,
                 memory,
@@ -16994,8 +16978,7 @@ fn dispatch_supported_import(
                     handles,
                     handle_states,
                 );
-                let handle =
-                    process_memory_manager.copy_bytes_to_new_native_handle(memory, &bytes);
+                let handle = process_memory_manager.copy_bytes_to_new_native_handle(memory, &bytes);
                 ppc_apply_process_native_allocator(
                     process_memory_manager,
                     memory,
@@ -17045,7 +17028,8 @@ fn dispatch_supported_import(
                         .copied()
                         .or_else(|| ppc_system_handle_record(memory, source_handle))
                     {
-                        if let Some(bytes) = ppc_memory_read_bytes(memory, source.ptr, source.size) {
+                        if let Some(bytes) = ppc_memory_read_bytes(memory, source.ptr, source.size)
+                        {
                             ppc_synchronize_process_native_allocator(
                                 process_memory_manager,
                                 *heap_cursor,
@@ -17060,8 +17044,8 @@ fn dispatch_supported_import(
                                 handles,
                                 handle_states,
                             );
-                            let copy =
-                                process_memory_manager.copy_bytes_to_new_native_handle(memory, &bytes);
+                            let copy = process_memory_manager
+                                .copy_bytes_to_new_native_handle(memory, &bytes);
                             ppc_apply_process_native_allocator(
                                 process_memory_manager,
                                 memory,
@@ -17169,11 +17153,7 @@ fn dispatch_supported_import(
                 free_ptr_blocks,
                 free_handle_blocks,
             );
-            ppc_synchronize_process_native_handles(
-                process_memory_manager,
-                handles,
-                handle_states,
-            );
+            ppc_synchronize_process_native_handles(process_memory_manager, handles, handle_states);
             let handle = process_memory_manager.new_native_handle(memory, size, clear);
             ppc_apply_process_native_allocator(
                 process_memory_manager,
@@ -17211,11 +17191,7 @@ fn dispatch_supported_import(
                 free_ptr_blocks,
                 free_handle_blocks,
             );
-            ppc_synchronize_process_native_handles(
-                process_memory_manager,
-                handles,
-                handle_states,
-            );
+            ppc_synchronize_process_native_handles(process_memory_manager, handles, handle_states);
             let handle = process_memory_manager.new_native_handle(memory, cpu.gpr[3], false);
             ppc_apply_process_native_allocator(
                 process_memory_manager,
@@ -17283,11 +17259,7 @@ fn dispatch_supported_import(
                 free_ptr_blocks,
                 free_handle_blocks,
             );
-            ppc_synchronize_process_native_handles(
-                process_memory_manager,
-                handles,
-                handle_states,
-            );
+            ppc_synchronize_process_native_handles(process_memory_manager, handles, handle_states);
             *last_mem_error = process_memory_manager.empty_native_handle(memory, handle);
             ppc_apply_process_native_allocator(
                 process_memory_manager,
@@ -17298,12 +17270,7 @@ fn dispatch_supported_import(
                 free_ptr_blocks,
                 free_handle_blocks,
             );
-            ppc_apply_process_native_handle(
-                process_memory_manager,
-                handles,
-                handle_states,
-                handle,
-            );
+            ppc_apply_process_native_handle(process_memory_manager, handles, handle_states, handle);
             Some(PpcImportAction::ReturnPreserve)
         }
         PpcImportDispatcherTarget::HLock => {
@@ -17476,13 +17443,8 @@ fn dispatch_supported_import(
                 free_ptr_blocks,
                 free_handle_blocks,
             );
-            ppc_synchronize_process_native_handles(
-                process_memory_manager,
-                handles,
-                handle_states,
-            );
-            *last_mem_error =
-                process_memory_manager.set_native_handle_size(memory, handle, size);
+            ppc_synchronize_process_native_handles(process_memory_manager, handles, handle_states);
+            *last_mem_error = process_memory_manager.set_native_handle_size(memory, handle, size);
             ppc_apply_process_native_allocator(
                 process_memory_manager,
                 memory,
@@ -17493,10 +17455,7 @@ fn dispatch_supported_import(
                 free_handle_blocks,
             );
             if let Some(updated) = process_memory_manager.native_allocation(handle) {
-                if let Some(record) = handles
-                    .iter_mut()
-                    .find(|record| record.handle == handle)
-                {
+                if let Some(record) = handles.iter_mut().find(|record| record.handle == handle) {
                     *record = updated;
                 }
             }
@@ -19311,12 +19270,12 @@ fn dispatch_supported_import(
         PpcImportDispatcherTarget::FixRound => Some(PpcImportAction::Return(ppc_i16_result(
             ppc_fix_round(cpu.gpr[3] as i32),
         ))),
-        PpcImportDispatcherTarget::Fix2Frac => Some(PpcImportAction::Return(
-            ppc_fix_to_frac(cpu.gpr[3] as i32) as u32,
-        )),
-        PpcImportDispatcherTarget::Frac2Fix => Some(PpcImportAction::Return(
-            ppc_frac_to_fix(cpu.gpr[3] as i32) as u32,
-        )),
+        PpcImportDispatcherTarget::Fix2Frac => Some(PpcImportAction::Return(ppc_fix_to_frac(
+            cpu.gpr[3] as i32,
+        ) as u32)),
+        PpcImportDispatcherTarget::Frac2Fix => Some(PpcImportAction::Return(ppc_frac_to_fix(
+            cpu.gpr[3] as i32,
+        ) as u32)),
         PpcImportDispatcherTarget::Frac2X => {
             let frac = cpu.gpr[3] as i32;
             cpu.fpr[1] = (f64::from(frac) / 1_073_741_824.0).to_bits();
@@ -20215,8 +20174,16 @@ fn dispatch_supported_import(
         }
         PpcImportDispatcherTarget::NewCWindow => {
             let previous_front = ppc_front_visible_window(memory, gworlds);
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
             let window = ppc_new_window_from_cpu(
                 cpu,
+                Some(&mut allocator),
                 memory,
                 heap_cursor,
                 heap_limit,
@@ -20263,11 +20230,16 @@ fn dispatch_supported_import(
             let previous_front = ppc_front_visible_window(memory, gworlds);
             let window = ppc_get_new_cwindow(
                 cpu,
+                process_memory_manager,
                 memory,
                 heap_cursor,
                 heap_limit,
                 last_mem_error,
+                ptrs,
+                free_ptr_blocks,
                 handles,
+                free_handle_blocks,
+                handle_states,
                 gworlds,
                 *current_gdevice,
                 vfs_resources,
@@ -20330,24 +20302,12 @@ fn dispatch_supported_import(
         }
         PpcImportDispatcherTarget::SizeWindow => {
             let _ = ppc_size_window(cpu, memory, gworlds);
-            ppc_recalculate_window_vis_regions(
-                memory,
-                gworlds,
-                heap_cursor,
-                heap_limit,
-                handles,
-            );
+            ppc_recalculate_window_vis_regions(memory, gworlds, heap_cursor, heap_limit, handles);
             Some(PpcImportAction::ReturnPreserve)
         }
         PpcImportDispatcherTarget::MoveWindow => {
             let _ = ppc_move_window(cpu, memory, gworlds);
-            ppc_recalculate_window_vis_regions(
-                memory,
-                gworlds,
-                heap_cursor,
-                heap_limit,
-                handles,
-            );
+            ppc_recalculate_window_vis_regions(memory, gworlds, heap_cursor, heap_limit, handles);
             Some(PpcImportAction::ReturnPreserve)
         }
         PpcImportDispatcherTarget::ShowWindow => {
@@ -20355,13 +20315,7 @@ fn dispatch_supported_import(
             let previous_front = ppc_front_visible_window(memory, gworlds);
             let was_visible = ppc_window_is_visible(memory, window);
             let _ = ppc_set_window_visible(memory, window, true);
-            ppc_recalculate_window_vis_regions(
-                memory,
-                gworlds,
-                heap_cursor,
-                heap_limit,
-                handles,
-            );
+            ppc_recalculate_window_vis_regions(memory, gworlds, heap_cursor, heap_limit, handles);
             ppc_transition_front_window_chrome(
                 memory,
                 gworlds,
@@ -20404,13 +20358,7 @@ fn dispatch_supported_import(
             let previous_front = ppc_front_visible_window(memory, gworlds);
             let _ = ppc_set_window_visible(memory, window, false);
             let _ = ppc_set_window_hilited(memory, window, false);
-            ppc_recalculate_window_vis_regions(
-                memory,
-                gworlds,
-                heap_cursor,
-                heap_limit,
-                handles,
-            );
+            ppc_recalculate_window_vis_regions(memory, gworlds, heap_cursor, heap_limit, handles);
             let next_front = ppc_front_visible_window(memory, gworlds);
             ppc_transition_front_window_chrome(
                 memory,
@@ -20444,13 +20392,7 @@ fn dispatch_supported_import(
             let previous_front = ppc_front_visible_window(memory, gworlds);
             let was_visible = ppc_window_is_visible(memory, window);
             let _ = ppc_set_window_visible(memory, window, visible);
-            ppc_recalculate_window_vis_regions(
-                memory,
-                gworlds,
-                heap_cursor,
-                heap_limit,
-                handles,
-            );
+            ppc_recalculate_window_vis_regions(memory, gworlds, heap_cursor, heap_limit, handles);
             ppc_transition_front_window_chrome(
                 memory,
                 gworlds,
@@ -21019,11 +20961,20 @@ fn dispatch_supported_import(
             Some(PpcImportAction::Return(ppc_has_depth(cpu, memory)))
         }
         PpcImportDispatcherTarget::SetDepth => {
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
             Some(PpcImportAction::Return(ppc_i16_result(ppc_set_depth(
                 cpu,
+                Some(&mut allocator),
                 memory,
                 heap_cursor,
                 heap_limit,
+                last_mem_error,
                 handles,
                 gworlds,
                 toolbox_startup,
@@ -21072,11 +21023,7 @@ fn dispatch_supported_import(
                 free_ptr_blocks,
                 free_handle_blocks,
             );
-            ppc_synchronize_process_native_handles(
-                process_memory_manager,
-                handles,
-                handle_states,
-            );
+            ppc_synchronize_process_native_handles(process_memory_manager, handles, handle_states);
             let result = ppc_new_gworld(
                 cpu,
                 process_memory_manager,
@@ -21109,11 +21056,7 @@ fn dispatch_supported_import(
                 free_ptr_blocks,
                 free_handle_blocks,
             );
-            ppc_synchronize_process_native_handles(
-                process_memory_manager,
-                handles,
-                handle_states,
-            );
+            ppc_synchronize_process_native_handles(process_memory_manager, handles, handle_states);
             let result = ppc_update_gworld(
                 cpu,
                 process_memory_manager,
@@ -21337,11 +21280,20 @@ fn dispatch_supported_import(
             Some(PpcImportAction::Return(ppc_next_ct_seed(toolbox_startup)))
         }
         PpcImportDispatcherTarget::MakeITable => {
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
             ppc_make_itable(
                 cpu,
+                Some(&mut allocator),
                 memory,
                 heap_cursor,
                 heap_limit,
+                last_mem_error,
                 handles,
                 *current_gdevice,
                 color_manager_clut,
@@ -21540,8 +21492,16 @@ fn dispatch_supported_import(
             )))
         }
         PpcImportDispatcherTarget::OpenPort => {
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
             if ppc_open_port(
                 cpu,
+                &mut allocator,
                 memory,
                 heap_cursor,
                 heap_limit,
@@ -21562,8 +21522,16 @@ fn dispatch_supported_import(
             Some(PpcImportAction::ReturnPreserve)
         }
         PpcImportDispatcherTarget::OpenCPort => {
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
             if ppc_open_cport(
                 cpu,
+                &mut allocator,
                 memory,
                 heap_cursor,
                 heap_limit,
@@ -22202,11 +22170,20 @@ fn dispatch_supported_import(
             // Inside Macintosh: More Macintosh Toolbox (1993), pp. 2-38--2-40:
             // return the first matching flavor, resize the destination handle,
             // and report its offset in the ordered desktop scrap.
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
             Some(PpcImportAction::Return(ppc_get_scrap(
                 cpu,
+                Some(&mut allocator),
                 memory,
                 heap_cursor,
                 heap_limit,
+                last_mem_error,
                 handles,
                 scrap,
             )))
@@ -22545,6 +22522,9 @@ fn dispatch_supported_import(
                 heap_limit,
                 last_mem_error,
                 handles,
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
                 gworlds,
                 *current_gdevice,
             );
@@ -22592,6 +22572,9 @@ fn dispatch_supported_import(
                 heap_limit,
                 last_mem_error,
                 handles,
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
                 gworlds,
                 *current_gdevice,
             );
@@ -22675,14 +22658,22 @@ fn dispatch_supported_import(
                     decode_mac_roman(&text)
                 );
             }
-            *last_mem_error = ppc_set_handle_size(
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
+            let result = allocator.resize_handle(
                 memory,
                 heap_cursor,
-                heap_limit,
+                last_mem_error,
                 handles,
                 item_handle,
                 text.len() as u32,
             );
+            *last_mem_error = result;
             if *last_mem_error == PPC_NO_ERR {
                 if let Some(ptr) = memory.read_u32_be(item_handle) {
                     for (offset, byte) in text.iter().copied().enumerate() {
@@ -22787,11 +22778,16 @@ fn dispatch_supported_import(
         }
         PpcImportDispatcherTarget::ModalDialog => Some(ppc_modal_dialog(
             cpu,
+            process_memory_manager,
             memory,
             heap_cursor,
             heap_limit,
             last_mem_error,
+            ptrs,
+            free_ptr_blocks,
             handles,
+            free_handle_blocks,
+            handle_states,
             controls,
             gworlds,
             current_gworld,
@@ -22806,8 +22802,16 @@ fn dispatch_supported_import(
             *current_resource_refnum,
         )),
         PpcImportDispatcherTarget::SetControlTitle => {
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
             ppc_set_control_title(
                 cpu,
+                Some(&mut allocator),
                 memory,
                 heap_cursor,
                 heap_limit,
@@ -22969,10 +22973,19 @@ fn dispatch_supported_import(
                 binding.dispatcher_target,
                 PpcImportDispatcherTarget::TEStyleNew
             );
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
             let te_handle = ppc_te_initialize_record(
+                Some(&mut allocator),
                 memory,
                 heap_cursor,
                 heap_limit,
+                last_mem_error,
                 handles,
                 cpu.gpr[3],
                 cpu.gpr[4],
@@ -23003,7 +23016,23 @@ fn dispatch_supported_import(
         PpcImportDispatcherTarget::TEDispose => {
             // Inside Macintosh: Text (1993), p. 2-79: dispose the TERec, its
             // text handle, and every auxiliary handle owned by a styled TERec.
-            ppc_te_dispose(memory, handles, handle_states, cpu.gpr[3]);
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
+            ppc_te_dispose(
+                Some(&mut allocator),
+                None,
+                memory,
+                heap_cursor,
+                heap_limit,
+                last_mem_error,
+                handles,
+                cpu.gpr[3],
+            );
             Some(PpcImportAction::ReturnPreserve)
         }
         PpcImportDispatcherTarget::TEActivate { active } => {
@@ -23039,13 +23068,44 @@ fn dispatch_supported_import(
             // hText, resize it, recalculate lineStarts, and place the insertion
             // point after the copied text.
             let bytes = ppc_memory_read_bytes(memory, cpu.gpr[3], cpu.gpr[4]).unwrap_or_default();
-            *last_mem_error =
-                ppc_te_set_text(memory, heap_cursor, heap_limit, handles, cpu.gpr[5], &bytes);
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
+            let result = ppc_te_set_text(
+                Some(&mut allocator),
+                memory,
+                heap_cursor,
+                heap_limit,
+                last_mem_error,
+                handles,
+                cpu.gpr[5],
+                &bytes,
+            );
+            *last_mem_error = result;
             Some(PpcImportAction::ReturnPreserve)
         }
         PpcImportDispatcherTarget::TECalText => {
-            *last_mem_error =
-                ppc_te_recalculate_layout(memory, heap_cursor, heap_limit, handles, cpu.gpr[3]);
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
+            let result = ppc_te_recalculate_layout(
+                Some(&mut allocator),
+                memory,
+                heap_cursor,
+                heap_limit,
+                last_mem_error,
+                handles,
+                cpu.gpr[3],
+            );
+            *last_mem_error = result;
             Some(PpcImportAction::ReturnPreserve)
         }
         PpcImportDispatcherTarget::TEInsert { styled } => {
@@ -23054,14 +23114,24 @@ fn dispatch_supported_import(
             // precedes the final TEHandle argument in the native ABI.
             let te_handle = if styled { cpu.gpr[6] } else { cpu.gpr[5] };
             let bytes = ppc_memory_read_bytes(memory, cpu.gpr[3], cpu.gpr[4]).unwrap_or_default();
-            *last_mem_error = ppc_te_replace_selection(
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
+            let result = ppc_te_replace_selection(
+                Some(&mut allocator),
                 memory,
                 heap_cursor,
                 heap_limit,
+                last_mem_error,
                 handles,
                 te_handle,
                 &bytes,
             );
+            *last_mem_error = result;
             ppc_te_draw(
                 memory,
                 handles,
@@ -23076,8 +23146,24 @@ fn dispatch_supported_import(
         PpcImportDispatcherTarget::TEDelete => {
             // Text (1993), p. 2-58: deleting is selection replacement with an
             // empty byte sequence and does not alter either scrap.
-            *last_mem_error =
-                ppc_te_replace_selection(memory, heap_cursor, heap_limit, handles, cpu.gpr[3], &[]);
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
+            let result = ppc_te_replace_selection(
+                Some(&mut allocator),
+                memory,
+                heap_cursor,
+                heap_limit,
+                last_mem_error,
+                handles,
+                cpu.gpr[3],
+                &[],
+            );
+            *last_mem_error = result;
             ppc_te_draw(
                 memory,
                 handles,
@@ -23093,14 +23179,24 @@ fn dispatch_supported_import(
             // Inside Macintosh: Text (1993), pp. 2-81--2-82: TEKey replaces
             // the selection, with Backspace deleting either that selection or
             // the preceding character, and moves the insertion point.
-            *last_mem_error = ppc_te_key(
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
+            let result = ppc_te_key(
+                Some(&mut allocator),
                 memory,
                 heap_cursor,
                 heap_limit,
+                last_mem_error,
                 handles,
                 cpu.gpr[4],
                 cpu.gpr[3] as u8,
             );
+            *last_mem_error = result;
             ppc_te_draw(
                 memory,
                 handles,
@@ -23257,15 +23353,25 @@ fn dispatch_supported_import(
             } else {
                 cpu.gpr[3]
             };
-            *last_mem_error = ppc_te_copy_or_cut(
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
+            let result = ppc_te_copy_or_cut(
+                Some(&mut allocator),
                 memory,
                 heap_cursor,
                 heap_limit,
+                last_mem_error,
                 handles,
                 scrap,
                 te_handle,
                 cut,
             );
+            *last_mem_error = result;
             ppc_te_draw(
                 memory,
                 handles,
@@ -23286,14 +23392,24 @@ fn dispatch_supported_import(
                 cpu.gpr[3]
             };
             let bytes = ppc_te_scrap_bytes(memory, handles, scrap);
-            *last_mem_error = ppc_te_replace_selection(
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
+            let result = ppc_te_replace_selection(
+                Some(&mut allocator),
                 memory,
                 heap_cursor,
                 heap_limit,
+                last_mem_error,
                 handles,
                 te_handle,
                 &bytes,
             );
+            *last_mem_error = result;
             ppc_te_draw(
                 memory,
                 handles,
@@ -23316,7 +23432,23 @@ fn dispatch_supported_import(
                     .find(|(flavor, _)| *flavor == u32::from_be_bytes(*b"TEXT"))
                     .map(|(_, bytes)| bytes.clone());
                 if let Some(bytes) = bytes {
-                    ppc_te_set_scrap_bytes(memory, heap_cursor, heap_limit, handles, scrap, &bytes)
+                    let mut allocator = PpcProcessAllocatorView {
+                        memory_manager: process_memory_manager,
+                        ptrs: Some(ptrs),
+                        free_ptr_blocks,
+                        free_handle_blocks,
+                        handle_states,
+                    };
+                    ppc_te_set_scrap_bytes(
+                        Some(&mut allocator),
+                        memory,
+                        heap_cursor,
+                        heap_limit,
+                        last_mem_error,
+                        handles,
+                        scrap,
+                        &bytes,
+                    )
                 } else {
                     PPC_NO_TYPE_ERR
                 }
@@ -23331,7 +23463,22 @@ fn dispatch_supported_import(
             Some(PpcImportAction::Return(ppc_i16_result(result)))
         }
         PpcImportDispatcherTarget::TEScrapHandle => {
-            let handle = ppc_te_scrap_handle(memory, heap_cursor, heap_limit, handles, scrap);
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
+            let handle = ppc_te_scrap_handle(
+                Some(&mut allocator),
+                memory,
+                heap_cursor,
+                heap_limit,
+                last_mem_error,
+                handles,
+                scrap,
+            );
             *last_mem_error = if handle == 0 {
                 PPC_MEM_FULL_ERR
             } else {
@@ -23348,10 +23495,19 @@ fn dispatch_supported_import(
                 } else {
                     let mut resized = existing;
                     resized.resize((requested as usize).min(i16::MAX as usize), 0);
+                    let mut allocator = PpcProcessAllocatorView {
+                        memory_manager: process_memory_manager,
+                        ptrs: Some(ptrs),
+                        free_ptr_blocks,
+                        free_handle_blocks,
+                        handle_states,
+                    };
                     ppc_te_set_scrap_bytes(
+                        Some(&mut allocator),
                         memory,
                         heap_cursor,
                         heap_limit,
+                        last_mem_error,
                         handles,
                         scrap,
                         &resized,
@@ -23368,12 +23524,21 @@ fn dispatch_supported_import(
             }
         }
         PpcImportDispatcherTarget::SelectDialogItemText => {
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
             ppc_select_dialog_item_text(
+                Some(&mut allocator),
+                None,
                 memory,
                 heap_cursor,
                 heap_limit,
+                last_mem_error,
                 handles,
-                handle_states,
                 cpu.gpr[3],
                 cpu.gpr[4] as u16 as usize,
                 cpu.gpr[5] as u16,
@@ -23429,7 +23594,23 @@ fn dispatch_supported_import(
             // Inside Macintosh: More Macintosh Toolbox (1993), pp. 4-70--4-72:
             // construct the public ListRec, cell-data handle, bounds, default
             // cell dimensions, and variable cell-offset array.
-            let list = ppc_list_new(cpu, memory, heap_cursor, heap_limit, handles, list_manager);
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
+            let list = ppc_list_new(
+                cpu,
+                Some(&mut allocator),
+                memory,
+                heap_cursor,
+                heap_limit,
+                last_mem_error,
+                handles,
+                list_manager,
+            );
             *last_mem_error = if list == 0 {
                 PPC_MEM_FULL_ERR
             } else {
@@ -23453,8 +23634,29 @@ fn dispatch_supported_import(
                 .position(|record| record.handle == cpu.gpr[3])
             {
                 let record = list_manager.lists.remove(index);
-                ppc_dispose_tracked_handle(record.cells_handle, memory, handles, handle_states);
-                ppc_dispose_tracked_handle(record.handle, memory, handles, handle_states);
+                let mut allocator = PpcProcessAllocatorView {
+                    memory_manager: process_memory_manager,
+                    ptrs: Some(ptrs),
+                    free_ptr_blocks,
+                    free_handle_blocks,
+                    handle_states,
+                };
+                let _ = allocator.dispose_handle(
+                    memory,
+                    heap_cursor,
+                    heap_limit,
+                    last_mem_error,
+                    handles,
+                    record.cells_handle,
+                );
+                let _ = allocator.dispose_handle(
+                    memory,
+                    heap_cursor,
+                    heap_limit,
+                    last_mem_error,
+                    handles,
+                    record.handle,
+                );
             }
             Some(PpcImportAction::ReturnPreserve)
         }
@@ -23485,13 +23687,23 @@ fn dispatch_supported_import(
                         std::iter::repeat_n(false, added_cells),
                     );
                     record.data_bounds.2 = record.data_bounds.2.saturating_add(count);
-                    *last_mem_error = ppc_list_sync_guest_storage(
+                    let mut allocator = PpcProcessAllocatorView {
+                        memory_manager: process_memory_manager,
+                        ptrs: Some(ptrs),
+                        free_ptr_blocks,
+                        free_handle_blocks,
+                        handle_states,
+                    };
+                    let result = ppc_list_sync_guest_storage(
+                        Some(&mut allocator),
                         memory,
                         heap_cursor,
                         heap_limit,
+                        last_mem_error,
                         handles,
                         record,
                     );
+                    *last_mem_error = result;
                     if record.draw_enabled {
                         ppc_list_draw(memory, gworlds, record);
                     }
@@ -23530,13 +23742,23 @@ fn dispatch_supported_import(
                         .data_bounds
                         .2
                         .saturating_sub(delete_rows.min(i16::MAX as usize) as i16);
-                    *last_mem_error = ppc_list_sync_guest_storage(
+                    let mut allocator = PpcProcessAllocatorView {
+                        memory_manager: process_memory_manager,
+                        ptrs: Some(ptrs),
+                        free_ptr_blocks,
+                        free_handle_blocks,
+                        handle_states,
+                    };
+                    let result = ppc_list_sync_guest_storage(
+                        Some(&mut allocator),
                         memory,
                         heap_cursor,
                         heap_limit,
+                        last_mem_error,
                         handles,
                         record,
                     );
+                    *last_mem_error = result;
                     if record.draw_enabled {
                         ppc_list_draw(memory, gworlds, record);
                     }
@@ -23588,13 +23810,23 @@ fn dispatch_supported_import(
             {
                 if let Some(index) = ppc_list_cell_index(record, v, h) {
                     record.selected[index] = cpu.gpr[3] != 0;
-                    *last_mem_error = ppc_list_sync_guest_storage(
+                    let mut allocator = PpcProcessAllocatorView {
+                        memory_manager: process_memory_manager,
+                        ptrs: Some(ptrs),
+                        free_ptr_blocks,
+                        free_handle_blocks,
+                        handle_states,
+                    };
+                    let result = ppc_list_sync_guest_storage(
+                        Some(&mut allocator),
                         memory,
                         heap_cursor,
                         heap_limit,
+                        last_mem_error,
                         handles,
                         record,
                     );
+                    *last_mem_error = result;
                     if record.draw_enabled {
                         ppc_list_draw(memory, gworlds, record);
                     }
@@ -23616,13 +23848,23 @@ fn dispatch_supported_import(
             ) {
                 if let Some(index) = ppc_list_cell_index(record, v, h) {
                     record.cells[index] = bytes;
-                    *last_mem_error = ppc_list_sync_guest_storage(
+                    let mut allocator = PpcProcessAllocatorView {
+                        memory_manager: process_memory_manager,
+                        ptrs: Some(ptrs),
+                        free_ptr_blocks,
+                        free_handle_blocks,
+                        handle_states,
+                    };
+                    let result = ppc_list_sync_guest_storage(
+                        Some(&mut allocator),
                         memory,
                         heap_cursor,
                         heap_limit,
+                        last_mem_error,
                         handles,
                         record,
                     );
+                    *last_mem_error = result;
                     if record.draw_enabled {
                         ppc_list_draw(memory, gworlds, record);
                     }
@@ -23714,13 +23956,23 @@ fn dispatch_supported_import(
                             .write_u16_be(list_ptr + PPC_LIST_LAST_CLICK_OFFSET + 2, column as u16);
                         let _ =
                             memory.write_u32_be(list_ptr + PPC_LIST_CLICK_TIME_OFFSET, *tick_count);
-                        *last_mem_error = ppc_list_sync_guest_storage(
+                        let mut allocator = PpcProcessAllocatorView {
+                            memory_manager: process_memory_manager,
+                            ptrs: Some(ptrs),
+                            free_ptr_blocks,
+                            free_handle_blocks,
+                            handle_states,
+                        };
+                        let result = ppc_list_sync_guest_storage(
+                            Some(&mut allocator),
                             memory,
                             heap_cursor,
                             heap_limit,
+                            last_mem_error,
                             handles,
                             record,
                         );
+                        *last_mem_error = result;
                         if record.draw_enabled {
                             ppc_list_draw(memory, gworlds, record);
                         }
@@ -24306,10 +24558,7 @@ fn dispatch_supported_import(
         }
         PpcImportDispatcherTarget::StdCalloc => {
             let count = cpu.gpr[3];
-            let ptr = if let Some(size) = count
-                .checked_mul(cpu.gpr[4])
-                .filter(|size| *size != 0)
-            {
+            let ptr = if let Some(size) = count.checked_mul(cpu.gpr[4]).filter(|size| *size != 0) {
                 let preserved_mem_error = *last_mem_error;
                 ppc_synchronize_process_native_allocator(
                     process_memory_manager,
@@ -24348,8 +24597,7 @@ fn dispatch_supported_import(
                 free_ptr_blocks,
                 free_handle_blocks,
             );
-            let ptr =
-                process_memory_manager.reallocate_native_ptr(memory, cpu.gpr[3], cpu.gpr[4]);
+            let ptr = process_memory_manager.reallocate_native_ptr(memory, cpu.gpr[3], cpu.gpr[4]);
             process_memory_manager.set_native_mem_error(preserved_mem_error);
             ppc_apply_process_native_allocator(
                 process_memory_manager,
@@ -24407,7 +24655,10 @@ fn dispatch_supported_import(
             Some(PpcImportAction::Return(ppc_std_strlen(memory, cpu.gpr[3])))
         }
         PpcImportDispatcherTarget::StdMemchr => Some(PpcImportAction::Return(ppc_std_memchr(
-            memory, cpu.gpr[3], cpu.gpr[4] as u8, cpu.gpr[5],
+            memory,
+            cpu.gpr[3],
+            cpu.gpr[4] as u8,
+            cpu.gpr[5],
         ))),
         PpcImportDispatcherTarget::StdStrchr => Some(PpcImportAction::Return(ppc_std_strchr(
             memory,
@@ -24911,9 +25162,7 @@ fn dispatch_supported_import(
                 );
             }
             let mut dialog = gworlds.iter().rev().find_map(|record| {
-                (memory
-                    .read_u16_be(record.port + PPC_CWINDOW_WINDOW_KIND_OFFSET)
-                    == Some(2)
+                (memory.read_u16_be(record.port + PPC_CWINDOW_WINDOW_KIND_OFFSET) == Some(2)
                     && ppc_window_is_visible(memory, record.port)
                     && memory.read_u16_be(record.port + PPC_DIALOG_RESOURCE_ID_OFFSET)
                         == Some(alert_id as u16))
@@ -24943,8 +25192,7 @@ fn dispatch_supported_import(
                     return Some(PpcImportAction::Return(ppc_i16_result(-1)));
                 }
                 *current_gworld = created;
-                *current_gdevice =
-                    ppc_gworld_device(gworlds, created).unwrap_or(*current_gdevice);
+                *current_gdevice = ppc_gworld_device(gworlds, created).unwrap_or(*current_gdevice);
                 let _ = ppc_draw_dialog(
                     memory,
                     handles,
@@ -24964,11 +25212,16 @@ fn dispatch_supported_import(
             modal_cpu.gpr[4] = dialog + PPC_DIALOG_ALERT_HIT_HLE_OFFSET;
             let action = ppc_modal_dialog(
                 &mut modal_cpu,
+                process_memory_manager,
                 memory,
                 heap_cursor,
                 heap_limit,
                 last_mem_error,
+                ptrs,
+                free_ptr_blocks,
                 handles,
+                free_handle_blocks,
+                handle_states,
                 controls,
                 gworlds,
                 current_gworld,
@@ -24986,10 +25239,20 @@ fn dispatch_supported_import(
                 let hit = memory
                     .read_u16_be(dialog + PPC_DIALOG_ALERT_HIT_HLE_OFFSET)
                     .unwrap_or(1);
-                ppc_dispose_window(
-                    memory,
-                    handles,
+                let mut allocator = PpcProcessAllocatorView {
+                    memory_manager: process_memory_manager,
+                    ptrs: Some(ptrs),
+                    free_ptr_blocks,
                     free_handle_blocks,
+                    handle_states,
+                };
+                ppc_dispose_window(
+                    &mut allocator,
+                    memory,
+                    heap_cursor,
+                    heap_limit,
+                    last_mem_error,
+                    handles,
                     controls,
                     gworlds,
                     current_gworld,
@@ -27078,12 +27341,7 @@ fn dispatch_supported_import(
         )),
         PpcImportDispatcherTarget::ISpElementListNew => {
             Some(PpcImportAction::Return(ppc_i16_result(
-                ppc_isp_element_list_new(
-                    cpu,
-                    process_memory_manager,
-                    memory,
-                    heap_cursor,
-                ),
+                ppc_isp_element_list_new(cpu, process_memory_manager, memory, heap_cursor),
             )))
         }
         PpcImportDispatcherTarget::ISpElementListGetNextEvent => Some(PpcImportAction::Return(
@@ -27283,8 +27541,8 @@ fn dispatch_supported_import(
         PpcImportDispatcherTarget::CloseComponent => Some(PpcImportAction::Return(ppc_i16_result(
             ppc_close_component(cpu, quicktime),
         ))),
-        PpcImportDispatcherTarget::NewRoutineDescriptor => Some(PpcImportAction::Return(
-            ppc_new_routine_descriptor(
+        PpcImportDispatcherTarget::NewRoutineDescriptor => {
+            Some(PpcImportAction::Return(ppc_new_routine_descriptor(
                 cpu,
                 memory,
                 heap_cursor,
@@ -27292,10 +27550,10 @@ fn dispatch_supported_import(
                 ptrs,
                 free_ptr_blocks,
                 last_mem_error,
-            ),
-        )),
-        PpcImportDispatcherTarget::NewFatRoutineDescriptor => Some(PpcImportAction::Return(
-            ppc_new_fat_routine_descriptor(
+            )))
+        }
+        PpcImportDispatcherTarget::NewFatRoutineDescriptor => {
+            Some(PpcImportAction::Return(ppc_new_fat_routine_descriptor(
                 cpu,
                 memory,
                 heap_cursor,
@@ -27303,8 +27561,8 @@ fn dispatch_supported_import(
                 ptrs,
                 free_ptr_blocks,
                 last_mem_error,
-            ),
-        )),
+            )))
+        }
         PpcImportDispatcherTarget::DisposeRoutineDescriptor => {
             // DisposeRoutineDescriptor(theProcPtr: UniversalProcPtr): void.
             // PowerPC ABI: r3 carries the descriptor and is preserved on return.
@@ -27323,16 +27581,14 @@ fn dispatch_supported_import(
             toolbox_startup,
             GuestIsa::PowerPc,
         ),
-        PpcImportDispatcherTarget::CallOSTrapUniversalProc => {
-            ppc_call_os_trap_universal_proc(
-                cpu,
-                process_memory_manager,
-                memory,
-                heap_cursor,
-                heap_limit,
-                toolbox_startup,
-            )
-        }
+        PpcImportDispatcherTarget::CallOSTrapUniversalProc => ppc_call_os_trap_universal_proc(
+            cpu,
+            process_memory_manager,
+            memory,
+            heap_cursor,
+            heap_limit,
+            toolbox_startup,
+        ),
         PpcImportDispatcherTarget::NGetTrapAddress
         | PpcImportDispatcherTarget::GetToolTrapAddress
         | PpcImportDispatcherTarget::GetOSTrapAddress => {
@@ -27445,12 +27701,16 @@ fn dispatch_supported_import(
         PpcImportDispatcherTarget::LegacyControl => ppc_dispatch_legacy_control(
             binding,
             cpu,
+            process_memory_manager,
             memory,
             heap_cursor,
             heap_limit,
             last_mem_error,
+            ptrs,
+            free_ptr_blocks,
             handles,
             free_handle_blocks,
+            handle_states,
             controls,
             gworlds,
             screen_clut,
@@ -27461,12 +27721,16 @@ fn dispatch_supported_import(
         PpcImportDispatcherTarget::LegacyWindow => ppc_dispatch_legacy_window(
             binding,
             cpu,
+            process_memory_manager,
             memory,
             heap_cursor,
             heap_limit,
             last_mem_error,
+            ptrs,
+            free_ptr_blocks,
             handles,
             free_handle_blocks,
+            handle_states,
             controls,
             gworlds,
             current_gworld,
@@ -27504,11 +27768,16 @@ fn dispatch_supported_import(
         PpcImportDispatcherTarget::DialogCompatibility => Some(ppc_dispatch_dialog_compatibility(
             binding,
             cpu,
+            process_memory_manager,
             memory,
             heap_cursor,
             heap_limit,
             last_mem_error,
+            ptrs,
+            free_ptr_blocks,
             handles,
+            free_handle_blocks,
+            handle_states,
             controls,
             gworlds,
             screen_clut,
@@ -27547,11 +27816,16 @@ fn dispatch_supported_import(
         PpcImportDispatcherTarget::SystemCompatibility => Some(ppc_dispatch_system_compatibility(
             binding,
             cpu,
+            process_memory_manager,
             memory,
             heap_cursor,
             heap_limit,
             last_mem_error,
+            ptrs,
+            free_ptr_blocks,
             handles,
+            free_handle_blocks,
+            handle_states,
             quickdraw_cursor_level,
             launched_app_path,
         )),
@@ -27595,9 +27869,7 @@ fn dispatch_supported_import(
         PpcImportDispatcherTarget::MathCompatibility => {
             Some(ppc_dispatch_math_compatibility(binding, cpu, memory))
         }
-        PpcImportDispatcherTarget::Math64 => {
-            Some(ppc_dispatch_math64(binding, cpu, memory))
-        }
+        PpcImportDispatcherTarget::Math64 => Some(ppc_dispatch_math64(binding, cpu, memory)),
         PpcImportDispatcherTarget::StdCCompatibility => Some(ppc_dispatch_stdc_compatibility(
             binding,
             cpu,
@@ -27737,12 +28009,7 @@ fn ppc_create_process_owned_ae_desc(
         free_ptr_blocks,
         free_handle_blocks,
     );
-    ppc_apply_process_native_handle(
-        process_memory_manager,
-        handles,
-        handle_states,
-        handle,
-    );
+    ppc_apply_process_native_handle(process_memory_manager, handles, handle_states, handle);
     PPC_NO_ERR
 }
 
@@ -27922,11 +28189,16 @@ fn ppc_offset_ditl_items(bytes: &mut [u8], items: &[PpcDialogItemView], dv: i16,
 fn ppc_dispatch_dialog_compatibility(
     binding: &PpcImportBinding,
     cpu: &mut PpcCpu,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
     last_mem_error: &mut i16,
+    ptrs: &mut Vec<PpcPtrRecord>,
+    free_ptr_blocks: &mut Vec<PpcPtrRecord>,
     handles: &mut Vec<PpcHandleRecord>,
+    free_handle_blocks: &mut Vec<PpcHandleRecord>,
+    handle_states: &mut Vec<PpcHandleStateRecord>,
     controls: &[PpcControlRecord],
     gworlds: &mut Vec<PpcGWorldRecord>,
     screen_clut: &[[u16; 3]; 256],
@@ -28065,14 +28337,24 @@ fn ppc_dispatch_dialog_compatibility(
                     if !editable || !matches!(character, 0x08 | 0x20..=0x7e) {
                         return PpcImportAction::Return(0);
                     }
-                    *last_mem_error = ppc_te_key(
+                    let mut allocator = PpcProcessAllocatorView {
+                        memory_manager: process_memory_manager,
+                        ptrs: Some(ptrs),
+                        free_ptr_blocks,
+                        free_handle_blocks,
+                        handle_states,
+                    };
+                    let result = ppc_te_key(
+                        Some(&mut allocator),
                         memory,
                         heap_cursor,
                         heap_limit,
+                        last_mem_error,
                         handles,
                         te_handle,
                         character,
                     );
+                    *last_mem_error = result;
                     if *last_mem_error != PPC_NO_ERR {
                         return PpcImportAction::Return(0);
                     }
@@ -28178,8 +28460,15 @@ fn ppc_dispatch_dialog_compatibility(
             let count_minus_one = total_count.saturating_sub(1).min(i16::MAX as usize) as i16;
             combined[0..2].copy_from_slice(&count_minus_one.to_be_bytes());
             let size = u32::try_from(combined.len()).unwrap_or(u32::MAX);
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
             let result =
-                ppc_set_handle_size(memory, heap_cursor, heap_limit, handles, handle, size);
+                allocator.resize_handle(memory, heap_cursor, last_mem_error, handles, handle, size);
             *last_mem_error = result;
             if result == PPC_NO_ERR {
                 if let Some(ptr) = memory.read_u32_be(handle) {
@@ -28208,10 +28497,17 @@ fn ppc_dispatch_dialog_compatibility(
                 retained.saturating_sub(1).min(i16::MAX as usize) as i16
             };
             bytes[0..2].copy_from_slice(&count_minus_one.to_be_bytes());
-            let result = ppc_set_handle_size(
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
+            let result = allocator.resize_handle(
                 memory,
                 heap_cursor,
-                heap_limit,
+                last_mem_error,
                 handles,
                 handle,
                 u32::try_from(bytes.len()).unwrap_or(u32::MAX),
@@ -28491,10 +28787,17 @@ fn ppc_dispatch_quickdraw_compatibility(
             let dst_count = u32::from(memory.read_u16_be(dst_ptr).unwrap_or(0));
             if required_entries > dst_count && required_entries <= i16::MAX as u32 {
                 let size = 16u32.saturating_add(required_entries.saturating_mul(16));
-                let result = ppc_set_handle_size(
+                let mut allocator = PpcProcessAllocatorView {
+                    memory_manager: process_memory_manager,
+                    ptrs: None,
+                    free_ptr_blocks,
+                    free_handle_blocks,
+                    handle_states,
+                };
+                let result = allocator.resize_handle(
                     memory,
                     heap_cursor,
-                    heap_limit,
+                    last_mem_error,
                     handles,
                     dst_palette,
                     size,
@@ -28598,7 +28901,21 @@ fn ppc_dispatch_quickdraw_compatibility(
             toolbox_startup
                 .palette_allocations
                 .retain(|allocation| allocation.gdevice != cpu.gpr[3]);
-            let _ = ppc_dispose_tracked_handle(cpu.gpr[3], memory, handles, handle_states);
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: None,
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
+            let _ = allocator.dispose_handle(
+                memory,
+                heap_cursor,
+                heap_limit,
+                last_mem_error,
+                handles,
+                cpu.gpr[3],
+            );
             PpcImportAction::ReturnPreserve
         }
         "DisposePalette" => {
@@ -28616,11 +28933,33 @@ fn ppc_dispatch_quickdraw_compatibility(
                 toolbox_startup.application_palette = 0;
                 toolbox_startup.application_palette_updates = 0;
             }
-            let _ = ppc_dispose_tracked_handle(cpu.gpr[3], memory, handles, handle_states);
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: None,
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
+            let _ = allocator.dispose_handle(
+                memory,
+                heap_cursor,
+                heap_limit,
+                last_mem_error,
+                handles,
+                cpu.gpr[3],
+            );
             PpcImportAction::ReturnPreserve
         }
         "Palette2CTab" => {
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: None,
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
             ppc_palette_to_ctab(
+                Some(&mut allocator),
                 memory,
                 heap_cursor,
                 heap_limit,
@@ -28659,10 +28998,17 @@ fn ppc_dispatch_quickdraw_compatibility(
                 .map_or(0, |last| u32::from(last) + 1)
                 .min(256);
             let size = 16u32.saturating_add(entry_count.saturating_mul(16));
-            let result = ppc_set_handle_size(
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: None,
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
+            let result = allocator.resize_handle(
                 memory,
                 heap_cursor,
-                heap_limit,
+                last_mem_error,
                 handles,
                 palette_handle,
                 size,
@@ -28690,7 +29036,15 @@ fn ppc_dispatch_quickdraw_compatibility(
             PpcImportAction::ReturnPreserve
         }
         "GetNewPalette" => {
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: None,
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
             let palette = ppc_copy_palette_resource(
+                Some(&mut allocator),
                 memory,
                 heap_cursor,
                 heap_limit,
@@ -28982,6 +29336,7 @@ fn ppc_dispatch_quickdraw_compatibility(
 
 fn ppc_munger_compatibility(
     cpu: &PpcCpu,
+    allocator: Option<&mut PpcProcessAllocatorView<'_>>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -29028,10 +29383,12 @@ fn ppc_munger_compatibility(
         return u32::MAX;
     };
     contents.splice(position..position + needle.len(), replacement);
-    let result = ppc_set_handle_size(
+    let result = ppc_allocator_view_resize_handle(
+        allocator,
         memory,
         heap_cursor,
         heap_limit,
+        last_mem_error,
         handles,
         handle,
         u32::try_from(contents.len()).unwrap_or(u32::MAX),
@@ -29098,23 +29455,38 @@ fn ppc_dequeue_compatibility(memory: &mut PpcSectionMem, element: u32, header: u
 fn ppc_dispatch_system_compatibility(
     binding: &PpcImportBinding,
     cpu: &mut PpcCpu,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
     last_mem_error: &mut i16,
+    ptrs: &mut Vec<PpcPtrRecord>,
+    free_ptr_blocks: &mut Vec<PpcPtrRecord>,
     handles: &mut Vec<PpcHandleRecord>,
+    free_handle_blocks: &mut Vec<PpcHandleRecord>,
+    handle_states: &mut Vec<PpcHandleStateRecord>,
     quickdraw_cursor_level: &mut i16,
     launched_app_path: Option<&str>,
 ) -> PpcImportAction {
     match binding.symbol_name.as_str() {
-        "Munger" => PpcImportAction::Return(ppc_munger_compatibility(
-            cpu,
-            memory,
-            heap_cursor,
-            heap_limit,
-            last_mem_error,
-            handles,
-        )),
+        "Munger" => {
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
+            PpcImportAction::Return(ppc_munger_compatibility(
+                cpu,
+                Some(&mut allocator),
+                memory,
+                heap_cursor,
+                heap_limit,
+                last_mem_error,
+                handles,
+            ))
+        }
         "Enqueue" => {
             let _ = ppc_enqueue_compatibility(memory, cpu.gpr[3], cpu.gpr[4]);
             PpcImportAction::ReturnPreserve
@@ -29735,10 +30107,7 @@ fn ppc_dispatch_math64(
             let dividend = left as i64;
             let divisor = right as i64;
             let (quotient, remainder) = if divisor == 0 {
-                (
-                    if dividend < 0 { i64::MIN } else { i64::MAX },
-                    dividend,
-                )
+                (if dividend < 0 { i64::MIN } else { i64::MAX }, dividend)
             } else if dividend == i64::MIN && divisor == -1 {
                 (i64::MIN, 0)
             } else {
@@ -29760,16 +30129,17 @@ fn ppc_dispatch_math64(
             }
             quotient
         }
-        "LongDoubleToSInt64" => ppc_math64_long_double_to_signed(
-            f64::from_bits(cpu.fpr[1]),
-            f64::from_bits(cpu.fpr[2]),
-        ) as u64,
+        "LongDoubleToSInt64" => {
+            ppc_math64_long_double_to_signed(f64::from_bits(cpu.fpr[1]), f64::from_bits(cpu.fpr[2]))
+                as u64
+        }
         "LongDoubleToUInt64" => ppc_math64_long_double_to_unsigned(
             f64::from_bits(cpu.fpr[1]),
             f64::from_bits(cpu.fpr[2]),
         ),
         "SInt64ToLongDouble" => {
-            let (head, tail) = ppc_math64_signed_to_long_double(ppc_math64_read_gprs(cpu, 3) as i64);
+            let (head, tail) =
+                ppc_math64_signed_to_long_double(ppc_math64_read_gprs(cpu, 3) as i64);
             cpu.fpr[1] = head.to_bits();
             cpu.fpr[2] = tail.to_bits();
             return PpcImportAction::ReturnPreserve;
@@ -29795,8 +30165,7 @@ fn ppc_dispatch_math64(
         }
         "S64Eor" | "U64Eor" => {
             return PpcImportAction::Return(u32::from(
-                (ppc_math64_read_gprs(cpu, 3) != 0)
-                    ^ (ppc_math64_read_gprs(cpu, 5) != 0),
+                (ppc_math64_read_gprs(cpu, 3) != 0) ^ (ppc_math64_read_gprs(cpu, 5) != 0),
             ));
         }
         "S64Not" | "U64Not" => {
@@ -30420,14 +30789,21 @@ fn ppc_dispatch_stdio_compatibility_with_manager(
                 return PpcImportAction::Return(u32::MAX);
             }
             let saved_heap_cursor = *heap_cursor;
-            let scratch = ppc_heap_alloc(memory, heap_cursor, heap_limit, SCRATCH_SIZE, true);
+            let process_scratch = process_memory_manager.is_some();
+            let scratch = if let Some(memory_manager) = process_memory_manager.as_deref_mut() {
+                memory_manager.native_scratch_bytes(memory, SCRATCH_SIZE, true)
+            } else {
+                ppc_heap_alloc(memory, heap_cursor, heap_limit, SCRATCH_SIZE, true)
+            };
             if scratch == 0 {
                 return PpcImportAction::Return(u32::MAX);
             }
             let mut sprintf_cpu = cpu.clone();
             sprintf_cpu.gpr[3] = scratch;
             let length = ppc_std_sprintf(&sprintf_cpu, memory);
-            *heap_cursor = saved_heap_cursor;
+            if !process_scratch {
+                *heap_cursor = saved_heap_cursor;
+            }
             if length >= SCRATCH_SIZE {
                 ppc_stdio_set_error(stream, stdio_streams);
                 return PpcImportAction::Return(u32::MAX);
@@ -32426,15 +32802,13 @@ fn ppc_q3_trimesh_new(
     let Some(data) = ppc_q3_read_bytes(memory, data_ptr, PPC_Q3_TRIMESH_DATA_SIZE) else {
         return 0;
     };
-    let Some(data) =
-        ppc_q3_trimesh_copy_get_data_arrays(
-            process_memory_manager,
-            memory,
-            heap_cursor,
-            last_mem_error,
-            &data,
-        )
-    else {
+    let Some(data) = ppc_q3_trimesh_copy_get_data_arrays(
+        process_memory_manager,
+        memory,
+        heap_cursor,
+        last_mem_error,
+        &data,
+    ) else {
         return 0;
     };
     let trimesh = ppc_q3_alloc_object(
@@ -32559,15 +32933,13 @@ fn ppc_q3_trimesh_get_data(
         return false;
     };
     ppc_q3_trace_trimesh_header("GetData object copy-arrays source", cpu, trimesh, &data);
-    let Some(data) =
-        ppc_q3_trimesh_copy_get_data_arrays(
-            process_memory_manager,
-            memory,
-            heap_cursor,
-            last_mem_error,
-            &data,
-        )
-    else {
+    let Some(data) = ppc_q3_trimesh_copy_get_data_arrays(
+        process_memory_manager,
+        memory,
+        heap_cursor,
+        last_mem_error,
+        &data,
+    ) else {
         return false;
     };
     ppc_q3_trace_trimesh_header("GetData object copy-arrays result", cpu, trimesh, &data);
@@ -37795,12 +38167,8 @@ fn ppc_q3_file_decode_mipmap_3dmf_body(
         return None;
     }
     let image = ppc_q3_read_bytes(memory, body_ptr.checked_add(HEADER_SIZE)?, image_size)?;
-    let image_ptr = ppc_q3_file_alloc_and_write_bytes(
-        process_memory_manager,
-        memory,
-        heap_cursor,
-        &image,
-    )?;
+    let image_ptr =
+        ppc_q3_file_alloc_and_write_bytes(process_memory_manager, memory, heap_cursor, &image)?;
     let image_storage = ppc_q3_alloc_object(
         q3_objects,
         next_q3_object,
@@ -38209,13 +38577,7 @@ fn ppc_q3_file_alloc_and_write_bytes(
         return Some(0);
     }
     let size = u32::try_from(data.len()).ok()?;
-    let ptr = ppc_process_heap_alloc(
-        process_memory_manager,
-        memory,
-        heap_cursor,
-        size,
-        true,
-    );
+    let ptr = ppc_process_heap_alloc(process_memory_manager, memory, heap_cursor, size, true);
     if ptr == 0 || !ppc_q3_write_bytes(memory, ptr, data) {
         return None;
     }
@@ -38344,8 +38706,7 @@ fn ppc_q3_file_attach_trimesh_attribute_array(
         memory,
         heap_cursor,
         &attribute.data,
-    )
-    else {
+    ) else {
         return false;
     };
     let use_array_ptr = if attribute.use_array.is_empty() {
@@ -44507,14 +44868,13 @@ fn ppc_begin_m68k_universal_proc(
         _ => return None,
     }
 
-    let (gateway, stack_top) =
-        ppc_mixed_mode_m68k_storage(
-            process_memory_manager,
-            memory,
-            heap_cursor,
-            heap_limit,
-            startup,
-        )?;
+    let (gateway, stack_top) = ppc_mixed_mode_m68k_storage(
+        process_memory_manager,
+        memory,
+        heap_cursor,
+        heap_limit,
+        startup,
+    )?;
     let return_pc = gateway.checked_add(PPC_MIXED_MODE_M68K_RETURN_OFFSET)?;
     if stack_top < 4 {
         return None;
@@ -49943,10 +50303,7 @@ fn ppc_gestalt_response(selector: u32) -> Option<(u32, i16)> {
             PPC_NO_ERR,
         )),
         b"ostt" => Some((crate::trap::dispatch::OS_TRAP_TABLE_BASE, PPC_NO_ERR)),
-        b"tbtt" => Some((
-            crate::trap::dispatch::TOOLBOX_TRAP_TABLE_BASE,
-            PPC_NO_ERR,
-        )),
+        b"tbtt" => Some((crate::trap::dispatch::TOOLBOX_TRAP_TABLE_BASE, PPC_NO_ERR)),
         b"evnt" => Some((0x0001, PPC_NO_ERR)),
         b"cput" => Some((PPC_GESTALT_CPU_604, PPC_NO_ERR)),
         b"proc" => Some((PPC_GESTALT_PROCESSOR_POWERPC, PPC_NO_ERR)),
@@ -51045,6 +51402,7 @@ fn ppc_seed_dsp_back_gworld(memory: &mut PpcSectionMem) -> PpcGWorldRecord {
 #[allow(clippy::too_many_arguments)]
 fn ppc_open_port(
     cpu: &PpcCpu,
+    allocator: &mut PpcProcessAllocatorView<'_>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -51073,8 +51431,22 @@ fn ppc_open_port(
         height: PPC_MAIN_SCREEN_HEIGHT,
         depth: PPC_MAIN_PIXEL_DEPTH,
     });
-    let vis_rgn = ppc_new_rgn(memory, heap_cursor, heap_limit, last_mem_error, handles);
-    let clip_rgn = ppc_new_rgn(memory, heap_cursor, heap_limit, last_mem_error, handles);
+    let vis_rgn = ppc_allocator_view_new_rgn(
+        Some(allocator),
+        memory,
+        heap_cursor,
+        heap_limit,
+        last_mem_error,
+        handles,
+    );
+    let clip_rgn = ppc_allocator_view_new_rgn(
+        Some(allocator),
+        memory,
+        heap_cursor,
+        heap_limit,
+        last_mem_error,
+        handles,
+    );
     if vis_rgn == 0 || clip_rgn == 0 {
         return false;
     }
@@ -51164,6 +51536,7 @@ fn ppc_open_port(
 
 fn ppc_open_cport(
     cpu: &PpcCpu,
+    allocator: &mut PpcProcessAllocatorView<'_>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -51210,10 +51583,24 @@ fn ppc_open_cport(
         *last_mem_error = PPC_MEM_FULL_ERR;
         return false;
     }
-    let pixmap = ppc_heap_alloc(memory, heap_cursor, heap_limit, PPC_PIXMAP_SIZE, true);
-    let pixmap_handle = ppc_heap_alloc(memory, heap_cursor, heap_limit, 4, true);
-    let vis_rgn = ppc_new_rgn(memory, heap_cursor, heap_limit, last_mem_error, handles);
-    let clip_rgn = ppc_new_rgn(memory, heap_cursor, heap_limit, last_mem_error, handles);
+    let pixmap = allocator.reserve_bytes(memory, heap_cursor, PPC_PIXMAP_SIZE, true);
+    let pixmap_handle = allocator.reserve_bytes(memory, heap_cursor, 4, true);
+    let vis_rgn = ppc_allocator_view_new_rgn(
+        Some(allocator),
+        memory,
+        heap_cursor,
+        heap_limit,
+        last_mem_error,
+        handles,
+    );
+    let clip_rgn = ppc_allocator_view_new_rgn(
+        Some(allocator),
+        memory,
+        heap_cursor,
+        heap_limit,
+        last_mem_error,
+        handles,
+    );
     if pixmap == 0
         || pixmap_handle == 0
         || vis_rgn == 0
@@ -51404,6 +51791,7 @@ fn ppc_update_window_manager_regions(
 
 fn ppc_new_cwindow(
     cpu: &PpcCpu,
+    mut allocator: Option<&mut PpcProcessAllocatorView<'_>>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -51512,19 +51900,84 @@ fn ppc_new_cwindow(
         return 0;
     }
 
-    let pixmap = ppc_heap_alloc(memory, heap_cursor, heap_limit, PPC_PIXMAP_SIZE, true);
-    let pixmap_handle = ppc_heap_alloc(memory, heap_cursor, heap_limit, 4, true);
+    let pixmap = ppc_allocator_view_reserve_bytes(
+        allocator.as_deref_mut(),
+        memory,
+        heap_cursor,
+        heap_limit,
+        PPC_PIXMAP_SIZE,
+        true,
+    );
+    let pixmap_handle = ppc_allocator_view_reserve_bytes(
+        allocator.as_deref_mut(),
+        memory,
+        heap_cursor,
+        heap_limit,
+        4,
+        true,
+    );
     let port = if storage_ptr != 0 {
         storage_ptr
     } else {
-        ppc_heap_alloc(memory, heap_cursor, heap_limit, PPC_CGRAF_PORT_SIZE, true)
+        ppc_allocator_view_reserve_bytes(
+            allocator.as_deref_mut(),
+            memory,
+            heap_cursor,
+            heap_limit,
+            PPC_CGRAF_PORT_SIZE,
+            true,
+        )
     };
-    let vis_rgn = ppc_new_rgn(memory, heap_cursor, heap_limit, last_mem_error, handles);
-    let clip_rgn = ppc_new_rgn(memory, heap_cursor, heap_limit, last_mem_error, handles);
-    let structure_rgn = ppc_new_rgn(memory, heap_cursor, heap_limit, last_mem_error, handles);
-    let content_rgn = ppc_new_rgn(memory, heap_cursor, heap_limit, last_mem_error, handles);
-    let update_rgn = ppc_new_rgn(memory, heap_cursor, heap_limit, last_mem_error, handles);
-    let def_proc = ppc_alloc_handle(memory, heap_cursor, heap_limit, handles, 4, true);
+    let vis_rgn = ppc_allocator_view_new_rgn(
+        allocator.as_deref_mut(),
+        memory,
+        heap_cursor,
+        heap_limit,
+        last_mem_error,
+        handles,
+    );
+    let clip_rgn = ppc_allocator_view_new_rgn(
+        allocator.as_deref_mut(),
+        memory,
+        heap_cursor,
+        heap_limit,
+        last_mem_error,
+        handles,
+    );
+    let structure_rgn = ppc_allocator_view_new_rgn(
+        allocator.as_deref_mut(),
+        memory,
+        heap_cursor,
+        heap_limit,
+        last_mem_error,
+        handles,
+    );
+    let content_rgn = ppc_allocator_view_new_rgn(
+        allocator.as_deref_mut(),
+        memory,
+        heap_cursor,
+        heap_limit,
+        last_mem_error,
+        handles,
+    );
+    let update_rgn = ppc_allocator_view_new_rgn(
+        allocator.as_deref_mut(),
+        memory,
+        heap_cursor,
+        heap_limit,
+        last_mem_error,
+        handles,
+    );
+    let def_proc = ppc_allocator_view_allocate_handle(
+        allocator.as_deref_mut(),
+        memory,
+        heap_cursor,
+        heap_limit,
+        last_mem_error,
+        handles,
+        4,
+        true,
+    );
     if pixmap == 0
         || pixmap_handle == 0
         || port == 0
@@ -51849,8 +52302,7 @@ fn ppc_recalculate_window_vis_regions(
             |front| ppc_window_is_visible(memory, front),
         );
         for front in occluders {
-            let Some(structure_rgn) =
-                memory.read_u32_be(front + PPC_CWINDOW_STRUCTURE_RGN_OFFSET)
+            let Some(structure_rgn) = memory.read_u32_be(front + PPC_CWINDOW_STRUCTURE_RGN_OFFSET)
             else {
                 continue;
             };
@@ -51969,11 +52421,16 @@ fn ppc_draw_dialog_box_frame(
 
 fn ppc_get_new_cwindow(
     cpu: &PpcCpu,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
     last_mem_error: &mut i16,
+    ptrs: &mut Vec<PpcPtrRecord>,
+    free_ptr_blocks: &mut Vec<PpcPtrRecord>,
     handles: &mut Vec<PpcHandleRecord>,
+    free_handle_blocks: &mut Vec<PpcHandleRecord>,
+    handle_states: &mut Vec<PpcHandleStateRecord>,
     gworlds: &mut Vec<PpcGWorldRecord>,
     current_gdevice: u32,
     vfs_resources: &[PpcVfsResourceRecord],
@@ -51996,9 +52453,20 @@ fn ppc_get_new_cwindow(
         return 0;
     };
     let bytes = resource.data.clone();
-    let Some((bounds_ptr, title_ptr)) =
-        ppc_materialize_window_resource_parameters(memory, heap_cursor, heap_limit, &bytes)
-    else {
+    let mut allocator = PpcProcessAllocatorView {
+        memory_manager: process_memory_manager,
+        ptrs: Some(ptrs),
+        free_ptr_blocks,
+        free_handle_blocks,
+        handle_states,
+    };
+    let Some((bounds_ptr, title_ptr)) = ppc_materialize_window_resource_parameters(
+        Some(&mut allocator),
+        memory,
+        heap_cursor,
+        heap_limit,
+        &bytes,
+    ) else {
         *last_resource_error = PPC_PARAM_ERR;
         *last_mem_error = PPC_PARAM_ERR;
         return 0;
@@ -52014,6 +52482,7 @@ fn ppc_get_new_cwindow(
     window_cpu.gpr[10] = u32::from_be_bytes([bytes[14], bytes[15], bytes[16], bytes[17]]);
     let window = ppc_new_window_from_cpu(
         &window_cpu,
+        Some(&mut allocator),
         memory,
         heap_cursor,
         heap_limit,
@@ -52033,6 +52502,7 @@ fn ppc_get_new_cwindow(
     // is absent, the application palette ('pltt' 0) is the default.
     // Inside Macintosh Volume VI (1991), pp. 20-18--20-19.
     let palette = ppc_copy_palette_resource(
+        Some(&mut allocator),
         memory,
         heap_cursor,
         heap_limit,
@@ -52044,6 +52514,7 @@ fn ppc_get_new_cwindow(
     );
     let palette = if palette == 0 && window_id != 0 {
         ppc_copy_palette_resource(
+            Some(&mut allocator),
             memory,
             heap_cursor,
             heap_limit,
@@ -52492,7 +52963,8 @@ fn ppc_paint_behind(
             if let Some(front_buffer) = ppc_front_buffer_for_gworld(gworlds, PPC_MAIN_GWORLD) {
                 for v in i32::from(paint.0)..i32::from(paint.2) {
                     for h in i32::from(paint.1)..i32::from(paint.3) {
-                        let color = if crate::window_manager::standard_desktop_pattern_is_ink(h, v) {
+                        let color = if crate::window_manager::standard_desktop_pattern_is_ink(h, v)
+                        {
                             PPC_RGB_BLACK
                         } else {
                             PPC_RGB_WHITE
@@ -53346,11 +53818,8 @@ fn ppc_update_gworld(
                 0
             }
         } else {
-            let handle = process_memory_manager.new_native_handle(
-                memory,
-                desired_ctable_size,
-                false,
-            );
+            let handle =
+                process_memory_manager.new_native_handle(memory, desired_ctable_size, false);
             if handle == 0 {
                 allocation_error = PPC_MEM_FULL_ERR;
             } else if process_memory_manager
@@ -57348,10 +57817,12 @@ fn ppc_preflight_ctable_growth(
 }
 
 fn ppc_grow_ctables(
+    mut allocator: Option<&mut PpcProcessAllocatorView<'_>>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
-    handles: &mut [PpcHandleRecord],
+    last_mem_error: &mut i16,
+    handles: &mut Vec<PpcHandleRecord>,
     ctable_handles: &[u32],
     required_size: u32,
 ) -> Result<(), i16> {
@@ -57369,10 +57840,12 @@ fn ppc_grow_ctables(
         if record.capacity >= required_size {
             continue;
         }
-        let result = ppc_set_handle_size(
+        let result = ppc_allocator_view_resize_handle(
+            allocator.as_deref_mut(),
             memory,
             heap_cursor,
             heap_limit,
+            last_mem_error,
             handles,
             *ctable_handle,
             required_size,
@@ -57386,10 +57859,12 @@ fn ppc_grow_ctables(
 
 fn ppc_set_depth(
     cpu: &PpcCpu,
+    mut allocator: Option<&mut PpcProcessAllocatorView<'_>>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
-    handles: &mut [PpcHandleRecord],
+    last_mem_error: &mut i16,
+    handles: &mut Vec<PpcHandleRecord>,
     gworlds: &mut [PpcGWorldRecord],
     toolbox_startup: &mut PpcToolboxStartupState,
     screen_clut: &mut [[u16; 3]; 256],
@@ -57616,9 +58091,11 @@ fn ppc_set_depth(
     {
         if *install_tables {
             if let Err(error) = ppc_grow_ctables(
+                allocator.as_deref_mut(),
                 memory,
                 heap_cursor,
                 heap_limit,
+                last_mem_error,
                 handles,
                 ctable_handles,
                 *required_size,
@@ -58173,13 +58650,7 @@ fn ppc_dsp_alt_buffer_new(
         return PPC_PARAM_ERR;
     }
 
-    let rect_ptr = ppc_process_heap_alloc(
-        process_memory_manager,
-        memory,
-        heap_cursor,
-        8,
-        true,
-    );
+    let rect_ptr = ppc_process_heap_alloc(process_memory_manager, memory, heap_cursor, 8, true);
     if rect_ptr == 0
         || ppc_write_rect(memory, rect_ptr, 0, 0, height as i16, width as i16).is_none()
     {
@@ -60280,6 +60751,7 @@ fn ppc_alloc_handle_with_bytes(
 }
 
 fn ppc_copy_palette_resource(
+    allocator: Option<&mut PpcProcessAllocatorView<'_>>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -60309,10 +60781,12 @@ fn ppc_copy_palette_resource(
     if resource.len() < byte_count {
         return 0;
     }
-    let handle = ppc_alloc_handle_with_bytes(
+    let handle = ppc_allocator_view_allocate_handle_with_bytes(
+        allocator,
         memory,
         heap_cursor,
         heap_limit,
+        last_mem_error,
         handles,
         &resource[..byte_count],
     );
@@ -61571,8 +62045,7 @@ fn ppc_materialize_vfs_resource_handle(
         // SetResLoad(FALSE) still returns a resource Handle, but its master
         // pointer remains NIL until LoadResource (or a later loading lookup).
         let data = load_data.then(|| vfs_resources[index].data.clone());
-        let handle = process_memory_manager
-            .new_native_resource_handle(memory, data.as_deref());
+        let handle = process_memory_manager.new_native_resource_handle(memory, data.as_deref());
         ppc_apply_process_native_resource_handle(
             process_memory_manager,
             memory,
@@ -61594,8 +62067,7 @@ fn ppc_materialize_vfs_resource_handle(
         let data = vfs_resources[index].data.clone();
         let handle = vfs_resources[index].handle;
         if process_memory_manager.native_allocation(handle).is_some() {
-            let result =
-                process_memory_manager.load_native_resource_handle(memory, handle, &data);
+            let result = process_memory_manager.load_native_resource_handle(memory, handle, &data);
             ppc_apply_process_native_resource_handle(
                 process_memory_manager,
                 memory,
@@ -61616,17 +62088,14 @@ fn ppc_materialize_vfs_resource_handle(
             // mapping. Keep that mapping authoritative while allocating its
             // resource data from the shared process heap.
             let size = u32::try_from(data.len()).unwrap_or(u32::MAX);
-            let ptr = ppc_process_heap_alloc(
-                process_memory_manager,
-                memory,
-                heap_cursor,
-                size,
-                false,
-            );
+            let ptr =
+                ppc_process_heap_alloc(process_memory_manager, memory, heap_cursor, size, false);
             if ptr == 0
-                || data.iter().copied().enumerate().any(|(offset, byte)| {
-                    memory.write_u8(ptr + offset as u32, byte).is_none()
-                })
+                || data
+                    .iter()
+                    .copied()
+                    .enumerate()
+                    .any(|(offset, byte)| memory.write_u8(ptr + offset as u32, byte).is_none())
                 || memory.write_u32_be(handle, ptr).is_none()
             {
                 *last_mem_error = PPC_MEM_FULL_ERR;
@@ -62158,10 +62627,9 @@ fn ppc_process_apple_event(
     let Some((PPC_HIGH_LEVEL_EVENT, event_class, event_id)) = event.flatten() else {
         return PpcImportAction::Return(ppc_i16_result(PPC_ERR_AE_EVENT_NOT_HANDLED));
     };
-    let Some(handler) =
-        apple_events
-            .handlers
-            .handler_for(event_class, event_id, PPC_TYPE_WILDCARD)
+    let Some(handler) = apple_events
+        .handlers
+        .handler_for(event_class, event_id, PPC_TYPE_WILDCARD)
     else {
         return PpcImportAction::Return(ppc_i16_result(PPC_ERR_AE_EVENT_NOT_HANDLED));
     };
@@ -62230,18 +62698,8 @@ fn ppc_process_apple_event(
         free_ptr_blocks,
         free_handle_blocks,
     );
-    ppc_apply_process_native_handle(
-        process_memory_manager,
-        handles,
-        handle_states,
-        event_handle,
-    );
-    ppc_apply_process_native_handle(
-        process_memory_manager,
-        handles,
-        handle_states,
-        reply_handle,
-    );
+    ppc_apply_process_native_handle(process_memory_manager, handles, handle_states, event_handle);
+    ppc_apply_process_native_handle(process_memory_manager, handles, handle_states, reply_handle);
     apple_events
         .pending_dispatches
         .push(PpcAppleEventDispatchAllocation {
@@ -62878,13 +63336,7 @@ fn ppc_new_alert_dialog(
         return 0;
     }
     let bounds = ppc_position_dialog_bounds(bounds, position, gworlds);
-    let scratch = ppc_process_heap_alloc(
-        process_memory_manager,
-        memory,
-        heap_cursor,
-        9,
-        true,
-    );
+    let scratch = ppc_process_heap_alloc(process_memory_manager, memory, heap_cursor, 9, true);
     let Some(items_slot) = ppc_parameter_area_slot_addr(cpu.gpr[1], PPC_NATIVE_PARAMETER_GPR_COUNT)
     else {
         *last_mem_error = PPC_PARAM_ERR;
@@ -62919,6 +63371,9 @@ fn ppc_new_alert_dialog(
         heap_limit,
         last_mem_error,
         handles,
+        free_ptr_blocks,
+        free_handle_blocks,
+        handle_states,
         gworlds,
         current_gdevice,
     );
@@ -62939,8 +63394,7 @@ fn ppc_new_alert_dialog(
             vfs_resources,
             current_resource_refnum,
             last_resource_error,
-        )
-    {
+        ) {
         0
     } else {
         dialog
@@ -63066,6 +63520,9 @@ fn ppc_get_new_dialog(
         heap_limit,
         last_mem_error,
         handles,
+        free_ptr_blocks,
+        free_handle_blocks,
+        handle_states,
         gworlds,
         current_gdevice,
     );
@@ -63107,6 +63564,9 @@ fn ppc_new_dialog(
     heap_limit: u32,
     last_mem_error: &mut i16,
     handles: &mut Vec<PpcHandleRecord>,
+    free_ptr_blocks: &mut Vec<PpcPtrRecord>,
+    free_handle_blocks: &mut Vec<PpcHandleRecord>,
+    handle_states: &mut Vec<PpcHandleStateRecord>,
     gworlds: &mut Vec<PpcGWorldRecord>,
     current_gdevice: u32,
 ) -> u32 {
@@ -63158,8 +63618,16 @@ fn ppc_new_dialog(
     window_cpu.gpr[8] = behind;
     window_cpu.gpr[9] = u32::from(go_away);
     window_cpu.gpr[10] = ref_con;
+    let mut allocator = PpcProcessAllocatorView {
+        memory_manager: process_memory_manager,
+        ptrs: None,
+        free_ptr_blocks,
+        free_handle_blocks,
+        handle_states,
+    };
     let dialog = ppc_new_cwindow(
         &window_cpu,
+        Some(&mut allocator),
         memory,
         heap_cursor,
         heap_limit,
@@ -63176,8 +63644,13 @@ fn ppc_new_dialog(
     let mut title_string = Vec::with_capacity(title.len().saturating_add(1));
     title_string.push(title.len().min(255) as u8);
     title_string.extend(title.into_iter().take(255));
-    let title_handle =
-        ppc_alloc_handle_with_bytes(memory, heap_cursor, heap_limit, handles, &title_string);
+    let title_handle = allocator.allocate_handle_with_bytes(
+        memory,
+        heap_cursor,
+        last_mem_error,
+        handles,
+        &title_string,
+    );
     if title_handle == 0
         || memory
             .write_u16_be(dialog + PPC_CWINDOW_WINDOW_KIND_OFFSET, 2)
@@ -63266,7 +63739,15 @@ fn ppc_initialize_dialog_items(
                     PPC_DIALOG_ITEM_RADIO => 2,
                     _ => 0,
                 };
+                let mut allocator = PpcProcessAllocatorView {
+                    memory_manager: process_memory_manager,
+                    ptrs: None,
+                    free_ptr_blocks,
+                    free_handle_blocks,
+                    handle_states,
+                };
                 ppc_new_control_record_values(
+                    Some(&mut allocator),
                     memory,
                     heap_cursor,
                     heap_limit,
@@ -63304,7 +63785,15 @@ fn ppc_initialize_dialog_items(
                         return false;
                     }
                     let title_len = usize::from(bytes[22]).min(bytes.len().saturating_sub(23));
+                    let mut allocator = PpcProcessAllocatorView {
+                        memory_manager: process_memory_manager,
+                        ptrs: None,
+                        free_ptr_blocks,
+                        free_handle_blocks,
+                        handle_states,
+                    };
                     ppc_new_control_record_values(
+                        Some(&mut allocator),
                         memory,
                         heap_cursor,
                         heap_limit,
@@ -63413,12 +63902,21 @@ fn ppc_initialize_dialog_items(
         }
     }
     if let Some((item_index, item_handle, rect)) = first_edit {
+        let mut allocator = PpcProcessAllocatorView {
+            memory_manager: process_memory_manager,
+            ptrs: None,
+            free_ptr_blocks,
+            free_handle_blocks,
+            handle_states,
+        };
         let te_handle = ppc_te_create_for_dialog_item(
+            Some(&mut allocator),
+            None,
             memory,
             heap_cursor,
             heap_limit,
+            last_mem_error,
             handles,
-            handle_states,
             dialog,
             item_handle,
             rect,
@@ -63455,11 +63953,13 @@ fn ppc_initialize_dialog_items(
 
 #[allow(clippy::too_many_arguments)]
 fn ppc_te_create_for_dialog_item(
+    mut allocator: Option<&mut PpcProcessAllocatorView<'_>>,
+    mut legacy_handle_states: Option<&mut Vec<PpcHandleStateRecord>>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
+    last_mem_error: &mut i16,
     handles: &mut Vec<PpcHandleRecord>,
-    handle_states: &mut Vec<PpcHandleStateRecord>,
     dialog: u32,
     item_text_handle: u32,
     rect: (i16, i16, i16, i16),
@@ -63468,7 +63968,14 @@ fn ppc_te_create_for_dialog_item(
     text_size: i16,
     fore_color: PpcRgbColor,
 ) -> u32 {
-    let scratch = ppc_heap_alloc(memory, heap_cursor, heap_limit, 16, true);
+    let scratch = ppc_allocator_view_reserve_bytes(
+        allocator.as_deref_mut(),
+        memory,
+        heap_cursor,
+        heap_limit,
+        16,
+        true,
+    );
     if scratch == 0
         || ppc_write_rect(memory, scratch, rect.0, rect.1, rect.2, rect.3).is_none()
         || ppc_write_rect(memory, scratch + 8, rect.0, rect.1, rect.2, rect.3).is_none()
@@ -63476,9 +63983,11 @@ fn ppc_te_create_for_dialog_item(
         return 0;
     }
     let te_handle = ppc_te_initialize_record(
+        allocator.as_deref_mut(),
         memory,
         heap_cursor,
         heap_limit,
+        last_mem_error,
         handles,
         scratch,
         scratch + 8,
@@ -63509,8 +64018,25 @@ fn ppc_te_create_for_dialog_item(
     {
         return 0;
     }
-    ppc_te_forget_handle(memory, handles, handle_states, temporary_text_handle);
-    if ppc_te_recalculate_layout(memory, heap_cursor, heap_limit, handles, te_handle) != PPC_NO_ERR
+    ppc_te_forget_handle(
+        allocator.as_deref_mut(),
+        legacy_handle_states.as_deref_mut(),
+        memory,
+        heap_cursor,
+        heap_limit,
+        last_mem_error,
+        handles,
+        temporary_text_handle,
+    );
+    if ppc_te_recalculate_layout(
+        allocator,
+        memory,
+        heap_cursor,
+        heap_limit,
+        last_mem_error,
+        handles,
+        te_handle,
+    ) != PPC_NO_ERR
     {
         return 0;
     }
@@ -63529,11 +64055,13 @@ fn ppc_te_create_for_dialog_item(
 
 #[allow(clippy::too_many_arguments)]
 fn ppc_select_dialog_item_text(
+    mut allocator: Option<&mut PpcProcessAllocatorView<'_>>,
+    mut legacy_handle_states: Option<&mut Vec<PpcHandleStateRecord>>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
+    last_mem_error: &mut i16,
     handles: &mut Vec<PpcHandleRecord>,
-    handle_states: &mut Vec<PpcHandleStateRecord>,
     dialog: u32,
     item_number: usize,
     selection_start: u16,
@@ -63563,14 +64091,25 @@ fn ppc_select_dialog_item_text(
             // A DialogRecord's TERec borrows the live DITL text handle; detach
             // it before disposing the old edit record when focus changes.
             let _ = memory.write_u32_be(te_ptr + PPC_TE_HTEXT_OFFSET, 0);
-            ppc_te_dispose(memory, handles, handle_states, te_handle);
+            ppc_te_dispose(
+                allocator.as_deref_mut(),
+                legacy_handle_states.as_deref_mut(),
+                memory,
+                heap_cursor,
+                heap_limit,
+                last_mem_error,
+                handles,
+                te_handle,
+            );
         }
         te_handle = ppc_te_create_for_dialog_item(
+            allocator,
+            legacy_handle_states,
             memory,
             heap_cursor,
             heap_limit,
+            last_mem_error,
             handles,
-            handle_states,
             dialog,
             item.handle,
             item.rect,
@@ -63628,11 +64167,12 @@ fn ppc_palette_entry_color(
 
 #[allow(clippy::too_many_arguments)]
 fn ppc_palette_to_ctab(
+    allocator: Option<&mut PpcProcessAllocatorView<'_>>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
     last_mem_error: &mut i16,
-    handles: &mut [PpcHandleRecord],
+    handles: &mut Vec<PpcHandleRecord>,
     toolbox_startup: &mut PpcToolboxStartupState,
     palette_handle: u32,
     ctable_handle: u32,
@@ -63660,10 +64200,12 @@ fn ppc_palette_to_ctab(
         *last_mem_error = PPC_MEM_FULL_ERR;
         return;
     };
-    let resize_result = ppc_set_handle_size(
+    let resize_result = ppc_allocator_view_resize_handle(
+        allocator,
         memory,
         heap_cursor,
         heap_limit,
+        last_mem_error,
         handles,
         ctable_handle,
         byte_count,
@@ -64765,9 +65307,11 @@ fn ppc_inverse_table_bytes(colors: &[(u8, [u16; 3])], resolution: u16) -> Vec<u8
 #[allow(clippy::too_many_arguments)]
 fn ppc_make_itable(
     cpu: &PpcCpu,
+    mut allocator: Option<&mut PpcProcessAllocatorView<'_>>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
+    last_mem_error: &mut i16,
     handles: &mut Vec<PpcHandleRecord>,
     current_gdevice: u32,
     screen_clut: &[[u16; 3]; 256],
@@ -64823,8 +65367,16 @@ fn ppc_make_itable(
         };
         itable_handle = memory.read_u32_be(gdevice + 6).unwrap_or(0);
         if itable_handle == 0 {
-            itable_handle =
-                ppc_alloc_handle(memory, heap_cursor, heap_limit, handles, record_size, true);
+            itable_handle = ppc_allocator_view_allocate_handle(
+                allocator.as_deref_mut(),
+                memory,
+                heap_cursor,
+                heap_limit,
+                last_mem_error,
+                handles,
+                record_size,
+                true,
+            );
             if itable_handle == 0 || memory.write_u32_be(gdevice + 6, itable_handle).is_none() {
                 toolbox_startup.last_quickdraw_error = PPC_MEM_FULL_ERR;
                 return;
@@ -64832,10 +65384,12 @@ fn ppc_make_itable(
         }
     }
 
-    let resize_result = ppc_set_handle_size(
+    let resize_result = ppc_allocator_view_resize_handle(
+        allocator,
         memory,
         heap_cursor,
         heap_limit,
+        last_mem_error,
         handles,
         itable_handle,
         record_size,
@@ -66036,11 +66590,7 @@ fn ppc_frame_front_rect(
 
 fn ppc_dialog_text_lines(bytes: &[u8], max_width: i16) -> Vec<Vec<u8>> {
     crate::quickdraw::text::wrap_classic_text(bytes, max_width, |_, byte| {
-        ppc_text_byte_advance_for_font(
-            byte,
-            PPC_QD_TEXT_FONT_DEFAULT,
-            PPC_QD_TEXT_SIZE_SYSTEM,
-        )
+        ppc_text_byte_advance_for_font(byte, PPC_QD_TEXT_FONT_DEFAULT, PPC_QD_TEXT_SIZE_SYSTEM)
     })
     .into_iter()
     .map(|line| bytes[line.start..line.visible_end].to_vec())
@@ -66333,11 +66883,16 @@ fn ppc_dialog_cancel_item(
 
 fn ppc_modal_dialog(
     cpu: &mut PpcCpu,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
     last_mem_error: &mut i16,
+    ptrs: &mut Vec<PpcPtrRecord>,
+    free_ptr_blocks: &mut Vec<PpcPtrRecord>,
     handles: &mut Vec<PpcHandleRecord>,
+    free_handle_blocks: &mut Vec<PpcHandleRecord>,
+    handle_states: &mut Vec<PpcHandleStateRecord>,
     controls: &[PpcControlRecord],
     gworlds: &[PpcGWorldRecord],
     current_gworld: &mut u32,
@@ -66463,10 +67018,19 @@ fn ppc_modal_dialog(
                 let te_handle = memory
                     .read_u32_be(dialog + PPC_DIALOG_TEXT_HANDLE_OFFSET)
                     .unwrap_or(0);
+                let mut allocator = PpcProcessAllocatorView {
+                    memory_manager: process_memory_manager,
+                    ptrs: Some(ptrs),
+                    free_ptr_blocks,
+                    free_handle_blocks,
+                    handle_states,
+                };
                 let result = ppc_te_key(
+                    Some(&mut allocator),
                     memory,
                     heap_cursor,
                     heap_limit,
+                    last_mem_error,
                     handles,
                     te_handle,
                     character,
@@ -66551,6 +67115,7 @@ fn ppc_modal_dialog(
 
 fn ppc_set_control_title(
     cpu: &PpcCpu,
+    allocator: Option<&mut PpcProcessAllocatorView<'_>>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -66564,10 +67129,12 @@ fn ppc_set_control_title(
         *last_mem_error = PPC_PARAM_ERR;
         return;
     }
-    let result = ppc_set_handle_size(
+    let result = ppc_allocator_view_resize_handle(
+        allocator,
         memory,
         heap_cursor,
         heap_limit,
+        last_mem_error,
         handles,
         control_handle,
         PPC_CONTROL_RECORD_SIZE,
@@ -66597,12 +67164,16 @@ fn ppc_set_control_title(
 fn ppc_dispatch_legacy_control(
     binding: &PpcImportBinding,
     cpu: &mut PpcCpu,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
     last_mem_error: &mut i16,
+    ptrs: &mut Vec<PpcPtrRecord>,
+    free_ptr_blocks: &mut Vec<PpcPtrRecord>,
     handles: &mut Vec<PpcHandleRecord>,
     free_handle_blocks: &mut Vec<PpcHandleRecord>,
+    handle_states: &mut Vec<PpcHandleStateRecord>,
     controls: &mut Vec<PpcControlRecord>,
     gworlds: &[PpcGWorldRecord],
     _screen_clut: &[[u16; 3]; 256],
@@ -66615,7 +67186,15 @@ fn ppc_dispatch_legacy_control(
             let ref_con = ppc_parameter_area_slot_addr(cpu.gpr[1], PPC_NATIVE_PARAMETER_GPR_COUNT)
                 .and_then(|address| memory.read_u32_be(address))
                 .unwrap_or(0);
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
             let handle = ppc_new_control_values(
+                Some(&mut allocator),
                 memory,
                 heap_cursor,
                 heap_limit,
@@ -66659,7 +67238,15 @@ fn ppc_dispatch_legacy_control(
                 return Some(PpcImportAction::Return(0));
             };
             let bytes = vfs_resources[index].data.clone();
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
             let Some((bounds, title_ptr)) = ppc_materialize_control_resource_parameters(
+                Some(&mut allocator),
                 memory,
                 heap_cursor,
                 heap_limit,
@@ -66669,6 +67256,7 @@ fn ppc_dispatch_legacy_control(
                 return Some(PpcImportAction::Return(0));
             };
             let handle = ppc_new_control_values(
+                Some(&mut allocator),
                 memory,
                 heap_cursor,
                 heap_limit,
@@ -66704,14 +67292,48 @@ fn ppc_dispatch_legacy_control(
             Some(PpcImportAction::Return(handle))
         }
         "DisposeControl" => {
-            ppc_dispose_control(memory, handles, free_handle_blocks, controls, cpu.gpr[3]);
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
+            ppc_dispose_control(
+                Some(&mut allocator),
+                None,
+                memory,
+                heap_cursor,
+                heap_limit,
+                last_mem_error,
+                handles,
+                controls,
+                cpu.gpr[3],
+            );
             Some(PpcImportAction::ReturnPreserve)
         }
         "KillControls" => {
             let owner = cpu.gpr[3];
             let control_handles = ppc_window_control_handles(memory, owner);
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
             for handle in control_handles {
-                ppc_dispose_control(memory, handles, free_handle_blocks, controls, handle);
+                ppc_dispose_control(
+                    Some(&mut allocator),
+                    None,
+                    memory,
+                    heap_cursor,
+                    heap_limit,
+                    last_mem_error,
+                    handles,
+                    controls,
+                    handle,
+                );
             }
             let _ = memory.write_u32_be(owner.wrapping_add(PPC_CWINDOW_CONTROL_LIST_OFFSET), 0);
             Some(PpcImportAction::ReturnPreserve)
@@ -66891,6 +67513,7 @@ fn ppc_dispatch_legacy_control(
 
 #[allow(clippy::too_many_arguments)]
 fn ppc_new_control_values(
+    allocator: Option<&mut PpcProcessAllocatorView<'_>>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -66913,6 +67536,7 @@ fn ppc_new_control_values(
     };
     let title = ppc_read_pstring_bytes(memory, title_ptr).unwrap_or_default();
     ppc_new_control_record_values(
+        allocator,
         memory,
         heap_cursor,
         heap_limit,
@@ -66933,6 +67557,7 @@ fn ppc_new_control_values(
 
 #[allow(clippy::too_many_arguments)]
 fn ppc_new_control_record_values(
+    allocator: Option<&mut PpcProcessAllocatorView<'_>>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -66957,10 +67582,12 @@ fn ppc_new_control_record_values(
         *last_mem_error = PPC_PARAM_ERR;
         return 0;
     }
-    let handle = ppc_alloc_handle(
+    let handle = ppc_allocator_view_allocate_handle(
+        allocator,
         memory,
         heap_cursor,
         heap_limit,
+        last_mem_error,
         handles,
         PPC_CONTROL_RECORD_SIZE,
         true,
@@ -67039,6 +67666,7 @@ fn ppc_new_control_record_values(
 }
 
 fn ppc_materialize_control_resource_parameters(
+    allocator: Option<&mut PpcProcessAllocatorView<'_>>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -67048,7 +67676,8 @@ fn ppc_materialize_control_resource_parameters(
         return None;
     }
     let title_len = usize::from(bytes[22]).min(bytes.len().saturating_sub(23));
-    let scratch = ppc_heap_alloc(
+    let scratch = ppc_allocator_view_reserve_bytes(
+        allocator,
         memory,
         heap_cursor,
         heap_limit,
@@ -67086,9 +67715,13 @@ fn ppc_window_control_handles(memory: &mut PpcSectionMem, owner: u32) -> Vec<u32
 }
 
 fn ppc_dispose_control(
+    allocator: Option<&mut PpcProcessAllocatorView<'_>>,
+    legacy_free_handle_blocks: Option<&mut Vec<PpcHandleRecord>>,
     memory: &mut PpcSectionMem,
+    heap_cursor: &mut u32,
+    heap_limit: u32,
+    last_mem_error: &mut i16,
     handles: &mut Vec<PpcHandleRecord>,
-    free_handle_blocks: &mut Vec<PpcHandleRecord>,
     controls: &mut Vec<PpcControlRecord>,
     handle: u32,
 ) {
@@ -67119,10 +67752,21 @@ fn ppc_dispose_control(
             }
         }
     }
-    if let Some(index) = handles.iter().position(|record| record.handle == handle) {
-        let record = handles.remove(index);
-        let _ = memory.write_u32_be(handle, 0);
-        free_handle_blocks.push(record);
+    if let Some(allocator) = allocator {
+        let _ = allocator.dispose_handle(
+            memory,
+            heap_cursor,
+            heap_limit,
+            last_mem_error,
+            handles,
+            handle,
+        );
+    } else if let Some(free_handle_blocks) = legacy_free_handle_blocks {
+        if let Some(index) = handles.iter().position(|record| record.handle == handle) {
+            let record = handles.remove(index);
+            let _ = memory.write_u32_be(handle, 0);
+            free_handle_blocks.push(record);
+        }
     }
     controls.retain(|record| record.handle != handle);
 }
@@ -67344,12 +67988,7 @@ fn ppc_blit_theme_bitmap(
                 vis_storage.as_deref(),
                 clip_storage.as_deref(),
             ) {
-                wrote |= ppc_quickdraw_write_raw_pixel(
-                    memory,
-                    surface.front_buffer,
-                    point,
-                    pixel,
-                );
+                wrote |= ppc_quickdraw_write_raw_pixel(memory, surface.front_buffer, point, pixel);
             }
         }
     }
@@ -67398,9 +68037,8 @@ fn ppc_draw_control_inner(
             // Macintosh Toolbox Essentials (1992), pp. 5-15--5-16: the
             // standard checkbox CDEF draws a compact indicator at the left
             // of the control title and marks it when contrlValue is nonzero.
-            let layout = crate::control_manager::standard_checkbox_layout((
-                top, left, bottom, right,
-            ));
+            let layout =
+                crate::control_manager::standard_checkbox_layout((top, left, bottom, right));
             let (box_top, box_left, box_bottom, box_right) = layout.indicator;
             let indicator_size = box_bottom.saturating_sub(box_top);
             let mut wrote = ppc_line_to(
@@ -67464,27 +68102,13 @@ fn ppc_draw_control_inner(
         2 => {
             // Inside Macintosh Volume I (1985), p. I-322: radioButProc is a
             // round indicator whose on state is a small filled black circle.
-            let layout = crate::control_manager::standard_radio_button_layout((
-                top, left, bottom, right,
-            ));
+            let layout =
+                crate::control_manager::standard_radio_button_layout((top, left, bottom, right));
             let indicator = layout.indicator;
-            let mut wrote = ppc_paint_rect_bounds(
-                memory,
-                gworlds,
-                owner,
-                indicator,
-                PPC_RGB_WHITE,
-                None,
-            );
-            wrote |= ppc_draw_oval_bounds(
-                memory,
-                gworlds,
-                owner,
-                indicator,
-                PPC_RGB_BLACK,
-                None,
-                true,
-            );
+            let mut wrote =
+                ppc_paint_rect_bounds(memory, gworlds, owner, indicator, PPC_RGB_WHITE, None);
+            wrote |=
+                ppc_draw_oval_bounds(memory, gworlds, owner, indicator, PPC_RGB_BLACK, None, true);
             if memory
                 .read_u16_be(control + PPC_CONTROL_VALUE_OFFSET)
                 .unwrap_or(0)
@@ -67671,10 +68295,14 @@ fn ppc_draw_control_inner(
         );
         let title_h = match proc_id {
             0 => centered_h,
-            1 => crate::control_manager::standard_checkbox_layout((top, left, bottom, right))
-                .label_left,
-            2 => crate::control_manager::standard_radio_button_layout((top, left, bottom, right))
-                .label_left,
+            1 => {
+                crate::control_manager::standard_checkbox_layout((top, left, bottom, right))
+                    .label_left
+            }
+            2 => {
+                crate::control_manager::standard_radio_button_layout((top, left, bottom, right))
+                    .label_left
+            }
             _ => left.saturating_add(16),
         };
         let title_v = centered_v.min(bottom.saturating_sub(1));
@@ -67698,12 +68326,16 @@ fn ppc_draw_control_inner(
 fn ppc_dispatch_legacy_window(
     binding: &PpcImportBinding,
     cpu: &mut PpcCpu,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
     last_mem_error: &mut i16,
+    ptrs: &mut Vec<PpcPtrRecord>,
+    free_ptr_blocks: &mut Vec<PpcPtrRecord>,
     handles: &mut Vec<PpcHandleRecord>,
     free_handle_blocks: &mut Vec<PpcHandleRecord>,
+    handle_states: &mut Vec<PpcHandleStateRecord>,
     controls: &mut Vec<PpcControlRecord>,
     gworlds: &mut Vec<PpcGWorldRecord>,
     current_gworld: &mut u32,
@@ -67725,8 +68357,16 @@ fn ppc_dispatch_legacy_window(
     match binding.symbol_name.as_str() {
         "NewWindow" => {
             let previous_front = ppc_front_visible_window(memory, gworlds);
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
             let window = ppc_new_window_from_cpu(
                 cpu,
+                Some(&mut allocator),
                 memory,
                 heap_cursor,
                 heap_limit,
@@ -67774,9 +68414,20 @@ fn ppc_dispatch_legacy_window(
                 return Some(PpcImportAction::Return(0));
             };
             let bytes = vfs_resources[index].data.clone();
-            let Some((bounds, title)) =
-                ppc_materialize_window_resource_parameters(memory, heap_cursor, heap_limit, &bytes)
-            else {
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
+            let Some((bounds, title)) = ppc_materialize_window_resource_parameters(
+                Some(&mut allocator),
+                memory,
+                heap_cursor,
+                heap_limit,
+                &bytes,
+            ) else {
                 *last_resource_error = PPC_PARAM_ERR;
                 return Some(PpcImportAction::Return(0));
             };
@@ -67791,6 +68442,7 @@ fn ppc_dispatch_legacy_window(
             window_cpu.gpr[10] = u32::from_be_bytes([bytes[14], bytes[15], bytes[16], bytes[17]]);
             let window = ppc_new_window_from_cpu(
                 &window_cpu,
+                Some(&mut allocator),
                 memory,
                 heap_cursor,
                 heap_limit,
@@ -67843,7 +68495,15 @@ fn ppc_dispatch_legacy_window(
             Some(PpcImportAction::ReturnPreserve)
         }
         "SetWTitle" => {
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
             let changed = ppc_set_window_title(
+                Some(&mut allocator),
                 memory,
                 heap_cursor,
                 heap_limit,
@@ -67876,23 +68536,27 @@ fn ppc_dispatch_legacy_window(
                 })
                 .map(|record| record.pixmap_handle);
             let was_current = *current_gworld == window;
-            ppc_dispose_window(
-                memory,
-                handles,
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
                 free_handle_blocks,
+                handle_states,
+            };
+            ppc_dispose_window(
+                &mut allocator,
+                memory,
+                heap_cursor,
+                heap_limit,
+                last_mem_error,
+                handles,
                 controls,
                 gworlds,
                 current_gworld,
                 current_gdevice,
                 window,
             );
-            ppc_recalculate_window_vis_regions(
-                memory,
-                gworlds,
-                heap_cursor,
-                heap_limit,
-                handles,
-            );
+            ppc_recalculate_window_vis_regions(memory, gworlds, heap_cursor, heap_limit, handles);
             ppc_transition_front_window_chrome(
                 memory,
                 gworlds,
@@ -67964,13 +68628,7 @@ fn ppc_dispatch_legacy_window(
         "BringToFront" => {
             let previous_front = ppc_front_visible_window(memory, gworlds);
             ppc_reorder_window(gworlds, cpu.gpr[3], 0, true);
-            ppc_recalculate_window_vis_regions(
-                memory,
-                gworlds,
-                heap_cursor,
-                heap_limit,
-                handles,
-            );
+            ppc_recalculate_window_vis_regions(memory, gworlds, heap_cursor, heap_limit, handles);
             if ppc_front_visible_window(memory, gworlds) != previous_front {
                 let _ = ppc_activate_front_window_palette(
                     memory,
@@ -67988,13 +68646,7 @@ fn ppc_dispatch_legacy_window(
         "SendBehind" => {
             let previous_front = ppc_front_visible_window(memory, gworlds);
             ppc_reorder_window(gworlds, cpu.gpr[3], cpu.gpr[4], false);
-            ppc_recalculate_window_vis_regions(
-                memory,
-                gworlds,
-                heap_cursor,
-                heap_limit,
-                handles,
-            );
+            ppc_recalculate_window_vis_regions(memory, gworlds, heap_cursor, heap_limit, handles);
             if ppc_front_visible_window(memory, gworlds) != previous_front {
                 let _ = ppc_activate_front_window_palette(
                     memory,
@@ -68058,7 +68710,21 @@ fn ppc_dispatch_legacy_window(
                 .read_u32_be(window.wrapping_add(PPC_CGRAF_PORT_VIS_RGN_OFFSET))
                 .unwrap_or(0);
             if vis_rgn == 0 {
-                vis_rgn = ppc_new_rgn(memory, heap_cursor, heap_limit, last_mem_error, handles);
+                let mut allocator = PpcProcessAllocatorView {
+                    memory_manager: process_memory_manager,
+                    ptrs: Some(ptrs),
+                    free_ptr_blocks,
+                    free_handle_blocks,
+                    handle_states,
+                };
+                vis_rgn = ppc_allocator_view_new_rgn(
+                    Some(&mut allocator),
+                    memory,
+                    heap_cursor,
+                    heap_limit,
+                    last_mem_error,
+                    handles,
+                );
                 let _ = memory
                     .write_u32_be(window.wrapping_add(PPC_CGRAF_PORT_VIS_RGN_OFFSET), vis_rgn);
             }
@@ -68074,6 +68740,7 @@ fn ppc_dispatch_legacy_window(
 #[allow(clippy::too_many_arguments)]
 fn ppc_new_window_from_cpu(
     cpu: &PpcCpu,
+    mut allocator: Option<&mut PpcProcessAllocatorView<'_>>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -68086,6 +68753,7 @@ fn ppc_new_window_from_cpu(
     let previous_front = ppc_front_visible_window(memory, gworlds);
     let window = ppc_new_cwindow(
         cpu,
+        allocator.as_deref_mut(),
         memory,
         heap_cursor,
         heap_limit,
@@ -68099,6 +68767,7 @@ fn ppc_new_window_from_cpu(
     }
     let _ = memory.write_u32_be(window + PPC_CWINDOW_CONTROL_LIST_OFFSET, 0);
     if !ppc_set_window_title(
+        allocator.as_deref_mut(),
         memory,
         heap_cursor,
         heap_limit,
@@ -68109,7 +68778,16 @@ fn ppc_new_window_from_cpu(
     ) {
         return 0;
     }
-    let state_handle = ppc_alloc_handle(memory, heap_cursor, heap_limit, handles, 16, true);
+    let state_handle = ppc_allocator_view_allocate_handle(
+        allocator.as_deref_mut(),
+        memory,
+        heap_cursor,
+        heap_limit,
+        last_mem_error,
+        handles,
+        16,
+        true,
+    );
     let Some(state) = memory.read_u32_be(state_handle).filter(|state| *state != 0) else {
         *last_mem_error = PPC_MEM_FULL_ERR;
         return 0;
@@ -68141,6 +68819,7 @@ fn ppc_new_window_from_cpu(
 }
 
 fn ppc_set_window_title(
+    mut allocator: Option<&mut PpcProcessAllocatorView<'_>>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -68163,15 +68842,32 @@ fn ppc_set_window_title(
         .read_u32_be(window + PPC_CWINDOW_TITLE_HANDLE_OFFSET)
         .unwrap_or(0);
     let handle = if existing != 0 {
-        if ppc_set_handle_size(memory, heap_cursor, heap_limit, handles, existing, size)
-            != PPC_NO_ERR
+        if ppc_allocator_view_resize_handle(
+            allocator.as_deref_mut(),
+            memory,
+            heap_cursor,
+            heap_limit,
+            last_mem_error,
+            handles,
+            existing,
+            size,
+        ) != PPC_NO_ERR
         {
             *last_mem_error = PPC_MEM_FULL_ERR;
             return false;
         }
         existing
     } else {
-        ppc_alloc_handle(memory, heap_cursor, heap_limit, handles, size, true)
+        ppc_allocator_view_allocate_handle(
+            allocator.as_deref_mut(),
+            memory,
+            heap_cursor,
+            heap_limit,
+            last_mem_error,
+            handles,
+            size,
+            true,
+        )
     };
     let Some(data) = memory.read_u32_be(handle).filter(|data| *data != 0) else {
         *last_mem_error = PPC_MEM_FULL_ERR;
@@ -68196,6 +68892,7 @@ fn ppc_set_window_title(
 }
 
 fn ppc_materialize_window_resource_parameters(
+    allocator: Option<&mut PpcProcessAllocatorView<'_>>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -68208,7 +68905,8 @@ fn ppc_materialize_window_resource_parameters(
     if bytes.len() < 19usize.checked_add(title_len)? {
         return None;
     }
-    let scratch = ppc_heap_alloc(
+    let scratch = ppc_allocator_view_reserve_bytes(
+        allocator,
         memory,
         heap_cursor,
         heap_limit,
@@ -68226,9 +68924,12 @@ fn ppc_materialize_window_resource_parameters(
 
 #[allow(clippy::too_many_arguments)]
 fn ppc_dispose_window(
+    allocator: &mut PpcProcessAllocatorView<'_>,
     memory: &mut PpcSectionMem,
+    heap_cursor: &mut u32,
+    heap_limit: u32,
+    last_mem_error: &mut i16,
     handles: &mut Vec<PpcHandleRecord>,
-    free_handle_blocks: &mut Vec<PpcHandleRecord>,
     controls: &mut Vec<PpcControlRecord>,
     gworlds: &mut Vec<PpcGWorldRecord>,
     current_gworld: &mut u32,
@@ -68236,7 +68937,17 @@ fn ppc_dispose_window(
     window: u32,
 ) {
     for control in ppc_window_control_handles(memory, window) {
-        ppc_dispose_control(memory, handles, free_handle_blocks, controls, control);
+        ppc_dispose_control(
+            Some(allocator),
+            None,
+            memory,
+            heap_cursor,
+            heap_limit,
+            last_mem_error,
+            handles,
+            controls,
+            control,
+        );
     }
     for offset in [
         PPC_CGRAF_PORT_VIS_RGN_OFFSET,
@@ -68249,7 +68960,14 @@ fn ppc_dispose_window(
         PPC_CWINDOW_STATE_HANDLE_OFFSET,
     ] {
         let handle = memory.read_u32_be(window.wrapping_add(offset)).unwrap_or(0);
-        ppc_release_window_handle(memory, handles, free_handle_blocks, handle);
+        let _ = allocator.dispose_handle(
+            memory,
+            heap_cursor,
+            heap_limit,
+            last_mem_error,
+            handles,
+            handle,
+        );
         let _ = memory.write_u32_be(window.wrapping_add(offset), 0);
     }
     gworlds.retain(|record| {
@@ -68266,19 +68984,6 @@ fn ppc_dispose_window(
             })
             .unwrap_or(PPC_MAIN_GWORLD);
         *current_gdevice = ppc_gworld_device(gworlds, *current_gworld).unwrap_or(PPC_MAIN_GDEVICE);
-    }
-}
-
-fn ppc_release_window_handle(
-    memory: &mut PpcSectionMem,
-    handles: &mut Vec<PpcHandleRecord>,
-    free_handle_blocks: &mut Vec<PpcHandleRecord>,
-    handle: u32,
-) {
-    if let Some(index) = handles.iter().position(|record| record.handle == handle) {
-        let record = handles.remove(index);
-        let _ = memory.write_u32_be(handle, 0);
-        free_handle_blocks.push(record);
     }
 }
 
@@ -69365,20 +70070,24 @@ fn ppc_list_cell_for_index(record: &PpcListRecord, index: usize) -> Option<(i16,
 }
 
 fn ppc_list_sync_guest_storage(
+    mut allocator: Option<&mut PpcProcessAllocatorView<'_>>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
-    handles: &mut [PpcHandleRecord],
+    last_mem_error: &mut i16,
+    handles: &mut Vec<PpcHandleRecord>,
     record: &PpcListRecord,
 ) -> i16 {
     let offsets_size = (record.cells.len() as u32)
         .saturating_add(1)
         .saturating_mul(2);
     let list_size = PPC_LIST_REC_MIN_SIZE.max(PPC_LIST_CELL_ARRAY_OFFSET + offsets_size);
-    let result = ppc_set_handle_size(
+    let result = ppc_allocator_view_resize_handle(
+        allocator.as_deref_mut(),
         memory,
         heap_cursor,
         heap_limit,
+        last_mem_error,
         handles,
         record.handle,
         list_size,
@@ -69392,10 +70101,12 @@ fn ppc_list_sync_guest_storage(
     if data_size > 32_000 {
         return PPC_MEM_FULL_ERR;
     }
-    let result = ppc_set_handle_size(
+    let result = ppc_allocator_view_resize_handle(
+        allocator.as_deref_mut(),
         memory,
         heap_cursor,
         heap_limit,
+        last_mem_error,
         handles,
         record.cells_handle,
         data_size,
@@ -69458,9 +70169,11 @@ fn ppc_list_sync_guest_storage(
 #[allow(clippy::too_many_arguments)]
 fn ppc_list_new(
     cpu: &PpcCpu,
+    mut allocator: Option<&mut PpcProcessAllocatorView<'_>>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
+    last_mem_error: &mut i16,
     handles: &mut Vec<PpcHandleRecord>,
     list_manager: &mut PpcListManagerState,
 ) -> u32 {
@@ -69477,15 +70190,26 @@ fn ppc_list_new(
     else {
         return 0;
     };
-    let list_handle = ppc_alloc_handle(
+    let list_handle = ppc_allocator_view_allocate_handle(
+        allocator.as_deref_mut(),
         memory,
         heap_cursor,
         heap_limit,
+        last_mem_error,
         handles,
         PPC_LIST_REC_MIN_SIZE + (cell_count as u32 + 1) * 2,
         true,
     );
-    let cells_handle = ppc_alloc_handle(memory, heap_cursor, heap_limit, handles, 0, true);
+    let cells_handle = ppc_allocator_view_allocate_handle(
+        allocator.as_deref_mut(),
+        memory,
+        heap_cursor,
+        heap_limit,
+        last_mem_error,
+        handles,
+        0,
+        true,
+    );
     let Some(list_ptr) = memory.read_u32_be(list_handle).filter(|ptr| *ptr != 0) else {
         return 0;
     };
@@ -69583,7 +70307,15 @@ fn ppc_list_new(
         selected: vec![false; cell_count],
         draw_enabled: cpu.gpr[8] != 0,
     };
-    if ppc_list_sync_guest_storage(memory, heap_cursor, heap_limit, handles, &record) != PPC_NO_ERR
+    if ppc_list_sync_guest_storage(
+        allocator.as_deref_mut(),
+        memory,
+        heap_cursor,
+        heap_limit,
+        last_mem_error,
+        handles,
+        &record,
+    ) != PPC_NO_ERR
     {
         return 0;
     }
@@ -69672,9 +70404,11 @@ fn ppc_te_write_rect(memory: &mut PpcSectionMem, rect_ptr: u32, rect: [u16; 4]) 
 
 #[allow(clippy::too_many_arguments)]
 fn ppc_te_initialize_record(
+    mut allocator: Option<&mut PpcProcessAllocatorView<'_>>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
+    last_mem_error: &mut i16,
     handles: &mut Vec<PpcHandleRecord>,
     dest_rect_ptr: u32,
     view_rect_ptr: u32,
@@ -69691,10 +70425,12 @@ fn ppc_te_initialize_record(
     ) else {
         return 0;
     };
-    let te_handle = ppc_alloc_handle(
+    let te_handle = ppc_allocator_view_allocate_handle(
+        allocator.as_deref_mut(),
         memory,
         heap_cursor,
         heap_limit,
+        last_mem_error,
         handles,
         PPC_TE_REC_MIN_SIZE,
         true,
@@ -69702,7 +70438,16 @@ fn ppc_te_initialize_record(
     let Some(te_ptr) = memory.read_u32_be(te_handle).filter(|ptr| *ptr != 0) else {
         return 0;
     };
-    let h_text = ppc_alloc_handle(memory, heap_cursor, heap_limit, handles, 0, true);
+    let h_text = ppc_allocator_view_allocate_handle(
+        allocator.as_deref_mut(),
+        memory,
+        heap_cursor,
+        heap_limit,
+        last_mem_error,
+        handles,
+        0,
+        true,
+    );
     let text_font = ppc_current_text_font(memory, current_port);
     let text_face = memory
         .read_u8(current_port.wrapping_add(PPC_CGRAF_PORT_TX_FACE_OFFSET))
@@ -69743,42 +70488,52 @@ fn ppc_te_initialize_record(
     // Inside Macintosh: Text (1993), p. 2-78: TEStyleNew installs -1 in
     // txSize, lineHeight, and fontAscent, overlays a TEStyleHandle on
     // txFont/txFace, and creates the null style scrap used for its lifetime.
-    let style_table = ppc_alloc_handle(
+    let style_table = ppc_allocator_view_allocate_handle(
+        allocator.as_deref_mut(),
         memory,
         heap_cursor,
         heap_limit,
+        last_mem_error,
         handles,
         PPC_TE_ST_ELEMENT_SIZE,
         true,
     );
-    let lh_table = ppc_alloc_handle(
+    let lh_table = ppc_allocator_view_allocate_handle(
+        allocator.as_deref_mut(),
         memory,
         heap_cursor,
         heap_limit,
+        last_mem_error,
         handles,
         PPC_TE_LH_ELEMENT_SIZE,
         true,
     );
-    let null_scrap = ppc_alloc_handle(
+    let null_scrap = ppc_allocator_view_allocate_handle(
+        allocator.as_deref_mut(),
         memory,
         heap_cursor,
         heap_limit,
+        last_mem_error,
         handles,
         PPC_TE_STYLE_SCRAP_REC_SIZE,
         true,
     );
-    let null_style = ppc_alloc_handle(
+    let null_style = ppc_allocator_view_allocate_handle(
+        allocator.as_deref_mut(),
         memory,
         heap_cursor,
         heap_limit,
+        last_mem_error,
         handles,
         PPC_TE_NULL_STYLE_REC_SIZE,
         true,
     );
-    let style_handle = ppc_alloc_handle(
+    let style_handle = ppc_allocator_view_allocate_handle(
+        allocator.as_deref_mut(),
         memory,
         heap_cursor,
         heap_limit,
+        last_mem_error,
         handles,
         PPC_TE_STYLE_REC_SIZE,
         true,
@@ -69881,10 +70636,12 @@ fn ppc_te_primary_font_and_size(memory: &mut PpcSectionMem, te_ptr: u32) -> (i16
 }
 
 fn ppc_te_recalculate_layout(
+    allocator: Option<&mut PpcProcessAllocatorView<'_>>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
-    handles: &mut [PpcHandleRecord],
+    last_mem_error: &mut i16,
+    handles: &mut Vec<PpcHandleRecord>,
     te_handle: u32,
 ) -> i16 {
     let Some(te_ptr) = ppc_te_record_ptr(memory, te_handle) else {
@@ -69907,10 +70664,12 @@ fn ppc_te_recalculate_layout(
         PPC_TE_LINE_STARTS_OFFSET
             .saturating_add((starts.len() as u32).saturating_add(2).saturating_mul(2)),
     );
-    let result = ppc_set_handle_size(
+    let result = ppc_allocator_view_resize_handle(
+        allocator,
         memory,
         heap_cursor,
         heap_limit,
+        last_mem_error,
         handles,
         te_handle,
         required_size,
@@ -69946,9 +70705,11 @@ fn ppc_te_recalculate_layout(
 }
 
 fn ppc_te_set_text(
+    mut allocator: Option<&mut PpcProcessAllocatorView<'_>>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
+    last_mem_error: &mut i16,
     handles: &mut Vec<PpcHandleRecord>,
     te_handle: u32,
     text: &[u8],
@@ -69963,10 +70724,12 @@ fn ppc_te_set_text(
         return PPC_NIL_HANDLE_ERR;
     }
     let length = text.len().min(i16::MAX as usize);
-    let result = ppc_set_handle_size(
+    let result = ppc_allocator_view_resize_handle(
+        allocator.as_deref_mut(),
         memory,
         heap_cursor,
         heap_limit,
+        last_mem_error,
         handles,
         text_handle,
         length as u32,
@@ -69986,13 +70749,23 @@ fn ppc_te_set_text(
     let _ = memory.write_u16_be(te_ptr + PPC_TE_LENGTH_OFFSET, length as u16);
     let _ = memory.write_u16_be(te_ptr + PPC_TE_SEL_START_OFFSET, length as u16);
     let _ = memory.write_u16_be(te_ptr + PPC_TE_SEL_END_OFFSET, length as u16);
-    ppc_te_recalculate_layout(memory, heap_cursor, heap_limit, handles, te_handle)
+    ppc_te_recalculate_layout(
+        allocator,
+        memory,
+        heap_cursor,
+        heap_limit,
+        last_mem_error,
+        handles,
+        te_handle,
+    )
 }
 
 fn ppc_te_replace_selection(
+    allocator: Option<&mut PpcProcessAllocatorView<'_>>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
+    last_mem_error: &mut i16,
     handles: &mut Vec<PpcHandleRecord>,
     te_handle: u32,
     inserted: &[u8],
@@ -70002,9 +70775,11 @@ fn ppc_te_replace_selection(
     };
     buffer.replace_selection(inserted);
     ppc_te_commit_edit_buffer(
+        allocator,
         memory,
         heap_cursor,
         heap_limit,
+        last_mem_error,
         handles,
         te_handle,
         &buffer,
@@ -70027,17 +70802,21 @@ fn ppc_te_edit_buffer(
 }
 
 fn ppc_te_commit_edit_buffer(
+    mut allocator: Option<&mut PpcProcessAllocatorView<'_>>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
+    last_mem_error: &mut i16,
     handles: &mut Vec<PpcHandleRecord>,
     te_handle: u32,
     buffer: &crate::text_edit::TextEditBuffer,
 ) -> i16 {
     let result = ppc_te_set_text(
+        allocator.as_deref_mut(),
         memory,
         heap_cursor,
         heap_limit,
+        last_mem_error,
         handles,
         te_handle,
         buffer.text(),
@@ -70060,9 +70839,11 @@ fn ppc_te_commit_edit_buffer(
 }
 
 fn ppc_te_key(
+    allocator: Option<&mut PpcProcessAllocatorView<'_>>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
+    last_mem_error: &mut i16,
     handles: &mut Vec<PpcHandleRecord>,
     te_handle: u32,
     key: u8,
@@ -70072,9 +70853,11 @@ fn ppc_te_key(
     };
     buffer.apply_key(key);
     ppc_te_commit_edit_buffer(
+        allocator,
         memory,
         heap_cursor,
         heap_limit,
+        last_mem_error,
         handles,
         te_handle,
         &buffer,
@@ -70446,9 +71229,11 @@ fn ppc_te_scroll(memory: &mut PpcSectionMem, te_handle: u32, dh: i16, dv: i16, p
 }
 
 fn ppc_te_scrap_handle(
+    allocator: Option<&mut PpcProcessAllocatorView<'_>>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
+    last_mem_error: &mut i16,
     handles: &mut Vec<PpcHandleRecord>,
     scrap: &mut PpcScrapState,
 ) -> u32 {
@@ -70459,7 +71244,16 @@ fn ppc_te_scrap_handle(
     {
         return scrap.private_text_handle;
     }
-    scrap.private_text_handle = ppc_alloc_handle(memory, heap_cursor, heap_limit, handles, 0, true);
+    scrap.private_text_handle = ppc_allocator_view_allocate_handle(
+        allocator,
+        memory,
+        heap_cursor,
+        heap_limit,
+        last_mem_error,
+        handles,
+        0,
+        true,
+    );
     scrap.private_text_handle
 }
 
@@ -70472,22 +71266,34 @@ fn ppc_te_scrap_bytes(
 }
 
 fn ppc_te_set_scrap_bytes(
+    mut allocator: Option<&mut PpcProcessAllocatorView<'_>>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
+    last_mem_error: &mut i16,
     handles: &mut Vec<PpcHandleRecord>,
     scrap: &mut PpcScrapState,
     bytes: &[u8],
 ) -> i16 {
-    let handle = ppc_te_scrap_handle(memory, heap_cursor, heap_limit, handles, scrap);
+    let handle = ppc_te_scrap_handle(
+        allocator.as_deref_mut(),
+        memory,
+        heap_cursor,
+        heap_limit,
+        last_mem_error,
+        handles,
+        scrap,
+    );
     if handle == 0 {
         return PPC_MEM_FULL_ERR;
     }
     let length = bytes.len().min(i16::MAX as usize);
-    let result = ppc_set_handle_size(
+    let result = ppc_allocator_view_resize_handle(
+        allocator,
         memory,
         heap_cursor,
         heap_limit,
+        last_mem_error,
         handles,
         handle,
         length as u32,
@@ -70520,9 +71326,11 @@ fn ppc_te_selected_bytes(
 
 #[allow(clippy::too_many_arguments)]
 fn ppc_te_copy_or_cut(
+    mut allocator: Option<&mut PpcProcessAllocatorView<'_>>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
+    last_mem_error: &mut i16,
     handles: &mut Vec<PpcHandleRecord>,
     scrap: &mut PpcScrapState,
     te_handle: u32,
@@ -70534,11 +71342,29 @@ fn ppc_te_copy_or_cut(
     if selected.is_empty() {
         return PPC_NO_ERR;
     }
-    let result = ppc_te_set_scrap_bytes(memory, heap_cursor, heap_limit, handles, scrap, &selected);
+    let result = ppc_te_set_scrap_bytes(
+        allocator.as_deref_mut(),
+        memory,
+        heap_cursor,
+        heap_limit,
+        last_mem_error,
+        handles,
+        scrap,
+        &selected,
+    );
     if result != PPC_NO_ERR || !cut {
         return result;
     }
-    ppc_te_replace_selection(memory, heap_cursor, heap_limit, handles, te_handle, &[])
+    ppc_te_replace_selection(
+        allocator,
+        memory,
+        heap_cursor,
+        heap_limit,
+        last_mem_error,
+        handles,
+        te_handle,
+        &[],
+    )
 }
 
 fn ppc_scrap_flavor_offset(scrap: &PpcScrapState, flavor_index: usize) -> u32 {
@@ -70553,10 +71379,12 @@ fn ppc_scrap_flavor_offset(scrap: &PpcScrapState, flavor_index: usize) -> u32 {
 
 fn ppc_get_scrap(
     cpu: &PpcCpu,
+    allocator: Option<&mut PpcProcessAllocatorView<'_>>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
-    handles: &mut [PpcHandleRecord],
+    last_mem_error: &mut i16,
+    handles: &mut Vec<PpcHandleRecord>,
     scrap: &PpcScrapState,
 ) -> u32 {
     let Some((index, (_, bytes))) = scrap
@@ -70574,10 +71402,12 @@ fn ppc_get_scrap(
         let _ = memory.write_u32_be(cpu.gpr[5], ppc_scrap_flavor_offset(scrap, index));
     }
     if cpu.gpr[3] != 0 {
-        let result = ppc_set_handle_size(
+        let result = ppc_allocator_view_resize_handle(
+            allocator,
             memory,
             heap_cursor,
             heap_limit,
+            last_mem_error,
             handles,
             cpu.gpr[3],
             bytes.len() as u32,
@@ -70698,25 +71528,47 @@ fn ppc_te_draw(
 }
 
 fn ppc_te_forget_handle(
+    allocator: Option<&mut PpcProcessAllocatorView<'_>>,
+    legacy_handle_states: Option<&mut Vec<PpcHandleStateRecord>>,
     memory: &mut PpcSectionMem,
+    heap_cursor: &mut u32,
+    heap_limit: u32,
+    last_mem_error: &mut i16,
     handles: &mut Vec<PpcHandleRecord>,
-    handle_states: &mut Vec<PpcHandleStateRecord>,
     handle: u32,
 ) {
     if handle == 0 {
         return;
     }
-    if let Some(index) = handles.iter().position(|record| record.handle == handle) {
-        handles.remove(index);
-        let _ = memory.write_u32_be(handle, 0);
+    if let Some(allocator) = allocator {
+        let _ = allocator.dispose_handle(
+            memory,
+            heap_cursor,
+            heap_limit,
+            last_mem_error,
+            handles,
+            handle,
+        );
+    } else {
+        if let Some(index) = handles.iter().position(|record| record.handle == handle) {
+            handles.remove(index);
+            let _ = memory.write_u32_be(handle, 0);
+        }
+        if let Some(handle_states) = legacy_handle_states {
+            ppc_forget_handle_state(handle, handle_states);
+        }
     }
-    ppc_forget_handle_state(handle, handle_states);
 }
 
+#[allow(clippy::too_many_arguments)]
 fn ppc_te_dispose(
+    mut allocator: Option<&mut PpcProcessAllocatorView<'_>>,
+    mut legacy_handle_states: Option<&mut Vec<PpcHandleStateRecord>>,
     memory: &mut PpcSectionMem,
+    heap_cursor: &mut u32,
+    heap_limit: u32,
+    last_mem_error: &mut i16,
     handles: &mut Vec<PpcHandleRecord>,
-    handle_states: &mut Vec<PpcHandleStateRecord>,
     te_handle: u32,
 ) {
     let Some(te_ptr) = memory.read_u32_be(te_handle).filter(|ptr| *ptr != 0) else {
@@ -70748,12 +71600,39 @@ fn ppc_te_dispose(
                 .and_then(|ptr| memory.read_u32_be(ptr + PPC_TE_NULL_STYLE_SCRAP_OFFSET))
                 .unwrap_or(0);
             for nested in [style_table, lh_table, null_scrap, null_style, style_handle] {
-                ppc_te_forget_handle(memory, handles, handle_states, nested);
+                ppc_te_forget_handle(
+                    allocator.as_deref_mut(),
+                    legacy_handle_states.as_deref_mut(),
+                    memory,
+                    heap_cursor,
+                    heap_limit,
+                    last_mem_error,
+                    handles,
+                    nested,
+                );
             }
         }
     }
-    ppc_te_forget_handle(memory, handles, handle_states, h_text);
-    ppc_te_forget_handle(memory, handles, handle_states, te_handle);
+    ppc_te_forget_handle(
+        allocator.as_deref_mut(),
+        legacy_handle_states.as_deref_mut(),
+        memory,
+        heap_cursor,
+        heap_limit,
+        last_mem_error,
+        handles,
+        h_text,
+    );
+    ppc_te_forget_handle(
+        allocator,
+        legacy_handle_states,
+        memory,
+        heap_cursor,
+        heap_limit,
+        last_mem_error,
+        handles,
+        te_handle,
+    );
 }
 
 fn ppc_menu_handle_bytes(
@@ -75387,12 +76266,7 @@ fn ppc_std_memchr(memory: &mut PpcSectionMem, bytes: u32, needle: u8, count: u32
     0
 }
 
-fn ppc_std_strchr(
-    memory: &mut PpcSectionMem,
-    string: u32,
-    needle: u8,
-    reverse: bool,
-) -> u32 {
+fn ppc_std_strchr(memory: &mut PpcSectionMem, string: u32, needle: u8, reverse: bool) -> u32 {
     let mut offset = 0u32;
     let mut last = 0u32;
     loop {
@@ -76408,8 +77282,7 @@ fn ppc_open_region_include_rows(
     };
     let shape_top = i32::from(rows_top) + first as i32;
     let shape_bottom = i32::from(rows_top) + last as i32 + 1;
-    let (Ok(shape_top), Ok(shape_bottom)) =
-        (i16::try_from(shape_top), i16::try_from(shape_bottom))
+    let (Ok(shape_top), Ok(shape_bottom)) = (i16::try_from(shape_top), i16::try_from(shape_bottom))
     else {
         return;
     };
@@ -76490,11 +77363,7 @@ fn ppc_open_region_include_rect(
     let Ok(height) = usize::try_from(i32::from(rect_bottom) - i32::from(rect_top)) else {
         return;
     };
-    ppc_open_region_include_rows(
-        startup,
-        rect_top,
-        vec![vec![rect_left, rect_right]; height],
-    );
+    ppc_open_region_include_rows(startup, rect_top, vec![vec![rect_left, rect_right]; height]);
 }
 
 fn ppc_open_region_include_region(
@@ -76787,6 +77656,37 @@ fn ppc_process_new_rgn(
         free_ptr_blocks,
         free_handle_blocks,
         handle_states,
+        10,
+        true,
+    );
+    if handle == 0 {
+        *last_mem_error = PPC_MEM_FULL_ERR;
+        return 0;
+    }
+    if ppc_set_empty_rgn(memory, handle).is_none() {
+        *last_mem_error = PPC_PARAM_ERR;
+        return 0;
+    }
+    *last_mem_error = PPC_NO_ERR;
+    handle
+}
+
+#[allow(clippy::too_many_arguments)]
+fn ppc_allocator_view_new_rgn(
+    allocator: Option<&mut PpcProcessAllocatorView<'_>>,
+    memory: &mut PpcSectionMem,
+    heap_cursor: &mut u32,
+    heap_limit: u32,
+    last_mem_error: &mut i16,
+    handles: &mut Vec<PpcHandleRecord>,
+) -> u32 {
+    let handle = ppc_allocator_view_allocate_handle(
+        allocator,
+        memory,
+        heap_cursor,
+        heap_limit,
+        last_mem_error,
+        handles,
         10,
         true,
     );
@@ -83096,6 +83996,206 @@ fn ppc_process_alloc_handle(
     handle
 }
 
+struct PpcProcessAllocatorView<'a> {
+    memory_manager: &'a mut ProcessNativeMemoryManager,
+    ptrs: Option<&'a mut Vec<PpcPtrRecord>>,
+    free_ptr_blocks: &'a mut Vec<PpcPtrRecord>,
+    free_handle_blocks: &'a mut Vec<PpcHandleRecord>,
+    handle_states: &'a mut Vec<PpcHandleStateRecord>,
+}
+
+impl PpcProcessAllocatorView<'_> {
+    fn reserve_bytes(
+        &mut self,
+        memory: &mut PpcSectionMem,
+        heap_cursor: &mut u32,
+        size: u32,
+        clear: bool,
+    ) -> u32 {
+        ppc_process_heap_alloc(self.memory_manager, memory, heap_cursor, size, clear)
+    }
+
+    fn allocate_handle(
+        &mut self,
+        memory: &mut PpcSectionMem,
+        heap_cursor: &mut u32,
+        last_mem_error: &mut i16,
+        handles: &mut Vec<PpcHandleRecord>,
+        size: u32,
+        clear: bool,
+    ) -> u32 {
+        ppc_process_alloc_handle(
+            self.memory_manager,
+            memory,
+            heap_cursor,
+            last_mem_error,
+            handles,
+            self.free_ptr_blocks,
+            self.free_handle_blocks,
+            self.handle_states,
+            size,
+            clear,
+        )
+    }
+
+    fn allocate_handle_with_bytes(
+        &mut self,
+        memory: &mut PpcSectionMem,
+        heap_cursor: &mut u32,
+        last_mem_error: &mut i16,
+        handles: &mut Vec<PpcHandleRecord>,
+        bytes: &[u8],
+    ) -> u32 {
+        ppc_process_alloc_handle_with_bytes(
+            self.memory_manager,
+            memory,
+            heap_cursor,
+            last_mem_error,
+            handles,
+            self.free_ptr_blocks,
+            self.free_handle_blocks,
+            self.handle_states,
+            bytes,
+        )
+    }
+
+    fn resize_handle(
+        &mut self,
+        memory: &mut PpcSectionMem,
+        heap_cursor: &mut u32,
+        last_mem_error: &mut i16,
+        handles: &mut Vec<PpcHandleRecord>,
+        handle: u32,
+        size: u32,
+    ) -> i16 {
+        let result = self
+            .memory_manager
+            .set_native_handle_size(memory, handle, size);
+        ppc_apply_process_native_resource_handle(
+            self.memory_manager,
+            memory,
+            heap_cursor,
+            last_mem_error,
+            self.free_ptr_blocks,
+            self.free_handle_blocks,
+            handles,
+            self.handle_states,
+            handle,
+        );
+        result
+    }
+
+    fn dispose_handle(
+        &mut self,
+        memory: &mut PpcSectionMem,
+        heap_cursor: &mut u32,
+        heap_limit: u32,
+        last_mem_error: &mut i16,
+        handles: &mut Vec<PpcHandleRecord>,
+        handle: u32,
+    ) -> bool {
+        if let Some(ptrs) = self.ptrs.as_deref_mut() {
+            return ppc_dispose_process_native_handle(
+                self.memory_manager,
+                memory,
+                heap_cursor,
+                heap_limit,
+                last_mem_error,
+                ptrs,
+                self.free_ptr_blocks,
+                handles,
+                self.free_handle_blocks,
+                self.handle_states,
+                handle,
+            );
+        }
+        let disposed = self
+            .memory_manager
+            .dispose_native_handle(memory, handle)
+            .is_some();
+        if let Some(allocator) = self.memory_manager.native_allocator_snapshot() {
+            *heap_cursor = allocator.heap.heap_cursor;
+            *last_mem_error = allocator.heap.last_mem_error;
+            *self.free_ptr_blocks = allocator.free_ptr_blocks;
+            *self.free_handle_blocks = allocator.free_handle_blocks;
+            ppc_update_zone_free_bytes(memory, *heap_cursor, allocator.heap.heap_limit);
+        }
+        if disposed {
+            handles.retain(|record| record.handle != handle);
+            ppc_forget_handle_state(handle, self.handle_states);
+        }
+        disposed
+    }
+}
+
+fn ppc_allocator_view_reserve_bytes(
+    allocator: Option<&mut PpcProcessAllocatorView<'_>>,
+    memory: &mut PpcSectionMem,
+    heap_cursor: &mut u32,
+    heap_limit: u32,
+    size: u32,
+    clear: bool,
+) -> u32 {
+    if let Some(allocator) = allocator {
+        allocator.reserve_bytes(memory, heap_cursor, size, clear)
+    } else {
+        ppc_heap_alloc(memory, heap_cursor, heap_limit, size, clear)
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn ppc_allocator_view_allocate_handle(
+    allocator: Option<&mut PpcProcessAllocatorView<'_>>,
+    memory: &mut PpcSectionMem,
+    heap_cursor: &mut u32,
+    heap_limit: u32,
+    last_mem_error: &mut i16,
+    handles: &mut Vec<PpcHandleRecord>,
+    size: u32,
+    clear: bool,
+) -> u32 {
+    if let Some(allocator) = allocator {
+        allocator.allocate_handle(memory, heap_cursor, last_mem_error, handles, size, clear)
+    } else {
+        ppc_alloc_handle(memory, heap_cursor, heap_limit, handles, size, clear)
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn ppc_allocator_view_allocate_handle_with_bytes(
+    allocator: Option<&mut PpcProcessAllocatorView<'_>>,
+    memory: &mut PpcSectionMem,
+    heap_cursor: &mut u32,
+    heap_limit: u32,
+    last_mem_error: &mut i16,
+    handles: &mut Vec<PpcHandleRecord>,
+    bytes: &[u8],
+) -> u32 {
+    if let Some(allocator) = allocator {
+        allocator.allocate_handle_with_bytes(memory, heap_cursor, last_mem_error, handles, bytes)
+    } else {
+        ppc_alloc_handle_with_bytes(memory, heap_cursor, heap_limit, handles, bytes)
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn ppc_allocator_view_resize_handle(
+    allocator: Option<&mut PpcProcessAllocatorView<'_>>,
+    memory: &mut PpcSectionMem,
+    heap_cursor: &mut u32,
+    heap_limit: u32,
+    last_mem_error: &mut i16,
+    handles: &mut Vec<PpcHandleRecord>,
+    handle: u32,
+    size: u32,
+) -> i16 {
+    if let Some(allocator) = allocator {
+        allocator.resize_handle(memory, heap_cursor, last_mem_error, handles, handle, size)
+    } else {
+        ppc_set_handle_size(memory, heap_cursor, heap_limit, handles, handle, size)
+    }
+}
+
 fn ppc_heap_allocation_bounds(
     memory: &PpcSectionMem,
     heap_cursor: u32,
@@ -83171,11 +84271,7 @@ fn ppc_seed_zone_header(
     let _ = memory.write_u16_be(zone + 52, 0); // heapData
 }
 
-fn ppc_update_zone_free_bytes(
-    memory: &mut PpcSectionMem,
-    heap_cursor: u32,
-    heap_limit: u32,
-) {
+fn ppc_update_zone_free_bytes(memory: &mut PpcSectionMem, heap_cursor: u32, heap_limit: u32) {
     let free_bytes = ppc_heap_free_capacity(memory, heap_cursor, heap_limit).0;
     let _ = memory.write_u32_be(PPC_APPLICATION_ZONE + 12, free_bytes);
     let _ = memory.write_u32_be(PPC_SYSTEM_ZONE + 12, free_bytes);
@@ -83606,11 +84702,7 @@ fn ppc_allocation_size(size: u32) -> Option<u32> {
         .map(|size| size.max(PPC_HEAP_ALIGNMENT))
 }
 
-fn ppc_heap_free_capacity(
-    memory: &PpcSectionMem,
-    heap_cursor: u32,
-    heap_limit: u32,
-) -> (u32, u32) {
+fn ppc_heap_free_capacity(memory: &PpcSectionMem, heap_cursor: u32, heap_limit: u32) -> (u32, u32) {
     memory.readonly_allocation_available_bytes(heap_cursor, heap_limit)
 }
 
@@ -84350,7 +85442,8 @@ pub(crate) mod tests {
 
     fn draw_current_test_menu_bar(loaded: &mut PpcLoadedApp) -> bool {
         let menu_list = ppc_current_menu_list(&mut loaded.memory);
-        let menu_color_bytes = ppc_menu_color_table_bytes(&mut loaded.memory, &test_handle_records!(loaded));
+        let menu_color_bytes =
+            ppc_menu_color_table_bytes(&mut loaded.memory, &test_handle_records!(loaded));
         ppc_draw_menu_bar_with_colors(
             &mut loaded.memory,
             &loaded.gworlds,
@@ -84398,9 +85491,17 @@ pub(crate) mod tests {
         loaded.cpu.gpr[3] = root_menu;
         loaded.cpu.gpr[4] = 1;
         loaded.cpu.gpr[5] = 0x1b;
-        ppc_set_item_cmd(&loaded.cpu, &mut loaded.memory, &test_handle_records!(loaded));
+        ppc_set_item_cmd(
+            &loaded.cpu,
+            &mut loaded.memory,
+            &test_handle_records!(loaded),
+        );
         loaded.cpu.gpr[5] = CHILD_MENU_ID as u32;
-        ppc_set_item_mark(&loaded.cpu, &mut loaded.memory, &test_handle_records!(loaded));
+        ppc_set_item_mark(
+            &loaded.cpu,
+            &mut loaded.memory,
+            &test_handle_records!(loaded),
+        );
 
         let root_record = loaded.memory.read_u32_be(root_menu).unwrap();
         let child_record = loaded.memory.read_u32_be(child_menu).unwrap();
@@ -84950,7 +86051,8 @@ pub(crate) mod tests {
         assert_eq!(loaded.memory.read_u16_be(menu_list + 22), Some(0));
         assert_eq!(
             loaded
-                .handles().iter()
+                .handles()
+                .iter()
                 .find(|record| record.handle == menu_list_handle)
                 .map(|record| record.size),
             Some(24)
@@ -85337,7 +86439,13 @@ pub(crate) mod tests {
         let mut loaded = load_pef_application(&pef).unwrap();
         install_test_menu(&mut loaded, PPC_DATA_BASE + 0x1000, 128, b"File", b"Open");
         let city = install_test_menu(&mut loaded, PPC_DATA_BASE + 0x1400, 129, b"City", b"Map");
-        ppc_set_menu_item_enabled(&mut loaded.memory, &test_handle_records!(loaded), city, 0, false);
+        ppc_set_menu_item_enabled(
+            &mut loaded.memory,
+            &test_handle_records!(loaded),
+            city,
+            0,
+            false,
+        );
 
         let menu_list_handle = ppc_current_menu_list(&mut loaded.memory);
         let regions = ppc_menu_list_definition(&mut loaded.memory, menu_list_handle)
@@ -87005,9 +88113,17 @@ pub(crate) mod tests {
         loaded.cpu.gpr[3] = root;
         loaded.cpu.gpr[4] = 1;
         loaded.cpu.gpr[5] = 0x1B;
-        ppc_set_item_cmd(&loaded.cpu, &mut loaded.memory, &test_handle_records!(loaded));
+        ppc_set_item_cmd(
+            &loaded.cpu,
+            &mut loaded.memory,
+            &test_handle_records!(loaded),
+        );
         loaded.cpu.gpr[5] = 141;
-        ppc_set_item_mark(&loaded.cpu, &mut loaded.memory, &test_handle_records!(loaded));
+        ppc_set_item_mark(
+            &loaded.cpu,
+            &mut loaded.memory,
+            &test_handle_records!(loaded),
+        );
         assert_eq!(
             ppc_insert_menu(
                 &mut loaded.memory,
@@ -89321,10 +90437,7 @@ pub(crate) mod tests {
                 let allocator = memory_manager.native_allocator().unwrap();
                 assert_eq!(allocator.ptrs.last().map(|record| record.size), Some(8));
                 assert_eq!(
-                    allocator
-                        .free_ptr_blocks
-                        .last()
-                        .map(|record| record.size),
+                    allocator.free_ptr_blocks.last().map(|record| record.size),
                     Some(4)
                 );
                 assert_eq!(
@@ -89366,7 +90479,8 @@ pub(crate) mod tests {
         assert_eq!(
             manager.native_allocation(handle),
             native
-                .handles().iter()
+                .handles()
+                .iter()
                 .copied()
                 .find(|record| record.handle == handle)
         );
@@ -89389,19 +90503,11 @@ pub(crate) mod tests {
             resource: false,
         };
         let mut memory_manager = ProcessMemoryManager::default();
-        ppc_synchronize_process_native_handles(
-            &mut memory_manager,
-            &[record],
-            &[stale_state],
-        );
+        ppc_synchronize_process_native_handles(&mut memory_manager, &[record], &[stale_state]);
         let detached = memory_manager.detached_clone();
 
         memory_manager.lock_process_handle(handle, true);
-        ppc_synchronize_process_native_handles(
-            &mut memory_manager,
-            &[record],
-            &[stale_state],
-        );
+        ppc_synchronize_process_native_handles(&mut memory_manager, &[record], &[stale_state]);
 
         let state = memory_manager.native_handle_state(handle);
         assert!(state.locked);
@@ -89482,7 +90588,10 @@ pub(crate) mod tests {
             .any(|record| record.handle == handle));
         assert!(handles.iter().all(|record| record.handle != handle));
         assert!(handle_states.iter().all(|state| state.handle != handle));
-        assert_eq!(detached.native_allocation(handle).map(|record| record.ptr), Some(ptr));
+        assert_eq!(
+            detached.native_allocation(handle).map(|record| record.ptr),
+            Some(ptr)
+        );
         assert_eq!(detached.recover_handle(ptr), Some(handle));
     }
 
@@ -89579,7 +90688,10 @@ pub(crate) mod tests {
             &memory_manager,
         );
         assert_eq!(standalone.handles(), attached.handles());
-        assert_eq!(standalone.free_handle_blocks(), attached.free_handle_blocks());
+        assert_eq!(
+            standalone.free_handle_blocks(),
+            attached.free_handle_blocks()
+        );
         assert_eq!(standalone.memory.read_u32_be(handle), Some(0));
         assert_eq!(attached.memory.read_u32_be(handle), Some(0));
     }
@@ -89643,12 +90755,8 @@ pub(crate) mod tests {
                 native.cpu.lr = PPC_HALT_PC;
                 native.imports[0].dispatcher_target = PpcImportDispatcherTarget::HGetState;
                 native.cpu.gpr[3] = handle;
-                let probe = native.run_with_process_memory_manager(
-                    64,
-                    false,
-                    false,
-                    memory_manager,
-                );
+                let probe =
+                    native.run_with_process_memory_manager(64, false, false, memory_manager);
                 assert_eq!(probe.handled_import_count, 1);
                 assert_eq!(probe.unsupported_import_index, None);
                 assert_eq!(native.cpu.gpr[3], 0x40);
@@ -89657,12 +90765,8 @@ pub(crate) mod tests {
                 native.cpu.lr = PPC_HALT_PC;
                 native.imports[0].dispatcher_target = PpcImportDispatcherTarget::GetHandleSize;
                 native.cpu.gpr[3] = handle;
-                let probe = native.run_with_process_memory_manager(
-                    64,
-                    false,
-                    false,
-                    memory_manager,
-                );
+                let probe =
+                    native.run_with_process_memory_manager(64, false, false, memory_manager);
                 assert_eq!(probe.handled_import_count, 1);
                 assert_eq!(native.cpu.gpr[3], 19);
 
@@ -89670,24 +90774,16 @@ pub(crate) mod tests {
                 native.cpu.lr = PPC_HALT_PC;
                 native.imports[0].dispatcher_target = PpcImportDispatcherTarget::HLock;
                 native.cpu.gpr[3] = handle;
-                let probe = native.run_with_process_memory_manager(
-                    64,
-                    false,
-                    false,
-                    memory_manager,
-                );
+                let probe =
+                    native.run_with_process_memory_manager(64, false, false, memory_manager);
                 assert_eq!(probe.handled_import_count, 1);
 
                 native.cpu.pc = native.entry_pc;
                 native.cpu.lr = PPC_HALT_PC;
                 native.imports[0].dispatcher_target = PpcImportDispatcherTarget::HGetState;
                 native.cpu.gpr[3] = handle;
-                let probe = native.run_with_process_memory_manager(
-                    64,
-                    false,
-                    false,
-                    memory_manager,
-                );
+                let probe =
+                    native.run_with_process_memory_manager(64, false, false, memory_manager);
                 assert_eq!(probe.handled_import_count, 1);
                 assert_eq!(native.cpu.gpr[3], 0xc0);
             },
@@ -89780,10 +90876,7 @@ pub(crate) mod tests {
         assert_eq!(detached.master_pointer_blocks_requested(), 0);
         assert_eq!(native.ptrs().last().map(|record| record.size), Some(16));
         assert_eq!(
-            native
-                .free_ptr_blocks()
-                .last()
-                .map(|record| record.size),
+            native.free_ptr_blocks().last().map(|record| record.size),
             Some(32)
         );
         assert!(detached.ptrs().is_empty());
@@ -89855,12 +90948,8 @@ pub(crate) mod tests {
                     &allocator.free_handle_blocks,
                 );
                 assert_eq!(prior_ptr, PPC_HEAP_BASE);
-                let probe = native.run_with_process_memory_manager(
-                    64,
-                    false,
-                    false,
-                    memory_manager,
-                );
+                let probe =
+                    native.run_with_process_memory_manager(64, false, false, memory_manager);
                 assert_eq!(probe.handled_import_count, 1);
                 let ptr = native.cpu.gpr[3];
                 assert_eq!(ptr, PPC_HEAP_BASE + ppc_allocation_size(24).unwrap());
@@ -89968,10 +91057,7 @@ pub(crate) mod tests {
                 native.run_with_process_memory_manager(64, false, false, memory_manager);
                 assert_eq!(memory_manager.handle_state(handle), 0xc0);
                 assert_eq!(classic_dispatcher.handle_state_bits(handle), Some(0xc0));
-                assert_eq!(
-                    detached_memory_manager.state_for_handle(handle),
-                    Some(0x40)
-                );
+                assert_eq!(detached_memory_manager.state_for_handle(handle), Some(0x40));
 
                 native.cpu.pc = native.entry_pc;
                 native.cpu.lr = PPC_HALT_PC;
@@ -89995,8 +91081,9 @@ pub(crate) mod tests {
                 native.cpu.gpr[3] = handle;
                 native.run_with_process_memory_manager(64, false, false, memory_manager);
                 assert_eq!(native.cpu.gpr[3], 0xa0);
-                assert!((0..32)
-                    .all(|offset| native.memory.read_u8(original.ptr + offset) == Some(0)));
+                assert!(
+                    (0..32).all(|offset| native.memory.read_u8(original.ptr + offset) == Some(0))
+                );
                 native
                     .memory
                     .write_bytes(original.ptr, b"process-owned")
@@ -90186,13 +91273,8 @@ pub(crate) mod tests {
                     handle: 0,
                 }];
                 let mut last_resource_error = PPC_NO_ERR;
-                let legacy_ptr = ppc_heap_alloc(
-                    &mut native.memory,
-                    &mut heap_cursor,
-                    heap_limit,
-                    32,
-                    true,
-                );
+                let legacy_ptr =
+                    ppc_heap_alloc(&mut native.memory, &mut heap_cursor, heap_limit, 32, true);
                 assert_ne!(legacy_ptr, 0);
                 let cursor_after_legacy_allocation = heap_cursor;
 
@@ -90280,9 +91362,15 @@ pub(crate) mod tests {
                 assert_eq!(memory_manager.native_allocation(external_handle), None);
                 let external_ptr = native.memory.read_u32_be(external_handle).unwrap();
                 assert_ne!(external_ptr, 0);
-                assert_eq!(memory_manager.recover_handle(external_ptr), Some(external_handle));
+                assert_eq!(
+                    memory_manager.recover_handle(external_ptr),
+                    Some(external_handle)
+                );
                 assert_eq!(memory_manager.state_for_handle(external_handle), Some(0x60));
-                assert_eq!(classic_dispatcher.handle_state_bits(external_handle), Some(0x60));
+                assert_eq!(
+                    classic_dispatcher.handle_state_bits(external_handle),
+                    Some(0x60)
+                );
                 assert_eq!(
                     classic_bus.read_bytes(external_ptr, b"PEF master pointer".len()),
                     b"PEF master pointer"
@@ -90601,7 +91689,13 @@ pub(crate) mod tests {
         let pef = synthetic_pef_with_import(b"MenuSelect");
         let mut loaded = load_pef_application(&pef).unwrap();
         let menu = install_test_menu(&mut loaded, PPC_DATA_BASE + 0x1000, 128, b"File", b"Open/O");
-        ppc_set_menu_item_enabled(&mut loaded.memory, &test_handle_records!(loaded), menu, 1, false);
+        ppc_set_menu_item_enabled(
+            &mut loaded.memory,
+            &test_handle_records!(loaded),
+            menu,
+            1,
+            false,
+        );
         assert!(draw_current_test_menu_bar(&mut loaded));
 
         let title_h = STANDARD_MENU_BAR_FIRST_TITLE_LEFT + 2;
@@ -90917,7 +92011,8 @@ pub(crate) mod tests {
         );
         assert_eq!(
             loaded
-                .handles().iter()
+                .handles()
+                .iter()
                 .find(|record| record.handle == current)
                 .map(|record| record.size),
             Some(12)
@@ -90988,7 +92083,11 @@ pub(crate) mod tests {
         let standard_mdef = loaded.memory.read_u32_be(first_menu_ptr + 6).unwrap();
         assert_ne!(standard_mdef, 0);
         assert_eq!(
-            ppc_menu_handle_bytes(&mut loaded.memory, &test_handle_records!(loaded), standard_mdef),
+            ppc_menu_handle_bytes(
+                &mut loaded.memory,
+                &test_handle_records!(loaded),
+                standard_mdef
+            ),
             Some(STANDARD_MENU_DEFINITION_SHIM.to_vec())
         );
 
@@ -91066,7 +92165,11 @@ pub(crate) mod tests {
         let standard_menu_ptr = loaded.memory.read_u32_be(standard_menu).unwrap();
         let standard_mdef = loaded.memory.read_u32_be(standard_menu_ptr + 6).unwrap();
         assert_eq!(
-            ppc_menu_handle_bytes(&mut loaded.memory, &test_handle_records!(loaded), standard_mdef),
+            ppc_menu_handle_bytes(
+                &mut loaded.memory,
+                &test_handle_records!(loaded),
+                standard_mdef
+            ),
             Some(STANDARD_MENU_DEFINITION_SHIM.to_vec())
         );
 
@@ -91084,7 +92187,11 @@ pub(crate) mod tests {
             .unwrap();
         assert_eq!(custom_mdef, custom_resource.handle);
         assert_eq!(
-            ppc_menu_handle_bytes(&mut loaded.memory, &test_handle_records!(loaded), custom_mdef),
+            ppc_menu_handle_bytes(
+                &mut loaded.memory,
+                &test_handle_records!(loaded),
+                custom_mdef
+            ),
             Some(vec![0x4e, 0x75])
         );
 
@@ -91322,7 +92429,10 @@ pub(crate) mod tests {
             Some(color_handle),
             "ClearMenuBar must preserve the manager-owned MenuCInfo handle"
         );
-        assert!(ppc_menu_color_table_bytes(&mut loaded.memory, &test_handle_records!(loaded)).is_empty());
+        assert!(
+            ppc_menu_color_table_bytes(&mut loaded.memory, &test_handle_records!(loaded))
+                .is_empty()
+        );
     }
 
     #[test]
@@ -92003,18 +93113,15 @@ pub(crate) mod tests {
         // Universal Interfaces 3.4 FixMath.h declares these as InterfaceLib
         // exports; examples and boundaries are from Inside Macintosh IV-65
         // and Operating System Utilities (1994), pp. 3-40 through 3-46.
-        let cases: [
-            (
-                &str,
-                PpcImportDispatcherTarget,
-                u32,
-                u32,
-                Option<f64>,
-                Option<u32>,
-                Option<f64>,
-            );
-            11
-        ] = [
+        let cases: [(
+            &str,
+            PpcImportDispatcherTarget,
+            u32,
+            u32,
+            Option<f64>,
+            Option<u32>,
+            Option<f64>,
+        ); 11] = [
             (
                 "FixRound",
                 PpcImportDispatcherTarget::FixRound,
@@ -92495,12 +93602,15 @@ pub(crate) mod tests {
         cpu.gpr[5] = 4;
         let mut startup = PpcToolboxStartupState::default();
         ppc_set_clut_entry_flag(&mut startup.clut_reserved, 7, true);
+        let mut last_mem_error = PPC_NO_ERR;
 
         ppc_make_itable(
             &cpu,
+            None,
             &mut memory,
             &mut heap_cursor,
             heap_limit,
+            &mut last_mem_error,
             &mut handles,
             PPC_MAIN_GDEVICE,
             &[[0; 3]; 256],
@@ -92541,12 +93651,15 @@ pub(crate) mod tests {
         cpu.gpr[4] = itable_handle;
         cpu.gpr[5] = 2;
         let mut startup = PpcToolboxStartupState::default();
+        let mut last_mem_error = PPC_NO_ERR;
 
         ppc_make_itable(
             &cpu,
+            None,
             &mut memory,
             &mut heap_cursor,
             heap_limit,
+            &mut last_mem_error,
             &mut handles,
             0,
             &[[0; 3]; 256],
@@ -93375,6 +94488,7 @@ pub(crate) mod tests {
         let mut loaded = load_pef_application(&synthetic_pef()).unwrap();
         let mut last_mem_error = loaded.last_mem_error();
         let handle = ppc_new_control_record_values(
+            None,
             &mut loaded.memory,
             test_heap_cursor!(loaded),
             test_heap_limit!(loaded),
@@ -93434,6 +94548,7 @@ pub(crate) mod tests {
         let mut loaded = load_pef_application(&synthetic_pef()).unwrap();
         let mut last_mem_error = loaded.last_mem_error();
         let handle = ppc_new_control_record_values(
+            None,
             &mut loaded.memory,
             test_heap_cursor!(loaded),
             test_heap_limit!(loaded),
@@ -93504,6 +94619,7 @@ pub(crate) mod tests {
         let mut loaded = load_pef_application(&synthetic_pef_with_import(b"DrawControls")).unwrap();
         let mut last_mem_error = loaded.last_mem_error();
         let handle = ppc_new_control_record_values(
+            None,
             &mut loaded.memory,
             test_heap_cursor!(loaded),
             test_heap_limit!(loaded),
@@ -93559,6 +94675,7 @@ pub(crate) mod tests {
         ppc_write_rect(&mut loaded.memory, scratch, 5, 6, 25, 86).unwrap();
         write_ppc_pstring(&mut loaded.memory, scratch + 8, b"OK");
         let handle = ppc_new_control_values(
+            None,
             &mut loaded.memory,
             test_heap_cursor!(loaded),
             test_heap_limit!(loaded),
@@ -93588,9 +94705,13 @@ pub(crate) mod tests {
         );
 
         ppc_dispose_control(
+            None,
+            Some(&mut free_handle_blocks),
             &mut loaded.memory,
+            test_heap_cursor!(loaded),
+            test_heap_limit!(loaded),
+            &mut last_mem_error,
             test_handles!(loaded),
-            &mut free_handle_blocks,
             &mut loaded.controls,
             handle,
         );
@@ -93619,6 +94740,7 @@ pub(crate) mod tests {
         ppc_write_rect(&mut loaded.memory, scratch, 5, 6, 25, 86).unwrap();
         write_ppc_pstring(&mut loaded.memory, scratch + 8, b"OK");
         let handle = ppc_new_control_values(
+            None,
             &mut loaded.memory,
             test_heap_cursor!(loaded),
             test_heap_limit!(loaded),
@@ -93730,6 +94852,7 @@ pub(crate) mod tests {
         wind.extend_from_slice(b"Game");
 
         let (bounds, title) = ppc_materialize_window_resource_parameters(
+            None,
             &mut loaded.memory,
             test_heap_cursor!(loaded),
             test_heap_limit!(loaded),
@@ -95472,7 +96595,10 @@ pub(crate) mod tests {
                 "CallOSTrapUniversalProc",
                 PpcImportDispatcherTarget::CallOSTrapUniversalProc,
             ),
-            ("NGetTrapAddress", PpcImportDispatcherTarget::NGetTrapAddress),
+            (
+                "NGetTrapAddress",
+                PpcImportDispatcherTarget::NGetTrapAddress,
+            ),
             (
                 "GetToolTrapAddress",
                 PpcImportDispatcherTarget::GetToolTrapAddress,
@@ -95489,7 +96615,10 @@ pub(crate) mod tests {
                 "SetOSTrapAddress",
                 PpcImportDispatcherTarget::SetOSTrapAddress,
             ),
-            ("NSetTrapAddress", PpcImportDispatcherTarget::NSetTrapAddress),
+            (
+                "NSetTrapAddress",
+                PpcImportDispatcherTarget::NSetTrapAddress,
+            ),
             ("LMGetCurrentA5", PpcImportDispatcherTarget::LMGetCurrentA5),
             ("VInstall", PpcImportDispatcherTarget::VInstall),
             ("VRemove", PpcImportDispatcherTarget::VRemove),
@@ -97080,7 +98209,9 @@ pub(crate) mod tests {
             loaded.imports[0].dispatcher_target = target;
             let trap_word = 0xFFFF_A823u32;
             let entry = ppc_raw_trap_table_entry(trap_word as u16, toolbox);
-            loaded.memory.add_region(entry, 0x1234_5678u32.to_be_bytes().to_vec());
+            loaded
+                .memory
+                .add_region(entry, 0x1234_5678u32.to_be_bytes().to_vec());
             loaded.cpu.gpr[3] = PPC_CODE_BASE;
             loaded.cpu.gpr[4] = trap_word;
             loaded.cpu.gpr[5] = u32::from(general && toolbox);
@@ -97307,12 +98438,14 @@ pub(crate) mod tests {
             .has_readonly_allocation_exclusion(reservation.0, reservation.1));
         assert_eq!(
             loaded.memory.read_u32_be(PPC_APPLICATION_ZONE + 12),
-            Some(ppc_heap_free_capacity(
-                &loaded.memory,
-                loaded.heap_cursor(),
-                test_heap_limit!(loaded)
+            Some(
+                ppc_heap_free_capacity(
+                    &loaded.memory,
+                    loaded.heap_cursor(),
+                    test_heap_limit!(loaded)
+                )
+                .0
             )
-            .0)
         );
         assert_eq!(bus.read_byte(reservation_base), 0x5a);
 
@@ -97320,7 +98453,11 @@ pub(crate) mod tests {
         assert!(installed.prepare_shared_system_reservation(reservation.0, reservation.1));
         let (shared_base, shared) = bus.shared_synthetic_reservation().unwrap();
         // SAFETY: this focused fixture serializes both adapters.
-        unsafe { installed.memory.add_shared_readonly_region(shared_base, shared) };
+        unsafe {
+            installed
+                .memory
+                .add_shared_readonly_region(shared_base, shared)
+        };
         assert!(!installed
             .memory
             .has_readonly_allocation_exclusion(reservation.0, reservation.1));
@@ -97341,7 +98478,11 @@ pub(crate) mod tests {
         loaded.set_heap_limit(reservation_base + reservation_len + 0x2000);
         let expected = (0x3000, 0x2000);
         assert_eq!(
-            ppc_heap_free_capacity(&loaded.memory, loaded.heap_cursor(), test_heap_limit!(loaded)),
+            ppc_heap_free_capacity(
+                &loaded.memory,
+                loaded.heap_cursor(),
+                test_heap_limit!(loaded)
+            ),
             expected
         );
 
@@ -97409,8 +98550,7 @@ pub(crate) mod tests {
             );
         }
 
-        let trampoline_reservation_base =
-            PPC_APPLICATION_INIT_RETURN_PC + 44 - 64 * 1024;
+        let trampoline_reservation_base = PPC_APPLICATION_INIT_RETURN_PC + 44 - 64 * 1024;
         let (_bus, trampoline_reservation) = reservation_at(trampoline_reservation_base);
         load_pef_application_with_config_and_system_reservation(
             &synthetic_pef(),
@@ -97451,10 +98591,7 @@ pub(crate) mod tests {
 
         assert!(!loaded.prepare_shared_system_reservation(PPC_CODE_BASE, 64 * 1024));
         assert_eq!(loaded.memory.read_u32_be(PPC_CODE_BASE), original_code);
-        assert!(loaded.prepare_shared_system_reservation(
-            PPC_HEAP_BASE + 0x1000,
-            64 * 1024
-        ));
+        assert!(loaded.prepare_shared_system_reservation(PPC_HEAP_BASE + 0x1000, 64 * 1024));
     }
 
     #[test]
@@ -97837,8 +98974,7 @@ pub(crate) mod tests {
 
         loaded.cpu.pc = loaded.entry_pc;
         loaded.cpu.lr = PPC_HALT_PC;
-        loaded.imports[0].dispatcher_target =
-            PpcImportDispatcherTarget::DisposeRoutineDescriptor;
+        loaded.imports[0].dispatcher_target = PpcImportDispatcherTarget::DisposeRoutineDescriptor;
         loaded.set_last_mem_error(PPC_MEM_FULL_ERR);
         loaded.cpu.gpr[3] = descriptor;
 
@@ -100465,7 +101601,9 @@ pub(crate) mod tests {
         assert_eq!(loaded.cpu.gpr[3], handle);
         assert_eq!(loaded.last_mem_error(), PPC_NO_ERR);
         assert_eq!(loaded.heap_cursor(), heap_cursor);
-        assert!(test_handle_records!(loaded).iter().all(|record| record.handle != handle));
+        assert!(test_handle_records!(loaded)
+            .iter()
+            .all(|record| record.handle != handle));
         assert_eq!(loaded.memory.read_u32_be(handle), Some(0));
         assert!(loaded.aliases.is_empty());
         assert_eq!(loaded.vfs_resources[0].handle, 0);
@@ -100705,7 +101843,9 @@ pub(crate) mod tests {
         assert_eq!(probe.handled_import_count, 1);
         assert_eq!(probe.unsupported_import_index, None);
         assert!(loaded.handle_states().is_empty());
-        assert!(test_handle_records!(loaded).iter().all(|record| record.handle != handle));
+        assert!(test_handle_records!(loaded)
+            .iter()
+            .all(|record| record.handle != handle));
         assert_eq!(loaded.memory.read_u32_be(handle), Some(0));
     }
 
@@ -100745,8 +101885,14 @@ pub(crate) mod tests {
         assert_eq!(test_handle_records!(loaded)[0].handle, handle);
         assert_eq!(handle, heap_cursor);
         assert_eq!(handle & (PPC_HEAP_ALIGNMENT - 1), 0);
-        assert_eq!(test_handle_records!(loaded)[0].ptr, heap_cursor + PPC_HEAP_ALIGNMENT);
-        assert_eq!(test_handle_records!(loaded)[0].ptr & (PPC_HEAP_ALIGNMENT - 1), 0);
+        assert_eq!(
+            test_handle_records!(loaded)[0].ptr,
+            heap_cursor + PPC_HEAP_ALIGNMENT
+        );
+        assert_eq!(
+            test_handle_records!(loaded)[0].ptr & (PPC_HEAP_ALIGNMENT - 1),
+            0
+        );
         assert_eq!(test_handle_records!(loaded)[0].size, 12);
         assert_eq!(
             loaded.memory.read_u32_be(handle),
@@ -101340,7 +102486,10 @@ pub(crate) mod tests {
             );
 
             assert_eq!(action, PpcImportAction::Return(ppc_i16_result(PPC_NO_ERR)));
-            assert_eq!(loaded.memory.read_u32_be(address_ptr), Some(expected_address));
+            assert_eq!(
+                loaded.memory.read_u32_be(address_ptr),
+                Some(expected_address)
+            );
             assert_eq!(loaded.memory.read_u8(class_ptr), Some(1));
             assert_eq!(loaded.imports.len(), import_len_before);
             assert_eq!(loaded.import_count, import_count_before);
@@ -128404,7 +129553,10 @@ pub(crate) mod tests {
         assert_eq!(loaded.imports[0].address, PPC_IMPORT_MATH_FE_DFL_ENV);
         assert_eq!(loaded.imports[0].tvector_address, None);
         assert_ne!(PPC_IMPORT_MATH_FE_DFL_ENV, PPC_IMPORT_MATH_PI);
-        assert_eq!(loaded.memory.read_u32_be(PPC_IMPORT_MATH_FE_DFL_ENV), Some(0));
+        assert_eq!(
+            loaded.memory.read_u32_be(PPC_IMPORT_MATH_FE_DFL_ENV),
+            Some(0)
+        );
         assert_eq!(
             loaded.memory.read_u32_be(PPC_DATA_BASE),
             Some(PPC_IMPORT_MATH_FE_DFL_ENV)
@@ -128414,9 +129566,21 @@ pub(crate) mod tests {
     #[test]
     fn stdclib_floating_point_data_imports_bind_to_ieee_constants() {
         let double_constants = [
-            (b"_DBL_EPSILON".as_slice(), PPC_IMPORT_STD_DBL_EPSILON, f64::EPSILON.to_bits()),
-            (b"_DBL_MAX".as_slice(), PPC_IMPORT_STD_DBL_MAX, f64::MAX.to_bits()),
-            (b"_DBL_MIN".as_slice(), PPC_IMPORT_STD_DBL_MIN, f64::MIN_POSITIVE.to_bits()),
+            (
+                b"_DBL_EPSILON".as_slice(),
+                PPC_IMPORT_STD_DBL_EPSILON,
+                f64::EPSILON.to_bits(),
+            ),
+            (
+                b"_DBL_MAX".as_slice(),
+                PPC_IMPORT_STD_DBL_MAX,
+                f64::MAX.to_bits(),
+            ),
+            (
+                b"_DBL_MIN".as_slice(),
+                PPC_IMPORT_STD_DBL_MIN,
+                f64::MIN_POSITIVE.to_bits(),
+            ),
         ];
         for (symbol, expected_address, expected_bits) in double_constants {
             let pef = synthetic_pef_with_loader(synthetic_loader_with_symbol_class(
@@ -128431,14 +129595,32 @@ pub(crate) mod tests {
             assert_eq!(loaded.imports[0].address, expected_address);
             assert_eq!(loaded.imports[0].tvector_address, None);
             assert_eq!(expected_address % 8, 0);
-            assert_eq!(loaded.memory.read_u64_be(expected_address), Some(expected_bits));
-            assert_eq!(loaded.memory.read_u32_be(PPC_DATA_BASE), Some(expected_address));
+            assert_eq!(
+                loaded.memory.read_u64_be(expected_address),
+                Some(expected_bits)
+            );
+            assert_eq!(
+                loaded.memory.read_u32_be(PPC_DATA_BASE),
+                Some(expected_address)
+            );
         }
 
         let float_constants = [
-            (b"_FLT_EPSILON".as_slice(), PPC_IMPORT_STD_FLT_EPSILON, f32::EPSILON.to_bits()),
-            (b"_FLT_MAX".as_slice(), PPC_IMPORT_STD_FLT_MAX, f32::MAX.to_bits()),
-            (b"_FLT_MIN".as_slice(), PPC_IMPORT_STD_FLT_MIN, f32::MIN_POSITIVE.to_bits()),
+            (
+                b"_FLT_EPSILON".as_slice(),
+                PPC_IMPORT_STD_FLT_EPSILON,
+                f32::EPSILON.to_bits(),
+            ),
+            (
+                b"_FLT_MAX".as_slice(),
+                PPC_IMPORT_STD_FLT_MAX,
+                f32::MAX.to_bits(),
+            ),
+            (
+                b"_FLT_MIN".as_slice(),
+                PPC_IMPORT_STD_FLT_MIN,
+                f32::MIN_POSITIVE.to_bits(),
+            ),
         ];
         for (symbol, expected_address, expected_bits) in float_constants {
             let pef = synthetic_pef_with_loader(synthetic_loader_with_symbol_class(
@@ -128453,8 +129635,14 @@ pub(crate) mod tests {
             assert_eq!(loaded.imports[0].address, expected_address);
             assert_eq!(loaded.imports[0].tvector_address, None);
             assert_eq!(expected_address % 4, 0);
-            assert_eq!(loaded.memory.read_u32_be(expected_address), Some(expected_bits));
-            assert_eq!(loaded.memory.read_u32_be(PPC_DATA_BASE), Some(expected_address));
+            assert_eq!(
+                loaded.memory.read_u32_be(expected_address),
+                Some(expected_bits)
+            );
+            assert_eq!(
+                loaded.memory.read_u32_be(PPC_DATA_BASE),
+                Some(expected_address)
+            );
         }
 
         let occupied = [
@@ -128486,8 +129674,14 @@ pub(crate) mod tests {
         assert_eq!(first.imports[0].address, PPC_IMPORT_STD_ERRNO);
         assert_eq!(first.imports[0].tvector_address, None);
         assert_eq!(first.memory.read_u32_be(PPC_IMPORT_STD_ERRNO), Some(0));
-        assert_eq!(first.memory.read_u32_be(PPC_DATA_BASE), Some(PPC_IMPORT_STD_ERRNO));
-        assert!(first.memory.write_u32_be(PPC_IMPORT_STD_ERRNO, 34).is_some());
+        assert_eq!(
+            first.memory.read_u32_be(PPC_DATA_BASE),
+            Some(PPC_IMPORT_STD_ERRNO)
+        );
+        assert!(first
+            .memory
+            .write_u32_be(PPC_IMPORT_STD_ERRNO, 34)
+            .is_some());
         assert_eq!(first.memory.read_u32_be(PPC_IMPORT_STD_ERRNO), Some(34));
 
         let mut second = load_pef_application(&errno_pef).unwrap();
@@ -128503,7 +129697,10 @@ pub(crate) mod tests {
         assert_eq!(loaded.imports[0].class, 1);
         assert_eq!(loaded.imports[0].address, PPC_IMPORT_STD_MAC_OS_ERR);
         assert_eq!(loaded.imports[0].tvector_address, None);
-        assert_eq!(loaded.memory.read_u16_be(PPC_IMPORT_STD_MAC_OS_ERR), Some(0));
+        assert_eq!(
+            loaded.memory.read_u16_be(PPC_IMPORT_STD_MAC_OS_ERR),
+            Some(0)
+        );
         assert_eq!(
             loaded.memory.read_u32_be(PPC_DATA_BASE),
             Some(PPC_IMPORT_STD_MAC_OS_ERR)
@@ -128691,7 +129888,10 @@ pub(crate) mod tests {
         assert_ne!(handle, 0);
         assert_eq!(test_handle_records!(loaded).len(), 1);
         assert_eq!(test_handle_records!(loaded)[0].handle, handle);
-        assert_eq!(test_handle_records!(loaded)[0].size, minimal_pict_bytes().len() as u32);
+        assert_eq!(
+            test_handle_records!(loaded)[0].size,
+            minimal_pict_bytes().len() as u32
+        );
         let ptr = loaded.memory.read_u32_be(handle).unwrap();
         assert_eq!(ptr, test_handle_records!(loaded)[0].ptr);
         assert_eq!(loaded.memory.read_u16_be(ptr), Some(0x000c));
@@ -128769,7 +129969,11 @@ pub(crate) mod tests {
         assert_ne!(first_handle, 0);
         assert_eq!(loaded.vfs_resources[0].handle, 0);
         assert_eq!(
-            ppc_handle_bytes(&mut loaded.memory, &test_handle_records!(loaded), first_handle),
+            ppc_handle_bytes(
+                &mut loaded.memory,
+                &test_handle_records!(loaded),
+                first_handle
+            ),
             Some(pattern.clone())
         );
         assert_eq!(loaded.last_mem_error(), PPC_NO_ERR);
@@ -128786,7 +129990,11 @@ pub(crate) mod tests {
         assert_ne!(second_handle, 0);
         assert_ne!(second_handle, first_handle);
         assert_eq!(
-            ppc_handle_bytes(&mut loaded.memory, &test_handle_records!(loaded), second_handle),
+            ppc_handle_bytes(
+                &mut loaded.memory,
+                &test_handle_records!(loaded),
+                second_handle
+            ),
             Some(pattern)
         );
     }
@@ -130485,12 +131693,15 @@ pub(crate) mod tests {
         let mut depth_cpu = loaded.cpu.clone();
         depth_cpu.gpr[3] = PPC_MAIN_GDEVICE;
         depth_cpu.gpr[4] = 8;
+        let mut last_mem_error = PPC_NO_ERR;
         assert_eq!(
             ppc_set_depth(
                 &depth_cpu,
+                None,
                 &mut loaded.memory,
                 test_heap_cursor!(loaded),
                 test_heap_limit!(loaded),
+                &mut last_mem_error,
                 test_handles!(loaded),
                 &mut loaded.gworlds,
                 &mut loaded.toolbox_startup,
@@ -131229,7 +132440,8 @@ pub(crate) mod tests {
         );
         assert_eq!(
             loaded
-                .handles().iter()
+                .handles()
+                .iter()
                 .find(|record| record.handle == dst_palette)
                 .map(|record| record.size),
             Some(64)
@@ -131421,7 +132633,8 @@ pub(crate) mod tests {
         }
         assert_eq!(
             loaded
-                .handles().iter()
+                .handles()
+                .iter()
                 .find(|record| record.handle == ctable_handle)
                 .map(|record| record.size),
             Some(32)
@@ -131439,7 +132652,8 @@ pub(crate) mod tests {
         assert_eq!(loaded.memory.read_u16_be(ctable_ptr + 6), Some(u16::MAX));
         assert_eq!(
             loaded
-                .handles().iter()
+                .handles()
+                .iter()
                 .find(|record| record.handle == ctable_handle)
                 .map(|record| record.size),
             Some(8)
@@ -134504,7 +135718,9 @@ pub(crate) mod tests {
 
         assert_eq!(probe.handled_import_count, 1);
         assert_eq!(probe.unsupported_import_index, None);
-        assert!(test_handle_records!(loaded).iter().all(|record| record.handle != handle));
+        assert!(test_handle_records!(loaded)
+            .iter()
+            .all(|record| record.handle != handle));
         assert_eq!(loaded.memory.read_u32_be(handle), Some(0));
     }
 
@@ -136175,7 +137391,10 @@ pub(crate) mod tests {
             loaded.cpu.gpr[8] = CLIP_PIX;
             run_test_import(&mut loaded, PpcImportDispatcherTarget::UpdateGWorld);
             assert_eq!(loaded.cpu.gpr[3] & (1 << 31), 0, "depth={depth}");
-            assert_eq!(test_handle_records!(loaded).len(), handle_count_with_sentinel);
+            assert_eq!(
+                test_handle_records!(loaded).len(),
+                handle_count_with_sentinel
+            );
             let result = loaded.cpu.gpr[3];
             let updated = *loaded
                 .gworlds
@@ -136233,10 +137452,12 @@ pub(crate) mod tests {
             Some(sentinel_bytes.to_vec())
         );
         assert!(loaded
-            .handles().iter()
+            .handles()
+            .iter()
             .any(|record| record.handle == sentinel));
         assert!(!loaded
-            .handles().iter()
+            .handles()
+            .iter()
             .any(|record| record.handle == private_ctable));
         assert_eq!(test_handle_records!(loaded).len(), initial_handle_count + 1);
         assert!(!loaded.gworlds.iter().any(|record| record.port == gworld));
@@ -139026,7 +140247,10 @@ pub(crate) mod tests {
         assert_eq!(loaded.heap_cursor(), heap_cursor + expected_heap_advance);
         assert_eq!(test_handle_records!(loaded).len(), 1);
         assert_eq!(test_handle_records!(loaded)[0].handle, alias_handle);
-        assert_eq!(test_handle_records!(loaded)[0].size, PPC_CLASSIC_ALIAS_RECORD_SIZE as u32);
+        assert_eq!(
+            test_handle_records!(loaded)[0].size,
+            PPC_CLASSIC_ALIAS_RECORD_SIZE as u32
+        );
         assert_eq!(loaded.aliases.len(), 1);
         assert_eq!(loaded.aliases[0].handle, alias_handle);
         assert_eq!(loaded.aliases[0].target_vref, PPC_BOOT_VOLUME_REF_NUM);
@@ -139368,9 +140592,13 @@ pub(crate) mod tests {
             loaded.aliases[0].target_name.as_slice(),
             b"Test App HighScores"
         );
-        let decoded =
-            ppc_alias_record_from_handle(&mut loaded.memory, &test_handle_records!(loaded), alias_handle, None)
-                .expect("updated handle should contain a classic AliasRecord");
+        let decoded = ppc_alias_record_from_handle(
+            &mut loaded.memory,
+            &test_handle_records!(loaded),
+            alias_handle,
+            None,
+        )
+        .expect("updated handle should contain a classic AliasRecord");
         assert_eq!(decoded.target_vref, PPC_BOOT_VOLUME_REF_NUM);
         assert_eq!(decoded.target_dir_id, PPC_PREFERENCES_DIR_ID);
         assert_eq!(decoded.target_name.as_slice(), b"Test App HighScores");
@@ -139436,7 +140664,10 @@ pub(crate) mod tests {
         assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_NO_ERR));
         assert_eq!(loaded.memory.read_u8(was_changed_ptr), Some(0));
         assert_eq!(loaded.heap_cursor(), heap_cursor);
-        assert_eq!(test_handle_records!(loaded)[0].size, PPC_CLASSIC_ALIAS_RECORD_SIZE as u32);
+        assert_eq!(
+            test_handle_records!(loaded)[0].size,
+            PPC_CLASSIC_ALIAS_RECORD_SIZE as u32
+        );
         assert_eq!(loaded.aliases[0].target_name.as_slice(), b"Test App Prefs");
     }
 
@@ -139487,9 +140718,13 @@ pub(crate) mod tests {
         assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_PARAM_ERR));
         assert_eq!(loaded.last_mem_error(), PPC_NO_ERR);
         assert_eq!(loaded.aliases[0].target_name.as_slice(), b"Test App Prefs");
-        let decoded =
-            ppc_alias_record_from_handle(&mut loaded.memory, &test_handle_records!(loaded), alias_handle, None)
-                .expect("original handle should remain decodable");
+        let decoded = ppc_alias_record_from_handle(
+            &mut loaded.memory,
+            &test_handle_records!(loaded),
+            alias_handle,
+            None,
+        )
+        .expect("original handle should remain decodable");
         assert_eq!(decoded.target_name.as_slice(), b"Test App Prefs");
     }
 
@@ -139534,10 +140769,17 @@ pub(crate) mod tests {
         assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_MEM_FULL_ERR));
         assert_eq!(loaded.last_mem_error(), PPC_MEM_FULL_ERR);
         assert_eq!(loaded.memory.read_u8(was_changed_ptr), Some(0xff));
-        assert_eq!(test_handle_records!(loaded)[0].size, PPC_ALIAS_RECORD_SIZE as u32);
-        let decoded =
-            ppc_alias_record_from_handle(&mut loaded.memory, &test_handle_records!(loaded), alias_handle, None)
-                .expect("legacy handle should remain unchanged");
+        assert_eq!(
+            test_handle_records!(loaded)[0].size,
+            PPC_ALIAS_RECORD_SIZE as u32
+        );
+        let decoded = ppc_alias_record_from_handle(
+            &mut loaded.memory,
+            &test_handle_records!(loaded),
+            alias_handle,
+            None,
+        )
+        .expect("legacy handle should remain unchanged");
         assert_eq!(decoded.target_name.as_slice(), b"Test App Prefs");
     }
 
@@ -144387,7 +145629,8 @@ pub(crate) mod tests {
         assert_eq!(loaded.vfs_resources[0].handle, 0);
         assert_eq!(loaded.memory.read_u32_be(resource_handle), Some(0));
         assert!(!loaded
-            .handles().iter()
+            .handles()
+            .iter()
             .any(|record| record.handle == resource_handle));
         assert!(loaded
             .free_handle_blocks()
@@ -144458,7 +145701,8 @@ pub(crate) mod tests {
         assert_eq!(loaded.last_resource_error, PPC_NO_ERR);
         assert_eq!(loaded.vfs_resources[0].handle, 0);
         assert!(loaded
-            .handles().iter()
+            .handles()
+            .iter()
             .all(|record| record.handle != released_handle));
         assert!(loaded.handle_states().is_empty());
         assert_eq!(loaded.memory.read_u32_be(released_handle), Some(0));
@@ -144538,7 +145782,9 @@ pub(crate) mod tests {
         assert_eq!(loaded.last_resource_error, PPC_NO_ERR);
         assert_eq!(loaded.vfs_resources[0].handle, handle);
         assert_eq!(loaded.memory.read_u32_be(handle), Some(ptr));
-        assert!(test_handle_records!(loaded).iter().any(|record| record.handle == handle));
+        assert!(test_handle_records!(loaded)
+            .iter()
+            .any(|record| record.handle == handle));
         assert_eq!(
             loaded.handle_states(),
             vec![PpcHandleStateRecord {
@@ -144585,7 +145831,9 @@ pub(crate) mod tests {
         assert_eq!(loaded.last_resource_error, PPC_NO_ERR);
         assert_eq!(loaded.vfs_resources[0].handle, 0);
         assert_eq!(loaded.memory.read_u32_be(handle), Some(ptr));
-        assert!(test_handle_records!(loaded).iter().any(|record| record.handle == handle));
+        assert!(test_handle_records!(loaded)
+            .iter()
+            .any(|record| record.handle == handle));
 
         loaded.cpu.pc = loaded.entry_pc;
         loaded.imports[0].dispatcher_target = PpcImportDispatcherTarget::GetResAttrs;
@@ -144628,7 +145876,9 @@ pub(crate) mod tests {
         assert_eq!(probe.handled_import_count, 1);
         assert_eq!(probe.unsupported_import_index, None);
         assert_eq!(loaded.cpu.gpr[3], handle);
-        assert!(test_handle_records!(loaded).iter().all(|record| record.handle != handle));
+        assert!(test_handle_records!(loaded)
+            .iter()
+            .all(|record| record.handle != handle));
         assert_eq!(loaded.memory.read_u32_be(handle), Some(0));
 
         loaded.cpu.pc = loaded.entry_pc;
@@ -145431,7 +146681,11 @@ pub(crate) mod tests {
         loaded.cpu.gpr[3] = 128;
         loaded.run_with_hle_imports(64);
         assert_eq!(
-            ppc_handle_bytes(&mut loaded.memory, &test_handle_records!(loaded), loaded.cpu.gpr[3]),
+            ppc_handle_bytes(
+                &mut loaded.memory,
+                &test_handle_records!(loaded),
+                loaded.cpu.gpr[3]
+            ),
             Some(b"icon".to_vec())
         );
 
@@ -145440,7 +146694,11 @@ pub(crate) mod tests {
         loaded.cpu.gpr[3] = 129;
         loaded.run_with_hle_imports(64);
         assert_eq!(
-            ppc_handle_bytes(&mut loaded.memory, &test_handle_records!(loaded), loaded.cpu.gpr[3]),
+            ppc_handle_bytes(
+                &mut loaded.memory,
+                &test_handle_records!(loaded),
+                loaded.cpu.gpr[3]
+            ),
             Some(b"pattern".to_vec())
         );
 
@@ -146692,7 +147950,13 @@ pub(crate) mod tests {
             install_test_menu(&mut loaded, PPC_DATA_BASE + 0x1400, 129, b"Edit", b"Cut");
         let disabled_menu =
             install_test_menu(&mut loaded, PPC_DATA_BASE + 0x1800, 130, b"View", b"Zoom");
-        ppc_set_menu_item_enabled(&mut loaded.memory, &test_handle_records!(loaded), disabled_menu, 0, false);
+        ppc_set_menu_item_enabled(
+            &mut loaded.memory,
+            &test_handle_records!(loaded),
+            disabled_menu,
+            0,
+            false,
+        );
 
         let file_left = STANDARD_MENU_BAR_FIRST_TITLE_LEFT;
         let edit_left = file_left
@@ -147235,10 +148499,13 @@ pub(crate) mod tests {
         loaded.memory.add_region(rects, vec![0; 16]);
         ppc_write_rect(&mut loaded.memory, rects, 10, 20, 80, 220).unwrap();
         ppc_write_rect(&mut loaded.memory, rects + 8, 10, 20, 80, 220).unwrap();
+        let mut last_mem_error = PPC_NO_ERR;
         let te_handle = ppc_te_initialize_record(
+            None,
             &mut loaded.memory,
             test_heap_cursor!(loaded),
             test_heap_limit!(loaded),
+            &mut last_mem_error,
             test_handles!(loaded),
             rects,
             rects + 8,
@@ -147255,9 +148522,11 @@ pub(crate) mod tests {
         );
         assert_eq!(
             ppc_te_set_text(
+                None,
                 &mut loaded.memory,
                 test_heap_cursor!(loaded),
                 test_heap_limit!(loaded),
+                &mut last_mem_error,
                 test_handles!(loaded),
                 te_handle,
                 b"abc",
@@ -147344,15 +148613,7 @@ pub(crate) mod tests {
         let font = PPC_QD_TEXT_FONT_DEFAULT;
         let size = PPC_QD_TEXT_SIZE_SYSTEM;
         let first_line_width = ppc_text_bytes_advance_for_font(b"one two", font, size);
-        ppc_write_rect(
-            &mut loaded.memory,
-            rects,
-            10,
-            20,
-            80,
-            20 + first_line_width,
-        )
-        .unwrap();
+        ppc_write_rect(&mut loaded.memory, rects, 10, 20, 80, 20 + first_line_width).unwrap();
         ppc_write_rect(
             &mut loaded.memory,
             rects + 8,
@@ -147362,10 +148623,13 @@ pub(crate) mod tests {
             20 + first_line_width,
         )
         .unwrap();
+        let mut last_mem_error = PPC_NO_ERR;
         let te_handle = ppc_te_initialize_record(
+            None,
             &mut loaded.memory,
             test_heap_cursor!(loaded),
             test_heap_limit!(loaded),
+            &mut last_mem_error,
             test_handles!(loaded),
             rects,
             rects + 8,
@@ -147379,9 +148643,11 @@ pub(crate) mod tests {
 
         assert_eq!(
             ppc_te_set_text(
+                None,
                 &mut loaded.memory,
                 test_heap_cursor!(loaded),
                 test_heap_limit!(loaded),
+                &mut last_mem_error,
                 test_handles!(loaded),
                 te_handle,
                 b"one two three",
@@ -147435,10 +148701,13 @@ pub(crate) mod tests {
 
         ppc_write_rect(&mut loaded.memory, te_rects, 60, 10, 100, 100).unwrap();
         ppc_write_rect(&mut loaded.memory, te_rects + 8, 60, 10, 100, 100).unwrap();
+        let mut last_mem_error = PPC_NO_ERR;
         let te_handle = ppc_te_initialize_record(
+            None,
             &mut loaded.memory,
             test_heap_cursor!(loaded),
             test_heap_limit!(loaded),
+            &mut last_mem_error,
             test_handles!(loaded),
             te_rects,
             te_rects + 8,
@@ -147451,9 +148720,11 @@ pub(crate) mod tests {
         );
         assert_eq!(
             ppc_te_set_text(
+                None,
                 &mut loaded.memory,
                 test_heap_cursor!(loaded),
                 test_heap_limit!(loaded),
+                &mut last_mem_error,
                 test_handles!(loaded),
                 te_handle,
                 b"0",
@@ -147484,10 +148755,13 @@ pub(crate) mod tests {
         loaded.memory.add_region(rects, vec![0; 0x40]);
         ppc_write_rect(&mut loaded.memory, rects, 0, 0, 80, 220).unwrap();
         ppc_write_rect(&mut loaded.memory, rects + 8, 0, 0, 80, 220).unwrap();
+        let mut last_mem_error = PPC_NO_ERR;
         let te_handle = ppc_te_initialize_record(
+            None,
             &mut loaded.memory,
             test_heap_cursor!(loaded),
             test_heap_limit!(loaded),
+            &mut last_mem_error,
             test_handles!(loaded),
             rects,
             rects + 8,
@@ -147499,9 +148773,11 @@ pub(crate) mod tests {
             false,
         );
         ppc_te_set_text(
+            None,
             &mut loaded.memory,
             test_heap_cursor!(loaded),
             test_heap_limit!(loaded),
+            &mut last_mem_error,
             test_handles!(loaded),
             te_handle,
             b"Pilot Name",
@@ -147518,7 +148794,11 @@ pub(crate) mod tests {
         loaded.cpu.gpr[3] = te_handle;
         loaded.run_with_hle_imports(64);
         assert_eq!(
-            ppc_te_scrap_bytes(&mut loaded.memory, &test_handle_records!(loaded), &loaded.scrap),
+            ppc_te_scrap_bytes(
+                &mut loaded.memory,
+                &test_handle_records!(loaded),
+                &loaded.scrap
+            ),
             b"Pilot"
         );
 
@@ -147552,7 +148832,11 @@ pub(crate) mod tests {
         assert_eq!(loaded.cpu.gpr[3], 5);
         assert_eq!(loaded.memory.read_u32_be(offset_ptr), Some(0));
         assert_eq!(
-            ppc_handle_bytes(&mut loaded.memory, &test_handle_records!(loaded), destination),
+            ppc_handle_bytes(
+                &mut loaded.memory,
+                &test_handle_records!(loaded),
+                destination
+            ),
             Some(b"Pilot".to_vec())
         );
     }
@@ -147976,10 +149260,7 @@ pub(crate) mod tests {
         loaded.memory.add_region(pb, vec![0; 0x200]);
         loaded.memory.write_u32_be(pb + 18, name_ptr).unwrap();
         loaded.memory.write_u16_be(pb + 22, 0).unwrap();
-        loaded
-            .memory
-            .write_u16_be(pb + 28, (-1i16) as u16)
-            .unwrap();
+        loaded.memory.write_u16_be(pb + 28, (-1i16) as u16).unwrap();
         assert!(ppc_write_pstring_bytes(
             &mut loaded.memory,
             name_ptr,
@@ -149215,12 +150496,9 @@ pub(crate) mod tests {
         .unwrap();
         loaded.memory.write_bytes(text, b"\x04PICT").unwrap();
         ppc_write_rect(&mut loaded.memory, destination, 50, 50, 90, 90).unwrap();
-        let surface = ppc_live_quickdraw_surface(
-            &mut loaded.memory,
-            &loaded.gworlds,
-            loaded.current_gworld,
-        )
-        .unwrap();
+        let surface =
+            ppc_live_quickdraw_surface(&mut loaded.memory, &loaded.gworlds, loaded.current_gworld)
+                .unwrap();
         let before = ppc_quickdraw_read_pixel(
             &mut loaded.memory,
             surface.front_buffer,
@@ -149228,7 +150506,10 @@ pub(crate) mod tests {
         );
 
         loaded.cpu.gpr[3] = frame;
-        run_test_import(&mut loaded, PpcImportDispatcherTarget::QuickDrawCompatibility);
+        run_test_import(
+            &mut loaded,
+            PpcImportDispatcherTarget::QuickDrawCompatibility,
+        );
         let handle = loaded.cpu.gpr[3];
         assert_ne!(handle, 0);
         loaded.cpu.gpr[3] = color;
@@ -149261,8 +150542,12 @@ pub(crate) mod tests {
         );
 
         loaded.imports[0].symbol_name = "ClosePicture".to_string();
-        run_test_import(&mut loaded, PpcImportDispatcherTarget::QuickDrawCompatibility);
-        let picture = ppc_handle_bytes(&mut loaded.memory, &test_handle_records!(loaded), handle).unwrap();
+        run_test_import(
+            &mut loaded,
+            PpcImportDispatcherTarget::QuickDrawCompatibility,
+        );
+        let picture =
+            ppc_handle_bytes(&mut loaded.memory, &test_handle_records!(loaded), handle).unwrap();
         for opcode in [[0x00, 0x31], [0x00, 0x40], [0x00, 0x28]] {
             assert!(picture.windows(2).any(|word| word == opcode));
         }
@@ -149303,6 +150588,7 @@ pub(crate) mod tests {
         window_cpu.gpr[6] = 1;
         let window = ppc_new_cwindow(
             &window_cpu,
+            None,
             &mut loaded.memory,
             test_heap_cursor!(loaded),
             test_heap_limit!(loaded),
@@ -149388,6 +150674,7 @@ pub(crate) mod tests {
         window_cpu.gpr[6] = 1;
         let window = ppc_new_cwindow(
             &window_cpu,
+            None,
             &mut loaded.memory,
             test_heap_cursor!(loaded),
             test_heap_limit!(loaded),
@@ -150745,8 +152032,7 @@ pub(crate) mod tests {
         loaded.quickdraw_fore_indices.insert(PPC_MAIN_GWORLD, 103);
 
         let front = ppc_front_buffer_for_gworld(&loaded.gworlds, PPC_MAIN_GWORLD).unwrap();
-        let clipped_pixel_before =
-            ppc_quickdraw_read_pixel(&mut loaded.memory, front, (10, 20));
+        let clipped_pixel_before = ppc_quickdraw_read_pixel(&mut loaded.memory, front, (10, 20));
 
         loaded.cpu.gpr[3] = clip_ptr;
         loaded.run_with_hle_imports(64);
@@ -151561,12 +152847,12 @@ pub(crate) mod tests {
         assert!(apple_events.pending_dispatches.is_empty());
         assert_eq!(native.memory.read_u32_be(event_handle), Some(0));
         assert_eq!(native.memory.read_u32_be(reply_handle), Some(0));
-        assert!(handles.iter().all(|record| {
-            record.handle != event_handle && record.handle != reply_handle
-        }));
-        assert!(handle_states.iter().all(|record| {
-            record.handle != event_handle && record.handle != reply_handle
-        }));
+        assert!(handles
+            .iter()
+            .all(|record| { record.handle != event_handle && record.handle != reply_handle }));
+        assert!(handle_states
+            .iter()
+            .all(|record| { record.handle != event_handle && record.handle != reply_handle }));
     }
 
     #[test]
@@ -151664,7 +152950,10 @@ pub(crate) mod tests {
         let event_handle = classic_bus.read_long(event_desc + 4);
         let event_data = classic_bus.read_long(event_handle);
         assert_eq!(native.memory.read_u32_be(event_desc), Some(event_class));
-        assert_eq!(native.memory.read_u32_be(event_desc + 4), Some(event_handle));
+        assert_eq!(
+            native.memory.read_u32_be(event_desc + 4),
+            Some(event_handle)
+        );
         assert_eq!(native.memory.read_u32_be(event_handle), Some(event_data));
         classic_bus.write_byte(event_data, b'C');
         assert_eq!(native.memory.read_u8(event_data), Some(b'C'));
@@ -151803,8 +153092,14 @@ pub(crate) mod tests {
         assert!(apple_events.pending_dispatches.is_empty());
         let manager = context.memory_manager_mut();
         let after_allocator = manager.native_allocator_snapshot().unwrap();
-        assert_eq!(after_allocator.heap.heap_cursor, before_allocator.heap.heap_cursor);
-        assert_eq!(after_allocator.heap.heap_limit, before_allocator.heap.heap_limit);
+        assert_eq!(
+            after_allocator.heap.heap_cursor,
+            before_allocator.heap.heap_cursor
+        );
+        assert_eq!(
+            after_allocator.heap.heap_limit,
+            before_allocator.heap.heap_limit
+        );
         assert_eq!(after_allocator.ptrs, before_allocator.ptrs);
         assert_eq!(
             after_allocator.free_ptr_blocks,
@@ -153671,7 +154966,8 @@ pub(crate) mod tests {
         }
 
         let grown = loaded
-            .handles().iter()
+            .handles()
+            .iter()
             .find(|record| record.handle == private_ctable_handle)
             .copied()
             .unwrap();
@@ -160361,11 +161657,9 @@ pub(crate) mod tests {
             assert_eq!(dispatcher_target_for_import("StdCLib", name), target);
         }
 
-        let mut loaded = load_pef_application(&synthetic_pef_with_library_import(
-            b"StdCLib",
-            b"memchr",
-        ))
-        .unwrap();
+        let mut loaded =
+            load_pef_application(&synthetic_pef_with_library_import(b"StdCLib", b"memchr"))
+                .unwrap();
         let string = PPC_DATA_BASE + 0x2400;
         let set = string + 0x40;
         let reject = string + 0x50;
@@ -160377,7 +161671,10 @@ pub(crate) mod tests {
         loaded.memory.write_bytes(reject, b"13\0").unwrap();
         loaded.memory.write_bytes(needle, b"123a\0").unwrap();
 
-        assert_eq!(ppc_std_memchr(&mut loaded.memory, string, b'c', 3), string + 2);
+        assert_eq!(
+            ppc_std_memchr(&mut loaded.memory, string, b'c', 3),
+            string + 2
+        );
         assert_eq!(ppc_std_memchr(&mut loaded.memory, string, b'c', 2), 0);
         assert_eq!(ppc_std_memchr(&mut loaded.memory, string, b'a', 0), 0);
         assert_eq!(
@@ -160423,15 +161720,10 @@ pub(crate) mod tests {
             (b"strpbrk".as_slice(), reject, 0, string + 3),
             (b"strstr".as_slice(), needle, 0, string + 3),
         ] {
-            let mut imported = load_pef_application(&synthetic_pef_with_library_import(
-                b"StdCLib", name,
-            ))
-            .unwrap();
+            let mut imported =
+                load_pef_application(&synthetic_pef_with_library_import(b"StdCLib", name)).unwrap();
             imported.memory.add_region(string, vec![0; 0x100]);
-            imported
-                .memory
-                .write_bytes(string, b"abc123abc\0")
-                .unwrap();
+            imported.memory.write_bytes(string, b"abc123abc\0").unwrap();
             imported.memory.write_bytes(set, b"abc\0").unwrap();
             imported.memory.write_bytes(reject, b"13\0").unwrap();
             imported.memory.write_bytes(needle, b"123a\0").unwrap();
@@ -162033,8 +163325,14 @@ pub(crate) mod tests {
         assert_eq!(native.memory.read_u32_be(descriptor + 4), Some(0xaaaa_aaaa));
         let manager = context.memory_manager_mut();
         let after_allocator = manager.native_allocator_snapshot().unwrap();
-        assert_eq!(after_allocator.heap.heap_cursor, before_allocator.heap.heap_cursor);
-        assert_eq!(after_allocator.heap.heap_limit, before_allocator.heap.heap_limit);
+        assert_eq!(
+            after_allocator.heap.heap_cursor,
+            before_allocator.heap.heap_cursor
+        );
+        assert_eq!(
+            after_allocator.heap.heap_limit,
+            before_allocator.heap.heap_limit
+        );
         assert_eq!(after_allocator.ptrs, before_allocator.ptrs);
         assert_eq!(
             after_allocator.free_ptr_blocks,
@@ -162049,8 +163347,7 @@ pub(crate) mod tests {
 
     #[test]
     fn object_specifier_descriptors_are_immediately_process_owned() {
-        let pef =
-            synthetic_pef_with_library_import(b"ObjectSupportLib", b"CreateObjSpecifier");
+        let pef = synthetic_pef_with_library_import(b"ObjectSupportLib", b"CreateObjSpecifier");
         let mut native = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
         native.attach_process_context(&mut context);
@@ -162155,11 +163452,7 @@ pub(crate) mod tests {
     }
 
     fn math64_binding(symbol_name: &str) -> PpcImportBinding {
-        compatibility_binding(
-            "Math64Lib",
-            symbol_name,
-            PpcImportDispatcherTarget::Math64,
-        )
+        compatibility_binding("Math64Lib", symbol_name, PpcImportDispatcherTarget::Math64)
     }
 
     fn math64_set_gprs(cpu: &mut PpcCpu, high_register: usize, value: u64) {
@@ -162336,31 +163629,15 @@ pub(crate) mod tests {
             (128, i64::MIN as u64),
         ] {
             cpu.gpr[6] = shift;
-            let _ = ppc_dispatch_math64(
-                &math64_binding("S64ShiftRight"),
-                &mut cpu,
-                &mut memory,
-            );
-            assert_eq!(
-                math64_read_memory(&mut memory, 0x1000),
-                expected,
-                "{shift}",
-            );
+            let _ = ppc_dispatch_math64(&math64_binding("S64ShiftRight"), &mut cpu, &mut memory);
+            assert_eq!(math64_read_memory(&mut memory, 0x1000), expected, "{shift}",);
         }
 
         math64_set_gprs(&mut cpu, 4, 1);
         for (shift, expected) in [(0, 1), (63, 1 << 63), (64, 0), (127, 0), (128, 1)] {
             cpu.gpr[6] = shift;
-            let _ = ppc_dispatch_math64(
-                &math64_binding("U64ShiftLeft"),
-                &mut cpu,
-                &mut memory,
-            );
-            assert_eq!(
-                math64_read_memory(&mut memory, 0x1000),
-                expected,
-                "{shift}",
-            );
+            let _ = ppc_dispatch_math64(&math64_binding("U64ShiftLeft"), &mut cpu, &mut memory);
+            assert_eq!(math64_read_memory(&mut memory, 0x1000), expected, "{shift}",);
         }
     }
 
@@ -162392,11 +163669,7 @@ pub(crate) mod tests {
         cpu.gpr[3] = 0x1000;
         math64_set_gprs(&mut cpu, 4, 0xf0f0_ffff_0000_aaaa);
         math64_set_gprs(&mut cpu, 6, 0x0ff0_00ff_ffff_5555);
-        let _ = ppc_dispatch_math64(
-            &math64_binding("U64BitwiseEor"),
-            &mut cpu,
-            &mut memory,
-        );
+        let _ = ppc_dispatch_math64(&math64_binding("U64BitwiseEor"), &mut cpu, &mut memory);
         assert_eq!(
             math64_read_memory(&mut memory, 0x1000),
             0xff00_ff00_ffff_ffff,
@@ -162411,33 +163684,21 @@ pub(crate) mod tests {
 
         for value in [i64::MIN, -1, 0, i64::MAX - 1, i64::MAX] {
             math64_set_gprs(&mut cpu, 3, value as u64);
-            let _ = ppc_dispatch_math64(
-                &math64_binding("SInt64ToLongDouble"),
-                &mut cpu,
-                &mut memory,
-            );
+            let _ =
+                ppc_dispatch_math64(&math64_binding("SInt64ToLongDouble"), &mut cpu, &mut memory);
             cpu.gpr[3] = 0x1000;
-            let _ = ppc_dispatch_math64(
-                &math64_binding("LongDoubleToSInt64"),
-                &mut cpu,
-                &mut memory,
-            );
+            let _ =
+                ppc_dispatch_math64(&math64_binding("LongDoubleToSInt64"), &mut cpu, &mut memory);
             assert_eq!(math64_read_memory(&mut memory, 0x1000), value as u64);
         }
 
         for value in [0, 1, u64::MAX - 1, u64::MAX] {
             math64_set_gprs(&mut cpu, 3, value);
-            let _ = ppc_dispatch_math64(
-                &math64_binding("UInt64ToLongDouble"),
-                &mut cpu,
-                &mut memory,
-            );
+            let _ =
+                ppc_dispatch_math64(&math64_binding("UInt64ToLongDouble"), &mut cpu, &mut memory);
             cpu.gpr[3] = 0x1008;
-            let _ = ppc_dispatch_math64(
-                &math64_binding("LongDoubleToUInt64"),
-                &mut cpu,
-                &mut memory,
-            );
+            let _ =
+                ppc_dispatch_math64(&math64_binding("LongDoubleToUInt64"), &mut cpu, &mut memory);
             assert_eq!(math64_read_memory(&mut memory, 0x1008), value);
         }
     }
@@ -162491,6 +163752,7 @@ pub(crate) mod tests {
         assert_eq!(
             ppc_munger_compatibility(
                 &cpu,
+                None,
                 &mut memory,
                 &mut heap_cursor,
                 0x5000,

--- a/src/loader/ppc.rs
+++ b/src/loader/ppc.rs
@@ -71,8 +71,9 @@ use crate::menu_manager::{
 use crate::menu_model::GuestMenuSnapshot;
 use crate::process_context::{
     ProcessAppleEventHandler, ProcessContext, ProcessHandleRecord, ProcessHandleStateRecord,
-    ProcessMemoryManager, ProcessNativeAllocatorState, ProcessNativeHeapState, ProcessPtrRecord,
-    SharedProcessAppleEventHandlers, SharedProcessMemoryManager,
+    ProcessMemoryManager, ProcessNativeAllocatorState, ProcessNativeHeapState,
+    ProcessNativeMemoryManager, ProcessPtrRecord, SharedProcessAppleEventHandlers,
+    SharedProcessMemoryManager,
 };
 use crate::quickdraw::fonts::heuristics::get_italic_slant;
 use crate::quickdraw::fonts::{
@@ -8916,6 +8917,7 @@ impl PpcLoadedApp {
             .map(|binding| binding.symbol_index);
         let input = self.input;
         let mut event_queue = std::mem::take(&mut self.event_queue);
+        let process_memory_manager = process_memory_manager.native_mut();
         let native_allocator = process_memory_manager
             .native_allocator_snapshot()
             .expect("native allocator registered before execution");
@@ -16537,7 +16539,7 @@ fn dispatcher_target_for_import(
 
 #[allow(clippy::too_many_arguments)]
 fn ppc_synchronize_process_native_allocator(
-    memory_manager: &mut ProcessMemoryManager,
+    memory_manager: &mut ProcessNativeMemoryManager,
     heap_cursor: u32,
     heap_limit: u32,
     last_mem_error: i16,
@@ -16556,7 +16558,7 @@ fn ppc_synchronize_process_native_allocator(
 }
 
 fn ppc_synchronize_process_native_handles(
-    memory_manager: &mut ProcessMemoryManager,
+    memory_manager: &mut ProcessNativeMemoryManager,
     handles: &[PpcHandleRecord],
     handle_states: &[PpcHandleStateRecord],
 ) {
@@ -16589,7 +16591,7 @@ fn ppc_process_handle_state_bits(
 }
 
 fn ppc_apply_process_native_allocator(
-    memory_manager: &ProcessMemoryManager,
+    memory_manager: &ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     last_mem_error: &mut i16,
@@ -16610,7 +16612,7 @@ fn ppc_apply_process_native_allocator(
 
 #[allow(clippy::too_many_arguments)]
 fn ppc_dispose_process_native_handle(
-    memory_manager: &mut ProcessMemoryManager,
+    memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -16650,7 +16652,7 @@ fn ppc_dispose_process_native_handle(
 }
 
 fn ppc_apply_process_native_handle(
-    memory_manager: &ProcessMemoryManager,
+    memory_manager: &ProcessNativeMemoryManager,
     handles: &mut Vec<PpcHandleRecord>,
     handle_states: &mut Vec<PpcHandleStateRecord>,
     handle: u32,
@@ -16678,7 +16680,7 @@ fn ppc_apply_process_native_handle(
 }
 
 fn ppc_apply_process_handle_state(
-    memory_manager: &ProcessMemoryManager,
+    memory_manager: &ProcessNativeMemoryManager,
     handle_states: &mut Vec<PpcHandleStateRecord>,
     handle: u32,
 ) {
@@ -16695,7 +16697,7 @@ fn ppc_apply_process_handle_state(
 
 #[allow(clippy::too_many_arguments)]
 fn ppc_apply_process_native_resource_handle(
-    memory_manager: &ProcessMemoryManager,
+    memory_manager: &ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     last_mem_error: &mut i16,
@@ -16720,7 +16722,7 @@ fn dispatch_supported_import(
     binding: &PpcImportBinding,
     cpu: &mut PpcCpu,
     memory: &mut PpcSectionMem,
-    process_memory_manager: &mut ProcessMemoryManager,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     heap_cursor: &mut u32,
     heap_limit: u32,
     application_heap_limit: &mut u32,
@@ -27583,7 +27585,7 @@ fn ppc_write_ae_desc(
 
 #[allow(clippy::too_many_arguments)]
 fn ppc_create_process_owned_ae_desc(
-    process_memory_manager: &mut ProcessMemoryManager,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -27669,7 +27671,7 @@ fn ppc_create_process_owned_ae_desc(
 fn ppc_dispatch_apple_event_compatibility(
     binding: &PpcImportBinding,
     cpu: &mut PpcCpu,
-    process_memory_manager: &mut ProcessMemoryManager,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -31021,7 +31023,7 @@ fn ppc_dispatch_stdc_qsort(
 #[allow(clippy::too_many_arguments)]
 fn ppc_dispatch_object_support_compatibility(
     cpu: &mut PpcCpu,
-    process_memory_manager: &mut ProcessMemoryManager,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -52269,7 +52271,7 @@ fn ppc_color_table_clut_from_bytes(bytes: &[u8]) -> Option<PpcGWorldClut> {
 #[allow(clippy::too_many_arguments)]
 fn ppc_new_gworld(
     cpu: &mut PpcCpu,
-    process_memory_manager: &mut ProcessMemoryManager,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -52566,7 +52568,7 @@ fn ppc_new_gworld(
 #[allow(clippy::too_many_arguments)]
 fn ppc_update_gworld(
     cpu: &PpcCpu,
-    process_memory_manager: &mut ProcessMemoryManager,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -57806,7 +57808,7 @@ fn ppc_dsp_context_global_to_local(cpu: &PpcCpu, memory: &mut PpcSectionMem) -> 
 #[allow(clippy::too_many_arguments)]
 fn ppc_dsp_alt_buffer_new(
     cpu: &PpcCpu,
-    process_memory_manager: &mut ProcessMemoryManager,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -60207,7 +60209,7 @@ fn ppc_handle_resize_allocation_size(
 
 fn ppc_get_resource(
     cpu: &mut PpcCpu,
-    process_memory_manager: &mut ProcessMemoryManager,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -60284,7 +60286,7 @@ const PPC_ICON_SUITE_MAGIC: u32 = u32::from_be_bytes(*b"ISUT");
 #[allow(clippy::too_many_arguments)]
 fn ppc_get_icon_suite(
     cpu: &PpcCpu,
-    process_memory_manager: &mut ProcessMemoryManager,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -60406,7 +60408,7 @@ fn ppc_resource_name_eq(left: &[u8], right: &[u8]) -> bool {
 #[allow(clippy::too_many_arguments)]
 fn ppc_get_named_resource(
     cpu: &PpcCpu,
-    process_memory_manager: &mut ProcessMemoryManager,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -60479,7 +60481,7 @@ fn ppc_get_named_resource(
 
 fn ppc_get_ind_resource(
     cpu: &mut PpcCpu,
-    process_memory_manager: &mut ProcessMemoryManager,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -60558,7 +60560,7 @@ fn ppc_get_ind_resource(
 
 fn ppc_get_ind_string(
     cpu: &mut PpcCpu,
-    process_memory_manager: &mut ProcessMemoryManager,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -60614,7 +60616,7 @@ fn ppc_get_ind_string(
 
 fn ppc_get_ccursor(
     cpu: &mut PpcCpu,
-    process_memory_manager: &mut ProcessMemoryManager,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -61076,7 +61078,7 @@ fn ppc_plot_cicon(
 #[allow(clippy::too_many_arguments)]
 fn ppc_dispose_cicon(
     cpu: &PpcCpu,
-    process_memory_manager: &mut ProcessMemoryManager,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -61139,7 +61141,7 @@ fn ppc_set_cursor(
 
 fn ppc_get_cursor(
     cpu: &mut PpcCpu,
-    process_memory_manager: &mut ProcessMemoryManager,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -61207,7 +61209,7 @@ fn ppc_get_cursor(
 }
 
 fn ppc_materialize_vfs_resource_handle(
-    process_memory_manager: &mut ProcessMemoryManager,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -61792,7 +61794,7 @@ fn ppc_install_apple_event_handler(
 #[allow(clippy::too_many_arguments)]
 fn ppc_process_apple_event(
     cpu: &mut PpcCpu,
-    process_memory_manager: &mut ProcessMemoryManager,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -61991,7 +61993,7 @@ fn ppc_process_apple_event(
 fn ppc_complete_apple_event_dispatch(
     apple_events: &mut PpcAppleEventState,
     guest_call_depth: usize,
-    process_memory_manager: &mut ProcessMemoryManager,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     last_mem_error: &mut i16,
@@ -62163,7 +62165,7 @@ fn ppc_remove_resource(
 
 fn ppc_release_resource(
     cpu: &mut PpcCpu,
-    process_memory_manager: &mut ProcessMemoryManager,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -62465,7 +62467,7 @@ fn ppc_position_dialog_bounds(
 #[allow(clippy::too_many_arguments)]
 fn ppc_new_alert_dialog(
     cpu: &PpcCpu,
-    process_memory_manager: &mut ProcessMemoryManager,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -62605,7 +62607,7 @@ fn ppc_new_alert_dialog(
 #[allow(clippy::too_many_arguments)]
 fn ppc_get_new_dialog(
     cpu: &PpcCpu,
-    process_memory_manager: &mut ProcessMemoryManager,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -62846,7 +62848,7 @@ fn ppc_new_dialog(
 
 #[allow(clippy::too_many_arguments)]
 fn ppc_initialize_dialog_items(
-    process_memory_manager: &mut ProcessMemoryManager,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -70658,7 +70660,7 @@ fn ppc_insert_resource_menu_names(
 
 #[allow(clippy::too_many_arguments)]
 fn ppc_insert_resource_menu(
-    process_memory_manager: &mut ProcessMemoryManager,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -73599,7 +73601,7 @@ fn ppc_finish_menu_bar_tracking(
 #[allow(clippy::too_many_arguments)]
 fn ppc_load_menu_resource(
     menu_id: i16,
-    process_memory_manager: &mut ProcessMemoryManager,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -73679,7 +73681,7 @@ fn ppc_load_menu_resource(
 #[allow(clippy::too_many_arguments)]
 fn ppc_menu_definition_handle(
     mdef_id: i16,
-    process_memory_manager: &mut ProcessMemoryManager,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -73744,7 +73746,7 @@ fn ppc_menu_definition_handle(
 #[allow(clippy::too_many_arguments)]
 fn ppc_resolve_menu_definition(
     menu_handle: u32,
-    process_memory_manager: &mut ProcessMemoryManager,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -73976,7 +73978,7 @@ fn ppc_alloc_menu_list_definition_handle(
 #[allow(clippy::too_many_arguments)]
 fn ppc_get_new_mbar(
     mbar_id: i16,
-    process_memory_manager: &mut ProcessMemoryManager,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -80811,7 +80813,7 @@ fn ppc_open_resource_path(
 
 fn ppc_close_res_file(
     cpu: &mut PpcCpu,
-    process_memory_manager: &mut ProcessMemoryManager,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,

--- a/src/loader/ppc.rs
+++ b/src/loader/ppc.rs
@@ -24388,17 +24388,20 @@ fn dispatch_supported_import(
         PpcImportDispatcherTarget::StdSprintf => {
             Some(PpcImportAction::Return(ppc_std_sprintf(cpu, memory)))
         }
-        PpcImportDispatcherTarget::StdIoCompatibility => Some(ppc_dispatch_stdio_compatibility(
-            binding,
-            cpu,
-            memory,
-            heap_cursor,
-            heap_limit,
-            files,
-            vfs_files,
-            next_file_ref_num,
-            stdio_streams,
-        )),
+        PpcImportDispatcherTarget::StdIoCompatibility => {
+            Some(ppc_dispatch_process_stdio_compatibility(
+                binding,
+                cpu,
+                process_memory_manager,
+                memory,
+                heap_cursor,
+                heap_limit,
+                files,
+                vfs_files,
+                next_file_ref_num,
+                stdio_streams,
+            ))
+        }
         PpcImportDispatcherTarget::StdAbs => Some(PpcImportAction::Return(
             (cpu.gpr[3] as i32).wrapping_abs() as u32,
         )),
@@ -29932,9 +29935,64 @@ fn ppc_stdio_set_error(stream: u32, stdio_streams: &mut HashMap<u32, PpcStdioStr
 }
 
 #[allow(clippy::too_many_arguments)]
+#[cfg(test)]
 fn ppc_dispatch_stdio_compatibility(
     binding: &PpcImportBinding,
     cpu: &mut PpcCpu,
+    memory: &mut PpcSectionMem,
+    heap_cursor: &mut u32,
+    heap_limit: u32,
+    files: &mut Vec<PpcFileRecord>,
+    vfs_files: &mut Vec<PpcVfsFileRecord>,
+    next_file_ref_num: &mut i16,
+    stdio_streams: &mut HashMap<u32, PpcStdioStreamRecord>,
+) -> PpcImportAction {
+    ppc_dispatch_stdio_compatibility_with_manager(
+        binding,
+        cpu,
+        None,
+        memory,
+        heap_cursor,
+        heap_limit,
+        files,
+        vfs_files,
+        next_file_ref_num,
+        stdio_streams,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn ppc_dispatch_process_stdio_compatibility(
+    binding: &PpcImportBinding,
+    cpu: &mut PpcCpu,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
+    memory: &mut PpcSectionMem,
+    heap_cursor: &mut u32,
+    heap_limit: u32,
+    files: &mut Vec<PpcFileRecord>,
+    vfs_files: &mut Vec<PpcVfsFileRecord>,
+    next_file_ref_num: &mut i16,
+    stdio_streams: &mut HashMap<u32, PpcStdioStreamRecord>,
+) -> PpcImportAction {
+    ppc_dispatch_stdio_compatibility_with_manager(
+        binding,
+        cpu,
+        Some(process_memory_manager),
+        memory,
+        heap_cursor,
+        heap_limit,
+        files,
+        vfs_files,
+        next_file_ref_num,
+        stdio_streams,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn ppc_dispatch_stdio_compatibility_with_manager(
+    binding: &PpcImportBinding,
+    cpu: &mut PpcCpu,
+    mut process_memory_manager: Option<&mut ProcessNativeMemoryManager>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -29974,8 +30032,17 @@ fn ppc_dispatch_stdio_compatibility(
             let Some(next_ref_num) = next_file_ref_num.checked_add(1) else {
                 return PpcImportAction::Return(0);
             };
-            let stream_ptr =
-                ppc_heap_alloc(memory, heap_cursor, heap_limit, PPC_STDIO_FILE_SIZE, true);
+            let stream_ptr = if let Some(memory_manager) = process_memory_manager.as_deref_mut() {
+                ppc_process_heap_alloc(
+                    memory_manager,
+                    memory,
+                    heap_cursor,
+                    PPC_STDIO_FILE_SIZE,
+                    true,
+                )
+            } else {
+                ppc_heap_alloc(memory, heap_cursor, heap_limit, PPC_STDIO_FILE_SIZE, true)
+            };
             if stream_ptr == 0 {
                 return PpcImportAction::Return(0);
             }
@@ -82521,6 +82588,21 @@ fn ppc_heap_alloc(
     }
     *heap_cursor = next;
     ppc_update_zone_free_bytes(memory, next, heap_limit);
+    ptr
+}
+
+fn ppc_process_heap_alloc(
+    memory_manager: &mut ProcessNativeMemoryManager,
+    memory: &mut PpcSectionMem,
+    heap_cursor: &mut u32,
+    size: u32,
+    clear: bool,
+) -> u32 {
+    let ptr = memory_manager.reserve_native_bytes(memory, size, clear);
+    if let Some(heap) = memory_manager.native_heap_state() {
+        *heap_cursor = heap.heap_cursor;
+        ppc_update_zone_free_bytes(memory, heap.heap_cursor, heap.heap_limit);
+    }
     ptr
 }
 
@@ -159651,6 +159733,51 @@ pub(crate) mod tests {
             .any(|record| record.ptr == replacement));
         assert!(detached.native_allocator().unwrap().ptrs.is_empty());
         assert_eq!(native.last_mem_error(), PPC_PARAM_ERR);
+    }
+
+    #[test]
+    fn stdio_records_advance_the_process_owned_heap_immediately() {
+        let pef = synthetic_pef_with_library_import(b"StdCLib", b"fopen");
+        let mut native = load_pef_application(&pef).unwrap();
+        let mut context = ProcessContext::default();
+        native.attach_process_context(&mut context);
+        let detached = context.memory_manager_mut().detached_clone();
+        let heap_before = context
+            .memory_manager_mut()
+            .native_heap_state()
+            .unwrap()
+            .heap_cursor;
+        let path = PPC_DATA_BASE + 0x2000;
+        let mode = path + 0x20;
+        native.memory.add_region(path, vec![0; 0x100]);
+        native.memory.write_bytes(path, b"test.bin\0").unwrap();
+        native.memory.write_bytes(mode, b"rb\0").unwrap();
+        native.vfs_files.push(PpcVfsFileRecord {
+            path: "Volume/test.bin".to_string(),
+            data: b"payload".to_vec(),
+            creator: 0,
+            file_type: 0,
+            finder_flags: 0,
+            dirty: false,
+        });
+        native.cpu.gpr[3] = path;
+        native.cpu.gpr[4] = mode;
+
+        run_test_import(&mut native, PpcImportDispatcherTarget::StdIoCompatibility);
+
+        let stream = native.cpu.gpr[3];
+        assert_ne!(stream, 0);
+        let heap_after = context
+            .memory_manager_mut()
+            .native_heap_state()
+            .unwrap()
+            .heap_cursor;
+        assert!(heap_after > heap_before);
+        assert_eq!(native.heap_cursor(), heap_after);
+        assert_eq!(
+            detached.native_heap_state().unwrap().heap_cursor,
+            heap_before
+        );
     }
 
     #[test]

--- a/src/loader/ppc.rs
+++ b/src/loader/ppc.rs
@@ -24793,7 +24793,13 @@ fn dispatch_supported_import(
             ppc_complete_pb(memory, cpu.gpr[3], PPC_NO_ERR),
         ))),
         PpcImportDispatcherTarget::SndNewChannel => Some(PpcImportAction::Return(ppc_i16_result(
-            ppc_snd_new_channel(cpu, memory, heap_cursor, heap_limit, last_mem_error),
+            ppc_snd_new_channel(
+                cpu,
+                process_memory_manager,
+                memory,
+                heap_cursor,
+                last_mem_error,
+            ),
         ))),
         PpcImportDispatcherTarget::SndDisposeChannel => Some(PpcImportAction::Return(
             ppc_i16_result(ppc_snd_dispose_channel(cpu, sound)),
@@ -27253,6 +27259,7 @@ fn dispatch_supported_import(
         }
         PpcImportDispatcherTarget::CallUniversalProc => ppc_call_universal_proc(
             cpu,
+            process_memory_manager,
             memory,
             heap_cursor,
             heap_limit,
@@ -27260,7 +27267,14 @@ fn dispatch_supported_import(
             GuestIsa::PowerPc,
         ),
         PpcImportDispatcherTarget::CallOSTrapUniversalProc => {
-            ppc_call_os_trap_universal_proc(cpu, memory, heap_cursor, heap_limit, toolbox_startup)
+            ppc_call_os_trap_universal_proc(
+                cpu,
+                process_memory_manager,
+                memory,
+                heap_cursor,
+                heap_limit,
+                toolbox_startup,
+            )
         }
         PpcImportDispatcherTarget::NGetTrapAddress
         | PpcImportDispatcherTarget::GetToolTrapAddress
@@ -27451,11 +27465,14 @@ fn dispatch_supported_import(
             Some(ppc_dispatch_quickdraw_compatibility(
                 binding,
                 cpu,
+                process_memory_manager,
                 memory,
                 heap_cursor,
                 heap_limit,
                 last_mem_error,
                 handles,
+                free_ptr_blocks,
+                free_handle_blocks,
                 handle_states,
                 vfs_resources,
                 *current_resource_refnum,
@@ -28189,11 +28206,14 @@ fn ppc_dispatch_dialog_compatibility(
 fn ppc_dispatch_quickdraw_compatibility(
     binding: &PpcImportBinding,
     cpu: &mut PpcCpu,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
     last_mem_error: &mut i16,
     handles: &mut Vec<PpcHandleRecord>,
+    free_ptr_blocks: &mut Vec<PpcPtrRecord>,
+    free_handle_blocks: &mut Vec<PpcHandleRecord>,
     handle_states: &mut Vec<PpcHandleStateRecord>,
     vfs_resources: &[PpcVfsResourceRecord],
     current_resource_refnum: i16,
@@ -28289,8 +28309,17 @@ fn ppc_dispatch_quickdraw_compatibility(
             bytes[4..6].copy_from_slice(&rect.1.to_be_bytes());
             bytes[6..8].copy_from_slice(&rect.2.to_be_bytes());
             bytes[8..10].copy_from_slice(&rect.3.to_be_bytes());
-            let handle =
-                ppc_alloc_handle_with_bytes(memory, heap_cursor, heap_limit, handles, &bytes);
+            let handle = ppc_process_alloc_handle_with_bytes(
+                process_memory_manager,
+                memory,
+                heap_cursor,
+                last_mem_error,
+                handles,
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+                &bytes,
+            );
             *last_mem_error = if handle == 0 {
                 PPC_MEM_FULL_ERR
             } else {
@@ -28303,13 +28332,17 @@ fn ppc_dispatch_quickdraw_compatibility(
             if let Some((handle, _, frame, commands)) = toolbox_startup.open_picture.take() {
                 let picture = pict::finish_recording(frame, commands);
                 let size = u32::try_from(picture.len()).unwrap_or(u32::MAX);
-                let result = ppc_set_handle_size(
+                let result = process_memory_manager.set_native_handle_size(memory, handle, size);
+                ppc_apply_process_native_resource_handle(
+                    process_memory_manager,
                     memory,
                     heap_cursor,
-                    heap_limit,
+                    last_mem_error,
+                    free_ptr_blocks,
+                    free_handle_blocks,
                     handles,
+                    handle_states,
                     handle,
-                    size,
                 );
                 if result == PPC_NO_ERR {
                     if let Some(ptr) = memory.read_u32_be(handle) {
@@ -28434,8 +28467,18 @@ fn ppc_dispatch_quickdraw_compatibility(
         "NewPalette" => {
             let entry_count = u32::from(cpu.gpr[3] as u16);
             let byte_count = 16u32.saturating_add(entry_count.saturating_mul(16));
-            let handle =
-                ppc_alloc_handle(memory, heap_cursor, heap_limit, handles, byte_count, true);
+            let handle = ppc_process_alloc_handle(
+                process_memory_manager,
+                memory,
+                heap_cursor,
+                last_mem_error,
+                handles,
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+                byte_count,
+                true,
+            );
             *last_mem_error = if handle == 0 {
                 PPC_MEM_FULL_ERR
             } else {
@@ -28468,7 +28511,18 @@ fn ppc_dispatch_quickdraw_compatibility(
             PpcImportAction::Return(handle)
         }
         "NewGDevice" => {
-            let handle = ppc_alloc_handle(memory, heap_cursor, heap_limit, handles, 62, true);
+            let handle = ppc_process_alloc_handle(
+                process_memory_manager,
+                memory,
+                heap_cursor,
+                last_mem_error,
+                handles,
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+                62,
+                true,
+            );
             *last_mem_error = if handle == 0 {
                 PPC_MEM_FULL_ERR
             } else {
@@ -43938,6 +43992,7 @@ fn ppc_install_legacy_call_universal_proc_arguments(cpu: &mut PpcCpu) {
 
 fn ppc_call_universal_proc(
     cpu: &mut PpcCpu,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -44025,6 +44080,7 @@ fn ppc_call_universal_proc(
         }
         GuestIsa::M68k => ppc_begin_m68k_universal_proc(
             cpu,
+            Some(process_memory_manager),
             memory,
             heap_cursor,
             heap_limit,
@@ -44044,19 +44100,31 @@ const PPC_MIXED_MODE_M68K_RETURN_OFFSET: u32 = 50;
 const PPC_MIXED_MODE_M68K_STACK_SIZE: u32 = 64 * 1024;
 
 fn ppc_mixed_mode_m68k_storage(
+    mut process_memory_manager: Option<&mut ProcessNativeMemoryManager>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
     startup: &mut PpcToolboxStartupState,
 ) -> Option<(u32, u32)> {
     if startup.mixed_mode_m68k_gateway == 0 {
-        startup.mixed_mode_m68k_gateway = ppc_heap_alloc(
-            memory,
-            heap_cursor,
-            heap_limit,
-            PPC_MIXED_MODE_M68K_GATEWAY_SIZE,
-            true,
-        );
+        startup.mixed_mode_m68k_gateway =
+            if let Some(memory_manager) = process_memory_manager.as_deref_mut() {
+                ppc_process_heap_alloc(
+                    memory_manager,
+                    memory,
+                    heap_cursor,
+                    PPC_MIXED_MODE_M68K_GATEWAY_SIZE,
+                    true,
+                )
+            } else {
+                ppc_heap_alloc(
+                    memory,
+                    heap_cursor,
+                    heap_limit,
+                    PPC_MIXED_MODE_M68K_GATEWAY_SIZE,
+                    true,
+                )
+            };
         if startup.mixed_mode_m68k_gateway == 0 {
             return None;
         }
@@ -44066,13 +44134,23 @@ fn ppc_mixed_mode_m68k_storage(
         )?;
     }
     if startup.mixed_mode_m68k_stack_top == 0 {
-        let base = ppc_heap_alloc(
-            memory,
-            heap_cursor,
-            heap_limit,
-            PPC_MIXED_MODE_M68K_STACK_SIZE,
-            true,
-        );
+        let base = if let Some(memory_manager) = process_memory_manager.as_deref_mut() {
+            ppc_process_heap_alloc(
+                memory_manager,
+                memory,
+                heap_cursor,
+                PPC_MIXED_MODE_M68K_STACK_SIZE,
+                true,
+            )
+        } else {
+            ppc_heap_alloc(
+                memory,
+                heap_cursor,
+                heap_limit,
+                PPC_MIXED_MODE_M68K_STACK_SIZE,
+                true,
+            )
+        };
         if base == 0 {
             return None;
         }
@@ -44087,6 +44165,7 @@ fn ppc_mixed_mode_m68k_storage(
 #[allow(clippy::too_many_arguments)]
 fn ppc_begin_m68k_universal_proc(
     cpu: &PpcCpu,
+    process_memory_manager: Option<&mut ProcessNativeMemoryManager>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -44295,7 +44374,13 @@ fn ppc_begin_m68k_universal_proc(
     }
 
     let (gateway, stack_top) =
-        ppc_mixed_mode_m68k_storage(memory, heap_cursor, heap_limit, startup)?;
+        ppc_mixed_mode_m68k_storage(
+            process_memory_manager,
+            memory,
+            heap_cursor,
+            heap_limit,
+            startup,
+        )?;
     let return_pc = gateway.checked_add(PPC_MIXED_MODE_M68K_RETURN_OFFSET)?;
     if stack_top < 4 {
         return None;
@@ -44525,6 +44610,7 @@ fn ppc_push_m68k_stack_value(
 
 fn ppc_call_os_trap_universal_proc(
     cpu: &mut PpcCpu,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -44535,6 +44621,7 @@ fn ppc_call_os_trap_universal_proc(
     }
     ppc_call_universal_proc(
         cpu,
+        process_memory_manager,
         memory,
         heap_cursor,
         heap_limit,
@@ -44548,9 +44635,9 @@ fn ppc_call_os_trap_universal_proc(
 
 fn ppc_snd_new_channel(
     cpu: &mut PpcCpu,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
-    heap_limit: u32,
     last_mem_error: &mut i16,
 ) -> i16 {
     let channel_out_ptr = cpu.gpr[3];
@@ -44578,10 +44665,10 @@ fn ppc_snd_new_channel(
         };
         (existing_channel, preserved_user_info, q_length.max(1))
     } else {
-        let channel = ppc_heap_alloc(
+        let channel = ppc_process_heap_alloc(
+            process_memory_manager,
             memory,
             heap_cursor,
-            heap_limit,
             PPC_GUEST_SND_CHANNEL_SIZE,
             true,
         );
@@ -62019,6 +62106,7 @@ fn ppc_process_apple_event(
             let saved_stack_top = toolbox_startup.mixed_mode_m68k_stack_top;
             let action = ppc_begin_m68k_universal_proc(
                 cpu,
+                Some(process_memory_manager),
                 memory,
                 heap_cursor,
                 heap_limit,
@@ -71198,7 +71286,7 @@ fn ppc_begin_m68k_menu_definition(
         return None;
     }
     let (gateway, stack_top) =
-        ppc_mixed_mode_m68k_storage(memory, heap_cursor, heap_limit, startup)?;
+        ppc_mixed_mode_m68k_storage(None, memory, heap_cursor, heap_limit, startup)?;
     if stack_top < 4 {
         return None;
     }
@@ -82676,6 +82764,34 @@ fn ppc_process_alloc_handle_with_bytes(
     bytes: &[u8],
 ) -> u32 {
     let handle = memory_manager.copy_bytes_to_new_native_handle(memory, bytes);
+    ppc_apply_process_native_resource_handle(
+        memory_manager,
+        memory,
+        heap_cursor,
+        last_mem_error,
+        free_ptr_blocks,
+        free_handle_blocks,
+        handles,
+        handle_states,
+        handle,
+    );
+    handle
+}
+
+#[allow(clippy::too_many_arguments)]
+fn ppc_process_alloc_handle(
+    memory_manager: &mut ProcessNativeMemoryManager,
+    memory: &mut PpcSectionMem,
+    heap_cursor: &mut u32,
+    last_mem_error: &mut i16,
+    handles: &mut Vec<PpcHandleRecord>,
+    free_ptr_blocks: &mut Vec<PpcPtrRecord>,
+    free_handle_blocks: &mut Vec<PpcHandleRecord>,
+    handle_states: &mut Vec<PpcHandleStateRecord>,
+    size: u32,
+    clear: bool,
+) -> u32 {
+    let handle = memory_manager.new_native_handle(memory, size, clear);
     ppc_apply_process_native_resource_handle(
         memory_manager,
         memory,
@@ -97881,6 +97997,7 @@ pub(crate) mod tests {
             };
             let action = ppc_begin_m68k_universal_proc(
                 &loaded.cpu,
+                None,
                 &mut loaded.memory,
                 test_heap_cursor!(loaded),
                 test_heap_limit!(loaded),

--- a/src/loader/ppc.rs
+++ b/src/loader/ppc.rs
@@ -14311,6 +14311,7 @@ fn load_pef_application_with_config_and_optional_system_reservation(
             return Err(PpcLoadError::AddressOverflow);
         }
         let init_block = ppc_create_mem_fragment_init_block(
+            None,
             &mut memory,
             &mut heap_cursor,
             stack_base,
@@ -20026,15 +20027,30 @@ fn dispatch_supported_import(
         PpcImportDispatcherTarget::BitMapToRegion => Some(PpcImportAction::Return(ppc_i16_result(
             ppc_bitmap_to_region(cpu, memory, heap_cursor, heap_limit, handles),
         ))),
-        PpcImportDispatcherTarget::NewRgn => Some(PpcImportAction::Return(ppc_new_rgn(
+        PpcImportDispatcherTarget::NewRgn => Some(PpcImportAction::Return(ppc_process_new_rgn(
+            process_memory_manager,
             memory,
             heap_cursor,
-            heap_limit,
             last_mem_error,
             handles,
+            free_ptr_blocks,
+            free_handle_blocks,
+            handle_states,
         ))),
         PpcImportDispatcherTarget::DisposeRgn => {
-            ppc_dispose_tracked_handle(cpu.gpr[3], memory, handles, handle_states);
+            let _ = ppc_dispose_process_native_handle(
+                process_memory_manager,
+                memory,
+                heap_cursor,
+                heap_limit,
+                last_mem_error,
+                ptrs,
+                free_ptr_blocks,
+                handles,
+                free_handle_blocks,
+                handle_states,
+                cpu.gpr[3],
+            );
             Some(PpcImportAction::ReturnPreserve)
         }
         PpcImportDispatcherTarget::CopyRgn => {
@@ -20143,11 +20159,14 @@ fn dispatch_supported_import(
             ppc_rect_in_region(memory, cpu.gpr[3], cpu.gpr[4]),
         ))),
         PpcImportDispatcherTarget::OpenPoly => Some(PpcImportAction::Return(ppc_open_poly(
+            process_memory_manager,
             memory,
             heap_cursor,
-            heap_limit,
             last_mem_error,
             handles,
+            free_ptr_blocks,
+            free_handle_blocks,
+            handle_states,
             *current_gworld,
         ))),
         PpcImportDispatcherTarget::ClosePoly => {
@@ -21293,11 +21312,14 @@ fn dispatch_supported_import(
         PpcImportDispatcherTarget::GetCTable => {
             let handle = ppc_get_ctable(
                 cpu,
+                process_memory_manager,
                 memory,
                 heap_cursor,
-                heap_limit,
                 last_mem_error,
                 handles,
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
                 vfs_resources,
                 *current_resource_refnum,
             );
@@ -21421,25 +21443,48 @@ fn dispatch_supported_import(
         }
         PpcImportDispatcherTarget::DisposeCTable => {
             let ctable_handle = cpu.gpr[3];
-            ppc_dispose_tracked_handle(ctable_handle, memory, handles, handle_states);
+            let _ = ppc_dispose_process_native_handle(
+                process_memory_manager,
+                memory,
+                heap_cursor,
+                heap_limit,
+                last_mem_error,
+                ptrs,
+                free_ptr_blocks,
+                handles,
+                free_handle_blocks,
+                handle_states,
+                ctable_handle,
+            );
             toolbox_startup
                 .indexed_screen_ctables
                 .retain(|_, handle| *handle != ctable_handle);
             Some(PpcImportAction::ReturnPreserve)
         }
         PpcImportDispatcherTarget::NewPixMap => Some(PpcImportAction::Return(ppc_new_pixmap(
+            process_memory_manager,
             memory,
             heap_cursor,
             heap_limit,
             last_mem_error,
             handles,
+            free_ptr_blocks,
+            free_handle_blocks,
+            handle_states,
             *current_gdevice,
         ))),
         PpcImportDispatcherTarget::DisposePixMap => {
             ppc_dispose_pixmap(
                 cpu.gpr[3],
+                process_memory_manager,
                 memory,
+                heap_cursor,
+                heap_limit,
+                last_mem_error,
+                ptrs,
+                free_ptr_blocks,
                 handles,
+                free_handle_blocks,
                 handle_states,
                 &mut toolbox_startup.indexed_screen_ctables,
             );
@@ -21913,6 +21958,7 @@ fn dispatch_supported_import(
         ))),
         PpcImportDispatcherTarget::GetSharedLibrary => Some(ppc_get_shared_library(
             cpu,
+            process_memory_manager,
             memory,
             heap_cursor,
             heap_limit,
@@ -21936,6 +21982,7 @@ fn dispatch_supported_import(
         )),
         PpcImportDispatcherTarget::GetMemFragment => Some(ppc_get_mem_fragment(
             cpu,
+            process_memory_manager,
             memory,
             heap_cursor,
             heap_limit,
@@ -21988,11 +22035,14 @@ fn dispatch_supported_import(
         PpcImportDispatcherTarget::NewAlias => {
             Some(PpcImportAction::Return(ppc_i16_result(ppc_new_alias(
                 cpu,
+                process_memory_manager,
                 memory,
                 heap_cursor,
-                heap_limit,
                 last_mem_error,
                 handles,
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
                 aliases,
             ))))
         }
@@ -25043,37 +25093,37 @@ fn dispatch_supported_import(
         PpcImportDispatcherTarget::Q3MemoryStorageNew => {
             Some(PpcImportAction::Return(ppc_q3_memory_storage_new(
                 cpu,
+                process_memory_manager,
                 memory,
                 q3_objects,
                 next_q3_object,
                 q3_memory_storages,
                 heap_cursor,
-                heap_limit,
                 last_mem_error,
             )))
         }
         PpcImportDispatcherTarget::Q3MemoryStorageNewBuffer => {
             Some(PpcImportAction::Return(ppc_q3_memory_storage_new_buffer(
                 cpu,
+                process_memory_manager,
                 memory,
                 q3_objects,
                 next_q3_object,
                 q3_memory_storages,
                 heap_cursor,
-                heap_limit,
                 last_mem_error,
             )))
         }
         PpcImportDispatcherTarget::Q3FSSpecStorageNew => {
             Some(PpcImportAction::Return(ppc_q3_fsspec_storage_new(
                 cpu,
+                process_memory_manager,
                 memory,
                 q3_objects,
                 next_q3_object,
                 vfs_directories,
                 vfs_files,
                 heap_cursor,
-                heap_limit,
                 last_mem_error,
             )))
         }
@@ -25389,13 +25439,13 @@ fn dispatch_supported_import(
         PpcImportDispatcherTarget::Q3MemoryStorageSet => Some(PpcImportAction::Return(u32::from(
             ppc_q3_memory_storage_set(
                 cpu,
+                process_memory_manager,
                 memory,
                 q3_objects,
                 q3_error_state,
                 q3_memory_storages,
                 q3_files,
                 heap_cursor,
-                heap_limit,
                 last_mem_error,
             ),
         ))),
@@ -25411,13 +25461,13 @@ fn dispatch_supported_import(
         PpcImportDispatcherTarget::Q3MemoryStorageSetBuffer => Some(PpcImportAction::Return(
             u32::from(ppc_q3_memory_storage_set_buffer(
                 cpu,
+                process_memory_manager,
                 memory,
                 q3_objects,
                 q3_error_state,
                 q3_memory_storages,
                 q3_files,
                 heap_cursor,
-                heap_limit,
                 last_mem_error,
             )),
         )),
@@ -25910,12 +25960,12 @@ fn dispatch_supported_import(
         PpcImportDispatcherTarget::Q3TriMeshNew => {
             Some(PpcImportAction::Return(ppc_q3_trimesh_new(
                 cpu,
+                process_memory_manager,
                 memory,
                 q3_objects,
                 q3_object_refs,
                 next_q3_object,
                 heap_cursor,
-                heap_limit,
                 last_mem_error,
                 q3_trimeshes,
             )))
@@ -25923,9 +25973,9 @@ fn dispatch_supported_import(
         PpcImportDispatcherTarget::Q3TriMeshGetData => {
             Some(PpcImportAction::Return(u32::from(ppc_q3_trimesh_get_data(
                 cpu,
+                process_memory_manager,
                 memory,
                 heap_cursor,
-                heap_limit,
                 last_mem_error,
                 q3_objects,
                 q3_object_refs,
@@ -26105,6 +26155,7 @@ fn dispatch_supported_import(
         }
         PpcImportDispatcherTarget::Q3StorageSetData => {
             Some(PpcImportAction::Return(u32::from(ppc_q3_storage_set_data(
+                process_memory_manager,
                 memory,
                 q3_objects,
                 q3_error_state,
@@ -26115,7 +26166,6 @@ fn dispatch_supported_import(
                 cpu.gpr[6],
                 cpu.gpr[7],
                 heap_cursor,
-                heap_limit,
                 last_mem_error,
             ))))
         }
@@ -26300,6 +26350,7 @@ fn dispatch_supported_import(
         PpcImportDispatcherTarget::Q3FileReadObject => {
             Some(PpcImportAction::Return(ppc_q3_file_read_object(
                 cpu,
+                process_memory_manager,
                 memory,
                 q3_objects,
                 next_q3_object,
@@ -27017,6 +27068,7 @@ fn dispatch_supported_import(
         PpcImportDispatcherTarget::ISpElementNewVirtualFromNeeds => Some(PpcImportAction::Return(
             ppc_i16_result(ppc_isp_element_new_virtual_from_needs(
                 cpu,
+                process_memory_manager,
                 memory,
                 heap_cursor,
                 heap_limit,
@@ -27026,7 +27078,12 @@ fn dispatch_supported_import(
         )),
         PpcImportDispatcherTarget::ISpElementListNew => {
             Some(PpcImportAction::Return(ppc_i16_result(
-                ppc_isp_element_list_new(cpu, memory, heap_cursor, heap_limit),
+                ppc_isp_element_list_new(
+                    cpu,
+                    process_memory_manager,
+                    memory,
+                    heap_cursor,
+                ),
             )))
         }
         PpcImportDispatcherTarget::ISpElementListGetNextEvent => Some(PpcImportAction::Return(
@@ -32353,12 +32410,12 @@ fn ppc_q3_validate_draw_context_handle(
 
 fn ppc_q3_trimesh_new(
     cpu: &PpcCpu,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     q3_objects: &mut Vec<PpcQ3ObjectRecord>,
     q3_object_refs: &mut Vec<PpcQ3ObjectReferenceRecord>,
     next_q3_object: &mut u32,
     heap_cursor: &mut u32,
-    heap_limit: u32,
     last_mem_error: &mut i16,
     q3_trimeshes: &mut Vec<PpcQ3TriMeshRecord>,
 ) -> u32 {
@@ -32370,7 +32427,13 @@ fn ppc_q3_trimesh_new(
         return 0;
     };
     let Some(data) =
-        ppc_q3_trimesh_copy_get_data_arrays(memory, heap_cursor, heap_limit, last_mem_error, &data)
+        ppc_q3_trimesh_copy_get_data_arrays(
+            process_memory_manager,
+            memory,
+            heap_cursor,
+            last_mem_error,
+            &data,
+        )
     else {
         return 0;
     };
@@ -32396,9 +32459,9 @@ fn ppc_q3_trimesh_new(
 
 fn ppc_q3_trimesh_get_data(
     cpu: &PpcCpu,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
-    heap_limit: u32,
     last_mem_error: &mut i16,
     q3_objects: &[PpcQ3ObjectRecord],
     q3_object_refs: &mut Vec<PpcQ3ObjectReferenceRecord>,
@@ -32454,9 +32517,9 @@ fn ppc_q3_trimesh_get_data(
             })
             .or_else(|| {
                 ppc_q3_trimesh_copy_get_data_arrays(
+                    process_memory_manager,
                     memory,
                     heap_cursor,
-                    heap_limit,
                     last_mem_error,
                     &source_data,
                 )
@@ -32497,7 +32560,13 @@ fn ppc_q3_trimesh_get_data(
     };
     ppc_q3_trace_trimesh_header("GetData object copy-arrays source", cpu, trimesh, &data);
     let Some(data) =
-        ppc_q3_trimesh_copy_get_data_arrays(memory, heap_cursor, heap_limit, last_mem_error, &data)
+        ppc_q3_trimesh_copy_get_data_arrays(
+            process_memory_manager,
+            memory,
+            heap_cursor,
+            last_mem_error,
+            &data,
+        )
     else {
         return false;
     };
@@ -32688,17 +32757,17 @@ fn ppc_q3_trimesh_empty_data(cpu: &PpcCpu, memory: &mut PpcSectionMem) -> bool {
 }
 
 fn ppc_q3_trimesh_copy_get_data_arrays(
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
-    heap_limit: u32,
     last_mem_error: &mut i16,
     data: &[u8],
 ) -> Option<Vec<u8>> {
     let mut data = data.to_vec();
     ppc_q3_trimesh_copy_get_data_array(
+        process_memory_manager,
         memory,
         heap_cursor,
-        heap_limit,
         last_mem_error,
         &mut data,
         PPC_Q3_TRIMESH_NUM_TRIANGLES_OFFSET,
@@ -32707,9 +32776,9 @@ fn ppc_q3_trimesh_copy_get_data_arrays(
         PPC_Q3_SOFTWARE_RENDER_MAX_TRIANGLES,
     )?;
     ppc_q3_trimesh_copy_get_data_array(
+        process_memory_manager,
         memory,
         heap_cursor,
-        heap_limit,
         last_mem_error,
         &mut data,
         PPC_Q3_TRIMESH_NUM_TRIANGLE_ATTRIBUTE_TYPES_OFFSET,
@@ -32718,9 +32787,9 @@ fn ppc_q3_trimesh_copy_get_data_arrays(
         PPC_Q3_SOFTWARE_RENDER_MAX_ATTRIBUTE_TYPES,
     )?;
     ppc_q3_trimesh_copy_get_data_attribute_payloads(
+        process_memory_manager,
         memory,
         heap_cursor,
-        heap_limit,
         last_mem_error,
         &mut data,
         PPC_Q3_TRIMESH_NUM_TRIANGLES_OFFSET,
@@ -32729,9 +32798,9 @@ fn ppc_q3_trimesh_copy_get_data_arrays(
         PPC_Q3_SOFTWARE_RENDER_MAX_TRIANGLES,
     )?;
     ppc_q3_trimesh_copy_get_data_array(
+        process_memory_manager,
         memory,
         heap_cursor,
-        heap_limit,
         last_mem_error,
         &mut data,
         PPC_Q3_TRIMESH_NUM_EDGES_OFFSET,
@@ -32740,9 +32809,9 @@ fn ppc_q3_trimesh_copy_get_data_arrays(
         PPC_Q3_SOFTWARE_RENDER_MAX_EDGES,
     )?;
     ppc_q3_trimesh_copy_get_data_array(
+        process_memory_manager,
         memory,
         heap_cursor,
-        heap_limit,
         last_mem_error,
         &mut data,
         PPC_Q3_TRIMESH_NUM_EDGE_ATTRIBUTE_TYPES_OFFSET,
@@ -32751,9 +32820,9 @@ fn ppc_q3_trimesh_copy_get_data_arrays(
         PPC_Q3_SOFTWARE_RENDER_MAX_ATTRIBUTE_TYPES,
     )?;
     ppc_q3_trimesh_copy_get_data_attribute_payloads(
+        process_memory_manager,
         memory,
         heap_cursor,
-        heap_limit,
         last_mem_error,
         &mut data,
         PPC_Q3_TRIMESH_NUM_EDGES_OFFSET,
@@ -32762,9 +32831,9 @@ fn ppc_q3_trimesh_copy_get_data_arrays(
         PPC_Q3_SOFTWARE_RENDER_MAX_EDGES,
     )?;
     ppc_q3_trimesh_copy_get_data_array(
+        process_memory_manager,
         memory,
         heap_cursor,
-        heap_limit,
         last_mem_error,
         &mut data,
         PPC_Q3_TRIMESH_NUM_POINTS_OFFSET,
@@ -32773,9 +32842,9 @@ fn ppc_q3_trimesh_copy_get_data_arrays(
         PPC_Q3_SOFTWARE_RENDER_MAX_POINTS,
     )?;
     ppc_q3_trimesh_copy_get_data_array(
+        process_memory_manager,
         memory,
         heap_cursor,
-        heap_limit,
         last_mem_error,
         &mut data,
         PPC_Q3_TRIMESH_NUM_VERTEX_ATTRIBUTE_TYPES_OFFSET,
@@ -32784,9 +32853,9 @@ fn ppc_q3_trimesh_copy_get_data_arrays(
         PPC_Q3_SOFTWARE_RENDER_MAX_ATTRIBUTE_TYPES,
     )?;
     ppc_q3_trimesh_copy_get_data_attribute_payloads(
+        process_memory_manager,
         memory,
         heap_cursor,
-        heap_limit,
         last_mem_error,
         &mut data,
         PPC_Q3_TRIMESH_NUM_POINTS_OFFSET,
@@ -32916,9 +32985,9 @@ fn ppc_q3_trimesh_refresh_get_data_arrays(
 }
 
 fn ppc_q3_trimesh_copy_get_data_array(
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
-    heap_limit: u32,
     last_mem_error: &mut i16,
     data: &mut [u8],
     count_offset: u32,
@@ -32935,7 +33004,13 @@ fn ppc_q3_trimesh_copy_get_data_array(
     if !ppc_memory_can_read_bytes(memory, source_ptr, byte_count) {
         return Some(());
     }
-    let dest_ptr = ppc_heap_alloc(memory, heap_cursor, heap_limit, byte_count, false);
+    let dest_ptr = ppc_process_heap_alloc(
+        process_memory_manager,
+        memory,
+        heap_cursor,
+        byte_count,
+        false,
+    );
     if dest_ptr == 0 {
         *last_mem_error = PPC_MEM_FULL_ERR;
         return None;
@@ -32947,9 +33022,9 @@ fn ppc_q3_trimesh_copy_get_data_array(
 }
 
 fn ppc_q3_trimesh_copy_get_data_attribute_payloads(
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
-    heap_limit: u32,
     last_mem_error: &mut i16,
     data: &mut [u8],
     element_count_offset: u32,
@@ -32984,8 +33059,13 @@ fn ppc_q3_trimesh_copy_get_data_attribute_payloads(
         if source_data_ptr != 0
             && ppc_memory_can_read_bytes(memory, source_data_ptr, data_byte_count)
         {
-            let dest_data_ptr =
-                ppc_heap_alloc(memory, heap_cursor, heap_limit, data_byte_count, false);
+            let dest_data_ptr = ppc_process_heap_alloc(
+                process_memory_manager,
+                memory,
+                heap_cursor,
+                data_byte_count,
+                false,
+            );
             if dest_data_ptr == 0 {
                 *last_mem_error = PPC_MEM_FULL_ERR;
                 return None;
@@ -32999,8 +33079,13 @@ fn ppc_q3_trimesh_copy_get_data_attribute_payloads(
             continue;
         };
         if source_use_ptr != 0 && ppc_memory_can_read_bytes(memory, source_use_ptr, element_count) {
-            let dest_use_ptr =
-                ppc_heap_alloc(memory, heap_cursor, heap_limit, element_count, false);
+            let dest_use_ptr = ppc_process_heap_alloc(
+                process_memory_manager,
+                memory,
+                heap_cursor,
+                element_count,
+                false,
+            );
             if dest_use_ptr == 0 {
                 *last_mem_error = PPC_MEM_FULL_ERR;
                 return None;
@@ -36545,12 +36630,12 @@ fn ppc_q3_write_bytes(memory: &mut PpcSectionMem, dest_ptr: u32, data: &[u8]) ->
 
 fn ppc_q3_memory_storage_new(
     cpu: &PpcCpu,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     q3_objects: &mut Vec<PpcQ3ObjectRecord>,
     next_q3_object: &mut u32,
     q3_memory_storages: &mut Vec<PpcQ3MemoryStorageRecord>,
     heap_cursor: &mut u32,
-    heap_limit: u32,
     last_mem_error: &mut i16,
 ) -> u32 {
     let source_ptr = cpu.gpr[3];
@@ -36562,9 +36647,9 @@ fn ppc_q3_memory_storage_new(
     };
     let valid_size = if source_ptr == 0 { 0 } else { requested_size };
     let Some(buffer_ptr) = ppc_q3_allocate_owned_storage_buffer(
+        process_memory_manager,
         memory,
         heap_cursor,
-        heap_limit,
         buffer_size,
         last_mem_error,
     ) else {
@@ -36589,12 +36674,12 @@ fn ppc_q3_memory_storage_new(
 
 fn ppc_q3_memory_storage_new_buffer(
     cpu: &PpcCpu,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     q3_objects: &mut Vec<PpcQ3ObjectRecord>,
     next_q3_object: &mut u32,
     q3_memory_storages: &mut Vec<PpcQ3MemoryStorageRecord>,
     heap_cursor: &mut u32,
-    heap_limit: u32,
     last_mem_error: &mut i16,
 ) -> u32 {
     let buffer_ptr = cpu.gpr[3];
@@ -36605,9 +36690,9 @@ fn ppc_q3_memory_storage_new_buffer(
             .max(valid_size)
             .max(PPC_Q3_MEMORY_STORAGE_DEFAULT_BUFFER_SIZE);
         let Some(allocated_ptr) = ppc_q3_allocate_owned_storage_buffer(
+            process_memory_manager,
             memory,
             heap_cursor,
-            heap_limit,
             allocated_size,
             last_mem_error,
         ) else {
@@ -36640,13 +36725,13 @@ fn ppc_q3_memory_storage_new_buffer(
 
 fn ppc_q3_fsspec_storage_new(
     cpu: &PpcCpu,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     q3_objects: &mut Vec<PpcQ3ObjectRecord>,
     next_q3_object: &mut u32,
     vfs_directories: &[PpcVfsDirectory],
     vfs_files: &[PpcVfsFileRecord],
     heap_cursor: &mut u32,
-    heap_limit: u32,
     last_mem_error: &mut i16,
 ) -> u32 {
     let spec_ptr = cpu.gpr[3];
@@ -36667,9 +36752,9 @@ fn ppc_q3_fsspec_storage_new(
         return 0;
     };
     let Some(buffer_ptr) = ppc_q3_allocate_owned_storage_buffer(
+        process_memory_manager,
         memory,
         heap_cursor,
-        heap_limit,
         data_size,
         last_mem_error,
     ) else {
@@ -36726,13 +36811,13 @@ fn ppc_q3_memory_storage_create(
 
 fn ppc_q3_memory_storage_set(
     cpu: &PpcCpu,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     q3_objects: &mut [PpcQ3ObjectRecord],
     q3_error_state: &mut PpcQ3ErrorState,
     q3_memory_storages: &mut Vec<PpcQ3MemoryStorageRecord>,
     q3_files: &[PpcQ3FileRecord],
     heap_cursor: &mut u32,
-    heap_limit: u32,
     last_mem_error: &mut i16,
 ) -> bool {
     let storage = cpu.gpr[3];
@@ -36756,9 +36841,9 @@ fn ppc_q3_memory_storage_set(
     };
     let valid_size = if source_ptr == 0 { 0 } else { requested_size };
     let Some(buffer_ptr) = ppc_q3_allocate_owned_storage_buffer(
+        process_memory_manager,
         memory,
         heap_cursor,
-        heap_limit,
         buffer_size,
         last_mem_error,
     ) else {
@@ -36830,13 +36915,13 @@ fn ppc_q3_memory_storage_get_buffer(
 
 fn ppc_q3_memory_storage_set_buffer(
     cpu: &PpcCpu,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     q3_objects: &mut [PpcQ3ObjectRecord],
     q3_error_state: &mut PpcQ3ErrorState,
     q3_memory_storages: &mut Vec<PpcQ3MemoryStorageRecord>,
     q3_files: &[PpcQ3FileRecord],
     heap_cursor: &mut u32,
-    heap_limit: u32,
     last_mem_error: &mut i16,
 ) -> bool {
     let storage = cpu.gpr[3];
@@ -36859,9 +36944,9 @@ fn ppc_q3_memory_storage_set_buffer(
             .max(valid_size)
             .max(PPC_Q3_MEMORY_STORAGE_DEFAULT_BUFFER_SIZE);
         let Some(allocated_ptr) = ppc_q3_allocate_owned_storage_buffer(
+            process_memory_manager,
             memory,
             heap_cursor,
-            heap_limit,
             allocated_size,
             last_mem_error,
         ) else {
@@ -37037,6 +37122,7 @@ fn ppc_q3_storage_get_data(
 }
 
 fn ppc_q3_storage_set_data(
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     q3_objects: &mut [PpcQ3ObjectRecord],
     q3_error_state: &mut PpcQ3ErrorState,
@@ -37047,7 +37133,6 @@ fn ppc_q3_storage_set_data(
     source_ptr: u32,
     size_written_ptr: u32,
     heap_cursor: &mut u32,
-    heap_limit: u32,
     last_mem_error: &mut i16,
 ) -> bool {
     if size_written_ptr == 0 || !ppc_memory_can_write_bytes(memory, size_written_ptr, 4) {
@@ -37071,13 +37156,13 @@ fn ppc_q3_storage_set_data(
         };
         if end_offset > q3_memory_storages[side_index].buffer_size
             && !ppc_q3_memory_storage_grow_for_write(
+                process_memory_manager,
                 memory,
                 q3_objects,
                 q3_memory_storages,
                 side_index,
                 end_offset,
                 heap_cursor,
-                heap_limit,
                 last_mem_error,
             )
         {
@@ -37128,9 +37213,9 @@ fn ppc_q3_storage_set_data(
 }
 
 fn ppc_q3_allocate_owned_storage_buffer(
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
-    heap_limit: u32,
     buffer_size: u32,
     last_mem_error: &mut i16,
 ) -> Option<u32> {
@@ -37138,7 +37223,13 @@ fn ppc_q3_allocate_owned_storage_buffer(
         *last_mem_error = PPC_NO_ERR;
         return Some(0);
     }
-    let ptr = ppc_heap_alloc(memory, heap_cursor, heap_limit, buffer_size, true);
+    let ptr = ppc_process_heap_alloc(
+        process_memory_manager,
+        memory,
+        heap_cursor,
+        buffer_size,
+        true,
+    );
     if ptr == 0 {
         *last_mem_error = PPC_MEM_FULL_ERR;
         None
@@ -37198,13 +37289,13 @@ fn ppc_q3_storage_is_open(q3_files: &[PpcQ3FileRecord], storage: u32) -> bool {
 }
 
 fn ppc_q3_memory_storage_grow_for_write(
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     q3_objects: &mut [PpcQ3ObjectRecord],
     q3_memory_storages: &mut Vec<PpcQ3MemoryStorageRecord>,
     side_index: usize,
     required_size: u32,
     heap_cursor: &mut u32,
-    heap_limit: u32,
     last_mem_error: &mut i16,
 ) -> bool {
     let old_record = q3_memory_storages[side_index];
@@ -37212,9 +37303,9 @@ fn ppc_q3_memory_storage_grow_for_write(
         .max(old_record.buffer_size.saturating_mul(2))
         .max(PPC_Q3_MEMORY_STORAGE_DEFAULT_BUFFER_SIZE);
     let Some(new_ptr) = ppc_q3_allocate_owned_storage_buffer(
+        process_memory_manager,
         memory,
         heap_cursor,
-        heap_limit,
         grown_size,
         last_mem_error,
     ) else {
@@ -37434,6 +37525,7 @@ fn ppc_q3_file_open_read(
 
 fn ppc_q3_file_read_object(
     cpu: &PpcCpu,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     q3_objects: &mut Vec<PpcQ3ObjectRecord>,
     next_q3_object: &mut u32,
@@ -37525,6 +37617,7 @@ fn ppc_q3_file_read_object(
             ppc_q3_group_add_membership_once(q3_group_memberships, parent_group, object);
         }
         ppc_q3_file_record_object_body(
+            process_memory_manager,
             memory,
             q3_objects,
             next_q3_object,
@@ -37542,6 +37635,7 @@ fn ppc_q3_file_read_object(
         );
         if chunk.object_type == PPC_Q3_TYPE_CONTAINER {
             let container_state = ppc_q3_file_record_container_children(
+                process_memory_manager,
                 memory,
                 q3_objects,
                 next_q3_object,
@@ -37593,6 +37687,7 @@ fn ppc_q3_file_read_object(
 }
 
 fn ppc_q3_file_record_object_body(
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     q3_objects: &mut Vec<PpcQ3ObjectRecord>,
     next_q3_object: &mut u32,
@@ -37613,6 +37708,7 @@ fn ppc_q3_file_record_object_body(
     };
     if object_type == PPC_Q3_TYPE_TRIMESH {
         if let Some(data) = ppc_q3_file_decode_trimesh_3dmf_body(
+            process_memory_manager,
             memory,
             body_ptr,
             body_size,
@@ -37640,6 +37736,7 @@ fn ppc_q3_file_record_object_body(
         }
     } else if object_type == PPC_Q3_TEXTURE_TYPE_MIPMAP && body_size > 0 {
         if let Some(data) = ppc_q3_file_decode_mipmap_3dmf_body(
+            process_memory_manager,
             memory,
             q3_objects,
             next_q3_object,
@@ -37647,7 +37744,6 @@ fn ppc_q3_file_record_object_body(
             body_ptr,
             body_size,
             heap_cursor,
-            heap_limit,
             last_mem_error,
         )
         .or_else(|| ppc_q3_read_bytes(memory, body_ptr, body_size))
@@ -37664,6 +37760,7 @@ fn ppc_q3_file_record_object_body(
 }
 
 fn ppc_q3_file_decode_mipmap_3dmf_body(
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     q3_objects: &mut Vec<PpcQ3ObjectRecord>,
     next_q3_object: &mut u32,
@@ -37671,7 +37768,6 @@ fn ppc_q3_file_decode_mipmap_3dmf_body(
     body_ptr: u32,
     body_size: u32,
     heap_cursor: &mut u32,
-    heap_limit: u32,
     last_mem_error: &mut i16,
 ) -> Option<Vec<u8>> {
     const HEADER_SIZE: u32 = 32;
@@ -37699,7 +37795,12 @@ fn ppc_q3_file_decode_mipmap_3dmf_body(
         return None;
     }
     let image = ppc_q3_read_bytes(memory, body_ptr.checked_add(HEADER_SIZE)?, image_size)?;
-    let image_ptr = ppc_q3_file_alloc_and_write_bytes(memory, heap_cursor, heap_limit, &image)?;
+    let image_ptr = ppc_q3_file_alloc_and_write_bytes(
+        process_memory_manager,
+        memory,
+        heap_cursor,
+        &image,
+    )?;
     let image_storage = ppc_q3_alloc_object(
         q3_objects,
         next_q3_object,
@@ -37767,6 +37868,7 @@ struct PpcQ3Decoded3dmfTriMesh {
 }
 
 fn ppc_q3_file_decode_trimesh_3dmf_body(
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     body_ptr: u32,
     body_size: u32,
@@ -37811,43 +37913,60 @@ fn ppc_q3_file_decode_trimesh_3dmf_body(
         return None;
     }
 
-    let triangles_ptr =
-        ppc_q3_file_alloc_and_write_bytes(memory, heap_cursor, heap_limit, &decoded.triangles)?;
-    let points_ptr =
-        ppc_q3_file_alloc_and_write_bytes(memory, heap_cursor, heap_limit, &decoded.points)?;
+    let triangles_ptr = ppc_q3_file_alloc_and_write_bytes(
+        process_memory_manager,
+        memory,
+        heap_cursor,
+        &decoded.triangles,
+    )?;
+    let points_ptr = ppc_q3_file_alloc_and_write_bytes(
+        process_memory_manager,
+        memory,
+        heap_cursor,
+        &decoded.points,
+    )?;
     let edges_ptr = if decoded.edges.is_empty() {
         0
     } else {
-        ppc_q3_file_alloc_and_write_bytes(memory, heap_cursor, heap_limit, &decoded.edges)?
+        ppc_q3_file_alloc_and_write_bytes(
+            process_memory_manager,
+            memory,
+            heap_cursor,
+            &decoded.edges,
+        )?
     };
     let triangle_attribute_types_ptr = ppc_q3_file_alloc_and_write_zeroes(
+        process_memory_manager,
         memory,
         heap_cursor,
-        heap_limit,
         triangle_attribute_types_size,
     )?;
     let edge_attribute_types_ptr = ppc_q3_file_alloc_and_write_zeroes(
+        process_memory_manager,
         memory,
         heap_cursor,
-        heap_limit,
         edge_attribute_types_size,
     )?;
     let vertex_attribute_types_ptr = ppc_q3_file_alloc_and_write_zeroes(
+        process_memory_manager,
         memory,
         heap_cursor,
-        heap_limit,
         vertex_attribute_types_size,
     )?;
     for attribute in &decoded.attributes {
-        let data_ptr =
-            ppc_q3_file_alloc_and_write_bytes(memory, heap_cursor, heap_limit, &attribute.data)?;
+        let data_ptr = ppc_q3_file_alloc_and_write_bytes(
+            process_memory_manager,
+            memory,
+            heap_cursor,
+            &attribute.data,
+        )?;
         let use_array_ptr = if attribute.use_array.is_empty() {
             0
         } else {
             ppc_q3_file_alloc_and_write_bytes(
+                process_memory_manager,
                 memory,
                 heap_cursor,
-                heap_limit,
                 &attribute.use_array,
             )?
         };
@@ -38081,16 +38200,22 @@ fn ppc_q3_file_parse_trimesh_attribute_array(
 }
 
 fn ppc_q3_file_alloc_and_write_bytes(
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
-    heap_limit: u32,
     data: &[u8],
 ) -> Option<u32> {
     if data.is_empty() {
         return Some(0);
     }
     let size = u32::try_from(data.len()).ok()?;
-    let ptr = ppc_heap_alloc(memory, heap_cursor, heap_limit, size, true);
+    let ptr = ppc_process_heap_alloc(
+        process_memory_manager,
+        memory,
+        heap_cursor,
+        size,
+        true,
+    );
     if ptr == 0 || !ppc_q3_write_bytes(memory, ptr, data) {
         return None;
     }
@@ -38098,16 +38223,16 @@ fn ppc_q3_file_alloc_and_write_bytes(
 }
 
 fn ppc_q3_file_alloc_and_write_zeroes(
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
-    heap_limit: u32,
     size: u32,
 ) -> Option<u32> {
     if size == 0 {
         return Some(0);
     }
     let data = vec![0; usize::try_from(size).ok()?];
-    ppc_q3_file_alloc_and_write_bytes(memory, heap_cursor, heap_limit, &data)
+    ppc_q3_file_alloc_and_write_bytes(process_memory_manager, memory, heap_cursor, &data)
 }
 
 fn ppc_q3_file_write_trimesh_attribute_record(
@@ -38130,6 +38255,7 @@ fn ppc_q3_file_write_trimesh_attribute_record(
 }
 
 fn ppc_q3_file_attach_trimesh_attribute_array(
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     target_trimesh: u32,
     body_ptr: u32,
@@ -38213,8 +38339,12 @@ fn ppc_q3_file_attach_trimesh_attribute_array(
         *last_mem_error = PPC_MEM_FULL_ERR;
         return false;
     }
-    let Some(data_ptr) =
-        ppc_q3_file_alloc_and_write_bytes(memory, heap_cursor, heap_limit, &attribute.data)
+    let Some(data_ptr) = ppc_q3_file_alloc_and_write_bytes(
+        process_memory_manager,
+        memory,
+        heap_cursor,
+        &attribute.data,
+    )
     else {
         return false;
     };
@@ -38222,9 +38352,9 @@ fn ppc_q3_file_attach_trimesh_attribute_array(
         0
     } else {
         let Some(ptr) = ppc_q3_file_alloc_and_write_bytes(
+            process_memory_manager,
             memory,
             heap_cursor,
-            heap_limit,
             &attribute.use_array,
         ) else {
             return false;
@@ -38489,6 +38619,7 @@ fn ppc_q3_file_promote_container_root_object(
 }
 
 fn ppc_q3_file_record_container_children(
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     q3_objects: &mut Vec<PpcQ3ObjectRecord>,
     next_q3_object: &mut u32,
@@ -38641,6 +38772,7 @@ fn ppc_q3_file_record_container_children(
                 }
             }
             ppc_q3_file_record_object_body(
+                process_memory_manager,
                 memory,
                 q3_objects,
                 next_q3_object,
@@ -38662,6 +38794,7 @@ fn ppc_q3_file_record_container_children(
                 if let Some(target_trimesh) = current_trimesh {
                     if let Some(body_ptr) = header_ptr.checked_add(8) {
                         let _ = ppc_q3_file_attach_trimesh_attribute_array(
+                            process_memory_manager,
                             memory,
                             target_trimesh,
                             body_ptr,
@@ -38692,6 +38825,7 @@ fn ppc_q3_file_record_container_children(
             }
             if object_type == PPC_Q3_TYPE_CONTAINER {
                 let child_state = ppc_q3_file_record_container_children(
+                    process_memory_manager,
                     memory,
                     q3_objects,
                     next_q3_object,
@@ -49856,6 +49990,7 @@ fn ppc_gestalt_response(selector: u32) -> Option<(u32, i16)> {
 
 fn ppc_get_shared_library(
     cpu: &mut PpcCpu,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -49925,8 +50060,13 @@ fn ppc_get_shared_library(
                     Ok(size) => size,
                     Err(_) => return return_error(PPC_FRAG_NO_MEM),
                 };
-                let fragment_addr =
-                    ppc_heap_alloc(memory, heap_cursor, heap_limit, fragment_size, false);
+                let fragment_addr = ppc_process_heap_alloc(
+                    process_memory_manager,
+                    memory,
+                    heap_cursor,
+                    fragment_size,
+                    false,
+                );
                 if fragment_addr == 0
                     || memory.write_bytes(fragment_addr, &fragment.bytes).is_none()
                 {
@@ -49934,6 +50074,7 @@ fn ppc_get_shared_library(
                 }
                 let prepared = match ppc_prepare_mem_fragment(
                     &fragment.bytes,
+                    Some(process_memory_manager),
                     memory,
                     heap_cursor,
                     heap_limit,
@@ -49954,6 +50095,7 @@ fn ppc_get_shared_library(
                 };
                 if prepared.init_addr != 0 {
                     let init_block = match ppc_create_mem_fragment_init_block(
+                        Some(process_memory_manager),
                         memory,
                         heap_cursor,
                         heap_limit,
@@ -50142,6 +50284,7 @@ fn ppc_find_symbol(
 
 fn ppc_get_mem_fragment(
     cpu: &mut PpcCpu,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -50222,6 +50365,7 @@ fn ppc_get_mem_fragment(
             };
             let prepared = match ppc_prepare_mem_fragment(
                 &fragment,
+                Some(process_memory_manager),
                 memory,
                 heap_cursor,
                 heap_limit,
@@ -50254,6 +50398,7 @@ fn ppc_get_mem_fragment(
             };
             if prepared.init_addr != 0 {
                 let init_block = match ppc_create_mem_fragment_init_block(
+                    Some(process_memory_manager),
                     memory,
                     heap_cursor,
                     heap_limit,
@@ -50311,6 +50456,7 @@ fn ppc_get_mem_fragment(
 }
 
 fn ppc_create_mem_fragment_init_block(
+    mut process_memory_manager: Option<&mut ProcessNativeMemoryManager>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -50326,14 +50472,28 @@ fn ppc_create_mem_fragment_init_block(
     let name = encode_mac_roman_lossy(fragment_name);
     let name_len = name.len().min(255);
     let name_size = u32::try_from(name_len + 1).map_err(|_| PPC_FRAG_NO_MEM)?;
-    let init_block = ppc_heap_alloc(
-        memory,
-        heap_cursor,
-        heap_limit,
-        PPC_CFM_INIT_BLOCK_SIZE,
-        true,
-    );
-    let name_ptr = ppc_heap_alloc(memory, heap_cursor, heap_limit, name_size, true);
+    let init_block = if let Some(memory_manager) = process_memory_manager.as_deref_mut() {
+        ppc_process_heap_alloc(
+            memory_manager,
+            memory,
+            heap_cursor,
+            PPC_CFM_INIT_BLOCK_SIZE,
+            true,
+        )
+    } else {
+        ppc_heap_alloc(
+            memory,
+            heap_cursor,
+            heap_limit,
+            PPC_CFM_INIT_BLOCK_SIZE,
+            true,
+        )
+    };
+    let name_ptr = if let Some(memory_manager) = process_memory_manager.as_deref_mut() {
+        ppc_process_heap_alloc(memory_manager, memory, heap_cursor, name_size, true)
+    } else {
+        ppc_heap_alloc(memory, heap_cursor, heap_limit, name_size, true)
+    };
     if init_block == 0 || name_ptr == 0 {
         return Err(PPC_FRAG_NO_MEM);
     }
@@ -50372,6 +50532,7 @@ fn ppc_create_mem_fragment_init_block(
 
 fn ppc_prepare_mem_fragment(
     fragment: &[u8],
+    process_memory_manager: Option<&mut ProcessNativeMemoryManager>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -50456,6 +50617,11 @@ fn ppc_prepare_mem_fragment(
 
     for section in &mapped_sections {
         if memory.write_bytes(section.base, &section.bytes).is_none() {
+            return Err(PPC_FRAG_NO_ADDR_SPACE);
+        }
+    }
+    if let Some(memory_manager) = process_memory_manager {
+        if !memory_manager.commit_native_heap_cursor(next_heap_cursor) {
             return Err(PPC_FRAG_NO_ADDR_SPACE);
         }
     }
@@ -58696,6 +58862,7 @@ fn ppc_write_c_string(memory: &mut PpcSectionMem, ptr: u32, bytes: &[u8]) -> Opt
 
 fn ppc_isp_element_new_virtual_from_needs(
     cpu: &mut PpcCpu,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -58754,10 +58921,10 @@ fn ppc_isp_element_new_virtual_from_needs(
 
     let mut created_records = Vec::with_capacity(drafts.len());
     for draft in drafts {
-        let element = ppc_heap_alloc(
+        let element = ppc_process_heap_alloc(
+            process_memory_manager,
             memory,
             heap_cursor,
-            heap_limit,
             PPC_ISP_VIRTUAL_ELEMENT_RECORD_SIZE,
             true,
         );
@@ -58816,9 +58983,9 @@ fn ppc_isp_element_new_virtual_from_needs(
 
 fn ppc_isp_element_list_new(
     cpu: &mut PpcCpu,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
-    heap_limit: u32,
 ) -> i16 {
     let count = cpu.gpr[3];
     let elements_ptr = cpu.gpr[4];
@@ -58840,10 +59007,10 @@ fn ppc_isp_element_list_new(
     // the returned value is an opaque list reference initialized with the
     // supplied elements. Keep only the state needed by the empty event queue.
     let _ = memory.write_u32_be(out_list_ptr, 0);
-    let list = ppc_heap_alloc(
+    let list = ppc_process_heap_alloc(
+        process_memory_manager,
         memory,
         heap_cursor,
-        heap_limit,
         PPC_ISP_ELEMENT_LIST_RECORD_SIZE,
         true,
     );
@@ -65241,11 +65408,14 @@ fn ppc_pb_status(cpu: &PpcCpu, memory: &mut PpcSectionMem) -> i16 {
 
 fn ppc_get_ctable(
     cpu: &PpcCpu,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
-    heap_limit: u32,
     last_mem_error: &mut i16,
     handles: &mut Vec<PpcHandleRecord>,
+    free_ptr_blocks: &mut Vec<PpcPtrRecord>,
+    free_handle_blocks: &mut Vec<PpcHandleRecord>,
+    handle_states: &mut Vec<PpcHandleStateRecord>,
     vfs_resources: &[PpcVfsResourceRecord],
     current_resource_refnum: i16,
 ) -> u32 {
@@ -65284,7 +65454,17 @@ fn ppc_get_ctable(
     let Some(data) = data else {
         return 0;
     };
-    let handle = ppc_alloc_handle_with_bytes(memory, heap_cursor, heap_limit, handles, &data);
+    let handle = ppc_process_alloc_handle_with_bytes(
+        process_memory_manager,
+        memory,
+        heap_cursor,
+        last_mem_error,
+        handles,
+        free_ptr_blocks,
+        free_handle_blocks,
+        handle_states,
+        &data,
+    );
     *last_mem_error = if handle == 0 {
         PPC_MEM_FULL_ERR
     } else {
@@ -65322,11 +65502,15 @@ fn ppc_read_ctable_clut(
 }
 
 fn ppc_new_pixmap(
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
     last_mem_error: &mut i16,
     handles: &mut Vec<PpcHandleRecord>,
+    free_ptr_blocks: &mut Vec<PpcPtrRecord>,
+    free_handle_blocks: &mut Vec<PpcHandleRecord>,
+    handle_states: &mut Vec<PpcHandleStateRecord>,
     current_gdevice: u32,
 ) -> u32 {
     // Inside Macintosh: Imaging With QuickDraw (1994), pp. 4-85--4-86:
@@ -65357,13 +65541,26 @@ fn ppc_new_pixmap(
         *last_mem_error = PPC_MEM_FULL_ERR;
         return 0;
     }
-    let ctable_handle =
-        ppc_alloc_handle_with_bytes(memory, heap_cursor, heap_limit, handles, &ctable_bytes);
-    let pixmap_handle = ppc_alloc_handle(
+    let ctable_handle = ppc_process_alloc_handle_with_bytes(
+        process_memory_manager,
         memory,
         heap_cursor,
-        heap_limit,
+        last_mem_error,
         handles,
+        free_ptr_blocks,
+        free_handle_blocks,
+        handle_states,
+        &ctable_bytes,
+    );
+    let pixmap_handle = ppc_process_alloc_handle(
+        process_memory_manager,
+        memory,
+        heap_cursor,
+        last_mem_error,
+        handles,
+        free_ptr_blocks,
+        free_handle_blocks,
+        handle_states,
         PPC_PIXMAP_SIZE,
         true,
     );
@@ -65389,8 +65586,15 @@ fn ppc_new_pixmap(
 
 fn ppc_dispose_pixmap(
     pixmap_handle: u32,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
+    heap_cursor: &mut u32,
+    heap_limit: u32,
+    last_mem_error: &mut i16,
+    ptrs: &mut Vec<PpcPtrRecord>,
+    free_ptr_blocks: &mut Vec<PpcPtrRecord>,
     handles: &mut Vec<PpcHandleRecord>,
+    free_handle_blocks: &mut Vec<PpcHandleRecord>,
     handle_states: &mut Vec<PpcHandleStateRecord>,
     indexed_screen_ctables: &mut HashMap<u32, u32>,
 ) {
@@ -65407,11 +65611,35 @@ fn ppc_dispose_pixmap(
         .or_else(|| indexed_screen_ctables.remove(&pixmap_handle))
         .unwrap_or(0);
     if ctable_handle != 0 {
-        ppc_dispose_tracked_handle(ctable_handle, memory, handles, handle_states);
+        let _ = ppc_dispose_process_native_handle(
+            process_memory_manager,
+            memory,
+            heap_cursor,
+            heap_limit,
+            last_mem_error,
+            ptrs,
+            free_ptr_blocks,
+            handles,
+            free_handle_blocks,
+            handle_states,
+            ctable_handle,
+        );
         indexed_screen_ctables.retain(|_, handle| *handle != ctable_handle);
     }
     indexed_screen_ctables.remove(&pixmap_handle);
-    ppc_dispose_tracked_handle(pixmap_handle, memory, handles, handle_states);
+    let _ = ppc_dispose_process_native_handle(
+        process_memory_manager,
+        memory,
+        heap_cursor,
+        heap_limit,
+        last_mem_error,
+        ptrs,
+        free_ptr_blocks,
+        handles,
+        free_handle_blocks,
+        handle_states,
+        pixmap_handle,
+    );
 }
 
 fn ppc_get_dialog_item(cpu: &mut PpcCpu, memory: &mut PpcSectionMem, handles: &[PpcHandleRecord]) {
@@ -76539,6 +76767,41 @@ fn ppc_new_rgn(
     handle
 }
 
+#[allow(clippy::too_many_arguments)]
+fn ppc_process_new_rgn(
+    process_memory_manager: &mut ProcessNativeMemoryManager,
+    memory: &mut PpcSectionMem,
+    heap_cursor: &mut u32,
+    last_mem_error: &mut i16,
+    handles: &mut Vec<PpcHandleRecord>,
+    free_ptr_blocks: &mut Vec<PpcPtrRecord>,
+    free_handle_blocks: &mut Vec<PpcHandleRecord>,
+    handle_states: &mut Vec<PpcHandleStateRecord>,
+) -> u32 {
+    let handle = ppc_process_alloc_handle(
+        process_memory_manager,
+        memory,
+        heap_cursor,
+        last_mem_error,
+        handles,
+        free_ptr_blocks,
+        free_handle_blocks,
+        handle_states,
+        10,
+        true,
+    );
+    if handle == 0 {
+        *last_mem_error = PPC_MEM_FULL_ERR;
+        return 0;
+    }
+    if ppc_set_empty_rgn(memory, handle).is_none() {
+        *last_mem_error = PPC_PARAM_ERR;
+        return 0;
+    }
+    *last_mem_error = PPC_NO_ERR;
+    handle
+}
+
 fn ppc_clip_rect(
     cpu: &PpcCpu,
     memory: &mut PpcSectionMem,
@@ -77172,18 +77435,32 @@ fn ppc_open_polygon(memory: &mut PpcSectionMem, current_gworld: u32) -> Option<u
 }
 
 fn ppc_open_poly(
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
-    heap_limit: u32,
     last_mem_error: &mut i16,
     handles: &mut Vec<PpcHandleRecord>,
+    free_ptr_blocks: &mut Vec<PpcPtrRecord>,
+    free_handle_blocks: &mut Vec<PpcHandleRecord>,
+    handle_states: &mut Vec<PpcHandleStateRecord>,
     current_gworld: u32,
 ) -> u32 {
     if current_gworld == 0 || ppc_open_polygon(memory, current_gworld).is_some() {
         *last_mem_error = PPC_PARAM_ERR;
         return 0;
     }
-    let handle = ppc_alloc_handle(memory, heap_cursor, heap_limit, handles, 10, true);
+    let handle = ppc_process_alloc_handle(
+        process_memory_manager,
+        memory,
+        heap_cursor,
+        last_mem_error,
+        handles,
+        free_ptr_blocks,
+        free_handle_blocks,
+        handle_states,
+        10,
+        true,
+    );
     let Some(ptr) = memory.read_u32_be(handle).filter(|ptr| *ptr != 0) else {
         *last_mem_error = PPC_MEM_FULL_ERR;
         return 0;
@@ -81870,11 +82147,14 @@ fn ppc_find_folder_dir_id(folder_type: u32) -> u32 {
 
 fn ppc_new_alias(
     cpu: &mut PpcCpu,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
-    heap_limit: u32,
     last_mem_error: &mut i16,
     handles: &mut Vec<PpcHandleRecord>,
+    free_ptr_blocks: &mut Vec<PpcPtrRecord>,
+    free_handle_blocks: &mut Vec<PpcHandleRecord>,
+    handle_states: &mut Vec<PpcHandleStateRecord>,
     aliases: &mut Vec<PpcAliasRecord>,
 ) -> i16 {
     let _from_file_ptr = cpu.gpr[3];
@@ -81898,7 +82178,17 @@ fn ppc_new_alias(
         return PPC_PARAM_ERR;
     };
 
-    let handle = ppc_alloc_handle_with_bytes(memory, heap_cursor, heap_limit, handles, &alias_data);
+    let handle = ppc_process_alloc_handle_with_bytes(
+        process_memory_manager,
+        memory,
+        heap_cursor,
+        last_mem_error,
+        handles,
+        free_ptr_blocks,
+        free_handle_blocks,
+        handle_states,
+        &alias_data,
+    );
     if handle == 0 {
         *last_mem_error = PPC_MEM_FULL_ERR;
         return PPC_MEM_FULL_ERR;

--- a/src/loader/ppc.rs
+++ b/src/loader/ppc.rs
@@ -5032,19 +5032,23 @@ impl Clone for PpcProcessMemoryManager {
 impl PpcProcessMemoryManager {
     pub(crate) fn with_heap(heap_cursor: u32, heap_limit: u32) -> Self {
         let memory_manager = Self::default();
-        memory_manager.0.borrow_mut().publish_native_allocator(
-            ProcessNativeHeapState {
-                heap_base: PPC_HEAP_BASE,
-                heap_cursor,
-                heap_limit,
-                last_mem_error: PPC_NO_ERR,
-                heap_maximized: false,
-                master_pointer_blocks_requested: 0,
-            },
-            &[],
-            &[],
-            &[],
-        );
+        memory_manager
+            .0
+            .borrow_mut()
+            .native_mut()
+            .publish_native_allocator(
+                ProcessNativeHeapState {
+                    heap_base: PPC_HEAP_BASE,
+                    heap_cursor,
+                    heap_limit,
+                    last_mem_error: PPC_NO_ERR,
+                    heap_maximized: false,
+                    master_pointer_blocks_requested: 0,
+                },
+                &[],
+                &[],
+                &[],
+            );
         memory_manager
     }
 

--- a/src/loader/ppc.rs
+++ b/src/loader/ppc.rs
@@ -22489,6 +22489,7 @@ fn dispatch_supported_import(
         PpcImportDispatcherTarget::NewDialog => {
             let dialog = ppc_new_dialog(
                 cpu,
+                process_memory_manager,
                 memory,
                 heap_cursor,
                 heap_limit,
@@ -22535,6 +22536,7 @@ fn dispatch_supported_import(
             // reads it; Systemless renders the standard non-themed dialog.
             let dialog = ppc_new_dialog(
                 cpu,
+                process_memory_manager,
                 memory,
                 heap_cursor,
                 heap_limit,
@@ -57918,7 +57920,13 @@ fn ppc_dsp_alt_buffer_new(
         return PPC_PARAM_ERR;
     }
 
-    let rect_ptr = ppc_heap_alloc(memory, heap_cursor, heap_limit, 8, true);
+    let rect_ptr = ppc_process_heap_alloc(
+        process_memory_manager,
+        memory,
+        heap_cursor,
+        8,
+        true,
+    );
     if rect_ptr == 0
         || ppc_write_rect(memory, rect_ptr, 0, 0, height as i16, width as i16).is_none()
     {
@@ -61354,7 +61362,13 @@ fn ppc_materialize_vfs_resource_handle(
             // mapping. Keep that mapping authoritative while allocating its
             // resource data from the shared process heap.
             let size = u32::try_from(data.len()).unwrap_or(u32::MAX);
-            let ptr = ppc_heap_alloc(memory, heap_cursor, heap_limit, size, false);
+            let ptr = ppc_process_heap_alloc(
+                process_memory_manager,
+                memory,
+                heap_cursor,
+                size,
+                false,
+            );
             if ptr == 0
                 || data.iter().copied().enumerate().any(|(offset, byte)| {
                     memory.write_u8(ptr + offset as u32, byte).is_none()
@@ -62593,14 +62607,29 @@ fn ppc_new_alert_dialog(
         *last_resource_error = PPC_PARAM_ERR;
         return 0;
     }
-    let items_handle =
-        ppc_alloc_handle_with_bytes(memory, heap_cursor, heap_limit, handles, &ditl_bytes);
+    let items_handle = ppc_process_alloc_handle_with_bytes(
+        process_memory_manager,
+        memory,
+        heap_cursor,
+        last_mem_error,
+        handles,
+        free_ptr_blocks,
+        free_handle_blocks,
+        handle_states,
+        &ditl_bytes,
+    );
     if items_handle == 0 {
         *last_mem_error = PPC_MEM_FULL_ERR;
         return 0;
     }
     let bounds = ppc_position_dialog_bounds(bounds, position, gworlds);
-    let scratch = ppc_heap_alloc(memory, heap_cursor, heap_limit, 9, true);
+    let scratch = ppc_process_heap_alloc(
+        process_memory_manager,
+        memory,
+        heap_cursor,
+        9,
+        true,
+    );
     let Some(items_slot) = ppc_parameter_area_slot_addr(cpu.gpr[1], PPC_NATIVE_PARAMETER_GPR_COUNT)
     else {
         *last_mem_error = PPC_PARAM_ERR;
@@ -62629,6 +62658,7 @@ fn ppc_new_alert_dialog(
     dialog_cpu.gpr[10] = alert_id as u16 as u32;
     let dialog = ppc_new_dialog(
         &dialog_cpu,
+        process_memory_manager,
         memory,
         heap_cursor,
         heap_limit,
@@ -62723,15 +62753,30 @@ fn ppc_get_new_dialog(
     // GetNewDialog copies the DITL into an application-owned handle. Item
     // handles are then installed in that copy, so GetDialogItem and guest
     // mutations observe the same live list rather than the resource bytes.
-    let items_handle =
-        ppc_alloc_handle_with_bytes(memory, heap_cursor, heap_limit, handles, &ditl_bytes);
+    let items_handle = ppc_process_alloc_handle_with_bytes(
+        process_memory_manager,
+        memory,
+        heap_cursor,
+        last_mem_error,
+        handles,
+        free_ptr_blocks,
+        free_handle_blocks,
+        handle_states,
+        &ditl_bytes,
+    );
     if items_handle == 0 {
         *last_mem_error = PPC_MEM_FULL_ERR;
         return 0;
     }
     let bounds = ppc_position_dialog_bounds(template.bounds, template.position, gworlds);
     let scratch_size = 8u32.saturating_add(1 + template.title.len().min(255) as u32);
-    let scratch = ppc_heap_alloc(memory, heap_cursor, heap_limit, scratch_size, true);
+    let scratch = ppc_process_heap_alloc(
+        process_memory_manager,
+        memory,
+        heap_cursor,
+        scratch_size,
+        true,
+    );
     if scratch == 0
         || ppc_write_rect(memory, scratch, bounds.0, bounds.1, bounds.2, bounds.3).is_none()
         || !ppc_write_pstring_bytes(memory, scratch + 8, &template.title)
@@ -62760,6 +62805,7 @@ fn ppc_get_new_dialog(
     new_cpu.gpr[10] = template.ref_con;
     let dialog = ppc_new_dialog(
         &new_cpu,
+        process_memory_manager,
         memory,
         heap_cursor,
         heap_limit,
@@ -62800,6 +62846,7 @@ fn ppc_get_new_dialog(
 #[allow(clippy::too_many_arguments)]
 fn ppc_new_dialog(
     cpu: &PpcCpu,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -62825,10 +62872,10 @@ fn ppc_new_dialog(
     }
 
     let storage = if requested_storage == 0 {
-        ppc_heap_alloc(
+        ppc_process_heap_alloc(
+            process_memory_manager,
             memory,
             heap_cursor,
-            heap_limit,
             PPC_DIALOG_RECORD_SIZE,
             true,
         )
@@ -63026,7 +63073,17 @@ fn ppc_initialize_dialog_items(
                 }
             }
             PPC_DIALOG_ITEM_STATIC_TEXT | PPC_DIALOG_ITEM_EDIT_TEXT => {
-                ppc_alloc_handle_with_bytes(memory, heap_cursor, heap_limit, handles, &item.payload)
+                ppc_process_alloc_handle_with_bytes(
+                    process_memory_manager,
+                    memory,
+                    heap_cursor,
+                    last_mem_error,
+                    handles,
+                    free_ptr_blocks,
+                    free_handle_blocks,
+                    handle_states,
+                    &item.payload,
+                )
             }
             PPC_DIALOG_ITEM_ICON | PPC_DIALOG_ITEM_PICTURE => {
                 let resource_id = item
@@ -82604,6 +82661,33 @@ fn ppc_process_heap_alloc(
         ppc_update_zone_free_bytes(memory, heap.heap_cursor, heap.heap_limit);
     }
     ptr
+}
+
+#[allow(clippy::too_many_arguments)]
+fn ppc_process_alloc_handle_with_bytes(
+    memory_manager: &mut ProcessNativeMemoryManager,
+    memory: &mut PpcSectionMem,
+    heap_cursor: &mut u32,
+    last_mem_error: &mut i16,
+    handles: &mut Vec<PpcHandleRecord>,
+    free_ptr_blocks: &mut Vec<PpcPtrRecord>,
+    free_handle_blocks: &mut Vec<PpcHandleRecord>,
+    handle_states: &mut Vec<PpcHandleStateRecord>,
+    bytes: &[u8],
+) -> u32 {
+    let handle = memory_manager.copy_bytes_to_new_native_handle(memory, bytes);
+    ppc_apply_process_native_resource_handle(
+        memory_manager,
+        memory,
+        heap_cursor,
+        last_mem_error,
+        free_ptr_blocks,
+        free_handle_blocks,
+        handles,
+        handle_states,
+        handle,
+    );
+    handle
 }
 
 fn ppc_heap_allocation_bounds(

--- a/src/loader/ppc.rs
+++ b/src/loader/ppc.rs
@@ -9890,21 +9890,6 @@ impl PpcLoadedApp {
         self.list_manager = list_manager;
         self.event_queue = event_queue;
         self.draw_sprocket = draw_sprocket;
-        ppc_synchronize_process_native_allocator(
-            process_memory_manager,
-            heap_cursor,
-            heap_limit,
-            last_mem_error,
-            &ptrs,
-            &free_ptr_blocks,
-            &free_handle_blocks,
-        );
-        ppc_synchronize_process_native_handles(
-            process_memory_manager,
-            &handles,
-            &handle_states,
-        );
-
         if trace_recent_on_halt && !matches!(result, PpcRunResult::CycleLimit { .. }) {
             let indirect = self.cpu.gpr[12];
             eprintln!(

--- a/src/loader/ppc.rs
+++ b/src/loader/ppc.rs
@@ -5498,12 +5498,6 @@ impl PpcLoadedApp {
                 .as_ref()
                 .map_or(&[], |allocator| allocator.free_handle_blocks.as_slice()),
         );
-        let handles = memory_manager.native_handle_records().to_vec();
-        let handle_states: Vec<_> = handles
-            .iter()
-            .map(|record| memory_manager.native_handle_state(record.handle))
-            .collect();
-        ppc_synchronize_process_native_handles(memory_manager, &handles, &handle_states);
     }
 
     fn apply_process_memory_manager(&mut self, memory_manager: &ProcessMemoryManager) {
@@ -9541,6 +9535,12 @@ impl PpcLoadedApp {
                     )
                 };
 
+                // MemError is process Memory Manager state even when a
+                // Toolbox helper reports it through the native ABI cache.
+                // Publish at the import boundary so a following 68K callback
+                // observes the result immediately, not at slice teardown.
+                process_memory_manager.set_native_mem_error(last_mem_error);
+
                 default_dir_id = memory
                     .read_u32_be(crate::memory::globals::addr::CUR_DIR_STORE)
                     .unwrap_or(default_dir_id);
@@ -9885,17 +9885,6 @@ impl PpcLoadedApp {
         self.list_manager = list_manager;
         self.event_queue = event_queue;
         self.draw_sprocket = draw_sprocket;
-        ppc_synchronize_process_native_allocator(
-            process_memory_manager,
-            heap_cursor,
-            heap_limit,
-            last_mem_error,
-            &ptrs,
-            &free_ptr_blocks,
-            &free_handle_blocks,
-        );
-        ppc_synchronize_process_native_handles(process_memory_manager, &handles, &handle_states);
-
         if trace_recent_on_halt && !matches!(result, PpcRunResult::CycleLimit { .. }) {
             let indirect = self.cpu.gpr[12];
             eprintln!(
@@ -14342,15 +14331,28 @@ fn load_pef_application_with_config_and_optional_system_reservation(
     let mut handles = Vec::new();
     let mut screen_clut = TrapDispatcher::standard_mac_8bpp_clut();
     let mut color_manager_clut = screen_clut;
+    let process_memory_manager = PpcProcessMemoryManager::with_heap(heap_cursor, stack_base);
     if config.screen_depth != PPC_MAIN_PIXEL_DEPTH {
         let saved_r3 = cpu.gpr[3];
         let saved_r4 = cpu.gpr[4];
         cpu.gpr[3] = PPC_MAIN_GDEVICE;
         cpu.gpr[4] = config.screen_depth;
         let mut last_mem_error = PPC_NO_ERR;
+        let mut free_ptr_blocks = Vec::new();
+        let mut free_handle_blocks = Vec::new();
+        let mut handle_states = Vec::new();
+        let shared_memory_manager = process_memory_manager.0.clone();
+        let mut memory_manager = shared_memory_manager.borrow_mut();
+        let mut allocator = PpcProcessAllocatorView {
+            memory_manager: memory_manager.native_mut(),
+            ptrs: None,
+            free_ptr_blocks: &mut free_ptr_blocks,
+            free_handle_blocks: &mut free_handle_blocks,
+            handle_states: &mut handle_states,
+        };
         let result = ppc_set_depth(
             &cpu,
-            None,
+            Some(&mut allocator),
             &mut memory,
             &mut heap_cursor,
             stack_base,
@@ -14368,12 +14370,6 @@ fn load_pef_application_with_config_and_optional_system_reservation(
                 requested: config.screen_depth,
             });
         }
-    }
-
-    let process_memory_manager = PpcProcessMemoryManager::with_heap(heap_cursor, stack_base);
-    {
-        let mut memory_manager = process_memory_manager.0.borrow_mut();
-        ppc_synchronize_process_native_handles(&mut memory_manager, &handles, &[]);
     }
 
     Ok(PpcLoadedApp {
@@ -16531,39 +16527,6 @@ fn dispatcher_target_for_import(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
-fn ppc_synchronize_process_native_allocator(
-    memory_manager: &mut ProcessNativeMemoryManager,
-    heap_cursor: u32,
-    heap_limit: u32,
-    last_mem_error: i16,
-    ptrs: &[PpcPtrRecord],
-    free_ptr_blocks: &[PpcPtrRecord],
-    free_handle_blocks: &[PpcHandleRecord],
-) {
-    memory_manager.synchronize_native_allocator(
-        heap_cursor,
-        heap_limit,
-        last_mem_error,
-        ptrs,
-        free_ptr_blocks,
-        free_handle_blocks,
-    );
-}
-
-fn ppc_synchronize_process_native_handles(
-    memory_manager: &mut ProcessNativeMemoryManager,
-    handles: &[PpcHandleRecord],
-    handle_states: &[PpcHandleStateRecord],
-) {
-    memory_manager.refresh_native_handle_records(handles.iter().map(|record| {
-        (
-            *record,
-            ppc_process_handle_state_bits(handle_states, record.handle),
-        )
-    }));
-}
-
 fn ppc_process_handle_state_bits(handle_states: &[PpcHandleStateRecord], handle: u32) -> u8 {
     let state = handle_states.iter().find(|state| state.handle == handle);
     let mut bits = 0u8;
@@ -16604,7 +16567,7 @@ fn ppc_dispose_process_native_handle(
     memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
-    heap_limit: u32,
+    _heap_limit: u32,
     last_mem_error: &mut i16,
     ptrs: &mut Vec<PpcPtrRecord>,
     free_ptr_blocks: &mut Vec<PpcPtrRecord>,
@@ -16613,16 +16576,6 @@ fn ppc_dispose_process_native_handle(
     handle_states: &mut Vec<PpcHandleStateRecord>,
     handle: u32,
 ) -> bool {
-    ppc_synchronize_process_native_allocator(
-        memory_manager,
-        *heap_cursor,
-        heap_limit,
-        *last_mem_error,
-        ptrs,
-        free_ptr_blocks,
-        free_handle_blocks,
-    );
-    ppc_synchronize_process_native_handles(memory_manager, handles, handle_states);
     let disposed = memory_manager
         .dispose_native_handle(memory, handle)
         .is_some();
@@ -16834,15 +16787,6 @@ fn dispatch_supported_import(
         }
         PpcImportDispatcherTarget::NewPtr { clear } => {
             let size = cpu.gpr[3];
-            ppc_synchronize_process_native_allocator(
-                process_memory_manager,
-                *heap_cursor,
-                heap_limit,
-                *last_mem_error,
-                ptrs,
-                free_ptr_blocks,
-                free_handle_blocks,
-            );
             let ptr = process_memory_manager.new_native_ptr(memory, size, clear);
             ppc_apply_process_native_allocator(
                 process_memory_manager,
@@ -16862,15 +16806,6 @@ fn dispatch_supported_import(
             Some(PpcImportAction::Return(ptr))
         }
         PpcImportDispatcherTarget::DisposePtr => {
-            ppc_synchronize_process_native_allocator(
-                process_memory_manager,
-                *heap_cursor,
-                heap_limit,
-                *last_mem_error,
-                ptrs,
-                free_ptr_blocks,
-                free_handle_blocks,
-            );
             let _ = process_memory_manager.dispose_native_ptr(cpu.gpr[3]);
             ppc_apply_process_native_allocator(
                 process_memory_manager,
@@ -16884,15 +16819,6 @@ fn dispatch_supported_import(
             Some(PpcImportAction::ReturnPreserve)
         }
         PpcImportDispatcherTarget::GetPtrSize => {
-            ppc_synchronize_process_native_allocator(
-                process_memory_manager,
-                *heap_cursor,
-                heap_limit,
-                *last_mem_error,
-                ptrs,
-                free_ptr_blocks,
-                free_handle_blocks,
-            );
             let size = process_memory_manager.native_ptr_size(cpu.gpr[3]);
             ppc_apply_process_native_allocator(
                 process_memory_manager,
@@ -16906,15 +16832,6 @@ fn dispatch_supported_import(
             Some(PpcImportAction::Return(size))
         }
         PpcImportDispatcherTarget::SetPtrSize => {
-            ppc_synchronize_process_native_allocator(
-                process_memory_manager,
-                *heap_cursor,
-                heap_limit,
-                *last_mem_error,
-                ptrs,
-                free_ptr_blocks,
-                free_handle_blocks,
-            );
             *last_mem_error =
                 process_memory_manager.set_native_ptr_size(memory, cpu.gpr[3], cpu.gpr[4]);
             ppc_apply_process_native_allocator(
@@ -16964,20 +16881,6 @@ fn dispatch_supported_import(
             {
                 PPC_PARAM_ERR
             } else if let Some(bytes) = ppc_memory_read_bytes(memory, source_ptr, size) {
-                ppc_synchronize_process_native_allocator(
-                    process_memory_manager,
-                    *heap_cursor,
-                    heap_limit,
-                    *last_mem_error,
-                    ptrs,
-                    free_ptr_blocks,
-                    free_handle_blocks,
-                );
-                ppc_synchronize_process_native_handles(
-                    process_memory_manager,
-                    handles,
-                    handle_states,
-                );
                 let handle = process_memory_manager.copy_bytes_to_new_native_handle(memory, &bytes);
                 ppc_apply_process_native_allocator(
                     process_memory_manager,
@@ -17030,20 +16933,6 @@ fn dispatch_supported_import(
                     {
                         if let Some(bytes) = ppc_memory_read_bytes(memory, source.ptr, source.size)
                         {
-                            ppc_synchronize_process_native_allocator(
-                                process_memory_manager,
-                                *heap_cursor,
-                                heap_limit,
-                                *last_mem_error,
-                                ptrs,
-                                free_ptr_blocks,
-                                free_handle_blocks,
-                            );
-                            ppc_synchronize_process_native_handles(
-                                process_memory_manager,
-                                handles,
-                                handle_states,
-                            );
                             let copy = process_memory_manager
                                 .copy_bytes_to_new_native_handle(memory, &bytes);
                             ppc_apply_process_native_allocator(
@@ -17095,20 +16984,6 @@ fn dispatch_supported_import(
                     .or_else(|| ppc_system_handle_record(memory, source_handle));
                 let result = if let Some(source) = source {
                     if let Some(bytes) = ppc_memory_read_bytes(memory, source.ptr, source.size) {
-                        ppc_synchronize_process_native_allocator(
-                            process_memory_manager,
-                            *heap_cursor,
-                            heap_limit,
-                            *last_mem_error,
-                            ptrs,
-                            free_ptr_blocks,
-                            free_handle_blocks,
-                        );
-                        ppc_synchronize_process_native_handles(
-                            process_memory_manager,
-                            handles,
-                            handle_states,
-                        );
                         let result = process_memory_manager.append_bytes_to_native_handle(
                             memory,
                             destination_handle,
@@ -17144,16 +17019,6 @@ fn dispatch_supported_import(
         }
         PpcImportDispatcherTarget::NewHandle { clear } => {
             let size = cpu.gpr[3];
-            ppc_synchronize_process_native_allocator(
-                process_memory_manager,
-                *heap_cursor,
-                heap_limit,
-                *last_mem_error,
-                ptrs,
-                free_ptr_blocks,
-                free_handle_blocks,
-            );
-            ppc_synchronize_process_native_handles(process_memory_manager, handles, handle_states);
             let handle = process_memory_manager.new_native_handle(memory, size, clear);
             ppc_apply_process_native_allocator(
                 process_memory_manager,
@@ -17182,16 +17047,6 @@ fn dispatch_supported_import(
                 *last_mem_error = PPC_PARAM_ERR;
                 return Some(PpcImportAction::Return(0));
             }
-            ppc_synchronize_process_native_allocator(
-                process_memory_manager,
-                *heap_cursor,
-                heap_limit,
-                *last_mem_error,
-                ptrs,
-                free_ptr_blocks,
-                free_handle_blocks,
-            );
-            ppc_synchronize_process_native_handles(process_memory_manager, handles, handle_states);
             let handle = process_memory_manager.new_native_handle(memory, cpu.gpr[3], false);
             ppc_apply_process_native_allocator(
                 process_memory_manager,
@@ -17250,16 +17105,6 @@ fn dispatch_supported_import(
         }
         PpcImportDispatcherTarget::EmptyHandle => {
             let handle = cpu.gpr[3];
-            ppc_synchronize_process_native_allocator(
-                process_memory_manager,
-                *heap_cursor,
-                heap_limit,
-                *last_mem_error,
-                ptrs,
-                free_ptr_blocks,
-                free_handle_blocks,
-            );
-            ppc_synchronize_process_native_handles(process_memory_manager, handles, handle_states);
             *last_mem_error = process_memory_manager.empty_native_handle(memory, handle);
             ppc_apply_process_native_allocator(
                 process_memory_manager,
@@ -17434,16 +17279,6 @@ fn dispatch_supported_import(
         PpcImportDispatcherTarget::SetHandleSize => {
             let handle = cpu.gpr[3];
             let size = cpu.gpr[4];
-            ppc_synchronize_process_native_allocator(
-                process_memory_manager,
-                *heap_cursor,
-                heap_limit,
-                *last_mem_error,
-                ptrs,
-                free_ptr_blocks,
-                free_handle_blocks,
-            );
-            ppc_synchronize_process_native_handles(process_memory_manager, handles, handle_states);
             *last_mem_error = process_memory_manager.set_native_handle_size(memory, handle, size);
             ppc_apply_process_native_allocator(
                 process_memory_manager,
@@ -17752,12 +17587,20 @@ fn dispatch_supported_import(
             let menu = if menu_proc == 0 {
                 0
             } else {
+                let mut allocator = PpcProcessAllocatorView {
+                    memory_manager: process_memory_manager,
+                    ptrs: Some(ptrs),
+                    free_ptr_blocks,
+                    free_handle_blocks,
+                    handle_states,
+                };
                 ppc_alloc_new_menu(
+                    Some(&mut allocator),
                     memory,
                     heap_cursor,
                     heap_limit,
+                    last_mem_error,
                     handles,
-                    free_handle_blocks,
                     menu_proc,
                     cpu.gpr[3] as u16 as i16,
                     cpu.gpr[4],
@@ -17778,7 +17621,21 @@ fn dispatch_supported_import(
             {
                 resource.handle = 0;
             }
-            ppc_dispose_tracked_handle(menu_handle, memory, handles, handle_states);
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
+            let _ = allocator.dispose_handle(
+                memory,
+                heap_cursor,
+                heap_limit,
+                last_mem_error,
+                handles,
+                menu_handle,
+            );
             Some(PpcImportAction::ReturnPreserve)
         }
         PpcImportDispatcherTarget::GetMenu => {
@@ -17803,6 +17660,7 @@ fn dispatch_supported_import(
                 // pp. 3-148--3-151.
                 if let Some(action) = ppc_dispatch_native_menu_definition_with_return(
                     cpu,
+                    Some(process_memory_manager),
                     memory,
                     heap_cursor,
                     heap_limit,
@@ -17849,22 +17707,49 @@ fn dispatch_supported_import(
             Some(PpcImportAction::ReturnPreserve)
         }
         PpcImportDispatcherTarget::SetMenuItemText => {
-            *last_mem_error = ppc_set_menu_item_text(cpu, memory, heap_cursor, heap_limit, handles);
-            Some(PpcImportAction::ReturnPreserve)
-        }
-        PpcImportDispatcherTarget::DeleteMenuItem => {
-            *last_mem_error = ppc_delete_menu_item(
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
+            let result = ppc_set_menu_item_text_with_allocator(
+                cpu,
+                Some(&mut allocator),
                 memory,
                 heap_cursor,
                 heap_limit,
+                last_mem_error,
+                handles,
+            );
+            *last_mem_error = result;
+            Some(PpcImportAction::ReturnPreserve)
+        }
+        PpcImportDispatcherTarget::DeleteMenuItem => {
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
+            let result = ppc_delete_menu_item_with_allocator(
+                Some(&mut allocator),
+                memory,
+                heap_cursor,
+                heap_limit,
+                last_mem_error,
                 handles,
                 cpu.gpr[3],
                 cpu.gpr[4] as u16 as i16,
             );
+            *last_mem_error = result;
             Some(PpcImportAction::ReturnPreserve)
         }
         PpcImportDispatcherTarget::CalcMenuSize => Some(ppc_dispatch_calc_menu_size(
             cpu,
+            process_memory_manager,
             memory,
             heap_cursor,
             heap_limit,
@@ -17887,6 +17772,7 @@ fn dispatch_supported_import(
                 if toolbox_startup.popup_menu_call.is_some() {
                     Some(ppc_continue_custom_popup_menu_tracking(
                         cpu,
+                        process_memory_manager,
                         memory,
                         heap_cursor,
                         heap_limit,
@@ -17905,6 +17791,7 @@ fn dispatch_supported_import(
             } else if toolbox_startup.menu_tracking.is_none() {
                 if let Some(action) = ppc_begin_custom_popup_menu_tracking(
                     cpu,
+                    process_memory_manager,
                     memory,
                     heap_cursor,
                     heap_limit,
@@ -17943,50 +17830,90 @@ fn dispatch_supported_import(
             }
         }
         PpcImportDispatcherTarget::InsertMenu => {
-            *last_mem_error = ppc_insert_menu(
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
+            let result = ppc_insert_menu_with_allocator(
+                Some(&mut allocator),
+                None,
                 memory,
                 heap_cursor,
                 heap_limit,
+                last_mem_error,
                 handles,
-                free_handle_blocks,
                 cpu.gpr[3],
                 cpu.gpr[4] as u16 as i16,
             );
+            *last_mem_error = result;
             Some(PpcImportAction::ReturnPreserve)
         }
         PpcImportDispatcherTarget::DeleteMenu => {
-            *last_mem_error = ppc_delete_menu(
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
+            let result = ppc_delete_menu_with_allocator(
+                Some(&mut allocator),
                 memory,
                 heap_cursor,
                 heap_limit,
+                last_mem_error,
                 handles,
                 current_menu_list,
                 cpu.gpr[3] as u16 as i16,
             );
+            *last_mem_error = result;
             Some(PpcImportAction::ReturnPreserve)
         }
         PpcImportDispatcherTarget::AppendMenu => {
-            *last_mem_error = ppc_insert_menu_items(
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
+            let result = ppc_insert_menu_items_with_allocator(
+                Some(&mut allocator),
                 memory,
                 heap_cursor,
                 heap_limit,
+                last_mem_error,
                 handles,
                 cpu.gpr[3],
                 cpu.gpr[4],
                 i16::MAX,
             );
+            *last_mem_error = result;
             Some(PpcImportAction::ReturnPreserve)
         }
         PpcImportDispatcherTarget::InsertMenuItem => {
-            *last_mem_error = ppc_insert_menu_items(
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
+            let result = ppc_insert_menu_items_with_allocator(
+                Some(&mut allocator),
                 memory,
                 heap_cursor,
                 heap_limit,
+                last_mem_error,
                 handles,
                 cpu.gpr[3],
                 cpu.gpr[4],
                 cpu.gpr[5] as u16 as i16,
             );
+            *last_mem_error = result;
             Some(PpcImportAction::ReturnPreserve)
         }
         PpcImportDispatcherTarget::AppendResMenu => {
@@ -18058,19 +17985,30 @@ fn dispatch_supported_import(
             ppc_check_menu_item(cpu, memory, handles);
             Some(PpcImportAction::ReturnPreserve)
         }
-        PpcImportDispatcherTarget::GetMenuBar => Some(PpcImportAction::Return(ppc_get_menu_bar(
-            current_menu_list,
-            memory,
-            heap_cursor,
-            heap_limit,
-            last_mem_error,
-            handles,
-            free_handle_blocks,
-        ))),
+        PpcImportDispatcherTarget::GetMenuBar => {
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
+            Some(PpcImportAction::Return(ppc_get_menu_bar_with_allocator(
+                current_menu_list,
+                Some(&mut allocator),
+                None,
+                memory,
+                heap_cursor,
+                heap_limit,
+                last_mem_error,
+                handles,
+            )))
+        }
         PpcImportDispatcherTarget::GetNewMBar => {
             if toolbox_startup.pending_menu_bar_build.is_some() {
                 return Some(ppc_continue_menu_bar_build(
                     cpu,
+                    process_memory_manager,
                     memory,
                     heap_cursor,
                     heap_limit,
@@ -18106,6 +18044,7 @@ fn dispatch_supported_import(
             });
             Some(ppc_continue_menu_bar_build(
                 cpu,
+                process_memory_manager,
                 memory,
                 heap_cursor,
                 heap_limit,
@@ -18163,6 +18102,13 @@ fn dispatch_supported_import(
             Some(PpcImportAction::ReturnPreserve)
         }
         PpcImportDispatcherTarget::ClearMenuBar => {
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
             // Macintosh Toolbox Essentials (1992), p. 3-110: ClearMenuBar
             // removes every menu from the current list without disposing the
             // menu records themselves. Preserve the current list Handle when
@@ -18171,14 +18117,17 @@ fn dispatch_supported_import(
                 let mut menu_list =
                     ppc_menu_list_definition(memory, current_menu_list).unwrap_or_default();
                 menu_list.clear_entries();
-                *last_mem_error = ppc_replace_menu_list_definition(
+                let result = ppc_replace_menu_list_definition_with_allocator(
+                    Some(&mut allocator),
                     memory,
                     heap_cursor,
                     heap_limit,
+                    last_mem_error,
                     handles,
                     current_menu_list,
                     &menu_list,
                 );
+                *last_mem_error = result;
                 if *last_mem_error == PPC_NO_ERR {
                     let _ = memory.write_u16_be(PPC_THE_MENU_ADDR, 0);
                 }
@@ -18186,7 +18135,14 @@ fn dispatch_supported_import(
             // ClearMenuBar also deletes every entry from the application
             // MenuCInfo table without disposing its stable handle. Macintosh
             // Toolbox Essentials (1992), p. 3-110.
-            ppc_clear_menu_color_table(memory, heap_cursor, heap_limit, handles);
+            ppc_clear_menu_color_table_with_allocator(
+                Some(&mut allocator),
+                memory,
+                heap_cursor,
+                heap_limit,
+                last_mem_error,
+                handles,
+            );
             Some(PpcImportAction::ReturnPreserve)
         }
         PpcImportDispatcherTarget::SetMenuBar => {
@@ -18195,24 +18151,32 @@ fn dispatch_supported_import(
                 *last_mem_error = PPC_PARAM_ERR;
                 return Some(PpcImportAction::ReturnPreserve);
             };
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
             let installation =
                 install_menu_list_copy(current_menu_list, &menu_list, |request| match request {
                     MenuListInstallRequest::Allocate { bytes } => {
-                        let handle = ppc_alloc_recyclable_handle_with_bytes(
+                        let handle = allocator.allocate_handle_with_bytes(
                             memory,
                             heap_cursor,
-                            heap_limit,
+                            last_mem_error,
                             handles,
-                            free_handle_blocks,
                             bytes,
                         );
                         (handle != 0).then_some(handle).ok_or(PPC_MEM_FULL_ERR)
                     }
                     MenuListInstallRequest::Replace { handle, bytes } => {
-                        let result = ppc_replace_menu_bytes(
+                        let result = ppc_replace_menu_bytes_with_allocator(
+                            Some(&mut allocator),
                             memory,
                             heap_cursor,
                             heap_limit,
+                            last_mem_error,
                             handles,
                             handle,
                             bytes,
@@ -18381,6 +18345,7 @@ fn dispatch_supported_import(
             } else if toolbox_startup.active_menu_definition().is_some() {
                 Some(ppc_continue_custom_menu_bar_tracking(
                     cpu,
+                    process_memory_manager,
                     memory,
                     heap_cursor,
                     heap_limit,
@@ -18459,6 +18424,7 @@ fn dispatch_supported_import(
                 if toolbox_startup.menu_tracking.is_none() {
                     if let Some(action) = ppc_begin_custom_menu_bar_tracking(
                         cpu,
+                        process_memory_manager,
                         memory,
                         heap_cursor,
                         heap_limit,
@@ -18501,6 +18467,7 @@ fn dispatch_supported_import(
                     );
                     if let Some(action) = ppc_dispatch_native_menu_definition(
                         cpu,
+                        Some(process_memory_manager),
                         memory,
                         heap_cursor,
                         heap_limit,
@@ -18543,6 +18510,7 @@ fn dispatch_supported_import(
                 if toolbox_startup.menu_tracking.is_none() {
                     if let Some(action) = ppc_begin_custom_menu_bar_tracking(
                         cpu,
+                        process_memory_manager,
                         memory,
                         heap_cursor,
                         heap_limit,
@@ -18808,13 +18776,16 @@ fn dispatch_supported_import(
         PpcImportDispatcherTarget::GetPicture => {
             let picture = ppc_get_picture(
                 cpu,
+                process_memory_manager,
                 memory,
                 heap_cursor,
                 heap_limit,
                 last_mem_error,
                 last_resource_error,
                 handles,
+                free_ptr_blocks,
                 free_handle_blocks,
+                handle_states,
                 vfs_resources,
                 *current_resource_refnum,
             );
@@ -18880,12 +18851,14 @@ fn dispatch_supported_import(
         }
         PpcImportDispatcherTarget::GetPixPat => Some(PpcImportAction::Return(ppc_get_pix_pat(
             cpu,
+            process_memory_manager,
             memory,
             heap_cursor,
-            heap_limit,
             last_mem_error,
             handles,
+            free_ptr_blocks,
             free_handle_blocks,
+            handle_states,
             vfs_resources,
             *current_resource_refnum,
             last_resource_error,
@@ -18907,7 +18880,22 @@ fn dispatch_supported_import(
             Some(PpcImportAction::ReturnPreserve)
         }
         PpcImportDispatcherTarget::KillPicture => {
-            ppc_kill_picture(cpu, memory, handles, handle_states);
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
+            ppc_kill_picture(
+                cpu,
+                &mut allocator,
+                memory,
+                heap_cursor,
+                heap_limit,
+                last_mem_error,
+                handles,
+            );
             Some(PpcImportAction::ReturnPreserve)
         }
         PpcImportDispatcherTarget::InitCursor => {
@@ -18980,12 +18968,15 @@ fn dispatch_supported_import(
         ))),
         PpcImportDispatcherTarget::GetCIcon => Some(PpcImportAction::Return(ppc_get_cicon(
             cpu,
+            process_memory_manager,
             memory,
             heap_cursor,
             heap_limit,
             last_mem_error,
             handles,
+            free_ptr_blocks,
             free_handle_blocks,
+            handle_states,
             vfs_resources,
             *current_resource_refnum,
             last_resource_error,
@@ -19343,10 +19334,14 @@ fn dispatch_supported_import(
             *quickdraw_pen_v = cpu.gpr[4] as u16 as i16;
             if let Some(polygon) = ppc_open_polygon(memory, *current_gworld) {
                 let _ = ppc_record_polygon_point(
+                    process_memory_manager,
                     memory,
                     heap_cursor,
-                    heap_limit,
+                    last_mem_error,
                     handles,
+                    free_ptr_blocks,
+                    free_handle_blocks,
+                    handle_states,
                     polygon,
                     *quickdraw_pen_h,
                     *quickdraw_pen_v,
@@ -19360,10 +19355,14 @@ fn dispatch_supported_import(
             *quickdraw_pen_v = quickdraw_pen_v.wrapping_add(cpu.gpr[4] as u16 as i16);
             if let Some(polygon) = ppc_open_polygon(memory, *current_gworld) {
                 let _ = ppc_record_polygon_point(
+                    process_memory_manager,
                     memory,
                     heap_cursor,
-                    heap_limit,
+                    last_mem_error,
                     handles,
+                    free_ptr_blocks,
+                    free_handle_blocks,
+                    handle_states,
                     polygon,
                     *quickdraw_pen_h,
                     *quickdraw_pen_v,
@@ -19380,19 +19379,27 @@ fn dispatch_supported_import(
                 ppc_open_region_include_point(toolbox_startup, new_h, new_v);
             } else if let Some(polygon) = ppc_open_polygon(memory, *current_gworld) {
                 let _ = ppc_record_polygon_point(
+                    process_memory_manager,
                     memory,
                     heap_cursor,
-                    heap_limit,
+                    last_mem_error,
                     handles,
+                    free_ptr_blocks,
+                    free_handle_blocks,
+                    handle_states,
                     polygon,
                     *quickdraw_pen_h,
                     *quickdraw_pen_v,
                 );
                 let _ = ppc_record_polygon_point(
+                    process_memory_manager,
                     memory,
                     heap_cursor,
-                    heap_limit,
+                    last_mem_error,
                     handles,
+                    free_ptr_blocks,
+                    free_handle_blocks,
+                    handle_states,
                     polygon,
                     new_h,
                     new_v,
@@ -19421,19 +19428,27 @@ fn dispatch_supported_import(
                 ppc_open_region_include_point(toolbox_startup, new_h, new_v);
             } else if let Some(polygon) = ppc_open_polygon(memory, *current_gworld) {
                 let _ = ppc_record_polygon_point(
+                    process_memory_manager,
                     memory,
                     heap_cursor,
-                    heap_limit,
+                    last_mem_error,
                     handles,
+                    free_ptr_blocks,
+                    free_handle_blocks,
+                    handle_states,
                     polygon,
                     *quickdraw_pen_h,
                     *quickdraw_pen_v,
                 );
                 let _ = ppc_record_polygon_point(
+                    process_memory_manager,
                     memory,
                     heap_cursor,
-                    heap_limit,
+                    last_mem_error,
                     handles,
+                    free_ptr_blocks,
+                    free_handle_blocks,
+                    handle_states,
                     polygon,
                     new_h,
                     new_v,
@@ -19871,8 +19886,16 @@ fn dispatch_supported_import(
             Some(PpcImportAction::ReturnPreserve)
         }
         PpcImportDispatcherTarget::ClipRect => {
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
             ppc_clip_rect(
                 cpu,
+                Some(&mut allocator),
                 memory,
                 *current_gworld,
                 heap_cursor,
@@ -19894,14 +19917,24 @@ fn dispatch_supported_import(
             } else {
                 (cpu.gpr[3], clip_rgn)
             };
-            *last_mem_error = ppc_copy_rgn(
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
+            let result = ppc_copy_rgn(
+                Some(&mut allocator),
                 memory,
                 heap_cursor,
                 heap_limit,
+                last_mem_error,
                 handles,
                 source,
                 destination,
             );
+            *last_mem_error = result;
             Some(PpcImportAction::ReturnPreserve)
         }
         PpcImportDispatcherTarget::GetPen => {
@@ -19983,9 +20016,26 @@ fn dispatch_supported_import(
             );
             Some(PpcImportAction::ReturnPreserve)
         }
-        PpcImportDispatcherTarget::BitMapToRegion => Some(PpcImportAction::Return(ppc_i16_result(
-            ppc_bitmap_to_region(cpu, memory, heap_cursor, heap_limit, handles),
-        ))),
+        PpcImportDispatcherTarget::BitMapToRegion => {
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
+            Some(PpcImportAction::Return(ppc_i16_result(
+                ppc_bitmap_to_region(
+                    cpu,
+                    Some(&mut allocator),
+                    memory,
+                    heap_cursor,
+                    heap_limit,
+                    last_mem_error,
+                    handles,
+                ),
+            )))
+        }
         PpcImportDispatcherTarget::NewRgn => Some(PpcImportAction::Return(ppc_process_new_rgn(
             process_memory_manager,
             memory,
@@ -20013,10 +20063,19 @@ fn dispatch_supported_import(
             Some(PpcImportAction::ReturnPreserve)
         }
         PpcImportDispatcherTarget::CopyRgn => {
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
             *last_mem_error = ppc_copy_rgn(
+                Some(&mut allocator),
                 memory,
                 heap_cursor,
                 heap_limit,
+                last_mem_error,
                 handles,
                 cpu.gpr[3],
                 cpu.gpr[4],
@@ -20024,27 +20083,43 @@ fn dispatch_supported_import(
             Some(PpcImportAction::ReturnPreserve)
         }
         PpcImportDispatcherTarget::OpenRgn => {
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
             ppc_open_rgn(
+                Some(&mut allocator),
                 memory,
                 *current_gworld,
                 heap_cursor,
                 heap_limit,
                 last_mem_error,
                 handles,
-                handle_states,
+                None,
                 toolbox_startup,
             );
             Some(PpcImportAction::ReturnPreserve)
         }
         PpcImportDispatcherTarget::CloseRgn => {
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
             ppc_close_rgn(
+                Some(&mut allocator),
                 memory,
                 cpu.gpr[3],
                 heap_cursor,
                 heap_limit,
                 last_mem_error,
                 handles,
-                handle_states,
+                None,
                 toolbox_startup,
             );
             Some(PpcImportAction::ReturnPreserve)
@@ -20060,10 +20135,19 @@ fn dispatch_supported_import(
                 PpcImportDispatcherTarget::XorRgn => PpcRegionBooleanOp::Xor,
                 _ => unreachable!(),
             };
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
             *last_mem_error = ppc_region_boolean_op(
+                Some(&mut allocator),
                 memory,
                 heap_cursor,
                 heap_limit,
+                last_mem_error,
                 handles,
                 cpu.gpr[3],
                 cpu.gpr[4],
@@ -20139,7 +20223,21 @@ fn dispatch_supported_import(
             if ppc_open_polygon(memory, *current_gworld) == Some(polygon) {
                 let _ = memory.write_u32_be(current_gworld.wrapping_add(100), 0);
             }
-            ppc_dispose_tracked_handle(polygon, memory, handles, handle_states);
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
+            let _ = allocator.dispose_handle(
+                memory,
+                heap_cursor,
+                heap_limit,
+                last_mem_error,
+                handles,
+                polygon,
+            );
             Some(PpcImportAction::ReturnPreserve)
         }
         PpcImportDispatcherTarget::FramePoly => {
@@ -20195,11 +20293,17 @@ fn dispatch_supported_import(
             );
             if window != 0 {
                 ppc_recalculate_window_vis_regions(
+                    process_memory_manager,
                     memory,
                     gworlds,
                     heap_cursor,
                     heap_limit,
+                    last_mem_error,
+                    ptrs,
+                    free_ptr_blocks,
                     handles,
+                    free_handle_blocks,
+                    handle_states,
                 );
                 quickdraw_fore_indices.remove(&window);
                 *current_gworld = window;
@@ -20249,11 +20353,17 @@ fn dispatch_supported_import(
             );
             if window != 0 {
                 ppc_recalculate_window_vis_regions(
+                    process_memory_manager,
                     memory,
                     gworlds,
                     heap_cursor,
                     heap_limit,
+                    last_mem_error,
+                    ptrs,
+                    free_ptr_blocks,
                     handles,
+                    free_handle_blocks,
+                    handle_states,
                 );
                 quickdraw_fore_indices.remove(&window);
                 *current_gworld = window;
@@ -20302,12 +20412,36 @@ fn dispatch_supported_import(
         }
         PpcImportDispatcherTarget::SizeWindow => {
             let _ = ppc_size_window(cpu, memory, gworlds);
-            ppc_recalculate_window_vis_regions(memory, gworlds, heap_cursor, heap_limit, handles);
+            ppc_recalculate_window_vis_regions(
+                process_memory_manager,
+                memory,
+                gworlds,
+                heap_cursor,
+                heap_limit,
+                last_mem_error,
+                ptrs,
+                free_ptr_blocks,
+                handles,
+                free_handle_blocks,
+                handle_states,
+            );
             Some(PpcImportAction::ReturnPreserve)
         }
         PpcImportDispatcherTarget::MoveWindow => {
             let _ = ppc_move_window(cpu, memory, gworlds);
-            ppc_recalculate_window_vis_regions(memory, gworlds, heap_cursor, heap_limit, handles);
+            ppc_recalculate_window_vis_regions(
+                process_memory_manager,
+                memory,
+                gworlds,
+                heap_cursor,
+                heap_limit,
+                last_mem_error,
+                ptrs,
+                free_ptr_blocks,
+                handles,
+                free_handle_blocks,
+                handle_states,
+            );
             Some(PpcImportAction::ReturnPreserve)
         }
         PpcImportDispatcherTarget::ShowWindow => {
@@ -20315,7 +20449,19 @@ fn dispatch_supported_import(
             let previous_front = ppc_front_visible_window(memory, gworlds);
             let was_visible = ppc_window_is_visible(memory, window);
             let _ = ppc_set_window_visible(memory, window, true);
-            ppc_recalculate_window_vis_regions(memory, gworlds, heap_cursor, heap_limit, handles);
+            ppc_recalculate_window_vis_regions(
+                process_memory_manager,
+                memory,
+                gworlds,
+                heap_cursor,
+                heap_limit,
+                last_mem_error,
+                ptrs,
+                free_ptr_blocks,
+                handles,
+                free_handle_blocks,
+                handle_states,
+            );
             ppc_transition_front_window_chrome(
                 memory,
                 gworlds,
@@ -20358,7 +20504,19 @@ fn dispatch_supported_import(
             let previous_front = ppc_front_visible_window(memory, gworlds);
             let _ = ppc_set_window_visible(memory, window, false);
             let _ = ppc_set_window_hilited(memory, window, false);
-            ppc_recalculate_window_vis_regions(memory, gworlds, heap_cursor, heap_limit, handles);
+            ppc_recalculate_window_vis_regions(
+                process_memory_manager,
+                memory,
+                gworlds,
+                heap_cursor,
+                heap_limit,
+                last_mem_error,
+                ptrs,
+                free_ptr_blocks,
+                handles,
+                free_handle_blocks,
+                handle_states,
+            );
             let next_front = ppc_front_visible_window(memory, gworlds);
             ppc_transition_front_window_chrome(
                 memory,
@@ -20392,7 +20550,19 @@ fn dispatch_supported_import(
             let previous_front = ppc_front_visible_window(memory, gworlds);
             let was_visible = ppc_window_is_visible(memory, window);
             let _ = ppc_set_window_visible(memory, window, visible);
-            ppc_recalculate_window_vis_regions(memory, gworlds, heap_cursor, heap_limit, handles);
+            ppc_recalculate_window_vis_regions(
+                process_memory_manager,
+                memory,
+                gworlds,
+                heap_cursor,
+                heap_limit,
+                last_mem_error,
+                ptrs,
+                free_ptr_blocks,
+                handles,
+                free_handle_blocks,
+                handle_states,
+            );
             ppc_transition_front_window_chrome(
                 memory,
                 gworlds,
@@ -20458,11 +20628,17 @@ fn dispatch_supported_import(
                         || gworld.port != window
                 });
                 ppc_recalculate_window_vis_regions(
+                    process_memory_manager,
                     memory,
                     gworlds,
                     heap_cursor,
                     heap_limit,
+                    last_mem_error,
+                    ptrs,
+                    free_ptr_blocks,
                     handles,
+                    free_handle_blocks,
+                    handle_states,
                 );
                 ppc_transition_front_window_chrome(
                     memory,
@@ -20590,7 +20766,15 @@ fn dispatch_supported_import(
             Some(PpcImportAction::ReturnPreserve)
         }
         PpcImportDispatcherTarget::PaintOne => {
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
             ppc_paint_one(
+                Some(&mut allocator),
                 memory,
                 gworlds,
                 cpu.gpr[3],
@@ -20603,7 +20787,15 @@ fn dispatch_supported_import(
             Some(PpcImportAction::ReturnPreserve)
         }
         PpcImportDispatcherTarget::PaintBehind => {
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
             ppc_paint_behind(
+                Some(&mut allocator),
                 memory,
                 gworlds,
                 cpu.gpr[3],
@@ -20616,7 +20808,15 @@ fn dispatch_supported_import(
             Some(PpcImportAction::ReturnPreserve)
         }
         PpcImportDispatcherTarget::CalcVisBehind => {
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
             ppc_calc_vis_behind(
+                Some(&mut allocator),
                 memory,
                 gworlds,
                 cpu.gpr[3],
@@ -20657,11 +20857,17 @@ fn dispatch_supported_import(
                 let previous_front = ppc_front_visible_window(memory, gworlds);
                 ppc_reorder_window(gworlds, cpu.gpr[3], 0, true);
                 ppc_recalculate_window_vis_regions(
+                    process_memory_manager,
                     memory,
                     gworlds,
                     heap_cursor,
                     heap_limit,
+                    last_mem_error,
+                    ptrs,
+                    free_ptr_blocks,
                     handles,
+                    free_handle_blocks,
+                    handle_states,
                 );
                 if previous_front == Some(cpu.gpr[3]) {
                     let _ = ppc_set_window_hilited(memory, cpu.gpr[3], true);
@@ -21014,16 +21220,6 @@ fn dispatch_supported_import(
             }
         }
         PpcImportDispatcherTarget::NewGWorld => {
-            ppc_synchronize_process_native_allocator(
-                process_memory_manager,
-                *heap_cursor,
-                heap_limit,
-                *last_mem_error,
-                ptrs,
-                free_ptr_blocks,
-                free_handle_blocks,
-            );
-            ppc_synchronize_process_native_handles(process_memory_manager, handles, handle_states);
             let result = ppc_new_gworld(
                 cpu,
                 process_memory_manager,
@@ -21047,16 +21243,6 @@ fn dispatch_supported_import(
             Some(PpcImportAction::Return(ppc_i16_result(result)))
         }
         PpcImportDispatcherTarget::UpdateGWorld => {
-            ppc_synchronize_process_native_allocator(
-                process_memory_manager,
-                *heap_cursor,
-                heap_limit,
-                *last_mem_error,
-                ptrs,
-                free_ptr_blocks,
-                free_handle_blocks,
-            );
-            ppc_synchronize_process_native_handles(process_memory_manager, handles, handle_states);
             let result = ppc_update_gworld(
                 cpu,
                 process_memory_manager,
@@ -21098,20 +21284,6 @@ fn dispatch_supported_import(
                 .copied();
             gworlds.retain(|gworld| gworld.port == PPC_MAIN_GWORLD || gworld.port != port);
             if let Some(record) = disposed {
-                ppc_synchronize_process_native_allocator(
-                    process_memory_manager,
-                    *heap_cursor,
-                    heap_limit,
-                    *last_mem_error,
-                    ptrs,
-                    free_ptr_blocks,
-                    free_handle_blocks,
-                );
-                ppc_synchronize_process_native_handles(
-                    process_memory_manager,
-                    handles,
-                    handle_states,
-                );
                 quickdraw_fore_indices.remove(&port);
                 let allocation = toolbox_startup.gworld_allocations.remove(&port);
                 let saved_ctable = toolbox_startup
@@ -22305,11 +22477,13 @@ fn dispatch_supported_import(
         PpcImportDispatcherTarget::DMNewDisplayModeList => {
             let result = ppc_dm_new_display_mode_list(
                 cpu,
+                process_memory_manager,
                 memory,
                 heap_cursor,
-                heap_limit,
+                last_mem_error,
                 ptrs,
                 free_ptr_blocks,
+                free_handle_blocks,
             );
             Some(PpcImportAction::Return(ppc_i16_result(result)))
         }
@@ -22317,7 +22491,24 @@ fn dispatch_supported_import(
             ppc_dm_get_indexed_display_mode(cpu, memory)
         }
         PpcImportDispatcherTarget::DMDisposeList => {
-            let result = ppc_dm_dispose_list_values(memory, ptrs, free_ptr_blocks, cpu.gpr[3]);
+            let list = cpu.gpr[3];
+            let result = if process_memory_manager.native_ptr_size(list) != 0
+                && memory.read_u32_be(list) == Some(PPC_DM_MODE_LIST_MAGIC)
+            {
+                let _ = process_memory_manager.dispose_native_ptr(list);
+                ppc_apply_process_native_allocator(
+                    process_memory_manager,
+                    memory,
+                    heap_cursor,
+                    last_mem_error,
+                    ptrs,
+                    free_ptr_blocks,
+                    free_handle_blocks,
+                );
+                PPC_NO_ERR
+            } else {
+                PPC_PARAM_ERR
+            };
             Some(PpcImportAction::Return(ppc_i16_result(result)))
         }
         PpcImportDispatcherTarget::DMBeginConfigureDisplays => {
@@ -22894,18 +23085,27 @@ fn dispatch_supported_import(
         PpcImportDispatcherTarget::InitMenus => {
             toolbox_startup.menus_initialized = true;
             let _ = memory.write_u16_be(PPC_THE_MENU_ADDR, 0);
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+                ptrs: Some(ptrs),
+                free_ptr_blocks,
+                free_handle_blocks,
+                handle_states,
+            };
             // Inside Macintosh Volume V (1986), pp. V-228--V-230: the first
             // InitMenus call allocates the stable DynamicMenuList whose handle
             // is published in the MenuList low-memory global. Later calls do
             // not replace that manager-owned handle.
             if current_menu_list == 0 {
-                current_menu_list = ppc_alloc_menu_list_handle(
+                current_menu_list = ppc_alloc_menu_list_handle_with_allocator(
                     &[],
+                    Some(&mut allocator),
+                    None,
                     memory,
                     heap_cursor,
                     heap_limit,
+                    last_mem_error,
                     handles,
-                    free_handle_blocks,
                 );
                 *last_mem_error = if current_menu_list == 0 {
                     PPC_MEM_FULL_ERR
@@ -22917,33 +23117,40 @@ fn dispatch_supported_import(
                 // Macintosh Toolbox Essentials (1992), pp. 3-103--3-104:
                 // InitMenus restores the standard MBDF and an empty menu list.
                 // Reinitialization reuses the existing MenuList handle.
-                *last_mem_error = ppc_replace_menu_list_definition(
+                let result = ppc_replace_menu_list_definition_with_allocator(
+                    Some(&mut allocator),
                     memory,
                     heap_cursor,
                     heap_limit,
+                    last_mem_error,
                     handles,
                     current_menu_list,
                     &PpcMenuListDefinition::default(),
                 );
+                *last_mem_error = result;
             }
             // InitMenus creates the process MenuCInfo table and automatically
             // adds entries from the current resource chain's `'mctb'` 0.
             // Inside Macintosh Volume V (1986), pp. V-242--V-244; Macintosh
             // Toolbox Essentials (1992), pp. 3-154--3-156.
-            let _ = ppc_ensure_menu_color_table_handle(
+            let _ = ppc_ensure_menu_color_table_handle_with_allocator(
+                Some(&mut allocator),
+                None,
                 memory,
                 heap_cursor,
                 heap_limit,
+                last_mem_error,
                 handles,
-                free_handle_blocks,
             );
-            ppc_load_menu_color_resource(
+            ppc_load_menu_color_resource_with_allocator(
                 0,
+                Some(&mut allocator),
+                None,
                 memory,
                 heap_cursor,
                 heap_limit,
+                last_mem_error,
                 handles,
-                free_handle_blocks,
                 vfs_resources,
                 *current_resource_refnum,
             );
@@ -24510,15 +24717,6 @@ fn dispatch_supported_import(
         PpcImportDispatcherTarget::StdMalloc => {
             let size = cpu.gpr[3];
             let preserved_mem_error = *last_mem_error;
-            ppc_synchronize_process_native_allocator(
-                process_memory_manager,
-                *heap_cursor,
-                heap_limit,
-                *last_mem_error,
-                ptrs,
-                free_ptr_blocks,
-                free_handle_blocks,
-            );
             let ptr = process_memory_manager.new_native_ptr(memory, size, false);
             process_memory_manager.set_native_mem_error(preserved_mem_error);
             ppc_apply_process_native_allocator(
@@ -24534,15 +24732,6 @@ fn dispatch_supported_import(
         }
         PpcImportDispatcherTarget::StdFree => {
             let preserved_mem_error = *last_mem_error;
-            ppc_synchronize_process_native_allocator(
-                process_memory_manager,
-                *heap_cursor,
-                heap_limit,
-                *last_mem_error,
-                ptrs,
-                free_ptr_blocks,
-                free_handle_blocks,
-            );
             let _ = process_memory_manager.dispose_native_ptr(cpu.gpr[3]);
             process_memory_manager.set_native_mem_error(preserved_mem_error);
             ppc_apply_process_native_allocator(
@@ -24560,15 +24749,6 @@ fn dispatch_supported_import(
             let count = cpu.gpr[3];
             let ptr = if let Some(size) = count.checked_mul(cpu.gpr[4]).filter(|size| *size != 0) {
                 let preserved_mem_error = *last_mem_error;
-                ppc_synchronize_process_native_allocator(
-                    process_memory_manager,
-                    *heap_cursor,
-                    heap_limit,
-                    *last_mem_error,
-                    ptrs,
-                    free_ptr_blocks,
-                    free_handle_blocks,
-                );
                 let ptr = process_memory_manager.new_native_ptr(memory, size, true);
                 process_memory_manager.set_native_mem_error(preserved_mem_error);
                 ppc_apply_process_native_allocator(
@@ -24588,15 +24768,6 @@ fn dispatch_supported_import(
         }
         PpcImportDispatcherTarget::StdRealloc => {
             let preserved_mem_error = *last_mem_error;
-            ppc_synchronize_process_native_allocator(
-                process_memory_manager,
-                *heap_cursor,
-                heap_limit,
-                *last_mem_error,
-                ptrs,
-                free_ptr_blocks,
-                free_handle_blocks,
-            );
             let ptr = process_memory_manager.reallocate_native_ptr(memory, cpu.gpr[3], cpu.gpr[4]);
             process_memory_manager.set_native_mem_error(preserved_mem_error);
             ppc_apply_process_native_allocator(
@@ -27544,23 +27715,25 @@ fn dispatch_supported_import(
         PpcImportDispatcherTarget::NewRoutineDescriptor => {
             Some(PpcImportAction::Return(ppc_new_routine_descriptor(
                 cpu,
+                process_memory_manager,
                 memory,
                 heap_cursor,
-                heap_limit,
+                last_mem_error,
                 ptrs,
                 free_ptr_blocks,
-                last_mem_error,
+                free_handle_blocks,
             )))
         }
         PpcImportDispatcherTarget::NewFatRoutineDescriptor => {
             Some(PpcImportAction::Return(ppc_new_fat_routine_descriptor(
                 cpu,
+                process_memory_manager,
                 memory,
                 heap_cursor,
-                heap_limit,
+                last_mem_error,
                 ptrs,
                 free_ptr_blocks,
-                last_mem_error,
+                free_handle_blocks,
             )))
         }
         PpcImportDispatcherTarget::DisposeRoutineDescriptor => {
@@ -27568,7 +27741,16 @@ fn dispatch_supported_import(
             // PowerPC ABI: r3 carries the descriptor and is preserved on return.
             // The Mixed Mode Manager releases only creation-allocated heap storage.
             // Inside Macintosh: PowerPC System Software (1994), pp. 2-21, 2-41.
-            ppc_release_ptr(ptrs, free_ptr_blocks, cpu.gpr[3]);
+            let _ = process_memory_manager.dispose_native_ptr(cpu.gpr[3]);
+            ppc_apply_process_native_allocator(
+                process_memory_manager,
+                memory,
+                heap_cursor,
+                last_mem_error,
+                ptrs,
+                free_ptr_blocks,
+                free_handle_blocks,
+            );
             *last_mem_error = PPC_NO_ERR;
             Some(PpcImportAction::ReturnPreserve)
         }
@@ -27939,7 +28121,7 @@ fn ppc_create_process_owned_ae_desc(
     process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
-    heap_limit: u32,
+    _heap_limit: u32,
     last_mem_error: &mut i16,
     ptrs: &mut Vec<PpcPtrRecord>,
     free_ptr_blocks: &mut Vec<PpcPtrRecord>,
@@ -27953,16 +28135,6 @@ fn ppc_create_process_owned_ae_desc(
     if result == 0 || !ppc_memory_can_write_bytes(memory, result, 8) {
         return PPC_PARAM_ERR;
     }
-    ppc_synchronize_process_native_allocator(
-        process_memory_manager,
-        *heap_cursor,
-        heap_limit,
-        *last_mem_error,
-        ptrs,
-        free_ptr_blocks,
-        free_handle_blocks,
-    );
-    ppc_synchronize_process_native_handles(process_memory_manager, handles, handle_states);
     let snapshot = process_memory_manager.detached_clone();
     // Interapplication Communication (1993), pp. 3-13 and 4-39: an AEDesc's
     // data lives in a handle allocated in the client process's application
@@ -44064,12 +44236,13 @@ fn ppc_current_process_app_metadata(
 
 fn ppc_new_routine_descriptor(
     cpu: &mut PpcCpu,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
-    heap_limit: u32,
+    last_mem_error: &mut i16,
     ptrs: &mut Vec<PpcPtrRecord>,
     free_ptr_blocks: &mut Vec<PpcPtrRecord>,
-    last_mem_error: &mut i16,
+    free_handle_blocks: &mut Vec<PpcHandleRecord>,
 ) -> u32 {
     let proc_ptr = cpu.gpr[3];
     if ppc_hle_trace_enabled() {
@@ -44088,11 +44261,13 @@ fn ppc_new_routine_descriptor(
     let isa = cpu.gpr[5] as u8;
     let descriptor_size = PPC_ROUTINE_DESCRIPTOR_HEADER_SIZE + PPC_ROUTINE_RECORD_SIZE;
     let descriptor = ppc_alloc_routine_descriptor(
+        process_memory_manager,
         memory,
         heap_cursor,
-        heap_limit,
+        last_mem_error,
         ptrs,
         free_ptr_blocks,
+        free_handle_blocks,
         descriptor_size,
         0,
     );
@@ -44109,7 +44284,16 @@ fn ppc_new_routine_descriptor(
     };
     let ok = ppc_write_routine_record(memory, record, proc_info, isa, flags, proc_ptr);
     if !ok {
-        ppc_release_ptr(ptrs, free_ptr_blocks, descriptor);
+        let _ = process_memory_manager.dispose_native_ptr(descriptor);
+        ppc_apply_process_native_allocator(
+            process_memory_manager,
+            memory,
+            heap_cursor,
+            last_mem_error,
+            ptrs,
+            free_ptr_blocks,
+            free_handle_blocks,
+        );
         *last_mem_error = PPC_PARAM_ERR;
         return 0;
     }
@@ -44120,12 +44304,13 @@ fn ppc_new_routine_descriptor(
 
 fn ppc_new_fat_routine_descriptor(
     cpu: &mut PpcCpu,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
-    heap_limit: u32,
+    last_mem_error: &mut i16,
     ptrs: &mut Vec<PpcPtrRecord>,
     free_ptr_blocks: &mut Vec<PpcPtrRecord>,
-    last_mem_error: &mut i16,
+    free_handle_blocks: &mut Vec<PpcHandleRecord>,
 ) -> u32 {
     let m68k_proc = cpu.gpr[3];
     let powerpc_proc = cpu.gpr[4];
@@ -44135,11 +44320,13 @@ fn ppc_new_fat_routine_descriptor(
     let proc_info = cpu.gpr[5];
     let descriptor_size = PPC_ROUTINE_DESCRIPTOR_HEADER_SIZE + (PPC_ROUTINE_RECORD_SIZE * 2);
     let descriptor = ppc_alloc_routine_descriptor(
+        process_memory_manager,
         memory,
         heap_cursor,
-        heap_limit,
+        last_mem_error,
         ptrs,
         free_ptr_blocks,
+        free_handle_blocks,
         descriptor_size,
         1,
     );
@@ -44166,7 +44353,16 @@ fn ppc_new_fat_routine_descriptor(
         powerpc_proc,
     );
     if !ok {
-        ppc_release_ptr(ptrs, free_ptr_blocks, descriptor);
+        let _ = process_memory_manager.dispose_native_ptr(descriptor);
+        ppc_apply_process_native_allocator(
+            process_memory_manager,
+            memory,
+            heap_cursor,
+            last_mem_error,
+            ptrs,
+            free_ptr_blocks,
+            free_handle_blocks,
+        );
         *last_mem_error = PPC_PARAM_ERR;
         return 0;
     }
@@ -44176,22 +44372,25 @@ fn ppc_new_fat_routine_descriptor(
 }
 
 fn ppc_alloc_routine_descriptor(
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
-    heap_limit: u32,
+    last_mem_error: &mut i16,
     ptrs: &mut Vec<PpcPtrRecord>,
     free_ptr_blocks: &mut Vec<PpcPtrRecord>,
+    free_handle_blocks: &mut Vec<PpcHandleRecord>,
     descriptor_size: u32,
     routine_count: u16,
 ) -> u32 {
-    let descriptor = ppc_alloc_ptr(
+    let descriptor = process_memory_manager.new_native_ptr(memory, descriptor_size, true);
+    ppc_apply_process_native_allocator(
+        process_memory_manager,
         memory,
         heap_cursor,
-        heap_limit,
+        last_mem_error,
         ptrs,
         free_ptr_blocks,
-        descriptor_size,
-        true,
+        free_handle_blocks,
     );
     if descriptor == 0 {
         return 0;
@@ -44212,7 +44411,16 @@ fn ppc_alloc_routine_descriptor(
     if ok {
         descriptor
     } else {
-        ppc_release_ptr(ptrs, free_ptr_blocks, descriptor);
+        let _ = process_memory_manager.dispose_native_ptr(descriptor);
+        ppc_apply_process_native_allocator(
+            process_memory_manager,
+            memory,
+            heap_cursor,
+            last_mem_error,
+            ptrs,
+            free_ptr_blocks,
+            free_handle_blocks,
+        );
         0
     }
 }
@@ -52262,12 +52470,25 @@ fn ppc_transition_front_window_chrome(
 }
 
 fn ppc_recalculate_window_vis_regions(
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     gworlds: &[PpcGWorldRecord],
     heap_cursor: &mut u32,
     heap_limit: u32,
+    last_mem_error: &mut i16,
+    ptrs: &mut Vec<PpcPtrRecord>,
+    free_ptr_blocks: &mut Vec<PpcPtrRecord>,
     handles: &mut Vec<PpcHandleRecord>,
+    free_handle_blocks: &mut Vec<PpcHandleRecord>,
+    handle_states: &mut Vec<PpcHandleStateRecord>,
 ) {
+    let mut allocator = PpcProcessAllocatorView {
+        memory_manager: process_memory_manager,
+        ptrs: Some(ptrs),
+        free_ptr_blocks,
+        free_handle_blocks,
+        handle_states,
+    };
     let front_to_back: Vec<u32> = gworlds
         .iter()
         .rev()
@@ -52286,9 +52507,11 @@ fn ppc_recalculate_window_vis_regions(
             continue;
         };
         if ppc_copy_rgn(
+            Some(&mut allocator),
             memory,
             heap_cursor,
             heap_limit,
+            last_mem_error,
             handles,
             content_rgn,
             vis_rgn,
@@ -52307,9 +52530,11 @@ fn ppc_recalculate_window_vis_regions(
                 continue;
             };
             let _ = ppc_region_boolean_op(
+                Some(&mut allocator),
                 memory,
                 heap_cursor,
                 heap_limit,
+                last_mem_error,
                 handles,
                 vis_rgn,
                 structure_rgn,
@@ -52663,6 +52888,7 @@ fn ppc_move_window(
 
 #[allow(clippy::too_many_arguments)]
 fn ppc_paint_one(
+    mut allocator: Option<&mut PpcProcessAllocatorView<'_>>,
     memory: &mut PpcSectionMem,
     gworlds: &[PpcGWorldRecord],
     window: u32,
@@ -52674,6 +52900,7 @@ fn ppc_paint_one(
 ) {
     if window == 0 {
         ppc_paint_behind(
+            allocator.as_deref_mut(),
             memory,
             gworlds,
             0,
@@ -52723,7 +52950,14 @@ fn ppc_paint_one(
     let update_addr = record.port.wrapping_add(PPC_CWINDOW_UPDATE_RGN_OFFSET);
     let mut update_rgn = memory.read_u32_be(update_addr).unwrap_or(0);
     if ppc_rgn_ptr(memory, update_rgn).is_none() {
-        update_rgn = ppc_new_rgn(memory, heap_cursor, heap_limit, last_mem_error, handles);
+        update_rgn = ppc_allocator_view_new_rgn(
+            allocator.as_deref_mut(),
+            memory,
+            heap_cursor,
+            heap_limit,
+            last_mem_error,
+            handles,
+        );
         if update_rgn == 0 || memory.write_u32_be(update_addr, update_rgn).is_none() {
             *last_mem_error = PPC_MEM_FULL_ERR;
             return;
@@ -52765,6 +52999,7 @@ fn ppc_paint_one(
 
 #[allow(clippy::too_many_arguments)]
 fn ppc_calc_vis_behind(
+    mut allocator: Option<&mut PpcProcessAllocatorView<'_>>,
     memory: &mut PpcSectionMem,
     gworlds: &[PpcGWorldRecord],
     start_window: u32,
@@ -52827,7 +53062,14 @@ fn ppc_calc_vis_behind(
         let vis_rgn_addr = record.port.wrapping_add(24);
         let mut vis_rgn = memory.read_u32_be(vis_rgn_addr).unwrap_or(0);
         if ppc_rgn_ptr(memory, vis_rgn).is_none() {
-            vis_rgn = ppc_new_rgn(memory, heap_cursor, heap_limit, last_mem_error, handles);
+            vis_rgn = ppc_allocator_view_new_rgn(
+                allocator.as_deref_mut(),
+                memory,
+                heap_cursor,
+                heap_limit,
+                last_mem_error,
+                handles,
+            );
             if vis_rgn == 0 || memory.write_u32_be(vis_rgn_addr, vis_rgn).is_none() {
                 *last_mem_error = PPC_MEM_FULL_ERR;
                 return;
@@ -52856,6 +53098,7 @@ fn ppc_calc_vis_behind(
 
 #[allow(clippy::too_many_arguments)]
 fn ppc_paint_behind(
+    mut allocator: Option<&mut PpcProcessAllocatorView<'_>>,
     memory: &mut PpcSectionMem,
     gworlds: &[PpcGWorldRecord],
     start_window: u32,
@@ -52919,7 +53162,14 @@ fn ppc_paint_behind(
         let update_addr = record.port.wrapping_add(PPC_CWINDOW_UPDATE_RGN_OFFSET);
         let mut update_rgn = memory.read_u32_be(update_addr).unwrap_or(0);
         if ppc_rgn_ptr(memory, update_rgn).is_none() {
-            update_rgn = ppc_new_rgn(memory, heap_cursor, heap_limit, last_mem_error, handles);
+            update_rgn = ppc_allocator_view_new_rgn(
+                allocator.as_deref_mut(),
+                memory,
+                heap_cursor,
+                heap_limit,
+                last_mem_error,
+                handles,
+            );
             if update_rgn == 0 || memory.write_u32_be(update_addr, update_rgn).is_none() {
                 *last_mem_error = PPC_MEM_FULL_ERR;
                 return;
@@ -58664,16 +58914,6 @@ fn ppc_dsp_alt_buffer_new(
     world_cpu.gpr[6] = 0;
     world_cpu.gpr[7] = current_gdevice;
     world_cpu.gpr[8] = 0;
-    ppc_synchronize_process_native_allocator(
-        process_memory_manager,
-        *heap_cursor,
-        heap_limit,
-        *last_mem_error,
-        ptrs,
-        free_ptr_blocks,
-        free_handle_blocks,
-    );
-    ppc_synchronize_process_native_handles(process_memory_manager, handles, handle_states);
     ppc_new_gworld(
         &mut world_cpu,
         process_memory_manager,
@@ -60349,13 +60589,16 @@ fn ppc_i32_to_i16_saturating(value: i32) -> i16 {
 
 fn ppc_get_picture(
     cpu: &mut PpcCpu,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
-    heap_limit: u32,
+    _heap_limit: u32,
     last_mem_error: &mut i16,
     last_resource_error: &mut i16,
     handles: &mut Vec<PpcHandleRecord>,
+    free_ptr_blocks: &mut Vec<PpcPtrRecord>,
     free_handle_blocks: &mut Vec<PpcHandleRecord>,
+    handle_states: &mut Vec<PpcHandleStateRecord>,
     vfs_resources: &mut [PpcVfsResourceRecord],
     current_resource_refnum: i16,
 ) -> u32 {
@@ -60370,12 +60613,15 @@ fn ppc_get_picture(
     ) {
         if vfs_resources[index].handle == 0 {
             let data = vfs_resources[index].data.clone();
-            let handle = ppc_alloc_recyclable_handle_with_bytes(
+            let handle = ppc_process_alloc_handle_with_bytes(
+                process_memory_manager,
                 memory,
                 heap_cursor,
-                heap_limit,
+                last_mem_error,
                 handles,
+                free_ptr_blocks,
                 free_handle_blocks,
+                handle_states,
                 &data,
             );
             if handle == 0 {
@@ -60401,12 +60647,15 @@ fn ppc_get_picture(
         }
         return vfs_resources[index].handle;
     }
-    let handle = ppc_alloc_recyclable_handle_with_bytes(
+    let handle = ppc_process_alloc_handle_with_bytes(
+        process_memory_manager,
         memory,
         heap_cursor,
-        heap_limit,
+        last_mem_error,
         handles,
+        free_ptr_blocks,
         free_handle_blocks,
+        handle_states,
         &minimal_pict_bytes(),
     );
     if handle == 0 {
@@ -60479,12 +60728,14 @@ fn ppc_get_ind_pattern(
 
 fn ppc_get_pix_pat(
     cpu: &PpcCpu,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
-    heap_limit: u32,
     last_mem_error: &mut i16,
     handles: &mut Vec<PpcHandleRecord>,
+    free_ptr_blocks: &mut Vec<PpcPtrRecord>,
     free_handle_blocks: &mut Vec<PpcHandleRecord>,
+    handle_states: &mut Vec<PpcHandleStateRecord>,
     vfs_resources: &[PpcVfsResourceRecord],
     current_resource_refnum: i16,
     last_resource_error: &mut i16,
@@ -60514,12 +60765,15 @@ fn ppc_get_pix_pat(
     // its documented offsets intact also lets Color QuickDraw consume the
     // pattern without tying its lifetime to the Resource Manager's handle.
     let data = &vfs_resources[index].data;
-    let handle = ppc_alloc_recyclable_handle_with_bytes(
+    let handle = ppc_process_alloc_handle_with_bytes(
+        process_memory_manager,
         memory,
         heap_cursor,
-        heap_limit,
+        last_mem_error,
         handles,
+        free_ptr_blocks,
         free_handle_blocks,
+        handle_states,
         data,
     );
     if handle == 0 {
@@ -60681,12 +60935,22 @@ fn ppc_quilt_picture_zero_is_opaque(
 
 fn ppc_kill_picture(
     cpu: &mut PpcCpu,
+    allocator: &mut PpcProcessAllocatorView<'_>,
     memory: &mut PpcSectionMem,
+    heap_cursor: &mut u32,
+    heap_limit: u32,
+    last_mem_error: &mut i16,
     handles: &mut Vec<PpcHandleRecord>,
-    handle_states: &mut Vec<PpcHandleStateRecord>,
 ) {
     let pic_handle = cpu.gpr[3];
-    ppc_dispose_tracked_handle(pic_handle, memory, handles, handle_states);
+    let _ = allocator.dispose_handle(
+        memory,
+        heap_cursor,
+        heap_limit,
+        last_mem_error,
+        handles,
+        pic_handle,
+    );
 }
 
 fn ppc_dispose_tracked_handle(
@@ -61163,12 +61427,15 @@ fn ppc_get_icon_suite(
         bytes.extend_from_slice(&resource_type.to_be_bytes());
         bytes.extend_from_slice(&handle.to_be_bytes());
     }
-    let suite = ppc_alloc_recyclable_handle_with_bytes(
+    let suite = ppc_process_alloc_handle_with_bytes(
+        process_memory_manager,
         memory,
         heap_cursor,
-        heap_limit,
+        last_mem_error,
         handles,
+        free_ptr_blocks,
         free_handle_blocks,
+        handle_states,
         &bytes,
     );
     if suite == 0 {
@@ -61463,12 +61730,15 @@ fn ppc_get_ccursor(
 
 fn ppc_get_cicon(
     cpu: &PpcCpu,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
     last_mem_error: &mut i16,
     handles: &mut Vec<PpcHandleRecord>,
+    free_ptr_blocks: &mut Vec<PpcPtrRecord>,
     free_handle_blocks: &mut Vec<PpcHandleRecord>,
+    handle_states: &mut Vec<PpcHandleStateRecord>,
     vfs_resources: &[PpcVfsResourceRecord],
     current_resource_refnum: i16,
     last_resource_error: &mut i16,
@@ -61556,35 +61826,57 @@ fn ppc_get_cicon(
     // stores its mask, monochrome bitmap, color table, and pixels inline.
     // GetCIcon returns a private live CIcon with address/Handle fields fixed
     // up to independently owned copies.
-    let icon_handle = ppc_alloc_recyclable_handle_with_bytes(
+    let icon_handle = ppc_process_alloc_handle_with_bytes(
+        process_memory_manager,
         memory,
         heap_cursor,
-        heap_limit,
+        last_mem_error,
         handles,
+        free_ptr_blocks,
         free_handle_blocks,
+        handle_states,
         data,
     );
-    let color_table_handle = ppc_alloc_recyclable_handle_with_bytes(
+    let color_table_handle = ppc_process_alloc_handle_with_bytes(
+        process_memory_manager,
         memory,
         heap_cursor,
-        heap_limit,
+        last_mem_error,
         handles,
+        free_ptr_blocks,
         free_handle_blocks,
+        handle_states,
         color_table,
     );
-    let pixel_data_handle = ppc_alloc_recyclable_handle_with_bytes(
+    let pixel_data_handle = ppc_process_alloc_handle_with_bytes(
+        process_memory_manager,
         memory,
         heap_cursor,
-        heap_limit,
+        last_mem_error,
         handles,
+        free_ptr_blocks,
         free_handle_blocks,
+        handle_states,
         pixel_data,
     );
     if icon_handle == 0 || color_table_handle == 0 || pixel_data_handle == 0 {
-        let mut states = Vec::new();
-        let _ = ppc_dispose_tracked_handle(icon_handle, memory, handles, &mut states);
-        let _ = ppc_dispose_tracked_handle(color_table_handle, memory, handles, &mut states);
-        let _ = ppc_dispose_tracked_handle(pixel_data_handle, memory, handles, &mut states);
+        let mut allocator = PpcProcessAllocatorView {
+            memory_manager: process_memory_manager,
+            ptrs: None,
+            free_ptr_blocks,
+            free_handle_blocks,
+            handle_states,
+        };
+        for handle in [icon_handle, color_table_handle, pixel_data_handle] {
+            let _ = allocator.dispose_handle(
+                memory,
+                heap_cursor,
+                heap_limit,
+                last_mem_error,
+                handles,
+                handle,
+            );
+        }
         *last_mem_error = PPC_MEM_FULL_ERR;
         return 0;
     }
@@ -62015,7 +62307,7 @@ fn ppc_materialize_vfs_resource_handle(
     process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
-    heap_limit: u32,
+    _heap_limit: u32,
     last_mem_error: &mut i16,
     handles: &mut Vec<PpcHandleRecord>,
     free_ptr_blocks: &mut Vec<PpcPtrRecord>,
@@ -62026,20 +62318,6 @@ fn ppc_materialize_vfs_resource_handle(
     load_data: bool,
     last_resource_error: &mut i16,
 ) -> u32 {
-    let ptrs = process_memory_manager
-        .native_allocator_snapshot()
-        .map_or_else(Vec::new, |allocator| allocator.ptrs);
-    ppc_synchronize_process_native_allocator(
-        process_memory_manager,
-        *heap_cursor,
-        heap_limit,
-        *last_mem_error,
-        &ptrs,
-        free_ptr_blocks,
-        free_handle_blocks,
-    );
-    ppc_synchronize_process_native_handles(process_memory_manager, handles, handle_states);
-
     if vfs_resources[index].handle == 0 {
         // Inside Macintosh Volume I (1985), I-118 through I-120:
         // SetResLoad(FALSE) still returns a resource Handle, but its master
@@ -62634,16 +62912,6 @@ fn ppc_process_apple_event(
         return PpcImportAction::Return(ppc_i16_result(PPC_ERR_AE_EVENT_NOT_HANDLED));
     };
 
-    ppc_synchronize_process_native_allocator(
-        process_memory_manager,
-        *heap_cursor,
-        heap_limit,
-        *last_mem_error,
-        ptrs,
-        free_ptr_blocks,
-        free_handle_blocks,
-    );
-    ppc_synchronize_process_native_handles(process_memory_manager, handles, handle_states);
     let snapshot = process_memory_manager.detached_clone();
     // Interapplication Communication (1993), pp. 4-33 and 4-39: the server's
     // event and reply descriptors live in its application heap and the Apple
@@ -62742,15 +63010,6 @@ fn ppc_process_apple_event(
                 vec![descriptors, descriptors + 8, handler.refcon],
                 cpu.lr,
                 PpcNativeReturnGpr3::Preserve,
-            );
-            ppc_synchronize_process_native_allocator(
-                process_memory_manager,
-                *heap_cursor,
-                heap_limit,
-                *last_mem_error,
-                ptrs,
-                free_ptr_blocks,
-                free_handle_blocks,
             );
             if let Some(action) = action {
                 action
@@ -68378,11 +68637,17 @@ fn ppc_dispatch_legacy_window(
             );
             if window != 0 {
                 ppc_recalculate_window_vis_regions(
+                    process_memory_manager,
                     memory,
                     gworlds,
                     heap_cursor,
                     heap_limit,
+                    last_mem_error,
+                    ptrs,
+                    free_ptr_blocks,
                     handles,
+                    free_handle_blocks,
+                    handle_states,
                 );
                 *current_gworld = window;
                 if ppc_front_visible_window(memory, gworlds) != previous_front {
@@ -68459,11 +68724,17 @@ fn ppc_dispatch_legacy_window(
             };
             if window != 0 {
                 ppc_recalculate_window_vis_regions(
+                    process_memory_manager,
                     memory,
                     gworlds,
                     heap_cursor,
                     heap_limit,
+                    last_mem_error,
+                    ptrs,
+                    free_ptr_blocks,
                     handles,
+                    free_handle_blocks,
+                    handle_states,
                 );
                 *current_gworld = window;
                 if ppc_front_visible_window(memory, gworlds) != previous_front {
@@ -68556,7 +68827,19 @@ fn ppc_dispatch_legacy_window(
                 current_gdevice,
                 window,
             );
-            ppc_recalculate_window_vis_regions(memory, gworlds, heap_cursor, heap_limit, handles);
+            ppc_recalculate_window_vis_regions(
+                process_memory_manager,
+                memory,
+                gworlds,
+                heap_cursor,
+                heap_limit,
+                last_mem_error,
+                ptrs,
+                free_ptr_blocks,
+                handles,
+                free_handle_blocks,
+                handle_states,
+            );
             ppc_transition_front_window_chrome(
                 memory,
                 gworlds,
@@ -68628,7 +68911,19 @@ fn ppc_dispatch_legacy_window(
         "BringToFront" => {
             let previous_front = ppc_front_visible_window(memory, gworlds);
             ppc_reorder_window(gworlds, cpu.gpr[3], 0, true);
-            ppc_recalculate_window_vis_regions(memory, gworlds, heap_cursor, heap_limit, handles);
+            ppc_recalculate_window_vis_regions(
+                process_memory_manager,
+                memory,
+                gworlds,
+                heap_cursor,
+                heap_limit,
+                last_mem_error,
+                ptrs,
+                free_ptr_blocks,
+                handles,
+                free_handle_blocks,
+                handle_states,
+            );
             if ppc_front_visible_window(memory, gworlds) != previous_front {
                 let _ = ppc_activate_front_window_palette(
                     memory,
@@ -68646,7 +68941,19 @@ fn ppc_dispatch_legacy_window(
         "SendBehind" => {
             let previous_front = ppc_front_visible_window(memory, gworlds);
             ppc_reorder_window(gworlds, cpu.gpr[3], cpu.gpr[4], false);
-            ppc_recalculate_window_vis_regions(memory, gworlds, heap_cursor, heap_limit, handles);
+            ppc_recalculate_window_vis_regions(
+                process_memory_manager,
+                memory,
+                gworlds,
+                heap_cursor,
+                heap_limit,
+                last_mem_error,
+                ptrs,
+                free_ptr_blocks,
+                handles,
+                free_handle_blocks,
+                handle_states,
+            );
             if ppc_front_visible_window(memory, gworlds) != previous_front {
                 let _ = ppc_activate_front_window_palette(
                     memory,
@@ -69826,18 +70133,22 @@ fn ppc_dm_write_switch_info(
 
 fn ppc_dm_new_display_mode_list(
     cpu: &PpcCpu,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
-    heap_limit: u32,
+    last_mem_error: &mut i16,
     ptrs: &mut Vec<PpcPtrRecord>,
     free_ptr_blocks: &mut Vec<PpcPtrRecord>,
+    free_handle_blocks: &mut Vec<PpcHandleRecord>,
 ) -> i16 {
     ppc_dm_new_display_mode_list_values(
+        process_memory_manager,
         memory,
         heap_cursor,
-        heap_limit,
+        last_mem_error,
         ptrs,
         free_ptr_blocks,
+        free_handle_blocks,
         cpu.gpr[3],
         cpu.gpr[6],
         cpu.gpr[7],
@@ -69845,11 +70156,13 @@ fn ppc_dm_new_display_mode_list(
 }
 
 fn ppc_dm_new_display_mode_list_values(
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
-    heap_limit: u32,
+    last_mem_error: &mut i16,
     ptrs: &mut Vec<PpcPtrRecord>,
     free_ptr_blocks: &mut Vec<PpcPtrRecord>,
+    free_handle_blocks: &mut Vec<PpcHandleRecord>,
     display_id: u32,
     count_out: u32,
     list_out: u32,
@@ -69865,14 +70178,15 @@ fn ppc_dm_new_display_mode_list_values(
     let Some(mode) = ppc_dm_live_display_mode(memory, PPC_MAIN_GDEVICE) else {
         return PPC_PARAM_ERR;
     };
-    let list = ppc_alloc_ptr(
+    let list = process_memory_manager.new_native_ptr(memory, PPC_DM_MODE_LIST_SIZE, true);
+    ppc_apply_process_native_allocator(
+        process_memory_manager,
         memory,
         heap_cursor,
-        heap_limit,
+        last_mem_error,
         ptrs,
         free_ptr_blocks,
-        PPC_DM_MODE_LIST_SIZE,
-        true,
+        free_handle_blocks,
     );
     if list == 0 {
         return PPC_MEM_FULL_ERR;
@@ -70009,24 +70323,6 @@ fn ppc_dm_get_indexed_display_mode_values(
         restore_rtoc,
         return_gpr3: PpcNativeReturnGpr3::Set(ppc_i16_result(PPC_NO_ERR)),
     })
-}
-
-fn ppc_dm_dispose_list_values(
-    memory: &mut PpcSectionMem,
-    ptrs: &mut Vec<PpcPtrRecord>,
-    free_ptr_blocks: &mut Vec<PpcPtrRecord>,
-    list: u32,
-) -> i16 {
-    // Universal Interfaces 3.4.1 Displays.h: a DMListType is opaque and its
-    // lifetime ends at DMDisposeList.
-    if let Some(index) = ptrs.iter().position(|record| {
-        record.ptr == list && memory.read_u32_be(record.ptr) == Some(PPC_DM_MODE_LIST_MAGIC)
-    }) {
-        free_ptr_blocks.push(ptrs.remove(index));
-        PPC_NO_ERR
-    } else {
-        PPC_PARAM_ERR
-    }
 }
 
 fn ppc_te_read_rect(memory: &mut PpcSectionMem, rect_ptr: u32) -> Option<[u16; 4]> {
@@ -71645,28 +71941,48 @@ fn ppc_menu_handle_bytes(
     ppc_memory_read_bytes(memory, ptr, record.size)
 }
 
+fn ppc_replace_menu_bytes_with_allocator(
+    allocator: Option<&mut PpcProcessAllocatorView<'_>>,
+    memory: &mut PpcSectionMem,
+    heap_cursor: &mut u32,
+    heap_limit: u32,
+    last_mem_error: &mut i16,
+    handles: &mut Vec<PpcHandleRecord>,
+    menu_handle: u32,
+    bytes: &[u8],
+) -> i16 {
+    ppc_allocator_view_replace_handle_bytes(
+        allocator,
+        memory,
+        heap_cursor,
+        heap_limit,
+        last_mem_error,
+        handles,
+        menu_handle,
+        bytes,
+    )
+}
+
+#[cfg(test)]
 fn ppc_replace_menu_bytes(
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
-    handles: &mut [PpcHandleRecord],
+    handles: &mut Vec<PpcHandleRecord>,
     menu_handle: u32,
     bytes: &[u8],
 ) -> i16 {
-    let Ok(size) = u32::try_from(bytes.len()) else {
-        return PPC_MEM_FULL_ERR;
-    };
-    let result = ppc_set_handle_size(memory, heap_cursor, heap_limit, handles, menu_handle, size);
-    if result != PPC_NO_ERR {
-        return result;
-    }
-    let Some(ptr) = memory.read_u32_be(menu_handle).filter(|ptr| *ptr != 0) else {
-        return PPC_NIL_HANDLE_ERR;
-    };
-    if memory.write_bytes(ptr, bytes).is_none() {
-        return PPC_PARAM_ERR;
-    }
-    PPC_NO_ERR
+    let mut last_mem_error = PPC_NO_ERR;
+    ppc_replace_menu_bytes_with_allocator(
+        None,
+        memory,
+        heap_cursor,
+        heap_limit,
+        &mut last_mem_error,
+        handles,
+        menu_handle,
+        bytes,
+    )
 }
 
 fn ppc_mutate_menu_items_in_place(
@@ -71700,11 +72016,12 @@ fn ppc_decode_menu_items(bytes: &[u8]) -> Option<(usize, u32, Vec<PpcMenuItemDef
 
 #[allow(clippy::too_many_arguments)]
 fn ppc_alloc_new_menu(
+    allocator: Option<&mut PpcProcessAllocatorView<'_>>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
+    last_mem_error: &mut i16,
     handles: &mut Vec<PpcHandleRecord>,
-    free_handle_blocks: &mut Vec<PpcHandleRecord>,
     menu_proc: u32,
     menu_id: i16,
     title_ptr: u32,
@@ -71714,12 +72031,13 @@ fn ppc_alloc_new_menu(
     // creates an empty standard MenuRecord, loads the standard MDEF if
     // necessary, and stores its Handle in MenuInfo.menuProc.
     let bytes = new_standard_menu_record(menu_id, menu_proc, &title);
-    ppc_alloc_recyclable_handle_with_bytes(
+    ppc_allocator_view_allocate_handle_with_bytes(
+        allocator,
         memory,
         heap_cursor,
         heap_limit,
+        last_mem_error,
         handles,
-        free_handle_blocks,
         &bytes,
     )
 }
@@ -71730,16 +72048,18 @@ fn ppc_new_menu(
     heap_cursor: &mut u32,
     heap_limit: u32,
     handles: &mut Vec<PpcHandleRecord>,
-    free_handle_blocks: &mut Vec<PpcHandleRecord>,
+    _free_handle_blocks: &mut Vec<PpcHandleRecord>,
     menu_id: i16,
     title_ptr: u32,
 ) -> u32 {
+    let mut last_mem_error = PPC_NO_ERR;
     ppc_alloc_new_menu(
+        None,
         memory,
         heap_cursor,
         heap_limit,
+        &mut last_mem_error,
         handles,
-        free_handle_blocks,
         0,
         menu_id,
         title_ptr,
@@ -71814,12 +72134,14 @@ fn ppc_get_menu_item_text(cpu: &PpcCpu, memory: &mut PpcSectionMem) {
     let _ = ppc_write_pstring_bytes(memory, item_string, &text);
 }
 
-fn ppc_set_menu_item_text(
+fn ppc_set_menu_item_text_with_allocator(
     cpu: &PpcCpu,
+    allocator: Option<&mut PpcProcessAllocatorView<'_>>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
-    handles: &mut [PpcHandleRecord],
+    last_mem_error: &mut i16,
+    handles: &mut Vec<PpcHandleRecord>,
 ) -> i16 {
     let Some(original) = ppc_menu_handle_bytes(memory, handles, cpu.gpr[3]) else {
         return PPC_NIL_HANDLE_ERR;
@@ -71835,14 +72157,45 @@ fn ppc_set_menu_item_text(
     let Some(bytes) = items.rebuild(&original) else {
         return PPC_PARAM_ERR;
     };
-    ppc_replace_menu_bytes(memory, heap_cursor, heap_limit, handles, cpu.gpr[3], &bytes)
+    ppc_replace_menu_bytes_with_allocator(
+        allocator,
+        memory,
+        heap_cursor,
+        heap_limit,
+        last_mem_error,
+        handles,
+        cpu.gpr[3],
+        &bytes,
+    )
 }
 
-fn ppc_delete_menu_item(
+#[cfg(test)]
+fn ppc_set_menu_item_text(
+    cpu: &PpcCpu,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
-    handles: &mut [PpcHandleRecord],
+    handles: &mut Vec<PpcHandleRecord>,
+) -> i16 {
+    let mut last_mem_error = PPC_NO_ERR;
+    ppc_set_menu_item_text_with_allocator(
+        cpu,
+        None,
+        memory,
+        heap_cursor,
+        heap_limit,
+        &mut last_mem_error,
+        handles,
+    )
+}
+
+fn ppc_delete_menu_item_with_allocator(
+    mut allocator: Option<&mut PpcProcessAllocatorView<'_>>,
+    memory: &mut PpcSectionMem,
+    heap_cursor: &mut u32,
+    heap_limit: u32,
+    last_mem_error: &mut i16,
+    handles: &mut Vec<PpcHandleRecord>,
     menu_handle: u32,
     item_number: i16,
 ) -> i16 {
@@ -71864,27 +72217,59 @@ fn ppc_delete_menu_item(
     let Some(bytes) = items.rebuild(&original) else {
         return PPC_PARAM_ERR;
     };
-    let result = ppc_replace_menu_bytes(
+    let result = ppc_replace_menu_bytes_with_allocator(
+        allocator.as_deref_mut(),
         memory,
         heap_cursor,
         heap_limit,
+        last_mem_error,
         handles,
         menu_handle,
         &bytes,
     );
     if result == PPC_NO_ERR {
-        ppc_filter_menu_color_table(memory, heap_cursor, heap_limit, handles, |id, item| {
-            id != menu_id || item != item_number
-        });
+        ppc_filter_menu_color_table_with_allocator(
+            allocator,
+            memory,
+            heap_cursor,
+            heap_limit,
+            last_mem_error,
+            handles,
+            |id, item| id != menu_id || item != item_number,
+        );
     }
     result
 }
 
-fn ppc_insert_menu_items(
+#[cfg(test)]
+fn ppc_delete_menu_item(
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
-    handles: &mut [PpcHandleRecord],
+    handles: &mut Vec<PpcHandleRecord>,
+    menu_handle: u32,
+    item_number: i16,
+) -> i16 {
+    let mut last_mem_error = PPC_NO_ERR;
+    ppc_delete_menu_item_with_allocator(
+        None,
+        memory,
+        heap_cursor,
+        heap_limit,
+        &mut last_mem_error,
+        handles,
+        menu_handle,
+        item_number,
+    )
+}
+
+fn ppc_insert_menu_items_with_allocator(
+    allocator: Option<&mut PpcProcessAllocatorView<'_>>,
+    memory: &mut PpcSectionMem,
+    heap_cursor: &mut u32,
+    heap_limit: u32,
+    last_mem_error: &mut i16,
+    handles: &mut Vec<PpcHandleRecord>,
     menu_handle: u32,
     data_ptr: u32,
     after_item: i16,
@@ -71904,13 +72289,39 @@ fn ppc_insert_menu_items(
     let Some(bytes) = items.rebuild(&original) else {
         return PPC_PARAM_ERR;
     };
-    ppc_replace_menu_bytes(
+    ppc_replace_menu_bytes_with_allocator(
+        allocator,
         memory,
         heap_cursor,
         heap_limit,
+        last_mem_error,
         handles,
         menu_handle,
         &bytes,
+    )
+}
+
+#[cfg(test)]
+fn ppc_insert_menu_items(
+    memory: &mut PpcSectionMem,
+    heap_cursor: &mut u32,
+    heap_limit: u32,
+    handles: &mut Vec<PpcHandleRecord>,
+    menu_handle: u32,
+    data_ptr: u32,
+    after_item: i16,
+) -> i16 {
+    let mut last_mem_error = PPC_NO_ERR;
+    ppc_insert_menu_items_with_allocator(
+        None,
+        memory,
+        heap_cursor,
+        heap_limit,
+        &mut last_mem_error,
+        handles,
+        menu_handle,
+        data_ptr,
+        after_item,
     )
 }
 
@@ -71946,11 +72357,13 @@ fn ppc_resource_menu_indices(
     indices
 }
 
-fn ppc_insert_resource_menu_names(
+fn ppc_insert_resource_menu_names_with_allocator(
+    allocator: Option<&mut PpcProcessAllocatorView<'_>>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
-    handles: &mut [PpcHandleRecord],
+    last_mem_error: &mut i16,
+    handles: &mut Vec<PpcHandleRecord>,
     menu_handle: u32,
     names: Vec<Vec<u8>>,
     after_item: i16,
@@ -71967,10 +72380,12 @@ fn ppc_insert_resource_menu_names(
     let Some(bytes) = items.rebuild(&original) else {
         return PPC_PARAM_ERR;
     };
-    ppc_replace_menu_bytes(
+    ppc_replace_menu_bytes_with_allocator(
+        allocator,
         memory,
         heap_cursor,
         heap_limit,
+        last_mem_error,
         handles,
         menu_handle,
         &bytes,
@@ -72031,10 +72446,19 @@ fn ppc_insert_resource_menu(
             }
         }
     }
-    ppc_insert_resource_menu_names(
+    let mut allocator = PpcProcessAllocatorView {
+        memory_manager: process_memory_manager,
+        ptrs: None,
+        free_ptr_blocks,
+        free_handle_blocks,
+        handle_states,
+    };
+    ppc_insert_resource_menu_names_with_allocator(
+        Some(&mut allocator),
         memory,
         heap_cursor,
         heap_limit,
+        last_mem_error,
         handles,
         menu_handle,
         names,
@@ -72271,6 +72695,7 @@ fn ppc_calc_menu_size_with_resources(
 
 fn ppc_dispatch_calc_menu_size(
     cpu: &mut PpcCpu,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -72281,6 +72706,7 @@ fn ppc_dispatch_calc_menu_size(
     let menu_handle = cpu.gpr[3];
     if let Some(action) = ppc_dispatch_native_menu_definition(
         cpu,
+        Some(process_memory_manager),
         memory,
         heap_cursor,
         heap_limit,
@@ -72298,6 +72724,7 @@ fn ppc_dispatch_calc_menu_size(
 #[allow(clippy::too_many_arguments)]
 fn ppc_dispatch_native_menu_definition(
     cpu: &mut PpcCpu,
+    process_memory_manager: Option<&mut ProcessNativeMemoryManager>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -72308,6 +72735,7 @@ fn ppc_dispatch_native_menu_definition(
 ) -> Option<PpcImportAction> {
     ppc_dispatch_native_menu_definition_with_return(
         cpu,
+        process_memory_manager,
         memory,
         heap_cursor,
         heap_limit,
@@ -72322,6 +72750,7 @@ fn ppc_dispatch_native_menu_definition(
 #[allow(clippy::too_many_arguments)]
 fn ppc_dispatch_native_menu_definition_with_return(
     cpu: &mut PpcCpu,
+    mut process_memory_manager: Option<&mut ProcessNativeMemoryManager>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -72334,8 +72763,13 @@ fn ppc_dispatch_native_menu_definition_with_return(
     let menu_handle = invocation.menu_handle;
     let target = ppc_menu_definition_target(cpu, memory, resources, menu_handle)?;
     if toolbox_startup.menu_def_scratch == 0 {
-        toolbox_startup.menu_def_scratch =
-            ppc_heap_alloc(memory, heap_cursor, heap_limit, 10, true);
+        toolbox_startup.menu_def_scratch = if let Some(memory_manager) =
+            process_memory_manager.as_deref_mut()
+        {
+            ppc_process_heap_alloc(memory_manager, memory, heap_cursor, 10, true)
+        } else {
+            ppc_heap_alloc(memory, heap_cursor, heap_limit, 10, true)
+        };
     }
     let scratch = toolbox_startup.menu_def_scratch;
     if scratch == 0 {
@@ -72359,6 +72793,7 @@ fn ppc_dispatch_native_menu_definition_with_return(
         }
         GuestIsa::M68k => ppc_begin_m68k_menu_definition(
             cpu,
+            process_memory_manager.as_deref_mut(),
             memory,
             heap_cursor,
             heap_limit,
@@ -72376,6 +72811,7 @@ const MDEF_PASCAL_PROC_INFO: u32 = 0x0000_ff80;
 #[allow(clippy::too_many_arguments)]
 fn ppc_begin_m68k_menu_definition(
     cpu: &PpcCpu,
+    process_memory_manager: Option<&mut ProcessNativeMemoryManager>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -72392,8 +72828,13 @@ fn ppc_begin_m68k_menu_definition(
     if target.proc_info != 0 && target.proc_info != MDEF_PASCAL_PROC_INFO {
         return None;
     }
-    let (gateway, stack_top) =
-        ppc_mixed_mode_m68k_storage(None, memory, heap_cursor, heap_limit, startup)?;
+    let (gateway, stack_top) = ppc_mixed_mode_m68k_storage(
+        process_memory_manager,
+        memory,
+        heap_cursor,
+        heap_limit,
+        startup,
+    )?;
     if stack_top < 4 {
         return None;
     }
@@ -72610,6 +73051,7 @@ fn ppc_popup_menu_layout_with_resources(
 #[allow(clippy::too_many_arguments)]
 fn ppc_begin_custom_popup_menu_tracking(
     cpu: &mut PpcCpu,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -72640,6 +73082,7 @@ fn ppc_begin_custom_popup_menu_tracking(
         .and_then(MenuDefinitionTracking::pending_invocation)?;
     let action = ppc_dispatch_native_menu_definition(
         cpu,
+        Some(process_memory_manager),
         memory,
         heap_cursor,
         heap_limit,
@@ -72659,6 +73102,7 @@ fn ppc_begin_custom_popup_menu_tracking(
 #[allow(clippy::too_many_arguments)]
 fn ppc_continue_custom_popup_menu_tracking(
     cpu: &mut PpcCpu,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -72728,6 +73172,7 @@ fn ppc_continue_custom_popup_menu_tracking(
             .unwrap();
         if let Some(action) = ppc_dispatch_native_menu_definition(
             cpu,
+            Some(process_memory_manager),
             memory,
             heap_cursor,
             heap_limit,
@@ -72796,6 +73241,7 @@ fn ppc_continue_custom_popup_menu_tracking(
             .unwrap();
         if let Some(action) = ppc_dispatch_native_menu_definition(
             cpu,
+            Some(process_memory_manager),
             memory,
             heap_cursor,
             heap_limit,
@@ -72814,6 +73260,7 @@ fn ppc_continue_custom_popup_menu_tracking(
         if let Some(invocation) = choose {
             if let Some(action) = ppc_dispatch_native_menu_definition(
                 cpu,
+                Some(process_memory_manager),
                 memory,
                 heap_cursor,
                 heap_limit,
@@ -74267,6 +74714,7 @@ fn ppc_begin_menu_bar_tracking_with_resources(
 #[allow(clippy::too_many_arguments)]
 fn ppc_begin_custom_menu_bar_tracking(
     cpu: &mut PpcCpu,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -74343,6 +74791,7 @@ fn ppc_begin_custom_menu_bar_tracking(
         .and_then(MenuDefinitionTracking::pending_invocation)?;
     let action = ppc_dispatch_native_menu_definition(
         cpu,
+        Some(process_memory_manager),
         memory,
         heap_cursor,
         heap_limit,
@@ -74375,6 +74824,7 @@ fn ppc_begin_custom_menu_bar_tracking(
 #[allow(clippy::too_many_arguments)]
 fn ppc_continue_custom_menu_bar_tracking(
     cpu: &mut PpcCpu,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -74454,6 +74904,7 @@ fn ppc_continue_custom_menu_bar_tracking(
                 {
                     if let Some(action) = ppc_dispatch_native_menu_definition(
                         cpu,
+                        Some(process_memory_manager),
                         memory,
                         heap_cursor,
                         heap_limit,
@@ -74520,6 +74971,7 @@ fn ppc_continue_custom_menu_bar_tracking(
             .unwrap();
         if let Some(action) = ppc_dispatch_native_menu_definition(
             cpu,
+            Some(process_memory_manager),
             memory,
             heap_cursor,
             heap_limit,
@@ -74540,6 +74992,7 @@ fn ppc_continue_custom_menu_bar_tracking(
             .expect("choose installed the invocation");
         if let Some(action) = ppc_dispatch_native_menu_definition(
             cpu,
+            Some(process_memory_manager),
             memory,
             heap_cursor,
             heap_limit,
@@ -74979,13 +75432,22 @@ fn ppc_load_menu_resource(
         return 0;
     }
     if handle != 0 {
-        ppc_load_menu_color_resource(
+        let mut allocator = PpcProcessAllocatorView {
+            memory_manager: process_memory_manager,
+            ptrs: None,
+            free_ptr_blocks,
+            free_handle_blocks,
+            handle_states,
+        };
+        ppc_load_menu_color_resource_with_allocator(
             menu_id,
+            Some(&mut allocator),
+            None,
             memory,
             heap_cursor,
             heap_limit,
+            last_mem_error,
             handles,
-            free_handle_blocks,
             vfs_resources,
             current_resource_refnum,
         );
@@ -75126,12 +75588,14 @@ fn ppc_menu_color_table_bytes(memory: &mut PpcSectionMem, handles: &[PpcHandleRe
     ppc_menu_handle_bytes(memory, handles, handle).unwrap_or_default()
 }
 
-fn ppc_ensure_menu_color_table_handle(
+fn ppc_ensure_menu_color_table_handle_with_allocator(
+    allocator: Option<&mut PpcProcessAllocatorView<'_>>,
+    legacy_free_handle_blocks: Option<&mut Vec<PpcHandleRecord>>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
+    last_mem_error: &mut i16,
     handles: &mut Vec<PpcHandleRecord>,
-    free_handle_blocks: &mut Vec<PpcHandleRecord>,
 ) -> u32 {
     let current = memory
         .read_u32_be(crate::memory::globals::addr::MENU_C_INFO)
@@ -75139,28 +75603,54 @@ fn ppc_ensure_menu_color_table_handle(
     if current != 0 {
         return current;
     }
-    let handle = ppc_alloc_recyclable_handle_with_bytes(
-        memory,
-        heap_cursor,
-        heap_limit,
-        handles,
-        free_handle_blocks,
-        &[],
-    );
+    let handle = if let Some(allocator) = allocator {
+        allocator.allocate_handle_with_bytes(memory, heap_cursor, last_mem_error, handles, &[])
+    } else {
+        ppc_alloc_recyclable_handle_with_bytes(
+            memory,
+            heap_cursor,
+            heap_limit,
+            handles,
+            legacy_free_handle_blocks.expect("legacy menu allocation requires a free list"),
+            &[],
+        )
+    };
     if handle != 0 {
         let _ = memory.write_u32_be(crate::memory::globals::addr::MENU_C_INFO, handle);
     }
     handle
 }
 
-#[allow(clippy::too_many_arguments)]
-fn ppc_load_menu_color_resource(
-    resource_id: i16,
+#[cfg(test)]
+fn ppc_ensure_menu_color_table_handle(
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
     handles: &mut Vec<PpcHandleRecord>,
     free_handle_blocks: &mut Vec<PpcHandleRecord>,
+) -> u32 {
+    let mut last_mem_error = PPC_NO_ERR;
+    ppc_ensure_menu_color_table_handle_with_allocator(
+        None,
+        Some(free_handle_blocks),
+        memory,
+        heap_cursor,
+        heap_limit,
+        &mut last_mem_error,
+        handles,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn ppc_load_menu_color_resource_with_allocator(
+    resource_id: i16,
+    mut allocator: Option<&mut PpcProcessAllocatorView<'_>>,
+    legacy_free_handle_blocks: Option<&mut Vec<PpcHandleRecord>>,
+    memory: &mut PpcSectionMem,
+    heap_cursor: &mut u32,
+    heap_limit: u32,
+    last_mem_error: &mut i16,
+    handles: &mut Vec<PpcHandleRecord>,
     vfs_resources: &[PpcVfsResourceRecord],
     current_resource_refnum: i16,
 ) {
@@ -75177,35 +75667,58 @@ fn ppc_load_menu_color_resource(
     if incoming.is_empty() {
         return;
     }
-    let handle = ppc_ensure_menu_color_table_handle(
+    let handle = ppc_ensure_menu_color_table_handle_with_allocator(
+        allocator.as_deref_mut(),
+        legacy_free_handle_blocks,
         memory,
         heap_cursor,
         heap_limit,
+        last_mem_error,
         handles,
-        free_handle_blocks,
     );
     if handle == 0 {
         return;
     }
     let current = ppc_menu_color_table_bytes(memory, handles);
     let merged = merge_menu_color_entries(&current, &incoming);
-    let _ = ppc_replace_menu_bytes(memory, heap_cursor, heap_limit, handles, handle, &merged);
+    let _ = ppc_replace_menu_bytes_with_allocator(
+        allocator,
+        memory,
+        heap_cursor,
+        heap_limit,
+        last_mem_error,
+        handles,
+        handle,
+        &merged,
+    );
 }
 
-fn ppc_clear_menu_color_table(
+fn ppc_clear_menu_color_table_with_allocator(
+    allocator: Option<&mut PpcProcessAllocatorView<'_>>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
-    handles: &mut [PpcHandleRecord],
+    last_mem_error: &mut i16,
+    handles: &mut Vec<PpcHandleRecord>,
 ) {
-    ppc_filter_menu_color_table(memory, heap_cursor, heap_limit, handles, |_id, _item| false);
+    ppc_filter_menu_color_table_with_allocator(
+        allocator,
+        memory,
+        heap_cursor,
+        heap_limit,
+        last_mem_error,
+        handles,
+        |_id, _item| false,
+    );
 }
 
-fn ppc_filter_menu_color_table(
+fn ppc_filter_menu_color_table_with_allocator(
+    allocator: Option<&mut PpcProcessAllocatorView<'_>>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
-    handles: &mut [PpcHandleRecord],
+    last_mem_error: &mut i16,
+    handles: &mut Vec<PpcHandleRecord>,
     keep: impl FnMut(i16, i16) -> bool,
 ) {
     let handle = memory
@@ -75216,18 +75729,28 @@ fn ppc_filter_menu_color_table(
     }
     let current = ppc_menu_color_table_bytes(memory, handles);
     let filtered = filter_menu_color_entries(&current, keep);
-    let _ = ppc_replace_menu_bytes(memory, heap_cursor, heap_limit, handles, handle, &filtered);
+    let _ = ppc_replace_menu_bytes_with_allocator(
+        allocator,
+        memory,
+        heap_cursor,
+        heap_limit,
+        last_mem_error,
+        handles,
+        handle,
+        &filtered,
+    );
 }
 
 #[allow(clippy::too_many_arguments)]
-fn ppc_get_menu_bar(
+fn ppc_get_menu_bar_with_allocator(
     current_menu_list: u32,
+    allocator: Option<&mut PpcProcessAllocatorView<'_>>,
+    legacy_free_handle_blocks: Option<&mut Vec<PpcHandleRecord>>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
     last_mem_error: &mut i16,
     handles: &mut Vec<PpcHandleRecord>,
-    free_handle_blocks: &mut Vec<PpcHandleRecord>,
 ) -> u32 {
     let menu_list = if current_menu_list == 0 {
         PpcMenuListDefinition::default()
@@ -75238,13 +75761,15 @@ fn ppc_get_menu_bar(
         };
         menu_list
     };
-    let handle = ppc_alloc_menu_list_definition_handle(
+    let handle = ppc_alloc_menu_list_definition_handle_with_allocator(
         &menu_list,
+        allocator,
+        legacy_free_handle_blocks,
         memory,
         heap_cursor,
         heap_limit,
+        last_mem_error,
         handles,
-        free_handle_blocks,
     );
     *last_mem_error = if handle == 0 {
         PPC_MEM_FULL_ERR
@@ -75254,6 +75779,32 @@ fn ppc_get_menu_bar(
     handle
 }
 
+fn ppc_alloc_menu_list_handle_with_allocator(
+    menu_handles: &[u32],
+    allocator: Option<&mut PpcProcessAllocatorView<'_>>,
+    legacy_free_handle_blocks: Option<&mut Vec<PpcHandleRecord>>,
+    memory: &mut PpcSectionMem,
+    heap_cursor: &mut u32,
+    heap_limit: u32,
+    last_mem_error: &mut i16,
+    handles: &mut Vec<PpcHandleRecord>,
+) -> u32 {
+    let mut menu_list =
+        PpcMenuListDefinition::from_regular_handles(0, menu_handles.iter().copied());
+    ppc_relayout_menu_list(memory, &mut menu_list);
+    ppc_alloc_menu_list_definition_handle_with_allocator(
+        &menu_list,
+        allocator,
+        legacy_free_handle_blocks,
+        memory,
+        heap_cursor,
+        heap_limit,
+        last_mem_error,
+        handles,
+    )
+}
+
+#[cfg(test)]
 fn ppc_alloc_menu_list_handle(
     menu_handles: &[u32],
     memory: &mut PpcSectionMem,
@@ -75262,19 +75813,45 @@ fn ppc_alloc_menu_list_handle(
     handles: &mut Vec<PpcHandleRecord>,
     free_handle_blocks: &mut Vec<PpcHandleRecord>,
 ) -> u32 {
-    let mut menu_list =
-        PpcMenuListDefinition::from_regular_handles(0, menu_handles.iter().copied());
-    ppc_relayout_menu_list(memory, &mut menu_list);
-    ppc_alloc_menu_list_definition_handle(
-        &menu_list,
+    let mut last_mem_error = PPC_NO_ERR;
+    ppc_alloc_menu_list_handle_with_allocator(
+        menu_handles,
+        None,
+        Some(free_handle_blocks),
         memory,
         heap_cursor,
         heap_limit,
+        &mut last_mem_error,
         handles,
-        free_handle_blocks,
     )
 }
 
+fn ppc_alloc_menu_list_definition_handle_with_allocator(
+    menu_list: &PpcMenuListDefinition,
+    allocator: Option<&mut PpcProcessAllocatorView<'_>>,
+    legacy_free_handle_blocks: Option<&mut Vec<PpcHandleRecord>>,
+    memory: &mut PpcSectionMem,
+    heap_cursor: &mut u32,
+    heap_limit: u32,
+    last_mem_error: &mut i16,
+    handles: &mut Vec<PpcHandleRecord>,
+) -> u32 {
+    let bytes = ppc_menu_list_bytes(menu_list);
+    if let Some(allocator) = allocator {
+        allocator.allocate_handle_with_bytes(memory, heap_cursor, last_mem_error, handles, &bytes)
+    } else {
+        ppc_alloc_recyclable_handle_with_bytes(
+            memory,
+            heap_cursor,
+            heap_limit,
+            handles,
+            legacy_free_handle_blocks.expect("legacy menu allocation requires a free list"),
+            &bytes,
+        )
+    }
+}
+
+#[cfg(test)]
 fn ppc_alloc_menu_list_definition_handle(
     menu_list: &PpcMenuListDefinition,
     memory: &mut PpcSectionMem,
@@ -75283,14 +75860,16 @@ fn ppc_alloc_menu_list_definition_handle(
     handles: &mut Vec<PpcHandleRecord>,
     free_handle_blocks: &mut Vec<PpcHandleRecord>,
 ) -> u32 {
-    let bytes = ppc_menu_list_bytes(menu_list);
-    ppc_alloc_recyclable_handle_with_bytes(
+    let mut last_mem_error = PPC_NO_ERR;
+    ppc_alloc_menu_list_definition_handle_with_allocator(
+        menu_list,
+        None,
+        Some(free_handle_blocks),
         memory,
         heap_cursor,
         heap_limit,
+        &mut last_mem_error,
         handles,
-        free_handle_blocks,
-        &bytes,
     )
 }
 
@@ -75329,7 +75908,23 @@ fn ppc_get_new_mbar(
     // calls GetMenu for each compiled menu ID. The rebuilt color table remains
     // current after the old menu list is restored. Macintosh Toolbox
     // Essentials (1992), pp. 3-111--3-112.
-    ppc_clear_menu_color_table(memory, heap_cursor, heap_limit, handles);
+    {
+        let mut allocator = PpcProcessAllocatorView {
+            memory_manager: process_memory_manager,
+            ptrs: None,
+            free_ptr_blocks,
+            free_handle_blocks,
+            handle_states,
+        };
+        ppc_clear_menu_color_table_with_allocator(
+            Some(&mut allocator),
+            memory,
+            heap_cursor,
+            heap_limit,
+            last_mem_error,
+            handles,
+        );
+    }
     let menu_handles = mbar.load_regular_handles(|menu_id| {
         let handle = ppc_load_menu_resource(
             menu_id,
@@ -75354,13 +75949,22 @@ fn ppc_get_new_mbar(
     // caller-owned menu-list handle; it does not install or draw that list.
     let mut menu_list = PpcMenuListDefinition::from_regular_handles(mbar_id, menu_handles);
     ppc_relayout_menu_list(memory, &mut menu_list);
-    let handle = ppc_alloc_menu_list_definition_handle(
+    let mut allocator = PpcProcessAllocatorView {
+        memory_manager: process_memory_manager,
+        ptrs: None,
+        free_ptr_blocks,
+        free_handle_blocks,
+        handle_states,
+    };
+    let handle = ppc_alloc_menu_list_definition_handle_with_allocator(
         &menu_list,
+        Some(&mut allocator),
+        None,
         memory,
         heap_cursor,
         heap_limit,
+        last_mem_error,
         handles,
-        free_handle_blocks,
     );
     if handle == 0 {
         *last_mem_error = PPC_MEM_FULL_ERR;
@@ -75373,6 +75977,7 @@ fn ppc_get_new_mbar(
 
 fn ppc_continue_menu_bar_build(
     cpu: &mut PpcCpu,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
@@ -75401,6 +76006,7 @@ fn ppc_continue_menu_bar_build(
         };
         if let Some(action) = ppc_dispatch_native_menu_definition(
             cpu,
+            Some(process_memory_manager),
             memory,
             heap_cursor,
             heap_limit,
@@ -75467,32 +76073,60 @@ fn ppc_relayout_menu_list(memory: &mut PpcSectionMem, menu_list: &mut PpcMenuLis
     );
 }
 
-fn ppc_replace_menu_list_definition(
+fn ppc_replace_menu_list_definition_with_allocator(
+    allocator: Option<&mut PpcProcessAllocatorView<'_>>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
-    handles: &mut [PpcHandleRecord],
+    last_mem_error: &mut i16,
+    handles: &mut Vec<PpcHandleRecord>,
     menu_list_handle: u32,
     menu_list: &PpcMenuListDefinition,
 ) -> i16 {
     let bytes = ppc_menu_list_bytes(menu_list);
-    ppc_replace_menu_bytes(
+    ppc_replace_menu_bytes_with_allocator(
+        allocator,
         memory,
         heap_cursor,
         heap_limit,
+        last_mem_error,
         handles,
         menu_list_handle,
         &bytes,
     )
 }
 
-#[allow(clippy::too_many_arguments)]
-fn ppc_insert_menu(
+#[cfg(test)]
+fn ppc_replace_menu_list_definition(
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
     handles: &mut Vec<PpcHandleRecord>,
-    free_handle_blocks: &mut Vec<PpcHandleRecord>,
+    menu_list_handle: u32,
+    menu_list: &PpcMenuListDefinition,
+) -> i16 {
+    let mut last_mem_error = PPC_NO_ERR;
+    ppc_replace_menu_list_definition_with_allocator(
+        None,
+        memory,
+        heap_cursor,
+        heap_limit,
+        &mut last_mem_error,
+        handles,
+        menu_list_handle,
+        menu_list,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn ppc_insert_menu_with_allocator(
+    mut allocator: Option<&mut PpcProcessAllocatorView<'_>>,
+    legacy_free_handle_blocks: Option<&mut Vec<PpcHandleRecord>>,
+    memory: &mut PpcSectionMem,
+    heap_cursor: &mut u32,
+    heap_limit: u32,
+    last_mem_error: &mut i16,
+    handles: &mut Vec<PpcHandleRecord>,
     menu_handle: u32,
     before_id: i16,
 ) -> i16 {
@@ -75505,13 +76139,15 @@ fn ppc_insert_menu(
     }
     let mut current_menu_list = ppc_current_menu_list(memory);
     if current_menu_list == 0 {
-        current_menu_list = ppc_alloc_menu_list_handle(
+        current_menu_list = ppc_alloc_menu_list_handle_with_allocator(
             &[],
+            allocator.as_deref_mut(),
+            legacy_free_handle_blocks,
             memory,
             heap_cursor,
             heap_limit,
+            last_mem_error,
             handles,
-            free_handle_blocks,
         );
         if current_menu_list == 0 {
             return PPC_MEM_FULL_ERR;
@@ -75530,21 +76166,50 @@ fn ppc_insert_menu(
         return PPC_NO_ERR;
     }
     ppc_relayout_menu_list(memory, &mut menu_list);
-    ppc_replace_menu_list_definition(
+    ppc_replace_menu_list_definition_with_allocator(
+        allocator,
         memory,
         heap_cursor,
         heap_limit,
+        last_mem_error,
         handles,
         current_menu_list,
         &menu_list,
     )
 }
 
-fn ppc_delete_menu(
+#[cfg(test)]
+#[allow(clippy::too_many_arguments)]
+fn ppc_insert_menu(
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
-    handles: &mut [PpcHandleRecord],
+    handles: &mut Vec<PpcHandleRecord>,
+    free_handle_blocks: &mut Vec<PpcHandleRecord>,
+    menu_handle: u32,
+    before_id: i16,
+) -> i16 {
+    let mut last_mem_error = PPC_NO_ERR;
+    ppc_insert_menu_with_allocator(
+        None,
+        Some(free_handle_blocks),
+        memory,
+        heap_cursor,
+        heap_limit,
+        &mut last_mem_error,
+        handles,
+        menu_handle,
+        before_id,
+    )
+}
+
+fn ppc_delete_menu_with_allocator(
+    mut allocator: Option<&mut PpcProcessAllocatorView<'_>>,
+    memory: &mut PpcSectionMem,
+    heap_cursor: &mut u32,
+    heap_limit: u32,
+    last_mem_error: &mut i16,
+    handles: &mut Vec<PpcHandleRecord>,
     menu_list_handle: u32,
     menu_id: i16,
 ) -> i16 {
@@ -75566,20 +76231,50 @@ fn ppc_delete_menu(
         return PPC_NO_ERR;
     }
     ppc_relayout_menu_list(memory, &mut menu_list);
-    let result = ppc_replace_menu_list_definition(
+    let result = ppc_replace_menu_list_definition_with_allocator(
+        allocator.as_deref_mut(),
         memory,
         heap_cursor,
         heap_limit,
+        last_mem_error,
         handles,
         menu_list_handle,
         &menu_list,
     );
     if result == PPC_NO_ERR {
-        ppc_filter_menu_color_table(memory, heap_cursor, heap_limit, handles, |id, _item| {
-            id != menu_id
-        });
+        ppc_filter_menu_color_table_with_allocator(
+            allocator,
+            memory,
+            heap_cursor,
+            heap_limit,
+            last_mem_error,
+            handles,
+            |id, _item| id != menu_id,
+        );
     }
     result
+}
+
+#[cfg(test)]
+fn ppc_delete_menu(
+    memory: &mut PpcSectionMem,
+    heap_cursor: &mut u32,
+    heap_limit: u32,
+    handles: &mut Vec<PpcHandleRecord>,
+    menu_list_handle: u32,
+    menu_id: i16,
+) -> i16 {
+    let mut last_mem_error = PPC_NO_ERR;
+    ppc_delete_menu_with_allocator(
+        None,
+        memory,
+        heap_cursor,
+        heap_limit,
+        &mut last_mem_error,
+        handles,
+        menu_list_handle,
+        menu_id,
+    )
 }
 
 fn ppc_get_menu_handle(memory: &mut PpcSectionMem, menu_list_handle: u32, menu_id: i16) -> u32 {
@@ -77412,24 +78107,36 @@ fn ppc_open_region_include_polygon(
 
 #[allow(clippy::too_many_arguments)]
 fn ppc_open_rgn(
+    mut allocator: Option<&mut PpcProcessAllocatorView<'_>>,
     memory: &mut PpcSectionMem,
     current_gworld: u32,
     heap_cursor: &mut u32,
     heap_limit: u32,
     last_mem_error: &mut i16,
     handles: &mut Vec<PpcHandleRecord>,
-    handle_states: &mut Vec<PpcHandleStateRecord>,
+    mut legacy_handle_states: Option<&mut Vec<PpcHandleStateRecord>>,
     startup: &mut PpcToolboxStartupState,
 ) {
     if startup.open_region_save_handle != 0 {
-        let _ = ppc_dispose_tracked_handle(
-            startup.open_region_save_handle,
+        let _ = ppc_allocator_view_dispose_handle(
+            allocator.as_deref_mut(),
             memory,
+            heap_cursor,
+            heap_limit,
+            last_mem_error,
             handles,
-            handle_states,
+            legacy_handle_states.as_deref_mut(),
+            startup.open_region_save_handle,
         );
     }
-    let save_handle = ppc_new_rgn(memory, heap_cursor, heap_limit, last_mem_error, handles);
+    let save_handle = ppc_allocator_view_new_rgn(
+        allocator.as_deref_mut(),
+        memory,
+        heap_cursor,
+        heap_limit,
+        last_mem_error,
+        handles,
+    );
     if save_handle == 0 {
         startup.open_region_port = 0;
         startup.open_region_save_handle = 0;
@@ -77464,21 +78171,24 @@ fn ppc_open_rgn(
 }
 
 fn ppc_close_rgn(
+    mut allocator: Option<&mut PpcProcessAllocatorView<'_>>,
     memory: &mut PpcSectionMem,
     destination: u32,
     heap_cursor: &mut u32,
     heap_limit: u32,
     last_mem_error: &mut i16,
     handles: &mut Vec<PpcHandleRecord>,
-    handle_states: &mut Vec<PpcHandleStateRecord>,
+    mut legacy_handle_states: Option<&mut Vec<PpcHandleStateRecord>>,
     startup: &mut PpcToolboxStartupState,
 ) {
     *last_mem_error = if let Some((top, rows)) = startup.open_region_rows.take() {
         ppc_region_storage_from_rows(top, &rows).map_or(PPC_PARAM_ERR, |storage| {
             ppc_write_region_storage(
+                allocator.as_deref_mut(),
                 memory,
                 heap_cursor,
                 heap_limit,
+                last_mem_error,
                 handles,
                 destination,
                 &storage,
@@ -77517,11 +78227,15 @@ fn ppc_close_rgn(
         }
     }
     if startup.open_region_save_handle != 0 {
-        let _ = ppc_dispose_tracked_handle(
-            startup.open_region_save_handle,
+        let _ = ppc_allocator_view_dispose_handle(
+            allocator.as_deref_mut(),
             memory,
+            heap_cursor,
+            heap_limit,
+            last_mem_error,
             handles,
-            handle_states,
+            legacy_handle_states.as_deref_mut(),
+            startup.open_region_save_handle,
         );
     }
     startup.open_region_port = 0;
@@ -77532,10 +78246,12 @@ fn ppc_close_rgn(
 
 fn ppc_bitmap_to_region(
     cpu: &PpcCpu,
+    allocator: Option<&mut PpcProcessAllocatorView<'_>>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
-    handles: &mut [PpcHandleRecord],
+    last_mem_error: &mut i16,
+    handles: &mut Vec<PpcHandleRecord>,
 ) -> i16 {
     let region_handle = cpu.gpr[3];
     let bitmap = cpu.gpr[4];
@@ -77591,9 +78307,11 @@ fn ppc_bitmap_to_region(
         return PPC_RGN_TOO_BIG_ERR;
     }
     let result = ppc_write_region_storage(
+        allocator,
         memory,
         heap_cursor,
         heap_limit,
+        last_mem_error,
         handles,
         region_handle,
         &storage,
@@ -77616,6 +78334,7 @@ fn ppc_bitmap_to_region(
     result
 }
 
+#[cfg(test)]
 fn ppc_new_rgn(
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
@@ -77704,6 +78423,7 @@ fn ppc_allocator_view_new_rgn(
 
 fn ppc_clip_rect(
     cpu: &PpcCpu,
+    allocator: Option<&mut PpcProcessAllocatorView<'_>>,
     memory: &mut PpcSectionMem,
     current_gworld: u32,
     heap_cursor: &mut u32,
@@ -77724,7 +78444,14 @@ fn ppc_clip_rect(
     };
     let mut clip_rgn = memory.read_u32_be(clip_addr).unwrap_or(0);
     if ppc_rgn_ptr(memory, clip_rgn).is_none() {
-        clip_rgn = ppc_new_rgn(memory, heap_cursor, heap_limit, last_mem_error, handles);
+        clip_rgn = ppc_allocator_view_new_rgn(
+            allocator,
+            memory,
+            heap_cursor,
+            heap_limit,
+            last_mem_error,
+            handles,
+        );
         if clip_rgn == 0 || memory.write_u32_be(clip_addr, clip_rgn).is_none() {
             *last_mem_error = PPC_PARAM_ERR;
             return;
@@ -77772,10 +78499,12 @@ fn ppc_set_empty_rgn(memory: &mut PpcSectionMem, rgn_handle: u32) -> Option<()> 
 }
 
 fn ppc_copy_rgn(
+    allocator: Option<&mut PpcProcessAllocatorView<'_>>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
-    handles: &mut [PpcHandleRecord],
+    last_mem_error: &mut i16,
+    handles: &mut Vec<PpcHandleRecord>,
     src_rgn: u32,
     dst_rgn: u32,
 ) -> i16 {
@@ -77820,7 +78549,16 @@ fn ppc_copy_rgn(
             PPC_PARAM_ERR
         };
     }
-    let result = ppc_set_handle_size(memory, heap_cursor, heap_limit, handles, dst_rgn, size);
+    let result = ppc_allocator_view_resize_handle(
+        allocator,
+        memory,
+        heap_cursor,
+        heap_limit,
+        last_mem_error,
+        handles,
+        dst_rgn,
+        size,
+    );
     if result != PPC_NO_ERR {
         return result;
     }
@@ -78096,17 +78834,21 @@ fn ppc_region_storage_from_rows(top: i16, rows: &[Vec<i16>]) -> Option<Vec<u8>> 
 }
 
 fn ppc_write_region_storage(
+    allocator: Option<&mut PpcProcessAllocatorView<'_>>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
-    handles: &mut [PpcHandleRecord],
+    last_mem_error: &mut i16,
+    handles: &mut Vec<PpcHandleRecord>,
     rgn_handle: u32,
     storage: &[u8],
 ) -> i16 {
-    let result = ppc_set_handle_size(
+    let result = ppc_allocator_view_resize_handle(
+        allocator,
         memory,
         heap_cursor,
         heap_limit,
+        last_mem_error,
         handles,
         rgn_handle,
         u32::try_from(storage.len()).unwrap_or(u32::MAX),
@@ -78126,10 +78868,12 @@ fn ppc_write_region_storage(
 }
 
 fn ppc_region_boolean_op(
+    allocator: Option<&mut PpcProcessAllocatorView<'_>>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
-    handles: &mut [PpcHandleRecord],
+    last_mem_error: &mut i16,
+    handles: &mut Vec<PpcHandleRecord>,
     src_a: u32,
     src_b: u32,
     dst: u32,
@@ -78179,7 +78923,16 @@ fn ppc_region_boolean_op(
     } else {
         vec![0, 10, 0, 0, 0, 0, 0, 0, 0, 0]
     };
-    ppc_write_region_storage(memory, heap_cursor, heap_limit, handles, dst, &output)
+    ppc_write_region_storage(
+        allocator,
+        memory,
+        heap_cursor,
+        heap_limit,
+        last_mem_error,
+        handles,
+        dst,
+        &output,
+    )
 }
 
 fn ppc_set_rect_rgn(
@@ -78382,10 +79135,14 @@ fn ppc_open_poly(
 }
 
 fn ppc_record_polygon_point(
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
-    heap_limit: u32,
-    handles: &mut [PpcHandleRecord],
+    last_mem_error: &mut i16,
+    handles: &mut Vec<PpcHandleRecord>,
+    free_ptr_blocks: &mut Vec<PpcPtrRecord>,
+    free_handle_blocks: &mut Vec<PpcHandleRecord>,
+    handle_states: &mut Vec<PpcHandleStateRecord>,
     handle: u32,
     h: i16,
     v: i16,
@@ -78408,7 +79165,18 @@ fn ppc_record_polygon_point(
     let Some(new_size) = size.checked_add(4) else {
         return PPC_MEM_FULL_ERR;
     };
-    let result = ppc_set_handle_size(memory, heap_cursor, heap_limit, handles, handle, new_size);
+    let result = process_memory_manager.set_native_handle_size(memory, handle, new_size);
+    ppc_apply_process_native_resource_handle(
+        process_memory_manager,
+        memory,
+        heap_cursor,
+        last_mem_error,
+        free_ptr_blocks,
+        free_handle_blocks,
+        handles,
+        handle_states,
+        handle,
+    );
     if result != PPC_NO_ERR {
         return result;
     }
@@ -84196,6 +84964,36 @@ fn ppc_allocator_view_resize_handle(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
+fn ppc_allocator_view_dispose_handle(
+    allocator: Option<&mut PpcProcessAllocatorView<'_>>,
+    memory: &mut PpcSectionMem,
+    heap_cursor: &mut u32,
+    heap_limit: u32,
+    last_mem_error: &mut i16,
+    handles: &mut Vec<PpcHandleRecord>,
+    legacy_handle_states: Option<&mut Vec<PpcHandleStateRecord>>,
+    handle: u32,
+) -> bool {
+    if let Some(allocator) = allocator {
+        allocator.dispose_handle(
+            memory,
+            heap_cursor,
+            heap_limit,
+            last_mem_error,
+            handles,
+            handle,
+        )
+    } else {
+        ppc_dispose_tracked_handle(
+            handle,
+            memory,
+            handles,
+            legacy_handle_states.expect("legacy handle disposal requires handle state"),
+        )
+    }
+}
+
 fn ppc_heap_allocation_bounds(
     memory: &PpcSectionMem,
     heap_cursor: u32,
@@ -84277,6 +85075,43 @@ fn ppc_update_zone_free_bytes(memory: &mut PpcSectionMem, heap_cursor: u32, heap
     let _ = memory.write_u32_be(PPC_SYSTEM_ZONE + 12, free_bytes);
 }
 
+#[allow(clippy::too_many_arguments)]
+fn ppc_allocator_view_replace_handle_bytes(
+    allocator: Option<&mut PpcProcessAllocatorView<'_>>,
+    memory: &mut PpcSectionMem,
+    heap_cursor: &mut u32,
+    heap_limit: u32,
+    last_mem_error: &mut i16,
+    handles: &mut Vec<PpcHandleRecord>,
+    handle: u32,
+    bytes: &[u8],
+) -> i16 {
+    let Ok(size) = u32::try_from(bytes.len()) else {
+        return PPC_MEM_FULL_ERR;
+    };
+    let result = ppc_allocator_view_resize_handle(
+        allocator,
+        memory,
+        heap_cursor,
+        heap_limit,
+        last_mem_error,
+        handles,
+        handle,
+        size,
+    );
+    if result != PPC_NO_ERR {
+        return result;
+    }
+    let Some(ptr) = memory.read_u32_be(handle).filter(|ptr| *ptr != 0) else {
+        return PPC_NIL_HANDLE_ERR;
+    };
+    if memory.write_bytes(ptr, bytes).is_none() {
+        return PPC_PARAM_ERR;
+    }
+    PPC_NO_ERR
+}
+
+#[cfg(test)]
 fn ppc_alloc_ptr(
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
@@ -84318,18 +85153,6 @@ fn ppc_alloc_ptr(
     // returns a nonrelocatable block to the application heap for later use.
     ptrs.push(PpcPtrRecord { ptr, size });
     ptr
-}
-
-fn ppc_release_ptr(
-    ptrs: &mut Vec<PpcPtrRecord>,
-    free_ptr_blocks: &mut Vec<PpcPtrRecord>,
-    ptr: u32,
-) -> bool {
-    let Some(index) = ptrs.iter().position(|record| record.ptr == ptr) else {
-        return false;
-    };
-    free_ptr_blocks.push(ptrs.remove(index));
-    true
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -87898,6 +88721,7 @@ pub(crate) mod tests {
         let final_pc = 0x1234_5678;
         let action = ppc_dispatch_native_menu_definition(
             &mut loaded.cpu,
+            None,
             &mut loaded.memory,
             test_heap_cursor!(loaded),
             test_heap_limit!(loaded),
@@ -90487,7 +91311,7 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn stale_native_handle_snapshot_preserves_process_owned_state() {
+    fn detached_native_handle_state_remains_independent() {
         let handle = PPC_HEAP_BASE + 0x20;
         let record = ProcessHandleRecord {
             handle,
@@ -90503,11 +91327,13 @@ pub(crate) mod tests {
             resource: false,
         };
         let mut memory_manager = ProcessMemoryManager::default();
-        ppc_synchronize_process_native_handles(&mut memory_manager, &[record], &[stale_state]);
+        memory_manager.register_native_handle_records([(
+            record,
+            ppc_process_handle_state_bits(&[stale_state], handle),
+        )]);
         let detached = memory_manager.detached_clone();
 
         memory_manager.lock_process_handle(handle, true);
-        ppc_synchronize_process_native_handles(&mut memory_manager, &[record], &[stale_state]);
 
         let state = memory_manager.native_handle_state(handle);
         assert!(state.locked);
@@ -90925,28 +91751,7 @@ pub(crate) mod tests {
             menu_tracking,
             memory_manager,
             |native, memory_manager| {
-                let allocator = memory_manager.native_allocator_snapshot().unwrap();
-                let mut heap_cursor = allocator.heap.heap_cursor;
-                let mut ptrs = allocator.ptrs;
-                let mut free_ptr_blocks = allocator.free_ptr_blocks;
-                let prior_ptr = ppc_alloc_ptr(
-                    &mut native.memory,
-                    &mut heap_cursor,
-                    allocator.heap.heap_limit,
-                    &mut ptrs,
-                    &mut free_ptr_blocks,
-                    24,
-                    false,
-                );
-                ppc_synchronize_process_native_allocator(
-                    memory_manager,
-                    heap_cursor,
-                    allocator.heap.heap_limit,
-                    allocator.heap.last_mem_error,
-                    &ptrs,
-                    &free_ptr_blocks,
-                    &allocator.free_handle_blocks,
-                );
+                let prior_ptr = memory_manager.new_native_ptr(&mut native.memory, 24, false);
                 assert_eq!(prior_ptr, PPC_HEAP_BASE);
                 let probe =
                     native.run_with_process_memory_manager(64, false, false, memory_manager);
@@ -91089,28 +91894,7 @@ pub(crate) mod tests {
                     .write_bytes(original.ptr, b"process-owned")
                     .unwrap();
 
-                let allocator = memory_manager.native_allocator_snapshot().unwrap();
-                let mut heap_cursor = allocator.heap.heap_cursor;
-                let mut ptrs = allocator.ptrs;
-                let mut free_ptr_blocks = allocator.free_ptr_blocks;
-                let blocking_ptr = ppc_alloc_ptr(
-                    &mut native.memory,
-                    &mut heap_cursor,
-                    allocator.heap.heap_limit,
-                    &mut ptrs,
-                    &mut free_ptr_blocks,
-                    16,
-                    false,
-                );
-                ppc_synchronize_process_native_allocator(
-                    memory_manager,
-                    heap_cursor,
-                    allocator.heap.heap_limit,
-                    allocator.heap.last_mem_error,
-                    &ptrs,
-                    &free_ptr_blocks,
-                    &allocator.free_handle_blocks,
-                );
+                let blocking_ptr = memory_manager.new_native_ptr(&mut native.memory, 16, false);
                 assert_ne!(blocking_ptr, 0);
                 native.cpu.pc = native.entry_pc;
                 native.cpu.lr = PPC_HALT_PC;
@@ -91273,10 +92057,13 @@ pub(crate) mod tests {
                     handle: 0,
                 }];
                 let mut last_resource_error = PPC_NO_ERR;
-                let legacy_ptr =
-                    ppc_heap_alloc(&mut native.memory, &mut heap_cursor, heap_limit, 32, true);
-                assert_ne!(legacy_ptr, 0);
-                let cursor_after_legacy_allocation = heap_cursor;
+                let canonical_ptr =
+                    memory_manager.new_native_ptr(&mut native.memory, 32, true);
+                assert_ne!(canonical_ptr, 0);
+                let cursor_after_canonical_allocation = memory_manager
+                    .native_heap_state()
+                    .unwrap()
+                    .heap_cursor;
 
                 let handle = ppc_materialize_vfs_resource_handle(
                     memory_manager,
@@ -91294,7 +92081,7 @@ pub(crate) mod tests {
                     &mut last_resource_error,
                 );
                 assert_ne!(handle, 0);
-                assert!(handle >= cursor_after_legacy_allocation);
+                assert!(handle >= cursor_after_canonical_allocation);
                 assert_eq!(memory_manager.native_allocation(handle).unwrap().ptr, 0);
                 assert_eq!(memory_manager.state_for_handle(handle), Some(0x60));
                 assert_eq!(classic_dispatcher.handle_state_bits(handle), Some(0x60));
@@ -138179,9 +138966,11 @@ pub(crate) mod tests {
         .unwrap();
         assert_eq!(
             ppc_write_region_storage(
+                None,
                 &mut loaded.memory,
                 test_heap_cursor!(loaded),
                 test_heap_limit!(loaded),
+                &mut last_mem_error,
                 test_handles!(loaded),
                 mask_rgn,
                 &mask_storage,
@@ -150307,13 +151096,14 @@ pub(crate) mod tests {
 
         let mut handle_states = loaded.handle_states();
         ppc_open_rgn(
+            None,
             &mut loaded.memory,
             PPC_MAIN_GWORLD,
             test_heap_cursor!(loaded),
             test_heap_limit!(loaded),
             &mut last_mem_error,
             test_handles!(loaded),
-            &mut handle_states,
+            Some(&mut handle_states),
             &mut loaded.toolbox_startup,
         );
         loaded.replace_handle_states(handle_states);
@@ -150336,13 +151126,14 @@ pub(crate) mod tests {
 
         let mut handle_states = loaded.handle_states();
         ppc_close_rgn(
+            None,
             &mut loaded.memory,
             destination,
             test_heap_cursor!(loaded),
             test_heap_limit!(loaded),
             &mut last_mem_error,
             test_handles!(loaded),
-            &mut handle_states,
+            Some(&mut handle_states),
             &mut loaded.toolbox_startup,
         );
         loaded.replace_handle_states(handle_states);
@@ -150386,13 +151177,14 @@ pub(crate) mod tests {
         );
         let mut handle_states = loaded.handle_states();
         ppc_open_rgn(
+            None,
             &mut loaded.memory,
             PPC_MAIN_GWORLD,
             test_heap_cursor!(loaded),
             test_heap_limit!(loaded),
             &mut last_mem_error,
             test_handles!(loaded),
-            &mut handle_states,
+            Some(&mut handle_states),
             &mut loaded.toolbox_startup,
         );
         loaded.replace_handle_states(handle_states);
@@ -150400,13 +151192,14 @@ pub(crate) mod tests {
         loaded.run_with_hle_imports(64);
         let mut handle_states = loaded.handle_states();
         ppc_close_rgn(
+            None,
             &mut loaded.memory,
             oval,
             test_heap_cursor!(loaded),
             test_heap_limit!(loaded),
             &mut last_mem_error,
             test_handles!(loaded),
-            &mut handle_states,
+            Some(&mut handle_states),
             &mut loaded.toolbox_startup,
         );
         loaded.replace_handle_states(handle_states);
@@ -150430,13 +151223,14 @@ pub(crate) mod tests {
         );
         let mut handle_states = loaded.handle_states();
         ppc_open_rgn(
+            None,
             &mut loaded.memory,
             PPC_MAIN_GWORLD,
             test_heap_cursor!(loaded),
             test_heap_limit!(loaded),
             &mut last_mem_error,
             test_handles!(loaded),
-            &mut handle_states,
+            Some(&mut handle_states),
             &mut loaded.toolbox_startup,
         );
         loaded.replace_handle_states(handle_states);
@@ -150449,13 +151243,14 @@ pub(crate) mod tests {
         loaded.run_with_hle_imports(64);
         let mut handle_states = loaded.handle_states();
         ppc_close_rgn(
+            None,
             &mut loaded.memory,
             rounded,
             test_heap_cursor!(loaded),
             test_heap_limit!(loaded),
             &mut last_mem_error,
             test_handles!(loaded),
-            &mut handle_states,
+            Some(&mut handle_states),
             &mut loaded.toolbox_startup,
         );
         loaded.replace_handle_states(handle_states);

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -739,10 +739,7 @@ impl ProcessNativeMemoryManager {
     ///
     /// `NewEmptyHandle` returns a handle containing `NIL`. Inside Macintosh:
     /// Memory (1992), pp. 2-33--2-34.
-    pub(crate) fn new_empty_classic_handle(
-        &mut self,
-        bus: &mut MacMemoryBus,
-    ) -> Result<u32, i16> {
+    pub(crate) fn new_empty_classic_handle(&mut self, bus: &mut MacMemoryBus) -> Result<u32, i16> {
         self.assert_classic_memory_bus_attached(bus);
         let handle = bus.alloc(4);
         if handle == 0 {
@@ -851,9 +848,10 @@ impl ProcessNativeMemoryManager {
         if ptr == 0 {
             return Self::NIL_HANDLE_ERR;
         }
-        let native_index = self.native_allocator.as_ref().and_then(|allocator| {
-            allocator.ptrs.iter().position(|record| record.ptr == ptr)
-        });
+        let native_index = self
+            .native_allocator
+            .as_ref()
+            .and_then(|allocator| allocator.ptrs.iter().position(|record| record.ptr == ptr));
         let old_size = native_index
             .and_then(|index| {
                 self.native_allocator
@@ -887,11 +885,7 @@ impl ProcessNativeMemoryManager {
 
     /// Return the logical size of a native or classic relocatable block.
     /// Inside Macintosh: Memory (1992), pp. 2-39--2-40.
-    pub(crate) fn process_handle_size(
-        &self,
-        bus: &MacMemoryBus,
-        handle: u32,
-    ) -> Option<u32> {
+    pub(crate) fn process_handle_size(&self, bus: &MacMemoryBus, handle: u32) -> Option<u32> {
         self.assert_classic_memory_bus_attached(bus);
         self.native_allocations
             .iter()
@@ -1422,8 +1416,7 @@ impl ProcessNativeMemoryManager {
 
     fn native_allocation_size(size: u32) -> Option<u32> {
         Some(
-            size.checked_add(Self::NATIVE_HEAP_ALIGNMENT - 1)?
-                & !(Self::NATIVE_HEAP_ALIGNMENT - 1),
+            size.checked_add(Self::NATIVE_HEAP_ALIGNMENT - 1)? & !(Self::NATIVE_HEAP_ALIGNMENT - 1),
         )
         .map(|size| size.max(Self::NATIVE_HEAP_ALIGNMENT))
     }
@@ -1434,8 +1427,7 @@ impl ProcessNativeMemoryManager {
         aligned_size: u32,
         mut readonly_overlap_end: impl FnMut(u32, u32) -> Option<u32>,
     ) -> Option<(u32, u32)> {
-        let mut ptr = heap_cursor
-            .checked_add(Self::NATIVE_HEAP_ALIGNMENT - 1)?
+        let mut ptr = heap_cursor.checked_add(Self::NATIVE_HEAP_ALIGNMENT - 1)?
             & !(Self::NATIVE_HEAP_ALIGNMENT - 1);
         loop {
             let next = ptr.checked_add(aligned_size)?;
@@ -1445,8 +1437,7 @@ impl ProcessNativeMemoryManager {
             let Some(reserved_end) = readonly_overlap_end(ptr, aligned_size) else {
                 return Some((ptr, next));
             };
-            ptr = reserved_end
-                .checked_add(Self::NATIVE_HEAP_ALIGNMENT - 1)?
+            ptr = reserved_end.checked_add(Self::NATIVE_HEAP_ALIGNMENT - 1)?
                 & !(Self::NATIVE_HEAP_ALIGNMENT - 1);
         }
     }
@@ -1491,8 +1482,8 @@ impl ProcessNativeMemoryManager {
         required: u32,
         clear: bool,
     ) -> bool {
-        let fully_mapped = (0..required)
-            .all(|offset| PpcMemory::read_u8(memory, ptr + offset).is_some());
+        let fully_mapped =
+            (0..required).all(|offset| PpcMemory::read_u8(memory, ptr + offset).is_some());
         if !fully_mapped {
             let Ok(required) = usize::try_from(required) else {
                 return false;
@@ -1500,9 +1491,7 @@ impl ProcessNativeMemoryManager {
             memory.add_region(ptr, vec![0; required]);
             return true;
         }
-        !clear
-            || (0..required)
-                .all(|offset| PpcMemory::write_u8(memory, ptr + offset, 0).is_some())
+        !clear || (0..required).all(|offset| PpcMemory::write_u8(memory, ptr + offset, 0).is_some())
     }
 
     /// Reserve process-owned native heap bytes for Toolbox records that are
@@ -1537,6 +1526,36 @@ impl ProcessNativeMemoryManager {
         allocator.heap.heap_cursor = next;
         self.native_allocator_dirty = true;
         ptr
+    }
+
+    /// Borrow unmapped tail space for a non-reentrant native import scratch buffer.
+    ///
+    /// The cursor is intentionally unchanged: the caller must consume the
+    /// bytes before another process allocation occurs and must not publish the
+    /// address to guest code.
+    pub(crate) fn native_scratch_bytes(
+        &mut self,
+        memory: &mut GuestAddressSpace,
+        size: u32,
+        clear: bool,
+    ) -> u32 {
+        let Some(required) = Self::native_allocation_size(size) else {
+            return 0;
+        };
+        let Some(heap) = self.native_heap_state() else {
+            return 0;
+        };
+        let Some((ptr, _)) = Self::native_allocation_bounds(
+            heap.heap_cursor,
+            heap.heap_limit,
+            required,
+            |ptr, len| memory.readonly_allocation_overlap_end(ptr, len),
+        ) else {
+            return 0;
+        };
+        Self::prepare_native_allocation(memory, ptr, required, clear)
+            .then_some(ptr)
+            .unwrap_or(0)
     }
 
     /// Commit a validated CFM mapping layout to the process-owned native heap.
@@ -1856,9 +1875,7 @@ impl ProcessNativeMemoryManager {
             };
             memory.add_region(old_end, vec![0; growth]);
         }
-        if (old_end..new_end)
-            .any(|address| PpcMemory::write_u8(memory, address, 0).is_none())
-        {
+        if (old_end..new_end).any(|address| PpcMemory::write_u8(memory, address, 0).is_none()) {
             self.set_native_mem_error(Self::PARAM_ERR);
             return Self::PARAM_ERR;
         }
@@ -1996,8 +2013,7 @@ impl ProcessNativeMemoryManager {
             record.handle,
             Self::native_allocation_size(4).expect("four-byte master pointer fits"),
             true,
-        )
-            || !Self::prepare_native_allocation(memory, record.ptr, required, clear)
+        ) || !Self::prepare_native_allocation(memory, record.ptr, required, clear)
             || PpcMemory::write_u32_be(memory, record.handle, record.ptr).is_none()
         {
             self.set_native_mem_error(Self::MEM_FULL_ERR);
@@ -2350,8 +2366,7 @@ impl ProcessNativeMemoryManager {
             || bytes.iter().copied().enumerate().any(|(offset, byte)| {
                 PpcMemory::write_u8(memory, new_ptr + offset as u32, byte).is_none()
             })
-            || (new_ptr != record.ptr
-                && PpcMemory::write_u32_be(memory, handle, new_ptr).is_none())
+            || (new_ptr != record.ptr && PpcMemory::write_u32_be(memory, handle, new_ptr).is_none())
         {
             self.set_native_mem_error(Self::PARAM_ERR);
             return Self::PARAM_ERR;
@@ -2647,13 +2662,15 @@ impl ProcessNativeMemoryManager {
         {
             return;
         }
-        self.ptr_to_handle.extend(source.ptr_to_handle.take_entries());
+        self.ptr_to_handle
+            .extend(source.ptr_to_handle.take_entries());
         self.handle_state_bits
             .extend(source.handle_state_bits.take_entries());
         self.handle_high_locked
             .extend(source.handle_high_locked.take_entries());
         if self.native_allocations.is_empty() {
-            self.native_allocations.append(&mut source.native_allocations);
+            self.native_allocations
+                .append(&mut source.native_allocations);
             self.native_handle_ptrs
                 .extend(source.native_handle_ptrs.drain());
             self.native_handles.extend(source.native_handles.drain());
@@ -2689,7 +2706,9 @@ impl ProcessContext {
     }
 
     pub(crate) fn attach_classic_memory_bus(&mut self, bus: &mut MacMemoryBus) {
-        self.memory_manager.borrow_mut().attach_classic_memory_bus(bus);
+        self.memory_manager
+            .borrow_mut()
+            .attach_classic_memory_bus(bus);
     }
 
     #[cfg(test)]
@@ -2697,10 +2716,7 @@ impl ProcessContext {
         self.memory_manager.borrow().handle_for_ptr(ptr)
     }
 
-    pub(crate) fn attach_memory_manager(
-        &self,
-        adapter: &mut Option<SharedProcessMemoryManager>,
-    ) {
+    pub(crate) fn attach_memory_manager(&self, adapter: &mut Option<SharedProcessMemoryManager>) {
         if let Some(attached) = adapter {
             assert!(
                 attached.ptr_eq(&self.memory_manager),
@@ -2871,7 +2887,9 @@ mod tests {
         let mut primary = MacMemoryBus::new(8 * 1024 * 1024);
         context.attach_classic_memory_bus(&mut primary);
 
-        let ptr = context.memory_manager_mut().new_classic_ptr(&mut primary, 37);
+        let ptr = context
+            .memory_manager_mut()
+            .new_classic_ptr(&mut primary, 37);
         assert_ne!(ptr, 0);
         assert_eq!(
             context.memory_manager.borrow().classic_allocation_size(ptr),
@@ -2926,10 +2944,7 @@ mod tests {
 
         context.attach_memory(0, low, &mut native);
         context.attach_memory(0x3000, high, &mut native);
-        assert_eq!(
-            context.memory_ranges(),
-            vec![(0, 0x1000), (0x3000, 0x1000)]
-        );
+        assert_eq!(context.memory_ranges(), vec![(0, 0x1000), (0x3000, 0x1000)]);
 
         let mut detached = native.clone();
         native.write_u32_be(0x100, 0x99aa_bbcc).unwrap();
@@ -3816,11 +3831,7 @@ mod tests {
         let blocking_ptr = manager.new_native_ptr(&mut native, 16, false);
         assert_ne!(blocking_ptr, 0);
         assert_eq!(
-            manager.append_bytes_to_native_handle(
-                &mut native,
-                handle,
-                b" process memory manager",
-            ),
+            manager.append_bytes_to_native_handle(&mut native, handle, b" process memory manager",),
             ProcessMemoryManager::NO_ERR
         );
 
@@ -3832,10 +3843,7 @@ mod tests {
             b"native process memory manager"
         );
         bus.write_byte(appended.ptr + appended.size - 1, b'!');
-        assert_eq!(
-            native.read_u8(appended.ptr + appended.size - 1),
-            Some(b'!')
-        );
+        assert_eq!(native.read_u8(appended.ptr + appended.size - 1), Some(b'!'));
     }
 
     #[test]
@@ -3875,9 +3883,15 @@ mod tests {
         );
         let loaded = manager.native_allocation(unloaded).unwrap();
         assert_eq!(loaded.ptr, recycled_ptr);
-        assert_eq!(manager.native_heap_state().unwrap().heap_cursor, cursor_before_load);
+        assert_eq!(
+            manager.native_heap_state().unwrap().heap_cursor,
+            cursor_before_load
+        );
         assert_eq!(manager.recover_handle(loaded.ptr), Some(unloaded));
-        assert_eq!(bus.read_bytes(loaded.ptr, loaded.size as usize), b"resource");
+        assert_eq!(
+            bus.read_bytes(loaded.ptr, loaded.size as usize),
+            b"resource"
+        );
         assert_eq!(manager.state_for_handle(unloaded), Some(0x60));
 
         let second = manager.new_native_resource_handle(&mut native, Some(b"second"));

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -245,6 +245,13 @@ impl<V: Copy> SharedProcessMap<V> {
 #[derive(Debug, Default)]
 pub(crate) struct ProcessMemoryManager {
     classic_allocator: Option<SharedClassicHeapAllocator>,
+    native: ProcessNativeMemoryManager,
+}
+
+/// Canonical architecture-neutral allocation state used directly by native
+/// imports and by the classic Memory Manager bridge.
+#[derive(Debug, Default)]
+pub(crate) struct ProcessNativeMemoryManager {
     ptr_to_handle: SharedProcessMap<u32>,
     handle_state_bits: SharedProcessMap<u8>,
     handle_high_locked: SharedProcessMap<bool>,
@@ -253,6 +260,20 @@ pub(crate) struct ProcessMemoryManager {
     native_allocations: Vec<ProcessHandleRecord>,
     native_allocator: Option<ProcessNativeAllocatorState>,
     native_allocator_dirty: bool,
+}
+
+impl std::ops::Deref for ProcessMemoryManager {
+    type Target = ProcessNativeMemoryManager;
+
+    fn deref(&self) -> &Self::Target {
+        &self.native
+    }
+}
+
+impl std::ops::DerefMut for ProcessMemoryManager {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.native
+    }
 }
 
 /// Shared ownership handle for one process's architecture-neutral Memory Manager.
@@ -278,6 +299,104 @@ pub(crate) struct SharedProcessMemoryManager {
 impl Default for SharedProcessMemoryManager {
     fn default() -> Self {
         Self::from_manager(ProcessMemoryManager::default())
+    }
+}
+
+impl ProcessNativeMemoryManager {
+    const NATIVE_HEAP_ALIGNMENT: u32 = 16;
+    const MEM_FULL_ERR: i16 = -108;
+    const NIL_HANDLE_ERR: i16 = -109;
+    const MEM_WZ_ERR: i16 = -111;
+    const MEM_PUR_ERR: i16 = -112;
+    const NO_ERR: i16 = 0;
+    const PARAM_ERR: i16 = -50;
+
+    fn detached_clone(&self) -> Self {
+        Self {
+            ptr_to_handle: self.ptr_to_handle.detached_clone(),
+            handle_state_bits: self.handle_state_bits.detached_clone(),
+            handle_high_locked: self.handle_high_locked.detached_clone(),
+            native_handle_ptrs: self.native_handle_ptrs.clone(),
+            native_handles: self.native_handles.clone(),
+            native_allocations: self.native_allocations.clone(),
+            native_allocator: self.native_allocator.clone(),
+            native_allocator_dirty: self.native_allocator_dirty,
+        }
+    }
+
+    fn restore_snapshot(&mut self, snapshot: Self) {
+        self.ptr_to_handle.replace_from(&snapshot.ptr_to_handle);
+        self.handle_state_bits
+            .replace_from(&snapshot.handle_state_bits);
+        self.handle_high_locked
+            .replace_from(&snapshot.handle_high_locked);
+        self.native_handle_ptrs = snapshot.native_handle_ptrs;
+        self.native_handles = snapshot.native_handles;
+        self.native_allocations = snapshot.native_allocations;
+        self.native_allocator = snapshot.native_allocator;
+        self.native_allocator_dirty = snapshot.native_allocator_dirty;
+    }
+
+    fn commit_dispose_native_handle(&mut self, index: usize, record: ProcessHandleRecord) {
+        self.native_allocations.remove(index);
+        if record.ptr != 0 {
+            self.ptr_to_handle.remove(&record.ptr);
+            self.native_handle_ptrs.remove(&record.ptr);
+        }
+        self.handle_state_bits.remove(&record.handle);
+        self.handle_high_locked.remove(&record.handle);
+        self.native_handles.remove(&record.handle);
+        if let Some(allocator) = &mut self.native_allocator {
+            allocator.free_handle_blocks.push(record);
+            allocator.heap.last_mem_error = Self::NO_ERR;
+            self.native_allocator_dirty = true;
+        }
+    }
+
+    fn commit_empty_native_handle(&mut self, record: ProcessHandleRecord) {
+        if record.ptr != 0 {
+            self.ptr_to_handle.remove(&record.ptr);
+            self.native_handle_ptrs.remove(&record.ptr);
+        }
+        self.set_native_allocation_record(ProcessHandleRecord {
+            handle: record.handle,
+            ptr: 0,
+            size: 0,
+            capacity: 0,
+        });
+        if let Some(allocator) = &mut self.native_allocator {
+            if record.ptr != 0 {
+                allocator.free_ptr_blocks.push(ProcessPtrRecord {
+                    ptr: record.ptr,
+                    size: record.capacity,
+                });
+            }
+            allocator.heap.last_mem_error = Self::NO_ERR;
+            self.native_allocator_dirty = true;
+        }
+    }
+
+    pub(crate) fn empty_native_handle(
+        &mut self,
+        memory: &mut GuestAddressSpace,
+        handle: u32,
+    ) -> i16 {
+        let Some(record) = self.native_allocation(handle) else {
+            self.set_native_mem_error(Self::NIL_HANDLE_ERR);
+            return Self::NIL_HANDLE_ERR;
+        };
+        if self.state_for_handle(handle).unwrap_or(0) & 0x80 != 0 {
+            self.set_native_mem_error(Self::MEM_PUR_ERR);
+            return Self::MEM_PUR_ERR;
+        }
+        if PpcMemory::read_u32_be(memory, handle) != Some(record.ptr)
+            || PpcMemory::write_u32_be(memory, handle, 0).is_none()
+        {
+            self.set_native_mem_error(Self::NIL_HANDLE_ERR);
+            return Self::NIL_HANDLE_ERR;
+        }
+        self.commit_empty_native_handle(record);
+        Self::NO_ERR
     }
 }
 
@@ -372,7 +491,6 @@ impl SharedProcessMemoryManager {
 }
 
 impl ProcessMemoryManager {
-    const NATIVE_HEAP_ALIGNMENT: u32 = 16;
     const MEM_FULL_ERR: i16 = -108;
     const NIL_HANDLE_ERR: i16 = -109;
     const MEM_WZ_ERR: i16 = -111;
@@ -383,34 +501,22 @@ impl ProcessMemoryManager {
     pub(crate) fn detached_clone(&self) -> Self {
         Self {
             classic_allocator: None,
-            ptr_to_handle: self.ptr_to_handle.detached_clone(),
-            handle_state_bits: self.handle_state_bits.detached_clone(),
-            handle_high_locked: self.handle_high_locked.detached_clone(),
-            native_handle_ptrs: self.native_handle_ptrs.clone(),
-            native_handles: self.native_handles.clone(),
-            native_allocations: self.native_allocations.clone(),
-            native_allocator: self.native_allocator.clone(),
-            native_allocator_dirty: self.native_allocator_dirty,
+            native: self.native.detached_clone(),
         }
     }
 
     /// Restore native Memory Manager metadata from an isolated transaction
     /// snapshot while preserving the shared indexes held by CPU adapters.
     pub(crate) fn restore_native_snapshot(&mut self, snapshot: Self) {
-        self.ptr_to_handle.replace_from(&snapshot.ptr_to_handle);
-        self.handle_state_bits
-            .replace_from(&snapshot.handle_state_bits);
-        self.handle_high_locked
-            .replace_from(&snapshot.handle_high_locked);
-        self.native_handle_ptrs = snapshot.native_handle_ptrs;
-        self.native_handles = snapshot.native_handles;
-        self.native_allocations = snapshot.native_allocations;
-        self.native_allocator = snapshot.native_allocator;
-        self.native_allocator_dirty = snapshot.native_allocator_dirty;
+        self.native.restore_snapshot(snapshot.native);
     }
 
     pub(crate) fn has_native_allocator(&self) -> bool {
         self.native_allocator.is_some()
+    }
+
+    pub(crate) fn native_mut(&mut self) -> &mut ProcessNativeMemoryManager {
+        &mut self.native
     }
 
     /// Adopt the classic heap used by the process's 68K memory-bus adapter.
@@ -1024,7 +1130,7 @@ impl ProcessMemoryManager {
         }
 
         let relocated = if let Some(record) = native_record {
-            let Some(required) = Self::native_allocation_size(size) else {
+            let Some(required) = ProcessNativeMemoryManager::native_allocation_size(size) else {
                 self.set_native_mem_error(Self::MEM_FULL_ERR);
                 return Err(Self::MEM_FULL_ERR);
             };
@@ -1034,11 +1140,11 @@ impl ProcessMemoryManager {
             };
             let reusable = allocator.free_ptr_blocks.iter().any(|free| {
                 free.ptr != record.ptr
-                    && Self::native_allocation_size(free.size)
+                    && ProcessNativeMemoryManager::native_allocation_size(free.size)
                         .is_some_and(|capacity| capacity >= required)
             });
             if !reusable
-                && Self::native_allocation_bounds(
+                && ProcessNativeMemoryManager::native_allocation_bounds(
                     allocator.heap.heap_cursor,
                     allocator.heap.heap_limit,
                     required,
@@ -1082,57 +1188,6 @@ impl ProcessMemoryManager {
         Ok(relocated)
     }
 
-    fn commit_empty_native_handle(&mut self, record: ProcessHandleRecord) {
-        if record.ptr != 0 {
-            self.ptr_to_handle.remove(&record.ptr);
-            self.native_handle_ptrs.remove(&record.ptr);
-        }
-        self.set_native_allocation_record(ProcessHandleRecord {
-            handle: record.handle,
-            ptr: 0,
-            size: 0,
-            capacity: 0,
-        });
-        if let Some(allocator) = &mut self.native_allocator {
-            if record.ptr != 0 {
-                allocator.free_ptr_blocks.push(ProcessPtrRecord {
-                    ptr: record.ptr,
-                    size: record.capacity,
-                });
-            }
-            allocator.heap.last_mem_error = Self::NO_ERR;
-            self.native_allocator_dirty = true;
-        }
-    }
-
-    /// Release a native relocatable block while retaining its master pointer.
-    ///
-    /// The handle becomes empty and may later be repopulated by
-    /// `ReallocateHandle`. A locked block is preserved and reports
-    /// `memPurErr`. Inside Macintosh: Memory (1992), pp. 2-51--2-52.
-    pub(crate) fn empty_native_handle(
-        &mut self,
-        memory: &mut GuestAddressSpace,
-        handle: u32,
-    ) -> i16 {
-        let Some(record) = self.native_allocation(handle) else {
-            self.set_native_mem_error(Self::NIL_HANDLE_ERR);
-            return Self::NIL_HANDLE_ERR;
-        };
-        if self.state_for_handle(handle).unwrap_or(0) & 0x80 != 0 {
-            self.set_native_mem_error(Self::MEM_PUR_ERR);
-            return Self::MEM_PUR_ERR;
-        }
-        if PpcMemory::read_u32_be(memory, handle) != Some(record.ptr)
-            || PpcMemory::write_u32_be(memory, handle, 0).is_none()
-        {
-            self.set_native_mem_error(Self::NIL_HANDLE_ERR);
-            return Self::NIL_HANDLE_ERR;
-        }
-        self.commit_empty_native_handle(record);
-        Self::NO_ERR
-    }
-
     /// Empty a native or classic relocatable block through the attached 68K bus.
     ///
     /// Allocation ownership and the reverse master-pointer index change as one
@@ -1166,12 +1221,14 @@ impl ProcessMemoryManager {
         let ptr = bus.read_long(handle);
         if ptr != 0 {
             bus.free(ptr);
-            self.ptr_to_handle.remove(&ptr);
+            self.native.ptr_to_handle.remove(&ptr);
         }
         bus.write_long(handle, 0);
         Self::NO_ERR
     }
+}
 
+impl ProcessNativeMemoryManager {
     #[cfg(test)]
     pub(crate) fn register_native_handle_records(
         &mut self,
@@ -1581,7 +1638,7 @@ impl ProcessMemoryManager {
             return 0;
         }
         if memory.write_bytes(replacement, &bytes).is_none() {
-            self.restore_native_snapshot(snapshot);
+            self.restore_snapshot(snapshot);
             self.set_native_mem_error(Self::PARAM_ERR);
             return 0;
         }

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -1505,6 +1505,45 @@ impl ProcessNativeMemoryManager {
                 .all(|offset| PpcMemory::write_u8(memory, ptr + offset, 0).is_some())
     }
 
+    /// Reserve process-owned native heap bytes for Toolbox records that are
+    /// not exposed as caller-disposable pointers.
+    pub(crate) fn reserve_native_bytes(
+        &mut self,
+        memory: &mut GuestAddressSpace,
+        size: u32,
+        clear: bool,
+    ) -> u32 {
+        let Some(required) = Self::native_allocation_size(size) else {
+            self.set_native_mem_error(Self::MEM_FULL_ERR);
+            return 0;
+        };
+        let Some(heap) = self.native_heap_state() else {
+            self.set_native_mem_error(Self::MEM_FULL_ERR);
+            return 0;
+        };
+        let Some((ptr, next)) = Self::native_allocation_bounds(
+            heap.heap_cursor,
+            heap.heap_limit,
+            required,
+            |ptr, len| memory.readonly_allocation_overlap_end(ptr, len),
+        ) else {
+            self.set_native_mem_error(Self::MEM_FULL_ERR);
+            return 0;
+        };
+        if !Self::prepare_native_allocation(memory, ptr, required, clear) {
+            self.set_native_mem_error(Self::MEM_FULL_ERR);
+            return 0;
+        }
+        let allocator = self
+            .native_allocator
+            .as_mut()
+            .expect("native allocator remains registered");
+        allocator.heap.heap_cursor = next;
+        allocator.heap.last_mem_error = Self::NO_ERR;
+        self.native_allocator_dirty = true;
+        ptr
+    }
+
     /// Allocate a native nonrelocatable block in the process heap.
     ///
     /// `NewPtr` reserves fixed storage and `DisposePtr` returns it to the

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -187,7 +187,7 @@ impl<V> Default for SharedProcessMap<V> {
 }
 
 impl<V: Copy> SharedProcessMap<V> {
-    fn detached_clone(&self) -> Self {
+    pub(crate) fn detached_clone(&self) -> Self {
         Self(Rc::new(RefCell::new(self.0.borrow().clone())))
     }
 
@@ -244,7 +244,6 @@ impl<V: Copy> SharedProcessMap<V> {
 /// (1992), pp. 2-12, 2-40--2-41.
 #[derive(Debug, Default)]
 pub(crate) struct ProcessMemoryManager {
-    classic_allocator: Option<SharedClassicHeapAllocator>,
     native: ProcessNativeMemoryManager,
 }
 
@@ -252,6 +251,7 @@ pub(crate) struct ProcessMemoryManager {
 /// imports and by the classic Memory Manager bridge.
 #[derive(Debug, Default)]
 pub(crate) struct ProcessNativeMemoryManager {
+    classic_allocator: Option<SharedClassicHeapAllocator>,
     ptr_to_handle: SharedProcessMap<u32>,
     handle_state_bits: SharedProcessMap<u8>,
     handle_high_locked: SharedProcessMap<bool>,
@@ -311,8 +311,9 @@ impl ProcessNativeMemoryManager {
     const NO_ERR: i16 = 0;
     const PARAM_ERR: i16 = -50;
 
-    fn detached_clone(&self) -> Self {
+    pub(crate) fn detached_clone(&self) -> Self {
         Self {
+            classic_allocator: None,
             ptr_to_handle: self.ptr_to_handle.detached_clone(),
             handle_state_bits: self.handle_state_bits.detached_clone(),
             handle_high_locked: self.handle_high_locked.detached_clone(),
@@ -324,7 +325,7 @@ impl ProcessNativeMemoryManager {
         }
     }
 
-    fn restore_snapshot(&mut self, snapshot: Self) {
+    pub(crate) fn restore_native_snapshot(&mut self, snapshot: Self) {
         self.ptr_to_handle.replace_from(&snapshot.ptr_to_handle);
         self.handle_state_bits
             .replace_from(&snapshot.handle_state_bits);
@@ -335,22 +336,6 @@ impl ProcessNativeMemoryManager {
         self.native_allocations = snapshot.native_allocations;
         self.native_allocator = snapshot.native_allocator;
         self.native_allocator_dirty = snapshot.native_allocator_dirty;
-    }
-
-    fn commit_dispose_native_handle(&mut self, index: usize, record: ProcessHandleRecord) {
-        self.native_allocations.remove(index);
-        if record.ptr != 0 {
-            self.ptr_to_handle.remove(&record.ptr);
-            self.native_handle_ptrs.remove(&record.ptr);
-        }
-        self.handle_state_bits.remove(&record.handle);
-        self.handle_high_locked.remove(&record.handle);
-        self.native_handles.remove(&record.handle);
-        if let Some(allocator) = &mut self.native_allocator {
-            allocator.free_handle_blocks.push(record);
-            allocator.heap.last_mem_error = Self::NO_ERR;
-            self.native_allocator_dirty = true;
-        }
     }
 
     fn commit_empty_native_handle(&mut self, record: ProcessHandleRecord) {
@@ -491,24 +476,21 @@ impl SharedProcessMemoryManager {
 }
 
 impl ProcessMemoryManager {
-    const MEM_FULL_ERR: i16 = -108;
-    const NIL_HANDLE_ERR: i16 = -109;
-    const MEM_WZ_ERR: i16 = -111;
-    const MEM_PUR_ERR: i16 = -112;
-    const NO_ERR: i16 = 0;
-    const PARAM_ERR: i16 = -50;
+    #[cfg(test)]
+    const MEM_FULL_ERR: i16 = ProcessNativeMemoryManager::MEM_FULL_ERR;
+    #[cfg(test)]
+    const NIL_HANDLE_ERR: i16 = ProcessNativeMemoryManager::NIL_HANDLE_ERR;
+    #[cfg(test)]
+    const MEM_PUR_ERR: i16 = ProcessNativeMemoryManager::MEM_PUR_ERR;
+    #[cfg(test)]
+    const NO_ERR: i16 = ProcessNativeMemoryManager::NO_ERR;
+    #[cfg(test)]
+    const PARAM_ERR: i16 = ProcessNativeMemoryManager::PARAM_ERR;
 
     pub(crate) fn detached_clone(&self) -> Self {
         Self {
-            classic_allocator: None,
             native: self.native.detached_clone(),
         }
-    }
-
-    /// Restore native Memory Manager metadata from an isolated transaction
-    /// snapshot while preserving the shared indexes held by CPU adapters.
-    pub(crate) fn restore_native_snapshot(&mut self, snapshot: Self) {
-        self.native.restore_snapshot(snapshot.native);
     }
 
     pub(crate) fn has_native_allocator(&self) -> bool {
@@ -519,6 +501,13 @@ impl ProcessMemoryManager {
         &mut self.native
     }
 
+    #[cfg(test)]
+    pub(crate) fn restore_native_snapshot(&mut self, snapshot: Self) {
+        self.native.restore_native_snapshot(snapshot.native);
+    }
+}
+
+impl ProcessNativeMemoryManager {
     /// Adopt the classic heap used by the process's 68K memory-bus adapter.
     ///
     /// The first attached bus contributes its live launch-time allocator;
@@ -1221,7 +1210,7 @@ impl ProcessMemoryManager {
         let ptr = bus.read_long(handle);
         if ptr != 0 {
             bus.free(ptr);
-            self.native.ptr_to_handle.remove(&ptr);
+            self.ptr_to_handle.remove(&ptr);
         }
         bus.write_long(handle, 0);
         Self::NO_ERR
@@ -1638,7 +1627,7 @@ impl ProcessNativeMemoryManager {
             return 0;
         }
         if memory.write_bytes(replacement, &bytes).is_none() {
-            self.restore_snapshot(snapshot);
+            self.restore_native_snapshot(snapshot);
             self.set_native_mem_error(Self::PARAM_ERR);
             return 0;
         }

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -1514,11 +1514,9 @@ impl ProcessNativeMemoryManager {
         clear: bool,
     ) -> u32 {
         let Some(required) = Self::native_allocation_size(size) else {
-            self.set_native_mem_error(Self::MEM_FULL_ERR);
             return 0;
         };
         let Some(heap) = self.native_heap_state() else {
-            self.set_native_mem_error(Self::MEM_FULL_ERR);
             return 0;
         };
         let Some((ptr, next)) = Self::native_allocation_bounds(
@@ -1527,11 +1525,9 @@ impl ProcessNativeMemoryManager {
             required,
             |ptr, len| memory.readonly_allocation_overlap_end(ptr, len),
         ) else {
-            self.set_native_mem_error(Self::MEM_FULL_ERR);
             return 0;
         };
         if !Self::prepare_native_allocation(memory, ptr, required, clear) {
-            self.set_native_mem_error(Self::MEM_FULL_ERR);
             return 0;
         }
         let allocator = self
@@ -1539,7 +1535,6 @@ impl ProcessNativeMemoryManager {
             .as_mut()
             .expect("native allocator remains registered");
         allocator.heap.heap_cursor = next;
-        allocator.heap.last_mem_error = Self::NO_ERR;
         self.native_allocator_dirty = true;
         ptr
     }

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -1217,38 +1217,14 @@ impl ProcessNativeMemoryManager {
         &mut self,
         handles: impl IntoIterator<Item = (ProcessHandleRecord, u8)>,
     ) {
-        self.replace_native_handle_records(handles, false);
+        self.replace_native_handle_records(handles);
     }
 
-    /// Refresh native allocation records without allowing an adapter snapshot
-    /// to replace canonical state changed by another CPU during the same run.
-    pub(crate) fn refresh_native_handle_records(
-        &mut self,
-        handles: impl IntoIterator<Item = (ProcessHandleRecord, u8)>,
-    ) {
-        self.replace_native_handle_records(handles, true);
-    }
-
+    #[cfg(test)]
     fn replace_native_handle_records(
         &mut self,
         handles: impl IntoIterator<Item = (ProcessHandleRecord, u8)>,
-        retain_process_state: bool,
     ) {
-        let mut retained_states = HashMap::new();
-        let mut retained_high_locks = HashSet::new();
-        if retain_process_state {
-            retained_states.extend(self.native_handles.iter().filter_map(|handle| {
-                self.handle_state_bits
-                    .get(handle)
-                    .map(|state| (*handle, state))
-            }));
-            retained_high_locks.extend(
-                self.native_handles
-                    .iter()
-                    .filter(|handle| self.handle_high_locked.get(handle).unwrap_or(false))
-                    .copied(),
-            );
-        }
         for ptr in self.native_handle_ptrs.drain() {
             self.ptr_to_handle.remove(&ptr);
         }
@@ -1260,18 +1236,11 @@ impl ProcessNativeMemoryManager {
         for (record, adapter_state) in handles {
             let ProcessHandleRecord { handle, ptr, .. } = record;
             if handle != 0 {
-                // Existing handles already have canonical process state. A CPU
-                // adapter's end-of-slice snapshot may predate a nested callback,
-                // so only use adapter state when admitting a new native handle.
-                let state = retained_states.remove(&handle).unwrap_or(adapter_state);
                 if ptr != 0 {
                     self.ptr_to_handle.insert(ptr, handle);
                     self.native_handle_ptrs.insert(ptr);
                 }
-                self.handle_state_bits.insert(handle, state);
-                if state & 0x80 != 0 && retained_high_locks.contains(&handle) {
-                    self.handle_high_locked.insert(handle, true);
-                }
+                self.handle_state_bits.insert(handle, adapter_state);
                 self.native_handles.insert(handle);
                 self.native_allocations.push(record);
             }
@@ -2575,37 +2544,6 @@ impl ProcessNativeMemoryManager {
         self.native_allocator_dirty = false;
     }
 
-    pub(crate) fn synchronize_native_allocator(
-        &mut self,
-        heap_cursor: u32,
-        heap_limit: u32,
-        last_mem_error: i16,
-        ptrs: &[ProcessPtrRecord],
-        free_ptr_blocks: &[ProcessPtrRecord],
-        free_handle_blocks: &[ProcessHandleRecord],
-    ) {
-        let Some(heap) = self
-            .native_allocator
-            .as_ref()
-            .map(|allocator| allocator.heap)
-        else {
-            return;
-        };
-        self.publish_native_allocator(
-            ProcessNativeHeapState {
-                heap_base: heap.heap_base,
-                heap_cursor,
-                heap_limit,
-                last_mem_error,
-                heap_maximized: heap.heap_maximized,
-                master_pointer_blocks_requested: heap.master_pointer_blocks_requested,
-            },
-            ptrs,
-            free_ptr_blocks,
-            free_handle_blocks,
-        );
-    }
-
     pub(crate) fn native_allocator_update(&self) -> Option<ProcessNativeAllocatorState> {
         self.native_allocator_dirty
             .then(|| self.native_allocator.clone())
@@ -3095,7 +3033,7 @@ mod tests {
     }
 
     #[test]
-    fn native_allocator_synchronization_preserves_process_heap_operations() {
+    fn native_heap_operations_update_canonical_state_directly() {
         const HEAP_BASE: u32 = 0x0300_0000;
         let mut manager = ProcessMemoryManager::default();
         manager.publish_native_allocator(
@@ -3114,14 +3052,10 @@ mod tests {
 
         manager.maximize_native_heap();
         manager.request_native_master_pointers();
-        manager.synchronize_native_allocator(
-            HEAP_BASE + 0x20,
-            HEAP_BASE + 0x1000,
-            ProcessMemoryManager::PARAM_ERR,
-            &[],
-            &[],
-            &[],
-        );
+        manager.set_native_mem_error(ProcessMemoryManager::PARAM_ERR);
+        let mut memory = GuestAddressSpace::new();
+        memory.add_region(HEAP_BASE, vec![0; 0x1000]);
+        assert_eq!(manager.reserve_native_bytes(&mut memory, 0x20, true), HEAP_BASE);
 
         let heap = manager.native_heap_state().unwrap();
         assert_eq!(heap.heap_cursor, HEAP_BASE + 0x20);

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -1539,6 +1539,23 @@ impl ProcessNativeMemoryManager {
         ptr
     }
 
+    /// Commit a validated CFM mapping layout to the process-owned native heap.
+    ///
+    /// Dynamic PEF sections choose their individual alignment before they are
+    /// installed, so the loader validates the complete sparse layout first and
+    /// advances the canonical cursor only after every section has been mapped.
+    pub(crate) fn commit_native_heap_cursor(&mut self, heap_cursor: u32) -> bool {
+        let Some(allocator) = self.native_allocator.as_mut() else {
+            return false;
+        };
+        if heap_cursor < allocator.heap.heap_cursor || heap_cursor >= allocator.heap.heap_limit {
+            return false;
+        }
+        allocator.heap.heap_cursor = heap_cursor;
+        self.native_allocator_dirty = true;
+        true
+    }
+
     /// Allocate a native nonrelocatable block in the process heap.
     ///
     /// `NewPtr` reserves fixed storage and `DisposePtr` returns it to the


### PR DESCRIPTION
Closes #1076.

Moves native allocation and handle ownership behind the process-level Memory Manager, routes PPC runtime storage through it, and removes deferred and slice-end allocator synchronization. Cross-ISA mutations are immediately visible while PEF mappings retain priority.

Verified with:
- `cargo test --locked --lib` (4,719 passed; 0 failed; 3 ignored)
- strict all-features rustdoc
- Marathon canonical gameplay and audio lane
- Escape Velocity 1.0.5 canonical gameplay lane
- Tomb Raider Gold canonical PowerPC gameplay lane