### PR TITLE
refactor: remove runner Memory Manager handoffs

### DIFF
--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -3901,11 +3901,11 @@ impl PpcLoadedApp {
 
     /// Run one native slice while publishing its live relocatable blocks to
     /// the process Memory Manager before another CPU adapter can execute.
-    pub(crate) fn with_process_state_and_memory_manager<R>(
+    pub(crate) fn with_process_memory_manager<R>(
         &mut self,
-        memory_manager: &SharedProcessMemoryManager,
         f: impl FnOnce(&mut Self, &mut ProcessMemoryManager) -> R,
     ) -> R {
+        let memory_manager = self.process_memory_manager.0.clone();
         self.with_process_state(|app| {
             let mut memory_manager = memory_manager.borrow_mut();
             app.apply_process_memory_manager(&memory_manager);
@@ -90132,8 +90132,7 @@ pub(crate) mod tests {
             });
         }
 
-        native.with_process_state_and_memory_manager(
-            memory_manager,
+        native.with_process_memory_manager(
             |_native, memory_manager| {
                 assert_eq!(
                     memory_manager
@@ -90191,6 +90190,37 @@ pub(crate) mod tests {
                 .copied()
                 .find(|record| record.handle == handle)
         );
+    }
+
+    #[test]
+    fn attached_native_memory_manager_survives_panic_without_runner_handoff() {
+        let pef = synthetic_pef_with_import(b"NewPtr");
+        let mut native = load_pef_application(&pef).unwrap();
+        let mut context = ProcessContext::default();
+        native.attach_process_context(&mut context);
+        let memory_manager = context.memory_manager_handle().clone();
+
+        let panic_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            native.with_process_memory_manager(|native, memory_manager| {
+                native.cpu.gpr[3] = 24;
+                let probe =
+                    native.run_with_process_memory_manager(64, false, false, memory_manager);
+                assert_eq!(probe.handled_import_count, 1);
+                panic!("simulated panic after a native Memory Manager import");
+            });
+        }));
+
+        assert!(panic_result.is_err());
+        let ptr = native.cpu.gpr[3];
+        assert_ne!(ptr, 0);
+        assert!(native.process_memory_manager.ptr_eq(&memory_manager));
+        assert!(memory_manager
+            .borrow()
+            .native_allocator()
+            .unwrap()
+            .ptrs
+            .iter()
+            .any(|record| record.ptr == ptr && record.size == 24));
     }
 
     #[test]
@@ -90451,8 +90481,7 @@ pub(crate) mod tests {
         classic.set_handle_state_bits(handle, 0x40);
         let detached = memory_manager.detached_clone();
 
-        native.with_process_state_and_memory_manager(
-            memory_manager,
+        native.with_process_memory_manager(
             |native, memory_manager| {
                 native.cpu.pc = native.entry_pc;
                 native.cpu.lr = PPC_HALT_PC;
@@ -90617,10 +90646,7 @@ pub(crate) mod tests {
         native.cpu.gpr[3] = 24;
         let mut context = ProcessContext::default();
         native.attach_process_context(&mut context);
-        let memory_manager = context.memory_manager_handle();
-
-        native.with_process_state_and_memory_manager(
-            memory_manager,
+        native.with_process_memory_manager(
             |native, memory_manager| {
                 let prior_ptr = memory_manager.new_native_ptr(&mut native.memory, 24, false);
                 assert_eq!(prior_ptr, PPC_HEAP_BASE);
@@ -90704,10 +90730,7 @@ pub(crate) mod tests {
         native.attach_process_context(&mut context);
         let mut classic_dispatcher = TrapDispatcher::new();
         classic_dispatcher.attach_process_context(&mut context);
-        let memory_manager = context.memory_manager_handle();
-
-        native.with_process_state_and_memory_manager(
-            memory_manager,
+        native.with_process_memory_manager(
             |native, memory_manager| {
                 native.run_with_process_memory_manager(64, false, false, memory_manager);
                 let handle = native.cpu.gpr[3];
@@ -90896,10 +90919,7 @@ pub(crate) mod tests {
         native.attach_process_context(&mut context);
         let mut classic_dispatcher = TrapDispatcher::new();
         classic_dispatcher.attach_process_context(&mut context);
-        let memory_manager = context.memory_manager_handle();
-
-        native.with_process_state_and_memory_manager(
-            memory_manager,
+        native.with_process_memory_manager(
             |native, memory_manager| {
                 let allocator = memory_manager.native_allocator_snapshot().unwrap();
                 let mut heap_cursor = allocator.heap.heap_cursor;
@@ -91048,10 +91068,7 @@ pub(crate) mod tests {
 
         let mut context = ProcessContext::default();
         native.attach_process_context(&mut context);
-        let memory_manager = context.memory_manager_handle();
-
-        native.with_process_state_and_memory_manager(
-            memory_manager,
+        native.with_process_memory_manager(
             |native, memory_manager| {
                 native.cpu.gpr[3] = source;
                 native.cpu.gpr[4] = output;

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -3616,6 +3616,7 @@ impl ProcessContext {
         *self.menu_tracking = state;
     }
 
+    #[cfg(test)]
     pub(crate) fn memory_manager_handle(&self) -> &SharedProcessMemoryManager {
         &self.memory_manager
     }

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -5467,9 +5467,7 @@ impl FixtureRunner {
                     }
 
                     self.dispatcher.yield_for_ui = yield_for_ui;
-                    let memory_manager = self.process_context.memory_manager_handle();
-                    let dispatch_result = self.dispatcher.with_process_state_and_memory_manager(
-                        memory_manager,
+                    let dispatch_result = self.dispatcher.with_process_state(
                         |dispatcher| dispatcher.dispatch(opcode, &mut self.cpu, &mut self.bus),
                     );
                     match dispatch_result {
@@ -5816,9 +5814,7 @@ impl FixtureRunner {
         let trace_ppc_imports = record_ppc_imports || trace_ppc_import_hist;
         let trace_ppc_fetches = trace_ppc_fetch_counts_enabled();
         let profile_run_start = profile_ppc.then(Instant::now);
-        let memory_manager = self.process_context.memory_manager_handle();
-        let probe = ppc_app.with_process_state_and_memory_manager(
-            memory_manager,
+        let probe = ppc_app.with_process_memory_manager(
             |app, memory_manager| {
                 app.run_with_process_memory_manager(
                     ppc_max_steps as u64,
@@ -5866,9 +5862,7 @@ impl FixtureRunner {
         } else {
             self.advance_ticks_for_ppc_cycles(cycles, tick_cap);
             let elapsed_ticks = self.dispatcher.tick_count.wrapping_sub(ppc_start_tick);
-            let memory_manager = self.process_context.memory_manager_handle();
-            ppc_app.with_process_state_and_memory_manager(
-                memory_manager,
+            ppc_app.with_process_memory_manager(
                 |app, memory_manager| {
                     Self::fire_ppc_tick_callbacks(
                         app,
@@ -6180,9 +6174,7 @@ impl FixtureRunner {
                         self.cpu.core.take_aline_exception(&mut self.bus);
                         continue;
                     }
-                    let memory_manager = self.process_context.memory_manager_handle();
-                    let dispatch_err = self.dispatcher.with_process_state_and_memory_manager(
-                        memory_manager,
+                    let dispatch_err = self.dispatcher.with_process_state(
                         |dispatcher| {
                             dispatcher
                                 .dispatch(opcode, &mut self.cpu, &mut self.bus)
@@ -7515,9 +7507,7 @@ impl FixtureRunner {
         while !ppc_app.sound.pending_doublebacks.is_empty() && fired_count < 16 {
             let doubleback = ppc_app.sound.pending_doublebacks.remove(0);
             let resume_pc = ppc_app.cpu.pc;
-            let memory_manager = self.process_context.memory_manager_handle();
-            let probe = ppc_app.with_process_state_and_memory_manager(
-                memory_manager,
+            let probe = ppc_app.with_process_memory_manager(
                 |app, memory_manager| {
                     app.run_sound_doubleback_callback_with_process_memory_manager(
                         doubleback,
@@ -7626,9 +7616,7 @@ impl FixtureRunner {
         let mut fired_count = 0usize;
         while !ppc_app.sound.pending_completions.is_empty() && fired_count < 16 {
             let completion = ppc_app.sound.pending_completions.remove(0);
-            let memory_manager = self.process_context.memory_manager_handle();
-            let probe = ppc_app.with_process_state_and_memory_manager(
-                memory_manager,
+            let probe = ppc_app.with_process_memory_manager(
                 |app, memory_manager| {
                     app.run_sound_completion_callback_with_process_memory_manager(
                         completion,
@@ -10366,9 +10354,7 @@ impl FixtureRunner {
                         count += 1;
                         continue;
                     }
-                    let memory_manager = self.process_context.memory_manager_handle();
-                    let dispatch_result = self.dispatcher.with_process_state_and_memory_manager(
-                        memory_manager,
+                    let dispatch_result = self.dispatcher.with_process_state(
                         |dispatcher| dispatcher.dispatch(opcode, &mut self.cpu, &mut self.bus),
                     );
                     match dispatch_result {

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -2979,16 +2979,6 @@ impl TrapDispatcher {
         self.process_memory_manager().has_handle_state(handle)
     }
 
-    /// Attach the canonical process Memory Manager to this 68K adapter.
-    pub(crate) fn with_memory_manager<R>(
-        &mut self,
-        memory_manager: &SharedProcessMemoryManager,
-        f: impl FnOnce(&mut Self) -> R,
-    ) -> R {
-        self.attach_memory_manager_handle(memory_manager.clone());
-        f(self)
-    }
-
     /// Replace bytes in a native relocatable block through the process-level
     /// Memory Manager attached for the current serialized 68K dispatch.
     pub(crate) fn replace_process_native_handle_bytes(
@@ -3017,14 +3007,6 @@ impl TrapDispatcher {
                 false
             }
         }
-    }
-
-    pub(crate) fn with_process_state_and_memory_manager<R>(
-        &mut self,
-        memory_manager: &SharedProcessMemoryManager,
-        f: impl FnOnce(&mut Self) -> R,
-    ) -> R {
-        self.with_memory_manager(memory_manager, f)
     }
 
     /// Run one 68K operation with every process manager continuously attached.
@@ -11169,7 +11151,7 @@ mod tests {
     }
 
     #[test]
-    fn with_process_state_restores_all_canonical_slots_on_panic() {
+    fn attached_process_state_remains_canonical_through_panic() {
         let mut dispatcher = TrapDispatcher::new();
         let mut context = ProcessContext::default();
         context.set_menu_tracking(Some(crate::menu_manager::test_process_menu_tracking(0x9abc)));
@@ -11177,22 +11159,19 @@ mod tests {
         let memory_manager = context.memory_manager_handle().clone();
 
         let panic_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            dispatcher.with_process_state_and_memory_manager(
-                &memory_manager,
-                |disp| {
-                    disp.event_queue.push_back(QueuedEvent {
-                        what: 1,
-                        message: 0x3333,
-                        where_v: 1,
-                        where_h: 2,
-                        modifiers: 0,
-                    });
-                    disp.menu_tracking.as_mut().unwrap().highlighted_item = 7;
-                    disp.track_handle_ptr(0x4444, 0x5555);
-                    disp.set_handle_state_bits(0x5555, 0xc0);
-                    panic!("simulated panic inside a complete guest execution slice");
-                },
-            );
+            dispatcher.with_process_state(|disp| {
+                disp.event_queue.push_back(QueuedEvent {
+                    what: 1,
+                    message: 0x3333,
+                    where_v: 1,
+                    where_h: 2,
+                    modifiers: 0,
+                });
+                disp.menu_tracking.as_mut().unwrap().highlighted_item = 7;
+                disp.track_handle_ptr(0x4444, 0x5555);
+                disp.set_handle_state_bits(0x5555, 0xc0);
+                panic!("simulated panic inside a complete guest execution slice");
+            });
         }));
 
         assert!(panic_result.is_err());

--- a/src/trap/memory.rs
+++ b/src/trap/memory.rs
@@ -4521,8 +4521,7 @@ mod tests {
         cpu.write_reg(Register::D0, 24);
         let memory_manager = context.memory_manager_handle();
         dispatcher
-            .with_process_state_and_memory_manager(
-                memory_manager,
+            .with_process_state(
                 |dispatcher| {
                     dispatcher.current_trap_word = 0xA11E;
                     dispatcher
@@ -4541,8 +4540,7 @@ mod tests {
         cpu.write_reg(Register::D0, 13);
         let memory_manager = context.memory_manager_handle();
         dispatcher
-            .with_process_state_and_memory_manager(
-                memory_manager,
+            .with_process_state(
                 |dispatcher| {
                     dispatcher.current_trap_word = 0xA022;
                     dispatcher
@@ -4584,8 +4582,7 @@ mod tests {
         cpu.write_reg(Register::A0, ptr);
         let memory_manager = context.memory_manager_handle();
         dispatcher
-            .with_process_state_and_memory_manager(
-                memory_manager,
+            .with_process_state(
                 |dispatcher| {
                     dispatcher.current_trap_word = 0xA01F;
                     dispatcher
@@ -4599,8 +4596,7 @@ mod tests {
         cpu.write_reg(Register::A0, handle);
         let memory_manager = context.memory_manager_handle();
         dispatcher
-            .with_process_state_and_memory_manager(
-                memory_manager,
+            .with_process_state(
                 |dispatcher| {
                     dispatcher.current_trap_word = 0xA023;
                     dispatcher


### PR DESCRIPTION
Closes #1175.

The 68K and PowerPC adapters now use the process Memory Manager attached for their lifetimes, so `FixtureRunner` no longer passes the same shared handle through every dispatch, native slice, tick callback, or sound callback. Panic coverage verifies that native imports retain canonical manager ownership without a runner handoff.

Validation:
- `cargo test --locked --lib` (4,735 passed; 3 ignored)
- strict all-features rustdoc with private intra-doc links denied
- `cargo build --locked --all-targets --all-features`
- Marathon deterministic gameplay through terminal advancement
- Escape Velocity deterministic gameplay through landing, return to space, and acceleration
- Tomb Raider Gold deterministic gameplay through live level movement