### PR TITLE
refactor(vfs): keep the catalogue process-owned during execution

### DIFF
--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -123,9 +123,9 @@ pub(crate) fn ppc_initial_process_file_system() -> SharedProcessFileSystem {
     let mut state = ProcessFileSystemState::default();
     state.stdio_streams = ppc_initial_stdio_streams();
     state.next_file_ref_num = PPC_FIRST_FILE_REF_NUM;
-    state.vfs_directories = initial_ppc_vfs_directories();
-    state.next_vfs_dir_id = PPC_FIRST_DYNAMIC_DIR_ID;
-    state.default_dir_id = PPC_ROOT_DIR_ID;
+    *state.vfs_directories = initial_ppc_vfs_directories();
+    *state.next_vfs_dir_id = PPC_FIRST_DYNAMIC_DIR_ID;
+    *state.default_dir_id = PPC_ROOT_DIR_ID;
     SharedProcessFileSystem::from_state(state)
 }
 
@@ -7270,10 +7270,10 @@ impl PpcLoadedApp {
         let mut quickdraw_text_size = self.quickdraw_text_size;
         let process_quickdraw_port_state_attached = self.process_quickdraw_port_state_attached;
         let mut cursor_state = std::mem::take(&mut self.cursor_state);
-        let vfs_volumes = std::mem::take(&mut self.vfs_volumes);
-        let mut vfs_directories = std::mem::take(&mut self.vfs_directories);
-        let mut next_vfs_dir_id = self.next_vfs_dir_id;
-        let mut default_dir_id = self.default_dir_id;
+        let vfs_volumes = self.vfs_volumes.shared_handle();
+        let mut vfs_directories = self.vfs_directories.shared_handle();
+        let mut next_vfs_dir_id = self.next_vfs_dir_id.shared_handle();
+        let mut default_dir_id = self.default_dir_id.shared_handle();
         let mut param_text = std::mem::take(&mut self.param_text);
         let mut scrap = std::mem::take(&mut self.scrap);
         let mut list_manager = std::mem::take(&mut self.list_manager);
@@ -7814,7 +7814,7 @@ impl PpcLoadedApp {
                         &vfs_volumes,
                         &mut vfs_directories,
                         &mut next_vfs_dir_id,
-                        default_dir_id,
+                        *default_dir_id,
                         self.launched_app_path.as_deref(),
                         &mut param_text,
                         &mut scrap,
@@ -7847,9 +7847,9 @@ impl PpcLoadedApp {
                     true,
                 );
 
-                default_dir_id = memory
+                *default_dir_id = memory
                     .read_u32_be(crate::memory::globals::addr::CUR_DIR_STORE)
-                    .unwrap_or(default_dir_id);
+                    .unwrap_or(*default_dir_id);
 
                 match action {
                     Some(action) => {
@@ -8173,10 +8173,6 @@ impl PpcLoadedApp {
         self.quickdraw_text_mode = quickdraw_text_mode;
         self.quickdraw_text_size = quickdraw_text_size;
         self.cursor_state = cursor_state;
-        self.vfs_volumes = vfs_volumes;
-        self.vfs_directories = vfs_directories;
-        self.next_vfs_dir_id = next_vfs_dir_id;
-        self.default_dir_id = default_dir_id;
         self.process_file_system.publish_native_vfs_catalogue();
         self.param_text = param_text;
         self.scrap = scrap;
@@ -8222,18 +8218,18 @@ impl PpcLoadedApp {
             .map(|directory| directory.dir_id)
             .max()
             .unwrap_or(PPC_ROOT_DIR_ID);
-        self.vfs_directories = directories;
-        self.default_dir_id = default_dir_id;
+        *self.vfs_directories = directories;
+        *self.default_dir_id = default_dir_id;
         let _ = self
             .memory
             .write_u32_be(crate::memory::globals::addr::CUR_DIR_STORE, default_dir_id);
-        self.next_vfs_dir_id = next_dir_id
+        *self.next_vfs_dir_id = next_dir_id
             .max(max_seeded_dir_id.saturating_add(1))
             .max(PPC_FIRST_DYNAMIC_DIR_ID);
     }
 
     pub fn seed_vfs_volumes(&mut self, volumes: Vec<PpcVfsVolumeRecord>) {
-        self.vfs_volumes = volumes;
+        *self.vfs_volumes = volumes;
     }
 
     pub fn set_launched_app_path(&mut self, path: impl Into<String>) {
@@ -89427,8 +89423,8 @@ pub(crate) mod tests {
             finder_flags: 0x0400,
             dirty: true,
         });
-        second.next_vfs_dir_id = PPC_FIRST_DYNAMIC_DIR_ID + 1;
-        second.default_dir_id = PPC_FIRST_DYNAMIC_DIR_ID;
+        *second.next_vfs_dir_id = PPC_FIRST_DYNAMIC_DIR_ID + 1;
+        *second.default_dir_id = PPC_FIRST_DYNAMIC_DIR_ID;
 
         assert_eq!(first.vfs_files[0].data, b"first-second");
         assert_eq!(first.deleted_vfs_file_paths, ["Obsolete Data"]);
@@ -89444,6 +89440,11 @@ pub(crate) mod tests {
         let mut native = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
         native.attach_process_context(&mut context);
+        let executing_directories = native.vfs_directories.shared_handle();
+        let executing_volumes = native.vfs_volumes.shared_handle();
+        let executing_next_dir_id = native.next_vfs_dir_id.shared_handle();
+        let executing_default_dir_id = native.default_dir_id.shared_handle();
+        let detached = native.clone();
         let mut classic = TrapDispatcher::new();
         classic.attach_process_context(&mut context);
 
@@ -89481,8 +89482,8 @@ pub(crate) mod tests {
             created_date: 1,
             modified_date: 2,
         });
-        native.next_vfs_dir_id = PPC_FIRST_DYNAMIC_DIR_ID + 1;
-        native.default_dir_id = PPC_FIRST_DYNAMIC_DIR_ID;
+        *native.next_vfs_dir_id = PPC_FIRST_DYNAMIC_DIR_ID + 1;
+        *native.default_dir_id = PPC_FIRST_DYNAMIC_DIR_ID;
         native.process_file_system.publish_native_vfs_catalogue();
 
         assert_eq!(
@@ -89500,6 +89501,21 @@ pub(crate) mod tests {
         assert_eq!(classic.vfs_volume_for_ref_num(-2).unwrap().name, "Read Only");
 
         let classic_dir_id = classic.ensure_vfs_directory("Classic Folder");
+        let classic_volume_ref = classic.mount_vfs_volume(
+            "Classic Disk",
+            0,
+            0,
+            16,
+            4096,
+            4096,
+            8,
+            3,
+            4,
+            5,
+            PPC_FIRST_DYNAMIC_DIR_ID + 3,
+            10,
+            11,
+        );
         classic
             .vfs
             .insert("Classic Folder/Classic Data".to_string(), b"classic".to_vec());
@@ -89509,9 +89525,33 @@ pub(crate) mod tests {
             *b"ttxt",
             0x0100,
         );
+        classic.set_launched_app_path("Classic Folder/Classic Data");
         assert!(native.vfs_directories.iter().any(|directory| {
             directory.dir_id == classic_dir_id && directory.path == "Classic Folder"
         }));
+        assert!(executing_directories.iter().any(|directory| {
+            directory.dir_id == classic_dir_id && directory.path == "Classic Folder"
+        }));
+        assert!(executing_volumes.iter().any(|volume| {
+            volume.ref_num == classic_volume_ref && volume.name == "Classic Disk"
+        }));
+        assert_eq!(*executing_next_dir_id, *classic.next_vfs_dir_id);
+        assert_eq!(*executing_default_dir_id, classic_dir_id);
+        assert!(!detached
+            .vfs_directories
+            .iter()
+            .any(|directory| directory.path == "Classic Folder"));
+        assert!(!detached
+            .vfs_volumes
+            .iter()
+            .any(|volume| volume.name == "Classic Disk"));
+        assert_ne!(*detached.next_vfs_dir_id, *executing_next_dir_id);
+        assert_ne!(*detached.default_dir_id, *executing_default_dir_id);
+        run_test_import(&mut native, PpcImportDispatcherTarget::GetEOF);
+        assert!(native.vfs_directories.ptr_eq(&executing_directories));
+        assert!(native.vfs_volumes.ptr_eq(&executing_volumes));
+        assert!(native.next_vfs_dir_id.ptr_eq(&executing_next_dir_id));
+        assert!(native.default_dir_id.ptr_eq(&executing_default_dir_id));
         let classic_file = native
             .vfs_files
             .iter()
@@ -89595,7 +89635,7 @@ pub(crate) mod tests {
         original.vfs_files[0].data.copy_from_slice(b"change");
         original.vfs_resources[0].data.copy_from_slice(b"changed!");
         original.vfs_directories.last_mut().unwrap().path = "Changed Folder".to_string();
-        original.next_vfs_dir_id += 1;
+        *original.next_vfs_dir_id += 1;
 
         assert!(!original
             .process_file_system
@@ -89606,7 +89646,10 @@ pub(crate) mod tests {
         assert_eq!(detached.vfs_resources[0].data, b"resource");
         assert_eq!(original.vfs_directories.last().unwrap().path, "Changed Folder");
         assert_eq!(detached.vfs_directories.last().unwrap().path, "Detached Folder");
-        assert_eq!(original.next_vfs_dir_id, detached.next_vfs_dir_id + 1);
+        assert_eq!(
+            *original.next_vfs_dir_id,
+            *detached.next_vfs_dir_id + 1
+        );
     }
 
     #[test]
@@ -96181,7 +96224,7 @@ pub(crate) mod tests {
             .memory
             .write_u32_be(parameter_block + 18, volume_name)
             .unwrap();
-        loaded.default_dir_id = 0x1234_5678;
+        *loaded.default_dir_id = 0x1234_5678;
         loaded.cpu.gpr[3] = parameter_block;
 
         let probe = loaded.run_with_hle_imports(64);
@@ -141019,7 +141062,7 @@ pub(crate) mod tests {
     fn hle_import_runner_pb_get_finfo_uses_default_directory() {
         let pef = synthetic_pef_with_import(b"PBGetFInfoSync");
         let mut loaded = load_pef_application(&pef).unwrap();
-        loaded.default_dir_id = PPC_PREFERENCES_DIR_ID;
+        *loaded.default_dir_id = PPC_PREFERENCES_DIR_ID;
         let pb = PPC_DATA_BASE + 0x1000;
         let name_ptr = pb + 128;
         loaded.memory.add_region(pb, vec![0; 256]);
@@ -141295,7 +141338,7 @@ pub(crate) mod tests {
     fn hle_import_runner_pb_set_finfo_missing_target_returns_fnf() {
         let pef = synthetic_pef_with_import(b"PBSetFInfo");
         let mut loaded = load_pef_application(&pef).unwrap();
-        loaded.default_dir_id = PPC_PREFERENCES_DIR_ID;
+        *loaded.default_dir_id = PPC_PREFERENCES_DIR_ID;
         let pb = PPC_DATA_BASE + 0x1000;
         let name_ptr = pb + 128;
         loaded.memory.add_region(pb, vec![0; 256]);
@@ -141499,7 +141542,7 @@ pub(crate) mod tests {
         loaded.memory.add_region(vref_ptr, vec![0xcc; 2]);
         loaded.memory.add_region(dir_id_ptr, vec![0xcc; 4]);
         loaded.memory.add_region(proc_id_ptr, vec![0xcc; 4]);
-        loaded.default_dir_id = PPC_PREFERENCES_DIR_ID;
+        *loaded.default_dir_id = PPC_PREFERENCES_DIR_ID;
         loaded.cpu.gpr[3] = PPC_BOOT_VOLUME_REF_NUM as u16 as u32;
         loaded.cpu.gpr[4] = vref_ptr;
         loaded.cpu.gpr[5] = dir_id_ptr;
@@ -141531,7 +141574,7 @@ pub(crate) mod tests {
         loaded.memory.add_region(name_ptr, vec![0xcc; 32]);
         loaded.memory.add_region(vref_ptr, vec![0xcc; 2]);
         loaded.memory.add_region(dir_id_ptr, vec![0xcc; 4]);
-        loaded.default_dir_id = PPC_PREFERENCES_DIR_ID;
+        *loaded.default_dir_id = PPC_PREFERENCES_DIR_ID;
         loaded.cpu.gpr[3] = name_ptr;
         loaded.cpu.gpr[4] = vref_ptr;
         loaded.cpu.gpr[5] = dir_id_ptr;

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -704,10 +704,10 @@ impl ProcessResourceManagerState {
 pub struct ProcessFileSystemState {
     pub(crate) files: Vec<ProcessOpenFileRecord>,
     pub(crate) stdio_streams: HashMap<u32, ProcessStdioStreamRecord>,
-    pub(crate) vfs_volumes: Vec<ProcessVfsVolumeRecord>,
-    pub(crate) vfs_directories: Vec<ProcessVfsDirectory>,
-    pub(crate) next_vfs_dir_id: u32,
-    pub(crate) default_dir_id: u32,
+    pub(crate) vfs_volumes: SharedProcessValue<Vec<ProcessVfsVolumeRecord>>,
+    pub(crate) vfs_directories: SharedProcessValue<Vec<ProcessVfsDirectory>>,
+    pub(crate) next_vfs_dir_id: SharedProcessValue<u32>,
+    pub(crate) default_dir_id: SharedProcessValue<u32>,
     pub(crate) classic_vfs_metadata: SharedProcessValue<HashMap<String, ProcessVfsMetadata>>,
     pub(crate) classic_vfs_directories:
         SharedProcessValue<HashMap<String, ProcessClassicVfsDirectory>>,
@@ -715,11 +715,9 @@ pub struct ProcessFileSystemState {
     pub(crate) classic_vfs_volumes: SharedProcessValue<HashMap<i16, ProcessVfsVolumeRecord>>,
     pub(crate) classic_vfs_volume_names: SharedProcessValue<HashMap<String, i16>>,
     pub(crate) classic_locked_files: SharedProcessValue<HashSet<String>>,
-    pub(crate) classic_next_vfs_dir_id: SharedProcessValue<u32>,
     pub(crate) classic_next_vfs_volume_ref_num: SharedProcessValue<i16>,
     pub(crate) classic_next_vfs_file_id: SharedProcessValue<u32>,
     pub(crate) classic_next_vfs_timestamp: SharedProcessValue<u32>,
-    pub(crate) classic_default_dir_id: SharedProcessValue<u32>,
     pub(crate) vfs_files: ProcessVfsFileRecords,
     pub(crate) deleted_vfs_file_paths: Vec<String>,
     pub(crate) resource_manager: SharedProcessResourceManager,
@@ -731,21 +729,19 @@ impl Default for ProcessFileSystemState {
         Self {
             files: Vec::new(),
             stdio_streams: HashMap::new(),
-            vfs_volumes: Vec::new(),
-            vfs_directories: Vec::new(),
-            next_vfs_dir_id: 0,
-            default_dir_id: 0,
+            vfs_volumes: SharedProcessValue::default(),
+            vfs_directories: SharedProcessValue::default(),
+            next_vfs_dir_id: SharedProcessValue::from_value(0),
+            default_dir_id: SharedProcessValue::from_value(0),
             classic_vfs_metadata: SharedProcessValue::default(),
             classic_vfs_directories: SharedProcessValue::default(),
             classic_vfs_directory_paths: SharedProcessValue::default(),
             classic_vfs_volumes: SharedProcessValue::default(),
             classic_vfs_volume_names: SharedProcessValue::default(),
             classic_locked_files: SharedProcessValue::default(),
-            classic_next_vfs_dir_id: SharedProcessValue::from_value(16),
             classic_next_vfs_volume_ref_num: SharedProcessValue::from_value(-2),
             classic_next_vfs_file_id: SharedProcessValue::from_value(32),
             classic_next_vfs_timestamp: SharedProcessValue::from_value(1),
-            classic_default_dir_id: SharedProcessValue::from_value(2),
             vfs_files: ProcessVfsFileRecords::default(),
             deleted_vfs_file_paths: Vec::new(),
             resource_manager: SharedProcessResourceManager::default(),
@@ -787,10 +783,11 @@ impl ProcessFileSystemState {
             }
             self.vfs_directories.push(directory);
         }
-        self.next_vfs_dir_id = self.next_vfs_dir_id.max(source.next_vfs_dir_id);
-        if self.default_dir_id == 0 || (target_catalogue_was_pristine && source.default_dir_id != 0)
+        *self.next_vfs_dir_id = (*self.next_vfs_dir_id).max(*source.next_vfs_dir_id);
+        if *self.default_dir_id == 0
+            || (target_catalogue_was_pristine && *source.default_dir_id != 0)
         {
-            self.default_dir_id = source.default_dir_id;
+            *self.default_dir_id = *source.default_dir_id;
         }
 
         self.vfs_files.merge_from(&mut source.vfs_files);
@@ -847,18 +844,12 @@ impl ProcessFileSystemState {
             self.classic_locked_files
                 .extend(std::mem::take(&mut *source.classic_locked_files));
         }
-        *self.classic_next_vfs_dir_id =
-            (*self.classic_next_vfs_dir_id).max(*source.classic_next_vfs_dir_id);
         *self.classic_next_vfs_volume_ref_num =
             (*self.classic_next_vfs_volume_ref_num).min(*source.classic_next_vfs_volume_ref_num);
         *self.classic_next_vfs_file_id =
             (*self.classic_next_vfs_file_id).max(*source.classic_next_vfs_file_id);
         *self.classic_next_vfs_timestamp =
             (*self.classic_next_vfs_timestamp).max(*source.classic_next_vfs_timestamp);
-        if *self.classic_default_dir_id == 2 && *source.classic_default_dir_id != 2 {
-            *self.classic_default_dir_id = *source.classic_default_dir_id;
-        }
-
         source
             .resource_manager
             .attach_resource_manager_to(&self.resource_manager);
@@ -868,19 +859,17 @@ impl ProcessFileSystemState {
         let mut snapshot = Self::default();
         snapshot.vfs_volumes = self.vfs_volumes.clone();
         snapshot.vfs_directories = self.vfs_directories.clone();
-        snapshot.next_vfs_dir_id = self.next_vfs_dir_id;
-        snapshot.default_dir_id = self.default_dir_id;
+        snapshot.next_vfs_dir_id = self.next_vfs_dir_id.clone();
+        snapshot.default_dir_id = self.default_dir_id.clone();
         snapshot.classic_vfs_metadata = self.classic_vfs_metadata.clone();
         snapshot.classic_vfs_directories = self.classic_vfs_directories.clone();
         snapshot.classic_vfs_directory_paths = self.classic_vfs_directory_paths.clone();
         snapshot.classic_vfs_volumes = self.classic_vfs_volumes.clone();
         snapshot.classic_vfs_volume_names = self.classic_vfs_volume_names.clone();
         snapshot.classic_locked_files = self.classic_locked_files.clone();
-        snapshot.classic_next_vfs_dir_id = self.classic_next_vfs_dir_id.clone();
         snapshot.classic_next_vfs_volume_ref_num = self.classic_next_vfs_volume_ref_num.clone();
         snapshot.classic_next_vfs_file_id = self.classic_next_vfs_file_id.clone();
         snapshot.classic_next_vfs_timestamp = self.classic_next_vfs_timestamp.clone();
-        snapshot.classic_default_dir_id = self.classic_default_dir_id.clone();
         snapshot.vfs_files = self.vfs_files.clone();
         snapshot.resource_manager.vfs_resource_files = self.vfs_resource_files.clone();
         snapshot
@@ -900,8 +889,8 @@ impl ProcessFileSystemState {
     }
 
     pub(crate) fn publish_native_vfs_catalogue(&mut self) {
-        let directories = self.vfs_directories.clone();
-        let volumes = self.vfs_volumes.clone();
+        let directories = (*self.vfs_directories).clone();
+        let volumes = (*self.vfs_volumes).clone();
         let files = self.vfs_files.iter().cloned().collect::<Vec<_>>();
         let resource_files = self.vfs_resource_files.iter().cloned().collect::<Vec<_>>();
         let deleted_paths = self.deleted_vfs_file_paths.clone();
@@ -937,16 +926,13 @@ impl ProcessFileSystemState {
                 );
             }
         }
-        *self.classic_next_vfs_dir_id = (*self.classic_next_vfs_dir_id)
-            .max(self.next_vfs_dir_id)
-            .max(
-                directories
-                    .iter()
-                    .map(|directory| directory.dir_id.saturating_add(1))
-                    .max()
-                    .unwrap_or(16),
-            );
-        *self.classic_default_dir_id = self.default_dir_id;
+        *self.next_vfs_dir_id = (*self.next_vfs_dir_id).max(
+            directories
+                .iter()
+                .map(|directory| directory.dir_id.saturating_add(1))
+                .max()
+                .unwrap_or(16),
+        );
 
         for volume in volumes {
             self.classic_vfs_volume_names
@@ -1038,7 +1024,7 @@ impl ProcessFileSystemState {
             finder_flags: metadata.map(|metadata| metadata.finder_flags).unwrap_or(0),
             dirty: false,
         });
-        self.next_vfs_dir_id = self.next_vfs_dir_id.max(directory.dir_id.saturating_add(1));
+        *self.next_vfs_dir_id = (*self.next_vfs_dir_id).max(directory.dir_id.saturating_add(1));
     }
 
     pub(crate) fn publish_classic_vfs_catalogue(&mut self) {
@@ -1062,7 +1048,6 @@ impl ProcessFileSystemState {
         for ref_num in volumes {
             self.publish_classic_vfs_volume(ref_num);
         }
-        self.default_dir_id = *self.classic_default_dir_id;
     }
 
     pub(crate) fn publish_classic_vfs_metadata(&mut self, path: &str) {
@@ -4473,8 +4458,8 @@ impl ProcessContext {
             HashMap::is_empty,
         );
         locked_files.attach_to(&self.file_system.classic_locked_files, HashSet::is_empty);
-        next_dir_id.attach_to(&self.file_system.classic_next_vfs_dir_id, |value| {
-            matches!(*value, 16 | 18)
+        next_dir_id.attach_to(&self.file_system.next_vfs_dir_id, |value| {
+            matches!(*value, 0 | 16 | 18)
         });
         next_volume_ref_num.attach_to(&self.file_system.classic_next_vfs_volume_ref_num, |value| {
             *value == -2
@@ -4485,8 +4470,8 @@ impl ProcessContext {
         next_timestamp.attach_to(&self.file_system.classic_next_vfs_timestamp, |value| {
             *value == 1
         });
-        default_dir_id.attach_to(&self.file_system.classic_default_dir_id, |value| {
-            *value == 2
+        default_dir_id.attach_to(&self.file_system.default_dir_id, |value| {
+            matches!(*value, 0 | 2)
         });
     }
 
@@ -5962,7 +5947,7 @@ mod tests {
             dirty: false,
         });
         let mut first = SharedProcessFileSystem::from_state(ProcessFileSystemState {
-            vfs_volumes: vec![ProcessVfsVolumeRecord {
+            vfs_volumes: SharedProcessValue::from_value(vec![ProcessVfsVolumeRecord {
                 ref_num: -1,
                 name: "Macintosh HD".to_string(),
                 root_dir_id: 2,
@@ -5978,8 +5963,8 @@ mod tests {
                 next_catalog_id: 17,
                 created_date: 1,
                 modified_date: 2,
-            }],
-            vfs_directories: vec![ProcessVfsDirectory {
+            }]),
+            vfs_directories: SharedProcessValue::from_value(vec![ProcessVfsDirectory {
                 dir_id: 2,
                 parent_dir_id: 1,
                 path: String::new(),
@@ -5987,9 +5972,9 @@ mod tests {
                 file_type: 0,
                 finder_flags: 0,
                 dirty: false,
-            }],
-            next_vfs_dir_id: 16,
-            default_dir_id: 2,
+            }]),
+            next_vfs_dir_id: SharedProcessValue::from_value(16),
+            default_dir_id: SharedProcessValue::from_value(2),
             ..ProcessFileSystemState::default()
         });
         let mut second = SharedProcessFileSystem::default();
@@ -6009,8 +5994,8 @@ mod tests {
             dirty: true,
         });
         first.vfs_volumes[0].file_count = 2;
-        first.next_vfs_dir_id = 17;
-        first.default_dir_id = 16;
+        *first.next_vfs_dir_id = 17;
+        *first.default_dir_id = 16;
 
         assert!(files.ptr_eq(&first));
         assert!(first.ptr_eq(&second));

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -15515,8 +15515,8 @@ mod tests {
                 ProcessFileSystemState {
                 files: Vec::new(),
                 stdio_streams: ppc_initial_stdio_streams(),
-                vfs_volumes: Vec::new(),
-                vfs_directories: vec![PpcVfsDirectory {
+                vfs_volumes: crate::process_context::SharedProcessValue::default(),
+                vfs_directories: crate::process_context::SharedProcessValue::from_value(vec![PpcVfsDirectory {
                     dir_id: 18,
                     parent_dir_id: 17,
                     path: "System Folder/Preferences/Test App Saves".to_string(),
@@ -15524,9 +15524,9 @@ mod tests {
                     file_type: u32::from_be_bytes(*b"dir "),
                     finder_flags: 0x0080,
                     dirty: true,
-                }],
-                next_vfs_dir_id: 18,
-                default_dir_id: 2,
+                }]),
+                next_vfs_dir_id: crate::process_context::SharedProcessValue::from_value(18),
+                default_dir_id: crate::process_context::SharedProcessValue::from_value(2),
                 vfs_files: vec![PpcVfsFileRecord {
                     path: "System Folder/Preferences/Test App Prefs".to_string(),
                     data: (b"prefs".to_vec()).into(),

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -4773,7 +4773,7 @@ impl TrapDispatcher {
         self.ensure_vfs_file_metadata(&normalized);
         if let Some(metadata) = self.vfs_metadata.get(&normalized).copied() {
             *self.default_dir_id = metadata.parent_dir_id;
-            self.process_file_system.default_dir_id = metadata.parent_dir_id;
+            *self.process_file_system.default_dir_id = metadata.parent_dir_id;
             let app_volume_ref = self
                 .vfs_volume_for_path(&normalized)
                 .map(|volume| volume.ref_num)


### PR DESCRIPTION
Closes #1187.

The PPC execution loop now keeps live shared handles to the process-owned VFS volumes, directories, directory-ID cursor, and default directory instead of temporarily taking or copying them into adapter-local state. Classic callbacks therefore expose catalogue mutations to native execution immediately, while detached clones remain independent.

Validation:
- `cargo test --locked --lib` — 4,765 passed, 0 failed, 3 ignored
- strict rustdoc with private intra-doc links denied
- all-features/all-targets compile check
- Marathon terminal completion and resumed gameplay
- Escape Velocity landing, return to space, and live input
- Tomb Raider Gold in-level forward movement