### PR TITLE
refactor(scrap)!: make desktop scrap process-owned

### DIFF
--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -3889,6 +3889,7 @@ impl PpcLoadedApp {
             &mut self.vbl_tasks,
             &mut self.callback_scheduling,
         );
+        context.attach_scrap_state(&mut self.scrap.desktop);
         context.attach_cursor_state(&mut self.cursor_state);
         context.activate_quickdraw_selection(&mut self.current_gworld, &mut self.current_gdevice);
         context.attach_display_color_state(
@@ -20308,12 +20309,13 @@ fn dispatch_supported_import(
         PpcImportDispatcherTarget::PutScrap => {
             // More Macintosh Toolbox (1993), pp. 2-35--2-37: successive calls
             // add ordered flavors; a repeated type remains a later occurrence.
-            let result = if !scrap.desktop_initialized {
+            let result = if !scrap.desktop.initialized {
                 PPC_NO_SCRAP_ERR
             } else if (cpu.gpr[3] as i32) < 0 {
                 PPC_PARAM_ERR
             } else if let Some(bytes) = ppc_memory_read_bytes(memory, cpu.gpr[5], cpu.gpr[3]) {
-                scrap.desktop_flavors.push((cpu.gpr[4], bytes));
+                scrap.desktop.entries.push((cpu.gpr[4].to_be_bytes(), bytes));
+                scrap.desktop.handle_dirty = true;
                 PPC_NO_ERR
             } else {
                 PPC_PARAM_ERR
@@ -20321,14 +20323,21 @@ fn dispatch_supported_import(
             Some(PpcImportAction::Return((i32::from(result)) as u32))
         }
         PpcImportDispatcherTarget::ZeroScrap => {
-            scrap.desktop_initialized = true;
-            scrap.desktop_flavors.clear();
+            scrap.desktop.initialized = true;
+            scrap.desktop.entries.clear();
+            scrap.desktop.count = scrap.desktop.count.wrapping_add(1);
+            scrap.desktop.in_memory = true;
+            scrap.desktop.handle_dirty = true;
             Some(PpcImportAction::Return(0))
         }
         PpcImportDispatcherTarget::LoadScrap => {
             // The process-owned desktop scrap remains resident in HLE, so an
             // explicit disk-to-memory synchronization is already satisfied.
-            scrap.desktop_initialized = true;
+            scrap.desktop.initialized = true;
+            if !scrap.desktop.in_memory {
+                scrap.desktop.in_memory = true;
+                scrap.desktop.handle_dirty = true;
+            }
             Some(PpcImportAction::Return(0))
         }
         PpcImportDispatcherTarget::FSpOpenDF => {
@@ -21506,9 +21515,10 @@ fn dispatch_supported_import(
             // Scrap Manager's desktop scrap and return an OSErr.
             let result = if from_desktop {
                 let bytes = scrap
-                    .desktop_flavors
+                    .desktop
+                    .entries
                     .iter()
-                    .find(|(flavor, _)| *flavor == u32::from_be_bytes(*b"TEXT"))
+                    .find(|(flavor, _)| *flavor == *b"TEXT")
                     .map(|(_, bytes)| bytes.clone());
                 if let Some(bytes) = bytes {
                     let mut allocator = PpcProcessAllocatorView {
@@ -21529,10 +21539,12 @@ fn dispatch_supported_import(
                 }
             } else {
                 let bytes = ppc_te_scrap_bytes(memory, handles, scrap);
-                scrap.desktop_initialized = true;
+                scrap.desktop.initialized = true;
                 scrap
-                    .desktop_flavors
-                    .push((u32::from_be_bytes(*b"TEXT"), bytes));
+                    .desktop
+                    .entries
+                    .push((*b"TEXT", bytes));
+                scrap.desktop.handle_dirty = true;
                 PPC_NO_ERR
             };
             Some(PpcImportAction::Return(ppc_i16_result(result)))
@@ -69469,7 +69481,8 @@ fn ppc_te_copy_or_cut(
 
 fn ppc_scrap_flavor_offset(scrap: &PpcScrapState, flavor_index: usize) -> u32 {
     scrap
-        .desktop_flavors
+        .desktop
+        .entries
         .iter()
         .take(flavor_index)
         .fold(0u32, |offset, (_, bytes)| {
@@ -69488,10 +69501,11 @@ fn ppc_get_scrap(
     scrap: &PpcScrapState,
 ) -> u32 {
     let Some((index, (_, bytes))) = scrap
-        .desktop_flavors
+        .desktop
+        .entries
         .iter()
         .enumerate()
-        .find(|(_, (flavor, _))| *flavor == cpu.gpr[4])
+        .find(|(_, (flavor, _))| *flavor == cpu.gpr[4].to_be_bytes())
     else {
         if cpu.gpr[5] != 0 {
             let _ = memory.write_u32_be(cpu.gpr[5], 0);
@@ -148968,6 +148982,85 @@ pub(crate) mod tests {
             .is_ok());
 
         assert_eq!(native.cursor_data(), Some((classic_data, classic_mask, 5, 6)));
+    }
+
+    #[test]
+    fn attached_desktop_scrap_mutations_cross_isa_immediately() {
+        let pef = synthetic_pef_with_import(b"TestImport");
+        let mut native = load_pef_application(&pef).unwrap();
+        let (mut classic, mut classic_cpu, mut classic_bus) = setup_with_port();
+        let mut context = ProcessContext::default();
+        classic.attach_process_context(&mut context);
+        native.attach_process_context(&mut context);
+
+        run_test_import(&mut native, PpcImportDispatcherTarget::ZeroScrap);
+        let native_source = PPC_DATA_BASE + 0x2600;
+        native.memory.add_region(native_source, b"native scrap".to_vec());
+        native.cpu.gpr[3] = 12;
+        native.cpu.gpr[4] = u32::from_be_bytes(*b"TEXT");
+        native.cpu.gpr[5] = native_source;
+        run_test_import(&mut native, PpcImportDispatcherTarget::PutScrap);
+        assert_eq!(native.cpu.gpr[3], 0);
+
+        let classic_offset = 0x0002_7000;
+        classic_bus.write_long(TEST_SP, classic_offset);
+        classic_bus.write_long(TEST_SP + 4, u32::from_be_bytes(*b"TEXT"));
+        classic_bus.write_long(TEST_SP + 8, 0);
+        classic_cpu.write_reg(Register::A7, TEST_SP);
+        assert!(classic
+            .dispatch_toolbox(true, 0x1FD, &mut classic_cpu, &mut classic_bus)
+            .unwrap()
+            .is_ok());
+        assert_eq!(classic_bus.read_long(TEST_SP + 12), 12);
+        assert_eq!(classic_bus.read_long(classic_offset), 8);
+
+        classic_cpu.write_reg(Register::A7, TEST_SP);
+        assert!(classic
+            .dispatch_toolbox(true, 0x1FC, &mut classic_cpu, &mut classic_bus)
+            .unwrap()
+            .is_ok());
+        let classic_source = 0x0002_7100;
+        for (offset, byte) in b"classic scrap".iter().copied().enumerate() {
+            classic_bus.write_byte(classic_source + offset as u32, byte);
+        }
+        classic_bus.write_long(TEST_SP, classic_source);
+        classic_bus.write_long(TEST_SP + 4, u32::from_be_bytes(*b"PICT"));
+        classic_bus.write_long(TEST_SP + 8, 13);
+        classic_cpu.write_reg(Register::A7, TEST_SP);
+        assert!(classic
+            .dispatch_toolbox(true, 0x1FE, &mut classic_cpu, &mut classic_bus)
+            .unwrap()
+            .is_ok());
+        assert_eq!(classic_bus.read_long(TEST_SP + 12), 0);
+
+        let native_offset = PPC_DATA_BASE + 0x2680;
+        native.memory.add_region(native_offset, vec![0; 4]);
+        native.cpu.gpr[3] = 0;
+        native.cpu.gpr[4] = u32::from_be_bytes(*b"PICT");
+        native.cpu.gpr[5] = native_offset;
+        run_test_import(&mut native, PpcImportDispatcherTarget::GetScrap);
+        assert_eq!(native.cpu.gpr[3], 13);
+        assert_eq!(native.memory.read_u32_be(native_offset), Some(0));
+        assert_eq!(native.scrap.desktop.count, 2);
+    }
+
+    #[test]
+    fn cloned_native_adapter_detaches_desktop_scrap() {
+        let mut original =
+            load_pef_application(&synthetic_pef_with_import(b"TestImport")).unwrap();
+        run_test_import(&mut original, PpcImportDispatcherTarget::ZeroScrap);
+        let mut detached = original.clone();
+        let source = PPC_DATA_BASE + 0x2600;
+        detached.memory.add_region(source, b"detached".to_vec());
+        detached.cpu.gpr[3] = 8;
+        detached.cpu.gpr[4] = u32::from_be_bytes(*b"TEXT");
+        detached.cpu.gpr[5] = source;
+        run_test_import(&mut detached, PpcImportDispatcherTarget::PutScrap);
+
+        assert!(original.scrap.desktop.entries.is_empty());
+        assert_eq!(original.scrap.desktop.count, 1);
+        assert_eq!(detached.scrap.desktop.entries, vec![(*b"TEXT", b"detached".to_vec())]);
+        assert_eq!(detached.scrap.desktop.count, 1);
     }
 
     #[test]

--- a/src/loader/ppc/vfs.rs
+++ b/src/loader/ppc/vfs.rs
@@ -1,9 +1,9 @@
 //! PowerPC Virtual File System, Volume, Scrap, and List records.
 
 use crate::process_context::{
-    ProcessForkBytes, ProcessOpenFileRecord, ProcessResourceFileRecord,
-    ProcessStdioStreamRecord, ProcessVfsDirectory, ProcessVfsFileRecord,
-    ProcessVfsResourceFileRecord, ProcessVfsResourceRecord, ProcessVfsVolumeRecord,
+    ProcessForkBytes, ProcessOpenFileRecord, ProcessResourceFileRecord, ProcessStdioStreamRecord,
+    ProcessVfsDirectory, ProcessVfsFileRecord, ProcessVfsResourceFileRecord,
+    ProcessVfsResourceRecord, ProcessVfsVolumeRecord, SharedProcessScrapState,
 };
 
 pub type PpcVfsDirectory = ProcessVfsDirectory;
@@ -46,8 +46,7 @@ pub type PpcVfsResourceRecord = ProcessVfsResourceRecord;
 #[derive(Debug, Clone, Default)]
 pub struct PpcScrapState {
     pub(crate) private_text_handle: u32,
-    pub(crate) desktop_initialized: bool,
-    pub(crate) desktop_flavors: Vec<(u32, Vec<u8>)>,
+    pub(crate) desktop: SharedProcessScrapState,
 }
 
 #[derive(Debug, Clone)]

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -1227,6 +1227,46 @@ pub(crate) type SharedProcessInputState = SharedProcessValue<ProcessInputState>;
 pub(crate) type SharedProcessTimerTasks = SharedProcessValue<Vec<ProcessTimerTask>>;
 pub(crate) type SharedProcessVblTasks = SharedProcessValue<Vec<ProcessVblTask>>;
 pub(crate) type SharedProcessCallbackScheduling = SharedProcessValue<ProcessCallbackScheduling>;
+pub(crate) type SharedProcessScrapState = SharedProcessValue<ProcessScrapState>;
+
+/// Canonical desktop scrap for one Macintosh process.
+///
+/// The Scrap Manager exposes one ordered collection of typed flavors to every
+/// execution architecture in the process. TextEdit's private scrap remains a
+/// separate adapter detail. Inside Macintosh Volume I (1985), pp. I-453 and
+/// I-457--I-459.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ProcessScrapState {
+    pub(crate) entries: Vec<([u8; 4], Vec<u8>)>,
+    pub(crate) count: i16,
+    pub(crate) initialized: bool,
+    pub(crate) in_memory: bool,
+    pub(crate) clipboard_writable: bool,
+    pub(crate) handle: Option<u32>,
+    pub(crate) handle_dirty: bool,
+    pub(crate) stuff_ptr: Option<u32>,
+}
+
+impl Default for ProcessScrapState {
+    fn default() -> Self {
+        Self {
+            entries: Vec::new(),
+            count: 0,
+            initialized: false,
+            in_memory: true,
+            clipboard_writable: false,
+            handle: None,
+            handle_dirty: false,
+            stuff_ptr: None,
+        }
+    }
+}
+
+impl ProcessScrapState {
+    fn is_pristine(&self) -> bool {
+        self == &Self::default()
+    }
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct ProcessKeyRepeatState {
@@ -4139,6 +4179,7 @@ pub(crate) struct ProcessContext {
     timer_tasks: SharedProcessTimerTasks,
     vbl_tasks: SharedProcessVblTasks,
     callback_scheduling: SharedProcessCallbackScheduling,
+    scrap_state: SharedProcessScrapState,
     cursor_state: SharedProcessCursorState,
     current_graphics_port: SharedProcessValue<u32>,
     current_graphics_device: SharedProcessValue<u32>,
@@ -4164,6 +4205,7 @@ impl Default for ProcessContext {
             timer_tasks: SharedProcessTimerTasks::default(),
             vbl_tasks: SharedProcessVblTasks::default(),
             callback_scheduling: SharedProcessCallbackScheduling::default(),
+            scrap_state: SharedProcessScrapState::default(),
             cursor_state: SharedProcessCursorState::default(),
             current_graphics_port: SharedProcessValue::from_value(0),
             current_graphics_device: SharedProcessValue::from_value(0),
@@ -4234,7 +4276,13 @@ impl ProcessContext {
     ) {
         timer_tasks.attach_to(&self.timer_tasks, Vec::is_empty);
         vbl_tasks.attach_to(&self.vbl_tasks, Vec::is_empty);
-        scheduling.attach_to(&self.callback_scheduling, |state| state == &Default::default());
+        scheduling.attach_to(&self.callback_scheduling, |state| {
+            state == &Default::default()
+        });
+    }
+
+    pub(crate) fn attach_scrap_state(&self, adapter: &mut SharedProcessScrapState) {
+        adapter.attach_to(&self.scrap_state, ProcessScrapState::is_pristine);
     }
 
     pub(crate) fn attach_cursor_state(&self, adapter: &mut SharedProcessCursorState) {

--- a/src/scripted_traces.rs
+++ b/src/scripted_traces.rs
@@ -855,7 +855,7 @@ pub fn scripted_modaldialog_preferences_checkbox_input_trace() -> Result<String,
 
 fn scripted_menu_setup() -> (TrapDispatcher, M68kCpu, MacMemoryBus) {
     let mut dispatcher = TrapDispatcher::new();
-    dispatcher.scrap_clipboard_writable = true;
+    dispatcher.scrap.clipboard_writable = true;
     let mut cpu = M68kCpu::new();
     let mut bus = MacMemoryBus::new(4 * 1024 * 1024);
 

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -18,7 +18,8 @@ use crate::process_context::{
     ProcessVfsMetadata, ProcessVfsVolumeRecord, SharedProcessAppleEventHandlers,
     SharedProcessCursorState, SharedProcessEventQueue, SharedProcessInputState,
     SharedProcessFileSystem, SharedProcessMemoryManager, SharedProcessMenuTracking,
-    SharedProcessResourceManager, SharedProcessSoundManager, SharedProcessValue,
+    SharedProcessResourceManager, SharedProcessScrapState, SharedProcessSoundManager,
+    SharedProcessValue,
 };
 use crate::trace::{TraceEvent, TraceSink, TraceSource};
 use crate::ui_theme::{UiTheme, UiThemeId};
@@ -2687,35 +2688,11 @@ pub struct TrapDispatcher {
     /// ProcPtr install. Some apps query a full-width userItem, shrink it to a
     /// small arrow hit rect with SetDItem, and draw the menu title separately.
     pub(crate) dialog_popup_candidate_items: HashSet<(u32, i16)>,
-    /// Desk scrap contents: list of (type_code, data) entries.
-    /// Each entry stores a 4-byte ResType and the raw data bytes.
-    /// Inside Macintosh Volume I, I-453
-    pub scrap_entries: Vec<([u8; 4], Vec<u8>)>,
-    /// Scrap change counter, incremented by ZeroScrap.
-    /// Inside Macintosh Volume I, I-458
-    pub scrap_count: i16,
-    /// True when the desk scrap is resident in memory.
-    /// False means InfoScrap reports the scrap on disk and hides the handle
-    /// until LoadScrap/ZeroScrap brings it back into memory.
-    pub scrap_in_memory: bool,
-    /// Whether the desk scrap can be persisted to a writable clipboard file.
-    /// False keeps UnloadScrap on the observable error path when the scrap is
-    /// resident and a disk write would be required.
-    pub(crate) scrap_clipboard_writable: bool,
+    /// Process-owned desk scrap shared by classic and native gateways.
+    pub(crate) scrap: SharedProcessScrapState,
     /// Most recent pack ID passed to InitPack.
     /// Kept as lightweight bookkeeping for future pack-specific heuristics.
     pub last_init_pack_id: Option<i16>,
-    /// Guest address of the master pointer for the in-memory desk scrap.
-    /// Lazily allocated on first InfoScrap call.
-    /// Inside Macintosh Volume I, I-457
-    pub scrap_handle: Option<u32>,
-    /// True when the serialized desk scrap handle needs rebuilding from
-    /// `scrap_entries` before the next InfoScrap observation.
-    pub scrap_handle_dirty: bool,
-    /// Guest address of the ScrapStuff record returned by InfoScrap.
-    /// Lazily allocated on first InfoScrap call.
-    /// Inside Macintosh Volume I, I-457
-    pub scrap_stuff_ptr: Option<u32>,
     /// Whether SetResLoad(TRUE) is active (default: true).
     /// When false, resource-retrieval functions return empty handles.
     /// Inside Macintosh Volume I, I-118
@@ -2827,6 +2804,7 @@ impl TrapDispatcher {
             &mut self.vbl_tasks,
             &mut self.callback_scheduling,
         );
+        context.attach_scrap_state(&mut self.scrap);
         context.attach_cursor_state(&mut self.cursor_state);
         context.attach_quickdraw_selection(&mut self.current_port, &mut self.current_gdevice);
         context.attach_display_color_state(
@@ -4048,14 +4026,8 @@ impl TrapDispatcher {
             dialog_item_popup_menus: HashMap::new(),
             dialog_popup_original_rects: HashMap::new(),
             dialog_popup_candidate_items: HashSet::new(),
-            scrap_entries: Vec::new(),
-            scrap_count: 0,
-            scrap_in_memory: true,
-            scrap_clipboard_writable: false,
+            scrap: SharedProcessScrapState::default(),
             last_init_pack_id: None,
-            scrap_handle: None,
-            scrap_handle_dirty: false,
-            scrap_stuff_ptr: None,
             res_load: true,
             res_purge: false,
         };

--- a/src/trap/test_helpers.rs
+++ b/src/trap/test_helpers.rs
@@ -80,7 +80,7 @@ pub const TEST_SP: u32 = 0x100000;
 /// - screenBits set up at $0824/$0828
 pub fn setup() -> (TrapDispatcher, MockCpu, MacMemoryBus) {
     let mut dispatcher = TrapDispatcher::new();
-    dispatcher.scrap_clipboard_writable = true;
+    dispatcher.scrap.clipboard_writable = true;
     let mut cpu = MockCpu::new();
     let mut bus = MacMemoryBus::new(4 * 1024 * 1024);
 

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -3411,7 +3411,7 @@ impl super::TrapDispatcher {
     }
 
     fn serialized_scrap_size(&self) -> u32 {
-        self.scrap_entries
+        self.scrap.entries
             .iter()
             .map(|(_, data)| {
                 let padded = (data.len() as u32 + 1) & !1;
@@ -3422,7 +3422,7 @@ impl super::TrapDispatcher {
 
     fn serialize_scrap_entries(&self) -> Vec<u8> {
         let mut bytes = Vec::with_capacity(self.serialized_scrap_size() as usize);
-        for (entry_type, data) in &self.scrap_entries {
+        for (entry_type, data) in &self.scrap.entries {
             bytes.extend_from_slice(entry_type);
             bytes.extend_from_slice(&(data.len() as u32).to_be_bytes());
             bytes.extend_from_slice(data);
@@ -3606,7 +3606,7 @@ impl super::TrapDispatcher {
     }
 
     fn sync_scrap_handle(&mut self, bus: &mut MacMemoryBus) -> u32 {
-        let handle = *self.scrap_handle.get_or_insert_with(|| {
+        let handle = *self.scrap.handle.get_or_insert_with(|| {
             let handle = bus.alloc(4);
             if handle != 0 {
                 bus.write_long(handle, 0);
@@ -3616,7 +3616,7 @@ impl super::TrapDispatcher {
         if handle == 0 {
             return 0;
         }
-        if !self.scrap_handle_dirty {
+        if !self.scrap.handle_dirty {
             return handle;
         }
 
@@ -3628,7 +3628,7 @@ impl super::TrapDispatcher {
             self.write_bytes_to_handle(bus, handle, &bytes) != 0
         };
         if wrote {
-            self.scrap_handle_dirty = false;
+            self.scrap.handle_dirty = false;
         }
         handle
     }
@@ -8870,19 +8870,19 @@ impl super::TrapDispatcher {
             (true, 0x1F9) => {
                 let sp = cpu.read_reg(Register::A7);
                 // Allocate ScrapStuff at a fixed location if not yet done
-                let scrap_stuff_ptr = self.scrap_stuff_ptr.get_or_insert_with(|| bus.alloc(16));
+                let scrap_stuff_ptr = self.scrap.stuff_ptr.get_or_insert_with(|| bus.alloc(16));
                 let ptr = *scrap_stuff_ptr;
                 let total_size = self.serialized_scrap_size();
-                let scrap_handle = if self.scrap_in_memory {
+                let scrap_handle = if self.scrap.in_memory {
                     self.sync_scrap_handle(bus)
                 } else {
                     0
                 };
                 bus.write_long(ptr, total_size); // scrapSize
                 bus.write_long(ptr + 4, scrap_handle); // scrapHandle (live in-memory desk scrap)
-                bus.write_word(ptr + 8, self.scrap_count as u16); // scrapCount
+                bus.write_word(ptr + 8, self.scrap.count as u16); // scrapCount
                                                                   // IM:I I-457: scrapState is positive when the scrap is in memory.
-                bus.write_word(ptr + 10, if self.scrap_in_memory { 1 } else { 0 });
+                bus.write_word(ptr + 10, if self.scrap.in_memory { 1 } else { 0 });
                 bus.write_long(ptr + 12, 0); // scrapName (NIL)
                 bus.write_long(sp, ptr); // return value
                 Ok(())
@@ -8919,12 +8919,12 @@ impl super::TrapDispatcher {
             //   src/trap/toolbox.rs::tests::unloadscrap_and_loadscrap_return_noerr
             (true, 0x1FA) => {
                 let sp = cpu.read_reg(Register::A7);
-                if self.scrap_in_memory && !self.scrap_clipboard_writable {
+                if self.scrap.in_memory && !self.scrap.clipboard_writable {
                     bus.write_long(sp, (-1i32) as u32); // generic non-zero OSErr
-                } else if self.scrap_in_memory {
-                    self.scrap_in_memory = false;
-                    self.scrap_handle_dirty = true;
-                    if let Some(handle) = self.scrap_handle.take() {
+                } else if self.scrap.in_memory {
+                    self.scrap.in_memory = false;
+                    self.scrap.handle_dirty = true;
+                    if let Some(handle) = self.scrap.handle.take() {
                         let _ = self.write_bytes_to_handle(bus, handle, &[]);
                         bus.free(handle);
                     }
@@ -8965,10 +8965,11 @@ impl super::TrapDispatcher {
             //   src/trap/toolbox.rs::tests::loadscrap_writes_noerr_to_pascal_function_result_slot_and_preserves_stack_pointer
             (true, 0x1FB) => {
                 let sp = cpu.read_reg(Register::A7);
-                if !self.scrap_in_memory {
-                    self.scrap_in_memory = true;
-                    self.scrap_handle_dirty = true;
+                if !self.scrap.in_memory {
+                    self.scrap.in_memory = true;
+                    self.scrap.handle_dirty = true;
                 }
+                self.scrap.initialized = true;
                 bus.write_long(sp, 0); // noErr
                 Ok(())
             }
@@ -8984,10 +8985,11 @@ impl super::TrapDispatcher {
             // ZeroScrap ($A9FC): Clears scrap entries and increments scrap_count per IM:I I-458
             (true, 0x1FC) => {
                 let sp = cpu.read_reg(Register::A7);
-                self.scrap_entries.clear();
-                self.scrap_count = self.scrap_count.wrapping_add(1);
-                self.scrap_in_memory = true;
-                self.scrap_handle_dirty = true;
+                self.scrap.entries.clear();
+                self.scrap.count = self.scrap.count.wrapping_add(1);
+                self.scrap.initialized = true;
+                self.scrap.in_memory = true;
+                self.scrap.handle_dirty = true;
                 bus.write_long(sp, 0); // noErr
                 Ok(())
             }
@@ -9020,7 +9022,7 @@ impl super::TrapDispatcher {
                 // N the data offset is sum(8 + padded_len_i for i<N) + 8.
                 let mut found_offset: u32 = 0;
                 let mut found = None;
-                for entry in &self.scrap_entries {
+                for entry in &self.scrap.entries {
                     if entry.0 == the_type {
                         found = Some(entry.1.clone());
                         found_offset += 8; // skip the matched entry's own header
@@ -9081,8 +9083,8 @@ impl super::TrapDispatcher {
                     for (i, byte) in data.iter_mut().enumerate() {
                         *byte = bus.read_byte(source + i as u32);
                     }
-                    self.scrap_entries.push((the_type, data));
-                    self.scrap_handle_dirty = true;
+                    self.scrap.entries.push((the_type, data));
+                    self.scrap.handle_dirty = true;
                 }
 
                 bus.write_long(sp + 12, 0); // noErr
@@ -19459,7 +19461,7 @@ mod tests {
         let (mut disp, mut cpu, mut bus) = setup();
         let sp = TEST_SP;
 
-        disp.scrap_clipboard_writable = false;
+        disp.scrap.clipboard_writable = false;
 
         bus.write_long(sp, 0);
         let zero = disp.dispatch_toolbox(true, 0x1FC, &mut cpu, &mut bus);


### PR DESCRIPTION
Closes #1205.

Moves desktop Scrap Manager flavors, initialization/residency, change count, and classic ScrapStuff backing pointers into process-owned state shared by attached 68K and PowerPC gateways. TextEdit’s private scrap remains adapter-local, while ordinary clones remain detached.

Validated with 4,753 library tests, strict rustdoc, all targets/features compilation, both toolbox showcase architectures, a locked release build, and fresh Marathon, Escape Velocity, and Tomb Raider Gold gameplay runs.