### PR TITLE
refactor(files): share asynchronous completion queue

### DIFF
--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -17,7 +17,7 @@ use crate::sound::SoundManager;
 use crate::text_edit::ProcessTextEditManagerState;
 use ppc::PpcMemory;
 use std::cell::{RefCell, RefMut, UnsafeCell};
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::fmt;
 use std::hash::Hash;
 use std::rc::Rc;
@@ -846,12 +846,23 @@ impl ProcessResourceManagerState {
 /// native and classic adapters converge on the same mutations during nested
 /// Mixed Mode calls. Inside Macintosh: Files (1992), pp. 1-7--1-9; Inside
 /// Macintosh Volume I (1985), pp. I-109--I-110.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct PendingFileCompletion {
+    pub(crate) parameter_block: u32,
+    pub(crate) completion_addr: u32,
+    pub(crate) result: i16,
+}
+
 #[derive(Debug, Clone)]
 pub struct ProcessFileSystemState {
     pub(crate) files: SharedProcessOpenFiles,
     /// Access paths granted write permission, shared by both CPU adapters.
     /// Inside Macintosh: Files (1992), pp. 2-7--2-8.
     pub(crate) writable_refnums: SharedProcessValue<HashSet<u16>>,
+    /// Completed asynchronous requests awaiting `ioResult` publication and
+    /// optional completion-procedure delivery. Inside Macintosh: Files
+    /// (1992), p. 2-238.
+    pub(crate) pending_completions: SharedProcessValue<VecDeque<PendingFileCompletion>>,
     pub(crate) stdio_streams: HashMap<u32, ProcessStdioStreamRecord>,
     pub(crate) vfs_volumes: SharedProcessValue<Vec<ProcessVfsVolumeRecord>>,
     pub(crate) vfs_directories: SharedProcessValue<Vec<ProcessVfsDirectory>>,
@@ -878,6 +889,7 @@ impl Default for ProcessFileSystemState {
         Self {
             files: SharedProcessOpenFiles::default(),
             writable_refnums: SharedProcessValue::default(),
+            pending_completions: SharedProcessValue::default(),
             stdio_streams: HashMap::new(),
             vfs_volumes: SharedProcessValue::default(),
             vfs_directories: SharedProcessValue::default(),
@@ -912,6 +924,10 @@ impl ProcessFileSystemState {
         if !Rc::ptr_eq(&self.writable_refnums.0, &source.writable_refnums.0) {
             self.writable_refnums
                 .extend(std::mem::take(&mut *source.writable_refnums));
+        }
+        if !Rc::ptr_eq(&self.pending_completions.0, &source.pending_completions.0) {
+            self.pending_completions
+                .extend(std::mem::take(&mut *source.pending_completions));
         }
         for (stream, record) in std::mem::take(&mut source.stdio_streams) {
             self.stdio_streams.entry(stream).or_insert(record);
@@ -6174,6 +6190,56 @@ mod tests {
         assert_eq!(detached.vfs_volumes[0].file_count, 1);
         assert_eq!(detached.next_vfs_dir_id, 16);
         assert_eq!(detached.default_dir_id, 2);
+    }
+
+    #[test]
+    fn attached_file_systems_share_completion_fifo_while_clones_detach() {
+        let first_completion = PendingFileCompletion {
+            parameter_block: 0x1000,
+            completion_addr: 0x2000,
+            result: 0,
+        };
+        let second_completion = PendingFileCompletion {
+            parameter_block: 0x3000,
+            completion_addr: 0x4000,
+            result: -39,
+        };
+        let third_completion = PendingFileCompletion {
+            parameter_block: 0x5000,
+            completion_addr: 0x6000,
+            result: -51,
+        };
+
+        let mut process_state = ProcessFileSystemState::default();
+        process_state.pending_completions.push_back(first_completion);
+        let context = ProcessContext::with_file_system(
+            SharedProcessFileSystem::from_state(process_state),
+        );
+
+        let mut adapter_state = ProcessFileSystemState::default();
+        adapter_state
+            .pending_completions
+            .push_back(second_completion);
+        let mut first = SharedProcessFileSystem::from_state(adapter_state);
+        let mut second = SharedProcessFileSystem::default();
+        context.attach_file_system(&mut first);
+        context.attach_file_system(&mut second);
+
+        assert!(first
+            .pending_completions
+            .ptr_eq(&second.pending_completions));
+        second.pending_completions.push_back(third_completion);
+        let mut detached = second.clone();
+
+        assert_eq!(first.pending_completions.pop_front(), Some(first_completion));
+        assert_eq!(first.pending_completions.pop_front(), Some(second_completion));
+        assert_eq!(first.pending_completions.pop_front(), Some(third_completion));
+        assert!(second.pending_completions.is_empty());
+        assert_eq!(
+            detached.pending_completions.pop_front(),
+            Some(first_completion)
+        );
+        assert_eq!(detached.pending_completions.len(), 2);
     }
 
     #[test]

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -10880,15 +10880,16 @@ mod tests {
     use crate::loader::{ApplicationSizeResource, Code0Header, LoadedApp};
     use crate::menu_manager::TrackedMenuPaneView;
     use crate::process_context::{
-        ProcessFileSystemState, SharedProcessFileSystem, SharedProcessValue,
+        PendingFileCompletion, ProcessFileSystemState, SharedProcessFileSystem,
+        SharedProcessValue,
     };
     use crate::sound::{
         DoubleBufferState, PendingDoubleBackCallback, PendingSoundCallback, PlaybackKind,
         SndChannel, SndCommand, OUTPUT_RATE,
     };
     use crate::trap::dispatch::{
-        DialogItem, DialogTrackingState, LoadedResources, PendingFileCompletion,
-        PendingWaitNextEventReturn, QueuedEvent, ResourceFileMap, TimerTask, VblTask,
+        DialogItem, DialogTrackingState, LoadedResources, PendingWaitNextEventReturn,
+        QueuedEvent, ResourceFileMap, TimerTask, VblTask,
     };
     use ppc::{PpcCpu, PpcNativeReturnGpr3};
     use std::cell::RefCell;

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -14,8 +14,9 @@ use crate::managers::resource::ResourceFork;
 use crate::memory::{MacMemoryBus, MemoryBus};
 use crate::menu_manager::{ProcessMenuTrackingState, SharedNativeMenuSelection};
 use crate::process_context::{
-    ProcessClassicVfsDirectory, ProcessContext, ProcessForkMap, ProcessKeyRepeatState,
-    ProcessLoadedResources, ProcessResourceFileMap, ProcessResourceManagerState,
+    PendingFileCompletion, ProcessClassicVfsDirectory, ProcessContext, ProcessForkMap,
+    ProcessKeyRepeatState, ProcessLoadedResources, ProcessResourceFileMap,
+    ProcessResourceManagerState,
     ProcessVfsMetadata, ProcessVfsVolumeRecord, SharedProcessAppleEventHandlers,
     SharedProcessControlManager, SharedProcessCursorState, SharedProcessDialogText,
     SharedProcessEventQueue, SharedProcessFileSystem, SharedProcessInputState,
@@ -109,13 +110,6 @@ pub(crate) struct RecentFileRead {
     pub(crate) buffer: u32,
     pub(crate) start: usize,
     pub(crate) bytes_read: usize,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) struct PendingFileCompletion {
-    pub(crate) parameter_block: u32,
-    pub(crate) completion_addr: u32,
-    pub(crate) result: i16,
 }
 
 // Env-var lookups are cached via OnceLock. Tests/diagnostics that want
@@ -1979,7 +1973,7 @@ pub struct TrapDispatcher {
     pub(crate) recent_file_read: Option<RecentFileRead>,
     /// Completed asynchronous File Manager requests awaiting `ioResult`
     /// publication and optional completion-procedure delivery.
-    pub(crate) pending_file_completions: VecDeque<PendingFileCompletion>,
+    pub(crate) pending_file_completions: SharedProcessValue<VecDeque<PendingFileCompletion>>,
     /// Set of VFS keys whose `ioFlAttrib` lock bit is set.
     /// Maintained by SetFilLock/HSetFLock ($A041/$A241) and
     /// RstFilLock/HRstFLock ($A042/$A242); read by
@@ -2767,6 +2761,10 @@ impl TrapDispatcher {
         context.attach_file_system(&mut self.process_file_system);
         self.open_files = self.process_file_system.files.shared_handle();
         self.write_refnums = self.process_file_system.writable_refnums.shared_handle();
+        self.pending_file_completions = self
+            .process_file_system
+            .pending_completions
+            .shared_handle();
         self.file_positions = self.process_file_system.files.positions();
         context.attach_resource_manager(&mut self.process_resource_manager);
         context.attach_sound_manager(&mut self.sound_manager);
@@ -3687,6 +3685,7 @@ impl TrapDispatcher {
         let process_file_system = SharedProcessFileSystem::default();
         let open_files = process_file_system.files.shared_handle();
         let write_refnums = process_file_system.writable_refnums.shared_handle();
+        let pending_file_completions = process_file_system.pending_completions.shared_handle();
         let file_positions = process_file_system.files.positions();
 
         let mut dispatcher = Self {
@@ -3773,7 +3772,7 @@ impl TrapDispatcher {
             write_refnums,
             file_positions,
             recent_file_read: None,
-            pending_file_completions: VecDeque::new(),
+            pending_file_completions,
             locked_files: SharedProcessValue::default(),
             mmu_mode: 1,                      // true32b — 32-bit addressing by default
             default_video_rec: 0x0000,        // no default video device selected
@@ -11058,6 +11057,28 @@ mod tests {
         assert!(context.event_queue().menu_bar_is_invalid());
         assert_eq!(dispatcher.event_queue.len(), 2);
         assert!(dispatcher.event_queue.menu_bar_is_invalid());
+    }
+
+    #[test]
+    fn attached_dispatchers_share_file_completion_queue_immediately() {
+        let completion = PendingFileCompletion {
+            parameter_block: 0x1000,
+            completion_addr: 0x2000,
+            result: -39,
+        };
+        let mut context = ProcessContext::default();
+        let mut first = TrapDispatcher::new();
+        let mut second = TrapDispatcher::new();
+
+        first.attach_process_context(&mut context);
+        second.attach_process_context(&mut context);
+        assert!(first
+            .pending_file_completions
+            .ptr_eq(&second.pending_file_completions));
+
+        first.pending_file_completions.push_back(completion);
+        assert_eq!(second.pending_file_completions.pop_front(), Some(completion));
+        assert!(first.pending_file_completions.is_empty());
     }
 
     #[test]

--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -4135,7 +4135,7 @@ impl super::TrapDispatcher {
                 if async_call {
                     let result = cpu.read_reg(Register::D0) as i16;
                     self.pending_file_completions.push_back(
-                        super::dispatch::PendingFileCompletion {
+                        crate::process_context::PendingFileCompletion {
                             parameter_block: pb,
                             completion_addr,
                             result,
@@ -15095,7 +15095,7 @@ mod tests {
         assert_eq!(bus.read_bytes(read_buf, 4), vec![10, 20, 30, 40]);
         assert_eq!(
             disp.pending_file_completions.pop_front(),
-            Some(super::super::dispatch::PendingFileCompletion {
+            Some(crate::process_context::PendingFileCompletion {
                 parameter_block: pb,
                 completion_addr,
                 result: 0,


### PR DESCRIPTION
## Summary
- move completed asynchronous File Manager requests into process-owned File Manager state
- attach classic dispatchers to one immediately shared FIFO while preserving pre-attachment ordering
- keep ordinary process clones detached and independent

## Validation
- `cargo test --locked --lib` (4,774 passed; 0 failed; 3 ignored)
- `RUSTDOCFLAGS="-D warnings -D rustdoc::private_intra_doc_links" cargo doc --all-features --locked --no-deps --document-private-items`
- `cargo test --all-features --all-targets --locked --no-run`
- Marathon terminal completion and resumed gameplay
- Escape Velocity pilot, landing, return-to-space, and live input
- Tomb Raider Gold live 3D gameplay and forward movement

Closes #1241