### PR TITLE
fix(memory): release classic handles through PowerPC

### DIFF
--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -199,6 +199,8 @@ const PPC_MMU_32BIT_ADDR: u32 = 0x0000_0cb2;
 const PPC_CLASSIC_APP_MEMORY_SIZE: usize = 0x000f_0000;
 pub const PPC_MEM_FULL_ERR: i16 = -108;
 const PPC_NIL_HANDLE_ERR: i16 = -109;
+#[cfg(test)]
+const PPC_MEM_PUR_ERR: i16 = -112;
 const PPC_C_DEPTH_ERR: i16 = -157;
 pub const PPC_NO_ERR: i16 = 0;
 const PPC_EVT_NOT_ENB: i16 = 1;
@@ -15352,15 +15354,17 @@ fn dispatch_supported_import(
         }
         PpcImportDispatcherTarget::DisposeHandle => {
             let handle = cpu.gpr[3];
-            let disposed = ppc_dispose_process_native_handle(
+            let disposed = process_memory_manager
+                .dispose_process_handle_from_native_import(memory, handle);
+            ppc_apply_process_native_allocator(
                 process_memory_manager,
                 memory,
                 heap_cursor,
-                heap_limit,
                 last_mem_error,
-                handles,
-                handle,
             );
+            if disposed {
+                handles.retain(|record| record.handle != handle);
+            }
             if disposed {
                 toolbox_startup
                     .indexed_screen_ctables
@@ -15375,12 +15379,12 @@ fn dispatch_supported_import(
                     resource.handle = 0;
                 }
             }
-            *last_mem_error = PPC_NO_ERR;
             Some(PpcImportAction::ReturnPreserve)
         }
         PpcImportDispatcherTarget::EmptyHandle => {
             let handle = cpu.gpr[3];
-            *last_mem_error = process_memory_manager.empty_native_handle(memory, handle);
+            *last_mem_error = process_memory_manager
+                .empty_process_handle_from_native_import(memory, handle);
             ppc_apply_process_native_allocator(
                 process_memory_manager,
                 memory,
@@ -16947,7 +16951,12 @@ fn dispatch_supported_import(
             Some(PpcImportAction::ReturnPreserve)
         }
         PpcImportDispatcherTarget::DetachResource => {
-            ppc_detach_resource(cpu, vfs_resources, last_resource_error);
+            ppc_detach_resource(
+                cpu,
+                process_memory_manager,
+                vfs_resources,
+                last_resource_error,
+            );
             Some(PpcImportAction::ReturnPreserve)
         }
         PpcImportDispatcherTarget::ReadPartialResource => {
@@ -61669,6 +61678,7 @@ fn ppc_release_resource(
 
 fn ppc_detach_resource(
     cpu: &mut PpcCpu,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
     vfs_resources: &mut [PpcVfsResourceRecord],
     last_resource_error: &mut i16,
 ) {
@@ -61685,6 +61695,7 @@ fn ppc_detach_resource(
         return;
     }
     record.handle = 0;
+    process_memory_manager.set_process_handle_resource(handle, false);
     *last_resource_error = PPC_NO_ERR;
 }
 
@@ -91407,6 +91418,307 @@ pub(crate) mod tests {
 
         assert_eq!(classic.handle_state_bits(handle), Some(0xc0));
         assert_eq!(detached.borrow().state_for_handle(handle), Some(0x40));
+    }
+
+    #[test]
+    fn ppc_empty_handle_releases_a_process_owned_classic_block_atomically() {
+        let pef = synthetic_pef_with_import(b"EmptyHandle");
+        let mut native = load_pef_application(&pef).unwrap();
+        let mut context = ProcessContext::default();
+        native.attach_process_context(&mut context);
+
+        let mut classic_bus = MacMemoryBus::new(8 * 1024 * 1024);
+        context.attach_classic_memory_bus(&mut classic_bus);
+        let classic_heap = classic_bus
+            .shared_ram_region(0x0020_0000, 0x2000)
+            .expect("classic adapter owns its heap range");
+        context.attach_memory(0x0020_0000, classic_heap, &mut native.memory);
+        let (handle, ptr) = context
+            .memory_manager_mut()
+            .new_classic_handle(&mut classic_bus, 24)
+            .unwrap();
+        classic_bus.write_bytes(ptr, b"classic process handle");
+        let memory_manager = context.memory_manager_handle().clone();
+        memory_manager.borrow_mut().set_state_for_handle(handle, 0xc0);
+        let mut detached = native.clone();
+
+        native.with_process_memory_manager(|native, memory_manager| {
+            native.cpu.gpr[3] = handle;
+            let probe =
+                native.run_with_process_memory_manager(64, false, false, memory_manager);
+            assert_eq!(probe.handled_import_count, 1);
+            assert_eq!(
+                memory_manager
+                    .native_heap_state()
+                    .map(|heap| heap.last_mem_error),
+                Some(PPC_MEM_PUR_ERR)
+            );
+            assert_eq!(PpcMemory::read_u32_be(&mut native.memory, handle), Some(ptr));
+            assert_eq!(memory_manager.classic_allocation_size(ptr), Some(24));
+            assert_eq!(memory_manager.recover_handle(ptr), Some(handle));
+            assert_eq!(memory_manager.state_for_handle(handle), Some(0xc0));
+
+            memory_manager.set_state_for_handle(handle, 0x40);
+            native.cpu.pc = native.entry_pc;
+            native.cpu.lr = PPC_HALT_PC;
+            native.cpu.gpr[3] = handle;
+            let probe =
+                native.run_with_process_memory_manager(64, false, false, memory_manager);
+            assert_eq!(probe.handled_import_count, 1);
+            assert_eq!(
+                memory_manager
+                    .native_heap_state()
+                    .map(|heap| heap.last_mem_error),
+                Some(PPC_NO_ERR)
+            );
+            assert_eq!(PpcMemory::read_u32_be(&mut native.memory, handle), Some(0));
+            assert_eq!(memory_manager.classic_allocation_size(handle), Some(4));
+            assert_eq!(memory_manager.classic_allocation_size(ptr), None);
+            assert_eq!(memory_manager.recover_handle(ptr), None);
+            assert_eq!(memory_manager.state_for_handle(handle), Some(0x40));
+        });
+
+        assert_eq!(classic_bus.read_long(handle), 0);
+        assert_eq!(classic_bus.get_alloc_size(handle), Some(4));
+        assert_eq!(classic_bus.get_alloc_size(ptr), None);
+        assert_eq!(
+            PpcMemory::read_u32_be(&mut detached.memory, handle),
+            Some(ptr)
+        );
+        let detached_manager = detached.process_memory_manager.0.borrow();
+        assert_eq!(detached_manager.classic_allocation_size(handle), Some(4));
+        assert_eq!(detached_manager.classic_allocation_size(ptr), Some(24));
+        assert_eq!(detached_manager.recover_handle(ptr), Some(handle));
+        assert_eq!(detached_manager.state_for_handle(handle), Some(0xc0));
+    }
+
+    #[test]
+    fn ppc_dispose_handle_releases_classic_storage_and_preserves_stale_slot_rules() {
+        let pef = synthetic_pef_with_import(b"DisposeHandle");
+        let mut native = load_pef_application(&pef).unwrap();
+        let mut context = ProcessContext::default();
+        native.attach_process_context(&mut context);
+
+        let mut classic_bus = MacMemoryBus::new(8 * 1024 * 1024);
+        context.attach_classic_memory_bus(&mut classic_bus);
+        let classic_heap = classic_bus
+            .shared_ram_region(0x0020_0000, 0x2000)
+            .expect("classic adapter owns its heap range");
+        context.attach_memory(0x0020_0000, classic_heap, &mut native.memory);
+        let (handle, ptr) = context
+            .memory_manager_mut()
+            .new_classic_handle(&mut classic_bus, 16)
+            .unwrap();
+        classic_bus.write_bytes(ptr, b"disposed classic");
+        let memory_manager = context.memory_manager_handle().clone();
+        memory_manager.borrow_mut().set_state_for_handle(handle, 0x80);
+        let mut detached = native.clone();
+
+        native.with_process_memory_manager(|native, memory_manager| {
+            native.cpu.gpr[3] = handle;
+            let probe =
+                native.run_with_process_memory_manager(64, false, false, memory_manager);
+            assert_eq!(probe.handled_import_count, 1);
+            assert_eq!(
+                memory_manager
+                    .native_heap_state()
+                    .map(|heap| heap.last_mem_error),
+                Some(PPC_NO_ERR)
+            );
+            assert_eq!(PpcMemory::read_u32_be(&mut native.memory, handle), Some(ptr));
+            assert_eq!(memory_manager.classic_allocation_size(handle), None);
+            assert_eq!(memory_manager.classic_allocation_size(ptr), None);
+            assert_eq!(memory_manager.recover_handle(ptr), Some(handle));
+            assert_eq!(memory_manager.state_for_handle(handle), None);
+
+            native.cpu.pc = native.entry_pc;
+            native.cpu.lr = PPC_HALT_PC;
+            native.imports[0].dispatcher_target = PpcImportDispatcherTarget::RecoverHandle;
+            native.cpu.gpr[3] = ptr;
+            native.run_with_process_memory_manager(64, false, false, memory_manager);
+            assert_eq!(native.cpu.gpr[3], handle);
+        });
+
+        assert_eq!(classic_bus.read_long(handle), ptr);
+        let reused = context
+            .memory_manager_mut()
+            .new_empty_classic_handle(&mut classic_bus)
+            .unwrap();
+        assert_eq!(reused, handle);
+        native.with_process_memory_manager(|native, memory_manager| {
+            native.cpu.pc = native.entry_pc;
+            native.cpu.lr = PPC_HALT_PC;
+            native.cpu.gpr[3] = ptr;
+            native.run_with_process_memory_manager(64, false, false, memory_manager);
+            assert_eq!(native.cpu.gpr[3], 0);
+            assert_eq!(memory_manager.recover_handle(ptr), None);
+        });
+
+        assert_eq!(
+            PpcMemory::read_u32_be(&mut detached.memory, handle),
+            Some(ptr)
+        );
+        let detached_manager = detached.process_memory_manager.0.borrow();
+        assert_eq!(detached_manager.classic_allocation_size(handle), Some(4));
+        assert_eq!(detached_manager.classic_allocation_size(ptr), Some(16));
+        assert_eq!(detached_manager.recover_handle(ptr), Some(handle));
+        assert_eq!(detached_manager.state_for_handle(handle), Some(0x80));
+    }
+
+    #[test]
+    fn ppc_handle_release_does_not_bypass_classic_resource_manager_ownership() {
+        let pef = synthetic_pef_with_import(b"DisposeHandle");
+        let mut native = load_pef_application(&pef).unwrap();
+        let mut classic = TrapDispatcher::new();
+        let mut context = ProcessContext::default();
+        native.attach_process_context(&mut context);
+        classic.attach_process_context(&mut context);
+
+        let mut classic_bus = MacMemoryBus::new(8 * 1024 * 1024);
+        context.attach_classic_memory_bus(&mut classic_bus);
+        let classic_heap = classic_bus
+            .shared_ram_region(0x0020_0000, 0x2000)
+            .expect("classic adapter owns its heap range");
+        context.attach_memory(0x0020_0000, classic_heap, &mut native.memory);
+        let ptr = context
+            .memory_manager_mut()
+            .new_classic_ptr(&mut classic_bus, 16);
+        classic_bus.write_bytes(ptr, b"classic resource");
+        let handle =
+            classic.get_or_create_resource_handle(&mut classic_bus, *b"TEST", 128, ptr);
+        let memory_manager = context.memory_manager_handle().clone();
+        memory_manager
+            .borrow_mut()
+            .set_process_handle_purgeable(handle, false);
+        assert_eq!(memory_manager.borrow().state_for_handle(handle), Some(0x20));
+
+        native.with_process_memory_manager(|native, memory_manager| {
+            native.imports[0].dispatcher_target = PpcImportDispatcherTarget::DisposeHandle;
+            native.cpu.gpr[3] = handle;
+            let probe =
+                native.run_with_process_memory_manager(64, false, false, memory_manager);
+            assert_eq!(probe.handled_import_count, 1);
+            assert_eq!(
+                memory_manager
+                    .native_heap_state()
+                    .map(|heap| heap.last_mem_error),
+                Some(PPC_NO_ERR)
+            );
+            assert_eq!(PpcMemory::read_u32_be(&mut native.memory, handle), Some(ptr));
+            assert_eq!(memory_manager.classic_allocation_size(handle), Some(4));
+            assert_eq!(memory_manager.classic_allocation_size(ptr), Some(16));
+            assert_eq!(memory_manager.recover_handle(ptr), Some(handle));
+            assert_eq!(memory_manager.state_for_handle(handle), Some(0x20));
+
+            native.cpu.pc = native.entry_pc;
+            native.cpu.lr = PPC_HALT_PC;
+            native.imports[0].dispatcher_target = PpcImportDispatcherTarget::EmptyHandle;
+            native.cpu.gpr[3] = handle;
+            native.run_with_process_memory_manager(64, false, false, memory_manager);
+            assert_eq!(
+                memory_manager
+                    .native_heap_state()
+                    .map(|heap| heap.last_mem_error),
+                Some(PPC_NIL_HANDLE_ERR)
+            );
+            assert_eq!(PpcMemory::read_u32_be(&mut native.memory, handle), Some(ptr));
+            assert_eq!(memory_manager.classic_allocation_size(handle), Some(4));
+            assert_eq!(memory_manager.classic_allocation_size(ptr), Some(16));
+            assert_eq!(memory_manager.recover_handle(ptr), Some(handle));
+            assert_eq!(memory_manager.state_for_handle(handle), Some(0x20));
+        });
+
+        assert_eq!(classic_bus.read_long(handle), ptr);
+        assert_eq!(classic_bus.read_bytes(ptr, 16), b"classic resource");
+
+        let mut classic_cpu = crate::trap::test_helpers::MockCpu::new();
+        classic_cpu.write_reg(Register::A7, TEST_SP);
+        classic_bus.write_long(TEST_SP, handle);
+        assert!(classic
+            .dispatch_toolbox(true, 0x1ad, &mut classic_cpu, &mut classic_bus)
+            .unwrap()
+            .is_ok());
+        assert_eq!(classic_cpu.read_reg(Register::A7), TEST_SP + 4);
+        assert_eq!(classic_bus.read_word(0x0a60), 0);
+        assert_eq!(memory_manager.borrow().state_for_handle(handle), Some(0));
+
+        native.with_process_memory_manager(|native, memory_manager| {
+            native.cpu.pc = native.entry_pc;
+            native.cpu.lr = PPC_HALT_PC;
+            native.imports[0].dispatcher_target = PpcImportDispatcherTarget::DisposeHandle;
+            native.cpu.gpr[3] = handle;
+            native.run_with_process_memory_manager(64, false, false, memory_manager);
+            assert_eq!(memory_manager.classic_allocation_size(handle), None);
+            assert_eq!(memory_manager.classic_allocation_size(ptr), None);
+            assert_eq!(memory_manager.state_for_handle(handle), None);
+        });
+    }
+
+    #[test]
+    fn ppc_dispose_handle_does_not_claim_an_external_pef_master_pointer() {
+        let pef = synthetic_pef_with_loader_and_data(
+            synthetic_loader(b"InterfaceLib", b"DisposeHandle"),
+            &[0; 0x80],
+        );
+        let mut native = load_pef_application(&pef).unwrap();
+        let handle = PPC_DATA_BASE + 0x40;
+        let before = ppc_memory_read_bytes(&mut native.memory, PPC_DATA_BASE, 0x80).unwrap();
+
+        native.with_process_memory_manager(|native, memory_manager| {
+            let ptr = memory_manager.new_native_ptr(&mut native.memory, 32, true);
+            assert_ne!(ptr, 0);
+            PpcMemory::write_u32_be(&mut native.memory, handle, ptr).unwrap();
+            let heap_cursor = memory_manager.native_heap_state().unwrap().heap_cursor;
+            memory_manager.publish_external_native_resource_handle(handle, ptr, heap_cursor);
+            let expected =
+                ppc_memory_read_bytes(&mut native.memory, PPC_DATA_BASE, 0x80).unwrap();
+
+            native.cpu.gpr[3] = handle;
+            let probe =
+                native.run_with_process_memory_manager(64, false, false, memory_manager);
+            assert_eq!(probe.handled_import_count, 1);
+            assert_eq!(
+                memory_manager
+                    .native_heap_state()
+                    .map(|heap| heap.last_mem_error),
+                Some(PPC_NO_ERR)
+            );
+            assert_eq!(
+                ppc_memory_read_bytes(&mut native.memory, PPC_DATA_BASE, 0x80),
+                Some(expected.clone())
+            );
+            assert!(memory_manager
+                .native_allocator()
+                .unwrap()
+                .ptrs
+                .iter()
+                .any(|record| record.ptr == ptr && record.size == 32));
+            assert_eq!(memory_manager.recover_handle(ptr), Some(handle));
+            assert_eq!(memory_manager.state_for_handle(handle), Some(0x60));
+
+            native.cpu.pc = native.entry_pc;
+            native.cpu.lr = PPC_HALT_PC;
+            native.imports[0].dispatcher_target = PpcImportDispatcherTarget::EmptyHandle;
+            native.cpu.gpr[3] = handle;
+            native.run_with_process_memory_manager(64, false, false, memory_manager);
+            assert_eq!(
+                memory_manager
+                    .native_heap_state()
+                    .map(|heap| heap.last_mem_error),
+                Some(PPC_NIL_HANDLE_ERR)
+            );
+            assert_eq!(
+                ppc_memory_read_bytes(&mut native.memory, PPC_DATA_BASE, 0x80),
+                Some(expected)
+            );
+            assert_eq!(memory_manager.recover_handle(ptr), Some(handle));
+            assert_eq!(memory_manager.state_for_handle(handle), Some(0x60));
+        });
+
+        let after = ppc_memory_read_bytes(&mut native.memory, PPC_DATA_BASE, 0x80).unwrap();
+        assert_ne!(after, before);
+        assert_eq!(&after[..0x40], &before[..0x40]);
+        assert_eq!(&after[0x44..], &before[0x44..]);
     }
 
     #[test]
@@ -147235,6 +147547,24 @@ pub(crate) mod tests {
         );
         assert_ne!(handle, 0);
         let ptr = loaded.memory.read_u32_be(handle).unwrap();
+        loaded
+            .process_memory_manager
+            .0
+            .borrow_mut()
+            .set_process_handle_resource(handle, true);
+        loaded
+            .process_memory_manager
+            .0
+            .borrow_mut()
+            .set_process_handle_purgeable(handle, false);
+        assert_eq!(
+            loaded
+                .process_memory_manager
+                .0
+                .borrow()
+                .state_for_handle(handle),
+            Some(0x20)
+        );
         loaded.process_file_system.vfs_resources.push(PpcVfsResourceRecord {
             ref_num: 0,
             path: "Test App".to_string(),
@@ -147259,6 +147589,24 @@ pub(crate) mod tests {
         assert!(test_handle_records!(loaded)
             .iter()
             .any(|record| record.handle == handle));
+        assert_eq!(
+            loaded
+                .process_memory_manager
+                .0
+                .borrow()
+                .state_for_handle(handle),
+            Some(0)
+        );
+
+        loaded.cpu.pc = loaded.entry_pc;
+        loaded.imports[0].dispatcher_target = PpcImportDispatcherTarget::HGetState;
+        loaded.cpu.gpr[3] = handle;
+
+        let probe = loaded.run_with_hle_imports(64);
+
+        assert_eq!(probe.handled_import_count, 1);
+        assert_eq!(probe.unsupported_import_index, None);
+        assert_eq!(loaded.cpu.gpr[3], 0);
 
         loaded.cpu.pc = loaded.entry_pc;
         loaded.imports[0].dispatcher_target = PpcImportDispatcherTarget::GetResAttrs;

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -3818,6 +3818,104 @@ impl ProcessNativeMemoryManager {
         true
     }
 
+    /// Empty a native or classic relocatable block from a native import.
+    ///
+    /// The live master pointer is read and cleared through the process address
+    /// space before allocator metadata is committed, so a failed guest write
+    /// leaves the allocation intact. The stable master-pointer block and its
+    /// state bits remain allocated. Inside Macintosh: Memory (1992),
+    /// pp. 2-51--2-52.
+    pub(crate) fn empty_process_handle_from_native_import(
+        &mut self,
+        memory: &mut GuestAddressSpace,
+        handle: u32,
+    ) -> i16 {
+        if self.native_allocation(handle).is_some() {
+            return self.empty_native_handle(memory, handle);
+        }
+
+        let Some(allocator) = self.classic_allocator.clone() else {
+            self.set_native_mem_error(Self::NIL_HANDLE_ERR);
+            return Self::NIL_HANDLE_ERR;
+        };
+        if handle == 0 || allocator.allocation_size(handle) != Some(4) {
+            self.set_native_mem_error(Self::NIL_HANDLE_ERR);
+            return Self::NIL_HANDLE_ERR;
+        }
+        if self.state_for_handle(handle).unwrap_or(0) & 0x20 != 0 {
+            self.set_native_mem_error(Self::NIL_HANDLE_ERR);
+            return Self::NIL_HANDLE_ERR;
+        }
+        if self.state_for_handle(handle).unwrap_or(0) & 0x80 != 0 {
+            self.set_native_mem_error(Self::MEM_PUR_ERR);
+            return Self::MEM_PUR_ERR;
+        }
+        let Some(ptr) = PpcMemory::read_u32_be(memory, handle) else {
+            self.set_native_mem_error(Self::MEM_WZ_ERR);
+            return Self::MEM_WZ_ERR;
+        };
+        if ptr != 0 && allocator.allocation_size(ptr).is_none() {
+            self.set_native_mem_error(Self::MEM_WZ_ERR);
+            return Self::MEM_WZ_ERR;
+        }
+        if PpcMemory::write_u32_be(memory, handle, 0).is_none() {
+            self.set_native_mem_error(Self::NIL_HANDLE_ERR);
+            return Self::NIL_HANDLE_ERR;
+        }
+
+        if ptr != 0 {
+            allocator.free(ptr);
+            self.ptr_to_handle.remove(&ptr);
+        }
+        self.set_native_mem_error(Self::NO_ERR);
+        Self::NO_ERR
+    }
+
+    /// Dispose a native or classic relocatable block from a native import.
+    ///
+    /// Classic disposal releases both allocator records without rewriting the
+    /// freed master-pointer bytes. The stale reverse entry is intentionally
+    /// retained until validated `RecoverHandle` observes reuse of that slot,
+    /// preserving existing invalid-handle compatibility. Inside Macintosh:
+    /// Memory (1992), pp. 2-34--2-35 and 2-53--2-54.
+    pub(crate) fn dispose_process_handle_from_native_import(
+        &mut self,
+        memory: &mut GuestAddressSpace,
+        handle: u32,
+    ) -> bool {
+        if self.native_allocation(handle).is_some() {
+            return self.dispose_native_handle(memory, handle).is_some();
+        }
+
+        let Some(allocator) = self.classic_allocator.clone() else {
+            self.set_native_mem_error(Self::NO_ERR);
+            return false;
+        };
+        if handle == 0 || allocator.allocation_size(handle) != Some(4) {
+            self.set_native_mem_error(Self::NO_ERR);
+            return false;
+        }
+        if self.state_for_handle(handle).unwrap_or(0) & 0x20 != 0 {
+            self.set_native_mem_error(Self::NO_ERR);
+            return false;
+        }
+        let Some(ptr) = PpcMemory::read_u32_be(memory, handle) else {
+            self.set_native_mem_error(Self::MEM_WZ_ERR);
+            return false;
+        };
+        if ptr != 0 && allocator.allocation_size(ptr).is_none() {
+            self.set_native_mem_error(Self::MEM_WZ_ERR);
+            return false;
+        }
+
+        allocator.free(ptr);
+        allocator.free(handle);
+        self.handle_state_bits.remove(&handle);
+        self.handle_high_locked.remove(&handle);
+        self.set_native_mem_error(Self::NO_ERR);
+        true
+    }
+
     /// Change the logical size of a native nonrelocatable block in place.
     ///
     /// A nonrelocatable block cannot move, so growth can fail when another

--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -908,6 +908,9 @@ impl super::TrapDispatcher {
                         self.resident_resources.insert(key);
                         self.track_handle_ptr(existing_ptr, handle);
                     }
+                    self.update_handle_state_bits(handle, |state| {
+                        Some(state.unwrap_or(0x40) | 0x20)
+                    });
                     return handle;
                 }
             }
@@ -924,6 +927,9 @@ impl super::TrapDispatcher {
         self.loaded_handles.insert(handle, (ptr, res_type, res_id));
         self.resource_handle_files.insert(handle, refnum);
         self.remember_resource_handle_index(handle, key.0, key.1, key.2);
+        self.update_handle_state_bits(handle, |state| {
+            Some(state.unwrap_or(0x40) | 0x20)
+        });
         if materialize && ptr != 0 {
             self.resident_resources.insert(key);
             self.track_handle_ptr(ptr, handle);
@@ -1141,6 +1147,9 @@ impl super::TrapDispatcher {
 
     fn restore_loaded_resource_handle(&mut self, handle: u32, ptr: u32) {
         self.track_handle_ptr(ptr, handle);
+        self.update_handle_state_bits(handle, |state| {
+            Some(state.unwrap_or(0x40) | 0x20)
+        });
         if let (Some((_, res_type, res_id)), Some(refnum)) = (
             self.loaded_handles.get(&handle).copied(),
             self.resource_handle_files.get(&handle).copied(),
@@ -1307,6 +1316,9 @@ impl super::TrapDispatcher {
                 self.forget_resource_handle_index_for_handle(handle);
                 self.loaded_handles.remove(&handle);
                 self.resource_handle_files.remove(&handle);
+                self.update_handle_state_bits(handle, |state| {
+                    Some(state.unwrap_or(0x40) & !0x20)
+                });
                 bus.write_word(0x0A60, 0);
                 true
             }
@@ -2076,6 +2088,9 @@ impl super::TrapDispatcher {
                             self.detached_handle_files.insert(handle, refnum);
                         }
                         self.detached_handles.insert(handle, (res_type, res_id));
+                        self.update_handle_state_bits(handle, |state| {
+                            Some(state.unwrap_or(0x40) & !0x20)
+                        });
                         bus.write_word(0x0A60, 0);
                     }
                 } else {
@@ -3165,6 +3180,9 @@ impl super::TrapDispatcher {
                     self.loaded_handles.insert(handle, (ptr, res_type, res_id));
                     self.resource_handle_files.insert(handle, refnum);
                     self.remember_resource_handle_index(handle, refnum, res_type, res_id);
+                    self.update_handle_state_bits(handle, |state| {
+                        Some(state.unwrap_or(0x40) | 0x20)
+                    });
 
                     let mut added_to_file = false;
                     if let Some(resources) = self.resources.as_mut() {


### PR DESCRIPTION
## Summary

- route PowerPC `EmptyHandle` and `DisposeHandle` through the process Memory Manager so they can operate on classic allocations
- preserve native handle priority and protect classic Resource Manager and external PEF ownership
- keep canonical `MemError`, lock failure atomicity, stale-slot recovery compatibility, and detached snapshot independence
- publish and clear resource ownership consistently across classic resource lifecycle transitions and native `DetachResource`

## Root cause

The PowerPC imports only consulted native allocator records. Classic handle bytes and allocator metadata were process-visible, but `EmptyHandle` and `DisposeHandle` could not mutate those allocations. Resource ownership also needed an explicit process-level marker so the Memory Manager would not free live Resource Manager handles.

## Validation

- `cargo test --locked --lib`: 4,809 passed, 0 failed, 3 ignored
- strict rustdoc with private intra-doc links denied
- all features and all targets compiled with tests in no-run mode
- focused cross-ISA classic empty, dispose, stale reuse, detached snapshot, resource ownership, PEF mapping, and detach-state regressions
- Marathon canonical gameplay and terminal-input lane passed (1/1 assertion)
- Escape Velocity canonical gameplay reached live space and accepted acceleration input
- Tomb Raider Gold canonical gameplay reached the live 3D level and accepted forward input

Closes #1289
