### PR TITLE
refactor(files): attach classic catalog to process state

### DIFF
--- a/src/game/launch.rs
+++ b/src/game/launch.rs
@@ -3025,8 +3025,8 @@ fn ppc_diagnostic_vfs(
         files,
         resource_files,
         resources,
-        default_dir_id: dispatcher.default_dir_id,
-        next_dir_id: dispatcher.next_vfs_dir_id,
+        default_dir_id: *dispatcher.default_dir_id,
+        next_dir_id: *dispatcher.next_vfs_dir_id,
     }
 }
 

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -217,6 +217,24 @@ pub struct ProcessVfsVolumeRecord {
     pub modified_date: u32,
 }
 
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ProcessVfsMetadata {
+    pub file_id: u32,
+    pub parent_dir_id: u32,
+    pub file_type: u32,
+    pub creator: u32,
+    pub finder_flags: u16,
+    pub created_date: u32,
+    pub modified_date: u32,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ProcessClassicVfsDirectory {
+    pub dir_id: u32,
+    pub parent_dir_id: u32,
+    pub name: String,
+}
+
 /// Native record index backed by the canonical process data-fork map.
 #[derive(Debug, Default)]
 pub(crate) struct ProcessVfsFileRecords {
@@ -532,6 +550,16 @@ pub struct ProcessFileSystemState {
     pub(crate) vfs_directories: Vec<ProcessVfsDirectory>,
     pub(crate) next_vfs_dir_id: u32,
     pub(crate) default_dir_id: u32,
+    pub(crate) classic_vfs_metadata:
+        SharedProcessValue<HashMap<String, ProcessVfsMetadata>>,
+    pub(crate) classic_vfs_directories:
+        SharedProcessValue<HashMap<String, ProcessClassicVfsDirectory>>,
+    pub(crate) classic_vfs_directory_paths: SharedProcessValue<HashMap<u32, String>>,
+    pub(crate) classic_vfs_volumes:
+        SharedProcessValue<HashMap<i16, ProcessVfsVolumeRecord>>,
+    pub(crate) classic_vfs_volume_names: SharedProcessValue<HashMap<String, i16>>,
+    pub(crate) classic_next_vfs_dir_id: SharedProcessValue<u32>,
+    pub(crate) classic_default_dir_id: SharedProcessValue<u32>,
     pub(crate) vfs_files: ProcessVfsFileRecords,
     pub(crate) deleted_vfs_file_paths: Vec<String>,
     pub(crate) resource_manager: SharedProcessResourceManager,
@@ -547,6 +575,13 @@ impl Default for ProcessFileSystemState {
             vfs_directories: Vec::new(),
             next_vfs_dir_id: 0,
             default_dir_id: 0,
+            classic_vfs_metadata: SharedProcessValue::default(),
+            classic_vfs_directories: SharedProcessValue::default(),
+            classic_vfs_directory_paths: SharedProcessValue::default(),
+            classic_vfs_volumes: SharedProcessValue::default(),
+            classic_vfs_volume_names: SharedProcessValue::default(),
+            classic_next_vfs_dir_id: SharedProcessValue::from_value(16),
+            classic_default_dir_id: SharedProcessValue::from_value(2),
             vfs_files: ProcessVfsFileRecords::default(),
             deleted_vfs_file_paths: Vec::new(),
             resource_manager: SharedProcessResourceManager::default(),
@@ -730,6 +765,12 @@ impl<T> std::ops::DerefMut for SharedProcessValue<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         // SAFETY: see `Deref`.
         unsafe { &mut *self.0.get() }
+    }
+}
+
+impl<T> SharedProcessValue<T> {
+    pub(crate) fn from_value(value: T) -> Self {
+        Self(Rc::new(UnsafeCell::new(value)))
     }
 }
 
@@ -3618,6 +3659,39 @@ impl ProcessContext {
         );
     }
 
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn attach_classic_vfs_catalogue(
+        &self,
+        metadata: &mut SharedProcessValue<HashMap<String, ProcessVfsMetadata>>,
+        directories: &mut SharedProcessValue<HashMap<String, ProcessClassicVfsDirectory>>,
+        directory_paths: &mut SharedProcessValue<HashMap<u32, String>>,
+        volumes: &mut SharedProcessValue<HashMap<i16, ProcessVfsVolumeRecord>>,
+        volume_names: &mut SharedProcessValue<HashMap<String, i16>>,
+        next_dir_id: &mut SharedProcessValue<u32>,
+        default_dir_id: &mut SharedProcessValue<u32>,
+    ) {
+        metadata.attach_to(&self.file_system.classic_vfs_metadata, HashMap::is_empty);
+        directories.attach_to(
+            &self.file_system.classic_vfs_directories,
+            HashMap::is_empty,
+        );
+        directory_paths.attach_to(
+            &self.file_system.classic_vfs_directory_paths,
+            HashMap::is_empty,
+        );
+        volumes.attach_to(&self.file_system.classic_vfs_volumes, HashMap::is_empty);
+        volume_names.attach_to(
+            &self.file_system.classic_vfs_volume_names,
+            HashMap::is_empty,
+        );
+        next_dir_id.attach_to(&self.file_system.classic_next_vfs_dir_id, |value| {
+            *value == 16
+        });
+        default_dir_id.attach_to(&self.file_system.classic_default_dir_id, |value| {
+            *value == 2
+        });
+    }
+
     /// Install a canonical process-memory allocation and attach a CPU
     /// address-space adapter to it.
     ///
@@ -4978,6 +5052,81 @@ mod tests {
         assert_eq!(detached_data.get("Existing").unwrap(), b"before");
         assert!(!detached_data.contains_key("Created"));
         assert!(detached_resources.is_empty());
+    }
+
+    #[test]
+    fn attached_classic_catalogues_share_mutations_while_clones_detach() {
+        let context = ProcessContext::default();
+        let mut first_metadata =
+            SharedProcessValue::<HashMap<String, ProcessVfsMetadata>>::default();
+        let mut first_directories =
+            SharedProcessValue::<HashMap<String, ProcessClassicVfsDirectory>>::default();
+        let mut first_directory_paths = SharedProcessValue::<HashMap<u32, String>>::default();
+        let mut first_volumes =
+            SharedProcessValue::<HashMap<i16, ProcessVfsVolumeRecord>>::default();
+        let mut first_volume_names = SharedProcessValue::<HashMap<String, i16>>::default();
+        let mut first_next_dir_id = SharedProcessValue::from_value(16);
+        let mut first_default_dir_id = SharedProcessValue::from_value(2);
+        first_directories.insert(
+            String::new(),
+            ProcessClassicVfsDirectory {
+                dir_id: 2,
+                parent_dir_id: 1,
+                name: "MacintoshHD".to_string(),
+            },
+        );
+        first_directory_paths.insert(2, String::new());
+
+        context.attach_classic_vfs_catalogue(
+            &mut first_metadata,
+            &mut first_directories,
+            &mut first_directory_paths,
+            &mut first_volumes,
+            &mut first_volume_names,
+            &mut first_next_dir_id,
+            &mut first_default_dir_id,
+        );
+
+        let mut second_metadata =
+            SharedProcessValue::<HashMap<String, ProcessVfsMetadata>>::default();
+        let mut second_directories =
+            SharedProcessValue::<HashMap<String, ProcessClassicVfsDirectory>>::default();
+        let mut second_directory_paths = SharedProcessValue::<HashMap<u32, String>>::default();
+        let mut second_volumes =
+            SharedProcessValue::<HashMap<i16, ProcessVfsVolumeRecord>>::default();
+        let mut second_volume_names = SharedProcessValue::<HashMap<String, i16>>::default();
+        let mut second_next_dir_id = SharedProcessValue::from_value(16);
+        let mut second_default_dir_id = SharedProcessValue::from_value(2);
+        context.attach_classic_vfs_catalogue(
+            &mut second_metadata,
+            &mut second_directories,
+            &mut second_directory_paths,
+            &mut second_volumes,
+            &mut second_volume_names,
+            &mut second_next_dir_id,
+            &mut second_default_dir_id,
+        );
+        let detached_directories = second_directories.clone();
+        let detached_default_dir_id = second_default_dir_id.clone();
+
+        first_directories.insert(
+            "Games".to_string(),
+            ProcessClassicVfsDirectory {
+                dir_id: 16,
+                parent_dir_id: 2,
+                name: "Games".to_string(),
+            },
+        );
+        first_directory_paths.insert(16, "Games".to_string());
+        *first_next_dir_id = 17;
+        *first_default_dir_id = 16;
+
+        assert!(second_directories.contains_key("Games"));
+        assert_eq!(second_directory_paths.get(&16).map(String::as_str), Some("Games"));
+        assert_eq!(*second_next_dir_id, 17);
+        assert_eq!(*second_default_dir_id, 16);
+        assert!(!detached_directories.contains_key("Games"));
+        assert_eq!(*detached_default_dir_id, 2);
     }
 
     #[test]

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -3038,7 +3038,7 @@ impl FixtureRunner {
         let vfs_volume_names = self.dispatcher.vfs_volume_names.clone();
         let next_vfs_volume_ref_num = self.dispatcher.next_vfs_volume_ref_num;
         let locked_files = self.dispatcher.locked_files.clone();
-        let next_vfs_dir_id = self.dispatcher.next_vfs_dir_id;
+        let next_vfs_dir_id = self.dispatcher.next_vfs_dir_id.clone();
         let next_vfs_file_id = self.dispatcher.next_vfs_file_id;
         let next_vfs_timestamp = self.dispatcher.next_vfs_timestamp;
         let next_working_dir_refnum = self.dispatcher.next_working_dir_refnum;
@@ -3187,7 +3187,7 @@ impl FixtureRunner {
             .copied()
             .unwrap_or(crate::trap::dispatch::VfsMetadata {
                 file_id: 0,
-                parent_dir_id: self.dispatcher.default_dir_id,
+                parent_dir_id: *self.dispatcher.default_dir_id,
                 file_type: u32::from_be_bytes(*b"APPL"),
                 creator: u32::from_be_bytes(*b"????"),
                 finder_flags: 0,
@@ -3217,7 +3217,7 @@ impl FixtureRunner {
             crate::trap::dispatch::BOOT_VOLUME_REF_NUM as u16,
         ); // vcbVRefNum
         self.bus
-            .write_long(vcb_ptr + 172, self.dispatcher.default_dir_id);
+            .write_long(vcb_ptr + 172, *self.dispatcher.default_dir_id);
 
         self.bus.write_long(addr::DEF_VCB_PTR, vcb_ptr);
         self.bus.write_word(addr::VCB_Q_HDR, 0);
@@ -3451,7 +3451,7 @@ impl FixtureRunner {
         // CurDirStore: directory ID of directory last opened (long)
         // SFSaveDisk: negative of volume reference number (word)
         // Inside Macintosh Volume IV, IV-72
-        let app_dir_id = self.dispatcher.default_dir_id;
+        let app_dir_id = *self.dispatcher.default_dir_id;
         self.bus.write_long(addr::CUR_DIR_STORE, app_dir_id);
         self.bus.write_word(
             addr::SF_SAVE_DISK,
@@ -3714,7 +3714,7 @@ impl FixtureRunner {
         self.bus.write_word(addr::MBAR_HEIGHT, 20);
         self.bus.write_byte(addr::SOUND_LEVEL, 1);
 
-        let app_dir_id = self.dispatcher.default_dir_id;
+        let app_dir_id = *self.dispatcher.default_dir_id;
         self.bus.write_long(addr::CUR_DIR_STORE, app_dir_id);
         self.bus.write_word(
             addr::SF_SAVE_DISK,
@@ -15697,6 +15697,7 @@ mod tests {
                 ],
                 resource_manager: Default::default(),
                 next_file_ref_num: 128,
+                ..ProcessFileSystemState::default()
             }
             .with_resources(
                 Vec::new(),
@@ -18243,7 +18244,7 @@ mod tests {
         assert_eq!(runner.bus.read_long(fcb + 50), u32::from_be_bytes(*b"APPL"));
         assert_eq!(
             runner.bus.read_long(fcb + 58),
-            runner.dispatcher.default_dir_id
+            *runner.dispatcher.default_dir_id
         );
 
         let vcb = runner.bus.read_long(fcb + 20);

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -13,8 +13,9 @@ use crate::managers::resource::ResourceFork;
 use crate::memory::{MacMemoryBus, MemoryBus};
 use crate::menu_manager::{ProcessMenuTrackingState, SharedNativeMenuSelection};
 use crate::process_context::{
-    ProcessContext, ProcessForkMap, ProcessLoadedResources, ProcessResourceFileMap,
-    ProcessKeyRepeatState, ProcessResourceManagerState, SharedProcessAppleEventHandlers,
+    ProcessClassicVfsDirectory, ProcessContext, ProcessForkMap, ProcessKeyRepeatState,
+    ProcessLoadedResources, ProcessResourceFileMap, ProcessResourceManagerState,
+    ProcessVfsMetadata, ProcessVfsVolumeRecord, SharedProcessAppleEventHandlers,
     SharedProcessCursorState, SharedProcessEventQueue, SharedProcessInputState,
     SharedProcessMemoryManager, SharedProcessMenuTracking, SharedProcessResourceManager,
     SharedProcessSoundManager, SharedProcessValue,
@@ -1084,42 +1085,9 @@ pub(crate) struct ControlAuxRecordState {
     pub handle: u32,
 }
 
-#[derive(Clone, Copy, Debug)]
-pub(crate) struct VfsMetadata {
-    pub file_id: u32,
-    pub parent_dir_id: u32,
-    pub file_type: u32,
-    pub creator: u32,
-    pub finder_flags: u16,
-    pub created_date: u32,
-    pub modified_date: u32,
-}
-
-#[derive(Clone, Debug)]
-pub(crate) struct VfsDirectory {
-    pub dir_id: u32,
-    pub parent_dir_id: u32,
-    pub name: String,
-}
-
-#[derive(Clone, Debug)]
-pub(crate) struct VfsVolume {
-    pub ref_num: i16,
-    pub name: String,
-    pub root_dir_id: u32,
-    pub attributes: u16,
-    pub file_count: u16,
-    pub allocation_block_count: u16,
-    pub allocation_block_size: u32,
-    pub clump_size: u32,
-    pub free_blocks: u16,
-    pub bitmap_start: u16,
-    pub allocation_pointer: u16,
-    pub allocation_start: u16,
-    pub next_catalog_id: u32,
-    pub created_date: u32,
-    pub modified_date: u32,
-}
+pub(crate) type VfsMetadata = ProcessVfsMetadata;
+pub(crate) type VfsDirectory = ProcessClassicVfsDirectory;
+pub(crate) type VfsVolume = ProcessVfsVolumeRecord;
 
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct WorkingDirectory {
@@ -2042,15 +2010,15 @@ pub struct TrapDispatcher {
     /// Virtual filesystem: filename -> resource fork contents
     pub vfs_rsrc: SharedProcessValue<ProcessForkMap>,
     /// Finder metadata and catalog IDs for VFS file entries.
-    pub(crate) vfs_metadata: HashMap<String, VfsMetadata>,
+    pub(crate) vfs_metadata: SharedProcessValue<HashMap<String, VfsMetadata>>,
     /// Directory catalog metadata keyed by normalized path.
-    pub(crate) vfs_directories: HashMap<String, VfsDirectory>,
+    pub(crate) vfs_directories: SharedProcessValue<HashMap<String, VfsDirectory>>,
     /// Reverse directory lookup by catalog ID.
-    pub(crate) vfs_directory_paths: HashMap<u32, String>,
+    pub(crate) vfs_directory_paths: SharedProcessValue<HashMap<u32, String>>,
     /// Read-only disk-image volumes mounted alongside the synthetic boot volume.
-    pub(crate) vfs_volumes: HashMap<i16, VfsVolume>,
+    pub(crate) vfs_volumes: SharedProcessValue<HashMap<i16, VfsVolume>>,
     /// Mounted volume lookup by normalized, case-insensitive name.
-    pub(crate) vfs_volume_names: HashMap<String, i16>,
+    pub(crate) vfs_volume_names: SharedProcessValue<HashMap<String, i16>>,
     /// Open working directories keyed by working directory reference number.
     pub(crate) working_directories: HashMap<i16, WorkingDirectory>,
     /// Open file table: refnum -> filename
@@ -2099,7 +2067,7 @@ pub struct TrapDispatcher {
     /// Inside Macintosh Volume V, p. V-529.
     pub(crate) default_startup_rec: u32,
     /// Next synthetic catalog directory ID for VFS directories.
-    pub(crate) next_vfs_dir_id: u32,
+    pub(crate) next_vfs_dir_id: SharedProcessValue<u32>,
     /// Next stable negative volume reference for an extracted read-only volume.
     pub(crate) next_vfs_volume_ref_num: i16,
     /// Next synthetic file ID for VFS files.
@@ -2115,7 +2083,7 @@ pub struct TrapDispatcher {
     /// app next yields through WaitNextEvent/EventAvail/GetNextEvent.
     pub(crate) pending_launch_app: Option<PendingLaunchApplication>,
     /// Current default directory.
-    pub(crate) default_dir_id: u32,
+    pub(crate) default_dir_id: SharedProcessValue<u32>,
     /// Working directory reference number for the application's folder.
     pub(crate) app_wd_refnum: i16,
     /// Host directory to write output files to (if set)
@@ -2901,6 +2869,15 @@ impl TrapDispatcher {
         context.attach_input_state(&mut self.input_state);
         context.attach_menu_tracking(&mut self.menu_tracking);
         context.attach_classic_file_system(&mut self.vfs, &mut self.vfs_rsrc);
+        context.attach_classic_vfs_catalogue(
+            &mut self.vfs_metadata,
+            &mut self.vfs_directories,
+            &mut self.vfs_directory_paths,
+            &mut self.vfs_volumes,
+            &mut self.vfs_volume_names,
+            &mut self.next_vfs_dir_id,
+            &mut self.default_dir_id,
+        );
         let mut memory_manager = None;
         context.attach_memory_manager(&mut memory_manager);
         self.attach_memory_manager_handle(
@@ -3846,11 +3823,11 @@ impl TrapDispatcher {
             ui_theme_id: UiThemeId::ClassicSystem7,
             vfs: SharedProcessValue::default(),
             vfs_rsrc: SharedProcessValue::default(),
-            vfs_metadata: HashMap::new(),
-            vfs_directories,
-            vfs_directory_paths,
-            vfs_volumes: HashMap::new(),
-            vfs_volume_names: HashMap::new(),
+            vfs_metadata: SharedProcessValue::default(),
+            vfs_directories: SharedProcessValue::from_value(vfs_directories),
+            vfs_directory_paths: SharedProcessValue::from_value(vfs_directory_paths),
+            vfs_volumes: SharedProcessValue::default(),
+            vfs_volume_names: SharedProcessValue::default(),
             working_directories: HashMap::new(),
             open_files: HashMap::new(),
             synthetic_drivers: HashMap::new(),
@@ -3865,14 +3842,14 @@ impl TrapDispatcher {
             default_video_rec: 0x0000,        // no default video device selected
             default_os_rec: 0x0001,           // Macintosh Operating System
             default_startup_rec: 0x0000_0000, // zero-filled first-device startup default
-            next_vfs_dir_id: 16,
+            next_vfs_dir_id: SharedProcessValue::from_value(16),
             next_vfs_volume_ref_num: -2,
             next_vfs_file_id: 32,
             next_vfs_timestamp: 1,
             next_working_dir_refnum: 32,
             launched_app_path: None,
             pending_launch_app: None,
-            default_dir_id: 2,
+            default_dir_id: SharedProcessValue::from_value(2),
             app_wd_refnum: BOOT_VOLUME_REF_NUM,
             output_dir: None,
             fg_color: (0, 0, 0),
@@ -4795,8 +4772,8 @@ impl TrapDispatcher {
 
         let parent_path = Self::vfs_parent_path(&normalized).to_string();
         let parent_dir_id = self.ensure_vfs_directory(&parent_path);
-        let dir_id = self.next_vfs_dir_id;
-        self.next_vfs_dir_id = self.next_vfs_dir_id.saturating_add(1);
+        let dir_id = *self.next_vfs_dir_id;
+        *self.next_vfs_dir_id = self.next_vfs_dir_id.saturating_add(1);
 
         self.vfs_directories.insert(
             normalized.clone(),
@@ -4893,7 +4870,7 @@ impl TrapDispatcher {
         let normalized = Self::normalize_vfs_path(name);
         self.ensure_vfs_file_metadata(&normalized);
         if let Some(metadata) = self.vfs_metadata.get(&normalized).copied() {
-            self.default_dir_id = metadata.parent_dir_id;
+            *self.default_dir_id = metadata.parent_dir_id;
             let app_volume_ref = self
                 .vfs_volume_for_path(&normalized)
                 .map(|volume| volume.ref_num)
@@ -5137,7 +5114,7 @@ impl TrapDispatcher {
                 return working_directory.dir_id;
             }
             if dir_id == 0 && vref == 0 {
-                return self.default_dir_id;
+                return *self.default_dir_id;
             }
             if dir_id == 0 {
                 return 2;
@@ -5148,7 +5125,7 @@ impl TrapDispatcher {
             return dir_id;
         }
         if vref == 0 {
-            return self.default_dir_id;
+            return *self.default_dir_id;
         }
         if vref == Self::boot_volume_ref_num() {
             return 2;
@@ -5175,7 +5152,7 @@ impl TrapDispatcher {
         // Mirror that fallback so callers that leave ioDirID stale still find
         // files relative to the current working directory.
         let fallback_dir_id = if vref == 0 {
-            Some(self.default_dir_id)
+            Some(*self.default_dir_id)
         } else {
             self.working_directories.get(&vref).map(|wd| wd.dir_id)
         };

--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -4333,7 +4333,7 @@ impl super::TrapDispatcher {
                 let dir_id = self
                     .working_directory_info(self.app_wd_refnum)
                     .map(|wd| wd.dir_id)
-                    .unwrap_or(self.default_dir_id);
+                    .unwrap_or(*self.default_dir_id);
                 bus.write_long(pb + 48, dir_id); // ioWDDirID
                 bus.write_word(pb + 16, 0); // noErr
                 cpu.write_reg(Register::D0, 0);
@@ -5894,7 +5894,7 @@ impl super::TrapDispatcher {
                 {
                     requested_dir_id
                 } else if requested_vref == 0 {
-                    self.default_dir_id
+                    *self.default_dir_id
                 } else if requested_vref == Self::boot_volume_ref_num() {
                     // ioVRefNum = -1: boot volume, use root directory (dirID 2).
                     2
@@ -5922,7 +5922,7 @@ impl super::TrapDispatcher {
                     }
                 }
 
-                self.default_dir_id = target_dir_id;
+                *self.default_dir_id = target_dir_id;
                 self.app_wd_refnum = if target_dir_id == 2 {
                     target_volume_ref_num
                 } else {
@@ -5941,7 +5941,7 @@ impl super::TrapDispatcher {
                     requested_vref,
                     requested_dir_id,
                     self.app_wd_refnum,
-                    self.default_dir_id
+                    *self.default_dir_id
                 );
                 bus.write_word(pb + 16, 0);
                 cpu.write_reg(Register::D0, 0);
@@ -7343,12 +7343,12 @@ impl super::TrapDispatcher {
                             ref_num: self
                                 .open_working_directory(
                                     super::TrapDispatcher::boot_volume_ref_num(),
-                                    self.default_dir_id,
+                                    *self.default_dir_id,
                                     0,
                                 )
                                 .unwrap_or(super::TrapDispatcher::boot_volume_ref_num()),
                             volume_ref_num: super::TrapDispatcher::boot_volume_ref_num(),
-                            dir_id: self.default_dir_id,
+                            dir_id: *self.default_dir_id,
                             proc_id: 0,
                         })
                     } else {
@@ -8109,7 +8109,7 @@ impl super::TrapDispatcher {
         self.ensure_vfs_catalog();
         let mut entries = Vec::new();
 
-        for (path, directory) in &self.vfs_directories {
+        for (path, directory) in &*self.vfs_directories {
             let entry_volume_ref = self
                 .vfs_volume_for_path(path)
                 .map(|volume| volume.ref_num)
@@ -17188,7 +17188,7 @@ mod tests {
 
         assert_eq!(cpu.read_reg(Register::D0), 0);
         assert_eq!(bus.read_word(pb + 16), 0);
-        assert_eq!(disp.default_dir_id, dir_id);
+        assert_eq!(*disp.default_dir_id, dir_id);
         assert_eq!(bus.read_long(addr::CUR_DIR_STORE), dir_id);
         assert_eq!(
             bus.read_word(addr::SF_SAVE_DISK),
@@ -17217,7 +17217,7 @@ mod tests {
 
         assert_eq!(cpu.read_reg(Register::D0), 0);
         assert_eq!(bus.read_word(pb + 16), 0);
-        assert_eq!(disp.default_dir_id, root_dir_id);
+        assert_eq!(*disp.default_dir_id, root_dir_id);
         assert_eq!(disp.resolve_volume_ref_num(disp.app_wd_refnum), volume_ref);
         assert_eq!(bus.read_word(addr::SF_SAVE_DISK), (-volume_ref) as u16);
     }
@@ -17254,7 +17254,7 @@ mod tests {
 
         assert_eq!(cpu.read_reg(Register::D0) as i32, -35, "nsvErr");
         assert_eq!(bus.read_word(pb + 16) as i16, -35);
-        assert_eq!(disp.default_dir_id, 2);
+        assert_eq!(*disp.default_dir_id, 2);
     }
 
     #[test]
@@ -17416,7 +17416,7 @@ mod tests {
 
         assert_eq!(cpu.read_reg(Register::D0), 0);
         assert_eq!(bus.read_word(pb + 16), 0);
-        assert_eq!(disp.default_dir_id, 2);
+        assert_eq!(*disp.default_dir_id, 2);
         assert_eq!(
             disp.app_wd_refnum,
             super::super::dispatch::BOOT_VOLUME_REF_NUM
@@ -17443,7 +17443,7 @@ mod tests {
 
         assert_eq!(cpu.read_reg(Register::D0), 0);
         assert_eq!(bus.read_word(pb + 16), 0);
-        assert_eq!(disp.default_dir_id, dir_id);
+        assert_eq!(*disp.default_dir_id, dir_id);
         assert_ne!(
             disp.app_wd_refnum,
             super::super::dispatch::BOOT_VOLUME_REF_NUM
@@ -17607,7 +17607,7 @@ mod tests {
             .insert("EV/Escape Velocity".to_string(), vec![0xAB]);
         disp.set_vfs_entry_metadata("EV/Escape Velocity", *b"APPL", *b"EV  ", 0);
         disp.set_launched_app_path("EV/Escape Velocity");
-        let expected_parent_dir_id = disp.default_dir_id;
+        let expected_parent_dir_id = *disp.default_dir_id;
 
         let pb = 0x300000u32;
         let name_ptr = setup_param_block(

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -2003,7 +2003,7 @@ impl super::TrapDispatcher {
             return None;
         }
 
-        let default_dir_id = self.default_dir_id;
+        let default_dir_id = *self.default_dir_id;
         let vfs_key = self
             .find_vfs_file_in_directory(default_dir_id, requested)
             .or_else(|| self.find_vfs_rsrc_file_in_directory(default_dir_id, requested))
@@ -2054,7 +2054,7 @@ impl super::TrapDispatcher {
             None
         };
 
-        let default_dir_id = self.default_dir_id;
+        let default_dir_id = *self.default_dir_id;
         let entries = self.list_vfs_catalog_entries(default_dir_id);
         let mut all_types_match: Option<StandardFileSelection> = None;
         for entry in entries {
@@ -2128,7 +2128,7 @@ impl super::TrapDispatcher {
         else {
             return Vec::new();
         };
-        self.standard_file_get_candidates_in_directory(self.default_dir_id, file_types.as_deref())
+        self.standard_file_get_candidates_in_directory(*self.default_dir_id, file_types.as_deref())
     }
 
     fn standard_file_get_candidates_in_directory(
@@ -2528,7 +2528,7 @@ impl super::TrapDispatcher {
             stack_ptr,
             pop_total,
             entries,
-            current_dir_id: self.default_dir_id,
+            current_dir_id: *self.default_dir_id,
             file_types: Self::standard_file_get_type_list(bus, num_types, type_list_ptr).flatten(),
             selected: 0,
             bounds,
@@ -2843,7 +2843,7 @@ impl super::TrapDispatcher {
             pop_total,
             vref: self.resolve_volume_ref_num(self.app_wd_refnum),
             old_wd_ref,
-            dir_id: self.default_dir_id,
+            dir_id: *self.default_dir_id,
             prompt: Self::standard_file_put_prompt(bus, prompt_ptr),
             name,
             sel_start: 0,
@@ -2857,7 +2857,7 @@ impl super::TrapDispatcher {
 
     fn standard_file_old_reply_wd_ref(&mut self) -> i16 {
         let vref = self.resolve_volume_ref_num(self.app_wd_refnum);
-        self.open_working_directory(vref, self.default_dir_id, 0)
+        self.open_working_directory(vref, *self.default_dir_id, 0)
             .unwrap_or_else(|| self.resolve_volume_ref_num(self.app_wd_refnum))
     }
 
@@ -6007,7 +6007,7 @@ impl super::TrapDispatcher {
                         if app_name.is_empty() {
                             launch_result = (-43i32) as u32; // fnfErr
                         } else {
-                            let app_path = match self.directory_path_for_id(self.default_dir_id) {
+                            let app_path = match self.directory_path_for_id(*self.default_dir_id) {
                                 Some(dir_path) if !dir_path.is_empty() => {
                                     format!("{dir_path}/{app_name}")
                                 }
@@ -6078,7 +6078,7 @@ impl super::TrapDispatcher {
                         let app_name =
                             String::from_utf8_lossy(&bus.read_pstring(app_name_ptr)).into_owned();
                         if !app_name.is_empty() {
-                            let app_path = match self.directory_path_for_id(self.default_dir_id) {
+                            let app_path = match self.directory_path_for_id(*self.default_dir_id) {
                                 Some(dir_path) if !dir_path.is_empty() => {
                                     format!("{dir_path}/{app_name}")
                                 }
@@ -12523,7 +12523,7 @@ impl super::TrapDispatcher {
                     }
                     let name = standard_file_default_name(bus, default_name_ptr);
                     let vref = self.resolve_volume_ref_num(self.app_wd_refnum);
-                    let dir_id = self.default_dir_id;
+                    let dir_id = *self.default_dir_id;
                     if modern_reply {
                         let target_name = decode_mac_roman(&name);
                         let replacing = self
@@ -20801,7 +20801,7 @@ mod tests {
         let cmd_line = bus.alloc(8);
         let app_name = bus.alloc(32);
         let target_dir_id = disp.ensure_vfs_directory("LaunchTargets");
-        disp.default_dir_id = target_dir_id;
+        *disp.default_dir_id = target_dir_id;
         disp.vfs
             .insert("LaunchTargets/Legacy Helper".to_string(), Vec::new());
 
@@ -20842,7 +20842,7 @@ mod tests {
         let cmd_line = bus.alloc(8);
         let app_name = bus.alloc(32);
         let target_dir_id = disp.ensure_vfs_directory("LaunchTargets");
-        disp.default_dir_id = target_dir_id;
+        *disp.default_dir_id = target_dir_id;
 
         cpu.write_reg(Register::A0, cmd_line);
         cpu.write_reg(Register::D0, 0x89AB_CDEF);
@@ -20915,7 +20915,7 @@ mod tests {
             disp.launched_app_path.as_deref(),
             Some("LaunchTargets/NoSuchApp")
         );
-        assert_eq!(disp.default_dir_id, target_dir_id);
+        assert_eq!(*disp.default_dir_id, target_dir_id);
         assert_ne!(disp.app_wd_refnum, 0);
     }
 
@@ -20964,7 +20964,7 @@ mod tests {
             disp.launched_app_path.as_deref(),
             Some("LaunchTargets/NoSuchApp")
         );
-        assert_eq!(disp.default_dir_id, target_dir_id);
+        assert_eq!(*disp.default_dir_id, target_dir_id);
         assert_ne!(disp.app_wd_refnum, 0);
     }
 
@@ -21131,7 +21131,7 @@ mod tests {
         let app_name = bus.alloc(32);
         let target_dir_id = disp.ensure_vfs_directory("ChainTargets");
 
-        disp.default_dir_id = target_dir_id;
+        *disp.default_dir_id = target_dir_id;
         cpu.write_reg(Register::A0, cmd_line);
         cpu.write_reg(Register::D0, 0x1234_5678);
 
@@ -21157,7 +21157,7 @@ mod tests {
             disp.launched_app_path.as_deref(),
             Some("ChainTargets/NoSuchApp")
         );
-        assert_eq!(disp.default_dir_id, target_dir_id);
+        assert_eq!(*disp.default_dir_id, target_dir_id);
         assert_ne!(disp.app_wd_refnum, 0);
     }
 
@@ -27557,7 +27557,7 @@ mod tests {
         let sp = TEST_SP;
         let reply_ptr = 0x320080u32;
         let pilots_dir = disp.ensure_vfs_directory("Pilots");
-        disp.default_dir_id = pilots_dir;
+        *disp.default_dir_id = pilots_dir;
         disp.vfs_rsrc
             .insert("Pilots/Tom Fighter Paris".to_string(), vec![1, 2, 3]);
         disp.set_vfs_entry_metadata("Pilots/Tom Fighter Paris", *b"PIL ", *b"EVO!", 0x4000);
@@ -27596,7 +27596,7 @@ mod tests {
         let reply_ptr = 0x320500u32;
         let type_list_ptr = 0x320600u32;
         let app_dir = disp.ensure_vfs_directory("Data Folder");
-        disp.default_dir_id = app_dir;
+        *disp.default_dir_id = app_dir;
         disp.vfs
             .insert("Data Folder/Selected".to_string(), vec![1, 2, 3]);
         disp.set_vfs_entry_metadata("Data Folder/Selected", *b"DATA", *b"TEST", 0x4000);
@@ -27636,7 +27636,7 @@ mod tests {
         let sp = TEST_SP;
         let reply_ptr = 0x320900u32;
         let app_dir = disp.ensure_vfs_directory("Data Folder");
-        disp.default_dir_id = app_dir;
+        *disp.default_dir_id = app_dir;
         disp.vfs
             .insert("Data Folder/Only Choice".to_string(), vec![1, 2, 3]);
         disp.set_vfs_entry_metadata("Data Folder/Only Choice", *b"Flux", *b"Geek", 0x2000);
@@ -27676,7 +27676,7 @@ mod tests {
         let sp = TEST_SP;
         let reply_ptr = 0x320A00u32;
         let app_dir = disp.ensure_vfs_directory("Data Folder");
-        disp.default_dir_id = app_dir;
+        *disp.default_dir_id = app_dir;
         disp.vfs
             .insert("Data Folder/First".to_string(), vec![1, 2, 3]);
         disp.set_vfs_entry_metadata("Data Folder/First", *b"Flux", *b"Geek", 0);
@@ -27709,7 +27709,7 @@ mod tests {
         let reply_ptr = 0x320700u32;
         let type_list_ptr = 0x320800u32;
         let app_dir = disp.ensure_vfs_directory("Data Folder");
-        disp.default_dir_id = app_dir;
+        *disp.default_dir_id = app_dir;
         disp.vfs
             .insert("Data Folder/Selected".to_string(), vec![1, 2, 3]);
         disp.set_vfs_entry_metadata("Data Folder/Selected", *b"Flux", *b"Geek", 0);
@@ -27744,7 +27744,7 @@ mod tests {
         let type_list_ptr = 0x320C00u32;
         let app_dir = disp.ensure_vfs_directory("EV Override 1.0.1");
         let pilots_dir = disp.ensure_vfs_directory("EV Override 1.0.1/Pilots");
-        disp.default_dir_id = app_dir;
+        *disp.default_dir_id = app_dir;
         disp.yield_for_ui = true;
         disp.vfs_rsrc
             .insert("EV Override 1.0.1/Pilots/Last Pilot".to_string(), vec![1]);
@@ -27826,7 +27826,7 @@ mod tests {
         let sp = TEST_SP;
         let reply_ptr = 0x321000u32;
         let empty_dir = disp.ensure_vfs_directory("Empty Saves");
-        disp.default_dir_id = empty_dir;
+        *disp.default_dir_id = empty_dir;
         disp.yield_for_ui = true;
         bus.write_word(sp, 0x0006);
         bus.write_long(sp + 2, reply_ptr);
@@ -27887,7 +27887,7 @@ mod tests {
         let reply_ptr = 0x321100u32;
         let app_dir = disp.ensure_vfs_directory("Game");
         let saves_dir = disp.ensure_vfs_directory("Game/Saves");
-        disp.default_dir_id = app_dir;
+        *disp.default_dir_id = app_dir;
         disp.yield_for_ui = true;
         bus.write_byte(reply_ptr, 0xFF);
         bus.write_word(sp, 0x0006);
@@ -28004,7 +28004,7 @@ mod tests {
         let type_list_ptr = 0x320E00u32;
         let app_dir = disp.ensure_vfs_directory("Escape Velocity 1.0.5 ƒ");
         let pilots_dir = disp.ensure_vfs_directory("Escape Velocity 1.0.5 ƒ/Pilots");
-        disp.default_dir_id = app_dir;
+        *disp.default_dir_id = app_dir;
         disp.yield_for_ui = true;
         disp.vfs_rsrc.insert(
             "Escape Velocity 1.0.5 ƒ/Pilots/Ace".to_string(),
@@ -28071,7 +28071,7 @@ mod tests {
         let sp = TEST_SP;
         let reply_ptr = 0x320180u32;
         let default_name_ptr = 0x320300u32;
-        disp.default_dir_id = 18;
+        *disp.default_dir_id = 18;
         disp.app_wd_refnum = crate::trap::dispatch::TrapDispatcher::boot_volume_ref_num();
         bus.write_pstring(default_name_ptr, b"Twilight Save");
         bus.write_word(sp, 0x0005); // StandardPutFile selector
@@ -28104,7 +28104,7 @@ mod tests {
         let reply_ptr = 0x3201C0u32;
         let default_name_ptr = 0x320340u32;
         let pilots_dir = disp.ensure_vfs_directory("Pilots");
-        disp.default_dir_id = pilots_dir;
+        *disp.default_dir_id = pilots_dir;
         disp.app_wd_refnum = crate::trap::dispatch::TrapDispatcher::boot_volume_ref_num();
         disp.vfs_rsrc
             .insert("Pilots/Existing Pilot".to_string(), vec![1, 2, 3]);
@@ -28139,7 +28139,7 @@ mod tests {
         let prompt_ptr = 0x320300u32;
         let default_name_ptr = 0x320340u32;
         let pilots_dir = disp.ensure_vfs_directory("Pilots");
-        disp.default_dir_id = pilots_dir;
+        *disp.default_dir_id = pilots_dir;
         disp.app_wd_refnum = crate::trap::dispatch::TrapDispatcher::boot_volume_ref_num();
         disp.yield_for_ui = true;
 
@@ -28201,7 +28201,7 @@ mod tests {
         let prompt_ptr = 0x320700u32;
         let default_name_ptr = 0x320740u32;
         let pilots_dir = disp.ensure_vfs_directory("Pilots");
-        disp.default_dir_id = pilots_dir;
+        *disp.default_dir_id = pilots_dir;
         disp.app_wd_refnum = crate::trap::dispatch::TrapDispatcher::boot_volume_ref_num();
         disp.yield_for_ui = true;
 
@@ -28306,7 +28306,7 @@ mod tests {
         let reply_ptr = 0x320580u32;
         let original_name_ptr = 0x320680u32;
         let pilots_dir = disp.ensure_vfs_directory("Pilots");
-        disp.default_dir_id = pilots_dir;
+        *disp.default_dir_id = pilots_dir;
         disp.app_wd_refnum = crate::trap::dispatch::TrapDispatcher::boot_volume_ref_num();
         bus.write_pstring(original_name_ptr, b"Old Pilot");
         bus.write_word(sp, 0x0001); // SFPutFile selector
@@ -28341,7 +28341,7 @@ mod tests {
         let original_name_ptr = 0x320880u32;
         let prompt_ptr = 0x3208C0u32;
         let pilots_dir = disp.ensure_vfs_directory("Pilots");
-        disp.default_dir_id = pilots_dir;
+        *disp.default_dir_id = pilots_dir;
         disp.app_wd_refnum = crate::trap::dispatch::TrapDispatcher::boot_volume_ref_num();
         disp.yield_for_ui = true;
         bus.write_pstring(original_name_ptr, b"Old Pilot");


### PR DESCRIPTION
Advances #1187.

Moves the classic File Manager catalog maps, mounted-volume index, and directory counters behind process-owned attachment handles. Normal clones remain detached snapshots, while attached adapters observe the same catalog mutations.

Validation:
- cargo test --locked --lib --quiet (4,739 passed; 3 ignored)
- strict rustdoc with private intra-doc links denied
- cargo check --all-targets --all-features --locked
- Marathon gameplay and terminal interaction
- Escape Velocity gameplay, landing, and return to space
- Tomb Raider Gold gameplay and movement