### PR TITLE
refactor(display)!: make color state process-owned

### DIFF
--- a/src/bin/systemless.rs
+++ b/src/bin/systemless.rs
@@ -1281,8 +1281,8 @@ impl App {
         }
 
         let screen_mode = runner.dispatcher().screen_mode;
-        let device_clut = runner.dispatcher().device_clut;
-        let device_gamma = runner.dispatcher().device_gamma;
+        let device_clut = *runner.dispatcher().device_clut;
+        let device_gamma = *runner.dispatcher().device_gamma;
         #[cfg(target_os = "macos")]
         let cursor = if self.host_cursor.enabled() {
             None

--- a/src/display.rs
+++ b/src/display.rs
@@ -22,6 +22,37 @@ pub type RgbaPalette = [u32; 256];
 /// QuickDraw color component to its most-significant byte.
 pub type DisplayGamma = [[u8; 256]; 3];
 
+/// Generate the standard Mac 8-bit system palette as 16-bit RGB values.
+///
+/// The indexed device color table is shared graphics-device state. Imaging
+/// With QuickDraw (1994), pp. 1-22--1-24 and 4-92--4-93, describes the
+/// `GDevice` color table as the Color Manager's process-visible view of the
+/// video device CLUT.
+pub(crate) fn standard_mac_8bpp_clut() -> [[u16; 3]; 256] {
+    let mut clut = [[0u16; 3]; 256];
+    for i in 0u32..=214 {
+        let r = 5 - (i / 36);
+        let g = 5 - ((i / 6) % 6);
+        let b = 5 - (i % 6);
+        clut[i as usize] = [
+            (r as u16) * 0x3333,
+            (g as u16) * 0x3333,
+            (b as u16) * 0x3333,
+        ];
+    }
+    const RAMP: [u16; 10] = [
+        0xEEEE, 0xDDDD, 0xBBBB, 0xAAAA, 0x8888, 0x7777, 0x5555, 0x4444, 0x2222, 0x1111,
+    ];
+    for (offset, component) in RAMP.into_iter().enumerate() {
+        clut[215 + offset] = [component, 0, 0];
+        clut[225 + offset] = [0, component, 0];
+        clut[235 + offset] = [0, 0, component];
+        clut[245 + offset] = [component, component, component];
+    }
+    clut[255] = [0, 0, 0];
+    clut
+}
+
 /// Return the classic video-driver depth-mode token for a pixel size.
 ///
 /// Universal Interfaces `Video.h` defines the consecutive `oneBitMode`

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -76,7 +76,7 @@ use crate::process_context::{
     ProcessPtrRecord, ProcessResourceManagerState, ProcessVfsFileRecords,
     ProcessVfsResourceFileRecords, SharedProcessAppleEventHandlers, SharedProcessCursorState,
     SharedProcessEventQueue, SharedProcessFileSystem, SharedProcessInputState,
-    SharedProcessMemoryManager, SharedProcessMenuTracking,
+    SharedProcessMemoryManager, SharedProcessMenuTracking, SharedProcessValue,
 };
 use crate::quickdraw::fonts::heuristics::{
     get_italic_end_extend, get_italic_slant, get_italic_underline_extend_left,
@@ -3374,10 +3374,10 @@ pub struct PpcLoadedApp {
     pub(crate) process_file_system: SharedProcessFileSystem,
     pub current_gworld: u32,
     pub current_gdevice: u32,
-    pub screen_clut: [[u16; 3]; 256],
-    pub color_manager_clut: [[u16; 3]; 256],
-    pub device_gamma: crate::display::DisplayGamma,
-    pub device_gamma_explicit: bool,
+    pub screen_clut: SharedProcessValue<[[u16; 3]; 256]>,
+    pub color_manager_clut: SharedProcessValue<[[u16; 3]; 256]>,
+    pub device_gamma: SharedProcessValue<crate::display::DisplayGamma>,
+    pub device_gamma_explicit: SharedProcessValue<bool>,
     pub quickdraw_fore_color: PpcRgbColor,
     pub(crate) quickdraw_fore_indices: HashMap<u32, u8>,
     pub quickdraw_back_color: PpcRgbColor,
@@ -3857,6 +3857,12 @@ impl PpcLoadedApp {
         self.process_file_system.publish_native_vfs_catalogue();
         context.attach_sound_manager(&mut self.sound.manager);
         context.attach_cursor_state(&mut self.cursor_state);
+        context.attach_display_color_state(
+            &mut self.screen_clut,
+            &mut self.color_manager_clut,
+            &mut self.device_gamma,
+            &mut self.device_gamma_explicit,
+        );
         context.attach_event_queue(&mut self.event_queue);
         context.attach_input_state(&mut self.process_input);
         context.attach_menu_tracking(&mut self.toolbox_startup.menu_tracking);
@@ -4471,7 +4477,7 @@ impl PpcLoadedApp {
                         &self.color_manager_clut,
                     )
                 })
-                .unwrap_or(self.color_manager_clut)
+                .unwrap_or(*self.color_manager_clut)
         });
         let surface =
             PpcQ3SoftwareFrontBufferSurface::new(&mut self.memory, front_buffer, indexed_clut);
@@ -7178,10 +7184,10 @@ impl PpcLoadedApp {
         let mut next_file_ref_num = self.next_file_ref_num;
         let mut current_gworld = self.current_gworld;
         let mut current_gdevice = self.current_gdevice;
-        let mut screen_clut = self.screen_clut;
-        let mut color_manager_clut = self.color_manager_clut;
-        let mut device_gamma = self.device_gamma;
-        let mut device_gamma_explicit = self.device_gamma_explicit;
+        let mut screen_clut = self.screen_clut.shared_handle();
+        let mut color_manager_clut = self.color_manager_clut.shared_handle();
+        let mut device_gamma = self.device_gamma.shared_handle();
+        let mut device_gamma_explicit = self.device_gamma_explicit.shared_handle();
         let mut quickdraw_fore_color = self.quickdraw_fore_color;
         let mut quickdraw_fore_indices = std::mem::take(&mut self.quickdraw_fore_indices);
         let mut quickdraw_back_color = self.quickdraw_back_color;
@@ -8065,10 +8071,6 @@ impl PpcLoadedApp {
         self.next_file_ref_num = next_file_ref_num;
         self.current_gworld = current_gworld;
         self.current_gdevice = current_gdevice;
-        self.screen_clut = screen_clut;
-        self.color_manager_clut = color_manager_clut;
-        self.device_gamma = device_gamma;
-        self.device_gamma_explicit = device_gamma_explicit;
         self.quickdraw_fore_color = quickdraw_fore_color;
         self.quickdraw_fore_indices = quickdraw_fore_indices;
         self.quickdraw_back_color = quickdraw_back_color;
@@ -12699,10 +12701,10 @@ fn load_pef_application_with_config_and_optional_system_reservation(
         process_file_system: ppc_initial_process_file_system(),
         current_gworld: PPC_MAIN_GWORLD,
         current_gdevice: PPC_MAIN_GDEVICE,
-        screen_clut,
-        color_manager_clut,
-        device_gamma: crate::display::default_display_gamma(),
-        device_gamma_explicit: false,
+        screen_clut: SharedProcessValue::from_value(screen_clut),
+        color_manager_clut: SharedProcessValue::from_value(color_manager_clut),
+        device_gamma: SharedProcessValue::from_value(crate::display::default_display_gamma()),
+        device_gamma_explicit: SharedProcessValue::from_value(false),
         quickdraw_fore_color: PPC_RGB_BLACK,
         quickdraw_fore_indices: HashMap::new(),
         quickdraw_back_color: PPC_RGB_WHITE,
@@ -88727,6 +88729,53 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn attached_68k_and_powerpc_adapters_share_display_color_state_without_runner_copy() {
+        let (mut classic, _, _) = setup_with_port();
+        let pef = synthetic_pef_with_import(b"GetCTable");
+        let mut native = load_pef_application(&pef).unwrap();
+        let mut context = ProcessContext::default();
+
+        classic.attach_process_context(&mut context);
+        native.attach_process_context(&mut context);
+        let detached = native.clone();
+
+        native.screen_clut[7] = [0x1111, 0x2222, 0x3333];
+        native.color_manager_clut[9] = [0x4444, 0x5555, 0x6666];
+        native.device_gamma[1][42] = 0x7f;
+        *native.device_gamma_explicit = true;
+
+        assert!(classic.device_clut.ptr_eq(&native.screen_clut));
+        assert!(classic
+            .color_manager_clut
+            .ptr_eq(&native.color_manager_clut));
+        assert!(classic.device_gamma.ptr_eq(&native.device_gamma));
+        assert!(classic
+            .device_gamma_explicit
+            .ptr_eq(&native.device_gamma_explicit));
+        assert_eq!(classic.device_clut[7], [0x1111, 0x2222, 0x3333]);
+        assert_eq!(classic.color_manager_clut[9], [0x4444, 0x5555, 0x6666]);
+        assert_eq!(classic.device_gamma[1][42], 0x7f);
+        assert!(*classic.device_gamma_explicit);
+
+        classic.device_clut[3] = [0xaaaa, 0xbbbb, 0xcccc];
+        classic.device_gamma[2][99] = 0x55;
+        assert_eq!(native.screen_clut[3], [0xaaaa, 0xbbbb, 0xcccc]);
+        assert_eq!(native.device_gamma[2][99], 0x55);
+
+        assert!(!native.screen_clut.ptr_eq(&detached.screen_clut));
+        assert!(!native.device_gamma.ptr_eq(&detached.device_gamma));
+        assert_eq!(
+            detached.screen_clut,
+            crate::display::standard_mac_8bpp_clut()
+        );
+        assert_eq!(
+            detached.device_gamma,
+            crate::display::default_display_gamma()
+        );
+        assert!(!*detached.device_gamma_explicit);
+    }
+
+    #[test]
     fn attached_ppc_event_queue_remains_shared_through_panic() {
         let pef = synthetic_pef_with_import(b"InvalMenuBar");
         let mut native = load_pef_application(&pef).unwrap();
@@ -131537,8 +131586,8 @@ pub(crate) mod tests {
                 component.rotate_left(7),
             ]
         });
-        loaded.screen_clut = direct_clut;
-        loaded.color_manager_clut = direct_clut;
+        *loaded.screen_clut = direct_clut;
+        *loaded.color_manager_clut = direct_clut;
         ppc_write_device_color_table(
             &mut loaded.memory,
             PPC_MAIN_GDEVICE,
@@ -131651,7 +131700,7 @@ pub(crate) mod tests {
             &mut loaded.screen_clut,
             &mut loaded.color_manager_clut,
             &mut loaded.device_gamma,
-            loaded.device_gamma_explicit,
+            *loaded.device_gamma_explicit,
             &mut loaded.toolbox_startup,
         ));
 
@@ -131760,7 +131809,7 @@ pub(crate) mod tests {
             &mut loaded.screen_clut,
             &mut loaded.color_manager_clut,
             &mut loaded.device_gamma,
-            loaded.device_gamma_explicit,
+            *loaded.device_gamma_explicit,
             &mut loaded.toolbox_startup,
         ));
         assert_eq!(loaded.screen_clut[1], color);
@@ -132302,7 +132351,7 @@ pub(crate) mod tests {
                 )
                 .unwrap();
         }
