### PR TITLE
refactor(callback)!: make scheduling metadata process-owned

### DIFF
--- a/src/callback_manager.rs
+++ b/src/callback_manager.rs
@@ -1,5 +1,20 @@
 //! Process-owned Time Manager and Vertical Retrace Manager task records.
 
+use std::collections::HashMap;
+
+/// Scheduling metadata shared by every callback gateway in one process.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) struct ProcessCallbackScheduling {
+    /// Exact intended wake-up for extended Time Manager records.
+    pub(crate) extended_wakeups: HashMap<u32, u64>,
+    /// Exact Time Manager clock while callbacks are delivered.
+    pub(crate) current_subtick: u64,
+    /// Guest address of the dormant system VBL queue element.
+    pub(crate) system_vbl_queue_anchor: u32,
+    /// Slot number of the primary video monitor.
+    pub(crate) primary_vbl_slot: i16,
+}
+
 /// CPU architecture responsible for delivering an installed callback.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum CallbackTaskArchitecture {

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -14,7 +14,7 @@ use super::pef::{
     SECTION_KIND_PATTERN_DATA, SECTION_KIND_UNPACKED_DATA,
 };
 use super::ApplicationSizeResource;
-use crate::callback_manager::CallbackTaskArchitecture;
+use crate::callback_manager::{CallbackTaskArchitecture, ProcessCallbackScheduling};
 use crate::event_queue::{EventQueue, QueuedEvent};
 use crate::guest_call::SharedGuestCallStack;
 use crate::guest_procedure::{
@@ -75,10 +75,11 @@ use crate::process_context::{
     ProcessHandleRecord, ProcessHandleStateRecord, ProcessInputState, ProcessMemoryManager,
     ProcessNativeAllocatorState, ProcessNativeHeapState, ProcessNativeMemoryManager,
     ProcessPtrRecord, ProcessResourceManagerState, ProcessVfsFileRecords,
-    ProcessVfsResourceFileRecords, SharedProcessAppleEventHandlers, SharedProcessCursorState,
-    SharedProcessEventQueue, SharedProcessFileSystem, SharedProcessInputState,
-    SharedProcessMemoryManager, SharedProcessMenuTracking, SharedProcessTimerTasks,
-    SharedProcessValue, SharedProcessVblTasks,
+    ProcessVfsResourceFileRecords, SharedProcessAppleEventHandlers,
+    SharedProcessCallbackScheduling, SharedProcessCursorState, SharedProcessEventQueue,
+    SharedProcessFileSystem, SharedProcessInputState, SharedProcessMemoryManager,
+    SharedProcessMenuTracking, SharedProcessTimerTasks, SharedProcessValue,
+    SharedProcessVblTasks,
 };
 use crate::quickdraw::fonts::heuristics::{
     get_italic_end_extend, get_italic_slant, get_italic_underline_extend_left,
@@ -1842,6 +1843,7 @@ pub enum PpcImportDispatcherTarget {
     GetOSTrapAddress,
     LMGetCurrentA5,
     InsTime,
+    InsXTime,
     PrimeTime,
     RmvTime,
     VInstall,
@@ -3373,6 +3375,7 @@ pub struct PpcLoadedApp {
     pub sound: PpcSoundState,
     pub(crate) timer_tasks: SharedProcessTimerTasks,
     pub(crate) vbl_tasks: SharedProcessVblTasks,
+    pub(crate) callback_scheduling: SharedProcessCallbackScheduling,
     pub(crate) process_file_system: SharedProcessFileSystem,
     pub current_gworld: SharedProcessValue<u32>,
     pub current_gdevice: SharedProcessValue<u32>,
@@ -3881,7 +3884,11 @@ impl PpcLoadedApp {
         context.attach_file_system(&mut self.process_file_system);
         self.process_file_system.publish_native_vfs_catalogue();
         context.attach_sound_manager(&mut self.sound.manager);
-        context.attach_callback_tasks(&mut self.timer_tasks, &mut self.vbl_tasks);
+        context.attach_callback_tasks(
+            &mut self.timer_tasks,
+            &mut self.vbl_tasks,
+            &mut self.callback_scheduling,
+        );
         context.attach_cursor_state(&mut self.cursor_state);
         context.activate_quickdraw_selection(&mut self.current_gworld, &mut self.current_gdevice);
         context.attach_display_color_state(
@@ -4003,6 +4010,10 @@ impl PpcLoadedApp {
 
     pub fn set_tick_count(&mut self, tick_count: u32) {
         self.tick_count = tick_count;
+        self.callback_scheduling.current_subtick = self
+            .callback_scheduling
+            .current_subtick
+            .max(u64::from(tick_count) * 1_000_000);
     }
 
     pub fn set_clock_cycle_timing(&mut self, cycles_per_tick: u32, cycle_phase: u32) {
@@ -6667,6 +6678,7 @@ impl PpcLoadedApp {
         for tick_offset in 0..elapsed_ticks {
             let current_tick = start_tick.wrapping_add(tick_offset).wrapping_add(1);
             self.tick_count = current_tick;
+            self.callback_scheduling.current_subtick = u64::from(current_tick) * 1_000_000;
             loop {
                 if probes.len() >= max_callbacks {
                     return probes;
@@ -7208,6 +7220,7 @@ impl PpcLoadedApp {
         let mut sound = std::mem::take(&mut self.sound);
         let mut timer_tasks = std::mem::take(&mut self.timer_tasks);
         let mut vbl_tasks = std::mem::take(&mut self.vbl_tasks);
+        let mut callback_scheduling = std::mem::take(&mut self.callback_scheduling);
         let mut files = std::mem::take(&mut self.files);
         let mut stdio_streams = std::mem::take(&mut self.stdio_streams);
         let mut vfs_files = std::mem::take(&mut self.vfs_files);
@@ -7729,6 +7742,7 @@ impl PpcLoadedApp {
                         &mut sound,
                         &mut timer_tasks,
                         &mut vbl_tasks,
+                        &mut callback_scheduling,
                         &mut files,
                         &mut vfs_files,
                         &mut stdio_streams,
@@ -8094,6 +8108,7 @@ impl PpcLoadedApp {
         self.sound = sound;
         self.timer_tasks = timer_tasks;
         self.vbl_tasks = vbl_tasks;
+        self.callback_scheduling = callback_scheduling;
         self.files = files;
         self.stdio_streams = stdio_streams;
         self.vfs_files = vfs_files;
@@ -12728,6 +12743,7 @@ fn load_pef_application_with_config_and_optional_system_reservation(
         sound,
         timer_tasks: Default::default(),
         vbl_tasks: Default::default(),
+        callback_scheduling: Default::default(),
         process_file_system: ppc_initial_process_file_system(),
         current_gworld: SharedProcessValue::from_value(PPC_MAIN_GWORLD),
         current_gdevice: SharedProcessValue::from_value(PPC_MAIN_GDEVICE),
@@ -14641,9 +14657,8 @@ fn dispatcher_target_for_import(
         ("InterfaceLib", "SetOSTrapAddress") => PpcImportDispatcherTarget::SetOSTrapAddress,
         ("InterfaceLib", "NSetTrapAddress") => PpcImportDispatcherTarget::NSetTrapAddress,
         ("InterfaceLib", "LMGetCurrentA5") => PpcImportDispatcherTarget::LMGetCurrentA5,
-        ("InterfaceLib", "InsTime") | ("InterfaceLib", "InsXTime") => {
-            PpcImportDispatcherTarget::InsTime
-        }
+        ("InterfaceLib", "InsTime") => PpcImportDispatcherTarget::InsTime,
+        ("InterfaceLib", "InsXTime") => PpcImportDispatcherTarget::InsXTime,
         ("InterfaceLib", "PrimeTime") => PpcImportDispatcherTarget::PrimeTime,
         ("InterfaceLib", "RmvTime") => PpcImportDispatcherTarget::RmvTime,
         ("InterfaceLib", "VInstall") => PpcImportDispatcherTarget::VInstall,
@@ -14964,6 +14979,7 @@ fn dispatch_supported_import(
     sound: &mut PpcSoundState,
     timer_tasks: &mut Vec<PpcTimerTaskRecord>,
     vbl_tasks: &mut Vec<PpcVblTaskRecord>,
+    callback_scheduling: &mut ProcessCallbackScheduling,
     files: &mut Vec<PpcFileRecord>,
     vfs_files: &mut ProcessVfsFileRecords,
     stdio_streams: &mut HashMap<u32, PpcStdioStreamRecord>,
@@ -25575,14 +25591,21 @@ fn dispatch_supported_import(
             )
         }
         PpcImportDispatcherTarget::LMGetCurrentA5 => Some(PpcImportAction::Return(PPC_DATA_BASE)),
-        PpcImportDispatcherTarget::InsTime => {
-            ppc_install_time_task(memory, timer_tasks, cpu.gpr[3]);
+        PpcImportDispatcherTarget::InsTime | PpcImportDispatcherTarget::InsXTime => {
+            ppc_install_time_task(
+                memory,
+                timer_tasks,
+                callback_scheduling,
+                cpu.gpr[3],
+                binding.dispatcher_target == PpcImportDispatcherTarget::InsXTime,
+            );
             Some(PpcImportAction::ReturnPreserve)
         }
         PpcImportDispatcherTarget::PrimeTime => {
             ppc_prime_time_task(
                 memory,
                 timer_tasks,
+                callback_scheduling,
                 cpu.gpr[3],
                 cpu.gpr[4] as i32,
                 *tick_count,
@@ -25590,7 +25613,10 @@ fn dispatch_supported_import(
             Some(PpcImportAction::ReturnPreserve)
         }
         PpcImportDispatcherTarget::RmvTime => {
-            ppc_remove_time_task(memory, timer_tasks, cpu.gpr[3]);
+            callback_scheduling.current_subtick = callback_scheduling
+                .current_subtick
+                .max(u64::from(*tick_count) * 1_000_000);
+            ppc_remove_time_task(memory, timer_tasks, callback_scheduling, cpu.gpr[3]);
             Some(PpcImportAction::ReturnPreserve)
         }
         PpcImportDispatcherTarget::VInstall
@@ -25633,7 +25659,12 @@ fn dispatch_supported_import(
                 PpcImportDispatcherTarget::VInstall | PpcImportDispatcherTarget::SlotVInstall
             );
             let result = if installing {
-                ppc_install_vbl_task(memory, vbl_tasks, task_ptr)
+                let slot = matches!(
+                    binding.dispatcher_target,
+                    PpcImportDispatcherTarget::SlotVInstall
+                )
+                .then_some(cpu.gpr[4] as i16);
+                ppc_install_vbl_task(memory, vbl_tasks, task_ptr, slot)
             } else {
                 ppc_remove_vbl_task(memory, vbl_tasks, task_ptr)
             };
@@ -29434,6 +29465,7 @@ fn ppc_install_vbl_task(
     memory: &mut PpcSectionMem,
     vbl_tasks: &mut Vec<PpcVblTaskRecord>,
     task_ptr: u32,
+    slot: Option<i16>,
 ) -> i16 {
     if task_ptr == 0 || memory.read_u16_be(task_ptr + 4).unwrap_or(0) != 1 {
         return -2;
@@ -29446,7 +29478,7 @@ fn ppc_install_vbl_task(
     vbl_tasks.push(PpcVblTaskRecord {
         task_ptr,
         architecture: CallbackTaskArchitecture::PowerPc,
-        slot: None,
+        slot,
         pending: false,
     });
     ppc_sync_vbl_task_links(memory, vbl_tasks);
@@ -29456,7 +29488,9 @@ fn ppc_install_vbl_task(
 fn ppc_install_time_task(
     memory: &mut PpcSectionMem,
     timer_tasks: &mut Vec<PpcTimerTaskRecord>,
+    scheduling: &mut ProcessCallbackScheduling,
     task_ptr: u32,
+    extended: bool,
 ) {
     if task_ptr == 0 || !ppc_memory_can_write_bytes(memory, task_ptr, 14) {
         return;
@@ -29466,11 +29500,14 @@ fn ppc_install_time_task(
     let q_type = memory.read_u16_be(task_ptr + 4).unwrap_or(0) & 0x7fff;
     let _ = memory.write_u32_be(task_ptr, 0);
     let _ = memory.write_u16_be(task_ptr + 4, q_type);
+    if !extended || memory.read_u32_be(task_ptr + 14).unwrap_or(0) == 0 {
+        scheduling.extended_wakeups.remove(&task_ptr);
+    }
     timer_tasks.retain(|task| task.task_ptr != task_ptr);
     timer_tasks.push(PpcTimerTaskRecord {
         task_ptr,
         architecture: CallbackTaskArchitecture::PowerPc,
-        extended: false,
+        extended,
         callback: memory.read_u32_be(task_ptr + 6).unwrap_or(0),
         active: false,
         fire_at_tick: 0,
@@ -29489,6 +29526,7 @@ fn ppc_install_time_task(
 fn ppc_prime_time_task(
     memory: &mut PpcSectionMem,
     timer_tasks: &mut [PpcTimerTaskRecord],
+    scheduling: &mut ProcessCallbackScheduling,
     task_ptr: u32,
     count: i32,
     current_tick: u32,
@@ -29501,23 +29539,48 @@ fn ppc_prime_time_task(
     let q_type = memory.read_u16_be(task_ptr + 4).unwrap_or(0) | 0x8000;
     let _ = memory.write_u16_be(task_ptr + 4, q_type);
     let _ = memory.write_u32_be(task_ptr + 10, count as u32);
-    let delay_ticks = if count == 0 {
-        1
+    const SUBTICKS_PER_TICK: u64 = 1_000_000;
+    let requested_delay_subticks = if count == 0 {
+        0
     } else if count > 0 {
-        u32::try_from((u64::from(count as u32) * 60).div_ceil(1_000)).unwrap_or(u32::MAX)
+        u64::from(count as u32) * 60_000
     } else {
-        u32::try_from((u64::from(count.unsigned_abs()) * 60).div_ceil(1_000_000))
-            .unwrap_or(u32::MAX)
-            .max(1)
+        (u64::from(count.unsigned_abs()) * 60).max(1)
     };
+    let current_subtick = scheduling
+        .current_subtick
+        .max(u64::from(current_tick) * SUBTICKS_PER_TICK);
+    scheduling.current_subtick = current_subtick;
     if let Some(task) = timer_tasks
         .iter_mut()
         .find(|task| task.task_ptr == task_ptr)
     {
         task.callback = memory.read_u32_be(task_ptr + 6).unwrap_or(0);
         task.active = true;
-        task.fire_at_tick = current_tick.wrapping_add(delay_ticks.max(1));
-        task.fire_at_subtick = u64::from(task.fire_at_tick) * 1_000_000;
+        task.fire_at_subtick = if task.extended {
+            let prior_wakeup = if memory.read_u32_be(task_ptr + 14).unwrap_or(0) == 0 {
+                None
+            } else {
+                scheduling.extended_wakeups.get(&task_ptr).copied()
+            };
+            let intended_wakeup = prior_wakeup
+                .unwrap_or(current_subtick)
+                .saturating_add(requested_delay_subticks);
+            scheduling
+                .extended_wakeups
+                .insert(task_ptr, intended_wakeup);
+            let opaque_wakeup = ((intended_wakeup / 60) as u32).max(1);
+            let _ = memory.write_u32_be(task_ptr + 14, opaque_wakeup);
+            intended_wakeup.max(current_subtick)
+        } else {
+            let delay_subticks = if count == 0 {
+                SUBTICKS_PER_TICK
+            } else {
+                requested_delay_subticks
+            };
+            current_subtick.saturating_add(delay_subticks)
+        };
+        task.fire_at_tick = task.fire_at_subtick.div_ceil(SUBTICKS_PER_TICK) as u32;
         if ppc_timer_trace_enabled() {
             eprintln!(
                 "[TIMER-PPC] prime task=${task_ptr:08X} count={count} now={current_tick} fire_at={} callback=${:08X}",
@@ -29535,17 +29598,32 @@ fn ppc_prime_time_task(
 fn ppc_remove_time_task(
     memory: &mut PpcSectionMem,
     timer_tasks: &mut Vec<PpcTimerTaskRecord>,
+    scheduling: &mut ProcessCallbackScheduling,
     task_ptr: u32,
 ) {
     if task_ptr == 0 || !ppc_memory_can_write_bytes(memory, task_ptr, 14) {
         return;
     }
-    // RmvTime clears the active bit; callbacks are driven by the emulated
-    // guest's own tick loop, so an already-removed task has no delay left.
+    let current_subtick = scheduling.current_subtick;
+    let remaining_subticks = timer_tasks
+        .iter()
+        .find(|task| task.task_ptr == task_ptr && task.active)
+        .map(|task| task.fire_at_subtick.saturating_sub(current_subtick))
+        .unwrap_or(0);
+    let remaining_count = if remaining_subticks == 0 {
+        0
+    } else {
+        let remaining_us = remaining_subticks.div_ceil(60);
+        if remaining_us <= i32::MAX as u64 {
+            -(remaining_us as i32)
+        } else {
+            remaining_us.div_ceil(1_000).min(i32::MAX as u64) as i32
+        }
+    };
     let q_type = memory.read_u16_be(task_ptr + 4).unwrap_or(0) & 0x7fff;
     let _ = memory.write_u32_be(task_ptr, 0);
     let _ = memory.write_u16_be(task_ptr + 4, q_type);
-    let _ = memory.write_u32_be(task_ptr + 10, 0);
+    let _ = memory.write_u32_be(task_ptr + 10, remaining_count as u32);
     timer_tasks.retain(|task| task.task_ptr != task_ptr);
     ppc_sync_time_task_links(memory, timer_tasks);
     if ppc_timer_trace_enabled() {
@@ -97514,6 +97592,61 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn native_extended_timer_uses_process_owned_scheduling_metadata() {
+        let pef = synthetic_pef_with_import(b"InsXTime");
+        let mut native = load_pef_application(&pef).unwrap();
+        let mut classic = TrapDispatcher::new();
+        let mut context = ProcessContext::default();
+        native.attach_process_context(&mut context);
+        classic.attach_process_context(&mut context);
+        assert!(native
+            .callback_scheduling
+            .ptr_eq(&classic.callback_scheduling));
+
+        let task = ppc_heap_alloc(
+            &mut native.memory,
+            test_heap_cursor!(native),
+            test_heap_limit!(native),
+            22,
+            true,
+        );
+        native.memory.write_u32_be(task + 6, 0x1234_5678).unwrap();
+        native.cpu.gpr[3] = task;
+        native.run_with_hle_imports(64);
+        assert!(native.timer_tasks[0].extended);
+        assert!(classic.timer_tasks[0].extended);
+
+        native.set_tick_count(100);
+        native.set_clock_cycle_timing(1_000, 0);
+        native.imports[0].dispatcher_target = PpcImportDispatcherTarget::PrimeTime;
+        native.cpu.pc = native.entry_pc;
+        native.cpu.lr = PPC_HALT_PC;
+        native.cpu.gpr[3] = task;
+        native.cpu.gpr[4] = (-5_000i32) as u32;
+        native.run_with_hle_imports(64);
+        assert_eq!(native.timer_tasks[0].fire_at_subtick, 100_300_000);
+        assert_eq!(
+            classic.callback_scheduling.extended_wakeups.get(&task),
+            Some(&100_300_000)
+        );
+        assert_ne!(native.memory.read_u32_be(task + 14), Some(0));
+
+        let detached = classic.callback_scheduling.clone();
+        classic.callback_scheduling.primary_vbl_slot = 7;
+        classic.callback_scheduling.current_subtick = 100_150_000;
+        assert_eq!(native.callback_scheduling.primary_vbl_slot, 7);
+
+        native.imports[0].dispatcher_target = PpcImportDispatcherTarget::RmvTime;
+        native.cpu.pc = native.entry_pc;
+        native.cpu.lr = PPC_HALT_PC;
+        native.cpu.gpr[3] = task;
+        native.run_with_hle_imports(64);
+        assert_eq!(native.memory.read_u32_be(task + 10), Some((-2_500i32) as u32));
+        assert_eq!(detached.primary_vbl_slot, 0);
+        assert_eq!(detached.current_subtick, 100_000_000);
+    }
+
+    #[test]
     fn vbl_callback_receives_task_record_and_can_reschedule_itself() {
         let pef = synthetic_pef();
         let mut loaded = load_pef_application(&pef).unwrap();
@@ -97597,8 +97730,14 @@ pub(crate) mod tests {
         native.memory.write_u16_be(vbl + 4, 1).unwrap();
         native.memory.write_u16_be(vbl + 10, 2).unwrap();
 
-        ppc_install_time_task(&mut native.memory, &mut native.timer_tasks, timer);
-        ppc_install_vbl_task(&mut native.memory, &mut native.vbl_tasks, vbl);
+        ppc_install_time_task(
+            &mut native.memory,
+            &mut native.timer_tasks,
+            &mut native.callback_scheduling,
+            timer,
+            false,
+        );
+        ppc_install_vbl_task(&mut native.memory, &mut native.vbl_tasks, vbl, None);
         assert_eq!(classic.timer_tasks.len(), 1);
         assert_eq!(classic.vbl_tasks.len(), 1);
         assert_eq!(classic.timer_tasks[0].architecture, CallbackTaskArchitecture::PowerPc);
@@ -97606,7 +97745,12 @@ pub(crate) mod tests {
 
         let detached_timers = classic.timer_tasks.clone();
         let detached_vbls = classic.vbl_tasks.clone();
-        ppc_remove_time_task(&mut native.memory, &mut native.timer_tasks, timer);
+        ppc_remove_time_task(
+            &mut native.memory,
+            &mut native.timer_tasks,
+            &mut native.callback_scheduling,
+            timer,
+        );
         assert_eq!(
             ppc_remove_vbl_task(&mut native.memory, &mut native.vbl_tasks, vbl),
             PPC_NO_ERR

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -1,6 +1,6 @@
 //! Process-scoped state shared by classic and native CPU adapters.
 
-use crate::callback_manager::{ProcessTimerTask, ProcessVblTask};
+use crate::callback_manager::{ProcessCallbackScheduling, ProcessTimerTask, ProcessVblTask};
 use crate::display::{
     default_arrow_cursor_image, default_display_gamma, standard_mac_8bpp_clut, CursorImage,
     DisplayGamma,
@@ -1226,6 +1226,7 @@ pub(crate) type SharedProcessMenuTracking = SharedProcessValue<Option<ProcessMen
 pub(crate) type SharedProcessInputState = SharedProcessValue<ProcessInputState>;
 pub(crate) type SharedProcessTimerTasks = SharedProcessValue<Vec<ProcessTimerTask>>;
 pub(crate) type SharedProcessVblTasks = SharedProcessValue<Vec<ProcessVblTask>>;
+pub(crate) type SharedProcessCallbackScheduling = SharedProcessValue<ProcessCallbackScheduling>;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct ProcessKeyRepeatState {
@@ -4137,6 +4138,7 @@ pub(crate) struct ProcessContext {
     sound_manager: SharedProcessSoundManager,
     timer_tasks: SharedProcessTimerTasks,
     vbl_tasks: SharedProcessVblTasks,
+    callback_scheduling: SharedProcessCallbackScheduling,
     cursor_state: SharedProcessCursorState,
     current_graphics_port: SharedProcessValue<u32>,
     current_graphics_device: SharedProcessValue<u32>,
@@ -4161,6 +4163,7 @@ impl Default for ProcessContext {
             sound_manager: SharedProcessSoundManager::default(),
             timer_tasks: SharedProcessTimerTasks::default(),
             vbl_tasks: SharedProcessVblTasks::default(),
+            callback_scheduling: SharedProcessCallbackScheduling::default(),
             cursor_state: SharedProcessCursorState::default(),
             current_graphics_port: SharedProcessValue::from_value(0),
             current_graphics_device: SharedProcessValue::from_value(0),
@@ -4227,9 +4230,11 @@ impl ProcessContext {
         &self,
         timer_tasks: &mut SharedProcessTimerTasks,
         vbl_tasks: &mut SharedProcessVblTasks,
+        scheduling: &mut SharedProcessCallbackScheduling,
     ) {
         timer_tasks.attach_to(&self.timer_tasks, Vec::is_empty);
         vbl_tasks.attach_to(&self.vbl_tasks, Vec::is_empty);
+        scheduling.attach_to(&self.callback_scheduling, |state| state == &Default::default());
     }
 
     pub(crate) fn attach_cursor_state(&self, adapter: &mut SharedProcessCursorState) {

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -8921,7 +8921,7 @@ impl FixtureRunner {
         {
             let task_ptr = task.task_ptr;
             let tm_addr = task.callback;
-            self.dispatcher.timer_current_subtick = current_subtick;
+            self.dispatcher.callback_scheduling.current_subtick = current_subtick;
             // Mark only the task being delivered as fired. Other tasks that
             // expire on the same tick must remain active for a later interrupt.
             task.active = false;
@@ -9013,7 +9013,7 @@ impl FixtureRunner {
             }
             self.cpu.write_reg(Register::PC, tramp);
         } else {
-            self.dispatcher.timer_current_subtick = current_subtick;
+            self.dispatcher.callback_scheduling.current_subtick = current_subtick;
         }
     }
 
@@ -13420,6 +13420,7 @@ mod tests {
             sound,
             timer_tasks: Default::default(),
             vbl_tasks: Default::default(),
+            callback_scheduling: Default::default(),
             process_file_system: ppc_initial_process_file_system(),
             current_gworld: SharedProcessValue::from_value(PPC_MAIN_GWORLD),
             current_gdevice: SharedProcessValue::from_value(PPC_MAIN_GDEVICE),
@@ -15670,6 +15671,7 @@ mod tests {
             sound: Default::default(),
             timer_tasks: Default::default(),
             vbl_tasks: Default::default(),
+            callback_scheduling: Default::default(),
             process_file_system: SharedProcessFileSystem::from_state(
                 ProcessFileSystemState {
                 files: Vec::new(),
@@ -16688,6 +16690,7 @@ mod tests {
             sound: Default::default(),
             timer_tasks: Default::default(),
             vbl_tasks: Default::default(),
+            callback_scheduling: Default::default(),
             process_file_system: ppc_initial_process_file_system(),
             current_gworld: SharedProcessValue::from_value(PPC_MAIN_GWORLD),
             current_gdevice: SharedProcessValue::from_value(PPC_MAIN_GDEVICE),
@@ -16840,6 +16843,7 @@ mod tests {
             sound: Default::default(),
             timer_tasks: Default::default(),
             vbl_tasks: Default::default(),
+            callback_scheduling: Default::default(),
             process_file_system: ppc_initial_process_file_system(),
             current_gworld: SharedProcessValue::from_value(PPC_MAIN_GWORLD),
             current_gdevice: SharedProcessValue::from_value(PPC_MAIN_GDEVICE),
@@ -17251,6 +17255,7 @@ mod tests {
             sound: Default::default(),
             timer_tasks: Default::default(),
             vbl_tasks: Default::default(),
+            callback_scheduling: Default::default(),
             process_file_system: ppc_initial_process_file_system(),
             current_gworld: SharedProcessValue::from_value(PPC_MAIN_GWORLD),
             current_gdevice: SharedProcessValue::from_value(PPC_MAIN_GDEVICE),
@@ -17562,6 +17567,7 @@ mod tests {
             sound: Default::default(),
             timer_tasks: Default::default(),
             vbl_tasks: Default::default(),
+            callback_scheduling: Default::default(),
             process_file_system: ppc_initial_process_file_system(),
             current_gworld: SharedProcessValue::from_value(PPC_MAIN_GWORLD),
             current_gdevice: SharedProcessValue::from_value(PPC_MAIN_GDEVICE),

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -2561,23 +2561,14 @@ pub struct TrapDispatcher {
     /// Installed Time Manager tasks.
     /// Processes 1994, 3-14
     pub(crate) timer_tasks: crate::process_context::SharedProcessTimerTasks,
-    /// Exact scheduled wake-up retained for extended Time Manager records.
-    /// The guest `tmWakeUp` representation is explicitly private to the
-    /// manager; this map preserves its semantic deadline across RmvTime and
-    /// InsXTime without exposing host units. Processes 1994, pp. 3-8--3-9.
-    pub(crate) timer_extended_wakeups: HashMap<u32, u64>,
-    /// Exact Time Manager time while a callback is being delivered.
-    pub(crate) timer_current_subtick: u64,
+    /// Process-owned callback scheduling metadata.
+    pub(crate) callback_scheduling: crate::process_context::SharedProcessCallbackScheduling,
     /// Ordered Power Manager sleep queue. Each entry is a guest SleepQRec;
     /// its first longword remains the guest-visible next link.
     pub(crate) sleep_queue: Vec<u32>,
     /// Installed Vertical Retrace Manager tasks.
     /// Processes 1994, 4-6 to 4-7
     pub(crate) vbl_tasks: crate::process_context::SharedProcessVblTasks,
-    /// Dormant system-owned queue element kept ahead of application VBL tasks.
-    pub(crate) system_vbl_queue_anchor: u32,
-    /// Slot number of the primary video monitor for AttachVBL / VBL cursor routing.
-    pub(crate) primary_vbl_slot: i16,
     /// Active dialog tracking state (non-None while ModalDialog is tracking input)
     pub dialog_tracking: Option<DialogTrackingState>,
     /// Active Standard File Package save dialog tracking state.
@@ -2831,7 +2822,11 @@ impl TrapDispatcher {
         context.attach_file_system(&mut self.process_file_system);
         context.attach_resource_manager(&mut self.process_resource_manager);
         context.attach_sound_manager(&mut self.sound_manager);
-        context.attach_callback_tasks(&mut self.timer_tasks, &mut self.vbl_tasks);
+        context.attach_callback_tasks(
+            &mut self.timer_tasks,
+            &mut self.vbl_tasks,
+            &mut self.callback_scheduling,
+        );
         context.attach_cursor_state(&mut self.cursor_state);
         context.attach_quickdraw_selection(&mut self.current_port, &mut self.current_gdevice);
         context.attach_display_color_state(
@@ -4015,12 +4010,9 @@ impl TrapDispatcher {
             pending_native_trap_calls: HashMap::new(),
             bits_proc_reentry: None,
             timer_tasks: Default::default(),
-            timer_extended_wakeups: HashMap::new(),
-            timer_current_subtick: 0,
+            callback_scheduling: Default::default(),
             sleep_queue: Vec::new(),
             vbl_tasks: Default::default(),
-            system_vbl_queue_anchor: 0,
-            primary_vbl_slot: 0,
             dialog_tracking: None,
             standard_file_put_tracking: None,
             standard_file_get_tracking: None,

--- a/src/trap/event.rs
+++ b/src/trap/event.rs
@@ -938,7 +938,7 @@ impl super::TrapDispatcher {
                     cpu.write_reg(Register::D0, (-360i32) as u32);
                     return Some(Ok(()));
                 }
-                self.primary_vbl_slot = slot;
+                self.callback_scheduling.primary_vbl_slot = slot;
                 cpu.write_reg(Register::D0, 0);
                 Ok(())
             }
@@ -2011,7 +2011,7 @@ mod tests {
             "AttachVBL is register-based and should preserve A7"
         );
         assert_eq!(
-            disp.primary_vbl_slot, 10,
+            disp.callback_scheduling.primary_vbl_slot, 10,
             "AttachVBL should record the newly selected primary slot"
         );
     }
@@ -2022,7 +2022,7 @@ mod tests {
         // primary slot unchanged.
         let (mut disp, mut cpu, mut bus) = setup();
         let stack_ptr = 0x00F0_7000;
-        disp.primary_vbl_slot = 7;
+        disp.callback_scheduling.primary_vbl_slot = 7;
         cpu.write_reg(Register::D0, 16);
         cpu.write_reg(Register::A7, stack_ptr);
 
@@ -2040,7 +2040,7 @@ mod tests {
             "AttachVBL should preserve A7 on an invalid-slot path"
         );
         assert_eq!(
-            disp.primary_vbl_slot, 7,
+            disp.callback_scheduling.primary_vbl_slot, 7,
             "AttachVBL should not mutate the recorded primary slot on error"
         );
     }

--- a/src/trap/memory.rs
+++ b/src/trap/memory.rs
@@ -511,11 +511,11 @@ impl super::TrapDispatcher {
     }
 
     fn sync_vbl_links(&mut self, bus: &mut MacMemoryBus) {
-        if self.system_vbl_queue_anchor == 0 {
+        if self.callback_scheduling.system_vbl_queue_anchor == 0 {
             let anchor = bus.alloc_synthetic(14);
             if anchor != 0 {
                 bus.write_word(anchor + 4, 1); // vType
-                self.system_vbl_queue_anchor = anchor;
+                self.callback_scheduling.system_vbl_queue_anchor = anchor;
             }
         }
 
@@ -537,7 +537,7 @@ impl super::TrapDispatcher {
             .filter(|task| task.slot.is_none())
             .map(|task| task.task_ptr);
         let first_task = system_tasks.next().unwrap_or(0);
-        let anchor = self.system_vbl_queue_anchor;
+        let anchor = self.callback_scheduling.system_vbl_queue_anchor;
         if anchor != 0 {
             bus.write_long(anchor, first_task);
         }
@@ -1922,7 +1922,7 @@ impl super::TrapDispatcher {
                     OsRoutineVariant::TimeTaskExtended
                 );
                 if !extended || bus.read_long(task_ptr + 14) == 0 {
-                    self.timer_extended_wakeups.remove(&task_ptr);
+                    self.callback_scheduling.extended_wakeups.remove(&task_ptr);
                 }
                 // Remove any existing task for the same record address
                 self.timer_tasks.retain(|t| t.task_ptr != task_ptr);
@@ -1951,7 +1951,8 @@ impl super::TrapDispatcher {
             (false, 0x59) => {
                 let task_ptr = cpu.read_reg(Register::A0);
                 let current_subtick = self
-                    .timer_current_subtick
+                    .callback_scheduling
+                    .current_subtick
                     .max(bus.read_long(0x016A) as u64 * 1_000_000);
                 let remaining_subticks = self
                     .timer_tasks
@@ -2009,7 +2010,8 @@ impl super::TrapDispatcher {
                     (us * 60).max(1)
                 };
                 let current_subtick = self
-                    .timer_current_subtick
+                    .callback_scheduling
+                    .current_subtick
                     .max(current_ticks as u64 * SUBTICKS_PER_TICK);
                 let task_kind = self
                     .timer_tasks
@@ -2025,12 +2027,12 @@ impl super::TrapDispatcher {
                     let prior_wakeup = if bus.read_long(task_ptr + 14) == 0 {
                         None
                     } else {
-                        self.timer_extended_wakeups.get(&task_ptr).copied()
+                        self.callback_scheduling.extended_wakeups.get(&task_ptr).copied()
                     };
                     let intended_wakeup = prior_wakeup
                         .unwrap_or(current_subtick)
                         .saturating_add(requested_delay_subticks);
-                    self.timer_extended_wakeups
+                    self.callback_scheduling.extended_wakeups
                         .insert(task_ptr, intended_wakeup);
                     // tmWakeUp is explicitly an opaque internal format. Keep
                     // it nonzero so guest code can preserve or reset it, while
@@ -6967,11 +6969,11 @@ mod tests {
         );
         assert_eq!(
             bus.read_long(super::VBL_QUEUE_HEADER + 2),
-            dispatcher.system_vbl_queue_anchor,
+            dispatcher.callback_scheduling.system_vbl_queue_anchor,
             "VInstall should keep the system-owned queue anchor at the head"
         );
         assert_eq!(
-            bus.read_long(dispatcher.system_vbl_queue_anchor),
+            bus.read_long(dispatcher.callback_scheduling.system_vbl_queue_anchor),
             task_ptr,
             "the system-owned queue anchor should link to the application task"
         );
@@ -6998,7 +7000,7 @@ mod tests {
                 .expect("VInstall should return");
         }
 
-        let anchor = dispatcher.system_vbl_queue_anchor;
+        let anchor = dispatcher.callback_scheduling.system_vbl_queue_anchor;
         assert_ne!(anchor, 0);
         assert_eq!(bus.read_long(super::VBL_QUEUE_HEADER + 2), anchor);
         assert_eq!(bus.read_long(super::VBL_QUEUE_HEADER + 6), second);
@@ -10624,7 +10626,7 @@ mod tests {
         assert_eq!(dispatcher.timer_tasks[0].fire_at_subtick, 100_600_000);
         assert_ne!(bus.read_long(task_ptr + 14), 0);
 
-        dispatcher.timer_current_subtick = 100_750_000;
+        dispatcher.callback_scheduling.current_subtick = 100_750_000;
         cpu.write_reg(Register::A0, task_ptr);
         dispatcher
             .dispatch_memory(false, 0x59, &mut cpu, &mut bus)
@@ -10650,11 +10652,11 @@ mod tests {
             "callback latency must not shift the extended task's frequency"
         );
         assert_eq!(
-            dispatcher.timer_extended_wakeups.get(&task_ptr),
+            dispatcher.callback_scheduling.extended_wakeups.get(&task_ptr),
             Some(&101_200_000)
         );
 
-        dispatcher.timer_current_subtick = 102_000_000;
+        dispatcher.callback_scheduling.current_subtick = 102_000_000;
         dispatcher.timer_tasks[0].active = false;
         cpu.write_reg(Register::A0, task_ptr);
         cpu.write_reg(Register::D0, 1);
@@ -10667,7 +10669,7 @@ mod tests {
             "an intended expiry in the past must receive an actual zero delay"
         );
         assert_eq!(
-            dispatcher.timer_extended_wakeups.get(&task_ptr),
+            dispatcher.callback_scheduling.extended_wakeups.get(&task_ptr),
             Some(&101_260_000),
             "the past intended expiry remains the drift-free base"
         );
@@ -10773,7 +10775,7 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        dispatcher.timer_current_subtick = 100_150_000; // 2,500 us elapsed
+        dispatcher.callback_scheduling.current_subtick = 100_150_000; // 2,500 us elapsed
         cpu.write_reg(Register::A0, task_ptr);
         dispatcher
             .dispatch_memory(false, 0x59, &mut cpu, &mut bus)


### PR DESCRIPTION
Closes #1203.

Moves extended Time Manager deadlines, the exact callback clock, the system VBL queue anchor, and primary VBL slot into process-owned scheduling state shared by attached CPU gateways. Native InsXTime now preserves its extended-task identity and uses drift-free deadlines and RmvTime remaining-time semantics, while ordinary clones remain detached.

Validated with 4,751 library tests, strict rustdoc, all targets/features, both toolbox showcases, a locked release build, and fresh Marathon, Escape Velocity, and Tomb Raider Gold gameplay runs.