### PR TITLE
refactor(files): make launched application path process-owned

### DIFF
--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -3519,7 +3519,6 @@ pub struct PpcLoadedApp {
     pub quickdraw_text_mode: i16,
     pub quickdraw_text_size: i16,
     pub(crate) cursor_state: SharedProcessCursorState,
-    pub launched_app_path: Option<String>,
     pub param_text: SharedProcessDialogText,
     pub scrap: PpcScrapState,
     pub list_manager: PpcListManagerState,
@@ -7886,6 +7885,7 @@ impl PpcLoadedApp {
                     // may outlive this dispatch call or be retained in its
                     // returned action.
                     let action = {
+                        let launched_app_path = process_file_system.launched_app_path.clone();
                         let ProcessFileSystemState {
                             files,
                             writable_refnums,
@@ -8001,7 +8001,7 @@ impl PpcLoadedApp {
                             &mut working_directories,
                             &mut next_working_directory_ref_num,
                             &mut application_working_directory_ref_num,
-                            self.launched_app_path.as_deref(),
+                            launched_app_path.as_deref(),
                             &mut param_text,
                             &mut scrap,
                             &mut list_manager,
@@ -8424,8 +8424,12 @@ impl PpcLoadedApp {
     }
 
     pub fn set_launched_app_path(&mut self, path: impl Into<String>) {
-        self.launched_app_path = Some(ppc_normalize_vfs_path(&path.into()));
+        self.process_file_system.launched_app_path = Some(ppc_normalize_vfs_path(&path.into()));
         self.refresh_apple_event_launch_capability();
+    }
+
+    pub fn launched_app_path(&self) -> Option<&str> {
+        self.process_file_system.launched_app_path.as_deref()
     }
 
     pub fn seed_cfm_library_fragments(&mut self, fragments: Vec<PpcCfmLibraryFragment>) {
@@ -8454,7 +8458,7 @@ impl PpcLoadedApp {
     }
 
     fn refresh_apple_event_launch_capability(&mut self) {
-        let size_resource = self.launched_app_path.as_deref().and_then(|path| {
+        let size_resource = self.launched_app_path().and_then(|path| {
             [0, -1].into_iter().find_map(|id| {
                 self.vfs_resources
                     .iter()
@@ -8473,7 +8477,7 @@ impl PpcLoadedApp {
             eprintln!(
                 "[PPC-TRACE] launch AppleEvents aware={} path={:?} SIZE={:?}",
                 self.apple_events.application_high_level_event_aware,
-                self.launched_app_path,
+                self.launched_app_path(),
                 size_resource,
             );
         }
@@ -13045,7 +13049,6 @@ fn load_pef_application_with_config_and_optional_system_reservation(
         quickdraw_text_mode: PPC_QD_TEXT_MODE_SRC_OR,
         quickdraw_text_size: PPC_QD_TEXT_SIZE_SYSTEM,
         cursor_state: SharedProcessCursorState::default(),
-        launched_app_path: None,
         param_text: SharedProcessDialogText::default(),
         scrap: PpcScrapState::default(),
         list_manager: PpcListManagerState::default(),
@@ -94181,6 +94184,37 @@ pub(crate) mod tests {
         classic.vfs_resource_files[0].dirty = false;
         assert_eq!(native.vfs_resources[0].attrs, 0x0040);
         assert!(!native.vfs_resource_files[0].dirty);
+    }
+
+    #[test]
+    fn launched_application_path_crosses_adapters_and_native_imports_without_clone_aliasing() {
+        let pef = synthetic_pef_with_import(b"LMGetCurApName");
+        let mut native = load_pef_application(&pef).unwrap();
+        let mut context = ProcessContext::default();
+        native.attach_process_context(&mut context);
+        let mut classic = TrapDispatcher::new();
+        classic.attach_process_context(&mut context);
+
+        classic.set_launched_app_path("Apps/Classic App");
+        assert_eq!(native.launched_app_path(), Some("Apps/Classic App"));
+        run_test_import(&mut native, PpcImportDispatcherTarget::SystemCompatibility);
+        assert_eq!(
+            ppc_read_pstring_bytes(&mut native.memory, PPC_IMPORT_CUR_AP_NAME),
+            Some(b"Classic App".to_vec())
+        );
+
+        native.set_launched_app_path("Apps/Native App");
+        assert_eq!(classic.launched_app_path(), Some("Apps/Native App"));
+        run_test_import(&mut native, PpcImportDispatcherTarget::SystemCompatibility);
+        assert_eq!(
+            ppc_read_pstring_bytes(&mut native.memory, PPC_IMPORT_CUR_AP_NAME),
+            Some(b"Native App".to_vec())
+        );
+
+        let detached_clone = native.clone();
+        native.set_launched_app_path("Apps/Current App");
+        assert_eq!(classic.launched_app_path(), Some("Apps/Current App"));
+        assert_eq!(detached_clone.launched_app_path(), Some("Apps/Native App"));
     }
 
     #[test]

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -864,6 +864,10 @@ pub struct ProcessFileSystemState {
     pub(crate) classic_next_vfs_timestamp: SharedProcessValue<u32>,
     pub(crate) vfs_files: ProcessVfsFileRecords,
     pub(crate) deleted_vfs_file_paths: Vec<String>,
+    /// Normalized VFS path of the launched application, shared by every CPU
+    /// adapter in the process. Inside Macintosh Volume II (1985), pp. II-57--
+    /// II-58.
+    pub(crate) launched_app_path: Option<String>,
     pub(crate) resource_manager: SharedProcessResourceManager,
     pub(crate) next_file_ref_num: i16,
 }
@@ -889,6 +893,7 @@ impl Default for ProcessFileSystemState {
             classic_next_vfs_timestamp: SharedProcessValue::from_value(1),
             vfs_files: ProcessVfsFileRecords::default(),
             deleted_vfs_file_paths: Vec::new(),
+            launched_app_path: None,
             resource_manager: SharedProcessResourceManager::default(),
             next_file_ref_num: 128,
         }
@@ -903,6 +908,16 @@ impl ProcessFileSystemState {
         );
         if self.files.is_empty() {
             self.files = std::mem::take(&mut source.files);
+        }
+        match (&self.launched_app_path, &source.launched_app_path) {
+            (Some(target), Some(source)) => assert!(
+                target.eq_ignore_ascii_case(source),
+                "cannot attach two different launched application paths"
+            ),
+            (None, Some(_)) => {
+                self.launched_app_path = source.launched_app_path.take();
+            }
+            _ => {}
         }
         if !Rc::ptr_eq(&self.writable_refnums.0, &source.writable_refnums.0) {
             self.writable_refnums
@@ -1008,6 +1023,7 @@ impl ProcessFileSystemState {
         snapshot.classic_next_vfs_file_id = self.classic_next_vfs_file_id.clone();
         snapshot.classic_next_vfs_timestamp = self.classic_next_vfs_timestamp.clone();
         snapshot.vfs_files = self.vfs_files.clone();
+        snapshot.launched_app_path = self.launched_app_path.clone();
         snapshot.resource_manager.vfs_resource_files = self.vfs_resource_files.clone();
         snapshot
     }
@@ -8128,6 +8144,52 @@ mod tests {
         assert_eq!(detached.vfs_volumes[0].file_count, 1);
         assert_eq!(detached.next_vfs_dir_id, 16);
         assert_eq!(detached.default_dir_id, 2);
+    }
+
+    #[test]
+    fn attached_file_systems_share_launched_application_path_while_detaching_clones() {
+        let context = ProcessContext::default();
+        let mut source = SharedProcessFileSystem::from_state(ProcessFileSystemState {
+            launched_app_path: Some("Apps/Main App".to_string()),
+            ..ProcessFileSystemState::default()
+        });
+        let mut native = SharedProcessFileSystem::default();
+
+        context.attach_file_system(&mut source);
+        context.attach_file_system(&mut native);
+        assert!(source.ptr_eq(&native));
+        assert_eq!(native.launched_app_path.as_deref(), Some("Apps/Main App"));
+
+        let detached_clone = native.clone();
+        let detached_snapshot = native.detached_vfs_snapshot();
+        native.launched_app_path = Some("Apps/Other App".to_string());
+
+        assert_eq!(source.launched_app_path.as_deref(), Some("Apps/Other App"));
+        assert_eq!(
+            detached_clone.launched_app_path.as_deref(),
+            Some("Apps/Main App")
+        );
+        assert_eq!(
+            detached_snapshot.launched_app_path.as_deref(),
+            Some("Apps/Main App")
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "cannot attach two different launched application paths")]
+    fn attaching_file_systems_rejects_conflicting_launched_application_paths() {
+        let context = ProcessContext::default();
+        let mut first = SharedProcessFileSystem::from_state(ProcessFileSystemState {
+            launched_app_path: Some("Apps/Main App".to_string()),
+            ..ProcessFileSystemState::default()
+        });
+        let mut second = SharedProcessFileSystem::from_state(ProcessFileSystemState {
+            launched_app_path: Some("Apps/Other App".to_string()),
+            ..ProcessFileSystemState::default()
+        });
+
+        context.attach_file_system(&mut first);
+        context.attach_file_system(&mut second);
     }
 
     #[test]

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -114,10 +114,12 @@ fn resource_manager_snapshot_powerpc(
     ppc_app: &mut PpcLoadedApp,
 ) -> ResourceManagerSnapshot {
     let current_file = ppc_app.current_resource_refnum();
-    let app_path = ppc_app.launched_app_path.as_deref();
+    let app_path = ppc_app.launched_app_path().map(str::to_owned);
     let include_record = |resource: &&crate::process_context::ProcessVfsResourceRecord| {
         resource.ref_num == current_file
-            && app_path.is_none_or(|path| resource.path.eq_ignore_ascii_case(path))
+            && app_path
+                .as_deref()
+                .is_none_or(|path| resource.path.eq_ignore_ascii_case(path))
     };
 
     let mut counts = BTreeMap::new();
@@ -2971,8 +2973,8 @@ impl FixtureRunner {
     ) -> std::result::Result<(), String> {
         let app_path = self
             .dispatcher
-            .launched_app_path
-            .clone()
+            .launched_app_path()
+            .map(str::to_owned)
             .ok_or_else(|| "launched app path is not available".to_string())?;
         let app_parent = TrapDispatcher::vfs_parent_path(&app_path);
         if app_parent.is_empty() {
@@ -3311,7 +3313,7 @@ impl FixtureRunner {
     fn seed_current_application_file_manager_state(&mut self) {
         use crate::memory::globals::addr;
 
-        let Some(app_path) = self.dispatcher.launched_app_path.clone() else {
+        let Some(app_path) = self.dispatcher.launched_app_path().map(str::to_owned) else {
             return;
         };
         self.dispatcher.ensure_vfs_file_metadata(&app_path);
@@ -3574,7 +3576,7 @@ impl FixtureRunner {
         // AppParmHandle is allocated below, after the zone header is reserved.
         // Inside Macintosh Volume II, II-57 to II-58
         self.bus.write_word(addr::CUR_APREF_NUM, 0);
-        if let Some(app_path) = &self.dispatcher.launched_app_path {
+        if let Some(app_path) = self.dispatcher.launched_app_path() {
             let app_name = crate::trap::dispatch::TrapDispatcher::vfs_basename(app_path);
             let name_bytes = app_name.as_bytes();
             let len = name_bytes.len().min(31);
@@ -13096,7 +13098,7 @@ mod tests {
             "queued helper launch should not halt the runner"
         );
         assert_eq!(
-            runner.dispatcher.launched_app_path.as_deref(),
+            runner.dispatcher.launched_app_path(),
             Some("Apps/Register Helper")
         );
         assert_eq!(
@@ -13183,7 +13185,7 @@ mod tests {
             "immediate queued helper launch should not halt the runner"
         );
         assert_eq!(
-            runner.dispatcher.launched_app_path.as_deref(),
+            runner.dispatcher.launched_app_path(),
             Some("Apps/Register Helper")
         );
         assert_eq!(
@@ -13630,7 +13632,6 @@ mod tests {
             quickdraw_text_mode: PPC_QD_TEXT_MODE_SRC_OR,
             quickdraw_text_size: PPC_QD_TEXT_SIZE_SYSTEM,
             cursor_state: crate::process_context::SharedProcessCursorState::default(),
-            launched_app_path: None,
             param_text: Default::default(),
             scrap: Default::default(),
             list_manager: Default::default(),
@@ -16044,7 +16045,6 @@ mod tests {
             quickdraw_text_mode: PPC_QD_TEXT_MODE_SRC_OR,
             quickdraw_text_size: PPC_QD_TEXT_SIZE_SYSTEM,
             cursor_state: crate::process_context::SharedProcessCursorState::default(),
-            launched_app_path: None,
             param_text: Default::default(),
             scrap: Default::default(),
             list_manager: Default::default(),
@@ -16837,7 +16837,6 @@ mod tests {
             quickdraw_text_mode: PPC_QD_TEXT_MODE_SRC_OR,
             quickdraw_text_size: PPC_QD_TEXT_SIZE_SYSTEM,
             cursor_state: crate::process_context::SharedProcessCursorState::default(),
-            launched_app_path: None,
             param_text: Default::default(),
             scrap: Default::default(),
             list_manager: Default::default(),
@@ -16991,7 +16990,6 @@ mod tests {
             quickdraw_text_mode: PPC_QD_TEXT_MODE_SRC_OR,
             quickdraw_text_size: PPC_QD_TEXT_SIZE_SYSTEM,
             cursor_state: crate::process_context::SharedProcessCursorState::default(),
-            launched_app_path: None,
             param_text: Default::default(),
             scrap: Default::default(),
             list_manager: Default::default(),
@@ -17404,7 +17402,6 @@ mod tests {
             quickdraw_text_mode: PPC_QD_TEXT_MODE_SRC_OR,
             quickdraw_text_size: PPC_QD_TEXT_SIZE_SYSTEM,
             cursor_state: crate::process_context::SharedProcessCursorState::default(),
-            launched_app_path: None,
             param_text: Default::default(),
             scrap: Default::default(),
             list_manager: Default::default(),
@@ -17717,7 +17714,6 @@ mod tests {
             quickdraw_text_mode: PPC_QD_TEXT_MODE_SRC_OR,
             quickdraw_text_size: PPC_QD_TEXT_SIZE_SYSTEM,
             cursor_state: crate::process_context::SharedProcessCursorState::default(),
-            launched_app_path: None,
             param_text: Default::default(),
             scrap: Default::default(),
             list_manager: Default::default(),
@@ -23048,7 +23044,7 @@ mod tests {
         );
         assert!(!runner.is_halted());
         assert_eq!(
-            runner.dispatcher.launched_app_path.as_deref(),
+            runner.dispatcher.launched_app_path(),
             Some("Apps/Register Helper")
         );
     }

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -2005,8 +2005,6 @@ pub struct TrapDispatcher {
     pub(crate) next_vfs_timestamp: SharedProcessValue<u32>,
     /// Next working directory reference number.
     pub(crate) next_working_dir_refnum: SharedProcessValue<i16>,
-    /// Normalized VFS path of the launched application, if known.
-    pub(crate) launched_app_path: Option<String>,
     /// Foreground application launch queued by LaunchApplication. When
     /// `after_event_yield` is set, the runner starts it after the current
     /// app next yields through WaitNextEvent/EventAvail/GetNextEvent.
@@ -3805,7 +3803,6 @@ impl TrapDispatcher {
             next_vfs_file_id: SharedProcessValue::from_value(32),
             next_vfs_timestamp: SharedProcessValue::from_value(1),
             next_working_dir_refnum,
-            launched_app_path: None,
             pending_launch_app: None,
             default_dir_id: SharedProcessValue::from_value(2),
             app_wd_refnum,
@@ -4829,11 +4826,11 @@ impl TrapDispatcher {
                 *self.app_wd_refnum = wd_ref;
             }
         }
-        self.launched_app_path = Some(normalized);
+        self.process_file_system.launched_app_path = Some(normalized);
     }
 
     pub fn launched_app_path(&self) -> Option<&str> {
-        self.launched_app_path.as_deref()
+        self.process_file_system.launched_app_path.as_deref()
     }
 
     pub fn materialize_quilt_resources(&mut self) -> usize {
@@ -5013,7 +5010,7 @@ impl TrapDispatcher {
             return true;
         }
 
-        let Some(app_path) = self.launched_app_path.clone() else {
+        let Some(app_path) = self.launched_app_path().map(str::to_owned) else {
             return false;
         };
         let parent = Self::vfs_parent_path(&app_path);
@@ -7441,7 +7438,7 @@ impl TrapDispatcher {
     /// Load resources into guest memory for trap access.
     /// Loads ALL resource types from the fork (not just a hardcoded whitelist).
     pub fn load_resources(&mut self, fork: &ResourceFork, bus: &mut MacMemoryBus) {
-        if let Some(app_path) = self.launched_app_path.as_ref() {
+        if let Some(app_path) = self.launched_app_path().map(str::to_owned) {
             self.vfs
                 .insert(format!("__rsrc__{}", app_path), fork.serialized().to_vec());
         }

--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -6369,7 +6369,10 @@ impl super::TrapDispatcher {
                             return Some(Ok(()));
                         }
 
-                        let app_path = self.launched_app_path.clone().unwrap_or_default();
+                        let app_path = self
+                            .launched_app_path()
+                            .map(str::to_owned)
+                            .unwrap_or_default();
                         let app_name = if app_path.is_empty() {
                             "Application".to_string()
                         } else {
@@ -7547,8 +7550,8 @@ impl super::TrapDispatcher {
                     // resource forks into open_files as "__rsrc__<path>" so
                     // FSRead/FSWrite can share the data-fork code path.
                     let resolved_fcb = if ref_num == 0 {
-                        self.launched_app_path
-                            .clone()
+                        self.launched_app_path()
+                            .map(str::to_owned)
                             .map(|vfs_name| (vfs_name, true))
                     } else if let Some(vfs_name) = self.open_files.get(&ref_num).cloned() {
                         let is_resource_fork = vfs_name.starts_with("__rsrc__");

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -20836,7 +20836,7 @@ mod tests {
         assert_eq!(cpu.read_reg(Register::A7), sp_before);
         assert_eq!(bus.read_word(0x0936), 0xFFFF);
         assert_eq!(
-            disp.launched_app_path.as_deref(),
+            disp.launched_app_path(),
             Some("LaunchTargets/Legacy Helper")
         );
         assert_eq!(
@@ -20872,7 +20872,7 @@ mod tests {
         assert_eq!(cpu.read_reg(Register::A7), sp_before);
         assert_eq!(bus.read_word(0x0936), 1);
         assert_eq!(
-            disp.launched_app_path.as_deref(),
+            disp.launched_app_path(),
             Some("LaunchTargets/NoSuchApp")
         );
         assert!(
@@ -20923,7 +20923,7 @@ mod tests {
         assert_eq!(bus.read_long(launch_pb + 32), 0);
         assert_eq!(bus.read_long(launch_pb + 36), 0);
         assert_eq!(
-            disp.launched_app_path.as_deref(),
+            disp.launched_app_path(),
             Some("LaunchTargets/NoSuchApp")
         );
         assert_eq!(*disp.default_dir_id, target_dir_id);
@@ -20972,7 +20972,7 @@ mod tests {
         assert_eq!(bus.read_long(launch_pb + 32), 0);
         assert_eq!(bus.read_long(launch_pb + 36), 0);
         assert_eq!(
-            disp.launched_app_path.as_deref(),
+            disp.launched_app_path(),
             Some("LaunchTargets/NoSuchApp")
         );
         assert_eq!(*disp.default_dir_id, target_dir_id);
@@ -21018,7 +21018,7 @@ mod tests {
         assert_eq!(cpu.read_reg(Register::D0), 0);
         assert_eq!(cpu.read_reg(Register::A7), sp_before);
         assert_eq!(
-            disp.launched_app_path.as_deref(),
+            disp.launched_app_path(),
             Some("LaunchTargets/Register Helper")
         );
         assert!(
@@ -21070,7 +21070,7 @@ mod tests {
         assert_eq!(cpu.read_reg(Register::D0), 0);
         assert_eq!(cpu.read_reg(Register::A7), sp_before);
         assert_eq!(
-            disp.launched_app_path.as_deref(),
+            disp.launched_app_path(),
             Some("LaunchTargets/Register Helper")
         );
         assert_eq!(
@@ -21120,7 +21120,7 @@ mod tests {
         assert_eq!(cpu.read_reg(Register::D0), 0);
         assert_eq!(cpu.read_reg(Register::A7), sp_before);
         assert_eq!(
-            disp.launched_app_path.as_deref(),
+            disp.launched_app_path(),
             Some("LaunchTargets/Register Helper")
         );
         assert!(
@@ -21165,7 +21165,7 @@ mod tests {
         assert_eq!(cpu.read_reg(Register::A7), sp_before);
         assert_eq!(bus.read_word(0x0936), 0x0001);
         assert_eq!(
-            disp.launched_app_path.as_deref(),
+            disp.launched_app_path(),
             Some("ChainTargets/NoSuchApp")
         );
         assert_eq!(*disp.default_dir_id, target_dir_id);


### PR DESCRIPTION
## Summary

- move the launched application path into the process-owned File Manager state
- make classic and native adapters observe path changes immediately
- preserve detached clone independence and reject conflicting attachment state
- keep native import access scoped so no path reference crosses a continuation boundary

## Validation

- `cargo check --all-features --all-targets --locked`
- `cargo test --locked --lib launched_application_path`
- focused native execution panic tests for process-owned file and resource records
- `git diff --check`

Closes #1318
