### PR TITLE
refactor(files): unify process VFS catalog mutations

### DIFF
--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -3854,6 +3854,7 @@ impl PpcLoadedApp {
 
     pub(crate) fn attach_process_context(&mut self, context: &mut ProcessContext) {
         context.attach_file_system(&mut self.process_file_system);
+        self.process_file_system.publish_native_vfs_catalogue();
         context.attach_sound_manager(&mut self.sound.manager);
         context.attach_cursor_state(&mut self.cursor_state);
         context.attach_event_queue(&mut self.event_queue);
@@ -8080,6 +8081,7 @@ impl PpcLoadedApp {
         self.vfs_directories = vfs_directories;
         self.next_vfs_dir_id = next_vfs_dir_id;
         self.default_dir_id = default_dir_id;
+        self.process_file_system.publish_native_vfs_catalogue();
         self.param_text = param_text;
         self.scrap = scrap;
         self.list_manager = list_manager;
@@ -8265,6 +8267,7 @@ impl PpcLoadedApp {
     }
 
     pub fn take_deleted_vfs_file_paths(&mut self) -> Vec<String> {
+        self.process_file_system.publish_native_vfs_catalogue();
         std::mem::take(&mut self.deleted_vfs_file_paths)
     }
 
@@ -88813,6 +88816,125 @@ pub(crate) mod tests {
         assert_eq!(first.vfs_directories.last().unwrap().path, "Shared Folder");
         assert_eq!(first.next_vfs_dir_id, PPC_FIRST_DYNAMIC_DIR_ID + 1);
         assert_eq!(first.default_dir_id, PPC_FIRST_DYNAMIC_DIR_ID);
+    }
+
+    #[test]
+    fn catalogue_mutations_cross_cpu_adapters_without_runner_sync() {
+        let pef = synthetic_pef_with_import(b"GetEOF");
+        let mut native = load_pef_application(&pef).unwrap();
+        let mut context = ProcessContext::default();
+        native.attach_process_context(&mut context);
+        let mut classic = TrapDispatcher::new();
+        classic.attach_process_context(&mut context);
+
+        native.vfs_directories.push(PpcVfsDirectory {
+            dir_id: PPC_FIRST_DYNAMIC_DIR_ID,
+            parent_dir_id: PPC_ROOT_DIR_ID,
+            path: "Shared Folder".to_string(),
+            creator: u32::from_be_bytes(*b"TEST"),
+            file_type: u32::from_be_bytes(*b"fold"),
+            finder_flags: 0x0400,
+            dirty: true,
+        });
+        native.vfs_files.push(PpcVfsFileRecord {
+            path: "Shared Folder/Native Data".to_string(),
+            data: b"native".to_vec().into(),
+            creator: u32::from_be_bytes(*b"TEST"),
+            file_type: u32::from_be_bytes(*b"DATA"),
+            finder_flags: 0x0200,
+            dirty: true,
+        });
+        native.vfs_volumes.push(PpcVfsVolumeRecord {
+            ref_num: -2,
+            name: "Read Only".to_string(),
+            root_dir_id: PPC_FIRST_DYNAMIC_DIR_ID,
+            attributes: 0x0080,
+            file_count: 1,
+            allocation_block_count: 16,
+            allocation_block_size: 4096,
+            clump_size: 4096,
+            free_blocks: 0,
+            bitmap_start: 3,
+            allocation_pointer: 4,
+            allocation_start: 5,
+            next_catalog_id: PPC_FIRST_DYNAMIC_DIR_ID + 1,
+            created_date: 1,
+            modified_date: 2,
+        });
+        native.next_vfs_dir_id = PPC_FIRST_DYNAMIC_DIR_ID + 1;
+        native.default_dir_id = PPC_FIRST_DYNAMIC_DIR_ID;
+        native.process_file_system.publish_native_vfs_catalogue();
+
+        assert_eq!(
+            classic.directory_path_for_id(PPC_FIRST_DYNAMIC_DIR_ID),
+            Some("Shared Folder")
+        );
+        let metadata = classic
+            .vfs_file_metadata("Shared Folder/Native Data")
+            .unwrap();
+        assert_eq!(metadata.parent_dir_id, PPC_FIRST_DYNAMIC_DIR_ID);
+        assert_eq!(metadata.creator, u32::from_be_bytes(*b"TEST"));
+        assert_eq!(metadata.file_type, u32::from_be_bytes(*b"DATA"));
+        assert_eq!(metadata.finder_flags, 0x0200);
+        assert_eq!(*classic.default_dir_id, PPC_FIRST_DYNAMIC_DIR_ID);
+        assert_eq!(classic.vfs_volume_for_ref_num(-2).unwrap().name, "Read Only");
+
+        let classic_dir_id = classic.ensure_vfs_directory("Classic Folder");
+        classic
+            .vfs
+            .insert("Classic Folder/Classic Data".to_string(), b"classic".to_vec());
+        classic.set_vfs_entry_metadata(
+            "Classic Folder/Classic Data",
+            *b"TEXT",
+            *b"ttxt",
+            0x0100,
+        );
+        assert!(native.vfs_directories.iter().any(|directory| {
+            directory.dir_id == classic_dir_id && directory.path == "Classic Folder"
+        }));
+        let classic_file = native
+            .vfs_files
+            .iter()
+            .find(|file| file.path == "Classic Folder/Classic Data")
+            .unwrap();
+        assert_eq!(classic_file.data, b"classic");
+        assert_eq!(classic_file.file_type, u32::from_be_bytes(*b"TEXT"));
+        assert_eq!(classic_file.creator, u32::from_be_bytes(*b"ttxt"));
+        assert_eq!(classic_file.finder_flags, 0x0100);
+        classic
+            .vfs
+            .get_mut("Classic Folder/Classic Data")
+            .unwrap()
+            .extend_from_slice(b"-shared");
+        assert_eq!(
+            native
+                .vfs_files
+                .iter()
+                .find(|file| file.path == "Classic Folder/Classic Data")
+                .unwrap()
+                .data,
+            b"classic-shared"
+        );
+
+        classic
+            .locked_files
+            .insert("Shared Folder/Native Data".to_string());
+        native
+            .deleted_vfs_file_paths
+            .push("Shared Folder/Native Data".to_string());
+        native.process_file_system.publish_native_vfs_catalogue();
+        assert!(!classic
+            .vfs_metadata
+            .contains_key("Shared Folder/Native Data"));
+        assert!(!classic
+            .locked_files
+            .contains("Shared Folder/Native Data"));
+
+        assert!(classic.remove_vfs_path("Classic Folder/Classic Data"));
+        assert!(!native
+            .vfs_files
+            .iter()
+            .any(|file| file.path == "Classic Folder/Classic Data"));
     }
 
     #[test]

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -42,7 +42,10 @@ impl Clone for ProcessForkBytes {
 
 impl fmt::Debug for ProcessForkBytes {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.debug_tuple("ProcessForkBytes").field(&**self).finish()
+        formatter
+            .debug_tuple("ProcessForkBytes")
+            .field(&**self)
+            .finish()
     }
 }
 
@@ -159,7 +162,6 @@ impl ProcessForkMap {
         self.0.get_mut(path).map(|bytes| &mut **bytes)
     }
 
-    #[cfg(test)]
     pub(crate) fn get_shared<Q>(&self, path: &Q) -> Option<&ProcessForkBytes>
     where
         String: std::borrow::Borrow<Q>,
@@ -228,11 +230,74 @@ pub(crate) struct ProcessVfsMetadata {
     pub modified_date: u32,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct ProcessClassicVfsDirectory {
     pub dir_id: u32,
     pub parent_dir_id: u32,
     pub name: String,
+}
+
+fn process_classic_vfs_directories_are_pristine(
+    directories: &HashMap<String, ProcessClassicVfsDirectory>,
+) -> bool {
+    if directories.is_empty() {
+        return true;
+    }
+    let expected = [
+        ("", 2, 1),
+        ("System Folder", 16, 2),
+        ("System Folder/Preferences", 17, 16),
+    ];
+    directories.len() <= expected.len()
+        && directories.iter().all(|(path, directory)| {
+            expected
+                .iter()
+                .any(|(expected_path, dir_id, parent_dir_id)| {
+                    path == expected_path
+                        && directory.dir_id == *dir_id
+                        && directory.parent_dir_id == *parent_dir_id
+                })
+        })
+}
+
+fn process_classic_vfs_directory_paths_are_pristine(paths: &HashMap<u32, String>) -> bool {
+    if paths.is_empty() {
+        return true;
+    }
+    let expected = [
+        (2, ""),
+        (16, "System Folder"),
+        (17, "System Folder/Preferences"),
+    ];
+    paths.len() <= expected.len()
+        && paths.iter().all(|(dir_id, path)| {
+            expected
+                .iter()
+                .any(|(expected_id, expected_path)| dir_id == expected_id && path == expected_path)
+        })
+}
+
+fn process_native_vfs_catalogue_is_pristine(
+    volumes: &[ProcessVfsVolumeRecord],
+    directories: &[ProcessVfsDirectory],
+) -> bool {
+    if !volumes.is_empty() {
+        return false;
+    }
+    let expected = [
+        ("", 2, 1),
+        ("System Folder", 16, 2),
+        ("System Folder/Preferences", 17, 16),
+    ];
+    directories.len() <= expected.len()
+        && directories.iter().all(|directory| {
+            !directory.dirty
+                && expected.iter().any(|(path, dir_id, parent_dir_id)| {
+                    directory.path == *path
+                        && directory.dir_id == *dir_id
+                        && directory.parent_dir_id == *parent_dir_id
+                })
+        })
 }
 
 /// Native record index backed by the canonical process data-fork map.
@@ -298,11 +363,28 @@ impl ProcessVfsFileRecords {
         }
     }
 
-    fn adopt(&mut self, source: &mut Self) {
+    fn merge_from(&mut self, source: &mut Self) {
         for record in source.records.drain(..) {
+            if self
+                .records
+                .iter()
+                .any(|existing| existing.path.eq_ignore_ascii_case(&record.path))
+            {
+                continue;
+            }
             self.push(record);
         }
-        source.data_forks.clear();
+        let forks = source.data_forks.drain().collect::<Vec<_>>();
+        for (path, bytes) in forks {
+            if self
+                .data_forks
+                .keys()
+                .any(|existing| existing.eq_ignore_ascii_case(&path))
+            {
+                continue;
+            }
+            self.data_forks.insert_shared(path, &bytes);
+        }
     }
 }
 
@@ -393,8 +475,7 @@ impl ProcessVfsResourceFileRecords {
                 self.resource_forks
                     .insert_shared(record.path.clone(), raw_data);
             } else if !self.resource_forks.contains_key(&record.path) {
-                self.resource_forks
-                    .insert(record.path.clone(), Vec::new());
+                self.resource_forks.insert(record.path.clone(), Vec::new());
             }
         }
         self.records.push(record);
@@ -436,21 +517,29 @@ impl ProcessVfsResourceFileRecords {
         self.resource_forks.get(path)
     }
 
-    fn adopt(&mut self, source: &mut Self) {
-        let cached_forks = source
-            .resource_forks
-            .iter()
-            .map(|(path, bytes)| (path.clone(), bytes.to_vec()))
-            .collect::<Vec<_>>();
+    fn merge_from(&mut self, source: &mut Self) {
         for record in source.records.drain(..) {
+            if self
+                .records
+                .iter()
+                .any(|existing| existing.path.eq_ignore_ascii_case(&record.path))
+            {
+                continue;
+            }
             self.push(record);
         }
-        for (path, bytes) in cached_forks {
-            self.update_fork(&path, &bytes);
+        let forks = source.resource_forks.drain().collect::<Vec<_>>();
+        for (path, bytes) in forks {
+            if self
+                .resource_forks
+                .keys()
+                .any(|existing| existing.eq_ignore_ascii_case(&path))
+            {
+                continue;
+            }
+            self.resource_forks.insert_shared(path, &bytes);
         }
-        source.resource_forks.clear();
     }
-
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -503,7 +592,7 @@ pub struct ProcessResourceManagerState {
     pub(crate) vfs_resources: Vec<ProcessVfsResourceRecord>,
 }
 
-fn process_resource_manager_is_empty(manager: &ProcessResourceManagerState) -> bool {
+fn process_resource_manager_runtime_is_empty(manager: &ProcessResourceManagerState) -> bool {
     manager.loaded_handles.is_empty()
         && manager.resource_handles_by_key.is_empty()
         && manager.detached_handles.is_empty()
@@ -514,24 +603,42 @@ fn process_resource_manager_is_empty(manager: &ProcessResourceManagerState) -> b
         && manager.resource_backing_data.is_empty()
         && manager.resident_resources.is_empty()
         && manager.resource_files.is_empty()
-        && manager.vfs_resource_files.is_empty()
-        && manager.vfs_resources.is_empty()
 }
 
 impl ProcessResourceManagerState {
-    fn adopt(&mut self, source: &mut Self) {
-        self.loaded_handles = std::mem::take(&mut source.loaded_handles);
-        self.resource_handles_by_key = std::mem::take(&mut source.resource_handles_by_key);
-        self.detached_handles = std::mem::take(&mut source.detached_handles);
-        self.resource_handle_files = std::mem::take(&mut source.resource_handle_files);
-        self.detached_handle_files = std::mem::take(&mut source.detached_handle_files);
-        self.resources = std::mem::take(&mut source.resources);
-        self.resource_file_order = std::mem::take(&mut source.resource_file_order);
-        self.resource_backing_data = std::mem::take(&mut source.resource_backing_data);
-        self.resident_resources = std::mem::take(&mut source.resident_resources);
-        self.resource_files = std::mem::take(&mut source.resource_files);
-        self.vfs_resource_files.adopt(&mut source.vfs_resource_files);
-        self.vfs_resources = std::mem::take(&mut source.vfs_resources);
+    fn merge_from(&mut self, source: &mut Self) {
+        let source_runtime_is_empty = process_resource_manager_runtime_is_empty(source);
+        let target_runtime_is_empty = process_resource_manager_runtime_is_empty(self);
+        assert!(
+            source_runtime_is_empty || target_runtime_is_empty,
+            "cannot attach two active process Resource Managers"
+        );
+
+        self.vfs_resource_files
+            .merge_from(&mut source.vfs_resource_files);
+        for resource in source.vfs_resources.drain(..) {
+            if self.vfs_resources.iter().any(|existing| {
+                existing.path.eq_ignore_ascii_case(&resource.path)
+                    && existing.res_type == resource.res_type
+                    && existing.res_id == resource.res_id
+            }) {
+                continue;
+            }
+            self.vfs_resources.push(resource);
+        }
+
+        if target_runtime_is_empty && !source_runtime_is_empty {
+            self.loaded_handles = std::mem::take(&mut source.loaded_handles);
+            self.resource_handles_by_key = std::mem::take(&mut source.resource_handles_by_key);
+            self.detached_handles = std::mem::take(&mut source.detached_handles);
+            self.resource_handle_files = std::mem::take(&mut source.resource_handle_files);
+            self.detached_handle_files = std::mem::take(&mut source.detached_handle_files);
+            self.resources = std::mem::take(&mut source.resources);
+            self.resource_file_order = std::mem::take(&mut source.resource_file_order);
+            self.resource_backing_data = std::mem::take(&mut source.resource_backing_data);
+            self.resident_resources = std::mem::take(&mut source.resident_resources);
+            self.resource_files = std::mem::take(&mut source.resource_files);
+        }
     }
 }
 
@@ -550,15 +657,17 @@ pub struct ProcessFileSystemState {
     pub(crate) vfs_directories: Vec<ProcessVfsDirectory>,
     pub(crate) next_vfs_dir_id: u32,
     pub(crate) default_dir_id: u32,
-    pub(crate) classic_vfs_metadata:
-        SharedProcessValue<HashMap<String, ProcessVfsMetadata>>,
+    pub(crate) classic_vfs_metadata: SharedProcessValue<HashMap<String, ProcessVfsMetadata>>,
     pub(crate) classic_vfs_directories:
         SharedProcessValue<HashMap<String, ProcessClassicVfsDirectory>>,
     pub(crate) classic_vfs_directory_paths: SharedProcessValue<HashMap<u32, String>>,
-    pub(crate) classic_vfs_volumes:
-        SharedProcessValue<HashMap<i16, ProcessVfsVolumeRecord>>,
+    pub(crate) classic_vfs_volumes: SharedProcessValue<HashMap<i16, ProcessVfsVolumeRecord>>,
     pub(crate) classic_vfs_volume_names: SharedProcessValue<HashMap<String, i16>>,
+    pub(crate) classic_locked_files: SharedProcessValue<HashSet<String>>,
     pub(crate) classic_next_vfs_dir_id: SharedProcessValue<u32>,
+    pub(crate) classic_next_vfs_volume_ref_num: SharedProcessValue<i16>,
+    pub(crate) classic_next_vfs_file_id: SharedProcessValue<u32>,
+    pub(crate) classic_next_vfs_timestamp: SharedProcessValue<u32>,
     pub(crate) classic_default_dir_id: SharedProcessValue<u32>,
     pub(crate) vfs_files: ProcessVfsFileRecords,
     pub(crate) deleted_vfs_file_paths: Vec<String>,
@@ -580,7 +689,11 @@ impl Default for ProcessFileSystemState {
             classic_vfs_directory_paths: SharedProcessValue::default(),
             classic_vfs_volumes: SharedProcessValue::default(),
             classic_vfs_volume_names: SharedProcessValue::default(),
+            classic_locked_files: SharedProcessValue::default(),
             classic_next_vfs_dir_id: SharedProcessValue::from_value(16),
+            classic_next_vfs_volume_ref_num: SharedProcessValue::from_value(-2),
+            classic_next_vfs_file_id: SharedProcessValue::from_value(32),
+            classic_next_vfs_timestamp: SharedProcessValue::from_value(1),
             classic_default_dir_id: SharedProcessValue::from_value(2),
             vfs_files: ProcessVfsFileRecords::default(),
             deleted_vfs_file_paths: Vec::new(),
@@ -591,6 +704,137 @@ impl Default for ProcessFileSystemState {
 }
 
 impl ProcessFileSystemState {
+    fn merge_from(&mut self, source: &mut Self) {
+        assert!(
+            self.files.is_empty() || source.files.is_empty(),
+            "cannot attach two active native File Managers"
+        );
+        if self.files.is_empty() {
+            self.files = std::mem::take(&mut source.files);
+        }
+        for (stream, record) in std::mem::take(&mut source.stdio_streams) {
+            self.stdio_streams.entry(stream).or_insert(record);
+        }
+
+        let target_catalogue_was_pristine =
+            process_native_vfs_catalogue_is_pristine(&self.vfs_volumes, &self.vfs_directories);
+        for volume in source.vfs_volumes.drain(..) {
+            if self.vfs_volumes.iter().any(|existing| {
+                existing.ref_num == volume.ref_num
+                    || existing.name.eq_ignore_ascii_case(&volume.name)
+            }) {
+                continue;
+            }
+            self.vfs_volumes.push(volume);
+        }
+        for directory in source.vfs_directories.drain(..) {
+            if self.vfs_directories.iter().any(|existing| {
+                existing.dir_id == directory.dir_id
+                    || existing.path.eq_ignore_ascii_case(&directory.path)
+            }) {
+                continue;
+            }
+            self.vfs_directories.push(directory);
+        }
+        self.next_vfs_dir_id = self.next_vfs_dir_id.max(source.next_vfs_dir_id);
+        if self.default_dir_id == 0 || (target_catalogue_was_pristine && source.default_dir_id != 0)
+        {
+            self.default_dir_id = source.default_dir_id;
+        }
+
+        self.vfs_files.merge_from(&mut source.vfs_files);
+        for path in source.deleted_vfs_file_paths.drain(..) {
+            if !self
+                .deleted_vfs_file_paths
+                .iter()
+                .any(|existing| existing.eq_ignore_ascii_case(&path))
+            {
+                self.deleted_vfs_file_paths.push(path);
+            }
+        }
+        self.next_file_ref_num = self.next_file_ref_num.max(source.next_file_ref_num);
+
+        if !Rc::ptr_eq(&self.classic_vfs_metadata.0, &source.classic_vfs_metadata.0) {
+            for (path, metadata) in std::mem::take(&mut *source.classic_vfs_metadata) {
+                self.classic_vfs_metadata.entry(path).or_insert(metadata);
+            }
+        }
+        if !Rc::ptr_eq(
+            &self.classic_vfs_directories.0,
+            &source.classic_vfs_directories.0,
+        ) {
+            for (path, directory) in std::mem::take(&mut *source.classic_vfs_directories) {
+                self.classic_vfs_directories
+                    .entry(path)
+                    .or_insert(directory);
+            }
+        }
+        if !Rc::ptr_eq(
+            &self.classic_vfs_directory_paths.0,
+            &source.classic_vfs_directory_paths.0,
+        ) {
+            for (dir_id, path) in std::mem::take(&mut *source.classic_vfs_directory_paths) {
+                self.classic_vfs_directory_paths
+                    .entry(dir_id)
+                    .or_insert(path);
+            }
+        }
+        if !Rc::ptr_eq(&self.classic_vfs_volumes.0, &source.classic_vfs_volumes.0) {
+            for (ref_num, volume) in std::mem::take(&mut *source.classic_vfs_volumes) {
+                self.classic_vfs_volumes.entry(ref_num).or_insert(volume);
+            }
+        }
+        if !Rc::ptr_eq(
+            &self.classic_vfs_volume_names.0,
+            &source.classic_vfs_volume_names.0,
+        ) {
+            for (name, ref_num) in std::mem::take(&mut *source.classic_vfs_volume_names) {
+                self.classic_vfs_volume_names.entry(name).or_insert(ref_num);
+            }
+        }
+        if !Rc::ptr_eq(&self.classic_locked_files.0, &source.classic_locked_files.0) {
+            self.classic_locked_files
+                .extend(std::mem::take(&mut *source.classic_locked_files));
+        }
+        *self.classic_next_vfs_dir_id =
+            (*self.classic_next_vfs_dir_id).max(*source.classic_next_vfs_dir_id);
+        *self.classic_next_vfs_volume_ref_num =
+            (*self.classic_next_vfs_volume_ref_num).min(*source.classic_next_vfs_volume_ref_num);
+        *self.classic_next_vfs_file_id =
+            (*self.classic_next_vfs_file_id).max(*source.classic_next_vfs_file_id);
+        *self.classic_next_vfs_timestamp =
+            (*self.classic_next_vfs_timestamp).max(*source.classic_next_vfs_timestamp);
+        if *self.classic_default_dir_id == 2 && *source.classic_default_dir_id != 2 {
+            *self.classic_default_dir_id = *source.classic_default_dir_id;
+        }
+
+        source
+            .resource_manager
+            .attach_resource_manager_to(&self.resource_manager);
+    }
+
+    fn detached_vfs_snapshot(&self) -> Self {
+        let mut snapshot = Self::default();
+        snapshot.vfs_volumes = self.vfs_volumes.clone();
+        snapshot.vfs_directories = self.vfs_directories.clone();
+        snapshot.next_vfs_dir_id = self.next_vfs_dir_id;
+        snapshot.default_dir_id = self.default_dir_id;
+        snapshot.classic_vfs_metadata = self.classic_vfs_metadata.clone();
+        snapshot.classic_vfs_directories = self.classic_vfs_directories.clone();
+        snapshot.classic_vfs_directory_paths = self.classic_vfs_directory_paths.clone();
+        snapshot.classic_vfs_volumes = self.classic_vfs_volumes.clone();
+        snapshot.classic_vfs_volume_names = self.classic_vfs_volume_names.clone();
+        snapshot.classic_locked_files = self.classic_locked_files.clone();
+        snapshot.classic_next_vfs_dir_id = self.classic_next_vfs_dir_id.clone();
+        snapshot.classic_next_vfs_volume_ref_num = self.classic_next_vfs_volume_ref_num.clone();
+        snapshot.classic_next_vfs_file_id = self.classic_next_vfs_file_id.clone();
+        snapshot.classic_next_vfs_timestamp = self.classic_next_vfs_timestamp.clone();
+        snapshot.classic_default_dir_id = self.classic_default_dir_id.clone();
+        snapshot.vfs_files = self.vfs_files.clone();
+        snapshot.resource_manager.vfs_resource_files = self.vfs_resource_files.clone();
+        snapshot
+    }
+
     #[cfg(test)]
     pub(crate) fn with_resources(
         mut self,
@@ -602,6 +846,319 @@ impl ProcessFileSystemState {
         self.vfs_resource_files.replace(vfs_resource_files);
         self.vfs_resources = vfs_resources;
         self
+    }
+
+    pub(crate) fn publish_native_vfs_catalogue(&mut self) {
+        let directories = self.vfs_directories.clone();
+        let volumes = self.vfs_volumes.clone();
+        let files = self.vfs_files.iter().cloned().collect::<Vec<_>>();
+        let resource_files = self.vfs_resource_files.iter().cloned().collect::<Vec<_>>();
+        let deleted_paths = self.deleted_vfs_file_paths.clone();
+
+        for directory in &directories {
+            let path = directory.path.clone();
+            let name = if path.is_empty() {
+                "MacintoshHD".to_string()
+            } else {
+                process_vfs_basename(&path).to_string()
+            };
+            self.classic_vfs_directories.insert(
+                path.clone(),
+                ProcessClassicVfsDirectory {
+                    dir_id: directory.dir_id,
+                    parent_dir_id: directory.parent_dir_id,
+                    name,
+                },
+            );
+            self.classic_vfs_directory_paths
+                .insert(directory.dir_id, path.clone());
+            if directory.dirty && !path.is_empty() {
+                publish_native_vfs_metadata(
+                    &mut self.classic_vfs_metadata,
+                    &mut self.classic_next_vfs_file_id,
+                    &mut self.classic_next_vfs_timestamp,
+                    &path,
+                    directory.parent_dir_id,
+                    directory.file_type,
+                    directory.creator,
+                    directory.finder_flags,
+                    true,
+                );
+            }
+        }
+        *self.classic_next_vfs_dir_id = (*self.classic_next_vfs_dir_id)
+            .max(self.next_vfs_dir_id)
+            .max(
+                directories
+                    .iter()
+                    .map(|directory| directory.dir_id.saturating_add(1))
+                    .max()
+                    .unwrap_or(16),
+            );
+        *self.classic_default_dir_id = self.default_dir_id;
+
+        for volume in volumes {
+            self.classic_vfs_volume_names
+                .insert(volume.name.to_ascii_lowercase(), volume.ref_num);
+            self.classic_vfs_volumes.insert(volume.ref_num, volume);
+        }
+        if let Some(lowest_ref_num) = self.classic_vfs_volumes.keys().copied().min() {
+            *self.classic_next_vfs_volume_ref_num =
+                (*self.classic_next_vfs_volume_ref_num).min(lowest_ref_num.saturating_sub(1));
+        }
+
+        for file in files {
+            if file.path.is_empty() {
+                continue;
+            }
+            let parent_dir_id = process_vfs_parent_dir_id(&directories, &file.path);
+            publish_native_vfs_metadata(
+                &mut self.classic_vfs_metadata,
+                &mut self.classic_next_vfs_file_id,
+                &mut self.classic_next_vfs_timestamp,
+                &file.path,
+                parent_dir_id,
+                file.file_type,
+                file.creator,
+                file.finder_flags,
+                file.dirty,
+            );
+        }
+        for file in resource_files {
+            if file.path.is_empty() {
+                continue;
+            }
+            let parent_dir_id = process_vfs_parent_dir_id(&directories, &file.path);
+            publish_native_vfs_metadata(
+                &mut self.classic_vfs_metadata,
+                &mut self.classic_next_vfs_file_id,
+                &mut self.classic_next_vfs_timestamp,
+                &file.path,
+                parent_dir_id,
+                file.file_type,
+                file.creator,
+                file.finder_flags,
+                file.dirty,
+            );
+        }
+        for path in deleted_paths {
+            self.vfs_files.data_forks.remove(&path);
+            self.vfs_resource_files.resource_forks.remove(&path);
+            self.vfs_files
+                .records
+                .retain(|file| !file.path.eq_ignore_ascii_case(&path));
+            self.vfs_resource_files
+                .records
+                .retain(|file| !file.path.eq_ignore_ascii_case(&path));
+            self.classic_vfs_metadata.remove(&path);
+            self.classic_locked_files.remove(&path);
+        }
+    }
+
+    pub(crate) fn publish_classic_vfs_directory(&mut self, path: &str) {
+        let Some(directory) = self.classic_vfs_directories.get(path).cloned() else {
+            return;
+        };
+        let metadata = self.classic_vfs_metadata.get(path).copied();
+        if let Some(native) = self
+            .vfs_directories
+            .iter_mut()
+            .find(|native| native.path.eq_ignore_ascii_case(path))
+        {
+            native.dir_id = directory.dir_id;
+            native.parent_dir_id = directory.parent_dir_id;
+            if let Some(metadata) = metadata {
+                native.file_type = metadata.file_type;
+                native.creator = metadata.creator;
+                native.finder_flags = metadata.finder_flags;
+            }
+            return;
+        }
+        self.vfs_directories.push(ProcessVfsDirectory {
+            dir_id: directory.dir_id,
+            parent_dir_id: directory.parent_dir_id,
+            path: path.to_string(),
+            creator: metadata
+                .map(|metadata| metadata.creator)
+                .unwrap_or(u32::from_be_bytes(*b"MACS")),
+            file_type: metadata
+                .map(|metadata| metadata.file_type)
+                .unwrap_or(u32::from_be_bytes(*b"fold")),
+            finder_flags: metadata.map(|metadata| metadata.finder_flags).unwrap_or(0),
+            dirty: false,
+        });
+        self.next_vfs_dir_id = self.next_vfs_dir_id.max(directory.dir_id.saturating_add(1));
+    }
+
+    pub(crate) fn publish_classic_vfs_catalogue(&mut self) {
+        let directories = self
+            .classic_vfs_directories
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+        let metadata = self
+            .classic_vfs_metadata
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+        let volumes = self.classic_vfs_volumes.keys().copied().collect::<Vec<_>>();
+        for path in directories {
+            self.publish_classic_vfs_directory(&path);
+        }
+        for path in metadata {
+            self.publish_classic_vfs_metadata(&path);
+        }
+        for ref_num in volumes {
+            self.publish_classic_vfs_volume(ref_num);
+        }
+        self.default_dir_id = *self.classic_default_dir_id;
+    }
+
+    pub(crate) fn publish_classic_vfs_metadata(&mut self, path: &str) {
+        let Some(metadata) = self.classic_vfs_metadata.get(path).copied() else {
+            return;
+        };
+        if self.classic_vfs_directories.contains_key(path) {
+            self.publish_classic_vfs_directory(path);
+            return;
+        }
+        if let Some(data) = self.vfs_files.data_forks.get_shared(path) {
+            let data = data.shared_handle();
+            if let Some(file) = self
+                .vfs_files
+                .iter_mut()
+                .find(|file| file.path.eq_ignore_ascii_case(path))
+            {
+                file.creator = metadata.creator;
+                file.file_type = metadata.file_type;
+                file.finder_flags = metadata.finder_flags;
+            } else {
+                self.vfs_files.push(ProcessVfsFileRecord {
+                    path: path.to_string(),
+                    data,
+                    creator: metadata.creator,
+                    file_type: metadata.file_type,
+                    finder_flags: metadata.finder_flags,
+                    dirty: false,
+                });
+            }
+        }
+        if let Some(data) = self.vfs_resource_files.resource_forks.get_shared(path) {
+            let data = data.shared_handle();
+            if let Some(file) = self
+                .vfs_resource_files
+                .iter_mut()
+                .find(|file| file.path.eq_ignore_ascii_case(path))
+            {
+                file.creator = metadata.creator;
+                file.file_type = metadata.file_type;
+                file.finder_flags = metadata.finder_flags;
+            } else {
+                self.vfs_resource_files.push(ProcessVfsResourceFileRecord {
+                    path: path.to_string(),
+                    creator: metadata.creator,
+                    file_type: metadata.file_type,
+                    finder_flags: metadata.finder_flags,
+                    resource_len: data.len() as u32,
+                    raw_data: Some(data),
+                    map_attrs: 0,
+                    dirty: false,
+                });
+            }
+        }
+    }
+
+    pub(crate) fn publish_classic_vfs_volume(&mut self, ref_num: i16) {
+        let Some(volume) = self.classic_vfs_volumes.get(&ref_num).cloned() else {
+            return;
+        };
+        if let Some(native) = self
+            .vfs_volumes
+            .iter_mut()
+            .find(|native| native.ref_num == ref_num)
+        {
+            *native = volume;
+        } else {
+            self.vfs_volumes.push(volume);
+        }
+    }
+
+    pub(crate) fn remove_classic_vfs_path(&mut self, path: &str) {
+        let prefix = format!("{path}/");
+        self.vfs_files.retain(|file| {
+            !file.path.eq_ignore_ascii_case(path)
+                && !file
+                    .path
+                    .to_ascii_lowercase()
+                    .starts_with(&prefix.to_ascii_lowercase())
+        });
+        self.vfs_resource_files.retain(|file| {
+            !file.path.eq_ignore_ascii_case(path)
+                && !file
+                    .path
+                    .to_ascii_lowercase()
+                    .starts_with(&prefix.to_ascii_lowercase())
+        });
+        self.vfs_directories.retain(|directory| {
+            !directory.path.eq_ignore_ascii_case(path)
+                && !directory
+                    .path
+                    .to_ascii_lowercase()
+                    .starts_with(&prefix.to_ascii_lowercase())
+        });
+    }
+}
+
+fn process_vfs_basename(path: &str) -> &str {
+    path.rsplit('/').next().unwrap_or(path)
+}
+
+fn process_vfs_parent_dir_id(directories: &[ProcessVfsDirectory], path: &str) -> u32 {
+    let parent_path = path
+        .rsplit_once('/')
+        .map(|(parent, _)| parent)
+        .unwrap_or("");
+    directories
+        .iter()
+        .find(|directory| directory.path.eq_ignore_ascii_case(parent_path))
+        .map(|directory| directory.dir_id)
+        .unwrap_or(2)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn publish_native_vfs_metadata(
+    metadata: &mut HashMap<String, ProcessVfsMetadata>,
+    next_file_id: &mut u32,
+    next_timestamp: &mut u32,
+    path: &str,
+    parent_dir_id: u32,
+    file_type: u32,
+    creator: u32,
+    finder_flags: u16,
+    touch: bool,
+) {
+    let timestamp = *next_timestamp;
+    let entry = metadata.entry(path.to_string()).or_insert_with(|| {
+        let file_id = *next_file_id;
+        *next_file_id = next_file_id.saturating_add(1);
+        *next_timestamp = next_timestamp.saturating_add(1);
+        ProcessVfsMetadata {
+            file_id,
+            parent_dir_id,
+            file_type,
+            creator,
+            finder_flags,
+            created_date: timestamp,
+            modified_date: timestamp,
+        }
+    });
+    entry.parent_dir_id = parent_dir_id;
+    entry.file_type = file_type;
+    entry.creator = creator;
+    entry.finder_flags = finder_flags;
+    if touch {
+        entry.modified_date = *next_timestamp;
+        *next_timestamp = next_timestamp.saturating_add(1);
     }
 }
 
@@ -804,19 +1361,11 @@ impl SharedProcessValue<ProcessResourceManagerState> {
         if Rc::ptr_eq(&self.0, &target.0) {
             return;
         }
-        let source_is_empty = process_resource_manager_is_empty(self);
-        let target_is_empty = process_resource_manager_is_empty(target);
-        assert!(
-            source_is_empty || target_is_empty,
-            "cannot attach two populated process Resource Managers"
-        );
-        if target_is_empty && !source_is_empty {
-            // SAFETY: adapters attach before being exposed through the runner,
-            // and the target allocation must stay stable because its nested
-            // fork maps may already be shared with the classic dispatcher.
-            unsafe {
-                (&mut *target.0.get()).adopt(&mut *self.0.get());
-            }
+        // SAFETY: adapters attach before being exposed through the runner,
+        // and the target allocation must stay stable because its nested fork
+        // maps may already be shared with the classic dispatcher.
+        unsafe {
+            (&mut *target.0.get()).merge_from(&mut *self.0.get());
         }
         self.0 = Rc::clone(&target.0);
     }
@@ -857,62 +1406,19 @@ impl SharedProcessFileSystem {
         Self(Rc::new(UnsafeCell::new(state)))
     }
 
+    pub(crate) fn detached_vfs_snapshot(&self) -> Self {
+        Self::from_state((**self).detached_vfs_snapshot())
+    }
+
     pub(crate) fn attach_to(&mut self, process_file_system: &Self) {
         if Rc::ptr_eq(&self.0, &process_file_system.0) {
             return;
         }
-        let source_is_empty = self.vfs_files.is_empty()
-            && self.files.is_empty()
-            && self.resource_files.is_empty()
-            && self.vfs_resource_files.is_empty()
-            && self.vfs_resources.is_empty();
-        let target_is_empty = process_file_system.vfs_files.is_empty()
-            && process_file_system.files.is_empty()
-            && process_file_system.resource_files.is_empty()
-            && process_file_system.vfs_resource_files.is_empty()
-            && process_file_system.vfs_resources.is_empty();
-        let source_catalogue_is_pristine = self.vfs_volumes.is_empty()
-            && self.vfs_directories.iter().all(|directory| !directory.dirty);
-        let target_catalogue_is_empty = process_file_system.vfs_volumes.is_empty()
-            && process_file_system.vfs_directories.is_empty()
-            && process_file_system.next_vfs_dir_id == 0
-            && process_file_system.default_dir_id == 0;
-        assert!(
-            source_is_empty || target_is_empty,
-            "cannot attach two populated process filesystems"
-        );
-        assert!(
-            source_catalogue_is_pristine || target_catalogue_is_empty,
-            "cannot attach two populated process VFS catalogues"
-        );
-        if target_catalogue_is_empty {
-            // SAFETY: catalogue attachment follows the same pre-exposure
-            // serialization contract as the file and resource indexes below.
-            unsafe {
-                let source = &mut *self.0.get();
-                let target = &mut *process_file_system.0.get();
-                target.vfs_volumes = std::mem::take(&mut source.vfs_volumes);
-                target.vfs_directories = std::mem::take(&mut source.vfs_directories);
-                target.next_vfs_dir_id = source.next_vfs_dir_id;
-                target.default_dir_id = source.default_dir_id;
-            }
-        }
-        if target_is_empty {
-            // SAFETY: attachment occurs before the native adapter is exposed
-            // through the runner, so no references into either state exist.
-            unsafe {
-                let source = &mut *self.0.get();
-                let target = &mut *process_file_system.0.get();
-                target.vfs_files.adopt(&mut source.vfs_files);
-                target.files = std::mem::take(&mut source.files);
-                target.stdio_streams = std::mem::take(&mut source.stdio_streams);
-                target.deleted_vfs_file_paths =
-                    std::mem::take(&mut source.deleted_vfs_file_paths);
-                source
-                    .resource_manager
-                    .attach_resource_manager_to(&target.resource_manager);
-                target.next_file_ref_num = source.next_file_ref_num;
-            }
+        // SAFETY: adapters attach before being exposed through the runner.
+        // The process allocation must remain stable because the classic
+        // dispatcher may already share its nested catalogue and fork handles.
+        unsafe {
+            (&mut *process_file_system.0.get()).merge_from(&mut *self.0.get());
         }
         self.0 = Rc::clone(&process_file_system.0);
     }
@@ -3570,6 +4076,17 @@ pub(crate) struct ProcessContext {
 }
 
 impl ProcessContext {
+    pub(crate) fn with_file_system(file_system: SharedProcessFileSystem) -> Self {
+        Self {
+            file_system,
+            ..Self::default()
+        }
+    }
+
+    pub(crate) fn detached_vfs_snapshot(&self) -> SharedProcessFileSystem {
+        self.file_system.detached_vfs_snapshot()
+    }
+
     #[cfg(test)]
     pub(crate) fn memory_manager_mut(&self) -> RefMut<'_, ProcessMemoryManager> {
         self.memory_manager.borrow_mut()
@@ -3651,10 +4168,7 @@ impl ProcessContext {
             ProcessForkMap::is_empty,
         );
         resource_forks.attach_to(
-            &self
-                .file_system
-                .vfs_resource_files
-                .resource_forks,
+            &self.file_system.vfs_resource_files.resource_forks,
             ProcessForkMap::is_empty,
         );
     }
@@ -3667,25 +4181,39 @@ impl ProcessContext {
         directory_paths: &mut SharedProcessValue<HashMap<u32, String>>,
         volumes: &mut SharedProcessValue<HashMap<i16, ProcessVfsVolumeRecord>>,
         volume_names: &mut SharedProcessValue<HashMap<String, i16>>,
+        locked_files: &mut SharedProcessValue<HashSet<String>>,
         next_dir_id: &mut SharedProcessValue<u32>,
+        next_volume_ref_num: &mut SharedProcessValue<i16>,
+        next_file_id: &mut SharedProcessValue<u32>,
+        next_timestamp: &mut SharedProcessValue<u32>,
         default_dir_id: &mut SharedProcessValue<u32>,
     ) {
         metadata.attach_to(&self.file_system.classic_vfs_metadata, HashMap::is_empty);
         directories.attach_to(
             &self.file_system.classic_vfs_directories,
-            HashMap::is_empty,
+            process_classic_vfs_directories_are_pristine,
         );
         directory_paths.attach_to(
             &self.file_system.classic_vfs_directory_paths,
-            HashMap::is_empty,
+            process_classic_vfs_directory_paths_are_pristine,
         );
         volumes.attach_to(&self.file_system.classic_vfs_volumes, HashMap::is_empty);
         volume_names.attach_to(
             &self.file_system.classic_vfs_volume_names,
             HashMap::is_empty,
         );
+        locked_files.attach_to(&self.file_system.classic_locked_files, HashSet::is_empty);
         next_dir_id.attach_to(&self.file_system.classic_next_vfs_dir_id, |value| {
-            *value == 16
+            matches!(*value, 16 | 18)
+        });
+        next_volume_ref_num.attach_to(&self.file_system.classic_next_vfs_volume_ref_num, |value| {
+            *value == -2
+        });
+        next_file_id.attach_to(&self.file_system.classic_next_vfs_file_id, |value| {
+            *value == 32
+        });
+        next_timestamp.attach_to(&self.file_system.classic_next_vfs_timestamp, |value| {
+            *value == 1
         });
         default_dir_id.attach_to(&self.file_system.classic_default_dir_id, |value| {
             *value == 2
@@ -4058,7 +4586,10 @@ mod tests {
         manager.set_native_mem_error(ProcessMemoryManager::PARAM_ERR);
         let mut memory = GuestAddressSpace::new();
         memory.add_region(HEAP_BASE, vec![0; 0x1000]);
-        assert_eq!(manager.reserve_native_bytes(&mut memory, 0x20, true), HEAP_BASE);
+        assert_eq!(
+            manager.reserve_native_bytes(&mut memory, 0x20, true),
+            HEAP_BASE
+        );
 
         let heap = manager.native_heap_state().unwrap();
         assert_eq!(heap.heap_cursor, HEAP_BASE + 0x20);
@@ -5065,7 +5596,11 @@ mod tests {
         let mut first_volumes =
             SharedProcessValue::<HashMap<i16, ProcessVfsVolumeRecord>>::default();
         let mut first_volume_names = SharedProcessValue::<HashMap<String, i16>>::default();
+        let mut first_locked_files = SharedProcessValue::<HashSet<String>>::default();
         let mut first_next_dir_id = SharedProcessValue::from_value(16);
+        let mut first_next_volume_ref_num = SharedProcessValue::from_value(-2);
+        let mut first_next_file_id = SharedProcessValue::from_value(32);
+        let mut first_next_timestamp = SharedProcessValue::from_value(1);
         let mut first_default_dir_id = SharedProcessValue::from_value(2);
         first_directories.insert(
             String::new(),
@@ -5083,7 +5618,11 @@ mod tests {
             &mut first_directory_paths,
             &mut first_volumes,
             &mut first_volume_names,
+            &mut first_locked_files,
             &mut first_next_dir_id,
+            &mut first_next_volume_ref_num,
+            &mut first_next_file_id,
+            &mut first_next_timestamp,
             &mut first_default_dir_id,
         );
 
@@ -5095,7 +5634,11 @@ mod tests {
         let mut second_volumes =
             SharedProcessValue::<HashMap<i16, ProcessVfsVolumeRecord>>::default();
         let mut second_volume_names = SharedProcessValue::<HashMap<String, i16>>::default();
+        let mut second_locked_files = SharedProcessValue::<HashSet<String>>::default();
         let mut second_next_dir_id = SharedProcessValue::from_value(16);
+        let mut second_next_volume_ref_num = SharedProcessValue::from_value(-2);
+        let mut second_next_file_id = SharedProcessValue::from_value(32);
+        let mut second_next_timestamp = SharedProcessValue::from_value(1);
         let mut second_default_dir_id = SharedProcessValue::from_value(2);
         context.attach_classic_vfs_catalogue(
             &mut second_metadata,
@@ -5103,7 +5646,11 @@ mod tests {
             &mut second_directory_paths,
             &mut second_volumes,
             &mut second_volume_names,
+            &mut second_locked_files,
             &mut second_next_dir_id,
+            &mut second_next_volume_ref_num,
+            &mut second_next_file_id,
+            &mut second_next_timestamp,
             &mut second_default_dir_id,
         );
         let detached_directories = second_directories.clone();
@@ -5122,7 +5669,10 @@ mod tests {
         *first_default_dir_id = 16;
 
         assert!(second_directories.contains_key("Games"));
-        assert_eq!(second_directory_paths.get(&16).map(String::as_str), Some("Games"));
+        assert_eq!(
+            second_directory_paths.get(&16).map(String::as_str),
+            Some("Games")
+        );
         assert_eq!(*second_next_dir_id, 17);
         assert_eq!(*second_default_dir_id, 16);
         assert!(!detached_directories.contains_key("Games"));
@@ -5203,6 +5753,89 @@ mod tests {
         assert_eq!(detached.vfs_volumes[0].file_count, 1);
         assert_eq!(detached.next_vfs_dir_id, 16);
         assert_eq!(detached.default_dir_id, 2);
+    }
+
+    #[test]
+    fn attaching_populated_file_systems_merges_persistent_catalogues() {
+        let mut target_state = ProcessFileSystemState::default();
+        target_state.vfs_files.push(ProcessVfsFileRecord {
+            path: "Shared".to_string(),
+            data: b"classic".to_vec().into(),
+            creator: u32::from_be_bytes(*b"CLSC"),
+            file_type: u32::from_be_bytes(*b"TEXT"),
+            finder_flags: 0,
+            dirty: false,
+        });
+        target_state
+            .vfs_resource_files
+            .push(ProcessVfsResourceFileRecord {
+                path: "Shared".to_string(),
+                creator: u32::from_be_bytes(*b"CLSC"),
+                file_type: u32::from_be_bytes(*b"APPL"),
+                finder_flags: 0,
+                resource_len: 16,
+                raw_data: Some(b"classic-resource".to_vec().into()),
+                map_attrs: 0,
+                dirty: false,
+            });
+        target_state.vfs_resources.push(ProcessVfsResourceRecord {
+            ref_num: 2,
+            path: "Shared".to_string(),
+            res_type: u32::from_be_bytes(*b"TEST"),
+            res_id: 128,
+            name: b"Target".to_vec(),
+            data: b"target".to_vec(),
+            raw_data: None,
+            raw_attrs: None,
+            attrs: 0,
+            handle: 0,
+        });
+        let context =
+            ProcessContext::with_file_system(SharedProcessFileSystem::from_state(target_state));
+
+        let mut source_state = ProcessFileSystemState::default();
+        for (path, data) in [
+            ("Shared", b"native".as_slice()),
+            ("Native", b"new".as_slice()),
+        ] {
+            source_state.vfs_files.push(ProcessVfsFileRecord {
+                path: path.to_string(),
+                data: data.to_vec().into(),
+                creator: u32::from_be_bytes(*b"NATV"),
+                file_type: u32::from_be_bytes(*b"TEXT"),
+                finder_flags: 0,
+                dirty: false,
+            });
+        }
+        for (res_id, data) in [(128, b"source".as_slice()), (129, b"new".as_slice())] {
+            source_state.vfs_resources.push(ProcessVfsResourceRecord {
+                ref_num: 2,
+                path: "Shared".to_string(),
+                res_type: u32::from_be_bytes(*b"TEST"),
+                res_id,
+                name: Vec::new(),
+                data: data.to_vec(),
+                raw_data: None,
+                raw_attrs: None,
+                attrs: 0,
+                handle: 0,
+            });
+        }
+        let mut native = SharedProcessFileSystem::from_state(source_state);
+        context.attach_file_system(&mut native);
+
+        assert_eq!(native.vfs_files.len(), 2);
+        assert_eq!(native.vfs_files[0].data, b"classic");
+        assert_eq!(native.vfs_files[1].path, "Native");
+        assert_eq!(native.vfs_files[1].data, b"new");
+        assert_eq!(native.vfs_resources.len(), 2);
+        assert_eq!(native.vfs_resources[0].data, b"target");
+        assert_eq!(native.vfs_resources[1].res_id, 129);
+        assert_eq!(native.vfs_resources[1].data, b"new");
+        assert_eq!(
+            native.vfs_resource_files.fork("Shared").unwrap(),
+            b"classic-resource"
+        );
     }
 
     #[test]
@@ -5392,7 +6025,10 @@ mod tests {
 
         assert!(classic.ptr_eq(&native));
         assert_eq!(classic.level, -1);
-        assert_eq!(native.image.as_ref().unwrap().mono_parts(), (data, mask, 3, 4));
+        assert_eq!(
+            native.image.as_ref().unwrap().mono_parts(),
+            (data, mask, 3, 4)
+        );
         assert_eq!(detached.level, 0);
         assert_eq!(
             detached.image.as_ref().unwrap().mono_parts(),

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -17,7 +17,9 @@ use crate::managers::resource::ResourceFork;
 use crate::memory::GuestAddressSpace as PpcSectionMem;
 use crate::memory::{MacMemoryBus, MemoryBus};
 use crate::menu_model::GuestMenuSnapshot;
-use crate::process_context::{ProcessContext, ProcessMemoryManager};
+use crate::process_context::{
+    ProcessContext, ProcessMemoryManager, SharedProcessFileSystem,
+};
 use crate::trap::dispatch::TrapTableProfile;
 use crate::trap::TrapDispatcher;
 use crate::ui_theme::{ThemeMetricsMode, UiTheme, UiThemeId};
@@ -1599,6 +1601,14 @@ impl FixtureRunner {
     /// [`FixtureRunnerConfig`] or through
     /// [`set_menu_bar_policy`](Self::set_menu_bar_policy).
     pub fn new(ram_size: usize, config: FixtureRunnerConfig) -> Self {
+        Self::new_with_file_system(ram_size, config, SharedProcessFileSystem::default())
+    }
+
+    fn new_with_file_system(
+        ram_size: usize,
+        config: FixtureRunnerConfig,
+        file_system: SharedProcessFileSystem,
+    ) -> Self {
         // A 24-bit address space can expose at most 16 MiB. Keep all allocated
         // guest structures, the stack, and framebuffer below that boundary so
         // masking the flag byte cannot alias a high-memory layout onto low RAM.
@@ -1611,7 +1621,7 @@ impl FixtureRunner {
             matches!(config.screen_depth, 1 | 2 | 4 | 8),
             "screen_depth must be 1, 2, 4, or 8"
         );
-        let mut process_context = ProcessContext::default();
+        let mut process_context = ProcessContext::with_file_system(file_system);
         let mut dispatcher = TrapDispatcher::new();
         dispatcher.attach_process_context(&mut process_context);
         dispatcher.set_menu_bar_policy(config.menu_bar_policy);
@@ -2774,7 +2784,7 @@ impl FixtureRunner {
             return 0;
         };
         let materialized_count = ppc_app.prepare_vfs_resource_forks_for_native_export();
-        self.sync_ppc_vfs_to_dispatcher(&mut ppc_app);
+        self.persist_ppc_vfs_to_host(&mut ppc_app);
         self.ppc_app = Some(ppc_app);
         materialized_count
     }
@@ -2791,11 +2801,13 @@ impl FixtureRunner {
         self.dispatcher
             .vfs_rsrc
             .insert(normalized.clone(), file.resource_fork.clone());
-        self.dispatcher.ensure_vfs_file_metadata(&normalized);
+        self.dispatcher.set_vfs_entry_finfo(
+            &normalized,
+            file.file_type,
+            file.creator,
+            file.finder_flags,
+        );
         if let Some(metadata) = self.dispatcher.vfs_metadata.get_mut(&normalized) {
-            metadata.file_type = file.file_type;
-            metadata.creator = file.creator;
-            metadata.finder_flags = file.finder_flags;
             if file.created_date != 0 {
                 metadata.created_date = file.created_date;
             }
@@ -3029,21 +3041,9 @@ impl FixtureRunner {
         let mouse_pos = self.dispatcher.input_state.mouse_pos;
         let mouse_button = self.dispatcher.input_state.mouse_button;
         let output_dir = self.dispatcher.output_dir.clone();
-        let vfs = self.dispatcher.vfs.clone();
-        let vfs_rsrc = self.dispatcher.vfs_rsrc.clone();
-        let vfs_metadata = self.dispatcher.vfs_metadata.clone();
-        let vfs_directories = self.dispatcher.vfs_directories.clone();
-        let vfs_directory_paths = self.dispatcher.vfs_directory_paths.clone();
-        let vfs_volumes = self.dispatcher.vfs_volumes.clone();
-        let vfs_volume_names = self.dispatcher.vfs_volume_names.clone();
-        let next_vfs_volume_ref_num = self.dispatcher.next_vfs_volume_ref_num;
-        let locked_files = self.dispatcher.locked_files.clone();
-        let next_vfs_dir_id = self.dispatcher.next_vfs_dir_id.clone();
-        let next_vfs_file_id = self.dispatcher.next_vfs_file_id;
-        let next_vfs_timestamp = self.dispatcher.next_vfs_timestamp;
-        let next_working_dir_refnum = self.dispatcher.next_working_dir_refnum;
+        let file_system = self.process_context.detached_vfs_snapshot();
 
-        let mut replacement = FixtureRunner::new(ram_size, config);
+        let mut replacement = FixtureRunner::new_with_file_system(ram_size, config, file_system);
         replacement.dispatcher.menu_bar_policy = menu_bar_policy;
         replacement.dispatcher.menu_bar_hidden = menu_bar_hidden;
         replacement.dispatcher.initial_kiosk_guest_hide_observed =
@@ -3060,19 +3060,6 @@ impl FixtureRunner {
         replacement.total_instructions = total_instructions;
 
         replacement.dispatcher.output_dir = output_dir;
-        replacement.dispatcher.vfs = vfs;
-        replacement.dispatcher.vfs_rsrc = vfs_rsrc;
-        replacement.dispatcher.vfs_metadata = vfs_metadata;
-        replacement.dispatcher.vfs_directories = vfs_directories;
-        replacement.dispatcher.vfs_directory_paths = vfs_directory_paths;
-        replacement.dispatcher.vfs_volumes = vfs_volumes;
-        replacement.dispatcher.vfs_volume_names = vfs_volume_names;
-        replacement.dispatcher.next_vfs_volume_ref_num = next_vfs_volume_ref_num;
-        replacement.dispatcher.locked_files = locked_files;
-        replacement.dispatcher.next_vfs_dir_id = next_vfs_dir_id;
-        replacement.dispatcher.next_vfs_file_id = next_vfs_file_id;
-        replacement.dispatcher.next_vfs_timestamp = next_vfs_timestamp;
-        replacement.dispatcher.next_working_dir_refnum = next_working_dir_refnum;
         replacement.dispatcher.set_launched_app_path(&normalized);
 
         let app = replacement
@@ -5968,7 +5955,7 @@ impl FixtureRunner {
         let profile_sync_start = profile_ppc.then(Instant::now);
         if finish_frame {
             self.sync_ppc_front_buffer_to_host(&mut ppc_app);
-            self.sync_ppc_vfs_to_dispatcher(&mut ppc_app);
+            self.persist_ppc_vfs_to_host(&mut ppc_app);
         }
         self.service_ppc_sound_adapter(&mut ppc_app);
         let profile_sync_us = elapsed_profile_micros(profile_sync_start);
@@ -6616,7 +6603,7 @@ impl FixtureRunner {
         let pc = ppc_app.cpu.pc;
         self.render_ppc_completed_frames(&mut ppc_app, pc);
         self.sync_ppc_front_buffer_to_host(&mut ppc_app);
-        self.sync_ppc_vfs_to_dispatcher(&mut ppc_app);
+        self.persist_ppc_vfs_to_host(&mut ppc_app);
         self.ppc_app = Some(ppc_app);
     }
 
@@ -7587,7 +7574,7 @@ impl FixtureRunner {
                 break;
             }
         }
-        self.sync_ppc_vfs_to_dispatcher(&mut ppc_app);
+        self.persist_ppc_vfs_to_host(&mut ppc_app);
         self.service_ppc_sound_adapter(&mut ppc_app);
         self.ppc_app = Some(ppc_app);
     }
@@ -7668,21 +7655,17 @@ impl FixtureRunner {
                 break;
             }
         }
-        self.sync_ppc_vfs_to_dispatcher(&mut ppc_app);
+        self.persist_ppc_vfs_to_host(&mut ppc_app);
         self.service_ppc_sound_adapter(&mut ppc_app);
         self.ppc_app = Some(ppc_app);
     }
 
-    fn sync_ppc_vfs_to_dispatcher(&mut self, ppc_app: &mut PpcLoadedApp) {
+    fn persist_ppc_vfs_to_host(&mut self, ppc_app: &mut PpcLoadedApp) {
         for path in ppc_app.take_deleted_vfs_file_paths() {
             let normalized = crate::trap::dispatch::TrapDispatcher::normalize_vfs_path(&path);
             if normalized.is_empty() {
                 continue;
             }
-            self.dispatcher.vfs.remove(&normalized);
-            self.dispatcher.vfs_rsrc.remove(&normalized);
-            self.dispatcher.locked_files.remove(&normalized);
-            self.dispatcher.remove_vfs_entry_metadata(&normalized);
             if let Some(dir) = &self.dispatcher.output_dir {
                 let host_path = dir.join(&normalized);
                 let _ = std::fs::remove_file(&host_path);
@@ -7698,13 +7681,6 @@ impl FixtureRunner {
             if normalized.is_empty() {
                 continue;
             }
-            self.dispatcher.ensure_vfs_directory(&normalized);
-            self.dispatcher.set_vfs_entry_finfo(
-                &normalized,
-                directory.file_type,
-                directory.creator,
-                directory.finder_flags,
-            );
             if let Some(dir) = &self.dispatcher.output_dir {
                 let _ = std::fs::create_dir_all(dir.join(&normalized));
             }
@@ -7715,13 +7691,6 @@ impl FixtureRunner {
             if normalized.is_empty() {
                 continue;
             }
-            self.dispatcher.set_vfs_entry_finfo(
-                &normalized,
-                file.file_type,
-                file.creator,
-                file.finder_flags,
-            );
-            self.dispatcher.touch_vfs_entry(&normalized);
             if let Some(dir) = &self.dispatcher.output_dir {
                 let host_path = dir.join(&normalized);
                 if let Some(parent) = host_path.parent() {
@@ -7736,13 +7705,6 @@ impl FixtureRunner {
             if normalized.is_empty() {
                 continue;
             }
-            self.dispatcher.set_vfs_entry_finfo(
-                &normalized,
-                fork.file_type,
-                fork.creator,
-                fork.finder_flags,
-            );
-            self.dispatcher.touch_vfs_entry(&normalized);
             if let Some(dir) = &self.dispatcher.output_dir {
                 if let Some((parent, file_name)) = ppc_resource_sidecar_parent(dir, &normalized) {
                     let rsrc_dir = parent.join(".rsrc");

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -17,8 +17,8 @@ use crate::process_context::{
     ProcessLoadedResources, ProcessResourceFileMap, ProcessResourceManagerState,
     ProcessVfsMetadata, ProcessVfsVolumeRecord, SharedProcessAppleEventHandlers,
     SharedProcessCursorState, SharedProcessEventQueue, SharedProcessInputState,
-    SharedProcessMemoryManager, SharedProcessMenuTracking, SharedProcessResourceManager,
-    SharedProcessSoundManager, SharedProcessValue,
+    SharedProcessFileSystem, SharedProcessMemoryManager, SharedProcessMenuTracking,
+    SharedProcessResourceManager, SharedProcessSoundManager, SharedProcessValue,
 };
 use crate::trace::{TraceEvent, TraceSink, TraceSource};
 use crate::ui_theme::{UiTheme, UiThemeId};
@@ -1734,6 +1734,7 @@ pub struct TrapDispatcher {
     pub(crate) adb: crate::adb::AdbManager,
     /// Process-owned Resource Manager state shared by attached CPU adapters.
     process_resource_manager: SharedProcessResourceManager,
+    process_file_system: SharedProcessFileSystem,
     /// Per-page hold refcounts for `HoldMemory`/`UnholdMemory`.
     /// Keys are 4 KiB page numbers in logical address space.
     /// Inside Macintosh: Memory (1992), 3-25 to 3-27.
@@ -2045,7 +2046,7 @@ pub struct TrapDispatcher {
     /// Files 1992, 2-205 (`ioFlAttrib` field), 9302..9352 (HSetFLock/HRstFLock).
     /// Public to mirror `vfs`/`vfs_rsrc` so frontends and tests can
     /// inspect or seed lock state directly.
-    pub locked_files: std::collections::HashSet<String>,
+    pub locked_files: SharedProcessValue<std::collections::HashSet<String>>,
     /// Next available file reference number
     pub(crate) next_refnum: u16,
     /// Current MMU addressing mode (0=24-bit, 1=32-bit)
@@ -2069,11 +2070,11 @@ pub struct TrapDispatcher {
     /// Next synthetic catalog directory ID for VFS directories.
     pub(crate) next_vfs_dir_id: SharedProcessValue<u32>,
     /// Next stable negative volume reference for an extracted read-only volume.
-    pub(crate) next_vfs_volume_ref_num: i16,
+    pub(crate) next_vfs_volume_ref_num: SharedProcessValue<i16>,
     /// Next synthetic file ID for VFS files.
-    pub(crate) next_vfs_file_id: u32,
+    pub(crate) next_vfs_file_id: SharedProcessValue<u32>,
     /// Monotonic source for VFS creation and modification timestamps.
-    pub(crate) next_vfs_timestamp: u32,
+    pub(crate) next_vfs_timestamp: SharedProcessValue<u32>,
     /// Next working directory reference number.
     pub(crate) next_working_dir_refnum: i16,
     /// Normalized VFS path of the launched application, if known.
@@ -2862,6 +2863,7 @@ impl TrapDispatcher {
 
     /// Attach shared process resources to this dispatcher.
     pub(crate) fn attach_process_context(&mut self, context: &mut ProcessContext) {
+        context.attach_file_system(&mut self.process_file_system);
         context.attach_resource_manager(&mut self.process_resource_manager);
         context.attach_sound_manager(&mut self.sound_manager);
         context.attach_cursor_state(&mut self.cursor_state);
@@ -2875,9 +2877,14 @@ impl TrapDispatcher {
             &mut self.vfs_directory_paths,
             &mut self.vfs_volumes,
             &mut self.vfs_volume_names,
+            &mut self.locked_files,
             &mut self.next_vfs_dir_id,
+            &mut self.next_vfs_volume_ref_num,
+            &mut self.next_vfs_file_id,
+            &mut self.next_vfs_timestamp,
             &mut self.default_dir_id,
         );
+        self.process_file_system.publish_classic_vfs_catalogue();
         let mut memory_manager = None;
         context.attach_memory_manager(&mut memory_manager);
         self.attach_memory_manager_handle(
@@ -3755,6 +3762,7 @@ impl TrapDispatcher {
         let mut dispatcher = Self {
             adb: crate::adb::AdbManager::new(),
             process_resource_manager: SharedProcessResourceManager::default(),
+            process_file_system: SharedProcessFileSystem::default(),
             vm_held_page_counts: HashMap::new(),
             vm_held_page_history: HashSet::new(),
             vm_locked_page_counts: HashMap::new(),
@@ -3836,16 +3844,16 @@ impl TrapDispatcher {
             file_positions: HashMap::new(),
             recent_file_read: None,
             pending_file_completions: VecDeque::new(),
-            locked_files: HashSet::new(),
+            locked_files: SharedProcessValue::default(),
             next_refnum: 100,
             mmu_mode: 1,                      // true32b — 32-bit addressing by default
             default_video_rec: 0x0000,        // no default video device selected
             default_os_rec: 0x0001,           // Macintosh Operating System
             default_startup_rec: 0x0000_0000, // zero-filled first-device startup default
             next_vfs_dir_id: SharedProcessValue::from_value(16),
-            next_vfs_volume_ref_num: -2,
-            next_vfs_file_id: 32,
-            next_vfs_timestamp: 1,
+            next_vfs_volume_ref_num: SharedProcessValue::from_value(-2),
+            next_vfs_file_id: SharedProcessValue::from_value(32),
+            next_vfs_timestamp: SharedProcessValue::from_value(1),
             next_working_dir_refnum: 32,
             launched_app_path: None,
             pending_launch_app: None,
@@ -4637,14 +4645,14 @@ impl TrapDispatcher {
         }
 
         let root_dir_id = self.ensure_vfs_directory(&normalized);
-        let mut ref_num = self.next_vfs_volume_ref_num;
+        let mut ref_num = *self.next_vfs_volume_ref_num;
         while ref_num == 0
             || ref_num == Self::boot_volume_ref_num()
             || self.vfs_volumes.contains_key(&ref_num)
         {
             ref_num = ref_num.saturating_sub(1);
         }
-        self.next_vfs_volume_ref_num = ref_num.saturating_sub(1);
+        *self.next_vfs_volume_ref_num = ref_num.saturating_sub(1);
         self.vfs_volumes.insert(
             ref_num,
             VfsVolume {
@@ -4670,6 +4678,7 @@ impl TrapDispatcher {
             },
         );
         self.vfs_volume_names.insert(key, ref_num);
+        self.process_file_system.publish_classic_vfs_volume(ref_num);
         ref_num
     }
 
@@ -4714,8 +4723,8 @@ impl TrapDispatcher {
     }
 
     fn allocate_vfs_timestamp(&mut self) -> u32 {
-        let timestamp = self.next_vfs_timestamp;
-        self.next_vfs_timestamp = self.next_vfs_timestamp.saturating_add(1);
+        let timestamp = *self.next_vfs_timestamp;
+        *self.next_vfs_timestamp = self.next_vfs_timestamp.saturating_add(1);
         timestamp
     }
 
@@ -4766,8 +4775,14 @@ impl TrapDispatcher {
         if normalized.is_empty() {
             return 2;
         }
-        if let Some(dir) = self.vfs_directories.get(&normalized) {
-            return dir.dir_id;
+        if let Some(dir_id) = self
+            .vfs_directories
+            .get(&normalized)
+            .map(|directory| directory.dir_id)
+        {
+            self.process_file_system
+                .publish_classic_vfs_directory(&normalized);
+            return dir_id;
         }
 
         let parent_path = Self::vfs_parent_path(&normalized).to_string();
@@ -4783,13 +4798,20 @@ impl TrapDispatcher {
                 name: Self::vfs_basename(&normalized).to_string(),
             },
         );
-        self.vfs_directory_paths.insert(dir_id, normalized);
+        self.vfs_directory_paths.insert(dir_id, normalized.clone());
+        self.process_file_system
+            .publish_classic_vfs_directory(&normalized);
         dir_id
     }
 
     pub(crate) fn ensure_vfs_file_metadata(&mut self, path: &str) {
         let normalized = Self::normalize_vfs_path(path);
-        if normalized.is_empty() || self.vfs_metadata.contains_key(&normalized) {
+        if normalized.is_empty() {
+            return;
+        }
+        if self.vfs_metadata.contains_key(&normalized) {
+            self.process_file_system
+                .publish_classic_vfs_metadata(&normalized);
             return;
         }
 
@@ -4797,9 +4819,9 @@ impl TrapDispatcher {
         let parent_dir_id = self.ensure_vfs_directory(&parent_path);
         let timestamp = self.allocate_vfs_timestamp();
         self.vfs_metadata.insert(
-            normalized,
+            normalized.clone(),
             VfsMetadata {
-                file_id: self.next_vfs_file_id,
+                file_id: *self.next_vfs_file_id,
                 parent_dir_id,
                 file_type: u32::from_be_bytes(*b"????"),
                 creator: u32::from_be_bytes(*b"????"),
@@ -4808,7 +4830,9 @@ impl TrapDispatcher {
                 modified_date: timestamp,
             },
         );
-        self.next_vfs_file_id = self.next_vfs_file_id.saturating_add(1);
+        *self.next_vfs_file_id = self.next_vfs_file_id.saturating_add(1);
+        self.process_file_system
+            .publish_classic_vfs_metadata(&normalized);
     }
 
     pub(crate) fn ensure_vfs_catalog(&mut self) {
@@ -4848,6 +4872,8 @@ impl TrapDispatcher {
             metadata.creator = u32::from_be_bytes(creator);
             metadata.finder_flags = finder_flags;
         }
+        self.process_file_system
+            .publish_classic_vfs_metadata(&normalized);
     }
 
     pub(crate) fn set_vfs_entry_finfo(
@@ -4864,6 +4890,8 @@ impl TrapDispatcher {
             metadata.creator = creator;
             metadata.finder_flags = finder_flags;
         }
+        self.process_file_system
+            .publish_classic_vfs_metadata(&normalized);
     }
 
     pub(crate) fn set_launched_app_path(&mut self, name: &str) {
@@ -4871,6 +4899,7 @@ impl TrapDispatcher {
         self.ensure_vfs_file_metadata(&normalized);
         if let Some(metadata) = self.vfs_metadata.get(&normalized).copied() {
             *self.default_dir_id = metadata.parent_dir_id;
+            self.process_file_system.default_dir_id = metadata.parent_dir_id;
             let app_volume_ref = self
                 .vfs_volume_for_path(&normalized)
                 .map(|volume| volume.ref_num)
@@ -4994,11 +5023,24 @@ impl TrapDispatcher {
                 metadata.created_date = timestamp;
             }
         }
+        self.process_file_system
+            .publish_classic_vfs_metadata(&normalized);
     }
 
     pub(crate) fn remove_vfs_entry_metadata(&mut self, name: &str) {
         let normalized = Self::normalize_vfs_path(name);
         self.vfs_metadata.remove(&normalized);
+    }
+
+    pub(crate) fn publish_vfs_entry_to_process(&mut self, name: &str) {
+        let normalized = Self::normalize_vfs_path(name);
+        self.process_file_system
+            .publish_classic_vfs_metadata(&normalized);
+    }
+
+    pub(crate) fn remove_vfs_entry_from_process(&mut self, name: &str) {
+        let normalized = Self::normalize_vfs_path(name);
+        self.process_file_system.remove_classic_vfs_path(&normalized);
     }
 
     pub fn remove_vfs_path(&mut self, name: &str) -> bool {
@@ -5046,6 +5088,8 @@ impl TrapDispatcher {
                 removed = true;
             }
         }
+
+        self.process_file_system.remove_classic_vfs_path(&normalized);
 
         removed
     }

--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -5328,6 +5328,8 @@ impl super::TrapDispatcher {
                 if self.locked_files.remove(&old_key) {
                     self.locked_files.insert(new_key.clone());
                 }
+                self.remove_vfs_entry_from_process(&old_key);
+                self.publish_vfs_entry_to_process(&new_key);
                 // Open access paths must follow the rename so a
                 // subsequent FSRead/FSWrite still resolves to the file.
                 let open_refnums: Vec<u16> = self


### PR DESCRIPTION
## Summary

- make process state own classic catalogue maps, locks, allocation counters, native directory and volume indexes, and both fork maps
- publish native and classic catalogue mutations immediately across CPU adapters without a runner synchronization boundary
- merge overlapping persistent loader catalogues while preserving one live File Manager and Resource Manager
- reduce runner VFS synchronization to host persistence and carry catalogue state across application replacement with a detached process snapshot

## Root cause

The native adapter and classic dispatcher retained separate catalogue indexes. Guest-visible state crossed between them only when the runner drained dirty native records, so nested Mixed Mode calls could observe stale directory, deletion, Finder metadata, or fork state.

The adapters now attach to process-owned catalogue storage and publish mutations directly. The remaining host export path only persists already-committed process state.

## Validation

- `cargo test --locked --lib --quiet` — 4,741 passed, 0 failed, 3 ignored
- strict rustdoc with private intra-doc links denied
- `cargo check --all-targets --all-features --locked`
- deterministic Marathon gameplay and terminal interaction
- deterministic Escape Velocity launch, landing, return to space, and live flight input
- deterministic Tomb Raider Gold live 3D movement

Advances #1187