### PR TITLE
refactor(quickdraw): share highlight color across CPU adapters

### DIFF
--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -80,7 +80,9 @@ use crate::process_context::{
     SharedProcessCallbackScheduling, SharedProcessCursorState, SharedProcessDialogText,
     SharedProcessControlManager, SharedProcessEventQueue,
     SharedProcessFileSystem, SharedProcessInputState, SharedProcessMemoryManager,
-    SharedProcessMenuTracking, SharedProcessMixedModeM68kState, SharedProcessQuickDrawOpColors,
+    DEFAULT_QUICKDRAW_HILITE_COLOR, SharedProcessMenuTracking,
+    SharedProcessMixedModeM68kState,
+    SharedProcessQuickDrawHiliteColors, SharedProcessQuickDrawOpColors,
     SharedProcessTimerTasks, SharedProcessValue, SharedProcessVblTasks,
 };
 use crate::quickdraw::fonts::heuristics::{
@@ -1085,6 +1087,7 @@ pub enum PpcImportDispatcherTarget {
     RGBForeColor,
     RGBBackColor,
     OpColor,
+    HiliteColor,
     PmForeColor,
     PmBackColor,
     Color2Index,
@@ -3504,6 +3507,7 @@ pub struct PpcLoadedApp {
     pub current_gworld: SharedProcessValue<u32>,
     pub current_gdevice: SharedProcessValue<u32>,
     pub(crate) quickdraw_op_colors: SharedProcessQuickDrawOpColors,
+    pub(crate) quickdraw_hilite_colors: SharedProcessQuickDrawHiliteColors,
     pub screen_clut: SharedProcessValue<[[u16; 3]; 256]>,
     pub color_manager_clut: SharedProcessValue<[[u16; 3]; 256]>,
     pub device_gamma: SharedProcessValue<crate::display::DisplayGamma>,
@@ -4039,6 +4043,7 @@ impl PpcLoadedApp {
         context.attach_cursor_state(&mut self.cursor_state);
         context.activate_quickdraw_selection(&mut self.current_gworld, &mut self.current_gdevice);
         context.attach_quickdraw_op_colors(&mut self.quickdraw_op_colors);
+        context.attach_quickdraw_hilite_colors(&mut self.quickdraw_hilite_colors);
         self.process_quickdraw_port_state_attached = true;
         context.attach_quickdraw_error(&mut self.toolbox_startup.last_quickdraw_error);
         context.attach_display_color_state(
@@ -7401,6 +7406,7 @@ impl PpcLoadedApp {
         let mut current_gworld = self.current_gworld.shared_handle();
         let mut current_gdevice = self.current_gdevice.shared_handle();
         let quickdraw_op_colors = self.quickdraw_op_colors.shared_handle();
+        let quickdraw_hilite_colors = self.quickdraw_hilite_colors.shared_handle();
         let mut screen_clut = self.screen_clut.shared_handle();
         let mut color_manager_clut = self.color_manager_clut.shared_handle();
         let mut device_gamma = self.device_gamma.shared_handle();
@@ -7982,6 +7988,7 @@ impl PpcLoadedApp {
                             &mut current_gworld,
                             &mut current_gdevice,
                             &quickdraw_op_colors,
+                            &quickdraw_hilite_colors,
                             &mut screen_clut,
                             &mut color_manager_clut,
                             &mut device_gamma,
@@ -13036,6 +13043,7 @@ fn load_pef_application_with_config_and_optional_system_reservation(
         current_gworld: SharedProcessValue::from_value(PPC_MAIN_GWORLD),
         current_gdevice: SharedProcessValue::from_value(PPC_MAIN_GDEVICE),
         quickdraw_op_colors: SharedProcessQuickDrawOpColors::default(),
+        quickdraw_hilite_colors: SharedProcessQuickDrawHiliteColors::default(),
         screen_clut: SharedProcessValue::from_value(screen_clut),
         color_manager_clut: SharedProcessValue::from_value(color_manager_clut),
         device_gamma: SharedProcessValue::from_value(crate::display::default_display_gamma()),
@@ -14242,6 +14250,7 @@ fn dispatcher_target_for_import(
         ("InterfaceLib", "RGBForeColor") => PpcImportDispatcherTarget::RGBForeColor,
         ("InterfaceLib", "RGBBackColor") => PpcImportDispatcherTarget::RGBBackColor,
         ("InterfaceLib", "OpColor") => PpcImportDispatcherTarget::OpColor,
+        ("InterfaceLib", "HiliteColor") => PpcImportDispatcherTarget::HiliteColor,
         ("InterfaceLib", "PmForeColor") => PpcImportDispatcherTarget::PmForeColor,
         ("InterfaceLib", "PmBackColor") => PpcImportDispatcherTarget::PmBackColor,
         ("InterfaceLib", "Color2Index") => PpcImportDispatcherTarget::Color2Index,
@@ -15301,6 +15310,7 @@ fn dispatch_supported_import(
     current_gworld: &mut u32,
     current_gdevice: &mut u32,
     quickdraw_op_colors: &SharedProcessQuickDrawOpColors,
+    quickdraw_hilite_colors: &SharedProcessQuickDrawHiliteColors,
     screen_clut: &mut [[u16; 3]; 256],
     color_manager_clut: &mut [[u16; 3]; 256],
     device_gamma: &mut crate::display::DisplayGamma,
@@ -17578,6 +17588,21 @@ fn dispatch_supported_import(
             }
             Some(PpcImportAction::ReturnPreserve)
         }
+        PpcImportDispatcherTarget::HiliteColor => {
+            if let Some(color) = ppc_read_rgb_color(memory, cpu.gpr[3]) {
+                // Inside Macintosh: Imaging With QuickDraw (1994), pp. 4-62
+                // and 4-64: HiliteColor updates the current CGrafPort's
+                // GrafVars.rgbHiliteColor. Static ports without a valid
+                // handle use the process-owned per-port fallback.
+                ppc_write_port_hilite_color(
+                    memory,
+                    *current_gworld,
+                    color,
+                    quickdraw_hilite_colors,
+                );
+            }
+            Some(PpcImportAction::ReturnPreserve)
+        }
         PpcImportDispatcherTarget::PmForeColor => {
             // Inside Macintosh Volume VI 1991, p. 20-21: courteous and
             // tolerant entries select their palette RGB, while explicit
@@ -19644,6 +19669,7 @@ fn dispatch_supported_import(
             if let Some(record) = disposed {
                 quickdraw_fore_indices.remove(&port);
                 quickdraw_op_colors.remove_quickdraw_op_color(port);
+                quickdraw_hilite_colors.remove_quickdraw_hilite_color(port);
                 let allocation = toolbox_startup.gworld_allocations.remove(&port);
                 let saved_ctable = toolbox_startup
                     .indexed_screen_ctables
@@ -19787,6 +19813,8 @@ fn dispatch_supported_import(
                 handles,
                 vfs_resources,
                 *current_resource_refnum,
+                *current_gworld,
+                quickdraw_hilite_colors,
             );
             if ppc_hle_trace_enabled() {
                 eprintln!(
@@ -20068,6 +20096,7 @@ fn dispatch_supported_import(
                 quickdraw_fore_indices.remove(&port);
             }
             quickdraw_op_colors.remove_quickdraw_op_color(port);
+            quickdraw_hilite_colors.remove_quickdraw_hilite_color(port);
             if was_current && *current_gworld != port {
                 ppc_restore_port_colors(
                     memory,
@@ -57474,7 +57503,7 @@ fn ppc_standard_screen_clut(depth: u32, is_color: bool) -> Option<([[u16; 3]; 25
         // 2-bit screen uses the enhanced standard table, whose spare entry
         // carries the current highlight color. PPC currently exposes the
         // System 7 default highlight green used by the shared 68k Toolbox.
-        (clut, _) = TrapDispatcher::standard_mac_enhanced_clut(2, (0, 0x8000, 0))?;
+        (clut, _) = TrapDispatcher::standard_mac_enhanced_clut(2, DEFAULT_QUICKDRAW_HILITE_COLOR)?;
     }
     Some((clut, entry_count))
 }
@@ -58738,6 +58767,81 @@ fn ppc_write_port_op_color(
     // allocator-managed GrafVars handle. Keep their per-port fallback live
     // across attached 68K and PowerPC adapters.
     quickdraw_op_colors.set_quickdraw_op_color(port, (color.red, color.green, color.blue));
+}
+
+fn ppc_port_hilite_color_from_graf_vars(
+    memory: &mut PpcSectionMem,
+    port: u32,
+) -> Option<PpcRgbColor> {
+    // Inside Macintosh: Imaging With QuickDraw (1994), pp. 4-62 and 4-64:
+    // a CGrafPort's GrafVars.rgbHiliteColor follows rgbOpColor at offset 6.
+    // Do not consult the fallback map when a valid guest record is present;
+    // guest memory is the authoritative representation for that port.
+    if memory.read_u16_be(port.checked_add(6)?)? & 0xc000 != 0xc000 {
+        return None;
+    }
+    let graf_vars_handle = memory.read_u32_be(port.checked_add(PPC_CGRAF_PORT_GRAF_VARS_OFFSET)?)?;
+    if graf_vars_handle == 0 || !ppc_memory_can_write_bytes(memory, graf_vars_handle, 4) {
+        return None;
+    }
+    let graf_vars = memory.read_u32_be(graf_vars_handle)?;
+    let hilite_color = graf_vars.checked_add(6)?;
+    if graf_vars == 0 || !ppc_memory_can_write_bytes(memory, hilite_color, 6) {
+        return None;
+    }
+    ppc_read_rgb_color(memory, hilite_color)
+}
+
+fn ppc_current_hilite_color(
+    memory: &mut PpcSectionMem,
+    port: u32,
+    quickdraw_hilite_colors: &SharedProcessQuickDrawHiliteColors,
+) -> PpcRgbColor {
+    ppc_port_hilite_color_from_graf_vars(memory, port)
+        .or_else(|| {
+            quickdraw_hilite_colors
+                .quickdraw_hilite_color(port)
+                .map(|(red, green, blue)| PpcRgbColor { red, green, blue })
+        })
+        .unwrap_or_else(|| {
+            let (red, green, blue) = DEFAULT_QUICKDRAW_HILITE_COLOR;
+            PpcRgbColor { red, green, blue }
+        })
+}
+
+fn ppc_write_port_hilite_color(
+    memory: &mut PpcSectionMem,
+    port: u32,
+    color: PpcRgbColor,
+    quickdraw_hilite_colors: &SharedProcessQuickDrawHiliteColors,
+) {
+    let Some(port_version) = port.checked_add(6).and_then(|address| memory.read_u16_be(address))
+    else {
+        return;
+    };
+    if port_version & 0xc000 != 0xc000 {
+        return;
+    }
+    let graf_vars_handle = memory
+        .read_u32_be(port.wrapping_add(PPC_CGRAF_PORT_GRAF_VARS_OFFSET))
+        .unwrap_or(0);
+    if let Some(graf_vars) = (graf_vars_handle != 0)
+        .then(|| memory.read_u32_be(graf_vars_handle).unwrap_or(0))
+        .filter(|graf_vars| *graf_vars != 0)
+        .and_then(|graf_vars| graf_vars.checked_add(6))
+        .filter(|graf_vars| {
+            ppc_memory_can_write_bytes(memory, *graf_vars, 6)
+        })
+    {
+        let _ = ppc_write_rgb_color(memory, graf_vars, color);
+    }
+    // Static process ports (including the seeded main port) do not own an
+    // allocator-managed GrafVars handle. Keep their per-port fallback live
+    // across attached 68K and PowerPC adapters.
+    quickdraw_hilite_colors.set_quickdraw_hilite_color(
+        port,
+        (color.red, color.green, color.blue),
+    );
 }
 
 fn ppc_write_port_rgb_color(
@@ -65737,28 +65841,44 @@ fn ppc_get_ctable(
     handles: &mut Vec<PpcHandleRecord>,
     vfs_resources: &[PpcVfsResourceRecord],
     current_resource_refnum: i16,
+    current_gworld: u32,
+    quickdraw_hilite_colors: &SharedProcessQuickDrawHiliteColors,
 ) -> u32 {
     let ct_id = cpu.gpr[3] as u16 as i16;
     // Imaging With QuickDraw 1994, 4-92 through 4-93: GetCTable returns a
     // newly allocated ColorTable handle copied from a 'clut' resource, and
     // recognizes the standard depth IDs 1, 2, 4, and 8.
-    let data = if let Ok(depth) = u16::try_from(ct_id) {
-        TrapDispatcher::standard_mac_indexed_clut(depth).map(|(clut, entry_count)| {
-            let mut data = Vec::with_capacity(8 + entry_count * 8);
-            data.extend_from_slice(&(u32::from(depth)).to_be_bytes());
-            data.extend_from_slice(&0u16.to_be_bytes());
-            data.extend_from_slice(&((entry_count - 1) as u16).to_be_bytes());
-            for (index, rgb) in clut.into_iter().take(entry_count).enumerate() {
-                data.extend_from_slice(&(index as u16).to_be_bytes());
-                data.extend_from_slice(&rgb[0].to_be_bytes());
-                data.extend_from_slice(&rgb[1].to_be_bytes());
-                data.extend_from_slice(&rgb[2].to_be_bytes());
-            }
-            data
-        })
-    } else {
-        None
+    let data = match ct_id {
+        1 | 2 | 4 | 8 => TrapDispatcher::standard_mac_indexed_clut(ct_id as u16)
+            .map(|(clut, entry_count)| (clut, entry_count, ct_id as u32)),
+        66 | 68 | 72 => {
+            let depth = (ct_id - 64) as u16;
+            let hilite = ppc_current_hilite_color(
+                memory,
+                current_gworld,
+                quickdraw_hilite_colors,
+            );
+            TrapDispatcher::standard_mac_enhanced_clut(
+                depth,
+                (hilite.red, hilite.green, hilite.blue),
+            )
+            .map(|(clut, entry_count)| (clut, entry_count, u32::from(depth)))
+        }
+        _ => None,
     }
+    .map(|(clut, entry_count, seed)| {
+        let mut data = Vec::with_capacity(8 + entry_count * 8);
+        data.extend_from_slice(&seed.to_be_bytes());
+        data.extend_from_slice(&0u16.to_be_bytes());
+        data.extend_from_slice(&((entry_count - 1) as u16).to_be_bytes());
+        for (index, rgb) in clut.into_iter().take(entry_count).enumerate() {
+            data.extend_from_slice(&(index as u16).to_be_bytes());
+            data.extend_from_slice(&rgb[0].to_be_bytes());
+            data.extend_from_slice(&rgb[1].to_be_bytes());
+            data.extend_from_slice(&rgb[2].to_be_bytes());
+        }
+        data
+    })
     .or_else(|| {
         let index = ppc_vfs_resource_index(
             vfs_resources,
@@ -158176,6 +158296,235 @@ pub(crate) mod tests {
         assert_eq!(
             loaded.quickdraw_op_colors.quickdraw_op_color(PPC_MAIN_GWORLD),
             Some((color.red, color.green, color.blue))
+        );
+    }
+
+    #[test]
+    fn hle_import_runner_hilite_color_records_the_highlight_operand() {
+        assert_eq!(
+            dispatcher_target_for_import("InterfaceLib", "HiliteColor"),
+            PpcImportDispatcherTarget::HiliteColor
+        );
+        let pef = synthetic_pef_with_import(b"HiliteColor");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let color_ptr = PPC_DATA_BASE + 0x1000;
+        let color = PpcRgbColor {
+            red: 0x1234,
+            green: 0x5678,
+            blue: 0x9abc,
+        };
+        loaded.memory.add_region(color_ptr, vec![0; 6]);
+        ppc_write_rgb_color(&mut loaded.memory, color_ptr, color).unwrap();
+        loaded.cpu.gpr[3] = color_ptr;
+
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::HiliteColor);
+
+        assert_eq!(
+            loaded
+                .quickdraw_hilite_colors
+                .quickdraw_hilite_color(PPC_MAIN_GWORLD),
+            Some((color.red, color.green, color.blue))
+        );
+        assert_eq!(
+            ppc_current_hilite_color(
+                &mut loaded.memory,
+                PPC_MAIN_GWORLD,
+                &loaded.quickdraw_hilite_colors,
+            ),
+            color
+        );
+    }
+
+    #[test]
+    fn classic_hilite_color_is_immediately_visible_to_attached_native_get_ctable() {
+        let pef = synthetic_pef_with_import(b"GetCTable");
+        let mut native = load_pef_application(&pef).unwrap();
+        let mut classic = TrapDispatcher::new();
+        let mut context = ProcessContext::default();
+        native.attach_process_context(&mut context);
+        classic.attach_process_context(&mut context);
+
+        let mut classic_bus = MacMemoryBus::new(0x2000);
+        classic_bus.attach_guest_address_space(native.memory.shared_view());
+        context.attach_classic_memory_bus(&mut classic_bus);
+        let mut classic_cpu = MockCpu::new();
+        let sp = 0x0100;
+        let color_ptr = 0x0120;
+        classic_cpu.write_reg(Register::A7, sp);
+        classic_bus.write_long(sp, color_ptr);
+        classic_bus.write_word(color_ptr, 0x1357);
+        classic_bus.write_word(color_ptr + 2, 0x2468);
+        classic_bus.write_word(color_ptr + 4, 0x369a);
+        assert!(classic
+            .dispatch_quickdraw(true, 0x222, &mut classic_cpu, &mut classic_bus)
+            .expect("HiliteColor trap")
+            .is_ok());
+        assert_eq!(classic_cpu.read_reg(Register::A7), sp + 4);
+        assert_eq!(
+            native
+                .quickdraw_hilite_colors
+                .quickdraw_hilite_color(PPC_MAIN_GWORLD),
+            Some((0x1357, 0x2468, 0x369a))
+        );
+
+        native.cpu.gpr[3] = 66;
+        run_test_import(&mut native, PpcImportDispatcherTarget::GetCTable);
+        let ctable = native.cpu.gpr[3];
+        let ctable_ptr = native
+            .memory
+            .read_u32_be(ctable)
+            .expect("native enhanced ColorTable handle");
+        assert_eq!(native.memory.read_u16_be(ctable_ptr + 6), Some(3));
+        assert_eq!(native.memory.read_u16_be(ctable_ptr + 8 + 2 * 8 + 2), Some(0x1357));
+        assert_eq!(native.memory.read_u16_be(ctable_ptr + 8 + 2 * 8 + 4), Some(0x2468));
+        assert_eq!(native.memory.read_u16_be(ctable_ptr + 8 + 2 * 8 + 6), Some(0x369a));
+    }
+
+    #[test]
+    fn native_hilite_color_is_immediately_visible_to_attached_classic_grafvars() {
+        let pef = synthetic_pef_with_import(b"HiliteColor");
+        let mut native = load_pef_application(&pef).unwrap();
+        let mut classic = TrapDispatcher::new();
+        let mut context = ProcessContext::default();
+        native.attach_process_context(&mut context);
+        classic.attach_process_context(&mut context);
+
+        let base = PPC_HEAP_BASE + 0x15_000;
+        let port = base;
+        let graf_vars_handle = base + 0x100;
+        let graf_vars = base + 0x110;
+        let color_ptr = base + 0x120;
+        native.memory.add_region(base, vec![0; 0x140]);
+        native.memory.write_u16_be(port + 6, 0xc000).unwrap();
+        native
+            .memory
+            .write_u32_be(port + PPC_CGRAF_PORT_GRAF_VARS_OFFSET, graf_vars_handle)
+            .unwrap();
+        native.memory.write_u32_be(graf_vars_handle, graf_vars).unwrap();
+        let color = PpcRgbColor {
+            red: 0x1357,
+            green: 0x2468,
+            blue: 0x369a,
+        };
+        ppc_write_rgb_color(&mut native.memory, color_ptr, color).unwrap();
+        *native.current_gworld = port;
+
+        native.cpu.gpr[3] = color_ptr;
+        run_test_import(&mut native, PpcImportDispatcherTarget::HiliteColor);
+
+        let mut classic_bus = MacMemoryBus::new(0x2000);
+        classic_bus.attach_guest_address_space(native.memory.shared_view());
+        context.attach_classic_memory_bus(&mut classic_bus);
+        assert_eq!(*classic.current_port, port);
+        assert_eq!(classic_bus.read_word(graf_vars + 6), color.red);
+        assert_eq!(classic_bus.read_word(graf_vars + 8), color.green);
+        assert_eq!(classic_bus.read_word(graf_vars + 10), color.blue);
+        assert_eq!(classic.current_hilite_color(&classic_bus), (color.red, color.green, color.blue));
+    }
+
+    #[test]
+    fn hilite_color_keeps_distinct_values_when_switching_between_ports() {
+        let pef = synthetic_pef_with_import(b"HiliteColor");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let base = PPC_HEAP_BASE + 0x16_000;
+        let first_port = base;
+        let second_port = base + 0x40;
+        let basic_port = base + 0x80;
+        let first_color_ptr = base + 0x100;
+        let second_color_ptr = base + 0x110;
+        let basic_color_ptr = base + 0x120;
+        loaded.memory.add_region(base, vec![0; 0x140]);
+        for port in [first_port, second_port] {
+            loaded.memory.write_u16_be(port + 6, 0xc000).unwrap();
+        }
+        loaded.memory.write_u16_be(basic_port + 6, 0).unwrap();
+        let first_color = PpcRgbColor {
+            red: 0x1111,
+            green: 0x2222,
+            blue: 0x3333,
+        };
+        let second_color = PpcRgbColor {
+            red: 0xaaaa,
+            green: 0xbbbb,
+            blue: 0xcccc,
+        };
+        let basic_color = PpcRgbColor {
+            red: 0xdddd,
+            green: 0xeeee,
+            blue: 0xffff,
+        };
+        ppc_write_rgb_color(&mut loaded.memory, first_color_ptr, first_color).unwrap();
+        ppc_write_rgb_color(&mut loaded.memory, second_color_ptr, second_color).unwrap();
+        ppc_write_rgb_color(&mut loaded.memory, basic_color_ptr, basic_color).unwrap();
+
+        *loaded.current_gworld = first_port;
+        loaded.cpu.gpr[3] = first_color_ptr;
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::HiliteColor);
+        *loaded.current_gworld = second_port;
+        loaded.cpu.gpr[3] = second_color_ptr;
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::HiliteColor);
+
+        assert_eq!(
+            ppc_current_hilite_color(
+                &mut loaded.memory,
+                first_port,
+                &loaded.quickdraw_hilite_colors,
+            ),
+            first_color
+        );
+        assert_eq!(
+            ppc_current_hilite_color(
+                &mut loaded.memory,
+                second_port,
+                &loaded.quickdraw_hilite_colors,
+            ),
+            second_color
+        );
+
+        *loaded.current_gworld = basic_port;
+        loaded.cpu.gpr[3] = basic_color_ptr;
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::HiliteColor);
+        assert_eq!(
+            loaded
+                .quickdraw_hilite_colors
+                .quickdraw_hilite_color(basic_port),
+            None
+        );
+        let (red, green, blue) = DEFAULT_QUICKDRAW_HILITE_COLOR;
+        assert_eq!(
+            ppc_current_hilite_color(
+                &mut loaded.memory,
+                basic_port,
+                &loaded.quickdraw_hilite_colors,
+            ),
+            PpcRgbColor { red, green, blue }
+        );
+    }
+
+    #[test]
+    fn detached_ppc_clone_has_independent_quickdraw_hilite_colors() {
+        let pef = synthetic_pef_with_import(b"HiliteColor");
+        let loaded = load_pef_application(&pef).unwrap();
+        let port = PPC_HEAP_BASE + 0x17_000;
+        loaded
+            .quickdraw_hilite_colors
+            .set_quickdraw_hilite_color(port, (0x1111, 0x2222, 0x3333));
+        let detached = loaded.clone();
+        loaded
+            .quickdraw_hilite_colors
+            .set_quickdraw_hilite_color(port, (0xaaaa, 0xbbbb, 0xcccc));
+
+        assert_eq!(
+            loaded
+                .quickdraw_hilite_colors
+                .quickdraw_hilite_color(port),
+            Some((0xaaaa, 0xbbbb, 0xcccc))
+        );
+        assert_eq!(
+            detached
+                .quickdraw_hilite_colors
+                .quickdraw_hilite_color(port),
+            Some((0x1111, 0x2222, 0x3333))
         );
     }
 

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -1288,6 +1288,19 @@ pub type SharedProcessDialogText = SharedProcessValue<[Vec<u8>; 4]>;
 pub(crate) type SharedProcessQuickDrawOpColors =
     SharedProcessValue<HashMap<u32, (u16, u16, u16)>>;
 
+/// Default HiliteRGB used when a color graphics port has not received a
+/// HiliteColor call. The selected-list green matches the System 7.5.3
+/// BasiliskII reference used by the QuickDraw HLE.
+/// Inside Macintosh: Imaging With QuickDraw (1994), pp. 4-62 and 4-64.
+pub(crate) const DEFAULT_QUICKDRAW_HILITE_COLOR: (u16, u16, u16) = (0x0000, 0x8000, 0x0000);
+
+/// Canonical per-color-port highlight colors. The guest-visible
+/// `CGrafPort.grafVars.rgbHiliteColor` record remains authoritative when it
+/// exists; this process index covers static ports without owned GrafVars.
+/// Inside Macintosh: Imaging With QuickDraw (1994), pp. 4-62 and 4-64.
+pub(crate) type SharedProcessQuickDrawHiliteColors =
+    SharedProcessValue<HashMap<u32, (u16, u16, u16)>>;
+
 /// Canonical desktop scrap for one Macintosh process.
 ///
 /// The Scrap Manager exposes one ordered collection of typed flavors to every
@@ -1510,6 +1523,33 @@ impl SharedProcessValue<HashMap<u32, (u16, u16, u16)>> {
     /// Drop a disposed port's fallback operation color.
     pub(crate) fn remove_quickdraw_op_color(&self, port: u32) {
         // SAFETY: see `quickdraw_op_color`.
+        unsafe {
+            (&mut *self.0.get()).remove(&port);
+        }
+    }
+
+    /// Read one Color QuickDraw highlight color without exposing a reference
+    /// into the process-owned map to adapter code.
+    /// Inside Macintosh: Imaging With QuickDraw (1994), pp. 4-62 and 4-64.
+    pub(crate) fn quickdraw_hilite_color(&self, port: u32) -> Option<(u16, u16, u16)> {
+        // SAFETY: process adapters are serialized by the runner. The map is
+        // accessed only for the duration of this operation; no reference is
+        // returned to the UnsafeCell-backed value.
+        unsafe { (&*self.0.get()).get(&port).copied() }
+    }
+
+    /// Update one process-owned Color QuickDraw highlight color.
+    /// Inside Macintosh: Imaging With QuickDraw (1994), pp. 4-62 and 4-64.
+    pub(crate) fn set_quickdraw_hilite_color(&self, port: u32, color: (u16, u16, u16)) {
+        // SAFETY: see `quickdraw_hilite_color`.
+        unsafe {
+            (&mut *self.0.get()).insert(port, color);
+        }
+    }
+
+    /// Drop a disposed port's fallback highlight color.
+    pub(crate) fn remove_quickdraw_hilite_color(&self, port: u32) {
+        // SAFETY: see `quickdraw_hilite_color`.
         unsafe {
             (&mut *self.0.get()).remove(&port);
         }
@@ -5656,6 +5696,7 @@ pub(crate) struct ProcessContext {
     dialog_text: SharedProcessDialogText,
     cursor_state: SharedProcessCursorState,
     quickdraw_op_colors: SharedProcessQuickDrawOpColors,
+    quickdraw_hilite_colors: SharedProcessQuickDrawHiliteColors,
     current_graphics_port: SharedProcessValue<u32>,
     current_graphics_device: SharedProcessValue<u32>,
     quickdraw_error: SharedProcessValue<i16>,
@@ -5690,6 +5731,7 @@ impl Default for ProcessContext {
             dialog_text: SharedProcessDialogText::default(),
             cursor_state: SharedProcessCursorState::default(),
             quickdraw_op_colors: SharedProcessQuickDrawOpColors::default(),
+            quickdraw_hilite_colors: SharedProcessQuickDrawHiliteColors::default(),
             current_graphics_port: SharedProcessValue::from_value(0),
             current_graphics_device: SharedProcessValue::from_value(0),
             quickdraw_error: SharedProcessValue::from_value(0),
@@ -5833,6 +5875,17 @@ impl ProcessContext {
         adapter: &mut SharedProcessQuickDrawOpColors,
     ) {
         adapter.attach_to(&self.quickdraw_op_colors, |colors| colors.is_empty());
+    }
+
+    /// Attach Color QuickDraw's per-port `GrafVars.rgbHiliteColor` index.
+    /// Ordinary clones remain detached while attached 68K and PowerPC
+    /// adapters observe updates immediately.
+    /// Inside Macintosh: Imaging With QuickDraw (1994), pp. 4-62 and 4-64.
+    pub(crate) fn attach_quickdraw_hilite_colors(
+        &self,
+        adapter: &mut SharedProcessQuickDrawHiliteColors,
+    ) {
+        adapter.attach_to(&self.quickdraw_hilite_colors, |colors| colors.is_empty());
     }
 
     /// Attach a CPU adapter to the process's current QuickDraw port and device.

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -13669,6 +13669,7 @@ mod tests {
             current_gworld: SharedProcessValue::from_value(PPC_MAIN_GWORLD),
             current_gdevice: SharedProcessValue::from_value(PPC_MAIN_GDEVICE),
             quickdraw_op_colors: SharedProcessValue::default(),
+            quickdraw_hilite_colors: SharedProcessValue::default(),
             quickdraw_fore_color: PpcRgbColor {
                 red: 0,
                 green: 0,
@@ -16082,6 +16083,7 @@ mod tests {
             current_gworld: SharedProcessValue::from_value(PPC_MAIN_GWORLD),
             current_gdevice: SharedProcessValue::from_value(PPC_MAIN_GDEVICE),
             quickdraw_op_colors: SharedProcessValue::default(),
+            quickdraw_hilite_colors: SharedProcessValue::default(),
             quickdraw_fore_color: PpcRgbColor {
                 red: 0,
                 green: 0,
@@ -16874,6 +16876,7 @@ mod tests {
             current_gworld: SharedProcessValue::from_value(PPC_MAIN_GWORLD),
             current_gdevice: SharedProcessValue::from_value(PPC_MAIN_GDEVICE),
             quickdraw_op_colors: SharedProcessValue::default(),
+            quickdraw_hilite_colors: SharedProcessValue::default(),
             quickdraw_fore_color: PpcRgbColor {
                 red: 0,
                 green: 0,
@@ -17027,6 +17030,7 @@ mod tests {
             current_gworld: SharedProcessValue::from_value(PPC_MAIN_GWORLD),
             current_gdevice: SharedProcessValue::from_value(PPC_MAIN_GDEVICE),
             quickdraw_op_colors: SharedProcessValue::default(),
+            quickdraw_hilite_colors: SharedProcessValue::default(),
             quickdraw_fore_color: PpcRgbColor {
                 red: 0,
                 green: 0,
@@ -17439,6 +17443,7 @@ mod tests {
             current_gworld: SharedProcessValue::from_value(PPC_MAIN_GWORLD),
             current_gdevice: SharedProcessValue::from_value(PPC_MAIN_GDEVICE),
             quickdraw_op_colors: SharedProcessValue::default(),
+            quickdraw_hilite_colors: SharedProcessValue::default(),
             quickdraw_fore_color: PpcRgbColor {
                 red: 0,
                 green: 0,
@@ -17751,6 +17756,7 @@ mod tests {
             current_gworld: SharedProcessValue::from_value(PPC_MAIN_GWORLD),
             current_gdevice: SharedProcessValue::from_value(PPC_MAIN_GDEVICE),
             quickdraw_op_colors: SharedProcessValue::default(),
+            quickdraw_hilite_colors: SharedProcessValue::default(),
             quickdraw_fore_color: PpcRgbColor {
                 red: 0,
                 green: 0,

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -23,7 +23,7 @@ use crate::process_context::{
     SharedProcessEventQueue, SharedProcessFileSystem, SharedProcessInputState,
     SharedProcessListManager, SharedProcessMemoryManager, SharedProcessMenuTracking,
     SharedProcessOpenFilePositions, SharedProcessOpenFiles,
-    SharedProcessQuickDrawOpColors,
+    SharedProcessQuickDrawHiliteColors, SharedProcessQuickDrawOpColors,
     SharedProcessScrapState, SharedProcessSoundManager, SharedProcessTextEditManager,
     SharedProcessValue,
 };
@@ -2060,11 +2060,6 @@ pub struct TrapDispatcher {
     /// HLE keeps the source RGB so color fills can resolve it for the current
     /// destination depth at draw time.
     pub(crate) makergbpat_colors: HashMap<u32, (u16, u16, u16)>,
-    /// Current hilite color (RGBColor: R, G, B). Set by HiliteColor
-    /// ($AA22) and conceptually stored in the cGrafPort's grafVars
-    /// handle per IM:V V-149. Systemless uses a single dispatcher field
-    /// since most apps only have one cGrafPort active at a time.
-    pub hilite_color: (u16, u16, u16),
     /// Extra horizontal pixels added to each non-space character
     /// when drawing text, expressed as a Fixed16.16 value. Set by
     /// CharExtra ($AA23) per IM:V V-149.
@@ -2406,6 +2401,10 @@ pub struct TrapDispatcher {
     /// allocator-managed GrafVars handle. A valid guest GrafVars record is
     /// always preferred by OpColor reads and writes.
     pub(crate) quickdraw_op_colors: SharedProcessQuickDrawOpColors,
+    /// Process-owned fallback for ports whose guest record has no
+    /// allocator-managed GrafVars handle. A valid guest GrafVars record is
+    /// always preferred by HiliteColor reads and writes.
+    pub(crate) quickdraw_hilite_colors: SharedProcessQuickDrawHiliteColors,
     /// Whether the attached process's current CGrafPort record is canonical
     /// for draw state shared with the native QuickDraw adapter.
     pub(crate) process_quickdraw_port_state_attached: bool,
@@ -2838,6 +2837,7 @@ impl TrapDispatcher {
         context.attach_quickdraw_selection(&mut self.current_port, &mut self.current_gdevice);
         context.attach_quickdraw_error(&mut self.quickdraw_error);
         context.attach_quickdraw_op_colors(&mut self.quickdraw_op_colors);
+        context.attach_quickdraw_hilite_colors(&mut self.quickdraw_hilite_colors);
         self.process_quickdraw_port_state_attached = true;
         context.attach_display_color_state(
             &mut self.device_clut,
@@ -3846,10 +3846,6 @@ impl TrapDispatcher {
             pm_fg_color: None,
             pm_bg_color: None,
             makergbpat_colors: HashMap::new(),
-            // Default HiliteRGB used before an application calls HiliteColor.
-            // The System 7.5.3 BasiliskII reference resolves this to EV's
-            // darker selected-list green rather than a saturated primary.
-            hilite_color: (0x0000, 0x8000, 0x0000),
             char_extra: 0,
             bk_pat: [0x00; 8],
             pn_loc: (0, 0),
@@ -3978,6 +3974,7 @@ impl TrapDispatcher {
             current_port: SharedProcessValue::from_value(0),
             quickdraw_error: SharedProcessValue::from_value(0),
             quickdraw_op_colors: SharedProcessQuickDrawOpColors::default(),
+            quickdraw_hilite_colors: SharedProcessQuickDrawHiliteColors::default(),
             process_quickdraw_port_state_attached: false,
             port_draw_states: HashMap::new(),
             resolved_port_color_fields: HashMap::new(),

--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -6,6 +6,7 @@ use crate::cpu::{CpuOps, Register};
 use crate::display::{self, CursorImage};
 use crate::machine_profile::REFERENCE_MACHINE_PROFILE;
 use crate::memory::{MacMemoryBus, MemoryBus};
+use crate::process_context::DEFAULT_QUICKDRAW_HILITE_COLOR;
 use crate::quickdraw::fonts::{font_id_for_name, font_name_for_id, get_font_face_scaled};
 use crate::quickdraw::text::get_glyph;
 use crate::trap::pict;
@@ -1413,6 +1414,8 @@ impl super::TrapDispatcher {
                 self.resolved_port_color_fields.remove(&port_ptr);
                 self.quickdraw_op_colors
                     .remove_quickdraw_op_color(port_ptr);
+                self.quickdraw_hilite_colors
+                    .remove_quickdraw_hilite_color(port_ptr);
                 Ok(())
             }
 
@@ -6937,7 +6940,8 @@ impl super::TrapDispatcher {
                 let ct_handle = if let Some((depth, enhanced)) = standard_ctable {
                     self.recent_resource_ctable_fetch = None;
                     let (std_clut, entry_count) = if enhanced {
-                        Self::standard_mac_enhanced_clut(depth, self.hilite_color).unwrap()
+                        Self::standard_mac_enhanced_clut(depth, self.current_hilite_color(bus))
+                            .unwrap()
                     } else {
                         Self::standard_mac_indexed_clut(depth).unwrap()
                     };
@@ -12051,23 +12055,25 @@ impl super::TrapDispatcher {
             //
             // Documented behaviour: when color != NIL, three RGB words
             // (red, green, blue) are read from [color..color+6] and
-            // stored in the cGrafPort's grafVars handle (rgbHiliteColor
-            // field). When color == NIL both BII System 7.5.3 ROM Color
-            // QuickDraw and Systemless HLE take an early-exit no-op path
-            // before touching grafVars. Systemless stores the hilite color
-            // on the dispatcher (self.hilite_color) rather than per-port
-            // grafVars; this matches the single-port assumption used by
-            // fg_color / bg_color and differs from BII's WMgrCPort
-            // grafVars write on the non-NIL path. The NIL early-exit path
-            // shares the Pascal PROCEDURE pop-4 calling convention with BII.
+            // stored in the current cGrafPort's grafVars handle
+            // (rgbHiliteColor field). Static cGrafPort records without an
+            // owned grafVars handle use the process-owned per-port index as
+            // the same live state across attached adapters. When color ==
+            // NIL both BII System 7.5.3 ROM Color QuickDraw and Systemless
+            // HLE take an early-exit no-op path before touching grafVars.
+            // The NIL early-exit path shares the Pascal PROCEDURE pop-4
+            // calling convention with BII.
             (true, 0x222) => {
                 let sp = cpu.read_reg(Register::A7);
                 let rgb_ptr = bus.read_long(sp);
-                if rgb_ptr != 0 {
-                    let r = bus.read_word(rgb_ptr);
-                    let g = bus.read_word(rgb_ptr + 2);
-                    let b = bus.read_word(rgb_ptr + 4);
-                    self.hilite_color = (r, g, b);
+                if rgb_ptr != 0 && Self::guest_range_in_ram(bus, rgb_ptr, 6) {
+                    let color = (
+                        bus.read_word(rgb_ptr),
+                        bus.read_word(rgb_ptr + 2),
+                        bus.read_word(rgb_ptr + 4),
+                    );
+                    let port = *self.current_port;
+                    self.write_port_hilite_color(bus, port, color);
                 }
                 cpu.write_reg(Register::A7, sp + 4);
                 Ok(())
@@ -16214,6 +16220,8 @@ impl super::TrapDispatcher {
         bus.write_long(port + 96, 0); // +96 rgnSave
         bus.write_long(port + 100, 0); // +100 polySave
         bus.write_long(port + 104, 0); // +104 grafProcs
+        self.quickdraw_hilite_colors
+            .remove_quickdraw_hilite_color(port);
         self.port_draw_states.insert(port, PortDrawState::default());
     }
 
@@ -18874,6 +18882,8 @@ impl super::TrapDispatcher {
         self.port_draw_states.remove(&port);
         self.resolved_port_color_fields.remove(&port);
         self.quickdraw_op_colors.remove_quickdraw_op_color(port);
+        self.quickdraw_hilite_colors
+            .remove_quickdraw_hilite_color(port);
     }
 
     pub(super) fn effective_destination_ctab_handle(
@@ -19070,6 +19080,78 @@ impl super::TrapDispatcher {
         // authoritative read path above.
         self.quickdraw_op_colors
             .set_quickdraw_op_color(port, color);
+    }
+
+    /// Read the current Color QuickDraw port's highlight color. A valid
+    /// guest GrafVars record is authoritative; static ports use the
+    /// process-owned per-port fallback, then the default HiliteRGB value.
+    /// Inside Macintosh: Imaging With QuickDraw (1994), pp. 4-62 and 4-64.
+    pub(crate) fn current_hilite_color(&self, bus: &MacMemoryBus) -> (u16, u16, u16) {
+        self.hilite_color_for_port(bus, *self.current_port)
+    }
+
+    pub(crate) fn hilite_color_for_port(
+        &self,
+        bus: &MacMemoryBus,
+        port: u32,
+    ) -> (u16, u16, u16) {
+        self.port_hilite_color_from_graf_vars(bus, port)
+            .or_else(|| self.quickdraw_hilite_colors.quickdraw_hilite_color(port))
+            .unwrap_or(DEFAULT_QUICKDRAW_HILITE_COLOR)
+    }
+
+    fn port_hilite_color_from_graf_vars(
+        &self,
+        bus: &MacMemoryBus,
+        port: u32,
+    ) -> Option<(u16, u16, u16)> {
+        let port_range_mapped = port.checked_add(14).is_some_and(|end| {
+            end <= bus.ram_size()
+                || (port..end).all(|address| bus.is_foreign_ordinary_sparse_address(address))
+        });
+        if port == 0
+            || !port_range_mapped
+            || (bus.read_word(port + 6) & 0xC000) != 0xC000
+        {
+            return None;
+        }
+        let graf_vars_handle = bus.read_long(port + 8);
+        if !Self::handle_points_to_guest_range(bus, graf_vars_handle, 12) {
+            return None;
+        }
+        let graf_vars = bus.read_long(graf_vars_handle);
+        Some((
+            bus.read_word(graf_vars + 6),
+            bus.read_word(graf_vars + 8),
+            bus.read_word(graf_vars + 10),
+        ))
+    }
+
+    fn write_port_hilite_color(
+        &mut self,
+        bus: &mut MacMemoryBus,
+        port: u32,
+        color: (u16, u16, u16),
+    ) {
+        let port_range_mapped = port.checked_add(14).is_some_and(|end| {
+            end <= bus.ram_size()
+                || (port..end).all(|address| bus.is_foreign_ordinary_sparse_address(address))
+        });
+        if port == 0 || !port_range_mapped || (bus.read_word(port + 6) & 0xC000) != 0xC000 {
+            return;
+        }
+        let graf_vars_handle = bus.read_long(port + 8);
+        if Self::handle_points_to_guest_range(bus, graf_vars_handle, 12) {
+            let graf_vars = bus.read_long(graf_vars_handle);
+            bus.write_word(graf_vars + 6, color.0);
+            bus.write_word(graf_vars + 8, color.1);
+            bus.write_word(graf_vars + 10, color.2);
+        }
+        // Keep a process-owned per-port index for static records without a
+        // valid GrafVars handle. A valid guest GrafVars record remains the
+        // authoritative read path above.
+        self.quickdraw_hilite_colors
+            .set_quickdraw_hilite_color(port, color);
     }
 
     fn capture_port_region(
@@ -47496,7 +47578,7 @@ mod tests {
     #[test]
     fn test_get_ctable_enhanced_standard_ids() {
         let (mut d, mut cpu, mut bus) = setup();
-        let hilite = d.hilite_color;
+        let hilite = d.current_hilite_color(&bus);
 
         bus.write_word(TEST_SP, 66u16);
         d.dispatch_quickdraw(true, 0x218, &mut cpu, &mut bus)

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -4394,7 +4394,7 @@ impl super::TrapDispatcher {
 
         let selected = state.selected.contains(&(row, col));
         let bg = if selected {
-            self.hilite_color
+            self.hilite_color_for_port(bus, state.port)
         } else if self.list_cell_background_is_dark(bus, state.port, rect) {
             (0x0000, 0x0000, 0x0000)
         } else {
@@ -25011,7 +25011,8 @@ mod tests {
             *disp.device_clut = [[0xFFFF, 0xFFFF, 0xFFFF]; 256];
             disp.device_clut[0] = [0x0000, 0x0000, 0x0000];
             disp.device_clut[42] = [hilite.0, hilite.1, hilite.2];
-            disp.hilite_color = hilite;
+            disp.quickdraw_hilite_colors
+                .set_quickdraw_hilite_color(owner_port, hilite);
             bus.write_long(0x0824, screen_base);
             bus.write_word(crate::memory::globals::addr::MBAR_HEIGHT, 0);
             disp.init_cgraf_window(
@@ -25215,7 +25216,8 @@ mod tests {
         *disp.device_clut = [[0xFFFF, 0xFFFF, 0xFFFF]; 256];
         disp.device_clut[0] = [0x0000, 0x0000, 0x0000];
         disp.device_clut[42] = [hilite.0, hilite.1, hilite.2];
-        disp.hilite_color = hilite;
+        disp.quickdraw_hilite_colors
+            .set_quickdraw_hilite_color(window_ptr, hilite);
         bus.write_long(0x0824, screen_base);
         bus.write_word(crate::memory::globals::addr::MBAR_HEIGHT, 0);
         for offset in 0..(row_bytes * 96) {


### PR DESCRIPTION
## Summary

- make each color port's guest GrafVars highlight color authoritative
- share fallback highlight color state for static ports across CPU adapters
- add the native InterfaceLib `HiliteColor` route
- preserve basic GrafPort no-op behavior, per-port isolation, defaults, and detached clone independence

## Validation

- `cargo test --locked --lib hilite_color`
- `cargo test --locked --lib test_get_ctable_enhanced_standard_ids`
- `cargo test --locked --lib opcolor_hilitecolor_pascal_procedure_preserves_stack_across_five_calls`
- `cargo check --all-features --all-targets --locked`
- `git diff --check`

Closes #1319
