### PR TITLE
refactor(quickdraw)!: make port selection process-owned

### DIFF
--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -3372,8 +3372,8 @@ pub struct PpcLoadedApp {
     pub timer_tasks: Vec<PpcTimerTaskRecord>,
     pub vbl_tasks: Vec<PpcVblTaskRecord>,
     pub(crate) process_file_system: SharedProcessFileSystem,
-    pub current_gworld: u32,
-    pub current_gdevice: u32,
+    pub current_gworld: SharedProcessValue<u32>,
+    pub current_gdevice: SharedProcessValue<u32>,
     pub screen_clut: SharedProcessValue<[[u16; 3]; 256]>,
     pub color_manager_clut: SharedProcessValue<[[u16; 3]; 256]>,
     pub device_gamma: SharedProcessValue<crate::display::DisplayGamma>,
@@ -3857,6 +3857,7 @@ impl PpcLoadedApp {
         self.process_file_system.publish_native_vfs_catalogue();
         context.attach_sound_manager(&mut self.sound.manager);
         context.attach_cursor_state(&mut self.cursor_state);
+        context.activate_quickdraw_selection(&mut self.current_gworld, &mut self.current_gdevice);
         context.attach_display_color_state(
             &mut self.screen_clut,
             &mut self.color_manager_clut,
@@ -3984,7 +3985,7 @@ impl PpcLoadedApp {
     }
 
     pub fn current_front_buffer(&self) -> Option<PpcFrontBuffer> {
-        ppc_front_buffer_for_gworld(&self.gworlds, self.current_gworld)
+        ppc_front_buffer_for_gworld(&self.gworlds, *self.current_gworld)
     }
 
     pub fn presented_front_buffer(&self) -> Option<PpcFrontBuffer> {
@@ -4037,7 +4038,7 @@ impl PpcLoadedApp {
                         clear_color: None,
                         source: PpcQ3RenderTargetSource::CurrentGWorld,
                         draw_context: None,
-                        gworld: Some(self.current_gworld),
+                        gworld: Some(*self.current_gworld),
                     })
             })
     }
@@ -5021,7 +5022,7 @@ impl PpcLoadedApp {
             &self.q3_views,
             &self.q3_draw_contexts,
             &self.gworlds,
-            self.current_gworld,
+            *self.current_gworld,
             frame,
         )
     }
@@ -7182,8 +7183,8 @@ impl PpcLoadedApp {
         let mut vfs_resource_files = std::mem::take(&mut self.vfs_resource_files);
         let mut vfs_resources = std::mem::take(&mut self.vfs_resources);
         let mut next_file_ref_num = self.next_file_ref_num;
-        let mut current_gworld = self.current_gworld;
-        let mut current_gdevice = self.current_gdevice;
+        let mut current_gworld = self.current_gworld.shared_handle();
+        let mut current_gdevice = self.current_gdevice.shared_handle();
         let mut screen_clut = self.screen_clut.shared_handle();
         let mut color_manager_clut = self.color_manager_clut.shared_handle();
         let mut device_gamma = self.device_gamma.shared_handle();
@@ -7312,7 +7313,7 @@ impl PpcLoadedApp {
                             &q3_draw_contexts,
                             &q3_trimeshes,
                             &gworlds,
-                            current_gworld,
+                            *current_gworld,
                             &mut q3_error_state,
                             input.is_idle(),
                         );
@@ -7497,7 +7498,7 @@ impl PpcLoadedApp {
                             &q3_draw_contexts,
                             &q3_trimeshes,
                             &gworlds,
-                            current_gworld,
+                            *current_gworld,
                             &mut q3_error_state,
                             input.is_idle(),
                         );
@@ -8069,8 +8070,6 @@ impl PpcLoadedApp {
         self.vfs_resource_files = vfs_resource_files;
         self.vfs_resources = vfs_resources;
         self.next_file_ref_num = next_file_ref_num;
-        self.current_gworld = current_gworld;
-        self.current_gdevice = current_gdevice;
         self.quickdraw_fore_color = quickdraw_fore_color;
         self.quickdraw_fore_indices = quickdraw_fore_indices;
         self.quickdraw_back_color = quickdraw_back_color;
@@ -12699,8 +12698,8 @@ fn load_pef_application_with_config_and_optional_system_reservation(
         timer_tasks: Vec::new(),
         vbl_tasks: Vec::new(),
         process_file_system: ppc_initial_process_file_system(),
-        current_gworld: PPC_MAIN_GWORLD,
-        current_gdevice: PPC_MAIN_GDEVICE,
+        current_gworld: SharedProcessValue::from_value(PPC_MAIN_GWORLD),
+        current_gdevice: SharedProcessValue::from_value(PPC_MAIN_GDEVICE),
         screen_clut: SharedProcessValue::from_value(screen_clut),
         color_manager_clut: SharedProcessValue::from_value(color_manager_clut),
         device_gamma: SharedProcessValue::from_value(crate::display::default_display_gamma()),
@@ -85210,7 +85209,7 @@ pub(crate) mod tests {
         let mut loaded = load_pef_application(&pef).unwrap();
         let window_out = PPC_DATA_BASE + 0x1000;
         loaded.memory.add_region(window_out, vec![0xff; 4]);
-        loaded.current_gworld = PPC_MAIN_GWORLD;
+        *loaded.current_gworld = PPC_MAIN_GWORLD;
         loaded
             .memory
             .write_u16_be(PPC_MBAR_HEIGHT_ADDR, 12)
@@ -85271,7 +85270,7 @@ pub(crate) mod tests {
         assert_ne!(front_window, 0);
 
         // The current graphics port is not the Window Manager's z-order.
-        loaded.current_gworld = PPC_MAIN_GWORLD;
+        *loaded.current_gworld = PPC_MAIN_GWORLD;
         loaded.cpu.gpr[3] = (80 << 16) | 80;
         loaded.cpu.gpr[4] = window_out;
         run_test_import(&mut loaded, PpcImportDispatcherTarget::FindWindow);
@@ -85320,7 +85319,7 @@ pub(crate) mod tests {
                 pixels_no_purge: false,
             });
         }
-        loaded.current_gworld = dialog;
+        *loaded.current_gworld = dialog;
         loaded.cpu.gpr[3] = dialog;
 
         run_test_import(&mut loaded, PpcImportDispatcherTarget::DisposeDialog);
@@ -85328,7 +85327,7 @@ pub(crate) mod tests {
         assert_eq!(loaded.toolbox_startup.dispose_dialog_count, 1);
         assert_eq!(loaded.toolbox_startup.last_disposed_dialog, dialog);
         assert!(!loaded.gworlds.iter().any(|record| record.port == dialog));
-        assert_eq!(loaded.current_gworld, application_window);
+        assert_eq!(*loaded.current_gworld, application_window);
         assert_eq!(
             ppc_front_visible_window(&mut loaded.memory, &loaded.gworlds),
             Some(application_window)
@@ -86357,8 +86356,8 @@ pub(crate) mod tests {
         let before =
             ppc_memory_read_bytes(&mut loaded.memory, front.base_addr, framebuffer_len).unwrap();
         let return_address = loaded.cpu.lr;
-        loaded.current_gworld = 0x1234_0000;
-        loaded.current_gdevice = 0x1234_1000;
+        *loaded.current_gworld = 0x1234_0000;
+        *loaded.current_gdevice = 0x1234_1000;
         loaded.cpu.gpr[3] = (10u32 << 16) | 12;
         loaded.set_input_snapshot(PpcInputSnapshot {
             mouse_button: true,
@@ -86377,8 +86376,8 @@ pub(crate) mod tests {
                 .which_item(),
             2
         );
-        assert_eq!(loaded.current_gworld, PPC_MAIN_GWORLD);
-        assert_eq!(loaded.current_gdevice, PPC_MAIN_GDEVICE);
+        assert_eq!(*loaded.current_gworld, PPC_MAIN_GWORLD);
+        assert_eq!(*loaded.current_gdevice, PPC_MAIN_GDEVICE);
         assert_ne!(
             ppc_memory_read_bytes(&mut loaded.memory, front.base_addr, framebuffer_len),
             Some(before.clone())
@@ -86431,8 +86430,8 @@ pub(crate) mod tests {
         assert_eq!(loaded.toolbox_startup.menu_tracking, None);
         assert_eq!(loaded.toolbox_startup.menu_definition_tracking, None);
         assert_eq!(loaded.toolbox_startup.menu_select_call, None);
-        assert_eq!(loaded.current_gworld, 0x1234_0000);
-        assert_eq!(loaded.current_gdevice, 0x1234_1000);
+        assert_eq!(*loaded.current_gworld, 0x1234_0000);
+        assert_eq!(*loaded.current_gdevice, 0x1234_1000);
         let mut restored = Vec::new();
         for y in 0..i32::from(tracking.saved_height) {
             for x in 0..i32::from(tracking.saved_width) {
@@ -86551,8 +86550,8 @@ pub(crate) mod tests {
             .unwrap();
 
         let return_address = loaded.cpu.lr;
-        loaded.current_gworld = 0x1234_0000;
-        loaded.current_gdevice = 0x1234_1000;
+        *loaded.current_gworld = 0x1234_0000;
+        *loaded.current_gdevice = 0x1234_1000;
         loaded.cpu.gpr[3] = (10u32 << 16) | 12;
         loaded.set_input_snapshot(PpcInputSnapshot {
             mouse_button: true,
@@ -86603,8 +86602,8 @@ pub(crate) mod tests {
             .submenus
             .is_empty());
         assert_eq!(loaded.toolbox_startup.menu_select_call, None);
-        assert_eq!(loaded.current_gworld, 0x1234_0000);
-        assert_eq!(loaded.current_gdevice, 0x1234_1000);
+        assert_eq!(*loaded.current_gworld, 0x1234_0000);
+        assert_eq!(*loaded.current_gdevice, 0x1234_1000);
 
         loaded.set_input_snapshot(PpcInputSnapshot {
             mouse_button: true,
@@ -86661,8 +86660,8 @@ pub(crate) mod tests {
         assert_eq!(loaded.cpu.lr, return_address);
         assert_eq!(loaded.toolbox_startup.menu_tracking, None);
         assert_eq!(loaded.toolbox_startup.menu_select_call, None);
-        assert_eq!(loaded.current_gworld, 0x1234_0000);
-        assert_eq!(loaded.current_gdevice, 0x1234_1000);
+        assert_eq!(*loaded.current_gworld, 0x1234_0000);
+        assert_eq!(*loaded.current_gdevice, 0x1234_1000);
     }
 
     #[test]
@@ -88773,6 +88772,40 @@ pub(crate) mod tests {
             crate::display::default_display_gamma()
         );
         assert!(!*detached.device_gamma_explicit);
+    }
+
+    #[test]
+    fn attached_68k_and_powerpc_adapters_share_quickdraw_selection_without_runner_copy() {
+        let (mut classic, _, _) = setup_with_port();
+        let pef = synthetic_pef_with_import(b"GetGWorld");
+        let mut native = load_pef_application(&pef).unwrap();
+        let mut context = ProcessContext::default();
+
+        classic.attach_process_context(&mut context);
+        native.attach_process_context(&mut context);
+        let detached = native.clone();
+
+        assert!(classic.current_port.ptr_eq(&native.current_gworld));
+        assert!(classic
+            .current_gdevice
+            .ptr_eq(&native.current_gdevice));
+        assert_eq!(*classic.current_port, PPC_MAIN_GWORLD);
+        assert_eq!(*classic.current_gdevice, PPC_MAIN_GDEVICE);
+
+        *native.current_gworld = 0x0030_0000;
+        *native.current_gdevice = 0x0030_1000;
+        assert_eq!(*classic.current_port, 0x0030_0000);
+        assert_eq!(*classic.current_gdevice, 0x0030_1000);
+
+        *classic.current_port = 0x0040_0000;
+        *classic.current_gdevice = 0x0040_1000;
+        assert_eq!(*native.current_gworld, 0x0040_0000);
+        assert_eq!(*native.current_gdevice, 0x0040_1000);
+
+        assert!(!native.current_gworld.ptr_eq(&detached.current_gworld));
+        assert!(!native.current_gdevice.ptr_eq(&detached.current_gdevice));
+        assert_eq!(*detached.current_gworld, PPC_MAIN_GWORLD);
+        assert_eq!(*detached.current_gdevice, PPC_MAIN_GDEVICE);
     }
 
     #[test]
@@ -91621,7 +91654,7 @@ pub(crate) mod tests {
         loaded.memory.write_u16_be(table + 4, 0x2222).unwrap();
         loaded.memory.write_u16_be(table + 6, 0x3333).unwrap();
         let ctable_handle =
-            ppc_gdevice_ctable_handle(&mut loaded.memory, loaded.current_gdevice).unwrap();
+            ppc_gdevice_ctable_handle(&mut loaded.memory, *loaded.current_gdevice).unwrap();
         let logical_before = ppc_read_ctable_clut(
             &mut loaded.memory,
             ctable_handle,
@@ -91639,7 +91672,7 @@ pub(crate) mod tests {
             ppc_pb_control(
                 &cpu,
                 &mut loaded.memory,
-                loaded.current_gdevice,
+                *loaded.current_gdevice,
                 &mut screen_clut,
                 &mut device_gamma,
                 &mut device_gamma_explicit,
@@ -92836,8 +92869,8 @@ pub(crate) mod tests {
             loaded.sound.manager.default_output_volume(),
             PPC_DEFAULT_OUTPUT_VOLUME
         );
-        assert_eq!(loaded.current_gworld, PPC_MAIN_GWORLD);
-        assert_eq!(loaded.current_gdevice, PPC_MAIN_GDEVICE);
+        assert_eq!(*loaded.current_gworld, PPC_MAIN_GWORLD);
+        assert_eq!(*loaded.current_gdevice, PPC_MAIN_GDEVICE);
         assert_eq!(loaded.default_dir_id, PPC_ROOT_DIR_ID);
         assert_eq!(
             loaded.memory.read_u32_be(PPC_MAIN_GWORLD + 2),
@@ -109800,7 +109833,7 @@ pub(crate) mod tests {
         assert_eq!(stats.target_depth, Some(front_buffer.depth));
         assert_eq!(stats.target_source, Some("current_gworld"));
         assert_eq!(stats.target_draw_context, None);
-        assert_eq!(stats.target_gworld, Some(loaded.current_gworld));
+        assert_eq!(stats.target_gworld, Some(*loaded.current_gworld));
         assert!(stats.target_consistent);
     }
 
@@ -109843,7 +109876,7 @@ pub(crate) mod tests {
                 pixels_no_purge: false,
             },
         ];
-        loaded.current_gworld = PPC_MAIN_GWORLD;
+        *loaded.current_gworld = PPC_MAIN_GWORLD;
         loaded
             .q3_objects
             .push(test_q3_object(view, PPC_Q3_TYPE_VIEW));
@@ -109983,7 +110016,7 @@ pub(crate) mod tests {
             &mut loaded.q3_state_only_completed_frame_batches,
             &loaded.q3_draw_contexts,
             &loaded.gworlds,
-            loaded.current_gworld,
+            *loaded.current_gworld,
             &mut loaded.q3_error_state,
         );
 
@@ -110096,7 +110129,7 @@ pub(crate) mod tests {
             &mut loaded.q3_state_only_completed_frame_batches,
             &loaded.q3_draw_contexts,
             &loaded.gworlds,
-            loaded.current_gworld,
+            *loaded.current_gworld,
             &mut loaded.q3_error_state,
         );
 
@@ -115847,7 +115880,7 @@ pub(crate) mod tests {
             pixels_locked: false,
             pixels_no_purge: false,
         }];
-        loaded.current_gworld = PPC_MAIN_GWORLD;
+        *loaded.current_gworld = PPC_MAIN_GWORLD;
 
         loaded
             .memory
@@ -116010,7 +116043,7 @@ pub(crate) mod tests {
             pixels_locked: false,
             pixels_no_purge: false,
         }];
-        replay_loaded.current_gworld = PPC_MAIN_GWORLD;
+        *replay_loaded.current_gworld = PPC_MAIN_GWORLD;
         assert!(replay_loaded.q3_submissions.is_empty());
         assert!(replay_loaded.q3_submission_transforms.is_empty());
         assert!(replay_loaded.q3_submission_materials.is_empty());
@@ -116163,7 +116196,7 @@ pub(crate) mod tests {
             pixels_locked: false,
             pixels_no_purge: false,
         }];
-        loaded.current_gworld = PPC_MAIN_GWORLD;
+        *loaded.current_gworld = PPC_MAIN_GWORLD;
         loaded.q3_objects.push(PpcQ3ObjectRecord {
             object: draw_context,
             kind: PpcQ3ObjectKind::Generic,
@@ -116347,7 +116380,7 @@ pub(crate) mod tests {
                 pixels_no_purge: false,
             },
         ];
-        loaded.current_gworld = PPC_MAIN_GWORLD;
+        *loaded.current_gworld = PPC_MAIN_GWORLD;
         loaded.q3_objects.push(PpcQ3ObjectRecord {
             object: draw_context,
             kind: PpcQ3ObjectKind::Generic,
@@ -116503,7 +116536,7 @@ pub(crate) mod tests {
                 pixels_no_purge: false,
             },
         ];
-        loaded.current_gworld = PPC_MAIN_GWORLD;
+        *loaded.current_gworld = PPC_MAIN_GWORLD;
         loaded.draw_sprocket.front_buffer_gworld = PPC_MAIN_GWORLD;
         loaded.draw_sprocket.back_buffer_gworld = PPC_DSP_BACK_GWORLD;
 
@@ -116685,7 +116718,7 @@ pub(crate) mod tests {
                 pixels_locked: false,
                 pixels_no_purge: false,
             }];
-            loaded.current_gworld = PPC_MAIN_GWORLD;
+            *loaded.current_gworld = PPC_MAIN_GWORLD;
 
             loaded
                 .memory
@@ -116830,7 +116863,7 @@ pub(crate) mod tests {
             pixels_locked: false,
             pixels_no_purge: false,
         }];
-        loaded.current_gworld = PPC_MAIN_GWORLD;
+        *loaded.current_gworld = PPC_MAIN_GWORLD;
 
         loaded
             .memory
@@ -117062,7 +117095,7 @@ pub(crate) mod tests {
             pixels_locked: false,
             pixels_no_purge: false,
         }];
-        loaded.current_gworld = PPC_MAIN_GWORLD;
+        *loaded.current_gworld = PPC_MAIN_GWORLD;
 
         loaded
             .memory
@@ -117322,7 +117355,7 @@ pub(crate) mod tests {
             pixels_locked: false,
             pixels_no_purge: false,
         }];
-        loaded.current_gworld = PPC_MAIN_GWORLD;
+        *loaded.current_gworld = PPC_MAIN_GWORLD;
 
         loaded
             .memory
@@ -117526,7 +117559,7 @@ pub(crate) mod tests {
             pixels_locked: false,
             pixels_no_purge: false,
         }];
-        loaded.current_gworld = PPC_MAIN_GWORLD;
+        *loaded.current_gworld = PPC_MAIN_GWORLD;
 
         loaded
             .memory
@@ -117732,7 +117765,7 @@ pub(crate) mod tests {
                 pixels_locked: false,
                 pixels_no_purge: false,
             }];
-            loaded.current_gworld = PPC_MAIN_GWORLD;
+            *loaded.current_gworld = PPC_MAIN_GWORLD;
 
             loaded
                 .memory
@@ -117935,7 +117968,7 @@ pub(crate) mod tests {
                 pixels_locked: false,
                 pixels_no_purge: false,
             }];
-            loaded.current_gworld = PPC_MAIN_GWORLD;
+            *loaded.current_gworld = PPC_MAIN_GWORLD;
 
             loaded
                 .memory
@@ -118160,7 +118193,7 @@ pub(crate) mod tests {
             pixels_locked: false,
             pixels_no_purge: false,
         }];
-        loaded.current_gworld = PPC_MAIN_GWORLD;
+        *loaded.current_gworld = PPC_MAIN_GWORLD;
 
         write_triangle_mesh(
             &mut loaded.memory,
@@ -118316,7 +118349,7 @@ pub(crate) mod tests {
             pixels_locked: false,
             pixels_no_purge: false,
         }];
-        loaded.current_gworld = PPC_MAIN_GWORLD;
+        *loaded.current_gworld = PPC_MAIN_GWORLD;
 
         write_triangle_mesh(
             &mut loaded.memory,
@@ -118516,7 +118549,7 @@ pub(crate) mod tests {
                 pixels_locked: false,
                 pixels_no_purge: false,
             }];
-            loaded.current_gworld = PPC_MAIN_GWORLD;
+            *loaded.current_gworld = PPC_MAIN_GWORLD;
 
             write_trimesh(
                 &mut loaded.memory,
@@ -118676,7 +118709,7 @@ pub(crate) mod tests {
             pixels_locked: false,
             pixels_no_purge: false,
         }];
-        loaded.current_gworld = PPC_MAIN_GWORLD;
+        *loaded.current_gworld = PPC_MAIN_GWORLD;
 
         loaded
             .memory
@@ -118862,7 +118895,7 @@ pub(crate) mod tests {
             pixels_locked: false,
             pixels_no_purge: false,
         }];
-        loaded.current_gworld = PPC_MAIN_GWORLD;
+        *loaded.current_gworld = PPC_MAIN_GWORLD;
 
         loaded
             .memory
@@ -119036,7 +119069,7 @@ pub(crate) mod tests {
             pixels_locked: false,
             pixels_no_purge: false,
         }];
-        loaded.current_gworld = PPC_MAIN_GWORLD;
+        *loaded.current_gworld = PPC_MAIN_GWORLD;
 
         loaded
             .memory
@@ -119229,7 +119262,7 @@ pub(crate) mod tests {
             pixels_locked: false,
             pixels_no_purge: false,
         }];
-        loaded.current_gworld = PPC_MAIN_GWORLD;
+        *loaded.current_gworld = PPC_MAIN_GWORLD;
 
         loaded
             .memory
@@ -119379,7 +119412,7 @@ pub(crate) mod tests {
             pixels_locked: false,
             pixels_no_purge: false,
         }];
-        loaded.current_gworld = PPC_MAIN_GWORLD;
+        *loaded.current_gworld = PPC_MAIN_GWORLD;
 
         loaded
             .memory
@@ -119621,7 +119654,7 @@ pub(crate) mod tests {
             pixels_locked: false,
             pixels_no_purge: false,
         }];
-        loaded.current_gworld = PPC_MAIN_GWORLD;
+        *loaded.current_gworld = PPC_MAIN_GWORLD;
 
         loaded
             .memory
@@ -119788,7 +119821,7 @@ pub(crate) mod tests {
             pixels_locked: false,
             pixels_no_purge: false,
         }];
-        loaded.current_gworld = PPC_MAIN_GWORLD;
+        *loaded.current_gworld = PPC_MAIN_GWORLD;
 
         loaded
             .memory
@@ -120298,7 +120331,7 @@ pub(crate) mod tests {
         loaded.memory.add_region(trimesh_data, vec![0; 0x500]);
         loaded.memory.add_region(front_base, front_buffer_bytes);
         loaded.gworlds = vec![q3_software_test_front_gworld(front_base)];
-        loaded.current_gworld = PPC_MAIN_GWORLD;
+        *loaded.current_gworld = PPC_MAIN_GWORLD;
 
         loaded
             .memory
@@ -120408,7 +120441,7 @@ pub(crate) mod tests {
         loaded.memory.add_region(trimesh_data, vec![0; 0x500]);
         loaded.memory.add_region(front_base, front_buffer_bytes);
         loaded.gworlds = vec![q3_software_test_front_gworld(front_base)];
-        loaded.current_gworld = PPC_MAIN_GWORLD;
+        *loaded.current_gworld = PPC_MAIN_GWORLD;
 
         loaded
             .memory
@@ -120533,7 +120566,7 @@ pub(crate) mod tests {
         loaded.memory.add_region(trimesh_data, vec![0; 0x600]);
         loaded.memory.add_region(front_base, front_buffer_bytes);
         loaded.gworlds = vec![q3_software_test_front_gworld(front_base)];
-        loaded.current_gworld = PPC_MAIN_GWORLD;
+        *loaded.current_gworld = PPC_MAIN_GWORLD;
 
         loaded
             .memory
@@ -121108,7 +121141,7 @@ pub(crate) mod tests {
             pixels_locked: false,
             pixels_no_purge: false,
         }];
-        loaded.current_gworld = PPC_MAIN_GWORLD;
+        *loaded.current_gworld = PPC_MAIN_GWORLD;
 
         loaded
             .memory
@@ -121297,7 +121330,7 @@ pub(crate) mod tests {
             pixels_locked: false,
             pixels_no_purge: false,
         }];
-        loaded.current_gworld = PPC_MAIN_GWORLD;
+        *loaded.current_gworld = PPC_MAIN_GWORLD;
 
         loaded
             .memory
@@ -121504,7 +121537,7 @@ pub(crate) mod tests {
             pixels_locked: false,
             pixels_no_purge: false,
         }];
-        loaded.current_gworld = PPC_MAIN_GWORLD;
+        *loaded.current_gworld = PPC_MAIN_GWORLD;
 
         loaded
             .memory
@@ -121778,7 +121811,7 @@ pub(crate) mod tests {
             pixels_locked: false,
             pixels_no_purge: false,
         }];
-        loaded.current_gworld = PPC_MAIN_GWORLD;
+        *loaded.current_gworld = PPC_MAIN_GWORLD;
 
         write_lit_triangle_mesh(
             &mut loaded.memory,
@@ -121997,7 +122030,7 @@ pub(crate) mod tests {
             pixels_locked: false,
             pixels_no_purge: false,
         }];
-        loaded.current_gworld = PPC_MAIN_GWORLD;
+        *loaded.current_gworld = PPC_MAIN_GWORLD;
 
         write_lit_triangle_mesh(
             &mut loaded.memory,
@@ -122213,7 +122246,7 @@ pub(crate) mod tests {
                 pixels_locked: false,
                 pixels_no_purge: false,
             }];
-            loaded.current_gworld = PPC_MAIN_GWORLD;
+            *loaded.current_gworld = PPC_MAIN_GWORLD;
             write_lit_triangle_mesh(
                 &mut loaded.memory,
                 trimesh_data,
@@ -122426,7 +122459,7 @@ pub(crate) mod tests {
                 pixels_locked: false,
                 pixels_no_purge: false,
             }];
-            loaded.current_gworld = PPC_MAIN_GWORLD;
+            *loaded.current_gworld = PPC_MAIN_GWORLD;
 
             loaded
                 .memory
@@ -122625,7 +122658,7 @@ pub(crate) mod tests {
             pixels_locked: false,
             pixels_no_purge: false,
         }];
-        loaded.current_gworld = PPC_MAIN_GWORLD;
+        *loaded.current_gworld = PPC_MAIN_GWORLD;
 
         loaded
             .memory
@@ -122832,7 +122865,7 @@ pub(crate) mod tests {
             pixels_locked: false,
             pixels_no_purge: false,
         }];
-        loaded.current_gworld = PPC_MAIN_GWORLD;
+        *loaded.current_gworld = PPC_MAIN_GWORLD;
 
         loaded
             .memory
@@ -122994,7 +123027,7 @@ pub(crate) mod tests {
             pixels_locked: false,
             pixels_no_purge: false,
         }];
-        loaded.current_gworld = PPC_MAIN_GWORLD;
+        *loaded.current_gworld = PPC_MAIN_GWORLD;
 
         loaded
             .memory
@@ -123143,7 +123176,7 @@ pub(crate) mod tests {
             pixels_locked: false,
             pixels_no_purge: false,
         }];
