### PR TITLE
refactor(events): make queue process-owned

### DIFF
--- a/src/event_queue.rs
+++ b/src/event_queue.rs
@@ -34,6 +34,10 @@ impl EventQueue {
         Self::default()
     }
 
+    pub(crate) fn is_pristine(&self) -> bool {
+        self.events.is_empty() && !self.menu_bar_invalid
+    }
+
     /// Mark the menu bar for one deferred redraw by the Toolbox Event
     /// Manager. Repeated invalidations coalesce until the next event scan.
     /// Macintosh Toolbox Essentials (1992), pp. 3-93 and 3-114.

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -75,7 +75,7 @@ use crate::process_context::{
     ProcessNativeAllocatorState, ProcessNativeHeapState, ProcessNativeMemoryManager,
     ProcessPtrRecord, ProcessResourceManagerState, ProcessVfsFileRecords,
     ProcessVfsResourceFileRecords, SharedProcessAppleEventHandlers, SharedProcessCursorState,
-    SharedProcessFileSystem, SharedProcessMemoryManager,
+    SharedProcessEventQueue, SharedProcessFileSystem, SharedProcessMemoryManager,
 };
 use crate::quickdraw::fonts::heuristics::{
     get_italic_end_extend, get_italic_slant, get_italic_underline_extend_left,
@@ -3396,7 +3396,7 @@ pub struct PpcLoadedApp {
     pub imports: Vec<PpcImportBinding>,
     pub section_bases: Vec<Option<u32>>,
     pub input: PpcInputSnapshot,
-    pub(crate) event_queue: EventQueue,
+    pub(crate) event_queue: SharedProcessEventQueue,
     pub(crate) guest_calls: SharedGuestCallStack,
     pub(crate) process_memory_manager: PpcProcessMemoryManager,
     pub draw_sprocket: PpcDrawSprocketState,
@@ -3844,6 +3844,7 @@ impl PpcLoadedApp {
         context.attach_file_system(&mut self.process_file_system);
         context.attach_sound_manager(&mut self.sound.manager);
         context.attach_cursor_state(&mut self.cursor_state);
+        context.attach_event_queue(&mut self.event_queue);
         context.adopt_menu_tracking(&mut self.toolbox_startup.menu_tracking);
         let mut attached_memory_manager = None;
         context.attach_memory_manager(&mut attached_memory_manager);
@@ -3872,23 +3873,6 @@ impl PpcLoadedApp {
         context.attach_apple_event_handlers(&mut self.apple_events.handlers);
     }
 
-    /// Temporarily borrow the canonical event queue from [`ProcessContext`] into this
-    /// adapter's local queue for the duration of `f`, and guarantee it is swapped back
-    /// on normal exit, early return, or unwind.
-    pub(crate) fn with_event_queue<R>(
-        &mut self,
-        event_queue: &mut EventQueue,
-        f: impl FnOnce(&mut Self) -> R,
-    ) -> R {
-        std::mem::swap(&mut self.event_queue, event_queue);
-        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(self)));
-        std::mem::swap(&mut self.event_queue, event_queue);
-        match outcome {
-            Ok(result) => result,
-            Err(payload) => std::panic::resume_unwind(payload),
-        }
-    }
-
     /// Temporarily install the canonical retained Menu Manager continuation in
     /// this adapter, restoring it to the process owner on return or unwind.
     pub(crate) fn with_menu_tracking<R>(
@@ -3905,27 +3889,26 @@ impl PpcLoadedApp {
         }
     }
 
-    /// Install all directly owned process state needed by one native
-    /// execution slice, returning it before the scheduler changes CPU.
+    /// Temporarily install the retained Menu Manager continuation needed by
+    /// one native execution slice. The Event Manager queue stays attached to
+    /// its process owner for the adapter's entire lifetime.
     pub(crate) fn with_process_state<R>(
         &mut self,
-        event_queue: &mut EventQueue,
         menu_tracking: &mut Option<ProcessMenuTrackingState>,
         f: impl FnOnce(&mut Self) -> R,
     ) -> R {
-        self.with_event_queue(event_queue, |app| app.with_menu_tracking(menu_tracking, f))
+        self.with_menu_tracking(menu_tracking, f)
     }
 
     /// Run one native slice while publishing its live relocatable blocks to
     /// the process Memory Manager before another CPU adapter can execute.
     pub(crate) fn with_process_state_and_memory_manager<R>(
         &mut self,
-        event_queue: &mut EventQueue,
         menu_tracking: &mut Option<ProcessMenuTrackingState>,
         memory_manager: &SharedProcessMemoryManager,
         f: impl FnOnce(&mut Self, &mut ProcessMemoryManager) -> R,
     ) -> R {
-        self.with_process_state(event_queue, menu_tracking, |app| {
+        self.with_process_state(menu_tracking, |app| {
             let mut memory_manager = memory_manager.borrow_mut();
             app.apply_process_memory_manager(&memory_manager);
             app.publish_process_memory_manager(&mut memory_manager, None);
@@ -12775,7 +12758,7 @@ fn load_pef_application_with_config_and_optional_system_reservation(
         imports,
         section_bases,
         input: PpcInputSnapshot::default(),
-        event_queue: EventQueue::default(),
+        event_queue: SharedProcessEventQueue::default(),
         guest_calls: SharedGuestCallStack::default(),
         process_memory_manager,
         draw_sprocket: PpcDrawSprocketState::default(),
@@ -89843,64 +89826,79 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn attached_68k_and_powerpc_event_adapters_share_menu_bar_invalidation() {
+    fn attached_68k_and_powerpc_event_adapters_share_fifo_and_menu_bar_invalidation() {
         let (mut classic, _, _) = setup_with_port();
         let pef = synthetic_pef_with_import(b"InvalMenuBar");
         let mut native = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
 
-        assert!(!context.event_queue().menu_bar_is_invalid());
-
-        classic.with_event_queue(context.event_queue_mut(), |classic| {
-            classic.event_queue.invalidate_menu_bar();
-            assert!(classic.event_queue.menu_bar_is_invalid());
-        });
-
-        assert!(context.event_queue().menu_bar_is_invalid());
-
-        native.with_event_queue(context.event_queue_mut(), |native| {
-            assert!(native.event_queue.menu_bar_is_invalid());
-            assert!(native.event_queue.take_menu_bar_invalidation());
-            assert!(!native.event_queue.menu_bar_is_invalid());
-        });
+        classic.attach_process_context(&mut context);
+        native.attach_process_context(&mut context);
 
         assert!(!context.event_queue().menu_bar_is_invalid());
-    }
 
-    #[test]
-    fn ppc_with_event_queue_restores_context_and_adapter_state_on_panic() {
-        let pef = synthetic_pef_with_import(b"InvalMenuBar");
-        let mut native = load_pef_application(&pef).unwrap();
-        let mut context_queue = EventQueue::default();
-        context_queue.push_back(QueuedEvent {
+        classic.event_queue.push_back(QueuedEvent {
             what: 1,
             message: 0x1111,
             where_v: 10,
             where_h: 20,
             modifiers: 0,
         });
+        native.event_queue.push_back(QueuedEvent {
+            what: 2,
+            message: 0x2222,
+            where_v: 30,
+            where_h: 40,
+            modifiers: 0,
+        });
+        classic.event_queue.invalidate_menu_bar();
+
+        assert_eq!(context.event_queue().len(), 2);
+        assert_eq!(native.event_queue[0].message, 0x1111);
+        assert_eq!(native.event_queue[1].message, 0x2222);
+        assert!(context.event_queue().menu_bar_is_invalid());
+
+        assert_eq!(native.event_queue.pop_front().unwrap().message, 0x1111);
+        assert_eq!(classic.event_queue.front().unwrap().message, 0x2222);
+        assert!(native.event_queue.take_menu_bar_invalidation());
+
+        assert_eq!(context.event_queue().len(), 1);
+        assert!(!context.event_queue().menu_bar_is_invalid());
+    }
+
+    #[test]
+    fn attached_ppc_event_queue_remains_shared_through_panic() {
+        let pef = synthetic_pef_with_import(b"InvalMenuBar");
+        let mut native = load_pef_application(&pef).unwrap();
+        let mut context = ProcessContext::default();
+        context.event_queue_mut().push_back(QueuedEvent {
+            what: 1,
+            message: 0x1111,
+            where_v: 10,
+            where_h: 20,
+            modifiers: 0,
+        });
+        native.attach_process_context(&mut context);
 
         let panic_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            native.with_event_queue(&mut context_queue, |app| {
-                app.event_queue.push_back(QueuedEvent {
-                    what: 2,
-                    message: 0x2222,
-                    where_v: 30,
-                    where_h: 40,
-                    modifiers: 0,
-                });
-                app.event_queue.invalidate_menu_bar();
-                panic!("simulated panic inside PPC guest execution");
-            })
+            native.event_queue.push_back(QueuedEvent {
+                what: 2,
+                message: 0x2222,
+                where_v: 30,
+                where_h: 40,
+                modifiers: 0,
+            });
+            native.event_queue.invalidate_menu_bar();
+            panic!("simulated panic inside PPC guest execution");
         }));
 
         assert!(panic_result.is_err());
-        assert_eq!(context_queue.len(), 2);
-        assert_eq!(context_queue[0].message, 0x1111);
-        assert_eq!(context_queue[1].message, 0x2222);
-        assert!(context_queue.menu_bar_is_invalid());
-        assert!(native.event_queue.is_empty());
-        assert!(!native.event_queue.menu_bar_is_invalid());
+        assert_eq!(context.event_queue().len(), 2);
+        assert_eq!(context.event_queue()[0].message, 0x1111);
+        assert_eq!(context.event_queue()[1].message, 0x2222);
+        assert!(context.event_queue().menu_bar_is_invalid());
+        assert_eq!(native.event_queue.len(), 2);
+        assert!(native.event_queue.menu_bar_is_invalid());
     }
 
     #[test]
@@ -90050,8 +90048,7 @@ pub(crate) mod tests {
 
         let mut context = ProcessContext::default();
         native.attach_process_context(&mut context);
-        let (event_queue, menu_tracking, memory_manager) =
-            context.event_queue_menu_tracking_and_memory_manager();
+        let (menu_tracking, memory_manager) = context.menu_tracking_and_memory_manager();
         let expected_cursor = native.heap_cursor() + 16;
         {
             let mut manager = memory_manager.borrow_mut();
@@ -90080,7 +90077,6 @@ pub(crate) mod tests {
         }
 
         native.with_process_state_and_memory_manager(
-            event_queue,
             menu_tracking,
             memory_manager,
             |_native, memory_manager| {
@@ -90260,10 +90256,7 @@ pub(crate) mod tests {
         let mut attached = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
         attached.attach_process_context(&mut context);
-        let memory_manager = context
-            .event_queue_menu_tracking_and_memory_manager()
-            .2
-            .clone();
+        let memory_manager = context.menu_tracking_and_memory_manager().1.clone();
 
         standalone.cpu.gpr[3] = 24;
         attached.cpu.gpr[3] = 24;
@@ -90396,8 +90389,7 @@ pub(crate) mod tests {
         native.memory.add_region(ptr & !0x0fff, vec![0; 0x1000]);
         native.memory.write_u32_be(handle, ptr).unwrap();
         native.memory.write_u8(ptr, 0x5a).unwrap();
-        let (event_queue, menu_tracking, memory_manager) =
-            context.event_queue_menu_tracking_and_memory_manager();
+        let (menu_tracking, memory_manager) = context.menu_tracking_and_memory_manager();
         // HLock and HGetState operate on the live relocatable block while the
         // stable handle continues to identify its master pointer. Inside
         // Macintosh: Memory (1992), pp. 1-18--1-19 and 2-45--2-49.
@@ -90405,7 +90397,6 @@ pub(crate) mod tests {
         let detached = memory_manager.detached_clone();
 
         native.with_process_state_and_memory_manager(
-            event_queue,
             menu_tracking,
             memory_manager,
             |native, memory_manager| {
@@ -90470,10 +90461,7 @@ pub(crate) mod tests {
 
         let mut context = ProcessContext::default();
         native.attach_process_context(&mut context);
-        let process_memory_manager = context
-            .event_queue_menu_tracking_and_memory_manager()
-            .2
-            .clone();
+        let process_memory_manager = context.menu_tracking_and_memory_manager().1.clone();
         assert!(native
             .process_memory_manager
             .ptr_eq(&process_memory_manager));
@@ -90575,11 +90563,9 @@ pub(crate) mod tests {
         native.cpu.gpr[3] = 24;
         let mut context = ProcessContext::default();
         native.attach_process_context(&mut context);
-        let (event_queue, menu_tracking, memory_manager) =
-            context.event_queue_menu_tracking_and_memory_manager();
+        let (menu_tracking, memory_manager) = context.menu_tracking_and_memory_manager();
 
         native.with_process_state_and_memory_manager(
-            event_queue,
             menu_tracking,
             memory_manager,
             |native, memory_manager| {
@@ -90665,11 +90651,9 @@ pub(crate) mod tests {
         native.attach_process_context(&mut context);
         let mut classic_dispatcher = TrapDispatcher::new();
         classic_dispatcher.attach_process_context(&mut context);
-        let (event_queue, menu_tracking, memory_manager) =
-            context.event_queue_menu_tracking_and_memory_manager();
+        let (menu_tracking, memory_manager) = context.menu_tracking_and_memory_manager();
 
         native.with_process_state_and_memory_manager(
-            event_queue,
             menu_tracking,
             memory_manager,
             |native, memory_manager| {
@@ -90860,11 +90844,9 @@ pub(crate) mod tests {
         native.attach_process_context(&mut context);
         let mut classic_dispatcher = TrapDispatcher::new();
         classic_dispatcher.attach_process_context(&mut context);
-        let (event_queue, menu_tracking, memory_manager) =
-            context.event_queue_menu_tracking_and_memory_manager();
+        let (menu_tracking, memory_manager) = context.menu_tracking_and_memory_manager();
 
         native.with_process_state_and_memory_manager(
-            event_queue,
             menu_tracking,
             memory_manager,
             |native, memory_manager| {
@@ -91015,11 +90997,9 @@ pub(crate) mod tests {
 
         let mut context = ProcessContext::default();
         native.attach_process_context(&mut context);
-        let (event_queue, menu_tracking, memory_manager) =
-            context.event_queue_menu_tracking_and_memory_manager();
+        let (menu_tracking, memory_manager) = context.menu_tracking_and_memory_manager();
 
         native.with_process_state_and_memory_manager(
-            event_queue,
             menu_tracking,
             memory_manager,
             |native, memory_manager| {

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -565,6 +565,7 @@ pub struct SharedProcessValue<T>(Rc<UnsafeCell<T>>);
 pub(crate) type SharedProcessResourceManager = SharedProcessValue<ProcessResourceManagerState>;
 pub(crate) type SharedProcessSoundManager = SharedProcessValue<SoundManager>;
 pub(crate) type SharedProcessCursorState = SharedProcessValue<ProcessCursorState>;
+pub(crate) type SharedProcessEventQueue = SharedProcessValue<EventQueue>;
 
 /// Canonical QuickDraw cursor state for one Macintosh process.
 ///
@@ -3387,7 +3388,7 @@ impl ProcessNativeMemoryManager {
 pub(crate) struct ProcessContext {
     memory: Vec<ProcessMemoryRegion>,
     memory_manager: SharedProcessMemoryManager,
-    event_queue: EventQueue,
+    event_queue: SharedProcessEventQueue,
     menu_tracking: Option<ProcessMenuTrackingState>,
     pending_native_menu_selection: SharedNativeMenuSelection,
     guest_calls: SharedGuestCallStack,
@@ -3439,6 +3440,14 @@ impl ProcessContext {
 
     pub(crate) fn attach_cursor_state(&self, adapter: &mut SharedProcessCursorState) {
         adapter.attach_to(&self.cursor_state, ProcessCursorState::is_pristine);
+    }
+
+    pub(crate) fn attach_event_queue(&self, adapter: &mut SharedProcessEventQueue) {
+        // The Operating System Event Manager maintains one FIFO queue for the
+        // current process. GetNextEvent removes the first matching event while
+        // EventAvail observes it in place. Inside Macintosh Volume I (1985),
+        // pp. I-244--I-245 and I-257--I-259; Processes (1994), pp. 2-15--2-16.
+        adapter.attach_to(&self.event_queue, EventQueue::is_pristine);
     }
 
     pub(crate) fn attach_classic_file_system(
@@ -3512,7 +3521,7 @@ impl ProcessContext {
         &self.event_queue
     }
 
-    pub(crate) fn event_queue_mut(&mut self) -> &mut EventQueue {
+    pub(crate) fn event_queue_mut(&mut self) -> &mut SharedProcessEventQueue {
         &mut self.event_queue
     }
 
@@ -3535,7 +3544,6 @@ impl ProcessContext {
         self.menu_tracking = state;
     }
 
-    #[cfg(test)]
     pub(crate) fn menu_tracking_slot_mut(&mut self) -> &mut Option<ProcessMenuTrackingState> {
         &mut self.menu_tracking
     }
@@ -3551,25 +3559,13 @@ impl ProcessContext {
         }
     }
 
-    /// Borrow the process state temporarily installed in an active CPU adapter.
-    pub(crate) fn event_queue_and_menu_tracking_mut(
-        &mut self,
-    ) -> (&mut EventQueue, &mut Option<ProcessMenuTrackingState>) {
-        (&mut self.event_queue, &mut self.menu_tracking)
-    }
-
-    pub(crate) fn event_queue_menu_tracking_and_memory_manager(
+    pub(crate) fn menu_tracking_and_memory_manager(
         &mut self,
     ) -> (
-        &mut EventQueue,
         &mut Option<ProcessMenuTrackingState>,
         &SharedProcessMemoryManager,
     ) {
-        (
-            &mut self.event_queue,
-            &mut self.menu_tracking,
-            &self.memory_manager,
-        )
+        (&mut self.menu_tracking, &self.memory_manager)
     }
 
     pub(crate) fn attach_native_menu_selection(&self, adapter: &mut SharedNativeMenuSelection) {
@@ -3733,15 +3729,15 @@ mod tests {
         assert_eq!(taken.map(|t| t.menu_handle), Some(0x0012_3456));
         assert!(context.menu_tracking().is_none());
 
-        let (queue, menu) = context.event_queue_and_menu_tracking_mut();
-        queue.push_back(QueuedEvent {
+        context.event_queue_mut().push_back(QueuedEvent {
             what: 2,
             message: 0x5678,
             where_v: 0,
             where_h: 0,
             modifiers: 0,
         });
-        *menu = Some(crate::menu_manager::test_process_menu_tracking(0x0065_4321));
+        *context.menu_tracking_slot_mut() =
+            Some(crate::menu_manager::test_process_menu_tracking(0x0065_4321));
         assert_eq!(context.event_queue().len(), 1);
         assert_eq!(
             context.menu_tracking().map(|t| t.menu_handle),
@@ -4923,6 +4919,41 @@ mod tests {
         assert_eq!(classic.sys_beep_volume(), 0x0080_0040);
         assert_eq!(detached.channels.len(), 1);
         assert_eq!(detached.sys_beep_volume(), 0x0100_0100);
+    }
+
+    #[test]
+    fn attached_event_queues_share_fifo_and_invalidation_while_clones_detach() {
+        let context = ProcessContext::default();
+        let mut classic = SharedProcessEventQueue::default();
+        classic.push_back(QueuedEvent {
+            what: 1,
+            message: 0x1111,
+            where_v: 10,
+            where_h: 20,
+            modifiers: 0,
+        });
+        let mut native = SharedProcessEventQueue::default();
+
+        context.attach_event_queue(&mut classic);
+        context.attach_event_queue(&mut native);
+        let detached = native.clone();
+
+        native.push_back(QueuedEvent {
+            what: 2,
+            message: 0x2222,
+            where_v: 30,
+            where_h: 40,
+            modifiers: 0,
+        });
+        classic.invalidate_menu_bar();
+
+        assert!(classic.ptr_eq(&native));
+        assert_eq!(classic.pop_front().unwrap().message, 0x1111);
+        assert_eq!(native.front().unwrap().message, 0x2222);
+        assert!(native.take_menu_bar_invalidation());
+        assert_eq!(detached.len(), 1);
+        assert_eq!(detached.front().unwrap().message, 0x1111);
+        assert!(!detached.menu_bar_is_invalid());
     }
 
     #[test]

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -2336,9 +2336,9 @@ impl FixtureRunner {
     }
 
     fn redraw_chrome(&mut self) {
-        let (event_queue, menu_tracking) = self.process_context.event_queue_and_menu_tracking_mut();
+        let menu_tracking = self.process_context.menu_tracking_slot_mut();
         self.dispatcher
-            .with_process_state(event_queue, menu_tracking, |dispatcher| {
+            .with_process_state(menu_tracking, |dispatcher| {
                 dispatcher.redraw_chrome(&mut self.bus);
             });
     }
@@ -2460,9 +2460,9 @@ impl FixtureRunner {
     }
 
     fn push_canonical_mouse_down(&mut self, v: i16, h: i16) {
-        let (event_queue, menu_tracking) = self.process_context.event_queue_and_menu_tracking_mut();
+        let menu_tracking = self.process_context.menu_tracking_slot_mut();
         self.dispatcher
-            .with_process_state(event_queue, menu_tracking, |d| d.push_mouse_down(v, h));
+            .with_process_state(menu_tracking, |d| d.push_mouse_down(v, h));
         self.sync_mouse_lowmem();
         self.wake_pending_wait_next_event_if_input_available();
         self.wake_foreground_after_input();
@@ -2502,9 +2502,9 @@ impl FixtureRunner {
     }
 
     fn push_canonical_mouse_up(&mut self, v: i16, h: i16) {
-        let (event_queue, menu_tracking) = self.process_context.event_queue_and_menu_tracking_mut();
+        let menu_tracking = self.process_context.menu_tracking_slot_mut();
         self.dispatcher
-            .with_process_state(event_queue, menu_tracking, |d| d.push_mouse_up(v, h));
+            .with_process_state(menu_tracking, |d| d.push_mouse_up(v, h));
         self.sync_mouse_lowmem();
         self.wake_pending_wait_next_event_if_input_available();
         self.wake_foreground_after_input();
@@ -2552,9 +2552,9 @@ impl FixtureRunner {
     /// Inject a key-down event, applying arrow→numpad remapping if configured.
     pub fn push_key_down(&mut self, mac_key: u8, char_code: u8) {
         let (key, char_code) = self.remap_key(mac_key, char_code);
-        let (event_queue, menu_tracking) = self.process_context.event_queue_and_menu_tracking_mut();
+        let menu_tracking = self.process_context.menu_tracking_slot_mut();
         self.dispatcher
-            .with_process_state(event_queue, menu_tracking, |d| {
+            .with_process_state(menu_tracking, |d| {
                 d.push_key_down(key, char_code);
             });
         self.sync_key_map_lowmem();
@@ -2568,9 +2568,9 @@ impl FixtureRunner {
         let sys_evt_mask = self
             .bus
             .read_word(crate::memory::globals::addr::SYS_EVT_MASK);
-        let (event_queue, menu_tracking) = self.process_context.event_queue_and_menu_tracking_mut();
+        let menu_tracking = self.process_context.menu_tracking_slot_mut();
         self.dispatcher
-            .with_process_state(event_queue, menu_tracking, |d| {
+            .with_process_state(menu_tracking, |d| {
                 d.push_key_up_with_system_event_mask(sys_evt_mask, key, char_code);
             });
         self.sync_key_map_lowmem();
@@ -3705,6 +3705,10 @@ impl FixtureRunner {
         self.dispatcher
             .materialize_trap_tables(&mut self.bus, TrapTableProfile::PowerPc604);
         self.share_ppc_process_memory(&mut ppc_app);
+        let detached_events = std::mem::take(&mut *ppc_app.event_queue);
+        self.process_context
+            .event_queue_mut()
+            .merge(detached_events);
         ppc_app.attach_process_context(&mut self.process_context);
         if let Some(time_base) = self.launch_ppc_time_base_override {
             ppc_app.cpu.set_time_base(time_base);
@@ -3750,10 +3754,6 @@ impl FixtureRunner {
         self.cpu.write_reg(Register::PC, 0);
         self.ppc_sound_synced_file_playback_count = 0;
         self.ppc_sound_host_playbacks.clear();
-        let detached_events = std::mem::take(&mut ppc_app.event_queue);
-        self.process_context
-            .event_queue_mut()
-            .merge(detached_events);
         self.ppc_app = Some(ppc_app);
     }
 
@@ -5472,11 +5472,9 @@ impl FixtureRunner {
                     }
 
                     self.dispatcher.yield_for_ui = yield_for_ui;
-                    let (event_queue, menu_tracking, memory_manager) = self
-                        .process_context
-                        .event_queue_menu_tracking_and_memory_manager();
+                    let (menu_tracking, memory_manager) =
+                        self.process_context.menu_tracking_and_memory_manager();
                     let dispatch_result = self.dispatcher.with_process_state_and_memory_manager(
-                        event_queue,
                         menu_tracking,
                         memory_manager,
                         |dispatcher| dispatcher.dispatch(opcode, &mut self.cpu, &mut self.bus),
@@ -5827,11 +5825,9 @@ impl FixtureRunner {
         let trace_ppc_imports = record_ppc_imports || trace_ppc_import_hist;
         let trace_ppc_fetches = trace_ppc_fetch_counts_enabled();
         let profile_run_start = profile_ppc.then(Instant::now);
-        let (event_queue, menu_tracking, memory_manager) = self
-            .process_context
-            .event_queue_menu_tracking_and_memory_manager();
+        let (menu_tracking, memory_manager) =
+            self.process_context.menu_tracking_and_memory_manager();
         let probe = ppc_app.with_process_state_and_memory_manager(
-            event_queue,
             menu_tracking,
             memory_manager,
             |app, memory_manager| {
@@ -5881,11 +5877,9 @@ impl FixtureRunner {
         } else {
             self.advance_ticks_for_ppc_cycles(cycles, tick_cap);
             let elapsed_ticks = self.dispatcher.tick_count.wrapping_sub(ppc_start_tick);
-            let (event_queue, menu_tracking, memory_manager) = self
-                .process_context
-                .event_queue_menu_tracking_and_memory_manager();
+            let (menu_tracking, memory_manager) =
+                self.process_context.menu_tracking_and_memory_manager();
             ppc_app.with_process_state_and_memory_manager(
-                event_queue,
                 menu_tracking,
                 memory_manager,
                 |app, memory_manager| {
@@ -6199,11 +6193,9 @@ impl FixtureRunner {
                         self.cpu.core.take_aline_exception(&mut self.bus);
                         continue;
                     }
-                    let (event_queue, menu_tracking, memory_manager) = self
-                        .process_context
-                        .event_queue_menu_tracking_and_memory_manager();
+                    let (menu_tracking, memory_manager) =
+                        self.process_context.menu_tracking_and_memory_manager();
                     let dispatch_err = self.dispatcher.with_process_state_and_memory_manager(
-                        event_queue,
                         menu_tracking,
                         memory_manager,
                         |dispatcher| {
@@ -7538,11 +7530,9 @@ impl FixtureRunner {
         while !ppc_app.sound.pending_doublebacks.is_empty() && fired_count < 16 {
             let doubleback = ppc_app.sound.pending_doublebacks.remove(0);
             let resume_pc = ppc_app.cpu.pc;
-            let (event_queue, menu_tracking, memory_manager) = self
-                .process_context
-                .event_queue_menu_tracking_and_memory_manager();
+            let (menu_tracking, memory_manager) =
+                self.process_context.menu_tracking_and_memory_manager();
             let probe = ppc_app.with_process_state_and_memory_manager(
-                event_queue,
                 menu_tracking,
                 memory_manager,
                 |app, memory_manager| {
@@ -7653,11 +7643,9 @@ impl FixtureRunner {
         let mut fired_count = 0usize;
         while !ppc_app.sound.pending_completions.is_empty() && fired_count < 16 {
             let completion = ppc_app.sound.pending_completions.remove(0);
-            let (event_queue, menu_tracking, memory_manager) = self
-                .process_context
-                .event_queue_menu_tracking_and_memory_manager();
+            let (menu_tracking, memory_manager) =
+                self.process_context.menu_tracking_and_memory_manager();
             let probe = ppc_app.with_process_state_and_memory_manager(
-                event_queue,
                 menu_tracking,
                 memory_manager,
                 |app, memory_manager| {
@@ -8489,9 +8477,9 @@ impl FixtureRunner {
         let sys_evt_mask = self
             .bus
             .read_word(crate::memory::globals::addr::SYS_EVT_MASK);
-        let (event_queue, menu_tracking) = self.process_context.event_queue_and_menu_tracking_mut();
+        let menu_tracking = self.process_context.menu_tracking_slot_mut();
         self.dispatcher
-            .with_process_state(event_queue, menu_tracking, |d| {
+            .with_process_state(menu_tracking, |d| {
                 d.post_auto_key_if_due(sys_evt_mask);
             });
 
@@ -8508,10 +8496,10 @@ impl FixtureRunner {
         // to 0x80 even when no GetNextEvent ever drains the queue —
         // critical for polling-only games (Bonkheads-Deluxe class titles)
         // that would otherwise see the button as "held forever".
-        let (event_queue, menu_tracking) = self.process_context.event_queue_and_menu_tracking_mut();
+        let menu_tracking = self.process_context.menu_tracking_slot_mut();
         let has_pending_unmatched_down =
             self.dispatcher
-                .with_process_state(event_queue, menu_tracking, |d| {
+                .with_process_state(menu_tracking, |d| {
                     d.has_unmatched_queued_mouse_down()
                 });
         let pressed = self.dispatcher.mouse_button || has_pending_unmatched_down;
@@ -8577,10 +8565,10 @@ impl FixtureRunner {
             }
         }
 
-        let (event_queue, menu_tracking) = self.process_context.event_queue_and_menu_tracking_mut();
+        let menu_tracking = self.process_context.menu_tracking_slot_mut();
         let (mut what, mut message, mut where_v, mut where_h, mut modifiers, mut has_event) = self
             .dispatcher
-            .with_process_state(event_queue, menu_tracking, |dispatcher| {
+            .with_process_state(menu_tracking, |dispatcher| {
                 dispatcher.dequeue_toolbox_event(&mut self.cpu, &mut self.bus, pending.event_mask)
             });
         if !has_event {
@@ -10400,11 +10388,9 @@ impl FixtureRunner {
                         count += 1;
                         continue;
                     }
-                    let (event_queue, menu_tracking, memory_manager) = self
-                        .process_context
-                        .event_queue_menu_tracking_and_memory_manager();
+                    let (menu_tracking, memory_manager) =
+                        self.process_context.menu_tracking_and_memory_manager();
                     let dispatch_result = self.dispatcher.with_process_state_and_memory_manager(
-                        event_queue,
                         menu_tracking,
                         memory_manager,
                         |dispatcher| dispatcher.dispatch(opcode, &mut self.cpu, &mut self.bus),
@@ -11897,7 +11883,7 @@ mod tests {
     }
 
     #[test]
-    fn init_ppc_app_merges_detached_events_and_menu_bar_invalidation() {
+    fn init_ppc_app_merges_detached_events_then_attaches_the_process_queue() {
         // Test case 1: Context has event and invalidation=true, detached PPC has event and invalidation=false
         {
             let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
@@ -11943,7 +11929,11 @@ mod tests {
                 queue.menu_bar_is_invalid(),
                 "menu_bar_invalid should be true when context was true"
             );
-            assert!(runner.ppc_app.as_ref().unwrap().event_queue.is_empty());
+            let native_queue = &runner.ppc_app.as_ref().unwrap().event_queue;
+            assert_eq!(native_queue.len(), 2);
+            assert_eq!(native_queue[0].message, 0x1111);
+            assert_eq!(native_queue[1].message, 0x2222);
+            assert!(native_queue.menu_bar_is_invalid());
         }
 
         // Test case 2: Context has event and invalidation=false, detached PPC has event and invalidation=true
@@ -11988,7 +11978,11 @@ mod tests {
                 queue.menu_bar_is_invalid(),
                 "menu_bar_invalid should be true when detached PPC was true"
             );
-            assert!(runner.ppc_app.as_ref().unwrap().event_queue.is_empty());
+            let native_queue = &runner.ppc_app.as_ref().unwrap().event_queue;
+            assert_eq!(native_queue.len(), 2);
+            assert_eq!(native_queue[0].message, 0x3333);
+            assert_eq!(native_queue[1].message, 0x4444);
+            assert!(native_queue.menu_bar_is_invalid());
         }
     }
 
@@ -15357,12 +15351,9 @@ mod tests {
             .back()
             .expect("mouseDown");
         assert_eq!((event.where_v, event.where_h), (12, 34));
-        let mut ppc_app = runner.ppc_app.take().expect("PPC app");
-        ppc_app.with_event_queue(runner.process_context.event_queue_mut(), |ppc_app| {
-            let native_event = ppc_app.event_queue.back().expect("shared mouseDown");
-            assert_eq!((native_event.where_v, native_event.where_h), (12, 34));
-        });
-        runner.ppc_app = Some(ppc_app);
+        let ppc_app = runner.ppc_app.as_ref().expect("PPC app");
+        let native_event = ppc_app.event_queue.back().expect("shared mouseDown");
+        assert_eq!((native_event.where_v, native_event.where_h), (12, 34));
         assert_eq!(runner.bus.read_word(addr::M_TEMP), 12);
         assert_eq!(runner.bus.read_word(addr::M_TEMP + 2), 34);
     }
@@ -15394,9 +15385,9 @@ mod tests {
             (10, 20)
         );
 
-        // PPC adapter receives canonical queue during execution
-        let mut ppc_app = runner.ppc_app.take().unwrap();
-        ppc_app.with_event_queue(runner.process_context.event_queue_mut(), |app| {
+        // The attached PPC adapter observes and mutates the canonical queue directly.
+        {
+            let app = runner.ppc_app.as_mut().unwrap();
             assert_eq!(app.event_queue.len(), 1);
             let event = app.event_queue.pop_front().unwrap();
             assert_eq!((event.where_v, event.where_h), (10, 20));
@@ -15407,24 +15398,19 @@ mod tests {
                 where_h: 40,
                 modifiers: 0,
             });
-        });
-        runner.ppc_app = Some(ppc_app);
+        }
 
-        // Immediately visible in ProcessContext without sync copies
+        // The mutation is immediately visible in ProcessContext without a sync copy.
         assert_eq!(runner.process_context.event_queue().len(), 1);
         assert_eq!(
             runner.process_context.event_queue().front().unwrap().what,
             2
         );
 
-        // 68k dispatcher receives canonical queue during execution
-        runner
-            .dispatcher
-            .with_event_queue(runner.process_context.event_queue_mut(), |classic| {
-                assert_eq!(classic.event_queue.len(), 1);
-                let event = classic.event_queue.pop_front().unwrap();
-                assert_eq!((event.where_v, event.where_h), (30, 40));
-            });
+        // The attached 68K dispatcher observes the same queue continuously.
+        assert_eq!(runner.dispatcher.event_queue.len(), 1);
+        let event = runner.dispatcher.event_queue.pop_front().unwrap();
+        assert_eq!((event.where_v, event.where_h), (30, 40));
 
         assert!(runner.process_context.event_queue().is_empty());
     }

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -7,7 +7,6 @@
 use super::types::UnderlineInfo;
 use crate::cpu::{CpuOps, Register};
 use crate::display::CursorImage;
-use crate::event_queue::EventQueue;
 use crate::guest_call::SharedGuestCallStack;
 use crate::machine_profile::reference_machine_profile;
 use crate::managers::resource::ResourceFork;
@@ -16,8 +15,8 @@ use crate::menu_manager::{ProcessMenuTrackingState, SharedNativeMenuSelection};
 use crate::process_context::{
     ProcessContext, ProcessForkMap, ProcessLoadedResources, ProcessResourceFileMap,
     ProcessResourceManagerState, SharedProcessAppleEventHandlers, SharedProcessCursorState,
-    SharedProcessMemoryManager, SharedProcessResourceManager, SharedProcessSoundManager,
-    SharedProcessValue,
+    SharedProcessEventQueue, SharedProcessMemoryManager, SharedProcessResourceManager,
+    SharedProcessSoundManager, SharedProcessValue,
 };
 use crate::trace::{TraceEvent, TraceSink, TraceSource};
 use crate::ui_theme::{UiTheme, UiThemeId};
@@ -2389,7 +2388,7 @@ pub struct TrapDispatcher {
     pub(crate) input_trace_enabled: bool,
     pub(crate) input_trace_log: Vec<String>,
     /// Queued events (mouseDown, mouseUp, etc.) to deliver via GetNextEvent
-    pub(crate) event_queue: EventQueue,
+    pub(crate) event_queue: SharedProcessEventQueue,
     /// A mouseDown consumed by ModalDialog can return to the application
     /// before the physical release arrives. Keep ownership of that release
     /// even if the application disposes the dialog in the meantime.
@@ -2916,6 +2915,7 @@ impl TrapDispatcher {
         context.attach_resource_manager(&mut self.process_resource_manager);
         context.attach_sound_manager(&mut self.sound_manager);
         context.attach_cursor_state(&mut self.cursor_state);
+        context.attach_event_queue(&mut self.event_queue);
         context.attach_classic_file_system(&mut self.vfs, &mut self.vfs_rsrc);
         context.adopt_menu_tracking(&mut self.menu_tracking);
         let mut memory_manager = None;
@@ -2996,23 +2996,6 @@ impl TrapDispatcher {
         self.process_memory_manager().has_handle_state(handle)
     }
 
-    /// Temporarily borrow the canonical event queue from [`ProcessContext`] into this
-    /// adapter's local queue for the duration of `f`, and guarantee it is swapped back
-    /// on normal exit, early return, or unwind.
-    pub(crate) fn with_event_queue<R>(
-        &mut self,
-        event_queue: &mut EventQueue,
-        f: impl FnOnce(&mut Self) -> R,
-    ) -> R {
-        std::mem::swap(&mut self.event_queue, event_queue);
-        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(self)));
-        std::mem::swap(&mut self.event_queue, event_queue);
-        match outcome {
-            Ok(result) => result,
-            Err(payload) => std::panic::resume_unwind(payload),
-        }
-    }
-
     /// Temporarily borrow the canonical menu tracking state from [`ProcessContext`]
     /// into this adapter's local tracking for the duration of `f`, and guarantee
     /// it is swapped back on normal exit, early return, or unwind.
@@ -3072,27 +3055,24 @@ impl TrapDispatcher {
 
     pub(crate) fn with_process_state_and_memory_manager<R>(
         &mut self,
-        event_queue: &mut EventQueue,
         menu_tracking: &mut Option<ProcessMenuTrackingState>,
         memory_manager: &SharedProcessMemoryManager,
         f: impl FnOnce(&mut Self) -> R,
     ) -> R {
-        self.with_process_state(event_queue, menu_tracking, |dispatcher| {
+        self.with_process_state(menu_tracking, |dispatcher| {
             dispatcher.with_memory_manager(memory_manager, f)
         })
     }
 
-    /// Install all directly owned process state needed by one 68k execution
-    /// slice, returning it to [`ProcessContext`] before another CPU can run.
+    /// Temporarily install the retained Menu Manager continuation needed by
+    /// one 68K execution slice. The Event Manager queue stays attached to its
+    /// ProcessContext owner for the dispatcher's entire lifetime.
     pub(crate) fn with_process_state<R>(
         &mut self,
-        event_queue: &mut EventQueue,
         menu_tracking: &mut Option<ProcessMenuTrackingState>,
         f: impl FnOnce(&mut Self) -> R,
     ) -> R {
-        self.with_event_queue(event_queue, |dispatcher| {
-            dispatcher.with_menu_tracking(menu_tracking, f)
-        })
+        self.with_menu_tracking(menu_tracking, f)
     }
 
     pub(crate) const AUTO_KEY_THRESHOLD_TICKS: u32 = 16;
@@ -4062,7 +4042,7 @@ impl TrapDispatcher {
             debug_scroll_rect_last_is_color: false,
             input_trace_enabled: false,
             input_trace_log: Vec::new(),
-            event_queue: EventQueue::default(),
+            event_queue: SharedProcessEventQueue::default(),
             pending_modal_dialog_mouse_up: false,
             pending_modal_dialog_mouse_down: None,
             flushed_update_events: VecDeque::new(),
@@ -11157,10 +11137,11 @@ mod tests {
     }
 
     #[test]
-    fn with_event_queue_restores_context_and_adapter_state_on_panic() {
+    fn attached_event_queue_remains_shared_through_panic() {
         let mut dispatcher = TrapDispatcher::new();
-        let mut context_queue = EventQueue::default();
-        context_queue.push_back(QueuedEvent {
+        let mut context = ProcessContext::default();
+        dispatcher.attach_process_context(&mut context);
+        context.event_queue_mut().push_back(QueuedEvent {
             what: 1,
             message: 0x1111,
             where_v: 10,
@@ -11169,26 +11150,24 @@ mod tests {
         });
 
         let panic_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            dispatcher.with_event_queue(&mut context_queue, |disp| {
-                disp.event_queue.push_back(QueuedEvent {
-                    what: 2,
-                    message: 0x2222,
-                    where_v: 30,
-                    where_h: 40,
-                    modifiers: 0,
-                });
-                disp.event_queue.invalidate_menu_bar();
-                panic!("simulated panic inside guest execution");
-            })
+            dispatcher.event_queue.push_back(QueuedEvent {
+                what: 2,
+                message: 0x2222,
+                where_v: 30,
+                where_h: 40,
+                modifiers: 0,
+            });
+            dispatcher.event_queue.invalidate_menu_bar();
+            panic!("simulated panic inside guest execution");
         }));
 
         assert!(panic_result.is_err());
-        assert_eq!(context_queue.len(), 2);
-        assert_eq!(context_queue[0].message, 0x1111);
-        assert_eq!(context_queue[1].message, 0x2222);
-        assert!(context_queue.menu_bar_is_invalid());
-        assert!(dispatcher.event_queue.is_empty());
-        assert!(!dispatcher.event_queue.menu_bar_is_invalid());
+        assert_eq!(context.event_queue().len(), 2);
+        assert_eq!(context.event_queue()[0].message, 0x1111);
+        assert_eq!(context.event_queue()[1].message, 0x2222);
+        assert!(context.event_queue().menu_bar_is_invalid());
+        assert_eq!(dispatcher.event_queue.len(), 2);
+        assert!(dispatcher.event_queue.menu_bar_is_invalid());
     }
 
     #[test]
@@ -11240,13 +11219,13 @@ mod tests {
     #[test]
     fn with_process_state_restores_all_canonical_slots_on_panic() {
         let mut dispatcher = TrapDispatcher::new();
-        let mut context_queue = EventQueue::default();
+        let mut context = ProcessContext::default();
+        dispatcher.attach_process_context(&mut context);
         let mut context_tracking = Some(crate::menu_manager::test_process_menu_tracking(0x9abc));
-        let memory_manager = SharedProcessMemoryManager::default();
+        let memory_manager = context.menu_tracking_and_memory_manager().1.clone();
 
         let panic_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             dispatcher.with_process_state_and_memory_manager(
-                &mut context_queue,
                 &mut context_tracking,
                 &memory_manager,
                 |disp| {
@@ -11266,7 +11245,10 @@ mod tests {
         }));
 
         assert!(panic_result.is_err());
-        assert_eq!(context_queue.front().map(|event| event.message), Some(0x3333));
+        assert_eq!(
+            context.event_queue().front().map(|event| event.message),
+            Some(0x3333)
+        );
         assert_eq!(
             memory_manager.borrow().handle_for_ptr(0x4444),
             Some(0x5555)
@@ -11284,7 +11266,7 @@ mod tests {
                 .map(|tracking| (tracking.menu_handle, tracking.highlighted_item)),
             Some((0x9abc, 7))
         );
-        assert!(dispatcher.event_queue.is_empty());
+        assert_eq!(dispatcher.event_queue.len(), 1);
         assert!(dispatcher.menu_tracking.is_none());
         assert!(dispatcher
             .process_memory_manager

--- a/src/trap/event.rs
+++ b/src/trap/event.rs
@@ -356,7 +356,7 @@ impl super::TrapDispatcher {
             remaining.push_back(event);
         }
 
-        *self.event_queue = remaining;
+        **self.event_queue = remaining;
         result
     }
 

--- a/src/trap/memory.rs
+++ b/src/trap/memory.rs
@@ -4519,11 +4519,9 @@ mod tests {
         dispatcher.attach_process_context(&mut context);
 
         cpu.write_reg(Register::D0, 24);
-        let (event_queue, menu_tracking, memory_manager) =
-            context.event_queue_menu_tracking_and_memory_manager();
+        let (menu_tracking, memory_manager) = context.menu_tracking_and_memory_manager();
         dispatcher
             .with_process_state_and_memory_manager(
-                event_queue,
                 menu_tracking,
                 memory_manager,
                 |dispatcher| {
@@ -4542,11 +4540,9 @@ mod tests {
         );
 
         cpu.write_reg(Register::D0, 13);
-        let (event_queue, menu_tracking, memory_manager) =
-            context.event_queue_menu_tracking_and_memory_manager();
+        let (menu_tracking, memory_manager) = context.menu_tracking_and_memory_manager();
         dispatcher
             .with_process_state_and_memory_manager(
-                event_queue,
                 menu_tracking,
                 memory_manager,
                 |dispatcher| {
@@ -4588,11 +4584,9 @@ mod tests {
         assert_eq!(cpu.read_reg(Register::D0), 13);
 
         cpu.write_reg(Register::A0, ptr);
-        let (event_queue, menu_tracking, memory_manager) =
-            context.event_queue_menu_tracking_and_memory_manager();
+        let (menu_tracking, memory_manager) = context.menu_tracking_and_memory_manager();
         dispatcher
             .with_process_state_and_memory_manager(
-                event_queue,
                 menu_tracking,
                 memory_manager,
                 |dispatcher| {
@@ -4606,11 +4600,9 @@ mod tests {
         assert_eq!(memory_manager.borrow().classic_allocation_size(ptr), None);
 
         cpu.write_reg(Register::A0, handle);
-        let (event_queue, menu_tracking, memory_manager) =
-            context.event_queue_menu_tracking_and_memory_manager();
+        let (menu_tracking, memory_manager) = context.menu_tracking_and_memory_manager();
         dispatcher
             .with_process_state_and_memory_manager(
-                event_queue,
                 menu_tracking,
                 memory_manager,
                 |dispatcher| {
@@ -4642,8 +4634,8 @@ mod tests {
         let mut context = ProcessContext::default();
         context.attach_classic_memory_bus(&mut bus);
         let memory_manager = context
-            .event_queue_menu_tracking_and_memory_manager()
-            .2
+            .menu_tracking_and_memory_manager()
+            .1
             .clone();
         {
             let mut manager = memory_manager.borrow_mut();
@@ -4718,8 +4710,8 @@ mod tests {
         let mut context = ProcessContext::default();
         context.attach_classic_memory_bus(&mut bus);
         let memory_manager = context
-            .event_queue_menu_tracking_and_memory_manager()
-            .2
+            .menu_tracking_and_memory_manager()
+            .1
             .clone();
         {
             let mut manager = memory_manager.borrow_mut();
@@ -4796,8 +4788,8 @@ mod tests {
         let mut context = ProcessContext::default();
         context.attach_classic_memory_bus(&mut bus);
         let memory_manager = context
-            .event_queue_menu_tracking_and_memory_manager()
-            .2
+            .menu_tracking_and_memory_manager()
+            .1
             .clone();
         {
             let mut manager = memory_manager.borrow_mut();
@@ -4883,8 +4875,8 @@ mod tests {
         let mut context = ProcessContext::default();
         context.attach_classic_memory_bus(&mut bus);
         let memory_manager = context
-            .event_queue_menu_tracking_and_memory_manager()
-            .2
+            .menu_tracking_and_memory_manager()
+            .1
             .clone();
         {
             let mut manager = memory_manager.borrow_mut();
@@ -4954,8 +4946,8 @@ mod tests {
         let mut context = ProcessContext::default();
         context.attach_classic_memory_bus(&mut bus);
         let memory_manager = context
-            .event_queue_menu_tracking_and_memory_manager()
-            .2
+            .menu_tracking_and_memory_manager()
+            .1
             .clone();
         {
             let mut manager = memory_manager.borrow_mut();


### PR DESCRIPTION
Closes #1169

## Summary

- make the per-process Event Manager queue continuously shared by the 68K and PowerPC adapters
- remove queue swap/restore boundaries from guest execution slices
- preserve FIFO ordering, deferred menu-bar invalidation, launch-time event merging, and detached clone isolation

## Validation

- `cargo test --locked --lib` (4,731 passed, 3 ignored)
- strict rustdoc with private intra-doc links denied
- `cargo build --locked --all-targets --all-features`
- deterministic gameplay gates: Marathon, Escape Velocity, Tomb Raider Gold