### PR TITLE
perf(runner): avoid single-stepping native trap handlers

### DIFF
--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -5582,6 +5582,7 @@ impl FixtureRunner {
             .active_interrupt_callback
             .map(|callback| is_sound_interrupt_source(callback.source))
             .unwrap_or(false);
+        let mut watch_buf = Vec::with_capacity(4);
 
         while count < max_steps && !self.halted && !tick_cap_reached {
             if sound_work_only
@@ -5935,11 +5936,6 @@ impl FixtureRunner {
             }
             let batch_max = if per_instruction_diagnostics_active() {
                 1
-            } else if self.dispatcher.has_pending_native_trap_call() {
-                // A patched trap handler can return with an ordinary RTS.
-                // Keep execution on exact instruction boundaries until its
-                // synthesized PC/SP continuation is observed and retired.
-                1
             } else {
                 let mut n = (max_steps - count).min(BATCH_CHUNK);
                 if charging && self.active_interrupt_callback.is_none() {
@@ -5952,15 +5948,18 @@ impl FixtureRunner {
             // must halt before low memory gets executed as code. While an
             // interrupt callback is active (including one fired by the
             // pre-charge above), its resume PC is watched so the resume
-            // PC+SP check above fires at the exact boundary.
-            let mut watch_buf = [0u32; 2];
-            let watch: &[u32] = if let Some(callback) = self.active_interrupt_callback {
-                watch_buf[1] = callback.resume_pc;
-                &watch_buf
-            } else {
-                &watch_buf[..1]
-            };
-            let batch = self.m68k.cpu.run_batch(&mut self.bus, batch_max, watch);
+            // PC+SP check above fires at the exact boundary. Native trap
+            // return PCs are watched for the same reason: ordinary RTS
+            // returns can then be retired exactly without globally reducing
+            // the batch size to one instruction.
+            watch_buf.clear();
+            watch_buf.push(0);
+            if let Some(callback) = self.active_interrupt_callback {
+                watch_buf.push(callback.resume_pc);
+            }
+            self.dispatcher
+                .append_pending_native_trap_return_pcs(&mut watch_buf);
+            let batch = self.m68k.cpu.run_batch(&mut self.bus, batch_max, &watch_buf);
             self.dispatcher
                 .retire_returned_native_trap_call(&mut self.m68k.cpu);
             // Trap exits consumed their opcode word too; count it like the
@@ -6808,6 +6807,7 @@ impl FixtureRunner {
 
         let mut executed = 0usize;
         let mut running = true;
+        let mut watch_buf = Vec::with_capacity(4);
         while executed < max_steps {
             if self.m68k.cpu.read_reg(Register::PC) == pending.return_pc {
                 running =
@@ -6815,15 +6815,12 @@ impl FixtureRunner {
                         .complete_pending(&mut ppc_app.memory, &mut ppc_app.cpu, pending);
                 break;
             }
-            let batch_max = if self.dispatcher.has_pending_native_trap_call() {
-                1
-            } else {
-                u32::try_from(max_steps - executed).unwrap_or(u32::MAX)
-            };
-            let batch = self
-                .m68k
-                .cpu
-                .run_batch(&mut self.bus, batch_max, &[pending.return_pc]);
+            let batch_max = u32::try_from(max_steps - executed).unwrap_or(u32::MAX);
+            watch_buf.clear();
+            watch_buf.push(pending.return_pc);
+            self.dispatcher
+                .append_pending_native_trap_return_pcs(&mut watch_buf);
+            let batch = self.m68k.cpu.run_batch(&mut self.bus, batch_max, &watch_buf);
             self.dispatcher
                 .retire_returned_native_trap_call(&mut self.m68k.cpu);
             let retired = batch.instructions as usize

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -7031,11 +7031,16 @@ impl TrapDispatcher {
         call
     }
 
-    /// Whether guest execution is currently inside any routine installed by
-    /// the Trap Manager. The runner keeps these uncommon calls on exact
-    /// instruction boundaries so an ordinary RTS can retire its continuation.
-    pub(crate) fn has_pending_native_trap_call(&self) -> bool {
-        !self.pending_native_trap_calls.is_empty()
+    /// Add every retained native-patch return PC to the current m68k batch's
+    /// watch list. Reaching one stops the batch before the return-site
+    /// instruction executes, so the runner can validate PC and SP and retire
+    /// the exact invocation without single-stepping all intervening code.
+    pub(crate) fn append_pending_native_trap_return_pcs(&self, pcs: &mut Vec<u32>) {
+        for call in self.pending_native_trap_calls.values().flatten() {
+            if !pcs.contains(&call.return_pc) {
+                pcs.push(call.return_pc);
+            }
+        }
     }
 
     /// Whether the canonical OS or Toolbox slot selected by an A-line word


### PR DESCRIPTION
## Summary

Keep normal m68k batch sizes while a call to a guest-installed trap handler is
in flight. Retained native-trap return PCs are now exact batch watch points;
the existing PC+SP check still decides whether an invocation really returned.

This fixes an accidental global-single-step mode exposed by SimCity 2000. On
the deterministic 400M-instruction replay, the change reduces median retired
host instructions by 73.35%, hardware cycles by 73.90%, user CPU time by
69.77%, and wall time by 68.10%, with identical guest instructions, scripted
input, and simulated ticks.

## Background: why SC2K replaces `_LoadSeg`

Classic Macintosh applications can divide their executable into numbered
`CODE` resources. Segment 1 normally contains the resident main program;
other segments can be loaded only when a routine in them is first called.
External calls go through an A5-relative jump table. When a target segment is
unloaded, its jump-table entry invokes `_LoadSeg`; the Segment Manager reads
the `CODE` resource into a relocatable Handle, locks it, rewrites the relevant
jump-table entries as direct jumps, and then executes the requested routine.
An unloaded segment can later be made purgeable and loaded again on demand.

That stock mechanism was designed around the ordinary MPW near-segment
format. Much 68k code and its jump-table metadata used 16-bit offsets, which
made 32 KB a practical segment-size boundary. Apple explicitly documented
that some development systems substituted their own jump-table formats to
circumvent this limit.

SC2K needs that extended model. The application used in this replay contains:

```text
CODE 1:   1,520 bytes   resident compiler/runtime and loader
CODE 2: 280,089 bytes   large game-code segment
CODE 3:  15,478 bytes   another relocatable segment
```

`CODE 2` is far beyond the near-model limit. The game's compiler/runtime
therefore installs its own `_LoadSeg` handler at `$008665DA` (and a matching
unload implementation immediately afterward). Patching the existing trap
lets every compiler-generated jump-table slot continue to invoke `$A9F0`
while giving the runtime control over its 32-bit offsets and relocation data.
The segment can still use the Resource and Memory Managers and retain the
normal lazy-load, movable, lockable, and purgeable behavior.

The private loader has three jobs beyond the stock near loader:

1. understand the runtime's eight-byte far jump-table slots;
2. relocate absolute longwords after the Resource Manager chooses an address
   for the movable segment; and
3. turn all slots owned by the segment into absolute-long jumps before
   entering the requested routine.

This is why the patch exists: it is compatibility machinery for the compiler's
large-code memory model, not a game-specific attempt to optimize the 68000.

Apple reference: [Inside Macintosh: Processes — Segment Manager](https://developer.apple.com/library/archive/documentation/mac/pdf/Processes/Segment_Manager.pdf), pp. 7-3 through 7-9.

## The SC2K jump-table and segment formats

SC2K's jump-table entries are eight bytes and are called at offset zero:

```text
offset  size  unloaded                         loaded
+0      2     A9F0  (_LoadSeg)                 4EF9  (JMP absolute-long)
+2      4     routine offset within segment    absolute routine address
+6      2     CODE resource/segment ID         unchanged, no longer executed
```

The same six bytes that encode `_LoadSeg` plus a 32-bit routine offset become
a complete `JMP <absolute-long>` instruction. The final segment-ID word is
outside the six-byte jump and can be left in place.

The nonresident `CODE` resources begin with this extended header. All values
are big-endian:

```c
struct Sc2kCodeHeader {
    uint16_t jt_offset16;       /* present, not read by this handler */
    uint16_t jt_entry_count;    /* number of consecutive 8-byte slots */
    uint32_t jt_a5_offset;      /* A5 + this = first owned slot */
    uint32_t relocation_offset; /* segment + this = first reloc stream */
};
```

The fields actually seen in the two resources are:

| resource | size | `jt_a5_offset` | entries | `relocation_offset` |
|---|---:|---:|---:|---:|
| `CODE 2` | 280,089 | `$0000321E` | 10 | `$00043268` |
| `CODE 3` | 15,478 | `$00002DDE` | 136 | `$00003BE0` |

The first slot of `CODE 3` is `$00859DDE`; its 136 slots end at
`$0085A216`. `CODE 2` begins at the immediately following slot,
`$0085A21E`, and owns ten slots through `$0085A266`. This adjacency is also a
check on the loop count: the 68k implementation branches to `DBRA` before the
first body iteration, so it patches exactly the header count, not count plus
one.

## What the patched `_LoadSeg` does

The handler lives in `CODE 1`:

```text
CODE 1 runtime base:           $00866294
relocation decoder:            $008664D2
three-stream relocation glue:  $00866546
A5-world entry shim:           $008665A4
patched _LoadSeg:              $008665DA
final RTS:                     $00866696
matching unload implementation:$00866698
```

The following is a semantic C rendering of the disassembly. It is not source
recovered from symbols: guest pointers, big-endian accesses, trap register
ABIs, and the saved 68k return address are made explicit. Names for private
A5-relative globals are descriptive; their offsets and behavior are exact.

```c
typedef uint32_t GuestPtr;
typedef GuestPtr Handle; /* address of a 32-bit master pointer */
typedef void (*SegmentHook)(int16_t segment_id);

enum {
    kLoadSegTrap       = 0xA9F0,
    kJmpAbsoluteLong   = 0x4EF9,
    kLoadTrap          = 0x012D, /* low-memory byte */
    kResLoad           = 0x0A5E, /* low-memory byte */
    kSegHiEnable       = 0x0BB2, /* low-memory byte */
};

#define A5_BEFORE_LOAD_HOOK       0x2DBC
#define A5_AFTER_LOAD_HOOK        0x2DC0
#define A5_MISSING_SEGMENT_HOOK   0x2DC8
#define A5_FLUSH_ICACHE_FLAG      0x2DCC
#define A5_MAIN_CODE_BASE         0x2DCE

static void sc2k_patched_LoadSeg(
    GuestPtr A5,
    GuestPtr *saved_return_pc
) {
    /*
     * The real entry first goes through an A5-world shim. If the incoming A5
     * is not SC2K's saved A5, compiler thunks transfer into the loader's A5
     * world. Both traced calls already had the correct A5, so this was a
     * no-op in the measured replay.
     */
    enter_sc2k_loader_a5_world(/* loading = */ true);

    /*
     * A9F0 has retired, so the synthesized JSR return is jump_entry + 2.
     * The assembly saves D0-D2/A0-A2 and then executes:
     *
     *     SUBQ.L #2,24(SP)
     *     MOVEA.L 24(SP),A2
     *
     * This changes the eventual RTS target back to the slot's first byte.
     */
    *saved_return_pc -= 2;
    GuestPtr invoking_slot = *saved_return_pc;
    int16_t segment_id = (int16_t)read_be16(invoking_slot + 6);

    SegmentHook before =
        (SegmentHook)read_be32(A5 + A5_BEFORE_LOAD_HOOK);
    if (before != NULL)
        before(segment_id);

    /* Force GetResource to materialize the resource rather than an empty Handle. */
    write_u8(kResLoad, 0xFF); /* ResLoad = TRUE */

    Handle h;
    for (;;) {
        h = GetResource(/* 'CODE' */ 0x434F4445, segment_id);
        if (h != 0)
            break;

        SegmentHook recover =
            (SegmentHook)read_be32(A5 + A5_MISSING_SEGMENT_HOOK);
        if (recover == NULL)
            SysError(15); /* documented segment-loader error */

        /* The callback can make/install the missing resource; then retry. */
        recover(segment_id);
    }

    /* Preserve the ordinary Segment Manager's heap policy. */
    if (read_u8(kSegHiEnable) != 0)
        MoveHHi(h);
    HLock(h);

    GuestPtr segment = StripAddress(read_be32(h)); /* StripAddress(*h) */
    GuestPtr reloc = segment + read_be32(segment + 8);

    /* Relocate references to the A5 world, resident CODE 1, and this segment. */
    reloc = apply_relocation_stream(reloc, segment, A5);
    reloc = apply_relocation_stream(
        reloc, segment, read_be32(A5 + A5_MAIN_CODE_BASE));
    reloc = apply_relocation_stream(reloc, segment, segment);

    GuestPtr slot = A5 + read_be32(segment + 4);
    uint16_t count = read_be16(segment + 2);
    for (uint16_t i = 0; i < count; ++i, slot += 8) {
        write_be16(slot + 0, kJmpAbsoluteLong);
        write_be32(slot + 2, read_be32(slot + 2) + segment);
        /* slot+6 retains the segment ID, but JMP never executes it. */
    }

    if (read_u8(A5 + A5_FLUSH_ICACHE_FLAG) != 0) {
        /* MOVEQ #1,D0; _HWPriv ($A198), selector 1 */
        FlushInstructionCache();
    }

    SegmentHook after =
        (SegmentHook)read_be32(A5 + A5_AFTER_LOAD_HOOK);
    if (after != NULL)
        after(segment_id);

    /* The real code restores D0-D2/A0-A2 here. */

    if (read_u8(kLoadTrap) != 0)
        Debugger();

    /* The real final instruction is RTS to the deliberately rewound PC. */
}
```

The A5-world shim exists because the installed trap can be reached from code
whose live A5 is not the game's application-globals base. It compares A5 with
a saved value at `$008665CE`; on mismatch it installs the saved A5 and
transfers through one of two compiler-runtime thunks, one for loading and one
for unloading. The traced calls already used `$00857000`, so the shim returned
immediately.

The handler also retains normal Segment Manager observability and memory
behavior: `ResLoad` is forced true, `SegHiEnable` controls `MoveHHi`, the
Handle is locked, `LoadTrap` can invoke `Debugger`, and `_HWPriv` selector 1
flushes the instruction cache after the self-modifying jump-table writes.

### Compressed relocation decoder

Each of the three adjacent streams starts with a big-endian 32-bit count. The
decoder maintains an even byte offset into the segment. Each item selects a
longword in the segment, and the stream's chosen base is added to that
longword modulo 32 bits.

The location encodings are:

1. bit 7 set: one-byte signed 7-bit running delta, in 16-bit words;
2. top bits `01`: two-byte signed 14-bit running delta, in words; or
3. top bits `00`: four-byte signed 30-bit absolute/reset location, in words.

The four-byte form is an assignment to the running location, not an addition.
That distinction is explicit in the disassembly: the short forms `ADD.L` into
D2, while the long form `MOVE.L`s into D2.

```c
static int32_t sign_extend(uint32_t x, unsigned bits) {
    uint32_t sign = 1u << (bits - 1);
    return (int32_t)((x ^ sign) - sign);
}

static GuestPtr apply_relocation_stream(
    GuestPtr stream,
    GuestPtr segment,
    uint32_t addend
) {
    int32_t remaining = (int32_t)read_be32(stream);
    stream += 4;
    int32_t location = 0;

    while (remaining > 0) {
        uint8_t first = read_u8(stream++);

        if ((first & 0x80) != 0) {
            location += sign_extend(first & 0x7F, 7) * 2;
        } else {
            uint16_t encoded =
                ((uint16_t)first << 8) | read_u8(stream++);

            if ((encoded & 0x4000) != 0) {
                location += sign_extend(encoded & 0x3FFF, 14) * 2;
            } else {
                uint32_t full =
                    ((uint32_t)encoded << 16) | read_be16(stream);
                stream += 2;
                location = sign_extend(full & 0x3FFFFFFF, 30) * 2;
            }
        }

        GuestPtr p = segment + (uint32_t)location;
        write_be32(p, read_be32(p) + addend);
        --remaining;
    }

    return stream;
}
```

The actual relocation counts and addends were:

| resource | A5-relative | main-`CODE 1`-relative | self-relative |
|---|---:|---:|---:|
| `CODE 2` | 139 | 486 | 3,060 |
| `CODE 3` | 91 | 7 | 0 |

The addends observed at runtime were `$00857000` for A5,
`$00866294` for `CODE 1`, and `$00200040` or `$00247B3C` for the newly
loaded segment. The streams consume the exact remainder of each resource,
which independently confirms the decoder boundaries.

The companion unload code at `$00866698` corroborates the interpretation. It
runs the same streams with negated addends, rewrites `$4EF9` back to `$A9F0`,
subtracts the segment base from each slot target, calls `_HUnlock` and
`_HPurge`, and then flushes the instruction cache when requested.

## The unusual return, instruction by instruction

The first observed invocation loaded `CODE 2` through slot `$0085A21E`:

| step | PC/state | effect |
|---:|---|---|
| 1 | `$0085A21E`: `$A9F0` | CPU retires `_LoadSeg`; architectural PC becomes `$0085A220`. |
| 2 | native trap dispatch | Systemless records return PC `$0085A220`, records the argument SP, pushes `$0085A220`, and enters `$008665DA`. |
| 3 | `$008665E8` | Handler subtracts 2 from the stacked return, producing `$0085A21E`. |
| 4 | load/relocate | Handler loads `CODE 2` at `$00200040` and applies 3,685 relocations. |
| 5 | patch slots | At `$0085A21E`, `$A9F0 + offset32` becomes `$4EF9 + absolute32`. Nine adjacent slots are patched as well. |
| 6 | `$00866696`: `RTS` | CPU pops `$0085A21E`, not the recorded normal continuation `$0085A220`. |
| 7 | `$0085A21E`: `$4EF9` | CPU executes the newly written absolute jump into `CODE 2`. Bytes at `$0085A220` are now part of that JMP's 32-bit operand. |

The second invocation performs the same transformation while loading
`CODE 3`:

```text
recorded normal return PC: $0085A200
rewound/final RTS target:  $0085A1FE
```

This is the essential fact behind the bug: SC2K's handler does not and should
not return to the instruction after `$A9F0`. It atomically replaces the trap
with a jump and re-executes the jump-table slot. Treating `$0085A21E` as a
normal return to `$0085A220` would be incorrect.

## How this became a host performance problem

When Systemless encounters an A-line trap whose table entry points at guest
code, it simulates a `JSR` into that installed handler. Conceptually:

```c
NativeTrapCallState call = {
    .return_pc  = cpu.PC, /* PC after the A-line instruction */
    .argument_sp = cpu.A7,
    .saved_nonvolatile_registers = ...,
    .optional_os_dispatch_frame = ...,
};
retain(call);
push_long(call.return_pc);
cpu.PC = installed_handler;
```

The retained state is needed for more than bookkeeping. Guest trap patches
can be nested, can return directly, or can daisy-chain to a saved older trap
handler. OS traps may also require restoration of a structural dispatcher
frame. A direct return is therefore retired only when both the exact expected
PC and the exact post-`RTS` SP match the most recent invocation. Matching only
PC could retire the wrong nested invocation; matching only SP could confuse a
handler's internal calls with its real return.

The runner must inspect that PC+SP pair at the instruction boundary where an
ordinary handler returns. Before this change, the conservative implementation
was effectively:

```c
if (per_instruction_diagnostics_active() ||
    dispatcher.has_pending_native_trap_call()) {
    batch_max = 1;
} else {
    batch_max = normal_batch_budget;
}
```

That is correct for short-lived conventional handlers, but it assumes every
retained invocation will soon revisit its recorded return PC. SC2K violates
that assumption intentionally. Its recorded `entry + 2` becomes the middle
of the new six-byte `JMP`, so normal execution never reaches it as an
instruction boundary. The exact PC+SP retirement check correctly refuses to
pretend the handler returned normally, but the retained state then keeps
`batch_max` at one for almost the whole run.

Diagnostic instrumentation on the earlier #1082-equivalent investigation
base measured:

```text
run_batch calls:              399,694,762
guest instructions executed: 398,387,644
```

The batch count is slightly higher because an A-line exit can end a batch
without contributing to the core's ordinary retired-instruction count. The
important point is that virtually every guest instruction required a separate
host-side batch call.

This did **not** make SC2K execute more 68k instructions. It made each one far
more expensive on the host: batch setup, Rust/core call boundaries, exit
classification, instruction/tick accounting, return checks, and loop control
were repeated for every instruction instead of being amortized across a
normal batch. This is why the change can remove roughly three quarters of
host instructions and cycles without changing guest instructions or
simulated ticks.

## Change: exact return watch points instead of global single-stepping

The runner now computes the ordinary batch budget and gives the core a small
list of PCs at which it must stop before executing the boundary instruction:

```c
watch_pcs.clear();
watch_pcs.push(0); /* clean-exit sentinel */

if (interrupt_callback_active)
    watch_pcs.push(interrupt_callback.resume_pc);

dispatcher.append_pending_native_trap_return_pcs(&watch_pcs);

BatchResult batch = cpu.run_batch(bus, normal_batch_budget, watch_pcs);
dispatcher.retire_returned_native_trap_call(cpu); /* still exact PC + SP */
```

Return PCs are deduplicated, and the same mechanism is used in both the
normal m68k runner and m68k guest calls made from PowerPC code.

For an ordinary native handler:

1. its `RTS` establishes the expected PC and SP;
2. the core notices that PC before executing its instruction and returns
   `BatchExit::WatchedPc`;
3. the runner applies the existing PC+SP identity test; and
4. only an exact match retires the invocation and restores any saved OS frame.

For SC2K's `_LoadSeg`, the watched PC remains `entry + 2`. The handler returns
to `entry`, and the core executes the newly written six-byte `JMP`; `entry + 2`
is an operand, not an instruction boundary, so the watch is never hit. The
small retained record stays inert without reducing the batch size.

This deliberately avoids an SC2K-specific “`return_pc - 2` now contains
`$4EF9`” retirement rule. Such a rule would assert that a handler completed
normally when it actually transferred control through self-modified code and
could interfere with nested calls or daisy-chain state. Watching real normal
return PCs is generic, preserves the existing lifecycle semantics, and solves
the performance problem without guessing at guest intent.

The change therefore does not:

- skip the patched `_LoadSeg` or any of its relocation work;
- skip any other guest instruction or trap;
- change the guest instruction count or tick charging;
- weaken the PC+SP identity check;
- retire SC2K's invocation under a made-up return convention; or
- special-case SC2K in the emulator.

## Validation

- Latest-upstream source/test base: `ea92dba`; single candidate commit:
  `432fc49`.
- Complete library suite on that exact latest source: 4,762 passed, 3 ignored,
  0 failed.
- All seven focused `native_trap` tests pass. These cover normal returns,
  nested same-trap calls, auto-pop frames, trap-chain bypass, and native
  return retirement.
- The deterministic 130M sanity pair replayed an identical input trace and
  ended at exactly `ticks=157437` on both arms. Its final baseline and
  candidate PNGs are byte-identical (SHA-256 `3a059a4e9f411ab17c460342c9fe604f03bdb7ed1727f7fae76cafd1699f458f`).
- At the 10M startup-dialog checkpoint, both arms ended at `ticks=17574` and
  again produced byte-identical PNGs (SHA-256
  `fb36884d00bd112a8cea369bf9b5bf6d61f4f3c10b33b7b7c98f188f7bc7ac8e`).
  This checkpoint includes the blue-button/green-border regression already
  present on upstream; exact equality proves this optimization does not
  exacerbate or otherwise alter it.
- The earlier `d1fe737`/`48e31fa` candidate was replayed at both checkpoints
  and reached `ticks=17574` and `ticks=157437`, with both PNGs byte-identical
  to the measured baseline. After the final rebase, the exact
  `ea92dba`/`432fc49` release candidate was replayed through 130M instructions
  again: it reached `ticks=157437` and reproduced the same
  `3a059a4e9f411ab17c460342c9fe604f03bdb7ed1727f7fae76cafd1699f458f`
  framebuffer hash.
- All six 400M measurement arms completed normally and ended at exactly
  `ticks=185810`.
- `git diff --check` passes; the latest-upstream patch is one commit touching
  only `src/runner/mod.rs` and `src/trap/dispatch.rs`.

## Actual host-CPU measurements

Three counter-enabled A/B pairs used fresh private save directories,
identical scripted input, and a 400,000,000 guest-instruction cap. The order
was A-B, B-A, A-B. Every arm exited successfully at `ticks=185810`; this patch
does not alter guest work, so the fixed instruction cap also represents equal
simulated work here. The release-counter snapshot used upstream master
`c085300` and the single patch commit `ecabc5e`. Subsequent upstream commits
move Toolbox and runtime state into process-owned structures; they do not
change this m68k batching or native-trap return mechanism. The complete tests
and deterministic 130M replay described above cover the final rebased
`ea92dba`/`432fc49` candidate itself.

| metric | baseline runs | candidate runs | median baseline | median candidate | median change |
|---|---:|---:|---:|---:|---:|
| host instructions retired | 303.537B, 303.281B, 303.142B | 81.058B, 80.837B, 80.542B | 303.281B | 80.837B | **-73.35%** |
| hardware cycles elapsed | 157.861B, 152.101B, 155.391B | 43.331B, 40.551B, 36.766B | 155.391B | 40.551B | **-73.90%** |
| user CPU | 63.30s, 59.99s, 61.20s | 19.69s, 18.50s, 11.63s | 61.20s | 18.50s | **-69.77%** |
| wall time | 70.85s, 63.97s, 64.88s | 22.61s, 20.70s, 12.13s | 64.88s | 20.70s | **-68.10%** |

The exact release binaries used for those runs were:

```text
baseline  7f20d164644a9e806cd58abe51a7d803d61ce01944618a2246f7c2e00b16d87e
candidate 7f9489637d40b1dbe09748ccfdd5cbc925f50faf84a50ba7aaf09dc840fd4a5c
```

Raw counter logs are in
`.work/steady/logs/journal-cpu-latest-c085300-native-trap-return-watch/`.

Windowed presentation remains paced at approximately 30 Hz, so a reading
around 29.6 FPS is expected and is not evidence that the optimization failed.
The improvement is reduced host CPU work and increased headroom, not a frame
rate above the presentation target.
