### PR TITLE
refactor(memory): transfer native allocator ownership on attachment

### DIFF
--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -73,8 +73,8 @@ use crate::menu_model::GuestMenuSnapshot;
 use crate::process_context::{
     ProcessAppleEventHandler, ProcessContext, ProcessCursorState, ProcessFileSystemState,
     ProcessHandleRecord, ProcessHandleStateRecord, ProcessInputState, ProcessMemoryManager,
-    ProcessNativeAllocatorState, ProcessNativeHeapState, ProcessNativeMemoryManager,
-    ProcessPtrRecord, ProcessResourceManagerState, ProcessVfsFileRecords,
+    ProcessNativeHeapState, ProcessNativeMemoryManager, ProcessPtrRecord,
+    ProcessResourceManagerState, ProcessVfsFileRecords,
     ProcessVfsResourceFileRecords, ProcessWorkingDirectory, SharedProcessAppleEventHandlers,
     SharedProcessCallbackScheduling, SharedProcessCursorState, SharedProcessDialogText,
     SharedProcessControlManager, SharedProcessEventQueue,
@@ -3721,53 +3721,8 @@ impl PpcLoadedApp {
         }
     }
 
-    fn initialize_process_memory_manager(
-        &self,
-        memory_manager: &mut ProcessMemoryManager,
-        pointer_records: Option<ProcessNativeAllocatorState>,
-    ) {
-        let existing_heap = memory_manager.native_heap_state();
-        let pointer_records =
-            pointer_records.or_else(|| memory_manager.native_allocator_snapshot());
-        let canonical_heap = pointer_records
-            .as_ref()
-            .map(|allocator| allocator.heap)
-            .or(existing_heap)
-            .or_else(|| self.process_memory_manager.0.borrow().native_heap_state());
-        memory_manager.publish_native_allocator(
-            ProcessNativeHeapState {
-                heap_base: canonical_heap.map_or(PPC_HEAP_BASE, |heap| heap.heap_base),
-                heap_cursor: canonical_heap.map_or(PPC_HEAP_BASE, |heap| heap.heap_cursor),
-                heap_limit: canonical_heap.map_or(self.stack_base, |heap| heap.heap_limit),
-                last_mem_error: canonical_heap.map_or(0, |heap| heap.last_mem_error),
-                heap_maximized: canonical_heap.is_some_and(|heap| heap.heap_maximized),
-                master_pointer_blocks_requested: canonical_heap
-                    .map_or(0, |heap| heap.master_pointer_blocks_requested),
-            },
-            pointer_records
-                .as_ref()
-                .map_or(&[], |allocator| allocator.ptrs.as_slice()),
-            pointer_records
-                .as_ref()
-                .map_or(&[], |allocator| allocator.free_ptr_blocks.as_slice()),
-            pointer_records
-                .as_ref()
-                .map_or(&[], |allocator| allocator.free_handle_blocks.as_slice()),
-        );
-    }
-
-    fn adopt_process_memory_manager(&mut self, memory_manager: &ProcessMemoryManager) {
-        if let Some(allocator) = memory_manager.native_allocator_snapshot() {
-            self.apply_process_native_allocator(allocator);
-        }
-    }
-
-    fn apply_process_native_allocator(&mut self, allocator: ProcessNativeAllocatorState) {
-        ppc_update_zone_free_bytes(
-            &mut self.memory,
-            allocator.heap.heap_cursor,
-            allocator.heap.heap_limit,
-        );
+    fn refresh_process_native_zone(&mut self, heap: ProcessNativeHeapState) {
+        ppc_update_zone_free_bytes(&mut self.memory, heap.heap_cursor, heap.heap_limit);
     }
 
     pub(crate) fn prepare_shared_system_reservation(&mut self, base: u32, len: u32) -> bool {
@@ -3905,6 +3860,16 @@ impl PpcLoadedApp {
     }
 
     pub(crate) fn attach_process_context(&mut self, context: &mut ProcessContext) {
+        let mut attached_memory_manager = None;
+        context.attach_memory_manager(&mut attached_memory_manager);
+        let attached_memory_manager =
+            attached_memory_manager.expect("process context supplies a Memory Manager");
+        if !self.process_memory_manager.ptr_eq(&attached_memory_manager) {
+            let standalone_memory_manager = self.process_memory_manager.0.borrow();
+            let memory_manager = attached_memory_manager.borrow();
+            memory_manager
+                .assert_can_adopt_process_memory_manager(&standalone_memory_manager);
+        }
         context.attach_file_system(&mut self.process_file_system);
         self.process_file_system.publish_native_vfs_catalogue();
         context.attach_sound_manager(&mut self.sound.manager);
@@ -3932,21 +3897,14 @@ impl PpcLoadedApp {
         context.attach_window_list(&mut self.window_list);
         context.attach_input_state(&mut self.process_input);
         context.attach_menu_tracking(&mut self.toolbox_startup.menu_tracking);
-        let mut attached_memory_manager = None;
-        context.attach_memory_manager(&mut attached_memory_manager);
-        let attached_memory_manager =
-            attached_memory_manager.expect("process context supplies a Memory Manager");
         if !self.process_memory_manager.ptr_eq(&attached_memory_manager) {
             {
                 let standalone_memory_manager = self.process_memory_manager.0.clone();
                 let mut standalone_memory_manager = standalone_memory_manager.borrow_mut();
                 let mut memory_manager = attached_memory_manager.borrow_mut();
-                memory_manager.adopt_handle_metadata(&mut standalone_memory_manager);
-                if memory_manager.has_native_allocator() {
-                    self.adopt_process_memory_manager(&memory_manager);
-                } else {
-                    let pointer_records = standalone_memory_manager.native_allocator_snapshot();
-                    self.initialize_process_memory_manager(&mut memory_manager, pointer_records);
+                memory_manager.adopt_process_memory_manager(&mut standalone_memory_manager);
+                if let Some(heap) = memory_manager.native_heap_state() {
+                    self.refresh_process_native_zone(heap);
                 }
             }
             self.process_memory_manager
@@ -91491,6 +91449,7 @@ pub(crate) mod tests {
     fn attaching_and_cloning_native_adapters_preserves_process_ownership() {
         let pef = synthetic_pef_with_import(b"NewHandleClear");
         let mut native = load_pef_application(&pef).unwrap();
+        let standalone_memory_manager = native.process_memory_manager.0.clone();
         native.cpu.gpr[3] = 24;
         run_test_import(
             &mut native,
@@ -91510,6 +91469,26 @@ pub(crate) mod tests {
         assert!(native
             .process_memory_manager
             .ptr_eq(&process_memory_manager));
+        assert!(!standalone_memory_manager.borrow().has_native_allocator());
+        assert!(standalone_memory_manager
+            .borrow()
+            .native_handle_records()
+            .is_empty());
+        let attached_heap = process_memory_manager.borrow().native_heap_state().unwrap();
+        let expected_free = ppc_heap_free_capacity(
+            &mut native.memory,
+            attached_heap.heap_cursor,
+            attached_heap.heap_limit,
+        )
+        .0;
+        assert_eq!(
+            native.memory.read_u32_be(PPC_APPLICATION_ZONE + 12),
+            Some(expected_free)
+        );
+        assert_eq!(
+            native.memory.read_u32_be(PPC_SYSTEM_ZONE + 12),
+            Some(expected_free)
+        );
         let detached_heap_cursor = detached.heap_cursor();
         let detached_handle_record = detached.handles()[0];
         let attached_heap_cursor = native.heap_cursor() + 0x80;
@@ -91599,6 +91578,85 @@ pub(crate) mod tests {
         detached.cpu.gpr[3] = handle;
         run_test_import(&mut detached, PpcImportDispatcherTarget::HGetState);
         assert_eq!(detached.cpu.gpr[3], 0x40);
+    }
+
+    #[test]
+    fn attaching_a_pristine_native_adapter_retains_the_populated_process_allocator() {
+        let pef = synthetic_pef_with_import(b"NewPtrClear");
+        let mut owner = load_pef_application(&pef).unwrap();
+        owner.cpu.gpr[3] = 24;
+        run_test_import(
+            &mut owner,
+            PpcImportDispatcherTarget::NewPtr { clear: true },
+        );
+        let ptr = owner.cpu.gpr[3];
+        let mut context = ProcessContext::default();
+        owner.attach_process_context(&mut context);
+        let canonical = context.memory_manager_handle().clone();
+        let canonical_allocator = canonical.borrow().native_allocator_snapshot();
+
+        let mut observer = load_pef_application(&pef).unwrap();
+        let standalone = observer.process_memory_manager.0.clone();
+        observer.attach_process_context(&mut context);
+
+        assert!(observer.process_memory_manager.ptr_eq(&canonical));
+        assert_eq!(canonical.borrow().native_allocator_snapshot(), canonical_allocator);
+        assert_eq!(canonical.borrow_mut().native_ptr_size(ptr), 24);
+        assert!(!standalone.borrow().has_native_allocator());
+        let heap = canonical.borrow().native_heap_state().unwrap();
+        let expected_free =
+            ppc_heap_free_capacity(&mut observer.memory, heap.heap_cursor, heap.heap_limit).0;
+        assert_eq!(
+            observer.memory.read_u32_be(PPC_APPLICATION_ZONE + 12),
+            Some(expected_free)
+        );
+        assert_eq!(
+            observer.memory.read_u32_be(PPC_SYSTEM_ZONE + 12),
+            Some(expected_free)
+        );
+    }
+
+    #[test]
+    fn attaching_two_populated_native_adapters_is_atomic() {
+        let pef = synthetic_pef_with_import(b"NewPtrClear");
+        let mut owner = load_pef_application(&pef).unwrap();
+        owner.cpu.gpr[3] = 24;
+        run_test_import(
+            &mut owner,
+            PpcImportDispatcherTarget::NewPtr { clear: true },
+        );
+        let mut context = ProcessContext::default();
+        owner.attach_process_context(&mut context);
+        let canonical = context.memory_manager_handle().clone();
+
+        let mut rejected = load_pef_application(&pef).unwrap();
+        rejected.cpu.gpr[3] = 48;
+        run_test_import(
+            &mut rejected,
+            PpcImportDispatcherTarget::NewPtr { clear: true },
+        );
+        let standalone = rejected.process_memory_manager.0.clone();
+        let canonical_allocator = canonical.borrow().native_allocator_snapshot();
+        let standalone_allocator = standalone.borrow().native_allocator_snapshot();
+        let application_zone = rejected.memory.read_u32_be(PPC_APPLICATION_ZONE + 12);
+        let system_zone = rejected.memory.read_u32_be(PPC_SYSTEM_ZONE + 12);
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            rejected.attach_process_context(&mut context);
+        }));
+
+        assert!(result.is_err());
+        assert!(!rejected.process_memory_manager.ptr_eq(&canonical));
+        assert_eq!(canonical.borrow().native_allocator_snapshot(), canonical_allocator);
+        assert_eq!(standalone.borrow().native_allocator_snapshot(), standalone_allocator);
+        assert_eq!(
+            rejected.memory.read_u32_be(PPC_APPLICATION_ZONE + 12),
+            application_zone
+        );
+        assert_eq!(
+            rejected.memory.read_u32_be(PPC_SYSTEM_ZONE + 12),
+            system_zone
+        );
     }
 
     #[test]

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -1717,6 +1717,7 @@ pub(crate) struct ProcessNativeHeapState {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ProcessNativeAllocatorState {
+    initial_heap: ProcessNativeHeapState,
     pub(crate) heap: ProcessNativeHeapState,
     pub(crate) ptrs: Vec<ProcessPtrRecord>,
     pub(crate) free_ptr_blocks: Vec<ProcessPtrRecord>,
@@ -1852,6 +1853,14 @@ impl SharedClassicHeapAllocator {
             "classic heap owner changed before process-manager handoff"
         );
         state.owner_id = Some(target_owner_id);
+    }
+
+    fn assert_owned_by(&self, owner_id: usize) {
+        assert_eq!(
+            self.0.borrow().owner_id,
+            Some(owner_id),
+            "classic heap owner changed before process-manager handoff"
+        );
     }
 
     pub(crate) fn is_pristine(&self) -> bool {
@@ -4458,6 +4467,7 @@ impl ProcessNativeMemoryManager {
         let allocator = self
             .native_allocator
             .get_or_insert_with(|| ProcessNativeAllocatorState {
+                initial_heap: heap,
                 heap,
                 ptrs: Vec::new(),
                 free_ptr_blocks: Vec::new(),
@@ -4543,12 +4553,19 @@ impl ProcessNativeMemoryManager {
         self.ptr_to_handle.insert(ptr, handle)
     }
 
-    pub(crate) fn adopt_handle_metadata(&mut self, source: &mut Self) {
+    fn assert_can_adopt_handle_metadata(&self, source: &Self) {
         if let Some(source_allocator) = source.classic_allocator.as_ref() {
             assert!(
                 self.classic_allocator.is_none(),
                 "cannot adopt a standalone classic heap into an attached process allocator"
             );
+            source_allocator.assert_owned_by(Rc::as_ptr(&source.classic_owner) as usize);
+        }
+    }
+
+    fn adopt_handle_metadata(&mut self, source: &mut Self) {
+        self.assert_can_adopt_handle_metadata(source);
+        if let Some(source_allocator) = source.classic_allocator.as_ref() {
             source_allocator.transfer_owner(
                 Rc::as_ptr(&source.classic_owner) as usize,
                 Rc::as_ptr(&self.classic_owner) as usize,
@@ -4574,6 +4591,67 @@ impl ProcessNativeMemoryManager {
                 .extend(source.native_handle_ptrs.drain());
             self.native_handles.extend(source.native_handles.drain());
         }
+    }
+
+    fn native_allocator_is_pristine(&self) -> bool {
+        self.native_allocations.is_empty()
+            && self.native_handle_ptrs.is_empty()
+            && self.native_handles.is_empty()
+            && self.native_allocator.as_ref().is_none_or(|allocator| {
+                allocator.heap == allocator.initial_heap
+                    && allocator.ptrs.is_empty()
+                    && allocator.free_ptr_blocks.is_empty()
+                    && allocator.free_handle_blocks.is_empty()
+            })
+    }
+
+    fn assert_can_adopt_native_allocator(&self, source: &Self) {
+        assert!(
+            self.native_allocator_is_pristine() || source.native_allocator_is_pristine(),
+            "cannot attach two populated native allocators"
+        );
+    }
+
+    /// Transfer one standalone native allocator into the process owner.
+    ///
+    /// An allocator with no state beyond its launch-time heap baseline may be
+    /// discarded. A populated allocator instead replaces a pristine target,
+    /// leaving no second owner behind after attachment.
+    fn adopt_native_allocator(&mut self, source: &mut Self) {
+        self.assert_can_adopt_native_allocator(source);
+        let target_is_pristine = self.native_allocator_is_pristine();
+        let source_is_pristine = source.native_allocator_is_pristine();
+        let source_supplies_allocator = !source_is_pristine
+            || (self.native_allocator.is_none() && source.native_allocator.is_some());
+
+        if target_is_pristine && source_supplies_allocator {
+            self.native_allocator = source.native_allocator.take();
+            self.native_allocator_dirty = source.native_allocator_dirty;
+            self.native_allocations = std::mem::take(&mut source.native_allocations);
+            self.native_handle_ptrs = std::mem::take(&mut source.native_handle_ptrs);
+            self.native_handles = std::mem::take(&mut source.native_handles);
+        }
+
+        source.native_allocator = None;
+        source.native_allocator_dirty = false;
+        source.native_allocations.clear();
+        source.native_handle_ptrs.clear();
+        source.native_handles.clear();
+    }
+
+    /// Reject an incompatible Memory Manager handoff before either owner is
+    /// modified.
+    pub(crate) fn assert_can_adopt_process_memory_manager(&self, source: &Self) {
+        self.assert_can_adopt_native_allocator(source);
+        self.assert_can_adopt_handle_metadata(source);
+    }
+
+    /// Transfer every standalone allocator and handle index into one process
+    /// owner after all compatibility checks have passed.
+    pub(crate) fn adopt_process_memory_manager(&mut self, source: &mut Self) {
+        self.assert_can_adopt_process_memory_manager(source);
+        self.adopt_native_allocator(source);
+        self.adopt_handle_metadata(source);
     }
 
     #[cfg(test)]
@@ -5009,6 +5087,17 @@ mod tests {
     use crate::memory::{MacMemoryBus, MemoryBus};
     use ppc::PpcMemory;
 
+    fn native_heap_state(heap_cursor: u32, heap_limit: u32) -> ProcessNativeHeapState {
+        ProcessNativeHeapState {
+            heap_base: 0x0300_0000,
+            heap_cursor,
+            heap_limit,
+            last_mem_error: 0,
+            heap_maximized: false,
+            master_pointer_blocks_requested: 0,
+        }
+    }
+
     #[test]
     fn process_context_owns_the_memory_mapping_for_cpu_adapters() {
         let mut context = ProcessContext::default();
@@ -5436,6 +5525,188 @@ mod tests {
         assert_eq!(heap.last_mem_error, ProcessMemoryManager::PARAM_ERR);
         assert!(heap.heap_maximized);
         assert_eq!(heap.master_pointer_blocks_requested, 1);
+    }
+
+    #[test]
+    fn native_allocator_attachment_transfers_the_populated_owner() {
+        const HEAP_BASE: u32 = 0x0300_0000;
+        let mut target = ProcessMemoryManager::default();
+        target.publish_native_allocator(
+            native_heap_state(HEAP_BASE, HEAP_BASE + 0x1000),
+            &[],
+            &[],
+            &[],
+        );
+        let mut source = ProcessMemoryManager::default();
+        source.publish_native_allocator(
+            native_heap_state(HEAP_BASE + 0x80, HEAP_BASE + 0x2000),
+            &[],
+            &[],
+            &[],
+        );
+        source.mutate_native_allocator(|allocator| {
+            allocator.heap.heap_cursor += 0x20;
+            allocator.ptrs.push(ProcessPtrRecord {
+                ptr: HEAP_BASE + 0x80,
+                size: 0x20,
+            });
+        });
+        let expected = source.native_allocator_snapshot();
+
+        target.adopt_process_memory_manager(&mut source);
+
+        assert_eq!(target.native_allocator_snapshot(), expected);
+        assert!(!source.has_native_allocator());
+        assert!(source.native_handle_records().is_empty());
+    }
+
+    #[test]
+    fn native_allocator_attachment_retains_a_populated_target() {
+        const HEAP_BASE: u32 = 0x0300_0000;
+        let mut target = ProcessMemoryManager::default();
+        target.publish_native_allocator(
+            native_heap_state(HEAP_BASE, HEAP_BASE + 0x2000),
+            &[],
+            &[],
+            &[],
+        );
+        target.mutate_native_allocator(|allocator| {
+            allocator.heap.heap_limit -= 0x100;
+            allocator.heap.last_mem_error = ProcessMemoryManager::PARAM_ERR;
+        });
+        let expected = target.native_allocator_snapshot();
+        let mut source = ProcessMemoryManager::default();
+        source.publish_native_allocator(
+            native_heap_state(HEAP_BASE + 0x80, HEAP_BASE + 0x3000),
+            &[],
+            &[],
+            &[],
+        );
+
+        target.adopt_process_memory_manager(&mut source);
+
+        assert_eq!(target.native_allocator_snapshot(), expected);
+        assert!(!source.has_native_allocator());
+    }
+
+    #[test]
+    fn native_allocator_attachment_moves_a_pristine_source_into_an_empty_target() {
+        const HEAP_BASE: u32 = 0x0300_0000;
+        let mut target = ProcessMemoryManager::default();
+        let mut source = ProcessMemoryManager::default();
+        let heap = native_heap_state(HEAP_BASE + 0x80, HEAP_BASE + 0x2000);
+        source.publish_native_allocator(heap, &[], &[], &[]);
+
+        target.adopt_process_memory_manager(&mut source);
+
+        assert_eq!(target.native_heap_state(), Some(heap));
+        assert!(!source.has_native_allocator());
+    }
+
+    #[test]
+    fn native_allocator_attachment_retains_the_target_when_both_are_pristine() {
+        const HEAP_BASE: u32 = 0x0300_0000;
+        let target_heap = native_heap_state(HEAP_BASE, HEAP_BASE + 0x1000);
+        let source_heap = native_heap_state(HEAP_BASE + 0x80, HEAP_BASE + 0x2000);
+        let mut target = ProcessMemoryManager::default();
+        target.publish_native_allocator(target_heap, &[], &[], &[]);
+        let mut source = ProcessMemoryManager::default();
+        source.publish_native_allocator(source_heap, &[], &[], &[]);
+
+        target.adopt_process_memory_manager(&mut source);
+
+        assert_eq!(target.native_heap_state(), Some(target_heap));
+        assert!(!source.has_native_allocator());
+    }
+
+    #[test]
+    fn native_allocator_attachment_rejects_two_populated_owners_atomically() {
+        const HEAP_BASE: u32 = 0x0300_0000;
+        let first_record = ProcessHandleRecord {
+            handle: HEAP_BASE,
+            ptr: HEAP_BASE + 0x20,
+            size: 16,
+            capacity: 16,
+        };
+        let second_record = ProcessHandleRecord {
+            handle: HEAP_BASE + 0x40,
+            ptr: HEAP_BASE + 0x60,
+            size: 32,
+            capacity: 32,
+        };
+        let mut target = ProcessMemoryManager::default();
+        target.publish_native_allocator(
+            native_heap_state(HEAP_BASE, HEAP_BASE + 0x2000),
+            &[],
+            &[],
+            &[],
+        );
+        target.register_native_handle_records([(first_record, 0x80)]);
+        let mut source = ProcessMemoryManager::default();
+        source.publish_native_allocator(
+            native_heap_state(HEAP_BASE + 0x100, HEAP_BASE + 0x3000),
+            &[],
+            &[],
+            &[],
+        );
+        source.register_native_handle_records([(second_record, 0x40)]);
+        let target_allocator = target.native_allocator_snapshot();
+        let source_allocator = source.native_allocator_snapshot();
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            target.adopt_process_memory_manager(&mut source);
+        }));
+
+        assert!(result.is_err());
+        assert_eq!(target.native_allocator_snapshot(), target_allocator);
+        assert_eq!(source.native_allocator_snapshot(), source_allocator);
+        assert_eq!(target.native_allocation(first_record.handle), Some(first_record));
+        assert_eq!(source.native_allocation(second_record.handle), Some(second_record));
+        assert_eq!(target.handle_for_ptr(first_record.ptr), Some(first_record.handle));
+        assert_eq!(source.handle_for_ptr(second_record.ptr), Some(second_record.handle));
+        assert_eq!(target.state_for_handle(first_record.handle), Some(0x80));
+        assert_eq!(source.state_for_handle(second_record.handle), Some(0x40));
+    }
+
+    #[test]
+    fn process_memory_manager_handoff_preflights_classic_metadata_before_native_transfer() {
+        const HEAP_BASE: u32 = 0x0300_0000;
+        let mut target = ProcessMemoryManager::default();
+        target.publish_native_allocator(
+            native_heap_state(HEAP_BASE, HEAP_BASE + 0x2000),
+            &[],
+            &[],
+            &[],
+        );
+        let mut target_bus = MacMemoryBus::new(8 * 1024 * 1024);
+        target.attach_classic_memory_bus(&mut target_bus);
+        let target_ptr = target.new_classic_ptr(&mut target_bus, 16);
+
+        let mut source = ProcessMemoryManager::default();
+        source.publish_native_allocator(
+            native_heap_state(HEAP_BASE, HEAP_BASE + 0x2000),
+            &[],
+            &[],
+            &[],
+        );
+        source.mutate_native_allocator(|allocator| allocator.heap.heap_cursor += 0x20);
+        let mut source_bus = MacMemoryBus::new(8 * 1024 * 1024);
+        source.attach_classic_memory_bus(&mut source_bus);
+        let source_ptr = source.new_classic_ptr(&mut source_bus, 32);
+        let target_allocator = target.native_allocator_snapshot();
+        let source_allocator = source.native_allocator_snapshot();
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            target.adopt_process_memory_manager(&mut source);
+        }));
+
+        assert!(result.is_err());
+        assert_eq!(target.native_allocator_snapshot(), target_allocator);
+        assert_eq!(source.native_allocator_snapshot(), source_allocator);
+        assert_eq!(target.classic_allocation_size(target_ptr), Some(16));
+        assert_eq!(source.classic_allocation_size(source_ptr), Some(32));
+        assert_ne!(target.new_classic_ptr(&mut target_bus, 8), 0);
+        assert_ne!(source.new_classic_ptr(&mut source_bus, 8), 0);
     }
 
     #[test]

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -2751,6 +2751,20 @@ impl TrapDispatcher {
 
     /// Attach shared process resources to this dispatcher.
     pub(crate) fn attach_process_context(&mut self, context: &mut ProcessContext) {
+        let mut memory_manager = None;
+        context.attach_memory_manager(&mut memory_manager);
+        let memory_manager =
+            memory_manager.expect("process context supplies a Memory Manager");
+        if let Some(attached) = &self.process_memory_manager {
+            assert!(
+                attached.ptr_eq(&memory_manager),
+                "cannot attach two process Memory Managers"
+            );
+        } else if !self.standalone_memory_manager.ptr_eq(&memory_manager) {
+            let target = memory_manager.borrow();
+            let standalone = self.standalone_memory_manager.borrow();
+            target.assert_can_adopt_process_memory_manager(&standalone);
+        }
         context.attach_file_system(&mut self.process_file_system);
         self.open_files = self.process_file_system.files.shared_handle();
         self.write_refnums = self.process_file_system.writable_refnums.shared_handle();
@@ -2813,11 +2827,7 @@ impl TrapDispatcher {
             &mut self.next_vfs_timestamp,
             &mut self.default_dir_id,
         );
-        let mut memory_manager = None;
-        context.attach_memory_manager(&mut memory_manager);
-        self.attach_memory_manager_handle(
-            memory_manager.expect("process context supplies a Memory Manager"),
-        );
+        self.attach_memory_manager_handle(memory_manager);
         context.attach_native_menu_selection(&mut self.pending_native_menu_selection);
         context.attach_guest_calls(&mut self.guest_calls);
         context.attach_apple_event_handlers(&mut self.ae_handlers);
@@ -2841,7 +2851,7 @@ impl TrapDispatcher {
         if !self.standalone_memory_manager.ptr_eq(&memory_manager) {
             let mut target = memory_manager.borrow_mut();
             let mut standalone = self.standalone_memory_manager.borrow_mut();
-            target.adopt_handle_metadata(&mut standalone);
+            target.adopt_process_memory_manager(&mut standalone);
         }
         self.process_memory_manager = Some(memory_manager);
     }
@@ -11244,6 +11254,43 @@ mod tests {
         assert_eq!(attached.borrow().state_for_handle(0x1100), Some(0x80));
         assert_eq!(standalone.borrow().handle_for_ptr(0x2200), None);
         assert_eq!(standalone.borrow().state_for_handle(0x1100), None);
+    }
+
+    #[test]
+    fn attaching_dispatcher_transfers_a_standalone_native_allocator() {
+        const HEAP_BASE: u32 = 0x0300_0000;
+        let mut dispatcher = TrapDispatcher::new();
+        let standalone = dispatcher.process_memory_manager();
+        standalone.borrow_mut().publish_native_allocator(
+            crate::process_context::ProcessNativeHeapState {
+                heap_base: HEAP_BASE,
+                heap_cursor: HEAP_BASE,
+                heap_limit: HEAP_BASE + 0x1000,
+                last_mem_error: 0,
+                heap_maximized: false,
+                master_pointer_blocks_requested: 0,
+            },
+            &[crate::process_context::ProcessPtrRecord {
+                ptr: HEAP_BASE,
+                size: 24,
+            }],
+            &[],
+            &[],
+        );
+
+        let mut context = ProcessContext::default();
+        dispatcher.attach_process_context(&mut context);
+        let attached = dispatcher.process_memory_manager();
+
+        assert!(!attached.ptr_eq(&standalone));
+        assert!(!standalone.borrow().has_native_allocator());
+        assert_eq!(
+            attached.borrow().native_ptr_records(),
+            [crate::process_context::ProcessPtrRecord {
+                ptr: HEAP_BASE,
+                size: 24,
+            }]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- transfer the complete native allocator, allocation records, and handle identity state into the process memory manager when a CPU adapter attaches
- preflight native and classic memory-manager compatibility before mutating either owner
- make populated/pristine, pristine/populated, and pristine/pristine attachment deterministic while rejecting two populated allocators atomically
- relinquish standalone allocator ownership after transfer and refresh PowerPC zone bookkeeping from the canonical process heap
- apply the same process-level handoff when a classic trap dispatcher attaches

## Validation

- `cargo test --locked --lib` — 4,796 passed; 0 failed; 3 ignored
- strict all-features rustdoc with private intra-doc links denied
- `cargo test --all-features --all-targets --locked --no-run`
- Marathon gameplay through title, new-game HUD, terminal interaction, and terminal advancement
- Escape Velocity through live space, landing, return to space, and post-landing ship control
- Tomb Raider Gold through live 3D gameplay and forward movement

Closes #1280