### PR TITLE
refactor(callback)!: make task queues process-owned

### DIFF
--- a/src/callback_manager.rs
+++ b/src/callback_manager.rs
@@ -1,0 +1,50 @@
+//! Process-owned Time Manager and Vertical Retrace Manager task records.
+
+/// CPU architecture responsible for delivering an installed callback.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CallbackTaskArchitecture {
+    /// Classic 68K callback delivery.
+    M68k,
+    /// Native PowerPC callback delivery.
+    PowerPc,
+}
+
+/// An installed Time Manager task shared by every CPU adapter.
+///
+/// The Time Manager owns one operating-system queue for the current process;
+/// the task record remains guest-visible while its exact deadline is private
+/// manager state. Inside Macintosh: Processes (1994), pp. 3-6--3-22.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ProcessTimerTask {
+    /// Guest address of the `TMTask` record.
+    pub task_ptr: u32,
+    /// Architecture that installed and delivers this callback.
+    pub architecture: CallbackTaskArchitecture,
+    /// Whether `InsXTime` installed the extended, drift-free record form.
+    pub extended: bool,
+    /// Address of the callback procedure from `tmAddr`.
+    pub callback: u32,
+    /// Whether the task is primed and waiting to fire.
+    pub active: bool,
+    /// Guest tick at which this task should fire.
+    pub fire_at_tick: u32,
+    /// Exact deadline in millionths of a 60 Hz guest tick.
+    pub fire_at_subtick: u64,
+    /// VBL tick in which this task was most recently dispatched.
+    pub last_fired_tick: Option<u32>,
+}
+
+/// An installed Vertical Retrace Manager task shared by every CPU adapter.
+///
+/// Inside Macintosh: Processes (1994), pp. 4-6--4-12.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ProcessVblTask {
+    /// Guest address of the `VBLTask` record.
+    pub task_ptr: u32,
+    /// Architecture that installed and delivers this callback.
+    pub architecture: CallbackTaskArchitecture,
+    /// Optional slot number for slot-based VBL tasks.
+    pub slot: Option<i16>,
+    /// The task reached a zero count but has not yet received its callback.
+    pub pending: bool,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@
 mod adb;
 pub mod audio;
 pub mod binhex;
+pub mod callback_manager;
 mod control_manager;
 pub mod cpu;
 pub mod debug_overlay;
@@ -78,9 +79,9 @@ pub mod runner;
 #[cfg(feature = "test-support")]
 pub mod scripted_traces;
 pub mod sound;
+mod text_edit;
 pub mod trace;
 pub mod trap;
-mod text_edit;
 mod ui_art;
 pub mod ui_theme;
 mod window_manager;

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -14,6 +14,7 @@ use super::pef::{
     SECTION_KIND_PATTERN_DATA, SECTION_KIND_UNPACKED_DATA,
 };
 use super::ApplicationSizeResource;
