### PR TITLE
refactor(memory): retain process address mappings

### DIFF
--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -89274,9 +89274,9 @@ pub(crate) mod tests {
         let mut context = ProcessContext::default();
         native.attach_process_context(&mut context);
         classic.attach_process_context(&mut context);
-        let shared = unsafe { native.memory.shared_view() };
+        let shared = native.memory.shared_view();
         let mut classic_bus = MacMemoryBus::new(8 * 1024 * 1024);
-        unsafe { classic_bus.attach_guest_address_space(shared) };
+        classic_bus.attach_guest_address_space(shared);
         context.attach_classic_memory_bus(&mut classic_bus);
         let (handle, ptr) = context
             .memory_manager_mut()
@@ -89792,9 +89792,9 @@ pub(crate) mod tests {
                 );
                 assert_eq!(loaded, handle);
                 let record = memory_manager.native_allocation(handle).unwrap();
-                let shared = unsafe { native.memory.shared_view() };
+                let shared = native.memory.shared_view();
                 let mut classic_bus = MacMemoryBus::new(0x2000);
-                unsafe { classic_bus.attach_guest_address_space(shared) };
+                classic_bus.attach_guest_address_space(shared);
                 assert_eq!(
                     classic_bus.read_bytes(record.ptr, record.size as usize),
                     b"process resource"
@@ -89863,8 +89863,8 @@ pub(crate) mod tests {
         native.memory.add_region(scratch, vec![0; 0x100]);
         native.memory.write_bytes(source, b"native").unwrap();
         let mut classic_bus = crate::memory::MacMemoryBus::new(0x2000);
-        let shared = unsafe { native.memory.shared_view() };
-        unsafe { classic_bus.attach_guest_address_space(shared) };
+        let shared = native.memory.shared_view();
+        classic_bus.attach_guest_address_space(shared);
 
         let mut context = ProcessContext::default();
         native.attach_process_context(&mut context);
@@ -134711,9 +134711,9 @@ pub(crate) mod tests {
             .any(|record| record.ptr == world.base_addr));
         assert_eq!(detached.native_allocation(ctable_handle), None);
 
-        let shared = unsafe { native.memory.shared_view() };
+        let shared = native.memory.shared_view();
         let mut classic_bus = MacMemoryBus::new(0x2000);
-        unsafe { classic_bus.attach_guest_address_space(shared) };
+        classic_bus.attach_guest_address_space(shared);
         context.attach_classic_memory_bus(&mut classic_bus);
         classic_bus.write_byte(world.base_addr, 0xa5);
         assert_eq!(native.memory.read_u8(world.base_addr), Some(0xa5));
@@ -134864,9 +134864,9 @@ pub(crate) mod tests {
             .iter()
             .any(|record| record.ptr == updated.base_addr));
 
-        let shared = unsafe { native.memory.shared_view() };
+        let shared = native.memory.shared_view();
         let mut classic_bus = MacMemoryBus::new(0x2000);
-        unsafe { classic_bus.attach_guest_address_space(shared) };
+        classic_bus.attach_guest_address_space(shared);
         context.attach_classic_memory_bus(&mut classic_bus);
         classic_bus.write_byte(updated.base_addr, 0xa5);
         assert_eq!(native.memory.read_u8(updated.base_addr), Some(0xa5));
@@ -151388,9 +151388,9 @@ pub(crate) mod tests {
         assert_eq!(detached.native_allocation(event_handle), None);
         assert_eq!(detached.native_allocation(reply_handle), None);
 
-        let shared = unsafe { native.memory.shared_view() };
+        let shared = native.memory.shared_view();
         let mut classic_bus = MacMemoryBus::new(0x2000);
-        unsafe { classic_bus.attach_guest_address_space(shared) };
+        classic_bus.attach_guest_address_space(shared);
         context.attach_classic_memory_bus(&mut classic_bus);
         assert_eq!(
             classic_bus.read_bytes(event_allocation.ptr, 8),
@@ -160089,9 +160089,9 @@ pub(crate) mod tests {
             .iter()
             .any(|record| record.ptr == original));
 
-        let shared = unsafe { native.memory.shared_view() };
+        let shared = native.memory.shared_view();
         let mut classic_bus = MacMemoryBus::new(0x2000);
-        unsafe { classic_bus.attach_guest_address_space(shared) };
+        classic_bus.attach_guest_address_space(shared);
         context.attach_classic_memory_bus(&mut classic_bus);
         classic_bus.write_bytes(original, b"payload!");
         assert_eq!(
@@ -161877,9 +161877,9 @@ pub(crate) mod tests {
         );
         assert_eq!(detached.native_allocation(handle), None);
 
-        let shared = unsafe { native.memory.shared_view() };
+        let shared = native.memory.shared_view();
         let mut classic_bus = MacMemoryBus::new(0x2000);
-        unsafe { classic_bus.attach_guest_address_space(shared) };
+        classic_bus.attach_guest_address_space(shared);
         context.attach_classic_memory_bus(&mut classic_bus);
         assert_eq!(classic_bus.read_bytes(allocation.ptr, 7), b"payload");
         classic_bus.write_byte(allocation.ptr, b'P');

--- a/src/memory/address_space.rs
+++ b/src/memory/address_space.rs
@@ -8,7 +8,8 @@
 use m68k::core::memory::{BusFault, BusFaultKind};
 use m68k::AddressBus;
 use ppc::{PpcMemory, PpcSectionMem, PpcSectionMemSpan};
-use std::ptr::NonNull;
+use std::cell::UnsafeCell;
+use std::rc::Rc;
 
 use super::bus::SharedRamRegion;
 
@@ -31,133 +32,172 @@ struct OrdinaryRegionMapping {
 /// depend on the architecture-neutral ownership boundary rather than a CPU
 /// crate's concrete memory type.
 #[derive(Debug, Default)]
-pub struct GuestAddressSpace {
+struct GuestAddressSpaceState {
     regions: PpcSectionMem,
     ordinary_regions: Vec<OrdinaryRegionMapping>,
     shared_regions: Vec<SharedRegionMapping>,
     readonly_allocation_exclusions: Vec<(u32, u32)>,
 }
 
-/// A temporary, non-owning view of one process address space.
+#[derive(Debug, Default)]
+pub struct GuestAddressSpace(Rc<UnsafeCell<GuestAddressSpaceState>>);
+
+/// A shared view of one process address space.
 ///
-/// The runner uses this only while the PowerPC application is parked and its
-/// emulated 68k context is executing. This keeps both CPU adapters on the same
-/// mapped bytes without changing the detached-snapshot semantics of
-/// [`GuestAddressSpace::clone`].
-#[derive(Clone, Copy, Debug)]
-pub(crate) struct SharedGuestAddressSpace(NonNull<GuestAddressSpace>);
+/// CPU adapters retain this handle while the runner serializes their access.
+/// Ordinary [`GuestAddressSpace::clone`] operations remain detached snapshots.
+#[derive(Clone, Debug)]
+pub(crate) struct SharedGuestAddressSpace(Rc<UnsafeCell<GuestAddressSpaceState>>);
 
 impl SharedGuestAddressSpace {
-    /// Borrow an address space through a stable raw pointer for a serialized
-    /// cross-ISA execution interval.
-    ///
-    /// # Safety
-    ///
-    /// The source address space must remain alive and unmoved, and no other
-    /// access may overlap any call through this view.
-    pub(crate) unsafe fn new(memory: &mut GuestAddressSpace) -> Self {
-        Self(NonNull::from(memory))
+    fn new(memory: &GuestAddressSpace) -> Self {
+        Self(Rc::clone(&memory.0))
+    }
+
+    fn state_mut(&self) -> &mut GuestAddressSpaceState {
+        // SAFETY: the process runner serializes all CPU-adapter access.
+        unsafe { &mut *self.0.get() }
+    }
+
+    fn adapter(&self) -> GuestAddressSpace {
+        GuestAddressSpace(Rc::clone(&self.0))
+    }
+
+    fn shared_overlaps(&self, address: u32, len: u32) -> bool {
+        if len == 0 {
+            return false;
+        }
+        let start = u64::from(address);
+        let end = start + u64::from(len);
+        self.state_mut().shared_regions.iter().any(|mapping| {
+            let mapping_start = u64::from(mapping.base);
+            let mapping_end = mapping_start.saturating_add(mapping.region.len() as u64);
+            start < mapping_end && mapping_start < end
+        })
     }
 
     #[inline]
-    pub(crate) unsafe fn read_u8(self, address: u32) -> Option<u8> {
-        // SAFETY: upheld by `new` and the caller's serialized interval.
-        unsafe { PpcMemory::read_u8(self.0.as_ptr().as_mut()?, address) }
+    pub(crate) fn read_u8(&self, address: u32) -> Option<u8> {
+        if self.shared_overlaps(address, 1) {
+            return None;
+        }
+        PpcMemory::read_u8(&mut self.state_mut().regions, address)
     }
 
     #[inline]
-    pub(crate) unsafe fn read_u16_be(self, address: u32) -> Option<u16> {
-        // SAFETY: upheld by `new` and the caller's serialized interval.
-        unsafe { PpcMemory::read_u16_be(self.0.as_ptr().as_mut()?, address) }
+    pub(crate) fn read_u16_be(&self, address: u32) -> Option<u16> {
+        if self.shared_overlaps(address, 2) {
+            return None;
+        }
+        PpcMemory::read_u16_be(&mut self.state_mut().regions, address)
     }
 
     #[inline]
-    pub(crate) unsafe fn read_u32_be(self, address: u32) -> Option<u32> {
-        // SAFETY: upheld by `new` and the caller's serialized interval.
-        unsafe { PpcMemory::read_u32_be(self.0.as_ptr().as_mut()?, address) }
+    pub(crate) fn read_u32_be(&self, address: u32) -> Option<u32> {
+        if self.shared_overlaps(address, 4) {
+            return None;
+        }
+        PpcMemory::read_u32_be(&mut self.state_mut().regions, address)
     }
 
     #[inline]
-    pub(crate) unsafe fn write_u8(self, address: u32, value: u8) -> Option<()> {
-        // SAFETY: upheld by `new` and the caller's serialized interval.
-        unsafe { PpcMemory::write_u8(self.0.as_ptr().as_mut()?, address, value) }
+    pub(crate) fn write_u8(&self, address: u32, value: u8) -> Option<()> {
+        if self.shared_overlaps(address, 1) {
+            return None;
+        }
+        PpcMemory::write_u8(&mut self.state_mut().regions, address, value)
     }
 
     #[inline]
-    pub(crate) unsafe fn write_u16_be(self, address: u32, value: u16) -> Option<()> {
-        // SAFETY: upheld by `new` and the caller's serialized interval.
-        unsafe { PpcMemory::write_u16_be(self.0.as_ptr().as_mut()?, address, value) }
+    pub(crate) fn write_u16_be(&self, address: u32, value: u16) -> Option<()> {
+        if self.shared_overlaps(address, 2) {
+            return None;
+        }
+        PpcMemory::write_u16_be(&mut self.state_mut().regions, address, value)
     }
 
     #[inline]
-    pub(crate) unsafe fn write_u32_be(self, address: u32, value: u32) -> Option<()> {
-        // SAFETY: upheld by `new` and the caller's serialized interval.
-        unsafe { PpcMemory::write_u32_be(self.0.as_ptr().as_mut()?, address, value) }
+    pub(crate) fn write_u32_be(&self, address: u32, value: u32) -> Option<()> {
+        if self.shared_overlaps(address, 4) {
+            return None;
+        }
+        PpcMemory::write_u32_be(&mut self.state_mut().regions, address, value)
     }
 
     /// Whether an address belongs to an ordinary sparse native mapping rather
     /// than a runner-owned shared flat-RAM overlay.
     #[inline]
-    pub(crate) unsafe fn is_ordinary_sparse_mapped(self, address: u32) -> bool {
-        // SAFETY: upheld by `new` and caller's serialized interval.
-        let Some(space) = (unsafe { self.0.as_ptr().as_mut() }) else {
-            return false;
-        };
-        if space.locate_shared_mapping(address).is_some() {
+    pub(crate) fn is_ordinary_sparse_mapped(&self, address: u32) -> bool {
+        !self.shared_overlaps(address, 1) && self.state_mut().regions.read_u8(address).is_some()
+    }
+
+    pub(crate) fn ordinary_mapping_overlaps(&self, address: u32, len: u32) -> bool {
+        if len == 0 {
             return false;
         }
-        space.regions.read_u8(address).is_some()
+        let range_start = u64::from(address);
+        let range_end = range_start + u64::from(len);
+        let state = self.state_mut();
+        state.ordinary_regions.iter().any(|ordinary| {
+            let mut cursor = u64::from(ordinary.base).max(range_start);
+            let ordinary_end = u64::from(ordinary.base)
+                .saturating_add(ordinary.len as u64)
+                .min(range_end);
+            while cursor < ordinary_end {
+                let covered_end = state
+                    .shared_regions
+                    .iter()
+                    .filter_map(|mapping| {
+                        let mapping_start = u64::from(mapping.base);
+                        let mapping_end =
+                            mapping_start.saturating_add(mapping.region.len() as u64);
+                        (mapping_start <= cursor && cursor < mapping_end).then_some(mapping_end)
+                    })
+                    .max();
+                let Some(covered_end) = covered_end else {
+                    return true;
+                };
+                cursor = covered_end;
+            }
+            false
+        })
     }
 
     /// Return the end of the highest read-only runtime reservation overlapping
     /// a candidate native heap allocation.
     #[inline]
-    pub(crate) unsafe fn readonly_allocation_overlap_end(
-        self,
+    pub(crate) fn readonly_allocation_overlap_end(
+        &self,
         address: u32,
         len: u32,
     ) -> Option<u32> {
-        // SAFETY: upheld by `new` and the caller's serialized interval.
-        unsafe {
-            self.0
-                .as_ptr()
-                .as_ref()?
-                .readonly_allocation_overlap_end(address, len)
-        }
+        self.adapter().readonly_allocation_overlap_end(address, len)
     }
 
     /// Write bytes only through the attached guest address space.
     #[inline]
-    pub(crate) unsafe fn write_bytes(self, address: u32, bytes: &[u8]) -> Option<()> {
-        // SAFETY: upheld by `new` and the caller's serialized interval.
-        let space = unsafe { self.0.as_ptr().as_mut()? };
-        for (offset, byte) in bytes.iter().copied().enumerate() {
-            PpcMemory::write_u8(space, address.checked_add(offset as u32)?, byte)?;
-        }
-        Some(())
+    pub(crate) fn write_bytes(&self, address: u32, bytes: &[u8]) -> Option<()> {
+        self.adapter().write_bytes(address, bytes)
     }
 
-    /// Exclusively borrow the parked process address space for one operation.
+    /// Exclusively borrow the retained process address space for one operation.
     ///
-    /// # Safety
-    ///
-    /// The source address space must remain alive and unmoved, and no other
-    /// access may overlap the closure.
-    pub(crate) unsafe fn with_mut<R>(
-        self,
+    /// The runner serializes this access with both CPU adapters.
+    pub(crate) fn with_mut<R>(
+        &self,
         f: impl FnOnce(&mut GuestAddressSpace) -> R,
-    ) -> Option<R> {
-        // SAFETY: upheld by `new` and the caller's serialized interval.
-        unsafe { self.0.as_ptr().as_mut().map(f) }
+    ) -> R {
+        f(&mut self.adapter())
     }
 }
 
 impl Clone for GuestAddressSpace {
     fn clone(&self) -> Self {
-        Self {
-            regions: self.regions.clone(),
-            ordinary_regions: self.ordinary_regions.clone(),
-            shared_regions: self
+        let state = self.state();
+        Self(Rc::new(UnsafeCell::new(GuestAddressSpaceState {
+            regions: state.regions.clone(),
+            ordinary_regions: state.ordinary_regions.clone(),
+            shared_regions: state
                 .shared_regions
                 .iter()
                 .map(|mapping| SharedRegionMapping {
@@ -166,44 +206,51 @@ impl Clone for GuestAddressSpace {
                     writable: mapping.writable,
                 })
                 .collect(),
-            readonly_allocation_exclusions: self.readonly_allocation_exclusions.clone(),
-        }
+            readonly_allocation_exclusions: state.readonly_allocation_exclusions.clone(),
+        })))
     }
 }
 
 impl GuestAddressSpace {
+    fn state(&self) -> &GuestAddressSpaceState {
+        // SAFETY: the process runner serializes all CPU-adapter access, and
+        // detached clones allocate independent state.
+        unsafe { &*self.0.get() }
+    }
+
+    fn state_mut(&mut self) -> &mut GuestAddressSpaceState {
+        // SAFETY: see `state`.
+        unsafe { &mut *self.0.get() }
+    }
+
     /// Construct an empty address space.
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// Create a temporary view for another serialized CPU adapter.
-    ///
-    /// # Safety
-    ///
-    /// The returned view must not outlive or move this address space, and all
-    /// accesses through it must be exclusive of ordinary address-space use.
-    pub(crate) unsafe fn shared_view(&mut self) -> SharedGuestAddressSpace {
-        // SAFETY: the caller inherits the contract above.
-        unsafe { SharedGuestAddressSpace::new(self) }
+    /// Create a process-lifetime view for another serialized CPU adapter.
+    pub(crate) fn shared_view(&self) -> SharedGuestAddressSpace {
+        SharedGuestAddressSpace::new(self)
     }
 
     /// Map a writable region. Newer mappings take precedence over overlaps.
     pub fn add_region(&mut self, base: u32, bytes: Vec<u8>) {
-        self.ordinary_regions.push(OrdinaryRegionMapping {
+        let state = self.state_mut();
+        state.ordinary_regions.push(OrdinaryRegionMapping {
             base,
             len: bytes.len(),
         });
-        self.regions.add_region(base, bytes);
+        state.regions.add_region(base, bytes);
     }
 
     /// Map a read-only region. Newer mappings take precedence over overlaps.
     pub fn add_readonly_region(&mut self, base: u32, bytes: Vec<u8>) {
-        self.ordinary_regions.push(OrdinaryRegionMapping {
+        let state = self.state_mut();
+        state.ordinary_regions.push(OrdinaryRegionMapping {
             base,
             len: bytes.len(),
         });
-        self.regions.add_readonly_region(base, bytes);
+        state.regions.add_readonly_region(base, bytes);
     }
 
     /// Return the disjoint holes not occupied by ordinary sparse mappings in
@@ -214,6 +261,7 @@ impl GuestAddressSpace {
         }
 
         let mut occupied = self
+            .state()
             .ordinary_regions
             .iter()
             .filter_map(|mapping| {
@@ -251,7 +299,7 @@ impl GuestAddressSpace {
     /// serializes all access. No source-bus slice or fast-memory window may be
     /// used while this address space mutates the shared allocation.
     pub(crate) unsafe fn add_shared_region(&mut self, base: u32, region: SharedRamRegion) {
-        self.shared_regions.push(SharedRegionMapping {
+        self.state_mut().shared_regions.push(SharedRegionMapping {
             base,
             region,
             writable: true,
@@ -267,13 +315,15 @@ impl GuestAddressSpace {
     /// The ownership and serialization requirements are the same as for
     /// [`Self::add_shared_region`].
     pub(crate) unsafe fn add_shared_readonly_region(&mut self, base: u32, region: SharedRamRegion) {
+        let state = self.state_mut();
         if let Ok(len) = u32::try_from(region.len()) {
-            self.readonly_allocation_exclusions
+            state
+                .readonly_allocation_exclusions
                 .retain(|&(excluded_base, excluded_len)| {
                     (excluded_base, excluded_len) != (base, len)
                 });
         }
-        self.shared_regions.push(SharedRegionMapping {
+        state.shared_regions.push(SharedRegionMapping {
             base,
             region,
             writable: false,
@@ -287,17 +337,20 @@ impl GuestAddressSpace {
         if len == 0 || u64::from(base) + u64::from(len) > (1u64 << 32) {
             return None;
         }
-        if !self
+        let state = self.state_mut();
+        if !state
             .readonly_allocation_exclusions
             .contains(&(base, len))
         {
-            self.readonly_allocation_exclusions.push((base, len));
+            state.readonly_allocation_exclusions.push((base, len));
         }
         Some(())
     }
 
     pub(crate) fn has_readonly_allocation_exclusion(&self, base: u32, len: u32) -> bool {
-        self.readonly_allocation_exclusions.contains(&(base, len))
+        self.state()
+            .readonly_allocation_exclusions
+            .contains(&(base, len))
     }
 
     /// Whether an ordinary sparse mapping already occupies any byte in the
@@ -308,7 +361,7 @@ impl GuestAddressSpace {
         }
         let start = u64::from(base);
         let end = start + u64::from(len);
-        self.ordinary_regions.iter().any(|mapping| {
+        self.state().ordinary_regions.iter().any(|mapping| {
             let mapping_start = u64::from(mapping.base);
             let mapping_end = mapping_start.saturating_add(mapping.len as u64);
             start < mapping_end && mapping_start < end
@@ -342,7 +395,8 @@ impl GuestAddressSpace {
         }
         let start = u64::from(address);
         let end = start.checked_add(u64::from(len))?;
-        let exclusion_ends = self
+        let state = self.state();
+        let exclusion_ends = state
             .readonly_allocation_exclusions
             .iter()
             .filter_map(|&(base, len)| {
@@ -350,7 +404,7 @@ impl GuestAddressSpace {
                 let mapping_end = mapping_start.checked_add(u64::from(len))?;
                 (start < mapping_end && mapping_start < end).then_some(mapping_end)
             });
-        let shared_ends = self
+        let shared_ends = state
             .shared_regions
             .iter()
             .filter(|mapping| !mapping.writable)
@@ -378,7 +432,8 @@ impl GuestAddressSpace {
         }
         let range_start = u64::from(start);
         let range_end = u64::from(end);
-        let excluded = self
+        let state = self.state();
+        let excluded = state
             .readonly_allocation_exclusions
             .iter()
             .filter_map(|&(base, len)| {
@@ -388,7 +443,7 @@ impl GuestAddressSpace {
                     .min(range_end);
                 (mapping_start < mapping_end).then_some((mapping_start, mapping_end))
             });
-        let shared = self
+        let shared = state
             .shared_regions
             .iter()
             .filter(|mapping| !mapping.writable)
@@ -426,13 +481,14 @@ impl GuestAddressSpace {
 
     /// Return the number of mapped regions.
     pub fn region_count(&self) -> usize {
-        self.regions.region_count() + self.shared_regions.len()
+        let state = self.state();
+        state.regions.region_count() + state.shared_regions.len()
     }
 
     /// Copy a fully mapped range into `dst`.
     pub fn read_bytes_into(&mut self, addr: u32, dst: &mut [u8]) -> Option<()> {
         if !self.shared_overlaps(addr, dst.len()) {
-            return self.regions.read_bytes_into(addr, dst);
+            return self.state_mut().regions.read_bytes_into(addr, dst);
         }
         for (offset, byte) in dst.iter_mut().enumerate() {
             *byte = self.read_u8(addr.wrapping_add(offset as u32))?;
@@ -443,7 +499,7 @@ impl GuestAddressSpace {
     /// Copy `src` into a fully mapped, writable range.
     pub fn write_bytes(&mut self, addr: u32, src: &[u8]) -> Option<()> {
         if !self.shared_overlaps(addr, src.len()) {
-            return self.regions.write_bytes(addr, src);
+            return self.state_mut().regions.write_bytes(addr, src);
         }
         if (0..src.len()).any(|offset| {
             self.locate_shared_mapping(addr.wrapping_add(offset as u32))
@@ -469,14 +525,15 @@ impl GuestAddressSpace {
             if self.locate_shared(address).is_some() {
                 shared.push((address, byte));
             } else {
-                ordinary.push((address, self.regions.read_u8(address)?, byte));
+                ordinary.push((address, self.state_mut().regions.read_u8(address)?, byte));
             }
         }
 
         for (committed, &(address, _, byte)) in ordinary.iter().enumerate() {
-            if self.regions.write_u8(address, byte).is_none() {
+            if self.state_mut().regions.write_u8(address, byte).is_none() {
                 for &(rollback_address, original, _) in ordinary[..committed].iter().rev() {
-                    self.regions
+                    self.state_mut()
+                        .regions
                         .write_u8(rollback_address, original)
                         .expect("a previously writable sparse byte remains writable");
                 }
@@ -495,7 +552,7 @@ impl GuestAddressSpace {
         if self.shared_overlaps(addr, len) {
             return None;
         }
-        self.regions.writable_span(addr, len)
+        self.state_mut().regions.writable_span(addr, len)
     }
 
     /// Read a big-endian word at an offset within a cached span.
@@ -504,7 +561,9 @@ impl GuestAddressSpace {
         span: PpcSectionMemSpan,
         relative_offset: usize,
     ) -> Option<u16> {
-        self.regions.read_u16_be_in_span(span, relative_offset)
+        self.state()
+            .regions
+            .read_u16_be_in_span(span, relative_offset)
     }
 
     /// Write a big-endian word at an offset within a cached writable span.
@@ -514,7 +573,8 @@ impl GuestAddressSpace {
         relative_offset: usize,
         value: u16,
     ) -> Option<()> {
-        self.regions
+        self.state_mut()
+            .regions
             .write_u16_be_in_span(span, relative_offset, value)
     }
 
@@ -528,7 +588,7 @@ impl GuestAddressSpace {
 
     #[inline]
     fn locate_shared_mapping(&self, addr: u32) -> Option<(&SharedRegionMapping, usize)> {
-        self.shared_regions.iter().rev().find_map(|mapping| {
+        self.state().shared_regions.iter().rev().find_map(|mapping| {
             let offset = usize::try_from(addr.checked_sub(mapping.base)?).ok()?;
             (offset < mapping.region.len()).then_some((mapping, offset))
         })
@@ -547,10 +607,10 @@ impl GuestAddressSpace {
         let start = u64::from(addr);
         let len = len as u64;
         if len >= ADDRESS_SPACE_SIZE {
-            return !self.shared_regions.is_empty();
+            return !self.state().shared_regions.is_empty();
         }
         let end = start + len;
-        self.shared_regions.iter().any(|mapping| {
+        self.state().shared_regions.iter().any(|mapping| {
             let mapping_start = u64::from(mapping.base);
             let mapping_end = mapping_start.saturating_add(mapping.region.len() as u64);
             if end <= ADDRESS_SPACE_SIZE {
@@ -570,14 +630,14 @@ impl PpcMemory for GuestAddressSpace {
             // serialize both adapters for the mapping's complete lifetime.
             unsafe { region.read(offset) }
         } else {
-            self.regions.read_u8(addr)
+            self.state_mut().regions.read_u8(addr)
         }
     }
 
     #[inline]
     fn read_u16_be(&mut self, addr: u32) -> Option<u16> {
         if !self.shared_overlaps(addr, 2) {
-            return self.regions.read_u16_be(addr);
+            return self.state_mut().regions.read_u16_be(addr);
         }
         let mut bytes = [0; 2];
         self.read_bytes_into(addr, &mut bytes)?;
@@ -587,7 +647,7 @@ impl PpcMemory for GuestAddressSpace {
     #[inline]
     fn read_u32_be(&mut self, addr: u32) -> Option<u32> {
         if !self.shared_overlaps(addr, 4) {
-            return self.regions.read_u32_be(addr);
+            return self.state_mut().regions.read_u32_be(addr);
         }
         let mut bytes = [0; 4];
         self.read_bytes_into(addr, &mut bytes)?;
@@ -597,7 +657,7 @@ impl PpcMemory for GuestAddressSpace {
     #[inline]
     fn read_u64_be(&mut self, addr: u32) -> Option<u64> {
         if !self.shared_overlaps(addr, 8) {
-            return self.regions.read_u64_be(addr);
+            return self.state_mut().regions.read_u64_be(addr);
         }
         let mut bytes = [0; 8];
         self.read_bytes_into(addr, &mut bytes)?;
@@ -609,7 +669,7 @@ impl PpcMemory for GuestAddressSpace {
         if self.shared_overlaps(addr, 4) {
             self.read_u32_be(addr)
         } else {
-            self.regions.read_instruction_u32_be(addr)
+            self.state_mut().regions.read_instruction_u32_be(addr)
         }
     }
 
@@ -618,7 +678,7 @@ impl PpcMemory for GuestAddressSpace {
         if self.shared_overlaps(addr, 4) {
             None
         } else {
-            self.regions.instruction_cache_token(addr)
+            self.state_mut().regions.instruction_cache_token(addr)
         }
     }
 
@@ -632,14 +692,14 @@ impl PpcMemory for GuestAddressSpace {
             // serialize both adapters for the mapping's complete lifetime.
             unsafe { mapping.region.write(offset, value) }
         } else {
-            self.regions.write_u8(addr, value)
+            self.state_mut().regions.write_u8(addr, value)
         }
     }
 
     #[inline]
     fn write_u16_be(&mut self, addr: u32, value: u16) -> Option<()> {
         if !self.shared_overlaps(addr, 2) {
-            return self.regions.write_u16_be(addr, value);
+            return self.state_mut().regions.write_u16_be(addr, value);
         }
         self.write_bytes(addr, &value.to_be_bytes())
     }
@@ -647,7 +707,7 @@ impl PpcMemory for GuestAddressSpace {
     #[inline]
     fn write_u32_be(&mut self, addr: u32, value: u32) -> Option<()> {
         if !self.shared_overlaps(addr, 4) {
-            return self.regions.write_u32_be(addr, value);
+            return self.state_mut().regions.write_u32_be(addr, value);
         }
         self.write_bytes(addr, &value.to_be_bytes())
     }
@@ -655,7 +715,7 @@ impl PpcMemory for GuestAddressSpace {
     #[inline]
     fn write_u64_be(&mut self, addr: u32, value: u64) -> Option<()> {
         if !self.shared_overlaps(addr, 8) {
-            return self.regions.write_u64_be(addr, value);
+            return self.state_mut().regions.write_u64_be(addr, value);
         }
         self.write_bytes(addr, &value.to_be_bytes())
     }
@@ -902,7 +962,7 @@ mod tests {
     }
 
     #[test]
-    fn parked_process_mappings_temporarily_extend_the_68k_bus() {
+    fn process_mappings_remain_attached_until_explicitly_replaced() {
         const FLAT: u32 = 0x2000;
         const SPARSE: u32 = 0x0100_0000;
         const READ_ONLY: u32 = SPARSE + 0x100;
@@ -913,12 +973,8 @@ mod tests {
         memory.add_region(SPARSE, vec![0x55, 0x66, 0x77, 0x88, 0, 0, 0, 0, 0, 0, 0, 0]);
         memory.add_readonly_region(READ_ONLY, 0x99aa_bbccu32.to_be_bytes().to_vec());
 
-        // SAFETY: the test keeps `memory` in place, performs no direct access
-        // while attached, and detaches before using it again.
-        let shared = unsafe { memory.shared_view() };
-        unsafe {
-            bus.attach_guest_address_space(shared);
-        }
+        let shared = memory.shared_view();
+        bus.attach_guest_address_space(shared);
         assert_eq!(MemoryBus::read_long(&bus, FLAT), 0x1122_3344);
         assert_eq!(MemoryBus::read_long(&bus, SPARSE), 0x5566_7788);
         MemoryBus::write_long(&mut bus, SPARSE, 0xdead_beef);
@@ -950,6 +1006,31 @@ mod tests {
     }
 
     #[test]
+    fn shared_process_view_survives_moves_while_clones_remain_detached() {
+        const SPARSE: u32 = 0x0100_0000;
+
+        let mut memory = GuestAddressSpace::new();
+        memory.add_region(SPARSE, 0x1122_3344u32.to_be_bytes().to_vec());
+        let mut detached = memory.clone();
+        let shared = memory.shared_view();
+        let mut moved = memory;
+
+        let mut bus = MacMemoryBus::new(64 * 1024);
+        bus.attach_guest_address_space(shared);
+        assert_eq!(MemoryBus::read_long(&bus, SPARSE), 0x1122_3344);
+
+        MemoryBus::write_long(&mut bus, SPARSE, 0x5566_7788);
+        assert_eq!(PpcMemory::read_u32_be(&mut moved, SPARSE), Some(0x5566_7788));
+        assert_eq!(PpcMemory::read_u32_be(&mut detached, SPARSE), Some(0x1122_3344));
+
+        PpcMemory::write_u32_be(&mut detached, SPARSE, 0x99aa_bbcc).unwrap();
+        assert_eq!(MemoryBus::read_long(&bus, SPARSE), 0x5566_7788);
+
+        drop(moved);
+        assert_eq!(MemoryBus::read_long(&bus, SPARSE), 0x5566_7788);
+    }
+
+    #[test]
     fn shared_view_distinguishes_ordinary_sparse_mappings_from_overlays() {
         let mut memory = GuestAddressSpace::new();
         memory.add_region(0x2000, vec![0; 0x100]);
@@ -960,15 +1041,13 @@ mod tests {
             memory.add_shared_region(0x0000, shared_region);
         }
 
-        let shared = unsafe { memory.shared_view() };
-        unsafe {
-            // Shared overlays are not ordinary sparse mappings.
-            assert!(!shared.is_ordinary_sparse_mapped(0x0500));
-            // Native heap regions are ordinary sparse mappings.
-            assert!(shared.is_ordinary_sparse_mapped(0x2050));
-            // Unmapped addresses belong to neither domain.
-            assert!(!shared.is_ordinary_sparse_mapped(0x9000));
-        }
+        let shared = memory.shared_view();
+        // Shared overlays are not ordinary sparse mappings.
+        assert!(!shared.is_ordinary_sparse_mapped(0x0500));
+        // Native heap regions are ordinary sparse mappings.
+        assert!(shared.is_ordinary_sparse_mapped(0x2050));
+        // Unmapped addresses belong to neither domain.
+        assert!(!shared.is_ordinary_sparse_mapped(0x9000));
     }
 
     #[test]

--- a/src/memory/bus.rs
+++ b/src/memory/bus.rs
@@ -722,9 +722,9 @@ pub struct MacMemoryBus {
     /// no guest code runs, so unbounded growth is impossible and overflow
     /// must not void the check).
     write_probe_uncapped: bool,
-    /// Temporary sparse-memory view used only while a parked native process
-    /// runs its emulated 68k context. The runner installs and removes this
-    /// view around each serialized execution interval.
+    /// Process-lifetime view of the native process's ordinary sparse mappings.
+    /// The runner replaces it when launching a different process and
+    /// serializes access between CPU adapters.
     foreign_address_space: Option<SharedGuestAddressSpace>,
 }
 
@@ -1273,11 +1273,13 @@ impl MacMemoryBus {
         }
         #[cfg(debug_assertions)]
         let fast = !WATCHPOINT_ARMED.load(Ordering::Relaxed)
-            && self.foreign_address_space.is_none()
+            && !self.foreign_ordinary_sparse_overlaps(src, count as usize)
+            && !self.foreign_ordinary_sparse_overlaps(dst, count as usize)
             && fb_write_trace_range().is_none()
             && self.write_probe_original.is_none();
         #[cfg(not(debug_assertions))]
-        let fast = self.foreign_address_space.is_none()
+        let fast = !self.foreign_ordinary_sparse_overlaps(src, count as usize)
+            && !self.foreign_ordinary_sparse_overlaps(dst, count as usize)
             && fb_write_trace_range().is_none()
             && self.write_probe_original.is_none();
         let count_usize = count as usize;
@@ -1445,14 +1447,8 @@ impl MacMemoryBus {
         }
     }
 
-    /// Attach one parked process's sparse mappings for a serialized 68k run.
-    ///
-    /// # Safety
-    ///
-    /// `memory` must remain alive and unmoved until
-    /// [`Self::detach_guest_address_space`] is called, and no other adapter
-    /// may access it during that interval.
-    pub(crate) unsafe fn attach_guest_address_space(&mut self, memory: SharedGuestAddressSpace) {
+    /// Retain one native process's sparse mappings for serialized cross-ISA access.
+    pub(crate) fn attach_guest_address_space(&mut self, memory: SharedGuestAddressSpace) {
         debug_assert!(self.foreign_address_space.is_none());
         self.foreign_address_space = Some(memory);
     }
@@ -1465,33 +1461,41 @@ impl MacMemoryBus {
     /// ordinary sparse regions (and not in a shared flat-RAM overlay).
     #[inline]
     pub(crate) fn is_foreign_ordinary_sparse_address(&self, address: u32) -> bool {
-        let Some(foreign) = self.foreign_address_space else {
+        let Some(foreign) = self.foreign_address_space.as_ref() else {
             return false;
         };
-        // SAFETY: see `foreign_read_u8`.
-        unsafe { foreign.is_ordinary_sparse_mapped(address) }
+        foreign.is_ordinary_sparse_mapped(address)
+    }
+
+    #[inline]
+    fn foreign_ordinary_sparse_overlaps(&self, address: u32, len: usize) -> bool {
+        let Some(foreign) = self.foreign_address_space.as_ref() else {
+            return false;
+        };
+        let Ok(len) = u32::try_from(len) else {
+            return true;
+        };
+        foreign.ordinary_mapping_overlaps(self.translate_guest_address(address), len)
     }
 
     /// Return the end of a read-only process mapping that overlaps a proposed
-    /// native heap allocation while the owning PowerPC process is parked.
+    /// native heap allocation while the owning PowerPC process is resident.
     pub(crate) fn foreign_readonly_allocation_overlap_end(
         &self,
         address: u32,
         len: u32,
     ) -> Option<u32> {
-        let foreign = self.foreign_address_space?;
-        // SAFETY: see `foreign_read_u8`.
-        unsafe { foreign.readonly_allocation_overlap_end(address, len) }
+        let foreign = self.foreign_address_space.as_ref()?;
+        foreign.readonly_allocation_overlap_end(address, len)
     }
 
-    /// Write bytes exclusively through the parked process address space.
+    /// Write bytes exclusively through the retained process address space.
     pub(crate) fn write_foreign_bytes(&mut self, address: u32, bytes: &[u8]) -> Option<()> {
-        let foreign = self.foreign_address_space?;
-        // SAFETY: see `foreign_read_u8`.
-        unsafe { foreign.write_bytes(address, bytes) }
+        let foreign = self.foreign_address_space.as_ref()?;
+        foreign.write_bytes(address, bytes)
     }
 
-    /// Exclusively operate on the parked process address space.
+    /// Exclusively operate on the retained process address space.
     ///
     /// The attachment contract serializes the native adapter while the 68K
     /// bus is active, and the mutable bus borrow prevents overlapping access
@@ -1500,78 +1504,63 @@ impl MacMemoryBus {
         &mut self,
         f: impl FnOnce(&mut GuestAddressSpace) -> R,
     ) -> Option<R> {
-        let foreign = self.foreign_address_space?;
-        // SAFETY: `attach_guest_address_space` requires an exclusive,
-        // serialized interval and `self` is mutably borrowed for the closure.
-        unsafe { foreign.with_mut(f) }
+        let foreign = self.foreign_address_space.as_ref()?;
+        Some(foreign.with_mut(f))
     }
 
     #[inline]
     fn foreign_read_u8(&self, address: u32) -> Option<u8> {
-        let memory = self.foreign_address_space?;
-        // SAFETY: attachment requires the runner to serialize the parked
-        // native process with this bus.
-        unsafe { memory.read_u8(address) }
+        let memory = self.foreign_address_space.as_ref()?;
+        memory.read_u8(address)
     }
 
     #[inline]
     fn foreign_read_u16(&self, address: u32) -> Option<u16> {
-        let memory = self.foreign_address_space?;
-        // SAFETY: see `foreign_read_u8`.
-        unsafe { memory.read_u16_be(address) }
+        let memory = self.foreign_address_space.as_ref()?;
+        memory.read_u16_be(address)
     }
 
     #[inline]
     fn foreign_read_u32(&self, address: u32) -> Option<u32> {
-        let memory = self.foreign_address_space?;
-        // SAFETY: see `foreign_read_u8`.
-        unsafe { memory.read_u32_be(address) }
+        let memory = self.foreign_address_space.as_ref()?;
+        memory.read_u32_be(address)
     }
 
     #[inline]
     fn foreign_write_u8_if_mapped(&mut self, address: u32, value: u8) -> bool {
-        let Some(memory) = self.foreign_address_space else {
+        let Some(memory) = self.foreign_address_space.as_ref() else {
             return false;
         };
         // A readable but non-writable mapping is still authoritative: ignore
         // the store instead of falling through into same-address flat RAM.
-        // SAFETY: see `attach_guest_address_space`.
-        unsafe {
-            if memory.read_u8(address).is_none() {
-                return false;
-            }
-            let _ = memory.write_u8(address, value);
+        if memory.read_u8(address).is_none() {
+            return false;
         }
+        let _ = memory.write_u8(address, value);
         true
     }
 
     #[inline]
     fn foreign_write_u16_if_mapped(&mut self, address: u32, value: u16) -> bool {
-        let Some(memory) = self.foreign_address_space else {
+        let Some(memory) = self.foreign_address_space.as_ref() else {
             return false;
         };
-        // SAFETY: see `attach_guest_address_space`.
-        unsafe {
-            if memory.read_u16_be(address).is_none() {
-                return false;
-            }
-            let _ = memory.write_u16_be(address, value);
+        if memory.read_u16_be(address).is_none() {
+            return false;
         }
+        let _ = memory.write_u16_be(address, value);
         true
     }
 
     #[inline]
     fn foreign_write_u32_if_mapped(&mut self, address: u32, value: u32) -> bool {
-        let Some(memory) = self.foreign_address_space else {
+        let Some(memory) = self.foreign_address_space.as_ref() else {
             return false;
         };
-        // SAFETY: see `attach_guest_address_space`.
-        unsafe {
-            if memory.read_u32_be(address).is_none() {
-                return false;
-            }
-            let _ = memory.write_u32_be(address, value);
+        if memory.read_u32_be(address).is_none() {
+            return false;
         }
+        let _ = memory.write_u32_be(address, value);
         true
     }
 
@@ -1849,7 +1838,9 @@ impl MacMemoryBus {
     /// tracing are active so diagnostics still observe each destination byte.
     #[inline]
     pub fn copy_ram_bytes(&mut self, src: u32, dst: u32, len: u32) -> bool {
-        if self.foreign_address_space.is_some() {
+        if self.foreign_ordinary_sparse_overlaps(src, len as usize)
+            || self.foreign_ordinary_sparse_overlaps(dst, len as usize)
+        {
             self.block_move(src, dst, len);
             return true;
         }
@@ -1895,7 +1886,9 @@ impl MacMemoryBus {
     /// translation without allocating a scratch row.
     #[inline]
     pub fn copy_mapped_ram_bytes(&mut self, src: u32, dst: u32, len: u32, map: &[u8; 256]) -> bool {
-        if self.foreign_address_space.is_some() {
+        if self.foreign_ordinary_sparse_overlaps(src, len as usize)
+            || self.foreign_ordinary_sparse_overlaps(dst, len as usize)
+        {
             if dst > src && dst < src.saturating_add(len) {
                 for offset in (0..len).rev() {
                     let value = map[self.read_byte(src.wrapping_add(offset)) as usize];
@@ -2117,7 +2110,7 @@ impl MemoryBus for MacMemoryBus {
             maybe_log_mem_read(address, 2, value as u32);
             return value;
         }
-        if self.foreign_address_space.is_some() {
+        if self.foreign_ordinary_sparse_overlaps(foreign_address, 2) {
             let value = (u16::from(self.read_byte(address)) << 8)
                 | u16::from(self.read_byte(address.wrapping_add(1)));
             maybe_log_mem_read(address, 2, value as u32);
@@ -2147,7 +2140,7 @@ impl MemoryBus for MacMemoryBus {
             maybe_log_mem_read(address, 4, value);
             return value;
         }
-        if self.foreign_address_space.is_some() {
+        if self.foreign_ordinary_sparse_overlaps(foreign_address, 4) {
             let value = (u32::from(self.read_word(address)) << 16)
                 | u32::from(self.read_word(address.wrapping_add(2)));
             maybe_log_mem_read(address, 4, value);
@@ -2354,11 +2347,11 @@ impl MemoryBus for MacMemoryBus {
         // Fast path: watchpoint disarmed + tracer disabled + write fully in-bounds.
         #[cfg(debug_assertions)]
         let fast = !WATCHPOINT_ARMED.load(Ordering::Relaxed)
-            && self.foreign_address_space.is_none()
+            && !self.foreign_ordinary_sparse_overlaps(protected_address, 2)
             && fb_write_trace_range().is_none()
             && self.write_probe_original.is_none();
         #[cfg(not(debug_assertions))]
-        let fast = self.foreign_address_space.is_none()
+        let fast = !self.foreign_ordinary_sparse_overlaps(protected_address, 2)
             && fb_write_trace_range().is_none()
             && self.write_probe_original.is_none();
         if let Some(address) =
@@ -2397,11 +2390,11 @@ impl MemoryBus for MacMemoryBus {
 
         #[cfg(debug_assertions)]
         let fast = !WATCHPOINT_ARMED.load(Ordering::Relaxed)
-            && self.foreign_address_space.is_none()
+            && !self.foreign_ordinary_sparse_overlaps(protected_address, 4)
             && fb_write_trace_range().is_none()
             && self.write_probe_original.is_none();
         #[cfg(not(debug_assertions))]
-        let fast = self.foreign_address_space.is_none()
+        let fast = !self.foreign_ordinary_sparse_overlaps(protected_address, 4)
             && fb_write_trace_range().is_none()
             && self.write_probe_original.is_none();
         if let Some(address) =
@@ -2427,7 +2420,7 @@ impl MemoryBus for MacMemoryBus {
     /// that pulls more than a few bytes at once.
     #[inline]
     fn read_bytes(&self, address: u32, len: usize) -> Vec<u8> {
-        if self.foreign_address_space.is_some() {
+        if self.foreign_ordinary_sparse_overlaps(address, len) {
             return (0..len)
                 .map(|offset| self.read_byte(address.wrapping_add(offset as u32)))
                 .collect();
@@ -2453,7 +2446,7 @@ impl MemoryBus for MacMemoryBus {
     /// copying twice per row.
     #[inline]
     fn read_bytes_into(&self, address: u32, dst: &mut [u8]) {
-        if self.foreign_address_space.is_some() {
+        if self.foreign_ordinary_sparse_overlaps(address, dst.len()) {
             for (offset, byte) in dst.iter_mut().enumerate() {
                 *byte = self.read_byte(address.wrapping_add(offset as u32));
             }
@@ -2480,7 +2473,7 @@ impl MemoryBus for MacMemoryBus {
     /// trigger; same for the FB-write tracer.
     #[inline]
     fn write_bytes(&mut self, address: u32, data: &[u8]) {
-        if self.foreign_address_space.is_some() {
+        if self.foreign_ordinary_sparse_overlaps(address, data.len()) {
             for (offset, byte) in data.iter().copied().enumerate() {
                 self.write_byte(address.wrapping_add(offset as u32), byte);
             }
@@ -2517,7 +2510,7 @@ impl MemoryBus for MacMemoryBus {
 
     #[inline]
     fn fill_zeros(&mut self, address: u32, len: u32) {
-        if self.foreign_address_space.is_some() {
+        if self.foreign_ordinary_sparse_overlaps(address, len as usize) {
             for offset in 0..len {
                 self.write_byte(address.wrapping_add(offset), 0);
             }
@@ -2564,13 +2557,15 @@ impl MemoryBus for MacMemoryBus {
         if count == 0 {
             return;
         }
-        if self.foreign_address_space.is_some() {
+        let span = u64::from(stride) * u64::from(count - 1) + 1;
+        if span > usize::MAX as u64
+            || self.foreign_ordinary_sparse_overlaps(address, span as usize)
+        {
             for offset in 0..count {
                 self.write_byte(address.wrapping_add(offset.wrapping_mul(stride)), value);
             }
             return;
         }
-        let span = u64::from(stride) * u64::from(count - 1) + 1;
         #[cfg(debug_assertions)]
         let fast = !WATCHPOINT_ARMED.load(Ordering::Relaxed)
             && fb_write_trace_range().is_none()
@@ -2600,7 +2595,7 @@ impl MemoryBus for MacMemoryBus {
 
     #[inline]
     fn fill_bytes(&mut self, address: u32, len: u32, value: u8) {
-        if self.foreign_address_space.is_some() {
+        if self.foreign_ordinary_sparse_overlaps(address, len as usize) {
             for offset in 0..len {
                 self.write_byte(address.wrapping_add(offset), value);
             }
@@ -3508,10 +3503,8 @@ mod tests {
             memory.add_shared_region(0x0000, shared_region);
         }
 
-        let shared = unsafe { memory.shared_view() };
-        unsafe {
-            bus.attach_guest_address_space(shared);
-        }
+        let shared = memory.shared_view();
+        bus.attach_guest_address_space(shared);
 
         assert!(!bus.is_foreign_ordinary_sparse_address(0x0500));
         assert!(bus.is_foreign_ordinary_sparse_address(0x2050));

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -3973,8 +3973,8 @@ mod tests {
         )]);
 
         let mut bus = MacMemoryBus::new(0x2000);
-        let shared = unsafe { native.shared_view() };
-        unsafe { bus.attach_guest_address_space(shared) };
+        let shared = native.shared_view();
+        bus.attach_guest_address_space(shared);
         let replacement = vec![0x5a; 48];
         let relocated = manager
             .replace_native_handle_bytes(&mut bus, handle, old_ptr, &replacement)
@@ -4036,8 +4036,8 @@ mod tests {
         )]);
 
         let mut bus = MacMemoryBus::new(0x2000);
-        let shared = unsafe { native.shared_view() };
-        unsafe { bus.attach_guest_address_space(shared) };
+        let shared = native.shared_view();
+        bus.attach_guest_address_space(shared);
         manager.attach_classic_memory_bus(&mut bus);
 
         assert_eq!(
@@ -4092,8 +4092,8 @@ mod tests {
         manager.register_native_handle_records([(record, 0xE0)]);
 
         let mut bus = MacMemoryBus::new(0x2000);
-        let shared = unsafe { native.shared_view() };
-        unsafe { bus.attach_guest_address_space(shared) };
+        let shared = native.shared_view();
+        bus.attach_guest_address_space(shared);
         manager.attach_classic_memory_bus(&mut bus);
 
         assert_eq!(
@@ -4149,8 +4149,8 @@ mod tests {
         manager.register_native_handle_records([(original, 0)]);
 
         let mut bus = MacMemoryBus::new(0x2000);
-        let shared = unsafe { native.shared_view() };
-        unsafe { bus.attach_guest_address_space(shared) };
+        let shared = native.shared_view();
+        bus.attach_guest_address_space(shared);
         assert_eq!(
             manager.replace_native_handle_bytes(&mut bus, handle, old_ptr, &[0x5a; 48]),
             Err(ProcessMemoryManager::MEM_FULL_ERR)
@@ -4200,8 +4200,8 @@ mod tests {
         manager.register_native_handle_records([(original, 0xE0)]);
 
         let mut bus = MacMemoryBus::new(0x2000);
-        let shared = unsafe { native.shared_view() };
-        unsafe { bus.attach_guest_address_space(shared) };
+        let shared = native.shared_view();
+        bus.attach_guest_address_space(shared);
         manager.attach_classic_memory_bus(&mut bus);
 
         assert_eq!(
@@ -4291,8 +4291,8 @@ mod tests {
         );
 
         let mut bus = MacMemoryBus::new(0x2000);
-        let shared = unsafe { native.shared_view() };
-        unsafe { bus.attach_guest_address_space(shared) };
+        let shared = native.shared_view();
+        bus.attach_guest_address_space(shared);
         manager.attach_classic_memory_bus(&mut bus);
         assert_eq!(
             manager.reallocate_process_handle(&mut bus, handle, 17),
@@ -4595,8 +4595,8 @@ mod tests {
             &[],
         );
         let mut bus = MacMemoryBus::new(0x2000);
-        let shared = unsafe { native.shared_view() };
-        unsafe { bus.attach_guest_address_space(shared) };
+        let shared = native.shared_view();
+        bus.attach_guest_address_space(shared);
 
         let handle = manager.new_native_handle(&mut native, 24, true);
         let record = manager.native_allocation(handle).unwrap();
@@ -4628,8 +4628,8 @@ mod tests {
             &[],
         );
         let mut bus = MacMemoryBus::new(0x2000);
-        let shared = unsafe { native.shared_view() };
-        unsafe { bus.attach_guest_address_space(shared) };
+        let shared = native.shared_view();
+        bus.attach_guest_address_space(shared);
 
         let handle = manager.copy_bytes_to_new_native_handle(&mut native, b"native");
         let original = manager.native_allocation(handle).unwrap();
@@ -4673,8 +4673,8 @@ mod tests {
             &[],
         );
         let mut bus = MacMemoryBus::new(0x2000);
-        let shared = unsafe { native.shared_view() };
-        unsafe { bus.attach_guest_address_space(shared) };
+        let shared = native.shared_view();
+        bus.attach_guest_address_space(shared);
 
         let unloaded = manager.new_native_resource_handle(&mut native, None);
         assert_ne!(unloaded, 0);

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -3277,6 +3277,7 @@ impl FixtureRunner {
             return;
         }
 
+        self.bus.detach_guest_address_space();
         self.ppc_app = None;
         self.ppc_sound_synced_file_playback_count = 0;
         self.ppc_sound_host_playbacks.clear();
@@ -3667,6 +3668,7 @@ impl FixtureRunner {
     fn init_ppc_app(&mut self, mut ppc_app: PpcLoadedApp) {
         use crate::memory::globals::addr;
 
+        self.bus.detach_guest_address_space();
         self.adopt_ppc_process_memory_image(&mut ppc_app);
         // These are process launch defaults, not PEF-loader state. Reapply
         // them after adopting a sparse construction image so a synthetic
@@ -3749,6 +3751,8 @@ impl FixtureRunner {
         self.cpu.write_reg(Register::PC, 0);
         self.ppc_sound_synced_file_playback_count = 0;
         self.ppc_sound_host_playbacks.clear();
+        self.bus
+            .attach_guest_address_space(ppc_app.memory.shared_view());
         self.ppc_app = Some(ppc_app);
     }
 
@@ -6132,14 +6136,6 @@ impl FixtureRunner {
             return Some((0, true));
         }
 
-        // SAFETY: `ppc_app` is parked for this whole interval. The address
-        // space remains in place, and all reads and writes are serialized
-        // through this runner until the bus is detached below.
-        let shared_memory = unsafe { ppc_app.memory.shared_view() };
-        unsafe {
-            self.bus.attach_guest_address_space(shared_memory);
-        }
-
         let mut executed = 0usize;
         let mut running = true;
         while executed < max_steps {
@@ -6204,7 +6200,6 @@ impl FixtureRunner {
                 }
             }
         }
-        self.bus.detach_guest_address_space();
         Some((executed, running))
     }
 
@@ -12271,17 +12266,11 @@ mod tests {
         assert_eq!(ppc_app.memory.read_u32_be(SECOND_HOLE), Some(0x0506_0708));
 
         assert_eq!(ppc_app.memory.read_u32_be(PEF_MAPPING), Some(0x1234_5678));
-        // SAFETY: the test parks `ppc_app`, accesses it only through the bus
-        // while attached, and detaches before borrowing its memory again.
-        let shared = unsafe { ppc_app.memory.shared_view() };
-        unsafe {
-            runner.bus.attach_guest_address_space(shared);
-        }
+        // Ordinary PEF mappings stay authoritative for the process lifetime,
+        // including while the native adapter is parked outside execution.
         assert_eq!(runner.bus.read_long(PEF_MAPPING), 0x1234_5678);
         runner.bus.write_long(PEF_MAPPING, 0);
         assert_eq!(runner.bus.read_long(PEF_MAPPING), 0x1234_5678);
-        runner.bus.detach_guest_address_space();
-        assert_eq!(runner.bus.read_long(PEF_MAPPING), 0xaabb_ccdd);
         assert_eq!(ppc_app.memory.read_u32_be(PEF_MAPPING), Some(0x1234_5678));
     }
 
@@ -14054,7 +14043,7 @@ mod tests {
         assert_eq!(ppc_app.cpu.gpr[3], 41);
         assert_eq!(ppc_app.cpu.pc, PPC_CODE_BASE);
         assert_eq!(ppc_app.cpu.lr, PPC_CODE_BASE);
-        assert_eq!(runner.bus.read_long(RESULT), 0);
+        assert_eq!(runner.bus.read_long(RESULT), 41);
     }
 
     #[test]

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -11281,8 +11281,8 @@ mod tests {
         }
 
         let mut bus = MacMemoryBus::new(0x2000);
-        let shared = unsafe { native.shared_view() };
-        unsafe { bus.attach_guest_address_space(shared) };
+        let shared = native.shared_view();
+        bus.attach_guest_address_space(shared);
         let mut dispatcher = TrapDispatcher::new();
         dispatcher.attach_process_context(&mut context);
         let replacement = vec![0x5a; 48];

--- a/src/trap/memory.rs
+++ b/src/trap/memory.rs
@@ -4618,8 +4618,8 @@ mod tests {
         let (mut dispatcher, mut cpu, mut bus) = setup();
         let mut native = GuestAddressSpace::new();
         native.add_region(HEAP_BASE, vec![0; 0x1000]);
-        let shared = unsafe { native.shared_view() };
-        unsafe { bus.attach_guest_address_space(shared) };
+        let shared = native.shared_view();
+        bus.attach_guest_address_space(shared);
         bus.write_long(handle, old_ptr);
         bus.write_bytes(old_ptr, b"original");
 
@@ -4691,8 +4691,8 @@ mod tests {
         let (mut dispatcher, mut cpu, mut bus) = setup();
         let mut native = GuestAddressSpace::new();
         native.add_region(HEAP_BASE, vec![0; 0x1000]);
-        let shared = unsafe { native.shared_view() };
-        unsafe { bus.attach_guest_address_space(shared) };
+        let shared = native.shared_view();
+        bus.attach_guest_address_space(shared);
         bus.write_long(handle, old_ptr);
         bus.write_bytes(old_ptr, b"original");
 
@@ -4766,8 +4766,8 @@ mod tests {
         let (mut dispatcher, mut cpu, mut bus) = setup();
         let mut native = GuestAddressSpace::new();
         native.add_region(HEAP_BASE, vec![0; 0x1000]);
-        let shared = unsafe { native.shared_view() };
-        unsafe { bus.attach_guest_address_space(shared) };
+        let shared = native.shared_view();
+        bus.attach_guest_address_space(shared);
         bus.write_long(handle, old_ptr);
         bus.write_bytes(old_ptr, b"original");
 
@@ -4850,8 +4850,8 @@ mod tests {
         let (mut dispatcher, mut cpu, mut bus) = setup();
         let mut native = GuestAddressSpace::new();
         native.add_region(HEAP_BASE, vec![0; 0x1000]);
-        let shared = unsafe { native.shared_view() };
-        unsafe { bus.attach_guest_address_space(shared) };
+        let shared = native.shared_view();
+        bus.attach_guest_address_space(shared);
         bus.write_long(handle, ptr);
         bus.write_bytes(ptr, b"original");
 
@@ -4918,8 +4918,8 @@ mod tests {
         let (mut dispatcher, mut cpu, mut bus) = setup();
         let mut native = GuestAddressSpace::new();
         native.add_region(HEAP_BASE, vec![0; 0x2000]);
-        let shared = unsafe { native.shared_view() };
-        unsafe { bus.attach_guest_address_space(shared) };
+        let shared = native.shared_view();
+        bus.attach_guest_address_space(shared);
         bus.write_long(SOURCE_HANDLE, SOURCE_PTR);
         bus.write_bytes(SOURCE_PTR, b"native");
 

--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -9525,8 +9525,8 @@ mod tests {
             .expect("test RAM should be shareable");
         let mut native = GuestAddressSpace::new();
         context.attach_memory(0, shared, &mut native);
-        let foreign = unsafe { native.shared_view() };
-        unsafe { bus.attach_guest_address_space(foreign) };
+        let foreign = native.shared_view();
+        bus.attach_guest_address_space(foreign);
         disp.attach_process_context(&mut context);
 
         let memory_manager = disp.process_memory_manager();


### PR DESCRIPTION
## Summary

- give shared CPU adapters a stable process-lifetime view of native mappings
- retain ordinary PEF mappings across serialized ISA switches while shared runner RAM keeps overlay priority
- preserve detached clone isolation and native mapping precedence

## Validation

- `cargo test --locked --lib --quiet` (4,737 passed, 3 ignored)
- `RUSTDOCFLAGS='-D warnings -D rustdoc::private_intra_doc_links' cargo doc --all-features --locked --no-deps --document-private-items`
- `cargo build --all-targets --all-features --locked`
- Marathon scripted gameplay
- Escape Velocity scripted gameplay
- Tomb Raider Gold scripted gameplay

Closes #1185
Advances #1076.
