### PR TITLE
refactor: route native double buffers through the process Sound Manager

### DIFF
--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -43612,11 +43612,12 @@ fn ppc_snd_play_double_buffer(
         host_initialized: false,
         host_buffer_loaded: false,
     };
+    sound.manager.note_double_buffer_submission();
+    playback.host_initialized = true;
     if let Some(samples) = ppc_decode_ready_double_buffer(memory, playback) {
         sound
             .manager
             .play_double_buffer_samples(channel, samples, sample_rate_fixed);
-        playback.host_initialized = true;
         playback.host_buffer_loaded = true;
     }
     sound.double_buffer_playbacks.push(playback);

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -7008,11 +7008,9 @@ impl FixtureRunner {
             }
             if !playback.host_initialized {
                 ppc_app.sound.double_buffer_playbacks[index].host_initialized = true;
-                self.dispatcher.sound_manager.debug_double_buffer_count = self
-                    .dispatcher
+                self.dispatcher
                     .sound_manager
-                    .debug_double_buffer_count
-                    .saturating_add(1);
+                    .note_double_buffer_submission();
             }
             if playback.host_buffer_loaded {
                 continue;
@@ -7104,51 +7102,14 @@ impl FixtureRunner {
         playback: PpcSoundDoubleBufferPlaybackRecord,
         decoded: &PpcDecodedDoubleBuffer,
     ) {
-        let channel_index = self
-            .dispatcher
-            .sound_manager
-            .channels
-            .iter()
-            .position(|channel| channel.guest_ptr == playback.channel)
-            .unwrap_or_else(|| {
-                self.dispatcher
-                    .sound_manager
-                    .channels
-                    .push(crate::sound::SndChannel::new(playback.channel, false));
-                self.dispatcher.sound_manager.channels.len() - 1
-            });
-        let host_channel = &mut self.dispatcher.sound_manager.channels[channel_index];
         let non_silent_frames = decoded
             .samples
             .iter()
             .filter(|sample| sample.left != 0x80 || sample.right != 0x80)
             .count();
-        host_channel.debug_double_buffer_loads =
-            host_channel.debug_double_buffer_loads.saturating_add(1);
-        host_channel.debug_double_buffer_frames_loaded = host_channel
-            .debug_double_buffer_frames_loaded
-            .saturating_add(decoded.samples.len() as u64);
-        host_channel.debug_double_buffer_non_silent_frames = host_channel
-            .debug_double_buffer_non_silent_frames
-            .saturating_add(non_silent_frames as u64);
-        if non_silent_frames > 0 {
-            host_channel.debug_double_buffer_non_silent_loads = host_channel
-                .debug_double_buffer_non_silent_loads
-                .saturating_add(1);
-        }
-        let capture_remaining = crate::sound::DEBUG_DOUBLE_BUFFER_CAPTURE_LIMIT
-            .saturating_sub(host_channel.debug_double_buffer_captured_samples.len());
-        host_channel.debug_double_buffer_captured_samples.extend(
-            decoded
-                .samples
-                .iter()
-                .take(capture_remaining)
-                .copied()
-                .map(crate::sound::StereoSample::downmix),
-        );
         if trace_sound_runner_enabled() {
             eprintln!(
-                "[PPC-SOUND] host double buffer chan=${:08X} buf=${:08X} index={} frames={} non_silent={} flags=${:08X}",
+                "[PPC-SOUND] process double buffer chan=${:08X} buf=${:08X} index={} frames={} non_silent={} flags=${:08X}",
                 playback.channel,
                 decoded.buffer_ptr,
                 playback.current_buffer_index,
@@ -7157,11 +7118,10 @@ impl FixtureRunner {
                 decoded.flags
             );
         }
-        host_channel.play_stereo_buffer(
+        self.dispatcher.sound_manager.play_double_buffer_samples(
+            playback.channel,
             decoded.samples.clone(),
             playback.sample_rate_fixed,
-            crate::sound::PlaybackKind::Buffer,
-            0,
         );
     }
 
@@ -15914,6 +15874,18 @@ mod tests {
             1
         );
         assert_eq!(runner.dispatcher().sound_manager.debug_samples_mixed, 4);
+        let channel = runner
+            .dispatcher()
+            .sound_manager
+            .channels
+            .iter()
+            .find(|candidate| candidate.guest_ptr == channel)
+            .expect("process Sound Manager channel");
+        assert_eq!(channel.debug_double_buffer_loads, 2);
+        assert_eq!(channel.debug_double_buffer_non_silent_loads, 2);
+        assert_eq!(channel.debug_double_buffer_frames_loaded, 4);
+        assert_eq!(channel.debug_double_buffer_non_silent_frames, 3);
+        assert_eq!(channel.debug_double_buffer_captured_samples, expected);
         let playback = runner
             .ppc_app
             .as_ref()

--- a/src/sound.rs
+++ b/src/sound.rs
@@ -548,16 +548,24 @@ impl SoundManager {
         channel.play_buffer(samples, sample_rate_fixed, PlaybackKind::File, 0);
     }
 
+    /// Record one architecture-neutral `SndPlayDoubleBuffer` submission.
+    /// Decoding and callback frames remain adapter-specific, while submission
+    /// accounting belongs to the process Sound Manager. Sound 1994,
+    /// pp. 2-138--2-140.
+    pub(crate) fn note_double_buffer_submission(&mut self) {
+        self.debug_double_buffer_count = self.debug_double_buffer_count.saturating_add(1);
+    }
+
     /// Install one decoded double-buffer payload on the process channel.
-    /// The native callback frame remains adapter-specific, but the samples
-    /// and playback cursor are Sound Manager state. Sound 1994, pp. 2-138--2-140.
+    /// The callback frame remains adapter-specific, but channel creation,
+    /// samples, playback cursor, and diagnostics are Sound Manager state.
+    /// Sound 1994, pp. 2-138--2-148.
     pub(crate) fn play_double_buffer_samples(
         &mut self,
         guest_ptr: u32,
         samples: Vec<StereoSample>,
         sample_rate_fixed: u32,
     ) {
-        self.debug_double_buffer_count = self.debug_double_buffer_count.saturating_add(1);
         let channel = self.ensure_channel_mut(guest_ptr);
         let non_silent_frames = samples
             .iter()

--- a/src/trap/sound.rs
+++ b/src/trap/sound.rs
@@ -2102,7 +2102,7 @@ impl super::TrapDispatcher {
         // Track valid double-buffer submissions separately from bufferCmd-style
         // single-buffer ones. Both feed mix_frame but through different
         // code paths.
-        self.sound_manager.debug_double_buffer_count += 1;
+        self.sound_manager.note_double_buffer_submission();
 
         // Find or create the channel.
         let chan = if let Some(c) = self.sound_manager.find_channel_mut(chan_ptr) {


### PR DESCRIPTION
Closes #1197.

Both CPU adapters now record double-buffer submissions through the process Sound Manager, and decoded PowerPC double-buffer payloads use its canonical channel/playback method. The runner no longer duplicates channel creation, playback cursor installation, waveform capture, or diagnostic accounting. Native doubleback callback metadata remains adapter-specific.

Focused coverage verifies consecutive native buffers preserve exact process-owned load, non-silent-frame, frame-count, and captured-waveform diagnostics.

Validation:
- `cargo test --locked --lib` (4,744 passed; 0 failed; 3 ignored)
- strict all-features rustdoc with private-link warnings denied
- all-features/all-targets compile
- 68K and PowerPC toolbox showcase
- Marathon terminal/gameplay acceptance script
- Escape Velocity gameplay acceptance script
- Tomb Raider Gold gameplay acceptance script

Behavior follows *Inside Macintosh: Sound* (1994), pp. 2-138–2-148.