### PR TITLE
refactor(mixed-mode): own PPC-to-68K gateway storage by process

### DIFF
--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -73,13 +73,15 @@ use crate::menu_model::GuestMenuSnapshot;
 use crate::process_context::{
     ProcessAppleEventHandler, ProcessContext, ProcessCursorState, ProcessFileSystemState,
     ProcessHandleRecord, ProcessHandleStateRecord, ProcessInputState, ProcessMemoryManager,
+    ProcessMixedModeM68kState,
     ProcessNativeHeapState, ProcessNativeMemoryManager, ProcessPtrRecord,
     ProcessResourceManagerState, ProcessVfsFileRecords,
     ProcessVfsResourceFileRecords, ProcessWorkingDirectory, SharedProcessAppleEventHandlers,
     SharedProcessCallbackScheduling, SharedProcessCursorState, SharedProcessDialogText,
     SharedProcessControlManager, SharedProcessEventQueue,
     SharedProcessFileSystem, SharedProcessInputState, SharedProcessMemoryManager,
-    SharedProcessMenuTracking, SharedProcessTimerTasks, SharedProcessValue,
+    SharedProcessMenuTracking, SharedProcessMixedModeM68kState, SharedProcessTimerTasks,
+    SharedProcessValue,
     SharedProcessVblTasks,
 };
 use crate::quickdraw::fonts::heuristics::{
@@ -3023,10 +3025,9 @@ pub struct PpcToolboxStartupState {
     popup_menu_call: Option<PpcPopUpMenuCall>,
     /// Reused guest storage for the by-reference MDEF rectangle and item.
     menu_def_scratch: u32,
-    /// Process-owned 68k switch marker/gateway and stack used whenever native
-    /// PowerPC enters classic code through Mixed Mode.
-    mixed_mode_m68k_gateway: u32,
-    mixed_mode_m68k_stack_top: u32,
+    /// Process-owned 68k switch marker/gateway and compatibility stack used
+    /// whenever native PowerPC enters classic code through Mixed Mode.
+    mixed_mode_m68k: SharedProcessMixedModeM68kState,
     guest_calls: SharedGuestCallStack,
     go_away_tracking: Option<PpcGoAwayTrackingState>,
     drag_window_tracking: Option<PpcDragWindowTrackingState>,
@@ -3095,8 +3096,7 @@ impl Default for PpcToolboxStartupState {
             menu_definition_saved_gworld: None,
             popup_menu_call: None,
             menu_def_scratch: 0,
-            mixed_mode_m68k_gateway: 0,
-            mixed_mode_m68k_stack_top: 0,
+            mixed_mode_m68k: SharedProcessMixedModeM68kState::default(),
             guest_calls: SharedGuestCallStack::default(),
             go_away_tracking: None,
             drag_window_tracking: None,
@@ -4081,6 +4081,7 @@ impl PpcLoadedApp {
             .attach_native_menu_selection(&mut self.toolbox_startup.pending_native_menu_selection);
         context.attach_guest_calls(&mut self.guest_calls);
         context.attach_guest_calls(&mut self.toolbox_startup.guest_calls);
+        context.attach_mixed_mode_m68k_state(&mut self.toolbox_startup.mixed_mode_m68k);
         context.attach_apple_event_handlers(&mut self.apple_events.handlers);
     }
 
@@ -43701,37 +43702,52 @@ fn ppc_mixed_mode_m68k_storage(
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
     heap_limit: u32,
-    startup: &mut PpcToolboxStartupState,
+    storage: &mut SharedProcessMixedModeM68kState,
 ) -> Option<(u32, u32)> {
-    if startup.mixed_mode_m68k_gateway == 0 {
-        startup.mixed_mode_m68k_gateway =
-            if let Some(memory_manager) = process_memory_manager.as_deref_mut() {
-                ppc_process_heap_alloc(
-                    memory_manager,
-                    memory,
-                    heap_cursor,
-                    PPC_MIXED_MODE_M68K_GATEWAY_SIZE,
-                    true,
-                )
-            } else {
-                ppc_heap_alloc(
-                    memory,
-                    heap_cursor,
-                    heap_limit,
-                    PPC_MIXED_MODE_M68K_GATEWAY_SIZE,
-                    true,
-                )
-            };
-        if startup.mixed_mode_m68k_gateway == 0 {
+    let state: &mut ProcessMixedModeM68kState = &mut **storage;
+    match (state.gateway, state.stack_top) {
+        (0, 0) => {}
+        (gateway, stack_top) if gateway != 0 && stack_top != 0 => {
+            return Some((gateway, stack_top));
+        }
+        _ => return None,
+    }
+
+    // The gateway and stack are one process-owned allocation transaction. Do
+    // not expose either address until both allocations and the gateway's
+    // return marker have succeeded. Inside Macintosh: PowerPC System Software
+    // (1994), pp. 2-12--2-20.
+    let initial_heap_cursor = *heap_cursor;
+    let native_snapshot = process_memory_manager
+        .as_deref()
+        .map(ProcessNativeMemoryManager::detached_clone);
+    let pair = (|| {
+        let gateway = if let Some(memory_manager) = process_memory_manager.as_deref_mut() {
+            ppc_process_heap_alloc(
+                memory_manager,
+                memory,
+                heap_cursor,
+                PPC_MIXED_MODE_M68K_GATEWAY_SIZE,
+                true,
+            )
+        } else {
+            ppc_heap_alloc(
+                memory,
+                heap_cursor,
+                heap_limit,
+                PPC_MIXED_MODE_M68K_GATEWAY_SIZE,
+                true,
+            )
+        };
+        if gateway == 0 {
             return None;
         }
         memory.write_u16_be(
-            startup.mixed_mode_m68k_gateway + PPC_MIXED_MODE_M68K_RETURN_OFFSET,
+            gateway.checked_add(PPC_MIXED_MODE_M68K_RETURN_OFFSET)?,
             0x4e71,
         )?;
-    }
-    if startup.mixed_mode_m68k_stack_top == 0 {
-        let base = if let Some(memory_manager) = process_memory_manager.as_deref_mut() {
+
+        let stack_base = if let Some(memory_manager) = process_memory_manager.as_deref_mut() {
             ppc_process_heap_alloc(
                 memory_manager,
                 memory,
@@ -43748,15 +43764,36 @@ fn ppc_mixed_mode_m68k_storage(
                 true,
             )
         };
-        if base == 0 {
+        if stack_base == 0 {
             return None;
         }
-        startup.mixed_mode_m68k_stack_top = base.checked_add(PPC_MIXED_MODE_M68K_STACK_SIZE)?;
-    }
-    Some((
-        startup.mixed_mode_m68k_gateway,
-        startup.mixed_mode_m68k_stack_top,
-    ))
+        let stack_top = stack_base.checked_add(PPC_MIXED_MODE_M68K_STACK_SIZE)?;
+        Some((gateway, stack_top))
+    })();
+
+    let Some((gateway, stack_top)) = pair else {
+        *heap_cursor = initial_heap_cursor;
+        if let (Some(memory_manager), Some(snapshot)) = (
+            process_memory_manager.as_deref_mut(),
+            native_snapshot,
+        ) {
+            memory_manager.restore_native_snapshot(snapshot);
+        }
+        let allocation_limit = process_memory_manager
+            .as_deref()
+            .and_then(|memory_manager| {
+                memory_manager
+                    .native_heap_state()
+                    .map(|heap| memory_manager.native_allocation_limit(heap.heap_limit))
+            })
+            .unwrap_or(heap_limit);
+        ppc_update_zone_free_bytes(memory, *heap_cursor, allocation_limit);
+        return None;
+    };
+
+    state.gateway = gateway;
+    state.stack_top = stack_top;
+    Some((gateway, stack_top))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -43975,7 +44012,7 @@ fn ppc_begin_m68k_universal_proc(
         memory,
         heap_cursor,
         heap_limit,
-        startup,
+        &mut startup.mixed_mode_m68k,
     )?;
     let return_pc = gateway.checked_add(PPC_MIXED_MODE_M68K_RETURN_OFFSET)?;
     if stack_top < 4 {
@@ -62408,8 +62445,7 @@ fn ppc_process_apple_event(
             } else {
                 handler.procedure.proc_info
             };
-            let saved_gateway = toolbox_startup.mixed_mode_m68k_gateway;
-            let saved_stack_top = toolbox_startup.mixed_mode_m68k_stack_top;
+            let saved_mixed_mode_m68k = *toolbox_startup.mixed_mode_m68k;
             let action = ppc_begin_m68k_universal_proc(
                 cpu,
                 Some(process_memory_manager),
@@ -62428,8 +62464,7 @@ fn ppc_process_apple_event(
                 action
             } else {
                 apple_events.pending_dispatches.pop();
-                toolbox_startup.mixed_mode_m68k_gateway = saved_gateway;
-                toolbox_startup.mixed_mode_m68k_stack_top = saved_stack_top;
+                *toolbox_startup.mixed_mode_m68k = saved_mixed_mode_m68k;
                 for handle in [event_handle, reply_handle] {
                     let _ = memory.write_u32_be(handle, 0);
                 }
@@ -73669,7 +73704,7 @@ fn ppc_begin_m68k_menu_definition(
         memory,
         heap_cursor,
         heap_limit,
-        startup,
+        &mut startup.mixed_mode_m68k,
     )?;
     if stack_top < 4 {
         return None;
@@ -98211,8 +98246,126 @@ pub(crate) mod tests {
         assert_eq!(loaded.memory.read_u16_be(menu + 2), Some(123));
         assert_eq!(loaded.memory.read_u16_be(menu + 4), Some(45));
         assert!(loaded.guest_calls.is_empty());
-        assert_ne!(loaded.toolbox_startup.mixed_mode_m68k_gateway, 0);
-        assert_ne!(loaded.toolbox_startup.mixed_mode_m68k_stack_top, 0);
+        assert_ne!(loaded.toolbox_startup.mixed_mode_m68k.gateway, 0);
+        assert_ne!(loaded.toolbox_startup.mixed_mode_m68k.stack_top, 0);
+    }
+
+    #[test]
+    fn mixed_mode_storage_does_not_publish_a_partial_pair_on_allocation_failure() {
+        let mut memory = PpcSectionMem::new();
+        let mut storage = SharedProcessMixedModeM68kState::default();
+        let initial_heap_cursor = 0x1000;
+        let mut heap_cursor = initial_heap_cursor;
+        let gateway_size = ppc_allocation_size(PPC_MIXED_MODE_M68K_GATEWAY_SIZE).unwrap();
+        let heap_limit = initial_heap_cursor + gateway_size + 16;
+
+        assert_eq!(
+            ppc_mixed_mode_m68k_storage(
+                None,
+                &mut memory,
+                &mut heap_cursor,
+                heap_limit,
+                &mut storage,
+            ),
+            None
+        );
+        assert_eq!(storage.gateway, 0);
+        assert_eq!(storage.stack_top, 0);
+        assert_eq!(heap_cursor, initial_heap_cursor);
+    }
+
+    #[test]
+    fn attached_mixed_mode_adapters_reuse_storage_without_allocating() {
+        let pef = synthetic_pef_with_import(b"TestImport");
+        let mut first = load_pef_application(&pef).unwrap();
+        let mut second = load_pef_application(&pef).unwrap();
+        let mut context = ProcessContext::default();
+        first.attach_process_context(&mut context);
+        second.attach_process_context(&mut context);
+        assert!(first
+            .toolbox_startup
+            .mixed_mode_m68k
+            .ptr_eq(&second.toolbox_startup.mixed_mode_m68k));
+
+        let first_manager_handle = first.process_memory_manager.0.clone();
+        let mut first_manager = first_manager_handle.borrow_mut();
+        let initial_heap = first_manager.native_heap_state().unwrap();
+        let mut heap_cursor = initial_heap.heap_cursor;
+        let pair = ppc_mixed_mode_m68k_storage(
+            Some(first_manager.native_mut()),
+            &mut first.memory,
+            &mut heap_cursor,
+            initial_heap.heap_limit,
+            &mut first.toolbox_startup.mixed_mode_m68k,
+        )
+        .unwrap();
+        drop(first_manager);
+        assert_eq!(second.toolbox_startup.mixed_mode_m68k.gateway, pair.0);
+        assert_eq!(second.toolbox_startup.mixed_mode_m68k.stack_top, pair.1);
+
+        let second_manager_handle = second.process_memory_manager.0.clone();
+        let mut second_manager = second_manager_handle.borrow_mut();
+        let second_heap_cursor_before = second_manager.native_heap_state().unwrap().heap_cursor;
+        let mut impossible_heap_cursor = 0;
+        assert_eq!(
+            ppc_mixed_mode_m68k_storage(
+                Some(second_manager.native_mut()),
+                &mut second.memory,
+                &mut impossible_heap_cursor,
+                0,
+                &mut second.toolbox_startup.mixed_mode_m68k,
+            ),
+            Some(pair)
+        );
+        assert_eq!(impossible_heap_cursor, 0);
+        assert_eq!(
+            second_manager.native_heap_state().unwrap().heap_cursor,
+            second_heap_cursor_before
+        );
+    }
+
+    #[test]
+    fn mixed_mode_storage_rolls_back_native_allocator_on_failure() {
+        let heap_base = 0x1000;
+        let gateway_size = ppc_allocation_size(PPC_MIXED_MODE_M68K_GATEWAY_SIZE).unwrap();
+        let heap_limit = heap_base + gateway_size + 16;
+        let mut memory_manager = ProcessNativeMemoryManager::default();
+        memory_manager.publish_native_allocator(
+            ProcessNativeHeapState {
+                heap_base,
+                heap_cursor: heap_base,
+                heap_limit,
+                last_mem_error: PPC_NO_ERR,
+                heap_maximized: false,
+                master_pointer_blocks_requested: 0,
+            },
+            &[],
+            &[],
+            &[],
+        );
+        let allocator_before = memory_manager.native_allocator_snapshot();
+        let mut memory = PpcSectionMem::new();
+        let mut heap_cursor = heap_base;
+        let mut storage = SharedProcessMixedModeM68kState::default();
+
+        assert_eq!(
+            ppc_mixed_mode_m68k_storage(
+                Some(&mut memory_manager),
+                &mut memory,
+                &mut heap_cursor,
+                heap_limit,
+                &mut storage,
+            ),
+            None
+        );
+        assert_eq!(storage.gateway, 0);
+        assert_eq!(storage.stack_top, 0);
+        assert_eq!(heap_cursor, heap_base);
+        assert_eq!(memory_manager.native_allocator_snapshot(), allocator_before);
+        assert_eq!(
+            memory_manager.native_heap_state().unwrap().heap_cursor,
+            heap_base
+        );
     }
 
     #[test]

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -1256,6 +1256,7 @@ pub(crate) type SharedProcessInputState = SharedProcessValue<ProcessInputState>;
 pub(crate) type SharedProcessTimerTasks = SharedProcessValue<Vec<ProcessTimerTask>>;
 pub(crate) type SharedProcessVblTasks = SharedProcessValue<Vec<ProcessVblTask>>;
 pub(crate) type SharedProcessCallbackScheduling = SharedProcessValue<ProcessCallbackScheduling>;
+pub(crate) type SharedProcessMixedModeM68kState = SharedProcessValue<ProcessMixedModeM68kState>;
 pub(crate) type SharedProcessScrapState = SharedProcessValue<ProcessScrapState>;
 pub(crate) type SharedProcessControlManager = SharedProcessValue<ProcessControlManagerState>;
 pub(crate) type SharedProcessListManager = SharedProcessValue<ProcessListManagerState>;
@@ -1307,6 +1308,22 @@ pub(crate) struct ProcessKeyRepeatState {
     pub(crate) key_code: u8,
     pub(crate) char_code: u8,
     pub(crate) next_tick: u32,
+}
+
+/// Process-owned storage for the generated 68K gateway and compatibility
+/// stack used by native Mixed Mode callbacks. Both CPU adapters use one
+/// logical bridge for a process. Inside Macintosh: PowerPC System Software
+/// (1994), pp. 2-12--2-20.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct ProcessMixedModeM68kState {
+    pub(crate) gateway: u32,
+    pub(crate) stack_top: u32,
+}
+
+impl ProcessMixedModeM68kState {
+    pub(crate) fn is_pristine(&self) -> bool {
+        *self == Self::default()
+    }
 }
 
 /// Canonical mouse and keyboard device state for one Macintosh process.
@@ -5575,6 +5592,7 @@ pub(crate) struct ProcessContext {
     timer_tasks: SharedProcessTimerTasks,
     vbl_tasks: SharedProcessVblTasks,
     callback_scheduling: SharedProcessCallbackScheduling,
+    mixed_mode_m68k: SharedProcessMixedModeM68kState,
     scrap_state: SharedProcessScrapState,
     control_manager: SharedProcessControlManager,
     list_manager: SharedProcessListManager,
@@ -5607,6 +5625,7 @@ impl Default for ProcessContext {
             timer_tasks: SharedProcessTimerTasks::default(),
             vbl_tasks: SharedProcessVblTasks::default(),
             callback_scheduling: SharedProcessCallbackScheduling::default(),
+            mixed_mode_m68k: SharedProcessMixedModeM68kState::default(),
             scrap_state: SharedProcessScrapState::default(),
             control_manager: SharedProcessControlManager::default(),
             list_manager: SharedProcessListManager::default(),
@@ -5708,6 +5727,16 @@ impl ProcessContext {
         scheduling.attach_to(&self.callback_scheduling, |state| {
             state == &Default::default()
         });
+    }
+
+    pub(crate) fn attach_mixed_mode_m68k_state(
+        &self,
+        adapter: &mut SharedProcessMixedModeM68kState,
+    ) {
+        adapter.attach_copy_to(
+            &self.mixed_mode_m68k,
+            ProcessMixedModeM68kState::is_pristine,
+        );
     }
 
     pub(crate) fn attach_scrap_state(&self, adapter: &mut SharedProcessScrapState) {
@@ -6559,6 +6588,29 @@ mod tests {
         assert_eq!(native_calls.len(), 1);
         assert!(native_calls.complete_m68k(0x2002, 0x3000));
         assert!(classic_calls.is_empty());
+    }
+
+    #[test]
+    fn mixed_mode_state_shares_as_one_pair_and_detaches_with_clone() {
+        let context = ProcessContext::default();
+        let mut first = SharedProcessMixedModeM68kState::default();
+        let mut second = SharedProcessMixedModeM68kState::default();
+
+        context.attach_mixed_mode_m68k_state(&mut first);
+        first.gateway = 0x1000;
+        first.stack_top = 0x20_0000;
+        context.attach_mixed_mode_m68k_state(&mut second);
+
+        assert!(first.ptr_eq(&second));
+        assert_eq!(second.gateway, 0x1000);
+        assert_eq!(second.stack_top, 0x20_0000);
+
+        let mut detached = first.clone();
+        detached.gateway = 0x3000;
+        detached.stack_top = 0x30_0000;
+        assert!(!first.ptr_eq(&detached));
+        assert_eq!(first.gateway, 0x1000);
+        assert_eq!(first.stack_top, 0x20_0000);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- replace the two adapter-local PPC-to-68K bridge addresses with one process-owned shared record
- attach every native adapter to the same gateway/compatibility-stack pair
- publish the pair transactionally and restore native allocator state when construction fails
- preserve adapter-owned registers, exception state, and ABI continuations

## Root cause

The native startup state labeled the generated gateway and compatibility stack as process-owned but stored their addresses as two ordinary fields. Each attached PowerPC adapter could therefore allocate a separate bridge, and a failed second allocation could leave only the gateway published.

## Validation

- `cargo check --lib --no-default-features`
- `cargo test --locked --lib mixed_mode --no-default-features` — 16 passed
- `cargo test --lib native_getmenu --no-default-features` — 4 passed
- `cargo test --lib hle_import_runner_call_universal_proc --no-default-features` — 23 passed
- focused tests cover two attached `PpcLoadedApp` instances, detached clone isolation, partial-allocation rollback, and native allocator rollback
- `git diff --check`

Closes #1313
