### PR TITLE
fix(memory): resize classic pointers through PowerPC imports

### DIFF
--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -15130,8 +15130,9 @@ fn dispatch_supported_import(
             Some(PpcImportAction::Return(size))
         }
         PpcImportDispatcherTarget::SetPtrSize => {
-            *last_mem_error =
-                process_memory_manager.set_native_ptr_size(memory, cpu.gpr[3], cpu.gpr[4]);
+            *last_mem_error = process_memory_manager.set_process_ptr_size_for_native_import(
+                memory, cpu.gpr[3], cpu.gpr[4],
+            );
             ppc_apply_process_native_allocator(
                 process_memory_manager,
                 memory,
@@ -91443,6 +91444,152 @@ pub(crate) mod tests {
         });
 
         assert_eq!(classic_bus.get_alloc_size(ptr), None);
+    }
+
+    #[test]
+    fn ppc_set_ptr_size_mutates_a_classic_pointer_without_moving_it() {
+        let pef = synthetic_pef_with_import(b"SetPtrSize");
+        let mut native = load_pef_application(&pef).unwrap();
+        let mut context = ProcessContext::default();
+        native.attach_process_context(&mut context);
+
+        let mut classic_bus = MacMemoryBus::new(8 * 1024 * 1024);
+        context.attach_classic_memory_bus(&mut classic_bus);
+        let classic_heap = classic_bus
+            .shared_ram_region(0x0020_0000, 0x1000)
+            .expect("classic adapter owns its heap range");
+        context.attach_memory(0x0020_0000, classic_heap, &mut native.memory);
+
+        let original = context
+            .memory_manager_mut()
+            .new_classic_ptr(&mut classic_bus, 64);
+        classic_bus.fill_bytes(original, 64, 0x6a);
+        context
+            .memory_manager_mut()
+            .dispose_process_ptr(&mut classic_bus, original);
+        let ptr = context
+            .memory_manager_mut()
+            .new_classic_ptr(&mut classic_bus, 16);
+        assert_eq!(ptr, original);
+        classic_bus.fill_bytes(ptr, 16, 0x5a);
+        let neighbor = context
+            .memory_manager_mut()
+            .new_classic_ptr(&mut classic_bus, 16);
+        classic_bus.fill_bytes(neighbor, 16, 0xa5);
+        let cursor = context.classic_heap_bump_ptr();
+        let mut detached = native.clone();
+
+        context
+            .memory_manager_mut()
+            .set_native_mem_error(PPC_PARAM_ERR);
+        assert_eq!(
+            context
+                .memory_manager_mut()
+                .set_process_ptr_size(&mut classic_bus, ptr, 12),
+            PPC_NO_ERR
+        );
+        native.with_process_memory_manager(|native, memory_manager| {
+            native.cpu.pc = native.entry_pc;
+            native.cpu.lr = PPC_HALT_PC;
+            native.imports[0].dispatcher_target = PpcImportDispatcherTarget::MemError;
+            native.run_with_process_memory_manager(64, false, false, memory_manager);
+            assert_eq!(native.cpu.gpr[3], ppc_i16_result(PPC_NO_ERR));
+        });
+        assert_eq!(
+            context
+                .memory_manager_mut()
+                .set_process_ptr_size(&mut classic_bus, ptr, 65),
+            PPC_MEM_FULL_ERR
+        );
+        native.with_process_memory_manager(|native, memory_manager| {
+            native.cpu.pc = native.entry_pc;
+            native.cpu.lr = PPC_HALT_PC;
+            native.imports[0].dispatcher_target = PpcImportDispatcherTarget::MemError;
+            native.run_with_process_memory_manager(64, false, false, memory_manager);
+            assert_eq!(native.cpu.gpr[3], ppc_i16_result(PPC_MEM_FULL_ERR));
+            native.imports[0].dispatcher_target = PpcImportDispatcherTarget::SetPtrSize;
+        });
+
+        native.with_process_memory_manager(|native, memory_manager| {
+            native.cpu.pc = native.entry_pc;
+            native.cpu.lr = PPC_HALT_PC;
+            native.cpu.gpr[3] = ptr;
+            native.cpu.gpr[4] = 8;
+            let probe = native.run_with_process_memory_manager(64, false, false, memory_manager);
+            assert_eq!(probe.handled_import_count, 1);
+            assert_eq!(native.cpu.gpr[3], ptr);
+            assert_eq!(memory_manager.classic_allocation_size(ptr), Some(8));
+            assert_eq!(
+                memory_manager
+                    .native_heap_state()
+                    .map(|heap| heap.last_mem_error),
+                Some(PPC_NO_ERR)
+            );
+
+            native.cpu.pc = native.entry_pc;
+            native.cpu.lr = PPC_HALT_PC;
+            native.imports[0].dispatcher_target = PpcImportDispatcherTarget::MemError;
+            native.run_with_process_memory_manager(64, false, false, memory_manager);
+            assert_eq!(native.cpu.gpr[3], ppc_i16_result(PPC_NO_ERR));
+            native.imports[0].dispatcher_target = PpcImportDispatcherTarget::SetPtrSize;
+
+            native.cpu.pc = native.entry_pc;
+            native.cpu.lr = PPC_HALT_PC;
+            native.cpu.gpr[3] = ptr;
+            native.cpu.gpr[4] = 48;
+            native.run_with_process_memory_manager(64, false, false, memory_manager);
+            assert_eq!(native.cpu.gpr[3], ptr);
+            assert_eq!(memory_manager.classic_allocation_size(ptr), Some(48));
+            assert_eq!(
+                memory_manager
+                    .native_heap_state()
+                    .map(|heap| heap.last_mem_error),
+                Some(PPC_NO_ERR)
+            );
+
+            let bytes_before_failure = ppc_memory_read_bytes(&mut native.memory, ptr, 64).unwrap();
+            native.cpu.pc = native.entry_pc;
+            native.cpu.lr = PPC_HALT_PC;
+            native.cpu.gpr[3] = ptr;
+            native.cpu.gpr[4] = 65;
+            native.run_with_process_memory_manager(64, false, false, memory_manager);
+            assert_eq!(native.cpu.gpr[3], ptr);
+            assert_eq!(memory_manager.classic_allocation_size(ptr), Some(48));
+            assert_eq!(
+                memory_manager
+                    .native_heap_state()
+                    .map(|heap| heap.last_mem_error),
+                Some(PPC_MEM_FULL_ERR)
+            );
+            assert_eq!(
+                ppc_memory_read_bytes(&mut native.memory, ptr, 64),
+                Some(bytes_before_failure)
+            );
+
+            native.cpu.pc = native.entry_pc;
+            native.cpu.lr = PPC_HALT_PC;
+            native.imports[0].dispatcher_target = PpcImportDispatcherTarget::MemError;
+            native.run_with_process_memory_manager(64, false, false, memory_manager);
+            assert_eq!(native.cpu.gpr[3], ppc_i16_result(PPC_MEM_FULL_ERR));
+        });
+
+        assert_eq!(context.classic_heap_bump_ptr(), cursor);
+        assert_eq!(classic_bus.get_alloc_size(ptr), Some(48));
+        assert_eq!(classic_bus.read_bytes(ptr, 8), vec![0x5a; 8]);
+        assert_eq!(classic_bus.read_bytes(ptr + 8, 8), vec![0; 8]);
+        assert_eq!(classic_bus.read_bytes(neighbor, 16), vec![0xa5; 16]);
+        assert_eq!(
+            detached
+                .process_memory_manager
+                .0
+                .borrow()
+                .classic_allocation_size(ptr),
+            Some(16)
+        );
+        assert_eq!(
+            ppc_memory_read_bytes(&mut detached.memory, ptr, 16),
+            Some(vec![0x5a; 16])
+        );
     }
 
     #[test]

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -1897,6 +1897,18 @@ impl SharedClassicHeapAllocator {
         self.0.borrow().alloc_sizes.get(&address).copied()
     }
 