-        loaded.current_gworld = PPC_MAIN_GWORLD;
+        *loaded.current_gworld = PPC_MAIN_GWORLD;
 
         loaded
             .memory
@@ -123319,7 +123352,7 @@ pub(crate) mod tests {
             pixels_locked: false,
             pixels_no_purge: false,
         }];
-        loaded.current_gworld = PPC_MAIN_GWORLD;
+        *loaded.current_gworld = PPC_MAIN_GWORLD;
 
         loaded
             .memory
@@ -123537,7 +123570,7 @@ pub(crate) mod tests {
             pixels_locked: false,
             pixels_no_purge: false,
         }];
-        loaded.current_gworld = PPC_MAIN_GWORLD;
+        *loaded.current_gworld = PPC_MAIN_GWORLD;
 
         loaded
             .memory
@@ -123734,7 +123767,7 @@ pub(crate) mod tests {
                 pixels_locked: false,
                 pixels_no_purge: false,
             }];
-            loaded.current_gworld = PPC_MAIN_GWORLD;
+            *loaded.current_gworld = PPC_MAIN_GWORLD;
 
             loaded
                 .memory
@@ -123924,7 +123957,7 @@ pub(crate) mod tests {
             pixels_locked: false,
             pixels_no_purge: false,
         }];
-        loaded.current_gworld = PPC_MAIN_GWORLD;
+        *loaded.current_gworld = PPC_MAIN_GWORLD;
 
         loaded
             .memory
@@ -124101,7 +124134,7 @@ pub(crate) mod tests {
             pixels_locked: false,
             pixels_no_purge: false,
         }];
-        loaded.current_gworld = PPC_MAIN_GWORLD;
+        *loaded.current_gworld = PPC_MAIN_GWORLD;
 
         loaded
             .memory
@@ -124272,7 +124305,7 @@ pub(crate) mod tests {
             pixels_locked: false,
             pixels_no_purge: false,
         }];
-        loaded.current_gworld = PPC_MAIN_GWORLD;
+        *loaded.current_gworld = PPC_MAIN_GWORLD;
 
         write_triangle_mesh(
             &mut loaded.memory,
@@ -124659,7 +124692,7 @@ pub(crate) mod tests {
             pixels_locked: false,
             pixels_no_purge: false,
         }];
-        loaded.current_gworld = PPC_MAIN_GWORLD;
+        *loaded.current_gworld = PPC_MAIN_GWORLD;
         write_triangle_mesh(&mut loaded.memory, trimesh_data, points_ptr, triangles_ptr);
 
         let mut view_state = PpcQ3ViewStateRecord::new(view);
@@ -124776,7 +124809,7 @@ pub(crate) mod tests {
             pixels_locked: false,
             pixels_no_purge: false,
         }];
-        loaded.current_gworld = PPC_MAIN_GWORLD;
+        *loaded.current_gworld = PPC_MAIN_GWORLD;
         loaded.q3_objects.push(PpcQ3ObjectRecord {
             object: draw_context,
             kind: PpcQ3ObjectKind::Generic,
@@ -128774,7 +128807,7 @@ pub(crate) mod tests {
             pixels_locked: false,
             pixels_no_purge: false,
         });
-        loaded.current_gworld = gworld;
+        *loaded.current_gworld = gworld;
 
         loaded.cpu.gpr[3] = handle;
         loaded.cpu.gpr[4] = rect_ptr;
@@ -128820,7 +128853,7 @@ pub(crate) mod tests {
             pixels_locked: false,
             pixels_no_purge: false,
         });
-        loaded.current_gworld = gworld;
+        *loaded.current_gworld = gworld;
 
         loaded.cpu.gpr[3] = handle;
         loaded.cpu.gpr[4] = rect_ptr;
@@ -128953,7 +128986,7 @@ pub(crate) mod tests {
             pixels_locked: false,
             pixels_no_purge: false,
         });
-        loaded.current_gworld = gworld;
+        *loaded.current_gworld = gworld;
 
         loaded.cpu.gpr[3] = handle;
         loaded.cpu.gpr[4] = rect_ptr;
@@ -129166,8 +129199,8 @@ pub(crate) mod tests {
         assert_eq!(probe.handled_import_count, 1);
         assert_eq!(probe.unsupported_import_index, None);
         assert_eq!(loaded.cpu.gpr[3], PPC_HEAP_BASE);
-        assert_eq!(loaded.current_gworld, PPC_HEAP_BASE);
-        assert_eq!(loaded.current_gdevice, PPC_HEAP_BASE + 4);
+        assert_eq!(*loaded.current_gworld, PPC_HEAP_BASE);
+        assert_eq!(*loaded.current_gdevice, PPC_HEAP_BASE + 4);
         assert_eq!(loaded.quickdraw_pen_h, 17);
         assert_eq!(loaded.quickdraw_pen_v, 23);
     }
