### PR TITLE
refactor(sound)!: make double-buffer playback process-owned

### DIFF
--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -43265,6 +43265,7 @@ fn ppc_snd_get_info(cpu: &PpcCpu, memory: &mut PpcSectionMem, sound: &PpcSoundSt
                 .iter()
                 .any(|record| record.channel == channel && record.active)
                 || sound
+                    .manager
                     .double_buffer_playbacks
                     .iter()
                     .any(|record| record.channel == channel && record.active);
@@ -43433,14 +43434,6 @@ fn ppc_snd_do_immediate(
             playback.paused = false;
             playback.quiet_now = true;
         }
-        for playback in sound
-            .double_buffer_playbacks
-            .iter_mut()
-            .filter(|record| record.channel == channel && record.active)
-        {
-            playback.active = false;
-            playback.host_buffer_loaded = false;
-        }
     }
     if command.command == 85 && command.param2 != 0 {
         if !ppc_memory_can_write_bytes(memory, command.param2, 4)
@@ -43543,14 +43536,6 @@ fn ppc_snd_dispose_channel(cpu: &mut PpcCpu, sound: &mut PpcSoundState) -> i16 {
         .filter(|record| record.channel == channel)
     {
         playback.samples.clear();
-    }
-    for playback in sound
-        .double_buffer_playbacks
-        .iter_mut()
-        .filter(|record| record.channel == channel)
-    {
-        playback.active = false;
-        playback.host_buffer_loaded = false;
     }
     PPC_NO_ERR
 }
@@ -43799,19 +43784,13 @@ fn ppc_snd_play_double_buffer(
             callback
         );
     }
