### PR TITLE
refactor(files): share VFS volume catalogue across CPU adapters

### DIFF
--- a/src/game/launch.rs
+++ b/src/game/launch.rs
@@ -2962,7 +2962,7 @@ fn ppc_diagnostic_vfs(
 
     let mut volumes = dispatcher
         .vfs_volumes
-        .values()
+        .iter()
         .map(|volume| PpcVfsVolumeRecord {
             ref_num: volume.ref_num,
             name: volume.name.clone(),

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -8257,6 +8257,13 @@ impl PpcLoadedApp {
     }
 
     pub fn seed_vfs_volumes(&mut self, volumes: Vec<PpcVfsVolumeRecord>) {
+        *self.next_vfs_volume_ref_num = volumes
+            .iter()
+            .map(|volume| volume.ref_num)
+            .min()
+            .unwrap_or(PPC_BOOT_VOLUME_REF_NUM)
+            .saturating_sub(1)
+            .min(-2);
         *self.vfs_volumes = volumes;
     }
 
@@ -90065,6 +90072,8 @@ pub(crate) mod tests {
         native.attach_process_context(&mut context);
         let executing_directories = native.vfs_directories.shared_handle();
         let executing_volumes = native.vfs_volumes.shared_handle();
+        let executing_next_volume_ref_num =
+            native.next_vfs_volume_ref_num.shared_handle();
         let executing_next_dir_id = native.next_vfs_dir_id.shared_handle();
         let executing_default_dir_id = native.default_dir_id.shared_handle();
         let executing_working_directories = native.working_directories.shared_handle();
@@ -90111,6 +90120,13 @@ pub(crate) mod tests {
         });
         *native.next_vfs_dir_id = PPC_FIRST_DYNAMIC_DIR_ID + 1;
         *native.default_dir_id = PPC_FIRST_DYNAMIC_DIR_ID;
+
+        // Volume records are canonical process state, so the classic adapter
+        // observes this native mutation before any catalogue publication pass.
+        assert_eq!(
+            classic.vfs_volume_for_ref_num(-2).map(|volume| volume.name.as_str()),
+            Some("Read Only")
+        );
         native.process_file_system.publish_native_vfs_catalogue();
 
         assert_eq!(
@@ -90142,6 +90158,15 @@ pub(crate) mod tests {
             PPC_FIRST_DYNAMIC_DIR_ID + 3,
             10,
             11,
+        );
+        assert_eq!(
+            native
+                .process_file_system
+                .vfs_volumes
+                .iter()
+                .find(|volume| volume.ref_num == classic_volume_ref)
+                .map(|volume| volume.name.as_str()),
+            Some("Classic Disk")
         );
         classic
             .vfs
@@ -90195,8 +90220,10 @@ pub(crate) mod tests {
         assert!(executing_volumes.iter().any(|volume| {
             volume.ref_num == classic_volume_ref && volume.name == "Classic Disk"
         }));
+        assert_eq!(*executing_next_volume_ref_num, classic_volume_ref - 1);
         assert_eq!(*executing_next_dir_id, *classic.next_vfs_dir_id);
         assert_eq!(*executing_default_dir_id, classic_dir_id);
+        assert_eq!(*detached.next_vfs_volume_ref_num, -2);
         assert!(!detached
             .vfs_directories
             .iter()
@@ -90215,6 +90242,9 @@ pub(crate) mod tests {
         run_test_import(&mut native, PpcImportDispatcherTarget::GetEOF);
         assert!(native.vfs_directories.ptr_eq(&executing_directories));
         assert!(native.vfs_volumes.ptr_eq(&executing_volumes));
+        assert!(native
+            .next_vfs_volume_ref_num
+            .ptr_eq(&executing_next_volume_ref_num));
         assert!(native.next_vfs_dir_id.ptr_eq(&executing_next_dir_id));
         assert!(native.default_dir_id.ptr_eq(&executing_default_dir_id));
         let classic_file = native

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -881,6 +881,7 @@ pub struct ProcessFileSystemState {
     pub(crate) application_working_directory_ref_num: SharedProcessValue<i16>,
     pub(crate) stdio_streams: HashMap<u32, ProcessStdioStreamRecord>,
     pub(crate) vfs_volumes: SharedProcessValue<Vec<ProcessVfsVolumeRecord>>,
+    pub(crate) next_vfs_volume_ref_num: SharedProcessValue<i16>,
     pub(crate) vfs_directories: SharedProcessValue<Vec<ProcessVfsDirectory>>,
     pub(crate) next_vfs_dir_id: SharedProcessValue<u32>,
     pub(crate) default_dir_id: SharedProcessValue<u32>,
@@ -888,10 +889,7 @@ pub struct ProcessFileSystemState {
     pub(crate) classic_vfs_directories:
         SharedProcessValue<HashMap<String, ProcessClassicVfsDirectory>>,
     pub(crate) classic_vfs_directory_paths: SharedProcessValue<HashMap<u32, String>>,
-    pub(crate) classic_vfs_volumes: SharedProcessValue<HashMap<i16, ProcessVfsVolumeRecord>>,
-    pub(crate) classic_vfs_volume_names: SharedProcessValue<HashMap<String, i16>>,
     pub(crate) classic_locked_files: SharedProcessValue<HashSet<String>>,
-    pub(crate) classic_next_vfs_volume_ref_num: SharedProcessValue<i16>,
     pub(crate) classic_next_vfs_file_id: SharedProcessValue<u32>,
     pub(crate) classic_next_vfs_timestamp: SharedProcessValue<u32>,
     pub(crate) vfs_files: ProcessVfsFileRecords,
@@ -911,16 +909,14 @@ impl Default for ProcessFileSystemState {
             application_working_directory_ref_num: SharedProcessValue::from_value(-1),
             stdio_streams: HashMap::new(),
             vfs_volumes: SharedProcessValue::default(),
+            next_vfs_volume_ref_num: SharedProcessValue::from_value(-2),
             vfs_directories: SharedProcessValue::default(),
             next_vfs_dir_id: SharedProcessValue::from_value(0),
             default_dir_id: SharedProcessValue::from_value(0),
             classic_vfs_metadata: SharedProcessValue::default(),
             classic_vfs_directories: SharedProcessValue::default(),
             classic_vfs_directory_paths: SharedProcessValue::default(),
-            classic_vfs_volumes: SharedProcessValue::default(),
-            classic_vfs_volume_names: SharedProcessValue::default(),
             classic_locked_files: SharedProcessValue::default(),
-            classic_next_vfs_volume_ref_num: SharedProcessValue::from_value(-2),
             classic_next_vfs_file_id: SharedProcessValue::from_value(32),
             classic_next_vfs_timestamp: SharedProcessValue::from_value(1),
             vfs_files: ProcessVfsFileRecords::default(),
@@ -980,6 +976,8 @@ impl ProcessFileSystemState {
             }
             self.vfs_volumes.push(volume);
         }
+        *self.next_vfs_volume_ref_num =
+            (*self.next_vfs_volume_ref_num).min(*source.next_vfs_volume_ref_num);
         for directory in source.vfs_directories.drain(..) {
             if self.vfs_directories.iter().any(|existing| {
                 existing.dir_id == directory.dir_id
@@ -1033,25 +1031,10 @@ impl ProcessFileSystemState {
                     .or_insert(path);
             }
         }
-        if !Rc::ptr_eq(&self.classic_vfs_volumes.0, &source.classic_vfs_volumes.0) {
-            for (ref_num, volume) in std::mem::take(&mut *source.classic_vfs_volumes) {
-                self.classic_vfs_volumes.entry(ref_num).or_insert(volume);
-            }
-        }
-        if !Rc::ptr_eq(
-            &self.classic_vfs_volume_names.0,
-            &source.classic_vfs_volume_names.0,
-        ) {
-            for (name, ref_num) in std::mem::take(&mut *source.classic_vfs_volume_names) {
-                self.classic_vfs_volume_names.entry(name).or_insert(ref_num);
-            }
-        }
         if !Rc::ptr_eq(&self.classic_locked_files.0, &source.classic_locked_files.0) {
             self.classic_locked_files
                 .extend(std::mem::take(&mut *source.classic_locked_files));
         }
-        *self.classic_next_vfs_volume_ref_num =
-            (*self.classic_next_vfs_volume_ref_num).min(*source.classic_next_vfs_volume_ref_num);
         *self.classic_next_vfs_file_id =
             (*self.classic_next_vfs_file_id).max(*source.classic_next_vfs_file_id);
         *self.classic_next_vfs_timestamp =
@@ -1064,16 +1047,14 @@ impl ProcessFileSystemState {
     fn detached_vfs_snapshot(&self) -> Self {
         let mut snapshot = Self::default();
         snapshot.vfs_volumes = self.vfs_volumes.clone();
+        snapshot.next_vfs_volume_ref_num = self.next_vfs_volume_ref_num.clone();
         snapshot.vfs_directories = self.vfs_directories.clone();
         snapshot.next_vfs_dir_id = self.next_vfs_dir_id.clone();
         snapshot.default_dir_id = self.default_dir_id.clone();
         snapshot.classic_vfs_metadata = self.classic_vfs_metadata.clone();
         snapshot.classic_vfs_directories = self.classic_vfs_directories.clone();
         snapshot.classic_vfs_directory_paths = self.classic_vfs_directory_paths.clone();
-        snapshot.classic_vfs_volumes = self.classic_vfs_volumes.clone();
-        snapshot.classic_vfs_volume_names = self.classic_vfs_volume_names.clone();
         snapshot.classic_locked_files = self.classic_locked_files.clone();
-        snapshot.classic_next_vfs_volume_ref_num = self.classic_next_vfs_volume_ref_num.clone();
         snapshot.classic_next_vfs_file_id = self.classic_next_vfs_file_id.clone();
         snapshot.classic_next_vfs_timestamp = self.classic_next_vfs_timestamp.clone();
         snapshot.vfs_files = self.vfs_files.clone();
@@ -1094,9 +1075,12 @@ impl ProcessFileSystemState {
         self
     }
 
+    /// Mirror native directory and file records into the classic path indexes.
+    /// Volume records intentionally do not participate in this compatibility
+    /// pass: both adapters query the canonical process-owned volume vector
+    /// directly. Files (1992), pp. 2-27--2-29 and 2-85.
     pub(crate) fn publish_native_vfs_catalogue(&mut self) {
         let directories = (*self.vfs_directories).clone();
-        let volumes = (*self.vfs_volumes).clone();
         let files = self.vfs_files.iter().cloned().collect::<Vec<_>>();
         let resource_files = self.vfs_resource_files.iter().cloned().collect::<Vec<_>>();
         let deleted_paths = self.deleted_vfs_file_paths.clone();
@@ -1139,16 +1123,6 @@ impl ProcessFileSystemState {
                 .max()
                 .unwrap_or(16),
         );
-
-        for volume in volumes {
-            self.classic_vfs_volume_names
-                .insert(volume.name.to_ascii_lowercase(), volume.ref_num);
-            self.classic_vfs_volumes.insert(volume.ref_num, volume);
-        }
-        if let Some(lowest_ref_num) = self.classic_vfs_volumes.keys().copied().min() {
-            *self.classic_next_vfs_volume_ref_num =
-                (*self.classic_next_vfs_volume_ref_num).min(lowest_ref_num.saturating_sub(1));
-        }
 
         for file in files {
             if file.path.is_empty() {
@@ -1244,15 +1218,11 @@ impl ProcessFileSystemState {
             .keys()
             .cloned()
             .collect::<Vec<_>>();
-        let volumes = self.classic_vfs_volumes.keys().copied().collect::<Vec<_>>();
         for path in directories {
             self.publish_classic_vfs_directory(&path);
         }
         for path in metadata {
             self.publish_classic_vfs_metadata(&path);
-        }
-        for ref_num in volumes {
-            self.publish_classic_vfs_volume(ref_num);
         }
     }
 
@@ -1307,21 +1277,6 @@ impl ProcessFileSystemState {
                     dirty: false,
                 });
             }
-        }
-    }
-
-    pub(crate) fn publish_classic_vfs_volume(&mut self, ref_num: i16) {
-        let Some(volume) = self.classic_vfs_volumes.get(&ref_num).cloned() else {
-            return;
-        };
-        if let Some(native) = self
-            .vfs_volumes
-            .iter_mut()
-            .find(|native| native.ref_num == ref_num)
-        {
-            *native = volume;
-        } else {
-            self.vfs_volumes.push(volume);
         }
     }
 
@@ -4646,17 +4601,19 @@ impl ProcessContext {
         );
     }
 
+    /// Attach the classic path indexes to the process File Manager.
+    ///
+    /// Volume records and their negative-reference allocator are attached by
+    /// the adapter's process-file-system handle, so this compatibility-index
+    /// method deliberately has no parallel volume arguments.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn attach_classic_vfs_catalogue(
         &self,
         metadata: &mut SharedProcessValue<HashMap<String, ProcessVfsMetadata>>,
         directories: &mut SharedProcessValue<HashMap<String, ProcessClassicVfsDirectory>>,
         directory_paths: &mut SharedProcessValue<HashMap<u32, String>>,
-        volumes: &mut SharedProcessValue<HashMap<i16, ProcessVfsVolumeRecord>>,
-        volume_names: &mut SharedProcessValue<HashMap<String, i16>>,
         locked_files: &mut SharedProcessValue<HashSet<String>>,
         next_dir_id: &mut SharedProcessValue<u32>,
-        next_volume_ref_num: &mut SharedProcessValue<i16>,
         next_file_id: &mut SharedProcessValue<u32>,
         next_timestamp: &mut SharedProcessValue<u32>,
         default_dir_id: &mut SharedProcessValue<u32>,
@@ -4670,17 +4627,9 @@ impl ProcessContext {
             &self.file_system.classic_vfs_directory_paths,
             process_classic_vfs_directory_paths_are_pristine,
         );
-        volumes.attach_to(&self.file_system.classic_vfs_volumes, HashMap::is_empty);
-        volume_names.attach_to(
-            &self.file_system.classic_vfs_volume_names,
-            HashMap::is_empty,
-        );
         locked_files.attach_to(&self.file_system.classic_locked_files, HashSet::is_empty);
         next_dir_id.attach_to(&self.file_system.next_vfs_dir_id, |value| {
             matches!(*value, 0 | 16 | 18)
-        });
-        next_volume_ref_num.attach_to(&self.file_system.classic_next_vfs_volume_ref_num, |value| {
-            *value == -2
         });
         next_file_id.attach_to(&self.file_system.classic_next_vfs_file_id, |value| {
             *value == 32
@@ -6066,12 +6015,8 @@ mod tests {
         let mut first_directories =
             SharedProcessValue::<HashMap<String, ProcessClassicVfsDirectory>>::default();
         let mut first_directory_paths = SharedProcessValue::<HashMap<u32, String>>::default();
-        let mut first_volumes =
-            SharedProcessValue::<HashMap<i16, ProcessVfsVolumeRecord>>::default();
-        let mut first_volume_names = SharedProcessValue::<HashMap<String, i16>>::default();
         let mut first_locked_files = SharedProcessValue::<HashSet<String>>::default();
         let mut first_next_dir_id = SharedProcessValue::from_value(16);
-        let mut first_next_volume_ref_num = SharedProcessValue::from_value(-2);
         let mut first_next_file_id = SharedProcessValue::from_value(32);
         let mut first_next_timestamp = SharedProcessValue::from_value(1);
         let mut first_default_dir_id = SharedProcessValue::from_value(2);
@@ -6089,11 +6034,8 @@ mod tests {
             &mut first_metadata,
             &mut first_directories,
             &mut first_directory_paths,
-            &mut first_volumes,
-            &mut first_volume_names,
             &mut first_locked_files,
             &mut first_next_dir_id,
-            &mut first_next_volume_ref_num,
             &mut first_next_file_id,
             &mut first_next_timestamp,
             &mut first_default_dir_id,
@@ -6104,12 +6046,8 @@ mod tests {
         let mut second_directories =
             SharedProcessValue::<HashMap<String, ProcessClassicVfsDirectory>>::default();
         let mut second_directory_paths = SharedProcessValue::<HashMap<u32, String>>::default();
-        let mut second_volumes =
-            SharedProcessValue::<HashMap<i16, ProcessVfsVolumeRecord>>::default();
-        let mut second_volume_names = SharedProcessValue::<HashMap<String, i16>>::default();
         let mut second_locked_files = SharedProcessValue::<HashSet<String>>::default();
         let mut second_next_dir_id = SharedProcessValue::from_value(16);
-        let mut second_next_volume_ref_num = SharedProcessValue::from_value(-2);
         let mut second_next_file_id = SharedProcessValue::from_value(32);
         let mut second_next_timestamp = SharedProcessValue::from_value(1);
         let mut second_default_dir_id = SharedProcessValue::from_value(2);
@@ -6117,11 +6055,8 @@ mod tests {
             &mut second_metadata,
             &mut second_directories,
             &mut second_directory_paths,
-            &mut second_volumes,
-            &mut second_volume_names,
             &mut second_locked_files,
             &mut second_next_dir_id,
-            &mut second_next_volume_ref_num,
             &mut second_next_file_id,
             &mut second_next_timestamp,
             &mut second_default_dir_id,

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -1945,9 +1945,7 @@ pub struct TrapDispatcher {
     /// Reverse directory lookup by catalog ID.
     pub(crate) vfs_directory_paths: SharedProcessValue<HashMap<u32, String>>,
     /// Read-only disk-image volumes mounted alongside the synthetic boot volume.
-    pub(crate) vfs_volumes: SharedProcessValue<HashMap<i16, VfsVolume>>,
-    /// Mounted volume lookup by normalized, case-insensitive name.
-    pub(crate) vfs_volume_names: SharedProcessValue<HashMap<String, i16>>,
+    pub(crate) vfs_volumes: SharedProcessValue<Vec<VfsVolume>>,
     /// Open working directories keyed by working directory reference number.
     pub(crate) working_directories:
         SharedProcessValue<HashMap<i16, WorkingDirectory>>,
@@ -2772,6 +2770,11 @@ impl TrapDispatcher {
             .process_file_system
             .application_working_directory_ref_num
             .shared_handle();
+        self.vfs_volumes = self.process_file_system.vfs_volumes.shared_handle();
+        self.next_vfs_volume_ref_num = self
+            .process_file_system
+            .next_vfs_volume_ref_num
+            .shared_handle();
         self.file_positions = self.process_file_system.files.positions();
         context.attach_resource_manager(&mut self.process_resource_manager);
         context.attach_sound_manager(&mut self.sound_manager);
@@ -2805,11 +2808,8 @@ impl TrapDispatcher {
             &mut self.vfs_metadata,
             &mut self.vfs_directories,
             &mut self.vfs_directory_paths,
-            &mut self.vfs_volumes,
-            &mut self.vfs_volume_names,
             &mut self.locked_files,
             &mut self.next_vfs_dir_id,
-            &mut self.next_vfs_volume_ref_num,
             &mut self.next_vfs_file_id,
             &mut self.next_vfs_timestamp,
             &mut self.default_dir_id,
@@ -3700,6 +3700,10 @@ impl TrapDispatcher {
         let app_wd_refnum = process_file_system
             .application_working_directory_ref_num
             .shared_handle();
+        let vfs_volumes = process_file_system.vfs_volumes.shared_handle();
+        let next_vfs_volume_ref_num = process_file_system
+            .next_vfs_volume_ref_num
+            .shared_handle();
         let file_positions = process_file_system.files.positions();
 
         let mut dispatcher = Self {
@@ -3777,8 +3781,7 @@ impl TrapDispatcher {
             vfs_metadata: SharedProcessValue::default(),
             vfs_directories: SharedProcessValue::from_value(vfs_directories),
             vfs_directory_paths: SharedProcessValue::from_value(vfs_directory_paths),
-            vfs_volumes: SharedProcessValue::default(),
-            vfs_volume_names: SharedProcessValue::default(),
+            vfs_volumes,
             working_directories,
             open_files,
             synthetic_drivers: HashMap::new(),
@@ -3793,7 +3796,7 @@ impl TrapDispatcher {
             default_os_rec: 0x0001,           // Macintosh Operating System
             default_startup_rec: 0x0000_0000, // zero-filled first-device startup default
             next_vfs_dir_id: SharedProcessValue::from_value(16),
-            next_vfs_volume_ref_num: SharedProcessValue::from_value(-2),
+            next_vfs_volume_ref_num,
             next_vfs_file_id: SharedProcessValue::from_value(32),
             next_vfs_timestamp: SharedProcessValue::from_value(1),
             next_working_dir_refnum,
@@ -4540,58 +4543,61 @@ impl TrapDispatcher {
         if normalized.is_empty() || normalized.eq_ignore_ascii_case(BOOT_VOLUME_NAME) {
             return Self::boot_volume_ref_num();
         }
-        let key = normalized.to_ascii_lowercase();
-        if let Some(ref_num) = self.vfs_volume_names.get(&key).copied() {
-            return ref_num;
+        if let Some(volume) = self
+            .vfs_volumes
+            .iter()
+            .find(|volume| volume.name.eq_ignore_ascii_case(&normalized))
+        {
+            return volume.ref_num;
         }
 
         let root_dir_id = self.ensure_vfs_directory(&normalized);
         let mut ref_num = *self.next_vfs_volume_ref_num;
         while ref_num == 0
             || ref_num == Self::boot_volume_ref_num()
-            || self.vfs_volumes.contains_key(&ref_num)
+            || self
+                .vfs_volumes
+                .iter()
+                .any(|volume| volume.ref_num == ref_num)
         {
             ref_num = ref_num.saturating_sub(1);
         }
         *self.next_vfs_volume_ref_num = ref_num.saturating_sub(1);
-        self.vfs_volumes.insert(
+        self.vfs_volumes.push(VfsVolume {
             ref_num,
-            VfsVolume {
-                ref_num,
-                name: normalized,
-                root_dir_id,
-                // Extracted images are immutable media. Report the VCB's
-                // hardware-lock bit so PBHGetVInfo agrees with mutations,
-                // which return wPrErr (hardware volume lock). Inside
-                // Macintosh: Files, pp. 2-127, 2-144, and 2-329.
-                attributes: attributes | 0x0080,
-                file_count,
-                allocation_block_count,
-                allocation_block_size,
-                clump_size,
-                free_blocks,
-                bitmap_start,
-                allocation_pointer,
-                allocation_start,
-                next_catalog_id,
-                created_date,
-                modified_date,
-            },
-        );
-        self.vfs_volume_names.insert(key, ref_num);
-        self.process_file_system.publish_classic_vfs_volume(ref_num);
+            name: normalized,
+            root_dir_id,
+            // Extracted images are immutable media. Report the VCB's
+            // hardware-lock bit so PBHGetVInfo agrees with mutations,
+            // which return wPrErr (hardware volume lock). Inside
+            // Macintosh: Files, pp. 2-127, 2-144, and 2-329.
+            attributes: attributes | 0x0080,
+            file_count,
+            allocation_block_count,
+            allocation_block_size,
+            clump_size,
+            free_blocks,
+            bitmap_start,
+            allocation_pointer,
+            allocation_start,
+            next_catalog_id,
+            created_date,
+            modified_date,
+        });
         ref_num
     }
 
     pub(crate) fn vfs_volume_by_name(&self, name: &str) -> Option<&VfsVolume> {
-        let key = Self::normalize_vfs_path(name).to_ascii_lowercase();
-        self.vfs_volume_names
-            .get(&key)
-            .and_then(|ref_num| self.vfs_volumes.get(ref_num))
+        let normalized = Self::normalize_vfs_path(name);
+        self.vfs_volumes
+            .iter()
+            .find(|volume| volume.name.eq_ignore_ascii_case(&normalized))
     }
 
     pub(crate) fn vfs_volume_for_ref_num(&self, ref_num: i16) -> Option<&VfsVolume> {
-        self.vfs_volumes.get(&ref_num)
+        self.vfs_volumes
+            .iter()
+            .find(|volume| volume.ref_num == ref_num)
     }
 
     pub(crate) fn vfs_volume_for_path(&self, path: &str) -> Option<&VfsVolume> {
@@ -5038,7 +5044,11 @@ impl TrapDispatcher {
         if vref == Self::boot_volume_ref_num() {
             return vref;
         }
-        if self.vfs_volumes.contains_key(&vref) {
+        if self
+            .vfs_volumes
+            .iter()
+            .any(|volume| volume.ref_num == vref)
+        {
             return vref;
         }
         if let Some(working_directory) = self.working_directories.get(&vref) {
@@ -5052,7 +5062,7 @@ impl TrapDispatcher {
         // ioDirID is 0 or 1, and they treat vRefNum=0 + ioDirID=0 as the
         // current default directory. Files 1992, 2-151 to 2-153.
         if dir_id <= 1 {
-            if let Some(volume) = self.vfs_volumes.get(&vref) {
+            if let Some(volume) = self.vfs_volume_for_ref_num(vref) {
                 return volume.root_dir_id;
             }
             if let Some(working_directory) = self.working_directories.get(&vref) {

--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -4397,7 +4397,10 @@ impl super::TrapDispatcher {
                 let volume_by_ref = |requested_vref: i16| {
                     let volume_ref_num = if requested_vref
                         == super::TrapDispatcher::boot_volume_ref_num()
-                        || self.vfs_volumes.contains_key(&requested_vref)
+                        || self
+                            .vfs_volumes
+                            .iter()
+                            .any(|volume| volume.ref_num == requested_vref)
                     {
                         Some(requested_vref)
                     } else {
@@ -4429,7 +4432,7 @@ impl super::TrapDispatcher {
                 } else if volume_index > 0 {
                     let mut mounted = self
                         .vfs_volumes
-                        .values()
+                        .iter()
                         .map(|volume| (volume.name.clone(), volume.ref_num, volume.attributes))
                         .collect::<Vec<_>>();
                     mounted.sort_by_key(|(_, ref_num, _)| std::cmp::Reverse(*ref_num));
@@ -4670,7 +4673,10 @@ impl super::TrapDispatcher {
                 let vref = bus.read_word(pb + 22) as i16;
                 let known_by_vref = vref == 0
                     || vref == Self::boot_volume_ref_num()
-                    || self.vfs_volumes.contains_key(&vref)
+                    || self
+                        .vfs_volumes
+                        .iter()
+                        .any(|volume| volume.ref_num == vref)
                     || self.working_directories.contains_key(&vref);
                 let known_by_name = !name.is_empty()
                     && (name.eq_ignore_ascii_case(super::TrapDispatcher::boot_volume_name())


### PR DESCRIPTION
Closes #1247.

Makes the mounted-volume registry and negative volume-reference allocator canonical process state shared by the 68K and PowerPC adapters. Volume mutations are immediately visible across both gateways without catalogue publication, while detached clones remain independent.

Validation:
- `cargo test --locked --lib`
- strict rustdoc warnings
- all-feature/all-target compilation
- Marathon gameplay and terminal interaction
- Escape Velocity live-space gameplay and input
- Tomb Raider Gold live 3D gameplay and input