### PR TITLE
refactor(files)!: share open sessions across CPU adapters

### DIFF
--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -89433,6 +89433,62 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn open_file_sessions_cross_cpu_adapters_and_detach_with_clone() {
+        let pef = synthetic_pef_with_import(b"GetEOF");
+        let mut native = load_pef_application(&pef).unwrap();
+        native
+            .files
+            .push(crate::process_context::ProcessOpenFileRecord {
+                ref_num: PPC_FIRST_FILE_REF_NUM,
+                path: "Shared Data".to_string(),
+                position: 4,
+            });
+        native.next_file_ref_num = PPC_FIRST_FILE_REF_NUM + 1;
+
+        let mut context = ProcessContext::default();
+        native.attach_process_context(&mut context);
+        let detached = native.clone();
+        let mut classic = TrapDispatcher::new();
+        classic.attach_process_context(&mut context);
+
+        assert!(classic.open_files.ptr_eq(&native.files));
+        assert_eq!(
+            classic
+                .open_files
+                .get(&(PPC_FIRST_FILE_REF_NUM as u16))
+                .map(String::as_str),
+            Some("Shared Data")
+        );
+
+        classic
+            .file_positions
+            .insert(PPC_FIRST_FILE_REF_NUM as u16, 9);
+        assert_eq!(native.files[0].position, 9);
+
+        native.files[0].position = 12;
+        assert_eq!(
+            classic
+                .file_positions
+                .get(&(PPC_FIRST_FILE_REF_NUM as u16)),
+            Some(&12)
+        );
+
+        let next_refnum = classic.allocate_process_file_refnum();
+        assert_eq!(next_refnum, (PPC_FIRST_FILE_REF_NUM + 1) as u16);
+        assert_eq!(native.next_file_ref_num, PPC_FIRST_FILE_REF_NUM + 2);
+        classic
+            .open_files
+            .insert(next_refnum, "Classic Data".to_string());
+        classic.file_positions.insert(next_refnum, 3);
+        assert_eq!(native.files.last().unwrap().path, "Classic Data");
+        assert_eq!(native.files.last().unwrap().position, 3);
+
+        assert_eq!(detached.files.len(), 1);
+        assert_eq!(detached.files[0].position, 4);
+        assert_eq!(detached.next_file_ref_num, PPC_FIRST_FILE_REF_NUM + 1);
+    }
+
+    #[test]
     fn catalogue_mutations_cross_cpu_adapters_without_runner_sync() {
         let pef = synthetic_pef_with_import(b"GetEOF");
         let mut native = load_pef_application(&pef).unwrap();

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -402,6 +402,152 @@ pub struct ProcessOpenFileRecord {
     pub position: u32,
 }
 
+/// Detached-by-default open-file records for one process File Manager.
+///
+/// Native code uses the record slice directly. The classic adapter installs
+/// map-shaped path and position views over the same allocation so both ABIs
+/// observe one refnum and one file mark during Mixed Mode calls.
+#[derive(Debug)]
+pub(crate) struct SharedProcessOpenFiles(Rc<UnsafeCell<Vec<ProcessOpenFileRecord>>>);
+
+impl Default for SharedProcessOpenFiles {
+    fn default() -> Self {
+        Self(Rc::new(UnsafeCell::new(Vec::new())))
+    }
+}
+
+impl Clone for SharedProcessOpenFiles {
+    fn clone(&self) -> Self {
+        Self::from_records((**self).clone())
+    }
+}
+
+impl std::ops::Deref for SharedProcessOpenFiles {
+    type Target = Vec<ProcessOpenFileRecord>;
+
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: process adapters execute serially and ordinary clones detach.
+        unsafe { &*self.0.get() }
+    }
+}
+
+impl std::ops::DerefMut for SharedProcessOpenFiles {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        // SAFETY: see `Deref`.
+        unsafe { &mut *self.0.get() }
+    }
+}
+
+impl SharedProcessOpenFiles {
+    fn from_records(records: Vec<ProcessOpenFileRecord>) -> Self {
+        Self(Rc::new(UnsafeCell::new(records)))
+    }
+
+    pub(crate) fn shared_handle(&self) -> Self {
+        Self(Rc::clone(&self.0))
+    }
+
+    pub(crate) fn positions(&self) -> SharedProcessOpenFilePositions {
+        SharedProcessOpenFilePositions(Rc::clone(&self.0))
+    }
+
+    pub(crate) fn get(&self, ref_num: &u16) -> Option<&String> {
+        let ref_num = i16::try_from(*ref_num).ok()?;
+        self.iter()
+            .find(|record| record.ref_num == ref_num)
+            .map(|record| &record.path)
+    }
+
+    pub(crate) fn insert(&mut self, ref_num: u16, path: String) -> Option<String> {
+        let Ok(ref_num) = i16::try_from(ref_num) else {
+            return None;
+        };
+        if let Some(record) = self.iter_mut().find(|record| record.ref_num == ref_num) {
+            return Some(std::mem::replace(&mut record.path, path));
+        }
+        self.push(ProcessOpenFileRecord {
+            ref_num,
+            path,
+            position: 0,
+        });
+        None
+    }
+
+    pub(crate) fn remove(&mut self, ref_num: &u16) -> Option<String> {
+        let ref_num = i16::try_from(*ref_num).ok()?;
+        let index = self.iter().position(|record| record.ref_num == ref_num)?;
+        Some(Vec::remove(self, index).path)
+    }
+
+    pub(crate) fn contains_key(&self, ref_num: &u16) -> bool {
+        self.get(ref_num).is_some()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn ptr_eq(&self, other: &Self) -> bool {
+        Rc::ptr_eq(&self.0, &other.0)
+    }
+}
+
+/// Classic File Manager position-map view over process open-file records.
+#[derive(Debug)]
+pub(crate) struct SharedProcessOpenFilePositions(
+    Rc<UnsafeCell<Vec<ProcessOpenFileRecord>>>,
+);
+
+impl SharedProcessOpenFilePositions {
+    pub(crate) fn get(&self, ref_num: &u16) -> Option<&u32> {
+        let ref_num = i16::try_from(*ref_num).ok()?;
+        // SAFETY: this view shares the same serialized process allocation as
+        // `SharedProcessOpenFiles`.
+        unsafe { &*self.0.get() }
+            .iter()
+            .find(|record| record.ref_num == ref_num)
+            .map(|record| &record.position)
+    }
+
+    pub(crate) fn get_mut(&mut self, ref_num: &u16) -> Option<&mut u32> {
+        let ref_num = i16::try_from(*ref_num).ok()?;
+        // SAFETY: see `get`; mutable adapter access is serialized.
+        unsafe { &mut *self.0.get() }
+            .iter_mut()
+            .find(|record| record.ref_num == ref_num)
+            .map(|record| &mut record.position)
+    }
+
+    pub(crate) fn insert(&mut self, ref_num: u16, position: usize) -> Option<usize> {
+        let position = u32::try_from(position).unwrap_or(u32::MAX);
+        if let Some(old) = self.get(&ref_num).copied() {
+            *self
+                .get_mut(&ref_num)
+                .expect("open file disappeared while updating its position") = position;
+            return usize::try_from(old).ok();
+        }
+        let Ok(ref_num) = i16::try_from(ref_num) else {
+            return None;
+        };
+        // Some focused File Manager fixtures seed the mark before the path.
+        // A later path insertion fills this same canonical record.
+        unsafe { &mut *self.0.get() }.push(ProcessOpenFileRecord {
+            ref_num,
+            path: String::new(),
+            position,
+        });
+        None
+    }
+
+    pub(crate) fn remove(&mut self, ref_num: &u16) -> Option<usize> {
+        self.get(ref_num)
+            .copied()
+            .and_then(|position| usize::try_from(position).ok())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn contains_key(&self, ref_num: &u16) -> bool {
+        self.get(ref_num).is_some()
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ProcessStdioStreamRecord {
     pub(crate) ref_num: Option<i16>,
@@ -702,7 +848,7 @@ impl ProcessResourceManagerState {
 /// Macintosh Volume I (1985), pp. I-109--I-110.
 #[derive(Debug, Clone)]
 pub struct ProcessFileSystemState {
-    pub(crate) files: Vec<ProcessOpenFileRecord>,
+    pub(crate) files: SharedProcessOpenFiles,
     pub(crate) stdio_streams: HashMap<u32, ProcessStdioStreamRecord>,
     pub(crate) vfs_volumes: SharedProcessValue<Vec<ProcessVfsVolumeRecord>>,
     pub(crate) vfs_directories: SharedProcessValue<Vec<ProcessVfsDirectory>>,
@@ -727,7 +873,7 @@ pub struct ProcessFileSystemState {
 impl Default for ProcessFileSystemState {
     fn default() -> Self {
         Self {
-            files: Vec::new(),
+            files: SharedProcessOpenFiles::default(),
             stdio_streams: HashMap::new(),
             vfs_volumes: SharedProcessValue::default(),
             vfs_directories: SharedProcessValue::default(),

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -15753,7 +15753,7 @@ mod tests {
             callback_scheduling: Default::default(),
             process_file_system: SharedProcessFileSystem::from_state(
                 ProcessFileSystemState {
-                files: Vec::new(),
+                files: Default::default(),
                 stdio_streams: ppc_initial_stdio_streams(),
                 vfs_volumes: crate::process_context::SharedProcessValue::default(),
                 vfs_directories: crate::process_context::SharedProcessValue::from_value(vec![PpcVfsDirectory {

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -18,10 +18,11 @@ use crate::process_context::{
     ProcessLoadedResources, ProcessResourceFileMap, ProcessResourceManagerState,
     ProcessVfsMetadata, ProcessVfsVolumeRecord, SharedProcessAppleEventHandlers,
     SharedProcessControlManager, SharedProcessCursorState, SharedProcessDialogText,
-    SharedProcessEventQueue,
-    SharedProcessFileSystem, SharedProcessInputState, SharedProcessMemoryManager,
-    SharedProcessListManager, SharedProcessMenuTracking, SharedProcessResourceManager, SharedProcessScrapState,
-    SharedProcessSoundManager, SharedProcessTextEditManager, SharedProcessValue,
+    SharedProcessEventQueue, SharedProcessFileSystem, SharedProcessInputState,
+    SharedProcessListManager, SharedProcessMemoryManager, SharedProcessMenuTracking,
+    SharedProcessOpenFilePositions, SharedProcessOpenFiles, SharedProcessResourceManager,
+    SharedProcessScrapState, SharedProcessSoundManager, SharedProcessTextEditManager,
+    SharedProcessValue,
 };
 use crate::trace::{TraceEvent, TraceSink, TraceSource};
 use crate::ui_theme::{UiTheme, UiThemeId};
@@ -1962,7 +1963,7 @@ pub struct TrapDispatcher {
     /// Open working directories keyed by working directory reference number.
     pub(crate) working_directories: HashMap<i16, WorkingDirectory>,
     /// Open file table: refnum -> filename
-    pub(crate) open_files: HashMap<u16, String>,
+    pub(crate) open_files: SharedProcessOpenFiles,
     /// Synthetic Device Manager drivers opened by name via PBOpen/OpenDriver.
     pub(crate) synthetic_drivers: HashMap<u16, String>,
     /// Guest SndChannel storage used by writes to the ROM Sound Driver
@@ -1972,7 +1973,7 @@ pub struct TrapDispatcher {
     /// Used to enforce opWrErr (-49) per IM:Files 9578.
     pub(crate) write_refnums: std::collections::HashSet<u16>,
     /// File position table: refnum -> current byte offset
-    pub(crate) file_positions: HashMap<u16, usize>,
+    pub(crate) file_positions: SharedProcessOpenFilePositions,
     /// Most recent successful PBRead/FSRead from a data fork.
     pub(crate) recent_file_read: Option<RecentFileRead>,
     /// Completed asynchronous File Manager requests awaiting `ioResult`
@@ -1986,8 +1987,6 @@ pub struct TrapDispatcher {
     /// Public to mirror `vfs`/`vfs_rsrc` so frontends and tests can
     /// inspect or seed lock state directly.
     pub locked_files: SharedProcessValue<std::collections::HashSet<String>>,
-    /// Next available file reference number
-    pub(crate) next_refnum: u16,
     /// Current MMU addressing mode (0=24-bit, 1=32-bit)
     /// Inside Macintosh Volume V, V-593
     pub(crate) mmu_mode: u8,
@@ -2765,6 +2764,8 @@ impl TrapDispatcher {
     /// Attach shared process resources to this dispatcher.
     pub(crate) fn attach_process_context(&mut self, context: &mut ProcessContext) {
         context.attach_file_system(&mut self.process_file_system);
+        self.open_files = self.process_file_system.files.shared_handle();
+        self.file_positions = self.process_file_system.files.positions();
         context.attach_resource_manager(&mut self.process_resource_manager);
         context.attach_sound_manager(&mut self.sound_manager);
         context.attach_callback_tasks(
@@ -3681,10 +3682,14 @@ impl TrapDispatcher {
         );
         vfs_directory_paths.insert(2, String::new());
 
+        let process_file_system = SharedProcessFileSystem::default();
+        let open_files = process_file_system.files.shared_handle();
+        let file_positions = process_file_system.files.positions();
+
         let mut dispatcher = Self {
             adb: crate::adb::AdbManager::new(),
             process_resource_manager: SharedProcessResourceManager::default(),
-            process_file_system: SharedProcessFileSystem::default(),
+            process_file_system,
             vm_held_page_counts: HashMap::new(),
             vm_held_page_history: HashSet::new(),
             vm_locked_page_counts: HashMap::new(),
@@ -3759,15 +3764,14 @@ impl TrapDispatcher {
             vfs_volumes: SharedProcessValue::default(),
             vfs_volume_names: SharedProcessValue::default(),
             working_directories: HashMap::new(),
-            open_files: HashMap::new(),
+            open_files,
             synthetic_drivers: HashMap::new(),
             legacy_sound_driver_channel: None,
             write_refnums: HashSet::new(),
-            file_positions: HashMap::new(),
+            file_positions,
             recent_file_read: None,
             pending_file_completions: VecDeque::new(),
             locked_files: SharedProcessValue::default(),
-            next_refnum: 100,
             mmu_mode: 1,                      // true32b — 32-bit addressing by default
             default_video_rec: 0x0000,        // no default video device selected
             default_os_rec: 0x0001,           // Macintosh Operating System
@@ -6199,6 +6203,30 @@ impl TrapDispatcher {
         }
     }
 
+    /// Allocate the next non-colliding process File Manager reference number.
+    pub(crate) fn allocate_process_file_refnum(&mut self) -> u16 {
+        let mut candidate = self.process_file_system.next_file_ref_num.max(100);
+        loop {
+            let refnum = u16::try_from(candidate).expect("positive File Manager refnum");
+            let resource_refnum_in_use = self
+                .resources
+                .as_ref()
+                .is_some_and(|resources| resources.files.contains_key(&refnum));
+            if !self.open_files.contains_key(&refnum)
+                && !self.synthetic_drivers.contains_key(&refnum)
+                && !resource_refnum_in_use
+            {
+                self.process_file_system.next_file_ref_num = candidate
+                    .checked_add(1)
+                    .expect("File Manager reference numbers exhausted");
+                return refnum;
+            }
+            candidate = candidate
+                .checked_add(1)
+                .expect("File Manager reference numbers exhausted");
+        }
+    }
+
     /// Allocate a new loaded resource-file slot for the given VFS key.
     ///
     /// The caller is responsible for resolving duplicates before calling
@@ -6212,8 +6240,7 @@ impl TrapDispatcher {
         wants_write: bool,
     ) -> u16 {
         let rsrc_data = self.vfs_rsrc.get(vfs_key).unwrap().clone();
-        let refnum = self.next_refnum;
-        self.next_refnum += 1;
+        let refnum = self.allocate_process_file_refnum();
         if let Some(fork) = ResourceFork::parse(&rsrc_data) {
             self.merge_resources_from_fork(&fork, bus, refnum);
         } else {

--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -44178,7 +44178,7 @@ mod tests {
         );
         assert_eq!(
             *d.file_positions.get(&100).unwrap(),
-            pic_size,
+            u32::try_from(pic_size).unwrap(),
             "spooled DrawPicture should ignore a short picSize and advance through EndOfPicture"
         );
     }

--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -3992,8 +3992,7 @@ impl super::TrapDispatcher {
                         cpu.write_reg(Register::D0, (-44i32) as u32);
                         return Some(Ok(()));
                     }
-                    let refnum = self.next_refnum;
-                    self.next_refnum += 1;
+                    let refnum = self.allocate_process_file_refnum();
                     self.open_files.insert(refnum, vfs_name.clone());
                     // Files 1992, 2-8: fsCurPerm (0) grants read/write when
                     // write access is available; fsWrPerm (2), fsRdWrPerm
@@ -4009,8 +4008,7 @@ impl super::TrapDispatcher {
                     cpu.write_reg(Register::D0, 0);
                     eprintln!("[TRAP] PBOpen -> refnum={} vfs=\"{}\"", refnum, vfs_name);
                 } else if Self::is_available_synthetic_driver_name(&filename) {
-                    let refnum = self.next_refnum;
-                    self.next_refnum += 1;
+                    let refnum = self.allocate_process_file_refnum();
                     self.synthetic_drivers.insert(refnum, filename.clone());
                     bus.write_word(pb + 24, refnum);
                     bus.write_word(pb + 16, 0);
@@ -4058,7 +4056,10 @@ impl super::TrapDispatcher {
                 if let Some(filename) = self.open_files.get(&ref_num).cloned() {
                     if let Some(file_buf) = self.vfs.get(&filename) {
                         let file_len = file_buf.len();
-                        let cur_pos = *self.file_positions.get(&ref_num).unwrap_or(&0);
+                        let cur_pos = usize::try_from(
+                            *self.file_positions.get(&ref_num).unwrap_or(&0),
+                        )
+                        .unwrap_or(usize::MAX);
                         match Self::resolve_file_mark_position(
                             pos_mode, pos_offset, cur_pos, file_len,
                         ) {
@@ -4203,7 +4204,10 @@ impl super::TrapDispatcher {
                 let (new_pos, host_sync_bytes) = {
                     let file_buf = self.vfs.entry(filename.clone()).or_default();
                     let file_len = file_buf.len();
-                    let cur_pos = *self.file_positions.get(&ref_num).unwrap_or(&0);
+                    let cur_pos = usize::try_from(
+                        *self.file_positions.get(&ref_num).unwrap_or(&0),
+                    )
+                    .unwrap_or(usize::MAX);
                     let Ok(start) =
                         Self::resolve_file_mark_position(pos_mode, pos_offset, cur_pos, file_len)
                     else {
@@ -4550,7 +4554,10 @@ impl super::TrapDispatcher {
 
                 if let Some(filename) = self.open_files.get(&ref_num).cloned() {
                     let file_len = self.vfs.get(&filename).map(|f| f.len()).unwrap_or(0);
-                    let cur_pos = *self.file_positions.get(&ref_num).unwrap_or(&0);
+                    let cur_pos = usize::try_from(
+                        *self.file_positions.get(&ref_num).unwrap_or(&0),
+                    )
+                    .unwrap_or(usize::MAX);
                     let Ok(requested_pos) =
                         Self::resolve_file_mark_position(pos_mode, pos_offset, cur_pos, file_len)
                     else {
@@ -4631,7 +4638,7 @@ impl super::TrapDispatcher {
                 let pb = cpu.read_reg(Register::A0);
                 let ref_num = bus.read_word(pb + 24);
                 if let Some(pos) = self.file_positions.get(&ref_num).copied() {
-                    bus.write_long(pb + 46, pos as u32); // ioPosOffset
+                    bus.write_long(pb + 46, pos); // ioPosOffset
                     bus.write_word(pb + 44, 0); // ioPosMode
                     bus.write_word(pb + 16, 0);
                     cpu.write_reg(Register::D0, 0);
@@ -5335,9 +5342,9 @@ impl super::TrapDispatcher {
                 let open_refnums: Vec<u16> = self
                     .open_files
                     .iter()
-                    .filter_map(|(refnum, name)| {
-                        if name == &old_key {
-                            Some(*refnum)
+                    .filter_map(|record| {
+                        if record.path == old_key {
+                            u16::try_from(record.ref_num).ok()
                         } else {
                             None
                         }
@@ -5643,9 +5650,9 @@ impl super::TrapDispatcher {
                     let stale_refs: Vec<u16> = self
                         .open_files
                         .iter()
-                        .filter_map(|(refnum, open_name)| {
-                            if open_name == &vfs_name {
-                                Some(*refnum)
+                        .filter_map(|record| {
+                            if record.path == vfs_name {
+                                u16::try_from(record.ref_num).ok()
                             } else {
                                 None
                             }
@@ -5704,8 +5711,8 @@ impl super::TrapDispatcher {
                     let open_refnum = self
                         .open_files
                         .iter()
-                        .find(|(_, path)| path.eq_ignore_ascii_case(&vfs_name))
-                        .map(|(refnum, _)| *refnum)
+                        .find(|record| record.path.eq_ignore_ascii_case(&vfs_name))
+                        .and_then(|record| u16::try_from(record.ref_num).ok())
                         .or_else(|| self.refnum_for_resource_file_name(&vfs_name));
                     if let Some(metadata) = self.vfs_file_metadata(&vfs_name) {
                         self.fill_file_catalog_info(bus, pb, &vfs_name, metadata);
@@ -6028,6 +6035,7 @@ impl super::TrapDispatcher {
                 };
 
                 if let Some(pos) = self.file_positions.get_mut(&ref_num) {
+                    let new_eof = u32::try_from(new_eof).unwrap_or(u32::MAX);
                     if *pos > new_eof {
                         *pos = new_eof;
                     }
@@ -6615,8 +6623,7 @@ impl super::TrapDispatcher {
                                 return Some(Ok(()));
                             }
 
-                            let refnum = self.next_refnum;
-                            self.next_refnum += 1;
+                            let refnum = self.allocate_process_file_refnum();
                             self.open_files.insert(refnum, vfs_name.clone());
                             if wants_write && !read_only {
                                 self.write_refnums.insert(refnum);
@@ -6683,8 +6690,7 @@ impl super::TrapDispatcher {
                         self.vfs
                             .entry(rsrc_key.clone())
                             .or_insert(rsrc_data.into());
-                        let refnum = self.next_refnum;
-                        self.next_refnum += 1;
+                        let refnum = self.allocate_process_file_refnum();
                         self.open_files.insert(refnum, rsrc_key.clone());
                         if wants_write {
                             self.write_refnums.insert(refnum);
@@ -7542,7 +7548,7 @@ impl super::TrapDispatcher {
                             .get(&ref_num)
                             .copied()
                             .unwrap_or(0)
-                            .min(file_len);
+                            .min(u32::try_from(file_len).unwrap_or(u32::MAX));
                         let mut flags = if is_resource_fork { 0x0200 } else { 0 };
                         if self.write_refnums.contains(&ref_num) {
                             flags |= 0x0100;
@@ -7563,7 +7569,7 @@ impl super::TrapDispatcher {
                         bus.write_word(pb + 38, 0); // ioFCBStBlk
                         bus.write_long(pb + 40, file_len as u32); // ioFCBEOF
                         bus.write_long(pb + 44, file_len as u32); // ioFCBPLen
-                        bus.write_long(pb + 48, current_pos as u32); // ioFCBCrPs
+                        bus.write_long(pb + 48, current_pos); // ioFCBCrPs
                         bus.write_word(pb + 52, file_volume_ref as u16); // ioFCBVRefNum
                         bus.write_long(pb + 54, 0); // ioFCBClpSiz
                         bus.write_long(pb + 58, parent_dir_id); // ioFCBParID
@@ -7658,8 +7664,7 @@ impl super::TrapDispatcher {
                     if let Some(vfs_name) =
                         self.find_vfs_file_for_hfs_lookup(vref, dir_id, &filename)
                     {
-                        let refnum = self.next_refnum;
-                        self.next_refnum += 1;
+                        let refnum = self.allocate_process_file_refnum();
                         self.open_files.insert(refnum, vfs_name.clone());
                         self.file_positions.insert(refnum, 0);
                         bus.write_word(pb + 24, refnum); // ioRefNum

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -6675,8 +6675,7 @@ impl super::TrapDispatcher {
                     // Mars Rising's installer pattern: open temp rsrc fork, write 81KB to
                     // it, close, then re-open and expect the 81KB to still be there. If we
                     // re-seed from vfs_rsrc here, the writes are lost.
-                    let refnum = self.next_refnum;
-                    self.next_refnum += 1;
+                    let refnum = self.allocate_process_file_refnum();
                     let rsrc_key = format!("__rsrc__{}", vfs_key);
                     self.vfs
                         .entry(rsrc_key.clone())
@@ -13773,8 +13772,7 @@ impl super::TrapDispatcher {
                             if let Some(existing) = self.refnum_for_resource_file_name(&vfs_key) {
                                 existing
                             } else {
-                                let refnum = self.next_refnum;
-                                self.next_refnum += 1;
+                                let refnum = self.allocate_process_file_refnum();
                                 self.register_empty_resource_file(refnum);
                                 self.set_resource_file_name(refnum, vfs_key.clone());
                                 if wants_write {


### PR DESCRIPTION
## Summary

- make classic File Manager path and position views use the process open-file records already used by native PowerPC
- allocate classic data, resource, and synthetic-driver refnums from the process File Manager counter
- preserve immediate file-mark visibility across Mixed Mode calls while keeping ordinary app clones detached

## Validation

- `cargo test --locked --lib` (4,772 passed; 0 failed; 3 ignored)
- `RUSTDOCFLAGS="-D warnings -D rustdoc::private_intra_doc_links" cargo doc --all-features --locked --no-deps --document-private-items`
- `cargo test --all-features --all-targets --locked --no-run`

Closes #1237