### PR TITLE
refactor(control)!: make metadata process-owned

### DIFF
--- a/src/control_manager.rs
+++ b/src/control_manager.rs
@@ -1,5 +1,139 @@
 //! Architecture-neutral Control Manager records and list operations.
 
+/// Host metadata for one guest `ControlRecord`.
+///
+/// The relocatable record and its window-list link remain canonical guest
+/// memory. This process-owned entry retains only information that the HLE
+/// cannot recover reliably from the record, including the original control
+/// definition ID and pop-up definition private values. Inside Macintosh
+/// Volume I (1985), pp. I-316--I-319 and I-328--I-333.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct ProcessControlRecord {
+    pub(crate) handle: u32,
+    pub(crate) pointer: u32,
+    pub(crate) proc_id: i16,
+    pub(crate) popup_menu_id: i16,
+    pub(crate) popup_title_width: Option<i16>,
+}
+
+/// Canonical Control Manager metadata for one Macintosh process.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) struct ProcessControlManagerState {
+    records: Vec<ProcessControlRecord>,
+}
+
+impl ProcessControlManagerState {
+    pub(crate) fn is_pristine(&self) -> bool {
+        self.records.is_empty()
+    }
+
+    pub(crate) fn register(&mut self, handle: u32, pointer: u32, proc_id: i16, popup_menu_id: i16) {
+        self.records
+            .retain(|record| handle == 0 || record.handle != handle || record.pointer == pointer);
+        if let Some(record) = self
+            .records
+            .iter_mut()
+            .find(|record| record.pointer == pointer && pointer != 0)
+        {
+            if handle != 0 {
+                record.handle = handle;
+            }
+            record.proc_id = proc_id;
+            record.popup_menu_id = popup_menu_id;
+            return;
+        }
+        self.records.push(ProcessControlRecord {
+            handle,
+            pointer,
+            proc_id,
+            popup_menu_id,
+            popup_title_width: None,
+        });
+    }
+
+    pub(crate) fn proc_id(&self, pointer: u32) -> i16 {
+        self.records
+            .iter()
+            .find(|record| record.pointer == pointer)
+            .map_or(0, |record| record.proc_id)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn contains_pointer(&self, pointer: u32) -> bool {
+        self.records.iter().any(|record| record.pointer == pointer)
+    }
+
+    pub(crate) fn set_proc_id(&mut self, pointer: u32, proc_id: i16) {
+        if let Some(record) = self
+            .records
+            .iter_mut()
+            .find(|record| record.pointer == pointer)
+        {
+            record.proc_id = proc_id;
+        } else {
+            self.register(0, pointer, proc_id, 0);
+        }
+    }
+
+    pub(crate) fn associate_handle(&mut self, handle: u32, pointer: u32) {
+        self.records
+            .retain(|record| record.handle != handle || record.pointer == pointer);
+        if let Some(record) = self
+            .records
+            .iter_mut()
+            .find(|record| record.pointer == pointer)
+        {
+            record.handle = handle;
+        } else {
+            self.register(handle, pointer, 0, 0);
+        }
+    }
+
+    pub(crate) fn set_popup_title_width(&mut self, pointer: u32, width: i16) {
+        if !self.records.iter().any(|record| record.pointer == pointer) {
+            self.register(0, pointer, 0, 0);
+        }
+        if let Some(record) = self
+            .records
+            .iter_mut()
+            .find(|record| record.pointer == pointer)
+        {
+            record.popup_title_width = Some(width);
+        }
+    }
+
+    pub(crate) fn popup_title_width(&self, pointer: u32, fallback: i16) -> i16 {
+        self.records
+            .iter()
+            .find(|record| record.pointer == pointer)
+            .and_then(|record| record.popup_title_width)
+            .unwrap_or(fallback)
+    }
+
+    pub(crate) fn remove_pointer(&mut self, pointer: u32) {
+        self.records.retain(|record| record.pointer != pointer);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn remove_handle(&mut self, handle: u32) {
+        self.records.retain(|record| record.handle != handle);
+    }
+}
+
+impl std::ops::Deref for ProcessControlManagerState {
+    type Target = Vec<ProcessControlRecord>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.records
+    }
+}
+
+impl std::ops::DerefMut for ProcessControlManagerState {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.records
+    }
+}
+
 /// Maximum number of controls accepted from one live guest `wControlList`.
 ///
 /// This is a defensive corruption bound, not a guest-visible Control Manager

--- a/src/loader/ppc/graphics.rs
+++ b/src/loader/ppc/graphics.rs
@@ -1,5 +1,6 @@
 //! PowerPC graphics, GWorld, and color representation records.
 