@@ -129198,8 +129231,8 @@ pub(crate) mod tests {
         let window = loaded.cpu.gpr[3];
         assert_ne!(window, 0);
         assert_eq!(loaded.last_mem_error(), PPC_NO_ERR);
-        assert_eq!(loaded.current_gworld, window);
-        assert_eq!(loaded.current_gdevice, PPC_MAIN_GDEVICE);
+        assert_eq!(*loaded.current_gworld, window);
+        assert_eq!(*loaded.current_gdevice, PPC_MAIN_GDEVICE);
         assert_eq!(loaded.gworlds.len(), gworld_count + 1);
         let record = loaded
             .gworlds
@@ -129927,7 +129960,7 @@ pub(crate) mod tests {
                 Some((140, 140, 240, 340)),
                 "{depth}bpp valid release did not apply the final delta",
             );
-            assert_eq!(loaded.current_gworld, window);
+            assert_eq!(*loaded.current_gworld, window);
             assert_eq!(
                 ppc_memory_read_bytes(&mut loaded.memory, front.base_addr, framebuffer_len),
                 Some(baseline.clone()),
@@ -130326,7 +130359,7 @@ pub(crate) mod tests {
             .memory
             .write_u8(window + PPC_CWINDOW_HILITED_OFFSET, 1)
             .unwrap();
-        loaded.current_gworld = window;
+        *loaded.current_gworld = window;
         loaded.cpu.gpr[3] = window;
 
         let probe = loaded.run_with_hle_imports(64);
@@ -130341,7 +130374,7 @@ pub(crate) mod tests {
             loaded.memory.read_u8(window + PPC_CWINDOW_HILITED_OFFSET),
             Some(0)
         );
-        assert_eq!(loaded.current_gworld, window);
+        assert_eq!(*loaded.current_gworld, window);
 
         let pef = synthetic_pef_with_import(b"ShowHide");
         let mut loaded = load_pef_application(&pef).unwrap();
@@ -130463,8 +130496,8 @@ pub(crate) mod tests {
         assert_eq!(probe.unsupported_import_index, None);
         assert_eq!(loaded.cpu.gpr[3], storage_ptr);
         assert_eq!(loaded.last_mem_error(), PPC_NO_ERR);
-        assert_eq!(loaded.current_gworld, storage_ptr);
-        assert_eq!(loaded.current_gdevice, PPC_MAIN_GDEVICE);
+        assert_eq!(*loaded.current_gworld, storage_ptr);
+        assert_eq!(*loaded.current_gdevice, PPC_MAIN_GDEVICE);
         assert_eq!(loaded.heap_cursor(), heap_cursor + required);
         assert_eq!(loaded.gworlds.len(), gworld_count + 1);
         let record = loaded
@@ -130516,8 +130549,8 @@ pub(crate) mod tests {
         assert_eq!(probe.unsupported_import_index, None);
         assert_eq!(loaded.cpu.gpr[3], storage_ptr);
         assert_eq!(loaded.last_mem_error(), PPC_NO_ERR);
-        assert_eq!(loaded.current_gworld, storage_ptr);
-        assert_eq!(loaded.current_gdevice, PPC_MAIN_GDEVICE);
+        assert_eq!(*loaded.current_gworld, storage_ptr);
+        assert_eq!(*loaded.current_gdevice, PPC_MAIN_GDEVICE);
         assert_eq!(loaded.gworlds.len(), gworld_count + 1);
         let record = loaded
             .gworlds
@@ -130900,16 +130933,16 @@ pub(crate) mod tests {
             pixels_locked: false,
             pixels_no_purge: false,
         });
-        loaded.current_gworld = PPC_MAIN_GWORLD;
-        loaded.current_gdevice = PPC_MAIN_GDEVICE;
+        *loaded.current_gworld = PPC_MAIN_GWORLD;
+        *loaded.current_gdevice = PPC_MAIN_GDEVICE;
         loaded.cpu.gpr[3] = window_ptr;
 
         let probe = loaded.run_with_hle_imports(64);
 
         assert_eq!(probe.handled_import_count, 1);
         assert_eq!(probe.unsupported_import_index, None);
-        assert_eq!(loaded.current_gworld, window_ptr);
-        assert_eq!(loaded.current_gdevice, gdevice);
+        assert_eq!(*loaded.current_gworld, window_ptr);
+        assert_eq!(*loaded.current_gdevice, gdevice);
         assert_eq!(
             ppc_front_visible_window(&mut loaded.memory, &loaded.gworlds),
             Some(window_ptr)
@@ -130969,8 +131002,8 @@ pub(crate) mod tests {
             pixels_locked: false,
             pixels_no_purge: false,
         });
-        loaded.current_gworld = window_ptr;
-        loaded.current_gdevice = gdevice;
+        *loaded.current_gworld = window_ptr;
+        *loaded.current_gdevice = gdevice;
         loaded.cpu.gpr[3] = window_ptr;
 
         let probe = loaded.run_with_hle_imports(64);
@@ -130989,8 +131022,8 @@ pub(crate) mod tests {
             .gworlds
             .iter()
             .any(|record| record.port == window_ptr));
-        assert_eq!(loaded.current_gworld, underlying_window);
-        assert_eq!(loaded.current_gdevice, gdevice);
+        assert_eq!(*loaded.current_gworld, underlying_window);
+        assert_eq!(*loaded.current_gdevice, gdevice);
         assert!(loaded
             .event_queue()
             .iter()
@@ -131131,7 +131164,7 @@ pub(crate) mod tests {
         loaded
             .memory
             .add_region(window, vec![0; PPC_CGRAF_PORT_SIZE as usize]);
-        loaded.current_gworld = window;
+        *loaded.current_gworld = window;
         let mut palette_resource = vec![0xbb; 32];
         palette_resource[..2].copy_from_slice(&1u16.to_be_bytes());
         palette_resource[16..22].copy_from_slice(&[0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc]);
@@ -131552,7 +131585,7 @@ pub(crate) mod tests {
         loaded.cpu.gpr[3] = window_b;
         run_target(&mut loaded, PpcImportDispatcherTarget::SelectWindow);
         assert_eq!(loaded.screen_clut[1], color_b);
-        assert_eq!(loaded.current_gworld, window_b);
+        assert_eq!(*loaded.current_gworld, window_b);
         assert_eq!(
             ppc_front_visible_window(&mut loaded.memory, &loaded.gworlds),
             Some(window_b)
@@ -131561,7 +131594,7 @@ pub(crate) mod tests {
         loaded.cpu.gpr[3] = window_b;
         run_target(&mut loaded, PpcImportDispatcherTarget::HideWindow);
         assert_eq!(loaded.screen_clut[1], color_a);
-        assert_eq!(loaded.current_gworld, window_b);
+        assert_eq!(*loaded.current_gworld, window_b);
 
         loaded.cpu.gpr[3] = window_b;
         loaded.cpu.gpr[4] = palette_b2_handle;
@@ -131709,7 +131742,7 @@ pub(crate) mod tests {
         loaded.cpu.gpr[4] = windows[0];
         run_target(&mut loaded, PpcImportDispatcherTarget::LegacyWindow);
         assert_eq!(loaded.screen_clut[1], colors[1]);
-        assert_eq!(loaded.current_gworld, PPC_MAIN_GWORLD);
+        assert_eq!(*loaded.current_gworld, PPC_MAIN_GWORLD);
 
         loaded.imports[0].symbol_name = "BringToFront".to_string();
         loaded.cpu.gpr[3] = windows[2];
@@ -134458,8 +134491,8 @@ pub(crate) mod tests {
         assert_eq!(loaded.memory.region_count(), region_count);
         assert_eq!(loaded.memory.read_u8(heap_cursor), Some(0));
         assert_eq!(loaded.gworlds.len(), gworld_count);
-        assert_eq!(loaded.current_gworld, PPC_MAIN_GWORLD);
-        assert_eq!(loaded.current_gdevice, PPC_MAIN_GDEVICE);
+        assert_eq!(*loaded.current_gworld, PPC_MAIN_GWORLD);
+        assert_eq!(*loaded.current_gdevice, PPC_MAIN_GDEVICE);
     }
 
     #[test]
@@ -134493,8 +134526,8 @@ pub(crate) mod tests {
         assert_eq!(loaded.memory.region_count(), region_count);
         assert_eq!(loaded.memory.read_u8(heap_cursor), Some(0));
         assert_eq!(loaded.gworlds.len(), gworld_count);
-        assert_eq!(loaded.current_gworld, PPC_MAIN_GWORLD);
-        assert_eq!(loaded.current_gdevice, PPC_MAIN_GDEVICE);
+        assert_eq!(*loaded.current_gworld, PPC_MAIN_GWORLD);
+        assert_eq!(*loaded.current_gdevice, PPC_MAIN_GDEVICE);
     }
 
     #[test]
@@ -134575,7 +134608,7 @@ pub(crate) mod tests {
             .expect("main device ColorTable");
         // Depth zero rescans physical screen devices, not an arbitrary
         // offscreen/custom device that happens to be current.
-        loaded.current_gdevice = 0x0bad_cafe;
+        *loaded.current_gdevice = 0x0bad_cafe;
         let handle_count = test_handle_records!(loaded).len();
         loaded.cpu.gpr[3] = gworld_out_ptr;
         loaded.cpu.gpr[4] = 0;
@@ -135120,8 +135153,8 @@ pub(crate) mod tests {
             ppc_memory_read_bytes(&mut loaded.memory, pixmap, PPC_PIXMAP_SIZE).unwrap();
 
         ppc_write_rect(&mut loaded.memory, bounds_ptr, 5, 6, 8, 10).unwrap();
-        loaded.current_gworld = gworld;
-        loaded.current_gdevice = PPC_MAIN_GDEVICE;
+        *loaded.current_gworld = gworld;
+        *loaded.current_gdevice = PPC_MAIN_GDEVICE;
         loaded.toolbox_startup.last_quickdraw_error = PPC_PARAM_ERR;
         loaded.cpu.gpr[3] = gworld_out_ptr;
         loaded.cpu.gpr[4] = u32::from(u16::MAX); // ignored when aGDevice is non-NIL
@@ -135140,8 +135173,8 @@ pub(crate) mod tests {
             .unwrap();
         assert_eq!(updated.gdevice, gdevice_handle);
         assert_eq!(updated.depth, 16);
-        assert_eq!(loaded.current_gworld, gworld);
-        assert_eq!(loaded.current_gdevice, gdevice_handle);
+        assert_eq!(*loaded.current_gworld, gworld);
+        assert_eq!(*loaded.current_gdevice, gdevice_handle);
         run_test_import(&mut loaded, PpcImportDispatcherTarget::GetGDevice);
         assert_eq!(loaded.cpu.gpr[3], gdevice_handle);
         assert_eq!(
@@ -136196,7 +136229,7 @@ pub(crate) mod tests {
 
         loaded.run_with_hle_imports(64);
 
-        assert_eq!(loaded.current_gworld, port);
+        assert_eq!(*loaded.current_gworld, port);
         assert_eq!(loaded.quickdraw_fore_color, port_color);
         assert_eq!(loaded.quickdraw_fore_indices.get(&port), Some(&22));
 
@@ -136206,7 +136239,7 @@ pub(crate) mod tests {
         loaded.cpu.gpr[3] = port;
         loaded.run_with_hle_imports(64);
 
-        assert_eq!(loaded.current_gworld, PPC_MAIN_GWORLD);
+        assert_eq!(*loaded.current_gworld, PPC_MAIN_GWORLD);
         assert_eq!(loaded.quickdraw_fore_color, main_color);
         assert_eq!(
             loaded.quickdraw_fore_indices.get(&PPC_MAIN_GWORLD),
@@ -136224,7 +136257,7 @@ pub(crate) mod tests {
         );
 
         loaded.gworlds.push(record);
-        loaded.current_gworld = port;
+        *loaded.current_gworld = port;
         loaded.quickdraw_fore_color = port_color;
         loaded.quickdraw_fore_indices.insert(port, 22);
         loaded.cpu.pc = loaded.entry_pc;
@@ -136233,7 +136266,7 @@ pub(crate) mod tests {
         loaded.cpu.gpr[3] = port;
         loaded.run_with_hle_imports(64);
 
-        assert_eq!(loaded.current_gworld, PPC_MAIN_GWORLD);
+        assert_eq!(*loaded.current_gworld, PPC_MAIN_GWORLD);
         assert_eq!(loaded.quickdraw_fore_color, main_color);
         assert!(!loaded.quickdraw_fore_indices.contains_key(&port));
         assert_eq!(
@@ -137629,7 +137662,7 @@ pub(crate) mod tests {
         loaded.memory.write_u8(src_pixels, 0xe0).unwrap();
         loaded.memory.write_u8(dst_pixels, 0x0a).unwrap();
         ppc_write_rect(&mut loaded.memory, rect, 0, 0, 1, 1).unwrap();
-        loaded.current_gdevice = gdevice_handle;
+        *loaded.current_gdevice = gdevice_handle;
         loaded.cpu.gpr[3] = src_pixmap;
         loaded.cpu.gpr[4] = dst_pixmap;
         loaded.cpu.gpr[5] = rect;
@@ -137942,7 +137975,7 @@ pub(crate) mod tests {
             .unwrap();
         loaded.memory.write_u8(src_pixels, 1).unwrap();
         ppc_write_rect(&mut loaded.memory, rect, 0, 0, 1, 1).unwrap();
-        loaded.current_gdevice = gdevice_handle;
+        *loaded.current_gdevice = gdevice_handle;
         loaded.cpu.gpr[3] = src_pixmap;
         loaded.cpu.gpr[4] = dst_pixmap;
         loaded.cpu.gpr[5] = rect;
@@ -145602,14 +145635,14 @@ pub(crate) mod tests {
         loaded.cpu.pc = loaded.entry_pc;
         loaded.cpu.lr = PPC_HALT_PC;
         loaded.cpu.gpr[3] = dialog;
-        loaded.current_gworld = PPC_MAIN_GWORLD;
+        *loaded.current_gworld = PPC_MAIN_GWORLD;
         let probe = loaded.run_with_hle_imports(128);
 
         assert!(matches!(probe.result, PpcRunResult::Halted { .. }));
         assert_eq!(probe.unsupported_import_index, None);
         assert_eq!(loaded.memory.read_u32_be(result), Some(dialog));
         assert_eq!(loaded.memory.read_u32_be(result + 4), Some(1));
-        assert_eq!(loaded.current_gworld, dialog);
+        assert_eq!(*loaded.current_gworld, dialog);
         assert!(loaded.dialog_callback_stack.is_empty());
     }
 
@@ -145658,7 +145691,7 @@ pub(crate) mod tests {
         assert_eq!(probe.unsupported_import_index, None);
         let dialog = loaded.cpu.gpr[3];
         assert_ne!(dialog, 0);
-        assert_eq!(loaded.current_gworld, dialog);
+        assert_eq!(*loaded.current_gworld, dialog);
         assert!(loaded.heap_cursor() > dialog);
         assert_eq!(loaded.last_mem_error(), PPC_NO_ERR);
         assert_eq!(loaded.last_resource_error, PPC_NO_ERR);
@@ -145714,7 +145747,7 @@ pub(crate) mod tests {
         assert_eq!(probe.unsupported_import_index, None);
         let dialog = loaded.cpu.gpr[3];
         assert_ne!(dialog, 0);
-        assert_eq!(loaded.current_gworld, dialog);
+        assert_eq!(*loaded.current_gworld, dialog);
         assert_eq!(loaded.last_mem_error(), PPC_NO_ERR);
         assert_eq!(
             loaded
@@ -145793,7 +145826,7 @@ pub(crate) mod tests {
         assert_eq!(probe.unsupported_import_index, None);
         let dialog = loaded.cpu.gpr[3];
         assert_ne!(dialog, 0);
-        assert_eq!(loaded.current_gworld, dialog);
+        assert_eq!(*loaded.current_gworld, dialog);
         assert_eq!(loaded.last_mem_error(), PPC_NO_ERR);
         assert_eq!(loaded.last_resource_error, PPC_NO_ERR);
         let items_ptr = loaded.memory.read_u32_be(items).unwrap();
@@ -147846,7 +147879,7 @@ pub(crate) mod tests {
         loaded.cpu.pc = loaded.entry_pc;
         loaded.cpu.lr = PPC_HALT_PC;
         loaded.cpu.gpr[4] = item_hit_ptr;
-        loaded.current_gworld = dialog;
+        *loaded.current_gworld = dialog;
         loaded.set_event_queue([PpcQueuedEvent {
             what: 3,
             message: (2 << 8) | u32::from(b'D'),
@@ -148829,7 +148862,7 @@ pub(crate) mod tests {
 
         assert_eq!(probe.handled_import_count, 1);
         assert_eq!(probe.unsupported_import_index, None);
-        let front = ppc_front_buffer_for_gworld(&loaded.gworlds, loaded.current_gworld).unwrap();
+        let front = ppc_front_buffer_for_gworld(&loaded.gworlds, *loaded.current_gworld).unwrap();
         let red_index = pict::closest_clut_index(0xffff, 0, 0, &loaded.screen_clut);
         assert_eq!(
             ppc_quickdraw_read_pixel(&mut loaded.memory, front, (2, 1)),
@@ -149304,7 +149337,7 @@ pub(crate) mod tests {
         loaded.memory.write_bytes(text, b"\x04PICT").unwrap();
         ppc_write_rect(&mut loaded.memory, destination, 50, 50, 90, 90).unwrap();
         let surface =
-            ppc_live_quickdraw_surface(&mut loaded.memory, &loaded.gworlds, loaded.current_gworld)
+            ppc_live_quickdraw_surface(&mut loaded.memory, &loaded.gworlds, *loaded.current_gworld)
                 .unwrap();
         let before = ppc_quickdraw_read_pixel(
             &mut loaded.memory,
@@ -149368,7 +149401,7 @@ pub(crate) mod tests {
             &test_handle_records!(loaded),
             &loaded.process_file_system.vfs_resources,
             &loaded.gworlds,
-            loaded.current_gworld,
+            *loaded.current_gworld,
             &loaded.screen_clut,
             &mut loaded.color_manager_clut,
         ));
@@ -149404,7 +149437,7 @@ pub(crate) mod tests {
             &mut last_mem_error,
             test_handles!(loaded),
             &mut loaded.gworlds,
-            loaded.current_gdevice,
+            *loaded.current_gdevice,
         );
         assert_ne!(window, 0);
 
@@ -149490,7 +149523,7 @@ pub(crate) mod tests {
             &mut last_mem_error,
             test_handles!(loaded),
             &mut loaded.gworlds,
-            loaded.current_gdevice,
+            *loaded.current_gdevice,
         );
         assert_ne!(window, 0);
 
@@ -149888,7 +149921,7 @@ pub(crate) mod tests {
         };
         loaded.quickdraw_back_color = cyan;
         loaded.cpu.gpr[3] = rect_ptr;
-        let front = ppc_front_buffer_for_gworld(&loaded.gworlds, loaded.current_gworld).unwrap();
+        let front = ppc_front_buffer_for_gworld(&loaded.gworlds, *loaded.current_gworld).unwrap();
 
         let probe = loaded.run_with_hle_imports(64);
 
@@ -149911,7 +149944,7 @@ pub(crate) mod tests {
         let rect_ptr = PPC_DATA_BASE + 0x1000;
         loaded.memory.add_region(rect_ptr, vec![0; 8]);
         ppc_write_rect(&mut loaded.memory, rect_ptr, 1, 2, 4, 5).unwrap();
-        let front = ppc_front_buffer_for_gworld(&loaded.gworlds, loaded.current_gworld).unwrap();
+        let front = ppc_front_buffer_for_gworld(&loaded.gworlds, *loaded.current_gworld).unwrap();
         assert_eq!(front.depth, 8);
         assert!(ppc_quickdraw_write_raw_pixel(
             &mut loaded.memory,
@@ -149971,7 +150004,7 @@ pub(crate) mod tests {
             pixels_locked: false,
             pixels_no_purge: false,
         });
-        loaded.current_gworld = port;
+        *loaded.current_gworld = port;
         loaded.cpu.gpr[3] = rect_ptr;
 
         let probe = loaded.run_with_hle_imports(64);
@@ -150024,7 +150057,7 @@ pub(crate) mod tests {
             test_handles!(loaded),
         );
         ppc_write_rgn_bbox(&mut loaded.memory, region, 1, 2, 4, 5).unwrap();
-        let front = ppc_front_buffer_for_gworld(&loaded.gworlds, loaded.current_gworld).unwrap();
+        let front = ppc_front_buffer_for_gworld(&loaded.gworlds, *loaded.current_gworld).unwrap();
         assert_eq!(front.depth, 8);
         assert!(ppc_quickdraw_write_raw_pixel(
             &mut loaded.memory,
@@ -150104,7 +150137,7 @@ pub(crate) mod tests {
             pixels_locked: false,
             pixels_no_purge: false,
         });
-        loaded.current_gworld = port;
+        *loaded.current_gworld = port;
         loaded.quickdraw_fore_color = PpcRgbColor {
             red: 0x1234,
             green: 0x5678,
@@ -150235,7 +150268,7 @@ pub(crate) mod tests {
             pixels_locked: false,
             pixels_no_purge: false,
         });
-        loaded.current_gworld = port;
+        *loaded.current_gworld = port;
         loaded
             .memory
             .write_u16_be(port + PPC_CGRAF_PORT_PN_SIZE_OFFSET, 1)
@@ -150368,7 +150401,7 @@ pub(crate) mod tests {
             pixels_locked: false,
             pixels_no_purge: false,
         });
-        loaded.current_gworld = port;
+        *loaded.current_gworld = port;
         loaded.quickdraw_fore_indices.insert(port, 2);
         ppc_write_rect(&mut loaded.memory, rect, 0, 0, 1, 8).unwrap();
         loaded.cpu.gpr[3] = rect;
@@ -150411,7 +150444,7 @@ pub(crate) mod tests {
             pixels_locked: false,
             pixels_no_purge: false,
         });
-        loaded.current_gworld = port;
+        *loaded.current_gworld = port;
         loaded
             .memory
             .write_u16_be(port + PPC_CGRAF_PORT_PN_SIZE_OFFSET, 1)
@@ -153244,7 +153277,7 @@ pub(crate) mod tests {
     fn hle_import_runner_handles_get_gdevice() {
         let pef = synthetic_pef_with_import(b"GetGDevice");
         let mut loaded = load_pef_application(&pef).unwrap();
-        loaded.current_gdevice = PPC_MAIN_GDEVICE;
+        *loaded.current_gdevice = PPC_MAIN_GDEVICE;
 
         let probe = loaded.run_with_hle_imports(64);
 
@@ -153258,7 +153291,7 @@ pub(crate) mod tests {
         let pef = synthetic_pef_with_import(b"SetGDevice");
         let mut loaded = load_pef_application(&pef).unwrap();
         let gdevice = PPC_HEAP_BASE + 0x100;
-        loaded.current_gdevice = PPC_MAIN_GDEVICE;
+        *loaded.current_gdevice = PPC_MAIN_GDEVICE;
         loaded.cpu.gpr[3] = gdevice;
 
         let probe = loaded.run_with_hle_imports(64);
@@ -153266,7 +153299,7 @@ pub(crate) mod tests {
         assert_eq!(probe.handled_import_count, 1);
         assert_eq!(probe.unsupported_import_index, None);
         assert_eq!(loaded.cpu.gpr[3], gdevice);
-        assert_eq!(loaded.current_gdevice, gdevice);
+        assert_eq!(*loaded.current_gdevice, gdevice);
         assert!(loaded.toolbox_startup.known_gdevices.contains(&gdevice));
 
         loaded.cpu.pc = loaded.entry_pc;
@@ -153277,7 +153310,7 @@ pub(crate) mod tests {
 
         assert_eq!(probe.handled_import_count, 1);
         assert_eq!(probe.unsupported_import_index, None);
-        assert_eq!(loaded.current_gdevice, gdevice);
+        assert_eq!(*loaded.current_gdevice, gdevice);
         assert!(!loaded.toolbox_startup.known_gdevices.contains(&0));
     }
 
@@ -153386,7 +153419,7 @@ pub(crate) mod tests {
         let metrics_ptr = PPC_DATA_BASE + 0x1000;
         loaded.memory.add_region(metrics_ptr, vec![0xaa; 20]);
         loaded.cpu.gpr[3] = metrics_ptr;
-        let text_font = ppc_current_text_font(&mut loaded.memory, loaded.current_gworld);
+        let text_font = ppc_current_text_font(&mut loaded.memory, *loaded.current_gworld);
         let (face, scale) = get_font_face_scaled(text_font, loaded.quickdraw_text_size);
         let metrics = face.metrics;
         let to_fixed = |value: i16| -> u32 { (i32::from(value) as u32) << 16 };
@@ -154719,7 +154752,7 @@ pub(crate) mod tests {
                 green: 0,
                 blue: 0,
             };
-            loaded.current_gworld = window;
+            *loaded.current_gworld = window;
             loaded.quickdraw_fore_color = red;
             loaded.quickdraw_fore_indices.remove(&window);
             ppc_write_rect(&mut loaded.memory, paint_rect, 1, 1, 4, 4).unwrap();
@@ -155298,7 +155331,7 @@ pub(crate) mod tests {
             if depth == 8 {
                 assert_eq!(black, 91);
                 assert_eq!(white, 92);
-                loaded.current_gworld = PPC_MAIN_GWORLD;
+                *loaded.current_gworld = PPC_MAIN_GWORLD;
                 loaded.quickdraw_fore_color = PPC_RGB_BLACK;
                 loaded.quickdraw_fore_indices.remove(&PPC_MAIN_GWORLD);
                 ppc_write_rect(&mut loaded.memory, paint_rect, 30, 30, 32, 32).unwrap();
@@ -156819,7 +156852,7 @@ pub(crate) mod tests {
     fn presented_front_buffer_uses_main_screen_without_active_draw_sprocket() {
         let pef = synthetic_pef_with_import(b"SetPort");
         let mut loaded = load_pef_application(&pef).unwrap();
-        loaded.current_gworld = PPC_DSP_BACK_GWORLD;
+        *loaded.current_gworld = PPC_DSP_BACK_GWORLD;
 
         let front_buffer = loaded.presented_front_buffer().unwrap();
 
@@ -156832,7 +156865,7 @@ pub(crate) mod tests {
     fn presented_front_buffer_uses_main_screen_before_first_draw_sprocket_swap() {
         let pef = synthetic_pef_with_import(b"SetPort");
         let mut loaded = load_pef_application(&pef).unwrap();
-        loaded.current_gworld = PPC_DSP_BACK_GWORLD;
+        *loaded.current_gworld = PPC_DSP_BACK_GWORLD;
         loaded.draw_sprocket.started = true;
         loaded.draw_sprocket.active_context = None;
         loaded.draw_sprocket.front_buffer_gworld = PPC_MAIN_GWORLD;
@@ -159714,7 +159747,7 @@ pub(crate) mod tests {
         let probe = loaded.run_with_hle_imports(128);
 
         assert!(matches!(probe.result, PpcRunResult::CycleLimit { .. }));
-        let dialog = loaded.current_gworld;
+        let dialog = *loaded.current_gworld;
         assert_eq!(
             loaded
                 .memory

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -88776,7 +88776,7 @@ pub(crate) mod tests {
 
     #[test]
     fn attached_68k_and_powerpc_adapters_share_quickdraw_selection_without_runner_copy() {
-        let (mut classic, _, _) = setup_with_port();
+        let (mut classic, _, mut classic_bus) = setup_with_port();
         let pef = synthetic_pef_with_import(b"GetGWorld");
         let mut native = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
@@ -88790,6 +88790,11 @@ pub(crate) mod tests {
             .current_gdevice
             .ptr_eq(&native.current_gdevice));
         assert_eq!(*classic.current_port, PPC_MAIN_GWORLD);
+        assert_eq!(*classic.current_gdevice, PPC_MAIN_GDEVICE);
+
+        classic.main_gdevice_handle = 0;
+        let classic_main_gdevice = classic.ensure_main_gdevice(&mut classic_bus);
+        assert_ne!(classic_main_gdevice, PPC_MAIN_GDEVICE);
         assert_eq!(*classic.current_gdevice, PPC_MAIN_GDEVICE);
 
         *native.current_gworld = 0x0030_0000;

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -1380,6 +1380,18 @@ impl<T: Copy + PartialEq> SharedProcessValue<T> {
         }
         self.0 = Rc::clone(&process_value.0);
     }
+
+    fn activate_copy_to(&mut self, process_value: &Self) {
+        if Rc::ptr_eq(&self.0, &process_value.0) {
+            return;
+        }
+        // SAFETY: application activation occurs while the runner exclusively
+        // owns both adapters and before guest execution resumes.
+        unsafe {
+            *process_value.0.get() = **self;
+        }
+        self.0 = Rc::clone(&process_value.0);
+    }
 }
 
 impl SharedProcessValue<ProcessResourceManagerState> {
@@ -4099,6 +4111,8 @@ pub(crate) struct ProcessContext {
     file_system: SharedProcessFileSystem,
     sound_manager: SharedProcessSoundManager,
     cursor_state: SharedProcessCursorState,
+    current_graphics_port: SharedProcessValue<u32>,
+    current_graphics_device: SharedProcessValue<u32>,
     device_clut: SharedProcessValue<[[u16; 3]; 256]>,
     color_manager_clut: SharedProcessValue<[[u16; 3]; 256]>,
     device_gamma: SharedProcessValue<DisplayGamma>,
@@ -4119,6 +4133,8 @@ impl Default for ProcessContext {
             file_system: SharedProcessFileSystem::default(),
             sound_manager: SharedProcessSoundManager::default(),
             cursor_state: SharedProcessCursorState::default(),
+            current_graphics_port: SharedProcessValue::from_value(0),
+            current_graphics_device: SharedProcessValue::from_value(0),
             device_clut: SharedProcessValue::from_value(standard_mac_8bpp_clut()),
             color_manager_clut: SharedProcessValue::from_value(standard_mac_8bpp_clut()),
             device_gamma: SharedProcessValue::from_value(default_display_gamma()),
@@ -4180,6 +4196,29 @@ impl ProcessContext {
 
     pub(crate) fn attach_cursor_state(&self, adapter: &mut SharedProcessCursorState) {
         adapter.attach_to(&self.cursor_state, ProcessCursorState::is_pristine);
+    }
+
+    /// Attach a CPU adapter to the process's current QuickDraw port and device.
+    ///
+    /// `GetPort`/`SetPort` expose one `thePort`, while `GetGWorld`/`SetGWorld`
+    /// preserve the associated current graphics device. Imaging With
+    /// QuickDraw (1994), pp. 2-41--2-42 and 6-29.
+    pub(crate) fn attach_quickdraw_selection(
+        &self,
+        current_port: &mut SharedProcessValue<u32>,
+        current_device: &mut SharedProcessValue<u32>,
+    ) {
+        current_port.attach_copy_to(&self.current_graphics_port, |address| *address == 0);
+        current_device.attach_copy_to(&self.current_graphics_device, |address| *address == 0);
+    }
+
+    pub(crate) fn activate_quickdraw_selection(
+        &self,
+        current_port: &mut SharedProcessValue<u32>,
+        current_device: &mut SharedProcessValue<u32>,
+    ) {
+        current_port.activate_copy_to(&self.current_graphics_port);
+        current_device.activate_copy_to(&self.current_graphics_device);
     }
 
     pub(crate) fn attach_display_color_state(

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -3708,7 +3708,8 @@ impl FixtureRunner {
 
         let gdh = self.dispatcher.ensure_main_gdevice(&mut self.bus);
         self.bus.write_long(0x8A4, gdh);
-        self.bus.write_long(0xCC8, gdh);
+        self.bus
+            .write_long(0xCC8, *self.dispatcher.current_gdevice);
         self.bus.write_long(0x8A8, gdh);
         if let Some(front_buffer) = ppc_app.presented_front_buffer() {
             self.ensure_ppc_host_screen_mode(front_buffer);

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -2210,7 +2210,7 @@ impl FixtureRunner {
                 &mut ppc_app.memory,
                 &ppc_app.gworlds,
                 PpcGWorldDumpState {
-                    current_gworld: ppc_app.current_gworld,
+                    current_gworld: *ppc_app.current_gworld,
                     front_gworld: ppc_app.draw_sprocket.front_buffer_gworld,
                     back_gworld: ppc_app.draw_sprocket.back_buffer_gworld,
                     swap_count: ppc_app.draw_sprocket.swap_count,
@@ -5968,7 +5968,7 @@ impl FixtureRunner {
                     tick: self.dispatcher.tick_count,
                     pc,
                     lr: ppc_app.cpu.lr,
-                    current_gworld: ppc_app.current_gworld,
+                    current_gworld: *ppc_app.current_gworld,
                     screen_events: self.dispatcher.screen_event_count,
                     handled_import_count: probe.handled_import_count,
                     last_import_index: probe.last_import_index,
@@ -13461,8 +13461,8 @@ mod tests {
             timer_tasks: Vec::new(),
             vbl_tasks: Vec::new(),
             process_file_system: ppc_initial_process_file_system(),
-            current_gworld: PPC_MAIN_GWORLD,
-            current_gdevice: PPC_MAIN_GDEVICE,
+            current_gworld: SharedProcessValue::from_value(PPC_MAIN_GWORLD),
+            current_gdevice: SharedProcessValue::from_value(PPC_MAIN_GDEVICE),
             quickdraw_fore_color: PpcRgbColor {
                 red: 0,
                 green: 0,
@@ -15694,8 +15694,8 @@ mod tests {
                 }],
             ),
             ),
-            current_gworld: PPC_MAIN_GWORLD,
-            current_gdevice: PPC_MAIN_GDEVICE,
+            current_gworld: SharedProcessValue::from_value(PPC_MAIN_GWORLD),
+            current_gdevice: SharedProcessValue::from_value(PPC_MAIN_GDEVICE),
             quickdraw_fore_color: PpcRgbColor {
                 red: 0,
                 green: 0,
@@ -16591,8 +16591,8 @@ mod tests {
             timer_tasks: Vec::new(),
             vbl_tasks: Vec::new(),
             process_file_system: ppc_initial_process_file_system(),
-            current_gworld: PPC_MAIN_GWORLD,
-            current_gdevice: PPC_MAIN_GDEVICE,
+            current_gworld: SharedProcessValue::from_value(PPC_MAIN_GWORLD),
+            current_gdevice: SharedProcessValue::from_value(PPC_MAIN_GDEVICE),
             quickdraw_fore_color: PpcRgbColor {
                 red: 0,
                 green: 0,
@@ -16744,8 +16744,8 @@ mod tests {
             timer_tasks: Vec::new(),
             vbl_tasks: Vec::new(),
             process_file_system: ppc_initial_process_file_system(),
-            current_gworld: PPC_MAIN_GWORLD,
-            current_gdevice: PPC_MAIN_GDEVICE,
+            current_gworld: SharedProcessValue::from_value(PPC_MAIN_GWORLD),
+            current_gdevice: SharedProcessValue::from_value(PPC_MAIN_GDEVICE),
             quickdraw_fore_color: PpcRgbColor {
                 red: 0,
                 green: 0,
@@ -17156,8 +17156,8 @@ mod tests {
             timer_tasks: Vec::new(),
             vbl_tasks: Vec::new(),
             process_file_system: ppc_initial_process_file_system(),
-            current_gworld: PPC_MAIN_GWORLD,
-            current_gdevice: PPC_MAIN_GDEVICE,
+            current_gworld: SharedProcessValue::from_value(PPC_MAIN_GWORLD),
+            current_gdevice: SharedProcessValue::from_value(PPC_MAIN_GDEVICE),
             quickdraw_fore_color: PpcRgbColor {
                 red: 0,
                 green: 0,
@@ -17468,8 +17468,8 @@ mod tests {
             timer_tasks: Vec::new(),
             vbl_tasks: Vec::new(),
             process_file_system: ppc_initial_process_file_system(),
-            current_gworld: PPC_MAIN_GWORLD,
-            current_gdevice: PPC_MAIN_GDEVICE,
+            current_gworld: SharedProcessValue::from_value(PPC_MAIN_GWORLD),
+            current_gdevice: SharedProcessValue::from_value(PPC_MAIN_GDEVICE),
             quickdraw_fore_color: PpcRgbColor {
                 red: 0,
                 green: 0,
@@ -23782,7 +23782,7 @@ mod tests {
             .dialog_ptr = dialog_ptr;
 
         assert!(runner.fire_dialog_filter_proc());
-        assert_eq!(runner.dispatcher.current_port, dialog_ptr);
+        assert_eq!(*runner.dispatcher.current_port, dialog_ptr);
         assert_eq!(
             runner
                 .active_interrupt_callback
@@ -23796,7 +23796,7 @@ mod tests {
         let (_steps, running) = runner.run_steps(1, None);
 
         assert!(running);
-        assert_eq!(runner.dispatcher.current_port, dialog_ptr);
+        assert_eq!(*runner.dispatcher.current_port, dialog_ptr);
         assert!(runner.active_interrupt_callback.is_none());
     }
 
@@ -24117,7 +24117,7 @@ mod tests {
         assert!(running);
         assert!(runner.active_interrupt_callback.is_none());
         assert_eq!(
-            runner.dispatcher.current_port, dialog_ptr,
+            *runner.dispatcher.current_port, dialog_ptr,
             "Dialog Manager must leave the dialog port current after the draw proc"
         );
     }
@@ -24202,7 +24202,7 @@ mod tests {
 
         assert!(running);
         assert!(runner.active_interrupt_callback.is_none());
-        assert_eq!(runner.dispatcher.current_port, dialog_ptr);
+        assert_eq!(*runner.dispatcher.current_port, dialog_ptr);
         assert_eq!(runner.bus.read_word(dialog_ptr + 52), 1);
         assert_eq!(runner.bus.read_word(dialog_ptr + 54), 1);
         assert_eq!(runner.bus.read_word(dialog_ptr + 56), 8);

--- a/src/trap/control.rs
+++ b/src/trap/control.rs
@@ -405,11 +405,11 @@ impl super::TrapDispatcher {
         if callable.is_empty() {
             return false;
         }
-        let restore_port = self.current_port;
-        let restore_gdevice = self.current_gdevice;
+        let restore_port = *self.current_port;
+        let restore_gdevice = *self.current_gdevice;
         let first_ctrl_ptr = Self::control_record_ptr(bus, callable[0].0);
         let owner = bus.read_long(first_ctrl_ptr + 4);
-        if owner != 0 && owner != self.current_port {
+        if owner != 0 && owner != *self.current_port {
             self.set_current_port_state(bus, cpu, owner, None);
         }
         let final_sp = cpu.read_reg(Register::A7);
@@ -1297,8 +1297,8 @@ impl super::TrapDispatcher {
                 return;
             }
         }
-        let saved_port = self.current_port;
-        let saved_gdevice = self.current_gdevice;
+        let saved_port = *self.current_port;
+        let saved_gdevice = *self.current_gdevice;
         if window_ptr != 0 && window_ptr != saved_port {
             self.set_current_port_state(bus, cpu, window_ptr, None);
         }
@@ -1580,7 +1580,7 @@ impl super::TrapDispatcher {
         for (top, left, width, height, pixels) in occluded_pixels {
             self.restore_screen_rect_pixels(bus, top, left, width, height, &pixels);
         }
-        if self.current_port != saved_port || self.current_gdevice != saved_gdevice {
+        if *self.current_port != saved_port || *self.current_gdevice != saved_gdevice {
             self.set_current_port_state(bus, cpu, saved_port, Some(saved_gdevice));
         }
     }
@@ -4058,7 +4058,7 @@ impl super::TrapDispatcher {
                 let sp = cpu.read_reg(Register::A7);
                 let ctrl_handle = bus.read_long(sp);
                 cpu.write_reg(Register::A7, sp + 4);
-                let saved_gdevice = self.current_gdevice;
+                let saved_gdevice = *self.current_gdevice;
                 // Treat stale or out-of-range handles as inert rather than
                 // dereferencing arbitrary guest memory. The control record's
                 // Pascal title begins at offset 40, so we also reject handles
@@ -4083,7 +4083,7 @@ impl super::TrapDispatcher {
                                 // reuse the same control path as DrawControls.
                                 self.draw_control(cpu, bus, ctrl_ptr);
                             }
-                            debug_assert_eq!(self.current_gdevice, saved_gdevice);
+                            debug_assert_eq!(*self.current_gdevice, saved_gdevice);
                         }
                     }
                 }
@@ -5337,7 +5337,7 @@ mod tests {
         );
         assert_eq!(bus.read_long(trampoline + 26), 0);
         assert_eq!(bus.read_long(trampoline + 32), cdef_proc);
-        assert_eq!(disp.current_port, owner);
+        assert_eq!(*disp.current_port, owner);
 
         cpu.write_reg(Register::A7, sp);
         cpu.write_reg(Register::PC, return_pc);
@@ -5475,7 +5475,7 @@ mod tests {
         for offset in 0..(row_bytes * 128) {
             bus.write_byte(screen_base + offset, 0);
         }
-        let window_ptr = disp.current_port;
+        let window_ptr = *disp.current_port;
         bus.write_word(window_ptr + 8, 0);
         bus.write_word(window_ptr + 10, 0);
         bus.write_word(window_ptr + 16, 0);
@@ -5550,7 +5550,7 @@ mod tests {
             bus.write_byte(screen_base + offset, 0);
         }
 
-        let window_ptr = disp.current_port;
+        let window_ptr = *disp.current_port;
         bus.write_word(window_ptr + 8, 0);
         bus.write_word(window_ptr + 10, 0);
         bus.write_word(window_ptr + 16, 0);
@@ -5665,7 +5665,7 @@ mod tests {
         for offset in 0..(row_bytes * 128) {
             bus.write_byte(screen_base + offset, 0);
         }
-        let window_ptr = disp.current_port;
+        let window_ptr = *disp.current_port;
         bus.write_word(window_ptr + 8, 0);
         bus.write_word(window_ptr + 10, 0);
         bus.write_word(window_ptr + 16, 0);
@@ -5810,7 +5810,7 @@ mod tests {
         disp.set_ui_theme_id(UiThemeId::SystemlessDefault);
         disp.enable_input_trace_capture();
         let sp = 0x300000u32;
-        let window = disp.current_port;
+        let window = *disp.current_port;
         let row_bytes = 64u32;
         let base = bus.alloc(row_bytes * 342);
         disp.set_screen_mode_for_test(base, row_bytes, 512, 342, 1);
@@ -5892,7 +5892,7 @@ mod tests {
         let (mut disp, mut cpu, mut bus) = setup_with_port();
         disp.set_ui_theme_id(theme_id);
         let sp = 0x300000u32;
-        let window = disp.current_port;
+        let window = *disp.current_port;
         let screen_base = bus.read_long(window + 2);
         let row_bytes = (bus.read_word(window + 6) & 0x3FFF) as u32;
         disp.set_screen_mode_for_test(screen_base, row_bytes, 512, 342, 1);
@@ -5963,7 +5963,7 @@ mod tests {
         let (mut disp, mut cpu, mut bus) = setup_with_port();
         disp.set_ui_theme_id(theme_id);
         let sp = 0x300000u32;
-        let window = disp.current_port;
+        let window = *disp.current_port;
         let screen_base = bus.read_long(window + 2);
         let row_bytes = (bus.read_word(window + 6) & 0x3FFF) as u32;
         disp.set_screen_mode_for_test(screen_base, row_bytes, 512, 342, 1);
@@ -6177,7 +6177,7 @@ mod tests {
         disp.set_ui_theme_id(UiThemeId::SystemlessDefault);
         disp.enable_input_trace_capture();
         let sp = 0x300000u32;
-        let window = disp.current_port;
+        let window = *disp.current_port;
         let screen_base = bus.read_long(window + 2);
         let row_bytes = (bus.read_word(window + 6) & 0x3FFF) as u32;
         disp.set_screen_mode_for_test(screen_base, row_bytes, 512, 342, 1);
@@ -6894,7 +6894,7 @@ mod tests {
         bus.write_word(0x0828, row_bytes as u16);
         clear_1bpp_screen(&mut bus, screen_base, row_bytes, 128);
 
-        let window_ptr = disp.current_port;
+        let window_ptr = *disp.current_port;
         bus.write_word(window_ptr + 16, 0);
         bus.write_word(window_ptr + 18, 0);
         bus.write_word(window_ptr + 20, 128);
@@ -7062,8 +7062,8 @@ mod tests {
     fn draw1control_popup_control_preserves_current_gdevice_and_pops_arg() {
         let (mut disp, mut cpu, mut bus) = setup_with_port();
         let sp = 0x300000u32;
-        let window_ptr = disp.current_port;
-        let gdevice_before = disp.current_gdevice;
+        let window_ptr = *disp.current_port;
+        let gdevice_before = *disp.current_gdevice;
         let (ctrl_handle, ctrl_ptr) =
             alloc_button_control(&mut disp, &mut bus, window_ptr, (20, 20, 260, 60));
         disp.control_proc_ids.insert(ctrl_ptr, 1008);
@@ -7076,7 +7076,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(cpu.read_reg(Register::A7), sp + 4);
-        assert_eq!(disp.current_gdevice, gdevice_before);
+        assert_eq!(*disp.current_gdevice, gdevice_before);
     }
 
     #[test]
@@ -7169,7 +7169,7 @@ mod tests {
         let bounds = (20, 20, 40, 120);
 
         let (mut classic, mut classic_cpu, mut classic_bus) = setup_with_port();
-        let classic_window = classic.current_port;
+        let classic_window = *classic.current_port;
         let classic_base = classic_bus.read_long(classic_window + 2);
         let classic_row_bytes = (classic_bus.read_word(classic_window + 6) & 0x3FFF) as u32;
         classic.set_screen_mode_for_test(classic_base, classic_row_bytes, 512, 342, 1);
@@ -7186,7 +7186,7 @@ mod tests {
 
         let (mut themed, mut themed_cpu, mut themed_bus) = setup_with_port();
         themed.set_ui_theme_id(UiThemeId::SystemlessDefault);
-        let themed_window = themed.current_port;
+        let themed_window = *themed.current_port;
         let themed_base = themed_bus.read_long(themed_window + 2);
         let themed_row_bytes = (themed_bus.read_word(themed_window + 6) & 0x3FFF) as u32;
         themed.set_screen_mode_for_test(themed_base, themed_row_bytes, 512, 342, 1);
@@ -7232,7 +7232,7 @@ mod tests {
         let sp = 0x300000u32;
         let (mut themed, mut themed_cpu, mut themed_bus) = setup_with_port();
         themed.set_ui_theme_id(UiThemeId::SystemlessDefault);
-        let themed_window = themed.current_port;
+        let themed_window = *themed.current_port;
         let row_bytes = 64u32;
         let base = themed_bus.alloc(row_bytes * 342);
         themed.set_screen_mode_for_test(base, row_bytes, 512, 342, 1);
@@ -7293,7 +7293,7 @@ mod tests {
         let bounds = (20, 20, 40, 80);
 
         let (mut classic, mut classic_cpu, mut classic_bus) = setup_with_port();
-        let classic_window = classic.current_port;
+        let classic_window = *classic.current_port;
         let classic_base = classic_bus.read_long(classic_window + 2);
         let classic_row_bytes = (classic_bus.read_word(classic_window + 6) & 0x3FFF) as u32;
         classic.set_screen_mode_for_test(classic_base, classic_row_bytes, 512, 342, 1);
@@ -7308,7 +7308,7 @@ mod tests {
 
         let (mut themed, mut themed_cpu, mut themed_bus) = setup_with_port();
         themed.set_ui_theme_id(UiThemeId::SystemlessDefault);
-        let themed_window = themed.current_port;
+        let themed_window = *themed.current_port;
         let themed_base = themed_bus.read_long(themed_window + 2);
         let themed_row_bytes = (themed_bus.read_word(themed_window + 6) & 0x3FFF) as u32;
         themed.set_screen_mode_for_test(themed_base, themed_row_bytes, 512, 342, 1);
@@ -7348,7 +7348,7 @@ mod tests {
         let sp = 0x300000u32;
         let (mut themed, mut cpu, mut bus) = setup_with_port();
         themed.set_ui_theme_id(UiThemeId::SystemlessDefault);
-        let window = themed.current_port;
+        let window = *themed.current_port;
         let row_bytes = 64u32;
         let base = bus.alloc(row_bytes * 342);
         themed.set_screen_mode_for_test(base, row_bytes, 512, 342, 1);
@@ -7418,7 +7418,7 @@ mod tests {
         let sp = 0x300000u32;
 
         let (mut classic, mut classic_cpu, mut classic_bus) = setup_with_port();
-        let classic_window = classic.current_port;
+        let classic_window = *classic.current_port;
         let classic_base = classic_bus.read_long(classic_window + 2);
         let classic_row_bytes = (classic_bus.read_word(classic_window + 6) & 0x3FFF) as u32;
         classic.set_screen_mode_for_test(classic_base, classic_row_bytes, 512, 342, 1);
@@ -7449,7 +7449,7 @@ mod tests {
 
         let (mut themed, mut themed_cpu, mut themed_bus) = setup_with_port();
         themed.set_ui_theme_id(UiThemeId::SystemlessDefault);
-        let themed_window = themed.current_port;
+        let themed_window = *themed.current_port;
         let themed_base = themed_bus.read_long(themed_window + 2);
         let themed_row_bytes = (themed_bus.read_word(themed_window + 6) & 0x3FFF) as u32;
         themed.set_screen_mode_for_test(themed_base, themed_row_bytes, 512, 342, 1);
@@ -7527,7 +7527,7 @@ mod tests {
         let sp = 0x300000u32;
         let (mut themed, mut cpu, mut bus) = setup_with_port();
         themed.set_ui_theme_id(UiThemeId::SystemlessDefault);
-        let window = themed.current_port;
+        let window = *themed.current_port;
         let row_bytes = 64u32;
         let base = bus.alloc(row_bytes * 342);
         themed.set_screen_mode_for_test(base, row_bytes, 512, 342, 1);
@@ -7621,7 +7621,7 @@ mod tests {
         let bounds = (20, 20, 180, 36);
 
         let (mut classic, _classic_cpu, mut classic_bus) = setup_with_port();
-        let classic_window = classic.current_port;
+        let classic_window = *classic.current_port;
         let classic_base = classic_bus.read_long(classic_window + 2);
         let classic_row_bytes = (classic_bus.read_word(classic_window + 6) & 0x3FFF) as u32;
         classic.set_screen_mode_for_test(classic_base, classic_row_bytes, 512, 342, 1);
@@ -7649,7 +7649,7 @@ mod tests {
 
         let (mut themed, mut themed_cpu, mut themed_bus) = setup_with_port();
         themed.set_ui_theme_id(UiThemeId::SystemlessDefault);
-        let themed_window = themed.current_port;
+        let themed_window = *themed.current_port;
         let themed_base = themed_bus.read_long(themed_window + 2);
         let themed_row_bytes = (themed_bus.read_word(themed_window + 6) & 0x3FFF) as u32;
         themed.set_screen_mode_for_test(themed_base, themed_row_bytes, 512, 342, 1);
@@ -7871,7 +7871,7 @@ mod tests {
     fn dragcontrol_pops_18_bytes_and_leaves_contrlrect_unchanged_on_no_drag_path() {
         let (mut disp, mut cpu, mut bus) = setup_with_port();
         let sp = 0x300000u32;
-        let window_ptr = disp.current_port;
+        let window_ptr = *disp.current_port;
         let (ctrl_handle, ctrl_ptr) = alloc_control_handle(&mut bus, (88, 96, 132, 220), 0, 0);
         let limit_rect_ptr = bus.alloc(8);
         let slop_rect_ptr = bus.alloc(8);

--- a/src/trap/dialog.rs
+++ b/src/trap/dialog.rs
@@ -2297,7 +2297,7 @@ impl super::TrapDispatcher {
         bus.write_byte(te_ptr + Self::TE_TX_FACE_OFFSET, self.tx_face as u8);
         bus.write_word(te_ptr + Self::TE_TX_MODE_OFFSET, self.tx_mode as u16);
         bus.write_word(te_ptr + Self::TE_TX_SIZE_OFFSET, self.tx_size as u16);
-        bus.write_long(te_ptr + Self::TE_IN_PORT_OFFSET, self.current_port);
+        bus.write_long(te_ptr + Self::TE_IN_PORT_OFFSET, *self.current_port);
         self.textedit_states.remove(&te_handle);
     }
 
@@ -2469,7 +2469,7 @@ impl super::TrapDispatcher {
         bus.write_long(te_ptr + Self::TE_TX_FONT_OFFSET, style_handle);
         bus.write_word(te_ptr + Self::TE_TX_MODE_OFFSET, self.tx_mode as u16);
         bus.write_word(te_ptr + Self::TE_TX_SIZE_OFFSET, 0xFFFF);
-        bus.write_long(te_ptr + Self::TE_IN_PORT_OFFSET, self.current_port);
+        bus.write_long(te_ptr + Self::TE_IN_PORT_OFFSET, *self.current_port);
         bus.write_word(te_ptr + Self::TE_N_LINES_OFFSET, 0);
         bus.write_word(te_ptr + Self::TE_LINE_STARTS_OFFSET, 0);
         self.textedit_states.remove(&te_handle);
@@ -2949,8 +2949,8 @@ impl super::TrapDispatcher {
         let old_size = self.tx_size;
         let old_fg = self.fg_color;
         let old_loc = self.pn_loc;
-        let previous_port = self.current_port;
-        let previous_gdevice = self.current_gdevice;
+        let previous_port = *self.current_port;
+        let previous_gdevice = *self.current_gdevice;
         let switched_port = te_port != 0 && te_port != previous_port;
         let color_port = te_port != 0 && (bus.read_word(te_port + 6) & 0xC000) == 0xC000;
         let old_port_fg_pixel = color_port.then(|| bus.read_long(te_port + 80));
@@ -2964,7 +2964,7 @@ impl super::TrapDispatcher {
         }
         if trace_textedit_enabled() {
             let (vis_top, vis_left, vis_bottom, vis_right) = {
-                let vis_handle = bus.read_long(self.current_port + 24);
+                let vis_handle = bus.read_long(*self.current_port + 24);
                 let vis_ptr = if vis_handle != 0 {
                     bus.read_long(vis_handle)
                 } else {
@@ -2982,7 +2982,7 @@ impl super::TrapDispatcher {
                 }
             };
             let (clip_top, clip_left, clip_bottom, clip_right) = {
-                let clip_handle = bus.read_long(self.current_port + 28);
+                let clip_handle = bus.read_long(*self.current_port + 28);
                 let clip_ptr = if clip_handle != 0 {
                     bus.read_long(clip_handle)
                 } else {
@@ -3004,7 +3004,7 @@ impl super::TrapDispatcher {
                 te_handle,
                 te_port,
                 previous_port,
-                self.current_port,
+                *self.current_port,
                 switched_port,
                 self.gworld_devices.contains_key(&te_port),
                 dest_rect.0,
@@ -3080,7 +3080,7 @@ impl super::TrapDispatcher {
                 sum
             };
         let checksum_before = if trace_textedit_enabled() {
-            checksum_view_rect(bus, self.current_port, view_rect)
+            checksum_view_rect(bus, *self.current_port, view_rect)
         } else {
             0
         };
@@ -3325,7 +3325,7 @@ impl super::TrapDispatcher {
                 "[TE] draw_te_contents checksum hTE=${:08X} before={} after={}",
                 te_handle,
                 checksum_before,
-                checksum_view_rect(bus, self.current_port, view_rect)
+                checksum_view_rect(bus, *self.current_port, view_rect)
             );
         }
 
@@ -5219,8 +5219,8 @@ impl super::TrapDispatcher {
         dialog_color_table: Option<u32>,
         dialog_item_color_table: Option<u32>,
     ) -> u32 {
-        let previous_port = self.current_port;
-        let previous_gdevice = self.current_gdevice;
+        let previous_port = *self.current_port;
+        let previous_gdevice = *self.current_gdevice;
         let dlg_ptr = if storage_ptr != 0 {
             storage_ptr
         } else {
@@ -15062,7 +15062,7 @@ impl super::TrapDispatcher {
                     };
                     eprintln!(
                         "[DIALOG-TEXT] TETextBox params current_port=${:08X} sp=${:08X} stack={:02X?} text_ptr=${:08X} len={} box=({},{}..{},{} ) align={} preview={:02X?}",
-                        self.current_port,
+                        *self.current_port,
                         sp,
                         stack_bytes,
                         text_ptr,
@@ -15109,7 +15109,7 @@ impl super::TrapDispatcher {
                             .is_some();
                             eprintln!(
                             "[DIALOG-TEXT] TETextBox current_port=${:08X} box=({},{}..{},{} ) align={} len={} txFont={} txFace=${:04X} txMode={} txSize={} firstChar={:?} firstGlyph={} text=\"{}\"",
-                            self.current_port,
+                            *self.current_port,
                             box_top,
                             box_left,
                             box_bottom,
@@ -15194,7 +15194,7 @@ impl super::TrapDispatcher {
                         }
                     }
                 }
-                self.refresh_visible_dialog_snapshot_for_port(bus, self.current_port);
+                self.refresh_visible_dialog_snapshot_for_port(bus, *self.current_port);
                 Ok(())
             }
 
@@ -21327,7 +21327,7 @@ mod tests {
         let update_vis_region_after =
             TrapDispatcher::region_handle_rect(&bus, bus.read_long(dialog_ptr + 24));
         let update_the_port_after = bus.read_long(crate::memory::globals::addr::THE_PORT);
-        let update_current_port_after = disp.current_port;
+        let update_current_port_after = *disp.current_port;
         let update_saved_vis_after = disp.saved_vis_regions.contains_key(&dialog_ptr);
         let update_queued_draw_procs = disp
             .modeless_dialog_draw_proc_queue
@@ -21954,7 +21954,7 @@ mod tests {
                 bus.read_long(dialog_ptr + 24),
             ),
             the_port_after: bus.read_long(crate::memory::globals::addr::THE_PORT),
-            current_port_after: disp.current_port,
+            current_port_after: *disp.current_port,
             saved_vis_after: disp.saved_vis_regions.contains_key(&dialog_ptr),
         }
     }
@@ -23051,7 +23051,7 @@ mod tests {
         seed_window_regions(&mut close_bus, close_previous_window, previous_bounds);
         close_bus.write_word(close_dialog_ptr + 108, 2);
         close_disp.front_window = close_dialog_ptr;
-        close_disp.current_port = close_dialog_ptr;
+        *close_disp.current_port = close_dialog_ptr;
         close_disp.window_bounds = bounds;
         close_disp.window_proc_id = 2;
         close_disp.window_list = vec![close_dialog_ptr, close_previous_window];
@@ -23115,7 +23115,7 @@ mod tests {
         let close_window_list_contains_dialog = close_disp.window_list.contains(&close_dialog_ptr);
         let close_front_window_after = close_disp.front_window;
         let close_the_port_after = close_bus.read_long(crate::memory::globals::addr::THE_PORT);
-        let close_current_port_after = close_disp.current_port;
+        let close_current_port_after = *close_disp.current_port;
         let close_update_event_for_previous_window = close_disp
             .event_queue
             .iter()
@@ -23137,7 +23137,7 @@ mod tests {
         seed_window_regions(&mut dispose_bus, dispose_previous_window, previous_bounds);
         dispose_bus.write_word(dispose_dialog_ptr + 108, 2);
         dispose_disp.front_window = dispose_dialog_ptr;
-        dispose_disp.current_port = dispose_dialog_ptr;
+        *dispose_disp.current_port = dispose_dialog_ptr;
         dispose_disp.window_bounds = bounds;
         dispose_disp.window_proc_id = 2;
         dispose_disp.window_list = vec![
@@ -23254,7 +23254,7 @@ mod tests {
                 .contains(&dispose_dialog_ptr),
             dispose_front_window_after: dispose_disp.front_window,
             dispose_the_port_after: dispose_bus.read_long(crate::memory::globals::addr::THE_PORT),
-            dispose_current_port_after: dispose_disp.current_port,
+            dispose_current_port_after: *dispose_disp.current_port,
             dispose_update_event_for_previous_window: dispose_disp
                 .event_queue
                 .iter()
@@ -23334,7 +23334,7 @@ mod tests {
         new_bus.write_long(0x0824, new_screen_base);
         new_disp.screen_mode = (new_screen_base, 640, 640, 480, 8);
         let new_previous_port = new_bus.alloc(170);
-        new_disp.current_port = new_previous_port;
+        *new_disp.current_port = new_previous_port;
         new_bus.write_long(crate::memory::globals::addr::THE_PORT, new_previous_port);
 
         let new_ditl = build_test_ditl_items(&[
@@ -23384,7 +23384,7 @@ mod tests {
         get_bus.write_long(0x0824, get_screen_base);
         get_disp.screen_mode = (get_screen_base, 640, 640, 480, 8);
         let get_previous_port = get_bus.alloc(170);
-        get_disp.current_port = get_previous_port;
+        *get_disp.current_port = get_previous_port;
         get_bus.write_long(crate::memory::globals::addr::THE_PORT, get_previous_port);
 
         let mut dlog = build_test_dlog((80, 90, 160, 240), 1901, 0);
@@ -23423,7 +23423,7 @@ mod tests {
             new_result_slot: new_bus.read_long(new_sp + 30),
             new_window_list: new_disp.window_list.clone(),
             new_front_window: new_disp.front_window,
-            new_current_port: new_disp.current_port,
+            new_current_port: *new_disp.current_port,
             new_the_port: new_bus.read_long(crate::memory::globals::addr::THE_PORT),
             new_visible_byte: new_bus.read_byte(new_dialog_ptr + 110),
             new_goaway_byte: new_bus.read_byte(new_dialog_ptr + 112),
@@ -23449,7 +23449,7 @@ mod tests {
             get_result_slot: get_bus.read_long(TEST_SP + 10),
             get_window_list: get_disp.window_list.clone(),
             get_front_window: get_disp.front_window,
-            get_current_port: get_disp.current_port,
+            get_current_port: *get_disp.current_port,
             get_the_port: get_bus.read_long(crate::memory::globals::addr::THE_PORT),
             get_visible_byte: get_bus.read_byte(get_dialog_ptr + 110),
             get_refcon: get_bus.read_long(get_dialog_ptr + 152),
@@ -23778,7 +23778,7 @@ mod tests {
         UpdtDialogUpdateRegionSnapshot {
             stack_after: cpu.read_reg(Register::A7),
             the_port_after: bus.read_long(crate::memory::globals::addr::THE_PORT),
-            current_port_after: disp.current_port,
+            current_port_after: *disp.current_port,
             deferred_after: disp.dialog_initial_draw_deferred.contains(&dialog_ptr),
             queued_draw_procs: disp
                 .modeless_dialog_draw_proc_queue
@@ -26848,7 +26848,7 @@ mod tests {
         }
 
         // Make sure the text renderer has a usable size and port state.
-        disp.current_port = port_ptr;
+        *disp.current_port = port_ptr;
         disp.tx_size = 12;
         bus.write_word(port_ptr + 74, 12);
 
@@ -26892,7 +26892,7 @@ mod tests {
             }
         }
 
-        disp.current_port = port_ptr;
+        *disp.current_port = port_ptr;
         disp.tx_size = 12;
         bus.write_word(port_ptr + 74, 12);
 
@@ -26924,7 +26924,7 @@ mod tests {
         // procedure taking text/length/box/align arguments.
         let (mut disp, mut cpu, mut bus) = setup_with_port();
         let port_ptr = 0x181000u32;
-        disp.current_port = port_ptr;
+        *disp.current_port = port_ptr;
         disp.tx_size = 12;
         bus.write_word(port_ptr + 74, 12);
 
@@ -26955,7 +26955,7 @@ mod tests {
         // teJustCenter(1), and teJustRight(-1) alignment values.
         let (mut disp, mut cpu, mut bus) = setup_with_port();
         let port_ptr = 0x181000u32;
-        disp.current_port = port_ptr;
+        *disp.current_port = port_ptr;
         disp.tx_size = 12;
         bus.write_word(port_ptr + 74, 12);
 
@@ -27031,7 +27031,7 @@ mod tests {
         // result slot written.
         let (mut disp, mut cpu, mut bus) = setup_with_port();
         let port_ptr = 0x181000u32;
-        disp.current_port = port_ptr;
+        *disp.current_port = port_ptr;
         disp.tx_size = 12;
         bus.write_word(port_ptr + 74, 12);
 
@@ -27069,7 +27069,7 @@ mod tests {
         // in the destination rectangle.
         let (mut disp, mut cpu, mut bus) = setup_with_port();
         let port_ptr = 0x181000u32;
-        disp.current_port = port_ptr;
+        *disp.current_port = port_ptr;
         disp.tx_size = 12;
         bus.write_word(port_ptr + 74, 12);
 
@@ -27170,7 +27170,7 @@ mod tests {
         bus.write_word(dialog_ptr + 108, 2);
         disp.window_proc_ids.insert(dialog_ptr, proc_id);
         disp.front_window = dialog_ptr;
-        disp.current_port = dialog_ptr;
+        *disp.current_port = dialog_ptr;
         disp.window_bounds = (0, 0, 100, 220);
         disp.window_proc_id = proc_id;
         disp.window_list = vec![dialog_ptr, prev_window];
@@ -27229,7 +27229,7 @@ mod tests {
         bus.write_word(dialog_structure_ptr + 8, 322);
 
         disp.front_window = dialog_ptr;
-        disp.current_port = dialog_ptr;
+        *disp.current_port = dialog_ptr;
         disp.window_bounds = (100, 120, 220, 320);
         bus.write_long(crate::memory::globals::addr::THE_PORT, dialog_ptr);
         let a5 = cpu.read_reg(Register::A5);
@@ -27243,7 +27243,7 @@ mod tests {
         let result = disp.dispatch_dialog(true, 0x182, &mut cpu, &mut bus);
         assert!(result.unwrap().is_ok());
         assert_eq!(disp.front_window, prev_window);
-        assert_eq!(disp.current_port, prev_window);
+        assert_eq!(*disp.current_port, prev_window);
         assert_eq!(
             bus.read_long(crate::memory::globals::addr::THE_PORT),
             prev_window
@@ -27281,7 +27281,7 @@ mod tests {
         seed_window_regions(&mut bus, visible_window, (0, 0, 342, 512));
 
         disp.front_window = dialog_ptr;
-        disp.current_port = dialog_ptr;
+        *disp.current_port = dialog_ptr;
         disp.window_bounds = (100, 120, 220, 320);
         disp.window_list = vec![dialog_ptr, visible_window];
         disp.window_stack.push((0, (0, 0, 0, 0), -1, String::new()));
@@ -27291,7 +27291,7 @@ mod tests {
         let result = disp.dispatch_dialog(true, 0x182, &mut cpu, &mut bus);
         assert!(result.unwrap().is_ok());
         assert_eq!(disp.front_window, visible_window);
-        assert_eq!(disp.current_port, visible_window);
+        assert_eq!(*disp.current_port, visible_window);
         assert_eq!(
             bus.read_long(crate::memory::globals::addr::THE_PORT),
             visible_window
@@ -27347,7 +27347,7 @@ mod tests {
         let other_front = 0x181000u32;
 
         disp.front_window = other_front;
-        disp.current_port = other_front;
+        *disp.current_port = other_front;
         bus.write_long(crate::memory::globals::addr::THE_PORT, other_front);
         let a5 = cpu.read_reg(Register::A5);
         let global_ptr = bus.read_long(a5);
@@ -27360,7 +27360,7 @@ mod tests {
         assert!(result.unwrap().is_ok());
 
         assert_eq!(disp.front_window, other_front);
-        assert_eq!(disp.current_port, other_front);
+        assert_eq!(*disp.current_port, other_front);
         assert_eq!(
             bus.read_long(crate::memory::globals::addr::THE_PORT),
             other_front
@@ -27445,7 +27445,7 @@ mod tests {
         seed_window_regions(&mut bus, prev_window, (0, 0, 342, 512));
 
         disp.front_window = dialog_ptr;
-        disp.current_port = dialog_ptr;
+        *disp.current_port = dialog_ptr;
         disp.window_bounds = (100, 120, 220, 320);
         bus.write_long(crate::memory::globals::addr::THE_PORT, dialog_ptr);
         let a5 = cpu.read_reg(Register::A5);
@@ -27459,7 +27459,7 @@ mod tests {
         let result = disp.dispatch_dialog(true, 0x183, &mut cpu, &mut bus);
         assert!(result.unwrap().is_ok());
         assert_eq!(disp.front_window, prev_window);
-        assert_eq!(disp.current_port, prev_window);
+        assert_eq!(*disp.current_port, prev_window);
         assert_eq!(
             bus.read_long(crate::memory::globals::addr::THE_PORT),
             prev_window
@@ -27494,7 +27494,7 @@ mod tests {
 
         disp.window_list = vec![dialog_ptr, prev_window];
         disp.front_window = dialog_ptr;
-        disp.current_port = dialog_ptr;
+        *disp.current_port = dialog_ptr;
         bus.write_byte(dialog_ptr + 110, 0xFF);
         bus.write_byte(prev_window + 110, 0xFF);
         disp.window_stack
@@ -27522,7 +27522,7 @@ mod tests {
         seed_window_regions(&mut bus, prev_window, (0, 0, 342, 512));
         disp.window_list = vec![dialog_ptr, prev_window];
         disp.front_window = dialog_ptr;
-        disp.current_port = dialog_ptr;
+        *disp.current_port = dialog_ptr;
         disp.window_bounds = (110, 155, 380, 645);
         disp.dialog_items.insert(
             dialog_ptr,
@@ -27562,7 +27562,7 @@ mod tests {
         seed_window_regions(&mut bus, prev_window, (0, 0, 342, 512));
         disp.window_list = vec![dialog_ptr, prev_window];
         disp.front_window = dialog_ptr;
-        disp.current_port = dialog_ptr;
+        *disp.current_port = dialog_ptr;
         disp.window_bounds = (110, 155, 380, 645);
         disp.dialog_modal_entered.insert(dialog_ptr);
         disp.pending_modal_button_dispose_dialog = Some(dialog_ptr);
@@ -28399,7 +28399,7 @@ mod tests {
         }
 
         disp.front_window = dialog_ptr;
-        disp.current_port = dialog_ptr;
+        *disp.current_port = dialog_ptr;
         disp.window_bounds = bounds;
         disp.window_list = vec![dialog_ptr];
         disp.window_stack.push((0, (0, 0, 0, 0), -1, String::new()));
@@ -28551,7 +28551,7 @@ mod tests {
         );
 
         disp.front_window = child_ptr;
-        disp.current_port = child_ptr;
+        *disp.current_port = child_ptr;
         disp.window_bounds = child_bounds;
         disp.window_list = vec![child_ptr, parent_ptr];
         disp.window_stack
@@ -28574,7 +28574,7 @@ mod tests {
             "disposing the child must restore the original parent userItem pixel"
         );
         assert_eq!(disp.front_window, parent_ptr);
-        assert_eq!(disp.current_port, parent_ptr);
+        assert_eq!(*disp.current_port, parent_ptr);
     }
 
     #[test]
@@ -30392,7 +30392,7 @@ mod tests {
         let item_hit_addr = 0x300000u32;
         let bounds = (40, 40, 130, 280);
         disp.front_window = dialog_ptr;
-        disp.current_port = dialog_ptr;
+        *disp.current_port = dialog_ptr;
         disp.window_bounds = bounds;
         disp.window_proc_id = 2;
         disp.window_title.clear();
@@ -31907,7 +31907,7 @@ mod tests {
         seed_window_regions(&mut bus, dialog_ptr, (100, 200, 200, 360));
         seed_window_regions(&mut bus, previous_window, (0, 0, 342, 512));
         disp.front_window = dialog_ptr;
-        disp.current_port = dialog_ptr;
+        *disp.current_port = dialog_ptr;
         disp.window_list = vec![dialog_ptr, previous_window];
         disp.window_stack
             .push((previous_window, (0, 0, 342, 512), 0, String::from("Map")));
@@ -31994,7 +31994,7 @@ mod tests {
         seed_window_regions(&mut bus, child, (100, 200, 200, 360));
         seed_window_regions(&mut bus, parent, (0, 0, 342, 512));
         disp.front_window = child;
-        disp.current_port = child;
+        *disp.current_port = child;
         disp.window_list = vec![child, parent];
         disp.window_stack
             .push((parent, (0, 0, 342, 512), 2, String::new()));
@@ -32323,7 +32323,7 @@ mod tests {
         text: &[u8],
     ) -> u32 {
         let te_handle = TrapDispatcher::allocate_te_handle(bus);
-        disp.current_port = 0x181000;
+        *disp.current_port = 0x181000;
         disp.tx_font = 4;
         disp.tx_face = 0;
         disp.tx_mode = 0;
@@ -35049,7 +35049,7 @@ mod tests {
         let (mut disp, mut cpu, mut bus) = setup();
 
         let te_handle = TrapDispatcher::allocate_te_handle(&mut bus);
-        disp.current_port = 0x181000;
+        *disp.current_port = 0x181000;
         disp.tx_font = 4;
         disp.tx_face = 1;
         disp.tx_mode = 2;
@@ -35086,7 +35086,7 @@ mod tests {
         let (mut disp, mut cpu, mut bus) = setup();
 
         let te_handle = TrapDispatcher::allocate_te_handle(&mut bus);
-        disp.current_port = 0x181000;
+        *disp.current_port = 0x181000;
         disp.tx_font = 4;
         disp.tx_face = 0;
         disp.tx_mode = 0;
@@ -35125,7 +35125,7 @@ mod tests {
         let (mut disp, mut cpu, mut bus) = setup();
 
         let te_handle = TrapDispatcher::allocate_te_handle(&mut bus);
-        disp.current_port = 0x181000;
+        *disp.current_port = 0x181000;
         disp.tx_font = 4;
         disp.tx_face = 0;
         disp.tx_mode = 0;

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -2438,9 +2438,9 @@ pub struct TrapDispatcher {
     /// Main GDevice handle in guest memory (0 = not yet allocated)
     pub(crate) main_gdevice_handle: u32,
     /// Current GDevice handle
-    pub(crate) current_gdevice: u32,
+    pub(crate) current_gdevice: SharedProcessValue<u32>,
     /// Current GrafPort/GWorld pointer
-    pub(crate) current_port: u32,
+    pub(crate) current_port: SharedProcessValue<u32>,
     /// Per-port pen/color/text state restored by SetPort and SetGWorld.
     pub(crate) port_draw_states: HashMap<u32, PortDrawState>,
     /// Bit 0/1 mark CGrafPort fgColor/bkColor fields that QuickDraw has
@@ -2867,6 +2867,7 @@ impl TrapDispatcher {
         context.attach_resource_manager(&mut self.process_resource_manager);
         context.attach_sound_manager(&mut self.sound_manager);
         context.attach_cursor_state(&mut self.cursor_state);
+        context.attach_quickdraw_selection(&mut self.current_port, &mut self.current_gdevice);
         context.attach_display_color_state(
             &mut self.device_clut,
             &mut self.color_manager_clut,
@@ -3288,7 +3289,7 @@ impl TrapDispatcher {
     /// Test-only: set the current port without going through SetPort.
     /// Used by integration test helpers like setup_with_cgraf_port().
     pub fn set_current_port_for_test(&mut self, port: u32) {
-        self.current_port = port;
+        *self.current_port = port;
     }
 
     /// Test-only: invoke save_dialog_pixels for the byte-isomorphism gate.
@@ -3997,8 +3998,8 @@ impl TrapDispatcher {
             copybits_screen_secs: Vec::new(),
             trace_sink: None,
             main_gdevice_handle: 0,
-            current_gdevice: 0,
-            current_port: 0,
+            current_gdevice: SharedProcessValue::from_value(0),
+            current_port: SharedProcessValue::from_value(0),
             port_draw_states: HashMap::new(),
             resolved_port_color_fields: HashMap::new(),
             gworld_devices: HashMap::new(),

--- a/src/trap/menu.rs
+++ b/src/trap/menu.rs
@@ -3292,7 +3292,7 @@ impl super::TrapDispatcher {
                 let sp = cpu.read_reg(Register::A7);
                 cpu.write_reg(Register::A7, sp + 8);
 
-                let port = self.current_port;
+                let port = *self.current_port;
                 if port == 0 {
                     return Some(Ok(()));
                 }
@@ -7431,7 +7431,7 @@ mod tests {
             .insert(mdef_handle, (mdef_ptr, *b"MDEF", 256));
         insert_menu(&mut disp, &mut cpu, &mut bus, handle);
         disp.draw_menu_bar_to_fb(&mut bus);
-        let original_port = disp.current_port;
+        let original_port = *disp.current_port;
 
         let trap_pc = 0x0012_3400;
         cpu.write_reg(Register::PC, trap_pc + 2);
@@ -7451,7 +7451,7 @@ mod tests {
         assert_eq!(bus.read_long(TEST_SP - 4), trap_pc);
         assert!(disp.is_menu_definition_callback_pending());
         assert_eq!(disp.guest_calls.len(), 1);
-        assert_eq!(disp.current_port, disp.window_manager_cport);
+        assert_eq!(*disp.current_port, disp.window_manager_cport);
 
         cpu.write_reg(Register::PC, trap_pc + 2);
         cpu.write_reg(Register::A7, TEST_SP);
@@ -7507,7 +7507,7 @@ mod tests {
         assert_eq!(disp.menu_tracking, None);
         assert_eq!(disp.menu_definition_tracking, None);
         assert!(disp.guest_calls.is_empty());
-        assert_eq!(disp.current_port, original_port);
+        assert_eq!(*disp.current_port, original_port);
     }
 
     #[test]
@@ -15984,7 +15984,7 @@ mod tests {
         setup_8bpp_menu_screen(&mut disp, &mut bus, 240, 120);
         disp.menu_bar_hidden = false;
         bus.write_word(crate::memory::globals::addr::MBAR_HEIGHT, 20);
-        let original_port = disp.current_port;
+        let original_port = *disp.current_port;
 
         let root = new_menu_with_title(&mut disp, &mut cpu, &mut bus, 140, 0x310600, "File");
         append_menu_data(
@@ -16073,7 +16073,7 @@ mod tests {
             .unwrap()
             .unwrap();
         assert!(disp.menu_tracking.as_ref().unwrap().submenus.is_empty());
-        assert_eq!(disp.current_port, original_port);
+        assert_eq!(*disp.current_port, original_port);
 
         disp.input_state.mouse_pos = (root_rect.0 + 8, root_rect.1 + 16);
         cpu.write_reg(Register::PC, trap_pc + 2);

--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -835,7 +835,7 @@ impl super::TrapDispatcher {
                 // code that avoids SetGWorld is expected to pair SetGDevice
                 // with SetPort for offscreen drawing (Imaging With QuickDraw
                 // 1994, p. 5-24; Inside Macintosh Volume V, p. V-124).
-                let current_gdevice = (self.current_gdevice != 0).then_some(self.current_gdevice);
+                let current_gdevice = (*self.current_gdevice != 0).then_some(*self.current_gdevice);
                 self.set_current_port_state(bus, cpu, port, current_gdevice);
                 Ok(())
             }
@@ -1119,8 +1119,8 @@ impl super::TrapDispatcher {
                 let sp = cpu.read_reg(Register::A7);
                 let src_handle = bus.read_long(sp);
                 cpu.write_reg(Register::A7, sp + 4);
-                let port_ptr = if self.current_port != 0 {
-                    self.current_port
+                let port_ptr = if *self.current_port != 0 {
+                    *self.current_port
                 } else {
                     let a5 = cpu.read_reg(Register::A5);
                     let global_ptr = if a5 != 0 { bus.read_long(a5) } else { 0 };
@@ -1176,8 +1176,8 @@ impl super::TrapDispatcher {
                 let sp = cpu.read_reg(Register::A7);
                 let rgn_handle = bus.read_long(sp);
                 cpu.write_reg(Register::A7, sp + 4);
-                let port_ptr = if self.current_port != 0 {
-                    self.current_port
+                let port_ptr = if *self.current_port != 0 {
+                    *self.current_port
                 } else {
                     let a5 = cpu.read_reg(Register::A5);
                     let global_ptr = if a5 != 0 { bus.read_long(a5) } else { 0 };
@@ -1227,8 +1227,8 @@ impl super::TrapDispatcher {
                 let sp = cpu.read_reg(Register::A7);
                 let rect_ptr = bus.read_long(sp);
                 cpu.write_reg(Register::A7, sp + 4);
-                let port_ptr = if self.current_port != 0 {
-                    self.current_port
+                let port_ptr = if *self.current_port != 0 {
+                    *self.current_port
                 } else {
                     let a5 = cpu.read_reg(Register::A5);
                     let global_ptr = if a5 != 0 { bus.read_long(a5) } else { 0 };
@@ -1480,8 +1480,8 @@ impl super::TrapDispatcher {
                 let sp = cpu.read_reg(Register::A7);
                 let device = bus.read_word(sp);
                 cpu.write_reg(Register::A7, sp + 2);
-                if self.current_port != 0 {
-                    bus.write_word(self.current_port, device);
+                if *self.current_port != 0 {
+                    bus.write_word(*self.current_port, device);
                 }
                 Ok(())
             }
@@ -1674,7 +1674,7 @@ impl super::TrapDispatcher {
                 if trace_dialog_text_enabled() {
                     eprintln!(
                         "[DIALOG-TEXT] MoveTo current_port=${:08X} pnLoc=({}, {})",
-                        self.current_port, v, h
+                        *self.current_port, v, h
                     );
                 }
                 Ok(())
@@ -2031,7 +2031,7 @@ impl super::TrapDispatcher {
                 if trace_dialog_text_enabled() {
                     eprintln!(
                         "[DIALOG-TEXT] DrawChar current_port=${:08X} pnLoc=({}, {}) fg=({:04X},{:04X},{:04X}) bg=({:04X},{:04X},{:04X}) mode={} ch={:?}",
-                        self.current_port,
+                        *self.current_port,
                         self.pn_loc.0,
                         self.pn_loc.1,
                         self.fg_color.0,
@@ -2045,7 +2045,7 @@ impl super::TrapDispatcher {
                     );
                 }
                 self.draw_char(cpu, bus, ch);
-                self.refresh_visible_dialog_snapshot_for_port(bus, self.current_port);
+                self.refresh_visible_dialog_snapshot_for_port(bus, *self.current_port);
                 Ok(())
             }
 
@@ -2068,7 +2068,7 @@ impl super::TrapDispatcher {
                     eprintln!(
                         "[DIALOG-TEXT] DrawString pc=${:08X} current_port=${:08X} pnLoc=({}, {}) fg=({:04X},{:04X},{:04X}) bg=({:04X},{:04X},{:04X}) mode={} text=\"{}\"",
                         pc,
-                        self.current_port,
+                        *self.current_port,
                         self.pn_loc.0,
                         self.pn_loc.1,
                         self.fg_color.0,
@@ -2103,7 +2103,7 @@ impl super::TrapDispatcher {
                     return Some(Ok(()));
                 }
                 self.draw_string(cpu, bus, str_ptr);
-                self.refresh_visible_dialog_snapshot_for_port(bus, self.current_port);
+                self.refresh_visible_dialog_snapshot_for_port(bus, *self.current_port);
                 Ok(())
             }
 
@@ -2129,7 +2129,7 @@ impl super::TrapDispatcher {
                     eprintln!(
                         "[DIALOG-TEXT] DrawText pc=${:08X} current_port=${:08X} pnLoc=({}, {}) fg=({:04X},{:04X},{:04X}) bg=({:04X},{:04X},{:04X}) mode={} text=\"{}\"",
                         pc,
-                        self.current_port,
+                        *self.current_port,
                         self.pn_loc.0,
                         self.pn_loc.1,
                         self.fg_color.0,
@@ -2146,7 +2146,7 @@ impl super::TrapDispatcher {
                     let ch = bus.read_byte(start + i as u32) as char;
                     self.draw_char(cpu, bus, ch);
                 }
-                self.refresh_visible_dialog_snapshot_for_port(bus, self.current_port);
+                self.refresh_visible_dialog_snapshot_for_port(bus, *self.current_port);
                 Ok(())
             }
 
@@ -2186,7 +2186,7 @@ impl super::TrapDispatcher {
                     eprintln!(
                         "[DIALOG-TEXT] StdText pc=${:08X} current_port=${:08X} pnLoc=({}, {}) fg=({:04X},{:04X},{:04X}) bg=({:04X},{:04X},{:04X}) mode={} numer=({}, {}) denom=({}, {}) text=\"{}\"",
                         pc,
-                        self.current_port,
+                        *self.current_port,
                         self.pn_loc.0,
                         self.pn_loc.1,
                         self.fg_color.0,
@@ -2210,7 +2210,7 @@ impl super::TrapDispatcher {
                     self.draw_char(cpu, bus, ch);
                 }
                 self.tx_size = saved_tx_size;
-                self.refresh_visible_dialog_snapshot_for_port(bus, self.current_port);
+                self.refresh_visible_dialog_snapshot_for_port(bus, *self.current_port);
                 Ok(())
             }
 
@@ -2655,7 +2655,7 @@ impl super::TrapDispatcher {
                 if trace_qd_colors_enabled() {
                     eprintln!(
                         "[QD-COLOR] EraseRect port=${:08X} rect=({},{}..{},{}) bg=({:04X},{:04X},{:04X}) tick={}",
-                        self.current_port,
+                        *self.current_port,
                         r.top,
                         r.left,
                         r.bottom,
@@ -2744,7 +2744,7 @@ impl super::TrapDispatcher {
                 if trace_qd_colors_enabled() {
                     eprintln!(
                         "[QD-COLOR] FillRect port=${:08X} rect=({},{},{},{}) pat={:02X?} fg=({:04X},{:04X},{:04X}) bg=({:04X},{:04X},{:04X}) tick={}",
-                        self.current_port,
+                        *self.current_port,
                         r.top,
                         r.left,
                         r.bottom,
@@ -3162,7 +3162,7 @@ impl super::TrapDispatcher {
                         "[TITLE-DIAG] CopyBits tick={} pc=${:08X} port=${:08X} srcBits=${:08X} dstBits=${:08X} srcBase=${:08X} dstBase=${:08X} srcRect=({},{}..{},{} ) dstRect=({},{}..{},{} ) mode={} srcCTab=${:08X} dstCTab=${:08X}",
                         self.tick_count,
                         trap_pc,
-                        self.current_port,
+                        *self.current_port,
                         src_bits_ptr,
                         dst_bits_ptr,
                         src_info.base,
@@ -3203,7 +3203,7 @@ impl super::TrapDispatcher {
                 if trace_dialog_draw_enabled() && self.dialog_tracking.is_some() {
                     eprintln!(
                         "[DIALOG-DRAW] CopyBits current_port=${:08X} srcBase=${:08X} dstBase=${:08X} mode={} src=({},{}..{},{} ) dst=({},{}..{},{} ) mask=${:08X}",
-                        self.current_port,
+                        *self.current_port,
                         src_info.base,
                         dst_info.base,
                         mode_base,
@@ -3219,10 +3219,10 @@ impl super::TrapDispatcher {
                     );
                 }
                 if trace_dialog_port_dump_enabled() && self.dialog_tracking.is_some() {
-                    Self::trace_port_snapshot(bus, "CopyBits-current", self.current_port);
+                    Self::trace_port_snapshot(bus, "CopyBits-current", *self.current_port);
                 }
                 if trace_dialog_port_dump_enabled() && self.dialog_tracking.is_some() {
-                    Self::trace_port_snapshot(bus, "CopyBits-current", self.current_port);
+                    Self::trace_port_snapshot(bus, "CopyBits-current", *self.current_port);
                 }
 
                 if src_bottom <= src_top
@@ -3485,7 +3485,7 @@ impl super::TrapDispatcher {
                         src_info.pixel_size,
                         dst_info.pixel_size,
                         mask_rgn,
-                        self.current_port,
+                        *self.current_port,
                         src_info.ctab_handle,
                         dst_info.ctab_handle,
                         dst_ctab_handle,
@@ -3663,7 +3663,7 @@ impl super::TrapDispatcher {
                         self.fill_kiosk_letterbox_for_copybits(bus, rect);
                         self.refresh_dialog_saved_pixels_after_screen_draw(
                             bus,
-                            self.current_port,
+                            *self.current_port,
                             (
                                 clip_t.saturating_sub(dst_info.bounds_top),
                                 clip_l.saturating_sub(dst_info.bounds_left),
@@ -3673,7 +3673,7 @@ impl super::TrapDispatcher {
                         );
                         self.refresh_visible_dialog_snapshot_after_bulk_port_draw(
                             bus,
-                            self.current_port,
+                            *self.current_port,
                             (rect.dst_top, rect.dst_left, rect.dst_bottom, rect.dst_right),
                         );
                     }
@@ -4438,7 +4438,7 @@ impl super::TrapDispatcher {
                     self.fill_kiosk_letterbox_for_copybits(bus, rect);
                     self.refresh_dialog_saved_pixels_after_screen_draw(
                         bus,
-                        self.current_port,
+                        *self.current_port,
                         (
                             clip_t.saturating_sub(dst_info.bounds_top),
                             clip_l.saturating_sub(dst_info.bounds_left),
@@ -4448,7 +4448,7 @@ impl super::TrapDispatcher {
                     );
                     self.refresh_visible_dialog_snapshot_after_bulk_port_draw(
                         bus,
-                        self.current_port,
+                        *self.current_port,
                         (rect.dst_top, rect.dst_left, rect.dst_bottom, rect.dst_right),
                     );
                 }
@@ -4607,7 +4607,7 @@ impl super::TrapDispatcher {
                 if trace_qd_colors_enabled() {
                     eprintln!(
                         "[QD-COLOR] ForeColor port=${:08X} color=${:08X} rgb=({:04X},{:04X},{:04X}) tick={}",
-                        self.current_port,
+                        *self.current_port,
                         color,
                         self.fg_color.0,
                         self.fg_color.1,
@@ -4618,7 +4618,7 @@ impl super::TrapDispatcher {
                 if trace_dialog_text_enabled() {
                     eprintln!(
                         "[DIALOG-TEXT] ForeColor current_port=${:08X} color=${:08X} rgb=({:04X},{:04X},{:04X})",
-                        self.current_port,
+                        *self.current_port,
                         color,
                         self.fg_color.0,
                         self.fg_color.1,
@@ -4641,7 +4641,7 @@ impl super::TrapDispatcher {
                 if trace_qd_colors_enabled() {
                     eprintln!(
                         "[QD-COLOR] BackColor port=${:08X} color=${:08X} rgb=({:04X},{:04X},{:04X}) tick={}",
-                        self.current_port,
+                        *self.current_port,
                         color,
                         self.bg_color.0,
                         self.bg_color.1,
@@ -4652,7 +4652,7 @@ impl super::TrapDispatcher {
                 if trace_dialog_text_enabled() {
                     eprintln!(
                         "[DIALOG-TEXT] BackColor current_port=${:08X} color=${:08X} rgb=({:04X},{:04X},{:04X})",
-                        self.current_port,
+                        *self.current_port,
                         color,
                         self.bg_color.0,
                         self.bg_color.1,
@@ -4685,7 +4685,7 @@ impl super::TrapDispatcher {
                 if trace_qd_colors_enabled() {
                     eprintln!(
                         "[QD-COLOR] RGBForeColor port=${:08X} ptr=${:08X} rgb=({:04X},{:04X},{:04X}) tick={}",
-                        self.current_port,
+                        *self.current_port,
                         color_ptr,
                         r, g, b,
                         self.tick_count,
@@ -4716,7 +4716,7 @@ impl super::TrapDispatcher {
                 if trace_qd_colors_enabled() {
                     eprintln!(
                         "[QD-COLOR] RGBBackColor port=${:08X} ptr=${:08X} rgb=({:04X},{:04X},{:04X}) tick={}",
-                        self.current_port, color_ptr, r, g, b, self.tick_count
+                        *self.current_port, color_ptr, r, g, b, self.tick_count
                     );
                 }
                 Ok(())
@@ -5107,7 +5107,7 @@ impl super::TrapDispatcher {
                 if trace_palette_enabled() {
                     eprintln!(
                         "[PALETTE] GetNewPalette id={} current_port=${:08X} -> ${:08X}",
-                        palette_id, self.current_port, palette
+                        palette_id, *self.current_port, palette
                     );
                 }
                 bus.write_long(sp + 2, palette);
@@ -5285,17 +5285,17 @@ impl super::TrapDispatcher {
                     self.pm_fg_color = Some((palette, entry));
                     self.sync_current_port_draw_state(bus);
                     if (explicit || (usage & PM_ANIMATED) != 0)
-                        && self.current_port != 0
-                        && (bus.read_word(self.current_port + 6) & 0xC000) == 0xC000
+                        && *self.current_port != 0
+                        && (bus.read_word(*self.current_port + 6) & 0xC000) == 0xC000
                     {
                         // Explicit entries name a device index directly.
                         // Animated entries select the distinct device index
                         // reserved for that palette entry; Systemless' single
                         // GDevice allocation maps it to the same index.
-                        bus.write_long(self.current_port + 80, (entry as u16 & 0x00FF) as u32);
+                        bus.write_long(*self.current_port + 80, (entry as u16 & 0x00FF) as u32);
                         *self
                             .resolved_port_color_fields
-                            .entry(self.current_port)
+                            .entry(*self.current_port)
                             .or_default() |= 0x01;
                     } else {
                         self.resolve_current_port_color_pixels(bus, true, false, false);
@@ -5303,7 +5303,7 @@ impl super::TrapDispatcher {
                     if trace_qd_colors_enabled() {
                         eprintln!(
                             "[QD-COLOR] PmForeColor port=${:08X} entry={} rgb=({:04X},{:04X},{:04X}) tick={}",
-                            self.current_port,
+                            *self.current_port,
                             entry,
                             self.fg_color.0,
                             self.fg_color.1,
@@ -5338,13 +5338,13 @@ impl super::TrapDispatcher {
                     self.pm_bg_color = Some((palette, entry));
                     self.sync_current_port_draw_state(bus);
                     if (explicit || (usage & PM_ANIMATED) != 0)
-                        && self.current_port != 0
-                        && (bus.read_word(self.current_port + 6) & 0xC000) == 0xC000
+                        && *self.current_port != 0
+                        && (bus.read_word(*self.current_port + 6) & 0xC000) == 0xC000
                     {
-                        bus.write_long(self.current_port + 84, (entry as u16 & 0x00FF) as u32);
+                        bus.write_long(*self.current_port + 84, (entry as u16 & 0x00FF) as u32);
                         *self
                             .resolved_port_color_fields
-                            .entry(self.current_port)
+                            .entry(*self.current_port)
                             .or_default() |= 0x02;
                     } else {
                         self.resolve_current_port_color_pixels(bus, false, true, false);
@@ -5352,7 +5352,7 @@ impl super::TrapDispatcher {
                     if trace_qd_colors_enabled() {
                         eprintln!(
                             "[QD-COLOR] PmBackColor port=${:08X} entry={} rgb=({:04X},{:04X},{:04X}) tick={}",
-                            self.current_port,
+                            *self.current_port,
                             entry,
                             self.bg_color.0,
                             self.bg_color.1,
@@ -5645,7 +5645,7 @@ impl super::TrapDispatcher {
                 // Resolve port pixel geometry from the dispatcher's
                 // current_port (kept in sync with the THE_PORT low-mem
                 // global at 0x09DA by set_current_port_state).
-                let the_port = self.current_port;
+                let the_port = *self.current_port;
                 let port_top;
                 let port_left;
                 let base_addr;
@@ -6082,8 +6082,8 @@ impl super::TrapDispatcher {
             // in the result slot.
             (true, 0x232) => {
                 let sp = cpu.read_reg(Register::A7);
-                let gdh = if self.current_gdevice != 0 {
-                    self.current_gdevice
+                let gdh = if *self.current_gdevice != 0 {
+                    *self.current_gdevice
                 } else {
                     self.ensure_main_gdevice(bus)
                 };
@@ -6109,7 +6109,7 @@ impl super::TrapDispatcher {
             (true, 0x231) => {
                 let sp = cpu.read_reg(Register::A7);
                 let gdh = bus.read_long(sp);
-                self.current_gdevice = gdh;
+                *self.current_gdevice = gdh;
                 bus.write_long(0x0CC8, gdh);
                 cpu.write_reg(Register::A7, sp + 4);
                 Ok(())
@@ -6908,7 +6908,7 @@ impl super::TrapDispatcher {
                 if trace_palette_enabled() {
                     eprintln!(
                         "[PALETTE] GetCTable id={} current_port=${:08X}",
-                        ct_id, self.current_port
+                        ct_id, *self.current_port
                     );
                 }
 
@@ -7602,8 +7602,8 @@ impl super::TrapDispatcher {
                                 bus.write_word(gd_ptr + 40, new_right as u16);
                             }
                         }
-                        if self.current_port == port {
-                            self.current_gdevice = self.gdevice_for_port(bus, port);
+                        if *self.current_port == port {
+                            *self.current_gdevice = self.gdevice_for_port(bus, port);
                         }
 
                         bus.write_long(sp + 22, result_flags);
@@ -7624,13 +7624,13 @@ impl super::TrapDispatcher {
                     0x0005 => {
                         let gd_ptr = bus.read_long(sp);
                         let port_ptr = bus.read_long(sp + 4);
-                        let gdh = if self.current_gdevice != 0 {
-                            self.current_gdevice
+                        let gdh = if *self.current_gdevice != 0 {
+                            *self.current_gdevice
                         } else {
                             self.ensure_main_gdevice(bus)
                         };
                         if port_ptr != 0 {
-                            bus.write_long(port_ptr, self.current_port);
+                            bus.write_long(port_ptr, *self.current_port);
                         }
                         if gd_ptr != 0 {
                             bus.write_long(gd_ptr, gdh);
@@ -7638,7 +7638,7 @@ impl super::TrapDispatcher {
                         if trace_dialog_gworld_enabled() {
                             eprintln!(
                                 "[DIALOG-GWORLD] GetGWorld port=${:08X} gdh=${:08X}",
-                                self.current_port, gdh
+                                *self.current_port, gdh
                             );
                         }
                         cpu.write_reg(Register::A7, sp + 8);
@@ -7799,8 +7799,8 @@ impl super::TrapDispatcher {
                     }
                     0x0012 => {
                         let gworld = bus.read_long(sp);
-                        let current_gdh = if self.current_gdevice != 0 {
-                            self.current_gdevice
+                        let current_gdh = if *self.current_gdevice != 0 {
+                            *self.current_gdevice
                         } else {
                             self.ensure_main_gdevice(bus)
                         };
@@ -7910,11 +7910,11 @@ impl super::TrapDispatcher {
                 let gd_ptr = bus.read_long(sp);
                 let port_ptr = bus.read_long(sp + 4);
                 if port_ptr != 0 {
-                    bus.write_long(port_ptr, self.current_port);
+                    bus.write_long(port_ptr, *self.current_port);
                 }
                 if gd_ptr != 0 {
-                    let gdh = if self.current_gdevice != 0 {
-                        self.current_gdevice
+                    let gdh = if *self.current_gdevice != 0 {
+                        *self.current_gdevice
                     } else {
                         self.ensure_main_gdevice(bus)
                     };
@@ -8360,7 +8360,7 @@ impl super::TrapDispatcher {
                                 String::from_utf8_lossy(&res_type),
                                 res_id,
                                 pic_handle,
-                                self.current_port,
+                                *self.current_port,
                                 port_base,
                                 use_top,
                                 use_left,
@@ -8371,7 +8371,7 @@ impl super::TrapDispatcher {
                             eprintln!(
                                 "[DIALOG-DRAW] DrawPicture handle=${:08X} current_port=${:08X} dstBase=${:08X} rect=({},{}..{},{} )",
                                 pic_handle,
-                                self.current_port,
+                                *self.current_port,
                                 port_base,
                                 use_top,
                                 use_left,
@@ -8381,10 +8381,10 @@ impl super::TrapDispatcher {
                         }
                     }
                     if trace_dialog_port_dump_enabled() && self.dialog_tracking.is_some() {
-                        Self::trace_port_snapshot(bus, "DrawPicture-current", self.current_port);
+                        Self::trace_port_snapshot(bus, "DrawPicture-current", *self.current_port);
                     }
                     if trace_dialog_port_dump_enabled() && self.dialog_tracking.is_some() {
-                        Self::trace_port_snapshot(bus, "DrawPicture-current", self.current_port);
+                        Self::trace_port_snapshot(bus, "DrawPicture-current", *self.current_port);
                     }
 
                     // Convert dst from port-local coordinates to pixel coordinates
@@ -8420,7 +8420,7 @@ impl super::TrapDispatcher {
                             eprintln!(
                                 "[TITLE-DIAG] DrawPicture tick={} port=${:08X} base=${:08X} handle=${:08X} type='{}' id={} rect=({},{}..{},{} )",
                                 self.tick_count,
-                                self.current_port,
+                                *self.current_port,
                                 port_base,
                                 pic_handle,
                                 String::from_utf8_lossy(&res_type),
@@ -8434,7 +8434,7 @@ impl super::TrapDispatcher {
                             eprintln!(
                                 "[TITLE-DIAG] DrawPicture tick={} port=${:08X} base=${:08X} handle=${:08X} rect=({},{}..{},{} )",
                                 self.tick_count,
-                                self.current_port,
+                                *self.current_port,
                                 port_base,
                                 pic_handle,
                                 use_top,
@@ -8902,7 +8902,7 @@ impl super::TrapDispatcher {
                     if ok && port_base == self.screen_mode.0 {
                         self.refresh_dialog_saved_pixels_after_screen_draw(
                             bus,
-                            self.current_port,
+                            *self.current_port,
                             (
                                 use_top.saturating_sub(port_bounds_top),
                                 use_left.saturating_sub(port_bounds_left),
@@ -8912,7 +8912,7 @@ impl super::TrapDispatcher {
                         );
                         self.refresh_visible_dialog_snapshot_after_bulk_port_draw(
                             bus,
-                            self.current_port,
+                            *self.current_port,
                             (
                                 use_top.saturating_sub(port_bounds_top),
                                 use_left.saturating_sub(port_bounds_left),
@@ -8987,7 +8987,7 @@ impl super::TrapDispatcher {
                     let picture = if let Some(snapshot) = self.recording_picture_bitmap.take() {
                         Some(snapshot)
                     } else if commands.is_empty() {
-                        let mut source = self.resolve_copy_bitmap(bus, self.current_port + 2);
+                        let mut source = self.resolve_copy_bitmap(bus, *self.current_port + 2);
                         if source.base == 0
                             || source.base == u32::MAX
                             || source.row_bytes == 0
@@ -9609,7 +9609,7 @@ impl super::TrapDispatcher {
                             String::from_utf8_lossy(&res_type),
                             res_id,
                             icon_handle,
-                            self.current_port,
+                            *self.current_port,
                             dst_base,
                             abs_top,
                             abs_left,
@@ -9620,7 +9620,7 @@ impl super::TrapDispatcher {
                         eprintln!(
                             "[DIALOG-DRAW] PlotCIcon handle=${:08X} current_port=${:08X} dstBase=${:08X} rect=({},{}..{},{} )",
                             icon_handle,
-                            self.current_port,
+                            *self.current_port,
                             dst_base,
                             abs_top,
                             abs_left,
@@ -10882,7 +10882,7 @@ impl super::TrapDispatcher {
                 let src_rect_ptr = bus.read_long(sp + 10);
                 let src_bits_ptr = bus.read_long(sp + 14);
                 cpu.write_reg(Register::A7, sp + 18);
-                let dst_bits_ptr = self.bitmap_ptr_for_port(bus, self.current_port);
+                let dst_bits_ptr = self.bitmap_ptr_for_port(bus, *self.current_port);
                 if dst_bits_ptr == 0 {
                     return Some(Ok(()));
                 }
@@ -13050,8 +13050,8 @@ impl super::TrapDispatcher {
                 let drawing_proc = bus.read_long(sp + 8);
                 let drawing_rgn = bus.read_long(sp + 12);
                 let main_gdevice = self.ensure_main_gdevice(bus);
-                let current_gdevice = if self.current_gdevice != 0 {
-                    self.current_gdevice
+                let current_gdevice = if *self.current_gdevice != 0 {
+                    *self.current_gdevice
                 } else {
                     main_gdevice
                 };
@@ -13561,7 +13561,7 @@ impl super::TrapDispatcher {
                     }
                     eprintln!(
                         "[QD-COLOR] FillCRect port=${:08X} rect=({},{},{},{}) pp=${:08X}->${:08X} patType={} patMap=${:08X} patData=${:08X} pat1={:02X?} raw={}",
-                        self.current_port,
+                        *self.current_port,
                         r.top,
                         r.left,
                         r.bottom,
@@ -14105,7 +14105,7 @@ impl super::TrapDispatcher {
                 // raw indices interchangeable when the tables contain
                 // different colors.
                 let dst_ctab_handle =
-                    self.copy_bits_destination_ctab_handle(bus, self.current_port, &dst_info);
+                    self.copy_bits_destination_ctab_handle(bus, *self.current_port, &dst_info);
                 let src_clut = matches!(src_info.pixel_size, 2 | 4 | 8)
                     .then(|| self.read_port_clut(bus, src_info.ctab_handle));
                 let screen_destination = dst_info.base == self.screen_mode.0
@@ -15173,7 +15173,7 @@ impl super::TrapDispatcher {
                         let new_main = bus.read_long(sp + 4);
                         if new_main != 0 {
                             self.main_gdevice_handle = new_main;
-                            self.current_gdevice = new_main;
+                            *self.current_gdevice = new_main;
                             bus.write_long(0x08A4, new_main); // MainDevice
                             bus.write_long(0x0CC8, new_main);
                         }
@@ -15735,8 +15735,8 @@ impl super::TrapDispatcher {
     }
 
     fn active_gdevice_or_main(&mut self, bus: &mut MacMemoryBus) -> u32 {
-        if Self::gdevice_pixmap_handle(bus, self.current_gdevice) != 0 {
-            self.current_gdevice
+        if Self::gdevice_pixmap_handle(bus, *self.current_gdevice) != 0 {
+            *self.current_gdevice
         } else {
             self.ensure_main_gdevice(bus)
         }
@@ -16241,7 +16241,7 @@ impl super::TrapDispatcher {
         bus.write_long(gd_handle, gd);
 
         self.main_gdevice_handle = gd_handle;
-        self.current_gdevice = gd_handle;
+        *self.current_gdevice = gd_handle;
 
         gd_handle
     }
@@ -16444,8 +16444,8 @@ impl super::TrapDispatcher {
     ) -> Option<[u16; 3]> {
         let device = if device != 0 {
             device
-        } else if self.current_gdevice != 0 {
-            self.current_gdevice
+        } else if *self.current_gdevice != 0 {
+            *self.current_gdevice
         } else {
             self.ensure_main_gdevice(bus)
         };
@@ -17194,8 +17194,8 @@ impl super::TrapDispatcher {
             }
         }
 
-        let gdh = if self.current_gdevice != 0 {
-            self.current_gdevice
+        let gdh = if *self.current_gdevice != 0 {
+            *self.current_gdevice
         } else {
             self.ensure_main_gdevice(bus)
         };
@@ -17357,7 +17357,7 @@ impl super::TrapDispatcher {
         if entry < 0 {
             return None;
         }
-        let palette_handle = self.window_palette_handle(self.current_port);
+        let palette_handle = self.window_palette_handle(*self.current_port);
         if palette_handle == 0 {
             return None;
         }
@@ -17691,13 +17691,13 @@ impl super::TrapDispatcher {
         self.recent_resource_ctable_fetch = Some(RecentColorTableFetch {
             ct_id,
             ctab_handle,
-            port: self.current_port,
+            port: *self.current_port,
             tick: self.tick_count,
         });
         if trace_palette_enabled() {
             eprintln!(
                 "[PALETTE] RememberGetCTable tick={} trap={} port=${:08X} ct_id={} handle=${:08X}",
-                self.tick_count, self.trap_count, self.current_port, ct_id, ctab_handle,
+                self.tick_count, self.trap_count, *self.current_port, ct_id, ctab_handle,
             );
         }
     }
@@ -18589,8 +18589,8 @@ impl super::TrapDispatcher {
     }
 
     pub(super) fn current_gdevice_ctab_handle(&self, bus: &MacMemoryBus) -> u32 {
-        let gdh = if self.current_gdevice != 0 {
-            self.current_gdevice
+        let gdh = if *self.current_gdevice != 0 {
+            *self.current_gdevice
         } else {
             self.main_gdevice_handle
         };
@@ -18749,16 +18749,16 @@ impl super::TrapDispatcher {
             false
         };
 
-        if self.current_port == port {
+        if *self.current_port == port {
             let main_gdevice = self.ensure_main_gdevice(bus);
             let fallback_port = self.ensure_color_window_manager_port(bus);
             self.set_current_port_state(bus, cpu, fallback_port, Some(main_gdevice));
-        } else if owns_attached_gdevice && attached_gdevice == self.current_gdevice {
+        } else if owns_attached_gdevice && attached_gdevice == *self.current_gdevice {
             let main_gdevice = self.ensure_main_gdevice(bus);
-            if self.current_port != 0 {
-                self.set_current_port_state(bus, cpu, self.current_port, Some(main_gdevice));
+            if *self.current_port != 0 {
+                self.set_current_port_state(bus, cpu, *self.current_port, Some(main_gdevice));
             } else {
-                self.current_gdevice = main_gdevice;
+                *self.current_gdevice = main_gdevice;
             }
         }
 
@@ -18874,8 +18874,8 @@ impl super::TrapDispatcher {
     ) {
         self.save_current_port_draw_state();
         let resolved_gdh = gdh.unwrap_or_else(|| self.gdevice_for_port(bus, port));
-        self.current_port = port;
-        self.current_gdevice = resolved_gdh;
+        *self.current_port = port;
+        *self.current_gdevice = resolved_gdh;
         // Re-selecting a port re-arms QDDone for that port.
         self.qddone_seen_ports.remove(&port);
         bus.write_long(crate::memory::globals::addr::THE_PORT, port);
@@ -18903,12 +18903,12 @@ impl super::TrapDispatcher {
     }
 
     fn save_current_port_draw_state(&mut self) {
-        if self.current_port == 0 {
+        if *self.current_port == 0 {
             return;
         }
 
         self.port_draw_states
-            .insert(self.current_port, self.current_draw_state());
+            .insert(*self.current_port, self.current_draw_state());
     }
 
     fn current_draw_state(&self) -> PortDrawState {
@@ -18988,7 +18988,7 @@ impl super::TrapDispatcher {
         &self,
         bus: &MacMemoryBus,
     ) -> super::dispatch::PortStateSnapshot {
-        let port = self.current_port;
+        let port = *self.current_port;
         let mut port_state_bytes = [0; 56];
         if Self::guest_range_in_ram(bus, port.wrapping_add(32), port_state_bytes.len() as u32) {
             for (i, byte) in port_state_bytes.iter_mut().enumerate() {
@@ -18997,7 +18997,7 @@ impl super::TrapDispatcher {
         }
         super::dispatch::PortStateSnapshot {
             port,
-            gdevice: self.current_gdevice,
+            gdevice: *self.current_gdevice,
             draw_state: self.current_draw_state(),
             port_state_bytes,
             vis_region: Self::capture_port_region(bus, port, 24),
@@ -19418,7 +19418,7 @@ impl super::TrapDispatcher {
         };
         let mut ports = self.cport_ports.iter().copied().collect::<Vec<_>>();
         ports.extend(self.window_list.iter().copied());
-        ports.extend([self.current_port, self.front_window]);
+        ports.extend([*self.current_port, self.front_window]);
         ports.sort_unstable();
         ports.dedup();
 
@@ -19469,7 +19469,7 @@ impl super::TrapDispatcher {
         let mut ctab_handles = vec![main_ctab_handle];
         let mut ports = self.cport_ports.iter().copied().collect::<Vec<_>>();
         ports.extend(self.window_list.iter().copied());
-        ports.extend([self.current_port, self.front_window]);
+        ports.extend([*self.current_port, self.front_window]);
         ports.sort_unstable();
         ports.dedup();
 
@@ -19498,15 +19498,15 @@ impl super::TrapDispatcher {
     }
 
     pub(super) fn sync_current_port_draw_state(&mut self, bus: &mut MacMemoryBus) {
-        if self.current_port == 0 {
+        if *self.current_port == 0 {
             return;
         }
-        if !self.port_allows_draw_state_memory_sync(bus, self.current_port) {
+        if !self.port_allows_draw_state_memory_sync(bus, *self.current_port) {
             return;
         }
         let state = self.current_draw_state();
-        self.port_draw_states.insert(self.current_port, state);
-        self.sync_port_draw_state(bus, self.current_port);
+        self.port_draw_states.insert(*self.current_port, state);
+        self.sync_port_draw_state(bus, *self.current_port);
     }
 
     pub(super) fn resolve_current_port_color_pixels(
@@ -19516,7 +19516,7 @@ impl super::TrapDispatcher {
         background: bool,
         use_screen_itable: bool,
     ) {
-        let port = self.current_port;
+        let port = *self.current_port;
         if port == 0
             || !self.port_allows_draw_state_memory_sync(bus, port)
             || (bus.read_word(port + 6) & 0xC000) != 0xC000
@@ -20107,7 +20107,7 @@ impl super::TrapDispatcher {
         if trace_dialog_draw_enabled() && self.dialog_tracking.is_some() {
             eprintln!(
                 "[DIALOG-DRAW] CopyBits current_port=${:08X} srcBase=${:08X} dstBase=${:08X} mode={} src=({},{}..{},{} ) dst=({},{}..{},{} ) mask=${:08X}",
-                self.current_port,
+                *self.current_port,
                 src_info.base,
                 dst_info.base,
                 mode_base,
@@ -20123,10 +20123,10 @@ impl super::TrapDispatcher {
             );
         }
         if trace_dialog_port_dump_enabled() && self.dialog_tracking.is_some() {
-            Self::trace_port_snapshot(bus, "CopyBits-current", self.current_port);
+            Self::trace_port_snapshot(bus, "CopyBits-current", *self.current_port);
         }
         if trace_dialog_port_dump_enabled() && self.dialog_tracking.is_some() {
-            Self::trace_port_snapshot(bus, "CopyBits-current", self.current_port);
+            Self::trace_port_snapshot(bus, "CopyBits-current", *self.current_port);
         }
 
         if src_bottom <= src_top
@@ -20816,7 +20816,7 @@ impl super::TrapDispatcher {
         if dst_info.base == self.screen_mode.0 {
             self.refresh_dialog_saved_pixels_after_screen_draw(
                 bus,
-                self.current_port,
+                *self.current_port,
                 (
                     clip_t.saturating_sub(dst_info.bounds_top),
                     clip_l.saturating_sub(dst_info.bounds_left),
@@ -20826,7 +20826,7 @@ impl super::TrapDispatcher {
             );
             self.refresh_visible_dialog_snapshot_after_bulk_port_draw(
                 bus,
-                self.current_port,
+                *self.current_port,
                 (
                     clip_t.saturating_sub(dst_info.bounds_top),
                     clip_l.saturating_sub(dst_info.bounds_left),
@@ -20942,7 +20942,7 @@ impl super::TrapDispatcher {
     /// custom proc that completes its work by calling CopyBits again gets the
     /// real blit instead of being handed back to itself.
     fn custom_bits_proc<C: CpuOps>(&self, bus: &MacMemoryBus, cpu: &C) -> Option<u32> {
-        let port = self.current_port;
+        let port = *self.current_port;
         if port == 0 || !Self::guest_range_in_ram(bus, port, 108) {
             return None;
         }
@@ -20969,7 +20969,7 @@ impl super::TrapDispatcher {
         dst_rect_ptr: u32,
         mask_rgn: u32,
     ) -> bool {
-        let port = self.current_port;
+        let port = *self.current_port;
         if port == 0 || !Self::guest_range_in_ram(bus, port, 32) {
             return false;
         }
@@ -23403,8 +23403,8 @@ impl super::TrapDispatcher {
     }
 
     fn palette_target_gdevice_handle(&self, bus: &MacMemoryBus) -> u32 {
-        if self.current_gdevice != 0 {
-            self.current_gdevice
+        if *self.current_gdevice != 0 {
+            *self.current_gdevice
         } else if self.main_gdevice_handle != 0 {
             self.main_gdevice_handle
         } else {
@@ -24166,7 +24166,7 @@ impl super::TrapDispatcher {
             reject!("invalid color table at offset ${:08X}", table_offset);
         };
 
-        let port = self.current_port;
+        let port = *self.current_port;
         if port == 0 {
             reject!("no current port");
         }
@@ -24545,8 +24545,8 @@ impl super::TrapDispatcher {
                 }
             }
         }
-        if self.current_port != 0 {
-            self.current_port
+        if *self.current_port != 0 {
+            *self.current_port
         } else {
             bus.read_long(crate::memory::globals::addr::THE_PORT)
         }
@@ -25022,7 +25022,7 @@ mod tests {
         let (mut d, mut cpu, mut bus) = setup_with_port();
         let (screen_base, screen_row_bytes, screen_width, screen_height, _) = d.screen_mode;
         let port = 0x181000;
-        d.current_port = port;
+        *d.current_port = port;
         let src_pixmap = bus.alloc(50);
         let src_base = bus.alloc(512 * 342);
         let dst_pixmap = bus.alloc(50);
@@ -25230,7 +25230,7 @@ mod tests {
         // equivalent to CopyRgn + InsetRgn + DiffRgn.  A complex region's
         // interior must therefore remain untouched.
         let (mut d, mut cpu, mut bus) = setup_with_port();
-        d.current_port = 0x181000;
+        *d.current_port = 0x181000;
         d.pn_size = (1, 1);
         d.pn_pat = [0xFF; 8];
         d.pn_mode = 8; // patCopy
@@ -25352,7 +25352,7 @@ mod tests {
         bus.write_long(port + 2, pixmap_handle);
         bus.write_word(port + 6, 0xC000);
         d.init_cgraf_port_defaults(port, bus);
-        d.current_port = port;
+        *d.current_port = port;
         (screen_base, row_bytes)
     }
 
@@ -26249,8 +26249,8 @@ mod tests {
             bus.read_long(crate::memory::globals::addr::THE_PORT),
             port_ptr
         );
-        assert_eq!(d.current_port, port_ptr);
-        assert_ne!(d.current_gdevice, 0);
+        assert_eq!(*d.current_port, port_ptr);
+        assert_ne!(*d.current_gdevice, 0);
     }
 
     #[test]
@@ -26303,8 +26303,8 @@ mod tests {
             bus.read_long(crate::memory::globals::addr::THE_PORT),
             port_ptr
         );
-        assert_eq!(d.current_port, port_ptr);
-        assert_ne!(d.current_gdevice, 0);
+        assert_eq!(*d.current_port, port_ptr);
+        assert_ne!(*d.current_gdevice, 0);
     }
 
     #[test]
@@ -26313,7 +26313,7 @@ mod tests {
         // GrafDevice writes the device field of the current grafPort.
         let (mut d, mut cpu, mut bus) = setup_with_port();
         let port_ptr = 0x181000u32;
-        d.current_port = port_ptr;
+        *d.current_port = port_ptr;
         bus.write_word(port_ptr, 0x0000);
         bus.write_word(TEST_SP, 0x1234);
 
@@ -26327,7 +26327,7 @@ mod tests {
         // Inside Macintosh Volume I (1985), p. I-165:
         // GrafDevice(device: INTEGER) consumes one INTEGER argument.
         let (mut d, mut cpu, mut bus) = setup_with_port();
-        d.current_port = 0x181000;
+        *d.current_port = 0x181000;
         bus.write_word(TEST_SP, 0xABCD);
 
         let result = d.dispatch_quickdraw(true, 0x072, &mut cpu, &mut bus);
@@ -26397,7 +26397,7 @@ mod tests {
     #[test]
     fn setport_ignores_invalid_proc_pointer_without_syncing_draw_state() {
         let (mut d, mut cpu, mut bus) = setup_with_port();
-        let original_port = d.current_port;
+        let original_port = *d.current_port;
         let invalid_port = 0x0001_6178u32;
         let watched = invalid_port + 56;
 
@@ -26411,7 +26411,7 @@ mod tests {
 
         assert!(result.unwrap().is_ok());
         assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 4);
-        assert_eq!(d.current_port, original_port);
+        assert_eq!(*d.current_port, original_port);
         assert_eq!(
             bus.read_long(crate::memory::globals::addr::THE_PORT),
             original_port
@@ -26435,7 +26435,7 @@ mod tests {
         let set_device = d.dispatch_quickdraw(true, 0x231, &mut cpu, &mut bus);
         assert!(set_device.unwrap().is_ok());
         assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 4);
-        assert_eq!(d.current_gdevice, custom_gdh);
+        assert_eq!(*d.current_gdevice, custom_gdh);
         assert_eq!(bus.read_long(0x0CC8), custom_gdh);
 
         cpu.write_reg(Register::A7, TEST_SP);
@@ -26444,8 +26444,8 @@ mod tests {
         assert!(set_port.unwrap().is_ok());
 
         assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 4);
-        assert_eq!(d.current_port, port_ptr);
-        assert_eq!(d.current_gdevice, custom_gdh);
+        assert_eq!(*d.current_port, port_ptr);
+        assert_eq!(*d.current_gdevice, custom_gdh);
         assert_eq!(
             bus.read_long(crate::memory::globals::addr::THE_PORT),
             port_ptr
@@ -27524,8 +27524,8 @@ mod tests {
             bus.read_long(crate::memory::globals::addr::THE_PORT),
             new_port
         );
-        assert_eq!(d.current_port, new_port);
-        assert_ne!(d.current_gdevice, 0);
+        assert_eq!(*d.current_port, new_port);
+        assert_ne!(*d.current_gdevice, 0);
     }
 
     #[test]
@@ -28579,7 +28579,7 @@ mod tests {
         let pattern = [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88];
         let port = bus.alloc(108);
         bus.write_word(port + 6, 0); // classic GrafPort rowBytes/version word
-        d.current_port = port;
+        *d.current_port = port;
         bus.write_bytes(pat_ptr, &pattern);
         bus.write_long(TEST_SP, pat_ptr);
         let result = d.dispatch_quickdraw(true, 0x07C, &mut cpu, &mut bus);
@@ -31124,7 +31124,7 @@ mod tests {
         // Inside Macintosh Volume I (1985), p. I-199:
         // StdBits consumes maskRgn/mode/dstRect/srcRect/srcBits stack frame.
         let (mut d, mut cpu, mut bus) = setup_with_port();
-        d.current_port = 0x181000;
+        *d.current_port = 0x181000;
         let src_base = 0x300300u32;
         bus.write_byte(src_base, 0x80);
         let src_bits_ptr = 0x300320u32;
@@ -31150,7 +31150,7 @@ mod tests {
         // Inside Macintosh Volume I (1985), pp. I-176 and I-199:
         // StdBits transfers bits as CopyBits to the current port bitmap.
         let (mut d, mut cpu, mut bus) = setup_with_port();
-        d.current_port = 0x181000;
+        *d.current_port = 0x181000;
         const PORT_PTR: u32 = 0x181000;
 
         let dst_base = 0x300380u32;
@@ -31246,7 +31246,7 @@ mod tests {
         bus.write_long(port + 28, clip_rgn_handle);
         let global_ptr = bus.read_long(cpu.read_reg(Register::A5));
         bus.write_long(global_ptr, port);
-        d.current_port = port;
+        *d.current_port = port;
         dst_pixmap
     }
 
@@ -31565,7 +31565,7 @@ mod tests {
 
         let global_ptr = bus.read_long(cpu.read_reg(Register::A5));
         bus.write_long(global_ptr, dialog_ptr);
-        d.current_port = dialog_ptr;
+        *d.current_port = dialog_ptr;
         d.front_window = dialog_ptr;
         d.dialog_items.insert(
             dialog_ptr,
@@ -31658,7 +31658,7 @@ mod tests {
         // HyperTint XCMD colourises HyperCard's black-and-white card blit this
         // way.
         let (mut d, mut cpu, mut bus) = setup_with_port();
-        d.current_port = 0x181000;
+        *d.current_port = 0x181000;
         const BITS_PROC: u32 = 0x0006_F123;
         const RETURN_PC: u32 = 0x0004_5678;
         let (src_bits_ptr, src_rect_ptr, dst_rect_ptr) =
@@ -31693,7 +31693,7 @@ mod tests {
         const PORT_PTR: u32 = 0x181000;
         const BITS_PROC: u32 = 0x0006_F123;
         const RETURN_PC: u32 = 0x0004_5678;
-        d.current_port = PORT_PTR;
+        *d.current_port = PORT_PTR;
         let _ = setup_copybits_through_port_bottleneck(&mut bus, BITS_PROC);
 
         let vis_rgn_ptr = bus.alloc(10);
@@ -31716,7 +31716,7 @@ mod tests {
         // (IM:I I-197). CopyBits is already executing that standard operation,
         // so it must draw directly rather than recursively tail-call itself.
         let (mut d, mut cpu, mut bus) = setup_with_port();
-        d.current_port = 0x181000;
+        *d.current_port = 0x181000;
         let std_bits = d.get_or_create_tool_trap_trampoline(&mut bus, 0xA8EB);
         let _ = setup_copybits_through_port_bottleneck(&mut bus, std_bits);
         cpu.write_reg(Register::PC, 0x0004_5678);
@@ -31734,7 +31734,7 @@ mod tests {
         // Handing that nested call back to the same proc would never terminate,
         // so while the stack is still inside the tail call CopyBits blits.
         let (mut d, mut cpu, mut bus) = setup_with_port();
-        d.current_port = 0x181000;
+        *d.current_port = 0x181000;
         const BITS_PROC: u32 = 0x0006_F123;
         let _ = setup_copybits_through_port_bottleneck(&mut bus, BITS_PROC);
         cpu.write_reg(Register::PC, 0x0004_5678);
@@ -33464,7 +33464,7 @@ mod tests {
         bus.write_long(clip_handle, clip);
         bus.write_long(port + 28, clip_handle);
 
-        d.current_port = port;
+        *d.current_port = port;
         let globals_ptr = bus.read_long(cpu.read_reg(Register::A5));
         bus.write_long(globals_ptr, port);
 
@@ -33596,7 +33596,7 @@ mod tests {
         bus.write_long(clip_handle, clip);
         bus.write_long(port + 28, clip_handle);
 
-        d.current_port = port;
+        *d.current_port = port;
         let globals_ptr = bus.read_long(cpu.read_reg(Register::A5));
         bus.write_long(globals_ptr, port);
 
@@ -33672,7 +33672,7 @@ mod tests {
         bus.write_long(clip_handle, clip);
         bus.write_long(port + 28, clip_handle);
 
-        d.current_port = port;
+        *d.current_port = port;
         d.front_window = port;
         d.menu_bar_hidden = true;
         let globals_ptr = bus.read_long(cpu.read_reg(Register::A5));
@@ -34711,7 +34711,7 @@ mod tests {
 
         let global_ptr = bus.read_long(cpu.read_reg(Register::A5));
         bus.write_long(global_ptr, dialog_ptr);
-        d.current_port = dialog_ptr;
+        *d.current_port = dialog_ptr;
         d.front_window = dialog_ptr;
         d.dialog_items.insert(
             dialog_ptr,
@@ -36654,7 +36654,7 @@ mod tests {
         bus.write_long(current_pm_handle, current_pixmap);
         bus.write_long(current_gd + 22, current_pm_handle);
         bus.write_long(current_gdh, current_gd);
-        d.current_gdevice = current_gdh;
+        *d.current_gdevice = current_gdh;
 
         bus.write_byte(src_base, 1);
         bus.write_byte(dst_base, 0);
@@ -37881,7 +37881,7 @@ mod tests {
         bus.write_word(offscreen_gd + 38, 47);
         bus.write_word(offscreen_gd + 40, 73);
 
-        d.current_gdevice = offscreen_gdh;
+        *d.current_gdevice = offscreen_gdh;
         bus.write_long(0x0CC8, offscreen_gdh);
 
         let port_ptr = 0x300000u32;
@@ -37889,7 +37889,7 @@ mod tests {
         let result = d.dispatch_quickdraw(true, 0x200, &mut cpu, &mut bus);
         assert!(result.unwrap().is_ok());
         assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 4);
-        assert_eq!(d.current_gdevice, offscreen_gdh);
+        assert_eq!(*d.current_gdevice, offscreen_gdh);
 
         let port_pm_handle = bus.read_long(port_ptr + 2);
         let port_pm = bus.read_long(port_pm_handle);
@@ -38787,7 +38787,7 @@ mod tests {
         bus.write_word(palette_ptr + 4, 0x9ABC);
         d.window_palettes.insert(u32::MAX, (palette_handle, 0));
         d.front_window = window;
-        d.current_port = window;
+        *d.current_port = window;
 
         let before = *d.device_clut;
         bus.write_long(TEST_SP, window);
@@ -38824,7 +38824,7 @@ mod tests {
 
         d.set_window_palette_association(window, palette_handle, 0);
         d.front_window = window;
-        d.current_port = window;
+        *d.current_port = window;
 
         let before = *d.device_clut;
         bus.write_long(TEST_SP, window);
@@ -38853,7 +38853,7 @@ mod tests {
         );
         d.set_window_palette_association(window, palette, 0);
         d.front_window = window;
-        d.current_port = window;
+        *d.current_port = window;
         let before = *d.device_clut;
         bus.write_long(TEST_SP, window);
 
@@ -38889,7 +38889,7 @@ mod tests {
         );
         d.set_window_palette_association(window, palette, super::PM_ALL_UPDATES);
         d.front_window = window;
-        d.current_port = window;
+        *d.current_port = window;
         let background_color = [0x0BAD, 0xC0DE, 0xCAFE];
         d.device_clut[200] = background_color;
         d.color_manager_clut[200] = background_color;
@@ -38955,7 +38955,7 @@ mod tests {
         d.set_window_palette_association(always, always_palette, super::PM_ALL_UPDATES);
         d.set_window_palette_association(quiet, quiet_palette, super::PM_NO_UPDATES);
         d.front_window = front;
-        d.current_port = front;
+        *d.current_port = front;
         bus.write_long(TEST_SP, front);
 
         let result = d.dispatch_quickdraw(true, 0x294, &mut cpu, &mut bus);
@@ -38983,7 +38983,7 @@ mod tests {
         );
         d.set_window_palette_association(window, palette, 0);
         d.front_window = window;
-        d.current_port = window;
+        *d.current_port = window;
         let before = *d.device_clut;
         bus.write_long(TEST_SP, window);
 
@@ -39019,7 +39019,7 @@ mod tests {
         );
         d.set_window_palette_association(window, palette, 0);
         d.front_window = window;
-        d.current_port = window;
+        *d.current_port = window;
         let before = *d.device_clut;
         bus.write_long(TEST_SP, window);
 
@@ -39067,7 +39067,7 @@ mod tests {
         bus.write_word(src_rgb + 4, 0x9999);
         d.window_palettes.insert(u32::MAX, (palette_handle, 0));
         d.front_window = window;
-        d.current_port = window;
+        *d.current_port = window;
 
         let before = *d.device_clut;
         bus.write_long(TEST_SP, src_rgb);
@@ -39093,7 +39093,7 @@ mod tests {
         bus.write_word(src_rgb + 4, animated_rgb[2]);
         d.set_window_palette_association(window, palette, 0);
         d.front_window = window;
-        d.current_port = window;
+        *d.current_port = window;
 
         let before = *d.device_clut;
         bus.write_long(TEST_SP, src_rgb);
@@ -39324,7 +39324,7 @@ mod tests {
         assert_eq!(bus.read_word(TEST_SP + 8), 0);
         assert_eq!(cpu.read_reg(Register::D0), 0);
         assert_eq!(d.main_gdevice_handle, new_main);
-        assert_eq!(d.current_gdevice, new_main);
+        assert_eq!(*d.current_gdevice, new_main);
         assert_eq!(bus.read_long(0x08A4), new_main);
         assert_eq!(bus.read_long(0x0CC8), new_main);
 
@@ -39661,7 +39661,7 @@ mod tests {
         let result = d.dispatch_quickdraw(true, 0x231, &mut cpu, &mut bus);
         assert!(result.unwrap().is_ok());
         assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 4);
-        assert_eq!(d.current_gdevice, gdh);
+        assert_eq!(*d.current_gdevice, gdh);
         assert_eq!(bus.read_long(0x0CC8), gdh);
     }
 
@@ -40609,12 +40609,12 @@ mod tests {
     #[test]
     fn test_palette_dispatch_init_preserves_current_port() {
         let (mut d, mut cpu, mut bus) = setup_with_port();
-        let saved_port = d.current_port;
+        let saved_port = *d.current_port;
         bus.write_word(TEST_SP, 0x0000u16); // selector: InitPalettes
         let result = d.dispatch_quickdraw(true, 0x2A2, &mut cpu, &mut bus);
         assert!(result.unwrap().is_ok());
         assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 2);
-        assert_eq!(d.current_port, saved_port);
+        assert_eq!(*d.current_port, saved_port);
     }
 
     #[test]
@@ -40642,7 +40642,7 @@ mod tests {
         let window = 0x181000u32;
         let target_rgb = [0x1111, 0x2222, 0x3333];
 
-        d.current_port = window;
+        *d.current_port = window;
         d.front_window = window;
         *d.device_clut = [[0, 0, 0]; 256];
         d.device_clut[42] = target_rgb;
@@ -40929,7 +40929,7 @@ mod tests {
         let src_ctab = make_test_ctab_handle(bus, &[[0x7777, 0x1111, 0x4444]], 0x3333_4444, 0);
         d.set_window_palette_association(window, palette, 0);
         d.front_window = window;
-        d.current_port = window;
+        *d.current_port = window;
 
         let before = TrapDispatcher::read_palette_color_info(bus, palette, 0);
         (window, palette, src_ctab, before)
@@ -40945,7 +40945,7 @@ mod tests {
         let src_ctab = make_test_ctab_handle(&mut bus, &[animated_rgb], 0x3333_4444, 0);
         d.set_window_palette_association(window, palette, 0);
         d.front_window = window;
-        d.current_port = window;
+        *d.current_port = window;
 
         let before = *d.device_clut;
         bus.write_word(TEST_SP, 1);
@@ -42305,8 +42305,8 @@ mod tests {
             bus.read_word(gw_entry + 6),
         ];
 
-        d.current_port = gworld;
-        d.current_gdevice = d.gdevice_for_port(&mut bus, gworld);
+        *d.current_port = gworld;
+        *d.current_gdevice = d.gdevice_for_port(&mut bus, gworld);
 
         let table_ptr = bus.alloc(8);
         bus.write_word(table_ptr, 17);
@@ -42353,16 +42353,16 @@ mod tests {
         let gworld = bus.read_long(gworld_ptr_ptr);
         assert_eq!(d.gworld_devices.get(&gworld).copied(), Some(gdh));
 
-        let prior_port = d.current_port;
-        let prior_gdevice = d.current_gdevice;
+        let prior_port = *d.current_port;
+        let prior_gdevice = *d.current_gdevice;
         cpu.write_reg(Register::A7, TEST_SP);
         bus.write_long(TEST_SP, 0u32); // would-be gdevice=nil
         bus.write_long(TEST_SP + 4, gworld); // would-be port
         let result = d.dispatch_quickdraw(true, 0x31C, &mut cpu, &mut bus);
         assert!(result.unwrap().is_ok());
         assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 8);
-        assert_eq!(d.current_port, prior_port);
-        assert_eq!(d.current_gdevice, prior_gdevice);
+        assert_eq!(*d.current_port, prior_port);
+        assert_eq!(*d.current_gdevice, prior_gdevice);
     }
 
     #[test]
@@ -42765,16 +42765,16 @@ mod tests {
         bus.write_long(TEST_SP + 4, gworld);
         let set_current = d.dispatch_quickdraw(true, 0x31D, &mut cpu, &mut bus);
         assert!(set_current.unwrap().is_ok());
-        assert_eq!(d.current_port, gworld);
-        assert_eq!(d.current_gdevice, attached_gdevice);
+        assert_eq!(*d.current_port, gworld);
+        assert_eq!(*d.current_gdevice, attached_gdevice);
 
         cpu.write_reg(Register::A7, TEST_SP);
         cpu.write_reg(Register::D0, 0x0004_0004);
         bus.write_long(TEST_SP, gworld);
         let dispose = d.dispatch_quickdraw(true, 0x31D, &mut cpu, &mut bus);
         assert!(dispose.unwrap().is_ok());
-        assert_eq!(d.current_gdevice, main_gdevice);
-        assert_ne!(d.current_port, gworld);
+        assert_eq!(*d.current_gdevice, main_gdevice);
+        assert_ne!(*d.current_port, gworld);
     }
 
     #[test]
@@ -42807,23 +42807,23 @@ mod tests {
         bus.write_long(TEST_SP + 4, gworld);
         let set_current = d.dispatch_quickdraw(true, 0x31D, &mut cpu, &mut bus);
         assert!(set_current.unwrap().is_ok());
-        assert_eq!(d.current_port, gworld);
-        assert_eq!(d.current_gdevice, attached_gdevice);
+        assert_eq!(*d.current_port, gworld);
+        assert_eq!(*d.current_gdevice, attached_gdevice);
 
         cpu.write_reg(Register::A7, TEST_SP);
         bus.write_long(TEST_SP, gworld);
         let dispose = d.dispatch_quickdraw(true, 0x31F, &mut cpu, &mut bus);
         assert!(dispose.unwrap().is_ok());
         assert_eq!(cpu.read_reg(Register::A7), TEST_SP);
-        assert_eq!(d.current_port, gworld);
-        assert_eq!(d.current_gdevice, attached_gdevice);
+        assert_eq!(*d.current_port, gworld);
+        assert_eq!(*d.current_gdevice, attached_gdevice);
     }
 
     #[test]
     fn test_get_gworld() {
         let (mut d, mut cpu, mut bus) = setup();
-        d.current_port = 0x400000;
-        d.current_gdevice = 0x500000;
+        *d.current_port = 0x400000;
+        *d.current_gdevice = 0x500000;
         let gd_ptr = 0x300000u32;
         let port_ptr = 0x300100u32;
         bus.write_long(TEST_SP, gd_ptr);
@@ -42998,9 +42998,9 @@ mod tests {
         // If the argument points to a regular GrafPort/CGrafPort,
         // GetGWorldDevice returns the current device.
         let (mut d, mut cpu, mut bus) = setup_with_port();
-        let regular_port = d.current_port;
+        let regular_port = *d.current_port;
         let main_gdh = d.ensure_main_gdevice(&mut bus);
-        d.current_gdevice = main_gdh;
+        *d.current_gdevice = main_gdh;
 
         let bounds_ptr = 0x300000u32;
         let gworld_ptr_ptr = 0x300100u32;
@@ -43020,8 +43020,8 @@ mod tests {
         assert_ne!(offscreen_gdh, 0);
         assert_ne!(offscreen_gdh, main_gdh);
 
-        d.current_port = gworld;
-        d.current_gdevice = offscreen_gdh;
+        *d.current_port = gworld;
+        *d.current_gdevice = offscreen_gdh;
 
         cpu.write_reg(Register::A7, TEST_SP);
         cpu.write_reg(Register::D0, 0x0004_0012);
@@ -43052,7 +43052,7 @@ mod tests {
         bus.write_word(linked_gd_ptr + 20, 0x2468);
         write_rect(&mut bus, linked_gd_ptr + 34, 900, 20, 940, 52);
         bus.write_long(main_gd + 30, linked_gdh);
-        d.current_gdevice = main_gdh;
+        *d.current_gdevice = main_gdh;
 
         let rgn_addr = bus.alloc(10);
         let rgn_handle = bus.alloc(4);
@@ -43205,15 +43205,15 @@ mod tests {
     #[test]
     fn test_ab1c_is_noop() {
         let (mut d, mut cpu, mut bus) = setup();
-        let prior_port = d.current_port;
-        let prior_gdevice = d.current_gdevice;
+        let prior_port = *d.current_port;
+        let prior_gdevice = *d.current_gdevice;
         bus.write_long(TEST_SP, 0x600000); // would-be gdevice
         bus.write_long(TEST_SP + 4, 0x700000); // would-be port
         let result = d.dispatch_quickdraw(true, 0x31C, &mut cpu, &mut bus);
         assert!(result.unwrap().is_ok());
         assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 8);
-        assert_eq!(d.current_port, prior_port);
-        assert_eq!(d.current_gdevice, prior_gdevice);
+        assert_eq!(*d.current_port, prior_port);
+        assert_eq!(*d.current_gdevice, prior_gdevice);
     }
 
     #[test]
@@ -43276,14 +43276,14 @@ mod tests {
         // IM:VI 1991 p. 17-13 / IWQD 1994 p. 6-45:
         // calling UnlockPixels on purged pixels does no harm.
         let (mut d, mut cpu, mut bus) = setup();
-        let prior_port = d.current_port;
-        let prior_gdevice = d.current_gdevice;
+        let prior_port = *d.current_port;
+        let prior_gdevice = *d.current_gdevice;
         bus.write_long(TEST_SP, 0); // stand-in for purged/invalid handle path
         let result = d.dispatch_quickdraw(true, 0x305, &mut cpu, &mut bus);
         assert!(result.unwrap().is_ok());
         assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 4);
-        assert_eq!(d.current_port, prior_port);
-        assert_eq!(d.current_gdevice, prior_gdevice);
+        assert_eq!(*d.current_port, prior_port);
+        assert_eq!(*d.current_gdevice, prior_gdevice);
     }
 
     #[test]
@@ -43453,7 +43453,7 @@ mod tests {
         assert_ne!(copy_handle, 0);
         assert_eq!(flags & (1 << 16), 1 << 16);
         assert_eq!(stack_flags, flags);
-        assert_eq!(d.current_port, gworld);
+        assert_eq!(*d.current_port, gworld);
         assert!(stack_ok);
     }
 
@@ -44044,7 +44044,7 @@ mod tests {
         bus.write_long(TEST_SP + 4, gworld);
         let set_current = d.dispatch_quickdraw(true, 0x31D, &mut cpu, &mut bus);
         assert!(set_current.unwrap().is_ok());
-        assert_eq!(d.current_port, gworld);
+        assert_eq!(*d.current_port, gworld);
 
         let pm_handle = bus.read_long(gworld + 2);
         let pm_ptr = bus.read_long(pm_handle);
@@ -45171,7 +45171,7 @@ mod tests {
         bus.write_long(offscreen_pm_handle, offscreen_pixmap);
         bus.write_long(offscreen_gd + 22, offscreen_pm_handle);
         bus.write_long(offscreen_gdh, offscreen_gd);
-        d.current_gdevice = offscreen_gdh;
+        *d.current_gdevice = offscreen_gdh;
 
         let table_ptr = 0x339000u32;
         for index in 0..256u32 {
@@ -45223,7 +45223,7 @@ mod tests {
     fn test_recent_resource_ctable_fetch_consumed_for_immediate_screen_drawpicture() {
         let (mut d, _cpu, mut bus) = setup();
         d.screen_mode = (0x00ABC000, 800, 800, 600, 8);
-        d.current_port = 0x00284CFC;
+        *d.current_port = 0x00284CFC;
         d.tick_count = 33;
         d.trap_count = 400;
 
@@ -45243,7 +45243,7 @@ mod tests {
 
         let fetch = d
             .take_recent_drawpicture_resource_ctable_fetch(
-                d.current_port,
+                *d.current_port,
                 d.screen_mode.0,
                 d.screen_mode.1,
                 8,
@@ -45259,7 +45259,7 @@ mod tests {
     fn test_recent_resource_ctable_fetch_consumed_for_immediate_offscreen_drawpicture() {
         let (mut d, _cpu, mut bus) = setup();
         d.screen_mode = (0x00ABC000, 800, 800, 600, 8);
-        d.current_port = 0x00284CFC;
+        *d.current_port = 0x00284CFC;
         d.tick_count = 33;
         d.trap_count = 400;
 
@@ -45273,7 +45273,7 @@ mod tests {
         d.remember_recent_resource_ctable_fetch(1001, ctab_handle);
 
         let fetch =
-            d.take_recent_drawpicture_resource_ctable_fetch(d.current_port, 0x00ABD000, 512, 8);
+            d.take_recent_drawpicture_resource_ctable_fetch(*d.current_port, 0x00ABD000, 512, 8);
 
         assert_eq!(
             fetch
@@ -45288,7 +45288,7 @@ mod tests {
     fn test_recent_resource_ctable_fetch_ignored_for_different_drawpicture_port() {
         let (mut d, _cpu, mut bus) = setup();
         d.screen_mode = (0x00ABC000, 800, 800, 600, 8);
-        d.current_port = 0x00284CFC;
+        *d.current_port = 0x00284CFC;
         d.tick_count = 33;
         d.trap_count = 400;
 
@@ -45337,8 +45337,8 @@ mod tests {
         bus.write_long(port + 2, pixmap_handle);
         let gdh = d.create_offscreen_gdevice(&mut bus, pixmap_handle, 0, 0, 64, 64);
         d.gworld_devices.insert(port, gdh);
-        d.current_port = port;
-        d.current_gdevice = gdh;
+        *d.current_port = port;
+        *d.current_gdevice = gdh;
 
         let fetch = RecentColorTableFetch {
             ct_id: 131,
@@ -45375,7 +45375,7 @@ mod tests {
     fn test_recent_resource_ctable_fetch_survives_intervening_traps_in_same_tick() {
         let (mut d, _cpu, mut bus) = setup();
         d.screen_mode = (0x00ABC000, 800, 800, 600, 8);
-        d.current_port = 0x00284CFC;
+        *d.current_port = 0x00284CFC;
         d.tick_count = 33;
         d.trap_count = 400;
 
@@ -45390,7 +45390,7 @@ mod tests {
         d.trap_count = 404;
 
         let fetch = d.take_recent_drawpicture_resource_ctable_fetch(
-            d.current_port,
+            *d.current_port,
             d.screen_mode.0,
             d.screen_mode.1,
             8,
@@ -45409,7 +45409,7 @@ mod tests {
     fn test_recent_resource_ctable_fetch_expires_after_tick_advances() {
         let (mut d, _cpu, mut bus) = setup();
         d.screen_mode = (0x00ABC000, 800, 800, 600, 8);
-        d.current_port = 0x00284CFC;
+        *d.current_port = 0x00284CFC;
         d.tick_count = 33;
         d.trap_count = 400;
 
@@ -45424,7 +45424,7 @@ mod tests {
         d.tick_count = 35;
 
         let fetch = d.take_recent_drawpicture_resource_ctable_fetch(
-            d.current_port,
+            *d.current_port,
             d.screen_mode.0,
             d.screen_mode.1,
             8,
@@ -45709,7 +45709,7 @@ mod tests {
         bus.write_long(port + 2, pixmap_handle);
         bus.write_word(port + 6, 0xC000);
         write_rect(&mut bus, port + 16, 0, 0, 2, 8);
-        d.current_port = port;
+        *d.current_port = port;
 
         let pic_frame = 0x3002C0u32;
         write_rect(&mut bus, pic_frame, 0, 0, 2, 8);
@@ -46921,7 +46921,7 @@ mod tests {
         let main_ctab = TrapDispatcher::gdevice_ctab_handle(&bus, main_gdh);
         let stale_gdh = bus.alloc(4);
         bus.write_long(stale_gdh, 0xFFFF_FFF0);
-        d.current_gdevice = stale_gdh;
+        *d.current_gdevice = stale_gdh;
 
         assert_eq!(d.current_gdevice_ctab_handle(&bus), main_ctab);
     }

--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -16241,7 +16241,9 @@ impl super::TrapDispatcher {
         bus.write_long(gd_handle, gd);
 
         self.main_gdevice_handle = gd_handle;
-        *self.current_gdevice = gd_handle;
+        if *self.current_gdevice == 0 {
+            *self.current_gdevice = gd_handle;
+        }
 
         gd_handle
     }

--- a/src/trap/shapes.rs
+++ b/src/trap/shapes.rs
@@ -431,7 +431,7 @@ impl super::TrapDispatcher {
                     r.bottom,
                     r.right,
                     area,
-                    self.current_port,
+                    *self.current_port,
                     self.tick_count,
                 );
             }
@@ -1169,12 +1169,12 @@ impl super::TrapDispatcher {
 
         if trace_dialog_text_enabled()
             && matches!(op, ShapeOp::Glyph(_))
-            && port != self.current_port
+            && port != *self.current_port
         {
             eprintln!(
                 "[DIALOG-TEXT] Glyph port mismatch a5_port=${:08X} current_port=${:08X} rect=({},{}..{},{} )",
                 port,
-                self.current_port,
+                *self.current_port,
                 r.top,
                 r.left,
                 r.bottom,
@@ -1433,7 +1433,7 @@ impl super::TrapDispatcher {
             let is_screen_port = pix_base == self.screen_mode.0
                 && pix_row_bytes == self.screen_mode.1
                 && pixel_size == self.screen_mode.4;
-            let current_ctab_handle = if port == self.current_port {
+            let current_ctab_handle = if port == *self.current_port {
                 self.current_gdevice_ctab_handle(bus)
             } else {
                 0
@@ -1636,7 +1636,7 @@ impl super::TrapDispatcher {
                 let is_screen_port = pix_base == self.screen_mode.0
                     && pix_row_bytes == self.screen_mode.1
                     && pixel_size == self.screen_mode.4;
-                let current_ctab_handle = if port == self.current_port {
+                let current_ctab_handle = if port == *self.current_port {
                     self.current_gdevice_ctab_handle(bus)
                 } else {
                     0

--- a/src/trap/text_render.rs
+++ b/src/trap/text_render.rs
@@ -803,13 +803,13 @@ impl super::TrapDispatcher {
             };
 
             if trace_dialog_text_enabled()
-                && self.current_port == 0x00B16310
+                && *self.current_port == 0x00B16310
                 && (353..603).contains(&h)
                 && (8..148).contains(&v)
             {
                 eprintln!(
                     "[DIALOG-TEXT] draw_char port=${:08X} ch={:?} pnLoc=({}, {}) glyphRect=({},{}..{},{} ) glyphOrigin=({}, {}) glyphSize=({}, {}) txFont={} txSize={}",
-                    self.current_port,
+                    *self.current_port,
                     ch,
                     v,
                     h,
@@ -1145,11 +1145,11 @@ impl super::TrapDispatcher {
     /// integer-pixel portion to add to a space character's advance.
     /// Per IM:I I-171, SpaceExtra adds this value to every space drawn.
     pub(super) fn space_extra_pixels(&self, bus: &MacMemoryBus) -> i16 {
-        if self.current_port == 0 {
+        if *self.current_port == 0 {
             return 0;
         }
         // Fixed = 16.16. >> 16 keeps the integer part with sign.
-        ((bus.read_long(self.current_port + 76) as i32) >> 16) as i16
+        ((bus.read_long(*self.current_port + 76) as i32) >> 16) as i16
     }
 
     pub(super) fn glyph_advance(&self, glyph: &Glyph) -> i16 {

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -4465,8 +4465,8 @@ impl super::TrapDispatcher {
             return;
         }
 
-        let previous_port = self.current_port;
-        let previous_gdevice = self.current_gdevice;
+        let previous_port = *self.current_port;
+        let previous_gdevice = *self.current_gdevice;
         let previous_state = self.qd_state_snapshot();
 
         self.set_current_port_state(bus, cpu, state.port, None);
@@ -10750,8 +10750,8 @@ impl super::TrapDispatcher {
                 let extra = bus.read_long(sp);
                 cpu.write_reg(Register::A7, sp + 4);
                 // Store spExtra at port offset +76 (Fixed)
-                if self.current_port != 0 {
-                    bus.write_long(self.current_port + 76, extra);
+                if *self.current_port != 0 {
+                    bus.write_long(*self.current_port + 76, extra);
                 }
                 Ok(())
             }
@@ -13982,12 +13982,12 @@ impl super::TrapDispatcher {
                         let movie = bus.alloc(16);
                         bus.write_long(movie, u32::from_be_bytes(*b"MooV"));
                         bus.write_long(movie + 4, flags);
-                        bus.write_long(movie + 8, self.current_port);
-                        bus.write_long(movie + 12, self.current_gdevice);
+                        bus.write_long(movie + 8, *self.current_port);
+                        bus.write_long(movie + 12, *self.current_gdevice);
                         let mut state =
                             MovieState::new(0, -1, flags as u16, (0, 0, 120, 160), 1, 600);
-                        state.gworld_port = self.current_port;
-                        state.gworld_gdh = self.current_gdevice;
+                        state.gworld_port = *self.current_port;
+                        state.gworld_gdh = *self.current_gdevice;
                         state.active = false;
                         self.movie_states.insert(movie, state);
                         bus.write_long(sp + 4, movie);
@@ -17019,7 +17019,7 @@ mod tests {
         // SpaceExtra sets the current GrafPort's spExtra field.
         let (mut disp, mut cpu, mut bus) = setup();
         let port = bus.alloc(128);
-        disp.current_port = port;
+        *disp.current_port = port;
         let extra = 0x0001_8000u32; // 1.5 Fixed
         bus.write_long(port + 76, 0xDEAD_BEEF);
         bus.write_long(TEST_SP, extra);
@@ -17036,7 +17036,7 @@ mod tests {
         // SpaceExtra(extra: Fixed) consumes one 4-byte Fixed argument.
         let (mut disp, mut cpu, mut bus) = setup();
         let port = bus.alloc(128);
-        disp.current_port = port;
+        *disp.current_port = port;
         let sp_before = cpu.read_reg(Register::A7);
         bus.write_long(sp_before, 0xFFFF_8000); // -0.5 Fixed
 
@@ -24968,7 +24968,7 @@ mod tests {
             white_pixels > 0,
             "LUpdate should render opposite-colored text pixels into a dark visible cell"
         );
-        assert_eq!(disp.current_port, window_ptr);
+        assert_eq!(*disp.current_port, window_ptr);
         assert_eq!(disp.fg_color, (0x1111, 0x2222, 0x3333));
         assert_eq!(disp.bg_color, (0xAAAA, 0xBBBB, 0xCCCC));
         assert_eq!(disp.pn_loc, (7, 8));
@@ -25131,7 +25131,7 @@ mod tests {
                 assert!(witness_pixels > 0, "trap ${trap:03X} lost row at y={top}");
             }
             assert_eq!(bus.read_byte(screen_base + 31 * row_bytes + 125), 42);
-            assert_eq!(disp.current_port, caller_port);
+            assert_eq!(*disp.current_port, caller_port);
             assert_eq!(disp.fg_color, (0x1111, 0x2222, 0x3333));
             assert_eq!(disp.bg_color, (0xAAAA, 0xBBBB, 0xCCCC));
             assert_eq!(disp.pn_loc, (7, 8));
@@ -33154,8 +33154,8 @@ mod tests {
     fn movietoolboxdispatch_new_movie_returns_empty_movie_with_current_gworld() {
         let (mut disp, mut cpu, mut bus) = setup();
         let sp = TEST_SP;
-        disp.current_port = 0x0033_0000;
-        disp.current_gdevice = 0x0044_0000;
+        *disp.current_port = 0x0033_0000;
+        *disp.current_gdevice = 0x0044_0000;
 
         cpu.write_reg(Register::A7, sp);
         cpu.write_reg(Register::D0, 0x0187); // NewMovie

--- a/src/trap/window.rs
+++ b/src/trap/window.rs
@@ -282,7 +282,7 @@ impl super::TrapDispatcher {
 
         let start_mouse = (bus.read_word(sp + 14) as i16, bus.read_word(sp + 16) as i16);
         let limit_rect_ptr = bus.read_long(sp + 10);
-        let port_bounds_origin = self.port_bounds_top_left(bus, self.current_port);
+        let port_bounds_origin = self.port_bounds_top_left(bus, *self.current_port);
         let outline_pattern = if use_drag_pattern {
             let mut pattern = [0u8; 8];
             for (offset, byte) in pattern.iter_mut().enumerate() {
@@ -337,10 +337,10 @@ impl super::TrapDispatcher {
 
     fn current_mouse_local_point(&self, bus: &MacMemoryBus) -> (i16, i16) {
         let (v, h) = self.input_state.mouse_pos;
-        if self.current_port == 0 {
+        if *self.current_port == 0 {
             return (v, h);
         }
-        let (bounds_top, bounds_left) = self.port_bounds_top_left(bus, self.current_port);
+        let (bounds_top, bounds_left) = self.port_bounds_top_left(bus, *self.current_port);
         (v.wrapping_add(bounds_top), h.wrapping_add(bounds_left))
     }
 
@@ -496,7 +496,7 @@ impl super::TrapDispatcher {
         state.bg_color = (r, g, b);
         self.port_draw_states.insert(window_ptr, state);
 
-        if self.current_port == window_ptr {
+        if *self.current_port == window_ptr {
             self.bg_color = (r, g, b);
             self.sync_current_port_draw_state(bus);
         }
@@ -2156,8 +2156,8 @@ impl super::TrapDispatcher {
                 return Some(window);
             }
 
-            let old_port = self.current_port;
-            let old_gdevice = self.current_gdevice;
+            let old_port = *self.current_port;
+            let old_gdevice = *self.current_gdevice;
             let old_sp = cpu.read_reg(Register::A7);
             self.set_current_port_state(bus, cpu, window, None);
             self.begin_update_window(bus, window);
@@ -2939,8 +2939,8 @@ impl super::TrapDispatcher {
                 .unwrap_or_else(|| self.window_list.first().copied().unwrap_or(0));
             self.sync_cached_front_window_render_state(bus);
         }
-        if self.current_port == window_ptr {
-            self.current_port = self.front_window;
+        if *self.current_port == window_ptr {
+            *self.current_port = self.front_window;
         }
         self.saved_draw_old_regions.remove(&window_ptr);
     }
@@ -3087,7 +3087,7 @@ impl super::TrapDispatcher {
     }
 
     fn current_window_port(&self) -> u32 {
-        self.current_port
+        *self.current_port
     }
 
     pub(super) fn invalidate_window_rect(
@@ -3555,8 +3555,8 @@ impl super::TrapDispatcher {
         }
 
         let (top, left, bottom, right) = self.window_port_rect(bus, window_ptr);
-        let old_port = self.current_port;
-        let old_gdevice = self.current_gdevice;
+        let old_port = *self.current_port;
+        let old_gdevice = *self.current_gdevice;
         self.set_current_port_state(bus, cpu, window_ptr, None);
         self.draw_rect(
             cpu,
@@ -3684,8 +3684,8 @@ impl super::TrapDispatcher {
                 );
 
                 let old_front = self.front_window;
-                let old_current_port = self.current_port;
-                let old_current_gdevice = self.current_gdevice;
+                let old_current_port = *self.current_port;
+                let old_current_gdevice = *self.current_gdevice;
                 self.init_graf_window(
                     bus,
                     cpu,
@@ -3880,8 +3880,8 @@ impl super::TrapDispatcher {
                 };
                 let screen_base: u32 = bus.read_long(0x0824);
                 let old_front = self.front_window;
-                let old_current_port = self.current_port;
-                let old_current_gdevice = self.current_gdevice;
+                let old_current_port = *self.current_port;
+                let old_current_gdevice = *self.current_gdevice;
                 self.init_cgraf_window(
                     bus,
                     cpu,
@@ -4242,8 +4242,8 @@ impl super::TrapDispatcher {
                         bus.write_byte(the_window + Self::WINDOW_VISIBLE_OFFSET, 0x00);
                         self.set_window_vis_from_content(bus, the_window, false);
                         self.clear_queued_update_events(the_window);
-                        if self.current_port == the_window {
-                            self.current_port = self.front_window;
+                        if *self.current_port == the_window {
+                            *self.current_port = self.front_window;
                         }
                         cpu.write_reg(Register::A7, sp + 4);
                         return Some(Ok(()));
@@ -4315,8 +4315,8 @@ impl super::TrapDispatcher {
                         } else {
                             self.front_window = 0;
                         }
-                        if self.current_port == the_window {
-                            self.current_port = new_front;
+                        if *self.current_port == the_window {
+                            *self.current_port = new_front;
                         }
                     }
                     self.invalidate_exposed_windows(bus, &windows_behind, exposed_rect);
@@ -5023,7 +5023,7 @@ impl super::TrapDispatcher {
                 if trace_inval_enabled() {
                     eprintln!(
                         "[INVAL] InvalRect tick={} port=${:08X} window=${:08X} front=${:08X}",
-                        self.tick_count, self.current_port, target_window, self.front_window
+                        self.tick_count, *self.current_port, target_window, self.front_window
                     );
                 }
                 if target_window != 0 && rect_ptr != 0 {
@@ -6085,7 +6085,7 @@ mod tests {
         let window_ptr = bus.read_long(cpu.read_reg(Register::A7));
         disp.window_list = vec![window_ptr];
         disp.front_window = window_ptr;
-        disp.current_port = window_ptr;
+        *disp.current_port = window_ptr;
         disp.validate_window_rect(&mut bus, window_ptr, (0, 0, 160, 260));
 
         (disp, cpu, bus, window_ptr)
@@ -6489,7 +6489,7 @@ mod tests {
         );
 
         disp.move_window_to_global(&mut bus, window_addr, 0, 0, false);
-        let current_gdevice = disp.current_gdevice;
+        let current_gdevice = *disp.current_gdevice;
         disp.set_current_port_state(&mut bus, &mut cpu, window_addr, Some(current_gdevice));
 
         let sp = TEST_SP - 4;
@@ -6740,7 +6740,7 @@ mod tests {
         assert_eq!(bus.read_long(draw_tramp + 62), window_ptr + 12);
         assert_eq!(bus.read_word(draw_tramp + 66), 0x4E75);
         assert_eq!(
-            disp.current_port, disp.window_manager_cport,
+            *disp.current_port, disp.window_manager_cport,
             "wDraw should run in the color Window Manager port"
         );
     }
@@ -7089,12 +7089,12 @@ mod tests {
         };
 
         let base = create_window(&mut disp, &mut cpu, &mut bus, true);
-        assert_eq!(disp.current_port, base);
+        assert_eq!(*disp.current_port, base);
 
         let hidden = create_window(&mut disp, &mut cpu, &mut bus, false);
         assert_ne!(hidden, 0);
         assert_eq!(
-            disp.current_port, base,
+            *disp.current_port, base,
             "hidden NewWindow must preserve the caller's current port"
         );
         assert_eq!(
@@ -7139,12 +7139,12 @@ mod tests {
         };
 
         let base = create_window(&mut disp, &mut cpu, &mut bus, 0xFFFF_FFFF);
-        assert_eq!(disp.current_port, base);
+        assert_eq!(*disp.current_port, base);
 
         let back = create_window(&mut disp, &mut cpu, &mut bus, 0);
         assert_ne!(back, 0);
         assert_eq!(
-            disp.current_port, base,
+            *disp.current_port, base,
             "visible NewWindow with behind=NIL must preserve the caller's current port"
         );
         assert_eq!(
@@ -8150,7 +8150,7 @@ mod tests {
         let next = 0x200140u32;
         disp.window_list = vec![front, next];
         disp.front_window = front;
-        disp.current_port = front;
+        *disp.current_port = front;
         disp.window_bounds = (240, 450, 480, 650);
         disp.window_proc_id = 4;
         disp.window_title = "Player".to_string();
@@ -8173,7 +8173,7 @@ mod tests {
         assert!(result.unwrap().is_ok());
         assert_eq!(cpu.read_reg(Register::A7), TEST_SP);
         assert_eq!(disp.front_window, next);
-        assert_eq!(disp.current_port, next);
+        assert_eq!(*disp.current_port, next);
         assert_eq!(
             disp.window_bounds,
             (10, 10, 50, 100),
@@ -8239,7 +8239,7 @@ mod tests {
         // Floating utilities may remain above an active document without
         // becoming the Window Manager's active front window.
         disp.front_window = document;
-        disp.current_port = document;
+        *disp.current_port = document;
         disp.dialog_visible_snapshots.insert(
             utility,
             PersistentDialogSnapshot {
@@ -8294,7 +8294,7 @@ mod tests {
         let next = 0x200140u32;
         disp.window_list = vec![front, next];
         disp.front_window = front;
-        disp.current_port = front;
+        *disp.current_port = front;
         disp.window_bounds = (240, 450, 480, 650);
         disp.window_proc_id = 4;
         disp.window_title = "Player".to_string();
@@ -8317,7 +8317,7 @@ mod tests {
         assert!(result.unwrap().is_ok());
         assert_eq!(cpu.read_reg(Register::A7), TEST_SP);
         assert_eq!(disp.front_window, next);
-        assert_eq!(disp.current_port, next);
+        assert_eq!(*disp.current_port, next);
         assert_eq!(
             disp.window_bounds,
             (10, 10, 50, 100),
@@ -8386,7 +8386,7 @@ mod tests {
         );
         disp.window_list = vec![window_addr];
         disp.front_window = window_addr;
-        disp.current_port = window_addr;
+        *disp.current_port = window_addr;
         assert_ne!(
             bus.read_byte(content_probe),
             desktop_content,
@@ -8665,7 +8665,7 @@ mod tests {
         bus.write_byte(window + 111, 0xFF);
         disp.window_list = vec![window];
         disp.front_window = window;
-        disp.current_port = window;
+        *disp.current_port = window;
 
         let sp = TEST_SP - 4;
         cpu.write_reg(Register::A7, sp);
@@ -8762,7 +8762,7 @@ mod tests {
         let probe = screen_base + 150 * 800 + 323;
         bus.write_byte(probe, 0x42);
 
-        let previous_port = disp.current_port;
+        let previous_port = *disp.current_port;
         let sp = TEST_SP - 4;
         cpu.write_reg(Register::A7, sp);
         bus.write_long(sp, window);
@@ -8776,7 +8776,7 @@ mod tests {
             "ShowWindow must erase stale pixels across the whole revealed content area"
         );
         assert_eq!(
-            disp.current_port, previous_port,
+            *disp.current_port, previous_port,
             "Window Manager painting must restore the application's current port"
         );
     }
@@ -8949,7 +8949,7 @@ mod tests {
         let win_b = 0x200140u32;
         disp.window_list = vec![win_b, win_a]; // b is front, a is behind
         disp.front_window = win_b;
-        disp.current_port = win_b;
+        *disp.current_port = win_b;
         for &base in &[win_a, win_b] {
             bus.write_word(base + 16, 10);
             bus.write_word(base + 18, 10);
@@ -8967,7 +8967,7 @@ mod tests {
         assert_eq!(cpu.read_reg(Register::A7), TEST_SP);
         assert_eq!(disp.front_window, win_a, "next visible must become front");
         assert_eq!(
-            disp.current_port, win_a,
+            *disp.current_port, win_a,
             "current_port must follow new front when it was the hidden window"
         );
         assert!(
@@ -9033,7 +9033,7 @@ mod tests {
         disp.window_list = vec![front, back];
         disp.sync_window_list_links(&mut bus);
         disp.front_window = front;
-        disp.current_port = front;
+        *disp.current_port = front;
         let update_handle = bus.read_long(back + 122);
         super::super::TrapDispatcher::write_region_handle_rect(&mut bus, update_handle, None);
         disp.clear_queued_update_events(back);
@@ -9059,7 +9059,7 @@ mod tests {
         let win_c = 0x200240u32;
         disp.window_list = vec![win_c, win_b, win_a];
         disp.front_window = win_c;
-        disp.current_port = win_c;
+        *disp.current_port = win_c;
         for &base in &[win_a, win_b, win_c] {
             bus.write_word(base + 16, 10);
             bus.write_word(base + 18, 10);
@@ -9193,7 +9193,7 @@ mod tests {
         );
         disp.window_list = vec![dialog];
         disp.front_window = dialog;
-        disp.current_port = dialog;
+        *disp.current_port = dialog;
         disp.dialog_items
             .insert(dialog, vec![DialogItem::default()]);
         disp.dialog_visible_snapshots.insert(
@@ -9236,7 +9236,7 @@ mod tests {
         // List: c front, b behind (hidden), a back-most (visible).
         disp.window_list = vec![win_c, win_b, win_a];
         disp.front_window = win_c;
-        disp.current_port = win_c;
+        *disp.current_port = win_c;
         for &base in &[win_a, win_b, win_c] {
             bus.write_word(base + 16, 10);
             bus.write_word(base + 18, 10);
@@ -9258,7 +9258,7 @@ mod tests {
             disp.front_window, win_a,
             "must skip hidden b and promote visible a to front"
         );
-        assert_eq!(disp.current_port, win_a);
+        assert_eq!(*disp.current_port, win_a);
     }
 
     #[test]
@@ -9271,7 +9271,7 @@ mod tests {
         let win_b = 0x200140u32;
         disp.window_list = vec![win_b, win_a];
         disp.front_window = win_b;
-        disp.current_port = win_b;
+        *disp.current_port = win_b;
         for &base in &[win_a, win_b] {
             bus.write_word(base + 16, 10);
             bus.write_word(base + 18, 10);
@@ -9301,7 +9301,7 @@ mod tests {
         let win_b = 0x200140u32;
         disp.window_list = vec![win_b, win_a];
         disp.front_window = win_b;
-        disp.current_port = win_b;
+        *disp.current_port = win_b;
         for &base in &[win_a, win_b] {
             bus.write_word(base + 16, 10);
             bus.write_word(base + 18, 10);
@@ -9316,7 +9316,7 @@ mod tests {
         let result = dispatch(&mut disp, 0x116, &mut cpu, &mut bus);
         assert!(result.unwrap().is_ok());
         assert_eq!(disp.front_window, win_b, "front must not change");
-        assert_eq!(disp.current_port, win_b, "current_port must not change");
+        assert_eq!(*disp.current_port, win_b, "current_port must not change");
     }
 
     // IM:I I-285: ShowHide(TRUE) makes the target window visible but does
@@ -9335,7 +9335,7 @@ mod tests {
 
         disp.window_list = vec![front_window, target_window];
         disp.front_window = front_window;
-        disp.current_port = front_window;
+        *disp.current_port = front_window;
 
         let activate_before = disp.event_queue.iter().filter(|e| e.what == 8).count();
 
@@ -9481,7 +9481,7 @@ mod tests {
 
         disp.window_list = vec![front_window, target_window];
         disp.front_window = front_window;
-        disp.current_port = front_window;
+        *disp.current_port = front_window;
         disp.queue_window_update_event(target_window);
         assert!(
             disp.event_queue
@@ -9567,7 +9567,7 @@ mod tests {
         disp.window_list = vec![target, back];
         disp.sync_window_list_links(&mut bus);
         disp.front_window = back;
-        disp.current_port = back;
+        *disp.current_port = back;
         disp.dialog_visible_snapshots.insert(
             target,
             PersistentDialogSnapshot {
@@ -12586,7 +12586,7 @@ mod tests {
         cpu.write_reg(Register::A7, sp);
 
         let port = 0x210000;
-        disp.current_port = port;
+        *disp.current_port = port;
         bus.write_word(port + 8, (-100i16) as u16);
         bus.write_word(port + 10, (-200i16) as u16);
 


### PR DESCRIPTION
## Root cause

The 68K trap adapter and PowerPC import adapter stored separate current QuickDraw port and graphics-device selections. Mixed Mode callbacks therefore depended on runner-level copies instead of observing the Macintosh process's current selection directly.

## Change

- make the current QuickDraw port and graphics device process-owned shared values
- attach both CPU adapters to the same selection and activate native defaults explicitly
- preserve detached clone independence
- add a focused cross-ISA visibility test

## Validation

- `cargo test --locked --lib` — 4,743 passed; 0 failed; 3 ignored
- strict rustdoc with all features and private items
- `cargo test --locked --all-targets --no-run`
- deterministic Marathon, Escape Velocity, and Tomb Raider Gold gameplay scripts completed successfully

Closes #1193