### PR TITLE
refactor(quickdraw)!: make error state process-owned

### DIFF
--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -2937,7 +2937,7 @@ pub struct PpcToolboxStartupState {
     pub last_disposed_dialog: u32,
     pub delay_deadline: Option<u32>,
     pub next_ct_seed: u32,
-    pub last_quickdraw_error: i16,
+    pub(crate) last_quickdraw_error: SharedProcessValue<i16>,
     pub open_region_port: u32,
     pub open_region_save_handle: u32,
     pub open_region_bounds: Option<(i16, i16, i16, i16)>,
@@ -2998,7 +2998,7 @@ impl Default for PpcToolboxStartupState {
             last_disposed_dialog: 0,
             delay_deadline: None,
             next_ct_seed: 0,
-            last_quickdraw_error: PPC_NO_ERR,
+            last_quickdraw_error: SharedProcessValue::from_value(PPC_NO_ERR),
             open_region_port: 0,
             open_region_save_handle: 0,
             open_region_bounds: None,
@@ -3913,6 +3913,7 @@ impl PpcLoadedApp {
         context.attach_cursor_state(&mut self.cursor_state);
         context.activate_quickdraw_selection(&mut self.current_gworld, &mut self.current_gdevice);
         self.process_quickdraw_port_state_attached = true;
+        context.attach_quickdraw_error(&mut self.toolbox_startup.last_quickdraw_error);
         context.attach_display_color_state(
             &mut self.screen_clut,
             &mut self.color_manager_clut,
@@ -19274,7 +19275,7 @@ fn dispatch_supported_import(
             // Imaging With QuickDraw (1994), pp. 6-20 and 6-24: QDError
             // reports NewGWorld and UpdateGWorld failures, and a successful
             // call clears the previous QuickDraw error.
-            toolbox_startup.last_quickdraw_error = result;
+            *toolbox_startup.last_quickdraw_error = result;
             Some(PpcImportAction::Return(ppc_i16_result(result)))
         }
         PpcImportDispatcherTarget::UpdateGWorld => {
@@ -19293,7 +19294,7 @@ fn dispatch_supported_import(
             );
             // Imaging With QuickDraw (1994), p. 6-24: after gwFlagErr the
             // caller uses QDError to obtain the reason UpdateGWorld failed.
-            toolbox_startup.last_quickdraw_error = if result & (1 << 31) != 0 {
+            *toolbox_startup.last_quickdraw_error = if result & (1 << 31) != 0 {
                 *last_mem_error
             } else {
                 PPC_NO_ERR
@@ -19492,7 +19493,7 @@ fn dispatch_supported_import(
             Some(PpcImportAction::ReturnPreserve)
         }
         PpcImportDispatcherTarget::QDError => Some(PpcImportAction::Return(ppc_i16_result(
-            toolbox_startup.last_quickdraw_error,
+            *toolbox_startup.last_quickdraw_error,
         ))),
         PpcImportDispatcherTarget::CTabChanged => {
             let color_table_handle = cpu.gpr[3];
@@ -63450,7 +63451,7 @@ fn ppc_make_itable(
         requested_resolution
     };
     if !(3..=5).contains(&resolution) {
-        toolbox_startup.last_quickdraw_error = PPC_C_RES_ERR;
+        *toolbox_startup.last_quickdraw_error = PPC_C_RES_ERR;
         return;
     }
 
@@ -63466,7 +63467,7 @@ fn ppc_make_itable(
         screen_clut,
         &ppc_device_clut_reserved(toolbox_startup, current_gdevice),
     ) else {
-        toolbox_startup.last_quickdraw_error = PPC_PARAM_ERR;
+        *toolbox_startup.last_quickdraw_error = PPC_PARAM_ERR;
         return;
     };
     let table = ppc_inverse_table_bytes(&colors, resolution);
@@ -63474,7 +63475,7 @@ fn ppc_make_itable(
         .ok()
         .and_then(|size| size.checked_add(6))
     else {
-        toolbox_startup.last_quickdraw_error = PPC_MEM_FULL_ERR;
+        *toolbox_startup.last_quickdraw_error = PPC_MEM_FULL_ERR;
         return;
     };
 
@@ -63482,7 +63483,7 @@ fn ppc_make_itable(
     let mut itable_handle = explicit_itable_handle;
     if itable_handle == 0 {
         let Some(gdevice) = gdevice else {
-            toolbox_startup.last_quickdraw_error = PPC_PARAM_ERR;
+            *toolbox_startup.last_quickdraw_error = PPC_PARAM_ERR;
             return;
         };
         itable_handle = memory.read_u32_be(gdevice + 6).unwrap_or(0);
@@ -63498,7 +63499,7 @@ fn ppc_make_itable(
                 true,
             );
             if itable_handle == 0 || memory.write_u32_be(gdevice + 6, itable_handle).is_none() {
-                toolbox_startup.last_quickdraw_error = PPC_MEM_FULL_ERR;
+                *toolbox_startup.last_quickdraw_error = PPC_MEM_FULL_ERR;
                 return;
             }
         }
@@ -63515,20 +63516,20 @@ fn ppc_make_itable(
         record_size,
     );
     if resize_result != PPC_NO_ERR {
-        toolbox_startup.last_quickdraw_error = resize_result;
+        *toolbox_startup.last_quickdraw_error = resize_result;
         return;
     }
     let Some(itable) = memory
         .read_u32_be(itable_handle)
         .filter(|itable| *itable != 0)
     else {
-        toolbox_startup.last_quickdraw_error = PPC_PARAM_ERR;
+        *toolbox_startup.last_quickdraw_error = PPC_PARAM_ERR;
         return;
     };
     let wrote_record = memory.write_u32_be(itable, seed).is_some()
         && memory.write_u16_be(itable + 4, resolution).is_some()
         && memory.write_bytes(itable + 6, &table).is_some();
-    toolbox_startup.last_quickdraw_error = if wrote_record {
+    *toolbox_startup.last_quickdraw_error = if wrote_record {
         PPC_NO_ERR
     } else {
         PPC_PARAM_ERR
@@ -89320,6 +89321,43 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn attached_quickdraw_error_crosses_isa_and_detaches_with_clone() {
+        let (mut classic, mut classic_cpu, mut classic_bus) = setup_with_port();
+        let mut native =
+            load_pef_application(&synthetic_pef_with_import(b"TestImport")).unwrap();
+        let mut context = ProcessContext::default();
+        classic.attach_process_context(&mut context);
+        native.attach_process_context(&mut context);
+        let mut detached = native.clone();
+
+        assert!(classic
+            .quickdraw_error
+            .ptr_eq(&native.toolbox_startup.last_quickdraw_error));
+        assert!(!classic
+            .quickdraw_error
+            .ptr_eq(&detached.toolbox_startup.last_quickdraw_error));
+
+        *native.toolbox_startup.last_quickdraw_error = PPC_PARAM_ERR;
+        classic_bus.write_word(TEST_SP, 0);
+        classic_cpu.write_reg(Register::A7, TEST_SP);
+        assert!(classic
+            .dispatch_quickdraw(true, 0x240, &mut classic_cpu, &mut classic_bus)
+            .unwrap()
+            .is_ok());
+        assert_eq!(classic_bus.read_word(TEST_SP) as i16, PPC_PARAM_ERR);
+
+        *classic.quickdraw_error = PPC_C_RES_ERR;
+        run_test_import(&mut native, PpcImportDispatcherTarget::QDError);
+        assert_eq!(native.cpu.gpr[3], ppc_i16_result(PPC_C_RES_ERR));
+
+        run_test_import(&mut detached, PpcImportDispatcherTarget::QDError);
+        assert_eq!(detached.cpu.gpr[3], ppc_i16_result(PPC_NO_ERR));
+        *detached.toolbox_startup.last_quickdraw_error = PPC_MEM_FULL_ERR;
+        assert_eq!(*classic.quickdraw_error, PPC_C_RES_ERR);
+        assert_eq!(*native.toolbox_startup.last_quickdraw_error, PPC_C_RES_ERR);
+    }
+
+    #[test]
     fn attached_ppc_event_queue_remains_shared_through_panic() {
         let pef = synthetic_pef_with_import(b"InvalMenuBar");
         let mut native = load_pef_application(&pef).unwrap();
@@ -92822,7 +92860,7 @@ pub(crate) mod tests {
             &mut startup,
         );
 
-        assert_eq!(startup.last_quickdraw_error, PPC_NO_ERR);
+        assert_eq!(*startup.last_quickdraw_error, PPC_NO_ERR);
         let record = handles
             .iter()
             .find(|record| record.handle == itable_handle)
@@ -92871,7 +92909,7 @@ pub(crate) mod tests {
             &mut startup,
         );
 
-        assert_eq!(startup.last_quickdraw_error, PPC_C_RES_ERR);
+        assert_eq!(*startup.last_quickdraw_error, PPC_C_RES_ERR);
         let itable = memory.read_u32_be(itable_handle).unwrap();
         assert_eq!(
             ppc_memory_read_bytes(&mut memory, itable, 9),
@@ -135365,7 +135403,7 @@ pub(crate) mod tests {
 
             assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_C_DEPTH_ERR));
             assert_eq!(loaded.last_mem_error(), PPC_C_DEPTH_ERR);
-            assert_eq!(loaded.toolbox_startup.last_quickdraw_error, PPC_C_DEPTH_ERR);
+            assert_eq!(*loaded.toolbox_startup.last_quickdraw_error, PPC_C_DEPTH_ERR);
             run_test_import(&mut loaded, PpcImportDispatcherTarget::QDError);
             assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_C_DEPTH_ERR));
             assert_eq!(loaded.memory.read_u32_be(gworld_out_ptr), Some(0xdead_beef));
@@ -135793,7 +135831,7 @@ pub(crate) mod tests {
         ppc_write_rect(&mut loaded.memory, bounds_ptr, 5, 6, 8, 10).unwrap();
         *loaded.current_gworld = gworld;
         *loaded.current_gdevice = PPC_MAIN_GDEVICE;
-        loaded.toolbox_startup.last_quickdraw_error = PPC_PARAM_ERR;
+        *loaded.toolbox_startup.last_quickdraw_error = PPC_PARAM_ERR;
         loaded.cpu.gpr[3] = gworld_out_ptr;
         loaded.cpu.gpr[4] = u32::from(u16::MAX); // ignored when aGDevice is non-NIL
         loaded.cpu.gpr[5] = bounds_ptr;
@@ -135803,7 +135841,7 @@ pub(crate) mod tests {
         run_test_import(&mut loaded, PpcImportDispatcherTarget::UpdateGWorld);
 
         assert_eq!(loaded.cpu.gpr[3] & (1 << 31), 0);
-        assert_eq!(loaded.toolbox_startup.last_quickdraw_error, PPC_NO_ERR);
+        assert_eq!(*loaded.toolbox_startup.last_quickdraw_error, PPC_NO_ERR);
         let updated = loaded
             .gworlds
             .iter()
@@ -136402,7 +136440,7 @@ pub(crate) mod tests {
         run_test_import(&mut loaded, PpcImportDispatcherTarget::UpdateGWorld);
         assert_eq!(loaded.cpu.gpr[3], GW_FLAG_ERR);
         assert_eq!(loaded.last_mem_error(), PPC_PARAM_ERR);
-        assert_eq!(loaded.toolbox_startup.last_quickdraw_error, PPC_PARAM_ERR);
+        assert_eq!(*loaded.toolbox_startup.last_quickdraw_error, PPC_PARAM_ERR);
         run_test_import(&mut loaded, PpcImportDispatcherTarget::QDError);
         assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_PARAM_ERR));
 
@@ -136457,7 +136495,7 @@ pub(crate) mod tests {
         loaded.cpu.gpr[8] = (1 << 3) | (1 << 28); // keepLocal + clipPix
         run_test_import(&mut loaded, PpcImportDispatcherTarget::UpdateGWorld);
         assert_eq!(loaded.cpu.gpr[3] & GW_FLAG_ERR, 0);
-        assert_eq!(loaded.toolbox_startup.last_quickdraw_error, PPC_NO_ERR);
+        assert_eq!(*loaded.toolbox_startup.last_quickdraw_error, PPC_NO_ERR);
 
         assert_eq!(loaded.heap_cursor(), heap_cursor_before);
         assert_eq!(test_handle_records!(loaded), handles_before);
@@ -137062,7 +137100,7 @@ pub(crate) mod tests {
         loaded.cpu.gpr[8] = 0;
         run_test_import(&mut loaded, PpcImportDispatcherTarget::NewGWorld);
         assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_C_DEPTH_ERR));
-        assert_eq!(loaded.toolbox_startup.last_quickdraw_error, PPC_C_DEPTH_ERR);
+        assert_eq!(*loaded.toolbox_startup.last_quickdraw_error, PPC_C_DEPTH_ERR);
         assert_eq!(loaded.memory.read_u32_be(gworld_out_ptr), Some(0xdead_beef));
         assert_eq!(loaded.heap_cursor(), heap_cursor_before);
         assert_eq!(test_handle_records!(loaded), handles_before);

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -4217,6 +4217,7 @@ pub(crate) struct ProcessContext {
     cursor_state: SharedProcessCursorState,
     current_graphics_port: SharedProcessValue<u32>,
     current_graphics_device: SharedProcessValue<u32>,
+    quickdraw_error: SharedProcessValue<i16>,
     device_clut: SharedProcessValue<[[u16; 3]; 256]>,
     color_manager_clut: SharedProcessValue<[[u16; 3]; 256]>,
     device_gamma: SharedProcessValue<DisplayGamma>,
@@ -4247,6 +4248,7 @@ impl Default for ProcessContext {
             cursor_state: SharedProcessCursorState::default(),
             current_graphics_port: SharedProcessValue::from_value(0),
             current_graphics_device: SharedProcessValue::from_value(0),
+            quickdraw_error: SharedProcessValue::from_value(0),
             device_clut: SharedProcessValue::from_value(standard_mac_8bpp_clut()),
             color_manager_clut: SharedProcessValue::from_value(standard_mac_8bpp_clut()),
             device_gamma: SharedProcessValue::from_value(default_display_gamma()),
@@ -4367,6 +4369,14 @@ impl ProcessContext {
     ) {
         current_port.activate_copy_to(&self.current_graphics_port);
         current_device.activate_copy_to(&self.current_graphics_device);
+    }
+
+    /// Attach the error from the last applicable Color QuickDraw or Color
+    /// Manager operation. QDError exposes one process result regardless of
+    /// which CPU ABI performed the operation. Imaging With QuickDraw (1994),
+    /// pp. 4-94--4-95.
+    pub(crate) fn attach_quickdraw_error(&self, error: &mut SharedProcessValue<i16>) {
+        error.attach_copy_to(&self.quickdraw_error, |value| *value == 0);
     }
 
     pub(crate) fn attach_display_color_state(

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -2380,6 +2380,8 @@ pub struct TrapDispatcher {
     pub(crate) current_gdevice: SharedProcessValue<u32>,
     /// Current GrafPort/GWorld pointer
     pub(crate) current_port: SharedProcessValue<u32>,
+    /// Error from the last applicable Color QuickDraw or Color Manager call.
+    pub(crate) quickdraw_error: SharedProcessValue<i16>,
     /// Whether the attached process's current CGrafPort record is canonical
     /// for draw state shared with the native QuickDraw adapter.
     pub(crate) process_quickdraw_port_state_attached: bool,
@@ -2773,6 +2775,7 @@ impl TrapDispatcher {
         context.attach_dialog_text(&mut self.param_text);
         context.attach_cursor_state(&mut self.cursor_state);
         context.attach_quickdraw_selection(&mut self.current_port, &mut self.current_gdevice);
+        context.attach_quickdraw_error(&mut self.quickdraw_error);
         self.process_quickdraw_port_state_attached = true;
         context.attach_display_color_state(
             &mut self.device_clut,
@@ -3906,6 +3909,7 @@ impl TrapDispatcher {
             main_gdevice_handle: 0,
             current_gdevice: SharedProcessValue::from_value(0),
             current_port: SharedProcessValue::from_value(0),
+            quickdraw_error: SharedProcessValue::from_value(0),
             process_quickdraw_port_state_attached: false,
             port_draw_states: HashMap::new(),
             resolved_port_color_fields: HashMap::new(),

--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -9114,16 +9114,10 @@ impl super::TrapDispatcher {
             // popping any argument frame, caller pops the 2-byte slot
             // (A7 += 2) — net A7 zero across the C-level call.
             //
-            // Per IM:V V-145 QDError returns the error result from the
-            // last QuickDraw or Color Manager call. Systemless HLE is a
-            // hardcoded noErr stub that does not track per-call error
-            // state; after clean InitGraf/InitFonts/InitWindows/OpenPort
-            // with no failing operations preceding the call, BII System
-            // 7.5.3 ROM Color QuickDraw also returns noErr.
-            //
-            // BII tracks per-call error codes through qdGlobals and can
-            // return non-zero error states, whereas Systemless always
-            // returns noErr.
+            // Per IM:V V-145 QDError returns the error result from the last
+            // applicable QuickDraw or Color Manager call. The process owns
+            // that result so a Mixed Mode caller observes errors posted by
+            // either CPU adapter immediately.
             //
             // Contract-test coverage in this file (mod tests):
             //   quickdraw::tests::qderror_returns_noerr_in_function_result_slot_without_stack_pop
@@ -9131,7 +9125,7 @@ impl super::TrapDispatcher {
             //   quickdraw::tests::qderror_pascal_function_preserves_stack_across_five_calls
             (true, 0x240) => {
                 let sp = cpu.read_reg(Register::A7);
-                bus.write_word(sp, 0u16); // noErr — no QD errors tracked
+                bus.write_word(sp, *self.quickdraw_error as u16);
                 Ok(())
             }
 


### PR DESCRIPTION
## Summary

- move the last QuickDraw/Color Manager error into the process context
- make classic `QDError` report the shared process result instead of a hardcoded `noErr`
- share native and classic QuickDraw errors immediately across Mixed Mode calls
- preserve detached-clone independence

This changes the public `PpcToolboxStartupState::last_quickdraw_error` field from an `i16` to the shared process-value representation.

## Validation

- `cargo test --locked --lib` — 4,765 passed, 0 failed, 3 ignored
- `RUSTDOCFLAGS='-D warnings -D rustdoc::private_intra_doc_links' cargo doc --all-features --locked --no-deps --document-private-items`
- `cargo test --all-features --all-targets --locked --no-run`
- Marathon terminal completion, return to gameplay, and resumed input
- Escape Velocity landing, return to space, and acceleration
- Tomb Raider Gold live level and forward movement

Closes #1221