### PR TITLE
ci: reserve cross-platform tests for release commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # Keep routine CI on Linux; release-please squash commits get the full
+        # cross-platform matrix.
+        os: >-
+          ${{ fromJSON(
+            github.event_name == 'push' &&
+            startsWith(github.event.head_commit.message, 'chore(master): release ') &&
+            '["ubuntu-latest","macos-latest","windows-latest"]' ||
+            '["ubuntu-latest"]'
+          ) }}
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary

- run the build/test matrix on Ubuntu for pull requests and ordinary `master` pushes
- add macOS and Windows only for Release Please release commits

## Root cause

The workflow used a static three-platform matrix for every event, so every pull request and ordinary push scheduled the more expensive hosted macOS and Windows runners. Release Please release commits already use the stable `chore(master): release ` subject prefix, which the workflow can detect from `github.event.head_commit.message` on pushes.

## Validation

- parsed `.github/workflows/ci.yml` with Ruby YAML
- ran `actionlint .github/workflows/ci.yml`
- ran `git diff --check`

Closes #1273