-    for playback in sound
-        .double_buffer_playbacks
-        .iter_mut()
-        .filter(|record| record.channel == channel && record.active)
-    {
-        playback.active = false;
-        playback.host_buffer_loaded = false;
-    }
+    sound.manager.stop_double_buffer_playbacks(channel);
     let mut playback = PpcSoundDoubleBufferPlaybackRecord {
         channel,
         header,
         buffers: [buffer0, buffer1],
         callback,
+        callback_architecture: CallbackTaskArchitecture::PowerPc,
         sample_rate_fixed,
         num_channels,
         sample_size,
@@ -43831,7 +43810,7 @@ fn ppc_snd_play_double_buffer(
             .play_double_buffer_samples(channel, samples, sample_rate_fixed);
         playback.host_buffer_loaded = true;
     }
-    sound.double_buffer_playbacks.push(playback);
+    sound.manager.double_buffer_playbacks.push(playback);
     sound.double_buffer_play_count = sound.double_buffer_play_count.saturating_add(1);
     sound.last_double_buffer_channel = channel;
     sound.last_double_buffer_header = header;
@@ -160110,12 +160089,13 @@ pub(crate) mod tests {
         assert_eq!(loaded.sound.last_double_buffer_channel, channel);
         assert_eq!(loaded.sound.last_double_buffer_header, header);
         assert_eq!(
-            loaded.sound.double_buffer_playbacks,
+            loaded.sound.manager.double_buffer_playbacks,
             vec![PpcSoundDoubleBufferPlaybackRecord {
                 channel,
                 header,
                 buffers: [PPC_DATA_BASE + 0x3000, PPC_DATA_BASE + 0x4000],
                 callback: PPC_CODE_BASE + 0x40,
+                callback_architecture: CallbackTaskArchitecture::PowerPc,
                 sample_rate_fixed: 22_050u32 << 16,
                 num_channels: 2,
                 sample_size: 16,
@@ -160135,7 +160115,7 @@ pub(crate) mod tests {
             .channels
             .iter()
             .any(|candidate| candidate.guest_ptr == channel && candidate.has_active_playback()));
-        assert!(loaded.sound.pending_doublebacks.is_empty());
+        assert!(loaded.sound.manager.pending_process_doublebacks.is_empty());
 
         loaded.cpu.pc = loaded.entry_pc;
         loaded.cpu.lr = PPC_HALT_PC;

--- a/src/loader/ppc/sound.rs
+++ b/src/loader/ppc/sound.rs
@@ -2,6 +2,10 @@
 
 use super::imports::PpcHleImportTraceEntry;
 use crate::process_context::SharedProcessSoundManager;
+pub use crate::sound::{
+    PendingProcessSoundDoubleBack as PpcSoundDoubleBackRecord,
+    ProcessSoundDoubleBufferPlayback as PpcSoundDoubleBufferPlaybackRecord,
+};
 use ppc::{PpcFetchHistogram, PpcRunResult};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -66,35 +70,6 @@ pub struct PpcDecodedBufferCommandRecord {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct PpcSoundDoubleBufferPlaybackRecord {
-    pub channel: u32,
-    pub header: u32,
-    pub buffers: [u32; 2],
-    pub callback: u32,
-    pub sample_rate_fixed: u32,
-    pub num_channels: u16,
-    pub sample_size: u16,
-    pub compression_id: i16,
-    pub packet_size: u16,
-    pub current_buffer_index: u8,
-    pub callback_pending_mask: u8,
-    pub active: bool,
-    pub host_initialized: bool,
-    pub host_buffer_loaded: bool,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct PpcSoundDoubleBackRecord {
-    pub channel: u32,
-    pub header: u32,
-    pub exhausted_buffer: u32,
-    pub exhausted_buffer_index: u32,
-    pub callback: u32,
-    pub tick: u32,
-    pub instruction_count: u64,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PpcSoundCompletionRecord {
     pub file_playback_index: u32,
     pub channel: u32,
@@ -137,11 +112,9 @@ pub struct PpcSoundState {
     pub(crate) manager: SharedProcessSoundManager,
     pub queued_commands: Vec<PpcSndCommandRecord>,
     pub immediate_commands: Vec<PpcSndCommandRecord>,
-    pub double_buffer_playbacks: Vec<PpcSoundDoubleBufferPlaybackRecord>,
     pub file_playbacks: Vec<PpcSoundFilePlaybackRecord>,
     pub decoded_file_playbacks: Vec<PpcDecodedAiffPlaybackRecord>,
     pub pending_completions: Vec<PpcSoundCompletionRecord>,
-    pub pending_doublebacks: Vec<PpcSoundDoubleBackRecord>,
     pub completion_invocations: Vec<PpcSoundCompletionInvocationRecord>,
     pub sys_beep_count: u32,
     pub last_sys_beep_duration: i16,
@@ -157,11 +130,9 @@ impl PartialEq for PpcSoundState {
     fn eq(&self, other: &Self) -> bool {
         self.queued_commands == other.queued_commands
             && self.immediate_commands == other.immediate_commands
-            && self.double_buffer_playbacks == other.double_buffer_playbacks
             && self.file_playbacks == other.file_playbacks
             && self.decoded_file_playbacks == other.decoded_file_playbacks
             && self.pending_completions == other.pending_completions
-            && self.pending_doublebacks == other.pending_doublebacks
             && self.completion_invocations == other.completion_invocations
             && self.sys_beep_count == other.sys_beep_count
             && self.last_sys_beep_duration == other.last_sys_beep_duration

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -6192,6 +6192,40 @@ mod tests {
             )),
         );
         native.mix_frame(1);
+        native.double_buffer_playbacks.push(
+            crate::sound::ProcessSoundDoubleBufferPlayback {
+                channel: 0x6000,
+                header: 0x6100,
+                buffers: [0x6200, 0x6300],
+                callback: 0x6400,
+                callback_architecture:
+                    crate::callback_manager::CallbackTaskArchitecture::PowerPc,
+                sample_rate_fixed: crate::sound::OUTPUT_RATE << 16,
+                num_channels: 1,
+                sample_size: 8,
+                compression_id: 0,
+                packet_size: 0,
+                current_buffer_index: 0,
+                callback_pending_mask: 1,
+                active: true,
+                host_initialized: true,
+                host_buffer_loaded: true,
+            },
+        );
+        native.pending_process_doublebacks.push(
+            crate::sound::PendingProcessSoundDoubleBack {
+                architecture: crate::callback_manager::CallbackTaskArchitecture::PowerPc,
+                channel: 0x6000,
+                header: 0x6100,
+                exhausted_buffer: 0x6200,
+                exhausted_buffer_index: 0,
+                callback: 0x6400,
+                tick: 12,
+                instruction_count: 34,
+            },
+        );
+        let playback_snapshot = native.clone();
+        classic.quiet_channel(0x6000);
 
         assert!(classic.ptr_eq(&native));
         assert_eq!(native.channels.len(), 3);
@@ -6208,6 +6242,12 @@ mod tests {
         assert_eq!(detached.channels.len(), 1);
         assert!(detached.pending_sound_callbacks.is_empty());
         assert_eq!(detached.sys_beep_volume(), 0x0100_0100);
+        assert!(!native.double_buffer_playbacks[0].active);
+        assert!(!native.double_buffer_playbacks[0].host_buffer_loaded);
+        assert!(classic.pending_process_doublebacks.is_empty());
+        assert!(playback_snapshot.double_buffer_playbacks[0].active);
+        assert!(playback_snapshot.double_buffer_playbacks[0].host_buffer_loaded);
+        assert_eq!(playback_snapshot.pending_process_doublebacks.len(), 1);
     }
 
     #[test]

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -7010,18 +7010,24 @@ impl FixtureRunner {
     }
 
     fn service_ppc_sound_adapter(&mut self, ppc_app: &mut PpcLoadedApp) {
-        self.sync_ppc_double_buffer_playbacks(ppc_app);
+        self.service_ppc_double_buffer_memory(ppc_app);
     }
 
-    fn sync_ppc_double_buffer_playbacks(&mut self, ppc_app: &mut PpcLoadedApp) {
+    /// Decode native guest buffer records into the process Sound Manager.
+    ///
+    /// Guest-byte decoding is an ABI adapter responsibility. Playback state,
+    /// buffer progression, and doubleback scheduling remain process-owned.
+    fn service_ppc_double_buffer_memory(&mut self, ppc_app: &mut PpcLoadedApp) {
         let stopped_channels = ppc_app
             .sound
+            .manager
             .double_buffer_playbacks
             .iter()
             .filter(|playback| !playback.active && playback.host_buffer_loaded)
             .filter(|playback| {
                 !ppc_app
                     .sound
+                    .manager
                     .double_buffer_playbacks
                     .iter()
                     .any(|other| other.active && other.channel == playback.channel)
@@ -7033,19 +7039,19 @@ impl FixtureRunner {
                 host_channel.quiet();
             }
         }
-        for playback in &mut ppc_app.sound.double_buffer_playbacks {
+        for playback in &mut ppc_app.sound.manager.double_buffer_playbacks {
             if !playback.active {
                 playback.host_buffer_loaded = false;
             }
         }
 
-        for index in 0..ppc_app.sound.double_buffer_playbacks.len() {
-            let playback = ppc_app.sound.double_buffer_playbacks[index];
+        for index in 0..ppc_app.sound.manager.double_buffer_playbacks.len() {
+            let playback = ppc_app.sound.manager.double_buffer_playbacks[index];
             if !playback.active {
                 continue;
             }
             if !playback.host_initialized {
-                ppc_app.sound.double_buffer_playbacks[index].host_initialized = true;
+                ppc_app.sound.manager.double_buffer_playbacks[index].host_initialized = true;
                 self.dispatcher
                     .sound_manager
                     .note_double_buffer_submission();
@@ -7071,7 +7077,7 @@ impl FixtureRunner {
             };
             if decoded.flags & 0x01 == 0 || decoded.samples.is_empty() {
                 Self::queue_ppc_doubleback(
-                    &mut ppc_app.sound,
+                    &mut ppc_app.sound.manager,
                     index,
                     self.dispatcher.tick_count,
                     self.total_instructions,
@@ -7080,7 +7086,7 @@ impl FixtureRunner {
             }
 
             self.play_ppc_decoded_double_buffer(playback, &decoded);
-            ppc_app.sound.double_buffer_playbacks[index].host_buffer_loaded = true;
+            ppc_app.sound.manager.double_buffer_playbacks[index].host_buffer_loaded = true;
         }
     }
 
@@ -7164,7 +7170,7 @@ impl FixtureRunner {
     }
 
     fn queue_ppc_doubleback(
-        sound: &mut crate::loader::ppc::PpcSoundState,
+        sound: &mut crate::sound::SoundManager,
         playback_index: usize,
         tick: u32,
         instruction_count: u64,
@@ -7182,15 +7188,18 @@ impl FixtureRunner {
             return;
         }
         playback.callback_pending_mask |= pending_bit;
-        sound.pending_doublebacks.push(PpcSoundDoubleBackRecord {
-            channel: playback.channel,
-            header: playback.header,
-            exhausted_buffer: buffer_ptr,
-            exhausted_buffer_index: u32::from(buffer_index),
-            callback: playback.callback,
-            tick,
-            instruction_count,
-        });
+        sound
+            .pending_process_doublebacks
+            .push(PpcSoundDoubleBackRecord {
+                architecture: playback.callback_architecture,
+                channel: playback.channel,
+                header: playback.header,
+                exhausted_buffer: buffer_ptr,
+                exhausted_buffer_index: u32::from(buffer_index),
+                callback: playback.callback,
+                tick,
+                instruction_count,
+            });
     }
 
     fn sync_ppc_sound_completions_from_dispatcher(&mut self) {
@@ -7258,8 +7267,8 @@ impl FixtureRunner {
             return;
         };
 
-        for index in 0..ppc_app.sound.double_buffer_playbacks.len() {
-            let playback = ppc_app.sound.double_buffer_playbacks[index];
+        for index in 0..ppc_app.sound.manager.double_buffer_playbacks.len() {
+            let playback = ppc_app.sound.manager.double_buffer_playbacks[index];
             if !playback.active || !playback.host_buffer_loaded {
                 continue;
             }
@@ -7285,29 +7294,30 @@ impl FixtureRunner {
                     .memory
                     .write_u32_be(buffer_ptr.wrapping_add(4), flags & !0x01);
             }
-            ppc_app.sound.double_buffer_playbacks[index].host_buffer_loaded = false;
+            ppc_app.sound.manager.double_buffer_playbacks[index].host_buffer_loaded = false;
             if flags & 0x04 != 0 {
-                ppc_app.sound.double_buffer_playbacks[index].active = false;
+                ppc_app.sound.manager.double_buffer_playbacks[index].active = false;
                 continue;
             }
 
             Self::queue_ppc_doubleback(
-                &mut ppc_app.sound,
+                &mut ppc_app.sound.manager,
                 index,
                 self.dispatcher.tick_count,
                 self.total_instructions,
             );
-            ppc_app.sound.double_buffer_playbacks[index].current_buffer_index = buffer_index ^ 1;
+            ppc_app.sound.manager.double_buffer_playbacks[index].current_buffer_index =
+                buffer_index ^ 1;
         }
 
-        self.sync_ppc_double_buffer_playbacks(&mut ppc_app);
+        self.service_ppc_double_buffer_memory(&mut ppc_app);
         self.ppc_app = Some(ppc_app);
         self.fire_pending_ppc_sound_doublebacks();
 
         let Some(mut ppc_app) = self.ppc_app.take() else {
             return;
         };
-        self.sync_ppc_double_buffer_playbacks(&mut ppc_app);
+        self.service_ppc_double_buffer_memory(&mut ppc_app);
         self.ppc_app = Some(ppc_app);
     }
 
@@ -7315,7 +7325,13 @@ impl FixtureRunner {
         let Some(ppc_app) = self.ppc_app.as_ref() else {
             return;
         };
-        if ppc_app.sound.pending_doublebacks.is_empty() {
+        if ppc_app
+            .sound
+            .manager
+            .pending_process_doublebacks
+            .iter()
+            .all(|doubleback| doubleback.architecture != CallbackTaskArchitecture::PowerPc)
+        {
             return;
         }
 
@@ -7328,8 +7344,23 @@ impl FixtureRunner {
         };
         self.prepare_ppc_execution_clock(&mut ppc_app);
         let mut fired_count = 0usize;
-        while !ppc_app.sound.pending_doublebacks.is_empty() && fired_count < 16 {
-            let doubleback = ppc_app.sound.pending_doublebacks.remove(0);
+        while fired_count < 16 {
+            let Some(index) = ppc_app
+                .sound
+                .manager
+                .pending_process_doublebacks
+                .iter()
+                .position(|doubleback| {
+                    doubleback.architecture == CallbackTaskArchitecture::PowerPc
+                })
+            else {
+                break;
+            };
+            let doubleback = ppc_app
+                .sound
+                .manager
+                .pending_process_doublebacks
+                .remove(index);
             let resume_pc = ppc_app.cpu.pc;
             let probe = ppc_app.with_process_memory_manager(
                 |app, memory_manager| {
@@ -7381,6 +7412,7 @@ impl FixtureRunner {
             if let Some(playback) =
                 ppc_app
                     .sound
+                    .manager
                     .double_buffer_playbacks
                     .iter_mut()
                     .rev()
@@ -15291,6 +15323,7 @@ mod tests {
     #[test]
     fn ppc_sound_doublebacks_preserve_centered_viewport_event_coordinates() {
         let callback = |callback| PpcSoundDoubleBackRecord {
+            architecture: CallbackTaskArchitecture::PowerPc,
             channel: 0x0300_1000,
             header: 0x0300_2000,
             exhausted_buffer: 0x0300_3000,
@@ -15299,14 +15332,13 @@ mod tests {
             tick: 0,
             instruction_count: 0,
         };
-        let app = halted_ppc_app_with_sound(PpcSoundState {
-            pending_doublebacks: vec![
-                callback(PPC_SOUND_GET_EVENT_CALLBACK),
-                callback(PPC_SOUND_POST_EVENT_CALLBACK),
-                callback(PPC_SOUND_SET_EVENT_MASK_CALLBACK),
-            ],
-            ..PpcSoundState::default()
-        });
+        let mut sound = PpcSoundState::default();
+        sound.manager.pending_process_doublebacks = vec![
+            callback(PPC_SOUND_GET_EVENT_CALLBACK),
+            callback(PPC_SOUND_POST_EVENT_CALLBACK),
+            callback(PPC_SOUND_SET_EVENT_MASK_CALLBACK),
+        ];
+        let app = halted_ppc_app_with_sound(sound);
 
         assert_ppc_sound_event_boundary(app, FixtureRunner::fire_pending_ppc_sound_doublebacks);
     }
@@ -15426,18 +15458,17 @@ mod tests {
         const BUFFER: u32 = 0x0300_3000;
         const CALLBACK: u32 = PPC_CODE_BASE + 0x1000;
 
-        let sound = PpcSoundState {
-            pending_doublebacks: vec![PpcSoundDoubleBackRecord {
-                channel: CHANNEL,
-                header: HEADER,
-                exhausted_buffer: BUFFER,
-                exhausted_buffer_index: 0,
-                callback: CALLBACK,
-                tick: 1,
-                instruction_count: 1,
-            }],
-            ..PpcSoundState::default()
-        };
+        let mut sound = PpcSoundState::default();
+        sound.manager.pending_process_doublebacks = vec![PpcSoundDoubleBackRecord {
+            architecture: CallbackTaskArchitecture::PowerPc,
+            channel: CHANNEL,
+            header: HEADER,
+            exhausted_buffer: BUFFER,
+            exhausted_buffer_index: 0,
+            callback: CALLBACK,
+            tick: 1,
+            instruction_count: 1,
+        }];
         let mut app = halted_ppc_app_with_sound(sound);
         let ppc_app = app.ppc.as_mut().expect("PPC app");
         let mut callback = Vec::with_capacity((CALLBACK_CYCLES + 1) * 4);
@@ -15453,7 +15484,7 @@ mod tests {
 
         assert!(!runner.is_halted());
         let sound = &runner.ppc_app.as_ref().expect("PPC app").sound;
-        assert!(sound.pending_doublebacks.is_empty());
+        assert!(sound.manager.pending_process_doublebacks.is_empty());
         let invocation = sound
             .completion_invocations
             .last()
@@ -15476,25 +15507,24 @@ mod tests {
         const CALLBACK: u32 = PPC_CODE_BASE + 0x1000;
         const SAMPLES: [u8; 4] = [0x80, 0x90, 0x70, 0xa0];
 
-        let sound = PpcSoundState {
-            double_buffer_playbacks: vec![PpcSoundDoubleBufferPlaybackRecord {
-                channel: CHANNEL,
-                header: HEADER,
-                buffers: [BUFFER, 0],
-                callback: CALLBACK,
-                sample_rate_fixed: crate::sound::OUTPUT_RATE << 16,
-                num_channels: 1,
-                sample_size: 8,
-                compression_id: 0,
-                packet_size: 0,
-                current_buffer_index: 0,
-                callback_pending_mask: 0,
-                active: true,
-                host_initialized: false,
-                host_buffer_loaded: false,
-            }],
-            ..PpcSoundState::default()
-        };
+        let mut sound = PpcSoundState::default();
+        sound.manager.double_buffer_playbacks = vec![PpcSoundDoubleBufferPlaybackRecord {
+            channel: CHANNEL,
+            header: HEADER,
+            buffers: [BUFFER, 0],
+            callback: CALLBACK,
+            callback_architecture: CallbackTaskArchitecture::PowerPc,
+            sample_rate_fixed: crate::sound::OUTPUT_RATE << 16,
+            num_channels: 1,
+            sample_size: 8,
+            compression_id: 0,
+            packet_size: 0,
+            current_buffer_index: 0,
+            callback_pending_mask: 0,
+            active: true,
+            host_initialized: false,
+            host_buffer_loaded: false,
+        }];
         let mut app = halted_ppc_app_with_sound(sound);
         let ppc_app = app.ppc.as_mut().expect("PPC app");
         ppc_app.memory.add_region(BUFFER, vec![0; 32]);
@@ -15531,7 +15561,7 @@ mod tests {
             Some(u32::from_be_bytes(SAMPLES))
         );
         assert_eq!(ppc_app.sound.completion_invocations.len(), 1);
-        assert!(!ppc_app.sound.double_buffer_playbacks[0].active);
+        assert!(!ppc_app.sound.manager.double_buffer_playbacks[0].active);
         assert_eq!(
             runner.dispatcher().sound_manager.debug_samples_mixed,
             SAMPLES.len() as u64
@@ -15983,25 +16013,24 @@ mod tests {
         let buffer0 = PPC_DATA_BASE + 0x200;
         let buffer1 = PPC_DATA_BASE + 0x300;
         let expected = vec![0x80, 0x90, 0x70, 0xa0];
-        let sound = PpcSoundState {
-            double_buffer_playbacks: vec![PpcSoundDoubleBufferPlaybackRecord {
-                channel,
-                header,
-                buffers: [buffer0, buffer1],
-                callback: 0,
-                sample_rate_fixed: crate::sound::OUTPUT_RATE << 16,
-                num_channels: 1,
-                sample_size: 8,
-                compression_id: 0,
-                packet_size: 0,
-                current_buffer_index: 0,
-                callback_pending_mask: 0,
-                active: true,
-                host_initialized: false,
-                host_buffer_loaded: false,
-            }],
-            ..PpcSoundState::default()
-        };
+        let mut sound = PpcSoundState::default();
+        sound.manager.double_buffer_playbacks = vec![PpcSoundDoubleBufferPlaybackRecord {
+            channel,
+            header,
+            buffers: [buffer0, buffer1],
+            callback: 0,
+            callback_architecture: CallbackTaskArchitecture::PowerPc,
+            sample_rate_fixed: crate::sound::OUTPUT_RATE << 16,
+            num_channels: 1,
+            sample_size: 8,
+            compression_id: 0,
+            packet_size: 0,
+            current_buffer_index: 0,
+            callback_pending_mask: 0,
+            active: true,
+            host_initialized: false,
+            host_buffer_loaded: false,
+        }];
         let mut app = halted_ppc_app_with_sound(sound);
         {
             let ppc_app = app.ppc.as_mut().expect("PPC app");
@@ -16049,6 +16078,7 @@ mod tests {
             .as_ref()
             .expect("PPC app should stay loaded")
             .sound
+            .manager
             .double_buffer_playbacks[0];
         assert!(!playback.active);
         assert!(!playback.host_buffer_loaded);
@@ -16092,7 +16122,6 @@ mod tests {
             manager: Default::default(),
             queued_commands: Vec::new(),
             immediate_commands: Vec::new(),
-            double_buffer_playbacks: Vec::new(),
             file_playbacks: vec![PpcSoundFilePlaybackRecord {
                 channel,
                 ref_num: 128,
@@ -16121,7 +16150,6 @@ mod tests {
                 samples: samples.clone(),
             }],
             pending_completions: Vec::new(),
-            pending_doublebacks: Vec::new(),
             completion_invocations: Vec::new(),
             sys_beep_count: 0,
             last_sys_beep_duration: 0,
@@ -16235,7 +16263,6 @@ mod tests {
             manager: Default::default(),
             queued_commands: Vec::new(),
             immediate_commands: Vec::new(),
-            double_buffer_playbacks: Vec::new(),
             file_playbacks: vec![PpcSoundFilePlaybackRecord {
                 channel,
                 ref_num: 128,
@@ -16264,7 +16291,6 @@ mod tests {
                 samples: samples.clone(),
             }],
             pending_completions: Vec::new(),
-            pending_doublebacks: Vec::new(),
             completion_invocations: Vec::new(),
             sys_beep_count: 0,
             last_sys_beep_duration: 0,

--- a/src/sound.rs
+++ b/src/sound.rs
@@ -188,6 +188,44 @@ pub enum PendingSoundCallback {
     },
 }
 
+/// Process-owned state for one active `SndPlayDoubleBuffer` submission.
+///
+/// The guest header and buffer records are shared memory objects. This host
+/// state tracks the Sound Manager's current buffer and callback scheduling;
+/// neither CPU adapter owns a private playback lifecycle. Inside Macintosh:
+/// Sound (1994), pp. 2-115--2-119.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProcessSoundDoubleBufferPlayback {
+    pub channel: u32,
+    pub header: u32,
+    pub buffers: [u32; 2],
+    pub callback: u32,
+    pub callback_architecture: CallbackTaskArchitecture,
+    pub sample_rate_fixed: u32,
+    pub num_channels: u16,
+    pub sample_size: u16,
+    pub compression_id: i16,
+    pub packet_size: u16,
+    pub current_buffer_index: u8,
+    pub callback_pending_mask: u8,
+    pub active: bool,
+    pub host_initialized: bool,
+    pub host_buffer_loaded: bool,
+}
+
+/// A doubleback waiting for its owning CPU adapter to construct the ABI frame.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PendingProcessSoundDoubleBack {
+    pub architecture: CallbackTaskArchitecture,
+    pub channel: u32,
+    pub header: u32,
+    pub exhausted_buffer: u32,
+    pub exhausted_buffer_index: u32,
+    pub callback: u32,
+    pub tick: u32,
+    pub instruction_count: u64,
+}
+
 /// Per-channel state.
 #[derive(Clone, Debug)]
 pub struct SndChannel {
@@ -406,6 +444,10 @@ impl SndChannel {
 #[derive(Clone, Debug)]
 pub struct SoundManager {
     pub channels: Vec<SndChannel>,
+    /// Active double-buffer lifecycles shared by every CPU adapter.
+    pub double_buffer_playbacks: Vec<ProcessSoundDoubleBufferPlayback>,
+    /// Doublebacks waiting at the architecture-neutral callback boundary.
+    pub pending_process_doublebacks: Vec<PendingProcessSoundDoubleBack>,
     /// Pending double-buffer callbacks to fire on the next frame.
     pub pending_callbacks: Vec<PendingDoubleBackCallback>,
     /// Pending sound callback procedures / completion routines.
@@ -454,6 +496,8 @@ impl SoundManager {
     pub fn new() -> Self {
         Self {
             channels: Vec::new(),
+            double_buffer_playbacks: Vec::new(),
+            pending_process_doublebacks: Vec::new(),
             pending_callbacks: Vec::new(),
             pending_sound_callbacks: Vec::new(),
             debug_cmd_count: 0,
@@ -470,6 +514,8 @@ impl SoundManager {
 
     pub(crate) fn is_pristine(&self) -> bool {
         self.channels.is_empty()
+            && self.double_buffer_playbacks.is_empty()
+            && self.pending_process_doublebacks.is_empty()
             && self.pending_callbacks.is_empty()
             && self.pending_sound_callbacks.is_empty()
             && self.debug_cmd_count == 0
@@ -624,9 +670,30 @@ impl SoundManager {
     }
 
     pub(crate) fn quiet_channel(&mut self, guest_ptr: u32) {
+        self.stop_double_buffer_playbacks(guest_ptr);
         if let Some(channel) = self.find_channel_mut(guest_ptr) {
             channel.quiet();
         }
+    }
+
+    pub(crate) fn flush_channel(&mut self, guest_ptr: u32) {
+        self.stop_double_buffer_playbacks(guest_ptr);
+        if let Some(channel) = self.find_channel_mut(guest_ptr) {
+            channel.flush();
+        }
+    }
+
+    pub(crate) fn stop_double_buffer_playbacks(&mut self, guest_ptr: u32) {
+        for playback in self
+            .double_buffer_playbacks
+            .iter_mut()
+            .filter(|playback| playback.channel == guest_ptr)
+        {
+            playback.active = false;
+            playback.host_buffer_loaded = false;
+        }
+        self.pending_process_doublebacks
+            .retain(|pending| pending.channel != guest_ptr);
     }
 
     /// Apply a native immediate command to the canonical process channel.
@@ -634,12 +701,11 @@ impl SoundManager {
     /// place. Sound 1994, pp. 2-93 and 2-128--2-130.
     pub(crate) fn execute_immediate_command(&mut self, guest_ptr: u32, command: SndCommand) {
         self.record_command(command.cmd);
-        let channel = self.ensure_channel_mut(guest_ptr);
         match command.cmd {
-            cmd::QUIET => channel.quiet(),
-            cmd::FLUSH => channel.flush(),
-            cmd::VOLUME => channel.set_volume(command.param2),
-            cmd::RATE => channel.set_rate(command.param2),
+            cmd::QUIET => self.quiet_channel(guest_ptr),
+            cmd::FLUSH => self.flush_channel(guest_ptr),
+            cmd::VOLUME => self.ensure_channel_mut(guest_ptr).set_volume(command.param2),
+            cmd::RATE => self.ensure_channel_mut(guest_ptr).set_rate(command.param2),
             _ => {}
         }
     }
@@ -673,6 +739,7 @@ impl SoundManager {
 
     /// Remove and return a channel by guest pointer.
     pub fn take_channel(&mut self, guest_ptr: u32) -> Option<SndChannel> {
+        self.stop_double_buffer_playbacks(guest_ptr);
         self.channels
             .iter()
             .position(|c| c.guest_ptr == guest_ptr)

--- a/src/trap/sound.rs
+++ b/src/trap/sound.rs
@@ -1445,14 +1445,10 @@ impl super::TrapDispatcher {
         match cmd.cmd {
             sound::cmd::NULL => {}
             sound::cmd::QUIET => {
-                if let Some(chan) = self.sound_manager.find_channel_mut(chan_ptr) {
-                    chan.quiet();
-                }
+                self.sound_manager.quiet_channel(chan_ptr);
             }
             sound::cmd::FLUSH => {
-                if let Some(chan) = self.sound_manager.find_channel_mut(chan_ptr) {
-                    chan.flush();
-                }
+                self.sound_manager.flush_channel(chan_ptr);
             }
             sound::cmd::REST => {
                 // Sound 1994, 2-95: restCmd inserts a rest of `param1`


### PR DESCRIPTION
## Summary

- move native double-buffer playback lifecycle into the process Sound Manager
- keep pending doublebacks in architecture-tagged process state while retaining ABI frame construction in the CPU adapter
- route quiet, flush, and channel disposal through the canonical lifecycle
- preserve detached process snapshots and immediate cross-adapter visibility

## Validation

- `cargo test --locked --lib` (4,771 passed; 3 ignored)
- strict rustdoc with all features and private items
- `cargo test --all-features --all-targets --locked --no-run`
- Toolbox Showcase, classic and PowerPC paths
- Marathon gameplay/terminal and audio assertion
- Escape Velocity gameplay, landing, and flight input
- Tomb Raider Gold live 3D gameplay and movement

Closes #1230