### PR TITLE
fix(memory): resize classic handles through PowerPC

### DIFF
--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -201,6 +201,8 @@ const PPC_CLASSIC_APP_MEMORY_SIZE: usize = 0x000f_0000;
 pub const PPC_MEM_FULL_ERR: i16 = -108;
 const PPC_NIL_HANDLE_ERR: i16 = -109;
 #[cfg(test)]
+const PPC_MEM_WZ_ERR: i16 = -111;
+#[cfg(test)]
 const PPC_MEM_PUR_ERR: i16 = -112;
 const PPC_C_DEPTH_ERR: i16 = -157;
 pub const PPC_NO_ERR: i16 = 0;
@@ -15649,7 +15651,8 @@ fn dispatch_supported_import(
         PpcImportDispatcherTarget::SetHandleSize => {
             let handle = cpu.gpr[3];
             let size = cpu.gpr[4];
-            *last_mem_error = process_memory_manager.set_native_handle_size(memory, handle, size);
+            *last_mem_error = process_memory_manager
+                .set_process_handle_size_from_native_import(memory, handle, size);
             ppc_apply_process_native_allocator(
                 process_memory_manager,
                 memory,
@@ -87716,6 +87719,21 @@ pub(crate) mod tests {
         drain_test_m68k_guest_calls(loaded);
     }
 
+    fn attach_test_classic_heap(
+        native: &mut PpcLoadedApp,
+        context: &mut ProcessContext,
+        ram_size: usize,
+        heap_len: usize,
+    ) -> MacMemoryBus {
+        let mut classic_bus = MacMemoryBus::new(ram_size);
+        context.attach_classic_memory_bus(&mut classic_bus);
+        let classic_heap = classic_bus
+            .shared_ram_region(0x0020_0000, heap_len as u32)
+            .expect("classic adapter owns its heap range");
+        context.attach_memory(0x0020_0000, classic_heap, &mut native.memory);
+        classic_bus
+    }
+
     fn drain_test_m68k_guest_calls(loaded: &mut PpcLoadedApp) {
         while let Some(pending) = loaded
             .guest_calls
@@ -94439,6 +94457,576 @@ pub(crate) mod tests {
         });
 
         assert_eq!(classic_bus.get_alloc_size(ptr), None);
+    }
+
+    #[test]
+    fn ppc_set_handle_size_resizes_process_owned_classic_handle_across_isa() {
+        let pef = synthetic_pef_with_import(b"SetHandleSize");
+        let mut native = load_pef_application(&pef).unwrap();
+        let mut context = ProcessContext::default();
+        native.attach_process_context(&mut context);
+        let mut classic_bus =
+            attach_test_classic_heap(&mut native, &mut context, 8 * 1024 * 1024, 0x4000);
+        let (handle, ptr) = context
+            .memory_manager_mut()
+            .new_classic_handle(&mut classic_bus, 16)
+            .unwrap();
+        let original = (0x10..=0x1f).collect::<Vec<_>>();
+        classic_bus.write_bytes(ptr, &original);
+        let neighbor = context
+            .memory_manager_mut()
+            .new_classic_ptr(&mut classic_bus, 16);
+        classic_bus.fill_bytes(neighbor, 16, 0xa5);
+        let memory_manager = context.memory_manager_handle().clone();
+        memory_manager
+            .borrow_mut()
+            .set_state_for_handle(handle, 0x40);
+        let mut detached = native.clone();
+
+        native.cpu.gpr[3] = handle;
+        native.cpu.gpr[4] = 8;
+        run_test_import_with_process_memory_manager(
+            &mut native,
+            PpcImportDispatcherTarget::SetHandleSize,
+            &memory_manager,
+        );
+        assert_eq!(native.cpu.gpr[3], handle);
+        assert_eq!(classic_bus.read_long(handle), ptr);
+        assert_eq!(classic_bus.get_alloc_size(ptr), Some(8));
+        assert_eq!(
+            classic_bus.read_bytes(ptr, 16),
+            [original[..8].to_vec(), vec![0; 8]].concat()
+        );
+        assert_eq!(memory_manager.borrow().handle_for_ptr(ptr), Some(handle));
+        assert_eq!(memory_manager.borrow().state_for_handle(handle), Some(0x40));
+        assert_eq!(
+            memory_manager
+                .borrow()
+                .native_heap_state()
+                .map(|heap| heap.last_mem_error),
+            Some(PPC_NO_ERR)
+        );
+
+        native.cpu.gpr[3] = handle;
+        native.cpu.gpr[4] = 12;
+        run_test_import_with_process_memory_manager(
+            &mut native,
+            PpcImportDispatcherTarget::SetHandleSize,
+            &memory_manager,
+        );
+        assert_eq!(classic_bus.read_long(handle), ptr);
+        assert_eq!(classic_bus.get_alloc_size(ptr), Some(12));
+        assert_eq!(
+            classic_bus.read_bytes(ptr, 12),
+            [original[..8].to_vec(), vec![0; 4]].concat()
+        );
+        classic_bus.write_bytes(ptr + 8, &[0x81, 0x82, 0x83, 0x84]);
+
+        native.cpu.gpr[3] = handle;
+        native.cpu.gpr[4] = 48;
+        run_test_import_with_process_memory_manager(
+            &mut native,
+            PpcImportDispatcherTarget::SetHandleSize,
+            &memory_manager,
+        );
+        let moved_ptr = classic_bus.read_long(handle);
+        assert_ne!(moved_ptr, ptr);
+        assert_eq!(classic_bus.get_alloc_size(ptr), None);
+        assert_eq!(classic_bus.get_alloc_size(moved_ptr), Some(48));
+        assert_eq!(
+            classic_bus.read_bytes(moved_ptr, 12),
+            [original[..8].to_vec(), vec![0x81, 0x82, 0x83, 0x84]].concat()
+        );
+        assert_eq!(classic_bus.read_bytes(neighbor, 16), vec![0xa5; 16]);
+        assert_eq!(
+            PpcMemory::read_u32_be(&mut native.memory, handle),
+            Some(moved_ptr)
+        );
+        assert_eq!(
+            memory_manager.borrow().classic_allocation_size(moved_ptr),
+            Some(48)
+        );
+        assert_eq!(memory_manager.borrow().handle_for_ptr(ptr), None);
+        assert_eq!(
+            memory_manager.borrow().handle_for_ptr(moved_ptr),
+            Some(handle)
+        );
+        assert_eq!(memory_manager.borrow().state_for_handle(handle), Some(0x40));
+        assert_eq!(
+            classic_bus.read_bytes(moved_ptr, 12),
+            ppc_memory_read_bytes(&mut native.memory, moved_ptr, 12).unwrap()
+        );
+
+        native.cpu.gpr[3] = ptr;
+        run_test_import_with_process_memory_manager(
+            &mut native,
+            PpcImportDispatcherTarget::RecoverHandle,
+            &memory_manager,
+        );
+        assert_eq!(native.cpu.gpr[3], 0);
+
+        native.cpu.gpr[3] = moved_ptr;
+        run_test_import_with_process_memory_manager(
+            &mut native,
+            PpcImportDispatcherTarget::RecoverHandle,
+            &memory_manager,
+        );
+        assert_eq!(native.cpu.gpr[3], handle);
+
+        native.cpu.gpr[3] = handle;
+        run_test_import_with_process_memory_manager(
+            &mut native,
+            PpcImportDispatcherTarget::GetHandleSize,
+            &memory_manager,
+        );
+        assert_eq!(native.cpu.gpr[3], 48);
+        assert_eq!(
+            classic_bus.read_bytes(moved_ptr, 12),
+            ppc_memory_read_bytes(&mut native.memory, moved_ptr, 12).unwrap()
+        );
+
+        let detached_manager = detached.process_memory_manager.0.borrow();
+        assert_eq!(
+            PpcMemory::read_u32_be(&mut detached.memory, handle),
+            Some(ptr)
+        );
+        assert_eq!(detached_manager.classic_allocation_size(handle), Some(4));
+        assert_eq!(detached_manager.classic_allocation_size(ptr), Some(16));
+        assert_eq!(detached_manager.classic_allocation_size(moved_ptr), None);
+        assert_eq!(detached_manager.handle_for_ptr(ptr), Some(handle));
+        assert_eq!(detached_manager.handle_for_ptr(moved_ptr), None);
+        assert_eq!(detached_manager.state_for_handle(handle), Some(0x40));
+        assert_eq!(
+            ppc_memory_read_bytes(&mut detached.memory, ptr, 16),
+            Some(original)
+        );
+    }
+
+    #[test]
+    fn ppc_set_handle_size_keeps_zero_size_empty_classic_handle_empty() {
+        let pef = synthetic_pef_with_import(b"SetHandleSize");
+        let mut native = load_pef_application(&pef).unwrap();
+        let mut context = ProcessContext::default();
+        native.attach_process_context(&mut context);
+        let mut classic_bus =
+            attach_test_classic_heap(&mut native, &mut context, 8 * 1024 * 1024, 0x4000);
+        let handle = context
+            .memory_manager_mut()
+            .new_empty_classic_handle(&mut classic_bus)
+            .unwrap();
+        let memory_manager = context.memory_manager_handle().clone();
+        let cursor = context.classic_heap_bump_ptr();
+
+        native.cpu.gpr[3] = handle;
+        native.cpu.gpr[4] = 0;
+        run_test_import_with_process_memory_manager(
+            &mut native,
+            PpcImportDispatcherTarget::SetHandleSize,
+            &memory_manager,
+        );
+
+        assert_eq!(classic_bus.read_long(handle), 0);
+        assert_eq!(classic_bus.get_alloc_size(handle), Some(4));
+        assert_eq!(context.classic_heap_bump_ptr(), cursor);
+        assert_eq!(memory_manager.borrow().handle_for_ptr(0), None);
+        assert_eq!(
+            memory_manager
+                .borrow()
+                .native_heap_state()
+                .map(|heap| heap.last_mem_error),
+            Some(PPC_NO_ERR)
+        );
+    }
+
+    #[test]
+    fn ppc_set_handle_size_preserves_classic_state_on_atomic_failure() {
+        let pef = synthetic_pef_with_import(b"SetHandleSize");
+        let mut native = load_pef_application(&pef).unwrap();
+        let mut context = ProcessContext::default();
+        native.attach_process_context(&mut context);
+        let mut classic_bus =
+            attach_test_classic_heap(&mut native, &mut context, 3 * 1024 * 1024, 0x4000);
+        let (handle, ptr) = context
+            .memory_manager_mut()
+            .new_classic_handle(&mut classic_bus, 16)
+            .unwrap();
+        let payload = (0xa0..=0xaf).collect::<Vec<_>>();
+        classic_bus.write_bytes(ptr, &payload);
+        let neighbor = context
+            .memory_manager_mut()
+            .new_classic_ptr(&mut classic_bus, 16);
+        classic_bus.fill_bytes(neighbor, 16, 0x5a);
+        let memory_manager = context.memory_manager_handle().clone();
+        memory_manager
+            .borrow_mut()
+            .set_state_for_handle(handle, 0x40);
+        let mut detached = native.clone();
+        let handle_bytes = classic_bus.read_bytes(handle, 4);
+        let cursor = context.classic_heap_bump_ptr();
+
+        native.cpu.gpr[3] = handle;
+        native.cpu.gpr[4] = 0x0010_0000;
+        run_test_import_with_process_memory_manager(
+            &mut native,
+            PpcImportDispatcherTarget::SetHandleSize,
+            &memory_manager,
+        );
+        assert_eq!(
+            memory_manager
+                .borrow()
+                .native_heap_state()
+                .map(|heap| heap.last_mem_error),
+            Some(PPC_MEM_FULL_ERR)
+        );
+        assert_eq!(classic_bus.read_bytes(handle, 4), handle_bytes);
+        assert_eq!(classic_bus.read_long(handle), ptr);
+        assert_eq!(classic_bus.get_alloc_size(handle), Some(4));
+        assert_eq!(classic_bus.get_alloc_size(ptr), Some(16));
+        assert_eq!(classic_bus.read_bytes(ptr, 16), payload);
+        assert_eq!(classic_bus.read_bytes(neighbor, 16), vec![0x5a; 16]);
+        assert_eq!(context.classic_heap_bump_ptr(), cursor);
+        assert_eq!(memory_manager.borrow().handle_for_ptr(ptr), Some(handle));
+        assert_eq!(memory_manager.borrow().handle_for_ptr(neighbor), None);
+        assert_eq!(memory_manager.borrow().state_for_handle(handle), Some(0x40));
+
+        let detached_manager = detached.process_memory_manager.0.borrow();
+        assert_eq!(
+            PpcMemory::read_u32_be(&mut detached.memory, handle),
+            Some(ptr)
+        );
+        assert_eq!(detached_manager.classic_allocation_size(ptr), Some(16));
+        assert_eq!(
+            ppc_memory_read_bytes(&mut detached.memory, ptr, 16),
+            Some((0xa0..=0xaf).collect::<Vec<_>>())
+        );
+    }
+
+    #[test]
+    fn ppc_set_handle_size_rejects_a_guest_mutated_classic_master_pointer() {
+        let pef = synthetic_pef_with_import(b"SetHandleSize");
+        let mut native = load_pef_application(&pef).unwrap();
+        let mut context = ProcessContext::default();
+        native.attach_process_context(&mut context);
+        let mut classic_bus =
+            attach_test_classic_heap(&mut native, &mut context, 8 * 1024 * 1024, 0x4000);
+        let (handle, ptr) = context
+            .memory_manager_mut()
+            .new_classic_handle(&mut classic_bus, 16)
+            .unwrap();
+        let payload = (0xb0..=0xbf).collect::<Vec<_>>();
+        classic_bus.write_bytes(ptr, &payload);
+        let memory_manager = context.memory_manager_handle().clone();
+        memory_manager
+            .borrow_mut()
+            .set_state_for_handle(handle, 0x40);
+        let mut detached = native.clone();
+        let invalid_ptr = 0xdead_beefu32;
+        classic_bus.write_long(handle, invalid_ptr);
+        let cursor = context.classic_heap_bump_ptr();
+
+        native.cpu.gpr[3] = handle;
+        native.cpu.gpr[4] = 48;
+        run_test_import_with_process_memory_manager(
+            &mut native,
+            PpcImportDispatcherTarget::SetHandleSize,
+            &memory_manager,
+        );
+        assert_eq!(
+            memory_manager
+                .borrow()
+                .native_heap_state()
+                .map(|heap| heap.last_mem_error),
+            Some(PPC_MEM_WZ_ERR)
+        );
+        assert_eq!(classic_bus.read_long(handle), invalid_ptr);
+        assert_eq!(classic_bus.get_alloc_size(ptr), Some(16));
+        assert_eq!(classic_bus.read_bytes(ptr, 16), payload);
+        assert_eq!(context.classic_heap_bump_ptr(), cursor);
+        assert_eq!(memory_manager.borrow().handle_for_ptr(ptr), Some(handle));
+        assert_eq!(memory_manager.borrow().state_for_handle(handle), Some(0x40));
+
+        let detached_manager = detached.process_memory_manager.0.borrow();
+        assert_eq!(
+            PpcMemory::read_u32_be(&mut detached.memory, handle),
+            Some(ptr)
+        );
+        assert_eq!(detached_manager.classic_allocation_size(ptr), Some(16));
+        assert_eq!(detached_manager.handle_for_ptr(ptr), Some(handle));
+    }
+
+    #[test]
+    fn ppc_set_handle_size_rejects_another_classic_handles_data_block() {
+        let pef = synthetic_pef_with_import(b"SetHandleSize");
+        let mut native = load_pef_application(&pef).unwrap();
+        let mut context = ProcessContext::default();
+        native.attach_process_context(&mut context);
+        let mut classic_bus =
+            attach_test_classic_heap(&mut native, &mut context, 8 * 1024 * 1024, 0x4000);
+        let (handle, ptr) = context
+            .memory_manager_mut()
+            .new_classic_handle(&mut classic_bus, 16)
+            .unwrap();
+        let (other_handle, other_ptr) = context
+            .memory_manager_mut()
+            .new_classic_handle(&mut classic_bus, 24)
+            .unwrap();
+        let original = (0x20..=0x2f).collect::<Vec<_>>();
+        let other = (0x80..=0x97).collect::<Vec<_>>();
+        classic_bus.write_bytes(ptr, &original);
+        classic_bus.write_bytes(other_ptr, &other);
+        classic_bus.write_long(handle, other_ptr);
+        let memory_manager = context.memory_manager_handle().clone();
+        let cursor = context.classic_heap_bump_ptr();
+
+        native.cpu.gpr[3] = handle;
+        native.cpu.gpr[4] = 48;
+        run_test_import_with_process_memory_manager(
+            &mut native,
+            PpcImportDispatcherTarget::SetHandleSize,
+            &memory_manager,
+        );
+
+        assert_eq!(
+            memory_manager
+                .borrow()
+                .native_heap_state()
+                .map(|heap| heap.last_mem_error),
+            Some(PPC_MEM_WZ_ERR)
+        );
+        assert_eq!(classic_bus.read_long(handle), other_ptr);
+        assert_eq!(classic_bus.read_long(other_handle), other_ptr);
+        assert_eq!(classic_bus.get_alloc_size(ptr), Some(16));
+        assert_eq!(classic_bus.get_alloc_size(other_ptr), Some(24));
+        assert_eq!(classic_bus.read_bytes(ptr, 16), original);
+        assert_eq!(classic_bus.read_bytes(other_ptr, 24), other);
+        assert_eq!(context.classic_heap_bump_ptr(), cursor);
+        assert_eq!(memory_manager.borrow().handle_for_ptr(ptr), Some(handle));
+        assert_eq!(
+            memory_manager.borrow().handle_for_ptr(other_ptr),
+            Some(other_handle)
+        );
+    }
+
+    #[test]
+    fn ppc_set_handle_size_rejects_locked_classic_relocation_without_mutation() {
+        let pef = synthetic_pef_with_import(b"SetHandleSize");
+        let mut native = load_pef_application(&pef).unwrap();
+        let mut context = ProcessContext::default();
+        native.attach_process_context(&mut context);
+        let mut classic_bus =
+            attach_test_classic_heap(&mut native, &mut context, 8 * 1024 * 1024, 0x4000);
+        let (handle, ptr) = context
+            .memory_manager_mut()
+            .new_classic_handle(&mut classic_bus, 16)
+            .unwrap();
+        let payload = (0xc0..=0xcf).collect::<Vec<_>>();
+        classic_bus.write_bytes(ptr, &payload);
+        let neighbor = context
+            .memory_manager_mut()
+            .new_classic_ptr(&mut classic_bus, 16);
+        classic_bus.fill_bytes(neighbor, 16, 0x6b);
+        let memory_manager = context.memory_manager_handle().clone();
+        memory_manager
+            .borrow_mut()
+            .set_state_for_handle(handle, 0x80);
+        let mut detached = native.clone();
+
+        native.cpu.gpr[3] = handle;
+        native.cpu.gpr[4] = 8;
+        run_test_import_with_process_memory_manager(
+            &mut native,
+            PpcImportDispatcherTarget::SetHandleSize,
+            &memory_manager,
+        );
+        assert_eq!(classic_bus.read_long(handle), ptr);
+        assert_eq!(classic_bus.get_alloc_size(ptr), Some(8));
+        assert_eq!(
+            classic_bus.read_bytes(ptr, 16),
+            [payload[..8].to_vec(), vec![0; 8]].concat()
+        );
+        assert_eq!(memory_manager.borrow().state_for_handle(handle), Some(0x80));
+
+        let before_handle = classic_bus.read_bytes(handle, 4);
+        let before_data = classic_bus.read_bytes(ptr, 16);
+        let before_cursor = context.classic_heap_bump_ptr();
+        native.cpu.gpr[3] = handle;
+        native.cpu.gpr[4] = 48;
+        run_test_import_with_process_memory_manager(
+            &mut native,
+            PpcImportDispatcherTarget::SetHandleSize,
+            &memory_manager,
+        );
+        assert_eq!(
+            memory_manager
+                .borrow()
+                .native_heap_state()
+                .map(|heap| heap.last_mem_error),
+            Some(PPC_MEM_FULL_ERR)
+        );
+        assert_eq!(classic_bus.read_bytes(handle, 4), before_handle);
+        assert_eq!(classic_bus.read_long(handle), ptr);
+        assert_eq!(classic_bus.get_alloc_size(ptr), Some(8));
+        assert_eq!(classic_bus.read_bytes(ptr, 16), before_data);
+        assert_eq!(classic_bus.read_bytes(neighbor, 16), vec![0x6b; 16]);
+        assert_eq!(context.classic_heap_bump_ptr(), before_cursor);
+        assert_eq!(memory_manager.borrow().handle_for_ptr(ptr), Some(handle));
+        assert_eq!(memory_manager.borrow().state_for_handle(handle), Some(0x80));
+
+        let detached_manager = detached.process_memory_manager.0.borrow();
+        assert_eq!(
+            PpcMemory::read_u32_be(&mut detached.memory, handle),
+            Some(ptr)
+        );
+        assert_eq!(detached_manager.classic_allocation_size(ptr), Some(16));
+        assert_eq!(detached_manager.state_for_handle(handle), Some(0x80));
+    }
+
+    #[test]
+    fn ppc_set_handle_size_does_not_bypass_classic_resource_ownership() {
+        let pef = synthetic_pef_with_import(b"SetHandleSize");
+        let mut native = load_pef_application(&pef).unwrap();
+        let mut classic = TrapDispatcher::new();
+        let mut context = ProcessContext::default();
+        native.attach_process_context(&mut context);
+        classic.attach_process_context(&mut context);
+        let mut classic_bus =
+            attach_test_classic_heap(&mut native, &mut context, 8 * 1024 * 1024, 0x4000);
+        let ptr = context
+            .memory_manager_mut()
+            .new_classic_ptr(&mut classic_bus, 16);
+        let payload = (0xd0..=0xdf).collect::<Vec<_>>();
+        classic_bus.write_bytes(ptr, &payload);
+        let handle = classic.get_or_create_resource_handle(&mut classic_bus, *b"TEST", 128, ptr);
+        let memory_manager = context.memory_manager_handle().clone();
+        memory_manager
+            .borrow_mut()
+            .set_process_handle_purgeable(handle, false);
+        assert_eq!(memory_manager.borrow().state_for_handle(handle), Some(0x20));
+        let mut detached = native.clone();
+        let before_handle = classic_bus.read_bytes(handle, 4);
+        let before_cursor = context.classic_heap_bump_ptr();
+
+        native.cpu.gpr[3] = handle;
+        native.cpu.gpr[4] = 48;
+        run_test_import_with_process_memory_manager(
+            &mut native,
+            PpcImportDispatcherTarget::SetHandleSize,
+            &memory_manager,
+        );
+        assert_eq!(
+            memory_manager
+                .borrow()
+                .native_heap_state()
+                .map(|heap| heap.last_mem_error),
+            Some(PPC_NIL_HANDLE_ERR)
+        );
+        assert_eq!(classic_bus.read_bytes(handle, 4), before_handle);
+        assert_eq!(classic_bus.read_long(handle), ptr);
+        assert_eq!(classic_bus.get_alloc_size(handle), Some(4));
+        assert_eq!(classic_bus.get_alloc_size(ptr), Some(16));
+        assert_eq!(classic_bus.read_bytes(ptr, 16), payload);
+        assert_eq!(context.classic_heap_bump_ptr(), before_cursor);
+        assert_eq!(memory_manager.borrow().handle_for_ptr(ptr), Some(handle));
+        assert_eq!(memory_manager.borrow().state_for_handle(handle), Some(0x20));
+
+        let detached_manager = detached.process_memory_manager.0.borrow();
+        assert_eq!(
+            PpcMemory::read_u32_be(&mut detached.memory, handle),
+            Some(ptr)
+        );
+        assert_eq!(detached_manager.classic_allocation_size(ptr), Some(16));
+        assert_eq!(detached_manager.state_for_handle(handle), Some(0x20));
+    }
+
+    #[test]
+    fn ppc_set_handle_size_does_not_claim_an_external_pef_master_pointer() {
+        let pef = synthetic_pef_with_loader_and_data(
+            synthetic_loader(b"InterfaceLib", b"SetHandleSize"),
+            &[0; 0x80],
+        );
+        let mut native = load_pef_application(&pef).unwrap();
+        let mut context = ProcessContext::default();
+        native.attach_process_context(&mut context);
+        let mut classic_bus =
+            attach_test_classic_heap(&mut native, &mut context, 8 * 1024 * 1024, 0x4000);
+        classic_bus.attach_guest_address_space(native.memory.shared_view());
+        let handle = PPC_DATA_BASE + 0x40;
+        let memory_manager = context.memory_manager_handle().clone();
+        let ptr = native.with_process_memory_manager(|native, memory_manager| {
+            let ptr = memory_manager.new_native_ptr(&mut native.memory, 32, true);
+            assert_ne!(ptr, 0);
+            native
+                .memory
+                .write_bytes(ptr, b"external PEF payload")
+                .unwrap();
+            PpcMemory::write_u32_be(&mut native.memory, handle, ptr).unwrap();
+            let heap_cursor = memory_manager.native_heap_state().unwrap().heap_cursor;
+            memory_manager.publish_external_native_resource_handle(handle, ptr, heap_cursor);
+            ptr
+        });
+        let mut detached = native.clone();
+        let before_handle = PpcMemory::read_u32_be(&mut native.memory, handle);
+        let expected_pef = ppc_memory_read_bytes(&mut native.memory, PPC_DATA_BASE, 0x80).unwrap();
+        let detached_pef =
+            ppc_memory_read_bytes(&mut detached.memory, PPC_DATA_BASE, 0x80).unwrap();
+
+        native.cpu.gpr[3] = handle;
+        native.cpu.gpr[4] = 64;
+        run_test_import_with_process_memory_manager(
+            &mut native,
+            PpcImportDispatcherTarget::SetHandleSize,
+            &memory_manager,
+        );
+        assert_eq!(
+            memory_manager
+                .borrow()
+                .native_heap_state()
+                .map(|heap| heap.last_mem_error),
+            Some(PPC_NIL_HANDLE_ERR)
+        );
+        assert_eq!(
+            PpcMemory::read_u32_be(&mut native.memory, handle),
+            before_handle
+        );
+        assert_eq!(
+            ppc_memory_read_bytes(&mut native.memory, PPC_DATA_BASE, 0x80),
+            Some(expected_pef)
+        );
+        assert_eq!(memory_manager.borrow().native_allocation(handle), None);
+        assert!(memory_manager
+            .borrow()
+            .native_ptr_records()
+            .iter()
+            .any(|record| record.ptr == ptr && record.size == 32));
+        assert_eq!(memory_manager.borrow().handle_for_ptr(ptr), Some(handle));
+        assert_eq!(memory_manager.borrow().state_for_handle(handle), Some(0x60));
+        assert_eq!(
+            ppc_memory_read_bytes(&mut native.memory, ptr, b"external PEF payload".len() as u32),
+            Some(b"external PEF payload".to_vec())
+        );
+
+        assert_eq!(
+            PpcMemory::read_u32_be(&mut detached.memory, handle),
+            Some(ptr)
+        );
+        assert_eq!(
+            ppc_memory_read_bytes(&mut detached.memory, PPC_DATA_BASE, 0x80),
+            Some(detached_pef)
+        );
+        let detached_manager = detached.process_memory_manager.0.borrow();
+        assert_eq!(detached_manager.native_allocation(handle), None);
+        assert!(detached_manager
+            .native_ptr_records()
+            .iter()
+            .any(|record| record.ptr == ptr && record.size == 32));
+        assert_eq!(
+            ppc_memory_read_bytes(
+                &mut detached.memory,
+                ptr,
+                b"external PEF payload".len() as u32,
+            ),
+            Some(b"external PEF payload".to_vec())
+        );
     }
 
     #[test]

--- a/src/memory/address_space.rs
+++ b/src/memory/address_space.rs
@@ -288,6 +288,38 @@ impl GuestAddressSpace {
         holes
     }
 
+    /// Return the disjoint occupied spans of ordinary sparse mappings.
+    ///
+    /// Shared flat-RAM overlays are intentionally not subtracted: callers
+    /// use these spans to keep process allocators away from the native PEF
+    /// layout before those overlays are installed. Inside Macintosh: Memory
+    /// (1992), pp. 2-19--2-21.
+    pub(crate) fn ordinary_mapping_ranges(&self) -> Vec<(u32, u32)> {
+        let mut ranges = self
+            .state()
+            .ordinary_regions
+            .iter()
+            .filter_map(|mapping| {
+                let end = u64::from(mapping.base).checked_add(mapping.len as u64)?;
+                (u64::from(mapping.base) < end)
+                    .then_some((mapping.base, u32::try_from(end).ok()?))
+            })
+            .collect::<Vec<_>>();
+        ranges.sort_unstable_by_key(|&(base, _)| base);
+
+        let mut merged = Vec::new();
+        for (base, end) in ranges {
+            if let Some((_, merged_end)) = merged.last_mut() {
+                if base <= *merged_end {
+                    *merged_end = (*merged_end).max(end);
+                    continue;
+                }
+            }
+            merged.push((base, end));
+        }
+        merged
+    }
+
     /// Overlay a runner-owned RAM range without copying it.
     ///
     /// Shared mappings remain authoritative over ordinary sparse mappings so
@@ -545,6 +577,33 @@ impl GuestAddressSpace {
                 .expect("located shared byte remains mapped");
         }
         Some(())
+    }
+
+    /// Verify that a non-wrapping range is mapped and writable without
+    /// changing its bytes. The write-back is deliberately byte-identical;
+    /// it exercises the same protection and shared-overlay path used by the
+    /// eventual commit while retaining atomicity for each chunk.
+    pub(crate) fn preflight_writable_range(&mut self, addr: u32, len: u32) -> bool {
+        if len == 0 {
+            return true;
+        }
+        if u64::from(addr) + u64::from(len) > (1u64 << 32) {
+            return false;
+        }
+        const PREFLIGHT_CHUNK: u32 = 4096;
+        let mut offset = 0;
+        while offset < len {
+            let chunk_len = (len - offset).min(PREFLIGHT_CHUNK) as usize;
+            let address = addr + offset;
+            let mut bytes = vec![0; chunk_len];
+            if self.read_bytes_into(address, &mut bytes).is_none()
+                || self.write_bytes(address, &bytes).is_none()
+            {
+                return false;
+            }
+            offset += chunk_len as u32;
+        }
+        true
     }
 
     /// Return a cached writable span contained in one mapped region.
@@ -1061,6 +1120,10 @@ mod tests {
             memory.ordinary_mapping_holes(0x1000, 0x1800),
             vec![(0x1000, 0x1200), (0x1300, 0x1400), (0x1700, 0x1800)]
         );
+        assert_eq!(
+            memory.ordinary_mapping_ranges(),
+            vec![(0x1200, 0x1300), (0x1400, 0x1700)]
+        );
         assert!(memory.ordinary_mapping_overlaps(0x1280, 0x100));
         assert!(!memory.ordinary_mapping_overlaps(0x1300, 0x100));
 
@@ -1068,6 +1131,10 @@ mod tests {
         assert_eq!(
             detached.ordinary_mapping_holes(0x1000, 0x1800),
             vec![(0x1000, 0x1200), (0x1300, 0x1400), (0x1700, 0x1800)]
+        );
+        assert_eq!(
+            detached.ordinary_mapping_ranges(),
+            vec![(0x1200, 0x1300), (0x1400, 0x1700)]
         );
     }
 }

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -1802,6 +1802,37 @@ struct ClassicHeapAllocatorState {
     alloc_bucket_sizes: HashMap<u32, u32>,
 }
 
