### PR TITLE
refactor(menus): make tracking process-owned

### DIFF
--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -76,6 +76,7 @@ use crate::process_context::{
     ProcessPtrRecord, ProcessResourceManagerState, ProcessVfsFileRecords,
     ProcessVfsResourceFileRecords, SharedProcessAppleEventHandlers, SharedProcessCursorState,
     SharedProcessEventQueue, SharedProcessFileSystem, SharedProcessMemoryManager,
+    SharedProcessMenuTracking,
 };
 use crate::quickdraw::fonts::heuristics::{
     get_italic_end_extend, get_italic_slant, get_italic_underline_extend_left,
@@ -2895,7 +2896,7 @@ pub struct PpcToolboxStartupState {
     pub menu_bar_draw_count: u32,
     pub host_menu_bar_hidden: bool,
     pub(crate) pending_native_menu_selection: SharedNativeMenuSelection,
-    pub(crate) menu_tracking: Option<ProcessMenuTrackingState>,
+    pub(crate) menu_tracking: SharedProcessMenuTracking,
     /// Custom popup MDEF state before its returned rectangle creates a pane.
     menu_definition_tracking: Option<MenuDefinitionTracking>,
     /// GetNewMBar result and remaining menus while custom mSizeMsg callbacks run.
@@ -2965,7 +2966,7 @@ impl Default for PpcToolboxStartupState {
             menu_bar_draw_count: 0,
             host_menu_bar_hidden: false,
             pending_native_menu_selection: SharedNativeMenuSelection::default(),
-            menu_tracking: None,
+            menu_tracking: SharedProcessMenuTracking::default(),
             menu_definition_tracking: None,
             pending_menu_bar_build: None,
             menu_select_call: None,
@@ -3845,7 +3846,7 @@ impl PpcLoadedApp {
         context.attach_sound_manager(&mut self.sound.manager);
         context.attach_cursor_state(&mut self.cursor_state);
         context.attach_event_queue(&mut self.event_queue);
-        context.adopt_menu_tracking(&mut self.toolbox_startup.menu_tracking);
+        context.attach_menu_tracking(&mut self.toolbox_startup.menu_tracking);
         let mut attached_memory_manager = None;
         context.attach_memory_manager(&mut attached_memory_manager);
         let attached_memory_manager =
@@ -3873,42 +3874,19 @@ impl PpcLoadedApp {
         context.attach_apple_event_handlers(&mut self.apple_events.handlers);
     }
 
-    /// Temporarily install the canonical retained Menu Manager continuation in
-    /// this adapter, restoring it to the process owner on return or unwind.
-    pub(crate) fn with_menu_tracking<R>(
-        &mut self,
-        menu_tracking: &mut Option<ProcessMenuTrackingState>,
-        f: impl FnOnce(&mut Self) -> R,
-    ) -> R {
-        std::mem::swap(&mut self.toolbox_startup.menu_tracking, menu_tracking);
-        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(self)));
-        std::mem::swap(&mut self.toolbox_startup.menu_tracking, menu_tracking);
-        match outcome {
-            Ok(result) => result,
-            Err(payload) => std::panic::resume_unwind(payload),
-        }
-    }
-
-    /// Temporarily install the retained Menu Manager continuation needed by
-    /// one native execution slice. The Event Manager queue stays attached to
-    /// its process owner for the adapter's entire lifetime.
-    pub(crate) fn with_process_state<R>(
-        &mut self,
-        menu_tracking: &mut Option<ProcessMenuTrackingState>,
-        f: impl FnOnce(&mut Self) -> R,
-    ) -> R {
-        self.with_menu_tracking(menu_tracking, f)
+    /// Run one native operation with every process manager continuously attached.
+    pub(crate) fn with_process_state<R>(&mut self, f: impl FnOnce(&mut Self) -> R) -> R {
+        f(self)
     }
 
     /// Run one native slice while publishing its live relocatable blocks to
     /// the process Memory Manager before another CPU adapter can execute.
     pub(crate) fn with_process_state_and_memory_manager<R>(
         &mut self,
-        menu_tracking: &mut Option<ProcessMenuTrackingState>,
         memory_manager: &SharedProcessMemoryManager,
         f: impl FnOnce(&mut Self, &mut ProcessMemoryManager) -> R,
     ) -> R {
-        self.with_process_state(menu_tracking, |app| {
+        self.with_process_state(|app| {
             let mut memory_manager = memory_manager.borrow_mut();
             app.apply_process_memory_manager(&memory_manager);
             app.publish_process_memory_manager(&mut memory_manager, None);
@@ -16650,14 +16628,14 @@ fn dispatch_supported_import(
                 let mut state = toolbox_startup.menu_tracking.take().unwrap();
                 if state.flash_delay > 0 {
                     state.flash_delay -= 1;
-                    toolbox_startup.menu_tracking = Some(state);
+                    *toolbox_startup.menu_tracking = Some(state);
                     return Some(PpcImportAction::Yield(u64::MAX));
                 }
                 state.flash_remaining -= 1;
                 state.flash_delay = STANDARD_MENU_FLASH_PHASE_DELAY;
                 let result = state.flash_result;
                 if state.flash_remaining == 0 {
-                    toolbox_startup.menu_tracking = Some(state);
+                    *toolbox_startup.menu_tracking = Some(state);
                     let result = ppc_complete_menu_bar_tracking_with_colors(
                         memory,
                         gworlds,
@@ -16680,7 +16658,7 @@ fn dispatch_supported_import(
                         state.flash_remaining & 1 == 0,
                     );
                 }
-                toolbox_startup.menu_tracking = Some(state);
+                *toolbox_startup.menu_tracking = Some(state);
                 Some(PpcImportAction::Yield(u64::MAX))
             } else if toolbox_startup
                 .menu_tracking
@@ -16836,7 +16814,7 @@ fn dispatch_supported_import(
                             vfs_resources,
                             *current_resource_refnum,
                         );
-                        toolbox_startup.menu_tracking = Some(state);
+                        *toolbox_startup.menu_tracking = Some(state);
                     }
                 }
                 if let Some(state) = toolbox_startup.menu_tracking.as_ref() {
@@ -57046,7 +57024,7 @@ fn ppc_set_depth(
         .menu_tracking
         .as_ref()
         .is_some_and(|state| state.kind == MenuTrackingKind::MenuBar);
-    toolbox_startup.menu_tracking = None;
+    *toolbox_startup.menu_tracking = None;
     toolbox_startup.popup_menu_call = None;
     toolbox_startup.go_away_tracking = None;
     toolbox_startup.drag_window_tracking = None;
@@ -71961,7 +71939,7 @@ fn ppc_continue_custom_popup_menu_tracking(
             return PpcImportAction::Return(0);
         }
         state.definition = startup.menu_definition_tracking.take();
-        startup.menu_tracking = Some(state);
+        *startup.menu_tracking = Some(state);
         startup.active_menu_definition_mut().unwrap().draw();
         let invocation = startup
             .active_menu_definition()
@@ -72106,7 +72084,7 @@ fn ppc_dispatch_pop_up_menu_select(
         if live_front.map(MenuTrackingSurface::from) != state.front_buffer {
             // A changed PixMap/depth makes the saved coordinates unsafe to
             // write. Abandon the overlay without touching either buffer.
-            startup.menu_tracking = None;
+            *startup.menu_tracking = None;
             startup.popup_menu_call = None;
             return PpcImportAction::Return(0);
         }
@@ -72125,7 +72103,7 @@ fn ppc_dispatch_pop_up_menu_select(
             };
             if state.flash_delay > 0 {
                 state.flash_delay -= 1;
-                startup.menu_tracking = Some(state);
+                *startup.menu_tracking = Some(state);
                 return PpcImportAction::Yield(u64::MAX);
             }
             state.flash_remaining -= 1;
@@ -72149,7 +72127,7 @@ fn ppc_dispatch_pop_up_menu_select(
                 &state,
                 visible_item,
             );
-            startup.menu_tracking = Some(state);
+            *startup.menu_tracking = Some(state);
             return PpcImportAction::Yield(u64::MAX);
         }
 
@@ -72189,7 +72167,7 @@ fn ppc_dispatch_pop_up_menu_select(
                 &state,
                 highlighted_item,
             );
-            startup.menu_tracking = Some(state);
+            *startup.menu_tracking = Some(state);
             return PpcImportAction::Yield(u64::MAX);
         }
 
@@ -72201,7 +72179,7 @@ fn ppc_dispatch_pop_up_menu_select(
             &state,
             highlighted_item,
         );
-        startup.menu_tracking = Some(state);
+        *startup.menu_tracking = Some(state);
         return PpcImportAction::Yield(u64::MAX);
     }
 
@@ -72256,7 +72234,7 @@ fn ppc_dispatch_pop_up_menu_select(
         &state,
         highlighted_item,
     );
-    startup.menu_tracking = Some(state);
+    *startup.menu_tracking = Some(state);
     startup.popup_menu_call = Some(call);
     PpcImportAction::Yield(u64::MAX)
 }
@@ -73508,7 +73486,7 @@ fn ppc_begin_custom_menu_bar_tracking(
         StandardMenuPaneKind::PullDown,
         &state,
     )?;
-    startup.menu_tracking = Some(state);
+    *startup.menu_tracking = Some(state);
     startup.menu_select_call = Some(PpcMenuSelectCall {
         initial_point,
         return_address: cpu.lr,
@@ -73618,7 +73596,7 @@ fn ppc_continue_custom_menu_bar_tracking(
                         resources,
                         current_resource_refnum,
                     );
-                    startup.menu_tracking = Some(state);
+                    *startup.menu_tracking = Some(state);
                 }
                 if startup.active_menu_definition().is_none() {
                     startup.menu_select_call = None;
@@ -73912,7 +73890,7 @@ fn ppc_track_menu_while_held_with_resources(
             .filter(|(menu_handle, _)| *menu_handle != previous.menu_handle);
         if let Some((menu_handle, title_left)) = switched {
             ppc_restore_menu_tracking(memory, Some(front.into()), &previous);
-            startup.menu_tracking = ppc_begin_menu_bar_tracking_with_resources(
+            *startup.menu_tracking = ppc_begin_menu_bar_tracking_with_resources(
                 memory,
                 front,
                 menu_handle,
@@ -73922,7 +73900,7 @@ fn ppc_track_menu_while_held_with_resources(
             );
             startup.popup_menu_call = None;
         } else {
-            startup.menu_tracking = Some(previous);
+            *startup.menu_tracking = Some(previous);
         }
     } else {
         let Some((menu_handle, title_left)) =
@@ -73940,7 +73918,7 @@ fn ppc_track_menu_while_held_with_resources(
         ) else {
             return;
         };
-        startup.menu_tracking = Some(state);
+        *startup.menu_tracking = Some(state);
         startup.popup_menu_call = None;
     }
     let active_menu_id = startup.menu_tracking.as_ref().and_then(|state| {
@@ -73978,7 +73956,7 @@ fn ppc_track_menu_while_held_with_resources(
             resources,
             current_resource_refnum,
         );
-        startup.menu_tracking = Some(state);
+        *startup.menu_tracking = Some(state);
     }
 }
 
@@ -74083,7 +74061,7 @@ fn ppc_finish_menu_bar_tracking(
             &[],
             0,
         );
-        startup.menu_tracking = Some(state);
+        *startup.menu_tracking = Some(state);
     }
     ppc_finish_menu_bar_tracking_with_colors(
         memory,
@@ -86825,7 +86803,7 @@ pub(crate) mod tests {
                 ..PpcInputSnapshot::default()
             },
         );
-        let tracking = loaded.toolbox_startup.menu_tracking.clone().unwrap();
+        let tracking = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
         let command_text_advance = ppc_text_bytes_advance_for_font(
             b"Command",
             PPC_QD_TEXT_FONT_DEFAULT,
@@ -87560,7 +87538,7 @@ pub(crate) mod tests {
             ppc_memory_read_bytes(&mut loaded.memory, front.base_addr, framebuffer_len),
             Some(before.clone())
         );
-        let tracking = loaded.toolbox_startup.menu_tracking.clone().unwrap();
+        let tracking = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
 
         loaded.set_input_snapshot(PpcInputSnapshot {
             mouse_button: false,
@@ -88051,7 +88029,7 @@ pub(crate) mod tests {
                 &loaded.process_file_system.vfs_resources,
                 loaded.current_resource_refnum,
             );
-            let tracking = loaded.toolbox_startup.menu_tracking.clone().unwrap();
+            let tracking = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
             assert_eq!(
                 tracking
                     .item_appearances
@@ -88242,7 +88220,7 @@ pub(crate) mod tests {
             &loaded.process_file_system.vfs_resources,
             loaded.current_resource_refnum,
         );
-        let root = loaded.toolbox_startup.menu_tracking.clone().unwrap();
+        let root = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
         assert_eq!(root.item_appearances[0].height, 34);
         let parent_top = root.popup_top + root.item_appearances[0].height;
         ppc_track_menu_while_held_with_resources(
@@ -88345,7 +88323,7 @@ pub(crate) mod tests {
                     ..PpcInputSnapshot::default()
                 },
             );
-            let tracking = loaded.toolbox_startup.menu_tracking.clone().unwrap();
+            let tracking = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
             assert_eq!(tracking.front_buffer, Some(front.into()));
             assert_eq!(tracking.popup_left, STANDARD_MENU_BAR_FIRST_TITLE_LEFT);
             assert_eq!(tracking.saved_width, tracking.popup_width + 1);
@@ -88592,7 +88570,7 @@ pub(crate) mod tests {
                     ..PpcInputSnapshot::default()
                 },
             );
-            let root = loaded.toolbox_startup.menu_tracking.clone().unwrap();
+            let root = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
             let parent_hover = PpcInputSnapshot {
                 mouse_button: true,
                 mouse_v: root.popup_top + 8,
@@ -88607,7 +88585,7 @@ pub(crate) mod tests {
                 12,
                 parent_hover,
             );
-            let tracking = loaded.toolbox_startup.menu_tracking.clone().unwrap();
+            let tracking = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
             let child = tracking.submenus.first().expect("submenu did not open");
             assert_eq!(tracking.highlighted_item, 1);
             assert_eq!(child.menu_handle, submenu);
@@ -88908,9 +88886,9 @@ pub(crate) mod tests {
                 );
             };
             track(&mut loaded, (10, 12));
-            let root = loaded.toolbox_startup.menu_tracking.clone().unwrap();
+            let root = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
             track(&mut loaded, (root.popup_top + 8, root.popup_left + 20));
-            let first = loaded.toolbox_startup.menu_tracking.clone().unwrap();
+            let first = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
             assert_eq!(first.submenus.len(), 1);
             assert_eq!(first.submenus[0].menu_handle, options);
             let options_pane = first.submenus[0].clone();
@@ -88918,7 +88896,7 @@ pub(crate) mod tests {
                 &mut loaded,
                 (options_pane.popup_top + 8, options_pane.popup_left + 20),
             );
-            let nested = loaded.toolbox_startup.menu_tracking.clone().unwrap();
+            let nested = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
             assert_eq!(nested.submenus.len(), 2);
             assert_eq!(nested.submenus[0].highlighted_item, 1);
             assert_eq!(nested.submenus[1].menu_handle, speed);
@@ -88930,14 +88908,14 @@ pub(crate) mod tests {
                     options_pane.popup_left + 20,
                 ),
             );
-            let switched = loaded.toolbox_startup.menu_tracking.clone().unwrap();
+            let switched = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
             assert_eq!(switched.submenus.len(), 1);
             assert_eq!(switched.submenus[0].highlighted_item, 2);
             track(
                 &mut loaded,
                 (options_pane.popup_top + 8, options_pane.popup_left + 20),
             );
-            let reopened = loaded.toolbox_startup.menu_tracking.clone().unwrap();
+            let reopened = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
             assert_eq!(reopened.submenus.len(), 2);
             let speed_pane = reopened.submenus[1].clone();
 
@@ -88945,7 +88923,7 @@ pub(crate) mod tests {
                 &mut loaded,
                 (speed_pane.popup_top + 8, speed_pane.popup_left + 20),
             );
-            let cycle = loaded.toolbox_startup.menu_tracking.clone().unwrap();
+            let cycle = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
             assert_eq!(cycle.submenus.len(), 2, "circular submenu grew the chain");
             assert_eq!(cycle.submenus[1].highlighted_item, 1);
             assert_eq!(
@@ -89172,7 +89150,7 @@ pub(crate) mod tests {
                 ..PpcInputSnapshot::default()
             },
         );
-        let tracking = loaded.toolbox_startup.menu_tracking.clone().unwrap();
+        let tracking = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
         assert_eq!(tracking.front_buffer, Some(live.into()));
         let selected = PpcInputSnapshot {
             mouse_button: true,
@@ -89758,7 +89736,7 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn process_owner_hands_one_retained_menu_continuation_between_adapters() {
+    fn process_owner_shares_one_retained_menu_continuation_between_adapters() {
         let (mut classic, mut classic_cpu, mut classic_bus) = setup_with_port();
         let pef = synthetic_pef_with_import(b"MenuSelect");
         let mut native = load_pef_application(&pef).unwrap();
@@ -89769,15 +89747,13 @@ pub(crate) mod tests {
         let mut tracking = crate::menu_manager::test_process_menu_tracking(0x0012_3456);
         tracking.highlighted_item = 2;
         context.set_menu_tracking(Some(tracking));
-        classic.with_menu_tracking(context.menu_tracking_slot_mut(), |classic| {
-            assert_eq!(
-                classic
-                    .menu_tracking
-                    .as_ref()
-                    .map(|tracking| (tracking.menu_handle, tracking.highlighted_item)),
-                Some((0x0012_3456, 2))
-            );
-        });
+        assert_eq!(
+            classic
+                .menu_tracking
+                .as_ref()
+                .map(|tracking| (tracking.menu_handle, tracking.highlighted_item)),
+            Some((0x0012_3456, 2))
+        );
         assert_eq!(
             context
                 .menu_tracking()
@@ -89785,16 +89761,15 @@ pub(crate) mod tests {
             Some((0x0012_3456, 2))
         );
 
-        native.with_menu_tracking(context.menu_tracking_slot_mut(), |native| {
-            native.cpu.gpr[3] = 0;
-            run_test_import(native, PpcImportDispatcherTarget::MenuSelect);
-            native
-                .toolbox_startup
-                .menu_tracking
-                .as_mut()
-                .unwrap()
-                .highlighted_item = 4;
-        });
+        native.cpu.gpr[3] = 0;
+        run_test_import(&mut native, PpcImportDispatcherTarget::MenuSelect);
+        native
+            .toolbox_startup
+            .menu_tracking
+            .as_mut()
+            .unwrap()
+            .highlighted_item = 4;
+        assert_eq!(classic.menu_tracking.as_ref().unwrap().highlighted_item, 4);
         assert_eq!(
             context
                 .menu_tracking()
@@ -89807,17 +89782,15 @@ pub(crate) mod tests {
         classic_cpu.write_reg(Register::A7, TEST_SP);
         classic_bus.write_long(TEST_SP, 0);
         classic_bus.write_long(TEST_SP + 4, u32::MAX);
-        classic.with_menu_tracking(context.menu_tracking_slot_mut(), |classic| {
-            assert!(classic
-                .dispatch_menu(true, 0x13D, &mut classic_cpu, &mut classic_bus)
-                .unwrap()
-                .is_ok());
-        });
+        assert!(classic
+            .dispatch_menu(true, 0x13D, &mut classic_cpu, &mut classic_bus)
+            .unwrap()
+            .is_ok());
         assert_eq!(classic_bus.read_long(TEST_SP + 4), 0);
         assert_eq!(
             context.menu_tracking().map(|tracking| tracking.menu_handle),
             Some(0x0012_3456),
-            "the classic slice must return the continuation to its process owner"
+            "the classic slice must retain the process-owned continuation"
         );
 
         context.take_menu_tracking();
@@ -89983,55 +89956,73 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn ppc_with_menu_tracking_returns_mutations_to_process_context() {
+    fn attached_ppc_menu_tracking_mutates_process_context_immediately() {
         let pef = synthetic_pef_with_import(b"MenuSelect");
         let mut native = load_pef_application(&pef).unwrap();
-        let mut context_tracking =
-            Some(crate::menu_manager::test_process_menu_tracking(0x0012_3456));
+        let mut context = ProcessContext::default();
+        context.set_menu_tracking(Some(crate::menu_manager::test_process_menu_tracking(
+            0x0012_3456,
+        )));
+        native.attach_process_context(&mut context);
+        let detached = native.clone();
 
-        native.with_menu_tracking(&mut context_tracking, |app| {
-            app.toolbox_startup
-                .menu_tracking
-                .as_mut()
-                .unwrap()
-                .highlighted_item = 3;
-        });
+        native
+            .toolbox_startup
+            .menu_tracking
+            .as_mut()
+            .unwrap()
+            .highlighted_item = 3;
 
         assert_eq!(
-            context_tracking
-                .as_ref()
+            context
+                .menu_tracking()
                 .map(|tracking| tracking.highlighted_item),
             Some(3)
         );
-        assert!(native.toolbox_startup.menu_tracking.is_none());
+        assert_eq!(native.toolbox_startup.menu_tracking.as_ref().unwrap().highlighted_item, 3);
+        assert!(!native
+            .toolbox_startup
+            .menu_tracking
+            .ptr_eq(&detached.toolbox_startup.menu_tracking));
+        assert_eq!(
+            detached
+                .toolbox_startup
+                .menu_tracking
+                .as_ref()
+                .unwrap()
+                .highlighted_item,
+            1
+        );
     }
 
     #[test]
-    fn ppc_with_menu_tracking_restores_process_context_on_panic() {
+    fn attached_ppc_menu_tracking_remains_shared_through_panic() {
         let pef = synthetic_pef_with_import(b"MenuSelect");
         let mut native = load_pef_application(&pef).unwrap();
-        let mut context_tracking =
-            Some(crate::menu_manager::test_process_menu_tracking(0x0012_3456));
+        let mut context = ProcessContext::default();
+        context.set_menu_tracking(Some(crate::menu_manager::test_process_menu_tracking(
+            0x0012_3456,
+        )));
+        native.attach_process_context(&mut context);
 
         let panic_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            native.with_menu_tracking(&mut context_tracking, |app| {
-                app.toolbox_startup
-                    .menu_tracking
-                    .as_mut()
-                    .unwrap()
-                    .highlighted_item = 5;
-                panic!("simulated panic inside PPC guest execution");
-            });
+            native
+                .toolbox_startup
+                .menu_tracking
+                .as_mut()
+                .unwrap()
+                .highlighted_item = 5;
+            panic!("simulated panic inside PPC guest execution");
         }));
 
         assert!(panic_result.is_err());
         assert_eq!(
-            context_tracking
-                .as_ref()
+            context
+                .menu_tracking()
                 .map(|tracking| tracking.highlighted_item),
             Some(5)
         );
-        assert!(native.toolbox_startup.menu_tracking.is_none());
+        assert_eq!(native.toolbox_startup.menu_tracking.as_ref().unwrap().highlighted_item, 5);
     }
 
     #[test]
@@ -90048,7 +90039,7 @@ pub(crate) mod tests {
 
         let mut context = ProcessContext::default();
         native.attach_process_context(&mut context);
-        let (menu_tracking, memory_manager) = context.menu_tracking_and_memory_manager();
+        let memory_manager = context.memory_manager_handle();
         let expected_cursor = native.heap_cursor() + 16;
         {
             let mut manager = memory_manager.borrow_mut();
@@ -90077,7 +90068,6 @@ pub(crate) mod tests {
         }
 
         native.with_process_state_and_memory_manager(
-            menu_tracking,
             memory_manager,
             |_native, memory_manager| {
                 assert_eq!(
@@ -90256,7 +90246,7 @@ pub(crate) mod tests {
         let mut attached = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
         attached.attach_process_context(&mut context);
-        let memory_manager = context.menu_tracking_and_memory_manager().1.clone();
+        let memory_manager = context.memory_manager_handle().clone();
 
         standalone.cpu.gpr[3] = 24;
         attached.cpu.gpr[3] = 24;
@@ -90389,7 +90379,7 @@ pub(crate) mod tests {
         native.memory.add_region(ptr & !0x0fff, vec![0; 0x1000]);
         native.memory.write_u32_be(handle, ptr).unwrap();
         native.memory.write_u8(ptr, 0x5a).unwrap();
-        let (menu_tracking, memory_manager) = context.menu_tracking_and_memory_manager();
+        let memory_manager = context.memory_manager_handle();
         // HLock and HGetState operate on the live relocatable block while the
         // stable handle continues to identify its master pointer. Inside
         // Macintosh: Memory (1992), pp. 1-18--1-19 and 2-45--2-49.
@@ -90397,7 +90387,6 @@ pub(crate) mod tests {
         let detached = memory_manager.detached_clone();
 
         native.with_process_state_and_memory_manager(
-            menu_tracking,
             memory_manager,
             |native, memory_manager| {
                 native.cpu.pc = native.entry_pc;
@@ -90461,7 +90450,7 @@ pub(crate) mod tests {
 
         let mut context = ProcessContext::default();
         native.attach_process_context(&mut context);
-        let process_memory_manager = context.menu_tracking_and_memory_manager().1.clone();
+        let process_memory_manager = context.memory_manager_handle().clone();
         assert!(native
             .process_memory_manager
             .ptr_eq(&process_memory_manager));
@@ -90563,10 +90552,9 @@ pub(crate) mod tests {
         native.cpu.gpr[3] = 24;
         let mut context = ProcessContext::default();
         native.attach_process_context(&mut context);
-        let (menu_tracking, memory_manager) = context.menu_tracking_and_memory_manager();
+        let memory_manager = context.memory_manager_handle();
 
         native.with_process_state_and_memory_manager(
-            menu_tracking,
             memory_manager,
             |native, memory_manager| {
                 let prior_ptr = memory_manager.new_native_ptr(&mut native.memory, 24, false);
@@ -90651,10 +90639,9 @@ pub(crate) mod tests {
         native.attach_process_context(&mut context);
         let mut classic_dispatcher = TrapDispatcher::new();
         classic_dispatcher.attach_process_context(&mut context);
-        let (menu_tracking, memory_manager) = context.menu_tracking_and_memory_manager();
+        let memory_manager = context.memory_manager_handle();
 
         native.with_process_state_and_memory_manager(
-            menu_tracking,
             memory_manager,
             |native, memory_manager| {
                 native.run_with_process_memory_manager(64, false, false, memory_manager);
@@ -90844,10 +90831,9 @@ pub(crate) mod tests {
         native.attach_process_context(&mut context);
         let mut classic_dispatcher = TrapDispatcher::new();
         classic_dispatcher.attach_process_context(&mut context);
-        let (menu_tracking, memory_manager) = context.menu_tracking_and_memory_manager();
+        let memory_manager = context.memory_manager_handle();
 
         native.with_process_state_and_memory_manager(
-            menu_tracking,
             memory_manager,
             |native, memory_manager| {
                 let allocator = memory_manager.native_allocator_snapshot().unwrap();
@@ -90997,10 +90983,9 @@ pub(crate) mod tests {
 
         let mut context = ProcessContext::default();
         native.attach_process_context(&mut context);
-        let (menu_tracking, memory_manager) = context.menu_tracking_and_memory_manager();
+        let memory_manager = context.memory_manager_handle();
 
         native.with_process_state_and_memory_manager(
-            menu_tracking,
             memory_manager,
             |native, memory_manager| {
                 native.cpu.gpr[3] = source;
@@ -91309,7 +91294,7 @@ pub(crate) mod tests {
             loaded.run_with_hle_imports(64).result,
             PpcRunResult::CycleLimit { .. }
         ));
-        let tracking = loaded.toolbox_startup.menu_tracking.clone().unwrap();
+        let tracking = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
 
         loaded.set_input_snapshot(PpcInputSnapshot {
             mouse_button: false,
@@ -147044,7 +147029,7 @@ pub(crate) mod tests {
             [loaded.cpu.gpr[4], loaded.cpu.gpr[5], loaded.cpu.gpr[6]],
             original_args
         );
-        let tracking = loaded.toolbox_startup.menu_tracking.clone().unwrap();
+        let tracking = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
         let parked_lr = loaded.cpu.lr;
         assert_eq!(tracking.kind, MenuTrackingKind::PopUp);
         assert_eq!(
@@ -147279,7 +147264,7 @@ pub(crate) mod tests {
             });
             let probe = loaded.run_with_hle_imports(64);
             assert!(matches!(probe.result, PpcRunResult::CycleLimit { .. }));
-            let tracking = loaded.toolbox_startup.menu_tracking.clone().unwrap();
+            let tracking = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
             loaded.set_input_snapshot(PpcInputSnapshot {
                 mouse_button: false,
                 mouse_v: tracking.popup_top + 16 + 4,
@@ -147360,7 +147345,7 @@ pub(crate) mod tests {
             let probe = loaded.run_with_hle_imports(64);
 
             assert!(matches!(probe.result, PpcRunResult::CycleLimit { .. }));
-            let tracking = loaded.toolbox_startup.menu_tracking.clone().unwrap();
+            let tracking = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
             assert_eq!(tracking.kind, MenuTrackingKind::PopUp);
             assert_eq!(
                 loaded.toolbox_startup.popup_menu_call,
@@ -147511,7 +147496,7 @@ pub(crate) mod tests {
                 Some(expected_bottom),
             );
         }
-        loaded.toolbox_startup.menu_tracking = Some(tracking);
+        *loaded.toolbox_startup.menu_tracking = Some(tracking);
     }
 
     #[test]
@@ -147712,7 +147697,7 @@ pub(crate) mod tests {
                 "{depth}bpp disabled title did not open",
             );
             assert_eq!(loaded.memory.read_u16_be(PPC_THE_MENU_ADDR), Some(130));
-            let disabled_tracking = loaded.toolbox_startup.menu_tracking.clone().unwrap();
+            let disabled_tracking = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
             assert_eq!(
                 disabled_tracking.highlighted_item, 0,
                 "{depth}bpp disabled menu item became highlighted",
@@ -147775,7 +147760,7 @@ pub(crate) mod tests {
             loaded.run_with_hle_imports(64).result,
             PpcRunResult::CycleLimit { .. }
         ));
-        let switched = loaded.toolbox_startup.menu_tracking.clone().unwrap();
+        let switched = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
         loaded
             .memory
             .write_u16_be(crate::memory::globals::addr::MENU_FLASH, 1)
@@ -147841,7 +147826,7 @@ pub(crate) mod tests {
             loaded.run_with_hle_imports(64).result,
             PpcRunResult::CycleLimit { .. }
         ));
-        let tracking = loaded.toolbox_startup.menu_tracking.clone().unwrap();
+        let tracking = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
         loaded.set_input_snapshot(PpcInputSnapshot {
             mouse_button: false,
             mouse_v: tracking.popup_top + 6,
@@ -155164,7 +155149,7 @@ pub(crate) mod tests {
             item_appearances: Vec::new(),
             submenus: Vec::new(),
         };
-        loaded.toolbox_startup.menu_tracking = Some(tracking.clone());
+        *loaded.toolbox_startup.menu_tracking = Some(tracking.clone());
         loaded.memory.write_u16_be(PPC_THE_MENU_ADDR, 128).unwrap();
 
         loaded.cpu.gpr[3] = PPC_MAIN_GDEVICE;
@@ -155196,7 +155181,7 @@ pub(crate) mod tests {
             stack_pointer: loaded.cpu.gpr[1],
             return_address: loaded.cpu.lr,
         });
-        loaded.toolbox_startup.menu_tracking = Some(popup_tracking);
+        *loaded.toolbox_startup.menu_tracking = Some(popup_tracking);
         loaded
             .memory
             .write_u16_be(PPC_THE_MENU_ADDR, 0x2468)

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -566,6 +566,7 @@ pub(crate) type SharedProcessResourceManager = SharedProcessValue<ProcessResourc
 pub(crate) type SharedProcessSoundManager = SharedProcessValue<SoundManager>;
 pub(crate) type SharedProcessCursorState = SharedProcessValue<ProcessCursorState>;
 pub(crate) type SharedProcessEventQueue = SharedProcessValue<EventQueue>;
+pub(crate) type SharedProcessMenuTracking = SharedProcessValue<Option<ProcessMenuTrackingState>>;
 
 /// Canonical QuickDraw cursor state for one Macintosh process.
 ///
@@ -624,6 +625,28 @@ impl<T: Default> Default for SharedProcessValue<T> {
 impl<T: Clone> Clone for SharedProcessValue<T> {
     fn clone(&self) -> Self {
         Self(Rc::new(UnsafeCell::new((**self).clone())))
+    }
+}
+
+impl<T: PartialEq> PartialEq for SharedProcessValue<T> {
+    fn eq(&self, other: &Self) -> bool {
+        **self == **other
+    }
+}
+
+impl<T: Eq> Eq for SharedProcessValue<T> {}
+
+impl<T: PartialEq> PartialEq<Option<T>> for SharedProcessValue<Option<T>> {
+    fn eq(&self, other: &Option<T>) -> bool {
+        **self == *other
+    }
+}
+
+#[cfg(test)]
+impl<T: Clone> SharedProcessValue<T> {
+    /// Copy a detached process snapshot for value-oriented assertions.
+    pub(crate) fn snapshot(&self) -> T {
+        (**self).clone()
     }
 }
 
@@ -3389,7 +3412,7 @@ pub(crate) struct ProcessContext {
     memory: Vec<ProcessMemoryRegion>,
     memory_manager: SharedProcessMemoryManager,
     event_queue: SharedProcessEventQueue,
-    menu_tracking: Option<ProcessMenuTrackingState>,
+    menu_tracking: SharedProcessMenuTracking,
     pending_native_menu_selection: SharedNativeMenuSelection,
     guest_calls: SharedGuestCallStack,
     apple_event_handlers: SharedProcessAppleEventHandlers,
@@ -3448,6 +3471,22 @@ impl ProcessContext {
         // EventAvail observes it in place. Inside Macintosh Volume I (1985),
         // pp. I-244--I-245 and I-257--I-259; Processes (1994), pp. 2-15--2-16.
         adapter.attach_to(&self.event_queue, EventQueue::is_pristine);
+    }
+
+    pub(crate) fn attach_menu_tracking(&self, adapter: &mut SharedProcessMenuTracking) {
+        // MenuSelect owns one retained selection and pane hierarchy until the
+        // mouse is released and any MenuFlash phases complete. Both ISA
+        // gateways therefore attach to the same process continuation. Inside
+        // Macintosh Volume I (1985), pp. I-354--I-366; Macintosh Toolbox
+        // Essentials (1992), pp. 3-87--3-92 and 3-140--3-142.
+        if Rc::ptr_eq(&adapter.0, &self.menu_tracking.0) {
+            return;
+        }
+        assert!(
+            adapter.is_none() || self.menu_tracking.is_none(),
+            "cannot attach two active Menu Manager continuations"
+        );
+        adapter.attach_to(&self.menu_tracking, Option::is_none);
     }
 
     pub(crate) fn attach_classic_file_system(
@@ -3541,31 +3580,11 @@ impl ProcessContext {
 
     #[cfg(test)]
     pub(crate) fn set_menu_tracking(&mut self, state: Option<ProcessMenuTrackingState>) {
-        self.menu_tracking = state;
+        *self.menu_tracking = state;
     }
 
-    pub(crate) fn menu_tracking_slot_mut(&mut self) -> &mut Option<ProcessMenuTrackingState> {
-        &mut self.menu_tracking
-    }
-
-    /// Transfer detached adapter state into the canonical process owner.
-    pub(crate) fn adopt_menu_tracking(&mut self, adapter: &mut Option<ProcessMenuTrackingState>) {
-        assert!(
-            adapter.is_none() || self.menu_tracking.is_none(),
-            "cannot attach two active Menu Manager continuations"
-        );
-        if self.menu_tracking.is_none() {
-            self.menu_tracking = adapter.take();
-        }
-    }
-
-    pub(crate) fn menu_tracking_and_memory_manager(
-        &mut self,
-    ) -> (
-        &mut Option<ProcessMenuTrackingState>,
-        &SharedProcessMemoryManager,
-    ) {
-        (&mut self.menu_tracking, &self.memory_manager)
+    pub(crate) fn memory_manager_handle(&self) -> &SharedProcessMemoryManager {
+        &self.memory_manager
     }
 
     pub(crate) fn attach_native_menu_selection(&self, adapter: &mut SharedNativeMenuSelection) {
@@ -3736,8 +3755,9 @@ mod tests {
             where_h: 0,
             modifiers: 0,
         });
-        *context.menu_tracking_slot_mut() =
-            Some(crate::menu_manager::test_process_menu_tracking(0x0065_4321));
+        context.set_menu_tracking(Some(crate::menu_manager::test_process_menu_tracking(
+            0x0065_4321,
+        )));
         assert_eq!(context.event_queue().len(), 1);
         assert_eq!(
             context.menu_tracking().map(|t| t.menu_handle),
@@ -3782,8 +3802,9 @@ mod tests {
         context.set_menu_tracking(Some(crate::menu_manager::test_process_menu_tracking(
             0x1000,
         )));
-        let mut second = Some(crate::menu_manager::test_process_menu_tracking(0x2000));
-        context.adopt_menu_tracking(&mut second);
+        let mut second = SharedProcessMenuTracking::default();
+        *second = Some(crate::menu_manager::test_process_menu_tracking(0x2000));
+        context.attach_menu_tracking(&mut second);
     }
 
     #[test]
@@ -4954,6 +4975,27 @@ mod tests {
         assert_eq!(detached.len(), 1);
         assert_eq!(detached.front().unwrap().message, 0x1111);
         assert!(!detached.menu_bar_is_invalid());
+    }
+
+    #[test]
+    fn attached_menu_tracking_is_immediate_while_clones_detach() {
+        let context = ProcessContext::default();
+        let mut classic = SharedProcessMenuTracking::default();
+        *classic = Some(crate::menu_manager::test_process_menu_tracking(0x1234));
+        let mut native = SharedProcessMenuTracking::default();
+
+        context.attach_menu_tracking(&mut classic);
+        context.attach_menu_tracking(&mut native);
+        let detached = native.clone();
+
+        classic.as_mut().unwrap().highlighted_item = 4;
+
+        assert!(classic.ptr_eq(&native));
+        assert_eq!(native.as_ref().unwrap().highlighted_item, 4);
+        assert_eq!(detached.as_ref().unwrap().highlighted_item, 1);
+        assert_eq!(native.take().unwrap().menu_handle, 0x1234);
+        assert!(classic.is_none());
+        assert_eq!(detached.as_ref().unwrap().menu_handle, 0x1234);
     }
 
     #[test]

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -2336,9 +2336,8 @@ impl FixtureRunner {
     }
 
     fn redraw_chrome(&mut self) {
-        let menu_tracking = self.process_context.menu_tracking_slot_mut();
         self.dispatcher
-            .with_process_state(menu_tracking, |dispatcher| {
+            .with_process_state(|dispatcher| {
                 dispatcher.redraw_chrome(&mut self.bus);
             });
     }
@@ -2460,9 +2459,8 @@ impl FixtureRunner {
     }
 
     fn push_canonical_mouse_down(&mut self, v: i16, h: i16) {
-        let menu_tracking = self.process_context.menu_tracking_slot_mut();
         self.dispatcher
-            .with_process_state(menu_tracking, |d| d.push_mouse_down(v, h));
+            .with_process_state(|d| d.push_mouse_down(v, h));
         self.sync_mouse_lowmem();
         self.wake_pending_wait_next_event_if_input_available();
         self.wake_foreground_after_input();
@@ -2502,9 +2500,8 @@ impl FixtureRunner {
     }
 
     fn push_canonical_mouse_up(&mut self, v: i16, h: i16) {
-        let menu_tracking = self.process_context.menu_tracking_slot_mut();
         self.dispatcher
-            .with_process_state(menu_tracking, |d| d.push_mouse_up(v, h));
+            .with_process_state(|d| d.push_mouse_up(v, h));
         self.sync_mouse_lowmem();
         self.wake_pending_wait_next_event_if_input_available();
         self.wake_foreground_after_input();
@@ -2552,9 +2549,8 @@ impl FixtureRunner {
     /// Inject a key-down event, applying arrow→numpad remapping if configured.
     pub fn push_key_down(&mut self, mac_key: u8, char_code: u8) {
         let (key, char_code) = self.remap_key(mac_key, char_code);
-        let menu_tracking = self.process_context.menu_tracking_slot_mut();
         self.dispatcher
-            .with_process_state(menu_tracking, |d| {
+            .with_process_state(|d| {
                 d.push_key_down(key, char_code);
             });
         self.sync_key_map_lowmem();
@@ -2568,9 +2564,8 @@ impl FixtureRunner {
         let sys_evt_mask = self
             .bus
             .read_word(crate::memory::globals::addr::SYS_EVT_MASK);
-        let menu_tracking = self.process_context.menu_tracking_slot_mut();
         self.dispatcher
-            .with_process_state(menu_tracking, |d| {
+            .with_process_state(|d| {
                 d.push_key_up_with_system_event_mask(sys_evt_mask, key, char_code);
             });
         self.sync_key_map_lowmem();
@@ -5472,10 +5467,8 @@ impl FixtureRunner {
                     }
 
                     self.dispatcher.yield_for_ui = yield_for_ui;
-                    let (menu_tracking, memory_manager) =
-                        self.process_context.menu_tracking_and_memory_manager();
+                    let memory_manager = self.process_context.memory_manager_handle();
                     let dispatch_result = self.dispatcher.with_process_state_and_memory_manager(
-                        menu_tracking,
                         memory_manager,
                         |dispatcher| dispatcher.dispatch(opcode, &mut self.cpu, &mut self.bus),
                     );
@@ -5825,10 +5818,8 @@ impl FixtureRunner {
         let trace_ppc_imports = record_ppc_imports || trace_ppc_import_hist;
         let trace_ppc_fetches = trace_ppc_fetch_counts_enabled();
         let profile_run_start = profile_ppc.then(Instant::now);
-        let (menu_tracking, memory_manager) =
-            self.process_context.menu_tracking_and_memory_manager();
+        let memory_manager = self.process_context.memory_manager_handle();
         let probe = ppc_app.with_process_state_and_memory_manager(
-            menu_tracking,
             memory_manager,
             |app, memory_manager| {
                 app.run_with_process_memory_manager(
@@ -5877,10 +5868,8 @@ impl FixtureRunner {
         } else {
             self.advance_ticks_for_ppc_cycles(cycles, tick_cap);
             let elapsed_ticks = self.dispatcher.tick_count.wrapping_sub(ppc_start_tick);
-            let (menu_tracking, memory_manager) =
-                self.process_context.menu_tracking_and_memory_manager();
+            let memory_manager = self.process_context.memory_manager_handle();
             ppc_app.with_process_state_and_memory_manager(
-                menu_tracking,
                 memory_manager,
                 |app, memory_manager| {
                     Self::fire_ppc_tick_callbacks(
@@ -6193,10 +6182,8 @@ impl FixtureRunner {
                         self.cpu.core.take_aline_exception(&mut self.bus);
                         continue;
                     }
-                    let (menu_tracking, memory_manager) =
-                        self.process_context.menu_tracking_and_memory_manager();
+                    let memory_manager = self.process_context.memory_manager_handle();
                     let dispatch_err = self.dispatcher.with_process_state_and_memory_manager(
-                        menu_tracking,
                         memory_manager,
                         |dispatcher| {
                             dispatcher
@@ -7530,10 +7517,8 @@ impl FixtureRunner {
         while !ppc_app.sound.pending_doublebacks.is_empty() && fired_count < 16 {
             let doubleback = ppc_app.sound.pending_doublebacks.remove(0);
             let resume_pc = ppc_app.cpu.pc;
-            let (menu_tracking, memory_manager) =
-                self.process_context.menu_tracking_and_memory_manager();
+            let memory_manager = self.process_context.memory_manager_handle();
             let probe = ppc_app.with_process_state_and_memory_manager(
-                menu_tracking,
                 memory_manager,
                 |app, memory_manager| {
                     app.run_sound_doubleback_callback_with_process_memory_manager(
@@ -7643,10 +7628,8 @@ impl FixtureRunner {
         let mut fired_count = 0usize;
         while !ppc_app.sound.pending_completions.is_empty() && fired_count < 16 {
             let completion = ppc_app.sound.pending_completions.remove(0);
-            let (menu_tracking, memory_manager) =
-                self.process_context.menu_tracking_and_memory_manager();
+            let memory_manager = self.process_context.memory_manager_handle();
             let probe = ppc_app.with_process_state_and_memory_manager(
-                menu_tracking,
                 memory_manager,
                 |app, memory_manager| {
                     app.run_sound_completion_callback_with_process_memory_manager(
@@ -8477,9 +8460,8 @@ impl FixtureRunner {
         let sys_evt_mask = self
             .bus
             .read_word(crate::memory::globals::addr::SYS_EVT_MASK);
-        let menu_tracking = self.process_context.menu_tracking_slot_mut();
         self.dispatcher
-            .with_process_state(menu_tracking, |d| {
+            .with_process_state(|d| {
                 d.post_auto_key_if_due(sys_evt_mask);
             });
 
@@ -8496,10 +8478,9 @@ impl FixtureRunner {
         // to 0x80 even when no GetNextEvent ever drains the queue —
         // critical for polling-only games (Bonkheads-Deluxe class titles)
         // that would otherwise see the button as "held forever".
-        let menu_tracking = self.process_context.menu_tracking_slot_mut();
         let has_pending_unmatched_down =
             self.dispatcher
-                .with_process_state(menu_tracking, |d| {
+                .with_process_state(|d| {
                     d.has_unmatched_queued_mouse_down()
                 });
         let pressed = self.dispatcher.mouse_button || has_pending_unmatched_down;
@@ -8565,10 +8546,9 @@ impl FixtureRunner {
             }
         }
 
-        let menu_tracking = self.process_context.menu_tracking_slot_mut();
         let (mut what, mut message, mut where_v, mut where_h, mut modifiers, mut has_event) = self
             .dispatcher
-            .with_process_state(menu_tracking, |dispatcher| {
+            .with_process_state(|dispatcher| {
                 dispatcher.dequeue_toolbox_event(&mut self.cpu, &mut self.bus, pending.event_mask)
             });
         if !has_event {
@@ -10388,10 +10368,8 @@ impl FixtureRunner {
                         count += 1;
                         continue;
                     }
-                    let (menu_tracking, memory_manager) =
-                        self.process_context.menu_tracking_and_memory_manager();
+                    let memory_manager = self.process_context.memory_manager_handle();
                     let dispatch_result = self.dispatcher.with_process_state_and_memory_manager(
-                        menu_tracking,
                         memory_manager,
                         |dispatcher| dispatcher.dispatch(opcode, &mut self.cpu, &mut self.bus),
                     );

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -15,8 +15,8 @@ use crate::menu_manager::{ProcessMenuTrackingState, SharedNativeMenuSelection};
 use crate::process_context::{
     ProcessContext, ProcessForkMap, ProcessLoadedResources, ProcessResourceFileMap,
     ProcessResourceManagerState, SharedProcessAppleEventHandlers, SharedProcessCursorState,
-    SharedProcessEventQueue, SharedProcessMemoryManager, SharedProcessResourceManager,
-    SharedProcessSoundManager, SharedProcessValue,
+    SharedProcessEventQueue, SharedProcessMemoryManager, SharedProcessMenuTracking,
+    SharedProcessResourceManager, SharedProcessSoundManager, SharedProcessValue,
 };
 use crate::trace::{TraceEvent, TraceSink, TraceSource};
 use crate::ui_theme::{UiTheme, UiThemeId};
@@ -2279,7 +2279,7 @@ pub struct TrapDispatcher {
     /// Menus loaded from MENU resources, in order of insertion
     pub(crate) menus: Vec<super::menu::Menu>,
     /// Active menu tracking state (non-None while MenuSelect is tracking the mouse)
-    pub(crate) menu_tracking: Option<ProcessMenuTrackingState>,
+    pub(crate) menu_tracking: SharedProcessMenuTracking,
     /// Process-owned nested guest-procedure continuations shared by both CPUs.
     pub(crate) guest_calls: SharedGuestCallStack,
     /// Custom popup MDEF state before its returned rectangle creates a pane.
@@ -2916,8 +2916,8 @@ impl TrapDispatcher {
         context.attach_sound_manager(&mut self.sound_manager);
         context.attach_cursor_state(&mut self.cursor_state);
         context.attach_event_queue(&mut self.event_queue);
+        context.attach_menu_tracking(&mut self.menu_tracking);
         context.attach_classic_file_system(&mut self.vfs, &mut self.vfs_rsrc);
-        context.adopt_menu_tracking(&mut self.menu_tracking);
         let mut memory_manager = None;
         context.attach_memory_manager(&mut memory_manager);
         self.attach_memory_manager_handle(
@@ -2996,23 +2996,6 @@ impl TrapDispatcher {
         self.process_memory_manager().has_handle_state(handle)
     }
 
-    /// Temporarily borrow the canonical menu tracking state from [`ProcessContext`]
-    /// into this adapter's local tracking for the duration of `f`, and guarantee
-    /// it is swapped back on normal exit, early return, or unwind.
-    pub(crate) fn with_menu_tracking<R>(
-        &mut self,
-        menu_tracking: &mut Option<ProcessMenuTrackingState>,
-        f: impl FnOnce(&mut Self) -> R,
-    ) -> R {
-        std::mem::swap(&mut self.menu_tracking, menu_tracking);
-        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(self)));
-        std::mem::swap(&mut self.menu_tracking, menu_tracking);
-        match outcome {
-            Ok(result) => result,
-            Err(payload) => std::panic::resume_unwind(payload),
-        }
-    }
-
     /// Attach the canonical process Memory Manager to this 68K adapter.
     pub(crate) fn with_memory_manager<R>(
         &mut self,
@@ -3055,24 +3038,15 @@ impl TrapDispatcher {
 
     pub(crate) fn with_process_state_and_memory_manager<R>(
         &mut self,
-        menu_tracking: &mut Option<ProcessMenuTrackingState>,
         memory_manager: &SharedProcessMemoryManager,
         f: impl FnOnce(&mut Self) -> R,
     ) -> R {
-        self.with_process_state(menu_tracking, |dispatcher| {
-            dispatcher.with_memory_manager(memory_manager, f)
-        })
+        self.with_memory_manager(memory_manager, f)
     }
 
-    /// Temporarily install the retained Menu Manager continuation needed by
-    /// one 68K execution slice. The Event Manager queue stays attached to its
-    /// ProcessContext owner for the dispatcher's entire lifetime.
-    pub(crate) fn with_process_state<R>(
-        &mut self,
-        menu_tracking: &mut Option<ProcessMenuTrackingState>,
-        f: impl FnOnce(&mut Self) -> R,
-    ) -> R {
-        self.with_menu_tracking(menu_tracking, f)
+    /// Run one 68K operation with every process manager continuously attached.
+    pub(crate) fn with_process_state<R>(&mut self, f: impl FnOnce(&mut Self) -> R) -> R {
+        f(self)
     }
 
     pub(crate) const AUTO_KEY_THRESHOLD_TICKS: u32 = 16;
@@ -3988,7 +3962,7 @@ impl TrapDispatcher {
             menu_bar_hidden: false,
             sound_manager: SharedProcessSoundManager::default(),
             menus: Vec::new(),
-            menu_tracking: None,
+            menu_tracking: SharedProcessMenuTracking::default(),
             guest_calls: SharedGuestCallStack::default(),
             menu_definition_tracking: None,
             pending_menu_bar_build: None,
@@ -10393,7 +10367,7 @@ mod tests {
     }
 
     fn install_menu_tracking(disp: &mut TrapDispatcher) {
-        disp.menu_tracking = Some(test_tracked_menu_state(0, (0, 0, 0, 0), 0));
+        *disp.menu_tracking = Some(test_tracked_menu_state(0, (0, 0, 0, 0), 0));
     }
 
     fn install_dialog_tracking(disp: &mut TrapDispatcher) {
@@ -11171,62 +11145,59 @@ mod tests {
     }
 
     #[test]
-    fn with_menu_tracking_restores_context_and_adapter_state_on_normal_exit() {
+    fn attached_menu_tracking_mutates_process_context_immediately() {
         let mut dispatcher = TrapDispatcher::new();
-        let mut context_tracking = Some(crate::menu_manager::test_process_menu_tracking(0x1234));
+        let mut context = ProcessContext::default();
+        context.set_menu_tracking(Some(crate::menu_manager::test_process_menu_tracking(0x1234)));
+        dispatcher.attach_process_context(&mut context);
 
-        let ran = dispatcher.with_menu_tracking(&mut context_tracking, |disp| {
-            assert_eq!(
-                disp.menu_tracking.as_ref().map(|t| t.menu_handle),
-                Some(0x1234)
-            );
-            disp.menu_tracking.as_mut().unwrap().highlighted_item = 5;
-            true
-        });
-
-        assert!(ran);
-        assert!(dispatcher.menu_tracking.is_none());
         assert_eq!(
-            context_tracking
-                .as_ref()
+            dispatcher.menu_tracking.as_ref().map(|t| t.menu_handle),
+            Some(0x1234)
+        );
+        dispatcher.menu_tracking.as_mut().unwrap().highlighted_item = 5;
+
+        assert_eq!(
+            context
+                .menu_tracking()
                 .map(|t| (t.menu_handle, t.highlighted_item)),
             Some((0x1234, 5))
         );
+        assert_eq!(dispatcher.menu_tracking.as_ref().unwrap().highlighted_item, 5);
     }
 
     #[test]
-    fn with_menu_tracking_restores_context_and_adapter_state_on_panic() {
+    fn attached_menu_tracking_remains_shared_through_panic() {
         let mut dispatcher = TrapDispatcher::new();
-        let mut context_tracking = Some(crate::menu_manager::test_process_menu_tracking(0x5678));
+        let mut context = ProcessContext::default();
+        context.set_menu_tracking(Some(crate::menu_manager::test_process_menu_tracking(0x5678)));
+        dispatcher.attach_process_context(&mut context);
 
         let panic_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            dispatcher.with_menu_tracking(&mut context_tracking, |disp| {
-                disp.menu_tracking.as_mut().unwrap().highlighted_item = 9;
-                panic!("simulated panic inside menu trap execution");
-            })
+            dispatcher.menu_tracking.as_mut().unwrap().highlighted_item = 9;
+            panic!("simulated panic inside menu trap execution");
         }));
 
         assert!(panic_result.is_err());
-        assert!(dispatcher.menu_tracking.is_none());
         assert_eq!(
-            context_tracking
-                .as_ref()
+            context
+                .menu_tracking()
                 .map(|t| (t.menu_handle, t.highlighted_item)),
             Some((0x5678, 9))
         );
+        assert_eq!(dispatcher.menu_tracking.as_ref().unwrap().highlighted_item, 9);
     }
 
     #[test]
     fn with_process_state_restores_all_canonical_slots_on_panic() {
         let mut dispatcher = TrapDispatcher::new();
         let mut context = ProcessContext::default();
+        context.set_menu_tracking(Some(crate::menu_manager::test_process_menu_tracking(0x9abc)));
         dispatcher.attach_process_context(&mut context);
-        let mut context_tracking = Some(crate::menu_manager::test_process_menu_tracking(0x9abc));
-        let memory_manager = context.menu_tracking_and_memory_manager().1.clone();
+        let memory_manager = context.memory_manager_handle().clone();
 
         let panic_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             dispatcher.with_process_state_and_memory_manager(
-                &mut context_tracking,
                 &memory_manager,
                 |disp| {
                     disp.event_queue.push_back(QueuedEvent {
@@ -11261,13 +11232,13 @@ mod tests {
             .track_handle_ptr(0x6666, 0x7777);
         assert_eq!(dispatcher.handle_for_ptr(0x6666), Some(0x7777));
         assert_eq!(
-            context_tracking
-                .as_ref()
+            context
+                .menu_tracking()
                 .map(|tracking| (tracking.menu_handle, tracking.highlighted_item)),
             Some((0x9abc, 7))
         );
         assert_eq!(dispatcher.event_queue.len(), 1);
-        assert!(dispatcher.menu_tracking.is_none());
+        assert_eq!(dispatcher.menu_tracking.as_ref().unwrap().highlighted_item, 7);
         assert!(dispatcher
             .process_memory_manager
             .as_ref()

--- a/src/trap/framebuffer.rs
+++ b/src/trap/framebuffer.rs
@@ -5118,7 +5118,7 @@ mod redraw_chrome_tests {
         tracking.submenus.push(child);
         tracking.flash_remaining = 5;
         tracking.flash_result = (701u32 << 16) | 1;
-        disp.menu_tracking = Some(tracking);
+        *disp.menu_tracking = Some(tracking);
 
         disp.redraw_chrome(&mut bus);
 

--- a/src/trap/memory.rs
+++ b/src/trap/memory.rs
@@ -4519,10 +4519,9 @@ mod tests {
         dispatcher.attach_process_context(&mut context);
 
         cpu.write_reg(Register::D0, 24);
-        let (menu_tracking, memory_manager) = context.menu_tracking_and_memory_manager();
+        let memory_manager = context.memory_manager_handle();
         dispatcher
             .with_process_state_and_memory_manager(
-                menu_tracking,
                 memory_manager,
                 |dispatcher| {
                     dispatcher.current_trap_word = 0xA11E;
@@ -4540,10 +4539,9 @@ mod tests {
         );
 
         cpu.write_reg(Register::D0, 13);
-        let (menu_tracking, memory_manager) = context.menu_tracking_and_memory_manager();
+        let memory_manager = context.memory_manager_handle();
         dispatcher
             .with_process_state_and_memory_manager(
-                menu_tracking,
                 memory_manager,
                 |dispatcher| {
                     dispatcher.current_trap_word = 0xA022;
@@ -4584,10 +4582,9 @@ mod tests {
         assert_eq!(cpu.read_reg(Register::D0), 13);
 
         cpu.write_reg(Register::A0, ptr);
-        let (menu_tracking, memory_manager) = context.menu_tracking_and_memory_manager();
+        let memory_manager = context.memory_manager_handle();
         dispatcher
             .with_process_state_and_memory_manager(
-                menu_tracking,
                 memory_manager,
                 |dispatcher| {
                     dispatcher.current_trap_word = 0xA01F;
@@ -4600,10 +4597,9 @@ mod tests {
         assert_eq!(memory_manager.borrow().classic_allocation_size(ptr), None);
 
         cpu.write_reg(Register::A0, handle);
-        let (menu_tracking, memory_manager) = context.menu_tracking_and_memory_manager();
+        let memory_manager = context.memory_manager_handle();
         dispatcher
             .with_process_state_and_memory_manager(
-                menu_tracking,
                 memory_manager,
                 |dispatcher| {
                     dispatcher.current_trap_word = 0xA023;
@@ -4633,10 +4629,7 @@ mod tests {
 
         let mut context = ProcessContext::default();
         context.attach_classic_memory_bus(&mut bus);
-        let memory_manager = context
-            .menu_tracking_and_memory_manager()
-            .1
-            .clone();
+        let memory_manager = context.memory_manager_handle().clone();
         {
             let mut manager = memory_manager.borrow_mut();
             manager.publish_native_allocator(
@@ -4709,10 +4702,7 @@ mod tests {
 
         let mut context = ProcessContext::default();
         context.attach_classic_memory_bus(&mut bus);
-        let memory_manager = context
-            .menu_tracking_and_memory_manager()
-            .1
-            .clone();
+        let memory_manager = context.memory_manager_handle().clone();
         {
             let mut manager = memory_manager.borrow_mut();
             manager.publish_native_allocator(
@@ -4787,10 +4777,7 @@ mod tests {
 
         let mut context = ProcessContext::default();
         context.attach_classic_memory_bus(&mut bus);
-        let memory_manager = context
-            .menu_tracking_and_memory_manager()
-            .1
-            .clone();
+        let memory_manager = context.memory_manager_handle().clone();
         {
             let mut manager = memory_manager.borrow_mut();
             manager.publish_native_allocator(
@@ -4874,10 +4861,7 @@ mod tests {
 
         let mut context = ProcessContext::default();
         context.attach_classic_memory_bus(&mut bus);
-        let memory_manager = context
-            .menu_tracking_and_memory_manager()
-            .1
-            .clone();
+        let memory_manager = context.memory_manager_handle().clone();
         {
             let mut manager = memory_manager.borrow_mut();
             manager.publish_native_allocator(
@@ -4945,10 +4929,7 @@ mod tests {
 
         let mut context = ProcessContext::default();
         context.attach_classic_memory_bus(&mut bus);
-        let memory_manager = context
-            .menu_tracking_and_memory_manager()
-            .1
-            .clone();
+        let memory_manager = context.memory_manager_handle().clone();
         {
             let mut manager = memory_manager.borrow_mut();
             manager.publish_native_allocator(

--- a/src/trap/menu.rs
+++ b/src/trap/menu.rs
@@ -2596,7 +2596,7 @@ impl super::TrapDispatcher {
                                 saved,
                             );
                             tracking.definition = self.menu_definition_tracking.take();
-                            self.menu_tracking = Some(tracking);
+                            *self.menu_tracking = Some(tracking);
                             self.draw_menu_dropdown_chrome(bus, menu_idx, rect);
                             self.active_menu_definition_mut().unwrap().draw();
                             if !self.arm_pending_menu_definition(
@@ -2758,7 +2758,7 @@ impl super::TrapDispatcher {
                         .position(|m| m.handle == menu_handle || m.id == menu_id)
                     {
                         if !self.menu_uses_standard_definition(bus, menu_ptr) {
-                            self.menu_tracking = Some(tracked_menu_state(
+                            *self.menu_tracking = Some(tracked_menu_state(
                                 MenuTrackingKind::PopUp,
                                 menu_handle,
                                 (0, 0, 0, 0),
@@ -2798,7 +2798,7 @@ impl super::TrapDispatcher {
 
                         self.restore_visible_dialog_snapshots(bus);
                         let saved = self.save_dropdown_pixels(bus, dd_rect);
-                        self.menu_tracking = Some(tracked_menu_state_with_content_top(
+                        *self.menu_tracking = Some(tracked_menu_state_with_content_top(
                             MenuTrackingKind::PopUp,
                             menu_handle,
                             dd_rect,
@@ -4462,7 +4462,7 @@ impl super::TrapDispatcher {
             tracked_menu_state(MenuTrackingKind::MenuBar, menu.handle, dropdown_rect, saved);
         tracking.definition = custom_definition
             .then(|| SharedMenuDefinitionTracking::begin_draw(menu.handle, dropdown_rect));
-        self.menu_tracking = Some(tracking);
+        *self.menu_tracking = Some(tracking);
         if !custom_definition {
             let rows = self.menu_rows(bus, &self.menus[menu_idx].items);
             Self::write_menu_scrolling_globals(bus, &rows, dropdown_rect.0);
@@ -4843,7 +4843,7 @@ impl super::TrapDispatcher {
     /// Determine which item (1-based) is at the given screen point, or 0.
     #[cfg(test)]
     fn dropdown_item_at_point(&self, bus: &MacMemoryBus, mouse_x: i16, mouse_y: i16) -> i16 {
-        if let Some(ref tracking) = self.menu_tracking {
+        if let Some(ref tracking) = *self.menu_tracking {
             let Some(menu_idx) = self.menu_index_for_handle(tracking.menu_handle) else {
                 return 0;
             };
@@ -11521,7 +11521,7 @@ mod tests {
         );
         classic.menus[0].items[0].mark = 0x12;
         classic.menus[0].items[1].icon = 7;
-        classic.menu_tracking = Some(test_tracked_menu_state(classic_menu, rect, 1));
+        *classic.menu_tracking = Some(test_tracked_menu_state(classic_menu, rect, 1));
         classic.draw_menu_dropdown(&mut classic_bus, 0, rect);
 
         let (mut themed, mut themed_cpu, mut themed_bus) = setup_with_port();
@@ -11548,7 +11548,7 @@ mod tests {
         );
         themed.menus[0].items[0].mark = 0x12;
         themed.menus[0].items[1].icon = 7;
-        themed.menu_tracking = Some(test_tracked_menu_state(themed_menu, rect, 1));
+        *themed.menu_tracking = Some(test_tracked_menu_state(themed_menu, rect, 1));
         themed.draw_menu_dropdown(&mut themed_bus, 0, rect);
 
         assert!(
@@ -11720,7 +11720,7 @@ mod tests {
         );
 
         clear_1bpp_screen(&mut themed_bus, themed_base, themed_row_bytes, 342);
-        themed.menu_tracking = Some(test_tracked_menu_state(themed_menu, rect, 1));
+        *themed.menu_tracking = Some(test_tracked_menu_state(themed_menu, rect, 1));
         themed.draw_menu_dropdown(&mut themed_bus, 0, rect);
 
         assert!(
@@ -11769,7 +11769,7 @@ mod tests {
         }
 
         clear_1bpp_screen(&mut themed_bus, themed_base, themed_row_bytes, 342);
-        themed.menu_tracking = None;
+        *themed.menu_tracking = None;
         themed.dialog_tracking = Some(super::super::dispatch::DialogTrackingState {
             active_popup: Some(super::super::dispatch::DialogPopupTrackingState {
                 item_no: 1,
@@ -12330,7 +12330,7 @@ mod tests {
             "4bpp cicn color should map through MainDevice instead of the foreign 8bpp TheGDevice"
         );
 
-        disp.menu_tracking = Some(test_tracked_menu_state(menu, rect, 1));
+        *disp.menu_tracking = Some(test_tracked_menu_state(menu, rect, 1));
         disp.draw_menu_dropdown(&mut bus, 0, rect);
         assert_eq!(
             packed_4bpp_screen_pixel_index(&bus, base, row_bytes, icon_pixel.0, icon_pixel.1,),
@@ -12600,7 +12600,7 @@ mod tests {
             screen_pixel_is_set(&bus, base, row_bytes, outside_edge.0, outside_edge.1);
         let before = bus.read_bytes(base, (row_bytes * 96) as usize);
 
-        disp.menu_tracking = Some(test_tracked_menu_state(menu, rect, 1));
+        *disp.menu_tracking = Some(test_tracked_menu_state(menu, rect, 1));
         disp.draw_menu_dropdown(&mut bus, 0, rect);
 
         for (component, pixel) in [
@@ -12711,7 +12711,7 @@ mod tests {
             .expect("precondition: item RGB3 black command key should draw");
         let before = bus.read_bytes(base, (row_bytes * 96) as usize);
 
-        disp.menu_tracking = Some(test_tracked_menu_state(menu, rect, 1));
+        *disp.menu_tracking = Some(test_tracked_menu_state(menu, rect, 1));
         disp.draw_menu_dropdown(&mut bus, 0, rect);
 
         assert_eq!(
@@ -12810,7 +12810,7 @@ mod tests {
             .expect("precondition: item RGB3 black command key should draw");
         let before = bus.read_bytes(base, (row_bytes * 96) as usize);
 
-        disp.menu_tracking = Some(test_tracked_menu_state(menu, rect, 1));
+        *disp.menu_tracking = Some(test_tracked_menu_state(menu, rect, 1));
         disp.draw_menu_dropdown(&mut bus, 0, rect);
 
         assert_eq!(
@@ -13496,7 +13496,7 @@ mod tests {
             new_menu_with_title(&mut disp, &mut cpu, &mut bus, 702, 0x302700, "Retained");
         append_menu_data(&mut disp, &mut cpu, &mut bus, retained, 0x302740, "Right");
 
-        disp.menu_tracking = Some(test_tracked_menu_state(retained, (20, 10, 38, 100), 1));
+        *disp.menu_tracking = Some(test_tracked_menu_state(retained, (20, 10, 38, 100), 1));
         disp.menus.swap(0, 1);
 
         assert_eq!(


### PR DESCRIPTION
Closes #1171.

Makes the retained Menu Manager continuation process-owned and continuously shared between the 68K and PowerPC adapters. Adapter clones retain detached snapshots, and attaching two active continuations remains rejected.

Validation:
- `cargo test --locked --lib` (4,732 passed; 0 failed; 3 ignored)
- strict rustdoc with private intra-doc links denied
- `cargo build --locked --all-targets --all-features`
- Marathon deterministic gameplay gate
- Escape Velocity deterministic gameplay gate
- Tomb Raider Gold deterministic gameplay gate