+pub(crate) use crate::control_manager::ProcessControlRecord as PpcControlRecord;
 use crate::menu_manager::MenuTrackingSurface;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -115,13 +116,6 @@ impl PpcQuickDrawSurface {
             right.wrapping_sub(self.left),
         )
     }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct PpcControlRecord {
-    pub handle: u32,
-    pub proc_id: i16,
-    pub popup_menu_id: i16,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -77,7 +77,7 @@ use crate::process_context::{
     ProcessPtrRecord, ProcessResourceManagerState, ProcessVfsFileRecords,
     ProcessVfsResourceFileRecords, SharedProcessAppleEventHandlers,
     SharedProcessCallbackScheduling, SharedProcessCursorState, SharedProcessDialogText,
-    SharedProcessEventQueue,
+    SharedProcessControlManager, SharedProcessEventQueue,
     SharedProcessFileSystem, SharedProcessInputState, SharedProcessMemoryManager,
     SharedProcessMenuTracking, SharedProcessTimerTasks, SharedProcessValue,
     SharedProcessVblTasks,
@@ -3334,7 +3334,7 @@ pub struct PpcLoadedApp {
     pub cfm_connections: Vec<PpcCfmConnection>,
     pub cfm_library_fragments: Vec<PpcCfmLibraryFragment>,
     pub next_cfm_connection_id: u32,
-    pub controls: Vec<PpcControlRecord>,
+    pub(crate) controls: SharedProcessControlManager,
     pub aliases: Vec<PpcAliasRecord>,
     pub gworlds: Vec<PpcGWorldRecord>,
     pub q3_objects: Vec<PpcQ3ObjectRecord>,
@@ -3891,6 +3891,7 @@ impl PpcLoadedApp {
             &mut self.callback_scheduling,
         );
         context.attach_scrap_state(&mut self.scrap.desktop);
+        context.attach_control_manager(&mut self.controls);
         context.attach_dialog_text(&mut self.param_text);
         context.attach_cursor_state(&mut self.cursor_state);
         context.activate_quickdraw_selection(&mut self.current_gworld, &mut self.current_gdevice);
@@ -12704,7 +12705,7 @@ fn load_pef_application_with_config_and_optional_system_reservation(
         cfm_connections,
         cfm_library_fragments: Vec::new(),
         next_cfm_connection_id,
-        controls: Vec::new(),
+        controls: SharedProcessControlManager::default(),
         aliases: Vec::new(),
         gworlds,
         q3_objects: Vec::new(),
@@ -65752,15 +65753,14 @@ fn ppc_new_control_record_values(
         *last_mem_error = PPC_PARAM_ERR;
         return 0;
     }
+    let popup = (1008..=1023).contains(&(proc_id & 0x0fff));
     controls.retain(|record| record.handle != handle);
     controls.push(PpcControlRecord {
         handle,
+        pointer: control,
         proc_id,
-        popup_menu_id: if (1008..=1023).contains(&(proc_id & 0x0fff)) {
-            min
-        } else {
-            0
-        },
+        popup_menu_id: if popup { min } else { 0 },
+        popup_title_width: popup.then_some(max),
     });
     *last_mem_error = PPC_NO_ERR;
     handle
@@ -93324,11 +93324,13 @@ pub(crate) mod tests {
             Some(b"Launch".to_vec())
         );
         assert_eq!(
-            loaded.controls,
-            vec![PpcControlRecord {
+            &**loaded.controls,
+            &vec![PpcControlRecord {
                 handle,
+                pointer: control,
                 proc_id: 16,
                 popup_menu_id: 0,
+                popup_title_width: None,
             }]
         );
     }
@@ -146182,11 +146184,13 @@ pub(crate) mod tests {
             Some(b"OK".to_vec())
         );
         assert_eq!(
-            loaded.controls,
-            vec![PpcControlRecord {
+            &**loaded.controls,
+            &vec![PpcControlRecord {
                 handle: control_handle,
+                pointer: control,
                 proc_id: 0,
                 popup_menu_id: 0,
+                popup_title_width: None,
             }]
         );
     }
@@ -149063,6 +149067,73 @@ pub(crate) mod tests {
         assert_eq!(original.scrap.desktop.count, 1);
         assert_eq!(detached.scrap.desktop.entries, vec![(*b"TEXT", b"detached".to_vec())]);
         assert_eq!(detached.scrap.desktop.count, 1);
+    }
+
+    #[test]
+    fn attached_control_manager_metadata_crosses_isa_immediately() {
+        let mut native =
+            load_pef_application(&synthetic_pef_with_import(b"TestImport")).unwrap();
+        let (mut classic, _classic_cpu, mut classic_bus) = setup_with_port();
+        let mut context = ProcessContext::default();
+        classic.attach_process_context(&mut context);
+        native.attach_process_context(&mut context);
+
+        let window = classic_bus.alloc(180);
+        let (classic_handle, classic_pointer) = classic.create_control_record(
+            &mut classic_bus,
+            window,
+            (10, 20, 30, 140),
+            b"Mode",
+            true,
+            1,
+            300,
+            96,
+            1009,
+            0,
+        );
+        let classic_record = native
+            .controls
+            .iter()
+            .find(|record| record.handle == classic_handle)
+            .copied()
+            .unwrap();
+        assert_eq!(classic_record.pointer, classic_pointer);
+        assert_eq!(classic_record.proc_id, 1009);
+        assert_eq!(classic_record.popup_menu_id, 300);
+        assert_eq!(classic_record.popup_title_width, Some(96));
+
+        native.controls.register(0x0030_1000, 0x0030_2000, 16, 0);
+        assert_eq!(classic.control_manager.proc_id(0x0030_2000), 16);
+
+        classic.dispose_control_handle(&mut classic_bus, classic_handle);
+        assert!(!native
+            .controls
+            .iter()
+            .any(|record| record.handle == classic_handle));
+        native.controls.remove_handle(0x0030_1000);
+        assert!(!classic.control_manager.contains_pointer(0x0030_2000));
+    }
+
+    #[test]
+    fn cloned_native_adapter_detaches_control_manager_metadata() {
+        let mut original =
+            load_pef_application(&synthetic_pef_with_import(b"TestImport")).unwrap();
+        original
+            .controls
+            .register(0x0031_1000, 0x0031_2000, 1, 0);
+        let mut detached = original.clone();
+
+        detached.controls.set_proc_id(0x0031_2000, 2);
+        detached
+            .controls
+            .register(0x0031_3000, 0x0031_4000, 16, 0);
+
+        assert_eq!(original.controls.proc_id(0x0031_2000), 1);
+        assert_eq!(detached.controls.proc_id(0x0031_2000), 2);
+        assert!(!original
+            .controls
+            .iter()
+            .any(|record| record.handle == 0x0031_3000));
     }
 
     #[test]

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -1,6 +1,7 @@
 //! Process-scoped state shared by classic and native CPU adapters.
 
 use crate::callback_manager::{ProcessCallbackScheduling, ProcessTimerTask, ProcessVblTask};
+use crate::control_manager::ProcessControlManagerState;
 use crate::display::{
     default_arrow_cursor_image, default_display_gamma, standard_mac_8bpp_clut, CursorImage,
     DisplayGamma,
@@ -1228,6 +1229,7 @@ pub(crate) type SharedProcessTimerTasks = SharedProcessValue<Vec<ProcessTimerTas
 pub(crate) type SharedProcessVblTasks = SharedProcessValue<Vec<ProcessVblTask>>;
 pub(crate) type SharedProcessCallbackScheduling = SharedProcessValue<ProcessCallbackScheduling>;
 pub(crate) type SharedProcessScrapState = SharedProcessValue<ProcessScrapState>;
+pub(crate) type SharedProcessControlManager = SharedProcessValue<ProcessControlManagerState>;
 /// Detached-by-default attachment handle for Dialog Manager `ParamText` slots.
 pub type SharedProcessDialogText = SharedProcessValue<[Vec<u8>; 4]>;
 
@@ -4182,6 +4184,7 @@ pub(crate) struct ProcessContext {
     vbl_tasks: SharedProcessVblTasks,
     callback_scheduling: SharedProcessCallbackScheduling,
     scrap_state: SharedProcessScrapState,
+    control_manager: SharedProcessControlManager,
     dialog_text: SharedProcessDialogText,
     cursor_state: SharedProcessCursorState,
     current_graphics_port: SharedProcessValue<u32>,
@@ -4209,6 +4212,7 @@ impl Default for ProcessContext {
             vbl_tasks: SharedProcessVblTasks::default(),
             callback_scheduling: SharedProcessCallbackScheduling::default(),
             scrap_state: SharedProcessScrapState::default(),
+            control_manager: SharedProcessControlManager::default(),
             dialog_text: SharedProcessDialogText::default(),
             cursor_state: SharedProcessCursorState::default(),
             current_graphics_port: SharedProcessValue::from_value(0),
@@ -4287,6 +4291,10 @@ impl ProcessContext {
 
     pub(crate) fn attach_scrap_state(&self, adapter: &mut SharedProcessScrapState) {
         adapter.attach_to(&self.scrap_state, ProcessScrapState::is_pristine);
+    }
+
+    pub(crate) fn attach_control_manager(&self, adapter: &mut SharedProcessControlManager) {
+        adapter.attach_to(&self.control_manager, ProcessControlManagerState::is_pristine);
     }
 
     pub(crate) fn attach_dialog_text(&self, adapter: &mut SharedProcessDialogText) {

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -13368,7 +13368,7 @@ mod tests {
             cfm_connections: Vec::new(),
             cfm_library_fragments: Vec::new(),
             next_cfm_connection_id: 1,
-            controls: Vec::new(),
+            controls: Default::default(),
             screen_clut: SharedProcessValue::from_value(
                 TrapDispatcher::standard_mac_8bpp_clut(),
             ),
@@ -15619,7 +15619,7 @@ mod tests {
             cfm_connections: Vec::new(),
             cfm_library_fragments: Vec::new(),
             next_cfm_connection_id: 1,
-            controls: Vec::new(),
+            controls: Default::default(),
             screen_clut: SharedProcessValue::from_value(
                 TrapDispatcher::standard_mac_8bpp_clut(),
             ),
@@ -16638,7 +16638,7 @@ mod tests {
             cfm_connections: Vec::new(),
             cfm_library_fragments: Vec::new(),
             next_cfm_connection_id: 1,
-            controls: Vec::new(),
+            controls: Default::default(),
             screen_clut: SharedProcessValue::from_value(
                 TrapDispatcher::standard_mac_8bpp_clut(),
             ),
@@ -16791,7 +16791,7 @@ mod tests {
             cfm_connections: Vec::new(),
             cfm_library_fragments: Vec::new(),
             next_cfm_connection_id: 1,
-            controls: Vec::new(),
+            controls: Default::default(),
             screen_clut: SharedProcessValue::from_value(
                 TrapDispatcher::standard_mac_8bpp_clut(),
             ),
@@ -17176,7 +17176,7 @@ mod tests {
             cfm_connections: Vec::new(),
             cfm_library_fragments: Vec::new(),
             next_cfm_connection_id: 1,
-            controls: Vec::new(),
+            controls: Default::default(),
             screen_clut: SharedProcessValue::from_value(
                 TrapDispatcher::standard_mac_8bpp_clut(),
             ),
@@ -17455,7 +17455,7 @@ mod tests {
             cfm_connections: Vec::new(),
             cfm_library_fragments: Vec::new(),
             next_cfm_connection_id: 1,
-            controls: Vec::new(),
+            controls: Default::default(),
             screen_clut: SharedProcessValue::from_value(
                 TrapDispatcher::standard_mac_8bpp_clut(),
             ),
@@ -22321,7 +22321,7 @@ mod tests {
         runner.bus.write_word(ctrl_ptr + 18, 40);
         runner.bus.write_word(ctrl_ptr + 20, 0);
         runner.bus.write_word(ctrl_ptr + 22, 100);
-        runner.dispatcher.control_proc_ids.insert(ctrl_ptr, 16);
+        runner.dispatcher.control_manager.set_proc_id(ctrl_ptr, 16);
         runner.dispatcher.input_state.mouse_button = true;
         runner.dispatcher.input_state.mouse_pos = (210, 248);
 

--- a/src/scripted_traces.rs
+++ b/src/scripted_traces.rs
@@ -1064,7 +1064,7 @@ fn scripted_install_modal_preferences_checkbox_dialog(
     dispatcher.window_bounds = bounds;
     dispatcher.window_proc_id = 1;
     dispatcher.window_title = "Preferences".to_string();
-    dispatcher.control_proc_ids.insert(checkbox_ptr, 1);
+    dispatcher.control_manager.set_proc_id(checkbox_ptr, 1);
     dispatcher
         .dialog_control_handles
         .insert(checkbox_handle, (dialog_ptr, 2));

--- a/src/trap/control.rs
+++ b/src/trap/control.rs
@@ -81,7 +81,7 @@ impl super::TrapDispatcher {
         let right = bus.read_word(ctrl_ptr + 14) as i16;
         let vis = bus.read_byte(ctrl_ptr + 16);
         let hilite = bus.read_byte(ctrl_ptr + 17);
-        let proc_id = self.control_proc_ids.get(&ctrl_ptr).copied().unwrap_or(0);
+        let proc_id = self.control_manager.proc_id(ctrl_ptr);
         format!(
             "control_handle={} control_ptr={} rect=({top},{left},{bottom},{right}) visible={} hilite={} proc_id={proc_id}",
             Self::control_trace_nonzero(ctrl_handle),
@@ -296,7 +296,7 @@ impl super::TrapDispatcher {
     }
 
     fn control_uses_application_def_proc(&self, bus: &MacMemoryBus, ctrl_ptr: u32) -> bool {
-        let proc_id = self.control_proc_ids.get(&ctrl_ptr).copied().unwrap_or(0);
+        let proc_id = self.control_manager.proc_id(ctrl_ptr);
         let proc_addr = Self::control_def_proc_addr(bus, ctrl_ptr);
         let callable = Self::control_def_entry_looks_callable(bus, proc_addr);
         if trace_controls_enabled() && !matches!(proc_id, 0 | 1 | 2 | 16) {
@@ -391,7 +391,7 @@ impl super::TrapDispatcher {
                 if ctrl_ptr == 0 || !self.control_uses_application_def_proc(bus, ctrl_ptr) {
                     return None;
                 }
-                let proc_id = self.control_proc_ids.get(&ctrl_ptr).copied().unwrap_or(0);
+                let proc_id = self.control_manager.proc_id(ctrl_ptr);
                 Some((
                     ctrl_handle,
                     message,
@@ -656,12 +656,12 @@ impl super::TrapDispatcher {
 
     fn control_aux_reserved_value(&self, bus: &MacMemoryBus, ctrl_handle: u32) -> u32 {
         let ctrl_ptr = Self::control_record_ptr(bus, ctrl_handle);
-        let proc_id = self.control_proc_ids.get(&ctrl_ptr).copied().unwrap_or(0);
+        let proc_id = self.control_manager.proc_id(ctrl_ptr);
         u32::from((proc_id & 0xF) as u16) << 24
     }
 
     fn standard_testcontrol_part_code(&self, ctrl_ptr: u32) -> u16 {
-        match self.control_proc_ids.get(&ctrl_ptr).copied().unwrap_or(0) {
+        match self.control_manager.proc_id(ctrl_ptr) {
             1 | 2 => 11, // inCheckBox for checkbox and radio-button variants
             _ => 10,     // inButton for push buttons and the current fallback path
         }
@@ -1127,7 +1127,7 @@ impl super::TrapDispatcher {
             // created. The standard CDEF then publishes the menu item count
             // in contrlMax, so retain the pixel width as private CDEF state.
             // Macintosh Toolbox Essentials 1992, pp. 5-25 to 5-27.
-            self.popup_control_title_widths.insert(ctrl_ptr, max);
+            self.control_manager.set_popup_title_width(ctrl_ptr, max);
             let data = self.create_popup_control_private_data(bus, min);
             let item_count = self
                 .menus
@@ -1145,7 +1145,7 @@ impl super::TrapDispatcher {
         bus.write_long(ctrl_ptr + 32, 0); // contrlAction
         bus.write_long(ctrl_ptr + 36, ref_con);
         Self::set_control_title_bytes(bus, ctrl_ptr, title);
-        self.control_proc_ids.insert(ctrl_ptr, proc_id);
+        self.control_manager.set_proc_id(ctrl_ptr, proc_id);
     }
 
     pub(crate) fn create_control_record(
@@ -1169,6 +1169,16 @@ impl super::TrapDispatcher {
         bus.write_long(handle, ctrl_ptr);
         self.initialize_control_record(
             bus, ctrl_ptr, window_ptr, bounds, title, visible, value, min, max, proc_id, ref_con,
+        );
+        self.control_manager.register(
+            handle,
+            ctrl_ptr,
+            proc_id,
+            if Self::is_popup_menu_proc_id(proc_id) {
+                min
+            } else {
+                0
+            },
         );
         self.ensure_control_aux_record(bus, handle);
         if window_ptr != 0 {
@@ -1211,8 +1221,7 @@ impl super::TrapDispatcher {
                 }
             }
             self.release_control_aux_record(bus, ctrl_handle);
-            self.control_proc_ids.remove(&ctrl_ptr);
-            self.popup_control_title_widths.remove(&ctrl_ptr);
+            self.control_manager.remove_pointer(ctrl_ptr);
             bus.free(ctrl_ptr);
         }
         bus.free(ctrl_handle);
@@ -1267,10 +1276,8 @@ impl super::TrapDispatcher {
     }
 
     pub(crate) fn popup_control_title_width(&self, ctrl_ptr: u32, fallback: i16) -> i16 {
-        self.popup_control_title_widths
-            .get(&ctrl_ptr)
-            .copied()
-            .unwrap_or(fallback)
+        self.control_manager
+            .popup_title_width(ctrl_ptr, fallback)
     }
 
     /// Draw a single control based on its procID, using QuickDraw primitives
@@ -1314,7 +1321,7 @@ impl super::TrapDispatcher {
         let title_bytes = Self::control_title_bytes(bus, ctrl_ptr);
         let title = decode_mac_roman_for_render(&title_bytes);
 
-        let proc_id = self.control_proc_ids.get(&ctrl_ptr).copied().unwrap_or(0);
+        let proc_id = self.control_manager.proc_id(ctrl_ptr);
 
         // Save pen state, set to defaults (PenNormal)
         let saved_pn_size = self.pn_size;
@@ -2698,7 +2705,7 @@ impl super::TrapDispatcher {
                         }
                         let next = bus.read_long(ctrl_ptr);
                         self.release_control_aux_record(bus, ctrl_handle);
-                        self.control_proc_ids.remove(&ctrl_ptr);
+                        self.control_manager.remove_pointer(ctrl_ptr);
                         bus.free(ctrl_ptr);
                         bus.free(ctrl_handle);
                         ctrl_handle = next;
@@ -3022,7 +3029,7 @@ impl super::TrapDispatcher {
                 }
                 let min = bus.read_word(ctrl_ptr + 20) as i16;
                 let max = bus.read_word(ctrl_ptr + 22) as i16;
-                let proc_id = self.control_proc_ids.get(&ctrl_ptr).copied().unwrap_or(0);
+                let proc_id = self.control_manager.proc_id(ctrl_ptr);
                 // If min > max the control is degenerate — IM doesn't
                 // define the behaviour. Be conservative: take the
                 // requested value unchanged in that case.
@@ -3103,7 +3110,7 @@ impl super::TrapDispatcher {
                 let ctrl_ptr = Self::control_record_ptr(bus, ctrl_handle);
                 if ctrl_ptr != 0 {
                     bus.write_word(ctrl_ptr + 20, min as u16);
-                    let proc_id = self.control_proc_ids.get(&ctrl_ptr).copied().unwrap_or(0);
+                    let proc_id = self.control_manager.proc_id(ctrl_ptr);
                     let value = bus.read_word(ctrl_ptr + 18) as i16;
                     if !Self::is_popup_menu_proc_id(proc_id) && value < min {
                         bus.write_word(ctrl_ptr + 18, min as u16);
@@ -3150,7 +3157,7 @@ impl super::TrapDispatcher {
                 let ctrl_ptr = Self::control_record_ptr(bus, ctrl_handle);
                 if ctrl_ptr != 0 {
                     bus.write_word(ctrl_ptr + 22, max as u16);
-                    let proc_id = self.control_proc_ids.get(&ctrl_ptr).copied().unwrap_or(0);
+                    let proc_id = self.control_manager.proc_id(ctrl_ptr);
                     let value = bus.read_word(ctrl_ptr + 18) as i16;
                     if !Self::is_popup_menu_proc_id(proc_id) && value > max {
                         bus.write_word(ctrl_ptr + 18, max as u16);
@@ -3193,8 +3200,7 @@ impl super::TrapDispatcher {
                         let r_bottom = bus.read_word(ctrl_ptr + 12) as i16;
                         let r_right = bus.read_word(ctrl_ptr + 14) as i16;
                         if pt_v >= r_top && pt_v < r_bottom && pt_h >= r_left && pt_h < r_right {
-                            part = match self.control_proc_ids.get(&ctrl_ptr).copied().unwrap_or(0)
-                            {
+                            part = match self.control_manager.proc_id(ctrl_ptr) {
                                 16 => self.standard_scrollbar_testcontrol_part_code(
                                     bus, ctrl_ptr, pt_v, pt_h,
                                 ),
@@ -3411,8 +3417,7 @@ impl super::TrapDispatcher {
                             outcome = "outside_control";
                             if pt_v >= r_top && pt_v < r_bottom && pt_h >= r_left && pt_h < r_right
                             {
-                                let proc_id =
-                                    self.control_proc_ids.get(&ctrl_ptr).copied().unwrap_or(0);
+                                let proc_id = self.control_manager.proc_id(ctrl_ptr);
                                 if proc_id == 16 {
                                     part = self.standard_scrollbar_testcontrol_part_code(
                                         bus, ctrl_ptr, pt_v, pt_h,
@@ -3642,7 +3647,7 @@ impl super::TrapDispatcher {
                             }
                             continue;
                         }
-                        let proc_id = self.control_proc_ids.get(&ctrl_ptr).copied().unwrap_or(0);
+                        let proc_id = self.control_manager.proc_id(ctrl_ptr);
                         if Self::is_popup_menu_proc_id(proc_id) {
                             // popupMenuProc needs special MENU resource lookup
                             let vis = bus.read_byte(ctrl_ptr + 16);
@@ -3885,6 +3890,7 @@ impl super::TrapDispatcher {
                     proc_id,
                     ref_con,
                 );
+                self.control_manager.associate_handle(handle, ctrl_ptr);
                 self.ensure_control_aux_record(bus, handle);
                 if trace_controls_enabled() {
                     eprintln!(
@@ -4106,12 +4112,11 @@ impl super::TrapDispatcher {
             // handle; for future compatibility, use the GetCVariant routine
             // to access this value."
             //
-            // Systemless's NewControl / GetNewControl (toolbox.rs:1144 and
-            // :1972) record the original procID in the side-table
-            // `control_proc_ids: HashMap<ctrl_ptr, i16>`, indexed by the
-            // dereferenced ControlPtr (i.e. *theControl). GetCVariant
-            // recovers the variation code by reading procID from that side
-            // table and masking the low 4 bits — the canonical IM:I I-323
+            // NewControl and GetNewControl retain the original procID in the
+            // process-owned Control Manager registry, indexed by the
+            // dereferenced ControlPtr (i.e. *theControl). GetCVariant recovers
+            // the variation code by reading procID from that registry and
+            // masking the low 4 bits — the canonical IM:I I-323
             // definition. Same formula independent of CDEF resource ID:
             //   pushButProc=0   → variant 0
             //   checkBoxProc=1  → variant 1
@@ -4132,7 +4137,7 @@ impl super::TrapDispatcher {
                 let ctrl_handle = bus.read_long(sp);
                 let variant: i16 = if ctrl_handle != 0 {
                     let ctrl_ptr = bus.read_long(ctrl_handle);
-                    let proc_id = self.control_proc_ids.get(&ctrl_ptr).copied().unwrap_or(0);
+                    let proc_id = self.control_manager.proc_id(ctrl_ptr);
                     proc_id & 0xF
                 } else {
                     0
@@ -4238,7 +4243,7 @@ mod tests {
         bus.write_word(ctrl_ptr + 18, value as u16);
         bus.write_word(ctrl_ptr + 20, min as u16);
         bus.write_word(ctrl_ptr + 22, max as u16);
-        disp.control_proc_ids.insert(ctrl_ptr, 16);
+        disp.control_manager.set_proc_id(ctrl_ptr, 16);
         (ctrl_handle, ctrl_ptr)
     }
 
@@ -5184,7 +5189,7 @@ mod tests {
         bus.write_word(ctrl_ptr + 22, 0);
         let handle = bus.alloc(4);
         bus.write_long(handle, ctrl_ptr);
-        disp.control_proc_ids.insert(ctrl_ptr, 1009);
+        disp.control_manager.set_proc_id(ctrl_ptr, 1009);
         bus.write_word(sp, 3);
         bus.write_long(sp + 2, handle);
 
@@ -5281,7 +5286,7 @@ mod tests {
         clear_1bpp_screen(&mut bus, screen_base, row_bytes, 342);
         let (ctrl_handle, ctrl_ptr) = alloc_control_handle(&mut bus, (10, 20, 30, 60), 0, 0);
         bus.write_long(ctrl_ptr + 4, window);
-        disp.control_proc_ids.insert(ctrl_ptr, 0);
+        disp.control_manager.set_proc_id(ctrl_ptr, 0);
         let before: Vec<u8> = (0..row_bytes * 342)
             .map(|offset| bus.read_byte(screen_base + offset))
             .collect();
@@ -5316,7 +5321,7 @@ mod tests {
         bus.write_long(cdef_handle, cdef_proc);
         bus.write_long(ctrl_ptr + 4, owner);
         bus.write_long(ctrl_ptr + 24, cdef_handle);
-        disp.control_proc_ids.insert(ctrl_ptr, (160 << 4) | 5);
+        disp.control_manager.set_proc_id(ctrl_ptr, (160 << 4) | 5);
 
         cpu.write_reg(Register::A7, sp);
         cpu.write_reg(Register::PC, return_pc);
@@ -5975,7 +5980,7 @@ mod tests {
         bus.write_word(ctrl_ptr + 18, 1);
         bus.write_word(ctrl_ptr + 20, 902);
         bus.write_word(ctrl_ptr + 22, 0);
-        disp.control_proc_ids.insert(ctrl_ptr, 1009);
+        disp.control_manager.set_proc_id(ctrl_ptr, 1009);
         disp.menus.push(Menu {
             id: 902,
             title: "Mode".to_string(),
@@ -6081,7 +6086,7 @@ mod tests {
         bus.write_word(ctrl_ptr + 18, 1);
         bus.write_word(ctrl_ptr + 20, 900); // popupMenuProc stores MENU id in min
         bus.write_word(ctrl_ptr + 22, 0);
-        disp.control_proc_ids.insert(ctrl_ptr, 1009);
+        disp.control_manager.set_proc_id(ctrl_ptr, 1009);
         disp.menus.push(Menu {
             id: 900,
             title: "Squadies".to_string(),
@@ -6189,7 +6194,7 @@ mod tests {
         bus.write_word(ctrl_ptr + 18, 1);
         bus.write_word(ctrl_ptr + 20, 901);
         bus.write_word(ctrl_ptr + 22, 0);
-        disp.control_proc_ids.insert(ctrl_ptr, 1009);
+        disp.control_manager.set_proc_id(ctrl_ptr, 1009);
         disp.menus.push(Menu {
             id: 901,
             title: "Formation".to_string(),
@@ -6545,7 +6550,7 @@ mod tests {
         let sp = 0x300000u32;
 
         let (button_handle, button_ptr) = alloc_control_handle(&mut bus, (10, 20, 30, 60), 255, 0);
-        disp.control_proc_ids.insert(button_ptr, 0);
+        disp.control_manager.set_proc_id(button_ptr, 0);
         cpu.write_reg(Register::A7, sp);
         bus.write_word(sp, 15);
         bus.write_word(sp + 2, 25);
@@ -6559,7 +6564,7 @@ mod tests {
 
         let (checkbox_handle, checkbox_ptr) =
             alloc_control_handle(&mut bus, (40, 50, 80, 120), 255, 0);
-        disp.control_proc_ids.insert(checkbox_ptr, 1);
+        disp.control_manager.set_proc_id(checkbox_ptr, 1);
         cpu.write_reg(Register::A7, sp);
         bus.write_word(sp, 60);
         bus.write_word(sp + 2, 70);
@@ -6572,7 +6577,7 @@ mod tests {
         assert_eq!(cpu.read_reg(Register::A7), sp + 8);
 
         let (radio_handle, radio_ptr) = alloc_control_handle(&mut bus, (90, 30, 120, 100), 255, 0);
-        disp.control_proc_ids.insert(radio_ptr, 2);
+        disp.control_manager.set_proc_id(radio_ptr, 2);
         cpu.write_reg(Register::A7, sp);
         bus.write_word(sp, 100);
         bus.write_word(sp + 2, 40);
@@ -6591,7 +6596,7 @@ mod tests {
         let sp = 0x300000u32;
 
         let (ctrl_handle, ctrl_ptr) = alloc_control_handle(&mut bus, (10, 20, 30, 60), 255, 0);
-        disp.control_proc_ids.insert(ctrl_ptr, 0);
+        disp.control_manager.set_proc_id(ctrl_ptr, 0);
 
         cpu.write_reg(Register::A7, sp);
         bus.write_word(sp, 5);
@@ -6633,7 +6638,7 @@ mod tests {
         let (mut disp, mut cpu, mut bus) = setup();
         let sp = 0x300000u32;
         let (ctrl_handle, ctrl_ptr) = alloc_control_handle(&mut bus, (10, 20, 30, 60), 255, 0);
-        disp.control_proc_ids.insert(ctrl_ptr, 0);
+        disp.control_manager.set_proc_id(ctrl_ptr, 0);
 
         cpu.write_reg(Register::A7, sp);
         bus.write_word(sp, 15);
@@ -6719,20 +6724,20 @@ mod tests {
         let mut results = Vec::new();
 
         let (button_handle, button_ptr) = alloc_control_handle(&mut bus, (10, 20, 30, 60), 255, 0);
-        disp.control_proc_ids.insert(button_ptr, 0);
+        disp.control_manager.set_proc_id(button_ptr, 0);
         let (part, stack, tail) =
             dispatch_testcontrol_part(&mut disp, &mut cpu, &mut bus, sp, button_handle, (15, 25));
         results.push(("button", part, stack, tail));
 
         let (checkbox_handle, checkbox_ptr) =
             alloc_control_handle(&mut bus, (40, 50, 80, 120), 255, 0);
-        disp.control_proc_ids.insert(checkbox_ptr, 1);
+        disp.control_manager.set_proc_id(checkbox_ptr, 1);
         let (part, stack, tail) =
             dispatch_testcontrol_part(&mut disp, &mut cpu, &mut bus, sp, checkbox_handle, (60, 70));
         results.push(("checkbox", part, stack, tail));
 
         let (radio_handle, radio_ptr) = alloc_control_handle(&mut bus, (90, 30, 120, 100), 255, 0);
-        disp.control_proc_ids.insert(radio_ptr, 2);
+        disp.control_manager.set_proc_id(radio_ptr, 2);
         let (part, stack, tail) =
             dispatch_testcontrol_part(&mut disp, &mut cpu, &mut bus, sp, radio_handle, (100, 40));
         results.push(("radio", part, stack, tail));
@@ -6753,14 +6758,14 @@ mod tests {
 
         let (outside_handle, outside_ptr) =
             alloc_control_handle(&mut bus, (130, 20, 160, 80), 255, 0);
-        disp.control_proc_ids.insert(outside_ptr, 0);
+        disp.control_manager.set_proc_id(outside_ptr, 0);
         let (part, stack, tail) =
             dispatch_testcontrol_part(&mut disp, &mut cpu, &mut bus, sp, outside_handle, (120, 15));
         results.push(("outside", part, stack, tail));
 
         let (inactive_handle, inactive_ptr) =
             alloc_control_handle(&mut bus, (170, 20, 200, 80), 255, 255);
-        disp.control_proc_ids.insert(inactive_ptr, 0);
+        disp.control_manager.set_proc_id(inactive_ptr, 0);
         let (part, stack, tail) = dispatch_testcontrol_part(
             &mut disp,
             &mut cpu,
@@ -6773,7 +6778,7 @@ mod tests {
 
         let (invisible_handle, invisible_ptr) =
             alloc_control_handle(&mut bus, (210, 20, 240, 80), 0, 0);
-        disp.control_proc_ids.insert(invisible_ptr, 0);
+        disp.control_manager.set_proc_id(invisible_ptr, 0);
         let (part, stack, tail) = dispatch_testcontrol_part(
             &mut disp,
             &mut cpu,
@@ -6956,7 +6961,7 @@ mod tests {
 
         let (ctrl_handle, ctrl_ptr) =
             alloc_button_control(&mut disp, &mut bus, window, (20, 20, 40, 100));
-        disp.control_proc_ids.insert(ctrl_ptr, 3216);
+        disp.control_manager.set_proc_id(ctrl_ptr, 3216);
         bus.write_byte(ctrl_ptr + 40, 4);
         bus.write_word(ctrl_ptr + 41, 4096);
         bus.write_word(ctrl_ptr + 43, 4097);
@@ -7011,7 +7016,7 @@ mod tests {
         let (titled_handle, titled_ptr) =
             alloc_button_control(&mut disp, &mut bus, window, (60, 20, 80, 140));
         for ptr in [blank_ptr, titled_ptr] {
-            disp.control_proc_ids.insert(ptr, 3216);
+            disp.control_manager.set_proc_id(ptr, 3216);
         }
         bus.write_byte(titled_ptr + 40, 4);
         bus.write_bytes(titled_ptr + 41, b"PLAY");
@@ -7066,7 +7071,7 @@ mod tests {
         let gdevice_before = *disp.current_gdevice;
         let (ctrl_handle, ctrl_ptr) =
             alloc_button_control(&mut disp, &mut bus, window_ptr, (20, 20, 260, 60));
-        disp.control_proc_ids.insert(ctrl_ptr, 1008);
+        disp.control_manager.set_proc_id(ctrl_ptr, 1008);
 
         cpu.write_reg(Register::A7, sp);
         bus.write_long(sp, ctrl_handle);
@@ -7176,7 +7181,7 @@ mod tests {
         clear_1bpp_screen(&mut classic_bus, classic_base, classic_row_bytes, 342);
         let (classic_handle, classic_ptr) =
             alloc_button_control(&mut classic, &mut classic_bus, classic_window, bounds);
-        classic.control_proc_ids.insert(classic_ptr, 1008);
+        classic.control_manager.set_proc_id(classic_ptr, 1008);
         classic_cpu.write_reg(Register::A7, sp);
         classic_bus.write_long(sp, classic_handle);
         classic
@@ -7193,7 +7198,7 @@ mod tests {
         clear_1bpp_screen(&mut themed_bus, themed_base, themed_row_bytes, 342);
         let (themed_handle, themed_ptr) =
             alloc_button_control(&mut themed, &mut themed_bus, themed_window, bounds);
-        themed.control_proc_ids.insert(themed_ptr, 1008);
+        themed.control_manager.set_proc_id(themed_ptr, 1008);
         themed_cpu.write_reg(Register::A7, sp);
         themed_bus.write_long(sp, themed_handle);
         themed
@@ -7257,7 +7262,7 @@ mod tests {
             (84, 20, 104, 120),
         );
         for ptr in [normal_ptr, pressed_ptr, inactive_ptr] {
-            themed.control_proc_ids.insert(ptr, 1008);
+            themed.control_manager.set_proc_id(ptr, 1008);
         }
         themed_bus.write_byte(pressed_ptr + 17, 1);
         themed_bus.write_byte(inactive_ptr + 17, 255);
@@ -7428,7 +7433,7 @@ mod tests {
             classic_window,
             (20, 20, 40, 120),
         );
-        classic.control_proc_ids.insert(classic_checkbox_ptr, 1);
+        classic.control_manager.set_proc_id(classic_checkbox_ptr, 1);
         classic_bus.write_word(classic_checkbox_ptr + 18, 1);
         let (classic_radio_handle, classic_radio_ptr) = alloc_button_control(
             &mut classic,
@@ -7436,7 +7441,7 @@ mod tests {
             classic_window,
             (50, 20, 70, 120),
         );
-        classic.control_proc_ids.insert(classic_radio_ptr, 2);
+        classic.control_manager.set_proc_id(classic_radio_ptr, 2);
         classic_bus.write_word(classic_radio_ptr + 18, 1);
         for handle in [classic_checkbox_handle, classic_radio_handle] {
             classic_cpu.write_reg(Register::A7, sp);
@@ -7459,7 +7464,7 @@ mod tests {
             themed_window,
             (20, 20, 40, 120),
         );
-        themed.control_proc_ids.insert(themed_checkbox_ptr, 1);
+        themed.control_manager.set_proc_id(themed_checkbox_ptr, 1);
         themed_bus.write_word(themed_checkbox_ptr + 18, 1);
         let (themed_radio_handle, themed_radio_ptr) = alloc_button_control(
             &mut themed,
@@ -7467,7 +7472,7 @@ mod tests {
             themed_window,
             (50, 20, 70, 120),
         );
-        themed.control_proc_ids.insert(themed_radio_ptr, 2);
+        themed.control_manager.set_proc_id(themed_radio_ptr, 2);
         themed_bus.write_word(themed_radio_ptr + 18, 1);
         for handle in [themed_checkbox_handle, themed_radio_handle] {
             themed_cpu.write_reg(Register::A7, sp);
@@ -7544,7 +7549,7 @@ mod tests {
             checkbox_pressed_ptr,
             checkbox_inactive_ptr,
         ] {
-            themed.control_proc_ids.insert(ptr, 1);
+            themed.control_manager.set_proc_id(ptr, 1);
         }
         bus.write_byte(checkbox_pressed_ptr + 17, 1);
         bus.write_byte(checkbox_inactive_ptr + 17, 255);
@@ -7556,7 +7561,7 @@ mod tests {
         let (radio_inactive_handle, radio_inactive_ptr) =
             alloc_button_control(&mut themed, &mut bus, window, (84, 140, 104, 220));
         for ptr in [radio_enabled_ptr, radio_pressed_ptr, radio_inactive_ptr] {
-            themed.control_proc_ids.insert(ptr, 2);
+            themed.control_manager.set_proc_id(ptr, 2);
         }
         bus.write_byte(radio_pressed_ptr + 17, 1);
         bus.write_byte(radio_inactive_ptr + 17, 255);
@@ -7628,7 +7633,7 @@ mod tests {
         clear_1bpp_screen(&mut classic_bus, classic_base, classic_row_bytes, 342);
         let (_classic_handle, classic_ptr) =
             alloc_button_control(&mut classic, &mut classic_bus, classic_window, bounds);
-        classic.control_proc_ids.insert(classic_ptr, 16);
+        classic.control_manager.set_proc_id(classic_ptr, 16);
         classic_bus.write_word(classic_ptr + 18, 40);
         classic_bus.write_word(classic_ptr + 20, 0);
         classic_bus.write_word(classic_ptr + 22, 100);
@@ -7656,7 +7661,7 @@ mod tests {
         clear_1bpp_screen(&mut themed_bus, themed_base, themed_row_bytes, 342);
         let (themed_handle, themed_ptr) =
             alloc_button_control(&mut themed, &mut themed_bus, themed_window, bounds);
-        themed.control_proc_ids.insert(themed_ptr, 16);
+        themed.control_manager.set_proc_id(themed_ptr, 16);
         themed_bus.write_word(themed_ptr + 18, 40);
         themed_bus.write_word(themed_ptr + 20, 0);
         themed_bus.write_word(themed_ptr + 22, 100);
@@ -7936,7 +7941,7 @@ mod tests {
         bus.write_long(ctrl_ptr + 32, 0);
         bus.write_long(ctrl_ptr + 36, 0);
         bus.write_byte(ctrl_ptr + 40, 0);
-        disp.control_proc_ids.insert(ctrl_ptr, 0);
+        disp.control_manager.set_proc_id(ctrl_ptr, 0);
         (ctrl_handle, ctrl_ptr)
     }
 
@@ -8123,7 +8128,7 @@ mod tests {
         let ctrl_ptr = bus.alloc(296);
         let ctrl_handle = bus.alloc(4);
         bus.write_long(ctrl_handle, ctrl_ptr);
-        disp.control_proc_ids.insert(ctrl_ptr, proc_id);
+        disp.control_manager.set_proc_id(ctrl_ptr, proc_id);
         ctrl_handle
     }
 

--- a/src/trap/dialog.rs
+++ b/src/trap/dialog.rs
@@ -3445,6 +3445,7 @@ impl super::TrapDispatcher {
                             proc_id,
                             ref_con,
                         );
+                        self.control_manager.associate_handle(handle, ctrl_ptr);
                         self.ensure_control_aux_record(bus, handle);
                         let old_head = bus.read_long(dialog_ptr + 140);
                         bus.write_long(ctrl_ptr, old_head);
@@ -3508,6 +3509,7 @@ impl super::TrapDispatcher {
             proc_id,
             0,
         );
+        self.control_manager.associate_handle(handle, ctrl_ptr);
         self.ensure_control_aux_record(bus, handle);
 
         let old_head = bus.read_long(dialog_ptr + 140);
@@ -4584,7 +4586,7 @@ impl super::TrapDispatcher {
                 }
             }
             self.release_control_aux_record(bus, ctrl_handle);
-            self.control_proc_ids.remove(&ctrl_ptr);
+            self.control_manager.remove_pointer(ctrl_ptr);
             bus.free(ctrl_ptr);
         }
         bus.free(ctrl_handle);
@@ -6502,7 +6504,7 @@ impl super::TrapDispatcher {
                     {
                         let ctrl_ptr = bus.read_long(ctrl_handle);
                         let proc_id_ctrl =
-                            self.control_proc_ids.get(&ctrl_ptr).copied().unwrap_or(0);
+                            self.control_manager.proc_id(ctrl_ptr);
                         let value = self
                             .dialog_control_values
                             .get(&(dialog_ptr, item_num))
@@ -6636,7 +6638,7 @@ impl super::TrapDispatcher {
                 if let Some(ctrl_handle) = self.dialog_control_handle_for_item(dialog_ptr, item_num)
                 {
                     let ctrl_ptr = bus.read_long(ctrl_handle);
-                    let proc_id_ctrl = self.control_proc_ids.get(&ctrl_ptr).copied().unwrap_or(0);
+                    let proc_id_ctrl = self.control_manager.proc_id(ctrl_ptr);
                     eprintln!(
                         "[DLG]     item={} control handle=${:08X} ptr=${:08X} visible={} hilite={} value={} min={} max={} proc_id={}",
                         item_num,
@@ -6714,7 +6716,7 @@ impl super::TrapDispatcher {
                     {
                         let ctrl_ptr = bus.read_long(ctrl_handle);
                         let proc_id_ctrl =
-                            self.control_proc_ids.get(&ctrl_ptr).copied().unwrap_or(0);
+                            self.control_manager.proc_id(ctrl_ptr);
                         let value = self
                             .dialog_control_values
                             .get(&(dialog_ptr, item_num))
@@ -6909,7 +6911,7 @@ impl super::TrapDispatcher {
                     {
                         let ctrl_ptr = bus.read_long(ctrl_handle);
                         let proc_id_ctrl =
-                            self.control_proc_ids.get(&ctrl_ptr).copied().unwrap_or(0);
+                            self.control_manager.proc_id(ctrl_ptr);
                         let value = self
                             .dialog_control_values
                             .get(&(dialog_ptr, item_num))
@@ -10264,7 +10266,7 @@ impl super::TrapDispatcher {
         if ctrl_ptr == 0 {
             return false;
         }
-        let proc_id = self.control_proc_ids.get(&ctrl_ptr).copied().unwrap_or(0);
+        let proc_id = self.control_manager.proc_id(ctrl_ptr);
         if !Self::is_popup_menu_proc_id(proc_id) {
             return false;
         }
@@ -11610,9 +11612,10 @@ impl super::TrapDispatcher {
                                 6 => 2, // radCtrl → radioButProc
                                 _ => 0,
                             };
-                            self.control_proc_ids.insert(ctrl_rec, proc_id);
+                            self.control_manager.set_proc_id(ctrl_rec, proc_id);
                             let handle = bus.alloc(4);
                             bus.write_long(handle, ctrl_rec);
+                            self.control_manager.associate_handle(handle, ctrl_rec);
                             bus.write_long(item_handle_ptr, handle);
                             self.dialog_control_handles
                                 .insert(handle, (dialog_ptr, item_no));
@@ -25324,7 +25327,7 @@ mod tests {
         bus.write_word(ctrl_ptr + 18, 0);
         bus.write_word(ctrl_ptr + 20, 0);
         bus.write_word(ctrl_ptr + 22, 1);
-        disp.control_proc_ids.insert(ctrl_ptr, 2);
+        disp.control_manager.set_proc_id(ctrl_ptr, 2);
         disp.dialog_control_handles
             .insert(ctrl_handle, (dialog_ptr, 1));
 
@@ -27702,7 +27705,7 @@ mod tests {
             disp.dialog_control_handles.get(&control_handle),
             Some(&(dialog_ptr, 1))
         );
-        assert!(disp.control_proc_ids.contains_key(&control_ptr));
+        assert!(disp.control_manager.contains_pointer(control_ptr));
         let aux_handle = disp.ensure_control_aux_record(&mut bus, control_handle);
         let aux_ptr = bus.read_long(aux_handle);
         assert_ne!(aux_handle, 0);
@@ -27720,7 +27723,7 @@ mod tests {
         assert_eq!(bus.get_alloc_size(aux_handle), None);
         assert!(disp.control_aux_state(control_handle).is_none());
         assert!(!disp.dialog_control_handles.contains_key(&control_handle));
-        assert!(!disp.control_proc_ids.contains_key(&control_ptr));
+        assert!(!disp.control_manager.contains_pointer(control_ptr));
     }
 
     #[test]
@@ -29790,7 +29793,7 @@ mod tests {
             Some(&(dialog_ptr, 1))
         );
         assert_eq!(disp.dialog_control_values.get(&(dialog_ptr, 1)), Some(&0));
-        assert_eq!(disp.control_proc_ids.get(&control_ptr), Some(&1));
+        assert_eq!(disp.control_manager.proc_id(control_ptr), 1);
     }
 
     #[test]
@@ -29846,7 +29849,7 @@ mod tests {
         assert_eq!(bus.read_word(ctrl_ptr + 18) as i16, 2);
         assert_eq!(bus.read_word(ctrl_ptr + 20) as i16, 1);
         assert_eq!(bus.read_word(ctrl_ptr + 22) as i16, 0);
-        assert_eq!(disp.control_proc_ids.get(&ctrl_ptr), Some(&1009));
+        assert_eq!(disp.control_manager.proc_id(ctrl_ptr), 1009);
         assert_eq!(
             disp.dialog_control_handles.get(&handle),
             Some(&(dialog_ptr, 1))

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -16,7 +16,8 @@ use crate::process_context::{
     ProcessClassicVfsDirectory, ProcessContext, ProcessForkMap, ProcessKeyRepeatState,
     ProcessLoadedResources, ProcessResourceFileMap, ProcessResourceManagerState,
     ProcessVfsMetadata, ProcessVfsVolumeRecord, SharedProcessAppleEventHandlers,
-    SharedProcessCursorState, SharedProcessDialogText, SharedProcessEventQueue,
+    SharedProcessControlManager, SharedProcessCursorState, SharedProcessDialogText,
+    SharedProcessEventQueue,
     SharedProcessFileSystem, SharedProcessInputState, SharedProcessMemoryManager,
     SharedProcessMenuTracking, SharedProcessResourceManager, SharedProcessScrapState,
     SharedProcessSoundManager, SharedProcessValue,
@@ -2662,14 +2663,8 @@ pub struct TrapDispatcher {
     pub(crate) list_states: HashMap<u32, ListState>,
     /// Host-side TextEdit feature state keyed by guest TEHandle.
     pub(crate) textedit_states: HashMap<u32, TextEditState>,
-    /// Maps guest ControlRecord pointer → procID, set by NewControl/GetNewControl.
-    /// Used by DrawControls to dispatch to the correct rendering routine.
-    /// Inside Macintosh Volume I, I-331
-    pub(crate) control_proc_ids: HashMap<u32, i16>,
-    /// Creation-time pop-up title widths keyed by ControlRecord pointer.
-    /// The standard pop-up CDEF replaces `contrlMax` with the menu item count,
-    /// so the original pixel width must remain in its private state.
-    pub(crate) popup_control_title_widths: HashMap<u32, i16>,
+    /// Process-owned Control Manager metadata shared with native execution.
+    pub(crate) control_manager: SharedProcessControlManager,
     /// The menu ID of the most recently inserted menu (via InsertMenu).
     /// Cleared when a type-0 userItem GetDItem is called immediately after.
     pub(crate) last_inserted_menu_id: Option<i16>,
@@ -2805,6 +2800,7 @@ impl TrapDispatcher {
             &mut self.callback_scheduling,
         );
         context.attach_scrap_state(&mut self.scrap);
+        context.attach_control_manager(&mut self.control_manager);
         context.attach_dialog_text(&mut self.param_text);
         context.attach_cursor_state(&mut self.cursor_state);
         context.attach_quickdraw_selection(&mut self.current_port, &mut self.current_gdevice);
@@ -4020,8 +4016,7 @@ impl TrapDispatcher {
             saved_vis_regions: HashMap::new(),
             list_states: HashMap::new(),
             textedit_states: HashMap::new(),
-            control_proc_ids: HashMap::new(),
-            popup_control_title_widths: HashMap::new(),
+            control_manager: SharedProcessControlManager::default(),
             last_inserted_menu_id: None,
             pending_dialog_popup_menu: None,
             dialog_item_popup_menus: HashMap::new(),


### PR DESCRIPTION
Closes #1209.

Moves Control Manager definition and pop-up private metadata into one process-owned registry attached through `ProcessContext`. Classic and native adapters now register, query, and dispose the same metadata while live `ControlRecord` bytes and window control lists remain canonical guest RAM.

Adds focused coverage for immediate classic-to-native and native-to-classic visibility, shared disposal, pop-up menu/title metadata, and detached native clones.

Validation:
- `cargo test --locked --lib` (4,754 passed; 0 failed; 3 ignored)
- strict rustdoc with private intra-doc links denied
- all targets and all features compiled
- 68K and PowerPC Toolbox Showcase integration tests
- locked release build
- Marathon terminal completion and resumed movement
- Escape Velocity landing, return to space, and acceleration
- Tomb Raider Gold live level and forward movement