### PR TITLE
fix(release): keep breaking changes pre-major

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,6 +5,7 @@
     ".": {
       "release-type": "rust",
       "package-name": "systemless",
+      "bump-minor-pre-major": true,
       "include-component-in-tag": false,
       "changelog-sections": [
         { "type": "feat", "section": "Features" },


### PR DESCRIPTION
## Root cause

The release configuration used release-please's default versioning strategy. Under that default, a breaking Conventional Commit increments the major version even while the current version is below 1.0.0, causing the open release PR to propose 1.0.0 before the crate is stabilized.

## Change

Enable `bump-minor-pre-major` for the `systemless` package so breaking changes increment the minor component while the crate remains pre-1.0.

## Validation

- `jq empty release-please-config.json`
- `git diff --check`
- release-please 17.3.0 dry run against this branch proposes `0.29.0` from `0.28.5`

Closes #1262