### PR TITLE
fix(quickdraw): resolve screen colors against logical palette

### DIFF
--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -17147,7 +17147,12 @@ fn dispatch_supported_import(
                 if main_8bpp {
                     quickdraw_fore_indices.insert(
                         *current_gworld,
-                        ppc_color_to_index(memory, *current_gdevice, screen_clut, color) as u8,
+                        ppc_color_to_index(
+                            memory,
+                            *current_gdevice,
+                            color_manager_clut,
+                            color,
+                        ) as u8,
                     );
                 } else {
                     quickdraw_fore_indices.remove(current_gworld);
@@ -17180,7 +17185,12 @@ fn dispatch_supported_import(
                 if main_8bpp {
                     toolbox_startup.quickdraw_back_indices.insert(
                         *current_gworld,
-                        ppc_color_to_index(memory, *current_gdevice, screen_clut, color) as u8,
+                        ppc_color_to_index(
+                            memory,
+                            *current_gdevice,
+                            color_manager_clut,
+                            color,
+                        ) as u8,
                     );
                 } else {
                     toolbox_startup
@@ -17306,7 +17316,9 @@ fn dispatch_supported_import(
         }
         PpcImportDispatcherTarget::Color2Index => {
             let pixel = ppc_read_rgb_color(memory, cpu.gpr[3])
-                .map(|color| ppc_color_to_index(memory, *current_gdevice, screen_clut, color))
+                .map(|color| {
+                    ppc_color_to_index(memory, *current_gdevice, color_manager_clut, color)
+                })
                 .unwrap_or(0);
             Some(PpcImportAction::Return(pixel))
         }
@@ -63169,7 +63181,7 @@ fn ppc_index_to_color(
 fn ppc_color_to_index(
     memory: &mut PpcSectionMem,
     current_gdevice: u32,
-    screen_clut: &[[u16; 3]; 256],
+    logical_screen_clut: &[[u16; 3]; 256],
     color: PpcRgbColor,
 ) -> u32 {
     let pixmap = ppc_current_gdevice_record(memory, current_gdevice)
@@ -63185,18 +63197,17 @@ fn ppc_color_to_index(
     }
 
     if current_gdevice == PPC_MAIN_GDEVICE && depth == 8 {
-        // Match the main screen's cached logical inverse table rather than
-        // scanning the live hardware CLUT, which may be independently faded
-        // or replaced. Inside Macintosh Volume V (1986), pp. V-137..V-143.
-        return u32::from(TrapDispatcher::standard_screen_itable_index([
-            color.red,
-            color.green,
-            color.blue,
-        ]));
+        // Match the main screen's logical ColorTable rather than scanning the
+        // independently animated hardware CLUT. A real ColorTable replacement
+        // changes this lookup; a hardware-only fade does not.
+        return u32::from(TrapDispatcher::screen_itable_index(
+            logical_screen_clut,
+            [color.red, color.green, color.blue],
+        ));
     }
 
     let entry_count = 1usize << usize::from(depth.clamp(1, 8));
-    let fallback = *screen_clut;
+    let fallback = *logical_screen_clut;
     let clut = pixmap
         .and_then(|pixmap| memory.read_u32_be(pixmap.checked_add(42)?))
         .filter(|handle| *handle != 0)
@@ -132487,6 +132498,40 @@ pub(crate) mod tests {
                 assert!(!loaded.quickdraw_fore_indices.contains_key(&PPC_MAIN_GWORLD));
             }
         }
+    }
+
+    #[test]
+    fn rgb_fore_color_uses_replaced_logical_screen_table_not_hardware_palette() {
+        let pef = synthetic_pef_with_import(b"RGBForeColor");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let gray = [0x9F9F; 3];
+        loaded.color_manager_clut[86] = [0, 0, 0x9B9B];
+        loaded.color_manager_clut[144] = gray;
+        loaded.screen_clut[86] = gray;
+        loaded.screen_clut[144] = [0, 0, 0x9B9B];
+
+        let color_ptr = PPC_DATA_BASE + 0x1000;
+        loaded.memory.add_region(color_ptr, vec![0; 6]);
+        ppc_write_rgb_color(
+            &mut loaded.memory,
+            color_ptr,
+            PpcRgbColor {
+                red: gray[0],
+                green: gray[1],
+                blue: gray[2],
+            },
+        )
+        .unwrap();
+        loaded.cpu.gpr[3] = color_ptr;
+
+        let probe = loaded.run_with_hle_imports(64);
+
+        assert_eq!(probe.unsupported_import_index, None);
+        assert_eq!(
+            loaded.quickdraw_fore_indices.get(&PPC_MAIN_GWORLD),
+            Some(&144)
+        );
+        assert_eq!(loaded.screen_clut[144], [0, 0, 0x9B9B]);
     }
 
     #[test]

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -4350,23 +4350,16 @@ impl TrapDispatcher {
         Self::standard_mac_4bpp_gworld_itable()[cell]
     }
 
-    /// 4-bit-per-channel inverse table (16x16x16 = 4096 cells) precomputed
-    /// from `standard_mac_8bpp_clut`. Each cell holds the CLUT index
-    /// whose entry is closest (by Euclidean distance in 16-bit RGB) to
-    /// the centre of that cube cell.
+    /// 4-bit-per-channel inverse table (16x16x16 = 4096 cells) for the
+    /// standard 8-bit ColorTable. Each cell holds the CLUT index whose entry
+    /// is closest (by Euclidean distance in 16-bit RGB) to the centre of that
+    /// cube cell.
     ///
-    /// This is the cached form the Mac ROM uses via MakeITable: built
-    /// once per GDevice from the GDevice's CTab, then consulted by
-    /// CopyBits/DrawPicture for every pixel mapping. CRITICALLY, the
-    /// ITable is NOT rebuilt when SetEntries modifies the active CLUT —
-    /// the active CLUT controls how stored framebuffer indices DISPLAY
-    /// (palette lookup at scan-out), but the ITable controls which
-    /// dst index gets WRITTEN to the framebuffer (during DrawPicture).
-    ///
-    /// Systemless's prior `closest_clut_index` re-runs full-precision
-    /// closest-match against `device_clut` per pixel, which produces
-    /// different dst indices than the ROM whenever device_clut has
-    /// drifted from the System palette via SetEntries fades.
+    /// QuickDraw associates an inverse table with a GDevice ColorTable. The
+    /// table remains stable across hardware-only palette animation, but a
+    /// logical ColorTable replacement requires a corresponding inverse table.
+    /// This standard-palette table is therefore only an oracle for GDevices
+    /// that still have the canonical System ColorTable.
     /// Imaging With QuickDraw 1994, p. 4-82 (MakeITable, default 4 bits)
     pub(crate) fn standard_mac_8bpp_itable() -> [u8; 4096] {
         let clut = Self::standard_mac_8bpp_clut();
@@ -4415,17 +4408,60 @@ impl TrapDispatcher {
         })
     }
 
-    /// Resolve an RGB color through the main 8-bit screen GDevice's cached
-    /// inverse table. Exact endpoints retain QuickDraw's conventional white
-    /// and black pixels; all other colors use the four-bit device lookup.
-    pub(crate) fn standard_screen_itable_index(rgb: [u16; 3]) -> u8 {
-        if rgb == [0xFFFF; 3] {
-            0
-        } else if rgb == [0; 3] {
-            255
-        } else {
-            Self::standard_itable_lookup(rgb[0], rgb[1], rgb[2])
+    /// Resolve an RGB color through the main 8-bit screen GDevice's logical
+    /// inverse table.
+    ///
+    /// The logical ColorTable is deliberately distinct from the live video
+    /// DAC palette: low-level fades change how existing pixels are displayed
+    /// without changing which pixel value QuickDraw selects. A genuine
+    /// ColorTable replacement, however, must change the inverse lookup. This
+    /// mirrors the `ctSeed`/`iTabSeed` relationship described by Inside
+    /// Macintosh: Advanced Color Imaging, "Inverse Tables".
+    pub(crate) fn screen_itable_index(clut: &[[u16; 3]; 256], rgb: [u16; 3]) -> u8 {
+        // Preserve the conventional endpoint pixels even when the ColorTable
+        // contains duplicate white or black entries.
+        if rgb == [0xFFFF; 3] && clut[0] == rgb {
+            return 0;
         }
+        if rgb == [0; 3] && clut[255] == rgb {
+            return 255;
+        }
+
+        // Keep the exact System 7.5.3 oracle, including its propagation and
+        // tie-breaking, while the logical GDevice table is canonical.
+        static STANDARD_CLUT: OnceLock<[[u16; 3]; 256]> = OnceLock::new();
+        let standard_clut = STANDARD_CLUT.get_or_init(Self::standard_mac_8bpp_clut);
+        if clut == standard_clut {
+            return Self::standard_itable_lookup(rgb[0], rgb[1], rgb[2]);
+        }
+
+        // Color2Index returns an exact ColorTable entry before consulting
+        // the quantized inverse-table cell.
+        if let Some(index) = clut.iter().position(|entry| *entry == rgb) {
+            return index as u8;
+        }
+
+        // A custom table uses the same four-bit cell-centre rule as
+        // `build_inverse_table_bytes`, but computing the one requested cell
+        // avoids constructing a 4096-byte table for infrequent RGBForeColor
+        // and RGBBackColor calls.
+        let centre = |component: u16| i64::from((component & 0xF000) | 0x0800);
+        let cr = centre(rgb[0]);
+        let cg = centre(rgb[1]);
+        let cb = centre(rgb[2]);
+        let mut best_index = 0u8;
+        let mut best_distance = i64::MAX;
+        for (index, entry) in clut.iter().enumerate() {
+            let dr = cr - i64::from(entry[0]);
+            let dg = cg - i64::from(entry[1]);
+            let db = cb - i64::from(entry[2]);
+            let distance = dr * dr + dg * dg + db * db;
+            if distance < best_distance {
+                best_index = index as u8;
+                best_distance = distance;
+            }
+        }
+        best_index
     }
 
     /// Register loaded segments for LoadSeg trap.

--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -17330,6 +17330,28 @@ impl super::TrapDispatcher {
         );
     }
 
+    fn restore_system_palette_for_window(&mut self, bus: &mut MacMemoryBus, window: u32) {
+        let current_clut = *self.device_clut;
+        let mut restored_clut = Self::standard_mac_8bpp_clut();
+
+        // Removing a window palette releases its ordinary allocations, but
+        // protected and reserved cells remain owned until their corresponding
+        // Color Manager operation releases them. This matches the native PPC
+        // Palette Manager path and Inside Macintosh: Advanced Color Imaging,
+        // pp. 1-8 and 1-14.
+        for index in 0..256 {
+            if self.clut_protected[index] || self.clut_reserved[index] {
+                restored_clut[index] = current_clut[index];
+            }
+        }
+
+        let color_environment_changed = restored_clut != current_clut;
+        self.install_application_clut(bus, restored_clut);
+        if color_environment_changed {
+            self.invalidate_windows_for_palette_change(bus, window);
+        }
+    }
+
     /// Trap-facing activation path that requires an exact window-to-palette
     /// association instead of falling back to the default-window palette.
     pub(crate) fn activate_associated_palette_for_window(
@@ -17342,6 +17364,17 @@ impl super::TrapDispatcher {
         }
 
         let palette_handle = self.window_palette_handle_exact(window);
+        if palette_handle == 0 {
+            // With neither a window palette nor an application-default
+            // palette, Palette Manager restores the System palette. This is
+            // also what the native PPC adapter does. Keep the exact lookup:
+            // an application-default palette is not silently substituted by
+            // this trap-facing path.
+            if self.window_palette_handle_exact(PALETTE_DEFAULT_WINDOW) == 0 {
+                self.restore_system_palette_for_window(bus, window);
+            }
+            return;
+        }
         self.apply_palette_to_active_device(
             bus,
             window,
@@ -19553,16 +19586,15 @@ impl super::TrapDispatcher {
         } else {
             (*self.device_clut, self.screen_mode.4 == 8)
         };
+        let logical_screen_clut = *self.color_manager_clut;
 
         if foreground {
             let rgb = [self.fg_color.0, self.fg_color.1, self.fg_color.2];
             let pixel = if use_screen_itable && screen_itable {
-                // The screen GDevice's inverse table is a logical color
-                // matcher, not a nearest-color scan of the live video DAC.
-                // Games can replace or fade the hardware CLUT while the
-                // cached screen lookup remains unchanged.
-                // Inside Macintosh Volume V (1986), pp. V-137..V-143.
-                Self::standard_screen_itable_index(rgb)
+                // The screen GDevice's inverse table follows its logical
+                // ColorTable, not the independently animated video DAC.
+                // Inside Macintosh: Advanced Color Imaging, "Inverse Tables".
+                Self::screen_itable_index(&logical_screen_clut, rgb)
             } else {
                 Self::nearest_palette_index(&resolution_clut, rgb)
             };
@@ -19572,7 +19604,7 @@ impl super::TrapDispatcher {
         if background {
             let rgb = [self.bg_color.0, self.bg_color.1, self.bg_color.2];
             let pixel = if use_screen_itable && screen_itable {
-                Self::standard_screen_itable_index(rgb)
+                Self::screen_itable_index(&logical_screen_clut, rgb)
             } else {
                 Self::nearest_palette_index(&resolution_clut, rgb)
             };
@@ -26830,7 +26862,8 @@ mod tests {
         hardware_clut[117] = [0x1010, 0x0A0A, 0x6969];
         hardware_clut[213] = [0x7B7B, 0x7373, 0x8484];
 
-        let pixel = TrapDispatcher::standard_screen_itable_index([0, 0, 0x6666]);
+        let logical_clut = TrapDispatcher::standard_mac_8bpp_clut();
+        let pixel = TrapDispatcher::screen_itable_index(&logical_clut, [0, 0, 0x6666]);
 
         assert_eq!(pixel, 213);
         assert_eq!(hardware_clut[pixel as usize], [0x7B7B, 0x7373, 0x8484]);
@@ -26839,6 +26872,36 @@ mod tests {
             117,
             "a live-hardware nearest-color scan reproduces the regressed saturated-blue pixel"
         );
+    }
+
+    #[test]
+    fn rgb_fore_color_uses_replaced_logical_screen_table_not_hardware_palette() {
+        let (mut d, mut cpu, mut bus) = setup_with_port();
+        let port = 0x181000u32;
+        bus.write_long(port + 2, 0);
+        bus.write_word(port + 6, 0xC000);
+        d.set_current_port_state(&mut bus, &mut cpu, port, None);
+
+        let gray = [0x9F9F; 3];
+        *d.color_manager_clut = TrapDispatcher::standard_mac_8bpp_clut();
+        d.color_manager_clut[86] = [0, 0, 0x9B9B];
+        d.color_manager_clut[144] = gray;
+        *d.device_clut = *d.color_manager_clut;
+        d.device_clut[86] = gray;
+        d.device_clut[144] = [0, 0, 0x9B9B];
+
+        let color = bus.alloc(6);
+        bus.write_word(color, gray[0]);
+        bus.write_word(color + 2, gray[1]);
+        bus.write_word(color + 4, gray[2]);
+        cpu.write_reg(Register::A7, TEST_SP);
+        bus.write_long(TEST_SP, color);
+
+        let result = d.dispatch_quickdraw(true, 0x214, &mut cpu, &mut bus);
+
+        assert!(result.unwrap().is_ok());
+        assert_eq!(bus.read_long(port + 80), 144);
+        assert_eq!(d.device_clut[144], [0, 0, 0x9B9B]);
     }
 
     #[test]
@@ -38798,6 +38861,27 @@ mod tests {
         assert!(result.unwrap().is_ok());
         assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 4);
         assert_eq!(d.device_clut, before);
+    }
+
+    #[test]
+    fn activatepalette_without_window_or_default_palette_restores_system_colors() {
+        let (mut d, mut cpu, mut bus) = setup();
+        let window = 0x0020_4080u32;
+        d.front_window = window;
+        *d.current_port = window;
+        d.device_clut[42] = [0x1234, 0x5678, 0x9ABC];
+        d.color_manager_clut[42] = [0x1234, 0x5678, 0x9ABC];
+        bus.write_long(TEST_SP, window);
+
+        let result = d.dispatch_quickdraw(true, 0x294, &mut cpu, &mut bus);
+
+        assert!(result.unwrap().is_ok());
+        assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 4);
+        assert_eq!(d.device_clut, TrapDispatcher::standard_mac_8bpp_clut());
+        assert_eq!(
+            d.color_manager_clut,
+            TrapDispatcher::standard_mac_8bpp_clut()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fix indexed-screen RGB color resolution after an application replaces the main screen's logical ColorTable.

This fixes the SimCity 2000 regression in which dialog borders became green and buttons became blue. It preserves the hardware-palette animation behavior fixed by #1152, while making the inverse lookup follow the GDevice's current *logical* palette instead of assuming that the logical palette is always the standard System 7.5.3 palette.

The same semantics are applied to the native 68K and PPC QuickDraw paths. The 68K Palette Manager path also now restores the System palette when `ActivatePalette` is called for a window with neither a window-specific palette nor an application-default palette, matching the existing PPC behavior.

Before:
<img width="800" height="600" alt="sc2k-color-regression-bad-94c5f8f" src="https://github.com/user-attachments/assets/c160dac4-ee96-4f78-a891-bfc96f90af31" />

After:
<img width="800" height="600" alt="sc2k-color-regression-good-parent-39e4ca1" src="https://github.com/user-attachments/assets/bb9502cb-df4a-41d9-85d6-521468c74922" />


## Root cause

#1152 correctly separated two pieces of indexed-color state that classic QuickDraw treats differently:

- The GDevice ColorTable and its inverse table determine which pixel index QuickDraw writes for a requested RGB color.
- The live hardware palette determines how an existing pixel index appears on the display. A game may animate or fade this palette without changing RGB-to-index mapping.

The regression came from implementing the first item as one permanently cached inverse table derived from the standard System 7.5.3 8-bit palette. That works while the screen's logical ColorTable is still canonical, and it prevents a hardware-only fade from feeding back into drawing. It is not sufficient when an application installs a genuinely different logical ColorTable: the inverse table belongs to that ColorTable and must change with it.

SimCity 2000 installs a custom logical screen palette. Its dialog grays exist at different indices than they do in the standard System palette. Looking them up in the standard inverse table therefore selected indices whose entries in SC2K's live palette were unrelated colors:

| Requested RGB | Index from stale standard ITable | SC2K color at that index | Exact index in SC2K logical table |
| --- | ---: | --- | ---: |
| `9F9F,9F9F,9F9F` | 86 | `0000,0000,9B9B` (blue) | 144 |
| `E3E3,E3E3,E3E3` | 245 | `FCFC,F3F3,0505` (yellow) | 139 |
| `5757,5757,5757` | 251 | `1F1F,B7B7,1414` (green) | 149 |
| `8383,8383,8383` | 249 | `9090,7171,3A3A` (brown) | 146 |
| `BBBB,BBBB,BBBB` | 247 | `8080,8080,8080` (wrong gray) | 142 |

That is why controls that should have used neutral grays appeared blue or green.

This follows the classic model described by Inside Macintosh: the inverse table is associated with a GDevice ColorTable, and `ctSeed`/`iTabSeed` track whether that relationship is current. Hardware-only palette changes do not require a new inverse table, but replacing the logical ColorTable does.

- [Inside Macintosh: Imaging With QuickDraw](https://developer.apple.com/library/archive/documentation/mac/pdf/Imaging_With_QuickDraw/Imaging_TOC.pdf), particularly `MakeITable` and inverse-table behavior
- [Inside Macintosh: QuickDraw GX / GDevice color-table management](https://dev.os9.ca/techpubs/mac/QuickDraw/QuickDraw-198.html)
- [Inside Macintosh: Advanced Color Imaging — inverse tables](https://dev.os9.ca/techpubs/mac/ACI/ACI-103.html)

## Implementation

- Resolve main-screen RGB colors against `color_manager_clut`, the logical GDevice ColorTable, in both native 68K and PPC `RGBForeColor`/`RGBBackColor`/`Color2Index` paths.
- Continue using `device_clut` as the displayed hardware palette, so `SetEntries`-style fades and palette animation do not alter the indices QuickDraw writes.
- Use the exact precomputed System 7.5.3 inverse-table oracle only when all 256 logical ColorTable entries are canonical.
- For a custom ColorTable, return an exact entry first; otherwise compute the nearest entry for the requested 4-bit inverse-table cell using the same cell-center rule as `build_inverse_table_bytes`.
- Restore the System palette on native 68K `ActivatePalette(window)` when the window has no associated palette and there is no application-default palette. Protected and reserved cells remain intact, consistent with the existing PPC path and Palette Manager ownership rules.

The standard CLUT is cached once. Canonical lookup remains constant-time after the 256-entry identity check. A custom lookup examines at most 256 entries for the one requested cell, avoiding construction of a complete 4,096-cell inverse table for infrequent RGB color traps. This does not change guest instruction execution or the runner's performance paths.

## Validation

- Rebased onto upstream `master` at `1637baa`.
- Added native 68K and PPC regressions in which the logical and hardware palettes deliberately disagree; both resolve `9F9F` gray to logical index 144 rather than the stale/hardware index.
- Added a regression for restoring System colors after a window and application-default palette are both absent.
- Preserved the #1152 hardware-fade regression: standard logical inverse lookup remains unchanged when only the hardware CLUT is altered.
- `cargo test --all --quiet`: 4,753 library tests passed (3 ignored), 79 binary tests passed, 4 `pack-web` tests passed, and the toolbox showcase passed.
- All 13 toolbox-showcase visual reference frames are unchanged.
- Deterministic SC2K headless replay with a fresh save directory and identical scripted input for 10,000,000 guest instructions reached 17,574 ticks. Its final framebuffer was byte-identical to the known-good parent of #1152:
  - fixed/current: `6e1120f807b105be2f59088098382cd444926949b56b5c06dbc35d53d1e91e6c`
  - known-good parent: `6e1120f807b105be2f59088098382cd444926949b56b5c06dbc35d53d1e91e6c`
  - regressed #1152/master image: `fb36884d00bd112a8cea369bf9b5bf6d61f4f3c10b33b7b7c98f188f7bc7ac8e`