+    pub(crate) fn allocation_capacity(&self, address: u32) -> Option<u32> {
+        let state = self.0.borrow();
+        let size = state.alloc_sizes.get(&address).copied()?;
+        Some(
+            state
+                .alloc_bucket_sizes
+                .get(&address)
+                .copied()
+                .unwrap_or_else(|| Self::allocation_bucket_size(size)),
+        )
+    }
+
     pub(crate) fn allocation_bucket_size(size: u32) -> u32 {
         ((size + 3) & !3).max(4)
     }
@@ -2039,7 +2051,13 @@ impl SharedClassicHeapAllocator {
 
     pub(crate) fn set_allocation_size(&self, address: u32, size: u32) {
         let mut state = self.0.borrow_mut();
-        if state.alloc_sizes.contains_key(&address) {
+        if let Some(old_size) = state.alloc_sizes.get(&address).copied() {
+            let capacity = state
+                .alloc_bucket_sizes
+                .get(&address)
+                .copied()
+                .unwrap_or_else(|| Self::allocation_bucket_size(old_size));
+            state.alloc_bucket_sizes.insert(address, capacity);
             state.alloc_sizes.insert(address, size);
         }
     }
@@ -2736,24 +2754,39 @@ impl ProcessNativeMemoryManager {
     ) -> i16 {
         self.assert_classic_memory_bus_attached(bus);
         if ptr == 0 {
+            self.set_native_mem_error(Self::NIL_HANDLE_ERR);
             return Self::NIL_HANDLE_ERR;
         }
         let native_index = self
             .native_allocator
             .as_ref()
             .and_then(|allocator| allocator.ptrs.iter().position(|record| record.ptr == ptr));
-        let old_size = native_index
-            .and_then(|index| {
-                self.native_allocator
-                    .as_ref()
-                    .and_then(|allocator| allocator.ptrs.get(index))
-                    .map(|record| record.size)
-            })
-            .or_else(|| self.classic_allocator().allocation_size(ptr))
-            .unwrap_or(0);
-        if SharedClassicHeapAllocator::allocation_bucket_size(new_size)
-            > SharedClassicHeapAllocator::allocation_bucket_size(old_size)
-        {
+        let (old_size, capacity) = if let Some(index) = native_index {
+            let old_size = self
+                .native_allocator
+                .as_ref()
+                .and_then(|allocator| allocator.ptrs.get(index))
+                .map(|record| record.size)
+                .unwrap_or(0);
+            (
+                old_size,
+                SharedClassicHeapAllocator::allocation_bucket_size(old_size),
+            )
+        } else {
+            let allocator = self.classic_allocator();
+            let Some(old_size) = allocator.allocation_size(ptr) else {
+                self.set_native_mem_error(Self::MEM_WZ_ERR);
+                return Self::MEM_WZ_ERR;
+            };
+            (
+                old_size,
+                allocator
+                    .allocation_capacity(ptr)
+                    .expect("classic pointer retains its allocation capacity"),
+            )
+        };
+        if SharedClassicHeapAllocator::allocation_bucket_size(new_size) > capacity {
+            self.set_native_mem_error(Self::MEM_FULL_ERR);
             return Self::MEM_FULL_ERR;
         }
         if new_size < old_size {
@@ -2765,11 +2798,11 @@ impl ProcessNativeMemoryManager {
                 .as_mut()
                 .expect("native pointer record retains its allocator");
             allocator.ptrs[index].size = new_size;
-            allocator.heap.last_mem_error = Self::NO_ERR;
             self.native_allocator_dirty = true;
         } else {
             self.classic_allocator().set_allocation_size(ptr, new_size);
         }
+        self.set_native_mem_error(Self::NO_ERR);
         Self::NO_ERR
     }
 
@@ -3712,6 +3745,60 @@ impl ProcessNativeMemoryManager {
         }
         self.set_native_mem_error(Self::PARAM_ERR);
         0
+    }
+
+    /// Resize a native or classic fixed block from a native import without
+    /// moving its guest address. Classic allocations retain their physical
+    /// bucket capacity even when their logical size shrinks. Inside
+    /// Macintosh: Memory (1992), pp. 2-42--2-44.
+    pub(crate) fn set_process_ptr_size_for_native_import(
+        &mut self,
+        memory: &mut GuestAddressSpace,
+        ptr: u32,
+        new_size: u32,
+    ) -> i16 {
+        if self
+            .native_allocator
+            .as_ref()
+            .is_some_and(|allocator| allocator.ptrs.iter().any(|record| record.ptr == ptr))
+        {
+            return self.set_native_ptr_size(memory, ptr, new_size);
+        }
+
+        let Some(allocator) = self.classic_allocator.clone() else {
+            self.set_native_mem_error(Self::MEM_WZ_ERR);
+            return Self::MEM_WZ_ERR;
+        };
+        let Some(old_size) = allocator.allocation_size(ptr) else {
+            self.set_native_mem_error(Self::MEM_WZ_ERR);
+            return Self::MEM_WZ_ERR;
+        };
+        let capacity = allocator
+            .allocation_capacity(ptr)
+            .expect("classic pointer retains its allocation capacity");
+        if SharedClassicHeapAllocator::allocation_bucket_size(new_size) > capacity {
+            self.set_native_mem_error(Self::MEM_FULL_ERR);
+            return Self::MEM_FULL_ERR;
+        }
+
+        if new_size < old_size {
+            let Some(tail) = ptr.checked_add(new_size) else {
+                self.set_native_mem_error(Self::PARAM_ERR);
+                return Self::PARAM_ERR;
+            };
+            let Ok(tail_len) = usize::try_from(old_size - new_size) else {
+                self.set_native_mem_error(Self::PARAM_ERR);
+                return Self::PARAM_ERR;
+            };
+            if memory.write_bytes(tail, &vec![0; tail_len]).is_none() {
+                self.set_native_mem_error(Self::PARAM_ERR);
+                return Self::PARAM_ERR;
+            }
+        }
+
+        allocator.set_allocation_size(ptr, new_size);
+        self.set_native_mem_error(Self::NO_ERR);
+        Self::NO_ERR
     }
 
     /// Dispose a classic fixed block from a native import when the process
@@ -5390,6 +5477,53 @@ mod tests {
 
         assert_eq!(second.alloc(64), 0x20_0000);
         assert_eq!(first.alloc(4), 0x20_0080);
+    }
+
+    #[test]
+    fn classic_ptr_resize_retains_reused_bucket_capacity() {
+        let mut context = ProcessContext::default();
+        let mut bus = MacMemoryBus::new(8 * 1024 * 1024);
+        context.attach_classic_memory_bus(&mut bus);
+
+        let original = context.memory_manager_mut().new_classic_ptr(&mut bus, 64);
+        context
+            .memory_manager_mut()
+            .dispose_process_ptr(&mut bus, original);
+        let reused = context.memory_manager_mut().new_classic_ptr(&mut bus, 16);
+        assert_eq!(reused, original);
+        let cursor = context.classic_heap_bump_ptr();
+        let detached = context.memory_manager_mut().detached_clone();
+
+        assert_eq!(
+            context
+                .memory_manager_mut()
+                .set_process_ptr_size(&mut bus, reused, 48),
+            ProcessMemoryManager::NO_ERR
+        );
+        assert_eq!(context.classic_heap_bump_ptr(), cursor);
+        assert_eq!(
+            context
+                .memory_manager
+                .borrow()
+                .classic_allocation_size(reused),
+            Some(48)
+        );
+        assert_eq!(detached.classic_allocation_size(reused), Some(16));
+
+        assert_eq!(
+            context
+                .memory_manager_mut()
+                .set_process_ptr_size(&mut bus, reused, 65),
+            ProcessMemoryManager::MEM_FULL_ERR
+        );
+        assert_eq!(context.classic_heap_bump_ptr(), cursor);
+        assert_eq!(
+            context
+                .memory_manager
+                .borrow()
+                .classic_allocation_size(reused),
+            Some(48)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- route PowerPC `SetPtrSize` through the process-owned Memory Manager so it can resize classic allocations
- preserve the physical capacity of reused classic heap buckets across logical shrink and regrowth
- publish resize results through the canonical process `MemError` observed by both CPU adapters
- keep native pointer behavior on the existing native resize path

## Root cause

The PowerPC import called the native-only pointer resize implementation. Classic allocations were visible to `GetPtrSize` and `DisposePtr`, but `SetPtrSize` could not mutate them. The classic allocator also discarded the retained physical bucket capacity after a logical resize, preventing safe same-address regrowth.

## Validation

- `cargo test --locked --lib` — 4,800 passed, 0 failed, 3 ignored
- strict rustdoc with private intra-doc links denied
- `cargo test --all-features --all-targets --locked --no-run`
- focused cross-ISA `SetPtrSize` and public `MemError` tests
- Marathon deterministic gameplay gate
- Escape Velocity deterministic gameplay gate
- Tomb Raider Gold deterministic gameplay gate

Closes #1285