### PR TITLE
refactor(window): make the window registry process-owned

### DIFF
--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -23308,6 +23308,7 @@ fn dispatch_supported_import(
                     handles,
                     controls,
                     gworlds,
+                    window_list,
                     current_gworld,
                     current_gdevice,
                     dialog,
@@ -66797,17 +66798,11 @@ fn ppc_dispatch_legacy_window(
                 handles,
                 controls,
                 gworlds,
+                window_list,
                 current_gworld,
                 current_gdevice,
                 window,
             );
-            window_list.retain(|candidate| *candidate != window);
-            if was_current {
-                *current_gworld = ppc_front_visible_process_window(memory, window_list)
-                    .unwrap_or(PPC_MAIN_GWORLD);
-                *current_gdevice =
-                    ppc_gworld_device(gworlds, *current_gworld).unwrap_or(PPC_MAIN_GDEVICE);
-            }
             ppc_recalculate_window_vis_regions(
                 process_memory_manager,
                 memory,
@@ -67213,6 +67208,7 @@ fn ppc_dispose_window(
     handles: &mut Vec<PpcHandleRecord>,
     controls: &mut Vec<PpcControlRecord>,
     gworlds: &mut Vec<PpcGWorldRecord>,
+    window_list: &mut Vec<u32>,
     current_gworld: &mut u32,
     current_gdevice: &mut u32,
     window: u32,
@@ -67254,15 +67250,9 @@ fn ppc_dispose_window(
     gworlds.retain(|record| {
         record.port != window || matches!(record.port, PPC_MAIN_GWORLD | PPC_DSP_BACK_GWORLD)
     });
+    window_list.retain(|candidate| *candidate != window);
     if *current_gworld == window {
-        *current_gworld = gworlds
-            .iter()
-            .rev()
-            .map(|record| record.port)
-            .find(|port| {
-                !matches!(*port, PPC_MAIN_GWORLD | PPC_DSP_BACK_GWORLD)
-                    && ppc_window_is_visible(memory, *port)
-            })
+        *current_gworld = ppc_front_visible_process_window(memory, window_list)
             .unwrap_or(PPC_MAIN_GWORLD);
         *current_gdevice = ppc_gworld_device(gworlds, *current_gworld).unwrap_or(PPC_MAIN_GDEVICE);
     }
@@ -161156,6 +161146,7 @@ pub(crate) mod tests {
 
         assert!(matches!(probe.result, PpcRunResult::CycleLimit { .. }));
         let dialog = *loaded.current_gworld;
+        assert_eq!(loaded.window_list.first().copied(), Some(dialog));
         assert_eq!(
             loaded
                 .memory
@@ -161182,6 +161173,8 @@ pub(crate) mod tests {
         ));
         assert_eq!(loaded.cpu.gpr[3], 1);
         assert!(!loaded.gworlds.iter().any(|record| record.port == dialog));
+        assert!(!loaded.window_list.contains(&dialog));
+        assert_eq!(loaded.memory.read_u32_be(0x09D6), Some(0));
     }
 
     #[test]

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -3405,6 +3405,7 @@ pub struct PpcLoadedApp {
     pub input: PpcInputSnapshot,
     pub(crate) process_input: SharedProcessInputState,
     pub(crate) event_queue: SharedProcessEventQueue,
+    pub(crate) window_list: crate::process_context::SharedProcessWindowList,
     pub(crate) guest_calls: SharedGuestCallStack,
     pub(crate) process_memory_manager: PpcProcessMemoryManager,
     pub draw_sprocket: PpcDrawSprocketState,
@@ -3921,6 +3922,7 @@ impl PpcLoadedApp {
             &mut self.device_gamma_explicit,
         );
         context.attach_event_queue(&mut self.event_queue);
+        context.attach_window_list(&mut self.window_list);
         context.attach_input_state(&mut self.process_input);
         context.attach_menu_tracking(&mut self.toolbox_startup.menu_tracking);
         let mut attached_memory_manager = None;
@@ -7204,6 +7206,16 @@ impl PpcLoadedApp {
         let mut controls = std::mem::take(&mut self.controls);
         let mut aliases = std::mem::take(&mut self.aliases);
         let mut gworlds = std::mem::take(&mut self.gworlds);
+        let mut window_list = self.window_list.shared_handle();
+        if window_list.is_empty() {
+            window_list.extend(
+                gworlds
+                    .iter()
+                    .rev()
+                    .map(|record| record.port)
+                    .filter(|port| !matches!(*port, PPC_MAIN_GWORLD | PPC_DSP_BACK_GWORLD)),
+            );
+        }
         let mut q3_objects = std::mem::take(&mut self.q3_objects);
         let mut q3_object_refs = std::mem::take(&mut self.q3_object_refs);
         let mut next_q3_object = self.next_q3_object;
@@ -7749,6 +7761,7 @@ impl PpcLoadedApp {
                         &mut controls,
                         &mut aliases,
                         &mut gworlds,
+                        &mut window_list,
                         &mut q3_objects,
                         &mut q3_object_refs,
                         &mut next_q3_object,
@@ -7824,6 +7837,8 @@ impl PpcLoadedApp {
                         &mut draw_sprocket,
                     )
                 };
+
+                ppc_sync_process_window_list(memory, &window_list);
 
                 // MemError is process Memory Manager state even when a
                 // Toolbox helper reports it through the native ABI cache.
@@ -10319,7 +10334,7 @@ fn ppc_live_quickdraw_surface(
     gworlds: &[PpcGWorldRecord],
     gworld: u32,
 ) -> Option<PpcQuickDrawSurface> {
-    let record = gworlds.iter().find(|record| record.port == gworld)?;
+    let record = gworlds.iter().find(|record| record.port == gworld);
     // Color QuickDraw permits callers to replace a CGrafPort's portPixMap
     // after OpenCPort. Resolve that live Handle on every drawing operation;
     // the host-side GWorld record describes the port at creation time only.
@@ -10377,6 +10392,7 @@ fn ppc_live_quickdraw_surface(
             ctable_handle,
         })
         .or_else(|| {
+            let record = record?;
             let ctable_handle = (record.pixmap != 0)
                 .then_some(record.pixmap)
                 .and_then(|pixmap| pixmap.checked_add(42))
@@ -12814,6 +12830,7 @@ fn load_pef_application_with_config_and_optional_system_reservation(
         input: PpcInputSnapshot::default(),
         process_input: SharedProcessInputState::default(),
         event_queue: SharedProcessEventQueue::default(),
+        window_list: Default::default(),
         guest_calls: SharedGuestCallStack::default(),
         process_memory_manager,
         draw_sprocket: PpcDrawSprocketState::default(),
@@ -14984,6 +15001,7 @@ fn dispatch_supported_import(
     controls: &mut Vec<PpcControlRecord>,
     aliases: &mut Vec<PpcAliasRecord>,
     gworlds: &mut Vec<PpcGWorldRecord>,
+    window_list: &mut Vec<u32>,
     q3_objects: &mut Vec<PpcQ3ObjectRecord>,
     q3_object_refs: &mut Vec<PpcQ3ObjectReferenceRecord>,
     next_q3_object: &mut u32,
@@ -18367,7 +18385,7 @@ fn dispatch_supported_import(
             Some(PpcImportAction::ReturnPreserve)
         }
         PpcImportDispatcherTarget::NewCWindow => {
-            let previous_front = ppc_front_visible_window(memory, gworlds);
+            let previous_front = ppc_front_visible_process_window(memory, window_list);
             let mut allocator = PpcProcessAllocatorView {
                 memory_manager: process_memory_manager,
             };
@@ -18380,6 +18398,7 @@ fn dispatch_supported_import(
                 last_mem_error,
                 handles,
                 gworlds,
+                window_list,
                 *current_gdevice,
                 toolbox_startup.host_menu_bar_hidden,
             );
@@ -18387,7 +18406,7 @@ fn dispatch_supported_import(
                 ppc_recalculate_window_vis_regions(
                     process_memory_manager,
                     memory,
-                    gworlds,
+                    window_list,
                     heap_cursor,
                     heap_limit,
                     last_mem_error,
@@ -18403,7 +18422,7 @@ fn dispatch_supported_import(
                     quickdraw_fore_color,
                     quickdraw_back_color,
                 );
-                if ppc_front_visible_window(memory, gworlds) != previous_front {
+                if ppc_front_visible_process_window(memory, window_list) != previous_front {
                     let _ = ppc_activate_front_window_palette(
                         memory,
                         gworlds,
@@ -18419,7 +18438,7 @@ fn dispatch_supported_import(
             Some(PpcImportAction::Return(window))
         }
         PpcImportDispatcherTarget::GetNewCWindow => {
-            let previous_front = ppc_front_visible_window(memory, gworlds);
+            let previous_front = ppc_front_visible_process_window(memory, window_list);
             let window = ppc_get_new_cwindow(
                 cpu,
                 process_memory_manager,
@@ -18429,6 +18448,7 @@ fn dispatch_supported_import(
                 last_mem_error,
                 handles,
                 gworlds,
+                window_list,
                 *current_gdevice,
                 vfs_resources,
                 *current_resource_refnum,
@@ -18439,7 +18459,7 @@ fn dispatch_supported_import(
                 ppc_recalculate_window_vis_regions(
                     process_memory_manager,
                     memory,
-                    gworlds,
+                    window_list,
                     heap_cursor,
                     heap_limit,
                     last_mem_error,
@@ -18455,7 +18475,7 @@ fn dispatch_supported_import(
                     quickdraw_fore_color,
                     quickdraw_back_color,
                 );
-                if ppc_front_visible_window(memory, gworlds) != previous_front {
+                if ppc_front_visible_process_window(memory, window_list) != previous_front {
                     let _ = ppc_activate_front_window_palette(
                         memory,
                         gworlds,
@@ -18495,7 +18515,7 @@ fn dispatch_supported_import(
             ppc_recalculate_window_vis_regions(
                 process_memory_manager,
                 memory,
-                gworlds,
+                window_list,
                 heap_cursor,
                 heap_limit,
                 last_mem_error,
@@ -18508,7 +18528,7 @@ fn dispatch_supported_import(
             ppc_recalculate_window_vis_regions(
                 process_memory_manager,
                 memory,
-                gworlds,
+                window_list,
                 heap_cursor,
                 heap_limit,
                 last_mem_error,
@@ -18518,13 +18538,13 @@ fn dispatch_supported_import(
         }
         PpcImportDispatcherTarget::ShowWindow => {
             let window = cpu.gpr[3];
-            let previous_front = ppc_front_visible_window(memory, gworlds);
+            let previous_front = ppc_front_visible_process_window(memory, window_list);
             let was_visible = ppc_window_is_visible(memory, window);
             let _ = ppc_set_window_visible(memory, window, true);
             ppc_recalculate_window_vis_regions(
                 process_memory_manager,
                 memory,
-                gworlds,
+                window_list,
                 heap_cursor,
                 heap_limit,
                 last_mem_error,
@@ -18533,11 +18553,12 @@ fn dispatch_supported_import(
             ppc_transition_front_window_chrome(
                 memory,
                 gworlds,
+                window_list,
                 previous_front,
                 toolbox_startup.host_menu_bar_hidden,
             );
             if !was_visible {
-                if ppc_front_visible_window(memory, gworlds) != Some(window) {
+                if ppc_front_visible_process_window(memory, window_list) != Some(window) {
                     ppc_draw_existing_window_frame(
                         memory,
                         gworlds,
@@ -18547,7 +18568,7 @@ fn dispatch_supported_import(
                 }
                 ppc_enqueue_window_update_event(event_queue, window, input);
             }
-            if ppc_front_visible_window(memory, gworlds) != previous_front {
+            if ppc_front_visible_process_window(memory, window_list) != previous_front {
                 let _ = ppc_activate_front_window_palette(
                     memory,
                     gworlds,
@@ -18569,22 +18590,23 @@ fn dispatch_supported_import(
         }
         PpcImportDispatcherTarget::HideWindow => {
             let window = cpu.gpr[3];
-            let previous_front = ppc_front_visible_window(memory, gworlds);
+            let previous_front = ppc_front_visible_process_window(memory, window_list);
             let _ = ppc_set_window_visible(memory, window, false);
             let _ = ppc_set_window_hilited(memory, window, false);
             ppc_recalculate_window_vis_regions(
                 process_memory_manager,
                 memory,
-                gworlds,
+                window_list,
                 heap_cursor,
                 heap_limit,
                 last_mem_error,
                 handles,
             );
-            let next_front = ppc_front_visible_window(memory, gworlds);
+            let next_front = ppc_front_visible_process_window(memory, window_list);
             ppc_transition_front_window_chrome(
                 memory,
                 gworlds,
+                window_list,
                 previous_front,
                 toolbox_startup.host_menu_bar_hidden,
             );
@@ -18611,13 +18633,13 @@ fn dispatch_supported_import(
         PpcImportDispatcherTarget::ShowHide => {
             let window = cpu.gpr[3];
             let visible = cpu.gpr[4] != 0;
-            let previous_front = ppc_front_visible_window(memory, gworlds);
+            let previous_front = ppc_front_visible_process_window(memory, window_list);
             let was_visible = ppc_window_is_visible(memory, window);
             let _ = ppc_set_window_visible(memory, window, visible);
             ppc_recalculate_window_vis_regions(
                 process_memory_manager,
                 memory,
-                gworlds,
+                window_list,
                 heap_cursor,
                 heap_limit,
                 last_mem_error,
@@ -18626,11 +18648,12 @@ fn dispatch_supported_import(
             ppc_transition_front_window_chrome(
                 memory,
                 gworlds,
+                window_list,
                 previous_front,
                 toolbox_startup.host_menu_bar_hidden,
             );
             if visible && !was_visible {
-                if ppc_front_visible_window(memory, gworlds) != Some(window) {
+                if ppc_front_visible_process_window(memory, window_list) != Some(window) {
                     ppc_draw_existing_window_frame(
                         memory,
                         gworlds,
@@ -18639,7 +18662,7 @@ fn dispatch_supported_import(
                     );
                 }
             }
-            if ppc_front_visible_window(memory, gworlds) != previous_front {
+            if ppc_front_visible_process_window(memory, window_list) != previous_front {
                 let _ = ppc_activate_front_window_palette(
                     memory,
                     gworlds,
@@ -18669,7 +18692,7 @@ fn dispatch_supported_import(
                     toolbox_startup.dispose_dialog_count.saturating_add(1);
                 toolbox_startup.last_disposed_dialog = window;
             }
-            let previous_front = ppc_front_visible_window(memory, gworlds);
+            let previous_front = ppc_front_visible_process_window(memory, window_list);
             if window != 0 {
                 let closed_palette = memory
                     .read_u32_be(window.wrapping_add(PPC_CGRAF_PORT_PALETTE_HANDLE_OFFSET))
@@ -18687,10 +18710,11 @@ fn dispatch_supported_import(
                         || gworld.port == PPC_DSP_BACK_GWORLD
                         || gworld.port != window
                 });
+                window_list.retain(|candidate| *candidate != window);
                 ppc_recalculate_window_vis_regions(
                     process_memory_manager,
                     memory,
-                    gworlds,
+                    window_list,
                     heap_cursor,
                     heap_limit,
                     last_mem_error,
@@ -18699,18 +18723,12 @@ fn dispatch_supported_import(
                 ppc_transition_front_window_chrome(
                     memory,
                     gworlds,
+                    window_list,
                     previous_front,
                     toolbox_startup.host_menu_bar_hidden,
                 );
                 if *current_gworld == window {
-                    *current_gworld = gworlds
-                        .iter()
-                        .rev()
-                        .map(|gworld| gworld.port)
-                        .find(|candidate| {
-                            !matches!(*candidate, PPC_MAIN_GWORLD | PPC_DSP_BACK_GWORLD)
-                                && ppc_window_is_visible(memory, *candidate)
-                        })
+                    *current_gworld = ppc_front_visible_process_window(memory, window_list)
                         .unwrap_or(PPC_MAIN_GWORLD);
                     *current_gdevice =
                         ppc_gworld_device(gworlds, *current_gworld).unwrap_or(PPC_MAIN_GDEVICE);
@@ -18753,7 +18771,7 @@ fn dispatch_supported_import(
                         quickdraw_back_color,
                     );
                 }
-                if ppc_front_visible_window(memory, gworlds) != previous_front {
+                if ppc_front_visible_process_window(memory, window_list) != previous_front {
                     let _ = ppc_activate_front_window_palette(
                         memory,
                         gworlds,
@@ -18777,7 +18795,7 @@ fn dispatch_supported_import(
             Some(PpcImportAction::ReturnPreserve)
         }
         PpcImportDispatcherTarget::FrontWindow => {
-            let window = ppc_front_visible_window(memory, gworlds).unwrap_or(0);
+            let window = ppc_front_visible_process_window(memory, window_list).unwrap_or(0);
             Some(PpcImportAction::Return(window))
         }
         PpcImportDispatcherTarget::SetWinColor => {
@@ -18898,12 +18916,12 @@ fn dispatch_supported_import(
         }
         PpcImportDispatcherTarget::SelectWindow => {
             if cpu.gpr[3] != 0 {
-                let previous_front = ppc_front_visible_window(memory, gworlds);
-                ppc_reorder_window(gworlds, cpu.gpr[3], 0, true);
+                let previous_front = ppc_front_visible_process_window(memory, window_list);
+                ppc_reorder_window(gworlds, window_list, cpu.gpr[3], 0, true);
                 ppc_recalculate_window_vis_regions(
                     process_memory_manager,
                     memory,
-                    gworlds,
+                    window_list,
                     heap_cursor,
                     heap_limit,
                     last_mem_error,
@@ -18921,6 +18939,7 @@ fn dispatch_supported_import(
                     ppc_transition_front_window_chrome(
                         memory,
                         gworlds,
+                        window_list,
                         previous_front,
                         toolbox_startup.host_menu_bar_hidden,
                     );
@@ -18936,7 +18955,7 @@ fn dispatch_supported_import(
                     quickdraw_back_color,
                 );
                 let _ = ppc_set_window_hilited(memory, *current_gworld, true);
-                if ppc_front_visible_window(memory, gworlds) != previous_front {
+                if ppc_front_visible_process_window(memory, window_list) != previous_front {
                     let _ = ppc_activate_front_window_palette(
                         memory,
                         gworlds,
@@ -18962,7 +18981,7 @@ fn dispatch_supported_import(
             // Inside Macintosh Volume VI (1991), p. 20-19: an explicit
             // ActivatePalette affects only the visible frontmost window;
             // calling it for an offscreen port has no effect.
-            let applied = ppc_front_visible_window(memory, gworlds) == Some(window_ptr)
+            let applied = ppc_front_visible_process_window(memory, window_list) == Some(window_ptr)
                 && ppc_gworld_device(gworlds, window_ptr).is_some_and(|gdevice| {
                     ppc_activate_window_palette(
                         memory,
@@ -19042,7 +19061,7 @@ fn dispatch_supported_import(
                 }
             }
             let previous_device_colors = *screen_clut;
-            let front_window = ppc_front_visible_window(memory, gworlds);
+            let front_window = ppc_front_visible_process_window(memory, window_list);
             let activation_window = if window_ptr == u32::MAX {
                 front_window.unwrap_or(PPC_MAIN_GWORLD)
             } else {
@@ -19991,7 +20010,7 @@ fn dispatch_supported_import(
             let (part, window) = if in_menu_bar {
                 (1, 0)
             } else if in_screen {
-                ppc_find_window_at_point(memory, gworlds, v, h, menu_bar_height)
+                ppc_find_window_at_point(memory, gworlds, window_list, v, h, menu_bar_height)
             } else {
                 (0, 0)
             };
@@ -20678,6 +20697,7 @@ fn dispatch_supported_import(
                 handles,
                 controls,
                 gworlds,
+                window_list,
                 *current_gdevice,
                 vfs_resources,
                 *current_resource_refnum,
@@ -20702,6 +20722,7 @@ fn dispatch_supported_import(
                 last_mem_error,
                 handles,
                 gworlds,
+                window_list,
                 *current_gdevice,
             );
             let dialog = if dialog != 0
@@ -20746,6 +20767,7 @@ fn dispatch_supported_import(
                 last_mem_error,
                 handles,
                 gworlds,
+                window_list,
                 *current_gdevice,
             );
             let dialog = if dialog != 0
@@ -23220,6 +23242,7 @@ fn dispatch_supported_import(
                     handles,
                     controls,
                     gworlds,
+                    window_list,
                     *current_gdevice,
                     vfs_resources,
                     *current_resource_refnum,
@@ -25772,6 +25795,7 @@ fn dispatch_supported_import(
             handles,
             controls,
             gworlds,
+            window_list,
             current_gworld,
             current_gdevice,
             quickdraw_fore_color,
@@ -49834,6 +49858,7 @@ fn ppc_new_cwindow(
     last_mem_error: &mut i16,
     handles: &mut Vec<PpcHandleRecord>,
     gworlds: &mut Vec<PpcGWorldRecord>,
+    window_list: &mut Vec<u32>,
     current_gdevice: u32,
 ) -> u32 {
     let storage_ptr = cpu.gpr[3];
@@ -50130,9 +50155,7 @@ fn ppc_new_cwindow(
         pixels_locked: false,
         pixels_no_purge: false,
     });
-    if behind != u32::MAX {
-        ppc_reorder_window(gworlds, port, behind, false);
-    }
+    ppc_reorder_window(gworlds, window_list, port, behind, false);
     if visible && proc_id == 1 {
         ppc_draw_dialog_box_frame(memory, gworlds, port, local_bottom, local_right);
     }
@@ -50272,18 +50295,35 @@ fn ppc_redraw_visible_window_frame(
     window: u32,
     host_menu_bar_hidden: bool,
 ) {
-    if gworlds.iter().any(|record| record.port == window) && ppc_window_is_visible(memory, window) {
+    if ppc_window_is_visible(memory, window) {
         ppc_draw_existing_window_frame(memory, gworlds, window, host_menu_bar_hidden);
+    }
+}
+
+fn ppc_sync_process_window_list(memory: &mut PpcSectionMem, window_list: &[u32]) {
+    const WINDOW_NEXT_WINDOW_OFFSET: u32 = 144;
+    const LOWMEM_WINDOW_LIST: u32 = 0x09D6;
+
+    for (index, &window) in window_list.iter().enumerate() {
+        let next = window_list.get(index + 1).copied().unwrap_or(0);
+        if memory.read_u32_be(window.wrapping_add(WINDOW_NEXT_WINDOW_OFFSET)) != Some(next) {
+            let _ = memory.write_u32_be(window.wrapping_add(WINDOW_NEXT_WINDOW_OFFSET), next);
+        }
+    }
+    let head = window_list.first().copied().unwrap_or(0);
+    if memory.read_u32_be(LOWMEM_WINDOW_LIST) != Some(head) {
+        let _ = memory.write_u32_be(LOWMEM_WINDOW_LIST, head);
     }
 }
 
 fn ppc_transition_front_window_chrome(
     memory: &mut PpcSectionMem,
     gworlds: &[PpcGWorldRecord],
+    window_list: &[u32],
     previous_front: Option<u32>,
     host_menu_bar_hidden: bool,
 ) {
-    let next_front = ppc_front_visible_window(memory, gworlds);
+    let next_front = ppc_front_visible_process_window(memory, window_list);
     if previous_front == next_front {
         return;
     }
@@ -50304,7 +50344,7 @@ fn ppc_transition_front_window_chrome(
 fn ppc_recalculate_window_vis_regions(
     process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
-    gworlds: &[PpcGWorldRecord],
+    window_list: &[u32],
     heap_cursor: &mut u32,
     heap_limit: u32,
     last_mem_error: &mut i16,
@@ -50313,12 +50353,7 @@ fn ppc_recalculate_window_vis_regions(
     let mut allocator = PpcProcessAllocatorView {
         memory_manager: process_memory_manager,
     };
-    let front_to_back: Vec<u32> = gworlds
-        .iter()
-        .rev()
-        .map(|record| record.port)
-        .filter(|port| !matches!(*port, PPC_MAIN_GWORLD | PPC_DSP_BACK_GWORLD))
-        .collect();
+    let front_to_back = window_list.to_vec();
     for window in front_to_back.iter().copied() {
         let Some(vis_rgn) = memory.read_u32_be(window + PPC_CGRAF_PORT_VIS_RGN_OFFSET) else {
             continue;
@@ -50433,6 +50468,7 @@ fn ppc_get_new_cwindow(
     last_mem_error: &mut i16,
     handles: &mut Vec<PpcHandleRecord>,
     gworlds: &mut Vec<PpcGWorldRecord>,
+    window_list: &mut Vec<u32>,
     current_gdevice: u32,
     vfs_resources: &[PpcVfsResourceRecord],
     current_resource_refnum: i16,
@@ -50486,6 +50522,7 @@ fn ppc_get_new_cwindow(
         last_mem_error,
         handles,
         gworlds,
+        window_list,
         current_gdevice,
         host_menu_bar_hidden,
     );
@@ -52367,6 +52404,16 @@ fn ppc_front_visible_window(
     })
 }
 
+fn ppc_front_visible_process_window(
+    memory: &mut PpcSectionMem,
+    window_list: &[u32],
+) -> Option<u32> {
+    window_list
+        .iter()
+        .copied()
+        .find(|window| ppc_window_is_visible(memory, *window))
+}
+
 fn ppc_window_global_content_bounds(
     memory: &mut PpcSectionMem,
     gworlds: &[PpcGWorldRecord],
@@ -52386,15 +52433,14 @@ fn ppc_window_global_content_bounds(
 fn ppc_find_window_at_point(
     memory: &mut PpcSectionMem,
     gworlds: &[PpcGWorldRecord],
+    window_list: &[u32],
     v: i16,
     h: i16,
     menu_bar_height: i16,
 ) -> (i16, u32) {
-    let front_window = ppc_front_visible_window(memory, gworlds);
-    for window in gworlds.iter().rev().map(|record| record.port) {
-        if matches!(window, PPC_MAIN_GWORLD | PPC_DSP_BACK_GWORLD)
-            || !ppc_window_is_visible(memory, window)
-        {
+    let front_window = ppc_front_visible_process_window(memory, window_list);
+    for &window in window_list {
+        if !ppc_window_is_visible(memory, window) {
             continue;
         }
         let Some((top, left, bottom, right)) =
@@ -61433,6 +61479,7 @@ fn ppc_new_alert_dialog(
     handles: &mut Vec<PpcHandleRecord>,
     controls: &mut Vec<PpcControlRecord>,
     gworlds: &mut Vec<PpcGWorldRecord>,
+    window_list: &mut Vec<u32>,
     current_gdevice: u32,
     vfs_resources: &mut [PpcVfsResourceRecord],
     current_resource_refnum: i16,
@@ -61530,6 +61577,7 @@ fn ppc_new_alert_dialog(
         last_mem_error,
         handles,
         gworlds,
+        window_list,
         current_gdevice,
     );
     let _ = memory.write_u32_be(items_slot, saved_items_slot);
@@ -61573,6 +61621,7 @@ fn ppc_get_new_dialog(
     handles: &mut Vec<PpcHandleRecord>,
     controls: &mut Vec<PpcControlRecord>,
     gworlds: &mut Vec<PpcGWorldRecord>,
+    window_list: &mut Vec<u32>,
     current_gdevice: u32,
     vfs_resources: &mut [PpcVfsResourceRecord],
     current_resource_refnum: i16,
@@ -61667,6 +61716,7 @@ fn ppc_get_new_dialog(
         last_mem_error,
         handles,
         gworlds,
+        window_list,
         current_gdevice,
     );
     let _ = memory.write_u32_be(items_slot, saved_items_slot);
@@ -61705,6 +61755,7 @@ fn ppc_new_dialog(
     last_mem_error: &mut i16,
     handles: &mut Vec<PpcHandleRecord>,
     gworlds: &mut Vec<PpcGWorldRecord>,
+    window_list: &mut Vec<u32>,
     current_gdevice: u32,
 ) -> u32 {
     let requested_storage = cpu.gpr[3];
@@ -61767,6 +61818,7 @@ fn ppc_new_dialog(
         last_mem_error,
         handles,
         gworlds,
+        window_list,
         current_gdevice,
     );
     if dialog == 0 {
@@ -66540,6 +66592,7 @@ fn ppc_dispatch_legacy_window(
     handles: &mut Vec<PpcHandleRecord>,
     controls: &mut Vec<PpcControlRecord>,
     gworlds: &mut Vec<PpcGWorldRecord>,
+    window_list: &mut Vec<u32>,
     current_gworld: &mut u32,
     current_gdevice: &mut u32,
     quickdraw_fore_color: &mut PpcRgbColor,
@@ -66558,7 +66611,7 @@ fn ppc_dispatch_legacy_window(
 ) -> Option<PpcImportAction> {
     match binding.symbol_name.as_str() {
         "NewWindow" => {
-            let previous_front = ppc_front_visible_window(memory, gworlds);
+            let previous_front = ppc_front_visible_process_window(memory, window_list);
             let mut allocator = PpcProcessAllocatorView {
                 memory_manager: process_memory_manager,
             };
@@ -66571,6 +66624,7 @@ fn ppc_dispatch_legacy_window(
                 last_mem_error,
                 handles,
                 gworlds,
+                window_list,
                 *current_gdevice,
                 toolbox_startup.host_menu_bar_hidden,
             );
@@ -66578,14 +66632,14 @@ fn ppc_dispatch_legacy_window(
                 ppc_recalculate_window_vis_regions(
                     process_memory_manager,
                     memory,
-                    gworlds,
+                    window_list,
                     heap_cursor,
                     heap_limit,
                     last_mem_error,
                     handles,
                 );
                 *current_gworld = window;
-                if ppc_front_visible_window(memory, gworlds) != previous_front {
+                if ppc_front_visible_process_window(memory, window_list) != previous_front {
                     let _ = ppc_activate_front_window_palette(
                         memory,
                         gworlds,
@@ -66601,7 +66655,7 @@ fn ppc_dispatch_legacy_window(
             Some(PpcImportAction::Return(window))
         }
         "GetNewWindow" => {
-            let previous_front = ppc_front_visible_window(memory, gworlds);
+            let previous_front = ppc_front_visible_process_window(memory, window_list);
             let resource_id = cpu.gpr[3] as u16 as i16;
             let Some(index) = ppc_vfs_resource_index(
                 vfs_resources,
@@ -66645,6 +66699,7 @@ fn ppc_dispatch_legacy_window(
                 last_mem_error,
                 handles,
                 gworlds,
+                window_list,
                 *current_gdevice,
                 toolbox_startup.host_menu_bar_hidden,
             );
@@ -66657,14 +66712,14 @@ fn ppc_dispatch_legacy_window(
                 ppc_recalculate_window_vis_regions(
                     process_memory_manager,
                     memory,
-                    gworlds,
+                    window_list,
                     heap_cursor,
                     heap_limit,
                     last_mem_error,
                     handles,
                 );
                 *current_gworld = window;
-                if ppc_front_visible_window(memory, gworlds) != previous_front {
+                if ppc_front_visible_process_window(memory, window_list) != previous_front {
                     let _ = ppc_activate_front_window_palette(
                         memory,
                         gworlds,
@@ -66718,7 +66773,7 @@ fn ppc_dispatch_legacy_window(
         }
         "DisposeWindow" => {
             let window = cpu.gpr[3];
-            let previous_front = ppc_front_visible_window(memory, gworlds);
+            let previous_front = ppc_front_visible_process_window(memory, window_list);
             let disposed_palette = memory
                 .read_u32_be(window.wrapping_add(PPC_CGRAF_PORT_PALETTE_HANDLE_OFFSET))
                 .unwrap_or(0);
@@ -66746,10 +66801,17 @@ fn ppc_dispatch_legacy_window(
                 current_gdevice,
                 window,
             );
+            window_list.retain(|candidate| *candidate != window);
+            if was_current {
+                *current_gworld = ppc_front_visible_process_window(memory, window_list)
+                    .unwrap_or(PPC_MAIN_GWORLD);
+                *current_gdevice =
+                    ppc_gworld_device(gworlds, *current_gworld).unwrap_or(PPC_MAIN_GDEVICE);
+            }
             ppc_recalculate_window_vis_regions(
                 process_memory_manager,
                 memory,
-                gworlds,
+                window_list,
                 heap_cursor,
                 heap_limit,
                 last_mem_error,
@@ -66758,6 +66820,7 @@ fn ppc_dispatch_legacy_window(
             ppc_transition_front_window_chrome(
                 memory,
                 gworlds,
+                window_list,
                 previous_front,
                 toolbox_startup.host_menu_bar_hidden,
             );
@@ -66796,7 +66859,7 @@ fn ppc_dispatch_legacy_window(
                     quickdraw_back_color,
                 );
             }
-            if ppc_front_visible_window(memory, gworlds) != previous_front {
+            if ppc_front_visible_process_window(memory, window_list) != previous_front {
                 let _ = ppc_activate_front_window_palette(
                     memory,
                     gworlds,
@@ -66824,18 +66887,18 @@ fn ppc_dispatch_legacy_window(
             Some(PpcImportAction::ReturnPreserve)
         }
         "BringToFront" => {
-            let previous_front = ppc_front_visible_window(memory, gworlds);
-            ppc_reorder_window(gworlds, cpu.gpr[3], 0, true);
+            let previous_front = ppc_front_visible_process_window(memory, window_list);
+            ppc_reorder_window(gworlds, window_list, cpu.gpr[3], 0, true);
             ppc_recalculate_window_vis_regions(
                 process_memory_manager,
                 memory,
-                gworlds,
+                window_list,
                 heap_cursor,
                 heap_limit,
                 last_mem_error,
                 handles,
             );
-            if ppc_front_visible_window(memory, gworlds) != previous_front {
+            if ppc_front_visible_process_window(memory, window_list) != previous_front {
                 let _ = ppc_activate_front_window_palette(
                     memory,
                     gworlds,
@@ -66850,18 +66913,18 @@ fn ppc_dispatch_legacy_window(
             Some(PpcImportAction::ReturnPreserve)
         }
         "SendBehind" => {
-            let previous_front = ppc_front_visible_window(memory, gworlds);
-            ppc_reorder_window(gworlds, cpu.gpr[3], cpu.gpr[4], false);
+            let previous_front = ppc_front_visible_process_window(memory, window_list);
+            ppc_reorder_window(gworlds, window_list, cpu.gpr[3], cpu.gpr[4], false);
             ppc_recalculate_window_vis_regions(
                 process_memory_manager,
                 memory,
-                gworlds,
+                window_list,
                 heap_cursor,
                 heap_limit,
                 last_mem_error,
                 handles,
             );
-            if ppc_front_visible_window(memory, gworlds) != previous_front {
+            if ppc_front_visible_process_window(memory, window_list) != previous_front {
                 let _ = ppc_activate_front_window_palette(
                     memory,
                     gworlds,
@@ -66957,6 +67020,7 @@ fn ppc_new_window_from_cpu(
     last_mem_error: &mut i16,
     handles: &mut Vec<PpcHandleRecord>,
     gworlds: &mut Vec<PpcGWorldRecord>,
+    window_list: &mut Vec<u32>,
     current_gdevice: u32,
     host_menu_bar_hidden: bool,
 ) -> u32 {
@@ -66970,6 +67034,7 @@ fn ppc_new_window_from_cpu(
         last_mem_error,
         handles,
         gworlds,
+        window_list,
         current_gdevice,
     );
     if window == 0 {
@@ -67020,8 +67085,14 @@ fn ppc_new_window_from_cpu(
         *last_mem_error = PPC_PARAM_ERR;
         return 0;
     }
-    ppc_transition_front_window_chrome(memory, gworlds, previous_front, host_menu_bar_hidden);
-    if cpu.gpr[6] != 0 && ppc_front_visible_window(memory, gworlds) != Some(window) {
+    ppc_transition_front_window_chrome(
+        memory,
+        gworlds,
+        window_list,
+        previous_front,
+        host_menu_bar_hidden,
+    );
+    if cpu.gpr[6] != 0 && ppc_front_visible_process_window(memory, window_list) != Some(window) {
         ppc_draw_existing_window_frame(memory, gworlds, window, host_menu_bar_hidden);
     }
     *last_mem_error = PPC_NO_ERR;
@@ -67197,7 +67268,27 @@ fn ppc_dispose_window(
     }
 }
 
-fn ppc_reorder_window(gworlds: &mut Vec<PpcGWorldRecord>, window: u32, behind: u32, front: bool) {
+fn ppc_reorder_window(
+    gworlds: &mut Vec<PpcGWorldRecord>,
+    window_list: &mut Vec<u32>,
+    window: u32,
+    behind: u32,
+    front: bool,
+) {
+    window_list.retain(|candidate| *candidate != window);
+    if front || behind == u32::MAX {
+        window_list.insert(0, window);
+    } else if behind == 0 {
+        window_list.push(window);
+    } else if let Some(index) = window_list
+        .iter()
+        .position(|candidate| *candidate == behind)
+    {
+        window_list.insert(index + 1, window);
+    } else {
+        window_list.push(window);
+    }
+
     let Some(index) = gworlds.iter().position(|record| {
         record.port == window && !matches!(record.port, PPC_MAIN_GWORLD | PPC_DSP_BACK_GWORLD)
     }) else {
@@ -107387,6 +107478,57 @@ pub(crate) mod tests {
         assert_eq!(probe.handled_import_count, 1);
         assert_eq!(probe.unsupported_import_index, None);
         assert_eq!(loaded.cpu.gpr[3], 0);
+    }
+
+    #[test]
+    fn front_window_uses_the_process_order_without_native_gworld_metadata() {
+        let pef = synthetic_pef_with_import(b"FrontWindow");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let back = PPC_DATA_BASE + 0x1000;
+        let front = back + 0x200;
+        loaded.memory.add_region(back, vec![0; 0x400]);
+        loaded
+            .memory
+            .write_u8(back + PPC_CWINDOW_VISIBLE_OFFSET, 1)
+            .unwrap();
+        loaded
+            .memory
+            .write_u8(front + PPC_CWINDOW_VISIBLE_OFFSET, 1)
+            .unwrap();
+        loaded.window_list.extend([front, back]);
+
+        let probe = loaded.run_with_hle_imports(64);
+
+        assert_eq!(probe.handled_import_count, 1);
+        assert_eq!(loaded.cpu.gpr[3], front);
+        loaded.window_list.swap(0, 1);
+        loaded.cpu.pc = loaded.entry_pc;
+        loaded.cpu.lr = PPC_HALT_PC;
+
+        let probe = loaded.run_with_hle_imports(64);
+
+        assert_eq!(probe.handled_import_count, 1);
+        assert_eq!(loaded.cpu.gpr[3], back);
+    }
+
+    #[test]
+    fn close_window_removes_process_membership_without_native_gworld_metadata() {
+        let pef = synthetic_pef_with_import(b"CloseWindow");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let window = PPC_DATA_BASE + 0x1000;
+        loaded.memory.add_region(window, vec![0; 0x200]);
+        loaded
+            .memory
+            .write_u8(window + PPC_CWINDOW_VISIBLE_OFFSET, 1)
+            .unwrap();
+        loaded.window_list.push(window);
+        loaded.cpu.gpr[3] = window;
+
+        let probe = loaded.run_with_hle_imports(64);
+
+        assert_eq!(probe.handled_import_count, 1);
+        assert!(loaded.window_list.is_empty());
+        assert_eq!(loaded.memory.read_u32_be(0x09D6), Some(0));
     }
 
     #[test]
@@ -150662,6 +150804,7 @@ pub(crate) mod tests {
             &mut last_mem_error,
             test_handles!(loaded),
             &mut loaded.gworlds,
+            &mut loaded.window_list,
             *loaded.current_gdevice,
         );
         assert_ne!(window, 0);
@@ -150748,6 +150891,7 @@ pub(crate) mod tests {
             &mut last_mem_error,
             test_handles!(loaded),
             &mut loaded.gworlds,
+            &mut loaded.window_list,
             *loaded.current_gdevice,
         );
         assert_ne!(window, 0);

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -1233,6 +1233,7 @@ pub(crate) type SharedProcessSoundManager = SharedProcessValue<SoundManager>;
 pub(crate) type SharedProcessCursorState = SharedProcessValue<ProcessCursorState>;
 pub(crate) type SharedProcessEventQueue = SharedProcessValue<EventQueue>;
 pub(crate) type SharedProcessMenuTracking = SharedProcessValue<Option<ProcessMenuTrackingState>>;
+pub(crate) type SharedProcessWindowList = SharedProcessValue<Vec<u32>>;
 pub(crate) type SharedProcessInputState = SharedProcessValue<ProcessInputState>;
 pub(crate) type SharedProcessTimerTasks = SharedProcessValue<Vec<ProcessTimerTask>>;
 pub(crate) type SharedProcessVblTasks = SharedProcessValue<Vec<ProcessVblTask>>;
@@ -4186,6 +4187,7 @@ pub(crate) struct ProcessContext {
     event_queue: SharedProcessEventQueue,
     input_state: SharedProcessInputState,
     menu_tracking: SharedProcessMenuTracking,
+    window_list: SharedProcessWindowList,
     pending_native_menu_selection: SharedNativeMenuSelection,
     guest_calls: SharedGuestCallStack,
     apple_event_handlers: SharedProcessAppleEventHandlers,
@@ -4217,6 +4219,7 @@ impl Default for ProcessContext {
             event_queue: SharedProcessEventQueue::default(),
             input_state: SharedProcessInputState::default(),
             menu_tracking: SharedProcessMenuTracking::default(),
+            window_list: SharedProcessWindowList::default(),
             pending_native_menu_selection: SharedNativeMenuSelection::default(),
             guest_calls: SharedGuestCallStack::default(),
             apple_event_handlers: SharedProcessAppleEventHandlers::default(),
@@ -4391,6 +4394,15 @@ impl ProcessContext {
         // EventAvail observes it in place. Inside Macintosh Volume I (1985),
         // pp. I-244--I-245 and I-257--I-259; Processes (1994), pp. 2-15--2-16.
         adapter.attach_to(&self.event_queue, EventQueue::is_pristine);
+    }
+
+    /// Attach the Window Manager's canonical front-to-back process list.
+    ///
+    /// WindowRecords remain guest-memory objects, while this list models the
+    /// process-wide ordering used by FrontWindow, FindWindow, activation, and
+    /// occlusion. Macintosh Toolbox Essentials (1992), pp. 4-64--4-65.
+    pub(crate) fn attach_window_list(&self, adapter: &mut SharedProcessWindowList) {
+        adapter.attach_to(&self.window_list, Vec::is_empty);
     }
 
     pub(crate) fn attach_input_state(&self, adapter: &mut SharedProcessInputState) {
@@ -6285,6 +6297,26 @@ mod tests {
         assert_eq!(native.take().unwrap().menu_handle, 0x1234);
         assert!(classic.is_none());
         assert_eq!(detached.as_ref().unwrap().menu_handle, 0x1234);
+    }
+
+    #[test]
+    fn attached_window_lists_share_order_immediately_while_clones_detach() {
+        let context = ProcessContext::default();
+        let mut classic = SharedProcessWindowList::from_value(vec![0x1000, 0x2000]);
+        let mut native = SharedProcessWindowList::default();
+
+        context.attach_window_list(&mut classic);
+        context.attach_window_list(&mut native);
+        let detached = native.clone();
+
+        native.remove(1);
+        native.insert(0, 0x3000);
+        classic.push(0x4000);
+
+        assert!(classic.ptr_eq(&native));
+        assert_eq!(&*classic, &[0x3000, 0x1000, 0x4000]);
+        assert_eq!(&*native, &[0x3000, 0x1000, 0x4000]);
+        assert_eq!(&*detached, &[0x1000, 0x2000]);
     }
 
     #[test]

--- a/src/runner/idle.rs
+++ b/src/runner/idle.rs
@@ -194,7 +194,7 @@ impl IdleCycleHostSnapshot {
             mouse_button: dispatcher.input_state.mouse_button,
             key_map: *dispatcher.key_map_bytes(),
             caps_lock_physically_pressed: dispatcher.input_state.caps_lock_physically_pressed,
-            window_list: dispatcher.window_list.clone(),
+            window_list: dispatcher.window_list.to_vec(),
             pending_native_menu_selection: dispatcher.pending_native_menu_selection.snapshot(),
         }
     }

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -11773,6 +11773,29 @@ mod tests {
     }
 
     #[test]
+    fn init_ppc_app_attaches_one_bidirectional_process_window_list() {
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        runner.dispatcher.window_list.extend([0x1000, 0x2000]);
+        let mut app = halted_ppc_app_with_sound(PpcSoundState::default());
+        app.ppc
+            .as_mut()
+            .expect("synthetic PPC app")
+            .memory
+            .add_region(PPC_HALT_PC, vec![0; 64 * 1024]);
+
+        runner.init_app(&app);
+
+        let ppc_app = runner.ppc_app.as_mut().expect("PPC app installed");
+        let detached = ppc_app.window_list.clone();
+        assert_eq!(&*ppc_app.window_list, &[0x1000, 0x2000]);
+        ppc_app.window_list.insert(0, 0x3000);
+        assert_eq!(&*runner.dispatcher.window_list, &[0x3000, 0x1000, 0x2000]);
+        runner.dispatcher.window_list.retain(|window| *window != 0x1000);
+        assert_eq!(&*ppc_app.window_list, &[0x3000, 0x2000]);
+        assert_eq!(&*detached, &[0x1000, 0x2000]);
+    }
+
+    #[test]
     fn ppc_slice_keeps_ticks_coherent_across_runner_and_guest_memory() {
         use crate::memory::globals::addr;
 
@@ -13372,6 +13395,7 @@ mod tests {
             input: PpcInputSnapshot::default(),
             process_input: Default::default(),
             event_queue: Default::default(),
+            window_list: Default::default(),
             guest_calls: Default::default(),
             process_memory_manager: PpcProcessMemoryManager::with_heap(
                 PPC_HEAP_BASE,
@@ -15791,6 +15815,7 @@ mod tests {
             input: PpcInputSnapshot::default(),
             process_input: Default::default(),
             event_queue: Default::default(),
+            window_list: Default::default(),
             guest_calls: Default::default(),
             process_memory_manager: PpcProcessMemoryManager::with_heap(
                 PPC_HEAP_BASE,
@@ -16593,6 +16618,7 @@ mod tests {
             input: PpcInputSnapshot::default(),
             process_input: Default::default(),
             event_queue: Default::default(),
+            window_list: Default::default(),
             guest_calls: Default::default(),
             process_memory_manager: PpcProcessMemoryManager::with_heap(
                 PPC_HEAP_BASE,
@@ -16745,6 +16771,7 @@ mod tests {
             input: PpcInputSnapshot::default(),
             process_input: Default::default(),
             event_queue: Default::default(),
+            window_list: Default::default(),
             guest_calls: Default::default(),
             process_memory_manager: PpcProcessMemoryManager::with_heap(
                 PPC_HEAP_BASE,
@@ -17145,6 +17172,7 @@ mod tests {
             input: PpcInputSnapshot::default(),
             process_input: Default::default(),
             event_queue: Default::default(),
+            window_list: Default::default(),
             guest_calls: Default::default(),
             process_memory_manager: PpcProcessMemoryManager::with_heap(
                 PPC_HEAP_BASE + 8,
@@ -17456,6 +17484,7 @@ mod tests {
             input: PpcInputSnapshot::default(),
             process_input: Default::default(),
             event_queue: Default::default(),
+            window_list: Default::default(),
             guest_calls: Default::default(),
             process_memory_manager: PpcProcessMemoryManager::with_heap(
                 PPC_HEAP_BASE + 8 * 16,

--- a/src/trap/dialog.rs
+++ b/src/trap/dialog.rs
@@ -18908,7 +18908,7 @@ mod tests {
         let (mut disp, mut cpu, mut bus) = setup();
         // Seed an existing window that will stay in front.
         let existing = 0x200040u32;
-        disp.window_list = vec![existing];
+        *disp.window_list = vec![existing];
         disp.front_window = existing;
         bus.write_byte(existing + 110u32, 0xFF); // visible
 
@@ -18973,7 +18973,7 @@ mod tests {
         // creation path as NewDialog but returns a color dialog pointer.
         let (mut disp, mut cpu, mut bus) = setup();
         let existing = 0x200040u32;
-        disp.window_list = vec![existing];
+        *disp.window_list = vec![existing];
         disp.front_window = existing;
         bus.write_byte(existing + 110u32, 0xFF); // visible
 
@@ -23048,7 +23048,7 @@ mod tests {
         *close_disp.current_port = close_dialog_ptr;
         close_disp.window_bounds = bounds;
         close_disp.window_proc_id = 2;
-        close_disp.window_list = vec![close_dialog_ptr, close_previous_window];
+        *close_disp.window_list = vec![close_dialog_ptr, close_previous_window];
         close_disp.window_stack.push((
             close_previous_window,
             previous_bounds,
@@ -23134,7 +23134,7 @@ mod tests {
         *dispose_disp.current_port = dispose_dialog_ptr;
         dispose_disp.window_bounds = bounds;
         dispose_disp.window_proc_id = 2;
-        dispose_disp.window_list = vec![
+        *dispose_disp.window_list = vec![
             dispose_dialog_ptr,
             dispose_previous_window,
             dispose_other_dialog_ptr,
@@ -23415,7 +23415,7 @@ mod tests {
             new_dialog_ptr,
             new_stack_after: new_cpu.read_reg(Register::A7),
             new_result_slot: new_bus.read_long(new_sp + 30),
-            new_window_list: new_disp.window_list.clone(),
+            new_window_list: new_disp.window_list.to_vec(),
             new_front_window: new_disp.front_window,
             new_current_port: *new_disp.current_port,
             new_the_port: new_bus.read_long(crate::memory::globals::addr::THE_PORT),
@@ -23441,7 +23441,7 @@ mod tests {
             get_dialog_ptr,
             get_stack_after: get_cpu.read_reg(Register::A7),
             get_result_slot: get_bus.read_long(TEST_SP + 10),
-            get_window_list: get_disp.window_list.clone(),
+            get_window_list: get_disp.window_list.to_vec(),
             get_front_window: get_disp.front_window,
             get_current_port: *get_disp.current_port,
             get_the_port: get_bus.read_long(crate::memory::globals::addr::THE_PORT),
@@ -26726,7 +26726,7 @@ mod tests {
         // update region. A NIL region should not trigger redraw work.
         let (mut disp, mut cpu, mut bus) = setup();
         let existing = 0x200040u32;
-        disp.window_list = vec![existing];
+        *disp.window_list = vec![existing];
         disp.front_window = existing;
         bus.write_byte(existing + 110, 0xFF);
 
@@ -27167,7 +27167,7 @@ mod tests {
         *disp.current_port = dialog_ptr;
         disp.window_bounds = (0, 0, 100, 220);
         disp.window_proc_id = proc_id;
-        disp.window_list = vec![dialog_ptr, prev_window];
+        *disp.window_list = vec![dialog_ptr, prev_window];
         disp.window_stack
             .push((prev_window, (0, 0, 342, 512), 0, "Game".to_string()));
         disp.dialog_items.insert(
@@ -27277,7 +27277,7 @@ mod tests {
         disp.front_window = dialog_ptr;
         *disp.current_port = dialog_ptr;
         disp.window_bounds = (100, 120, 220, 320);
-        disp.window_list = vec![dialog_ptr, visible_window];
+        *disp.window_list = vec![dialog_ptr, visible_window];
         disp.window_stack.push((0, (0, 0, 0, 0), -1, String::new()));
         bus.write_long(crate::memory::globals::addr::THE_PORT, dialog_ptr);
 
@@ -27486,7 +27486,7 @@ mod tests {
         let dialog_ptr = 0x200000u32;
         let prev_window = 0x181000u32;
 
-        disp.window_list = vec![dialog_ptr, prev_window];
+        *disp.window_list = vec![dialog_ptr, prev_window];
         disp.front_window = dialog_ptr;
         *disp.current_port = dialog_ptr;
         bus.write_byte(dialog_ptr + 110, 0xFF);
@@ -27514,7 +27514,7 @@ mod tests {
         let user_item_proc = 0x00016178u32;
 
         seed_window_regions(&mut bus, prev_window, (0, 0, 342, 512));
-        disp.window_list = vec![dialog_ptr, prev_window];
+        *disp.window_list = vec![dialog_ptr, prev_window];
         disp.front_window = dialog_ptr;
         *disp.current_port = dialog_ptr;
         disp.window_bounds = (110, 155, 380, 645);
@@ -27554,7 +27554,7 @@ mod tests {
         let stale_proc_arg = 0x00016178u32;
 
         seed_window_regions(&mut bus, prev_window, (0, 0, 342, 512));
-        disp.window_list = vec![dialog_ptr, prev_window];
+        *disp.window_list = vec![dialog_ptr, prev_window];
         disp.front_window = dialog_ptr;
         *disp.current_port = dialog_ptr;
         disp.window_bounds = (110, 155, 380, 645);
@@ -27721,7 +27721,7 @@ mod tests {
     fn dispose_dialog_clears_visible_snapshot() {
         let (mut disp, mut cpu, mut bus) = setup();
         let dialog_ptr = bus.alloc(170);
-        disp.window_list = vec![dialog_ptr];
+        *disp.window_list = vec![dialog_ptr];
         disp.dialog_visible_snapshots.insert(
             dialog_ptr,
             PersistentDialogSnapshot {
@@ -27742,7 +27742,7 @@ mod tests {
     fn dispose_dialog_clears_retained_click_state() {
         let (mut disp, mut cpu, mut bus) = setup();
         let dialog_ptr = bus.alloc(170);
-        disp.window_list = vec![dialog_ptr];
+        *disp.window_list = vec![dialog_ptr];
         disp.retained_modal_dialog_click = Some(RetainedModalDialogClickState {
             dialog_ptr,
             item_no: 1,
@@ -28395,7 +28395,7 @@ mod tests {
         disp.front_window = dialog_ptr;
         *disp.current_port = dialog_ptr;
         disp.window_bounds = bounds;
-        disp.window_list = vec![dialog_ptr];
+        *disp.window_list = vec![dialog_ptr];
         disp.window_stack.push((0, (0, 0, 0, 0), -1, String::new()));
 
         bus.write_long(TEST_SP, dialog_ptr);
@@ -28547,7 +28547,7 @@ mod tests {
         disp.front_window = child_ptr;
         *disp.current_port = child_ptr;
         disp.window_bounds = child_bounds;
-        disp.window_list = vec![child_ptr, parent_ptr];
+        *disp.window_list = vec![child_ptr, parent_ptr];
         disp.window_stack
             .push((parent_ptr, parent_bounds, 2, "Parent".to_string()));
         disp.dialog_modal_entered.insert(child_ptr);
@@ -30390,7 +30390,7 @@ mod tests {
         disp.window_bounds = bounds;
         disp.window_proc_id = 2;
         disp.window_title.clear();
-        disp.window_list = vec![dialog_ptr];
+        *disp.window_list = vec![dialog_ptr];
         bus.write_word(dialog_ptr + 108, 2);
         bus.write_word(dialog_ptr + 164, 0);
         bus.write_word(dialog_ptr + 168, 0);
@@ -31902,7 +31902,7 @@ mod tests {
         seed_window_regions(&mut bus, previous_window, (0, 0, 342, 512));
         disp.front_window = dialog_ptr;
         *disp.current_port = dialog_ptr;
-        disp.window_list = vec![dialog_ptr, previous_window];
+        *disp.window_list = vec![dialog_ptr, previous_window];
         disp.window_stack
             .push((previous_window, (0, 0, 342, 512), 0, String::from("Map")));
         disp.dialog_items.insert(
@@ -31989,7 +31989,7 @@ mod tests {
         seed_window_regions(&mut bus, parent, (0, 0, 342, 512));
         disp.front_window = child;
         *disp.current_port = child;
-        disp.window_list = vec![child, parent];
+        *disp.window_list = vec![child, parent];
         disp.window_stack
             .push((parent, (0, 0, 342, 512), 2, String::new()));
         disp.dialog_items.insert(child, Vec::new());

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -2160,7 +2160,11 @@ pub struct TrapDispatcher {
     /// the parked-cycle host snapshot carries a copy besides. FrontWindow
     /// and FindWindow are admitted to proofs on that basis
     /// (`runner::idle_cycle_trap_is_journal_complete`).
-    pub(crate) window_list: Vec<u32>,
+    pub(crate) window_list: crate::process_context::SharedProcessWindowList,
+    /// Whether `window_list` is the process-owned registry rather than a
+    /// standalone dispatcher fixture. Attached dispatchers derive the cached
+    /// front window even when the process list becomes empty.
+    process_window_list_attached: bool,
     /// Set once the game has entered fullscreen (window covers entire screen
     /// and MBarHeight was 0). While set, the menu bar is suppressed even if
     /// the game temporarily restores MBarHeight (e.g. on cursor-at-top).
@@ -2786,6 +2790,8 @@ impl TrapDispatcher {
         context.attach_event_queue(&mut self.event_queue);
         context.attach_input_state(&mut self.input_state);
         context.attach_menu_tracking(&mut self.menu_tracking);
+        context.attach_window_list(&mut self.window_list);
+        self.process_window_list_attached = true;
         context.attach_classic_file_system(&mut self.vfs, &mut self.vfs_rsrc);
         context.attach_classic_vfs_catalogue(
             &mut self.vfs_metadata,
@@ -3821,7 +3827,8 @@ impl TrapDispatcher {
             control_aux_records: HashMap::new(),
             control_aux_head: 0,
             go_away_flag: false,
-            window_list: Vec::new(),
+            window_list: Default::default(),
+            process_window_list_attached: false,
             fullscreen_locked: false,
             menu_bar_policy: crate::runner::MenuBarPolicy::GuestControlled,
             initial_kiosk_guest_hide_observed: false,
@@ -7662,6 +7669,14 @@ impl TrapDispatcher {
         cpu: &mut C,
         bus: &mut MacMemoryBus,
     ) -> Result<()> {
+        if self.process_window_list_attached {
+            self.front_window = self
+                .window_list
+                .iter()
+                .copied()
+                .find(|window| bus.read_byte(window.wrapping_add(110)) != 0)
+                .unwrap_or(0);
+        }
         // Opt-in per-trap wall-clock timing.
         let timing_start = if trap_timing_enabled() {
             Some(std::time::Instant::now())

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -2164,7 +2164,7 @@ pub struct TrapDispatcher {
     /// Whether `window_list` is the process-owned registry rather than a
     /// standalone dispatcher fixture. Attached dispatchers derive the cached
     /// front window even when the process list becomes empty.
-    process_window_list_attached: bool,
+    pub(crate) process_window_list_attached: bool,
     /// Set once the game has entered fullscreen (window covers entire screen
     /// and MBarHeight was 0). While set, the menu bar is suppressed even if
     /// the game temporarily restores MBarHeight (e.g. on cursor-at-top).

--- a/src/trap/event.rs
+++ b/src/trap/event.rs
@@ -179,7 +179,7 @@ impl super::TrapDispatcher {
         self.flushed_update_events
             .retain(|event| event.what == 6 && known_windows.contains(&event.message));
 
-        for &window in &self.window_list {
+        for &window in self.window_list.iter() {
             if !self.window_visible(bus, window) || !self.window_has_pending_update(bus, window) {
                 continue;
             }
@@ -2681,7 +2681,7 @@ mod tests {
         let (mut disp, mut cpu, mut bus) = setup();
         let front = make_dirty_visible_window(&mut bus);
         let back = make_dirty_visible_window(&mut bus);
-        disp.window_list = vec![front, back];
+        *disp.window_list = vec![front, back];
 
         disp.queue_window_update_event(front);
         disp.flush_events_with_masks(1 << 6, 0);
@@ -2706,7 +2706,7 @@ mod tests {
         let hidden = make_dirty_visible_window(&mut bus);
         bus.write_byte(hidden + 110, 0);
         let visible = make_dirty_visible_window(&mut bus);
-        disp.window_list = vec![hidden, visible];
+        *disp.window_list = vec![hidden, visible];
         disp.event_queue.push_back(QueuedEvent {
             what: 6,
             message: hidden,

--- a/src/trap/framebuffer.rs
+++ b/src/trap/framebuffer.rs
@@ -4824,6 +4824,13 @@ impl super::TrapDispatcher {
         if !skip_chrome && menu_bar_height > 0 {
             let list_snapshot = self.window_list.to_vec();
             for &w in list_snapshot.iter().rev() {
+                // Native PowerPC windows participate in the process-wide
+                // WindowList, but their adapter already rendered their WDEF
+                // chrome into the native front buffer. Only repaint windows
+                // whose classic adapter owns the per-window WDEF metadata.
+                if self.process_window_list_attached && !self.window_proc_ids.contains_key(&w) {
+                    continue;
+                }
                 if bus.read_byte(w + 110u32) == 0 {
                     continue;
                 }

--- a/src/trap/framebuffer.rs
+++ b/src/trap/framebuffer.rs
@@ -1332,7 +1332,7 @@ impl super::TrapDispatcher {
     fn visible_window_count(&self, bus: &MacMemoryBus) -> usize {
         let mut count = 0usize;
         let mut saw = HashSet::new();
-        for &window in &self.window_list {
+        for &window in self.window_list.iter() {
             if window != 0 && saw.insert(window) && bus.read_byte(window + 110u32) != 0 {
                 count += 1;
             }
@@ -4822,7 +4822,7 @@ impl super::TrapDispatcher {
         // the content pixels of windows above each frame.
         // Macintosh Toolbox Essentials (1992), pp. 4-65 and 4-69.
         if !skip_chrome && menu_bar_height > 0 {
-            let list_snapshot = self.window_list.clone();
+            let list_snapshot = self.window_list.to_vec();
             for &w in list_snapshot.iter().rev() {
                 if bus.read_byte(w + 110u32) == 0 {
                     continue;
@@ -5210,7 +5210,7 @@ mod redraw_chrome_tests {
         bus.write_word(PORT_PTR + 22, 640);
         bus.write_byte(PORT_PTR + WINDOW_VISIBLE_OFFSET, 0xFF);
         disp.front_window = PORT_PTR;
-        disp.window_list = vec![PORT_PTR];
+        *disp.window_list = vec![PORT_PTR];
         disp.window_bounds = (60, 80, 540, 720);
         disp.window_proc_id = 2;
         disp.window_proc_ids.insert(PORT_PTR, 2);
@@ -5443,7 +5443,7 @@ mod redraw_chrome_tests {
         bus.write_word(PORT_PTR + 22, 640);
         bus.write_byte(PORT_PTR + WINDOW_VISIBLE_OFFSET, 0xFF);
         disp.front_window = PORT_PTR;
-        disp.window_list = vec![PORT_PTR];
+        *disp.window_list = vec![PORT_PTR];
         disp.window_bounds = (60, 80, 540, 720);
         disp.window_proc_id = 2;
         disp.window_proc_ids.insert(PORT_PTR, 2);
@@ -5502,7 +5502,7 @@ mod redraw_chrome_tests {
         bus.write_byte(PORT_PTR + WINDOW_VISIBLE_OFFSET, 0xFF);
         set_window_structure_rect(&mut bus, PORT_PTR, (185, 232, 414, 568));
         disp.front_window = PORT_PTR;
-        disp.window_list = vec![PORT_PTR];
+        *disp.window_list = vec![PORT_PTR];
         disp.window_proc_ids.insert(PORT_PTR, 1);
         disp.last_screen_copybits_rect = Some(ScreenCopyBitsRect {
             src_top: 0,
@@ -5582,7 +5582,7 @@ mod redraw_chrome_tests {
             bus.write_byte(PORT_PTR + WINDOW_VISIBLE_OFFSET, 0xFF);
             set_window_structure_rect(&mut bus, PORT_PTR, structure);
             disp.front_window = PORT_PTR;
-            disp.window_list = vec![PORT_PTR];
+            *disp.window_list = vec![PORT_PTR];
             disp.window_proc_ids.insert(PORT_PTR, proc_id);
             disp.last_screen_copybits_rect = Some(ScreenCopyBitsRect {
                 src_top: 0,
@@ -5634,7 +5634,7 @@ mod redraw_chrome_tests {
         bus.write_word(PORT_PTR + 22, 320);
         bus.write_byte(PORT_PTR + WINDOW_VISIBLE_OFFSET, 0xFF);
         disp.front_window = PORT_PTR;
-        disp.window_list = vec![PORT_PTR];
+        *disp.window_list = vec![PORT_PTR];
         disp.window_proc_ids.insert(PORT_PTR, 1);
         disp.last_screen_copybits_rect = Some(ScreenCopyBitsRect {
             src_top: 0,
@@ -5668,7 +5668,7 @@ mod redraw_chrome_tests {
         bus.write_word(PORT_PTR + 22, 640);
         bus.write_byte(PORT_PTR + WINDOW_VISIBLE_OFFSET, 0xFF);
         disp.front_window = PORT_PTR;
-        disp.window_list = vec![PORT_PTR];
+        *disp.window_list = vec![PORT_PTR];
         disp.window_bounds = (60, 80, 540, 720);
         disp.window_proc_id = 0;
         disp.window_proc_ids.insert(PORT_PTR, 0);
@@ -5721,7 +5721,7 @@ mod redraw_chrome_tests {
         bus.write_byte(PORT_PTR + WINDOW_VISIBLE_OFFSET, 0);
         bus.write_word(crate::memory::globals::addr::MBAR_HEIGHT, 0);
         disp.front_window = PORT_PTR;
-        disp.window_list = vec![PORT_PTR];
+        *disp.window_list = vec![PORT_PTR];
         disp.window_bounds = (0, 0, screen_h as i16, screen_w as i16);
         disp.window_proc_id = 2;
         disp.window_proc_ids.remove(&PORT_PTR);
@@ -6473,7 +6473,7 @@ mod redraw_chrome_tests {
         disp.menu_bar_hidden = true;
         disp.fullscreen_locked = false;
         disp.front_window = PORT_PTR;
-        disp.window_list = vec![PORT_PTR];
+        *disp.window_list = vec![PORT_PTR];
         disp.window_bounds = (100, 180, 208, 620);
         disp.window_proc_id = 5;
         disp.window_proc_ids.insert(PORT_PTR, 5);
@@ -6520,7 +6520,7 @@ mod redraw_chrome_tests {
         disp.menu_bar_hidden = true;
         disp.fullscreen_locked = false;
         disp.front_window = PORT_PTR;
-        disp.window_list = vec![PORT_PTR];
+        *disp.window_list = vec![PORT_PTR];
         disp.window_bounds = (100, 180, 208, 620);
         disp.window_proc_id = 5;
         disp.window_proc_ids.insert(PORT_PTR, 5);
@@ -6817,7 +6817,7 @@ mod redraw_chrome_tests {
         set_window_structure_rect(&mut bus, front, (18, 18, 32, 32));
         bus.write_byte(dialog + 110, 0xFF);
         bus.write_byte(front + 110, 0xFF);
-        disp.window_list = vec![front, dialog];
+        *disp.window_list = vec![front, dialog];
         disp.front_window = front;
 
         for y in 2..48u32 {
@@ -7853,7 +7853,7 @@ mod redraw_chrome_tests {
         install_8bpp_cgrafport(&mut bus, screen_base, 800, 800, 600, 0);
         bus.write_byte(PORT_PTR + WINDOW_VISIBLE_OFFSET, 0xFF);
         disp.front_window = PORT_PTR;
-        disp.window_list = vec![PORT_PTR];
+        *disp.window_list = vec![PORT_PTR];
 
         let manual_port = bus.alloc(200);
         let manual_base = bus.alloc(640 * 420);
@@ -7928,7 +7928,7 @@ mod redraw_chrome_tests {
         install_8bpp_cgrafport(&mut bus, screen_base, 800, 800, 600, 0);
         bus.write_byte(PORT_PTR + WINDOW_VISIBLE_OFFSET, 0xFF);
         disp.front_window = PORT_PTR;
-        disp.window_list = vec![PORT_PTR];
+        *disp.window_list = vec![PORT_PTR];
         disp.window_bounds = (0, 0, 600, 800);
 
         // SetOrigin and related port operations can shift the local
@@ -7968,7 +7968,7 @@ mod redraw_chrome_tests {
         install_8bpp_cgrafport(&mut bus, screen_base, 800, 800, 600, 0);
         bus.write_byte(PORT_PTR + WINDOW_VISIBLE_OFFSET, 0xFF);
         disp.front_window = PORT_PTR;
-        disp.window_list = vec![PORT_PTR];
+        *disp.window_list = vec![PORT_PTR];
         disp.window_bounds = (185, 226, 415, 574);
 
         bus.write_word(PORT_PTR + 16, 0);
@@ -8009,7 +8009,7 @@ mod redraw_chrome_tests {
         install_8bpp_cgrafport(&mut bus, screen_base, 800, 800, 600, 0);
         bus.write_byte(PORT_PTR + WINDOW_VISIBLE_OFFSET, 0xFF);
         disp.front_window = PORT_PTR;
-        disp.window_list = vec![PORT_PTR];
+        *disp.window_list = vec![PORT_PTR];
         disp.window_bounds = (185, 226, 415, 574);
 
         bus.write_word(PORT_PTR + 16, 0);
@@ -8048,7 +8048,7 @@ mod redraw_chrome_tests {
         install_8bpp_cgrafport(&mut bus, screen_base, 800, 800, 600, 0);
         bus.write_byte(PORT_PTR + WINDOW_VISIBLE_OFFSET, 0xFF);
         disp.front_window = PORT_PTR;
-        disp.window_list = vec![PORT_PTR];
+        *disp.window_list = vec![PORT_PTR];
         disp.window_bounds = (0, 0, 600, 800);
 
         let manual_port = bus.alloc(200);
@@ -8094,7 +8094,7 @@ mod redraw_chrome_tests {
         install_8bpp_cgrafport(&mut bus, screen_base, 800, 800, 600, 0);
         bus.write_byte(PORT_PTR + WINDOW_VISIBLE_OFFSET, 0xFF);
         disp.front_window = PORT_PTR;
-        disp.window_list = vec![PORT_PTR];
+        *disp.window_list = vec![PORT_PTR];
         disp.window_bounds = (0, 0, 600, 800);
 
         let manual_port = bus.alloc(200);
@@ -8129,7 +8129,7 @@ mod redraw_chrome_tests {
         install_8bpp_cgrafport(&mut bus, screen_base, 800, 800, 600, 0);
         bus.write_byte(PORT_PTR + WINDOW_VISIBLE_OFFSET, 0xFF);
         disp.front_window = PORT_PTR;
-        disp.window_list = vec![PORT_PTR];
+        *disp.window_list = vec![PORT_PTR];
         disp.copybits_screen_count = 1;
 
         let manual_port = bus.alloc(200);
@@ -8161,7 +8161,7 @@ mod redraw_chrome_tests {
         install_8bpp_cgrafport(&mut bus, screen_base, 800, 800, 600, 0);
         bus.write_byte(PORT_PTR + WINDOW_VISIBLE_OFFSET, 0xFF);
         disp.front_window = PORT_PTR;
-        disp.window_list = vec![PORT_PTR];
+        *disp.window_list = vec![PORT_PTR];
 
         let manual_port = bus.alloc(200);
         let original_base = bus.alloc(800 * 600);
@@ -8209,7 +8209,7 @@ mod redraw_chrome_tests {
         install_8bpp_cgrafport(&mut bus, screen_base, 800, 800, 600, 0);
         bus.write_byte(PORT_PTR + WINDOW_VISIBLE_OFFSET, 0xFF);
         disp.front_window = PORT_PTR;
-        disp.window_list = vec![PORT_PTR];
+        *disp.window_list = vec![PORT_PTR];
 
         let manual_port = bus.alloc(200);
         let manual_base = bus.alloc(640 * 420);
@@ -8246,7 +8246,7 @@ mod redraw_chrome_tests {
         install_8bpp_cgrafport(&mut bus, screen_base, 800, 800, 600, 0);
         bus.write_byte(PORT_PTR + WINDOW_VISIBLE_OFFSET, 0xFF);
         disp.front_window = PORT_PTR;
-        disp.window_list = vec![PORT_PTR];
+        *disp.window_list = vec![PORT_PTR];
 
         let manual_port = bus.alloc(200);
         let manual_base = bus.alloc(640 * 420);

--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -17292,7 +17292,7 @@ impl super::TrapDispatcher {
         bus: &mut MacMemoryBus,
         active_window: u32,
     ) {
-        let windows = self.window_list.clone();
+        let windows = self.window_list.to_vec();
         for window in windows {
             let palette = self.window_palette_handle_exact(window);
             if palette == 0 {

--- a/src/trap/window.rs
+++ b/src/trap/window.rs
@@ -1814,7 +1814,7 @@ impl super::TrapDispatcher {
 
     fn window_is_active_for_standard_go_away(&self, bus: &MacMemoryBus, window_ptr: u32) -> bool {
         let ghost_window = bus.read_long(crate::memory::globals::addr::GHOST_WINDOW);
-        for &candidate in &self.window_list {
+        for &candidate in self.window_list.iter() {
             if candidate == ghost_window || !self.window_visible(bus, candidate) {
                 continue;
             }
@@ -2029,7 +2029,7 @@ impl super::TrapDispatcher {
         // I-297.
         self.recalculate_window_vis_regions(bus);
         if let Some(old_structure) = old_structure {
-            let windows = self.window_list.clone();
+            let windows = self.window_list.to_vec();
             if let Some(moved_index) = windows.iter().position(|&window| window == the_window) {
                 for &window in windows.iter().skip(moved_index + 1) {
                     if self.window_visible(bus, window) {
@@ -2083,7 +2083,7 @@ impl super::TrapDispatcher {
         pt_h: i16,
         mbar_h: i16,
     ) -> (i16, u32) {
-        for &window_ptr in &self.window_list {
+        for &window_ptr in self.window_list.iter() {
             if !self.window_visible(bus, window_ptr) {
                 continue;
             }
@@ -2146,7 +2146,7 @@ impl super::TrapDispatcher {
         cpu: &mut C,
         bus: &mut MacMemoryBus,
     ) -> Option<u32> {
-        let windows = self.window_list.clone();
+        let windows = self.window_list.to_vec();
         for window in windows {
             if !self.window_visible(bus, window) || !self.window_has_pending_update(bus, window) {
                 continue;
@@ -2375,7 +2375,7 @@ impl super::TrapDispatcher {
     /// PROCEDURE CalcVisBehind (startWindow: WindowPeek; clobberedRgn: RgnHandle);
     /// Inside Macintosh Volume I, I-297
     pub(crate) fn recalculate_window_vis_regions(&self, bus: &mut MacMemoryBus) {
-        for &window_ptr in &self.window_list {
+        for &window_ptr in self.window_list.iter() {
             // A window inside BeginUpdate/EndUpdate has a temporarily narrowed
             // visRgn that EndUpdate restores; recomputing it here would drop
             // the update clip. IM:I I-292.
@@ -2814,7 +2814,7 @@ impl super::TrapDispatcher {
         // remain in front. Add the overlap to each affected window's update
         // region so its application can repaint the exposed content.
         if let Some(rect) = covered_rect {
-            let windows = self.window_list.clone();
+            let windows = self.window_list.to_vec();
             for &window in &windows {
                 if window == window_ptr {
                     break;
@@ -2932,7 +2932,7 @@ impl super::TrapDispatcher {
             // CloseWindow and DisposeWindow both route through
             // untrack_window; IM:I I-286 requires the next front to be
             // visible.
-            let list = self.window_list.clone();
+            let list = self.window_list.to_vec();
             self.front_window = list
                 .into_iter()
                 .find(|&w| self.window_visible(bus, w))
@@ -4300,7 +4300,7 @@ impl super::TrapDispatcher {
                         // ordered front-to-back so the first visible
                         // entry after the hidden one becomes the new
                         // front.
-                        let list = self.window_list.clone();
+                        let list = self.window_list.to_vec();
                         let new_front = list
                             .into_iter()
                             .find(|&w| w != the_window && self.window_visible(bus, w))
@@ -5267,7 +5267,7 @@ impl super::TrapDispatcher {
                     Some(r) => r,
                     None => return Some(Ok(())),
                 };
-                let windows = self.window_list.clone();
+                let windows = self.window_list.to_vec();
                 let start_idx = if start_window == 0 {
                     0
                 } else {
@@ -5524,7 +5524,7 @@ impl super::TrapDispatcher {
                         // should redraw. Conservatively inval each
                         // surviving window's bounds intersected with the
                         // moved window's old rect.
-                        let windows = self.window_list.clone();
+                        let windows = self.window_list.to_vec();
                         for &w in &windows {
                             if w == the_window {
                                 continue;
@@ -5933,7 +5933,7 @@ mod tests {
         let front = make_window(&mut bus, true, false);
         let middle = make_window(&mut bus, true, true);
         let back = make_window(&mut bus, true, true);
-        disp.window_list = vec![front, middle, back];
+        *disp.window_list = vec![front, middle, back];
         disp.front_window = front;
         let event = disp
             .pending_update_event(&bus, 0xFFFF)
@@ -5943,7 +5943,7 @@ mod tests {
 
         // An invisible dirty window ahead of a visible dirty one is skipped.
         let hidden = make_window(&mut bus, false, true);
-        disp.window_list = vec![hidden, back];
+        *disp.window_list = vec![hidden, back];
         let event = disp
             .pending_update_event(&bus, 0xFFFF)
             .expect("update event");
@@ -5951,7 +5951,7 @@ mod tests {
 
         // Empty list: the front window serves as the fallback...
         let lone = make_window(&mut bus, true, true);
-        disp.window_list = Vec::new();
+        *disp.window_list = Vec::new();
         disp.front_window = lone;
         let event = disp
             .pending_update_event(&bus, 0xFFFF)
@@ -6083,7 +6083,7 @@ mod tests {
         assert!(result.unwrap().is_ok(), "NewWindow should return");
 
         let window_ptr = bus.read_long(cpu.read_reg(Register::A7));
-        disp.window_list = vec![window_ptr];
+        *disp.window_list = vec![window_ptr];
         disp.front_window = window_ptr;
         *disp.current_port = window_ptr;
         disp.validate_window_rect(&mut bus, window_ptr, (0, 0, 160, 260));
@@ -7170,7 +7170,7 @@ mod tests {
         // Pre-seed an existing window so `behind` has a meaningful
         // target for the middle-insert case.
         let existing = 0x200040u32;
-        disp.window_list = vec![existing];
+        *disp.window_list = vec![existing];
         disp.front_window = existing;
         bus.write_byte(existing + 110u32, 0xFF); // visible
 
@@ -7194,7 +7194,7 @@ mod tests {
 
         let new_sp = cpu.read_reg(Register::A7);
         let window_ptr = bus.read_long(new_sp);
-        (window_ptr, disp.window_list.clone(), disp.front_window)
+        (window_ptr, disp.window_list.to_vec(), disp.front_window)
     }
 
     #[test]
@@ -7329,7 +7329,7 @@ mod tests {
         // closing the final tracked window must publish NIL.
         let (mut disp, mut cpu, mut bus) = setup();
         let window_ptr = 0x200040u32;
-        disp.window_list = vec![window_ptr];
+        *disp.window_list = vec![window_ptr];
         disp.front_window = window_ptr;
         bus.write_byte(window_ptr + 110u32, 0xFF);
         bus.write_long(0x09D6, window_ptr);
@@ -7467,7 +7467,7 @@ mod tests {
     fn new_cwindow_behind_nil_places_new_window_at_back() {
         let (mut disp, mut cpu, mut bus) = setup();
         let existing = 0x200040u32;
-        disp.window_list = vec![existing];
+        *disp.window_list = vec![existing];
         disp.front_window = existing;
         bus.write_byte(existing + 110u32, 0xFF);
 
@@ -7514,7 +7514,7 @@ mod tests {
             b"Doc",
         );
         let existing = 0x200040u32;
-        disp.window_list = vec![existing];
+        *disp.window_list = vec![existing];
         disp.front_window = existing;
         bus.write_byte(existing + 110u32, 0xFF);
 
@@ -7552,7 +7552,7 @@ mod tests {
             b"CWin",
         );
         let existing = 0x200040u32;
-        disp.window_list = vec![existing];
+        *disp.window_list = vec![existing];
         disp.front_window = existing;
         bus.write_byte(existing + 110u32, 0xFF);
 
@@ -7594,7 +7594,7 @@ mod tests {
             bus.write_word(window + 22, rect.3 as u16);
         }
 
-        disp.window_list = vec![front, back];
+        *disp.window_list = vec![front, back];
         disp.front_window = back;
         disp.window_bounds = (0, 0, 600, 800);
 
@@ -7686,7 +7686,7 @@ mod tests {
             b"CWin",
         );
         let existing = 0x200040u32;
-        disp.window_list = vec![existing];
+        *disp.window_list = vec![existing];
         disp.front_window = existing;
         bus.write_byte(
             existing + super::super::TrapDispatcher::WINDOW_VISIBLE_OFFSET,
@@ -8148,7 +8148,7 @@ mod tests {
         let (mut disp, mut cpu, mut bus) = setup();
         let front = 0x200040u32;
         let next = 0x200140u32;
-        disp.window_list = vec![front, next];
+        *disp.window_list = vec![front, next];
         disp.front_window = front;
         *disp.current_port = front;
         disp.window_bounds = (240, 450, 480, 650);
@@ -8234,7 +8234,7 @@ mod tests {
             false,
             0,
         );
-        disp.window_list = vec![utility, document];
+        *disp.window_list = vec![utility, document];
         disp.sync_window_list_links(&mut bus);
         // Floating utilities may remain above an active document without
         // becoming the Window Manager's active front window.
@@ -8292,7 +8292,7 @@ mod tests {
         let (mut disp, mut cpu, mut bus) = setup();
         let front = 0x200040u32;
         let next = 0x200140u32;
-        disp.window_list = vec![front, next];
+        *disp.window_list = vec![front, next];
         disp.front_window = front;
         *disp.current_port = front;
         disp.window_bounds = (240, 450, 480, 650);
@@ -8384,7 +8384,7 @@ mod tests {
             true,
             0,
         );
-        disp.window_list = vec![window_addr];
+        *disp.window_list = vec![window_addr];
         disp.front_window = window_addr;
         *disp.current_port = window_addr;
         assert_ne!(
@@ -8446,7 +8446,7 @@ mod tests {
         // event-generating path.
         let win_a = 0x200040u32;
         let win_b = 0x200140u32;
-        disp.window_list = vec![win_a, win_b];
+        *disp.window_list = vec![win_a, win_b];
         disp.front_window = win_a;
         bus.write_byte(win_a + 110u32, 0xFF);
         bus.write_byte(win_b + 110u32, 0xFF);
@@ -8468,7 +8468,7 @@ mod tests {
         let (mut disp, mut cpu, mut bus) = setup();
         let win_a = 0x200040u32;
         let win_b = 0x200140u32;
-        disp.window_list = vec![win_a, win_b];
+        *disp.window_list = vec![win_a, win_b];
         disp.front_window = win_a;
         bus.write_byte(win_a + 110u32, 0xFF);
         bus.write_byte(win_b + 110u32, 0xFF);
@@ -8573,7 +8573,7 @@ mod tests {
         let (mut disp, _cpu, mut bus) = setup();
         let old_front = 0x200040u32;
         let new_front = 0x200140u32;
-        disp.window_list = vec![new_front, old_front];
+        *disp.window_list = vec![new_front, old_front];
         disp.front_window = old_front;
         bus.write_byte(old_front + 110, 0xFF);
         bus.write_byte(old_front + 111, 0xFF);
@@ -8608,7 +8608,7 @@ mod tests {
     fn select_window_already_front_is_idempotent() {
         let (mut disp, mut cpu, mut bus) = setup();
         let win_a = 0x200040u32;
-        disp.window_list = vec![win_a];
+        *disp.window_list = vec![win_a];
         disp.front_window = win_a;
         bus.write_byte(win_a + 110u32, 0xFF);
         bus.write_byte(win_a + 111u32, 0xFF);
@@ -8663,7 +8663,7 @@ mod tests {
             setup_full_window_with_regions(&mut bus, window, 20, 0, 424, 627);
         bus.write_byte(window + 110, 0xFF);
         bus.write_byte(window + 111, 0xFF);
-        disp.window_list = vec![window];
+        *disp.window_list = vec![window];
         disp.front_window = window;
         *disp.current_port = window;
 
@@ -8947,7 +8947,7 @@ mod tests {
         let (mut disp, mut cpu, mut bus) = setup();
         let win_a = 0x200040u32;
         let win_b = 0x200140u32;
-        disp.window_list = vec![win_b, win_a]; // b is front, a is behind
+        *disp.window_list = vec![win_b, win_a]; // b is front, a is behind
         disp.front_window = win_b;
         *disp.current_port = win_b;
         for &base in &[win_a, win_b] {
@@ -9030,7 +9030,7 @@ mod tests {
             false,
             0,
         );
-        disp.window_list = vec![front, back];
+        *disp.window_list = vec![front, back];
         disp.sync_window_list_links(&mut bus);
         disp.front_window = front;
         *disp.current_port = front;
@@ -9057,7 +9057,7 @@ mod tests {
         let win_a = 0x200040u32;
         let win_b = 0x200140u32;
         let win_c = 0x200240u32;
-        disp.window_list = vec![win_c, win_b, win_a];
+        *disp.window_list = vec![win_c, win_b, win_a];
         disp.front_window = win_c;
         *disp.current_port = win_c;
         for &base in &[win_a, win_b, win_c] {
@@ -9191,7 +9191,7 @@ mod tests {
             dialog + super::super::TrapDispatcher::WINDOW_VISIBLE_OFFSET,
             0xFF,
         );
-        disp.window_list = vec![dialog];
+        *disp.window_list = vec![dialog];
         disp.front_window = dialog;
         *disp.current_port = dialog;
         disp.dialog_items
@@ -9234,7 +9234,7 @@ mod tests {
         let win_b = 0x200140u32;
         let win_c = 0x200240u32;
         // List: c front, b behind (hidden), a back-most (visible).
-        disp.window_list = vec![win_c, win_b, win_a];
+        *disp.window_list = vec![win_c, win_b, win_a];
         disp.front_window = win_c;
         *disp.current_port = win_c;
         for &base in &[win_a, win_b, win_c] {
@@ -9269,7 +9269,7 @@ mod tests {
         let (mut disp, mut cpu, mut bus) = setup();
         let win_a = 0x200040u32;
         let win_b = 0x200140u32;
-        disp.window_list = vec![win_b, win_a];
+        *disp.window_list = vec![win_b, win_a];
         disp.front_window = win_b;
         *disp.current_port = win_b;
         for &base in &[win_a, win_b] {
@@ -9299,7 +9299,7 @@ mod tests {
         let (mut disp, mut cpu, mut bus) = setup();
         let win_a = 0x200040u32;
         let win_b = 0x200140u32;
-        disp.window_list = vec![win_b, win_a];
+        *disp.window_list = vec![win_b, win_a];
         disp.front_window = win_b;
         *disp.current_port = win_b;
         for &base in &[win_a, win_b] {
@@ -9333,7 +9333,7 @@ mod tests {
         bus.write_byte(target_window + 110, 0x00);
         bus.write_byte(target_window + 111, 0x00);
 
-        disp.window_list = vec![front_window, target_window];
+        *disp.window_list = vec![front_window, target_window];
         disp.front_window = front_window;
         *disp.current_port = front_window;
 
@@ -9479,7 +9479,7 @@ mod tests {
         bus.write_byte(target_window + 110, 0xFF);
         bus.write_byte(target_window + 111, 0x00);
 
-        disp.window_list = vec![front_window, target_window];
+        *disp.window_list = vec![front_window, target_window];
         disp.front_window = front_window;
         *disp.current_port = front_window;
         disp.queue_window_update_event(target_window);
@@ -9564,7 +9564,7 @@ mod tests {
             false,
             0,
         );
-        disp.window_list = vec![target, back];
+        *disp.window_list = vec![target, back];
         disp.sync_window_list_links(&mut bus);
         disp.front_window = back;
         *disp.current_port = back;
@@ -9939,7 +9939,7 @@ mod tests {
         // frontmost VISIBLE window. Seed a window_list entry with its
         // visible byte set so the visible-only walk finds it.
         let win = 0x200040u32;
-        disp.window_list = vec![win];
+        *disp.window_list = vec![win];
         disp.front_window = win;
         bus.write_byte(win + 110u32, 0xFF);
 
@@ -9962,7 +9962,7 @@ mod tests {
         let (mut disp, mut cpu, mut bus) = setup();
         let win_a = 0x200040u32;
         let win_b = 0x200140u32;
-        disp.window_list = vec![win_b, win_a]; // b first, a behind
+        *disp.window_list = vec![win_b, win_a]; // b first, a behind
         disp.front_window = win_b;
         // b hidden, a visible.
         bus.write_byte(win_a + 110u32, 0xFF);
@@ -9979,7 +9979,7 @@ mod tests {
         let (mut disp, mut cpu, mut bus) = setup();
         let ghost = 0x200040u32;
         let doc = 0x200140u32;
-        disp.window_list = vec![ghost, doc];
+        *disp.window_list = vec![ghost, doc];
         disp.front_window = ghost;
         bus.write_byte(ghost + 110u32, 0xFF);
         bus.write_byte(doc + 110u32, 0xFF);
@@ -9999,7 +9999,7 @@ mod tests {
         let (mut disp, mut cpu, mut bus) = setup();
         let win_a = 0x200040u32;
         let win_b = 0x200140u32;
-        disp.window_list = vec![win_b, win_a];
+        *disp.window_list = vec![win_b, win_a];
         disp.front_window = win_b;
         // Both hidden.
         bus.write_byte(win_a + 110u32, 0x00);
@@ -10280,7 +10280,7 @@ mod tests {
         let window_addr: u32 = 0x310000;
         setup_full_window_with_regions(&mut bus, window_addr, 40, 0, 342, 512);
         bus.write_byte(window_addr + 110, 0xFF);
-        disp.window_list = vec![window_addr];
+        *disp.window_list = vec![window_addr];
         disp.front_window = window_addr;
 
         let wnd_ptr_ptr: u32 = 0x300000;
@@ -10333,7 +10333,7 @@ mod tests {
             0,
         );
         disp.front_window = window;
-        disp.window_list = vec![window];
+        *disp.window_list = vec![window];
         bus.write_byte(
             window + super::super::TrapDispatcher::WINDOW_HILITED_OFFSET,
             0xFF,
@@ -10505,7 +10505,7 @@ mod tests {
         let window_addr: u32 = 0x310000;
         setup_full_window_with_regions(&mut bus, window_addr, 40, 0, 342, 512);
         bus.write_byte(window_addr + 110, 0xFF);
-        disp.window_list = vec![window_addr];
+        *disp.window_list = vec![window_addr];
         disp.front_window = window_addr;
 
         let wnd_ptr_ptr: u32 = 0x300000;
@@ -10878,7 +10878,7 @@ mod tests {
         let (back_vis, back_clip, back_struc, back_cont) =
             setup_window_regions(&mut bus, back, 10, 20, 110, 210, 0x330000);
 
-        disp.window_list = vec![front, middle, back];
+        *disp.window_list = vec![front, middle, back];
         disp.sync_window_list_links(&mut bus);
         disp.menu_bar_hidden = false;
         bus.write_word(crate::memory::globals::addr::MBAR_HEIGHT, 18);
@@ -11132,7 +11132,7 @@ mod tests {
             false,
             0,
         );
-        disp.window_list = vec![window_addr];
+        *disp.window_list = vec![window_addr];
         disp.sync_window_list_links(&mut bus);
 
         let clobbered_rgn = super::super::TrapDispatcher::alloc_rect_region_handle(
@@ -12210,7 +12210,7 @@ mod tests {
         bus.write_word(window_addr + 12, 560);
         bus.write_word(window_addr + 14, 780);
         bus.write_byte(window_addr + 110, 0xFF);
-        disp.window_list = vec![window_addr];
+        *disp.window_list = vec![window_addr];
         disp.front_window = window_addr;
         disp.window_bounds = (40, 20, 140, 220);
 
@@ -12284,7 +12284,7 @@ mod tests {
             bus.write_word(window + 14, (800 - left) as u16);
             bus.write_byte(window + 110, 0xFF);
         }
-        disp.window_list = vec![front, target];
+        *disp.window_list = vec![front, target];
         disp.front_window = front;
         disp.window_bounds = (80, 100, 180, 300);
 
@@ -12701,7 +12701,7 @@ mod tests {
             0,
         );
         disp.front_window = window;
-        disp.window_list = vec![window];
+        *disp.window_list = vec![window];
         bus.write_byte(
             window + super::super::TrapDispatcher::WINDOW_HILITED_OFFSET,
             0xFF,
@@ -12755,7 +12755,7 @@ mod tests {
             0,
         );
         disp.front_window = window;
-        disp.window_list = vec![window];
+        *disp.window_list = vec![window];
         bus.write_byte(
             window + super::super::TrapDispatcher::WINDOW_HILITED_OFFSET,
             0xFF,
@@ -12820,7 +12820,7 @@ mod tests {
         bus.write_word(window + 12, 560);
         bus.write_word(window + 14, 780);
         bus.write_byte(window + 110, 0xFF);
-        disp.window_list = vec![window];
+        *disp.window_list = vec![window];
         disp.front_window = window;
         disp.window_bounds = (40, 20, 140, 220);
 
@@ -12930,7 +12930,7 @@ mod tests {
             bus.write_word(window + 12, 200);
             bus.write_word(window + 14, 300);
             bus.write_byte(window + 110, 0xFF);
-            disp.window_list = vec![window];
+            *disp.window_list = vec![window];
             disp.front_window = window;
 
             let size_rect = 0x280000;
@@ -12979,7 +12979,7 @@ mod tests {
         bus.write_word(window + 12, 560);
         bus.write_word(window + 14, 780);
         bus.write_byte(window + 110, 0xFF);
-        disp.window_list = vec![window];
+        *disp.window_list = vec![window];
 
         let size_rect = 0x280000;
         bus.write_word(size_rect, 50);
@@ -13014,7 +13014,7 @@ mod tests {
         setup_window_with_regions(&mut bus, window, 0, 0, 100, 200);
         bus.write_word(window + 6, 0);
         bus.write_byte(window + 110, 0xFF);
-        disp.window_list = vec![window];
+        *disp.window_list = vec![window];
 
         let size_rect = 0x280000;
         bus.write_word(size_rect, 50);
@@ -13162,7 +13162,7 @@ mod tests {
         install_wstate_data(&mut bus, window, (30, 40, 130, 190), (10, 12, 50, 70));
         bus.write_byte(window + 110, 0xFF);
         bus.write_byte(front_window + 110, 0xFF);
-        disp.window_list = vec![front_window, window];
+        *disp.window_list = vec![front_window, window];
         disp.front_window = front_window;
 
         let sp = TEST_SP - 8;
@@ -13199,7 +13199,7 @@ mod tests {
         setup_full_window_with_regions(&mut bus, window, 0, 0, 20, 20);
         install_wstate_data(&mut bus, window, (12, 18, 52, 90), (50, 60, 170, 250));
         bus.write_byte(window + 110, 0xFF);
-        disp.window_list = vec![window];
+        *disp.window_list = vec![window];
         disp.front_window = window;
 
         let sp = TEST_SP - 8;
@@ -13242,7 +13242,7 @@ mod tests {
         bus.write_byte(old_front + 111, 0xFF);
         bus.write_byte(zoom_target + 111, 0x00);
 
-        disp.window_list = vec![old_front, zoom_target];
+        *disp.window_list = vec![old_front, zoom_target];
         disp.front_window = old_front;
 
         let sp = TEST_SP - 8;
@@ -13335,7 +13335,7 @@ mod tests {
         let win = 0x200040u32;
         let (_cont_rgn, update_rgn) =
             setup_full_window_with_regions(&mut bus, win, 10, 20, 50, 100);
-        disp.window_list = vec![win];
+        *disp.window_list = vec![win];
 
         let sp = TEST_SP - 8;
         cpu.write_reg(Register::A7, sp);
@@ -13372,7 +13372,7 @@ mod tests {
         let (_cont_rgn, update_rgn) =
             setup_full_window_with_regions(&mut bus, win, 10, 20, 50, 100);
         bus.write_byte(win + 110u32, 0xFF);
-        disp.window_list = vec![win];
+        *disp.window_list = vec![win];
         disp.front_window = win;
 
         let probe = screen_base + 30 * 800 + 50;
@@ -13416,7 +13416,7 @@ mod tests {
         let win = 0x200040u32;
         let (_cont_rgn, _update_rgn) =
             setup_full_window_with_regions(&mut bus, win, 10, 20, 50, 100);
-        disp.window_list = vec![win];
+        *disp.window_list = vec![win];
 
         let empty_rgn = bus.alloc(10);
         let empty_handle = bus.alloc(4);
@@ -13521,7 +13521,7 @@ mod tests {
             setup_paintbehind_window(&mut bus, window, (0, 0, 200, 200));
         }
         bus.write_byte(back + 110u32, 0x00);
-        disp.window_list = vec![front, middle, back];
+        *disp.window_list = vec![front, middle, back];
         disp.front_window = front;
 
         let clobbered_ptr = bus.alloc(10);
@@ -13638,7 +13638,7 @@ mod tests {
         let (mut disp, mut cpu, mut bus) = setup();
         let win_a = 0x200040u32;
         let win_b = 0x200140u32;
-        disp.window_list = vec![win_b, win_a];
+        *disp.window_list = vec![win_b, win_a];
         // Minimum: a 10-byte rect region at 0x300020.
         let rgn_ptr = 0x300020u32;
         bus.write_word(rgn_ptr, 10);
@@ -13738,7 +13738,7 @@ mod tests {
         let win_a = 0x200040u32;
         let win_b = 0x200140u32;
         let win_c = 0x200240u32;
-        disp.window_list = vec![win_a, win_b, win_c];
+        *disp.window_list = vec![win_a, win_b, win_c];
         disp.front_window = win_a;
         bus.write_byte(
             win_a + super::super::TrapDispatcher::WINDOW_HILITED_OFFSET,
@@ -13872,7 +13872,7 @@ mod tests {
         let (mut disp, mut cpu, mut bus) = setup();
         let win_a = 0x200040u32;
         let win_b = 0x200140u32;
-        disp.window_list = vec![win_b, win_a];
+        *disp.window_list = vec![win_b, win_a];
         for base in [win_a, win_b] {
             bus.write_word(base + 16, 10);
             bus.write_word(base + 18, 10);
@@ -13899,7 +13899,7 @@ mod tests {
         let (mut disp, mut cpu, mut bus) = setup();
         let win_a = 0x200040u32;
         let win_b = 0x200140u32;
-        disp.window_list = vec![win_b, win_a];
+        *disp.window_list = vec![win_b, win_a];
         disp.front_window = win_b;
         bus.write_byte(win_a + 110u32, 0xFF);
         bus.write_byte(win_b + 110u32, 0xFF);
@@ -13942,7 +13942,7 @@ mod tests {
         let visual_front = 0x200040u32;
         let active = 0x200140u32;
         let target = 0x200240u32;
-        disp.window_list = vec![visual_front, active, target];
+        *disp.window_list = vec![visual_front, active, target];
         disp.front_window = active;
         for base in [visual_front, active, target] {
             bus.write_byte(base + 110u32, 0xFF);
@@ -13976,7 +13976,7 @@ mod tests {
         // Two fake windows already in the list, newest at front.
         let win_a = 0x200040u32;
         let win_b = 0x200140u32;
-        disp.window_list = vec![win_b, win_a];
+        *disp.window_list = vec![win_b, win_a];
         disp.front_window = win_b;
         // Minimum portRect to satisfy the bounds read.
         for base in [win_a, win_b] {
@@ -14012,7 +14012,7 @@ mod tests {
         let win_a = 0x200040u32;
         let win_b = 0x200140u32;
         let win_c = 0x200240u32;
-        disp.window_list = vec![win_c, win_b, win_a];
+        *disp.window_list = vec![win_c, win_b, win_a];
         disp.front_window = win_c;
         for base in [win_a, win_b, win_c] {
             bus.write_word(base + 16, 10);
@@ -14042,7 +14042,7 @@ mod tests {
         let win_a = 0x200040u32;
         let win_b = 0x200140u32;
         let win_c = 0x200240u32;
-        disp.window_list = vec![win_c, win_b, win_a]; // c front
+        *disp.window_list = vec![win_c, win_b, win_a]; // c front
         disp.front_window = win_c;
         for &base in &[win_a, win_b, win_c] {
             bus.write_word(base + 16, 10);
@@ -14236,7 +14236,7 @@ mod tests {
         let (mut disp, mut cpu, mut bus) = setup();
         let win_a = 0x200040u32;
         let win_b = 0x200140u32;
-        disp.window_list = vec![win_a, win_b];
+        *disp.window_list = vec![win_a, win_b];
         disp.front_window = win_a;
         bus.write_byte(win_a + 110u32, 0xFF); // visible
         bus.write_byte(win_b + 110u32, 0xFF);
@@ -14276,7 +14276,7 @@ mod tests {
         let (mut disp, mut cpu, mut bus) = setup();
         let win_a = 0x200040u32;
         let win_b = 0x200140u32;
-        disp.window_list = vec![win_a, win_b];
+        *disp.window_list = vec![win_a, win_b];
         disp.front_window = win_a;
         bus.write_byte(win_a + 110u32, 0xFF);
         bus.write_byte(win_b + 110u32, 0xFF);
@@ -14318,7 +14318,7 @@ mod tests {
         // Mark window visible so invalidate_window_rect's clip
         // intersection picks up the content rect.
         bus.write_byte(window_addr + 110u32, 0xFF);
-        disp.window_list = vec![window_addr];
+        *disp.window_list = vec![window_addr];
         disp.front_window = window_addr;
 
         let sp = TEST_SP - 10;
@@ -14359,7 +14359,7 @@ mod tests {
         let (_cont_rgn, update_rgn) =
             setup_full_window_with_regions(&mut bus, window_addr, 0, 0, 100, 100);
         bus.write_byte(window_addr + 110u32, 0xFF);
-        disp.window_list = vec![window_addr];
+        *disp.window_list = vec![window_addr];
         disp.front_window = window_addr;
 
         let sp = TEST_SP - 10;
@@ -14403,7 +14403,7 @@ mod tests {
         let window_addr: u32 = 0x300000;
         let _ = setup_full_window_with_regions(&mut bus, window_addr, 10, 20, 60, 120);
         bus.write_byte(window_addr + 110u32, 0xFF);
-        disp.window_list = vec![window_addr];
+        *disp.window_list = vec![window_addr];
         disp.front_window = window_addr;
 
         let sp = TEST_SP - 6;
@@ -14429,7 +14429,7 @@ mod tests {
         let (cont_rgn, update_rgn) =
             setup_full_window_with_regions(&mut bus, window_addr, 10, 20, 60, 120);
         bus.write_byte(window_addr + 110u32, 0xFF);
-        disp.window_list = vec![window_addr];
+        *disp.window_list = vec![window_addr];
         disp.front_window = window_addr;
 
         let sp = TEST_SP - 4;
@@ -14476,7 +14476,7 @@ mod tests {
         bus.write_word(update_rgn + 6, 90);
         bus.write_word(update_rgn + 8, 140);
         bus.write_byte(window_addr + 110u32, 0xFF);
-        disp.window_list = vec![window_addr];
+        *disp.window_list = vec![window_addr];
         disp.front_window = window_addr;
 
         let sp = TEST_SP - 6;
@@ -14539,7 +14539,7 @@ mod tests {
         let (_cont_rgn, update_rgn) =
             setup_full_window_with_regions(&mut bus, window_addr, 0, 0, 200, 200);
         bus.write_byte(window_addr + 110u32, 0xFF);
-        disp.window_list = vec![window_addr];
+        *disp.window_list = vec![window_addr];
         disp.front_window = window_addr;
 
         let sp = TEST_SP - 10;


### PR DESCRIPTION
Closes #1227.

Make the Window Manager front-to-back registry process-owned so 68K traps and PowerPC imports observe the same window membership and ordering immediately. Preserve native GWorld metadata for native drawing while allowing PowerPC window operations to act on classic-created WindowRecords, and publish the shared chain through low memory at import boundaries.

Validation:
- `cargo test --locked --lib` (4,771 passed; 0 failed; 3 ignored)
- strict all-features rustdoc with private intra-doc links denied
- `cargo test --all-features --all-targets --locked --no-run`
- Marathon terminal-complete deterministic play script
- Escape Velocity gameplay deterministic play script
- Tomb Raider Gold gameplay deterministic play script