+use crate::callback_manager::CallbackTaskArchitecture;
 use crate::event_queue::{EventQueue, QueuedEvent};
 use crate::guest_call::SharedGuestCallStack;
 use crate::guest_procedure::{
@@ -76,7 +77,8 @@ use crate::process_context::{
     ProcessPtrRecord, ProcessResourceManagerState, ProcessVfsFileRecords,
     ProcessVfsResourceFileRecords, SharedProcessAppleEventHandlers, SharedProcessCursorState,
     SharedProcessEventQueue, SharedProcessFileSystem, SharedProcessInputState,
-    SharedProcessMemoryManager, SharedProcessMenuTracking, SharedProcessValue,
+    SharedProcessMemoryManager, SharedProcessMenuTracking, SharedProcessTimerTasks,
+    SharedProcessValue, SharedProcessVblTasks,
 };
 use crate::quickdraw::fonts::heuristics::{
     get_italic_end_extend, get_italic_slant, get_italic_underline_extend_left,
@@ -3369,8 +3371,8 @@ pub struct PpcLoadedApp {
     pub toolbox_startup: PpcToolboxStartupState,
     pub quicktime: PpcQuickTimeState,
     pub sound: PpcSoundState,
-    pub timer_tasks: Vec<PpcTimerTaskRecord>,
-    pub vbl_tasks: Vec<PpcVblTaskRecord>,
+    pub(crate) timer_tasks: SharedProcessTimerTasks,
+    pub(crate) vbl_tasks: SharedProcessVblTasks,
     pub(crate) process_file_system: SharedProcessFileSystem,
     pub current_gworld: SharedProcessValue<u32>,
     pub current_gdevice: SharedProcessValue<u32>,
@@ -3879,6 +3881,7 @@ impl PpcLoadedApp {
         context.attach_file_system(&mut self.process_file_system);
         self.process_file_system.publish_native_vfs_catalogue();
         context.attach_sound_manager(&mut self.sound.manager);
+        context.attach_callback_tasks(&mut self.timer_tasks, &mut self.vbl_tasks);
         context.attach_cursor_state(&mut self.cursor_state);
         context.activate_quickdraw_selection(&mut self.current_gworld, &mut self.current_gdevice);
         context.attach_display_color_state(
@@ -6673,7 +6676,8 @@ impl PpcLoadedApp {
                     .iter()
                     .copied()
                     .filter(|task| {
-                        task.active
+                        task.architecture == CallbackTaskArchitecture::PowerPc
+                            && task.active
                             && task.last_fired_tick != Some(current_tick)
                             && current_tick.wrapping_sub(task.fire_at_tick) < 0x8000_0000
                     })
@@ -6849,8 +6853,11 @@ impl PpcLoadedApp {
         }
         for tick_offset in 0..elapsed_ticks {
             self.tick_count = start_tick.wrapping_add(tick_offset).wrapping_add(1);
-            let tasks = self.vbl_tasks.clone();
+            let tasks = (*self.vbl_tasks).clone();
             for task in tasks {
+                if task.architecture != CallbackTaskArchitecture::PowerPc {
+                    continue;
+                }
                 if probes.len() >= max_callbacks {
                     return probes;
                 }
@@ -12719,8 +12726,8 @@ fn load_pef_application_with_config_and_optional_system_reservation(
         toolbox_startup,
         quicktime: PpcQuickTimeState::default(),
         sound,
-        timer_tasks: Vec::new(),
-        vbl_tasks: Vec::new(),
+        timer_tasks: Default::default(),
+        vbl_tasks: Default::default(),
         process_file_system: ppc_initial_process_file_system(),
         current_gworld: SharedProcessValue::from_value(PPC_MAIN_GWORLD),
         current_gdevice: SharedProcessValue::from_value(PPC_MAIN_GDEVICE),
@@ -29436,7 +29443,12 @@ fn ppc_install_vbl_task(
     let _ = memory.write_u16_be(task_ptr + 10, vbl_count.wrapping_add(vbl_phase));
 
     vbl_tasks.retain(|task| task.task_ptr != task_ptr);
-    vbl_tasks.push(PpcVblTaskRecord { task_ptr });
+    vbl_tasks.push(PpcVblTaskRecord {
+        task_ptr,
+        architecture: CallbackTaskArchitecture::PowerPc,
+        slot: None,
+        pending: false,
+    });
     ppc_sync_vbl_task_links(memory, vbl_tasks);
     PPC_NO_ERR
 }
@@ -29457,9 +29469,12 @@ fn ppc_install_time_task(
     timer_tasks.retain(|task| task.task_ptr != task_ptr);
     timer_tasks.push(PpcTimerTaskRecord {
         task_ptr,
+        architecture: CallbackTaskArchitecture::PowerPc,
+        extended: false,
         callback: memory.read_u32_be(task_ptr + 6).unwrap_or(0),
         active: false,
         fire_at_tick: 0,
+        fire_at_subtick: 0,
         last_fired_tick: None,
     });
     ppc_sync_time_task_links(memory, timer_tasks);
@@ -29502,6 +29517,7 @@ fn ppc_prime_time_task(
         task.callback = memory.read_u32_be(task_ptr + 6).unwrap_or(0);
         task.active = true;
         task.fire_at_tick = current_tick.wrapping_add(delay_ticks.max(1));
+        task.fire_at_subtick = u64::from(task.fire_at_tick) * 1_000_000;
         if ppc_timer_trace_enabled() {
             eprintln!(
                 "[TIMER-PPC] prime task=${task_ptr:08X} count={count} now={current_tick} fire_at={} callback=${:08X}",
@@ -29566,10 +29582,13 @@ fn ppc_remove_vbl_task(
 }
 
 fn ppc_sync_vbl_task_links(memory: &mut PpcSectionMem, vbl_tasks: &[PpcVblTaskRecord]) {
-    for (index, task) in vbl_tasks.iter().enumerate() {
+    for task in vbl_tasks {
         let next = vbl_tasks
-            .get(index.saturating_add(1))
-            .map(|next| next.task_ptr)
+            .iter()
+            .skip_while(|candidate| candidate.task_ptr != task.task_ptr)
+            .skip(1)
+            .find(|candidate| candidate.slot == task.slot)
+            .map(|candidate| candidate.task_ptr)
             .unwrap_or(0);
         let _ = memory.write_u32_be(task.task_ptr, next);
     }
@@ -97527,7 +97546,12 @@ pub(crate) mod tests {
             .write_u32_be(task_ptr + 6, callback_entry)
             .unwrap();
         loaded.memory.write_u16_be(task_ptr + 10, 1).unwrap();
-        loaded.vbl_tasks.push(PpcVblTaskRecord { task_ptr });
+        loaded.vbl_tasks.push(PpcVblTaskRecord {
+            task_ptr,
+            architecture: CallbackTaskArchitecture::PowerPc,
+            slot: None,
+            pending: false,
+        });
 
         let probes = loaded.fire_vbl_tasks_for_ticks(0, 3, 8, 64, false, false);
 
@@ -97544,7 +97568,54 @@ pub(crate) mod tests {
                 )
         }));
         assert_eq!(loaded.memory.read_u16_be(task_ptr + 10), Some(2));
-        assert_eq!(loaded.vbl_tasks, vec![PpcVblTaskRecord { task_ptr }]);
+        assert_eq!(
+            *loaded.vbl_tasks,
+            vec![PpcVblTaskRecord {
+                task_ptr,
+                architecture: CallbackTaskArchitecture::PowerPc,
+                slot: None,
+                pending: false,
+            }]
+        );
+    }
+
+    #[test]
+    fn native_callback_task_imports_mutate_the_attached_process_registry() {
+        let mut native = load_pef_application(&synthetic_pef()).unwrap();
+        let mut classic = TrapDispatcher::new();
+        let mut context = ProcessContext::default();
+        native.attach_process_context(&mut context);
+        classic.attach_process_context(&mut context);
+
+        assert!(native.timer_tasks.ptr_eq(&classic.timer_tasks));
+        assert!(native.vbl_tasks.ptr_eq(&classic.vbl_tasks));
+
+        let timer = PPC_HEAP_BASE + 0x800;
+        let vbl = timer + 0x20;
+        native.memory.add_region(timer, vec![0; 0x40]);
+        native.memory.write_u32_be(timer + 6, 0x1234_5678).unwrap();
+        native.memory.write_u16_be(vbl + 4, 1).unwrap();
+        native.memory.write_u16_be(vbl + 10, 2).unwrap();
+
+        ppc_install_time_task(&mut native.memory, &mut native.timer_tasks, timer);
+        ppc_install_vbl_task(&mut native.memory, &mut native.vbl_tasks, vbl);
+        assert_eq!(classic.timer_tasks.len(), 1);
+        assert_eq!(classic.vbl_tasks.len(), 1);
+        assert_eq!(classic.timer_tasks[0].architecture, CallbackTaskArchitecture::PowerPc);
+        assert_eq!(classic.vbl_tasks[0].architecture, CallbackTaskArchitecture::PowerPc);
+
+        let detached_timers = classic.timer_tasks.clone();
+        let detached_vbls = classic.vbl_tasks.clone();
+        ppc_remove_time_task(&mut native.memory, &mut native.timer_tasks, timer);
+        assert_eq!(
+            ppc_remove_vbl_task(&mut native.memory, &mut native.vbl_tasks, vbl),
+            PPC_NO_ERR
+        );
+
+        assert!(classic.timer_tasks.is_empty());
+        assert!(classic.vbl_tasks.is_empty());
+        assert_eq!(detached_timers.len(), 1);
+        assert_eq!(detached_vbls.len(), 1);
     }
 
     #[test]

--- a/src/loader/ppc/sound.rs
+++ b/src/loader/ppc/sound.rs
@@ -184,19 +184,9 @@ impl PartialEq for PpcSoundState {
 
 impl Eq for PpcSoundState {}
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct PpcVblTaskRecord {
-    pub task_ptr: u32,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct PpcTimerTaskRecord {
-    pub task_ptr: u32,
-    pub callback: u32,
-    pub active: bool,
-    pub fire_at_tick: u32,
-    pub last_fired_tick: Option<u32>,
-}
+pub use crate::callback_manager::{
+    ProcessTimerTask as PpcTimerTaskRecord, ProcessVblTask as PpcVblTaskRecord,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PpcTimerCallbackInvocationRecord {

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -1,5 +1,6 @@
 //! Process-scoped state shared by classic and native CPU adapters.
 
+use crate::callback_manager::{ProcessTimerTask, ProcessVblTask};
 use crate::display::{
     default_arrow_cursor_image, default_display_gamma, standard_mac_8bpp_clut, CursorImage,
     DisplayGamma,
@@ -1223,6 +1224,8 @@ pub(crate) type SharedProcessCursorState = SharedProcessValue<ProcessCursorState
 pub(crate) type SharedProcessEventQueue = SharedProcessValue<EventQueue>;
 pub(crate) type SharedProcessMenuTracking = SharedProcessValue<Option<ProcessMenuTrackingState>>;
 pub(crate) type SharedProcessInputState = SharedProcessValue<ProcessInputState>;
+pub(crate) type SharedProcessTimerTasks = SharedProcessValue<Vec<ProcessTimerTask>>;
+pub(crate) type SharedProcessVblTasks = SharedProcessValue<Vec<ProcessVblTask>>;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct ProcessKeyRepeatState {
@@ -4132,6 +4135,8 @@ pub(crate) struct ProcessContext {
     apple_event_handlers: SharedProcessAppleEventHandlers,
     file_system: SharedProcessFileSystem,
     sound_manager: SharedProcessSoundManager,
+    timer_tasks: SharedProcessTimerTasks,
+    vbl_tasks: SharedProcessVblTasks,
     cursor_state: SharedProcessCursorState,
     current_graphics_port: SharedProcessValue<u32>,
     current_graphics_device: SharedProcessValue<u32>,
@@ -4154,6 +4159,8 @@ impl Default for ProcessContext {
             apple_event_handlers: SharedProcessAppleEventHandlers::default(),
             file_system: SharedProcessFileSystem::default(),
             sound_manager: SharedProcessSoundManager::default(),
+            timer_tasks: SharedProcessTimerTasks::default(),
+            vbl_tasks: SharedProcessVblTasks::default(),
             cursor_state: SharedProcessCursorState::default(),
             current_graphics_port: SharedProcessValue::from_value(0),
             current_graphics_device: SharedProcessValue::from_value(0),
@@ -4214,6 +4221,15 @@ impl ProcessContext {
 
     pub(crate) fn attach_sound_manager(&self, adapter: &mut SharedProcessSoundManager) {
         adapter.attach_to(&self.sound_manager, SoundManager::is_pristine);
+    }
+
+    pub(crate) fn attach_callback_tasks(
+        &self,
+        timer_tasks: &mut SharedProcessTimerTasks,
+        vbl_tasks: &mut SharedProcessVblTasks,
+    ) {
+        timer_tasks.attach_to(&self.timer_tasks, Vec::is_empty);
+        vbl_tasks.attach_to(&self.vbl_tasks, Vec::is_empty);
     }
 
     pub(crate) fn attach_cursor_state(&self, adapter: &mut SharedProcessCursorState) {

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -1,5 +1,6 @@
 //! Fixture Runner - Loading and execution infrastructure
 
+use crate::callback_manager::CallbackTaskArchitecture;
 use crate::cpu::{M68kCpu, Register, StepResult};
 use crate::debug_overlay::{DebugOverlayFrameStats, DebugOverlaySnapshot};
 use crate::loader::ppc::{
@@ -8750,7 +8751,12 @@ impl FixtureRunner {
             .iter()
             .map(|task| task.pending)
             .collect();
-        for task in &mut self.dispatcher.vbl_tasks {
+        for task in self
+            .dispatcher
+            .vbl_tasks
+            .iter_mut()
+            .filter(|task| task.architecture == CallbackTaskArchitecture::M68k)
+        {
             let count = self.bus.read_word(task.task_ptr + 10) as i16;
             if count <= 0 {
                 continue;
@@ -8764,12 +8770,19 @@ impl FixtureRunner {
 
         let due_index = pending_before
             .iter()
-            .position(|pending| *pending)
+            .enumerate()
+            .position(|(index, pending)| {
+                *pending
+                    && self.dispatcher.vbl_tasks[index].architecture
+                        == CallbackTaskArchitecture::M68k
+            })
             .or_else(|| {
                 self.dispatcher
                     .vbl_tasks
                     .iter()
-                    .position(|task| task.pending)
+                    .position(|task| {
+                        task.architecture == CallbackTaskArchitecture::M68k && task.pending
+                    })
             });
         let due_task = due_index.map(|index| {
             let task = &mut self.dispatcher.vbl_tasks[index];
@@ -8899,11 +8912,15 @@ impl FixtureRunner {
             .dispatcher
             .timer_tasks
             .iter_mut()
-            .filter(|task| task.active && current_subtick >= task.fire_at_subtick)
+            .filter(|task| {
+                task.architecture == CallbackTaskArchitecture::M68k
+                    && task.active
+                    && current_subtick >= task.fire_at_subtick
+            })
             .min_by_key(|task| task.fire_at_subtick)
         {
             let task_ptr = task.task_ptr;
-            let tm_addr = task.tm_addr;
+            let tm_addr = task.callback;
             self.dispatcher.timer_current_subtick = current_subtick;
             // Mark only the task being delivered as fired. Other tasks that
             // expire on the same tick must remain active for a later interrupt.
@@ -11937,7 +11954,12 @@ mod tests {
         ppc_app.memory.add_region(TASK, vec![0; 0x104]);
         ppc_app.memory.write_u32_be(TASK + 6, CALLBACK).unwrap();
         ppc_app.memory.write_u16_be(TASK + 10, 1).unwrap();
-        ppc_app.vbl_tasks.push(PpcVblTaskRecord { task_ptr: TASK });
+        ppc_app.vbl_tasks.push(PpcVblTaskRecord {
+            task_ptr: TASK,
+            architecture: CallbackTaskArchitecture::PowerPc,
+            slot: None,
+            pending: false,
+        });
         let mut tick_count = test_ppc_import_binding(0, "InterfaceLib", "LMGetTicks");
         tick_count.address = PPC_IMPORT_TRAP_BASE;
         tick_count.trap_pc = PPC_IMPORT_TRAP_BASE;
@@ -11994,7 +12016,12 @@ mod tests {
                     .write_u32_be(callback + offset as u32 * 4, instruction)
                     .unwrap();
             }
-            ppc_app.vbl_tasks.push(PpcVblTaskRecord { task_ptr: task });
+            ppc_app.vbl_tasks.push(PpcVblTaskRecord {
+                task_ptr: task,
+                architecture: CallbackTaskArchitecture::PowerPc,
+                slot: None,
+                pending: false,
+            });
         }
 
         let mut memory_manager = runner.process_context.memory_manager_mut();
@@ -13391,8 +13418,8 @@ mod tests {
             toolbox_startup: Default::default(),
             quicktime: Default::default(),
             sound,
-            timer_tasks: Vec::new(),
-            vbl_tasks: Vec::new(),
+            timer_tasks: Default::default(),
+            vbl_tasks: Default::default(),
             process_file_system: ppc_initial_process_file_system(),
             current_gworld: SharedProcessValue::from_value(PPC_MAIN_GWORLD),
             current_gdevice: SharedProcessValue::from_value(PPC_MAIN_GDEVICE),
@@ -15024,12 +15051,18 @@ mod tests {
         ppc_app.imports = vec![exit];
         ppc_app.vbl_tasks.push(PpcVblTaskRecord {
             task_ptr: PPC_DATA_BASE + 0x3000,
+            architecture: CallbackTaskArchitecture::PowerPc,
+            slot: None,
+            pending: false,
         });
         ppc_app.timer_tasks.push(PpcTimerTaskRecord {
             task_ptr: PPC_DATA_BASE + 0x3100,
+            architecture: CallbackTaskArchitecture::PowerPc,
+            extended: false,
             callback: CALLBACK,
             active: true,
             fire_at_tick: 0,
+            fire_at_subtick: 0,
             last_fired_tick: None,
         });
 
@@ -15635,8 +15668,8 @@ mod tests {
             toolbox_startup: Default::default(),
             quicktime: Default::default(),
             sound: Default::default(),
-            timer_tasks: Vec::new(),
-            vbl_tasks: Vec::new(),
+            timer_tasks: Default::default(),
+            vbl_tasks: Default::default(),
             process_file_system: SharedProcessFileSystem::from_state(
                 ProcessFileSystemState {
                 files: Vec::new(),
@@ -16653,8 +16686,8 @@ mod tests {
             toolbox_startup: Default::default(),
             quicktime: Default::default(),
             sound: Default::default(),
-            timer_tasks: Vec::new(),
-            vbl_tasks: Vec::new(),
+            timer_tasks: Default::default(),
+            vbl_tasks: Default::default(),
             process_file_system: ppc_initial_process_file_system(),
             current_gworld: SharedProcessValue::from_value(PPC_MAIN_GWORLD),
             current_gdevice: SharedProcessValue::from_value(PPC_MAIN_GDEVICE),
@@ -16805,8 +16838,8 @@ mod tests {
             toolbox_startup: Default::default(),
             quicktime: Default::default(),
             sound: Default::default(),
-            timer_tasks: Vec::new(),
-            vbl_tasks: Vec::new(),
+            timer_tasks: Default::default(),
+            vbl_tasks: Default::default(),
             process_file_system: ppc_initial_process_file_system(),
             current_gworld: SharedProcessValue::from_value(PPC_MAIN_GWORLD),
             current_gdevice: SharedProcessValue::from_value(PPC_MAIN_GDEVICE),
@@ -17216,8 +17249,8 @@ mod tests {
             toolbox_startup: Default::default(),
             quicktime: Default::default(),
             sound: Default::default(),
-            timer_tasks: Vec::new(),
-            vbl_tasks: Vec::new(),
+            timer_tasks: Default::default(),
+            vbl_tasks: Default::default(),
             process_file_system: ppc_initial_process_file_system(),
             current_gworld: SharedProcessValue::from_value(PPC_MAIN_GWORLD),
             current_gdevice: SharedProcessValue::from_value(PPC_MAIN_GDEVICE),
@@ -17527,8 +17560,8 @@ mod tests {
             toolbox_startup: Default::default(),
             quicktime: Default::default(),
             sound: Default::default(),
-            timer_tasks: Vec::new(),
-            vbl_tasks: Vec::new(),
+            timer_tasks: Default::default(),
+            vbl_tasks: Default::default(),
             process_file_system: ppc_initial_process_file_system(),
             current_gworld: SharedProcessValue::from_value(PPC_MAIN_GWORLD),
             current_gdevice: SharedProcessValue::from_value(PPC_MAIN_GDEVICE),
@@ -19069,8 +19102,9 @@ mod tests {
 
         runner.dispatcher.timer_tasks.push(TimerTask {
             task_ptr: 0x0039_38C8,
+            architecture: CallbackTaskArchitecture::M68k,
             extended: false,
-            tm_addr: 0x0004_1234,
+            callback: 0x0004_1234,
             active: true,
             fire_at_tick: 10,
             fire_at_subtick: 10_000_000,
@@ -19122,8 +19156,9 @@ mod tests {
         runner.bus.write_word(callback_addr, 0x4E75); // RTS
         runner.dispatcher.timer_tasks.push(TimerTask {
             task_ptr: 0x0039_38C8,
+            architecture: CallbackTaskArchitecture::M68k,
             extended: false,
-            tm_addr: callback_addr,
+            callback: callback_addr,
             active: true,
             fire_at_tick: 101,
             fire_at_subtick: 101_000_000,
@@ -19162,8 +19197,9 @@ mod tests {
         runner.tick_budget = runner.instructions_per_tick as i32;
         runner.dispatcher.timer_tasks.push(TimerTask {
             task_ptr: 0x0039_38C8,
+            architecture: CallbackTaskArchitecture::M68k,
             extended: false,
-            tm_addr: callback_addr,
+            callback: callback_addr,
             active: true,
             fire_at_tick: 101,
             fire_at_subtick: 100_200_000,
@@ -19208,8 +19244,9 @@ mod tests {
         });
         runner.dispatcher.timer_tasks.push(TimerTask {
             task_ptr: 0x0039_38C8,
+            architecture: CallbackTaskArchitecture::M68k,
             extended: false,
-            tm_addr: callback_addr,
+            callback: callback_addr,
             active: true,
             fire_at_tick: 102,
             fire_at_subtick: 102_000_000,
@@ -19248,8 +19285,9 @@ mod tests {
         runner.dispatcher.timer_tasks.extend([
             TimerTask {
                 task_ptr: 0x0039_38C8,
+                architecture: CallbackTaskArchitecture::M68k,
                 extended: false,
-                tm_addr: 0x0002_0000,
+                callback: 0x0002_0000,
                 active: true,
                 fire_at_tick: 10,
                 fire_at_subtick: 10_000_000,
@@ -19257,8 +19295,9 @@ mod tests {
             },
             TimerTask {
                 task_ptr: 0x0039_3900,
+                architecture: CallbackTaskArchitecture::M68k,
                 extended: false,
-                tm_addr: 0x0002_1000,
+                callback: 0x0002_1000,
                 active: true,
                 fire_at_tick: 10,
                 fire_at_subtick: 10_000_000,
@@ -19307,8 +19346,9 @@ mod tests {
         runner.cpu.write_reg(Register::A7, interrupted_sp);
         runner.dispatcher.timer_tasks.push(TimerTask {
             task_ptr,
+            architecture: CallbackTaskArchitecture::M68k,
             extended: false,
-            tm_addr: 0x0002_0000,
+            callback: 0x0002_0000,
             active: true,
             fire_at_tick: 10,
             fire_at_subtick: 10_100_000,
@@ -20278,6 +20318,7 @@ mod tests {
         runner.bus.write_word(task_ptr + 12, 0); // vblPhase
         runner.dispatcher.vbl_tasks.push(VblTask {
             task_ptr,
+            architecture: CallbackTaskArchitecture::M68k,
             slot: Some(9),
             pending: false,
         });
@@ -20324,6 +20365,7 @@ mod tests {
             runner.bus.write_word(task_ptr + 10, 1);
             runner.dispatcher.vbl_tasks.push(VblTask {
                 task_ptr,
+                architecture: CallbackTaskArchitecture::M68k,
                 slot: None,
                 pending: false,
             });
@@ -20365,6 +20407,7 @@ mod tests {
         runner.bus.write_word(task_ptr + 12, 0);
         runner.dispatcher.vbl_tasks.push(VblTask {
             task_ptr,
+            architecture: CallbackTaskArchitecture::M68k,
             slot: None,
             pending: false,
         });
@@ -20397,6 +20440,7 @@ mod tests {
         runner.bus.write_word(task_ptr + 12, 0);
         runner.dispatcher.vbl_tasks.push(VblTask {
             task_ptr,
+            architecture: CallbackTaskArchitecture::M68k,
             slot: None,
             pending: false,
         });
@@ -22158,6 +22202,7 @@ mod tests {
         runner.bus.write_word(task_ptr + 12, 0);
         runner.dispatcher.vbl_tasks.push(VblTask {
             task_ptr,
+            architecture: CallbackTaskArchitecture::M68k,
             slot: None,
             pending: false,
         });
@@ -24368,6 +24413,7 @@ mod tests {
         runner.bus.write_word(task_ptr + 12, 0);
         runner.dispatcher.vbl_tasks.push(VblTask {
             task_ptr,
+            architecture: CallbackTaskArchitecture::M68k,
             slot: None,
             pending: false,
         });

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -839,42 +839,7 @@ pub(crate) struct RecentColorTableFetch {
     pub tick: u32,
 }
 
-/// An installed Time Manager task.
-/// Processes 1994, 3-14
-#[derive(Clone, Debug)]
-pub struct TimerTask {
-    /// Guest address of the TMTask record
-    pub task_ptr: u32,
-    /// Whether InsXTime installed the extended, drift-free record form.
-    pub extended: bool,
-    /// Address of the callback procedure (from tmAddr at task_ptr+6)
-    pub tm_addr: u32,
-    /// Whether the task is primed (waiting to fire)
-    pub active: bool,
-    /// Tick count at which this task should fire.
-    /// Computed from current ticks + delay when PrimeTime is called.
-    pub fire_at_tick: u32,
-    /// Revised Time Manager deadline in millionths of a 60 Hz guest tick.
-    /// This preserves negative PrimeTime microsecond delays below one VBL.
-    pub fire_at_subtick: u64,
-    /// VBL tick in which this task was most recently dispatched. The PPC
-    /// runner uses this to prevent repeat delivery within a VBL; the 68K
-    /// runner retains it as callback metadata while honoring revised
-    /// sub-VBL deadlines.
-    pub last_fired_tick: Option<u32>,
-}
-
-/// An installed Vertical Retrace Manager task.
-/// Processes 1994, 4-6 to 4-7
-#[derive(Clone, Debug)]
-pub struct VblTask {
-    /// Guest address of the VBLTask record.
-    pub task_ptr: u32,
-    /// Optional slot number for slot-based VBL tasks.
-    pub slot: Option<i16>,
-    /// The task reached a zero count but has not yet received its callback.
-    pub pending: bool,
-}
+pub use crate::callback_manager::{ProcessTimerTask as TimerTask, ProcessVblTask as VblTask};
 
 pub(crate) const LOADSEG_GETRESOURCE_SENTINEL: u16 = 0x51F0;
 
@@ -2595,7 +2560,7 @@ pub struct TrapDispatcher {
     pub(crate) bits_proc_reentry: Option<(u32, u32)>,
     /// Installed Time Manager tasks.
     /// Processes 1994, 3-14
-    pub(crate) timer_tasks: Vec<TimerTask>,
+    pub(crate) timer_tasks: crate::process_context::SharedProcessTimerTasks,
     /// Exact scheduled wake-up retained for extended Time Manager records.
     /// The guest `tmWakeUp` representation is explicitly private to the
     /// manager; this map preserves its semantic deadline across RmvTime and
@@ -2608,7 +2573,7 @@ pub struct TrapDispatcher {
     pub(crate) sleep_queue: Vec<u32>,
     /// Installed Vertical Retrace Manager tasks.
     /// Processes 1994, 4-6 to 4-7
-    pub(crate) vbl_tasks: Vec<VblTask>,
+    pub(crate) vbl_tasks: crate::process_context::SharedProcessVblTasks,
     /// Dormant system-owned queue element kept ahead of application VBL tasks.
     pub(crate) system_vbl_queue_anchor: u32,
     /// Slot number of the primary video monitor for AttachVBL / VBL cursor routing.
@@ -2866,6 +2831,7 @@ impl TrapDispatcher {
         context.attach_file_system(&mut self.process_file_system);
         context.attach_resource_manager(&mut self.process_resource_manager);
         context.attach_sound_manager(&mut self.sound_manager);
+        context.attach_callback_tasks(&mut self.timer_tasks, &mut self.vbl_tasks);
         context.attach_cursor_state(&mut self.cursor_state);
         context.attach_quickdraw_selection(&mut self.current_port, &mut self.current_gdevice);
         context.attach_display_color_state(
@@ -4048,11 +4014,11 @@ impl TrapDispatcher {
             trap_exception_vector_defaults: None,
             pending_native_trap_calls: HashMap::new(),
             bits_proc_reentry: None,
-            timer_tasks: Vec::new(),
+            timer_tasks: Default::default(),
             timer_extended_wakeups: HashMap::new(),
             timer_current_subtick: 0,
             sleep_queue: Vec::new(),
-            vbl_tasks: Vec::new(),
+            vbl_tasks: Default::default(),
             system_vbl_queue_anchor: 0,
             primary_vbl_slot: 0,
             dialog_tracking: None,

--- a/src/trap/memory.rs
+++ b/src/trap/memory.rs
@@ -3,6 +3,7 @@
 use super::dispatch::{
     raw_trap_route, selector_operation_route, OsRoutineVariant, SelectorOperationRoute,
 };
+use crate::callback_manager::CallbackTaskArchitecture;
 use crate::cpu::{CpuOps, Register};
 use crate::machine_profile::REFERENCE_MACHINE_PROFILE;
 use crate::memory::{globals::addr, MacMemoryBus, MemoryBus};
@@ -413,6 +414,17 @@ fn memory_manager_trap_updates_dispatcher_ccr(is_tool: bool, trap_num: u16) -> b
 }
 
 impl super::TrapDispatcher {
+    fn sync_time_task_links(&self, bus: &mut MacMemoryBus) {
+        for (index, task) in self.timer_tasks.iter().enumerate() {
+            let next = self
+                .timer_tasks
+                .get(index.saturating_add(1))
+                .map(|next| next.task_ptr)
+                .unwrap_or(0);
+            bus.write_long(task.task_ptr, next);
+        }
+    }
+
     /// Install a video-device gamma table from a `VDGammaRecord`.
     ///
     /// Universal Interfaces 3.4 `Video.h` defines `VDGammaRecord.csGTable`
@@ -507,7 +519,7 @@ impl super::TrapDispatcher {
             }
         }
 
-        for task in &self.vbl_tasks {
+        for task in self.vbl_tasks.iter() {
             let next = self
                 .vbl_tasks
                 .iter()
@@ -643,6 +655,7 @@ impl super::TrapDispatcher {
         self.vbl_tasks.retain(|task| task.task_ptr != task_ptr);
         self.vbl_tasks.push(super::dispatch::VblTask {
             task_ptr,
+            architecture: CallbackTaskArchitecture::M68k,
             slot,
             pending: false,
         });
@@ -1915,13 +1928,15 @@ impl super::TrapDispatcher {
                 self.timer_tasks.retain(|t| t.task_ptr != task_ptr);
                 self.timer_tasks.push(super::dispatch::TimerTask {
                     task_ptr,
+                    architecture: CallbackTaskArchitecture::M68k,
                     extended,
-                    tm_addr,
+                    callback: tm_addr,
                     active: false,
                     fire_at_tick: 0,
                     fire_at_subtick: 0,
                     last_fired_tick: None,
                 });
+                self.sync_time_task_links(bus);
                 // InsTime clears the qType high-order bit (task inactive until PrimeTime).
                 // Processes 1994, 3-12: "InsTime procedure initially clears this bit."
                 let q = bus.read_word(task_ptr + 4);
@@ -1945,6 +1960,7 @@ impl super::TrapDispatcher {
                     .map(|task| task.fire_at_subtick.saturating_sub(current_subtick))
                     .unwrap_or(0);
                 self.timer_tasks.retain(|t| t.task_ptr != task_ptr);
+                self.sync_time_task_links(bus);
 
                 // The revised and extended Time Managers return unused time
                 // through tmCount. Prefer negated microseconds for maximum
@@ -2039,7 +2055,7 @@ impl super::TrapDispatcher {
                     task.fire_at_tick = fire_at;
                     task.fire_at_subtick = fire_at_subtick;
                     // Re-read tmAddr in case it changed between InsTime and PrimeTime
-                    task.tm_addr = bus.read_long(task_ptr + 6);
+                    task.callback = bus.read_long(task_ptr + 6);
                 }
                 // PrimeTime sets the qType high-order bit (task now active/primed).
                 // Processes 1994, 3-20: "PrimeTime sets the high-order bit of the qType field to 1."
@@ -6999,6 +7015,63 @@ mod tests {
         assert_eq!(bus.read_long(super::VBL_QUEUE_HEADER + 6), second);
         assert_eq!(bus.read_long(anchor), second);
         assert_eq!(bus.read_long(second), 0);
+    }
+
+    #[test]
+    fn classic_callback_task_traps_mutate_the_attached_process_registry() {
+        let (mut classic, mut cpu, mut bus) = setup();
+        let mut attached_view = super::super::TrapDispatcher::new();
+        let mut context = ProcessContext::default();
+        classic.attach_process_context(&mut context);
+        attached_view.attach_process_context(&mut context);
+
+        let timer = bus.alloc(22);
+        bus.write_long(timer + 6, 0x1234_5678);
+        cpu.write_reg(Register::A0, timer);
+        classic.current_trap_word = 0xA058;
+        classic
+            .dispatch_memory(false, 0x58, &mut cpu, &mut bus)
+            .expect("InsTime should be handled")
+            .expect("InsTime should return");
+
+        let vbl = bus.alloc(14);
+        bus.write_word(vbl + 4, 1);
+        bus.write_long(vbl + 6, 0x1234_5678);
+        bus.write_word(vbl + 10, 2);
+        cpu.write_reg(Register::A0, vbl);
+        classic
+            .dispatch_memory(false, 0x33, &mut cpu, &mut bus)
+            .expect("VInstall should be handled")
+            .expect("VInstall should return");
+
+        assert!(classic.timer_tasks.ptr_eq(&attached_view.timer_tasks));
+        assert!(classic.vbl_tasks.ptr_eq(&attached_view.vbl_tasks));
+        assert_eq!(
+            attached_view.timer_tasks[0].architecture,
+            crate::callback_manager::CallbackTaskArchitecture::M68k
+        );
+        assert_eq!(
+            attached_view.vbl_tasks[0].architecture,
+            crate::callback_manager::CallbackTaskArchitecture::M68k
+        );
+        let detached_timers = attached_view.timer_tasks.clone();
+        let detached_vbls = attached_view.vbl_tasks.clone();
+
+        cpu.write_reg(Register::A0, timer);
+        classic
+            .dispatch_memory(false, 0x59, &mut cpu, &mut bus)
+            .expect("RmvTime should be handled")
+            .expect("RmvTime should return");
+        cpu.write_reg(Register::A0, vbl);
+        classic
+            .dispatch_memory(false, 0x34, &mut cpu, &mut bus)
+            .expect("VRemove should be handled")
+            .expect("VRemove should return");
+
+        assert!(attached_view.timer_tasks.is_empty());
+        assert!(attached_view.vbl_tasks.is_empty());
+        assert_eq!(detached_timers.len(), 1);
+        assert_eq!(detached_vbls.len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
Closes #1201.

Makes Time Manager and Vertical Retrace Manager task registries process-owned, with ISA-tagged delivery and immediate cross-adapter install/remove visibility. Guest queue links now stay coherent across both gateways, while detached clones remain independent.

Validated with the full 4,750-test library suite, strict rustdoc, all targets/features, both toolbox showcases, a locked release build, and fresh Marathon, Escape Velocity, and Tomb Raider Gold gameplay runs.