### PR TITLE
refactor(sound): make the Sound Manager process-owned

### DIFF
--- a/src/bin/systemless.rs
+++ b/src/bin/systemless.rs
@@ -3431,7 +3431,7 @@ mod tests {
 
         runner
             .dispatcher_mut()
-            .sound_manager
+            .sound_manager_mut()
             .pending_sound_callbacks
             .push(PendingSoundCallback::Command {
                 callback_addr,
@@ -3481,7 +3481,7 @@ mod tests {
 
         runner
             .dispatcher_mut()
-            .sound_manager
+            .sound_manager_mut()
             .pending_sound_callbacks
             .push(PendingSoundCallback::Command {
                 callback_addr,
@@ -3753,10 +3753,10 @@ mod tests {
             waiting_for_callback: true,
             pending_callback_buffers: [true, false],
         });
-        runner.dispatcher_mut().sound_manager.channels.push(chan);
+        runner.dispatcher_mut().sound_manager_mut().channels.push(chan);
         runner
             .dispatcher_mut()
-            .sound_manager
+            .sound_manager_mut()
             .pending_callbacks
             .push(PendingDoubleBackCallback {
                 callback_addr,
@@ -3867,7 +3867,7 @@ mod tests {
             1,
             8,
         );
-        runner.dispatcher_mut().sound_manager.channels.push(chan);
+        runner.dispatcher_mut().sound_manager_mut().channels.push(chan);
 
         let mut app = App::new(PathBuf::from("dummy"), false, true, false, 8);
         app.runner = Some(runner);

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -44074,9 +44074,6 @@ fn ppc_snd_dispose_channel(cpu: &mut PpcCpu, sound: &mut PpcSoundState) -> i16 {
     {
         playback.samples.clear();
     }
-    sound
-        .decoded_buffer_commands
-        .retain(|record| record.channel != channel);
     for playback in sound
         .double_buffer_playbacks
         .iter_mut()
@@ -44120,21 +44117,25 @@ fn ppc_snd_play(
         playback.paused = false;
     }
     let summary = decoded.summary;
+    let samples = decoded.samples;
     if ppc_sound_trace_enabled() {
         eprintln!(
             "[PPC-SOUND] SndPlay chan=${channel:08X} handle=${sound_handle:08X} async={} samples={} rate=${:08X}",
             async_play,
-            decoded.samples.len(),
+            samples.len(),
             summary.sample_rate_fixed
         );
     }
+    sound
+        .manager
+        .play_file_buffer(channel, samples.clone(), summary.sample_rate_fixed);
     sound
         .decoded_file_playbacks
         .push(PpcDecodedAiffPlaybackRecord {
             file_playback_index,
             channel,
             sample_rate_fixed: summary.sample_rate_fixed,
-            samples: decoded.samples,
+            samples,
         });
     sound.file_playbacks.push(PpcSoundFilePlaybackRecord {
         channel,
@@ -44339,28 +44340,75 @@ fn ppc_snd_play_double_buffer(
         playback.active = false;
         playback.host_buffer_loaded = false;
     }
-    sound
-        .double_buffer_playbacks
-        .push(PpcSoundDoubleBufferPlaybackRecord {
-            channel,
-            header,
-            buffers: [buffer0, buffer1],
-            callback,
-            sample_rate_fixed,
-            num_channels,
-            sample_size,
-            compression_id,
-            packet_size,
-            current_buffer_index: 0,
-            callback_pending_mask: 0,
-            active: true,
-            host_initialized: false,
-            host_buffer_loaded: false,
-        });
+    let mut playback = PpcSoundDoubleBufferPlaybackRecord {
+        channel,
+        header,
+        buffers: [buffer0, buffer1],
+        callback,
+        sample_rate_fixed,
+        num_channels,
+        sample_size,
+        compression_id,
+        packet_size,
+        current_buffer_index: 0,
+        callback_pending_mask: 0,
+        active: true,
+        host_initialized: false,
+        host_buffer_loaded: false,
+    };
+    if let Some(samples) = ppc_decode_ready_double_buffer(memory, playback) {
+        sound
+            .manager
+            .play_double_buffer_samples(channel, samples, sample_rate_fixed);
+        playback.host_initialized = true;
+        playback.host_buffer_loaded = true;
+    }
+    sound.double_buffer_playbacks.push(playback);
     sound.double_buffer_play_count = sound.double_buffer_play_count.saturating_add(1);
     sound.last_double_buffer_channel = channel;
     sound.last_double_buffer_header = header;
     PPC_NO_ERR
+}
+
+fn ppc_decode_ready_double_buffer(
+    memory: &mut PpcSectionMem,
+    playback: PpcSoundDoubleBufferPlaybackRecord,
+) -> Option<Vec<crate::sound::StereoSample>> {
+    const MAX_RETAINED_SAMPLE_BYTES: usize = 64 * 1024 * 1024;
+
+    if playback.compression_id != 0 {
+        return None;
+    }
+    let buffer_ptr = playback.buffers[usize::from(playback.current_buffer_index & 1)];
+    if buffer_ptr == 0 {
+        return None;
+    }
+    let num_frames = usize::try_from(memory.read_u32_be(buffer_ptr)?).ok()?;
+    let flags = memory.read_u32_be(buffer_ptr.checked_add(4)?)?;
+    if flags & 0x01 == 0 || num_frames == 0 {
+        return None;
+    }
+    let num_channels = usize::from(playback.num_channels);
+    let sample_size = usize::from(playback.sample_size);
+    let bytes_per_sample = match sample_size {
+        8 => 1usize,
+        16 => 2usize,
+        _ => return None,
+    };
+    let byte_count = num_frames
+        .checked_mul(num_channels)?
+        .checked_mul(bytes_per_sample)?;
+    if byte_count > MAX_RETAINED_SAMPLE_BYTES {
+        return None;
+    }
+    let mut raw = vec![0; byte_count];
+    memory.read_bytes_into(buffer_ptr.checked_add(16)?, &mut raw)?;
+    crate::trap::decode_interleaved_stereo_samples(
+        &raw,
+        num_frames,
+        num_channels,
+        sample_size,
+    )
 }
 
 fn ppc_read_snd_command(memory: &mut PpcSectionMem, cmd_ptr: u32) -> Option<PpcSndCommandRecord> {
@@ -44428,6 +44476,11 @@ fn ppc_snd_start_file_play(
         }
     }
     if let (Some(file_playback_index), Some(decoded_sound)) = (file_playback_index, decoded_sound) {
+        sound.manager.play_file_buffer(
+            channel,
+            decoded_sound.samples.clone(),
+            decoded_sound.summary.sample_rate_fixed,
+        );
         sound
             .decoded_file_playbacks
             .push(PpcDecodedAiffPlaybackRecord {
@@ -44770,6 +44823,7 @@ fn ppc_snd_pause_file_play(cpu: &mut PpcCpu, sound: &mut PpcSoundState) -> i16 {
         .find(|record| record.channel == channel && record.active)
     {
         playback.paused = !playback.paused;
+        sound.manager.set_file_paused(channel, playback.paused);
         return PPC_NO_ERR;
     }
     PPC_NO_ERR
@@ -44788,6 +44842,7 @@ fn ppc_snd_stop_file_play(cpu: &mut PpcCpu, sound: &mut PpcSoundState) -> i16 {
         playback.paused = false;
         playback.quiet_now = quiet_now;
     }
+    sound.manager.quiet_channel(channel);
     PPC_NO_ERR
 }
 
@@ -159490,6 +159545,23 @@ pub(crate) mod tests {
             .memory
             .add_region(channel, vec![0xdd; PPC_GUEST_SND_CHANNEL_SIZE as usize]);
         loaded.memory.add_region(header, vec![0; 24]);
+        loaded.memory.add_region(PPC_DATA_BASE + 0x3000, vec![0; 24]);
+        loaded.memory.add_region(PPC_DATA_BASE + 0x4000, vec![0; 24]);
+        loaded
+            .memory
+            .write_u32_be(PPC_DATA_BASE + 0x3000, 2)
+            .unwrap();
+        loaded
+            .memory
+            .write_u32_be(PPC_DATA_BASE + 0x3004, 1)
+            .unwrap();
+        loaded
+            .memory
+            .write_bytes(
+                PPC_DATA_BASE + 0x3010,
+                &[0x00, 0x00, 0x00, 0x00, 0x7f, 0xff, 0x7f, 0xff],
+            )
+            .unwrap();
         loaded.memory.write_u16_be(header, 2).unwrap();
         loaded.memory.write_u16_be(header + 2, 16).unwrap();
         loaded
@@ -159534,10 +159606,17 @@ pub(crate) mod tests {
                 current_buffer_index: 0,
                 callback_pending_mask: 0,
                 active: true,
-                host_initialized: false,
-                host_buffer_loaded: false,
+                host_initialized: true,
+                host_buffer_loaded: true,
             }]
         );
+        assert_eq!(loaded.sound.manager.debug_double_buffer_count, 1);
+        assert!(loaded
+            .sound
+            .manager
+            .channels
+            .iter()
+            .any(|candidate| candidate.guest_ptr == channel && candidate.has_active_playback()));
         assert!(loaded.sound.pending_doublebacks.is_empty());
 
         loaded.cpu.pc = loaded.entry_pc;
@@ -159835,7 +159914,6 @@ pub(crate) mod tests {
         assert_eq!(probe.handled_import_count, 1);
         assert_eq!(probe.unsupported_import_index, None);
         assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_NO_ERR));
-        assert!(loaded.sound.decoded_buffer_commands.is_empty());
         assert_eq!(loaded.sound.manager.debug_buffer_cmd_count, 1);
         assert!(loaded
             .sound
@@ -160246,6 +160324,13 @@ pub(crate) mod tests {
                 preview: expected_preview,
             })
         );
+        assert_eq!(loaded.sound.manager.debug_file_play_count, 1);
+        assert!(loaded
+            .sound
+            .manager
+            .channels
+            .iter()
+            .any(|candidate| candidate.guest_ptr == channel && candidate.has_active_playback()));
     }
 
     #[test]

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -3396,7 +3396,6 @@ pub struct PpcLoadedApp {
     pub next_vfs_dir_id: u32,
     pub default_dir_id: u32,
     pub launched_app_path: Option<String>,
-    pub default_output_volume: u32,
     pub param_text: [Vec<u8>; 4],
     pub scrap: PpcScrapState,
     pub list_manager: PpcListManagerState,
@@ -3844,6 +3843,7 @@ impl PpcLoadedApp {
 
     pub(crate) fn attach_process_context(&mut self, context: &mut ProcessContext) {
         context.attach_file_system(&mut self.process_file_system);
+        context.attach_sound_manager(&mut self.sound.manager);
         context.adopt_menu_tracking(&mut self.toolbox_startup.menu_tracking);
         let mut attached_memory_manager = None;
         context.attach_memory_manager(&mut attached_memory_manager);
@@ -7245,7 +7245,6 @@ impl PpcLoadedApp {
         let mut vfs_directories = std::mem::take(&mut self.vfs_directories);
         let mut next_vfs_dir_id = self.next_vfs_dir_id;
         let mut default_dir_id = self.default_dir_id;
-        let mut default_output_volume = self.default_output_volume;
         let mut param_text = std::mem::take(&mut self.param_text);
         let mut scrap = std::mem::take(&mut self.scrap);
         let mut list_manager = std::mem::take(&mut self.list_manager);
@@ -7763,7 +7762,6 @@ impl PpcLoadedApp {
                         &mut next_vfs_dir_id,
                         default_dir_id,
                         self.launched_app_path.as_deref(),
-                        &mut default_output_volume,
                         &mut param_text,
                         &mut scrap,
                         &mut list_manager,
@@ -8128,7 +8126,6 @@ impl PpcLoadedApp {
         self.vfs_directories = vfs_directories;
         self.next_vfs_dir_id = next_vfs_dir_id;
         self.default_dir_id = default_dir_id;
-        self.default_output_volume = default_output_volume;
         self.param_text = param_text;
         self.scrap = scrap;
         self.list_manager = list_manager;
@@ -12680,6 +12677,11 @@ fn load_pef_application_with_config_and_optional_system_reservation(
         }
     }
 
+    let mut sound = PpcSoundState::default();
+    sound
+        .manager
+        .set_default_output_volume(PPC_DEFAULT_OUTPUT_VOLUME);
+
     Ok(PpcLoadedApp {
         cpu,
         memory,
@@ -12741,7 +12743,7 @@ fn load_pef_application_with_config_and_optional_system_reservation(
         input_sprocket_virtual_elements: Vec::new(),
         toolbox_startup,
         quicktime: PpcQuickTimeState::default(),
-        sound: PpcSoundState::default(),
+        sound,
         timer_tasks: Vec::new(),
         vbl_tasks: Vec::new(),
         process_file_system: ppc_initial_process_file_system(),
@@ -12764,7 +12766,6 @@ fn load_pef_application_with_config_and_optional_system_reservation(
         next_vfs_dir_id: PPC_FIRST_DYNAMIC_DIR_ID,
         default_dir_id: PPC_ROOT_DIR_ID,
         launched_app_path: None,
-        default_output_volume: PPC_DEFAULT_OUTPUT_VOLUME,
         param_text: [Vec::new(), Vec::new(), Vec::new(), Vec::new()],
         scrap: PpcScrapState::default(),
         list_manager: PpcListManagerState::default(),
@@ -15060,7 +15061,6 @@ fn dispatch_supported_import(
     next_vfs_dir_id: &mut u32,
     default_dir_id: u32,
     launched_app_path: Option<&str>,
-    default_output_volume: &mut u32,
     param_text: &mut [Vec<u8>; 4],
     scrap: &mut PpcScrapState,
     list_manager: &mut PpcListManagerState,
@@ -23555,7 +23555,7 @@ fn dispatch_supported_import(
             if volume_out_ptr == 0
                 || !ppc_memory_can_write_bytes(memory, volume_out_ptr, 4)
                 || memory
-                    .write_u32_be(volume_out_ptr, *default_output_volume)
+                    .write_u32_be(volume_out_ptr, sound.manager.default_output_volume())
                     .is_none()
             {
                 Some(PpcImportAction::Return(ppc_i16_result(PPC_PARAM_ERR)))
@@ -23564,7 +23564,7 @@ fn dispatch_supported_import(
             }
         }
         PpcImportDispatcherTarget::SetDefaultOutputVolume => {
-            *default_output_volume = cpu.gpr[3];
+            sound.manager.set_default_output_volume(cpu.gpr[3]);
             Some(PpcImportAction::Return(ppc_i16_result(PPC_NO_ERR)))
         }
         // FUNCTION GetVol (volName: StringPtr; VAR vRefNum: Integer): OSErr;
@@ -23594,6 +23594,7 @@ fn dispatch_supported_import(
                 memory,
                 heap_cursor,
                 last_mem_error,
+                sound,
             ),
         ))),
         PpcImportDispatcherTarget::SndDisposeChannel => Some(PpcImportAction::Return(
@@ -43658,6 +43659,7 @@ fn ppc_snd_new_channel(
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     last_mem_error: &mut i16,
+    sound: &mut PpcSoundState,
 ) -> i16 {
     let channel_out_ptr = cpu.gpr[3];
     if channel_out_ptr == 0 || !ppc_memory_can_write_bytes(memory, channel_out_ptr, 4) {
@@ -43672,6 +43674,7 @@ fn ppc_snd_new_channel(
     }
     let user_routine = cpu.gpr[6];
     let existing_channel = memory.read_u32_be(channel_out_ptr).unwrap_or(0);
+    let allocated = existing_channel == 0;
     let (channel, preserved_user_info, q_length) = if existing_channel != 0 {
         if !ppc_memory_can_write_bytes(memory, existing_channel, 36) {
             return PPC_PARAM_ERR;
@@ -43716,6 +43719,9 @@ fn ppc_snd_new_channel(
         return PPC_PARAM_ERR;
     }
     *last_mem_error = PPC_NO_ERR;
+    sound
+        .manager
+        .register_channel(channel, allocated, user_routine);
     if ppc_sound_trace_enabled() {
         eprintln!(
             "[PPC-SOUND] SndNewChannel chan=${channel:08X} synth={synth} init=${:08X} user_routine=${user_routine:08X}",
@@ -43973,7 +43979,22 @@ fn ppc_snd_do_immediate(
             return PPC_PARAM_ERR;
         }
     }
-    ppc_decode_buffer_command(memory, sound, channel, command);
+    if let Some(decoded) = ppc_decode_buffer_command(memory, channel, command) {
+        sound.manager.play_buffer_command(
+            channel,
+            decoded.samples,
+            decoded.sample_rate_fixed,
+        );
+    } else {
+        sound.manager.execute_immediate_command(
+            channel,
+            crate::sound::SndCommand {
+                cmd: command.command,
+                param1: command.param1,
+                param2: command.param2,
+            },
+        );
+    }
     sound
         .immediate_commands
         .push(PpcSndCommandRecord { channel, ..command });
@@ -44012,7 +44033,22 @@ fn ppc_snd_do_command(cpu: &PpcCpu, memory: &mut PpcSectionMem, sound: &mut PpcS
     }
     // The HLE queue is unbounded, so the noWait distinction cannot produce
     // queueFull.
-    ppc_decode_buffer_command(memory, sound, channel, command);
+    if let Some(decoded) = ppc_decode_buffer_command(memory, channel, command) {
+        sound.manager.play_buffer_command(
+            channel,
+            decoded.samples,
+            decoded.sample_rate_fixed,
+        );
+    } else {
+        let _ = sound.manager.enqueue_command(
+            channel,
+            crate::sound::SndCommand {
+                cmd: command.command,
+                param1: command.param1,
+                param2: command.param2,
+            },
+        );
+    }
     sound
         .queued_commands
         .push(PpcSndCommandRecord { channel, ..command });
@@ -44021,6 +44057,7 @@ fn ppc_snd_do_command(cpu: &PpcCpu, memory: &mut PpcSectionMem, sound: &mut PpcS
 
 fn ppc_snd_dispose_channel(cpu: &mut PpcCpu, sound: &mut PpcSoundState) -> i16 {
     let channel = cpu.gpr[3];
+    sound.manager.remove_channel(channel);
     for playback in sound
         .file_playbacks
         .iter_mut()
@@ -44132,14 +44169,13 @@ fn ppc_snd_play(
 
 fn ppc_decode_buffer_command(
     memory: &mut PpcSectionMem,
-    sound: &mut PpcSoundState,
     channel: u32,
     command: PpcSndCommandRecord,
-) {
+) -> Option<PpcDecodedBufferCommandRecord> {
     const BUFFER_CMD: u16 = 81;
 
     if command.command != BUFFER_CMD || command.param2 == 0 {
-        return;
+        return None;
     }
     let Some(decoded) = ppc_decode_snd_header_from_memory(memory, command.param2) else {
         if ppc_sound_trace_enabled() {
@@ -44148,15 +44184,13 @@ fn ppc_decode_buffer_command(
                 command.param2
             );
         }
-        return;
+        return None;
     };
-    sound
-        .decoded_buffer_commands
-        .push(PpcDecodedBufferCommandRecord {
-            channel,
-            sample_rate_fixed: decoded.summary.sample_rate_fixed,
-            samples: decoded.samples,
-        });
+    Some(PpcDecodedBufferCommandRecord {
+        channel,
+        sample_rate_fixed: decoded.summary.sample_rate_fixed,
+        samples: decoded.samples,
+    })
 }
 
 /// Decode a Sound Manager SoundHeader referenced by bufferCmd.
@@ -93708,7 +93742,10 @@ pub(crate) mod tests {
         assert_eq!(loaded.vfs_resource_files.len(), 0);
         assert_eq!(loaded.process_file_system.vfs_resources.len(), 0);
         assert_eq!(loaded.next_file_ref_num, PPC_FIRST_FILE_REF_NUM);
-        assert_eq!(loaded.default_output_volume, PPC_DEFAULT_OUTPUT_VOLUME);
+        assert_eq!(
+            loaded.sound.manager.default_output_volume(),
+            PPC_DEFAULT_OUTPUT_VOLUME
+        );
         assert_eq!(loaded.current_gworld, PPC_MAIN_GWORLD);
         assert_eq!(loaded.current_gdevice, PPC_MAIN_GDEVICE);
         assert_eq!(loaded.default_dir_id, PPC_ROOT_DIR_ID);
@@ -159269,7 +159306,10 @@ pub(crate) mod tests {
         let pef = synthetic_pef_with_import(b"GetDefaultOutputVolume");
         let mut loaded = load_pef_application(&pef).unwrap();
         let volume_out_ptr = PPC_HEAP_BASE;
-        loaded.default_output_volume = 0x0000_8000;
+        loaded
+            .sound
+            .manager
+            .set_default_output_volume(0x0000_8000);
         loaded.memory.add_region(volume_out_ptr, vec![0; 4]);
         loaded.cpu.gpr[3] = volume_out_ptr;
 
@@ -159292,7 +159332,10 @@ pub(crate) mod tests {
         assert_eq!(probe.handled_import_count, 1);
         assert_eq!(probe.unsupported_import_index, None);
         assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_NO_ERR));
-        assert_eq!(loaded.default_output_volume, 0x0000_4000);
+        assert_eq!(
+            loaded.sound.manager.default_output_volume(),
+            0x0000_4000
+        );
     }
 
     #[test]
@@ -159792,12 +159835,21 @@ pub(crate) mod tests {
         assert_eq!(probe.handled_import_count, 1);
         assert_eq!(probe.unsupported_import_index, None);
         assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_NO_ERR));
+        assert!(loaded.sound.decoded_buffer_commands.is_empty());
+        assert_eq!(loaded.sound.manager.debug_buffer_cmd_count, 1);
+        assert!(loaded
+            .sound
+            .manager
+            .channels
+            .iter()
+            .any(|candidate| candidate.guest_ptr == channel && candidate.has_active_playback()));
         assert_eq!(
-            loaded.sound.decoded_buffer_commands,
-            vec![PpcDecodedBufferCommandRecord {
+            loaded.sound.queued_commands,
+            vec![PpcSndCommandRecord {
                 channel,
-                sample_rate_fixed: 22_050u32 << 16,
-                samples: samples.to_vec(),
+                command: 81,
+                param1: 0,
+                param2: header_ptr,
             }]
         );
     }

--- a/src/loader/ppc/sound.rs
+++ b/src/loader/ppc/sound.rs
@@ -145,7 +145,6 @@ pub struct PpcSoundState {
     pub(crate) manager: SharedProcessSoundManager,
     pub queued_commands: Vec<PpcSndCommandRecord>,
     pub immediate_commands: Vec<PpcSndCommandRecord>,
-    pub decoded_buffer_commands: Vec<PpcDecodedBufferCommandRecord>,
     pub double_buffer_playbacks: Vec<PpcSoundDoubleBufferPlaybackRecord>,
     pub file_playbacks: Vec<PpcSoundFilePlaybackRecord>,
     pub decoded_file_playbacks: Vec<PpcDecodedAiffPlaybackRecord>,
@@ -166,7 +165,6 @@ impl PartialEq for PpcSoundState {
     fn eq(&self, other: &Self) -> bool {
         self.queued_commands == other.queued_commands
             && self.immediate_commands == other.immediate_commands
-            && self.decoded_buffer_commands == other.decoded_buffer_commands
             && self.double_buffer_playbacks == other.double_buffer_playbacks
             && self.file_playbacks == other.file_playbacks
             && self.decoded_file_playbacks == other.decoded_file_playbacks

--- a/src/loader/ppc/sound.rs
+++ b/src/loader/ppc/sound.rs
@@ -1,6 +1,7 @@
 //! PowerPC Sound Manager, Timer, and VBL task state and records.
 
 use super::imports::PpcHleImportTraceEntry;
+use crate::process_context::SharedProcessSoundManager;
 use ppc::{PpcFetchHistogram, PpcRunResult};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -139,8 +140,9 @@ pub struct PpcSoundCompletionCallProbe {
     pub fetch_histogram: Option<PpcFetchHistogram>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct PpcSoundState {
+    pub(crate) manager: SharedProcessSoundManager,
     pub queued_commands: Vec<PpcSndCommandRecord>,
     pub immediate_commands: Vec<PpcSndCommandRecord>,
     pub decoded_buffer_commands: Vec<PpcDecodedBufferCommandRecord>,
@@ -159,6 +161,30 @@ pub struct PpcSoundState {
     pub last_double_buffer_channel: u32,
     pub last_double_buffer_header: u32,
 }
+
+impl PartialEq for PpcSoundState {
+    fn eq(&self, other: &Self) -> bool {
+        self.queued_commands == other.queued_commands
+            && self.immediate_commands == other.immediate_commands
+            && self.decoded_buffer_commands == other.decoded_buffer_commands
+            && self.double_buffer_playbacks == other.double_buffer_playbacks
+            && self.file_playbacks == other.file_playbacks
+            && self.decoded_file_playbacks == other.decoded_file_playbacks
+            && self.pending_completions == other.pending_completions
+            && self.pending_doublebacks == other.pending_doublebacks
+            && self.completion_invocations == other.completion_invocations
+            && self.sys_beep_count == other.sys_beep_count
+            && self.last_sys_beep_duration == other.last_sys_beep_duration
+            && self.start_count == other.start_count
+            && self.pause_count == other.pause_count
+            && self.stop_count == other.stop_count
+            && self.double_buffer_play_count == other.double_buffer_play_count
+            && self.last_double_buffer_channel == other.last_double_buffer_channel
+            && self.last_double_buffer_header == other.last_double_buffer_header
+    }
+}
+
+impl Eq for PpcSoundState {}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PpcVblTaskRecord {

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -6,6 +6,7 @@ use crate::guest_procedure::GuestProcedure;
 use crate::memory::bus::{SharedClassicHeapAllocator, SharedRamRegion};
 use crate::memory::{GuestAddressSpace, MacMemoryBus, MemoryBus};
 use crate::menu_manager::{ProcessMenuTrackingState, SharedNativeMenuSelection};
+use crate::sound::SoundManager;
 use ppc::PpcMemory;
 use std::cell::{RefCell, RefMut, UnsafeCell};
 use std::collections::{HashMap, HashSet};
@@ -561,6 +562,7 @@ pub(crate) struct SharedProcessFileSystem(Rc<UnsafeCell<ProcessFileSystemState>>
 pub struct SharedProcessValue<T>(Rc<UnsafeCell<T>>);
 
 pub(crate) type SharedProcessResourceManager = SharedProcessValue<ProcessResourceManagerState>;
+pub(crate) type SharedProcessSoundManager = SharedProcessValue<SoundManager>;
 
 impl<T: Default> Default for SharedProcessValue<T> {
     fn default() -> Self {
@@ -3341,6 +3343,7 @@ pub(crate) struct ProcessContext {
     guest_calls: SharedGuestCallStack,
     apple_event_handlers: SharedProcessAppleEventHandlers,
     file_system: SharedProcessFileSystem,
+    sound_manager: SharedProcessSoundManager,
 }
 
 impl ProcessContext {
@@ -3377,6 +3380,10 @@ impl ProcessContext {
 
     pub(crate) fn attach_resource_manager(&self, adapter: &mut SharedProcessResourceManager) {
         adapter.attach_resource_manager_to(&self.file_system.resource_manager);
+    }
+
+    pub(crate) fn attach_sound_manager(&self, adapter: &mut SharedProcessSoundManager) {
+        adapter.attach_to(&self.sound_manager, SoundManager::is_pristine);
     }
 
     pub(crate) fn attach_classic_file_system(
@@ -4835,5 +4842,31 @@ mod tests {
         );
         assert!(detached.resident_resources.is_empty());
         assert!(detached.vfs_resources.is_empty());
+    }
+
+    #[test]
+    fn attached_sound_managers_share_channels_while_clones_detach() {
+        let context = ProcessContext::default();
+        let mut classic = SharedProcessSoundManager::default();
+        classic
+            .channels
+            .push(crate::sound::SndChannel::new(0x2000, false));
+        let mut native = SharedProcessSoundManager::default();
+
+        context.attach_sound_manager(&mut classic);
+        context.attach_sound_manager(&mut native);
+        let detached = native.clone();
+
+        native.set_sys_beep_volume(0x0080_0040);
+        classic
+            .channels
+            .push(crate::sound::SndChannel::new(0x3000, false));
+
+        assert!(classic.ptr_eq(&native));
+        assert_eq!(native.channels.len(), 2);
+        assert_eq!(native.channels[0].guest_ptr, 0x2000);
+        assert_eq!(classic.sys_beep_volume(), 0x0080_0040);
+        assert_eq!(detached.channels.len(), 1);
+        assert_eq!(detached.sys_beep_volume(), 0x0100_0100);
     }
 }

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -4,7 +4,7 @@ use crate::cpu::{M68kCpu, Register, StepResult};
 use crate::debug_overlay::{DebugOverlayFrameStats, DebugOverlaySnapshot};
 use crate::display::CursorImage;
 use crate::loader::ppc::{
-    PpcDecodedAiffPlaybackRecord, PpcDecodedBufferCommandRecord, PpcDrawSprocketTraceEntry,
+    PpcDecodedAiffPlaybackRecord, PpcDrawSprocketTraceEntry,
     PpcFrontBuffer, PpcGWorldRecord, PpcHleImportTraceEntry, PpcImportBinding,
     PpcImportDispatcherTarget, PpcInputSnapshot, PpcInputSprocketSimpleStateTraceEntry,
     PpcLoadedApp, PpcQ3GpuFrame, PpcQ3SceneReplay, PpcQ3SoftwareRenderStats, PpcRgbColor,
@@ -6014,7 +6014,7 @@ impl FixtureRunner {
             self.sync_ppc_front_buffer_to_host(&mut ppc_app);
             self.sync_ppc_vfs_to_dispatcher(&mut ppc_app);
         }
-        self.sync_ppc_sound_to_dispatcher(&mut ppc_app);
+        self.service_ppc_sound_adapter(&mut ppc_app);
         sync_ppc_cursor_state(
             &mut self.dispatcher,
             ppc_app.quickdraw_cursor_level,
@@ -7020,11 +7020,7 @@ impl FixtureRunner {
         )
     }
 
-    fn sync_ppc_sound_to_dispatcher(&mut self, ppc_app: &mut PpcLoadedApp) {
-        let decoded_buffer_commands = std::mem::take(&mut ppc_app.sound.decoded_buffer_commands);
-        for decoded in decoded_buffer_commands {
-            self.play_ppc_decoded_buffer_command(decoded);
-        }
+    fn service_ppc_sound_adapter(&mut self, ppc_app: &mut PpcLoadedApp) {
         self.sync_ppc_double_buffer_playbacks(ppc_app);
 
         let start = self
@@ -7058,61 +7054,17 @@ impl FixtureRunner {
                 );
             }
             self.ensure_ppc_sound_playback_timing(ppc_app, index, &decoded);
-            let chan_index = self
-                .dispatcher
-                .sound_manager
-                .channels
-                .iter()
-                .position(|chan| chan.guest_ptr == channel)
-                .unwrap_or_else(|| {
-                    self.dispatcher
-                        .sound_manager
-                        .channels
-                        .push(crate::sound::SndChannel::new(channel, false));
-                    self.dispatcher.sound_manager.channels.len() - 1
-                });
-            let chan = &mut self.dispatcher.sound_manager.channels[chan_index];
-            chan.quiet();
-            chan.play_buffer(
-                decoded.samples.clone(),
-                decoded.sample_rate_fixed,
-                crate::sound::PlaybackKind::File,
-                0,
-            );
             self.ppc_sound_host_playbacks
                 .retain(|record| record.file_playback_index != index);
             self.ppc_sound_host_playbacks.push(PpcHostSoundPlayback {
                 file_playback_index: index,
                 channel,
             });
-            self.dispatcher.sound_manager.debug_file_play_count = self
-                .dispatcher
-                .sound_manager
-                .debug_file_play_count
-                .saturating_add(1);
         }
 
         self.ppc_sound_synced_file_playback_count = ppc_app.sound.file_playbacks.len();
         self.adjust_ppc_sound_pause_timing(ppc_app);
 
-        let mut seen_channels = Vec::new();
-        for playback in ppc_app.sound.file_playbacks.iter().rev() {
-            if seen_channels.contains(&playback.channel) {
-                continue;
-            }
-            seen_channels.push(playback.channel);
-            if let Some(chan) = self
-                .dispatcher
-                .sound_manager
-                .find_channel_mut(playback.channel)
-            {
-                if !playback.active || playback.quiet_now {
-                    chan.quiet();
-                } else {
-                    chan.set_file_paused(playback.paused);
-                }
-            }
-        }
         self.ppc_sound_host_playbacks.retain(|record| {
             ppc_app
                 .sound
@@ -7120,63 +7072,6 @@ impl FixtureRunner {
                 .get(record.file_playback_index)
                 .is_some_and(|playback| playback.active && !playback.quiet_now)
         });
-    }
-
-    fn play_ppc_decoded_buffer_command(&mut self, decoded: PpcDecodedBufferCommandRecord) {
-        let channel = decoded.channel;
-        if trace_sound_runner_enabled() {
-            let non_silent = decoded
-                .samples
-                .iter()
-                .filter(|sample| **sample != 0x80)
-                .count();
-            eprintln!(
-                "[PPC-SOUND] host bufferCmd chan=${channel:08X} rate=${:08X} samples={} non_silent={}",
-                decoded.sample_rate_fixed,
-                decoded.samples.len(),
-                non_silent
-            );
-        }
-        let chan_index = self
-            .dispatcher
-            .sound_manager
-            .channels
-            .iter()
-            .position(|chan| chan.guest_ptr == channel)
-            .unwrap_or_else(|| {
-                self.dispatcher
-                    .sound_manager
-                    .channels
-                    .push(crate::sound::SndChannel::new(channel, false));
-                self.dispatcher.sound_manager.channels.len() - 1
-            });
-        self.dispatcher.sound_manager.channels[chan_index].play_buffer(
-            decoded.samples,
-            decoded.sample_rate_fixed,
-            crate::sound::PlaybackKind::Buffer,
-            0,
-        );
-        self.dispatcher.sound_manager.debug_cmd_count = self
-            .dispatcher
-            .sound_manager
-            .debug_cmd_count
-            .saturating_add(1);
-        self.dispatcher.sound_manager.debug_buffer_cmd_count = self
-            .dispatcher
-            .sound_manager
-            .debug_buffer_cmd_count
-            .saturating_add(1);
-        if !self
-            .dispatcher
-            .sound_manager
-            .debug_cmd_codes_seen
-            .contains(&crate::sound::cmd::BUFFER)
-        {
-            self.dispatcher
-                .sound_manager
-                .debug_cmd_codes_seen
-                .push(crate::sound::cmd::BUFFER);
-        }
     }
 
     fn sync_ppc_double_buffer_playbacks(&mut self, ppc_app: &mut PpcLoadedApp) {
@@ -7763,7 +7658,7 @@ impl FixtureRunner {
             }
         }
         self.sync_ppc_vfs_to_dispatcher(&mut ppc_app);
-        self.sync_ppc_sound_to_dispatcher(&mut ppc_app);
+        self.service_ppc_sound_adapter(&mut ppc_app);
         self.ppc_app = Some(ppc_app);
     }
 
@@ -7850,7 +7745,7 @@ impl FixtureRunner {
             }
         }
         self.sync_ppc_vfs_to_dispatcher(&mut ppc_app);
-        self.sync_ppc_sound_to_dispatcher(&mut ppc_app);
+        self.service_ppc_sound_adapter(&mut ppc_app);
         self.ppc_app = Some(ppc_app);
     }
 
@@ -16183,14 +16078,12 @@ mod tests {
     fn ppc_decoded_buffer_command_feeds_host_audio_buffer() {
         let channel = 0x0500_1000;
         let samples = vec![0x80, 0x90, 0x70, 0xa0];
-        let sound = PpcSoundState {
-            decoded_buffer_commands: vec![PpcDecodedBufferCommandRecord {
-                channel,
-                sample_rate_fixed: crate::sound::OUTPUT_RATE << 16,
-                samples: samples.clone(),
-            }],
-            ..PpcSoundState::default()
-        };
+        let mut sound = PpcSoundState::default();
+        sound.manager.play_buffer_command(
+            channel,
+            samples.clone(),
+            crate::sound::OUTPUT_RATE << 16,
+        );
         let app = halted_ppc_app_with_sound(sound);
         let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
         runner.init_app(&app);
@@ -16203,13 +16096,6 @@ mod tests {
         assert_eq!(runner.dispatcher().sound_manager.debug_cmd_count, 1);
         assert_eq!(runner.dispatcher().sound_manager.debug_buffer_cmd_count, 1);
         assert_eq!(runner.dispatcher().sound_manager.debug_samples_mixed, 4);
-        assert!(runner
-            .ppc_app
-            .as_ref()
-            .expect("PPC app should stay loaded")
-            .sound
-            .decoded_buffer_commands
-            .is_empty());
     }
 
     #[test]
@@ -16225,7 +16111,6 @@ mod tests {
             manager: Default::default(),
             queued_commands: Vec::new(),
             immediate_commands: Vec::new(),
-            decoded_buffer_commands: Vec::new(),
             double_buffer_playbacks: Vec::new(),
             file_playbacks: vec![PpcSoundFilePlaybackRecord {
                 channel,
@@ -16276,6 +16161,11 @@ mod tests {
         });
         {
             let ppc_app = app.ppc.as_mut().expect("PPC app");
+            ppc_app.sound.manager.play_file_buffer(
+                channel,
+                samples.clone(),
+                crate::sound::OUTPUT_RATE << 16,
+            );
             let stw_r3_0_r2 = (36u32 << 26) | (3u32 << 21) | (2u32 << 16);
             let mut callback_bytes = Vec::new();
             callback_bytes.extend_from_slice(&stw_r3_0_r2.to_be_bytes());
@@ -16371,7 +16261,6 @@ mod tests {
             manager: Default::default(),
             queued_commands: Vec::new(),
             immediate_commands: Vec::new(),
-            decoded_buffer_commands: Vec::new(),
             double_buffer_playbacks: Vec::new(),
             file_playbacks: vec![PpcSoundFilePlaybackRecord {
                 channel,
@@ -16406,7 +16295,7 @@ mod tests {
                 file_playback_index: 0,
                 channel,
                 sample_rate_fixed: crate::sound::OUTPUT_RATE << 16,
-                samples,
+                samples: samples.clone(),
             }],
             pending_completions: Vec::new(),
             pending_doublebacks: Vec::new(),
@@ -16422,6 +16311,11 @@ mod tests {
         });
         {
             let ppc_app = app.ppc.as_mut().expect("PPC app");
+            ppc_app.sound.manager.play_file_buffer(
+                channel,
+                samples.clone(),
+                crate::sound::OUTPUT_RATE << 16,
+            );
             ppc_app
                 .memory
                 .write_u32_be(PPC_CODE_BASE, 0x4800_0000)
@@ -16509,7 +16403,6 @@ mod tests {
             manager: Default::default(),
             queued_commands: Vec::new(),
             immediate_commands: Vec::new(),
-            decoded_buffer_commands: Vec::new(),
             double_buffer_playbacks: Vec::new(),
             file_playbacks: vec![PpcSoundFilePlaybackRecord {
                 channel,

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -13709,7 +13709,6 @@ mod tests {
             next_vfs_dir_id: 18,
             default_dir_id: 2,
             launched_app_path: None,
-            default_output_volume: 0,
             param_text: [Vec::new(), Vec::new(), Vec::new(), Vec::new()],
             scrap: Default::default(),
             list_manager: Default::default(),
@@ -13748,6 +13747,50 @@ mod tests {
         assert_eq!(ppc_app.guest_calls.len(), 1);
         assert!(ppc_app.guest_calls.complete_m68k(0x2002, 0x3000));
         assert!(runner.dispatcher.guest_calls.is_empty());
+    }
+
+    #[test]
+    fn ppc_initialization_attaches_both_cpu_adapters_to_one_sound_manager() {
+        let app = halted_ppc_app_with_sound(PpcSoundState::default());
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        runner.init_app(&app);
+
+        {
+            let ppc_app = runner.ppc_app.as_mut().expect("PPC app");
+            assert!(ppc_app
+                .sound
+                .manager
+                .ptr_eq(&runner.dispatcher.sound_manager));
+            ppc_app
+                .sound
+                .manager
+                .register_channel(0x0050_1000, false, 0x0012_3456);
+            ppc_app
+                .sound
+                .manager
+                .set_default_output_volume(0x0000_8000);
+        }
+
+        let classic_channel = runner
+            .dispatcher
+            .sound_manager
+            .channels
+            .iter_mut()
+            .find(|channel| channel.guest_ptr == 0x0050_1000)
+            .expect("native channel visible to classic adapter");
+        assert_eq!(classic_channel.callback_addr, 0x0012_3456);
+        classic_channel.set_volume(0x0000_4000);
+        runner.dispatcher.sound_manager.set_sys_beep_volume(0x0000_2000);
+
+        let ppc_app = runner.ppc_app.as_ref().expect("PPC app");
+        assert_eq!(ppc_app.sound.manager.default_output_volume(), 0x0000_8000);
+        assert_eq!(ppc_app.sound.manager.sys_beep_volume(), 0x0000_2000);
+        assert!(ppc_app
+            .sound
+            .manager
+            .channels
+            .iter()
+            .any(|channel| channel.guest_ptr == 0x0050_1000));
     }
 
     #[test]
@@ -15899,7 +15942,6 @@ mod tests {
             next_vfs_dir_id: 18,
             default_dir_id: 2,
             launched_app_path: None,
-            default_output_volume: 0,
             param_text: [Vec::new(), Vec::new(), Vec::new(), Vec::new()],
             scrap: Default::default(),
             list_manager: Default::default(),
@@ -16180,6 +16222,7 @@ mod tests {
         let mut preview = [0; 16];
         preview[..samples.len()].copy_from_slice(&samples);
         let mut app = halted_ppc_app_with_sound(PpcSoundState {
+            manager: Default::default(),
             queued_commands: Vec::new(),
             immediate_commands: Vec::new(),
             decoded_buffer_commands: Vec::new(),
@@ -16325,6 +16368,7 @@ mod tests {
         let mut preview = [0; 16];
         preview[..samples.len()].copy_from_slice(&samples);
         let mut app = halted_ppc_app_with_sound(PpcSoundState {
+            manager: Default::default(),
             queued_commands: Vec::new(),
             immediate_commands: Vec::new(),
             decoded_buffer_commands: Vec::new(),
@@ -16462,6 +16506,7 @@ mod tests {
         let mut preview = [0; 16];
         preview[..samples.len()].copy_from_slice(&samples);
         let mut app = halted_ppc_app_with_sound(PpcSoundState {
+            manager: Default::default(),
             queued_commands: Vec::new(),
             immediate_commands: Vec::new(),
             decoded_buffer_commands: Vec::new(),
@@ -16791,7 +16836,6 @@ mod tests {
             next_vfs_dir_id: 18,
             default_dir_id: 2,
             launched_app_path: None,
-            default_output_volume: 0,
             param_text: [Vec::new(), Vec::new(), Vec::new(), Vec::new()],
             scrap: Default::default(),
             list_manager: Default::default(),
@@ -16942,7 +16986,6 @@ mod tests {
             next_vfs_dir_id: 18,
             default_dir_id: 2,
             launched_app_path: None,
-            default_output_volume: 0,
             param_text: [Vec::new(), Vec::new(), Vec::new(), Vec::new()],
             scrap: Default::default(),
             list_manager: Default::default(),
@@ -17352,7 +17395,6 @@ mod tests {
             next_vfs_dir_id: 18,
             default_dir_id: 2,
             launched_app_path: None,
-            default_output_volume: 0,
             param_text: [Vec::new(), Vec::new(), Vec::new(), Vec::new()],
             scrap: Default::default(),
             list_manager: Default::default(),
@@ -17662,7 +17704,6 @@ mod tests {
             next_vfs_dir_id: 18,
             default_dir_id: 2,
             launched_app_path: None,
-            default_output_volume: 0,
             param_text: [Vec::new(), Vec::new(), Vec::new(), Vec::new()],
             scrap: Default::default(),
             list_manager: Default::default(),

--- a/src/sound.rs
+++ b/src/sound.rs
@@ -533,6 +533,71 @@ impl SoundManager {
         );
     }
 
+    /// Start decoded file playback on the canonical process channel.
+    /// `SndStartFilePlay` submits file data to the same channel state used by
+    /// ordinary commands. Inside Macintosh: Sound (1994), pp. 2-134--2-137.
+    pub(crate) fn play_file_buffer(
+        &mut self,
+        guest_ptr: u32,
+        samples: Vec<u8>,
+        sample_rate_fixed: u32,
+    ) {
+        self.debug_file_play_count = self.debug_file_play_count.saturating_add(1);
+        let channel = self.ensure_channel_mut(guest_ptr);
+        channel.quiet();
+        channel.play_buffer(samples, sample_rate_fixed, PlaybackKind::File, 0);
+    }
+
+    /// Install one decoded double-buffer payload on the process channel.
+    /// The native callback frame remains adapter-specific, but the samples
+    /// and playback cursor are Sound Manager state. Sound 1994, pp. 2-138--2-140.
+    pub(crate) fn play_double_buffer_samples(
+        &mut self,
+        guest_ptr: u32,
+        samples: Vec<StereoSample>,
+        sample_rate_fixed: u32,
+    ) {
+        self.debug_double_buffer_count = self.debug_double_buffer_count.saturating_add(1);
+        let channel = self.ensure_channel_mut(guest_ptr);
+        let non_silent_frames = samples
+            .iter()
+            .filter(|sample| sample.left != 0x80 || sample.right != 0x80)
+            .count();
+        channel.debug_double_buffer_loads = channel.debug_double_buffer_loads.saturating_add(1);
+        channel.debug_double_buffer_frames_loaded = channel
+            .debug_double_buffer_frames_loaded
+            .saturating_add(samples.len() as u64);
+        channel.debug_double_buffer_non_silent_frames = channel
+            .debug_double_buffer_non_silent_frames
+            .saturating_add(non_silent_frames as u64);
+        if non_silent_frames > 0 {
+            channel.debug_double_buffer_non_silent_loads =
+                channel.debug_double_buffer_non_silent_loads.saturating_add(1);
+        }
+        let capture_remaining = DEBUG_DOUBLE_BUFFER_CAPTURE_LIMIT
+            .saturating_sub(channel.debug_double_buffer_captured_samples.len());
+        channel.debug_double_buffer_captured_samples.extend(
+            samples
+                .iter()
+                .take(capture_remaining)
+                .copied()
+                .map(StereoSample::downmix),
+        );
+        channel.play_stereo_buffer(samples, sample_rate_fixed, PlaybackKind::Buffer, 0);
+    }
+
+    pub(crate) fn set_file_paused(&mut self, guest_ptr: u32, paused: bool) {
+        if let Some(channel) = self.find_channel_mut(guest_ptr) {
+            channel.set_file_paused(paused);
+        }
+    }
+
+    pub(crate) fn quiet_channel(&mut self, guest_ptr: u32) {
+        if let Some(channel) = self.find_channel_mut(guest_ptr) {
+            channel.quiet();
+        }
+    }
+
     /// Apply a native immediate command to the canonical process channel.
     /// `SndDoImmediate` bypasses the FIFO while leaving queued commands in
     /// place. Sound 1994, pp. 2-93 and 2-128--2-130.

--- a/src/sound.rs
+++ b/src/sound.rs
@@ -389,7 +389,7 @@ impl SndChannel {
     }
 }
 
-/// Top-level sound manager state, owned by TrapDispatcher.
+/// Top-level process-owned sound manager state shared by CPU adapters.
 #[derive(Clone, Debug)]
 pub struct SoundManager {
     pub channels: Vec<SndChannel>,
@@ -455,10 +455,103 @@ impl SoundManager {
         }
     }
 
+    pub(crate) fn is_pristine(&self) -> bool {
+        self.channels.is_empty()
+            && self.pending_callbacks.is_empty()
+            && self.pending_sound_callbacks.is_empty()
+            && self.debug_cmd_count == 0
+            && self.debug_buffer_cmd_count == 0
+            && self.debug_double_buffer_count == 0
+            && self.debug_samples_mixed == 0
+            && self.debug_unhandled_cmds.is_empty()
+            && self.debug_cmd_codes_seen.is_empty()
+            && self.debug_file_play_count == 0
+            && self.sys_beep_volume == FULL_STEREO_VOLUME
+            // Classic construction uses packed full stereo volume, while a
+            // freshly loaded native process uses the Sound Manager's unity
+            // 16.16 device default. Both are unattached launch defaults.
+            && matches!(self.default_output_volume, FULL_STEREO_VOLUME | 0x0001_0000)
+    }
+
     pub(crate) fn has_playback_gated_callback(&self) -> bool {
         self.channels
             .iter()
             .any(SndChannel::has_playback_gated_callback)
+    }
+
+    /// Register a guest-visible channel in the canonical process manager.
+    ///
+    /// `SndNewChannel` creates the channel and its FIFO command queue in the
+    /// application's heap. Inside Macintosh: Sound (1994), pp. 2-19--2-21.
+    pub(crate) fn register_channel(
+        &mut self,
+        guest_ptr: u32,
+        allocated: bool,
+        callback_addr: u32,
+    ) {
+        self.remove_channel(guest_ptr);
+        let mut channel = SndChannel::new(guest_ptr, allocated);
+        channel.callback_addr = callback_addr;
+        self.channels.push(channel);
+    }
+
+    fn ensure_channel_mut(&mut self, guest_ptr: u32) -> &mut SndChannel {
+        if let Some(index) = self
+            .channels
+            .iter()
+            .position(|channel| channel.guest_ptr == guest_ptr)
+        {
+            return &mut self.channels[index];
+        }
+        self.channels.push(SndChannel::new(guest_ptr, false));
+        self.channels.last_mut().unwrap()
+    }
+
+    fn record_command(&mut self, command: u16) {
+        self.debug_cmd_count = self.debug_cmd_count.saturating_add(1);
+        if !self.debug_cmd_codes_seen.contains(&command) {
+            self.debug_cmd_codes_seen.push(command);
+        }
+    }
+
+    /// Submit decoded `bufferCmd` samples directly to the process channel.
+    /// Sound commands belong to the channel managed by the Sound Manager,
+    /// irrespective of the ISA that submitted them. Sound 1994, pp. 2-92--2-97.
+    pub(crate) fn play_buffer_command(
+        &mut self,
+        guest_ptr: u32,
+        samples: Vec<u8>,
+        sample_rate_fixed: u32,
+    ) {
+        self.record_command(cmd::BUFFER);
+        self.debug_buffer_cmd_count = self.debug_buffer_cmd_count.saturating_add(1);
+        self.ensure_channel_mut(guest_ptr).play_buffer(
+            samples,
+            sample_rate_fixed,
+            PlaybackKind::Buffer,
+            0,
+        );
+    }
+
+    /// Apply a native immediate command to the canonical process channel.
+    /// `SndDoImmediate` bypasses the FIFO while leaving queued commands in
+    /// place. Sound 1994, pp. 2-93 and 2-128--2-130.
+    pub(crate) fn execute_immediate_command(&mut self, guest_ptr: u32, command: SndCommand) {
+        self.record_command(command.cmd);
+        let channel = self.ensure_channel_mut(guest_ptr);
+        match command.cmd {
+            cmd::QUIET => channel.quiet(),
+            cmd::FLUSH => channel.flush(),
+            cmd::VOLUME => channel.set_volume(command.param2),
+            cmd::RATE => channel.set_rate(command.param2),
+            _ => {}
+        }
+    }
+
+    /// Queue a native command on the canonical process channel FIFO.
+    pub(crate) fn enqueue_command(&mut self, guest_ptr: u32, command: SndCommand) -> bool {
+        self.record_command(command.cmd);
+        self.ensure_channel_mut(guest_ptr).enqueue(command)
     }
 
     pub fn sys_beep_volume(&self) -> u32 {

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -16,7 +16,7 @@ use crate::menu_manager::{ProcessMenuTrackingState, SharedNativeMenuSelection};
 use crate::process_context::{
     ProcessContext, ProcessForkMap, ProcessLoadedResources, ProcessResourceFileMap,
     ProcessResourceManagerState, SharedProcessAppleEventHandlers, SharedProcessMemoryManager,
-    SharedProcessResourceManager, SharedProcessValue,
+    SharedProcessResourceManager, SharedProcessSoundManager, SharedProcessValue,
 };
 use crate::trace::{TraceEvent, TraceSink, TraceSource};
 use crate::ui_theme::{UiTheme, UiThemeId};
@@ -2275,7 +2275,7 @@ pub struct TrapDispatcher {
     /// may set it while leaving `fullscreen_locked` to model guest state.
     pub menu_bar_hidden: bool,
     /// Sound Manager state (channels, playback buffers).
-    pub sound_manager: crate::sound::SoundManager,
+    pub(crate) sound_manager: SharedProcessSoundManager,
     /// Menus loaded from MENU resources, in order of insertion
     pub(crate) menus: Vec<super::menu::Menu>,
     /// Active menu tracking state (non-None while MenuSelect is tracking the mouse)
@@ -2909,6 +2909,7 @@ impl TrapDispatcher {
     /// Attach shared process resources to this dispatcher.
     pub(crate) fn attach_process_context(&mut self, context: &mut ProcessContext) {
         context.attach_resource_manager(&mut self.process_resource_manager);
+        context.attach_sound_manager(&mut self.sound_manager);
         context.attach_classic_file_system(&mut self.vfs, &mut self.vfs_rsrc);
         context.adopt_menu_tracking(&mut self.menu_tracking);
         let mut memory_manager = None;
@@ -3999,7 +4000,7 @@ impl TrapDispatcher {
             menu_bar_policy: crate::runner::MenuBarPolicy::GuestControlled,
             initial_kiosk_guest_hide_observed: false,
             menu_bar_hidden: false,
-            sound_manager: crate::sound::SoundManager::new(),
+            sound_manager: SharedProcessSoundManager::default(),
             menus: Vec::new(),
             menu_tracking: None,
             guest_calls: SharedGuestCallStack::default(),

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -2906,6 +2906,16 @@ impl std::ops::DerefMut for TrapDispatcher {
 }
 
 impl TrapDispatcher {
+    /// Access the process-owned Sound Manager state.
+    pub fn sound_manager(&self) -> &crate::sound::SoundManager {
+        &self.sound_manager
+    }
+
+    /// Mutably access the process-owned Sound Manager state.
+    pub fn sound_manager_mut(&mut self) -> &mut crate::sound::SoundManager {
+        &mut self.sound_manager
+    }
+
     /// Attach shared process resources to this dispatcher.
     pub(crate) fn attach_process_context(&mut self, context: &mut ProcessContext) {
         context.attach_resource_manager(&mut self.process_resource_manager);


### PR DESCRIPTION
## Summary

- attach one process-owned Sound Manager to both classic and PowerPC CPU adapters
- apply native channel, command, volume, file-play, and ready double-buffer mutations immediately to canonical process state
- remove the deferred decoded-buffer/file-playback handoff while retaining architecture-specific callback scheduling at the adapter edge
- preserve detached clone isolation and native launch defaults

## Testing

- `cargo test --locked --lib` (4,725 passed; 0 failed; 3 ignored)
- `RUSTDOCFLAGS="-D warnings -D rustdoc::private_intra_doc_links" cargo doc --all-features --locked --no-deps --document-private-items`

Closes #1163