-        let original = loaded.screen_clut;
+        let original = *loaded.screen_clut;
 
         for window in [background, offscreen] {
             loaded.cpu.pc = loaded.entry_pc;
@@ -132324,7 +132373,7 @@ pub(crate) mod tests {
         loaded.memory.add_region(palette, vec![0; 16 + 5 * 16]);
         loaded.memory.write_u32_be(handle, palette).unwrap();
         loaded.memory.write_u16_be(palette, 5).unwrap();
-        let original = loaded.screen_clut;
+        let original = *loaded.screen_clut;
         let entries = [
             ([0x3333, 0, 0], 0x0000, 0),
             ([0x4444, 0, 0], 0x0002, 0xffff),
@@ -133053,8 +133102,8 @@ pub(crate) mod tests {
         loaded.screen_clut[1] = [0xaaaa, 0xbbbb, 0xcccc];
         loaded.color_manager_clut[1] = [0xaaaa, 0xbbbb, 0xcccc];
         loaded.toolbox_startup.clut_protected.fill(true);
-        let expected_screen = loaded.screen_clut;
-        let expected_manager = loaded.color_manager_clut;
+        let expected_screen = *loaded.screen_clut;
+        let expected_manager = *loaded.color_manager_clut;
 
         assert!(ppc_activate_window_palette(
             &mut loaded.memory,
@@ -133064,7 +133113,7 @@ pub(crate) mod tests {
             &mut loaded.screen_clut,
             &mut loaded.color_manager_clut,
             &mut loaded.device_gamma,
-            loaded.device_gamma_explicit,
+            *loaded.device_gamma_explicit,
             &mut loaded.toolbox_startup,
         ));
 
@@ -133126,8 +133175,8 @@ pub(crate) mod tests {
         );
         loaded.screen_clut[42] = [0xaaaa, 0xbbbb, 0xcccc];
         loaded.color_manager_clut[42] = [0xaaaa, 0xbbbb, 0xcccc];
-        let expected_screen = loaded.screen_clut;
-        let expected_manager = loaded.color_manager_clut;
+        let expected_screen = *loaded.screen_clut;
+        let expected_manager = *loaded.color_manager_clut;
 
         ppc_restore_device_clut(
             &mut loaded.memory,
@@ -133240,7 +133289,7 @@ pub(crate) mod tests {
         );
         ppc_device_clut_protected_mut(&mut loaded.toolbox_startup, other_gdevice)[42] = true;
         ppc_device_clut_reserved_mut(&mut loaded.toolbox_startup, other_gdevice)[43] = true;
-        let expected_screen = loaded.screen_clut;
+        let expected_screen = *loaded.screen_clut;
 
         assert!(ppc_activate_window_palette(
             &mut loaded.memory,
@@ -133250,7 +133299,7 @@ pub(crate) mod tests {
             &mut loaded.screen_clut,
             &mut loaded.color_manager_clut,
             &mut loaded.device_gamma,
-            loaded.device_gamma_explicit,
+            *loaded.device_gamma_explicit,
             &mut loaded.toolbox_startup,
         ));
 
@@ -133290,7 +133339,7 @@ pub(crate) mod tests {
             &mut loaded.screen_clut,
             &mut loaded.color_manager_clut,
             &mut loaded.device_gamma,
-            loaded.device_gamma_explicit,
+            *loaded.device_gamma_explicit,
             &mut loaded.toolbox_startup,
         ));
         assert_eq!(
@@ -133455,7 +133504,7 @@ pub(crate) mod tests {
         loaded.memory.add_region(palette, vec![0; 32]);
         loaded.memory.write_u32_be(handle, palette).unwrap();
         loaded.memory.write_u16_be(palette, 2).unwrap();
-        let original_clut = loaded.screen_clut;
+        let original_clut = *loaded.screen_clut;
         loaded.screen_clut[42] = [0x1234, 0x5678, 0x9abc];
         loaded
             .toolbox_startup
@@ -133467,7 +133516,7 @@ pub(crate) mod tests {
                 entry_mappings: vec![PpcPaletteEntryMapping::AnimatedReserved(42)],
                 reserved_indices: vec![42],
             });
-        let expected_clut = loaded.screen_clut;
+        let expected_clut = *loaded.screen_clut;
         let expected_allocations = loaded.toolbox_startup.palette_allocations.clone();
 
         assert!(!ppc_apply_palette(
@@ -134010,8 +134059,8 @@ pub(crate) mod tests {
         );
         loaded.screen_clut[42] = [0xaaaa, 0xbbbb, 0xcccc];
         loaded.color_manager_clut[42] = [0xaaaa, 0xbbbb, 0xcccc];
-        let expected_screen = loaded.screen_clut;
-        let expected_manager = loaded.color_manager_clut;
+        let expected_screen = *loaded.screen_clut;
+        let expected_manager = *loaded.color_manager_clut;
         loaded
             .toolbox_startup
             .palette_allocations
@@ -153800,8 +153849,8 @@ pub(crate) mod tests {
         )
         .unwrap();
         let before_startup = loaded.toolbox_startup.clone();
-        let before_screen_clut = loaded.screen_clut;
-        let before_color_manager_clut = loaded.color_manager_clut;
+        let before_screen_clut = *loaded.screen_clut;
+        let before_color_manager_clut = *loaded.color_manager_clut;
         loaded.set_heap_limit(loaded.heap_cursor() + 32);
 
         loaded.cpu.gpr[3] = PPC_MAIN_GDEVICE;
@@ -154072,8 +154121,8 @@ pub(crate) mod tests {
                 ppc_main_screen_buffer_size(),
             )
             .unwrap();
-            let before_screen_clut = loaded.screen_clut;
-            let before_color_manager_clut = loaded.color_manager_clut;
+            let before_screen_clut = *loaded.screen_clut;
+            let before_color_manager_clut = *loaded.color_manager_clut;
             let before_toolbox_startup = loaded.toolbox_startup.clone();
 
             loaded.cpu.gpr[3] = gdevice;

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -1,6 +1,9 @@
 //! Process-scoped state shared by classic and native CPU adapters.
 
-use crate::display::{default_arrow_cursor_image, CursorImage};
+use crate::display::{
+    default_arrow_cursor_image, default_display_gamma, standard_mac_8bpp_clut, CursorImage,
+    DisplayGamma,
+};
 use crate::event_queue::EventQueue;
 use crate::guest_call::SharedGuestCallStack;
 use crate::guest_procedure::GuestProcedure;
@@ -1292,13 +1295,13 @@ impl<T: PartialEq> PartialEq for SharedProcessValue<T> {
     }
 }
 
-impl<T: Eq> Eq for SharedProcessValue<T> {}
-
-impl<T: PartialEq> PartialEq<Option<T>> for SharedProcessValue<Option<T>> {
-    fn eq(&self, other: &Option<T>) -> bool {
+impl<T: PartialEq> PartialEq<T> for SharedProcessValue<T> {
+    fn eq(&self, other: &T) -> bool {
         **self == *other
     }
 }
+
+impl<T: Eq> Eq for SharedProcessValue<T> {}
 
 #[cfg(test)]
 impl<T: Clone> SharedProcessValue<T> {
@@ -1329,6 +1332,15 @@ impl<T> SharedProcessValue<T> {
     pub(crate) fn from_value(value: T) -> Self {
         Self(Rc::new(UnsafeCell::new(value)))
     }
+
+    pub(crate) fn shared_handle(&self) -> Self {
+        Self(Rc::clone(&self.0))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn ptr_eq(&self, other: &Self) -> bool {
+        Rc::ptr_eq(&self.0, &other.0)
+    }
 }
 
 impl<T: Default> SharedProcessValue<T> {
@@ -1349,10 +1361,24 @@ impl<T: Default> SharedProcessValue<T> {
         }
         self.0 = Rc::clone(&process_value.0);
     }
+}
 
-    #[cfg(test)]
-    pub(crate) fn ptr_eq(&self, other: &Self) -> bool {
-        Rc::ptr_eq(&self.0, &other.0)
+impl<T: Copy + PartialEq> SharedProcessValue<T> {
+    fn attach_copy_to(&mut self, process_value: &Self, is_pristine: impl Fn(&T) -> bool) {
+        if Rc::ptr_eq(&self.0, &process_value.0) {
+            return;
+        }
+        assert!(
+            is_pristine(self) || is_pristine(process_value) || **self == **process_value,
+            "cannot attach two populated process manager values"
+        );
+        if is_pristine(process_value) && !is_pristine(self) {
+            // SAFETY: attachment occurs before either adapter is exposed.
+            unsafe {
+                *process_value.0.get() = **self;
+            }
+        }
+        self.0 = Rc::clone(&process_value.0);
     }
 }
 
@@ -4060,7 +4086,7 @@ impl ProcessNativeMemoryManager {
 ///
 /// `FixtureRunner` owns this context and serializes all adapter access through
 /// its mutable borrow.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub(crate) struct ProcessContext {
     memory: Vec<ProcessMemoryRegion>,
     memory_manager: SharedProcessMemoryManager,
@@ -4073,6 +4099,32 @@ pub(crate) struct ProcessContext {
     file_system: SharedProcessFileSystem,
     sound_manager: SharedProcessSoundManager,
     cursor_state: SharedProcessCursorState,
+    device_clut: SharedProcessValue<[[u16; 3]; 256]>,
+    color_manager_clut: SharedProcessValue<[[u16; 3]; 256]>,
+    device_gamma: SharedProcessValue<DisplayGamma>,
+    device_gamma_explicit: SharedProcessValue<bool>,
+}
+
+impl Default for ProcessContext {
+    fn default() -> Self {
+        Self {
+            memory: Vec::new(),
+            memory_manager: SharedProcessMemoryManager::default(),
+            event_queue: SharedProcessEventQueue::default(),
+            input_state: SharedProcessInputState::default(),
+            menu_tracking: SharedProcessMenuTracking::default(),
+            pending_native_menu_selection: SharedNativeMenuSelection::default(),
+            guest_calls: SharedGuestCallStack::default(),
+            apple_event_handlers: SharedProcessAppleEventHandlers::default(),
+            file_system: SharedProcessFileSystem::default(),
+            sound_manager: SharedProcessSoundManager::default(),
+            cursor_state: SharedProcessCursorState::default(),
+            device_clut: SharedProcessValue::from_value(standard_mac_8bpp_clut()),
+            color_manager_clut: SharedProcessValue::from_value(standard_mac_8bpp_clut()),
+            device_gamma: SharedProcessValue::from_value(default_display_gamma()),
+            device_gamma_explicit: SharedProcessValue::from_value(false),
+        }
+    }
 }
 
 impl ProcessContext {
@@ -4128,6 +4180,27 @@ impl ProcessContext {
 
     pub(crate) fn attach_cursor_state(&self, adapter: &mut SharedProcessCursorState) {
         adapter.attach_to(&self.cursor_state, ProcessCursorState::is_pristine);
+    }
+
+    pub(crate) fn attach_display_color_state(
+        &self,
+        device_clut: &mut SharedProcessValue<[[u16; 3]; 256]>,
+        color_manager_clut: &mut SharedProcessValue<[[u16; 3]; 256]>,
+        device_gamma: &mut SharedProcessValue<DisplayGamma>,
+        device_gamma_explicit: &mut SharedProcessValue<bool>,
+    ) {
+        let clut_is_pristine =
+            |clut: &[[u16; 3]; 256]| *clut == [[0; 3]; 256] || *clut == standard_mac_8bpp_clut();
+        let gamma_is_pristine = |gamma: &DisplayGamma| {
+            gamma
+                .iter()
+                .all(|channel| channel.iter().all(|component| *component == 0))
+                || *gamma == default_display_gamma()
+        };
+        device_clut.attach_copy_to(&self.device_clut, clut_is_pristine);
+        color_manager_clut.attach_copy_to(&self.color_manager_clut, clut_is_pristine);
+        device_gamma.attach_copy_to(&self.device_gamma, gamma_is_pristine);
+        device_gamma_explicit.attach_copy_to(&self.device_gamma_explicit, |explicit| !*explicit);
     }
 
     pub(crate) fn attach_event_queue(&self, adapter: &mut SharedProcessEventQueue) {

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -17,9 +17,7 @@ use crate::managers::resource::ResourceFork;
 use crate::memory::GuestAddressSpace as PpcSectionMem;
 use crate::memory::{MacMemoryBus, MemoryBus};
 use crate::menu_model::GuestMenuSnapshot;
-use crate::process_context::{
-    ProcessContext, ProcessMemoryManager, SharedProcessFileSystem,
-};
+use crate::process_context::{ProcessContext, ProcessMemoryManager, SharedProcessFileSystem};
 use crate::trap::dispatch::TrapTableProfile;
 use crate::trap::TrapDispatcher;
 use crate::ui_theme::{ThemeMetricsMode, UiTheme, UiThemeId};
@@ -1652,8 +1650,8 @@ impl FixtureRunner {
         );
         let (clut, _) = TrapDispatcher::standard_mac_indexed_clut(config.screen_depth)
             .expect("validated indexed screen depth");
-        dispatcher.device_clut = clut;
-        dispatcher.color_manager_clut = clut;
+        *dispatcher.device_clut = clut;
+        *dispatcher.color_manager_clut = clut;
         dispatcher.seeded_picture_palette = clut;
         let standard_adb_service = bus.alloc_synthetic(2);
         bus.write_word(standard_adb_service, 0x4E75); // RTS
@@ -7720,11 +7718,6 @@ impl FixtureRunner {
         let Some(primary_buffer) = ppc_app.presented_front_buffer() else {
             return;
         };
-        if matches!(primary_buffer.depth, 1 | 2 | 4 | 8) {
-            self.dispatcher.device_clut = ppc_app.screen_clut;
-            self.dispatcher.color_manager_clut = ppc_app.color_manager_clut;
-            self.dispatcher.device_gamma = ppc_app.device_gamma;
-        }
         let (canvas_width, canvas_height) = Self::ppc_host_canvas_dimensions(primary_buffer);
         let Some(canvas_row_bytes) = Self::ppc_host_row_bytes(canvas_width, primary_buffer.depth)
         else {
@@ -10978,7 +10971,9 @@ mod tests {
     use crate::loader::ppc::*;
     use crate::loader::{ApplicationSizeResource, Code0Header, LoadedApp};
     use crate::menu_manager::TrackedMenuPaneView;
-    use crate::process_context::{ProcessFileSystemState, SharedProcessFileSystem};
+    use crate::process_context::{
+        ProcessFileSystemState, SharedProcessFileSystem, SharedProcessValue,
+    };
     use crate::sound::{
         DoubleBufferState, PendingDoubleBackCallback, PendingSoundCallback, PlaybackKind,
         SndChannel, SndCommand, OUTPUT_RATE,
@@ -13414,10 +13409,16 @@ mod tests {
             cfm_library_fragments: Vec::new(),
             next_cfm_connection_id: 1,
             controls: Vec::new(),
-            screen_clut: TrapDispatcher::standard_mac_8bpp_clut(),
-            device_gamma: crate::display::default_display_gamma(),
-            device_gamma_explicit: false,
-            color_manager_clut: TrapDispatcher::standard_mac_8bpp_clut(),
+            screen_clut: SharedProcessValue::from_value(
+                TrapDispatcher::standard_mac_8bpp_clut(),
+            ),
+            device_gamma: SharedProcessValue::from_value(
+                crate::display::default_display_gamma(),
+            ),
+            device_gamma_explicit: SharedProcessValue::from_value(false),
+            color_manager_clut: SharedProcessValue::from_value(
+                TrapDispatcher::standard_mac_8bpp_clut(),
+            ),
             aliases: Vec::new(),
             gworlds: Vec::new(),
             q3_objects: Vec::new(),
@@ -15584,10 +15585,16 @@ mod tests {
             cfm_library_fragments: Vec::new(),
             next_cfm_connection_id: 1,
             controls: Vec::new(),
-            screen_clut: TrapDispatcher::standard_mac_8bpp_clut(),
-            device_gamma: crate::display::default_display_gamma(),
-            device_gamma_explicit: false,
-            color_manager_clut: TrapDispatcher::standard_mac_8bpp_clut(),
+            screen_clut: SharedProcessValue::from_value(
+                TrapDispatcher::standard_mac_8bpp_clut(),
+            ),
+            device_gamma: SharedProcessValue::from_value(
+                crate::display::default_display_gamma(),
+            ),
+            device_gamma_explicit: SharedProcessValue::from_value(false),
+            color_manager_clut: SharedProcessValue::from_value(
+                TrapDispatcher::standard_mac_8bpp_clut(),
+            ),
             aliases: Vec::new(),
             gworlds: Vec::new(),
             q3_objects: Vec::new(),
@@ -16532,10 +16539,16 @@ mod tests {
             cfm_library_fragments: Vec::new(),
             next_cfm_connection_id: 1,
             controls: Vec::new(),
-            screen_clut: TrapDispatcher::standard_mac_8bpp_clut(),
-            device_gamma: crate::display::default_display_gamma(),
-            device_gamma_explicit: false,
-            color_manager_clut: TrapDispatcher::standard_mac_8bpp_clut(),
+            screen_clut: SharedProcessValue::from_value(
+                TrapDispatcher::standard_mac_8bpp_clut(),
+            ),
+            device_gamma: SharedProcessValue::from_value(
+                crate::display::default_display_gamma(),
+            ),
+            device_gamma_explicit: SharedProcessValue::from_value(false),
+            color_manager_clut: SharedProcessValue::from_value(
+                TrapDispatcher::standard_mac_8bpp_clut(),
+            ),
             aliases: Vec::new(),
             gworlds: Vec::new(),
             q3_objects: Vec::new(),
@@ -16679,10 +16692,16 @@ mod tests {
             cfm_library_fragments: Vec::new(),
             next_cfm_connection_id: 1,
             controls: Vec::new(),
-            screen_clut: TrapDispatcher::standard_mac_8bpp_clut(),
-            device_gamma: crate::display::default_display_gamma(),
-            device_gamma_explicit: false,
-            color_manager_clut: TrapDispatcher::standard_mac_8bpp_clut(),
+            screen_clut: SharedProcessValue::from_value(
+                TrapDispatcher::standard_mac_8bpp_clut(),
+            ),
+            device_gamma: SharedProcessValue::from_value(
+                crate::display::default_display_gamma(),
+            ),
+            device_gamma_explicit: SharedProcessValue::from_value(false),
+            color_manager_clut: SharedProcessValue::from_value(
+                TrapDispatcher::standard_mac_8bpp_clut(),
+            ),
             aliases: Vec::new(),
             gworlds: Vec::new(),
             q3_objects: Vec::new(),
@@ -17058,10 +17077,16 @@ mod tests {
             cfm_library_fragments: Vec::new(),
             next_cfm_connection_id: 1,
             controls: Vec::new(),
-            screen_clut: TrapDispatcher::standard_mac_8bpp_clut(),
-            device_gamma: crate::display::default_display_gamma(),
-            device_gamma_explicit: false,
-            color_manager_clut: TrapDispatcher::standard_mac_8bpp_clut(),
+            screen_clut: SharedProcessValue::from_value(
+                TrapDispatcher::standard_mac_8bpp_clut(),
+            ),
+            device_gamma: SharedProcessValue::from_value(
+                crate::display::default_display_gamma(),
+            ),
+            device_gamma_explicit: SharedProcessValue::from_value(false),
+            color_manager_clut: SharedProcessValue::from_value(
+                TrapDispatcher::standard_mac_8bpp_clut(),
+            ),
             aliases: Vec::new(),
             gworlds: vec![
                 PpcGWorldRecord {
@@ -17331,10 +17356,16 @@ mod tests {
             cfm_library_fragments: Vec::new(),
             next_cfm_connection_id: 1,
             controls: Vec::new(),
-            screen_clut: TrapDispatcher::standard_mac_8bpp_clut(),
-            device_gamma: crate::display::default_display_gamma(),
-            device_gamma_explicit: false,
-            color_manager_clut: TrapDispatcher::standard_mac_8bpp_clut(),
+            screen_clut: SharedProcessValue::from_value(
+                TrapDispatcher::standard_mac_8bpp_clut(),
+            ),
+            device_gamma: SharedProcessValue::from_value(
+                crate::display::default_display_gamma(),
+            ),
+            device_gamma_explicit: SharedProcessValue::from_value(false),
+            color_manager_clut: SharedProcessValue::from_value(
+                TrapDispatcher::standard_mac_8bpp_clut(),
+            ),
             aliases: Vec::new(),
             gworlds: vec![PpcGWorldRecord {
                 port: PPC_MAIN_GWORLD,
@@ -17646,8 +17677,8 @@ mod tests {
         runner.bus.fill_bytes(canary, 8, 0x5a);
 
         let (two_bit_clut, _) = TrapDispatcher::standard_mac_indexed_clut(2).expect("2bpp CLUT");
-        ppc_app.screen_clut = two_bit_clut;
-        ppc_app.color_manager_clut = two_bit_clut;
+        *ppc_app.screen_clut = two_bit_clut;
+        *ppc_app.color_manager_clut = two_bit_clut;
         ppc_app.gworlds[0].depth = 2;
         ppc_app.gworlds[0].row_bytes = 2;
 
@@ -17698,7 +17729,7 @@ mod tests {
     }
 
     #[test]
-    fn ppc_packed_front_buffers_sync_centered_pixels_and_color_state() {
+    fn ppc_packed_front_buffers_sync_centered_pixels_with_process_color_state() {
         const WIDTH: u32 = 513;
         const HEIGHT: u32 = 342;
         const CANVAS_WIDTH: u32 = 800;
@@ -17737,20 +17768,20 @@ mod tests {
                 pixels_locked: false,
                 pixels_no_purge: false,
             });
-            let (mut device_clut, _) =
-                TrapDispatcher::standard_mac_indexed_clut(depth).expect("standard indexed depth");
-            device_clut[0][0] = 0xfffe;
-            let mut color_manager_clut = device_clut;
-            color_manager_clut[0][1] = 0xfffd;
-            ppc_app.screen_clut = device_clut;
-            ppc_app.color_manager_clut = color_manager_clut;
-            ppc_app.device_gamma = crate::display::linear_display_gamma();
-
             let config = FixtureRunnerConfig::default()
                 .with_screen_depth(depth)
                 .expect("packed indexed mode");
             let mut runner = FixtureRunner::new(8 * 1024 * 1024, config);
             let mut ppc_app = app.ppc.take().expect("PPC app");
+            ppc_app.attach_process_context(&mut runner.process_context);
+            let (mut device_clut, _) =
+                TrapDispatcher::standard_mac_indexed_clut(depth).expect("standard indexed depth");
+            device_clut[0][0] = 0xfffe;
+            let mut color_manager_clut = device_clut;
+            color_manager_clut[0][1] = 0xfffd;
+            *ppc_app.screen_clut = device_clut;
+            *ppc_app.color_manager_clut = color_manager_clut;
+            *ppc_app.device_gamma = crate::display::linear_display_gamma();
             runner.sync_ppc_front_buffer_to_host(&mut ppc_app);
 
             let (base, host_row_bytes, width, height, host_depth) = runner.dispatcher.screen_mode;

--- a/src/trap/control.rs
+++ b/src/trap/control.rs
@@ -5431,7 +5431,7 @@ mod tests {
         let screen_base = bus.alloc(128 * 128);
         let row_bytes = 128u32;
         disp.set_screen_mode_for_test(screen_base, row_bytes, 128, 128, 8);
-        disp.device_clut = [[0x2020, 0x4040, 0x6060]; 256];
+        *disp.device_clut = [[0x2020, 0x4040, 0x6060]; 256];
         disp.device_clut[0] = [0xFFFF, 0xFFFF, 0xFFFF];
         disp.device_clut[42] = [0x7FFF, 0x7FFF, 0x7FFF];
         disp.device_clut[255] = [0, 0, 0];
@@ -5518,7 +5518,7 @@ mod tests {
 
         // A custom palette with only neutral white/black endpoints still
         // maps grayishTextOr's blend to a visible tinted intermediate entry.
-        disp.device_clut = [[0x2020, 0x4040, 0x6060]; 256];
+        *disp.device_clut = [[0x2020, 0x4040, 0x6060]; 256];
         disp.device_clut[0] = [0xFFFF, 0xFFFF, 0xFFFF];
         disp.device_clut[255] = [0, 0, 0];
         for offset in 0..(row_bytes * 128) {
@@ -5541,7 +5541,7 @@ mod tests {
         let screen_base = bus.alloc(256 * 128);
         let row_bytes = 256u32;
         disp.set_screen_mode_for_test(screen_base, row_bytes, 256, 128, 8);
-        disp.device_clut = [[0x2020, 0x4040, 0x6060]; 256];
+        *disp.device_clut = [[0x2020, 0x4040, 0x6060]; 256];
         disp.device_clut[0] = [0xFFFF, 0xFFFF, 0xFFFF];
         disp.device_clut[255] = [0, 0, 0];
         bus.write_long(0x0824, screen_base);
@@ -5632,7 +5632,7 @@ mod tests {
         disp.set_screen_mode_for_test(screen_base, row_bytes, 128, 128, 8);
 
         // Live device CLUT: black lives at 255, and index 1 is bright green.
-        disp.device_clut = [[0x8080, 0x8080, 0x8080]; 256];
+        *disp.device_clut = [[0x8080, 0x8080, 0x8080]; 256];
         disp.device_clut[0] = [0xFFFF, 0xFFFF, 0xFFFF];
         disp.device_clut[1] = [0, 0xFFFF, 0];
         disp.device_clut[255] = [0, 0, 0];

--- a/src/trap/dialog.rs
+++ b/src/trap/dialog.rs
@@ -6474,7 +6474,7 @@ impl super::TrapDispatcher {
                                 };
                                 self.read_port_clut(bus, ctab_handle)
                             } else {
-                                self.color_manager_clut
+                                *self.color_manager_clut
                             };
                             let device_ct_seed =
                                 Self::ctab_seed(bus, self.current_gdevice_ctab_handle(bus))
@@ -24763,7 +24763,7 @@ mod tests {
         assert_eq!(pixel_size, 8);
 
         // Hardware CLUT is faded completely black
-        disp.device_clut = [[0u16; 3]; 256];
+        *disp.device_clut = [[0u16; 3]; 256];
 
         bus.write_word(dialog_ptr + 8, 0);
         bus.write_word(dialog_ptr + 10, 0);
@@ -25967,7 +25967,7 @@ mod tests {
 
         let (mut dispatcher, _cpu, mut bus) = setup();
         dispatcher.set_screen_mode_for_test(screen_base, row_bytes, 160, 140, 8);
-        dispatcher.device_clut = [[0x2020, 0x4040, 0x6060]; 256];
+        *dispatcher.device_clut = [[0x2020, 0x4040, 0x6060]; 256];
         dispatcher.device_clut[0] = [0xFFFF, 0xFFFF, 0xFFFF];
         dispatcher.device_clut[42] = [0x7FFF, 0x7FFF, 0x7FFF];
         dispatcher.device_clut[255] = [0, 0, 0];
@@ -26042,7 +26042,7 @@ mod tests {
             );
         }
 
-        dispatcher.device_clut = [[0x2020, 0x4040, 0x6060]; 256];
+        *dispatcher.device_clut = [[0x2020, 0x4040, 0x6060]; 256];
         dispatcher.device_clut[0] = [0xFFFF, 0xFFFF, 0xFFFF];
         dispatcher.device_clut[255] = [0, 0, 0];
         for offset in 0..(row_bytes * 140) {
@@ -28584,7 +28584,7 @@ mod tests {
         bus.write_long(0x0824, screen_base);
         disp.screen_mode = (screen_base, 100, 100, 80, 8);
         disp.device_clut[0x22] = [0x3333, 0x7777, 0x2222];
-        disp.color_manager_clut = disp.device_clut;
+        *disp.color_manager_clut = *disp.device_clut;
 
         let offscreen_base = bus.alloc(100 * 80);
         bus.write_bytes(offscreen_base, &vec![0x22; 100 * 80]);

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -2484,18 +2484,18 @@ pub struct TrapDispatcher {
     /// Runtime device CLUT for 8bpp mode. 256 entries of [R, G, B] in 16-bit Mac values.
     /// Initialized to the standard Mac 8-bit system palette. Updated by SetEntries trap
     /// and low-level video driver cscSetEntries. Used for DISPLAY rendering only.
-    pub device_clut: [[u16; 3]; 256],
+    pub device_clut: SharedProcessValue<[[u16; 3]; 256]>,
     /// Per-channel transfer tables installed by the video driver's
     /// `cscSetGamma` control call. These affect presentation only; the device
     /// and Color Manager CLUTs retain the guest's uncorrected 16-bit values.
-    pub device_gamma: crate::display::DisplayGamma,
-    pub device_gamma_explicit: bool,
+    pub device_gamma: SharedProcessValue<crate::display::DisplayGamma>,
+    pub device_gamma_explicit: SharedProcessValue<bool>,
     /// Color Manager CLUT for 8bpp mode. Updated only by high-level SetEntries ($AA3F)
     /// and ActivatePalette — NOT by low-level video driver palette fades.
     /// Used by QuickDraw shape drawing (PaintRect, etc.) for RGB→index mapping,
     /// mirroring the real Mac OS ITable which is derived from the Color Manager palette.
     /// Imaging With QuickDraw 1994, p. 4-82
-    pub color_manager_clut: [[u16; 3]; 256],
+    pub color_manager_clut: SharedProcessValue<[[u16; 3]; 256]>,
     /// Cached inverse-table payloads keyed by actual CLUT contents and
     /// resolution. Used by MakeITable and bounded to avoid retaining arbitrary
     /// game palettes indefinitely.
@@ -2867,6 +2867,12 @@ impl TrapDispatcher {
         context.attach_resource_manager(&mut self.process_resource_manager);
         context.attach_sound_manager(&mut self.sound_manager);
         context.attach_cursor_state(&mut self.cursor_state);
+        context.attach_display_color_state(
+            &mut self.device_clut,
+            &mut self.color_manager_clut,
+            &mut self.device_gamma,
+            &mut self.device_gamma_explicit,
+        );
         context.attach_event_queue(&mut self.event_queue);
         context.attach_input_state(&mut self.input_state);
         context.attach_menu_tracking(&mut self.menu_tracking);
@@ -4014,10 +4020,10 @@ impl TrapDispatcher {
                     profile.screen_depth,
                 )
             },
-            device_clut: Self::standard_mac_8bpp_clut(),
-            device_gamma: crate::display::default_display_gamma(),
-            device_gamma_explicit: false,
-            color_manager_clut: Self::standard_mac_8bpp_clut(),
+            device_clut: SharedProcessValue::from_value(Self::standard_mac_8bpp_clut()),
+            device_gamma: SharedProcessValue::from_value(crate::display::default_display_gamma()),
+            device_gamma_explicit: SharedProcessValue::from_value(false),
+            color_manager_clut: SharedProcessValue::from_value(Self::standard_mac_8bpp_clut()),
             inverse_table_cache: Vec::new(),
             clut_protected: [false; 256],
             clut_reserved: [false; 256],
@@ -4225,39 +4231,7 @@ impl TrapDispatcher {
 
     /// Generate the standard Mac 8-bit system palette as 16-bit RGB values.
     pub(crate) fn standard_mac_8bpp_clut() -> [[u16; 3]; 256] {
-        let mut clut = [[0u16; 3]; 256];
-        // Indices 0-214: 6x6x6 color cube (215 entries)
-        // R varies slowest (÷36), G medium (÷6 %6), B fastest (%6)
-        // Each component has 6 levels: 5→0xFFFF, 4→0xCCCC, 3→0x9999, 2→0x6666, 1→0x3333, 0→0x0000
-        // Index 0 = (5,5,5) = white, index 214 = (0,0,1)
-        // Imaging With QuickDraw 1994, Table 4-6, p. 4-93
-        // references/executor/src/quickdraw/default_ctab_values.cpp
-        for i in 0u32..=214 {
-            let r = 5 - (i / 36);
-            let g = 5 - ((i / 6) % 6);
-            let b = 5 - (i % 6);
-            clut[i as usize] = [
-                (r as u16) * 0x3333,
-                (g as u16) * 0x3333,
-                (b as u16) * 0x3333,
-            ];
-        }
-        // Indices 215-254: primary + gray ramps (10 entries each)
-        // Brightness levels: n * 0x1111 for n in {14,13,11,10,8,7,5,4,2,1}
-        // (integers 1-14 excluding multiples of 3: 3,6,9,12)
-        // references/executor/src/quickdraw/default_ctab_values.cpp
-        const RAMP: [u16; 10] = [
-            0xEEEE, 0xDDDD, 0xBBBB, 0xAAAA, 0x8888, 0x7777, 0x5555, 0x4444, 0x2222, 0x1111,
-        ];
-        for j in 0..10usize {
-            clut[215 + j] = [RAMP[j], 0, 0]; // Red ramp
-            clut[225 + j] = [0, RAMP[j], 0]; // Green ramp
-            clut[235 + j] = [0, 0, RAMP[j]]; // Blue ramp
-            clut[245 + j] = [RAMP[j], RAMP[j], RAMP[j]]; // Gray ramp
-        }
-        // Index 255: black
-        clut[255] = [0, 0, 0];
-        clut
+        crate::display::standard_mac_8bpp_clut()
     }
 
     /// Return the canonical indexed Color QuickDraw table and entry count for

--- a/src/trap/framebuffer.rs
+++ b/src/trap/framebuffer.rs
@@ -5215,7 +5215,7 @@ mod redraw_chrome_tests {
         disp.window_proc_id = 2;
         disp.window_proc_ids.insert(PORT_PTR, 2);
         disp.menu_bar_hidden = true;
-        disp.device_clut = [[0xFFFF, 0xFFFF, 0xFFFF]; 256];
+        *disp.device_clut = [[0xFFFF, 0xFFFF, 0xFFFF]; 256];
         disp.device_clut[37] = [0, 0, 0];
 
         disp.menus = vec![overlay_test_menu(703, "Popup", "Choice", false, false)];
@@ -5448,7 +5448,7 @@ mod redraw_chrome_tests {
         disp.window_proc_id = 2;
         disp.window_proc_ids.insert(PORT_PTR, 2);
         disp.menu_bar_hidden = true;
-        disp.device_clut = [[0xFFFF, 0xFFFF, 0xFFFF]; 256];
+        *disp.device_clut = [[0xFFFF, 0xFFFF, 0xFFFF]; 256];
         disp.device_clut[37] = [0, 0, 0];
 
         disp.redraw_chrome(&mut bus);
@@ -5515,7 +5515,7 @@ mod redraw_chrome_tests {
             dst_right: 720,
         });
         disp.menu_bar_hidden = true;
-        disp.device_clut = [[0xFFFF, 0xFFFF, 0xFFFF]; 256];
+        *disp.device_clut = [[0xFFFF, 0xFFFF, 0xFFFF]; 256];
         disp.device_clut[255] = [0, 0, 0];
 
         disp.fill_kiosk_stage_for_centered_game_surface(&mut bus, PORT_PTR);
@@ -5595,7 +5595,7 @@ mod redraw_chrome_tests {
                 dst_right: 720,
             });
             disp.menu_bar_hidden = true;
-            disp.device_clut = [[0xFFFF, 0xFFFF, 0xFFFF]; 256];
+            *disp.device_clut = [[0xFFFF, 0xFFFF, 0xFFFF]; 256];
             disp.device_clut[255] = [0, 0, 0];
 
             disp.fill_kiosk_stage_for_centered_game_surface(&mut bus, PORT_PTR);
@@ -5647,7 +5647,7 @@ mod redraw_chrome_tests {
             dst_right: 720,
         });
         disp.menu_bar_hidden = true;
-        disp.device_clut = [[0xFFFF, 0xFFFF, 0xFFFF]; 256];
+        *disp.device_clut = [[0xFFFF, 0xFFFF, 0xFFFF]; 256];
         disp.device_clut[255] = [0, 0, 0];
 
         disp.fill_kiosk_stage_for_centered_game_surface(&mut bus, PORT_PTR);
@@ -5673,7 +5673,7 @@ mod redraw_chrome_tests {
         disp.window_proc_id = 0;
         disp.window_proc_ids.insert(PORT_PTR, 0);
         disp.menu_bar_hidden = true;
-        disp.device_clut = [[0xFFFF, 0xFFFF, 0xFFFF]; 256];
+        *disp.device_clut = [[0xFFFF, 0xFFFF, 0xFFFF]; 256];
         disp.device_clut[37] = [0, 0, 0];
         disp.last_screen_copybits_rect = Some(ScreenCopyBitsRect {
             src_top: 0,
@@ -5726,7 +5726,7 @@ mod redraw_chrome_tests {
         disp.window_proc_id = 2;
         disp.window_proc_ids.remove(&PORT_PTR);
         disp.menu_bar_hidden = true;
-        disp.device_clut = [[0xFFFF, 0xFFFF, 0xFFFF]; 256];
+        *disp.device_clut = [[0xFFFF, 0xFFFF, 0xFFFF]; 256];
         disp.device_clut[37] = [0, 0, 0];
         disp.last_screen_copybits_rect = Some(ScreenCopyBitsRect {
             src_top: 0,
@@ -7279,8 +7279,8 @@ mod redraw_chrome_tests {
         let screen_base = bus.alloc(8);
         disp.screen_mode = (screen_base, 4, 16, 1, 1);
         let (screen_clut, _) = TrapDispatcher::standard_mac_indexed_clut(1).unwrap();
-        disp.color_manager_clut = screen_clut;
-        disp.device_clut = screen_clut;
+        *disp.color_manager_clut = screen_clut;
+        *disp.device_clut = screen_clut;
         bus.write_long(0x0824, screen_base);
         let gdevice_handle = disp.ensure_main_gdevice(&mut bus);
         bus.write_long(0x08A4, gdevice_handle);
@@ -7315,8 +7315,8 @@ mod redraw_chrome_tests {
         let screen_base = bus.alloc(8);
         disp.screen_mode = (screen_base, 4, 12, 1, 2);
         let (screen_clut, _) = TrapDispatcher::standard_mac_indexed_clut(2).unwrap();
-        disp.color_manager_clut = screen_clut;
-        disp.device_clut = screen_clut;
+        *disp.color_manager_clut = screen_clut;
+        *disp.device_clut = screen_clut;
         bus.write_long(0x0824, screen_base);
         let gdevice_handle = disp.ensure_main_gdevice(&mut bus);
         bus.write_long(0x08A4, gdevice_handle);
@@ -7377,8 +7377,8 @@ mod redraw_chrome_tests {
         let screen_base = bus.alloc(8);
         disp.screen_mode = (screen_base, 4, 16, 1, 1);
         let (screen_clut, _) = TrapDispatcher::standard_mac_indexed_clut(1).unwrap();
-        disp.color_manager_clut = screen_clut;
-        disp.device_clut = screen_clut;
+        *disp.color_manager_clut = screen_clut;
+        *disp.device_clut = screen_clut;
         bus.write_long(0x0824, screen_base);
         let gdevice_handle = disp.ensure_main_gdevice(&mut bus);
         bus.write_long(0x08A4, gdevice_handle);
@@ -7532,8 +7532,8 @@ mod redraw_chrome_tests {
         disp.screen_mode = (screen_base, 4, 12, 1, 2);
         bus.write_long(0x0824, screen_base);
         let (clut, _) = TrapDispatcher::standard_mac_indexed_clut(2).unwrap();
-        disp.color_manager_clut = clut;
-        disp.device_clut = clut;
+        *disp.color_manager_clut = clut;
+        *disp.device_clut = clut;
         let gdevice_handle = disp.ensure_main_gdevice(&mut bus);
         bus.write_long(0x08A4, gdevice_handle);
         bus.write_long(0x0CC8, gdevice_handle);
@@ -7568,8 +7568,8 @@ mod redraw_chrome_tests {
             disp.screen_mode = (screen_base, 1, 16, 1, depth);
             bus.write_long(0x0824, screen_base);
             let (screen_clut, _) = TrapDispatcher::standard_mac_indexed_clut(depth).unwrap();
-            disp.color_manager_clut = screen_clut;
-            disp.device_clut = screen_clut;
+            *disp.color_manager_clut = screen_clut;
+            *disp.device_clut = screen_clut;
             let gdevice_handle = disp.ensure_main_gdevice(&mut bus);
             bus.write_long(0x08A4, gdevice_handle);
             bus.write_long(0x0CC8, gdevice_handle);
@@ -7634,8 +7634,8 @@ mod redraw_chrome_tests {
 
         let mut dst_clut = TrapDispatcher::standard_mac_8bpp_clut();
         dst_clut[1] = [0x1234, 0x5678, 0x9abc];
-        disp.color_manager_clut = dst_clut;
-        disp.device_clut = dst_clut;
+        *disp.color_manager_clut = dst_clut;
+        *disp.device_clut = dst_clut;
         let mut src_clut = dst_clut;
         src_clut[3] = dst_clut[1];
         src_clut[1] = [0xffff, 0, 0];
@@ -7684,8 +7684,8 @@ mod redraw_chrome_tests {
         for (index, color) in destination_indices.into_iter().zip(colors) {
             dst_clut[index as usize] = color;
         }
-        disp.color_manager_clut = dst_clut;
-        disp.device_clut = dst_clut;
+        *disp.color_manager_clut = dst_clut;
+        *disp.device_clut = dst_clut;
 
         let mut src_clut = [[0u16; 3]; 256];
         src_clut[..4].copy_from_slice(&colors);
@@ -7734,8 +7734,8 @@ mod redraw_chrome_tests {
         ];
         let mut dst_clut = [[0u16; 3]; 256];
         dst_clut[..4].copy_from_slice(&colors);
-        disp.color_manager_clut = dst_clut;
-        disp.device_clut = dst_clut;
+        *disp.color_manager_clut = dst_clut;
+        *disp.device_clut = dst_clut;
 
         let mut src_clut = [[0u16; 3]; 256];
         for (index, color) in src_clut[..16].iter_mut().enumerate() {

--- a/src/trap/memory.rs
+++ b/src/trap/memory.rs
@@ -432,8 +432,8 @@ impl super::TrapDispatcher {
 
         let gamma_ptr = bus.read_long(vd_gamma_ptr);
         if gamma_ptr == 0 {
-            self.device_gamma = crate::display::linear_display_gamma();
-            self.device_gamma_explicit = true;
+            *self.device_gamma = crate::display::linear_display_gamma();
+            *self.device_gamma_explicit = true;
             return NO_ERR;
         }
 
@@ -493,8 +493,8 @@ impl super::TrapDispatcher {
                 *value = bus.read_byte(source_base + source_index);
             }
         }
-        self.device_gamma = installed;
-        self.device_gamma_explicit = true;
+        *self.device_gamma = installed;
+        *self.device_gamma_explicit = true;
         NO_ERR
     }
 
@@ -2335,8 +2335,8 @@ impl super::TrapDispatcher {
                         // values. Keep explicit guest gamma authoritative, but
                         // otherwise stop applying the compatibility transfer
                         // used by the emulated high-level Color Manager path.
-                        if !self.device_gamma_explicit {
-                            self.device_gamma = crate::display::linear_display_gamma();
+                        if !*self.device_gamma_explicit {
+                            *self.device_gamma = crate::display::linear_display_gamma();
                         }
                         self.apply_set_entries(bus, cs_table, cs_start, safe_count);
                         if let Err(err) = self.record_trace_event(
@@ -10854,7 +10854,7 @@ mod tests {
         assert_eq!(dispatcher.device_gamma[0][0x44], 0x44);
         assert_eq!(dispatcher.device_gamma[1][0x88], 0x88);
         assert_eq!(dispatcher.device_gamma[2][0xCC], 0xCC);
-        assert!(!dispatcher.device_gamma_explicit);
+        assert!(!*dispatcher.device_gamma_explicit);
     }
 
     #[test]
@@ -10863,8 +10863,8 @@ mod tests {
         let pb = 0x300000u32;
         let record = bus.alloc(8);
         let table = bus.alloc(8);
-        dispatcher.device_gamma = [[0x42; 256]; 3];
-        dispatcher.device_gamma_explicit = true;
+        *dispatcher.device_gamma = [[0x42; 256]; 3];
+        *dispatcher.device_gamma_explicit = true;
 
         bus.write_word(table, 7);
         bus.write_word(table + 2, 0x4444);
@@ -10883,7 +10883,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(dispatcher.device_gamma, [[0x42; 256]; 3]);
-        assert!(dispatcher.device_gamma_explicit);
+        assert!(*dispatcher.device_gamma_explicit);
     }
 
     #[test]
@@ -10915,7 +10915,7 @@ mod tests {
 
         assert_eq!(cpu.read_reg(Register::D0), 0);
         assert_eq!(bus.read_word(pb + 16), 0);
-        for channel in &dispatcher.device_gamma {
+        for channel in dispatcher.device_gamma.iter() {
             assert_eq!(channel[0x00], 0x00);
             assert_eq!(channel[0x1F], 0x11);
             assert_eq!(channel[0xAB], 0xAA);
@@ -10955,7 +10955,7 @@ mod tests {
         assert_eq!(dispatcher.device_gamma[1][0xA5], 0x5A);
         assert_eq!(dispatcher.device_gamma[2][0xA5], 0x42);
         dispatcher.device_clut[7] = [0xA5A5; 3];
-        let raw_clut = dispatcher.device_clut;
+        let raw_clut = *dispatcher.device_clut;
         let palette = crate::display::argb_palette_from_clut_with_gamma(
             &dispatcher.device_clut,
             &dispatcher.device_gamma,
@@ -10970,7 +10970,7 @@ mod tests {
         let pb = 0x300000u32;
         let record = bus.alloc(4);
         let table = bus.alloc(12 + 16);
-        let before = dispatcher.device_gamma;
+        let before = *dispatcher.device_gamma;
 
         bus.write_word(table, 0);
         bus.write_word(table + 2, 0);
@@ -10999,7 +10999,7 @@ mod tests {
         let pb = 0x300000u32;
         let record = bus.alloc(4);
         let table = bus.alloc(12 + 8);
-        let before = dispatcher.device_gamma;
+        let before = *dispatcher.device_gamma;
 
         bus.write_word(table, 0);
         bus.write_word(table + 2, 0);
@@ -11026,7 +11026,7 @@ mod tests {
         let (mut dispatcher, mut cpu, mut bus) = setup();
         let pb = 0x300000u32;
         let record = bus.alloc(4);
-        dispatcher.device_gamma = [[0x42; 256]; 3];
+        *dispatcher.device_gamma = [[0x42; 256]; 3];
 
         bus.write_long(record, 0);
         bus.write_word(pb + 26, 4);
@@ -11039,7 +11039,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(cpu.read_reg(Register::D0), 0);
-        for channel in &dispatcher.device_gamma {
+        for channel in dispatcher.device_gamma.iter() {
             assert_eq!(channel[0x00], 0x00);
             assert_eq!(channel[0x7F], 0x7F);
             assert_eq!(channel[0xFF], 0xFF);

--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -8488,8 +8488,8 @@ impl super::TrapDispatcher {
                                         &self.color_manager_clut,
                                     ) && !pict_seed_clut_disabled()
                                     {
-                                        self.device_clut = pict_clut_array;
-                                        self.color_manager_clut = pict_clut_array;
+                                        *self.device_clut = pict_clut_array;
+                                        *self.color_manager_clut = pict_clut_array;
                                         self.seeded_picture_palette = pict_clut_array;
                                         self.seeded_picture_palette_until_tick =
                                             self.tick_count.saturating_add(48);
@@ -8517,7 +8517,7 @@ impl super::TrapDispatcher {
                                             } else {
                                                 0x8000
                                             };
-                                            let logical_screen_clut = self.color_manager_clut;
+                                            let logical_screen_clut = *self.color_manager_clut;
                                             let _ = self.overwrite_color_table_handle_with_clut(
                                                 bus,
                                                 port_ctab_handle,
@@ -8676,8 +8676,8 @@ impl super::TrapDispatcher {
                                             self.tick_count, cm_before[0], cm_before[1], cm_before[2], pict0[0], pict0[1], pict0[2]
                                         );
                                         }
-                                        self.device_clut = pict_clut_array;
-                                        self.color_manager_clut = pict_clut_array;
+                                        *self.device_clut = pict_clut_array;
+                                        *self.color_manager_clut = pict_clut_array;
                                         self.seeded_picture_palette = pict_clut_array;
                                         self.seeded_picture_palette_until_tick =
                                             self.tick_count.saturating_add(48);
@@ -8754,7 +8754,7 @@ impl super::TrapDispatcher {
                                         } else {
                                             0x8000
                                         };
-                                        let logical_screen_clut = self.color_manager_clut;
+                                        let logical_screen_clut = *self.color_manager_clut;
                                         let _ = self.overwrite_color_table_handle_with_clut(
                                             bus,
                                             port_ctab_handle,
@@ -9008,7 +9008,7 @@ impl super::TrapDispatcher {
                         let source_clut = if source.ctab_handle != 0 {
                             self.read_port_clut(bus, source.ctab_handle)
                         } else {
-                            self.device_clut
+                            *self.device_clut
                         };
                         Self::encode_bitmap_copy_pict(
                             bus,
@@ -9661,7 +9661,7 @@ impl super::TrapDispatcher {
                 let dst_clut = if effective_dst_ctab != 0 {
                     self.read_port_clut(bus, effective_dst_ctab)
                 } else {
-                    self.device_clut
+                    *self.device_clut
                 };
                 for dst_y_local in clip_top..clip_bottom {
                     let Some(sy) =
@@ -12283,11 +12283,11 @@ impl super::TrapDispatcher {
                     // Build the target CLUT to match against. NIL targetTbl =
                     // current device CLUT.
                     let target_clut: [[u16; 3]; 256] = if target_handle == 0 {
-                        self.device_clut
+                        *self.device_clut
                     } else {
                         let target_ptr = bus.read_long(target_handle);
                         if target_ptr == 0 {
-                            self.device_clut
+                            *self.device_clut
                         } else {
                             let mut clut = [[0u16; 3]; 256];
                             let target_size = (bus.read_word(target_ptr + 6) as usize).min(255);
@@ -17036,7 +17036,7 @@ impl super::TrapDispatcher {
         }
 
         let palette_entries = usize::from(Self::palette_entry_count(bus, palette_handle)).min(256);
-        let current_clut = self.device_clut;
+        let current_clut = *self.device_clut;
         // Palette activation changes only the cells claimed by this palette.
         // Resetting every other cell to the standard table reinterprets pixels
         // already drawn by visible background windows, even though their
@@ -17163,8 +17163,8 @@ impl super::TrapDispatcher {
             }
         }
         let color_environment_changed = updated_clut != current_clut;
-        self.device_clut = updated_clut;
-        self.color_manager_clut = updated_clut;
+        *self.device_clut = updated_clut;
+        *self.color_manager_clut = updated_clut;
         if color_environment_changed {
             let active_window = if window == DEFAULT_PALETTE_WINDOW {
                 self.front_window
@@ -17410,7 +17410,7 @@ impl super::TrapDispatcher {
         // Treat guest ColorTables as overrides on top of the Color Manager CLUT.
         // Some scratch/offscreen tables do not populate every logical index;
         // zero-filling the rest would collapse unrelated indices to black.
-        let mut clut = self.color_manager_clut;
+        let mut clut = *self.color_manager_clut;
         // Device ColorTables are addressed by entry position. Their
         // ColorSpec.value low byte is a Color Manager client ID, not a pixel
         // index; the high byte retains per-entry flags. Inside Macintosh
@@ -17436,7 +17436,7 @@ impl super::TrapDispatcher {
     /// Imaging With QuickDraw 1994, p. 4-82
     pub(crate) fn read_port_clut(&self, bus: &MacMemoryBus, ctab_handle: u32) -> [[u16; 3]; 256] {
         if ctab_handle == 0 {
-            return self.color_manager_clut;
+            return *self.color_manager_clut;
         }
         let screen_ctab_handle = if self.main_gdevice_handle != 0 {
             Self::gdevice_ctab_handle(bus, self.main_gdevice_handle)
@@ -17444,11 +17444,11 @@ impl super::TrapDispatcher {
             0
         };
         if ctab_handle == screen_ctab_handle {
-            return self.color_manager_clut;
+            return *self.color_manager_clut;
         }
         let ctab_ptr = bus.read_long(ctab_handle);
         if ctab_ptr == 0 {
-            return self.color_manager_clut;
+            return *self.color_manager_clut;
         }
         self.read_color_table_ptr_clut(bus, ctab_ptr)
     }
@@ -17475,7 +17475,7 @@ impl super::TrapDispatcher {
             // logical GDevice table; `device_clut` is the transient physical
             // hardware view used while fades are in progress. Imaging With
             // QuickDraw (1994), p. 3-117.
-            self.color_manager_clut
+            *self.color_manager_clut
         } else {
             self.read_port_clut(bus, ctab_handle)
         };
@@ -17493,11 +17493,11 @@ impl super::TrapDispatcher {
         ctab_handle: u32,
     ) -> [[u16; 3]; 256] {
         if ctab_handle == 0 {
-            return self.color_manager_clut;
+            return *self.color_manager_clut;
         }
         let ctab_ptr = bus.read_long(ctab_handle);
         if ctab_ptr == 0 {
-            return self.color_manager_clut;
+            return *self.color_manager_clut;
         }
         self.read_color_table_ptr_clut(bus, ctab_ptr)
     }
@@ -17785,12 +17785,12 @@ impl super::TrapDispatcher {
             return;
         }
         let scale = Self::screen_palette_brightness_scale(&self.device_clut);
-        self.device_clut = if palette_as_game_wrote_enabled() {
+        *self.device_clut = if palette_as_game_wrote_enabled() {
             *clut
         } else {
             Self::scale_clut(clut, scale)
         };
-        self.color_manager_clut = *clut;
+        *self.color_manager_clut = *clut;
         self.seeded_picture_palette = *clut;
         self.seeded_picture_palette_until_tick =
             self.seeded_picture_palette_until_tick_for_seed(48, true);
@@ -18186,8 +18186,8 @@ impl super::TrapDispatcher {
         bus: &mut MacMemoryBus,
         clut: [[u16; 3]; 256],
     ) {
-        self.device_clut = clut;
-        self.color_manager_clut = clut;
+        *self.device_clut = clut;
+        *self.color_manager_clut = clut;
 
         let gdh = self.ensure_main_gdevice(bus);
         let ctab_handle = Self::gdevice_ctab_handle(bus, gdh);
@@ -19385,8 +19385,8 @@ impl super::TrapDispatcher {
         let Some((clut, entry_count)) = Self::standard_screen_depth_clut(depth, is_color) else {
             return;
         };
-        self.device_clut = clut;
-        self.color_manager_clut = clut;
+        *self.device_clut = clut;
+        *self.color_manager_clut = clut;
 
         let gdh = self.ensure_main_gdevice(bus);
         let ctab_handle = Self::gdevice_ctab_handle(bus, gdh);
@@ -19544,12 +19544,12 @@ impl super::TrapDispatcher {
                 && row_bytes == self.screen_mode.1
                 && pixel_size == self.screen_mode.4;
             if screen_backed {
-                (self.device_clut, pixel_size == 8)
+                (*self.device_clut, pixel_size == 8)
             } else {
                 (self.read_port_clut(bus, bus.read_long(pixmap + 42)), false)
             }
         } else {
-            (self.device_clut, self.screen_mode.4 == 8)
+            (*self.device_clut, self.screen_mode.4 == 8)
         };
 
         if foreground {
@@ -23223,8 +23223,8 @@ impl super::TrapDispatcher {
         if !Self::set_entries_request_in_range(bus, table_ptr, start, count) {
             return;
         }
-        if !self.device_gamma_explicit {
-            self.device_gamma = crate::display::default_display_gamma();
+        if !*self.device_gamma_explicit {
+            *self.device_gamma = crate::display::default_display_gamma();
         }
         let incoming_default_palette = start == 0
             && count == 255
@@ -23244,7 +23244,7 @@ impl super::TrapDispatcher {
         if preserve_seeded_picture_palette && !strict_palette && !palette_as_game_wrote_enabled() {
             self.screen_palette_fade_active = true;
             if let Some(scale) = Self::canonical_table_brightness_scale(bus, table_ptr) {
-                self.device_clut = Self::scale_clut(&self.seeded_picture_palette, scale);
+                *self.device_clut = Self::scale_clut(&self.seeded_picture_palette, scale);
             }
             // Extend the window so consecutive fade-up/-down SetEntries
             // (which may run 60+ ticks for a single scene transition)
@@ -23295,7 +23295,7 @@ impl super::TrapDispatcher {
                     self.tick_count, cm_before[0], cm_before[1], cm_before[2], seed[0], seed[1], seed[2]
                 );
             }
-            self.color_manager_clut = self.seeded_picture_palette;
+            *self.color_manager_clut = self.seeded_picture_palette;
             return;
         }
 
@@ -23361,7 +23361,7 @@ impl super::TrapDispatcher {
                     self.tick_count, cm_before[0], cm_before[1], cm_before[2], dev0[0], dev0[1], dev0[2]
                 );
             }
-            self.color_manager_clut = self.device_clut;
+            *self.color_manager_clut = *self.device_clut;
             if trace_palette_enabled() {
                 eprintln!(
                     "[PALETTE] PublishCm tick={} — fresh full palette install cm[0]=({:04X},{:04X},{:04X}) cm[255]=({:04X},{:04X},{:04X})",
@@ -23916,7 +23916,7 @@ impl super::TrapDispatcher {
         if count == 0 || count > 256 {
             return None;
         }
-        let mut clut = self.device_clut;
+        let mut clut = *self.device_clut;
         for ordinal in 0..count {
             let entry = table_ptr + 8 + ordinal as u32 * 8;
             let value = usize::from(bus.read_word(entry));
@@ -24271,7 +24271,7 @@ impl super::TrapDispatcher {
         }
 
         let dst_clut = if is_screen_port {
-            self.device_clut
+            *self.device_clut
         } else {
             self.read_port_clut(bus, bus.read_long(pix_map_ptr + 42))
         };
@@ -24361,7 +24361,7 @@ impl super::TrapDispatcher {
     /// (when present and distinct from the main device) overrides that.
     fn cpixel_clut(&self, bus: &MacMemoryBus, ctab_handle: u32) -> [[u16; 3]; 256] {
         if ctab_handle == 0 {
-            return self.device_clut;
+            return *self.device_clut;
         }
         let screen_ctab_handle = if self.main_gdevice_handle != 0 {
             Self::gdevice_ctab_handle(bus, self.main_gdevice_handle)
@@ -24369,7 +24369,7 @@ impl super::TrapDispatcher {
             0
         };
         if ctab_handle == screen_ctab_handle {
-            return self.device_clut;
+            return *self.device_clut;
         }
         self.read_ctab_handle_clut(bus, ctab_handle)
     }
@@ -24931,7 +24931,7 @@ mod tests {
         let (screen_base, row_bytes, width, height, _) = d.screen_mode;
         bus.fill_bytes(screen_base, row_bytes * u32::from(height), 0x7F);
         d.menu_bar_hidden = true;
-        d.device_clut = [[0xFFFF, 0xFFFF, 0xFFFF]; 256];
+        *d.device_clut = [[0xFFFF, 0xFFFF, 0xFFFF]; 256];
         d.device_clut[37] = [0, 0, 0];
 
         d.fill_kiosk_letterbox_for_copybits(&mut bus, centered_640x480_copybits_rect());
@@ -24969,7 +24969,7 @@ mod tests {
         }
         let before = bus.read_bytes(screen_base, framebuffer_len as usize);
         d.menu_bar_hidden = true;
-        d.device_clut = [[0xFFFF, 0xFFFF, 0xFFFF]; 256];
+        *d.device_clut = [[0xFFFF, 0xFFFF, 0xFFFF]; 256];
         d.device_clut[37] = [0, 0, 0];
 
         d.fill_kiosk_letterbox_for_copybits(
@@ -25157,7 +25157,7 @@ mod tests {
             let (screen_base, row_bytes, _, height, _) = d.screen_mode;
             bus.fill_bytes(screen_base, row_bytes * u32::from(height), 0x7F);
             d.menu_bar_hidden = menu_bar_hidden;
-            d.device_clut = [[0xFFFF, 0xFFFF, 0xFFFF]; 256];
+            *d.device_clut = [[0xFFFF, 0xFFFF, 0xFFFF]; 256];
             d.device_clut[37] = [0, 0, 0];
 
             d.fill_kiosk_letterbox_for_copybits(&mut bus, rect);
@@ -26922,7 +26922,7 @@ mod tests {
         let screen_row_bytes = (bus.read_word(pixmap_ptr + 4) & 0x3FFF) as u32;
         d.screen_mode = (screen_base, screen_row_bytes, 800, 600, 8);
 
-        d.device_clut = [[0, 0, 0]; 256];
+        *d.device_clut = [[0, 0, 0]; 256];
         d.device_clut[1] = [0xFFFF, 0xFFFF, 0xFFFF];
         d.device_clut[255] = [0, 0, 0];
 
@@ -26969,7 +26969,7 @@ mod tests {
         let screen_row_bytes = (bus.read_word(pixmap_ptr + 4) & 0x3FFF) as u32;
         d.screen_mode = (screen_base, screen_row_bytes, 800, 600, 8);
 
-        d.device_clut = [[0xFFFF, 0xFFFF, 0xFFFF]; 256];
+        *d.device_clut = [[0xFFFF, 0xFFFF, 0xFFFF]; 256];
         d.device_clut[71] = [0, 0, 0];
         d.device_clut[255] = [0, 0, 0];
 
@@ -27012,7 +27012,7 @@ mod tests {
         let screen_row_bytes = (bus.read_word(pixmap_ptr + 4) & 0x3FFF) as u32;
         d.screen_mode = (screen_base, screen_row_bytes, 800, 600, 8);
 
-        d.device_clut = TrapDispatcher::standard_mac_8bpp_clut();
+        *d.device_clut = TrapDispatcher::standard_mac_8bpp_clut();
         d.device_clut[1] = [0, 0, 0];
         d.device_clut[255] = [0xFFFF, 0xFFFF, 0xCCCC];
 
@@ -33429,7 +33429,7 @@ mod tests {
         let screen_base = bus.alloc(row_bytes * 64);
         bus.fill_zeros(screen_base, row_bytes * 64);
         d.screen_mode = (screen_base, row_bytes, 64, 64, 8);
-        d.device_clut = [[0, 0, 0]; 256];
+        *d.device_clut = [[0, 0, 0]; 256];
         d.device_clut[7] = [0x1111, 0x0000, 0x0000];
         d.device_clut[8] = [0x0000, 0x2222, 0x0000];
         d.device_clut[9] = [0x0000, 0x0000, 0x3333];
@@ -33491,7 +33491,7 @@ mod tests {
     fn installed_raw_color_pixpats_drive_paint_and_erase_rect() {
         let (mut d, mut cpu, mut bus) = setup_with_port();
         let (screen_base, row_bytes) = setup_color_polygon_surface(&mut d, &cpu, &mut bus);
-        d.device_clut = [[0, 0, 0]; 256];
+        *d.device_clut = [[0, 0, 0]; 256];
         d.device_clut[7] = [0x1111, 0x0000, 0x0000];
         d.device_clut[8] = [0x0000, 0x2222, 0x0000];
         d.device_clut[9] = [0x0000, 0x0000, 0x3333];
@@ -33557,7 +33557,7 @@ mod tests {
         let screen_base = bus.alloc(row_bytes * 64);
         bus.fill_zeros(screen_base, row_bytes * 64);
         d.screen_mode = (screen_base, row_bytes, 64, 64, 8);
-        d.device_clut = [[0, 0, 0]; 256];
+        *d.device_clut = [[0, 0, 0]; 256];
         d.device_clut[7] = [0x1111, 0x0000, 0x0000];
         d.device_clut[8] = [0x0000, 0x2222, 0x0000];
         d.device_clut[9] = [0x0000, 0x0000, 0x3333];
@@ -33633,7 +33633,7 @@ mod tests {
         let screen_base = bus.alloc(row_bytes * 64);
         bus.fill_zeros(screen_base, row_bytes * 64);
         d.screen_mode = (screen_base, row_bytes, 64, 64, 8);
-        d.device_clut = [[0, 0, 0]; 256];
+        *d.device_clut = [[0, 0, 0]; 256];
         d.device_clut[7] = [0x1111, 0x0000, 0x0000];
         d.device_clut[8] = [0x0000, 0x2222, 0x0000];
         d.device_clut[9] = [0x0000, 0x0000, 0x3333];
@@ -36485,8 +36485,8 @@ mod tests {
         d.screen_mode = (screen_base, screen_row_bytes, 800, 600, 8);
 
         let baseline = TrapDispatcher::standard_mac_8bpp_clut();
-        d.color_manager_clut = baseline;
-        d.device_clut = TrapDispatcher::scale_clut(&baseline, 0.02);
+        *d.color_manager_clut = baseline;
+        *d.device_clut = TrapDispatcher::scale_clut(&baseline, 0.02);
         d.screen_palette_fade_active = true;
 
         let src_pixmap = 0x31A400u32;
@@ -36531,8 +36531,8 @@ mod tests {
         d.screen_mode = (screen_base, screen_row_bytes, 800, 600, 8);
 
         let baseline = TrapDispatcher::standard_mac_8bpp_clut();
-        d.color_manager_clut = baseline;
-        d.device_clut = TrapDispatcher::scale_clut(&baseline, 0.02);
+        *d.color_manager_clut = baseline;
+        *d.device_clut = TrapDispatcher::scale_clut(&baseline, 0.02);
         d.screen_palette_fade_active = true;
 
         let src_pixmap = 0x31A600u32;
@@ -37022,7 +37022,7 @@ mod tests {
         let port = 0x181000u32;
         bus.write_word(port + 6, 0xC000);
         d.set_current_port_state(&mut bus, &mut cpu, port, None);
-        d.device_clut = [[0, 0, 0]; 256];
+        *d.device_clut = [[0, 0, 0]; 256];
         d.device_clut[42] = [0xF2D7, 0x0856, 0x84EC];
         bus.write_long(TEST_SP, 139);
 
@@ -37066,7 +37066,7 @@ mod tests {
         bus.write_long(port + 2, pixmap_handle);
         bus.write_word(port + 6, 0xC000);
         d.set_current_port_state(&mut bus, &mut cpu, port, None);
-        d.device_clut = [[0, 0, 0]; 256];
+        *d.device_clut = [[0, 0, 0]; 256];
         d.device_clut[0] = green;
 
         let color = bus.alloc(6);
@@ -37595,7 +37595,7 @@ mod tests {
         // (1986), p. V-76: PlotCIcon stretches the iconPMap and remaps its
         // pixels to the current depth and color table.
         let (mut d, mut cpu, mut bus) = setup();
-        d.device_clut = [[0, 0, 0]; 256];
+        *d.device_clut = [[0, 0, 0]; 256];
         d.device_clut[7] = [0x1111, 0x0000, 0x0000];
         d.device_clut[9] = [0x0000, 0x2222, 0x0000];
         d.device_clut[42] = [0x0000, 0x0000, 0x3333];
@@ -37671,7 +37671,7 @@ mod tests {
         // control inverse mapping, just as it does for other screen drawing.
         // Imaging With QuickDraw (1994), pp. 4-55 to 4-59 and 5-28.
         let (mut d, mut cpu, mut bus) = setup();
-        d.device_clut = [[0, 0, 0]; 256];
+        *d.device_clut = [[0, 0, 0]; 256];
         d.device_clut[0] = [0xFFFF, 0xFFFF, 0xFFFF];
         d.device_clut[1] = [0x1010, 0x1010, 0x1010];
         d.device_clut[7] = [0x4040, 0x4545, 0x4545];
@@ -37723,7 +37723,7 @@ mod tests {
         // mapping them to the destination device. Macintosh Human Interface
         // Guidelines (1992), p. 241; More Macintosh Toolbox (1993), p. 5-37.
         let (mut d, mut cpu, mut bus) = setup();
-        d.device_clut = [[0, 0, 0]; 256];
+        *d.device_clut = [[0, 0, 0]; 256];
         d.device_clut[8] = [0x2222, 0x2222, 0x2222];
 
         let dst_base = bus.alloc(8);
@@ -38370,7 +38370,7 @@ mod tests {
         let (mut d, mut cpu, mut bus) = setup_with_port();
         let (screen_base, row_bytes) = setup_polygon_surface(&mut d, &mut bus);
         let requested = (0x1234, 0x5678, 0x9ABC);
-        d.device_clut = [[0xFFFF, 0xFFFF, 0xFFFF]; 256];
+        *d.device_clut = [[0xFFFF, 0xFFFF, 0xFFFF]; 256];
         d.device_clut[7] = [requested.0, requested.1, requested.2];
 
         let pp_handle =
@@ -38466,7 +38466,7 @@ mod tests {
         let (mut d, mut cpu, mut bus) = setup_with_port();
         let (screen_base, row_bytes) = setup_color_polygon_surface(&mut d, &cpu, &mut bus);
         let requested = (0, 0, 0xFFFF);
-        d.device_clut = [[0, 0, 0]; 256];
+        *d.device_clut = [[0, 0, 0]; 256];
         d.device_clut[7] = [requested.0, requested.1, requested.2];
 
         let pp_handle =
@@ -38789,7 +38789,7 @@ mod tests {
         d.front_window = window;
         d.current_port = window;
 
-        let before = d.device_clut;
+        let before = *d.device_clut;
         bus.write_long(TEST_SP, window);
 
         let result = d.dispatch_quickdraw(true, 0x294, &mut cpu, &mut bus);
@@ -38826,7 +38826,7 @@ mod tests {
         d.front_window = window;
         d.current_port = window;
 
-        let before = d.device_clut;
+        let before = *d.device_clut;
         bus.write_long(TEST_SP, window);
 
         let result = d.dispatch_quickdraw(true, 0x294, &mut cpu, &mut bus);
@@ -38854,7 +38854,7 @@ mod tests {
         d.set_window_palette_association(window, palette, 0);
         d.front_window = window;
         d.current_port = window;
-        let before = d.device_clut;
+        let before = *d.device_clut;
         bus.write_long(TEST_SP, window);
 
         let result = d.dispatch_quickdraw(true, 0x294, &mut cpu, &mut bus);
@@ -38984,7 +38984,7 @@ mod tests {
         d.set_window_palette_association(window, palette, 0);
         d.front_window = window;
         d.current_port = window;
-        let before = d.device_clut;
+        let before = *d.device_clut;
         bus.write_long(TEST_SP, window);
 
         let result = d.dispatch_quickdraw(true, 0x294, &mut cpu, &mut bus);
@@ -39020,7 +39020,7 @@ mod tests {
         d.set_window_palette_association(window, palette, 0);
         d.front_window = window;
         d.current_port = window;
-        let before = d.device_clut;
+        let before = *d.device_clut;
         bus.write_long(TEST_SP, window);
 
         let result = d.dispatch_quickdraw(true, 0x294, &mut cpu, &mut bus);
@@ -39069,7 +39069,7 @@ mod tests {
         d.front_window = window;
         d.current_port = window;
 
-        let before = d.device_clut;
+        let before = *d.device_clut;
         bus.write_long(TEST_SP, src_rgb);
         bus.write_word(TEST_SP + 4, 0);
         bus.write_long(TEST_SP + 6, window);
@@ -39095,7 +39095,7 @@ mod tests {
         d.front_window = window;
         d.current_port = window;
 
-        let before = d.device_clut;
+        let before = *d.device_clut;
         bus.write_long(TEST_SP, src_rgb);
         bus.write_word(TEST_SP + 4, 1);
         bus.write_long(TEST_SP + 6, window);
@@ -40330,8 +40330,8 @@ mod tests {
         let ctab_size = bus.get_alloc_size(ctab).unwrap();
 
         let before_screen_mode = d.screen_mode;
-        let before_device_clut = d.device_clut;
-        let before_color_manager_clut = d.color_manager_clut;
+        let before_device_clut = *d.device_clut;
+        let before_color_manager_clut = *d.color_manager_clut;
         let before_screen_base = bus.read_long(0x0824);
         let before_screen_row = bus.read_word(crate::memory::globals::addr::SCREEN_ROW);
         let before_screen_bits = bus.read_bytes(crate::memory::globals::addr::SCREEN_BITS, 14);
@@ -40406,7 +40406,7 @@ mod tests {
         d.cport_ports.insert(port);
 
         let before_screen_mode = d.screen_mode;
-        let before_device_clut = d.device_clut;
+        let before_device_clut = *d.device_clut;
         let before_main_pixmap = bus.read_bytes(main_pixmap, 50);
         let before_main_ctab = bus.read_bytes(old_main_ctab, 24);
         let before_port_pixmap = bus.read_bytes(port_pixmap, 50);
@@ -40644,7 +40644,7 @@ mod tests {
 
         d.current_port = window;
         d.front_window = window;
-        d.device_clut = [[0, 0, 0]; 256];
+        *d.device_clut = [[0, 0, 0]; 256];
         d.device_clut[42] = target_rgb;
 
         let palette = d.create_palette_from_ctab(&mut bus, 8, 0, super::PM_TOLERANT, 0);
@@ -40947,7 +40947,7 @@ mod tests {
         d.front_window = window;
         d.current_port = window;
 
-        let before = d.device_clut;
+        let before = *d.device_clut;
         bus.write_word(TEST_SP, 1);
         bus.write_word(TEST_SP + 2, 1);
         bus.write_word(TEST_SP + 4, 0);
@@ -44770,7 +44770,7 @@ mod tests {
         seeded[128] = [0x2222, 0x1111, 0x7777];
         seeded[255] = [0, 0, 0];
 
-        d.color_manager_clut = seeded;
+        *d.color_manager_clut = seeded;
         d.seeded_picture_palette = seeded;
         d.seeded_picture_palette_until_tick = 99;
         d.tick_count = 50;
@@ -44805,7 +44805,7 @@ mod tests {
         seeded[128] = [0x2222, 0x1111, 0x7777];
         seeded[255] = [0, 0, 0];
 
-        d.color_manager_clut = TrapDispatcher::standard_mac_8bpp_clut();
+        *d.color_manager_clut = TrapDispatcher::standard_mac_8bpp_clut();
         d.seeded_picture_palette = seeded;
         d.seeded_picture_palette_until_tick = 99;
         d.tick_count = 50;
@@ -44838,7 +44838,7 @@ mod tests {
         seeded[128] = [0x2222, 0x1111, 0x7777];
         seeded[255] = [0, 0, 0];
 
-        d.color_manager_clut = seeded;
+        *d.color_manager_clut = seeded;
         d.seeded_picture_palette = seeded;
         d.seeded_picture_palette_until_tick = 99;
         d.tick_count = 50;
@@ -44878,7 +44878,7 @@ mod tests {
             bus.write_word(entry + 6, rgb[2] / 2);
         }
 
-        d.color_manager_clut = TrapDispatcher::standard_mac_8bpp_clut();
+        *d.color_manager_clut = TrapDispatcher::standard_mac_8bpp_clut();
 
         d.apply_set_entries_with_gdevice_mode(&mut bus, table_ptr, 0, 255, true);
 
@@ -44904,8 +44904,8 @@ mod tests {
         d.ensure_main_gdevice(&mut bus);
         let table_ptr = 0x336800u32;
         let baseline = TrapDispatcher::standard_mac_8bpp_clut();
-        d.device_clut = baseline;
-        d.color_manager_clut = baseline;
+        *d.device_clut = baseline;
+        *d.color_manager_clut = baseline;
         d.seeded_picture_palette_until_tick = 0;
 
         for (index, rgb) in baseline.iter().enumerate() {
@@ -44943,8 +44943,8 @@ mod tests {
         d.ensure_main_gdevice(&mut bus);
         let table_ptr = 0x336C00u32;
         let baseline = TrapDispatcher::standard_mac_8bpp_clut();
-        d.device_clut = baseline;
-        d.color_manager_clut = baseline;
+        *d.device_clut = baseline;
+        *d.color_manager_clut = baseline;
         d.seeded_picture_palette_until_tick = 0;
 
         for (index, rgb) in baseline.iter().enumerate() {
@@ -44972,8 +44972,8 @@ mod tests {
         let (mut d, _cpu, mut bus) = setup_with_port();
         d.ensure_main_gdevice(&mut bus);
         let baseline = TrapDispatcher::standard_mac_8bpp_clut();
-        d.color_manager_clut = baseline;
-        d.device_clut = TrapDispatcher::scale_clut(&baseline, 0.02);
+        *d.color_manager_clut = baseline;
+        *d.device_clut = TrapDispatcher::scale_clut(&baseline, 0.02);
         let table_ptr = 0x336E00u32;
         for index in 0..256u32 {
             let entry = table_ptr + index * 8;
@@ -45004,8 +45004,8 @@ mod tests {
         let (mut d, _cpu, mut bus) = setup_with_port();
         d.ensure_main_gdevice(&mut bus);
         let baseline = TrapDispatcher::standard_mac_8bpp_clut();
-        d.color_manager_clut = baseline;
-        d.device_clut = baseline;
+        *d.color_manager_clut = baseline;
+        *d.device_clut = baseline;
         let table_ptr = 0x336E00u32;
 
         // Perform a 4-step fade down to 0%
@@ -45065,8 +45065,8 @@ mod tests {
         let (mut d, _cpu, mut bus) = setup_with_port();
         d.ensure_main_gdevice(&mut bus);
         let physical = TrapDispatcher::standard_mac_8bpp_clut();
-        d.device_clut = physical;
-        d.color_manager_clut = physical;
+        *d.device_clut = physical;
+        *d.color_manager_clut = physical;
         let table_ptr = 0x336E00u32;
 
         for pass in 0..2u16 {
@@ -45122,8 +45122,8 @@ mod tests {
         let (mut d, _cpu, mut bus) = setup_with_port();
         d.ensure_main_gdevice(&mut bus);
         let baseline = TrapDispatcher::standard_mac_8bpp_clut();
-        d.color_manager_clut = baseline;
-        d.device_clut = TrapDispatcher::scale_clut(&baseline, 0.02);
+        *d.color_manager_clut = baseline;
+        *d.device_clut = TrapDispatcher::scale_clut(&baseline, 0.02);
         let table_ptr = 0x337E00u32;
         for index in 0..256u32 {
             let entry = table_ptr + index * 8;
@@ -46004,7 +46004,7 @@ mod tests {
         // IM:V 1986 p. V-141: with iTabRes=4, RealColor is TRUE when
         // some table entry matches the top 4 bits of each RGB component.
         let (mut d, mut cpu, mut bus) = setup();
-        d.device_clut = [[0x0000, 0x0000, 0x0000]; 256];
+        *d.device_clut = [[0x0000, 0x0000, 0x0000]; 256];
         d.device_clut[42] = [0xA111, 0xB222, 0xC333];
 
         let rgb_ptr = 0x300300u32;
@@ -46025,7 +46025,7 @@ mod tests {
         // device table has no entry matching the requested RGB at the
         // active inverse-table resolution.
         let (mut d, mut cpu, mut bus) = setup();
-        d.device_clut = [[0x1000, 0x2000, 0x3000]; 256];
+        *d.device_clut = [[0x1000, 0x2000, 0x3000]; 256];
 
         let rgb_ptr = 0x300340u32;
         bus.write_word(rgb_ptr, 0xA000);
@@ -46104,7 +46104,7 @@ mod tests {
         // IM:V 1986 p. V-143: a reserved entry is not returned by
         // Color2Index or other search procedures.
         let (mut d, mut cpu, mut bus) = setup();
-        d.device_clut = [[0x0000, 0x0000, 0x0000]; 256];
+        *d.device_clut = [[0x0000, 0x0000, 0x0000]; 256];
         d.device_clut[3] = [0x4444, 0x5555, 0x6666];
         d.device_clut[9] = [0x4444, 0x5555, 0x6666];
 
@@ -46133,7 +46133,7 @@ mod tests {
         // IM:V 1986 p. V-143: ReserveEntry(FALSE) removes reservation so
         // the entry is again eligible for Color2Index matching.
         let (mut d, mut cpu, mut bus) = setup();
-        d.device_clut = [[0x0000, 0x0000, 0x0000]; 256];
+        *d.device_clut = [[0x0000, 0x0000, 0x0000]; 256];
         d.device_clut[3] = [0x4444, 0x5555, 0x6666];
         d.device_clut[9] = [0x4444, 0x5555, 0x6650];
         d.clut_reserved[3] = true;
@@ -46379,7 +46379,7 @@ mod tests {
         // "If any of the requested entries are protected or out of range, a
         // protection error is returned, and nothing happens."
         let (mut d, mut cpu, mut bus) = setup_with_port();
-        let before_device = d.device_clut;
+        let before_device = *d.device_clut;
         let ctab_handle = d.current_gdevice_ctab_handle(&bus);
         let ctab_ptr = bus.read_long(ctab_handle);
         let before_ctab = bus.read_bytes(ctab_ptr, 8 + 256 * 8);

--- a/src/trap/shapes.rs
+++ b/src/trap/shapes.rs
@@ -1446,7 +1446,7 @@ impl super::TrapDispatcher {
                 port_ctab_handle
             };
             let port_clut = if is_screen_port {
-                self.device_clut
+                *self.device_clut
             } else if use_raw_current_ctab {
                 self.read_ctab_handle_clut(bus, ctab_handle)
             } else {
@@ -1649,7 +1649,7 @@ impl super::TrapDispatcher {
                     port_ctab_handle
                 };
                 Some(if is_screen_port {
-                    self.device_clut
+                    *self.device_clut
                 } else if use_raw_current_ctab {
                     self.read_ctab_handle_clut(bus, ctab_handle)
                 } else {

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -4272,7 +4272,7 @@ impl super::TrapDispatcher {
                             && row_bytes == self.screen_mode.1
                             && pixel_size == self.screen_mode.4;
                         let clut = if is_screen_port {
-                            self.device_clut
+                            *self.device_clut
                         } else {
                             self.read_port_clut(bus, ctab_handle)
                         };
@@ -24992,7 +24992,7 @@ mod tests {
             let hilite = (0x0000, 0x8000, 0x0000);
 
             disp.set_screen_mode_for_test(screen_base, row_bytes, 192, 128, 8);
-            disp.device_clut = [[0xFFFF, 0xFFFF, 0xFFFF]; 256];
+            *disp.device_clut = [[0xFFFF, 0xFFFF, 0xFFFF]; 256];
             disp.device_clut[0] = [0x0000, 0x0000, 0x0000];
             disp.device_clut[42] = [hilite.0, hilite.1, hilite.2];
             disp.hilite_color = hilite;
@@ -25196,7 +25196,7 @@ mod tests {
         let hilite = (0x0000, 0x8000, 0x0000);
 
         disp.set_screen_mode_for_test(screen_base, row_bytes, 128, 96, 8);
-        disp.device_clut = [[0xFFFF, 0xFFFF, 0xFFFF]; 256];
+        *disp.device_clut = [[0xFFFF, 0xFFFF, 0xFFFF]; 256];
         disp.device_clut[0] = [0x0000, 0x0000, 0x0000];
         disp.device_clut[42] = [hilite.0, hilite.1, hilite.2];
         disp.hilite_color = hilite;


### PR DESCRIPTION
## Root cause

The classic trap dispatcher and native PowerPC adapter retained separate device palettes, Color Manager palettes, and gamma tables. The runner copied native color state into the classic adapter only while presenting a frame, so cross-ISA callbacks could observe stale display state.

## Change

- attach both CPU adapters to one process-owned device CLUT, Color Manager CLUT, gamma table, and explicit-gamma flag
- keep ordinary loaded-application clones detached
- remove the frame-presentation color-state handoff
- centralize construction of the standard 8-bit Macintosh palette
- add bidirectional cross-ISA visibility and detached-clone regression coverage

## Validation

- `cargo test --locked --lib` (4,742 passed; 0 failed; 3 ignored)
- strict all-features rustdoc with private intra-doc links denied
- all targets compile (one pre-existing dead-code warning)
- Marathon terminal completion script
- Escape Velocity launch, landing, return-to-space, and live-input script
- Tomb Raider Gold live 3D movement script

Closes #1191