### PR TITLE
refactor(files): share VFS directory catalogue across CPU adapters

### DIFF
--- a/src/game/launch.rs
+++ b/src/game/launch.rs
@@ -2940,25 +2940,8 @@ fn ppc_diagnostic_vfs(
     let dispatcher = runner.dispatcher();
     let app_resource_path =
         app_resource_path.map(crate::trap::dispatch::TrapDispatcher::normalize_vfs_path);
-    let mut directory_entries: Vec<_> = dispatcher.vfs_directory_paths.iter().collect();
-    directory_entries.sort_by_key(|(dir_id, _)| **dir_id);
-
-    let directories = directory_entries
-        .into_iter()
-        .filter_map(|(dir_id, _)| {
-            let path = dispatcher.directory_path_for_id(*dir_id)?;
-            let directory = dispatcher.directory_entry_for_id(*dir_id)?;
-            Some(PpcVfsDirectory {
-                dir_id: *dir_id,
-                parent_dir_id: directory.parent_dir_id,
-                path: path.to_string(),
-                creator: 0,
-                file_type: 0,
-                finder_flags: 0,
-                dirty: false,
-            })
-        })
-        .collect();
+    let mut directories = dispatcher.vfs_directories.iter().cloned().collect::<Vec<_>>();
+    directories.sort_by_key(|directory| directory.dir_id);
 
     let mut volumes = dispatcher
         .vfs_volumes

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -90083,6 +90083,8 @@ pub(crate) mod tests {
         let detached = native.clone();
         let mut classic = TrapDispatcher::new();
         classic.attach_process_context(&mut context);
+        assert!(classic.vfs_directories.ptr_eq(&executing_directories));
+        assert!(classic.next_vfs_dir_id.ptr_eq(&executing_next_dir_id));
 
         native.vfs_directories.push(PpcVfsDirectory {
             dir_id: PPC_FIRST_DYNAMIC_DIR_ID,
@@ -90121,6 +90123,20 @@ pub(crate) mod tests {
         *native.next_vfs_dir_id = PPC_FIRST_DYNAMIC_DIR_ID + 1;
         *native.default_dir_id = PPC_FIRST_DYNAMIC_DIR_ID;
 
+        // Directory records are canonical process state, so the classic
+        // adapter observes native mutations before any file compatibility
+        // publication pass.
+        let shared_directory = classic
+            .directory_entry_for_id(PPC_FIRST_DYNAMIC_DIR_ID)
+            .cloned()
+            .expect("native directory should be visible to classic adapter");
+        assert_eq!(shared_directory.path, "Shared Folder");
+        assert_eq!(shared_directory.parent_dir_id, PPC_ROOT_DIR_ID);
+        assert_eq!(shared_directory.creator, u32::from_be_bytes(*b"TEST"));
+        assert_eq!(shared_directory.file_type, u32::from_be_bytes(*b"fold"));
+        assert_eq!(shared_directory.finder_flags, 0x0400);
+        assert!(shared_directory.dirty);
+
         // Volume records are canonical process state, so the classic adapter
         // observes this native mutation before any catalogue publication pass.
         assert_eq!(
@@ -90144,6 +90160,17 @@ pub(crate) mod tests {
         assert_eq!(classic.vfs_volume_for_ref_num(-2).unwrap().name, "Read Only");
 
         let classic_dir_id = classic.ensure_vfs_directory("Classic Folder");
+        let classic_directory = native
+            .vfs_directories
+            .iter()
+            .find(|directory| directory.dir_id == classic_dir_id)
+            .cloned()
+            .expect("classic-created directory should be visible to native adapter");
+        assert_eq!(classic_directory.path, "Classic Folder");
+        assert_eq!(classic_directory.parent_dir_id, PPC_ROOT_DIR_ID);
+        assert_eq!(classic_directory.creator, u32::from_be_bytes(*b"MACS"));
+        assert_eq!(classic_directory.file_type, u32::from_be_bytes(*b"fold"));
+        assert!(classic_directory.dirty);
         let classic_volume_ref = classic.mount_vfs_volume(
             "Classic Disk",
             0,

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -237,18 +237,12 @@ pub(crate) struct ProcessVfsMetadata {
     pub modified_date: u32,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) struct ProcessClassicVfsDirectory {
-    pub dir_id: u32,
-    pub parent_dir_id: u32,
-    pub name: String,
-}
-
-fn process_classic_vfs_directories_are_pristine(
-    directories: &HashMap<String, ProcessClassicVfsDirectory>,
+fn process_native_vfs_catalogue_is_pristine(
+    volumes: &[ProcessVfsVolumeRecord],
+    directories: &[ProcessVfsDirectory],
 ) -> bool {
-    if directories.is_empty() {
-        return true;
+    if !volumes.is_empty() {
+        return false;
     }
     let expected = [
         ("", 2, 1),
@@ -256,40 +250,19 @@ fn process_classic_vfs_directories_are_pristine(
         ("System Folder/Preferences", 17, 16),
     ];
     directories.len() <= expected.len()
-        && directories.iter().all(|(path, directory)| {
-            expected
-                .iter()
-                .any(|(expected_path, dir_id, parent_dir_id)| {
-                    path == expected_path
+        && directories.iter().all(|directory| {
+            !directory.dirty
+                && expected.iter().any(|(path, dir_id, parent_dir_id)| {
+                    directory.path == *path
                         && directory.dir_id == *dir_id
                         && directory.parent_dir_id == *parent_dir_id
                 })
         })
 }
 
-fn process_classic_vfs_directory_paths_are_pristine(paths: &HashMap<u32, String>) -> bool {
-    if paths.is_empty() {
+fn process_vfs_directories_are_pristine(directories: &[ProcessVfsDirectory]) -> bool {
+    if directories.is_empty() {
         return true;
-    }
-    let expected = [
-        (2, ""),
-        (16, "System Folder"),
-        (17, "System Folder/Preferences"),
-    ];
-    paths.len() <= expected.len()
-        && paths.iter().all(|(dir_id, path)| {
-            expected
-                .iter()
-                .any(|(expected_id, expected_path)| dir_id == expected_id && path == expected_path)
-        })
-}
-
-fn process_native_vfs_catalogue_is_pristine(
-    volumes: &[ProcessVfsVolumeRecord],
-    directories: &[ProcessVfsDirectory],
-) -> bool {
-    if !volumes.is_empty() {
-        return false;
     }
     let expected = [
         ("", 2, 1),
@@ -886,9 +859,6 @@ pub struct ProcessFileSystemState {
     pub(crate) next_vfs_dir_id: SharedProcessValue<u32>,
     pub(crate) default_dir_id: SharedProcessValue<u32>,
     pub(crate) classic_vfs_metadata: SharedProcessValue<HashMap<String, ProcessVfsMetadata>>,
-    pub(crate) classic_vfs_directories:
-        SharedProcessValue<HashMap<String, ProcessClassicVfsDirectory>>,
-    pub(crate) classic_vfs_directory_paths: SharedProcessValue<HashMap<u32, String>>,
     pub(crate) classic_locked_files: SharedProcessValue<HashSet<String>>,
     pub(crate) classic_next_vfs_file_id: SharedProcessValue<u32>,
     pub(crate) classic_next_vfs_timestamp: SharedProcessValue<u32>,
@@ -914,8 +884,6 @@ impl Default for ProcessFileSystemState {
             next_vfs_dir_id: SharedProcessValue::from_value(0),
             default_dir_id: SharedProcessValue::from_value(0),
             classic_vfs_metadata: SharedProcessValue::default(),
-            classic_vfs_directories: SharedProcessValue::default(),
-            classic_vfs_directory_paths: SharedProcessValue::default(),
             classic_locked_files: SharedProcessValue::default(),
             classic_next_vfs_file_id: SharedProcessValue::from_value(32),
             classic_next_vfs_timestamp: SharedProcessValue::from_value(1),
@@ -967,25 +935,29 @@ impl ProcessFileSystemState {
 
         let target_catalogue_was_pristine =
             process_native_vfs_catalogue_is_pristine(&self.vfs_volumes, &self.vfs_directories);
-        for volume in source.vfs_volumes.drain(..) {
-            if self.vfs_volumes.iter().any(|existing| {
-                existing.ref_num == volume.ref_num
-                    || existing.name.eq_ignore_ascii_case(&volume.name)
-            }) {
-                continue;
+        if !Rc::ptr_eq(&self.vfs_volumes.0, &source.vfs_volumes.0) {
+            for volume in source.vfs_volumes.drain(..) {
+                if self.vfs_volumes.iter().any(|existing| {
+                    existing.ref_num == volume.ref_num
+                        || existing.name.eq_ignore_ascii_case(&volume.name)
+                }) {
+                    continue;
+                }
+                self.vfs_volumes.push(volume);
             }
-            self.vfs_volumes.push(volume);
         }
         *self.next_vfs_volume_ref_num =
             (*self.next_vfs_volume_ref_num).min(*source.next_vfs_volume_ref_num);
-        for directory in source.vfs_directories.drain(..) {
-            if self.vfs_directories.iter().any(|existing| {
-                existing.dir_id == directory.dir_id
-                    || existing.path.eq_ignore_ascii_case(&directory.path)
-            }) {
-                continue;
+        if !Rc::ptr_eq(&self.vfs_directories.0, &source.vfs_directories.0) {
+            for directory in source.vfs_directories.drain(..) {
+                if self.vfs_directories.iter().any(|existing| {
+                    existing.dir_id == directory.dir_id
+                        || existing.path.eq_ignore_ascii_case(&directory.path)
+                }) {
+                    continue;
+                }
+                self.vfs_directories.push(directory);
             }
-            self.vfs_directories.push(directory);
         }
         *self.next_vfs_dir_id = (*self.next_vfs_dir_id).max(*source.next_vfs_dir_id);
         if *self.default_dir_id == 0
@@ -1011,26 +983,6 @@ impl ProcessFileSystemState {
                 self.classic_vfs_metadata.entry(path).or_insert(metadata);
             }
         }
-        if !Rc::ptr_eq(
-            &self.classic_vfs_directories.0,
-            &source.classic_vfs_directories.0,
-        ) {
-            for (path, directory) in std::mem::take(&mut *source.classic_vfs_directories) {
-                self.classic_vfs_directories
-                    .entry(path)
-                    .or_insert(directory);
-            }
-        }
-        if !Rc::ptr_eq(
-            &self.classic_vfs_directory_paths.0,
-            &source.classic_vfs_directory_paths.0,
-        ) {
-            for (dir_id, path) in std::mem::take(&mut *source.classic_vfs_directory_paths) {
-                self.classic_vfs_directory_paths
-                    .entry(dir_id)
-                    .or_insert(path);
-            }
-        }
         if !Rc::ptr_eq(&self.classic_locked_files.0, &source.classic_locked_files.0) {
             self.classic_locked_files
                 .extend(std::mem::take(&mut *source.classic_locked_files));
@@ -1052,8 +1004,6 @@ impl ProcessFileSystemState {
         snapshot.next_vfs_dir_id = self.next_vfs_dir_id.clone();
         snapshot.default_dir_id = self.default_dir_id.clone();
         snapshot.classic_vfs_metadata = self.classic_vfs_metadata.clone();
-        snapshot.classic_vfs_directories = self.classic_vfs_directories.clone();
-        snapshot.classic_vfs_directory_paths = self.classic_vfs_directory_paths.clone();
         snapshot.classic_locked_files = self.classic_locked_files.clone();
         snapshot.classic_next_vfs_file_id = self.classic_next_vfs_file_id.clone();
         snapshot.classic_next_vfs_timestamp = self.classic_next_vfs_timestamp.clone();
@@ -1075,54 +1025,16 @@ impl ProcessFileSystemState {
         self
     }
 
-    /// Mirror native directory and file records into the classic path indexes.
-    /// Volume records intentionally do not participate in this compatibility
-    /// pass: both adapters query the canonical process-owned volume vector
-    /// directly. Files (1992), pp. 2-27--2-29 and 2-85.
+    /// Mirror native file records into the classic path indexes.
+    ///
+    /// Directory and volume records are canonical process-owned records and
+    /// therefore do not participate in this compatibility pass. Files (1992),
+    /// pp. 2-27--2-29 and 2-85.
     pub(crate) fn publish_native_vfs_catalogue(&mut self) {
         let directories = (*self.vfs_directories).clone();
         let files = self.vfs_files.iter().cloned().collect::<Vec<_>>();
         let resource_files = self.vfs_resource_files.iter().cloned().collect::<Vec<_>>();
         let deleted_paths = self.deleted_vfs_file_paths.clone();
-
-        for directory in &directories {
-            let path = directory.path.clone();
-            let name = if path.is_empty() {
-                "MacintoshHD".to_string()
-            } else {
-                process_vfs_basename(&path).to_string()
-            };
-            self.classic_vfs_directories.insert(
-                path.clone(),
-                ProcessClassicVfsDirectory {
-                    dir_id: directory.dir_id,
-                    parent_dir_id: directory.parent_dir_id,
-                    name,
-                },
-            );
-            self.classic_vfs_directory_paths
-                .insert(directory.dir_id, path.clone());
-            if directory.dirty && !path.is_empty() {
-                publish_native_vfs_metadata(
-                    &mut self.classic_vfs_metadata,
-                    &mut self.classic_next_vfs_file_id,
-                    &mut self.classic_next_vfs_timestamp,
-                    &path,
-                    directory.parent_dir_id,
-                    directory.file_type,
-                    directory.creator,
-                    directory.finder_flags,
-                    true,
-                );
-            }
-        }
-        *self.next_vfs_dir_id = (*self.next_vfs_dir_id).max(
-            directories
-                .iter()
-                .map(|directory| directory.dir_id.saturating_add(1))
-                .max()
-                .unwrap_or(16),
-        );
 
         for file in files {
             if file.path.is_empty() {
@@ -1172,66 +1084,15 @@ impl ProcessFileSystemState {
         }
     }
 
-    pub(crate) fn publish_classic_vfs_directory(&mut self, path: &str) {
-        let Some(directory) = self.classic_vfs_directories.get(path).cloned() else {
-            return;
-        };
-        let metadata = self.classic_vfs_metadata.get(path).copied();
-        if let Some(native) = self
-            .vfs_directories
-            .iter_mut()
-            .find(|native| native.path.eq_ignore_ascii_case(path))
-        {
-            native.dir_id = directory.dir_id;
-            native.parent_dir_id = directory.parent_dir_id;
-            if let Some(metadata) = metadata {
-                native.file_type = metadata.file_type;
-                native.creator = metadata.creator;
-                native.finder_flags = metadata.finder_flags;
-            }
-            return;
-        }
-        self.vfs_directories.push(ProcessVfsDirectory {
-            dir_id: directory.dir_id,
-            parent_dir_id: directory.parent_dir_id,
-            path: path.to_string(),
-            creator: metadata
-                .map(|metadata| metadata.creator)
-                .unwrap_or(u32::from_be_bytes(*b"MACS")),
-            file_type: metadata
-                .map(|metadata| metadata.file_type)
-                .unwrap_or(u32::from_be_bytes(*b"fold")),
-            finder_flags: metadata.map(|metadata| metadata.finder_flags).unwrap_or(0),
-            dirty: false,
-        });
-        *self.next_vfs_dir_id = (*self.next_vfs_dir_id).max(directory.dir_id.saturating_add(1));
-    }
-
-    pub(crate) fn publish_classic_vfs_catalogue(&mut self) {
-        let directories = self
-            .classic_vfs_directories
-            .keys()
-            .cloned()
-            .collect::<Vec<_>>();
-        let metadata = self
-            .classic_vfs_metadata
-            .keys()
-            .cloned()
-            .collect::<Vec<_>>();
-        for path in directories {
-            self.publish_classic_vfs_directory(&path);
-        }
-        for path in metadata {
-            self.publish_classic_vfs_metadata(&path);
-        }
-    }
-
     pub(crate) fn publish_classic_vfs_metadata(&mut self, path: &str) {
         let Some(metadata) = self.classic_vfs_metadata.get(path).copied() else {
             return;
         };
-        if self.classic_vfs_directories.contains_key(path) {
-            self.publish_classic_vfs_directory(path);
+        if self
+            .vfs_directories
+            .iter()
+            .any(|directory| directory.path.eq_ignore_ascii_case(path))
+        {
             return;
         }
         if let Some(data) = self.vfs_files.data_forks.get_shared(path) {
@@ -1304,10 +1165,6 @@ impl ProcessFileSystemState {
                     .starts_with(&prefix.to_ascii_lowercase())
         });
     }
-}
-
-fn process_vfs_basename(path: &str) -> &str {
-    path.rsplit('/').next().unwrap_or(path)
 }
 
 fn process_vfs_parent_dir_id(directories: &[ProcessVfsDirectory], path: &str) -> u32 {
@@ -4609,24 +4466,18 @@ impl ProcessContext {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn attach_classic_vfs_catalogue(
         &self,
+        directories: &mut SharedProcessValue<Vec<ProcessVfsDirectory>>,
         metadata: &mut SharedProcessValue<HashMap<String, ProcessVfsMetadata>>,
-        directories: &mut SharedProcessValue<HashMap<String, ProcessClassicVfsDirectory>>,
-        directory_paths: &mut SharedProcessValue<HashMap<u32, String>>,
         locked_files: &mut SharedProcessValue<HashSet<String>>,
         next_dir_id: &mut SharedProcessValue<u32>,
         next_file_id: &mut SharedProcessValue<u32>,
         next_timestamp: &mut SharedProcessValue<u32>,
         default_dir_id: &mut SharedProcessValue<u32>,
     ) {
+        directories.attach_to(&self.file_system.vfs_directories, |directories| {
+            process_vfs_directories_are_pristine(directories)
+        });
         metadata.attach_to(&self.file_system.classic_vfs_metadata, HashMap::is_empty);
-        directories.attach_to(
-            &self.file_system.classic_vfs_directories,
-            process_classic_vfs_directories_are_pristine,
-        );
-        directory_paths.attach_to(
-            &self.file_system.classic_vfs_directory_paths,
-            process_classic_vfs_directory_paths_are_pristine,
-        );
         locked_files.attach_to(&self.file_system.classic_locked_files, HashSet::is_empty);
         next_dir_id.attach_to(&self.file_system.next_vfs_dir_id, |value| {
             matches!(*value, 0 | 16 | 18)
@@ -6010,30 +5861,26 @@ mod tests {
     #[test]
     fn attached_classic_catalogues_share_mutations_while_clones_detach() {
         let context = ProcessContext::default();
+        let mut first_directories = SharedProcessValue::from_value(vec![ProcessVfsDirectory {
+            dir_id: 2,
+            parent_dir_id: 1,
+            path: String::new(),
+            creator: u32::from_be_bytes(*b"MACS"),
+            file_type: u32::from_be_bytes(*b"fold"),
+            finder_flags: 0,
+            dirty: false,
+        }]);
         let mut first_metadata =
             SharedProcessValue::<HashMap<String, ProcessVfsMetadata>>::default();
-        let mut first_directories =
-            SharedProcessValue::<HashMap<String, ProcessClassicVfsDirectory>>::default();
-        let mut first_directory_paths = SharedProcessValue::<HashMap<u32, String>>::default();
         let mut first_locked_files = SharedProcessValue::<HashSet<String>>::default();
         let mut first_next_dir_id = SharedProcessValue::from_value(16);
         let mut first_next_file_id = SharedProcessValue::from_value(32);
         let mut first_next_timestamp = SharedProcessValue::from_value(1);
         let mut first_default_dir_id = SharedProcessValue::from_value(2);
-        first_directories.insert(
-            String::new(),
-            ProcessClassicVfsDirectory {
-                dir_id: 2,
-                parent_dir_id: 1,
-                name: "MacintoshHD".to_string(),
-            },
-        );
-        first_directory_paths.insert(2, String::new());
 
         context.attach_classic_vfs_catalogue(
-            &mut first_metadata,
             &mut first_directories,
-            &mut first_directory_paths,
+            &mut first_metadata,
             &mut first_locked_files,
             &mut first_next_dir_id,
             &mut first_next_file_id,
@@ -6043,47 +5890,52 @@ mod tests {
 
         let mut second_metadata =
             SharedProcessValue::<HashMap<String, ProcessVfsMetadata>>::default();
-        let mut second_directories =
-            SharedProcessValue::<HashMap<String, ProcessClassicVfsDirectory>>::default();
-        let mut second_directory_paths = SharedProcessValue::<HashMap<u32, String>>::default();
+        let mut second_directories = SharedProcessValue::<Vec<ProcessVfsDirectory>>::default();
         let mut second_locked_files = SharedProcessValue::<HashSet<String>>::default();
         let mut second_next_dir_id = SharedProcessValue::from_value(16);
         let mut second_next_file_id = SharedProcessValue::from_value(32);
         let mut second_next_timestamp = SharedProcessValue::from_value(1);
         let mut second_default_dir_id = SharedProcessValue::from_value(2);
         context.attach_classic_vfs_catalogue(
-            &mut second_metadata,
             &mut second_directories,
-            &mut second_directory_paths,
+            &mut second_metadata,
             &mut second_locked_files,
             &mut second_next_dir_id,
             &mut second_next_file_id,
             &mut second_next_timestamp,
             &mut second_default_dir_id,
         );
+        assert!(first_directories.ptr_eq(&second_directories));
         let detached_directories = second_directories.clone();
         let detached_default_dir_id = second_default_dir_id.clone();
 
-        first_directories.insert(
-            "Games".to_string(),
-            ProcessClassicVfsDirectory {
-                dir_id: 16,
-                parent_dir_id: 2,
-                name: "Games".to_string(),
-            },
-        );
-        first_directory_paths.insert(16, "Games".to_string());
+        first_directories.push(ProcessVfsDirectory {
+            dir_id: 16,
+            parent_dir_id: 2,
+            path: "Games".to_string(),
+            creator: u32::from_be_bytes(*b"TEST"),
+            file_type: u32::from_be_bytes(*b"fold"),
+            finder_flags: 0x0400,
+            dirty: true,
+        });
         *first_next_dir_id = 17;
         *first_default_dir_id = 16;
 
-        assert!(second_directories.contains_key("Games"));
+        assert!(second_directories
+            .iter()
+            .any(|directory| directory.path == "Games"));
         assert_eq!(
-            second_directory_paths.get(&16).map(String::as_str),
+            second_directories
+                .iter()
+                .find(|directory| directory.dir_id == 16)
+                .map(|directory| directory.path.as_str()),
             Some("Games")
         );
         assert_eq!(*second_next_dir_id, 17);
         assert_eq!(*second_default_dir_id, 16);
-        assert!(!detached_directories.contains_key("Games"));
+        assert!(!detached_directories
+            .iter()
+            .any(|directory| directory.path == "Games"));
         assert_eq!(*detached_default_dir_id, 2);
     }
 

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -15958,9 +15958,15 @@ mod tests {
         let saves_directory = runner
             .dispatcher()
             .vfs_directories
-            .get("System Folder/Preferences/Test App Saves")
-            .expect("dirty PPC directory should sync to dispatcher catalog");
-        assert_eq!(saves_directory.name, "Test App Saves");
+            .iter()
+            .find(|directory| {
+                directory.path == "System Folder/Preferences/Test App Saves"
+            })
+            .expect("dirty PPC directory should remain in the shared catalogue");
+        assert_eq!(
+            TrapDispatcher::vfs_basename(&saves_directory.path),
+            "Test App Saves"
+        );
         assert!(output_dir
             .path()
             .join("System Folder/Preferences/Test App Saves")

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -14,10 +14,11 @@ use crate::managers::resource::ResourceFork;
 use crate::memory::{MacMemoryBus, MemoryBus};
 use crate::menu_manager::{ProcessMenuTrackingState, SharedNativeMenuSelection};
 use crate::process_context::{
-    PendingFileCompletion, ProcessClassicVfsDirectory, ProcessContext, ProcessForkMap,
+    PendingFileCompletion, ProcessContext, ProcessForkMap,
     ProcessKeyRepeatState, ProcessLoadedResources, ProcessResourceFileMap,
     ProcessResourceManagerState, ProcessWorkingDirectory,
-    ProcessVfsMetadata, ProcessVfsVolumeRecord, SharedProcessAppleEventHandlers,
+    ProcessVfsDirectory, ProcessVfsMetadata, ProcessVfsVolumeRecord,
+    SharedProcessAppleEventHandlers,
     SharedProcessControlManager, SharedProcessCursorState, SharedProcessDialogText,
     SharedProcessEventQueue, SharedProcessFileSystem, SharedProcessInputState,
     SharedProcessListManager, SharedProcessMemoryManager, SharedProcessMenuTracking,
@@ -1020,7 +1021,7 @@ pub(crate) struct ControlAuxRecordState {
 }
 
 pub(crate) type VfsMetadata = ProcessVfsMetadata;
-pub(crate) type VfsDirectory = ProcessClassicVfsDirectory;
+pub(crate) type VfsDirectory = ProcessVfsDirectory;
 pub(crate) type VfsVolume = ProcessVfsVolumeRecord;
 
 pub(crate) type WorkingDirectory = ProcessWorkingDirectory;
@@ -1940,10 +1941,9 @@ pub struct TrapDispatcher {
     pub vfs_rsrc: SharedProcessValue<ProcessForkMap>,
     /// Finder metadata and catalog IDs for VFS file entries.
     pub(crate) vfs_metadata: SharedProcessValue<HashMap<String, VfsMetadata>>,
-    /// Directory catalog metadata keyed by normalized path.
-    pub(crate) vfs_directories: SharedProcessValue<HashMap<String, VfsDirectory>>,
-    /// Reverse directory lookup by catalog ID.
-    pub(crate) vfs_directory_paths: SharedProcessValue<HashMap<u32, String>>,
+    /// Canonical process directory catalogue shared with the native adapter.
+    /// Files (1992), pp. 2-27--2-29 and 2-190--2-192.
+    pub(crate) vfs_directories: SharedProcessValue<Vec<VfsDirectory>>,
     /// Read-only disk-image volumes mounted alongside the synthetic boot volume.
     pub(crate) vfs_volumes: SharedProcessValue<Vec<VfsVolume>>,
     /// Open working directories keyed by working directory reference number.
@@ -2805,16 +2805,14 @@ impl TrapDispatcher {
         self.process_window_list_attached = true;
         context.attach_classic_file_system(&mut self.vfs, &mut self.vfs_rsrc);
         context.attach_classic_vfs_catalogue(
-            &mut self.vfs_metadata,
             &mut self.vfs_directories,
-            &mut self.vfs_directory_paths,
+            &mut self.vfs_metadata,
             &mut self.locked_files,
             &mut self.next_vfs_dir_id,
             &mut self.next_vfs_file_id,
             &mut self.next_vfs_timestamp,
             &mut self.default_dir_id,
         );
-        self.process_file_system.publish_classic_vfs_catalogue();
         let mut memory_manager = None;
         context.attach_memory_manager(&mut memory_manager);
         self.attach_memory_manager_handle(
@@ -3675,21 +3673,18 @@ impl TrapDispatcher {
     }
 
     pub fn new() -> Self {
-        let mut vfs_directories = HashMap::new();
-        let mut vfs_directory_paths = HashMap::new();
-        vfs_directories.insert(
-            String::new(),
-            VfsDirectory {
-                dir_id: 2,
-                parent_dir_id: 1,
-                // The root directory's catalog name is the volume name.
-                // Files 1992, 2-27 and 2-85.
-                name: BOOT_VOLUME_NAME.to_string(),
-            },
-        );
-        vfs_directory_paths.insert(2, String::new());
-
-        let process_file_system = SharedProcessFileSystem::default();
+        let mut process_file_system = SharedProcessFileSystem::default();
+        *process_file_system.vfs_directories = vec![ProcessVfsDirectory {
+            dir_id: 2,
+            parent_dir_id: 1,
+            // The root directory's catalog name is the volume name.
+            // Files 1992, 2-27 and 2-85.
+            path: String::new(),
+            creator: u32::from_be_bytes(*b"MACS"),
+            file_type: u32::from_be_bytes(*b"fold"),
+            finder_flags: 0,
+            dirty: false,
+        }];
         let open_files = process_file_system.files.shared_handle();
         let write_refnums = process_file_system.writable_refnums.shared_handle();
         let pending_file_completions = process_file_system.pending_completions.shared_handle();
@@ -3704,6 +3699,7 @@ impl TrapDispatcher {
         let next_vfs_volume_ref_num = process_file_system
             .next_vfs_volume_ref_num
             .shared_handle();
+        let vfs_directories = process_file_system.vfs_directories.shared_handle();
         let file_positions = process_file_system.files.positions();
 
         let mut dispatcher = Self {
@@ -3779,8 +3775,7 @@ impl TrapDispatcher {
             vfs: SharedProcessValue::default(),
             vfs_rsrc: SharedProcessValue::default(),
             vfs_metadata: SharedProcessValue::default(),
-            vfs_directories: SharedProcessValue::from_value(vfs_directories),
-            vfs_directory_paths: SharedProcessValue::from_value(vfs_directory_paths),
+            vfs_directories,
             vfs_volumes,
             working_directories,
             open_files,
@@ -4629,6 +4624,14 @@ impl TrapDispatcher {
         path.rsplit('/').next().unwrap_or(path)
     }
 
+    pub(crate) fn vfs_directory_name(path: &str) -> String {
+        if path.is_empty() {
+            BOOT_VOLUME_NAME.to_string()
+        } else {
+            Self::vfs_basename(path).to_string()
+        }
+    }
+
     fn allocate_vfs_timestamp(&mut self) -> u32 {
         let timestamp = *self.next_vfs_timestamp;
         *self.next_vfs_timestamp = self.next_vfs_timestamp.saturating_add(1);
@@ -4682,14 +4685,12 @@ impl TrapDispatcher {
         if normalized.is_empty() {
             return 2;
         }
-        if let Some(dir_id) = self
+        if let Some(directory) = self
             .vfs_directories
-            .get(&normalized)
-            .map(|directory| directory.dir_id)
+            .iter()
+            .find(|directory| directory.path.eq_ignore_ascii_case(&normalized))
         {
-            self.process_file_system
-                .publish_classic_vfs_directory(&normalized);
-            return dir_id;
+            return directory.dir_id;
         }
 
         let parent_path = Self::vfs_parent_path(&normalized).to_string();
@@ -4697,17 +4698,15 @@ impl TrapDispatcher {
         let dir_id = *self.next_vfs_dir_id;
         *self.next_vfs_dir_id = self.next_vfs_dir_id.saturating_add(1);
 
-        self.vfs_directories.insert(
-            normalized.clone(),
-            VfsDirectory {
-                dir_id,
-                parent_dir_id,
-                name: Self::vfs_basename(&normalized).to_string(),
-            },
-        );
-        self.vfs_directory_paths.insert(dir_id, normalized.clone());
-        self.process_file_system
-            .publish_classic_vfs_directory(&normalized);
+        self.vfs_directories.push(VfsDirectory {
+            dir_id,
+            parent_dir_id,
+            path: normalized,
+            creator: u32::from_be_bytes(*b"MACS"),
+            file_type: u32::from_be_bytes(*b"fold"),
+            finder_flags: 0,
+            dirty: true,
+        });
         dir_id
     }
 
@@ -4983,17 +4982,15 @@ impl TrapDispatcher {
 
         removed |= self.vfs_metadata.remove(&normalized).is_some();
 
-        let directory_keys: Vec<String> = self
-            .vfs_directories
-            .keys()
-            .filter(|key| *key == &normalized || key.starts_with(&prefix))
-            .cloned()
-            .collect();
-        for key in directory_keys {
-            if let Some(directory) = self.vfs_directories.remove(&key) {
-                self.vfs_directory_paths.remove(&directory.dir_id);
-                removed = true;
-            }
+        let directory_count = self.vfs_directories.len();
+        self.vfs_directories.retain(|directory| {
+            let path = directory.path.to_ascii_lowercase();
+            let normalized = normalized.to_ascii_lowercase();
+            let prefix = prefix.to_ascii_lowercase();
+            !(path == normalized || path.starts_with(&prefix))
+        });
+        if self.vfs_directories.len() != directory_count {
+            removed = true;
         }
 
         self.process_file_system.remove_classic_vfs_path(&normalized);
@@ -5028,13 +5025,16 @@ impl TrapDispatcher {
     }
 
     pub(crate) fn directory_path_for_id(&self, dir_id: u32) -> Option<&str> {
-        self.vfs_directory_paths.get(&dir_id).map(String::as_str)
+        self.vfs_directories
+            .iter()
+            .find(|directory| directory.dir_id == dir_id)
+            .map(|directory| directory.path.as_str())
     }
 
     pub(crate) fn directory_entry_for_id(&self, dir_id: u32) -> Option<&VfsDirectory> {
-        self.vfs_directory_paths
-            .get(&dir_id)
-            .and_then(|path| self.vfs_directories.get(path))
+        self.vfs_directories
+            .iter()
+            .find(|directory| directory.dir_id == dir_id)
     }
 
     pub(crate) fn resolve_volume_ref_num(&self, vref: i16) -> i16 {
@@ -5366,32 +5366,30 @@ impl TrapDispatcher {
                 );
             }
         }
-        // Sort vfs_directories keys before first-match .find() to avoid
-        // leaking HashMap hash-randomisation into directory resolution
-        // (and from there into resource load order, allocation order, and
-        // tick advancement under realtime cadence).
-        let mut sorted_keys: Vec<&String> = self.vfs_directories.keys().collect();
-        sorted_keys.sort_unstable();
+        // Sort paths before first-match .find() to keep directory resolution
+        // deterministic when an archive contains case-different spellings.
+        let mut sorted_directories: Vec<&VfsDirectory> = self.vfs_directories.iter().collect();
+        sorted_directories.sort_unstable_by(|left, right| left.path.cmp(&right.path));
         if let Some(dir_path) = self.directory_path_for_id(dir_id) {
             let candidate = if dir_path.is_empty() {
                 normalized.clone()
             } else {
                 format!("{dir_path}/{normalized}")
             };
-            if let Some(found) = sorted_keys
+            if let Some(found) = sorted_directories
                 .iter()
                 .copied()
-                .find(|path| path.eq_ignore_ascii_case(&candidate))
+                .find(|directory| directory.path.eq_ignore_ascii_case(&candidate))
             {
-                return Some(found.clone());
+                return Some(found.path.clone());
             }
         }
         if normalized.contains('/') {
-            return sorted_keys
+            return sorted_directories
                 .iter()
                 .copied()
-                .find(|path| path.eq_ignore_ascii_case(&normalized))
-                .cloned();
+                .find(|directory| directory.path.eq_ignore_ascii_case(&normalized))
+                .map(|directory| directory.path.clone());
         }
         None
     }
@@ -5399,29 +5397,23 @@ impl TrapDispatcher {
     pub(crate) fn list_vfs_catalog_entries(&mut self, dir_id: u32) -> Vec<VfsCatalogEntry> {
         self.ensure_vfs_catalog();
         let mut entries = Vec::new();
-        let effective_dir_id = if self.vfs_directory_paths.contains_key(&dir_id) {
+        let effective_dir_id = if self.directory_entry_for_id(dir_id).is_some() {
             dir_id
         } else {
             2
         };
 
-        // Iterate vfs_directories in path-sorted order so the entries Vec is
-        // built deterministically. The final entries.sort_by_key(name) below
-        // only sorts by name (case-insensitive), so two directories with the
-        // same name but different paths would otherwise land in HashMap-random
-        // order.
-        let mut dir_paths: Vec<&String> = self.vfs_directories.keys().collect();
-        dir_paths.sort_unstable();
-        for path in dir_paths {
-            let Some(directory) = self.vfs_directories.get(path) else {
-                continue;
-            };
-            if path.is_empty() || directory.parent_dir_id != effective_dir_id {
+        // Iterate the canonical directory vector in path-sorted order so the
+        // entries Vec is deterministic before the final name sort.
+        let mut directories: Vec<&VfsDirectory> = self.vfs_directories.iter().collect();
+        directories.sort_unstable_by(|left, right| left.path.cmp(&right.path));
+        for directory in directories {
+            if directory.path.is_empty() || directory.parent_dir_id != effective_dir_id {
                 continue;
             }
             entries.push(VfsCatalogEntry {
-                path: path.clone(),
-                name: directory.name.clone(),
+                path: directory.path.clone(),
+                name: Self::vfs_directory_name(&directory.path),
                 is_directory: true,
             });
         }
@@ -10611,10 +10603,16 @@ mod tests {
         assert!(!disp.vfs.contains_key("Game/Plug-Ins/MAGMA/Data"));
         assert!(!disp.vfs_rsrc.contains_key("Game/Plug-Ins/MAGMA/Data"));
         assert!(!disp.vfs_metadata.contains_key("Game/Plug-Ins/MAGMA/Data"));
-        assert!(!disp.vfs_directories.contains_key("Game/Plug-Ins/MAGMA"));
+        assert!(!disp
+            .vfs_directories
+            .iter()
+            .any(|directory| directory.path == "Game/Plug-Ins/MAGMA"));
         assert!(disp.vfs.contains_key("Game/Plug-Ins/Keep/Data"));
         assert!(disp.vfs_metadata.contains_key("Game/Plug-Ins/Keep/Data"));
-        assert!(disp.vfs_directories.contains_key("Game/Plug-Ins/Keep"));
+        assert!(disp
+            .vfs_directories
+            .iter()
+            .any(|directory| directory.path == "Game/Plug-Ins/Keep"));
     }
 
     #[test]

--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -6,6 +6,7 @@ use crate::machine_profile::REFERENCE_MACHINE_PROFILE;
 use crate::managers::resource::ResourceFork;
 use crate::memory::globals::addr;
 use crate::memory::{MacMemoryBus, MemoryBus};
+use crate::process_context::ProcessVfsDirectory;
 use crate::trap::types::{decode_mac_roman, encode_mac_roman_lossy, read_fsspec_name};
 use crate::{Error, Result};
 
@@ -5934,7 +5935,11 @@ impl super::TrapDispatcher {
 
                 if named_volume.is_none() && !name.is_empty() {
                     if let Some(path) = self.find_vfs_directory_in_directory(target_dir_id, &name) {
-                        if let Some(directory) = self.vfs_directories.get(&path) {
+                        if let Some(directory) = self
+                            .vfs_directories
+                            .iter()
+                            .find(|directory| directory.path.eq_ignore_ascii_case(&path))
+                        {
                             target_dir_id = directory.dir_id;
                         }
                     } else if let Some(path) = self.find_vfs_file_in_directory(target_dir_id, &name)
@@ -6568,8 +6573,8 @@ impl super::TrapDispatcher {
                                     .any(|path| path.eq_ignore_ascii_case(key))
                                 || self
                                     .vfs_directories
-                                    .keys()
-                                    .any(|path| path.eq_ignore_ascii_case(key))
+                                    .iter()
+                                    .any(|directory| directory.path.eq_ignore_ascii_case(key))
                         } else {
                             false
                         };
@@ -6850,8 +6855,10 @@ impl super::TrapDispatcher {
                                 };
                                 let duplicate = self
                                     .vfs_directories
-                                    .keys()
-                                    .any(|path| path.eq_ignore_ascii_case(&child_path))
+                                    .iter()
+                                    .any(|directory| {
+                                        directory.path.eq_ignore_ascii_case(&child_path)
+                                    })
                                     || self
                                         .vfs
                                         .keys()
@@ -7289,7 +7296,8 @@ impl super::TrapDispatcher {
                         self.find_vfs_directory_in_directory(base_dir_id, &name)
                     {
                         self.vfs_directories
-                            .get(&path)
+                            .iter()
+                            .find(|directory| directory.path.eq_ignore_ascii_case(&path))
                             .map(|directory| directory.dir_id)
                             .unwrap_or(base_dir_id)
                     } else {
@@ -7463,8 +7471,8 @@ impl super::TrapDispatcher {
                             };
                             let duplicate = self
                                 .vfs_directories
-                                .keys()
-                                .any(|path| path.eq_ignore_ascii_case(&child_path))
+                                .iter()
+                                .any(|directory| directory.path.eq_ignore_ascii_case(&child_path))
                                 || self
                                     .vfs
                                     .keys()
@@ -7620,7 +7628,13 @@ impl super::TrapDispatcher {
 
                     if let Some(entry) = lookup {
                         if entry.is_directory {
-                            if let Some(directory) = self.vfs_directories.get(&entry.path) {
+                            if let Some(directory) = self
+                                .vfs_directories
+                                .iter()
+                                .find(|directory| {
+                                    directory.path.eq_ignore_ascii_case(&entry.path)
+                                })
+                            {
                                 self.fill_directory_catalog_info(bus, pb, directory);
                                 eprintln!(
                                     "[TRAP] FSDispatch PBGetCatInfo dir \"{}\" -> dirID={} parentDirID={}",
@@ -8074,14 +8088,14 @@ impl super::TrapDispatcher {
         Self::write_finfo(
             bus,
             pb + 32,
-            u32::from_be_bytes(*b"fold"),
-            u32::from_be_bytes(*b"MACS"),
-            0,
+            directory.file_type,
+            directory.creator,
+            directory.finder_flags,
         );
         bus.write_long(pb + 48, directory.dir_id);
         let child_directory_count = self
             .vfs_directories
-            .values()
+            .iter()
             .filter(|child| {
                 child.dir_id != directory.dir_id && child.parent_dir_id == directory.dir_id
             })
@@ -8128,7 +8142,8 @@ impl super::TrapDispatcher {
         self.ensure_vfs_catalog();
         let mut entries = Vec::new();
 
-        for (path, directory) in &*self.vfs_directories {
+        for directory in &*self.vfs_directories {
+            let path = &directory.path;
             let entry_volume_ref = self
                 .vfs_volume_for_path(path)
                 .map(|volume| volume.ref_num)
@@ -8138,7 +8153,7 @@ impl super::TrapDispatcher {
             }
             let child_count = self
                 .vfs_directories
-                .values()
+                .iter()
                 .filter(|child| {
                     child.dir_id != directory.dir_id && child.parent_dir_id == directory.dir_id
                 })
@@ -8156,18 +8171,22 @@ impl super::TrapDispatcher {
                 } else {
                     self.vfs_volume_for_ref_num(volume_ref_num)
                         .map(|volume| volume.name.clone())
-                        .unwrap_or_else(|| directory.name.clone())
+                        .unwrap_or_else(|| Self::vfs_basename(&directory.path).to_string())
                 }
             } else {
-                Self::hfs_name_from_vfs_component(&directory.name)
+                Self::hfs_name_from_vfs_component(Self::vfs_basename(&directory.path))
             };
+            let mut finder_info = [0u8; 16];
+            finder_info[..4].copy_from_slice(&directory.file_type.to_be_bytes());
+            finder_info[4..8].copy_from_slice(&directory.creator.to_be_bytes());
+            finder_info[8..10].copy_from_slice(&directory.finder_flags.to_be_bytes());
             entries.push(CatSearchEntry {
                 name,
                 vref_num: volume_ref_num,
                 parent_dir_id: directory.parent_dir_id,
                 is_directory: true,
                 locked: false,
-                finder_info: [0; 16],
+                finder_info,
                 extended_finder_info: [0; 16],
                 data_length: 0,
                 resource_length: 0,
@@ -8406,7 +8425,9 @@ impl super::TrapDispatcher {
             let path = self.directory_path_for_id(dir_id)?.to_string();
             return Some(super::dispatch::VfsCatalogEntry {
                 path,
-                name: super::TrapDispatcher::hfs_name_from_vfs_component(&directory.name),
+                name: super::TrapDispatcher::hfs_name_from_vfs_component(
+                    &super::TrapDispatcher::vfs_directory_name(&directory.path),
+                ),
                 is_directory: true,
             });
         }
@@ -8424,16 +8445,23 @@ impl super::TrapDispatcher {
             let path = self.directory_path_for_id(dir_id)?.to_string();
             return Some(super::dispatch::VfsCatalogEntry {
                 path,
-                name: super::TrapDispatcher::hfs_name_from_vfs_component(&directory.name),
+                name: super::TrapDispatcher::hfs_name_from_vfs_component(
+                    &super::TrapDispatcher::vfs_directory_name(&directory.path),
+                ),
                 is_directory: true,
             });
         }
 
         if let Some(path) = self.find_vfs_directory_in_directory(dir_id, filename) {
-            let directory = self.vfs_directories.get(&path)?;
+            let directory = self
+                .vfs_directories
+                .iter()
+                .find(|directory| directory.path.eq_ignore_ascii_case(&path))?;
             return Some(super::dispatch::VfsCatalogEntry {
                 path: path.clone(),
-                name: super::TrapDispatcher::hfs_name_from_vfs_component(&directory.name),
+                name: super::TrapDispatcher::hfs_name_from_vfs_component(
+                    &super::TrapDispatcher::vfs_directory_name(&directory.path),
+                ),
                 is_directory: true,
             });
         }
@@ -8609,12 +8637,12 @@ impl super::TrapDispatcher {
             return Some(2);
         }
 
-        let mut sorted_keys: Vec<&String> = self.vfs_directories.keys().collect();
-        sorted_keys.sort_unstable();
-        sorted_keys
+        let mut sorted_directories: Vec<&ProcessVfsDirectory> = self.vfs_directories.iter().collect();
+        sorted_directories.sort_unstable_by(|left, right| left.path.cmp(&right.path));
+        sorted_directories
             .into_iter()
-            .find(|key| key.eq_ignore_ascii_case(&normalized))
-            .and_then(|key| self.vfs_directories.get(key).map(|dir| dir.dir_id))
+            .find(|directory| directory.path.eq_ignore_ascii_case(&normalized))
+            .map(|directory| directory.dir_id)
     }
 
     fn fsspec_parts_for_hfs_path(
@@ -16328,6 +16356,13 @@ mod tests {
 
         let app_dir_id = disp.ensure_vfs_directory("EV Override 1.0.1");
         let pilots_dir_id = disp.ensure_vfs_directory("EV Override 1.0.1/Pilots");
+        let pilots_directory = disp
+            .vfs_directories
+            .iter_mut()
+            .find(|directory| directory.dir_id == pilots_dir_id)
+            .expect("created directory should be canonical");
+        pilots_directory.creator = u32::from_be_bytes(*b"TEST");
+        pilots_directory.finder_flags = 0x0400;
         disp.vfs
             .insert("EV Override 1.0.1/Pilots/Ben".to_string(), vec![0x42]);
 
@@ -16350,7 +16385,8 @@ mod tests {
             "PBGetCatInfo returned a directory"
         );
         assert_eq!(bus.read_long(pb + 32), u32::from_be_bytes(*b"fold"));
-        assert_eq!(bus.read_long(pb + 36), u32::from_be_bytes(*b"MACS"));
+        assert_eq!(bus.read_long(pb + 36), u32::from_be_bytes(*b"TEST"));
+        assert_eq!(bus.read_word(pb + 40), 0x0400);
         assert_eq!(bus.read_long(pb + 48), pilots_dir_id);
         assert_eq!(
             bus.read_word(pb + 52),

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -2139,7 +2139,11 @@ impl super::TrapDispatcher {
         let mut entries = Vec::new();
         for entry in self.list_vfs_catalog_entries(dir_id) {
             if entry.is_directory {
-                let Some(directory) = self.vfs_directories.get(&entry.path) else {
+                let Some(directory) = self
+                    .vfs_directories
+                    .iter()
+                    .find(|directory| directory.path.eq_ignore_ascii_case(&entry.path))
+                else {
                     continue;
                 };
                 let mut name = encode_mac_roman_lossy(&entry.name);
@@ -3071,9 +3075,12 @@ impl super::TrapDispatcher {
         let target_name = crate::trap::types::read_fsspec_name(bus, target_ptr);
         let resolved_dir_id = self.resolve_directory_id(vref, dir_id);
         let target_key = self.vfs_key_for_fsspec(vref, dir_id, &target_name);
-        let target_directory = target_key
-            .as_ref()
-            .and_then(|key| self.vfs_directories.get(key).cloned());
+        let target_directory = target_key.as_ref().and_then(|key| {
+            self.vfs_directories
+                .iter()
+                .find(|directory| directory.path.eq_ignore_ascii_case(key))
+                .cloned()
+        });
         let target_metadata = target_key
             .as_ref()
             .and_then(|key| self.vfs_file_metadata(key));


### PR DESCRIPTION
Closes #1272.

Makes the VFS directory catalogue and directory-ID allocator canonical process state shared directly by the 68K and PowerPC adapters. Removes the classic path map, reverse-ID map, and directory publication passes while preserving case-insensitive lookup, deterministic enumeration, directory Finder metadata, and detached-clone isolation.

Validation:
- `cargo test --locked --lib`
- strict rustdoc warnings
- all-feature/all-target compilation
- Marathon gameplay and terminal interaction
- Escape Velocity live-space gameplay and input
- Tomb Raider Gold live 3D gameplay and input