### PR TITLE
refactor(files): share working-directory state across CPU adapters

### DIFF
--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -75,7 +75,7 @@ use crate::process_context::{
     ProcessHandleRecord, ProcessHandleStateRecord, ProcessInputState, ProcessMemoryManager,
     ProcessNativeAllocatorState, ProcessNativeHeapState, ProcessNativeMemoryManager,
     ProcessPtrRecord, ProcessResourceManagerState, ProcessVfsFileRecords,
-    ProcessVfsResourceFileRecords, SharedProcessAppleEventHandlers,
+    ProcessVfsResourceFileRecords, ProcessWorkingDirectory, SharedProcessAppleEventHandlers,
     SharedProcessCallbackScheduling, SharedProcessCursorState, SharedProcessDialogText,
     SharedProcessControlManager, SharedProcessEventQueue,
     SharedProcessFileSystem, SharedProcessInputState, SharedProcessMemoryManager,
@@ -7288,6 +7288,13 @@ impl PpcLoadedApp {
         let mut vfs_directories = self.vfs_directories.shared_handle();
         let mut next_vfs_dir_id = self.next_vfs_dir_id.shared_handle();
         let mut default_dir_id = self.default_dir_id.shared_handle();
+        let mut working_directories = self.working_directories.shared_handle();
+        let mut next_working_directory_ref_num = self
+            .next_working_directory_ref_num
+            .shared_handle();
+        let mut application_working_directory_ref_num = self
+            .application_working_directory_ref_num
+            .shared_handle();
         let mut param_text = std::mem::take(&mut self.param_text);
         let mut scrap = std::mem::take(&mut self.scrap);
         let mut list_manager = std::mem::take(&mut self.list_manager);
@@ -7831,6 +7838,9 @@ impl PpcLoadedApp {
                         &mut vfs_directories,
                         &mut next_vfs_dir_id,
                         *default_dir_id,
+                        &mut working_directories,
+                        &mut next_working_directory_ref_num,
+                        &mut application_working_directory_ref_num,
                         self.launched_app_path.as_deref(),
                         &mut param_text,
                         &mut scrap,
@@ -14817,7 +14827,7 @@ fn dispatcher_target_for_import(
             "InterfaceLib",
             "OpenDF" | "OpenRF" | "PBCatSearchSync" | "PBDirCreateSync" | "PBGetFPosSync"
             | "PBGetWDInfoSync" | "PBHGetVolParmsSync" | "PBHGetVolSync" | "PBHOpenRFSync"
-            | "PBHSetVolSync" | "PBOpenWDSync" | "create" | "fsopen",
+            | "PBHSetVolSync" | "PBCloseWDSync" | "PBOpenWDSync" | "create" | "fsopen",
         ) => PpcImportDispatcherTarget::FileCompatibility,
         (
             "InterfaceLib",
@@ -15072,6 +15082,9 @@ fn dispatch_supported_import(
     vfs_directories: &mut Vec<PpcVfsDirectory>,
     next_vfs_dir_id: &mut u32,
     default_dir_id: u32,
+    working_directories: &mut HashMap<i16, ProcessWorkingDirectory>,
+    next_working_directory_ref_num: &mut i16,
+    application_working_directory_ref_num: &mut i16,
     launched_app_path: Option<&str>,
     param_text: &mut [Vec<u8>; 4],
     scrap: &mut PpcScrapState,
@@ -23147,16 +23160,46 @@ fn dispatch_supported_import(
         // FUNCTION GetVol (volName: StringPtr; VAR vRefNum: Integer): OSErr;
         // Inside Macintosh: Files (1992), 2-134 (lines 7672-7695).
         PpcImportDispatcherTarget::GetVol => Some(PpcImportAction::Return(ppc_i16_result(
-            ppc_get_vol(cpu, memory),
+            ppc_get_vol(
+                cpu,
+                memory,
+                default_dir_id,
+                *application_working_directory_ref_num,
+                working_directories,
+                vfs_volumes,
+            ),
         ))),
         PpcImportDispatcherTarget::GetWDInfo => Some(PpcImportAction::Return(ppc_i16_result(
-            ppc_get_wd_info(cpu, memory, default_dir_id),
+            ppc_get_wd_info(
+                cpu,
+                memory,
+                default_dir_id,
+                *application_working_directory_ref_num,
+                working_directories,
+                vfs_volumes,
+            ),
         ))),
         PpcImportDispatcherTarget::HGetVol => Some(PpcImportAction::Return(ppc_i16_result(
-            ppc_hget_vol(cpu, memory, default_dir_id),
+            ppc_hget_vol(
+                cpu,
+                memory,
+                default_dir_id,
+                *application_working_directory_ref_num,
+                working_directories,
+                vfs_volumes,
+            ),
         ))),
         PpcImportDispatcherTarget::HSetVol => Some(PpcImportAction::Return(ppc_i16_result(
-            ppc_hset_vol(cpu, memory, vfs_directories, default_dir_id),
+            ppc_hset_vol(
+                cpu,
+                memory,
+                vfs_directories,
+                vfs_volumes,
+                default_dir_id,
+                working_directories,
+                next_working_directory_ref_num,
+                application_working_directory_ref_num,
+            ),
         ))),
         PpcImportDispatcherTarget::FlushVol => Some(PpcImportAction::Return(ppc_i16_result(
             ppc_flush_vol(cpu, memory),
@@ -25891,7 +25934,12 @@ fn dispatch_supported_import(
             cpu,
             memory,
             files,
+            vfs_directories,
+            vfs_volumes,
             default_dir_id,
+            working_directories,
+            next_working_directory_ref_num,
+            application_working_directory_ref_num,
         )),
         PpcImportDispatcherTarget::AppleTalkCompatibility => {
             Some(ppc_dispatch_appletalk_compatibility(binding, cpu, memory))
@@ -27588,7 +27636,12 @@ fn ppc_dispatch_file_compatibility(
     cpu: &mut PpcCpu,
     memory: &mut PpcSectionMem,
     files: &mut Vec<PpcFileRecord>,
+    vfs_directories: &[PpcVfsDirectory],
+    vfs_volumes: &[PpcVfsVolumeRecord],
     default_dir_id: u32,
+    working_directories: &mut HashMap<i16, ProcessWorkingDirectory>,
+    next_working_directory_ref_num: &mut i16,
+    application_working_directory_ref_num: &mut i16,
 ) -> PpcImportAction {
     match binding.symbol_name.as_str() {
         "PBGetFPosSync" => {
@@ -27607,20 +27660,260 @@ fn ppc_dispatch_file_compatibility(
         }
         "PBHGetVolSync" => {
             let pb = cpu.gpr[3];
+            let working_directory = ppc_working_directory_info(
+                0,
+                *application_working_directory_ref_num,
+                default_dir_id,
+                working_directories,
+                vfs_volumes,
+            )
+            .unwrap_or(ProcessWorkingDirectory {
+                ref_num: PPC_BOOT_VOLUME_REF_NUM,
+                volume_ref_num: PPC_BOOT_VOLUME_REF_NUM,
+                dir_id: default_dir_id,
+                proc_id: 0,
+            });
             if let Some(name) = memory.read_u32_be(pb + 18).filter(|name| *name != 0) {
                 let _ = ppc_write_pstring_bytes(
                     memory,
                     name,
-                    TrapDispatcher::boot_volume_name().as_bytes(),
+                    ppc_volume_name_for_ref_num(
+                        working_directory.volume_ref_num,
+                        vfs_volumes,
+                    ),
                 );
             }
-            let _ = memory.write_u16_be(pb + 22, PPC_BOOT_VOLUME_REF_NUM as u16);
-            let _ = memory.write_u32_be(pb + 28, 0);
-            let _ = memory.write_u16_be(pb + 32, PPC_BOOT_VOLUME_REF_NUM as u16);
-            let _ = memory.write_u32_be(pb + 48, default_dir_id);
+            let _ = memory.write_u16_be(pb + 22, working_directory.ref_num as u16);
+            let _ = memory.write_u32_be(pb + 28, working_directory.proc_id);
+            let _ = memory.write_u16_be(pb + 32, working_directory.volume_ref_num as u16);
+            let _ = memory.write_u32_be(pb + 48, working_directory.dir_id);
             PpcImportAction::Return(ppc_i16_result(ppc_complete_pb(memory, pb, PPC_NO_ERR)))
         }
-        "PBHSetVolSync" | "PBHGetVolParmsSync" | "PBOpenWDSync" | "PBGetWDInfoSync" => {
+        "PBOpenWDSync" => {
+            let pb = cpu.gpr[3];
+            let requested_vref = memory.read_u16_be(pb + 22).unwrap_or(0) as i16;
+            let requested_dir_id = memory.read_u32_be(pb + 48).unwrap_or(0);
+            let proc_id = memory.read_u32_be(pb + 28).unwrap_or(0);
+            let volume_ref_num = working_directories
+                .get(&requested_vref)
+                .map(|record| record.volume_ref_num)
+                .or_else(|| {
+                    (requested_vref == PPC_BOOT_VOLUME_REF_NUM
+                        || vfs_volumes
+                            .iter()
+                            .any(|volume| volume.ref_num == requested_vref))
+                    .then_some(requested_vref)
+                })
+                .unwrap_or(PPC_BOOT_VOLUME_REF_NUM);
+            let effective_dir_id = if requested_dir_id <= 1 {
+                working_directories
+                    .get(&requested_vref)
+                    .map(|record| record.dir_id)
+                    .unwrap_or_else(|| {
+                        ppc_resolve_directory_id(
+                            requested_vref,
+                            requested_dir_id,
+                            default_dir_id,
+                        )
+                    })
+            } else {
+                requested_dir_id
+            };
+            let result = if ppc_directory_path_for_id(vfs_directories, effective_dir_id).is_none() {
+                PPC_FNF_ERR
+            } else {
+                let root_dir_id = if volume_ref_num == PPC_BOOT_VOLUME_REF_NUM {
+                    PPC_ROOT_DIR_ID
+                } else {
+                    vfs_volumes
+                        .iter()
+                        .find(|volume| volume.ref_num == volume_ref_num)
+                        .map(|volume| volume.root_dir_id)
+                        .unwrap_or(PPC_ROOT_DIR_ID)
+                };
+                let wd_ref_num = if effective_dir_id == root_dir_id {
+                    volume_ref_num
+                } else if let Some(existing) = working_directories.values().find(|record| {
+                    record.volume_ref_num == volume_ref_num
+                        && record.dir_id == effective_dir_id
+                        && record.proc_id == proc_id
+                }) {
+                    existing.ref_num
+                } else {
+                    let mut ref_num = *next_working_directory_ref_num;
+                    while working_directories.contains_key(&ref_num) {
+                        ref_num = ref_num.saturating_add(1);
+                    }
+                    *next_working_directory_ref_num = ref_num.saturating_add(1);
+                    working_directories.insert(
+                        ref_num,
+                        ProcessWorkingDirectory {
+                            ref_num,
+                            volume_ref_num,
+                            dir_id: effective_dir_id,
+                            proc_id,
+                        },
+                    );
+                    ref_num
+                };
+                let _ = memory.write_u16_be(pb + 22, wd_ref_num as u16);
+                let _ = memory.write_u16_be(pb + 32, volume_ref_num as u16);
+                let _ = memory.write_u32_be(pb + 48, effective_dir_id);
+                PPC_NO_ERR
+            };
+            PpcImportAction::Return(ppc_i16_result(ppc_complete_pb(memory, pb, result)))
+        }
+        "PBGetWDInfoSync" => {
+            let pb = cpu.gpr[3];
+            let input_vref = memory.read_u16_be(pb + 22).unwrap_or(0) as i16;
+            let wd_index = memory.read_u16_be(pb + 26).unwrap_or(0) as i16;
+            let info = if wd_index > 0 {
+                let target_volume = (input_vref != 0).then(|| {
+                    working_directories
+                        .get(&input_vref)
+                        .map(|record| record.volume_ref_num)
+                        .unwrap_or(input_vref)
+                });
+                let mut records = working_directories
+                    .values()
+                    .copied()
+                    .filter(|record| {
+                        target_volume.is_none_or(|volume| record.volume_ref_num == volume)
+                    })
+                    .collect::<Vec<_>>();
+                records.sort_by_key(|record| record.ref_num);
+                records.get(wd_index as usize - 1).copied()
+            } else {
+                ppc_working_directory_info(
+                    input_vref,
+                    *application_working_directory_ref_num,
+                    default_dir_id,
+                    working_directories,
+                    vfs_volumes,
+                )
+            };
+            let result = if let Some(record) = info {
+                let returned_ref_num = if wd_index > 0 {
+                    record.volume_ref_num
+                } else {
+                    record.ref_num
+                };
+                let _ = memory.write_u16_be(pb + 22, returned_ref_num as u16);
+                let _ = memory.write_u32_be(pb + 28, record.proc_id);
+                let _ = memory.write_u16_be(pb + 32, record.volume_ref_num as u16);
+                let _ = memory.write_u32_be(pb + 48, record.dir_id);
+                PPC_NO_ERR
+            } else {
+                PPC_RF_NUM_ERR
+            };
+            PpcImportAction::Return(ppc_i16_result(ppc_complete_pb(memory, pb, result)))
+        }
+        "PBCloseWDSync" => {
+            let pb = cpu.gpr[3];
+            let wd_ref_num = memory.read_u16_be(pb + 22).unwrap_or(0) as i16;
+            let is_volume_ref_num = wd_ref_num == PPC_BOOT_VOLUME_REF_NUM
+                || vfs_volumes
+                    .iter()
+                    .any(|volume| volume.ref_num == wd_ref_num);
+            let closed = working_directories.remove(&wd_ref_num);
+            let result = if is_volume_ref_num || closed.is_some() {
+                if *application_working_directory_ref_num == wd_ref_num {
+                    *application_working_directory_ref_num = closed
+                        .map(|record| record.volume_ref_num)
+                        .unwrap_or(wd_ref_num);
+                }
+                PPC_NO_ERR
+            } else {
+                PPC_RF_NUM_ERR
+            };
+            PpcImportAction::Return(ppc_i16_result(ppc_complete_pb(memory, pb, result)))
+        }
+        "PBHSetVolSync" => {
+            let pb = cpu.gpr[3];
+            let requested_vref = memory.read_u16_be(pb + 22).unwrap_or(0) as i16;
+            let requested_dir_id = memory.read_u32_be(pb + 48).unwrap_or(0);
+            let volume_ref_num = if requested_vref == 0 {
+                ppc_working_directory_info(
+                    0,
+                    *application_working_directory_ref_num,
+                    default_dir_id,
+                    working_directories,
+                    vfs_volumes,
+                )
+                .map(|record| record.volume_ref_num)
+                .unwrap_or(PPC_BOOT_VOLUME_REF_NUM)
+            } else if let Some(record) = working_directories.get(&requested_vref) {
+                record.volume_ref_num
+            } else if requested_vref == PPC_BOOT_VOLUME_REF_NUM
+                || vfs_volumes
+                    .iter()
+                    .any(|volume| volume.ref_num == requested_vref)
+            {
+                requested_vref
+            } else {
+                let result = ppc_complete_pb(memory, pb, PPC_NSV_ERR);
+                return PpcImportAction::Return(ppc_i16_result(result));
+            };
+            let effective_dir_id = if requested_dir_id <= 1 {
+                working_directories
+                    .get(&requested_vref)
+                    .map(|record| record.dir_id)
+                    .unwrap_or_else(|| {
+                        ppc_resolve_directory_id(
+                            requested_vref,
+                            requested_dir_id,
+                            default_dir_id,
+                        )
+                    })
+            } else {
+                requested_dir_id
+            };
+            let result = if ppc_directory_path_for_id(vfs_directories, effective_dir_id).is_none() {
+                PPC_FNF_ERR
+            } else {
+                let root_dir_id = if volume_ref_num == PPC_BOOT_VOLUME_REF_NUM {
+                    PPC_ROOT_DIR_ID
+                } else {
+                    vfs_volumes
+                        .iter()
+                        .find(|volume| volume.ref_num == volume_ref_num)
+                        .map(|volume| volume.root_dir_id)
+                        .unwrap_or(PPC_ROOT_DIR_ID)
+                };
+                *application_working_directory_ref_num = if effective_dir_id == root_dir_id {
+                    volume_ref_num
+                } else if let Some(existing) = working_directories.values().find(|record| {
+                    record.volume_ref_num == volume_ref_num
+                        && record.dir_id == effective_dir_id
+                        && record.proc_id == 0
+                }) {
+                    existing.ref_num
+                } else {
+                    let mut ref_num = *next_working_directory_ref_num;
+                    while working_directories.contains_key(&ref_num) {
+                        ref_num = ref_num.saturating_add(1);
+                    }
+                    *next_working_directory_ref_num = ref_num.saturating_add(1);
+                    working_directories.insert(
+                        ref_num,
+                        ProcessWorkingDirectory {
+                            ref_num,
+                            volume_ref_num,
+                            dir_id: effective_dir_id,
+                            proc_id: 0,
+                        },
+                    );
+                    ref_num
+                };
+                let _ = memory.write_u32_be(
+                    crate::memory::globals::addr::CUR_DIR_STORE,
+                    effective_dir_id,
+                );
+                PPC_NO_ERR
+            };
+            PpcImportAction::Return(ppc_i16_result(ppc_complete_pb(memory, pb, result)))
+        }
+        "PBHGetVolParmsSync" => {
             PpcImportAction::Return(ppc_i16_result(ppc_complete_pb(
                 memory, cpu.gpr[3], PPC_NO_ERR,
             )))
@@ -75618,11 +75911,85 @@ fn ppc_sys_environs(memory: &mut PpcSectionMem, rec_ptr: u32) -> i16 {
     PPC_NO_ERR
 }
 
-fn ppc_hget_vol(cpu: &mut PpcCpu, memory: &mut PpcSectionMem, default_dir_id: u32) -> i16 {
+fn ppc_working_directory_info(
+    wd_ref_num: i16,
+    application_wd_ref_num: i16,
+    default_dir_id: u32,
+    working_directories: &HashMap<i16, ProcessWorkingDirectory>,
+    vfs_volumes: &[PpcVfsVolumeRecord],
+) -> Option<ProcessWorkingDirectory> {
+    let effective_ref_num = if wd_ref_num == 0 {
+        application_wd_ref_num
+    } else {
+        wd_ref_num
+    };
+    if let Some(record) = working_directories.get(&effective_ref_num) {
+        return Some(*record);
+    }
+    if effective_ref_num == PPC_BOOT_VOLUME_REF_NUM {
+        return Some(ProcessWorkingDirectory {
+            ref_num: effective_ref_num,
+            volume_ref_num: PPC_BOOT_VOLUME_REF_NUM,
+            dir_id: if effective_ref_num == application_wd_ref_num {
+                default_dir_id
+            } else {
+                PPC_ROOT_DIR_ID
+            },
+            proc_id: 0,
+        });
+    }
+    vfs_volumes
+        .iter()
+        .find(|volume| volume.ref_num == effective_ref_num)
+        .map(|volume| ProcessWorkingDirectory {
+            ref_num: effective_ref_num,
+            volume_ref_num: volume.ref_num,
+            dir_id: if effective_ref_num == application_wd_ref_num {
+                default_dir_id
+            } else {
+                volume.root_dir_id
+            },
+            proc_id: 0,
+        })
+}
+
+fn ppc_volume_name_for_ref_num<'a>(
+    volume_ref_num: i16,
+    vfs_volumes: &'a [PpcVfsVolumeRecord],
+) -> &'a [u8] {
+    if volume_ref_num == PPC_BOOT_VOLUME_REF_NUM {
+        crate::trap::TrapDispatcher::boot_volume_name().as_bytes()
+    } else {
+        vfs_volumes
+            .iter()
+            .find(|volume| volume.ref_num == volume_ref_num)
+            .map(|volume| volume.name.as_bytes())
+            .unwrap_or_else(|| crate::trap::TrapDispatcher::boot_volume_name().as_bytes())
+    }
+}
+
+fn ppc_hget_vol(
+    cpu: &mut PpcCpu,
+    memory: &mut PpcSectionMem,
+    default_dir_id: u32,
+    application_wd_ref_num: i16,
+    working_directories: &HashMap<i16, ProcessWorkingDirectory>,
+    vfs_volumes: &[PpcVfsVolumeRecord],
+) -> i16 {
     let name_ptr = cpu.gpr[3];
     let vref_ptr = cpu.gpr[4];
     let dir_id_ptr = cpu.gpr[5];
-    let volume_name = crate::trap::TrapDispatcher::boot_volume_name().as_bytes();
+    let Some(working_directory) = ppc_working_directory_info(
+        0,
+        application_wd_ref_num,
+        default_dir_id,
+        working_directories,
+        vfs_volumes,
+    ) else {
+        return PPC_RF_NUM_ERR;
+    };
+    let volume_name =
+        ppc_volume_name_for_ref_num(working_directory.volume_ref_num, vfs_volumes);
     if !ppc_optional_pstring_output_can_write(memory, name_ptr, volume_name)
         || !ppc_optional_output_can_write(memory, vref_ptr, 2)
         || !ppc_optional_output_can_write(memory, dir_id_ptr, 4)
@@ -75633,10 +76000,10 @@ fn ppc_hget_vol(cpu: &mut PpcCpu, memory: &mut PpcSectionMem, default_dir_id: u3
         let _ = ppc_write_pstring_bytes(memory, name_ptr, volume_name);
     }
     if vref_ptr != 0 {
-        let _ = memory.write_u16_be(vref_ptr, PPC_BOOT_VOLUME_REF_NUM as u16);
+        let _ = memory.write_u16_be(vref_ptr, working_directory.ref_num as u16);
     }
     if dir_id_ptr != 0 {
-        let _ = memory.write_u32_be(dir_id_ptr, default_dir_id);
+        let _ = memory.write_u32_be(dir_id_ptr, working_directory.dir_id);
     }
     PPC_NO_ERR
 }
@@ -75645,7 +76012,11 @@ fn ppc_hset_vol(
     cpu: &PpcCpu,
     memory: &mut PpcSectionMem,
     vfs_directories: &[PpcVfsDirectory],
+    vfs_volumes: &[PpcVfsVolumeRecord],
     default_dir_id: u32,
+    working_directories: &mut HashMap<i16, ProcessWorkingDirectory>,
+    next_working_directory_ref_num: &mut i16,
+    application_working_directory_ref_num: &mut i16,
 ) -> i16 {
     // Inside Macintosh: Files (1992), pp. 2-136--2-137. HSetVol accepts an
     // optional Pascal pathname plus a volume or working-directory reference
@@ -75653,9 +76024,27 @@ fn ppc_hset_vol(
     let name_ptr = cpu.gpr[3];
     let requested_vref = cpu.gpr[4] as u16 as i16;
     let requested_dir_id = cpu.gpr[5];
-    if requested_vref != 0 && requested_vref != PPC_BOOT_VOLUME_REF_NUM {
+    let volume_ref_num = if requested_vref == 0 {
+        ppc_working_directory_info(
+            0,
+            *application_working_directory_ref_num,
+            default_dir_id,
+            working_directories,
+            vfs_volumes,
+        )
+        .map(|record| record.volume_ref_num)
+        .unwrap_or(PPC_BOOT_VOLUME_REF_NUM)
+    } else if let Some(record) = working_directories.get(&requested_vref) {
+        record.volume_ref_num
+    } else if requested_vref == PPC_BOOT_VOLUME_REF_NUM
+        || vfs_volumes
+            .iter()
+            .any(|volume| volume.ref_num == requested_vref)
+    {
+        requested_vref
+    } else {
         return PPC_NSV_ERR;
-    }
+    };
     let name = if name_ptr == 0 {
         String::new()
     } else {
@@ -75665,7 +76054,16 @@ fn ppc_hset_vol(
         decode_mac_roman(&bytes)
     };
 
-    let base_dir_id = ppc_resolve_directory_id(requested_vref, requested_dir_id, default_dir_id);
+    let base_dir_id = if requested_dir_id <= 1 {
+        working_directories
+            .get(&requested_vref)
+            .map(|record| record.dir_id)
+            .unwrap_or_else(|| {
+                ppc_resolve_directory_id(requested_vref, requested_dir_id, default_dir_id)
+            })
+    } else {
+        requested_dir_id
+    };
     let target_dir_id = if name.is_empty() {
         base_dir_id
     } else {
@@ -75690,14 +76088,65 @@ fn ppc_hset_vol(
     if ppc_directory_path_for_id(vfs_directories, target_dir_id).is_none() {
         return PPC_FNF_ERR;
     }
+    let root_dir_id = if volume_ref_num == PPC_BOOT_VOLUME_REF_NUM {
+        PPC_ROOT_DIR_ID
+    } else {
+        vfs_volumes
+            .iter()
+            .find(|volume| volume.ref_num == volume_ref_num)
+            .map(|volume| volume.root_dir_id)
+            .unwrap_or(PPC_ROOT_DIR_ID)
+    };
+    *application_working_directory_ref_num = if target_dir_id == root_dir_id {
+        volume_ref_num
+    } else if let Some(existing) = working_directories.values().find(|record| {
+        record.volume_ref_num == volume_ref_num
+            && record.dir_id == target_dir_id
+            && record.proc_id == 0
+    }) {
+        existing.ref_num
+    } else {
+        let mut ref_num = *next_working_directory_ref_num;
+        while working_directories.contains_key(&ref_num) {
+            ref_num = ref_num.saturating_add(1);
+        }
+        *next_working_directory_ref_num = ref_num.saturating_add(1);
+        working_directories.insert(
+            ref_num,
+            ProcessWorkingDirectory {
+                ref_num,
+                volume_ref_num,
+                dir_id: target_dir_id,
+                proc_id: 0,
+            },
+        );
+        ref_num
+    };
     let _ = memory.write_u32_be(crate::memory::globals::addr::CUR_DIR_STORE, target_dir_id);
     PPC_NO_ERR
 }
 
-fn ppc_get_vol(cpu: &mut PpcCpu, memory: &mut PpcSectionMem) -> i16 {
+fn ppc_get_vol(
+    cpu: &mut PpcCpu,
+    memory: &mut PpcSectionMem,
+    default_dir_id: u32,
+    application_wd_ref_num: i16,
+    working_directories: &HashMap<i16, ProcessWorkingDirectory>,
+    vfs_volumes: &[PpcVfsVolumeRecord],
+) -> i16 {
     let name_ptr = cpu.gpr[3];
     let vref_ptr = cpu.gpr[4];
-    let volume_name = crate::trap::TrapDispatcher::boot_volume_name().as_bytes();
+    let Some(working_directory) = ppc_working_directory_info(
+        0,
+        application_wd_ref_num,
+        default_dir_id,
+        working_directories,
+        vfs_volumes,
+    ) else {
+        return PPC_RF_NUM_ERR;
+    };
+    let volume_name =
+        ppc_volume_name_for_ref_num(working_directory.volume_ref_num, vfs_volumes);
     if !ppc_optional_pstring_output_can_write(memory, name_ptr, volume_name)
         || !ppc_optional_output_can_write(memory, vref_ptr, 2)
     {
@@ -75707,12 +76156,19 @@ fn ppc_get_vol(cpu: &mut PpcCpu, memory: &mut PpcSectionMem) -> i16 {
         let _ = ppc_write_pstring_bytes(memory, name_ptr, volume_name);
     }
     if vref_ptr != 0 {
-        let _ = memory.write_u16_be(vref_ptr, PPC_BOOT_VOLUME_REF_NUM as u16);
+        let _ = memory.write_u16_be(vref_ptr, working_directory.ref_num as u16);
     }
     PPC_NO_ERR
 }
 
-fn ppc_get_wd_info(cpu: &mut PpcCpu, memory: &mut PpcSectionMem, default_dir_id: u32) -> i16 {
+fn ppc_get_wd_info(
+    cpu: &mut PpcCpu,
+    memory: &mut PpcSectionMem,
+    default_dir_id: u32,
+    application_wd_ref_num: i16,
+    working_directories: &HashMap<i16, ProcessWorkingDirectory>,
+    vfs_volumes: &[PpcVfsVolumeRecord],
+) -> i16 {
     let wd_ref_num = cpu.gpr[3] as u16 as i16;
     let vref_ptr = cpu.gpr[4];
     let dir_id_ptr = cpu.gpr[5];
@@ -75723,16 +76179,20 @@ fn ppc_get_wd_info(cpu: &mut PpcCpu, memory: &mut PpcSectionMem, default_dir_id:
     {
         return PPC_PARAM_ERR;
     }
-    // Inside Macintosh: Files 1992, 2-182: GetWDInfo converts a working
-    // directory reference into its volume reference number, directory ID,
-    // and user identifier. The PPC VFS exposes its current directory through
-    // the boot-volume reference returned by GetVol.
-    if !matches!(wd_ref_num, 0 | PPC_BOOT_VOLUME_REF_NUM) {
+    // Inside Macintosh: Files 1992, 2-182: GetWDInfo converts a process
+    // working-directory reference into its volume, directory, and user ID.
+    let Some(working_directory) = ppc_working_directory_info(
+        wd_ref_num,
+        application_wd_ref_num,
+        default_dir_id,
+        working_directories,
+        vfs_volumes,
+    ) else {
         return PPC_RF_NUM_ERR;
-    }
-    let _ = memory.write_u16_be(vref_ptr, PPC_BOOT_VOLUME_REF_NUM as u16);
-    let _ = memory.write_u32_be(dir_id_ptr, default_dir_id);
-    let _ = memory.write_u32_be(proc_id_ptr, 0);
+    };
+    let _ = memory.write_u16_be(vref_ptr, working_directory.volume_ref_num as u16);
+    let _ = memory.write_u32_be(dir_id_ptr, working_directory.dir_id);
+    let _ = memory.write_u32_be(proc_id_ptr, working_directory.proc_id);
     PPC_NO_ERR
 }
 
@@ -89607,6 +90067,10 @@ pub(crate) mod tests {
         let executing_volumes = native.vfs_volumes.shared_handle();
         let executing_next_dir_id = native.next_vfs_dir_id.shared_handle();
         let executing_default_dir_id = native.default_dir_id.shared_handle();
+        let executing_working_directories = native.working_directories.shared_handle();
+        let executing_application_wd_ref_num = native
+            .application_working_directory_ref_num
+            .shared_handle();
         let detached = native.clone();
         let mut classic = TrapDispatcher::new();
         classic.attach_process_context(&mut context);
@@ -89689,6 +90153,39 @@ pub(crate) mod tests {
             0x0100,
         );
         classic.set_launched_app_path("Classic Folder/Classic Data");
+        let classic_wd_ref_num = *classic.app_wd_refnum;
+        assert!(classic
+            .working_directories
+            .ptr_eq(&native.working_directories));
+        assert!(classic
+            .app_wd_refnum
+            .ptr_eq(&native.application_working_directory_ref_num));
+        assert_eq!(*executing_application_wd_ref_num, classic_wd_ref_num);
+        assert_eq!(
+            executing_working_directories[&classic_wd_ref_num].dir_id,
+            classic_dir_id
+        );
+
+        let wd_vref_ptr = PPC_DATA_BASE + 0x2800;
+        let wd_dir_id_ptr = wd_vref_ptr + 4;
+        let wd_proc_id_ptr = wd_vref_ptr + 8;
+        native.memory.add_region(wd_vref_ptr, vec![0; 12]);
+        native.cpu.gpr[3] = classic_wd_ref_num as u16 as u32;
+        native.cpu.gpr[4] = wd_vref_ptr;
+        native.cpu.gpr[5] = wd_dir_id_ptr;
+        native.cpu.gpr[6] = wd_proc_id_ptr;
+        native
+            .memory
+            .write_u32_be(crate::memory::globals::addr::CUR_DIR_STORE, classic_dir_id)
+            .unwrap();
+        run_test_import(&mut native, PpcImportDispatcherTarget::GetWDInfo);
+        assert_eq!(native.cpu.gpr[3], ppc_i16_result(PPC_NO_ERR));
+        assert_eq!(
+            native.memory.read_u16_be(wd_vref_ptr),
+            Some(PPC_BOOT_VOLUME_REF_NUM as u16)
+        );
+        assert_eq!(native.memory.read_u32_be(wd_dir_id_ptr), Some(classic_dir_id));
+        assert_eq!(native.memory.read_u32_be(wd_proc_id_ptr), Some(0));
         assert!(native.vfs_directories.iter().any(|directory| {
             directory.dir_id == classic_dir_id && directory.path == "Classic Folder"
         }));
@@ -89710,6 +90207,11 @@ pub(crate) mod tests {
             .any(|volume| volume.name == "Classic Disk"));
         assert_ne!(*detached.next_vfs_dir_id, *executing_next_dir_id);
         assert_ne!(*detached.default_dir_id, *executing_default_dir_id);
+        assert!(detached.working_directories.is_empty());
+        assert_eq!(*detached.application_working_directory_ref_num, -1);
+        assert!(!detached
+            .working_directories
+            .ptr_eq(&executing_working_directories));
         run_test_import(&mut native, PpcImportDispatcherTarget::GetEOF);
         assert!(native.vfs_directories.ptr_eq(&executing_directories));
         assert!(native.vfs_volumes.ptr_eq(&executing_volumes));
@@ -89737,6 +90239,22 @@ pub(crate) mod tests {
                 .unwrap()
                 .data,
             b"classic-shared"
+        );
+
+        native.cpu.gpr[3] = 0;
+        native.cpu.gpr[4] = PPC_BOOT_VOLUME_REF_NUM as u16 as u32;
+        native.cpu.gpr[5] = PPC_FIRST_DYNAMIC_DIR_ID;
+        run_test_import(&mut native, PpcImportDispatcherTarget::HSetVol);
+        assert_eq!(native.cpu.gpr[3], ppc_i16_result(PPC_NO_ERR));
+        assert_eq!(*classic.default_dir_id, PPC_FIRST_DYNAMIC_DIR_ID);
+        let native_wd_ref_num = *classic.app_wd_refnum;
+        assert_eq!(
+            classic.working_directories[&native_wd_ref_num].dir_id,
+            PPC_FIRST_DYNAMIC_DIR_ID
+        );
+        assert_eq!(
+            *native.application_working_directory_ref_num,
+            native_wd_ref_num
         );
 
         classic
@@ -96416,6 +96934,102 @@ pub(crate) mod tests {
             ppc_read_pstring_bytes(&mut loaded.memory, volume_name),
             Some(TrapDispatcher::boot_volume_name().as_bytes().to_vec())
         );
+    }
+
+    #[test]
+    fn native_parameter_block_working_directory_lifecycle_uses_process_registry() {
+        assert_eq!(
+            dispatcher_target_for_import("InterfaceLib", "PBCloseWDSync"),
+            PpcImportDispatcherTarget::FileCompatibility
+        );
+        let pef = synthetic_pef_with_import(b"PBOpenWDSync");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let parameter_block = PPC_DATA_BASE + 0x1000;
+        loaded.memory.add_region(parameter_block, vec![0; 64]);
+        loaded
+            .memory
+            .write_u16_be(parameter_block + 22, PPC_BOOT_VOLUME_REF_NUM as u16)
+            .unwrap();
+        loaded
+            .memory
+            .write_u32_be(parameter_block + 28, 0x1234_5678)
+            .unwrap();
+        loaded
+            .memory
+            .write_u32_be(parameter_block + 48, PPC_PREFERENCES_DIR_ID)
+            .unwrap();
+        loaded.cpu.gpr[3] = parameter_block;
+
+        let open_probe = loaded.run_with_hle_imports(64);
+
+        assert_eq!(open_probe.unsupported_import_index, None);
+        assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_NO_ERR));
+        let wd_ref_num = loaded.memory.read_u16_be(parameter_block + 22).unwrap() as i16;
+        assert_ne!(wd_ref_num, PPC_BOOT_VOLUME_REF_NUM);
+        assert_eq!(
+            loaded.working_directories.get(&wd_ref_num),
+            Some(&ProcessWorkingDirectory {
+                ref_num: wd_ref_num,
+                volume_ref_num: PPC_BOOT_VOLUME_REF_NUM,
+                dir_id: PPC_PREFERENCES_DIR_ID,
+                proc_id: 0x1234_5678,
+            })
+        );
+
+        loaded.imports[0].symbol_name = "PBGetWDInfoSync".to_string();
+        loaded.cpu.pc = loaded.entry_pc;
+        loaded.cpu.lr = loaded.halt_pc;
+        loaded.cpu.gpr[3] = parameter_block;
+        loaded
+            .memory
+            .write_u16_be(parameter_block + 22, wd_ref_num as u16)
+            .unwrap();
+        loaded.memory.write_u16_be(parameter_block + 26, 0).unwrap();
+
+        let info_probe = loaded.run_with_hle_imports(64);
+
+        assert_eq!(info_probe.unsupported_import_index, None);
+        assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_NO_ERR));
+        assert_eq!(
+            loaded.memory.read_u16_be(parameter_block + 32),
+            Some(PPC_BOOT_VOLUME_REF_NUM as u16)
+        );
+        assert_eq!(
+            loaded.memory.read_u32_be(parameter_block + 48),
+            Some(PPC_PREFERENCES_DIR_ID)
+        );
+        assert_eq!(
+            loaded.memory.read_u32_be(parameter_block + 28),
+            Some(0x1234_5678)
+        );
+
+        loaded.imports[0].symbol_name = "PBCloseWDSync".to_string();
+        loaded.cpu.pc = loaded.entry_pc;
+        loaded.cpu.lr = loaded.halt_pc;
+        loaded.cpu.gpr[3] = parameter_block;
+        loaded
+            .memory
+            .write_u16_be(parameter_block + 22, wd_ref_num as u16)
+            .unwrap();
+
+        let close_probe = loaded.run_with_hle_imports(64);
+
+        assert_eq!(close_probe.unsupported_import_index, None);
+        assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_NO_ERR));
+        assert!(!loaded.working_directories.contains_key(&wd_ref_num));
+
+        loaded.cpu.pc = loaded.entry_pc;
+        loaded.cpu.lr = loaded.halt_pc;
+        loaded.cpu.gpr[3] = parameter_block;
+        loaded
+            .memory
+            .write_u16_be(parameter_block + 22, PPC_BOOT_VOLUME_REF_NUM as u16)
+            .unwrap();
+
+        let volume_close_probe = loaded.run_with_hle_imports(64);
+
+        assert_eq!(volume_close_probe.unsupported_import_index, None);
+        assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_NO_ERR));
     }
 
     #[test]

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -853,6 +853,18 @@ pub(crate) struct PendingFileCompletion {
     pub(crate) result: i16,
 }
 
+/// One open File Manager working directory for the process.
+///
+/// Working-directory reference numbers are process-wide access paths, not
+/// CPU-adapter state. Inside Macintosh: Files (1992), pp. 2-173--2-183.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct ProcessWorkingDirectory {
+    pub(crate) ref_num: i16,
+    pub(crate) volume_ref_num: i16,
+    pub(crate) dir_id: u32,
+    pub(crate) proc_id: u32,
+}
+
 #[derive(Debug, Clone)]
 pub struct ProcessFileSystemState {
     pub(crate) files: SharedProcessOpenFiles,
@@ -863,6 +875,10 @@ pub struct ProcessFileSystemState {
     /// optional completion-procedure delivery. Inside Macintosh: Files
     /// (1992), p. 2-238.
     pub(crate) pending_completions: SharedProcessValue<VecDeque<PendingFileCompletion>>,
+    pub(crate) working_directories:
+        SharedProcessValue<HashMap<i16, ProcessWorkingDirectory>>,
+    pub(crate) next_working_directory_ref_num: SharedProcessValue<i16>,
+    pub(crate) application_working_directory_ref_num: SharedProcessValue<i16>,
     pub(crate) stdio_streams: HashMap<u32, ProcessStdioStreamRecord>,
     pub(crate) vfs_volumes: SharedProcessValue<Vec<ProcessVfsVolumeRecord>>,
     pub(crate) vfs_directories: SharedProcessValue<Vec<ProcessVfsDirectory>>,
@@ -890,6 +906,9 @@ impl Default for ProcessFileSystemState {
             files: SharedProcessOpenFiles::default(),
             writable_refnums: SharedProcessValue::default(),
             pending_completions: SharedProcessValue::default(),
+            working_directories: SharedProcessValue::default(),
+            next_working_directory_ref_num: SharedProcessValue::from_value(32),
+            application_working_directory_ref_num: SharedProcessValue::from_value(-1),
             stdio_streams: HashMap::new(),
             vfs_volumes: SharedProcessValue::default(),
             vfs_directories: SharedProcessValue::default(),
@@ -928,6 +947,23 @@ impl ProcessFileSystemState {
         if !Rc::ptr_eq(&self.pending_completions.0, &source.pending_completions.0) {
             self.pending_completions
                 .extend(std::mem::take(&mut *source.pending_completions));
+        }
+        if !Rc::ptr_eq(&self.working_directories.0, &source.working_directories.0) {
+            assert!(
+                self.working_directories.is_empty()
+                    || source.working_directories.is_empty()
+                    || *self.working_directories == *source.working_directories,
+                "cannot attach two different working-directory registries"
+            );
+            if self.working_directories.is_empty() {
+                *self.working_directories = std::mem::take(&mut *source.working_directories);
+            }
+        }
+        *self.next_working_directory_ref_num = (*self.next_working_directory_ref_num)
+            .max(*source.next_working_directory_ref_num);
+        if *self.application_working_directory_ref_num == -1 {
+            *self.application_working_directory_ref_num =
+                *source.application_working_directory_ref_num;
         }
         for (stream, record) in std::mem::take(&mut source.stdio_streams) {
             self.stdio_streams.entry(stream).or_insert(record);

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -16,7 +16,7 @@ use crate::menu_manager::{ProcessMenuTrackingState, SharedNativeMenuSelection};
 use crate::process_context::{
     PendingFileCompletion, ProcessClassicVfsDirectory, ProcessContext, ProcessForkMap,
     ProcessKeyRepeatState, ProcessLoadedResources, ProcessResourceFileMap,
-    ProcessResourceManagerState,
+    ProcessResourceManagerState, ProcessWorkingDirectory,
     ProcessVfsMetadata, ProcessVfsVolumeRecord, SharedProcessAppleEventHandlers,
     SharedProcessControlManager, SharedProcessCursorState, SharedProcessDialogText,
     SharedProcessEventQueue, SharedProcessFileSystem, SharedProcessInputState,
@@ -1023,13 +1023,7 @@ pub(crate) type VfsMetadata = ProcessVfsMetadata;
 pub(crate) type VfsDirectory = ProcessClassicVfsDirectory;
 pub(crate) type VfsVolume = ProcessVfsVolumeRecord;
 
-#[derive(Clone, Copy, Debug)]
-pub(crate) struct WorkingDirectory {
-    pub ref_num: i16,
-    pub volume_ref_num: i16,
-    pub dir_id: u32,
-    pub proc_id: u32,
-}
+pub(crate) type WorkingDirectory = ProcessWorkingDirectory;
 
 #[derive(Clone, Debug)]
 pub(crate) struct PendingLaunchApplication {
@@ -1955,7 +1949,8 @@ pub struct TrapDispatcher {
     /// Mounted volume lookup by normalized, case-insensitive name.
     pub(crate) vfs_volume_names: SharedProcessValue<HashMap<String, i16>>,
     /// Open working directories keyed by working directory reference number.
-    pub(crate) working_directories: HashMap<i16, WorkingDirectory>,
+    pub(crate) working_directories:
+        SharedProcessValue<HashMap<i16, WorkingDirectory>>,
     /// Open file table: refnum -> filename
     pub(crate) open_files: SharedProcessOpenFiles,
     /// Synthetic Device Manager drivers opened by name via PBOpen/OpenDriver.
@@ -2009,7 +2004,7 @@ pub struct TrapDispatcher {
     /// Monotonic source for VFS creation and modification timestamps.
     pub(crate) next_vfs_timestamp: SharedProcessValue<u32>,
     /// Next working directory reference number.
-    pub(crate) next_working_dir_refnum: i16,
+    pub(crate) next_working_dir_refnum: SharedProcessValue<i16>,
     /// Normalized VFS path of the launched application, if known.
     pub(crate) launched_app_path: Option<String>,
     /// Foreground application launch queued by LaunchApplication. When
@@ -2019,7 +2014,7 @@ pub struct TrapDispatcher {
     /// Current default directory.
     pub(crate) default_dir_id: SharedProcessValue<u32>,
     /// Working directory reference number for the application's folder.
-    pub(crate) app_wd_refnum: i16,
+    pub(crate) app_wd_refnum: SharedProcessValue<i16>,
     /// Host directory to write output files to (if set)
     pub output_dir: Option<std::path::PathBuf>,
     /// Current foreground color (RGBColor: R, G, B)
@@ -2764,6 +2759,18 @@ impl TrapDispatcher {
         self.pending_file_completions = self
             .process_file_system
             .pending_completions
+            .shared_handle();
+        self.working_directories = self
+            .process_file_system
+            .working_directories
+            .shared_handle();
+        self.next_working_dir_refnum = self
+            .process_file_system
+            .next_working_directory_ref_num
+            .shared_handle();
+        self.app_wd_refnum = self
+            .process_file_system
+            .application_working_directory_ref_num
             .shared_handle();
         self.file_positions = self.process_file_system.files.positions();
         context.attach_resource_manager(&mut self.process_resource_manager);
@@ -3686,6 +3693,13 @@ impl TrapDispatcher {
         let open_files = process_file_system.files.shared_handle();
         let write_refnums = process_file_system.writable_refnums.shared_handle();
         let pending_file_completions = process_file_system.pending_completions.shared_handle();
+        let working_directories = process_file_system.working_directories.shared_handle();
+        let next_working_dir_refnum = process_file_system
+            .next_working_directory_ref_num
+            .shared_handle();
+        let app_wd_refnum = process_file_system
+            .application_working_directory_ref_num
+            .shared_handle();
         let file_positions = process_file_system.files.positions();
 
         let mut dispatcher = Self {
@@ -3765,7 +3779,7 @@ impl TrapDispatcher {
             vfs_directory_paths: SharedProcessValue::from_value(vfs_directory_paths),
             vfs_volumes: SharedProcessValue::default(),
             vfs_volume_names: SharedProcessValue::default(),
-            working_directories: HashMap::new(),
+            working_directories,
             open_files,
             synthetic_drivers: HashMap::new(),
             legacy_sound_driver_channel: None,
@@ -3782,11 +3796,11 @@ impl TrapDispatcher {
             next_vfs_volume_ref_num: SharedProcessValue::from_value(-2),
             next_vfs_file_id: SharedProcessValue::from_value(32),
             next_vfs_timestamp: SharedProcessValue::from_value(1),
-            next_working_dir_refnum: 32,
+            next_working_dir_refnum,
             launched_app_path: None,
             pending_launch_app: None,
             default_dir_id: SharedProcessValue::from_value(2),
-            app_wd_refnum: BOOT_VOLUME_REF_NUM,
+            app_wd_refnum,
             output_dir: None,
             fg_color: (0, 0, 0),
             bg_color: (0xFFFF, 0xFFFF, 0xFFFF),
@@ -4797,7 +4811,7 @@ impl TrapDispatcher {
             if let Some(wd_ref) =
                 self.open_working_directory(app_volume_ref, metadata.parent_dir_id, 0)
             {
-                self.app_wd_refnum = wd_ref;
+                *self.app_wd_refnum = wd_ref;
             }
         }
         self.launched_app_path = Some(normalized);
@@ -5122,11 +5136,11 @@ impl TrapDispatcher {
             return Some(existing.ref_num);
         }
 
-        let mut ref_num = self.next_working_dir_refnum;
+        let mut ref_num = *self.next_working_dir_refnum;
         while self.working_directories.contains_key(&ref_num) {
             ref_num = ref_num.saturating_add(1);
         }
-        self.next_working_dir_refnum = ref_num.saturating_add(1);
+        *self.next_working_dir_refnum = ref_num.saturating_add(1);
         self.working_directories.insert(
             ref_num,
             WorkingDirectory {
@@ -5140,7 +5154,13 @@ impl TrapDispatcher {
     }
 
     pub(crate) fn close_working_directory(&mut self, wd_ref_num: i16) -> bool {
-        self.working_directories.remove(&wd_ref_num).is_some()
+        let Some(record) = self.working_directories.remove(&wd_ref_num) else {
+            return false;
+        };
+        if *self.app_wd_refnum == wd_ref_num {
+            *self.app_wd_refnum = record.volume_ref_num;
+        }
+        true
     }
 
     pub(crate) fn working_directory_info(&self, wd_ref_num: i16) -> Option<WorkingDirectory> {

--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -4327,12 +4327,12 @@ impl super::TrapDispatcher {
             // PBHGetVol ($A214): HFS variant aliased onto $A014
             (false, 0x14) => {
                 let pb = cpu.read_reg(Register::A0);
-                let volume_ref_num = self.resolve_volume_ref_num(self.app_wd_refnum);
+                let volume_ref_num = self.resolve_volume_ref_num(*self.app_wd_refnum);
                 let volume_name = self
                     .vfs_volume_for_ref_num(volume_ref_num)
                     .map(|volume| volume.name.as_str())
                     .unwrap_or(super::TrapDispatcher::boot_volume_name());
-                bus.write_word(pb + 22, self.app_wd_refnum as u16);
+                bus.write_word(pb + 22, *self.app_wd_refnum as u16);
                 let name_ptr = bus.read_long(pb + 18);
                 if name_ptr != 0 {
                     Self::write_pstring(bus, name_ptr, volume_name);
@@ -4342,7 +4342,7 @@ impl super::TrapDispatcher {
                 bus.write_long(pb + 28, 0); // ioWDProcID
                 bus.write_word(pb + 32, volume_ref_num as u16); // ioWDVRefNum
                 let dir_id = self
-                    .working_directory_info(self.app_wd_refnum)
+                    .working_directory_info(*self.app_wd_refnum)
                     .map(|wd| wd.dir_id)
                     .unwrap_or(*self.default_dir_id);
                 bus.write_long(pb + 48, dir_id); // ioWDDirID
@@ -4420,11 +4420,11 @@ impl super::TrapDispatcher {
                     if requested_vref != 0 {
                         volume_by_ref(requested_vref)
                     } else if relative_pathname {
-                        volume_by_ref(self.app_wd_refnum)
+                        volume_by_ref(*self.app_wd_refnum)
                     } else if !requested_name.is_empty() {
                         volume_by_name(&requested_name)
                     } else {
-                        volume_by_ref(self.app_wd_refnum)
+                        volume_by_ref(*self.app_wd_refnum)
                     }
                 } else if volume_index > 0 {
                     let mut mounted = self
@@ -4450,11 +4450,11 @@ impl super::TrapDispatcher {
                     } else if requested_vref != 0 {
                         volume_by_ref(requested_vref)
                     } else if relative_pathname {
-                        volume_by_ref(self.app_wd_refnum)
+                        volume_by_ref(*self.app_wd_refnum)
                     } else if !requested_name.is_empty() {
                         volume_by_name(&requested_name)
                     } else {
-                        volume_by_ref(self.app_wd_refnum)
+                        volume_by_ref(*self.app_wd_refnum)
                     }
                 };
                 let Some((volume_name, volume_ref_num, volume_attributes)) = volume_info else {
@@ -5940,7 +5940,7 @@ impl super::TrapDispatcher {
                 }
 
                 *self.default_dir_id = target_dir_id;
-                self.app_wd_refnum = if target_dir_id == 2 {
+                *self.app_wd_refnum = if target_dir_id == 2 {
                     target_volume_ref_num
                 } else {
                     self.open_working_directory(target_volume_ref_num, target_dir_id, 0)
@@ -5957,7 +5957,7 @@ impl super::TrapDispatcher {
                     name,
                     requested_vref,
                     requested_dir_id,
-                    self.app_wd_refnum,
+                    *self.app_wd_refnum,
                     *self.default_dir_id
                 );
                 bus.write_word(pb + 16, 0);
@@ -7322,18 +7322,10 @@ impl super::TrapDispatcher {
                     // Releases a working directory reference number.
                     // FUNCTION PBCloseWD(paramBlock: WDPBPtr; async: Boolean): OSErr;
                     // Files 1992, 2-202 to 2-203
-                    //
-                    // Behavioral note: for a phantom ioVRefNum=-999, real
-                    // Mac returns noErr (0) per IM:Files 10366 ("If you
-                    // specify a volume reference number in the ioVRefNum
-                    // field, PBCloseWD does nothing") — the close-side mirror
-                    // of PBGetWDInfo's polymorphic-input divergence (where
-                    // real Mac returned nsvErr -35 instead of rfNumErr
-                    // -51). Systemless returns rfNumErr (-51) on the
-                    // HashMap-miss fallback path below.
                     let wd_ref_num = bus.read_word(pb + 22) as i16;
                     eprintln!("[TRAP] FSDispatch PBCloseWD wdRefNum={}", wd_ref_num);
                     let err = if wd_ref_num == super::TrapDispatcher::boot_volume_ref_num()
+                        || self.vfs_volume_for_ref_num(wd_ref_num).is_some()
                         || self.close_working_directory(wd_ref_num)
                     {
                         0
@@ -15758,7 +15750,7 @@ mod tests {
         let pb = 0x300000u32;
         cpu.write_reg(Register::A0, pb);
         bus.write_long(pb + 18, 0);
-        bus.write_word(pb + 22, disp.app_wd_refnum as u16);
+        bus.write_word(pb + 22, *disp.app_wd_refnum as u16);
         bus.write_word(pb + 28, (-1i16) as u16);
 
         call(&mut disp, false, 0x07, &mut cpu, &mut bus).unwrap();
@@ -16638,7 +16630,7 @@ mod tests {
 
         let pb = 0x300000u32;
         let name_ptr = setup_param_block(&mut bus, &mut cpu, pb, b"stale output name");
-        bus.write_word(pb + 22, disp.app_wd_refnum as u16);
+        bus.write_word(pb + 22, *disp.app_wd_refnum as u16);
         bus.write_word(pb + 28, 2); // second file in Mission, not second catalog entry
 
         call(&mut disp, false, 0x0C, &mut cpu, &mut bus).unwrap();
@@ -16652,7 +16644,7 @@ mod tests {
 
         let pb2 = 0x300400u32;
         setup_param_block(&mut bus, &mut cpu, pb2, b"A Launcher");
-        bus.write_word(pb2 + 22, disp.app_wd_refnum as u16);
+        bus.write_word(pb2 + 22, *disp.app_wd_refnum as u16);
         bus.write_word(pb2 + 28, 99);
 
         call(&mut disp, false, 0x0C, &mut cpu, &mut bus).unwrap();
@@ -17219,7 +17211,7 @@ mod tests {
 
         let pb = 0x300000u32;
         cpu.write_reg(Register::A0, pb);
-        bus.write_word(pb + 22, disp.app_wd_refnum as u16);
+        bus.write_word(pb + 22, *disp.app_wd_refnum as u16);
 
         call(&mut disp, false, 0x15, &mut cpu, &mut bus).unwrap();
 
@@ -17255,7 +17247,7 @@ mod tests {
         assert_eq!(cpu.read_reg(Register::D0), 0);
         assert_eq!(bus.read_word(pb + 16), 0);
         assert_eq!(*disp.default_dir_id, root_dir_id);
-        assert_eq!(disp.resolve_volume_ref_num(disp.app_wd_refnum), volume_ref);
+        assert_eq!(disp.resolve_volume_ref_num(*disp.app_wd_refnum), volume_ref);
         assert_eq!(bus.read_word(addr::SF_SAVE_DISK), (-volume_ref) as u16);
     }
 

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -2841,7 +2841,7 @@ impl super::TrapDispatcher {
             reply_ptr,
             stack_ptr,
             pop_total,
-            vref: self.resolve_volume_ref_num(self.app_wd_refnum),
+            vref: self.resolve_volume_ref_num(*self.app_wd_refnum),
             old_wd_ref,
             dir_id: *self.default_dir_id,
             prompt: Self::standard_file_put_prompt(bus, prompt_ptr),
@@ -2856,9 +2856,9 @@ impl super::TrapDispatcher {
     }
 
     fn standard_file_old_reply_wd_ref(&mut self) -> i16 {
-        let vref = self.resolve_volume_ref_num(self.app_wd_refnum);
+        let vref = self.resolve_volume_ref_num(*self.app_wd_refnum);
         self.open_working_directory(vref, *self.default_dir_id, 0)
-            .unwrap_or_else(|| self.resolve_volume_ref_num(self.app_wd_refnum))
+            .unwrap_or_else(|| self.resolve_volume_ref_num(*self.app_wd_refnum))
     }
 
     fn service_standard_file_put_tracking<C: CpuOps>(
@@ -12527,7 +12527,7 @@ impl super::TrapDispatcher {
                         return Some(Ok(()));
                     }
                     let name = standard_file_default_name(bus, default_name_ptr);
-                    let vref = self.resolve_volume_ref_num(self.app_wd_refnum);
+                    let vref = self.resolve_volume_ref_num(*self.app_wd_refnum);
                     let dir_id = *self.default_dir_id;
                     if modern_reply {
                         let target_name = decode_mac_roman(&name);
@@ -28076,7 +28076,7 @@ mod tests {
         let reply_ptr = 0x320180u32;
         let default_name_ptr = 0x320300u32;
         *disp.default_dir_id = 18;
-        disp.app_wd_refnum = crate::trap::dispatch::TrapDispatcher::boot_volume_ref_num();
+        *disp.app_wd_refnum = crate::trap::dispatch::TrapDispatcher::boot_volume_ref_num();
         bus.write_pstring(default_name_ptr, b"Twilight Save");
         bus.write_word(sp, 0x0005); // StandardPutFile selector
         bus.write_long(sp + 2, reply_ptr); // VAR reply
@@ -28109,7 +28109,7 @@ mod tests {
         let default_name_ptr = 0x320340u32;
         let pilots_dir = disp.ensure_vfs_directory("Pilots");
         *disp.default_dir_id = pilots_dir;
-        disp.app_wd_refnum = crate::trap::dispatch::TrapDispatcher::boot_volume_ref_num();
+        *disp.app_wd_refnum = crate::trap::dispatch::TrapDispatcher::boot_volume_ref_num();
         disp.vfs_rsrc
             .insert("Pilots/Existing Pilot".to_string(), vec![1, 2, 3]);
         disp.set_vfs_entry_metadata("Pilots/Existing Pilot", *b"PIL ", *b"EVO!", 0);
@@ -28144,7 +28144,7 @@ mod tests {
         let default_name_ptr = 0x320340u32;
         let pilots_dir = disp.ensure_vfs_directory("Pilots");
         *disp.default_dir_id = pilots_dir;
-        disp.app_wd_refnum = crate::trap::dispatch::TrapDispatcher::boot_volume_ref_num();
+        *disp.app_wd_refnum = crate::trap::dispatch::TrapDispatcher::boot_volume_ref_num();
         disp.yield_for_ui = true;
 
         bus.write_pstring(prompt_ptr, b"Pilot file:");
@@ -28206,7 +28206,7 @@ mod tests {
         let default_name_ptr = 0x320740u32;
         let pilots_dir = disp.ensure_vfs_directory("Pilots");
         *disp.default_dir_id = pilots_dir;
-        disp.app_wd_refnum = crate::trap::dispatch::TrapDispatcher::boot_volume_ref_num();
+        *disp.app_wd_refnum = crate::trap::dispatch::TrapDispatcher::boot_volume_ref_num();
         disp.yield_for_ui = true;
 
         bus.write_pstring(prompt_ptr, b"Pilot file:");
@@ -28279,7 +28279,7 @@ mod tests {
         let sp = TEST_SP;
         let reply_ptr = 0x320380u32;
         let original_name_ptr = 0x320500u32;
-        disp.app_wd_refnum = crate::trap::dispatch::TrapDispatcher::boot_volume_ref_num();
+        *disp.app_wd_refnum = crate::trap::dispatch::TrapDispatcher::boot_volume_ref_num();
         bus.write_pstring(original_name_ptr, b"Old Save");
         bus.write_word(sp, 0x0001); // SFPutFile selector
         bus.write_long(sp + 2, reply_ptr); // VAR reply
@@ -28311,7 +28311,7 @@ mod tests {
         let original_name_ptr = 0x320680u32;
         let pilots_dir = disp.ensure_vfs_directory("Pilots");
         *disp.default_dir_id = pilots_dir;
-        disp.app_wd_refnum = crate::trap::dispatch::TrapDispatcher::boot_volume_ref_num();
+        *disp.app_wd_refnum = crate::trap::dispatch::TrapDispatcher::boot_volume_ref_num();
         bus.write_pstring(original_name_ptr, b"Old Pilot");
         bus.write_word(sp, 0x0001); // SFPutFile selector
         bus.write_long(sp + 2, reply_ptr); // VAR reply
@@ -28346,7 +28346,7 @@ mod tests {
         let prompt_ptr = 0x3208C0u32;
         let pilots_dir = disp.ensure_vfs_directory("Pilots");
         *disp.default_dir_id = pilots_dir;
-        disp.app_wd_refnum = crate::trap::dispatch::TrapDispatcher::boot_volume_ref_num();
+        *disp.app_wd_refnum = crate::trap::dispatch::TrapDispatcher::boot_volume_ref_num();
         disp.yield_for_ui = true;
         bus.write_pstring(original_name_ptr, b"Old Pilot");
         bus.write_pstring(prompt_ptr, b"Pilot file:");


### PR DESCRIPTION
Closes #1243

## Summary

- move working-directory records, reference allocation, and the application working directory into process-owned File Manager state
- make 68K and PowerPC volume and working-directory calls observe the same live registry
- support native parameter-block open, query, close, and set-volume operations against the canonical state
- keep detached adapter clones independent

## Validation

- `cargo test --locked --lib` — 4,775 passed; 0 failed; 3 ignored
- strict all-feature rustdoc with warnings denied
- all-feature/all-target compile validation
- Marathon gameplay, audio, terminal open, and terminal progression
- Escape Velocity pilot flow, live space, landing, return to space, and keyboard input
- Tomb Raider Gold live 3D gameplay and forward movement
