### PR TITLE
refactor(input): make state process-owned

### DIFF
--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -71,12 +71,12 @@ use crate::menu_manager::{
 use crate::menu_model::GuestMenuSnapshot;
 use crate::process_context::{
     ProcessAppleEventHandler, ProcessContext, ProcessCursorState, ProcessFileSystemState,
-    ProcessHandleRecord, ProcessHandleStateRecord, ProcessMemoryManager,
+    ProcessHandleRecord, ProcessHandleStateRecord, ProcessInputState, ProcessMemoryManager,
     ProcessNativeAllocatorState, ProcessNativeHeapState, ProcessNativeMemoryManager,
     ProcessPtrRecord, ProcessResourceManagerState, ProcessVfsFileRecords,
     ProcessVfsResourceFileRecords, SharedProcessAppleEventHandlers, SharedProcessCursorState,
-    SharedProcessEventQueue, SharedProcessFileSystem, SharedProcessMemoryManager,
-    SharedProcessMenuTracking,
+    SharedProcessEventQueue, SharedProcessFileSystem, SharedProcessInputState,
+    SharedProcessMemoryManager, SharedProcessMenuTracking,
 };
 use crate::quickdraw::fonts::heuristics::{
     get_italic_end_extend, get_italic_slant, get_italic_underline_extend_left,
@@ -3397,6 +3397,7 @@ pub struct PpcLoadedApp {
     pub imports: Vec<PpcImportBinding>,
     pub section_bases: Vec<Option<u32>>,
     pub input: PpcInputSnapshot,
+    pub(crate) process_input: SharedProcessInputState,
     pub(crate) event_queue: SharedProcessEventQueue,
     pub(crate) guest_calls: SharedGuestCallStack,
     pub(crate) process_memory_manager: PpcProcessMemoryManager,
@@ -3819,6 +3820,24 @@ impl PpcLoadedApp {
                 .write_u16_be(point_addr + 2, input.mouse_h as u16);
         }
         self.input = input;
+        self.process_input.key_map = input.key_map;
+        self.process_input.mouse_button = input.mouse_button;
+        self.process_input.mouse_pos = (input.mouse_v, input.mouse_h);
+    }
+
+    fn current_input_snapshot(&self) -> PpcInputSnapshot {
+        let ProcessInputState {
+            key_map,
+            mouse_button,
+            mouse_pos: (mouse_v, mouse_h),
+            ..
+        } = *self.process_input;
+        PpcInputSnapshot {
+            key_map,
+            mouse_button,
+            mouse_v,
+            mouse_h,
+        }
     }
 
     pub fn set_event_queue<I>(&mut self, events: I)
@@ -3846,6 +3865,7 @@ impl PpcLoadedApp {
         context.attach_sound_manager(&mut self.sound.manager);
         context.attach_cursor_state(&mut self.cursor_state);
         context.attach_event_queue(&mut self.event_queue);
+        context.attach_input_state(&mut self.process_input);
         context.attach_menu_tracking(&mut self.toolbox_startup.menu_tracking);
         let mut attached_memory_manager = None;
         context.attach_memory_manager(&mut attached_memory_manager);
@@ -7103,7 +7123,7 @@ impl PpcLoadedApp {
                 binding.dispatcher_target == PpcImportDispatcherTarget::Q3ViewEndRendering
             })
             .map(|binding| binding.symbol_index);
-        let input = self.input;
+        let input = self.current_input_snapshot();
         let mut event_queue = std::mem::take(&mut self.event_queue);
         let process_memory_manager = process_memory_manager.native_mut();
         let native_allocator = process_memory_manager
@@ -12736,6 +12756,7 @@ fn load_pef_application_with_config_and_optional_system_reservation(
         imports,
         section_bases,
         input: PpcInputSnapshot::default(),
+        process_input: SharedProcessInputState::default(),
         event_queue: SharedProcessEventQueue::default(),
         guest_calls: SharedGuestCallStack::default(),
         process_memory_manager,
@@ -89837,6 +89858,50 @@ pub(crate) mod tests {
 
         assert_eq!(context.event_queue().len(), 1);
         assert!(!context.event_queue().menu_bar_is_invalid());
+    }
+
+    #[test]
+    fn attached_68k_and_powerpc_adapters_share_live_input_without_runner_copy() {
+        let (mut classic, _, _) = setup_with_port();
+        let pef = synthetic_pef_with_import(b"Button");
+        let mut native = load_pef_application(&pef).unwrap();
+        let mut context = ProcessContext::default();
+
+        classic.attach_process_context(&mut context);
+        native.attach_process_context(&mut context);
+        let detached = native.clone();
+
+        classic.input_state.mouse_pos = (123, 456);
+        classic.input_state.mouse_button = true;
+        classic.input_state.key_map[6] = 0x20;
+
+        assert_eq!(
+            native.current_input_snapshot(),
+            PpcInputSnapshot {
+                key_map: {
+                    let mut key_map = [0; 16];
+                    key_map[6] = 0x20;
+                    key_map
+                },
+                mouse_button: true,
+                mouse_v: 123,
+                mouse_h: 456,
+            }
+        );
+        let probe = native.run_with_hle_imports(64);
+        assert_eq!(probe.handled_import_count, 1);
+        assert_eq!(native.cpu.gpr[3], 1);
+
+        native.process_input.mouse_pos = (-20, 99);
+        native.process_input.mouse_button = false;
+        native.process_input.key_map[1] = 0x08;
+
+        assert!(classic.input_state.ptr_eq(&native.process_input));
+        assert_eq!(classic.input_state.mouse_pos, (-20, 99));
+        assert!(!classic.input_state.mouse_button);
+        assert_eq!(classic.input_state.key_map[1], 0x08);
+        assert!(!native.process_input.ptr_eq(&detached.process_input));
+        assert_eq!(detached.current_input_snapshot(), PpcInputSnapshot::default());
     }
 
     #[test]

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -567,6 +567,34 @@ pub(crate) type SharedProcessSoundManager = SharedProcessValue<SoundManager>;
 pub(crate) type SharedProcessCursorState = SharedProcessValue<ProcessCursorState>;
 pub(crate) type SharedProcessEventQueue = SharedProcessValue<EventQueue>;
 pub(crate) type SharedProcessMenuTracking = SharedProcessValue<Option<ProcessMenuTrackingState>>;
+pub(crate) type SharedProcessInputState = SharedProcessValue<ProcessInputState>;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct ProcessKeyRepeatState {
+    pub(crate) key_code: u8,
+    pub(crate) char_code: u8,
+    pub(crate) next_tick: u32,
+}
+
+/// Canonical mouse and keyboard device state for one Macintosh process.
+///
+/// Event Manager calls, direct low-memory polling, and either ISA observe the
+/// same mouse position, button state, and 128-key map. Inside Macintosh Volume
+/// I (1985), pp. I-259--I-263 and I-273--I-275.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct ProcessInputState {
+    pub(crate) mouse_pos: (i16, i16),
+    pub(crate) mouse_button: bool,
+    pub(crate) key_map: [u8; 16],
+    pub(crate) caps_lock_physically_pressed: bool,
+    pub(crate) key_repeat: Option<ProcessKeyRepeatState>,
+}
+
+impl ProcessInputState {
+    pub(crate) fn is_pristine(&self) -> bool {
+        self == &Self::default()
+    }
+}
 
 /// Canonical QuickDraw cursor state for one Macintosh process.
 ///
@@ -3412,6 +3440,7 @@ pub(crate) struct ProcessContext {
     memory: Vec<ProcessMemoryRegion>,
     memory_manager: SharedProcessMemoryManager,
     event_queue: SharedProcessEventQueue,
+    input_state: SharedProcessInputState,
     menu_tracking: SharedProcessMenuTracking,
     pending_native_menu_selection: SharedNativeMenuSelection,
     guest_calls: SharedGuestCallStack,
@@ -3471,6 +3500,10 @@ impl ProcessContext {
         // EventAvail observes it in place. Inside Macintosh Volume I (1985),
         // pp. I-244--I-245 and I-257--I-259; Processes (1994), pp. 2-15--2-16.
         adapter.attach_to(&self.event_queue, EventQueue::is_pristine);
+    }
+
+    pub(crate) fn attach_input_state(&self, adapter: &mut SharedProcessInputState) {
+        adapter.attach_to(&self.input_state, ProcessInputState::is_pristine);
     }
 
     pub(crate) fn attach_menu_tracking(&self, adapter: &mut SharedProcessMenuTracking) {
@@ -4975,6 +5008,39 @@ mod tests {
         assert_eq!(detached.len(), 1);
         assert_eq!(detached.front().unwrap().message, 0x1111);
         assert!(!detached.menu_bar_is_invalid());
+    }
+
+    #[test]
+    fn attached_input_states_share_immediately_while_clones_detach() {
+        let context = ProcessContext::default();
+        let mut classic = SharedProcessInputState::default();
+        classic.mouse_pos = (12, 34);
+        classic.key_map[2] = 0x40;
+        let mut native = SharedProcessInputState::default();
+
+        context.attach_input_state(&mut classic);
+        context.attach_input_state(&mut native);
+        let detached = native.clone();
+
+        native.mouse_button = true;
+        native.mouse_pos = (56, 78);
+        native.caps_lock_physically_pressed = true;
+        native.key_repeat = Some(ProcessKeyRepeatState {
+            key_code: 0x24,
+            char_code: b'\r',
+            next_tick: 90,
+        });
+
+        assert!(classic.ptr_eq(&native));
+        assert_eq!(classic.mouse_pos, (56, 78));
+        assert!(classic.mouse_button);
+        assert_eq!(classic.key_map[2], 0x40);
+        assert!(classic.caps_lock_physically_pressed);
+        assert_eq!(classic.key_repeat.unwrap().next_tick, 90);
+        assert_eq!(detached.mouse_pos, (12, 34));
+        assert!(!detached.mouse_button);
+        assert!(!detached.caps_lock_physically_pressed);
+        assert!(detached.key_repeat.is_none());
     }
 
     #[test]

--- a/src/runner/idle.rs
+++ b/src/runner/idle.rs
@@ -190,10 +190,10 @@ pub(crate) struct IdleCycleHostSnapshot {
 impl IdleCycleHostSnapshot {
     pub(crate) fn capture(dispatcher: &TrapDispatcher) -> Self {
         Self {
-            mouse_pos: dispatcher.mouse_pos,
-            mouse_button: dispatcher.mouse_button,
+            mouse_pos: dispatcher.input_state.mouse_pos,
+            mouse_button: dispatcher.input_state.mouse_button,
             key_map: *dispatcher.key_map_bytes(),
-            caps_lock_physically_pressed: dispatcher.caps_lock_physically_pressed,
+            caps_lock_physically_pressed: dispatcher.input_state.caps_lock_physically_pressed,
             window_list: dispatcher.window_list.clone(),
             pending_native_menu_selection: dispatcher.pending_native_menu_selection.snapshot(),
         }

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -1822,7 +1822,7 @@ impl FixtureRunner {
             cursor_mask_nonzero_bytes,
             cursor_hotspot,
             cursor_position: dispatcher.mouse_position(),
-            mouse_button: dispatcher.mouse_button,
+            mouse_button: dispatcher.input_state.mouse_button,
             fullscreen_locked: dispatcher.fullscreen_locked,
             mbar_height: self.bus.read_word(addr::MBAR_HEIGHT),
             screen_width,
@@ -2508,10 +2508,10 @@ impl FixtureRunner {
     }
 
     /// Write the three mouse-position low-memory globals (MTemp $0828,
-    /// RawMouse $082C, Mouse $0830) from `self.dispatcher.mouse_pos`.
+    /// RawMouse $082C, Mouse $0830) from the process input state.
     /// Inside Macintosh Volume I, I-258.
     fn sync_mouse_position_lowmem(&mut self) {
-        let (v, h) = self.dispatcher.mouse_pos;
+        let (v, h) = self.dispatcher.input_state.mouse_pos;
         self.bus.write_word(0x0828, v as u16);
         self.bus.write_word(0x082A, h as u16);
         self.bus.write_word(0x082C, v as u16);
@@ -2526,7 +2526,7 @@ impl FixtureRunner {
     /// MTemp ($0828), RawMouse ($082C), Mouse ($0830): current position
     /// Inside Macintosh Volume I, I-258; Inside Macintosh Volume II, II-371
     fn sync_mouse_lowmem(&mut self) {
-        let mb_state: u8 = if self.dispatcher.mouse_button {
+        let mb_state: u8 = if self.dispatcher.input_state.mouse_button {
             0x00
         } else {
             0x80
@@ -3026,8 +3026,8 @@ impl FixtureRunner {
         let launch_tick = self.guest_tick();
         let launch_time = self.bus.read_long(addr::TIME);
         let launch_rnd_seed = self.bus.read_long(addr::RND_SEED);
-        let mouse_pos = self.dispatcher.mouse_pos;
-        let mouse_button = self.dispatcher.mouse_button;
+        let mouse_pos = self.dispatcher.input_state.mouse_pos;
+        let mouse_button = self.dispatcher.input_state.mouse_button;
         let output_dir = self.dispatcher.output_dir.clone();
         let vfs = self.dispatcher.vfs.clone();
         let vfs_rsrc = self.dispatcher.vfs_rsrc.clone();
@@ -3094,8 +3094,8 @@ impl FixtureRunner {
         if let Some(ppc_app) = replacement.ppc_app.as_mut() {
             ppc_app.set_tick_count(launch_tick);
         }
-        replacement.dispatcher.mouse_pos = mouse_pos;
-        replacement.dispatcher.mouse_button = mouse_button;
+        replacement.dispatcher.input_state.mouse_pos = mouse_pos;
+        replacement.dispatcher.input_state.mouse_button = mouse_button;
         replacement
             .bus
             .write_byte(addr::MB_STATE, if mouse_button { 0x00 } else { 0x80 });
@@ -4266,7 +4266,7 @@ impl FixtureRunner {
             self.dispatcher.tick_count == sleep.tick && self.bus.read_long(0x016A) == sleep.tick;
         let host_unchanged = sleep.host == IdleCycleHostSnapshot::capture(&self.dispatcher);
         let can_observe_events = self.active_interrupt_callback.is_none()
-            && self.dispatcher.key_repeat.is_none()
+            && self.dispatcher.input_state.key_repeat.is_none()
             && self.dispatcher.pending_launch_app.is_none()
             && !self.dispatcher.system_task_has_periodic_work();
         let event_stream_empty = can_observe_events
@@ -5763,13 +5763,11 @@ impl FixtureRunner {
         }
 
         self.dispatcher.instruction_count = self.total_instructions;
-        let input = self.ppc_input_snapshot();
         let Some(mut ppc_app) = self.ppc_app.take() else {
             return (0, !self.halted);
         };
 
         ppc_app.toolbox_startup.host_menu_bar_hidden = self.dispatcher.menu_bar_hidden;
-        ppc_app.set_input_snapshot(input);
         self.prepare_ppc_execution_clock(&mut ppc_app);
         let cycles_per_tick = self.instructions_per_tick.max(1);
         let remaining_cycles =
@@ -6941,10 +6939,10 @@ impl FixtureRunner {
 
     fn ppc_input_snapshot(&self) -> PpcInputSnapshot {
         PpcInputSnapshot {
-            key_map: self.dispatcher.key_map,
-            mouse_button: self.dispatcher.mouse_button,
-            mouse_v: self.dispatcher.mouse_pos.0,
-            mouse_h: self.dispatcher.mouse_pos.1,
+            key_map: self.dispatcher.input_state.key_map,
+            mouse_button: self.dispatcher.input_state.mouse_button,
+            mouse_v: self.dispatcher.input_state.mouse_pos.0,
+            mouse_h: self.dispatcher.input_state.mouse_pos.1,
         }
     }
 
@@ -8483,7 +8481,7 @@ impl FixtureRunner {
                 .with_process_state(|d| {
                     d.has_unmatched_queued_mouse_down()
                 });
-        let pressed = self.dispatcher.mouse_button || has_pending_unmatched_down;
+        let pressed = self.dispatcher.input_state.mouse_button || has_pending_unmatched_down;
         let mb_state: u8 = if pressed { 0x00 } else { 0x80 };
         self.bus.write_byte(0x0172, mb_state);
         if input_tick_trace_enabled() {
@@ -12407,7 +12405,7 @@ mod tests {
             .memory
             .read_bytes_into(addr::KEY_MAP_LM, &mut host_key_map)
             .unwrap();
-        assert_eq!(host_key_map, runner.dispatcher.key_map);
+        assert_eq!(host_key_map, runner.dispatcher.input_state.key_map);
         assert_eq!(ppc_app.memory.read_u8(addr::MB_STATE), Some(0));
         for point_addr in [addr::M_TEMP, addr::MOUSE_LOC, addr::MOUSE_LOC2] {
             assert_eq!(ppc_app.memory.read_u16_be(point_addr), Some((-7i16) as u16));
@@ -13557,6 +13555,7 @@ mod tests {
             imports: Vec::new(),
             section_bases: Vec::new(),
             input: PpcInputSnapshot::default(),
+            process_input: Default::default(),
             event_queue: Default::default(),
             guest_calls: Default::default(),
             process_memory_manager: PpcProcessMemoryManager::with_heap(
@@ -15782,6 +15781,7 @@ mod tests {
             imports: Vec::new(),
             section_bases: Vec::new(),
             input: PpcInputSnapshot::default(),
+            process_input: Default::default(),
             event_queue: Default::default(),
             guest_calls: Default::default(),
             process_memory_manager: PpcProcessMemoryManager::with_heap(
@@ -16687,6 +16687,7 @@ mod tests {
             }],
             section_bases: Vec::new(),
             input: PpcInputSnapshot::default(),
+            process_input: Default::default(),
             event_queue: Default::default(),
             guest_calls: Default::default(),
             process_memory_manager: PpcProcessMemoryManager::with_heap(
@@ -16837,6 +16838,7 @@ mod tests {
             }],
             section_bases: Vec::new(),
             input: PpcInputSnapshot::default(),
+            process_input: Default::default(),
             event_queue: Default::default(),
             guest_calls: Default::default(),
             process_memory_manager: PpcProcessMemoryManager::with_heap(
@@ -17235,6 +17237,7 @@ mod tests {
             imports: Vec::new(),
             section_bases: Vec::new(),
             input: PpcInputSnapshot::default(),
+            process_input: Default::default(),
             event_queue: Default::default(),
             guest_calls: Default::default(),
             process_memory_manager: PpcProcessMemoryManager::with_heap(
@@ -17544,6 +17547,7 @@ mod tests {
             imports: Vec::new(),
             section_bases: Vec::new(),
             input: PpcInputSnapshot::default(),
+            process_input: Default::default(),
             event_queue: Default::default(),
             guest_calls: Default::default(),
             process_memory_manager: PpcProcessMemoryManager::with_heap(
@@ -22256,8 +22260,8 @@ mod tests {
         runner.bus.write_word(ctrl_ptr + 20, 0);
         runner.bus.write_word(ctrl_ptr + 22, 100);
         runner.dispatcher.control_proc_ids.insert(ctrl_ptr, 16);
-        runner.dispatcher.mouse_button = true;
-        runner.dispatcher.mouse_pos = (210, 248);
+        runner.dispatcher.input_state.mouse_button = true;
+        runner.dispatcher.input_state.mouse_pos = (210, 248);
 
         runner.bus.write_long(sp, action_proc);
         runner.bus.write_word(sp + 4, 210);
@@ -24384,7 +24388,7 @@ mod tests {
 
         runner.set_mouse_position(123, 456);
 
-        assert_eq!(runner.dispatcher.mouse_pos, (123, 456));
+        assert_eq!(runner.dispatcher.input_state.mouse_pos, (123, 456));
         for off in [0x0828u32, 0x082C, 0x0830] {
             assert_eq!(runner.bus.read_word(off), 123u16, "v at ${:04X}", off);
             assert_eq!(runner.bus.read_word(off + 2), 456u16, "h at ${:04X}", off);

--- a/src/scripted_traces.rs
+++ b/src/scripted_traces.rs
@@ -1236,8 +1236,8 @@ fn scripted_record_modal_app_control_value_trace(
     let ctrl_ptr = bus.read_long(ctrl_handle);
     dispatcher.record_input_trace_line(format!(
         "A991 action=app_set_control_value live_mouse=({},{}) {} dialog={} bounds=({},{},{},{}) item_hit={} item_type={} control_handle={} control_ptr={} control_value={} result=app outcome={}",
-        dispatcher.mouse_pos.0,
-        dispatcher.mouse_pos.1,
+        dispatcher.input_state.mouse_pos.0,
+        dispatcher.input_state.mouse_pos.1,
         dispatcher.input_trace_state_fields(),
         scripted_trace_nonzero(dialog_ptr),
         bounds.0,

--- a/src/trap/control.rs
+++ b/src/trap/control.rs
@@ -122,8 +122,8 @@ impl super::TrapDispatcher {
             action,
             start,
             Self::control_trace_nonzero(action_proc),
-            self.mouse_pos.0,
-            self.mouse_pos.1,
+            self.input_state.mouse_pos.0,
+            self.input_state.mouse_pos.1,
             self.input_trace_state_fields(),
             self.control_trace_control_fields(bus, ctrl_handle),
             part,
@@ -137,7 +137,7 @@ impl super::TrapDispatcher {
         // MBState ($0172) is the classic low-memory button mirror (0=down,
         // $80=up), so guest callbacks/VBL tasks can hold or release tracking
         // between trap re-fires. Inside Macintosh Volume II, p. II-371.
-        self.mouse_button || bus.read_byte(addr::MB_STATE) == 0x00
+        self.input_state.mouse_button || bus.read_byte(addr::MB_STATE) == 0x00
     }
 
     fn control_tracking_mouse_pos(&self, bus: &MacMemoryBus) -> (i16, i16) {
@@ -150,7 +150,7 @@ impl super::TrapDispatcher {
         if v != 0 || h != 0 {
             (v, h)
         } else {
-            self.mouse_pos
+            self.input_state.mouse_pos
         }
     }
 
@@ -3534,7 +3534,7 @@ impl super::TrapDispatcher {
                                 // Preserve the old immediate path when the
                                 // mouse is already up; scripted callers that
                                 // model a real mouse-down take the refire path.
-                                if self.mouse_button
+                                if self.input_state.mouse_button
                                     && action_proc == 0
                                     && matches!(proc_id, 0 | 1 | 2)
                                 {
@@ -5760,8 +5760,8 @@ mod tests {
         // Returning from the initial action callback retains TrackControl.
         cpu.write_reg(Register::PC, trap_pc + 2);
         cpu.write_reg(Register::A7, sp);
-        disp.mouse_button = true;
-        disp.mouse_pos = (210, 248);
+        disp.input_state.mouse_button = true;
+        disp.input_state.mouse_pos = (210, 248);
         disp.dispatch_control(true, 0x168, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
@@ -5794,7 +5794,7 @@ mod tests {
         disp.dispatch_control(true, 0x168, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
-        disp.mouse_button = false;
+        disp.input_state.mouse_button = false;
         cpu.write_reg(Register::PC, trap_pc + 2);
         disp.dispatch_control(true, 0x168, &mut cpu, &mut bus)
             .unwrap()
@@ -5820,8 +5820,8 @@ mod tests {
         let probe_x = 30;
         let probe_y = 30;
 
-        disp.mouse_button = true;
-        disp.mouse_pos = (probe_y, probe_x);
+        disp.input_state.mouse_button = true;
+        disp.input_state.mouse_pos = (probe_y, probe_x);
         cpu.write_reg(Register::A7, sp);
         bus.write_long(sp, 0);
         bus.write_word(sp + 4, probe_y as u16);
@@ -5845,7 +5845,7 @@ mod tests {
             "held simple TrackControl should route pressed button chrome through the provider"
         );
 
-        disp.mouse_pos = (10, 10);
+        disp.input_state.mouse_pos = (10, 10);
         disp.dispatch_control(true, 0x168, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
@@ -5855,7 +5855,7 @@ mod tests {
             "dragging outside should redraw unpressed provider chrome"
         );
 
-        disp.mouse_pos = (probe_y, probe_x);
+        disp.input_state.mouse_pos = (probe_y, probe_x);
         disp.dispatch_control(true, 0x168, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
@@ -5865,7 +5865,7 @@ mod tests {
             "dragging back inside should restore provider pressed chrome"
         );
 
-        disp.mouse_button = false;
+        disp.input_state.mouse_button = false;
         disp.dispatch_control(true, 0x168, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
@@ -5899,8 +5899,8 @@ mod tests {
         let (ctrl_handle, ctrl_ptr) =
             alloc_button_control(&mut disp, &mut bus, window, (20, 20, 40, 80));
 
-        disp.mouse_button = true;
-        disp.mouse_pos = (30, 30);
+        disp.input_state.mouse_button = true;
+        disp.input_state.mouse_pos = (30, 30);
         cpu.write_reg(Register::A7, sp);
         bus.write_long(sp, 0);
         bus.write_word(sp + 4, 30);
@@ -5912,12 +5912,12 @@ mod tests {
             .unwrap();
 
         if !release_inside {
-            disp.mouse_pos = (10, 10);
+            disp.input_state.mouse_pos = (10, 10);
             disp.dispatch_control(true, 0x168, &mut cpu, &mut bus)
                 .unwrap()
                 .unwrap();
         }
-        disp.mouse_button = false;
+        disp.input_state.mouse_button = false;
         disp.dispatch_control(true, 0x168, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
@@ -6004,8 +6004,8 @@ mod tests {
             hierarchical: false,
         });
 
-        disp.mouse_button = true;
-        disp.mouse_pos = (15, 25);
+        disp.input_state.mouse_button = true;
+        disp.input_state.mouse_pos = (15, 25);
         cpu.write_reg(Register::A7, sp);
         bus.write_long(sp, 0xFFFF_FFFF);
         bus.write_word(sp + 4, 15);
@@ -6023,15 +6023,15 @@ mod tests {
             .map(|tracking| tracking.dropdown_rect)
             .expect("popup tracking should open a dropdown");
         if select_second_item {
-            disp.mouse_pos = (dropdown_top + 1 + 16 + 1, dropdown_left + 5);
+            disp.input_state.mouse_pos = (dropdown_top + 1 + 16 + 1, dropdown_left + 5);
         } else {
-            disp.mouse_pos = (dropdown_bottom + 8, dropdown_left + 5);
+            disp.input_state.mouse_pos = (dropdown_bottom + 8, dropdown_left + 5);
         }
         disp.dispatch_control(true, 0x168, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
 
-        disp.mouse_button = false;
+        disp.input_state.mouse_button = false;
         disp.dispatch_control(true, 0x168, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
@@ -6110,8 +6110,8 @@ mod tests {
             visible_in_menu_bar: false,
         });
 
-        disp.mouse_button = true;
-        disp.mouse_pos = (15, 25);
+        disp.input_state.mouse_button = true;
+        disp.input_state.mouse_pos = (15, 25);
         cpu.write_reg(Register::A7, sp);
         bus.write_long(sp, 0);
         bus.write_word(sp + 4, 15);
@@ -6141,7 +6141,7 @@ mod tests {
         );
         assert_eq!(bus.read_word(sp + 12), 0xBEEF);
 
-        disp.mouse_pos = (dropdown_top + 16 + 1, dropdown_left + 5);
+        disp.input_state.mouse_pos = (dropdown_top + 16 + 1, dropdown_left + 5);
         disp.dispatch_control(true, 0x168, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
@@ -6152,7 +6152,7 @@ mod tests {
             Some(2)
         );
 
-        disp.mouse_button = false;
+        disp.input_state.mouse_button = false;
         disp.dispatch_control(true, 0x168, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
@@ -6218,8 +6218,8 @@ mod tests {
             hierarchical: false,
         });
 
-        disp.mouse_button = true;
-        disp.mouse_pos = (15, 25);
+        disp.input_state.mouse_button = true;
+        disp.input_state.mouse_pos = (15, 25);
         cpu.write_reg(Register::A7, sp);
         bus.write_long(sp, 0);
         bus.write_word(sp + 4, 15);
@@ -6249,7 +6249,7 @@ mod tests {
             "unhighlighted popup item row should leave blank row space clear"
         );
 
-        disp.mouse_pos = (item_two_top + 1, dropdown_left + 5);
+        disp.input_state.mouse_pos = (item_two_top + 1, dropdown_left + 5);
         disp.dispatch_control(true, 0x168, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
@@ -6284,7 +6284,7 @@ mod tests {
             "systemless-default popup tracking must not use raw full-row inversion"
         );
 
-        disp.mouse_button = false;
+        disp.input_state.mouse_button = false;
         disp.dispatch_control(true, 0x168, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();

--- a/src/trap/dialog.rs
+++ b/src/trap/dialog.rs
@@ -213,8 +213,8 @@ impl super::TrapDispatcher {
         self.record_input_trace_line(format!(
             "A991 action={} live_mouse=({},{}) {} dialog={} bounds=({},{},{},{}) item_hit={} item_type={} highlighted={} result={} outcome={}",
             action,
-            self.mouse_pos.0,
-            self.mouse_pos.1,
+            self.input_state.mouse_pos.0,
+            self.input_state.mouse_pos.1,
             self.input_trace_state_fields(),
             input_trace_nonzero(dialog_ptr),
             bounds.0,
@@ -252,8 +252,8 @@ impl super::TrapDispatcher {
         self.record_input_trace_line(format!(
             "A991 action={} live_mouse=({},{}) {} dialog={} bounds=({},{},{},{}) edit_item={} item_type={} key_code=${:02X} char_code=${:02X} text_before={} text_after={} result={} outcome={}",
             action,
-            self.mouse_pos.0,
-            self.mouse_pos.1,
+            self.input_state.mouse_pos.0,
+            self.input_state.mouse_pos.1,
             self.input_trace_state_fields(),
             input_trace_nonzero(dialog_ptr),
             bounds.0,
@@ -309,8 +309,8 @@ impl super::TrapDispatcher {
         self.record_input_trace_line(format!(
             "A991 action={} live_mouse=({},{}) {} dialog={} bounds=({},{},{},{}) filter_proc={} event={} message={} where={} modifiers={} item_hit={} item_type={} handled_mouse_down={} dialog_retained={} result={} outcome={}",
             action,
-            self.mouse_pos.0,
-            self.mouse_pos.1,
+            self.input_state.mouse_pos.0,
+            self.input_state.mouse_pos.1,
             self.input_trace_state_fields(),
             input_trace_nonzero(dialog_ptr),
             bounds.0,
@@ -4266,7 +4266,7 @@ impl super::TrapDispatcher {
                 let rect = Self::dialog_item_screen_rect(bounds, item.rect);
                 let is_default = hit == default_item;
                 self.draw_dialog_button_highlight_state(bus, rect, &item.text, is_default, true);
-                if self.mouse_button {
+                if self.input_state.mouse_button {
                     let tracking = self.dialog_tracking.as_mut().unwrap();
                     tracking.active_button = Some(super::dispatch::DialogButtonTrackingState {
                         mouse_down: event.clone(),
@@ -9394,7 +9394,7 @@ impl super::TrapDispatcher {
     }
 
     pub(crate) fn mouse_down_over_dialog_button(&self) -> bool {
-        if !self.mouse_button {
+        if !self.input_state.mouse_button {
             return false;
         }
         let Some(tracking) = self.dialog_tracking.as_ref() else {
@@ -9403,20 +9403,20 @@ impl super::TrapDispatcher {
         Self::dialog_button_hit_test(
             &tracking.items,
             tracking.bounds,
-            self.mouse_pos.0,
-            self.mouse_pos.1,
+            self.input_state.mouse_pos.0,
+            self.input_state.mouse_pos.1,
         ) > 0
     }
 
     pub(crate) fn mouse_down_over_dialog_plain_user_item(&self) -> bool {
-        if !self.mouse_button {
+        if !self.input_state.mouse_button {
             return false;
         }
         let Some(tracking) = self.dialog_tracking.as_ref() else {
             return false;
         };
         tracking.active_user_item.is_some()
-            || self.dialog_plain_user_item_hit_test(tracking, self.mouse_pos.0, self.mouse_pos.1)
+            || self.dialog_plain_user_item_hit_test(tracking, self.input_state.mouse_pos.0, self.input_state.mouse_pos.1)
                 > 0
     }
 
@@ -9678,8 +9678,8 @@ impl super::TrapDispatcher {
                     self.event_queue.remove(idx);
                 }
             }
-            self.mouse_button = false;
-            self.adb.note_mouse_state(self.mouse_pos, false);
+            self.input_state.mouse_button = false;
+            self.adb.note_mouse_state(self.input_state.mouse_pos, false);
             bus.write_byte(0x0172, 0x80);
         }
 
@@ -10323,8 +10323,8 @@ impl super::TrapDispatcher {
     }
 
     fn handle_dialog_popup_tracking<C: CpuOps>(&mut self, cpu: &mut C, bus: &mut MacMemoryBus) {
-        if self.mouse_button {
-            let (mv, mh) = self.mouse_pos;
+        if self.input_state.mouse_button {
+            let (mv, mh) = self.input_state.mouse_pos;
             let new_item = self.dialog_popup_item_at_point(bus, mh, mv);
             let old_item = self
                 .dialog_tracking
@@ -10440,10 +10440,10 @@ impl super::TrapDispatcher {
         };
 
         let (top, left, bottom, right) = Self::dialog_item_screen_rect(bounds, rect);
-        let (mouse_v, mouse_h) = self.mouse_pos;
+        let (mouse_v, mouse_h) = self.input_state.mouse_pos;
         let inside = mouse_v >= top && mouse_v < bottom && mouse_h >= left && mouse_h < right;
 
-        if self.mouse_button {
+        if self.input_state.mouse_button {
             if inside != highlighted {
                 self.draw_dialog_button_highlight_state(
                     bus,
@@ -10544,7 +10544,7 @@ impl super::TrapDispatcher {
             return;
         };
 
-        if self.mouse_button {
+        if self.input_state.mouse_button {
             return;
         }
 
@@ -10554,7 +10554,7 @@ impl super::TrapDispatcher {
         }
 
         let (top, left, bottom, right) = Self::dialog_item_screen_rect(bounds, rect);
-        let (mouse_v, mouse_h) = self.mouse_pos;
+        let (mouse_v, mouse_h) = self.input_state.mouse_pos;
         let inside = mouse_v >= top && mouse_v < bottom && mouse_h >= left && mouse_h < right;
         if !inside {
             return;
@@ -12235,10 +12235,10 @@ impl super::TrapDispatcher {
                     };
 
                     if let Some(mut e) = event {
-                        if e.what == 0 && self.mouse_button {
+                        if e.what == 0 && self.input_state.mouse_button {
                             e.what = 1;
-                            e.where_v = self.mouse_pos.0;
-                            e.where_h = self.mouse_pos.1;
+                            e.where_v = self.input_state.mouse_pos.0;
+                            e.where_h = self.input_state.mouse_pos.1;
                         }
                         match e.what {
                             // updateEvt — re-snapshot rendered_pixels.
@@ -12335,7 +12335,7 @@ impl super::TrapDispatcher {
                                                     is_default,
                                                     true,
                                                 );
-                                                if self.mouse_button {
+                                                if self.input_state.mouse_button {
                                                     let t = self.dialog_tracking.as_mut().unwrap();
                                                     t.active_button = Some(
                                                         super::dispatch::DialogButtonTrackingState {
@@ -12534,7 +12534,7 @@ impl super::TrapDispatcher {
                                                         tracking, hit, item,
                                                     )
                                                 },
-                                            ) && self.mouse_button =>
+                                            ) && self.input_state.mouse_button =>
                                             {
                                                 let (dlg_ptr, edit_item, edit_text, items) = {
                                                     let tracking =
@@ -21672,8 +21672,8 @@ mod tests {
         });
         bus.write_word(item_hit_ptr, 0xCAFE);
         cpu.write_reg(Register::A7, TEST_SP);
-        disp.mouse_button = true;
-        disp.mouse_pos = (150, 240);
+        disp.input_state.mouse_button = true;
+        disp.input_state.mouse_pos = (150, 240);
         disp.event_queue
             .push_back(crate::trap::dispatch::QueuedEvent {
                 what: 1,
@@ -28056,8 +28056,8 @@ mod tests {
             ..Default::default()
         });
 
-        disp.mouse_button = true;
-        disp.mouse_pos = (probe_y, probe_x);
+        disp.input_state.mouse_button = true;
+        disp.input_state.mouse_pos = (probe_y, probe_x);
         disp.handle_dialog_button_tracking(&mut bus);
 
         assert!(
@@ -28072,7 +28072,7 @@ mod tests {
             Some(true)
         );
 
-        disp.mouse_pos = (40, 50);
+        disp.input_state.mouse_pos = (40, 50);
         disp.handle_dialog_button_tracking(&mut bus);
 
         assert!(
@@ -30627,8 +30627,8 @@ mod tests {
             active_button: None,
             active_user_item: None,
         });
-        disp.mouse_button = true;
-        disp.mouse_pos = (115, 125);
+        disp.input_state.mouse_button = true;
+        disp.input_state.mouse_pos = (115, 125);
         disp.event_queue
             .push_back(crate::trap::dispatch::QueuedEvent {
                 what: 1,
@@ -30658,7 +30658,7 @@ mod tests {
             .and_then(|tracking| tracking.active_popup.as_ref())
             .map(|popup| popup.dropdown_rect)
             .expect("popup tracking should expose the live dropdown rect");
-        disp.mouse_pos = (dropdown_top + 1 + 16 + 1, dropdown_left + 5);
+        disp.input_state.mouse_pos = (dropdown_top + 1 + 16 + 1, dropdown_left + 5);
         disp.dispatch_dialog(true, 0x191, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
@@ -30670,7 +30670,7 @@ mod tests {
             Some(2)
         );
 
-        disp.mouse_button = false;
+        disp.input_state.mouse_button = false;
         disp.event_queue
             .push_back(crate::trap::dispatch::QueuedEvent {
                 what: 2,
@@ -31467,8 +31467,8 @@ mod tests {
             active_button: None,
             active_user_item: None,
         });
-        disp.mouse_button = true;
-        disp.mouse_pos = (130, 240);
+        disp.input_state.mouse_button = true;
+        disp.input_state.mouse_pos = (130, 240);
         disp.event_queue
             .push_back(crate::trap::dispatch::QueuedEvent {
                 what: 1,
@@ -31533,8 +31533,8 @@ mod tests {
         disp.dialog_popup_original_rects
             .insert((dialog_ptr, 1), (20, 30, 40, 150));
         disp.dialog_popup_candidate_items.insert((dialog_ptr, 1));
-        disp.mouse_button = true;
-        disp.mouse_pos = (130, 260);
+        disp.input_state.mouse_button = true;
+        disp.input_state.mouse_pos = (130, 260);
         disp.event_queue
             .push_back(crate::trap::dispatch::QueuedEvent {
                 what: 1,
@@ -31601,8 +31601,8 @@ mod tests {
             active_button: None,
             active_user_item: None,
         });
-        disp.mouse_button = true;
-        disp.mouse_pos = (130, 240);
+        disp.input_state.mouse_button = true;
+        disp.input_state.mouse_pos = (130, 240);
         disp.event_queue
             .push_back(crate::trap::dispatch::QueuedEvent {
                 what: 1,
@@ -31622,7 +31622,7 @@ mod tests {
             .and_then(|tracking| tracking.active_button.as_ref())
             .is_some());
 
-        disp.mouse_button = false;
+        disp.input_state.mouse_button = false;
         disp.event_queue
             .push_back(crate::trap::dispatch::QueuedEvent {
                 what: 2,
@@ -31836,7 +31836,7 @@ mod tests {
         bus.write_word(item_hit_ptr, 1);
         disp.dialog_filter_result_addr = result_addr;
         disp.front_window = dialog_ptr;
-        disp.mouse_button = true;
+        disp.input_state.mouse_button = true;
         disp.dialog_tracking = Some(DialogTrackingState {
             dialog_ptr,
             bounds,
@@ -32024,7 +32024,7 @@ mod tests {
         assert_eq!(queued_downs.len(), 1);
         assert_eq!((queued_downs[0].where_v, queued_downs[0].where_h), (20, 30));
         assert!(disp.pending_modal_dialog_mouse_up);
-        assert!(!disp.mouse_button);
+        assert!(!disp.input_state.mouse_button);
         assert_eq!(bus.read_byte(0x0172), 0x80);
 
         for trap in [0x173, 0x174, 0x177] {
@@ -32185,8 +32185,8 @@ mod tests {
             active_button: None,
             active_user_item: None,
         });
-        disp.mouse_button = true;
-        disp.mouse_pos = (130, 240);
+        disp.input_state.mouse_button = true;
+        disp.input_state.mouse_pos = (130, 240);
 
         let result = disp.dispatch_dialog(true, 0x191, &mut cpu, &mut bus);
         assert!(result.unwrap().is_ok());

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -14,9 +14,10 @@ use crate::memory::{MacMemoryBus, MemoryBus};
 use crate::menu_manager::{ProcessMenuTrackingState, SharedNativeMenuSelection};
 use crate::process_context::{
     ProcessContext, ProcessForkMap, ProcessLoadedResources, ProcessResourceFileMap,
-    ProcessResourceManagerState, SharedProcessAppleEventHandlers, SharedProcessCursorState,
-    SharedProcessEventQueue, SharedProcessMemoryManager, SharedProcessMenuTracking,
-    SharedProcessResourceManager, SharedProcessSoundManager, SharedProcessValue,
+    ProcessKeyRepeatState, ProcessResourceManagerState, SharedProcessAppleEventHandlers,
+    SharedProcessCursorState, SharedProcessEventQueue, SharedProcessInputState,
+    SharedProcessMemoryManager, SharedProcessMenuTracking, SharedProcessResourceManager,
+    SharedProcessSoundManager, SharedProcessValue,
 };
 use crate::trace::{TraceEvent, TraceSink, TraceSource};
 use crate::ui_theme::{UiTheme, UiThemeId};
@@ -1045,13 +1046,6 @@ pub(crate) struct AeCoercionHandler {
     pub handler_ptr: u32,
     pub refcon: u32,
     pub from_type_is_desc: bool,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) struct KeyRepeatState {
-    pub key_code: u8,
-    pub char_code: u8,
-    pub next_tick: u32,
 }
 
 #[derive(Clone, Debug)]
@@ -2322,20 +2316,8 @@ pub struct TrapDispatcher {
     pub(crate) region_tracking: Option<RegionTrackingState>,
     /// Underline info for continuous underline across a string (set by draw_string)
     pub(crate) underline_info: Option<UnderlineInfo>,
-    /// Current mouse position in Mac screen coordinates (v, h)
-    pub(crate) mouse_pos: (i16, i16),
-    /// Current mouse button state: true = button is pressed
-    pub(crate) mouse_button: bool,
-    /// Current keyboard state as a classic 16-byte KeyMap (128 keys).
-    /// Bits are packed for direct byte/bit readers:
-    /// key >> 3 selects the byte, key & 7 selects the bit.
-    pub(crate) key_map: [u8; 16],
-    /// Physical Caps Lock press state, kept separately from its logical
-    /// latched bit in `key_map` so a release does not clear the latch and a
-    /// repeated host key-down cannot toggle it twice.
-    pub(crate) caps_lock_physically_pressed: bool,
-    /// Auto-key repeat state for the currently repeating character key.
-    pub(crate) key_repeat: Option<KeyRepeatState>,
+    /// Process-owned live mouse, keyboard, and key-repeat state.
+    pub(crate) input_state: SharedProcessInputState,
     /// Debug counter for GetKeys calls that observed at least one held key.
     pub debug_getkeys_nonzero_count: u64,
     /// Last non-zero KeyMap returned by GetKeys. Used by regression tests to
@@ -2916,6 +2898,7 @@ impl TrapDispatcher {
         context.attach_sound_manager(&mut self.sound_manager);
         context.attach_cursor_state(&mut self.cursor_state);
         context.attach_event_queue(&mut self.event_queue);
+        context.attach_input_state(&mut self.input_state);
         context.attach_menu_tracking(&mut self.menu_tracking);
         context.attach_classic_file_system(&mut self.vfs, &mut self.vfs_rsrc);
         let mut memory_manager = None;
@@ -3625,11 +3608,11 @@ impl TrapDispatcher {
     }
 
     pub(crate) fn key_is_down(&self, key_code: u8) -> bool {
-        key_map_key_is_down(&self.key_map, key_code)
+        key_map_key_is_down(&self.input_state.key_map, key_code)
     }
 
     pub(crate) fn key_map_bytes(&self) -> &[u8; 16] {
-        &self.key_map
+        &self.input_state.key_map
     }
 
     pub(crate) fn current_event_modifiers(&self) -> u16 {
@@ -3641,7 +3624,7 @@ impl TrapDispatcher {
         const CONTROL_KEY: u16 = 4096;
 
         let mut modifiers = 0u16;
-        if !self.mouse_button {
+        if !self.input_state.mouse_button {
             modifiers |= BTN_STATE;
         }
         if self.key_is_down(0x37) {
@@ -3688,8 +3671,8 @@ impl TrapDispatcher {
     }
 
     pub(crate) fn input_trace_state_fields(&self) -> String {
-        let key_map = if self.key_map.iter().any(|&byte| byte != 0) {
-            self.key_map
+        let key_map = if self.input_state.key_map.iter().any(|&byte| byte != 0) {
+            self.input_state.key_map
                 .iter()
                 .map(|byte| format!("{byte:02X}"))
                 .collect::<Vec<_>>()
@@ -3699,9 +3682,9 @@ impl TrapDispatcher {
         };
         format!(
             "state=mouse=({},{}) button={} live_modifiers=${:04X} key_map={} tracking=menu:{} dialog:{} control:{}",
-            self.mouse_pos.0,
-            self.mouse_pos.1,
-            if self.mouse_button { "down" } else { "up" },
+            self.input_state.mouse_pos.0,
+            self.input_state.mouse_pos.1,
+            if self.input_state.mouse_button { "down" } else { "up" },
             self.current_event_modifiers(),
             key_map,
             if self.is_menu_tracking() { "active" } else { "idle" },
@@ -3977,11 +3960,7 @@ impl TrapDispatcher {
             grow_window_tracking: None,
             region_tracking: None,
             underline_info: None,
-            mouse_pos: (0, 0),
-            mouse_button: false,
-            key_map: [0; 16],
-            caps_lock_physically_pressed: false,
-            key_repeat: None,
+            input_state: SharedProcessInputState::default(),
             debug_getkeys_nonzero_count: 0,
             debug_last_getkeys_nonzero_key_map: [0; 16],
             debug_key_event_delivery_count: 0,
@@ -5677,8 +5656,8 @@ impl TrapDispatcher {
     /// Update the current mouse position (called from GUI layer).
     /// Coordinates are in Mac screen space (0,0 = top-left of screen).
     pub fn set_mouse_position(&mut self, v: i16, h: i16) {
-        self.mouse_pos = (v, h);
-        self.adb.note_mouse_state(self.mouse_pos, self.mouse_button);
+        self.input_state.mouse_pos = (v, h);
+        self.adb.note_mouse_state(self.input_state.mouse_pos, self.input_state.mouse_button);
     }
 
     pub(crate) fn has_unmatched_queued_mouse_down(&self) -> bool {
@@ -5695,9 +5674,9 @@ impl TrapDispatcher {
 
     /// Push a mouse-down event into the event queue.
     pub fn push_mouse_down(&mut self, v: i16, h: i16) {
-        self.mouse_button = true;
-        self.mouse_pos = (v, h);
-        self.adb.note_mouse_state(self.mouse_pos, self.mouse_button);
+        self.input_state.mouse_button = true;
+        self.input_state.mouse_pos = (v, h);
+        self.adb.note_mouse_state(self.input_state.mouse_pos, self.input_state.mouse_button);
         let modifiers = self.current_event_modifiers();
         self.event_queue.push_back(QueuedEvent {
             what: 1, // mouseDown
@@ -5714,9 +5693,9 @@ impl TrapDispatcher {
     /// combine that state with pending mouse events to decide whether the
     /// original click is still in progress.
     pub fn push_mouse_up(&mut self, v: i16, h: i16) {
-        self.mouse_pos = (v, h);
-        self.mouse_button = false;
-        self.adb.note_mouse_state(self.mouse_pos, self.mouse_button);
+        self.input_state.mouse_pos = (v, h);
+        self.input_state.mouse_button = false;
+        self.adb.note_mouse_state(self.input_state.mouse_pos, self.input_state.mouse_button);
         // The classic mouse has one button, so the first physical release
         // after a ModalDialog-owned press is its matching mouseUp. Consume it
         // at injection time so event masks or FlushEvents cannot leave stale
@@ -5744,19 +5723,19 @@ impl TrapDispatcher {
         // Inside Macintosh Volume I, I-246. Ignore duplicate host callbacks
         // so they cannot enqueue extra keyDown records or restart autoKey.
         if key_code == Self::CAPS_LOCK_KEY_CODE {
-            if self.caps_lock_physically_pressed {
+            if self.input_state.caps_lock_physically_pressed {
                 return;
             }
-            self.caps_lock_physically_pressed = true;
+            self.input_state.caps_lock_physically_pressed = true;
             // Caps Lock latches on one physical press and releases on the
             // next. Inside Macintosh Volume I (1985), p. I-34.
             let latched = !self.key_is_down(key_code);
-            set_key_map_key(&mut self.key_map, key_code, latched);
+            set_key_map_key(&mut self.input_state.key_map, key_code, latched);
         } else {
             if self.key_is_down(key_code) {
                 return;
             }
-            set_key_map_key(&mut self.key_map, key_code, true);
+            set_key_map_key(&mut self.input_state.key_map, key_code, true);
         }
         let modifiers = self.current_event_modifiers();
         if trace_input_enabled() {
@@ -5774,15 +5753,15 @@ impl TrapDispatcher {
         self.event_queue.push_back(QueuedEvent {
             what: 3, // keyDown
             message,
-            where_v: self.mouse_pos.0,
-            where_h: self.mouse_pos.1,
+            where_v: self.input_state.mouse_pos.0,
+            where_h: self.input_state.mouse_pos.1,
             modifiers,
         });
 
         if Self::key_generates_auto_key(key_code) {
             // Auto-key timing defaults are 16 ticks for the first repeat and
             // 4 ticks thereafter. Inside Macintosh Volume I, I-246.
-            self.key_repeat = Some(KeyRepeatState {
+            self.input_state.key_repeat = Some(ProcessKeyRepeatState {
                 key_code,
                 char_code,
                 next_tick: self.tick_count.wrapping_add(Self::AUTO_KEY_THRESHOLD_TICKS),
@@ -5806,15 +5785,16 @@ impl TrapDispatcher {
         char_code: u8,
     ) {
         if key_code == Self::CAPS_LOCK_KEY_CODE {
-            self.caps_lock_physically_pressed = false;
+            self.input_state.caps_lock_physically_pressed = false;
         } else {
-            set_key_map_key(&mut self.key_map, key_code, false);
+            set_key_map_key(&mut self.input_state.key_map, key_code, false);
         }
         if self
+            .input_state
             .key_repeat
             .is_some_and(|repeat| repeat.key_code == key_code)
         {
-            self.key_repeat = None;
+            self.input_state.key_repeat = None;
         }
         let modifiers = self.current_event_modifiers();
         if trace_input_enabled() {
@@ -5838,8 +5818,8 @@ impl TrapDispatcher {
             self.event_queue.push_back(QueuedEvent {
                 what: 4, // keyUp
                 message,
-                where_v: self.mouse_pos.0,
-                where_h: self.mouse_pos.1,
+                where_v: self.input_state.mouse_pos.0,
+                where_h: self.input_state.mouse_pos.1,
                 modifiers,
             });
         }
@@ -5922,7 +5902,7 @@ impl TrapDispatcher {
 
     /// Get the current mouse position.
     pub fn mouse_position(&self) -> (i16, i16) {
-        self.mouse_pos
+        self.input_state.mouse_pos
     }
 
     /// Number of Time Manager tasks currently in the queue.

--- a/src/trap/event.rs
+++ b/src/trap/event.rs
@@ -252,7 +252,7 @@ impl super::TrapDispatcher {
         }
 
         if Self::region_bbox(bus, mouse_rgn).is_none()
-            || Self::region_contains_point(bus, mouse_rgn, self.mouse_pos.0, self.mouse_pos.1)
+            || Self::region_contains_point(bus, mouse_rgn, self.input_state.mouse_pos.0, self.input_state.mouse_pos.1)
         {
             return None;
         }
@@ -260,8 +260,8 @@ impl super::TrapDispatcher {
         Some(super::dispatch::QueuedEvent {
             what: Self::OS_EVENT,
             message: Self::MOUSE_MOVED_MESSAGE,
-            where_v: self.mouse_pos.0,
-            where_h: self.mouse_pos.1,
+            where_v: self.input_state.mouse_pos.0,
+            where_h: self.input_state.mouse_pos.1,
             modifiers: self.current_event_modifiers(),
         })
     }
@@ -288,8 +288,8 @@ impl super::TrapDispatcher {
         super::dispatch::QueuedEvent {
             what,
             message,
-            where_v: self.mouse_pos.0,
-            where_h: self.mouse_pos.1,
+            where_v: self.input_state.mouse_pos.0,
+            where_h: self.input_state.mouse_pos.1,
             modifiers: self.current_event_modifiers(),
         }
     }
@@ -414,18 +414,18 @@ impl super::TrapDispatcher {
         if !Self::posted_event_is_enabled(system_event_mask, Self::AUTO_KEY_EVENT) {
             return;
         }
-        let Some(repeat) = self.key_repeat else {
+        let Some(repeat) = self.input_state.key_repeat else {
             return;
         };
         if !Self::key_generates_auto_key(repeat.key_code) || !self.key_is_down(repeat.key_code) {
-            self.key_repeat = None;
+            self.input_state.key_repeat = None;
             return;
         }
         if !Self::tick_has_reached(self.tick_count, repeat.next_tick) {
             return;
         }
 
-        if let Some(state) = self.key_repeat.as_mut() {
+        if let Some(state) = self.input_state.key_repeat.as_mut() {
             state.next_tick = self.tick_count.wrapping_add(Self::AUTO_KEY_RATE_TICKS);
         }
 
@@ -434,8 +434,8 @@ impl super::TrapDispatcher {
         self.event_queue.push_back(super::dispatch::QueuedEvent {
             what: Self::AUTO_KEY_EVENT,
             message,
-            where_v: self.mouse_pos.0,
-            where_h: self.mouse_pos.1,
+            where_v: self.input_state.mouse_pos.0,
+            where_h: self.input_state.mouse_pos.1,
             modifiers,
         });
     }
@@ -645,8 +645,8 @@ impl super::TrapDispatcher {
                 return (
                     0,
                     0,
-                    self.mouse_pos.0,
-                    self.mouse_pos.1,
+                    self.input_state.mouse_pos.0,
+                    self.input_state.mouse_pos.1,
                     self.current_event_modifiers(),
                     false,
                 );
@@ -660,7 +660,7 @@ impl super::TrapDispatcher {
                 );
             }
             if event.what == 2 {
-                self.mouse_button = false;
+                self.input_state.mouse_button = false;
             }
             self.begin_app_owned_modal_dialog_button_tracking(bus, &event);
             if matches!(event.what, 3 | 4 | 5) {
@@ -706,8 +706,8 @@ impl super::TrapDispatcher {
         (
             0,
             0,
-            self.mouse_pos.0,
-            self.mouse_pos.1,
+            self.input_state.mouse_pos.0,
+            self.input_state.mouse_pos.1,
             self.current_event_modifiers(),
             false,
         )
@@ -750,12 +750,12 @@ impl super::TrapDispatcher {
 
         // Update low-memory mouse globals
         // Reference: Executor docs/globals.cpp — MTemp=$0828, MouseLocation=$082C, MouseLocation2=$0830
-        let mb_state: u8 = if self.mouse_button { 0x00 } else { 0x80 };
+        let mb_state: u8 = if self.input_state.mouse_button { 0x00 } else { 0x80 };
         bus.write_byte(0x0172, mb_state);
         // MTemp, MouseLocation, MouseLocation2 are 12 contiguous bytes at $0828
         // (3 × Point = 3 × (i16 v, i16 h)). Single packed write.
-        let v = self.mouse_pos.0 as u16;
-        let h = self.mouse_pos.1 as u16;
+        let v = self.input_state.mouse_pos.0 as u16;
+        let h = self.input_state.mouse_pos.1 as u16;
         let mouse_globals: [u8; 12] = [
             (v >> 8) as u8,
             v as u8,
@@ -812,7 +812,7 @@ impl super::TrapDispatcher {
             // push_mouse_up() already updates the physical state immediately,
             // but keeping this assignment is harmless and mirrors event delivery.
             if ev.what == 2 {
-                self.mouse_button = false;
+                self.input_state.mouse_button = false;
             }
 
             (
@@ -827,8 +827,8 @@ impl super::TrapDispatcher {
             (
                 0,
                 0,
-                self.mouse_pos.0,
-                self.mouse_pos.1,
+                self.input_state.mouse_pos.0,
+                self.input_state.mouse_pos.1,
                 self.current_event_modifiers(),
                 false,
             )
@@ -1251,8 +1251,8 @@ impl super::TrapDispatcher {
                         event_ptr,
                         0,
                         0,
-                        self.mouse_pos.0,
-                        self.mouse_pos.1,
+                        self.input_state.mouse_pos.0,
+                        self.input_state.mouse_pos.1,
                         self.current_event_modifiers(),
                     );
                     cpu.write_reg(Register::D0, 0xFFFF);
@@ -1546,13 +1546,13 @@ mod tests {
         disp.sent_open_app_event = true;
 
         disp.push_key_down(0x30, 9); // Tab
-        let first_repeat_tick = disp.key_repeat.expect("Tab should arm autoKey").next_tick;
+        let first_repeat_tick = disp.input_state.key_repeat.expect("Tab should arm autoKey").next_tick;
         disp.tick_count = disp.tick_count.wrapping_add(5);
         disp.push_key_down(0x30, 9); // host repeat while still held
 
         assert_eq!(disp.event_queue.len(), 1, "only one keyDown may be queued");
         assert_eq!(
-            disp.key_repeat
+            disp.input_state.key_repeat
                 .expect("autoKey should remain armed")
                 .next_tick,
             first_repeat_tick,

--- a/src/trap/framebuffer.rs
+++ b/src/trap/framebuffer.rs
@@ -6591,7 +6591,7 @@ mod redraw_chrome_tests {
         // Move mouse to the top of the screen — the very scenario
         // the task brief calls out. mouse_pos updates to (v=2, h=400)
         // which is well inside the would-be menu-bar band.
-        disp.mouse_pos = (2, 400);
+        disp.input_state.mouse_pos = (2, 400);
         bus.write_word(0x0828, 2u16); // MTemp.v
         bus.write_word(0x082A, 400u16); // MTemp.h
         bus.write_word(0x082C, 2u16); // RawMouse.v

--- a/src/trap/memory.rs
+++ b/src/trap/memory.rs
@@ -3587,7 +3587,7 @@ impl super::TrapDispatcher {
                         address,
                         bus.read_long(info_ptr),
                         bus.read_long(info_ptr + 4),
-                        self.mouse_button,
+                        self.input_state.mouse_button,
                     );
                 }
                 cpu.write_reg(Register::D0, 0); // noErr

--- a/src/trap/menu.rs
+++ b/src/trap/menu.rs
@@ -751,7 +751,7 @@ impl super::TrapDispatcher {
         // dispatcher state so guest callbacks that run during tracking can
         // release or hold the button between trap re-fires. Inside Macintosh
         // Volume II, p. II-371; Macintosh Toolbox Essentials 1992, p. 3-120.
-        self.mouse_button || bus.read_byte(addr::MB_STATE) == 0x00
+        self.input_state.mouse_button || bus.read_byte(addr::MB_STATE) == 0x00
     }
 
     fn menu_tracking_mouse_pos(&self, bus: &MacMemoryBus) -> (i16, i16) {
@@ -765,7 +765,7 @@ impl super::TrapDispatcher {
         if v != 0 || h != 0 {
             (v, h)
         } else {
-            self.mouse_pos
+            self.input_state.mouse_pos
         }
     }
 
@@ -825,8 +825,8 @@ impl super::TrapDispatcher {
             "A93D action={} start={} live_mouse=({},{}) {} {} highlighted_item={} result={} outcome={}",
             action,
             start,
-            self.mouse_pos.0,
-            self.mouse_pos.1,
+            self.input_state.mouse_pos.0,
+            self.input_state.mouse_pos.1,
             self.input_trace_state_fields(),
             self.menu_trace_menu_fields(menu_idx),
             highlighted,
@@ -13550,7 +13550,7 @@ mod tests {
         // no selection without disturbing the caller stack.
         let (mut disp, mut cpu, mut bus) = setup_with_port();
         disp.menu_bar_hidden = false;
-        disp.mouse_button = false;
+        disp.input_state.mouse_button = false;
         bus.write_word(crate::memory::globals::addr::MBAR_HEIGHT, 20);
 
         let menu = new_menu_with_title(&mut disp, &mut cpu, &mut bus, 128, 0x302000, "Pop");
@@ -13590,7 +13590,7 @@ mod tests {
         // PopUpMenuSelect returns 0."
         let (mut disp, mut cpu, mut bus) = setup_with_port();
         disp.menu_bar_hidden = false;
-        disp.mouse_button = false;
+        disp.input_state.mouse_button = false;
         bus.write_byte(crate::memory::globals::addr::MB_STATE, 0x80); // button up
         bus.write_word(crate::memory::globals::addr::MBAR_HEIGHT, 20);
 
@@ -14751,7 +14751,7 @@ mod tests {
     fn menuselect_no_menu_hit_returns_zero_and_pops_startpt() {
         let (mut disp, mut cpu, mut bus) = setup();
         disp.enable_input_trace_capture();
-        disp.mouse_pos = (40, 120);
+        disp.input_state.mouse_pos = (40, 120);
         cpu.write_reg(Register::A7, TEST_SP);
         bus.write_word(TEST_SP, 40);
         bus.write_word(TEST_SP + 2, 120);
@@ -14805,8 +14805,8 @@ mod tests {
             "menu title regions should be available"
         );
         let title_mid_h = (regions[0].0 + regions[0].1) / 2;
-        disp.mouse_pos = (10, title_mid_h);
-        disp.mouse_button = true;
+        disp.input_state.mouse_pos = (10, title_mid_h);
+        disp.input_state.mouse_button = true;
 
         cpu.write_reg(Register::A7, TEST_SP);
         bus.write_word(TEST_SP, 10);
@@ -14868,8 +14868,8 @@ mod tests {
         let regions = disp.menu_title_regions();
         let title_mid_h = (regions[0].0 + regions[0].1) / 2;
 
-        disp.mouse_pos = (10, title_mid_h);
-        disp.mouse_button = true;
+        disp.input_state.mouse_pos = (10, title_mid_h);
+        disp.input_state.mouse_button = true;
         cpu.write_reg(Register::A7, TEST_SP);
         bus.write_word(TEST_SP, 10);
         bus.write_word(TEST_SP + 2, title_mid_h as u16);
@@ -14881,7 +14881,7 @@ mod tests {
 
         let (dropdown_top, dropdown_left, _, _) =
             disp.menu_tracking.as_ref().unwrap().dropdown_rect();
-        disp.mouse_pos = (dropdown_top + 17, dropdown_left + 8);
+        disp.input_state.mouse_pos = (dropdown_top + 17, dropdown_left + 8);
         disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
@@ -14892,7 +14892,7 @@ mod tests {
             Some(2)
         );
 
-        disp.mouse_button = false;
+        disp.input_state.mouse_button = false;
         disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
@@ -14965,8 +14965,8 @@ mod tests {
             .unwrap();
         let title = disp.menu_title_regions()[0];
         let title_mid_h = (title.0 + title.1) / 2;
-        disp.mouse_pos = (10, title_mid_h);
-        disp.mouse_button = true;
+        disp.input_state.mouse_pos = (10, title_mid_h);
+        disp.input_state.mouse_button = true;
         cpu.write_reg(Register::A7, TEST_SP);
         bus.write_word(TEST_SP, 10);
         bus.write_word(TEST_SP + 2, title_mid_h as u16);
@@ -14977,7 +14977,7 @@ mod tests {
 
         let (dropdown_top, dropdown_left, _, _) =
             disp.menu_tracking.as_ref().unwrap().dropdown_rect();
-        disp.mouse_pos = (dropdown_top + 17, dropdown_left + 8);
+        disp.input_state.mouse_pos = (dropdown_top + 17, dropdown_left + 8);
         disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
@@ -14994,7 +14994,7 @@ mod tests {
             "a disabled row must not become the MenuSelect highlight",
         );
 
-        disp.mouse_button = false;
+        disp.input_state.mouse_button = false;
         disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
@@ -15029,8 +15029,8 @@ mod tests {
             .unwrap();
         let title = disp.menu_title_regions()[0];
         let title_mid_h = (title.0 + title.1) / 2;
-        disp.mouse_pos = (10, title_mid_h);
-        disp.mouse_button = true;
+        disp.input_state.mouse_pos = (10, title_mid_h);
+        disp.input_state.mouse_button = true;
         cpu.write_reg(Register::A7, TEST_SP);
         bus.write_word(TEST_SP, 10);
         bus.write_word(TEST_SP + 2, title_mid_h as u16);
@@ -15045,7 +15045,7 @@ mod tests {
         bus.write_long(menu_ptr + 10, enable_flags & !(1 << 1));
 
         let (top, left, _, _) = disp.menu_tracking.as_ref().unwrap().dropdown_rect();
-        disp.mouse_pos = (top + 8, left + 8);
+        disp.input_state.mouse_pos = (top + 8, left + 8);
         disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
@@ -15061,7 +15061,7 @@ mod tests {
             "the live-disabled item became highlighted",
         );
 
-        disp.mouse_button = false;
+        disp.input_state.mouse_button = false;
         disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
@@ -15100,8 +15100,8 @@ mod tests {
         let screen_before = bus.read_bytes(screen_base, screen_len);
         let title = disp.menu_title_regions()[0];
         let title_mid_h = (title.0 + title.1) / 2;
-        disp.mouse_pos = (10, title_mid_h);
-        disp.mouse_button = true;
+        disp.input_state.mouse_pos = (10, title_mid_h);
+        disp.input_state.mouse_button = true;
         cpu.write_reg(Register::A7, TEST_SP);
         bus.write_word(TEST_SP, 10);
         bus.write_word(TEST_SP + 2, title_mid_h as u16);
@@ -15115,7 +15115,7 @@ mod tests {
             .expect("disabled title should still open")
             .dropdown_rect();
 
-        disp.mouse_pos = (top + 8, left + 8);
+        disp.input_state.mouse_pos = (top + 8, left + 8);
         disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
@@ -15131,7 +15131,7 @@ mod tests {
             Some(0),
         );
 
-        disp.mouse_button = false;
+        disp.input_state.mouse_button = false;
         disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
@@ -15178,8 +15178,8 @@ mod tests {
         let title = disp.menu_title_regions()[0];
         let title_mid_h = (title.0 + title.1) / 2;
 
-        disp.mouse_pos = (10, title_mid_h);
-        disp.mouse_button = true;
+        disp.input_state.mouse_pos = (10, title_mid_h);
+        disp.input_state.mouse_button = true;
         cpu.write_reg(Register::A7, TEST_SP);
         bus.write_word(TEST_SP, 10);
         bus.write_word(TEST_SP + 2, title_mid_h as u16);
@@ -15189,13 +15189,13 @@ mod tests {
             .unwrap();
 
         let (top, left, _, _) = disp.menu_tracking.as_ref().unwrap().dropdown_rect();
-        disp.mouse_pos = (top + 17, left + 8);
+        disp.input_state.mouse_pos = (top + 17, left + 8);
         cpu.write_reg(Register::A7, TEST_SP);
         bus.write_word(TEST_SP, 0);
         disp.dispatch_menu(true, 0x14A, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
-        disp.mouse_button = false;
+        disp.input_state.mouse_button = false;
         cpu.write_reg(Register::A7, TEST_SP);
         disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
@@ -15478,7 +15478,7 @@ mod tests {
         disp.set_screen_mode_for_test(base, row_bytes, 512, 160, 1);
         clear_1bpp_screen(&mut bus, base, row_bytes, 160);
         disp.menu_bar_hidden = false;
-        disp.mouse_button = true;
+        disp.input_state.mouse_button = true;
 
         let menu = new_menu_with_title(&mut disp, &mut cpu, &mut bus, 733, 0x30BE00, "Crops");
         append_menu_data(&mut disp, &mut cpu, &mut bus, menu, 0x30BE40, "Corn;Wheat");
@@ -15529,7 +15529,7 @@ mod tests {
         clear_1bpp_screen(&mut bus, base, row_bytes, 600);
         bus.write_word(crate::memory::globals::addr::MBAR_HEIGHT, 20);
         disp.menu_bar_hidden = false;
-        disp.mouse_button = true;
+        disp.input_state.mouse_button = true;
 
         let menu = new_menu_with_title(&mut disp, &mut cpu, &mut bus, 734, 0x30BF00, "Long");
         let description = (0..40).map(|_| "A").collect::<Vec<_>>().join(";");
@@ -15595,7 +15595,7 @@ mod tests {
         cpu: &mut MockCpu,
         bus: &mut crate::memory::MacMemoryBus,
     ) -> (u32, u32, bool) {
-        disp.mouse_button = false;
+        disp.input_state.mouse_button = false;
         bus.write_byte(crate::memory::globals::addr::MB_STATE, 0x80);
         for _ in 0..80 {
             if disp.menu_tracking.is_none() {
@@ -15618,7 +15618,7 @@ mod tests {
         disp.set_screen_mode_for_test(base, row_bytes, 240, 160, 1);
         clear_1bpp_screen(&mut bus, base, row_bytes, 160);
         disp.menu_bar_hidden = false;
-        disp.mouse_button = true;
+        disp.input_state.mouse_button = true;
 
         let menu = new_menu_with_title(&mut disp, &mut cpu, &mut bus, 730, 0x30BB00, "Pop");
         append_menu_data(
@@ -15640,7 +15640,7 @@ mod tests {
         // PopUpMenuSelect re-evaluates the live mouse position on release.
         // Keep the synthetic release over the requested third item rather
         // than inheriting setup_with_port's default position at (0, 0).
-        disp.mouse_pos = (58, 35);
+        disp.input_state.mouse_pos = (58, 35);
         let (result, final_stack_after, tracking_finished) =
             finish_popupmenuselect(&mut disp, &mut cpu, &mut bus);
 
@@ -15650,7 +15650,7 @@ mod tests {
         clamp_disp.set_screen_mode_for_test(clamp_base, row_bytes, 240, 160, 1);
         clear_1bpp_screen(&mut clamp_bus, clamp_base, row_bytes, 160);
         clamp_disp.menu_bar_hidden = false;
-        clamp_disp.mouse_button = true;
+        clamp_disp.input_state.mouse_button = true;
         let clamp_menu = new_menu_with_title(
             &mut clamp_disp,
             &mut clamp_cpu,
@@ -15693,7 +15693,7 @@ mod tests {
         let (mut miss_disp, mut miss_cpu, mut miss_bus) = setup_with_port();
         miss_disp.set_ui_theme_id(theme_id);
         miss_disp.menu_bar_hidden = false;
-        miss_disp.mouse_button = false;
+        miss_disp.input_state.mouse_button = false;
         let miss_menu = new_menu_with_title(
             &mut miss_disp,
             &mut miss_cpu,
@@ -15816,8 +15816,8 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        disp.mouse_pos = (10, 15);
-        disp.mouse_button = true;
+        disp.input_state.mouse_pos = (10, 15);
+        disp.input_state.mouse_button = true;
         cpu.write_reg(Register::A7, TEST_SP);
         bus.write_word(TEST_SP, 10);
         bus.write_word(TEST_SP + 2, 15);
@@ -15828,12 +15828,12 @@ mod tests {
 
         let dropdown_rect = disp.menu_tracking.as_ref().unwrap().dropdown_rect();
         let (dropdown_top, dropdown_left, _, _) = dropdown_rect;
-        disp.mouse_pos = (dropdown_top + 17, dropdown_left + 8);
+        disp.input_state.mouse_pos = (dropdown_top + 17, dropdown_left + 8);
         disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
 
-        disp.mouse_button = false;
+        disp.input_state.mouse_button = false;
         disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
@@ -15912,8 +15912,8 @@ mod tests {
 
         let regions = disp.menu_title_regions();
         let file_mid_h = (regions[0].0 + regions[0].1) / 2;
-        disp.mouse_pos = (10, file_mid_h);
-        disp.mouse_button = true;
+        disp.input_state.mouse_pos = (10, file_mid_h);
+        disp.input_state.mouse_button = true;
         cpu.write_reg(Register::A7, TEST_SP);
         bus.write_word(TEST_SP, 10);
         bus.write_word(TEST_SP + 2, file_mid_h as u16);
@@ -15933,7 +15933,7 @@ mod tests {
         let parent_item_y =
             parent_rect.0 + disp.menu_rows(&bus, &disp.menus[0].items).offset(4) + 8;
 
-        disp.mouse_pos = (parent_item_y, parent_rect.1 + 24);
+        disp.input_state.mouse_pos = (parent_item_y, parent_rect.1 + 24);
         assert!(
             disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
                 .unwrap()
@@ -15941,7 +15941,7 @@ mod tests {
             "MenuSelect should track the hierarchical parent item"
         );
 
-        disp.mouse_pos = (parent_item_y, parent_rect.3 + 20);
+        disp.input_state.mouse_pos = (parent_item_y, parent_rect.3 + 20);
         assert!(
             disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
                 .unwrap()
@@ -15949,7 +15949,7 @@ mod tests {
             "MenuSelect should track into the submenu"
         );
 
-        disp.mouse_button = false;
+        disp.input_state.mouse_button = false;
         for _ in 0..40 {
             assert!(
                 disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
@@ -16031,14 +16031,14 @@ mod tests {
         cpu.write_reg(Register::A7, TEST_SP);
         bus.write_word(TEST_SP, 10);
         bus.write_word(TEST_SP + 2, title_mid_h as u16);
-        disp.mouse_pos = (10, title_mid_h);
-        disp.mouse_button = true;
+        disp.input_state.mouse_pos = (10, title_mid_h);
+        disp.input_state.mouse_button = true;
         disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
 
         let root_rect = disp.menu_tracking.as_ref().unwrap().dropdown_rect();
-        disp.mouse_pos = (root_rect.0 + 8, root_rect.1 + 16);
+        disp.input_state.mouse_pos = (root_rect.0 + 8, root_rect.1 + 16);
         cpu.write_reg(Register::PC, trap_pc + 2);
         cpu.write_reg(Register::A7, TEST_SP);
         disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
@@ -16059,7 +16059,7 @@ mod tests {
             Some(super::SharedMenuDefinitionPane::Submenu(0))
         );
 
-        disp.mouse_pos = (10, title_mid_h);
+        disp.input_state.mouse_pos = (10, title_mid_h);
         cpu.write_reg(Register::PC, trap_pc + 2);
         cpu.write_reg(Register::A7, TEST_SP);
         disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
@@ -16075,7 +16075,7 @@ mod tests {
         assert!(disp.menu_tracking.as_ref().unwrap().submenus.is_empty());
         assert_eq!(disp.current_port, original_port);
 
-        disp.mouse_pos = (root_rect.0 + 8, root_rect.1 + 16);
+        disp.input_state.mouse_pos = (root_rect.0 + 8, root_rect.1 + 16);
         cpu.write_reg(Register::PC, trap_pc + 2);
         cpu.write_reg(Register::A7, TEST_SP);
         disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
@@ -16083,7 +16083,7 @@ mod tests {
             .unwrap();
         assert_eq!(bus.read_word(trampoline + 6), 0);
 
-        disp.mouse_pos = (child_rect.0 + 8, child_rect.1 + 8);
+        disp.input_state.mouse_pos = (child_rect.0 + 8, child_rect.1 + 8);
         cpu.write_reg(Register::PC, trap_pc + 2);
         cpu.write_reg(Register::A7, TEST_SP);
         disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
@@ -16093,7 +16093,7 @@ mod tests {
         assert_eq!(bus.read_long(trampoline + 10), child);
 
         bus.write_word(trampoline + 58, 2);
-        disp.mouse_button = false;
+        disp.input_state.mouse_button = false;
         cpu.write_reg(Register::PC, trap_pc + 2);
         cpu.write_reg(Register::A7, TEST_SP);
         disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
@@ -16155,8 +16155,8 @@ mod tests {
 
         let regions = disp.menu_title_regions();
         let game_mid_h = (regions[0].0 + regions[0].1) / 2;
-        disp.mouse_pos = (10, game_mid_h);
-        disp.mouse_button = true;
+        disp.input_state.mouse_pos = (10, game_mid_h);
+        disp.input_state.mouse_button = true;
         cpu.write_reg(Register::A7, TEST_SP);
         bus.write_word(TEST_SP, 10);
         bus.write_word(TEST_SP + 2, game_mid_h as u16);
@@ -16166,17 +16166,17 @@ mod tests {
             .unwrap();
 
         let root_rect = disp.menu_tracking.as_ref().unwrap().dropdown_rect();
-        disp.mouse_pos = (root_rect.0 + 9, root_rect.1 + 24);
+        disp.input_state.mouse_pos = (root_rect.0 + 9, root_rect.1 + 24);
         disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
         let options_rect = disp.menu_tracking.as_ref().unwrap().submenus[0].dropdown_rect();
-        disp.mouse_pos = (options_rect.0 + 9, options_rect.1 + 24);
+        disp.input_state.mouse_pos = (options_rect.0 + 9, options_rect.1 + 24);
         disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
         let speed_rect = disp.menu_tracking.as_ref().unwrap().submenus[1].dropdown_rect();
-        disp.mouse_pos = (speed_rect.0 + 9, speed_rect.1 + 24);
+        disp.input_state.mouse_pos = (speed_rect.0 + 9, speed_rect.1 + 24);
         disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
@@ -16185,12 +16185,12 @@ mod tests {
             2,
             "a circular submenu must not grow the retained hierarchy"
         );
-        disp.mouse_pos = (speed_rect.0 + 1 + 16 + 8, speed_rect.1 + 24);
+        disp.input_state.mouse_pos = (speed_rect.0 + 1 + 16 + 8, speed_rect.1 + 24);
         disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
 
-        disp.mouse_button = false;
+        disp.input_state.mouse_button = false;
         for _ in 0..40 {
             disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
                 .unwrap()
@@ -16247,8 +16247,8 @@ mod tests {
             "hierarchical menu must not create a menu-bar title"
         );
         let edit_mid_h = (regions[1].0 + regions[1].1) / 2;
-        disp.mouse_pos = (10, edit_mid_h);
-        disp.mouse_button = true;
+        disp.input_state.mouse_pos = (10, edit_mid_h);
+        disp.input_state.mouse_button = true;
         cpu.write_reg(Register::A7, TEST_SP);
         bus.write_word(TEST_SP, 10);
         bus.write_word(TEST_SP + 2, edit_mid_h as u16);

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -5256,8 +5256,8 @@ impl super::TrapDispatcher {
                         event_ptr,
                         0,
                         0,
-                        self.mouse_pos.0,
-                        self.mouse_pos.1,
+                        self.input_state.mouse_pos.0,
+                        self.input_state.mouse_pos.1,
                         self.current_event_modifiers(),
                     );
                     bus.write_word(sp + 6, 0);
@@ -5288,7 +5288,7 @@ impl super::TrapDispatcher {
                 // the host dispatcher's last injected position.
                 let global_v = bus.read_word(crate::memory::globals::addr::MOUSE_LOC2) as i16;
                 let global_h = bus.read_word(crate::memory::globals::addr::MOUSE_LOC2 + 2) as i16;
-                self.mouse_pos = (global_v, global_h);
+                self.input_state.mouse_pos = (global_v, global_h);
 
                 let a5 = cpu.read_reg(Register::A5);
                 let global_ptr = bus.read_long(a5);
@@ -5331,7 +5331,7 @@ impl super::TrapDispatcher {
             (true, 0x173) => {
                 let sp = cpu.read_reg(Register::A7);
                 let has_mouse_up_event = self.event_queue.iter().any(|e| e.what == 2);
-                let result = self.mouse_button && !has_mouse_up_event;
+                let result = self.input_state.mouse_button && !has_mouse_up_event;
                 if result {
                     self.debug_still_down_true_count =
                         self.debug_still_down_true_count.saturating_add(1);
@@ -5343,7 +5343,7 @@ impl super::TrapDispatcher {
                     let pc = cpu.read_reg(Register::PC);
                     eprintln!(
                         "[INPUT] StillDown -> false (mouse_button={} has_mouse_up_event={}) PC=${:08X}",
-                        self.mouse_button, has_mouse_up_event, pc
+                        self.input_state.mouse_button, has_mouse_up_event, pc
                     );
                 }
                 bus.write_word(sp, if result { 0xFFFF } else { 0 });
@@ -5363,7 +5363,7 @@ impl super::TrapDispatcher {
                 let trap_pc = cpu.read_reg(Register::PC).wrapping_sub(2);
                 let mb_state = bus.read_byte(0x0172);
                 let queued_mouse_down = self.event_queue.iter().any(|event| event.what == 1);
-                let mut pressed = mb_state == 0x00 || self.mouse_button;
+                let mut pressed = mb_state == 0x00 || self.input_state.mouse_button;
                 // Diagnostic: force pressed=true at a specific PC via
                 // SYSTEMLESS_FORCE_BUTTON_TRUE_AT_PC=0xADDR.
                 if let Some(target) = force_button_true_at_pc() {
@@ -5378,7 +5378,7 @@ impl super::TrapDispatcher {
                 if super::dispatch::trace_input_enabled() {
                     eprintln!(
                         "[INPUT] Button pc=${:08X} -> {} (MBState=${:02X} mouse_button={} queued_mouse_down={})",
-                        trap_pc, pressed, mb_state, self.mouse_button, queued_mouse_down
+                        trap_pc, pressed, mb_state, self.input_state.mouse_button, queued_mouse_down
                     );
                 }
                 if pressed {
@@ -10203,22 +10203,22 @@ impl super::TrapDispatcher {
                 if super::dispatch::trace_input_enabled() {
                     eprintln!(
                         "[INPUT] GetKeys tick={} pc=${:08X} ptr=${:08X} key_map={:02X?}",
-                        self.tick_count, trap_pc, keys_ptr, self.key_map
+                        self.tick_count, trap_pc, keys_ptr, self.input_state.key_map
                     );
                 }
-                if trace_getkeys_nonzero_enabled() && self.key_map.iter().any(|&byte| byte != 0) {
+                if trace_getkeys_nonzero_enabled() && self.input_state.key_map.iter().any(|&byte| byte != 0) {
                     eprintln!(
                         "[INPUT] GetKeys nonzero tick={} pc=${:08X} ptr=${:08X} key_map={:02X?}",
-                        self.tick_count, trap_pc, keys_ptr, self.key_map
+                        self.tick_count, trap_pc, keys_ptr, self.input_state.key_map
                     );
                 }
-                if self.key_map.iter().any(|&byte| byte != 0) {
+                if self.input_state.key_map.iter().any(|&byte| byte != 0) {
                     self.debug_getkeys_nonzero_count =
                         self.debug_getkeys_nonzero_count.saturating_add(1);
-                    self.debug_last_getkeys_nonzero_key_map = self.key_map;
+                    self.debug_last_getkeys_nonzero_key_map = self.input_state.key_map;
                 }
                 if keys_ptr != 0 {
-                    bus.write_bytes(keys_ptr, &self.key_map);
+                    bus.write_bytes(keys_ptr, &self.input_state.key_map);
                 }
                 cpu.write_reg(Register::A7, sp + 4);
                 Ok(())
@@ -10234,7 +10234,7 @@ impl super::TrapDispatcher {
             (true, 0x177) => {
                 let sp = cpu.read_reg(Register::A7);
                 // Same logic as StillDown: button down and no pending mouseUp.
-                let still_down = if self.mouse_button {
+                let still_down = if self.input_state.mouse_button {
                     !self.event_queue.iter().any(|e| e.what == 2)
                 } else {
                     false
@@ -10243,13 +10243,13 @@ impl super::TrapDispatcher {
                     // Remove the first mouseUp event from the queue (if any)
                     if let Some(idx) = self.event_queue.iter().position(|e| e.what == 2) {
                         self.event_queue.remove(idx);
-                        self.mouse_button = false;
+                        self.input_state.mouse_button = false;
                     }
                 }
                 if super::dispatch::trace_input_enabled() {
                     eprintln!(
                         "[INPUT] WaitMouseUp -> {} (mouse_button={})",
-                        still_down, self.mouse_button
+                        still_down, self.input_state.mouse_button
                     );
                 }
                 if still_down {
@@ -18233,7 +18233,7 @@ mod tests {
     fn wait_next_event_mouse_rgn_outside_returns_mouse_moved_os_event() {
         let (mut disp, mut cpu, mut bus) = setup();
         disp.sent_open_app_event = true;
-        disp.mouse_pos = (50, 25);
+        disp.input_state.mouse_pos = (50, 25);
         let sp = TEST_SP;
         let event_ptr = 0x200000u32;
         let mouse_rgn = test_region_handle(&mut bus, 10, 20, 30, 40);
@@ -18261,7 +18261,7 @@ mod tests {
     fn wait_next_event_mouse_rgn_inside_takes_null_sleep_path() {
         let (mut disp, mut cpu, mut bus) = setup();
         disp.sent_open_app_event = true;
-        disp.mouse_pos = (20, 25);
+        disp.input_state.mouse_pos = (20, 25);
         let sp = TEST_SP;
         let event_ptr = 0x200000u32;
         let mouse_rgn = test_region_handle(&mut bus, 10, 20, 30, 40);
@@ -18285,7 +18285,7 @@ mod tests {
     fn wait_next_event_empty_mouse_rgn_suppresses_mouse_moved_event() {
         let (mut disp, mut cpu, mut bus) = setup();
         disp.sent_open_app_event = true;
-        disp.mouse_pos = (50, 25);
+        disp.input_state.mouse_pos = (50, 25);
         let sp = TEST_SP;
         let event_ptr = 0x200000u32;
         let empty_mouse_rgn = test_region_handle(&mut bus, 0, 0, 0, 0);
@@ -18309,7 +18309,7 @@ mod tests {
     fn wait_next_event_mouse_rgn_respects_event_mask() {
         let (mut disp, mut cpu, mut bus) = setup();
         disp.sent_open_app_event = true;
-        disp.mouse_pos = (50, 25);
+        disp.input_state.mouse_pos = (50, 25);
         let sp = TEST_SP;
         let event_ptr = 0x200000u32;
         let mouse_rgn = test_region_handle(&mut bus, 10, 20, 30, 40);
@@ -18630,7 +18630,7 @@ mod tests {
         let pt_ptr = 0x200000u32;
         bus.write_long(sp, pt_ptr);
 
-        disp.mouse_pos = (50, 100);
+        disp.input_state.mouse_pos = (50, 100);
         bus.write_word(crate::memory::globals::addr::MOUSE_LOC2, 50);
         bus.write_word(crate::memory::globals::addr::MOUSE_LOC2 + 2, 100);
 
@@ -18658,7 +18658,7 @@ mod tests {
         bus.write_word(port + 10, (-120i16) as u16);
         bus.write_word(port + 16, 0);
         bus.write_word(port + 18, 0);
-        disp.mouse_pos = (95, 145);
+        disp.input_state.mouse_pos = (95, 145);
         bus.write_word(crate::memory::globals::addr::MOUSE_LOC2, 95);
         bus.write_word(crate::memory::globals::addr::MOUSE_LOC2 + 2, 145);
 
@@ -18682,7 +18682,7 @@ mod tests {
         bus.write_word(port + 10, (-10i16) as u16);
         bus.write_word(port + 16, 80);
         bus.write_word(port + 18, 90);
-        disp.mouse_pos = (100, 100);
+        disp.input_state.mouse_pos = (100, 100);
         bus.write_word(crate::memory::globals::addr::MOUSE_LOC2, 100);
         bus.write_word(crate::memory::globals::addr::MOUSE_LOC2 + 2, 100);
 
@@ -18714,7 +18714,7 @@ mod tests {
         // BasiliskII's ROM GetMouse reads Mouse ($0830) and converts that
         // global point through the current GrafPort. Inside Macintosh
         // Volume I, I-259; Volume II, Appendix A, p. A-10.
-        disp.mouse_pos = (404, 526);
+        disp.input_state.mouse_pos = (404, 526);
         bus.write_word(crate::memory::globals::addr::MOUSE_LOC2, 300);
         bus.write_word(crate::memory::globals::addr::MOUSE_LOC2 + 2, 400);
         bus.write_word(port + 8, (-80i16) as u16);
@@ -18733,7 +18733,7 @@ mod tests {
             "GetMouse must honor a guest-updated Mouse global before converting to local coordinates"
         );
         assert_eq!(
-            disp.mouse_pos,
+            disp.input_state.mouse_pos,
             (300, 400),
             "GetMouse must synchronize the dispatcher with the guest-updated Mouse global"
         );
@@ -18747,7 +18747,7 @@ mod tests {
         let sp = TEST_SP;
         bus.write_word(sp, 0x0000);
 
-        disp.mouse_button = true;
+        disp.input_state.mouse_button = true;
 
         let result = disp.dispatch_toolbox(true, 0x173, &mut cpu, &mut bus);
         assert!(result.is_some());
@@ -18802,7 +18802,7 @@ mod tests {
         let sp = TEST_SP;
         bus.write_word(sp, 0xFFFF);
 
-        disp.mouse_button = false;
+        disp.input_state.mouse_button = false;
 
         let result = disp.dispatch_toolbox(true, 0x173, &mut cpu, &mut bus);
         assert!(result.is_some());
@@ -18944,7 +18944,7 @@ mod tests {
 
         // Internal state is released, but $0172 is still "pressed"
         // (runner hasn't advanced a tick yet).
-        assert!(!disp.mouse_button);
+        assert!(!disp.input_state.mouse_button);
         bus.write_word(sp, 0);
         let result = disp.dispatch_toolbox(true, 0x174, &mut cpu, &mut bus);
         assert!(result.unwrap().is_ok());

--- a/src/trap/window.rs
+++ b/src/trap/window.rs
@@ -336,7 +336,7 @@ impl super::TrapDispatcher {
     }
 
     fn current_mouse_local_point(&self, bus: &MacMemoryBus) -> (i16, i16) {
-        let (v, h) = self.mouse_pos;
+        let (v, h) = self.input_state.mouse_pos;
         if self.current_port == 0 {
             return (v, h);
         }
@@ -1572,7 +1572,7 @@ impl super::TrapDispatcher {
         // the initiating mouseDown remains queued, avoiding a zero-initialized
         // MBState falsely retaining synthetic/test calls forever.
         // Inside Macintosh Volume II (1985), p. II-371.
-        self.mouse_button
+        self.input_state.mouse_button
             || (bus.read_byte(crate::memory::globals::addr::MB_STATE) == 0x00
                 && self.has_unmatched_queued_mouse_down())
     }
@@ -1583,7 +1583,7 @@ impl super::TrapDispatcher {
         if (v, h) != (0, 0) {
             (v, h)
         } else {
-            self.mouse_pos
+            self.input_state.mouse_pos
         }
     }
 


### PR DESCRIPTION
Closes #1173.

Moves live mouse, button, KeyMap, Caps Lock, and key-repeat state into the shared Macintosh process. Both CPU adapters attach to the same state, native imports observe it directly, and the runner no longer copies a 68K-owned snapshot before each PowerPC slice. Detached application clones retain independent snapshots.

Validation:
- `cargo test --locked --lib` (4,734 passed; 0 failed; 3 ignored)
- strict rustdoc with private intra-doc links denied
- `cargo build --locked --all-targets --all-features`
- Marathon deterministic gameplay gate
- Escape Velocity deterministic gameplay gate
- Tomb Raider Gold deterministic gameplay gate