### PR TITLE
refactor(textedit): make private state process-owned

### DIFF
--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -3891,6 +3891,7 @@ impl PpcLoadedApp {
             &mut self.callback_scheduling,
         );
         context.attach_scrap_state(&mut self.scrap.desktop);
+        context.attach_text_edit_manager(&mut self.scrap.text_edit);
         context.attach_control_manager(&mut self.controls);
         context.attach_list_manager(&mut self.list_manager);
         context.attach_dialog_text(&mut self.param_text);
@@ -21092,6 +21093,22 @@ fn dispatch_supported_import(
         }
         PpcImportDispatcherTarget::TEInit => {
             toolbox_startup.text_edit_initialized = true;
+            let mut allocator = PpcProcessAllocatorView {
+                memory_manager: process_memory_manager,
+            };
+            let handle = ppc_te_scrap_handle(
+                Some(&mut allocator),
+                memory,
+                heap_cursor,
+                heap_limit,
+                last_mem_error,
+                handles,
+            );
+            *last_mem_error = if handle == 0 {
+                PPC_MEM_FULL_ERR
+            } else {
+                PPC_NO_ERR
+            };
             Some(PpcImportAction::ReturnPreserve)
         }
         PpcImportDispatcherTarget::TENew | PpcImportDispatcherTarget::TEStyleNew => {
@@ -21154,6 +21171,7 @@ fn dispatch_supported_import(
                 handles,
                 cpu.gpr[3],
             );
+            scrap.text_edit.remove(&cpu.gpr[3]);
             Some(PpcImportAction::ReturnPreserve)
         }
         PpcImportDispatcherTarget::TEActivate { active } => {
@@ -21441,9 +21459,10 @@ fn dispatch_supported_import(
         }
         PpcImportDispatcherTarget::TEAutoView => {
             // Inside Macintosh: Text (1993), pp. 2-90--2-91: TEAutoView
-            // changes only whether a later TESelView may scroll. TESelView is
-            // not needed by the native title set, so no public TERec field is
-            // altered by this private feature toggle.
+            // changes private feature state rather than a public TERec field.
+            scrap
+                .text_edit
+                .set_feature_bit(cpu.gpr[4], 0, cpu.gpr[3] != 0);
             Some(PpcImportAction::ReturnPreserve)
         }
         PpcImportDispatcherTarget::TECopy { cut, dialog } => {
@@ -21464,7 +21483,6 @@ fn dispatch_supported_import(
                 heap_limit,
                 last_mem_error,
                 handles,
-                scrap,
                 te_handle,
                 cut,
             );
@@ -21488,7 +21506,7 @@ fn dispatch_supported_import(
             } else {
                 cpu.gpr[3]
             };
-            let bytes = ppc_te_scrap_bytes(memory, handles, scrap);
+            let bytes = ppc_te_scrap_bytes(memory);
             let mut allocator = PpcProcessAllocatorView {
                 memory_manager: process_memory_manager,
             };
@@ -21536,14 +21554,13 @@ fn dispatch_supported_import(
                         heap_limit,
                         last_mem_error,
                         handles,
-                        scrap,
                         &bytes,
                     )
                 } else {
                     PPC_NO_TYPE_ERR
                 }
             } else {
-                let bytes = ppc_te_scrap_bytes(memory, handles, scrap);
+                let bytes = ppc_te_scrap_bytes(memory);
                 scrap.desktop.initialized = true;
                 scrap
                     .desktop
@@ -21565,7 +21582,6 @@ fn dispatch_supported_import(
                 heap_limit,
                 last_mem_error,
                 handles,
-                scrap,
             );
             *last_mem_error = if handle == 0 {
                 PPC_MEM_FULL_ERR
@@ -21577,7 +21593,7 @@ fn dispatch_supported_import(
         PpcImportDispatcherTarget::TEScrapLength { set } => {
             if set {
                 let requested = cpu.gpr[3] as i32;
-                let existing = ppc_te_scrap_bytes(memory, handles, scrap);
+                let existing = ppc_te_scrap_bytes(memory);
                 *last_mem_error = if requested < 0 {
                     PPC_PARAM_ERR
                 } else {
@@ -21593,18 +21609,15 @@ fn dispatch_supported_import(
                         heap_limit,
                         last_mem_error,
                         handles,
-                        scrap,
                         &resized,
                     )
                 };
                 Some(PpcImportAction::ReturnPreserve)
             } else {
-                let length = handles
-                    .iter()
-                    .find(|record| record.handle == scrap.private_text_handle)
-                    .map(|record| record.size)
+                let length = memory
+                    .read_u16_be(crate::memory::globals::addr::TE_SCRP_LENGTH)
                     .unwrap_or(0);
-                Some(PpcImportAction::Return(length))
+                Some(PpcImportAction::Return(u32::from(length)))
             }
         }
         PpcImportDispatcherTarget::SelectDialogItemText => {
@@ -69368,16 +69381,14 @@ fn ppc_te_scrap_handle(
     heap_limit: u32,
     last_mem_error: &mut i16,
     handles: &mut Vec<PpcHandleRecord>,
-    scrap: &mut PpcScrapState,
 ) -> u32 {
-    if scrap.private_text_handle != 0
-        && handles
-            .iter()
-            .any(|record| record.handle == scrap.private_text_handle)
-    {
-        return scrap.private_text_handle;
+    let existing = memory
+        .read_u32_be(crate::memory::globals::addr::TE_SCRP_HANDLE)
+        .unwrap_or(0);
+    if existing != 0 && memory.read_u32_be(existing).is_some() {
+        return existing;
     }
-    scrap.private_text_handle = ppc_allocator_view_allocate_handle(
+    let handle = ppc_allocator_view_allocate_handle(
         allocator,
         memory,
         heap_cursor,
@@ -69387,15 +69398,29 @@ fn ppc_te_scrap_handle(
         0,
         true,
     );
-    scrap.private_text_handle
+    if handle != 0 {
+        let _ = memory.write_u32_be(crate::memory::globals::addr::TE_SCRP_HANDLE, handle);
+        let _ = memory.write_u16_be(crate::memory::globals::addr::TE_SCRP_LENGTH, 0);
+    }
+    handle
 }
 
-fn ppc_te_scrap_bytes(
-    memory: &mut PpcSectionMem,
-    handles: &[PpcHandleRecord],
-    scrap: &PpcScrapState,
-) -> Vec<u8> {
-    ppc_handle_bytes(memory, handles, scrap.private_text_handle).unwrap_or_default()
+fn ppc_te_scrap_bytes(memory: &mut PpcSectionMem) -> Vec<u8> {
+    let handle = memory
+        .read_u32_be(crate::memory::globals::addr::TE_SCRP_HANDLE)
+        .unwrap_or(0);
+    let length = usize::from(
+        memory
+            .read_u16_be(crate::memory::globals::addr::TE_SCRP_LENGTH)
+            .unwrap_or(0),
+    );
+    let Some(ptr) = memory.read_u32_be(handle).filter(|ptr| *ptr != 0) else {
+        return Vec::new();
+    };
+    u32::try_from(length)
+        .ok()
+        .and_then(|length| ppc_memory_read_bytes(memory, ptr, length))
+        .unwrap_or_default()
 }
 
 fn ppc_te_set_scrap_bytes(
@@ -69405,7 +69430,6 @@ fn ppc_te_set_scrap_bytes(
     heap_limit: u32,
     last_mem_error: &mut i16,
     handles: &mut Vec<PpcHandleRecord>,
-    scrap: &mut PpcScrapState,
     bytes: &[u8],
 ) -> i16 {
     let handle = ppc_te_scrap_handle(
@@ -69415,7 +69439,6 @@ fn ppc_te_set_scrap_bytes(
         heap_limit,
         last_mem_error,
         handles,
-        scrap,
     );
     if handle == 0 {
         return PPC_MEM_FULL_ERR;
@@ -69442,6 +69465,10 @@ fn ppc_te_set_scrap_bytes(
             return PPC_PARAM_ERR;
         }
     }
+    let _ = memory.write_u16_be(
+        crate::memory::globals::addr::TE_SCRP_LENGTH,
+        length as u16,
+    );
     PPC_NO_ERR
 }
 
@@ -69465,7 +69492,6 @@ fn ppc_te_copy_or_cut(
     heap_limit: u32,
     last_mem_error: &mut i16,
     handles: &mut Vec<PpcHandleRecord>,
-    scrap: &mut PpcScrapState,
     te_handle: u32,
     cut: bool,
 ) -> i16 {
@@ -69482,7 +69508,6 @@ fn ppc_te_copy_or_cut(
         heap_limit,
         last_mem_error,
         handles,
-        scrap,
         &selected,
     );
     if result != PPC_NO_ERR || !cut {
@@ -147879,11 +147904,7 @@ pub(crate) mod tests {
         loaded.cpu.gpr[3] = te_handle;
         loaded.run_with_hle_imports(64);
         assert_eq!(
-            ppc_te_scrap_bytes(
-                &mut loaded.memory,
-                &test_handle_records!(loaded),
-                &loaded.scrap
-            ),
+            ppc_te_scrap_bytes(&mut loaded.memory),
             b"Pilot"
         );
 
@@ -149263,6 +149284,135 @@ pub(crate) mod tests {
         assert_eq!(native.cpu.gpr[3], 13);
         assert_eq!(native.memory.read_u32_be(native_offset), Some(0));
         assert_eq!(native.scrap.desktop.count, 2);
+    }
+
+    #[test]
+    fn attached_textedit_features_cross_isa_immediately() {
+        let mut native =
+            load_pef_application(&synthetic_pef_with_import(b"TestImport")).unwrap();
+        let (mut classic, mut classic_cpu, mut classic_bus) = setup_with_port();
+        let mut context = ProcessContext::default();
+        classic.attach_process_context(&mut context);
+        native.attach_process_context(&mut context);
+        let te_handle = 0x0033_1000;
+
+        classic_bus.write_long(TEST_SP, te_handle);
+        classic_bus.write_byte(TEST_SP + 4, 1);
+        classic_cpu.write_reg(Register::A7, TEST_SP);
+        assert!(classic
+            .dispatch_dialog(true, 0x013, &mut classic_cpu, &mut classic_bus)
+            .unwrap()
+            .is_ok());
+        assert!(native.scrap.text_edit.feature_bit(te_handle, 0));
+
+        native.cpu.gpr[3] = 0;
+        native.cpu.gpr[4] = te_handle;
+        run_test_import(&mut native, PpcImportDispatcherTarget::TEAutoView);
+        assert!(!classic.te_auto_scroll_enabled(te_handle));
+
+        native.cpu.gpr[3] = 1;
+        native.cpu.gpr[4] = te_handle;
+        run_test_import(&mut native, PpcImportDispatcherTarget::TEAutoView);
+        assert!(classic.te_auto_scroll_enabled(te_handle));
+
+        native.cpu.gpr[3] = te_handle;
+        run_test_import(&mut native, PpcImportDispatcherTarget::TEDispose);
+        assert!(!classic.te_auto_scroll_enabled(te_handle));
+    }
+
+    #[test]
+    fn attached_textedit_scrap_uses_canonical_low_memory_globals() {
+        let mut native =
+            load_pef_application(&synthetic_pef_with_import(b"TestImport")).unwrap();
+        let (mut classic, _classic_cpu, mut classic_bus) = setup_with_port();
+        let mut context = ProcessContext::default();
+        classic.attach_process_context(&mut context);
+        native.attach_process_context(&mut context);
+        let low_memory = classic_bus
+            .shared_ram_region(0, 0x0010_0000)
+            .expect("classic adapter owns low memory");
+        context.attach_memory(0, low_memory, &mut native.memory);
+        let ram_end = classic_bus.ram_size();
+        for (base, end) in native
+            .memory
+            .ordinary_mapping_holes(0x0010_0000, ram_end)
+        {
+            let memory = classic_bus
+                .shared_ram_region(base, end - base)
+                .expect("classic adapter owns the native mapping hole");
+            context.attach_memory(base, memory, &mut native.memory);
+        }
+        let shared = native.memory.shared_view();
+        classic_bus.attach_guest_address_space(shared);
+        context.attach_classic_memory_bus(&mut classic_bus);
+
+        run_test_import(&mut native, PpcImportDispatcherTarget::TEInit);
+        let native_handle = native
+            .memory
+            .read_u32_be(crate::memory::globals::addr::TE_SCRP_HANDLE)
+            .unwrap();
+        assert_ne!(native_handle, 0);
+        assert_eq!(
+            classic_bus.read_long(crate::memory::globals::addr::TE_SCRP_HANDLE),
+            native_handle
+        );
+        assert_eq!(
+            classic_bus.read_word(crate::memory::globals::addr::TE_SCRP_LENGTH),
+            0
+        );
+
+        native.scrap.desktop.entries = vec![(*b"TEXT", b"Native".to_vec())];
+        run_test_import(
+            &mut native,
+            PpcImportDispatcherTarget::TETransferScrap { from_desktop: true },
+        );
+        let native_ptr = classic_bus.read_long(native_handle);
+        assert_eq!(
+            classic_bus.read_word(crate::memory::globals::addr::TE_SCRP_LENGTH),
+            6
+        );
+        assert_eq!(classic_bus.read_bytes(native_ptr, 6), b"Native");
+
+        let (classic_handle, classic_ptr) = context
+            .memory_manager_mut()
+            .new_classic_handle(&mut classic_bus, 7)
+            .unwrap();
+        classic_bus.write_bytes(classic_ptr, b"Classic");
+        classic_bus.write_long(
+            crate::memory::globals::addr::TE_SCRP_HANDLE,
+            classic_handle,
+        );
+        classic_bus.write_word(crate::memory::globals::addr::TE_SCRP_LENGTH, 7);
+
+        run_test_import(&mut native, PpcImportDispatcherTarget::TEScrapHandle);
+        assert_eq!(native.cpu.gpr[3], classic_handle);
+        run_test_import(
+            &mut native,
+            PpcImportDispatcherTarget::TEScrapLength { set: false },
+        );
+        assert_eq!(native.cpu.gpr[3], 7);
+        assert_eq!(ppc_te_scrap_bytes(&mut native.memory), b"Classic");
+    }
+
+    #[test]
+    fn cloned_native_adapter_detaches_textedit_feature_state() {
+        let mut original =
+            load_pef_application(&synthetic_pef_with_import(b"TestImport")).unwrap();
+        original.scrap.text_edit.set_feature_bit(0x0033_1000, 0, true);
+        let mut detached = original.clone();
+
+        detached
+            .scrap
+            .text_edit
+            .set_feature_bit(0x0033_1000, 0, false);
+        detached
+            .scrap
+            .text_edit
+            .set_feature_bit(0x0033_2000, 2, true);
+
+        assert!(original.scrap.text_edit.feature_bit(0x0033_1000, 0));
+        assert!(!original.scrap.text_edit.feature_bit(0x0033_2000, 2));
+        assert!(!detached.scrap.text_edit.feature_bit(0x0033_1000, 0));
     }
 
     #[test]

--- a/src/loader/ppc/vfs.rs
+++ b/src/loader/ppc/vfs.rs
@@ -4,7 +4,7 @@ use crate::process_context::{
     ProcessForkBytes, ProcessOpenFileRecord, ProcessResourceFileRecord, ProcessStdioStreamRecord,
     ProcessVfsDirectory, ProcessVfsFileRecord, ProcessVfsResourceFileRecord,
     ProcessVfsResourceRecord, ProcessVfsVolumeRecord, SharedProcessScrapState,
-    SharedProcessValue,
+    SharedProcessTextEditManager, SharedProcessValue,
 };
 use crate::list_manager::{ProcessListManagerState, ProcessListRecord};
 
@@ -47,8 +47,8 @@ pub type PpcVfsResourceRecord = ProcessVfsResourceRecord;
 
 #[derive(Debug, Clone, Default)]
 pub struct PpcScrapState {
-    pub(crate) private_text_handle: u32,
     pub(crate) desktop: SharedProcessScrapState,
+    pub(crate) text_edit: SharedProcessTextEditManager,
 }
 
 pub(crate) type PpcListRecord = ProcessListRecord;

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -14,6 +14,7 @@ use crate::memory::bus::{SharedClassicHeapAllocator, SharedRamRegion};
 use crate::memory::{GuestAddressSpace, MacMemoryBus, MemoryBus};
 use crate::menu_manager::{ProcessMenuTrackingState, SharedNativeMenuSelection};
 use crate::sound::SoundManager;
+use crate::text_edit::ProcessTextEditManagerState;
 use ppc::PpcMemory;
 use std::cell::{RefCell, RefMut, UnsafeCell};
 use std::collections::{HashMap, HashSet};
@@ -1232,6 +1233,7 @@ pub(crate) type SharedProcessCallbackScheduling = SharedProcessValue<ProcessCall
 pub(crate) type SharedProcessScrapState = SharedProcessValue<ProcessScrapState>;
 pub(crate) type SharedProcessControlManager = SharedProcessValue<ProcessControlManagerState>;
 pub(crate) type SharedProcessListManager = SharedProcessValue<ProcessListManagerState>;
+pub(crate) type SharedProcessTextEditManager = SharedProcessValue<ProcessTextEditManagerState>;
 /// Detached-by-default attachment handle for Dialog Manager `ParamText` slots.
 pub type SharedProcessDialogText = SharedProcessValue<[Vec<u8>; 4]>;
 
@@ -4188,6 +4190,7 @@ pub(crate) struct ProcessContext {
     scrap_state: SharedProcessScrapState,
     control_manager: SharedProcessControlManager,
     list_manager: SharedProcessListManager,
+    text_edit_manager: SharedProcessTextEditManager,
     dialog_text: SharedProcessDialogText,
     cursor_state: SharedProcessCursorState,
     current_graphics_port: SharedProcessValue<u32>,
@@ -4217,6 +4220,7 @@ impl Default for ProcessContext {
             scrap_state: SharedProcessScrapState::default(),
             control_manager: SharedProcessControlManager::default(),
             list_manager: SharedProcessListManager::default(),
+            text_edit_manager: SharedProcessTextEditManager::default(),
             dialog_text: SharedProcessDialogText::default(),
             cursor_state: SharedProcessCursorState::default(),
             current_graphics_port: SharedProcessValue::from_value(0),
@@ -4303,6 +4307,13 @@ impl ProcessContext {
 
     pub(crate) fn attach_list_manager(&self, adapter: &mut SharedProcessListManager) {
         adapter.attach_to(&self.list_manager, ProcessListManagerState::is_pristine);
+    }
+
+    pub(crate) fn attach_text_edit_manager(&self, adapter: &mut SharedProcessTextEditManager) {
+        adapter.attach_to(
+            &self.text_edit_manager,
+            ProcessTextEditManagerState::is_pristine,
+        );
     }
 
     pub(crate) fn attach_dialog_text(&self, adapter: &mut SharedProcessDialogText) {

--- a/src/text_edit.rs
+++ b/src/text_edit.rs
@@ -3,7 +3,59 @@
 //! The 68K trap and PowerPC import layers translate guest ABI and memory into
 //! this model, then serialize the result back into their respective `TERec`.
 
+use std::collections::HashMap;
 use std::ops::Range;
+
+/// Private feature flags associated with one guest `TERec`.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct ProcessTextEditState {
+    pub(crate) feature_bits: u16,
+}
+
+/// Canonical host-only TextEdit metadata for one Macintosh process.
+///
+/// Edit records and the private TextEdit scrap remain canonical guest memory.
+/// This manager retains only feature bits that are not represented in a
+/// `TERec`. Inside Macintosh: Text (1993), pp. 2-90--2-92.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) struct ProcessTextEditManagerState {
+    records: HashMap<u32, ProcessTextEditState>,
+}
+
+impl ProcessTextEditManagerState {
+    pub(crate) fn is_pristine(&self) -> bool {
+        self.records.is_empty()
+    }
+
+    pub(crate) fn feature_bit(&self, handle: u32, feature: u16) -> bool {
+        let mask = 1u16.checked_shl(feature as u32).unwrap_or(0);
+        self.records
+            .get(&handle)
+            .is_some_and(|state| state.feature_bits & mask != 0)
+    }
+
+    pub(crate) fn set_feature_bit(&mut self, handle: u32, feature: u16, enabled: bool) {
+        let mask = 1u16.checked_shl(feature as u32).unwrap_or(0);
+        if mask == 0 {
+            return;
+        }
+        if enabled {
+            self.records.entry(handle).or_default().feature_bits |= mask;
+            return;
+        }
+
+        if let Some(state) = self.records.get_mut(&handle) {
+            state.feature_bits &= !mask;
+            if state.feature_bits == 0 {
+                self.records.remove(&handle);
+            }
+        }
+    }
+
+    pub(crate) fn remove(&mut self, handle: &u32) {
+        self.records.remove(handle);
+    }
+}
 
 /// Mutable text and normalized selection state for one TextEdit operation.
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/src/trap/dialog.rs
+++ b/src/trap/dialog.rs
@@ -3335,11 +3335,7 @@ impl super::TrapDispatcher {
     }
 
     fn te_feature_bit(&self, te_handle: u32, feature: u16) -> bool {
-        let mask = 1u16.checked_shl(feature as u32).unwrap_or(0);
-        self.textedit_states
-            .get(&te_handle)
-            .map(|state| (state.feature_bits & mask) != 0)
-            .unwrap_or(false)
+        self.textedit_states.feature_bit(te_handle, feature)
     }
 
     /// Whether auto-scroll is enabled on the TextEdit record at
@@ -3352,13 +3348,8 @@ impl super::TrapDispatcher {
     }
 
     fn set_te_feature_bit(&mut self, te_handle: u32, feature: u16, enabled: bool) {
-        let mask = 1u16.checked_shl(feature as u32).unwrap_or(0);
-        let state = self.textedit_states.entry(te_handle).or_default();
-        if enabled {
-            state.feature_bits |= mask;
-        } else {
-            state.feature_bits &= !mask;
-        }
+        self.textedit_states
+            .set_feature_bit(te_handle, feature, enabled);
     }
 
     fn initialize_dialog_item_handles(

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -21,7 +21,7 @@ use crate::process_context::{
     SharedProcessEventQueue,
     SharedProcessFileSystem, SharedProcessInputState, SharedProcessMemoryManager,
     SharedProcessListManager, SharedProcessMenuTracking, SharedProcessResourceManager, SharedProcessScrapState,
-    SharedProcessSoundManager, SharedProcessValue,
+    SharedProcessSoundManager, SharedProcessTextEditManager, SharedProcessValue,
 };
 use crate::trace::{TraceEvent, TraceSink, TraceSource};
 use crate::ui_theme::{UiTheme, UiThemeId};
@@ -1017,12 +1017,6 @@ pub(crate) struct AeCoercionHandler {
 }
 
 pub(crate) type ListState = ProcessListRecord;
-
-#[derive(Clone, Debug, Default)]
-pub(crate) struct TextEditState {
-    /// Feature bits toggled through TEFeatureFlag / TEAutoView.
-    pub feature_bits: u16,
-}
 
 #[derive(Clone, Copy, Debug, Default)]
 pub(crate) struct ControlAuxRecordState {
@@ -2639,8 +2633,8 @@ pub struct TrapDispatcher {
     pub(crate) saved_vis_regions: HashMap<u32, (i16, i16, i16, i16)>,
     /// Process-owned List Manager state shared with native execution.
     pub(crate) list_states: SharedProcessListManager,
-    /// Host-side TextEdit feature state keyed by guest TEHandle.
-    pub(crate) textedit_states: HashMap<u32, TextEditState>,
+    /// Process-owned TextEdit feature state shared with native execution.
+    pub(crate) textedit_states: SharedProcessTextEditManager,
     /// Process-owned Control Manager metadata shared with native execution.
     pub(crate) control_manager: SharedProcessControlManager,
     /// The menu ID of the most recently inserted menu (via InsertMenu).
@@ -2780,6 +2774,7 @@ impl TrapDispatcher {
         context.attach_scrap_state(&mut self.scrap);
         context.attach_control_manager(&mut self.control_manager);
         context.attach_list_manager(&mut self.list_states);
+        context.attach_text_edit_manager(&mut self.textedit_states);
         context.attach_dialog_text(&mut self.param_text);
         context.attach_cursor_state(&mut self.cursor_state);
         context.attach_quickdraw_selection(&mut self.current_port, &mut self.current_gdevice);
@@ -3994,7 +3989,7 @@ impl TrapDispatcher {
             window_stack: Vec::new(),
             saved_vis_regions: HashMap::new(),
             list_states: SharedProcessListManager::default(),
-            textedit_states: HashMap::new(),
+            textedit_states: SharedProcessTextEditManager::default(),
             control_manager: SharedProcessControlManager::default(),
             last_inserted_menu_id: None,
             pending_dialog_popup_menu: None,


### PR DESCRIPTION
## Summary

- attach one process-owned TextEdit feature manager to both 68K traps and PowerPC imports
- make the TextEdit private scrap use its canonical low-memory handle and length across both CPU adapters
- remove the native-only private scrap handle and cover immediate cross-ISA visibility plus detached clones

## Root cause

The 68K dispatcher retained private TextEdit feature bits in adapter-local state, while the PowerPC adapter treated `TEAutoView` as a no-op and kept a separate host-side private scrap handle. Switching ISA during one process could therefore lose feature mutations or expose a different TextEdit scrap even though TextEdit defines one application-private scrap.

The process context now owns the feature metadata that is absent from `TERec`. The private scrap itself remains canonical guest state through `TEScrpHandle` and `TEScrpLength`, so shared process RAM provides immediate bidirectional visibility without overlaying ordinary PEF mappings.

## Validation

- `cargo test --locked --lib` — 4,759 passed, 0 failed, 3 ignored
- strict rustdoc with private intra-doc links denied
- all targets and all features compiled for tests
- 68K and PowerPC Toolbox Showcase lanes passed
- Marathon terminal completion and resumed gameplay passed
- Escape Velocity landing, return to space, and acceleration passed
- Tomb Raider Gold live level and movement passed

Closes #1214