+#[derive(Debug, Clone, Copy)]
+enum ClassicAllocationPlanSource {
+    Free {
+        bucket: u32,
+        retains_capacity: bool,
+    },
+    Bump {
+        previous_heap_ptr: u32,
+        next_heap_ptr: u32,
+    },
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ClassicAllocationPlan {
+    address: u32,
+    requested_size: u32,
+    aligned_size: u32,
+    alignment: u32,
+    heap_limit: u32,
+    source: ClassicAllocationPlanSource,
+}
+
+impl ClassicAllocationPlan {
+    fn capacity(self) -> u32 {
+        match self.source {
+            ClassicAllocationPlanSource::Free { bucket, .. } => bucket,
+            ClassicAllocationPlanSource::Bump { .. } => self.aligned_size,
+        }
+    }
+}
+
 impl Default for ClassicHeapAllocatorState {
     fn default() -> Self {
         Self {
@@ -1913,6 +1944,10 @@ impl SharedClassicHeapAllocator {
         ((size + 3) & !3).max(4)
     }
 
+    fn checked_allocation_bucket_size(size: u32) -> Option<u32> {
+        size.checked_add(3).map(|size| (size & !3).max(4))
+    }
+
     fn can_reuse_bucket_for_request(bucket: u32, requested: u32) -> bool {
         let max_bucket = if requested <= 1024 {
             4096
@@ -1944,7 +1979,10 @@ impl SharedClassicHeapAllocator {
         size: u32,
         alignment: u32,
     ) -> Option<(u32, u32)> {
-        let mut ptr = (state.heap_ptr + alignment - 1) & !(alignment - 1);
+        let mut ptr = state
+            .heap_ptr
+            .checked_add(alignment - 1)?
+            & !(alignment - 1);
         loop {
             let new_ptr = ptr.checked_add(size)?;
             let overlap = state
@@ -1952,97 +1990,204 @@ impl SharedClassicHeapAllocator {
                 .iter()
                 .find(|&&(start, end)| ptr < end && new_ptr > start);
             if let Some(&(_, end)) = overlap {
-                ptr = (end + alignment - 1) & !(alignment - 1);
+                ptr = end.checked_add(alignment - 1)? & !(alignment - 1);
                 continue;
             }
             return Some((ptr, new_ptr));
         }
     }
 
-    pub(crate) fn allocate(&self, size: u32, alignment: u32, heap_limit: u32) -> u32 {
+    fn range_overlaps_reserved(
+        state: &ClassicHeapAllocatorState,
+        address: u32,
+        len: u32,
+    ) -> bool {
+        let Some(end) = address.checked_add(len) else {
+            return true;
+        };
+        state
+            .reserved_heap_ranges
+            .iter()
+            .any(|&(start, reserved_end)| address < reserved_end && start < end)
+    }
+
+    fn allocation_plan(
+        &self,
+        size: u32,
+        alignment: u32,
+        heap_limit: u32,
+    ) -> Option<ClassicAllocationPlan> {
         let alignment = if alignment > 4 && alignment.is_power_of_two() {
             alignment
         } else {
             4
         };
-        let aligned_size = Self::allocation_bucket_size(size);
-        let mut state = self.0.borrow_mut();
+        let aligned_size = Self::checked_allocation_bucket_size(size)?;
+        let state = self.0.borrow();
 
-        if let Some(blocks) = state.free_blocks.get_mut(&aligned_size) {
-            let index = if alignment == 4 {
-                blocks.len().checked_sub(1)
+        if let Some(blocks) = state.free_blocks.get(&aligned_size) {
+            let address = if alignment == 4 {
+                blocks
+                    .iter()
+                    .rev()
+                    .copied()
+                    .find(|&address| !Self::range_overlaps_reserved(&state, address, aligned_size))
             } else {
-                blocks.iter().position(|addr| addr % alignment == 0)
+                blocks.iter().copied().find(|&address| {
+                    address % alignment == 0
+                        && !Self::range_overlaps_reserved(&state, address, aligned_size)
+                })
             };
-            if let Some(index) = index {
-                let addr = blocks.swap_remove(index);
-                state.alloc_sizes.insert(addr, size);
-                let event = if alignment == 4 {
-                    "reuse-exact"
-                } else {
-                    "reuse-exact-aligned"
-                };
-                crate::memory::bus::trace_alloc_event(event, addr, size, aligned_size);
-                return addr;
+            if let Some(address) = address {
+                return Some(ClassicAllocationPlan {
+                    address,
+                    requested_size: size,
+                    aligned_size,
+                    alignment,
+                    heap_limit,
+                    source: ClassicAllocationPlanSource::Free {
+                        bucket: aligned_size,
+                        retains_capacity: false,
+                    },
+                });
             }
         }
 
         let best = state
             .free_blocks
             .iter()
-            .filter(|(&bucket, blocks)| {
-                bucket > aligned_size
-                    && !blocks.is_empty()
-                    && Self::can_reuse_bucket_for_request(bucket, aligned_size)
-                    && (alignment == 4 || blocks.iter().any(|addr| addr % alignment == 0))
+            .filter_map(|(&bucket, blocks)| {
+                if bucket <= aligned_size
+                    || blocks.is_empty()
+                    || !Self::can_reuse_bucket_for_request(bucket, aligned_size)
+                {
+                    return None;
+                }
+                let address = if alignment == 4 {
+                    blocks
+                        .iter()
+                        .rev()
+                        .copied()
+                        .find(|&address| !Self::range_overlaps_reserved(&state, address, bucket))
+                } else {
+                    blocks.iter().copied().find(|&address| {
+                        address % alignment == 0
+                            && !Self::range_overlaps_reserved(&state, address, bucket)
+                    })
+                }?;
+                Some((bucket, address))
             })
-            .map(|(&bucket, _)| bucket)
-            .min();
-        if let Some(bucket) = best {
-            let blocks = state
-                .free_blocks
-                .get_mut(&bucket)
-                .expect("free bucket exists");
-            let index = if alignment == 4 {
-                blocks.len() - 1
-            } else {
-                blocks
-                    .iter()
-                    .position(|addr| addr % alignment == 0)
-                    .expect("aligned free block exists")
-            };
-            let addr = blocks.swap_remove(index);
-            state.alloc_sizes.insert(addr, size);
-            state.alloc_bucket_sizes.insert(addr, bucket);
-            let event = if alignment == 4 {
-                "reuse-best"
-            } else {
-                "reuse-best-aligned"
-            };
-            crate::memory::bus::trace_alloc_event(event, addr, size, bucket);
-            return addr;
+            .min_by_key(|(bucket, _)| *bucket);
+        if let Some((bucket, address)) = best {
+            return Some(ClassicAllocationPlan {
+                address,
+                requested_size: size,
+                aligned_size,
+                alignment,
+                heap_limit,
+                source: ClassicAllocationPlanSource::Free {
+                    bucket,
+                    retains_capacity: true,
+                },
+            });
         }
 
-        let Some((ptr, new_ptr)) = Self::bump_allocation_address(&state, aligned_size, alignment)
-        else {
-            return 0;
-        };
-        if new_ptr >= heap_limit {
-            eprintln!(
-                "[ALLOC] Out of memory: requesting {} bytes aligned to {}, heap at ${:08X}, limit ${:08X}",
-                size, alignment, ptr, heap_limit
-            );
-            return 0;
+        let (address, next_heap_ptr) =
+            Self::bump_allocation_address(&state, aligned_size, alignment)?;
+        if next_heap_ptr >= heap_limit {
+            return None;
         }
-        state.heap_ptr = new_ptr;
-        state.alloc_sizes.insert(ptr, size);
-        let event = if alignment == 4 {
-            "bump"
-        } else {
-            "bump-aligned"
+        Some(ClassicAllocationPlan {
+            address,
+            requested_size: size,
+            aligned_size,
+            alignment,
+            heap_limit,
+            source: ClassicAllocationPlanSource::Bump {
+                previous_heap_ptr: state.heap_ptr,
+                next_heap_ptr,
+            },
+        })
+    }
+
+    fn commit_allocation_plan(&self, plan: ClassicAllocationPlan) -> bool {
+        let mut state = self.0.borrow_mut();
+        if state.alloc_sizes.contains_key(&plan.address)
+            || Self::range_overlaps_reserved(&state, plan.address, plan.capacity())
+        {
+            return false;
+        }
+
+        let event = match plan.source {
+            ClassicAllocationPlanSource::Free {
+                bucket,
+                retains_capacity,
+            } => {
+                let Some(blocks) = state.free_blocks.get_mut(&bucket) else {
+                    return false;
+                };
+                let Some(index) = blocks.iter().position(|&address| address == plan.address)
+                else {
+                    return false;
+                };
+                blocks.swap_remove(index);
+                if retains_capacity {
+                    state.alloc_bucket_sizes.insert(plan.address, bucket);
+                }
+                if plan.alignment == 4 {
+                    if retains_capacity {
+                        "reuse-best"
+                    } else {
+                        "reuse-exact"
+                    }
+                } else if retains_capacity {
+                    "reuse-best-aligned"
+                } else {
+                    "reuse-exact-aligned"
+                }
+            }
+            ClassicAllocationPlanSource::Bump {
+                previous_heap_ptr,
+                next_heap_ptr,
+            } => {
+                if state.heap_ptr != previous_heap_ptr
+                    || Self::bump_allocation_address(
+                        &state,
+                        plan.aligned_size,
+                        plan.alignment,
+                    ) != Some((plan.address, next_heap_ptr))
+                    || next_heap_ptr >= plan.heap_limit
+                {
+                    return false;
+                }
+                state.heap_ptr = next_heap_ptr;
+                if plan.alignment == 4 {
+                    "bump"
+                } else {
+                    "bump-aligned"
+                }
+            }
         };
-        crate::memory::bus::trace_alloc_event(event, ptr, size, aligned_size);
-        ptr
+
+        state.alloc_sizes.insert(plan.address, plan.requested_size);
+        crate::memory::bus::trace_alloc_event(
+            event,
+            plan.address,
+            plan.requested_size,
+            plan.aligned_size,
+        );
+        true
+    }
+
+    pub(crate) fn allocate(&self, size: u32, alignment: u32, heap_limit: u32) -> u32 {
+        let Some(plan) = self.allocation_plan(size, alignment, heap_limit) else {
+            return 0;
+        };
+        if self.commit_allocation_plan(plan) {
+            plan.address
+        } else {
+            0
+        }
     }
 
     pub(crate) fn heap_bump_ptr(&self) -> u32 {
@@ -2096,6 +2241,10 @@ pub(crate) struct ProcessMemoryManager {
 pub(crate) struct ProcessNativeMemoryManager {
     classic_owner: Rc<()>,
     classic_allocator: Option<SharedClassicHeapAllocator>,
+    /// Canonical upper bound for classic allocations in this process. The
+    /// adapter bus supplies it once at attachment; detached managers retain
+    /// the same ceiling even when their byte adapter is recreated.
+    classic_heap_limit: Option<u32>,
     ptr_to_handle: SharedProcessMap<u32>,
     handle_state_bits: SharedProcessMap<u8>,
     handle_high_locked: SharedProcessMap<bool>,
@@ -2164,6 +2313,7 @@ impl ProcessNativeMemoryManager {
                 .classic_allocator
                 .as_ref()
                 .map(|allocator| allocator.detached_clone_for_owner(classic_owner_id)),
+            classic_heap_limit: self.classic_heap_limit,
             ptr_to_handle: self.ptr_to_handle.detached_clone(),
             handle_state_bits: self.handle_state_bits.detached_clone(),
             handle_high_locked: self.handle_high_locked.detached_clone(),
@@ -2189,6 +2339,7 @@ impl ProcessNativeMemoryManager {
             }
             (None, None) => {}
         }
+        self.classic_heap_limit = snapshot.classic_heap_limit;
         self.ptr_to_handle.replace_from(&snapshot.ptr_to_handle);
         self.handle_state_bits
             .replace_from(&snapshot.handle_state_bits);
@@ -2381,6 +2532,14 @@ impl ProcessNativeMemoryManager {
     pub(crate) fn attach_classic_memory_bus(&mut self, bus: &mut MacMemoryBus) {
         let owner_id = Rc::as_ptr(&self.classic_owner) as usize;
         let bus_allocator = bus.shared_classic_heap_allocator();
+        let bus_heap_limit = bus.classic_heap_limit();
+
+        if let Some(heap_limit) = self.classic_heap_limit {
+            assert_eq!(
+                heap_limit, bus_heap_limit,
+                "cannot attach a classic bus with a different heap ceiling"
+            );
+        }
 
         bus_allocator.assert_can_claim_owner(owner_id);
         let bus_is_pristine = bus_allocator.is_pristine();
@@ -2407,6 +2566,7 @@ impl ProcessNativeMemoryManager {
         } else {
             self.classic_allocator = Some(bus_allocator);
         }
+        self.classic_heap_limit = Some(bus_heap_limit);
     }
 
     fn assert_classic_memory_bus_attached(&self, bus: &MacMemoryBus) {
@@ -2423,6 +2583,11 @@ impl ProcessNativeMemoryManager {
     fn classic_allocator(&self) -> &SharedClassicHeapAllocator {
         self.classic_allocator
             .as_ref()
+            .expect("classic Memory Manager operation requires an attached bus")
+    }
+
+    fn classic_heap_ceiling(&self) -> u32 {
+        self.classic_heap_limit
             .expect("classic Memory Manager operation requires an attached bus")
     }
 
@@ -2450,7 +2615,7 @@ impl ProcessNativeMemoryManager {
     pub(crate) fn new_classic_ptr(&mut self, bus: &mut MacMemoryBus, size: u32) -> u32 {
         self.assert_classic_memory_bus_attached(bus);
         self.classic_allocator()
-            .allocate(size, 4, bus.classic_heap_limit())
+            .allocate(size, 4, self.classic_heap_ceiling())
     }
 
     /// Release a native or classic nonrelocatable block owned by this process.
@@ -2488,11 +2653,11 @@ impl ProcessNativeMemoryManager {
     ) -> Result<(u32, u32), i16> {
         self.assert_classic_memory_bus_attached(bus);
         let allocator = self.classic_allocator();
-        let ptr = allocator.allocate(size, 4, bus.classic_heap_limit());
+        let ptr = allocator.allocate(size, 4, self.classic_heap_ceiling());
         if ptr == 0 && size > 0 {
             return Err(Self::MEM_FULL_ERR);
         }
-        let handle = allocator.allocate(4, 4, bus.classic_heap_limit());
+        let handle = allocator.allocate(4, 4, self.classic_heap_ceiling());
         if handle == 0 {
             allocator.free(ptr);
             return Err(Self::MEM_FULL_ERR);
@@ -2649,7 +2814,7 @@ impl ProcessNativeMemoryManager {
         self.assert_classic_memory_bus_attached(bus);
         let handle = self
             .classic_allocator()
-            .allocate(4, 4, bus.classic_heap_limit());
+            .allocate(4, 4, self.classic_heap_ceiling());
         if handle == 0 {
             return Err(Self::MEM_FULL_ERR);
         }
@@ -2908,7 +3073,7 @@ impl ProcessNativeMemoryManager {
 
         let new_ptr = self
             .classic_allocator()
-            .allocate(new_size, 4, bus.classic_heap_limit());
+            .allocate(new_size, 4, self.classic_heap_ceiling());
         if new_ptr == 0 && new_size > 0 {
             return Self::MEM_FULL_ERR;
         }
@@ -3004,7 +3169,7 @@ impl ProcessNativeMemoryManager {
 
         let new_ptr = self
             .classic_allocator()
-            .allocate(new_size, 4, bus.classic_heap_limit());
+            .allocate(new_size, 4, self.classic_heap_ceiling());
         if new_ptr == 0 && new_size > 0 {
             return Err(Self::MEM_FULL_ERR);
         }
@@ -3089,7 +3254,7 @@ impl ProcessNativeMemoryManager {
         } else {
             let new_ptr = self
                 .classic_allocator()
-                .allocate(size, 4, bus.classic_heap_limit());
+                .allocate(size, 4, self.classic_heap_ceiling());
             if new_ptr == 0 && size > 0 {
                 return Err(Self::MEM_FULL_ERR);
             }
@@ -4374,6 +4539,210 @@ impl ProcessNativeMemoryManager {
         Some(record)
     }
 
+    /// Change a native or classic relocatable block's logical size through
+    /// the process-owned native address space.
+    ///
+    /// Native records retain their existing allocator policy. Classic
+    /// handles use the shared four-byte bucket allocator, preserving larger
+    /// recycled capacities and the logical prefix while making relocation a
+    /// single process-manager transaction. A locked classic handle may grow
+    /// only while its current bucket can hold the request. Resource and
+    /// externally-owned handles are rejected because their backing metadata
+    /// is not part of the generic Memory Manager record. Inside Macintosh:
+    /// Memory (1992), pp. 2-40--2-43, 2-46--2-51.
+    pub(crate) fn set_process_handle_size_from_native_import(
+        &mut self,
+        memory: &mut GuestAddressSpace,
+        handle: u32,
+        new_size: u32,
+    ) -> i16 {
+        if self.native_allocation(handle).is_some() {
+            return self.set_native_handle_size(memory, handle, new_size);
+        }
+
+        let Some(allocator) = self.classic_allocator.clone() else {
+            self.set_native_mem_error(Self::NIL_HANDLE_ERR);
+            return Self::NIL_HANDLE_ERR;
+        };
+        if handle == 0 || allocator.allocation_size(handle) != Some(4) {
+            self.set_native_mem_error(Self::NIL_HANDLE_ERR);
+            return Self::NIL_HANDLE_ERR;
+        }
+
+        let state = self.state_for_handle(handle).unwrap_or(0);
+        if state & 0x20 != 0 {
+            self.set_native_mem_error(Self::NIL_HANDLE_ERR);
+            return Self::NIL_HANDLE_ERR;
+        }
+
+        let Some(master_ptr) = PpcMemory::read_u32_be(memory, handle) else {
+            self.set_native_mem_error(Self::NIL_HANDLE_ERR);
+            return Self::NIL_HANDLE_ERR;
+        };
+        let (old_size, old_capacity) = if master_ptr == 0 {
+            (0, 0)
+        } else {
+            let Some(old_size) = allocator.allocation_size(master_ptr) else {
+                self.set_native_mem_error(Self::MEM_WZ_ERR);
+                return Self::MEM_WZ_ERR;
+            };
+            let Some(old_capacity) = allocator.allocation_capacity(master_ptr) else {
+                self.set_native_mem_error(Self::MEM_WZ_ERR);
+                return Self::MEM_WZ_ERR;
+            };
+            if self.ptr_to_handle.get(&master_ptr) != Some(handle)
+                || old_size > old_capacity
+                || master_ptr == handle
+                || master_ptr
+                    .checked_add(old_capacity)
+                    .is_none()
+                || handle
+                    .checked_add(4)
+                    .is_some_and(|master_end| {
+                        master_ptr < master_end
+                            && handle < master_ptr.saturating_add(old_capacity)
+                    })
+            {
+                self.set_native_mem_error(Self::MEM_WZ_ERR);
+                return Self::MEM_WZ_ERR;
+            }
+            (old_size, old_capacity)
+        };
+
+        let Some(new_capacity) = SharedClassicHeapAllocator::checked_allocation_bucket_size(
+            new_size,
+        ) else {
+            self.set_native_mem_error(Self::MEM_FULL_ERR);
+            return Self::MEM_FULL_ERR;
+        };
+        // The master slot is part of the commit contract even when the
+        // pointer remains stable. Write-back of identical bytes verifies that
+        // an ordinary/PEF read-only mapping cannot be mistaken for a classic
+        // master pointer without changing any guest-visible value.
+        let master_bytes = master_ptr.to_be_bytes();
+        if !memory.preflight_writable_range(handle, 4) {
+            self.set_native_mem_error(Self::NIL_HANDLE_ERR);
+            return Self::NIL_HANDLE_ERR;
+        }
+
+        if master_ptr == 0 && new_size == 0 {
+            self.set_native_mem_error(Self::NO_ERR);
+            return Self::NO_ERR;
+        }
+
+        if new_capacity <= old_capacity && master_ptr != 0 {
+            if !memory.preflight_writable_range(master_ptr, new_capacity)
+                || (new_size < old_size
+                    && !memory.preflight_writable_range(
+                        master_ptr
+                            .checked_add(new_size)
+                            .expect("new size fits in the validated allocation"),
+                        old_size - new_size,
+                    ))
+            {
+                self.set_native_mem_error(Self::PARAM_ERR);
+                return Self::PARAM_ERR;
+            }
+            if new_size < old_size {
+                let tail = vec![0; (old_size - new_size) as usize];
+                memory
+                    .write_bytes(
+                        master_ptr
+                            .checked_add(new_size)
+                            .expect("new size fits in the validated allocation"),
+                        &tail,
+                    )
+                    .expect("the writable classic tail was preflighted");
+            }
+            allocator.set_allocation_size(master_ptr, new_size);
+            self.set_native_mem_error(Self::NO_ERR);
+            return Self::NO_ERR;
+        }
+
+        if state & 0x80 != 0 {
+            self.set_native_mem_error(Self::MEM_FULL_ERR);
+            return Self::MEM_FULL_ERR;
+        }
+
+        let Some(plan) = allocator.allocation_plan(
+            new_size,
+            4,
+            self.classic_heap_ceiling(),
+        ) else {
+            self.set_native_mem_error(Self::MEM_FULL_ERR);
+            return Self::MEM_FULL_ERR;
+        };
+        let new_ptr = plan.address;
+        let new_capacity = plan.capacity();
+        if new_ptr == handle
+            || master_ptr
+                .checked_add(old_capacity)
+                .is_some_and(|old_end| {
+                    new_ptr < old_end
+                        && master_ptr < new_ptr.saturating_add(new_capacity)
+                })
+            || allocator.allocation_size(new_ptr).is_some()
+            || self
+                .ptr_to_handle
+                .get(&new_ptr)
+                .is_some_and(|mapped_handle| mapped_handle != handle)
+        {
+            self.set_native_mem_error(Self::MEM_FULL_ERR);
+            return Self::MEM_FULL_ERR;
+        }
+
+        let copy_len = old_size.min(new_size);
+        let Ok(copy_len) = usize::try_from(copy_len) else {
+            self.set_native_mem_error(Self::MEM_FULL_ERR);
+            return Self::MEM_FULL_ERR;
+        };
+        let mut prefix = vec![0; copy_len];
+        if copy_len > 0 && memory.read_bytes_into(master_ptr, &mut prefix).is_none() {
+            self.set_native_mem_error(Self::PARAM_ERR);
+            return Self::PARAM_ERR;
+        }
+
+        if !memory.preflight_writable_range(new_ptr, new_capacity) {
+            self.set_native_mem_error(Self::PARAM_ERR);
+            return Self::PARAM_ERR;
+        }
+        let mut destination_before = vec![0; copy_len];
+        if copy_len > 0 && memory.read_bytes_into(new_ptr, &mut destination_before).is_none() {
+            self.set_native_mem_error(Self::PARAM_ERR);
+            return Self::PARAM_ERR;
+        }
+        if memory.write_bytes(new_ptr, &prefix).is_none() {
+            self.set_native_mem_error(Self::PARAM_ERR);
+            return Self::PARAM_ERR;
+        }
+
+        if memory.write_bytes(handle, &new_ptr.to_be_bytes()).is_none() {
+            if copy_len > 0 {
+                let _ = memory.write_bytes(new_ptr, &destination_before);
+            }
+            self.set_native_mem_error(Self::NIL_HANDLE_ERR);
+            return Self::NIL_HANDLE_ERR;
+        }
+
+        if !allocator.commit_allocation_plan(plan) {
+            let _ = memory.write_bytes(handle, &master_bytes);
+            if copy_len > 0 {
+                let _ = memory.write_bytes(new_ptr, &destination_before);
+            }
+            self.set_native_mem_error(Self::MEM_FULL_ERR);
+            return Self::MEM_FULL_ERR;
+        }
+        if master_ptr != 0 {
+            allocator.free(master_ptr);
+            if self.ptr_to_handle.get(&master_ptr) == Some(handle) {
+                self.ptr_to_handle.remove(&master_ptr);
+            }
+        }
+        self.ptr_to_handle.insert(new_ptr, handle);
+        self.set_native_mem_error(Self::NO_ERR);
+        Self::NO_ERR
+    }
+
     pub(crate) fn set_native_handle_size(
         &mut self,
         memory: &mut GuestAddressSpace,
@@ -4784,6 +5153,14 @@ impl ProcessNativeMemoryManager {
             );
             source_allocator.assert_owned_by(Rc::as_ptr(&source.classic_owner) as usize);
         }
+        if let (Some(target_limit), Some(source_limit)) =
+            (self.classic_heap_limit, source.classic_heap_limit)
+        {
+            assert_eq!(
+                target_limit, source_limit,
+                "cannot adopt process Memory Managers with different classic heap ceilings"
+            );
+        }
     }
 
     fn adopt_handle_metadata(&mut self, source: &mut Self) {
@@ -4794,6 +5171,7 @@ impl ProcessNativeMemoryManager {
                 Rc::as_ptr(&self.classic_owner) as usize,
             );
             self.classic_allocator = source.classic_allocator.take();
+            self.classic_heap_limit = source.classic_heap_limit.take();
         }
         if self.ptr_to_handle.ptr_eq(&source.ptr_to_handle)
             && self.handle_state_bits.ptr_eq(&source.handle_state_bits)

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -3773,6 +3773,22 @@ impl FixtureRunner {
     fn share_ppc_process_memory(&mut self, ppc_app: &mut PpcLoadedApp) {
         let ram_end = self.bus.ram_size();
         let low_memory_end = PROCESS_LOW_MEMORY_SIZE.min(ram_end);
+
+        // Native PEF sections retain precedence over the shared flat-RAM
+        // holes below. Keep the process-owned classic heap from selecting any
+        // of those occupied spans before the overlays are installed. Inside
+        // Macintosh: Memory (1992), pp. 2-19--2-21.
+        let classic_heap_floor = APP_HEAP_FLOOR;
+        let classic_heap_limit = self.bus.classic_heap_limit();
+        for (mapping_start, mapping_end) in ppc_app.memory.ordinary_mapping_ranges() {
+            let start = mapping_start.max(classic_heap_floor);
+            let end = mapping_end.min(classic_heap_limit);
+            if start < end {
+                self.process_context
+                    .reserve_classic_heap_range(start, end);
+            }
+        }
+
         let process_low_memory = self
             .bus
             .shared_ram_region(0, low_memory_end)


### PR DESCRIPTION
Closes #1292

Routes PowerPC `SetHandleSize` through the process-owned Memory Manager for classic handles while preserving native behavior. Classic resizes now support in-place changes and relocation with atomic validation, canonical reverse ownership, preserved handle state, and PEF mapping exclusions.

Validation:
- `cargo test --locked --lib` (4,832 passed; 0 failed; 3 ignored)
- strict rustdoc private-link warnings
- all-feature/all-target compile
- Marathon terminal and resumed gameplay
- Escape Velocity live-space input
- Tomb Raider Gold live 3D and forward input (the final exact-pixel oracle also misses identically on master)