### PR TITLE
refactor(apple-events): make launch delivery state process-owned

### DIFF
--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -77,6 +77,7 @@ use crate::process_context::{
     ProcessNativeHeapState, ProcessNativeMemoryManager, ProcessPtrRecord,
     ProcessResourceManagerState, ProcessVfsFileRecords,
     ProcessVfsResourceFileRecords, ProcessWorkingDirectory, SharedProcessAppleEventHandlers,
+    SharedProcessAppleEventLaunchState,
     SharedProcessCallbackScheduling, SharedProcessCursorState, SharedProcessDialogText,
     SharedProcessControlManager, SharedProcessEventQueue,
     SharedProcessFileSystem, SharedProcessInputState, SharedProcessMemoryManager,
@@ -2812,8 +2813,7 @@ struct PpcAppleEventDispatchAllocation {
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct PpcAppleEventState {
-    application_high_level_event_aware: bool,
-    sent_open_application_event: bool,
+    pub(crate) apple_event_launch_state: SharedProcessAppleEventLaunchState,
     handlers: SharedProcessAppleEventHandlers,
     pending_dispatches: Vec<PpcAppleEventDispatchAllocation>,
 }
@@ -4087,6 +4087,9 @@ impl PpcLoadedApp {
         context.attach_guest_calls(&mut self.toolbox_startup.guest_calls);
         context.attach_mixed_mode_m68k_state(&mut self.toolbox_startup.mixed_mode_m68k);
         context.attach_apple_event_handlers(&mut self.apple_events.handlers);
+        context.attach_apple_event_launch_state(
+            &mut self.apple_events.apple_event_launch_state,
+        );
     }
 
     /// Run one native operation with every process manager continuously attached.
@@ -8478,12 +8481,15 @@ impl PpcLoadedApp {
                     .filter(|size| size.preferred_partition_size().is_some())
             })
         });
-        self.apple_events.application_high_level_event_aware =
+        let high_level_event_aware =
             size_resource.is_some_and(ApplicationSizeResource::is_high_level_event_aware);
+        self.apple_events
+            .apple_event_launch_state
+            .set_high_level_event_aware(high_level_event_aware);
         if ppc_hle_trace_enabled() {
             eprintln!(
                 "[PPC-TRACE] launch AppleEvents aware={} path={:?} SIZE={:?}",
-                self.apple_events.application_high_level_event_aware,
+                high_level_event_aware,
                 self.launched_app_path(),
                 size_resource,
             );
@@ -62485,13 +62491,13 @@ fn ppc_enqueue_open_application_event_if_needed(
     // Finder posts kAEOpenApplication once at launch for applications whose
     // SIZE resource sets isHighLevelEventAware. The EventRecord carries the
     // core class in message and the event ID split across the Point fields.
-    if !apple_events.application_high_level_event_aware
-        || apple_events.sent_open_application_event
-        || event_mask & PPC_HIGH_LEVEL_EVENT_MASK == 0
+    if event_mask & PPC_HIGH_LEVEL_EVENT_MASK == 0
+        || !apple_events
+            .apple_event_launch_state
+            .claim_open_application_event()
     {
         return;
     }
-    apple_events.sent_open_application_event = true;
     event_queue.push_front(PpcQueuedEvent {
         what: PPC_HIGH_LEVEL_EVENT,
         message: PPC_CORE_EVENT_CLASS,
@@ -93770,6 +93776,189 @@ pub(crate) mod tests {
 
         assert_eq!(context.event_queue().len(), 1);
         assert!(!context.event_queue().menu_bar_is_invalid());
+    }
+
+    #[test]
+    fn attached_event_launch_state_shares_native_first_and_classic_first_oapp_once() {
+        let (mut classic, mut classic_cpu, mut classic_bus) = setup_with_port();
+        let pef = synthetic_pef_with_import(b"GetNextEvent");
+        let mut native = load_pef_application(&pef).unwrap();
+        let mut context = ProcessContext::default();
+        classic.attach_process_context(&mut context);
+        native.attach_process_context(&mut context);
+        assert!(classic
+            .apple_event_launch_state
+            .ptr_eq(&native.apple_events.apple_event_launch_state));
+        let low_memory = classic_bus
+            .shared_ram_region(0, 0x0010_0000)
+            .expect("classic adapter owns low memory");
+        context.attach_memory(0, low_memory, &mut native.memory);
+
+        let native_event = PPC_DATA_BASE + 0x3000;
+        native.memory.add_region(native_event, vec![0; 16]);
+        let classic_event = 0x0020_0000;
+        let detached = native.apple_events.apple_event_launch_state.clone();
+
+        // Native-first: the classic gateway must observe the same claimed
+        // OAPP after native GetNextEvent consumes it.
+        classic
+            .apple_event_launch_state
+            .reset_for_launch(true);
+        native.cpu.gpr[3] = u32::from(PPC_HIGH_LEVEL_EVENT_MASK);
+        native.cpu.gpr[4] = native_event;
+        run_test_import(&mut native, PpcImportDispatcherTarget::GetNextEvent);
+        assert_eq!(native.cpu.gpr[3], 1);
+        assert!(context.event_queue().is_empty());
+        assert!(classic
+            .apple_event_launch_state
+            .is_open_application_event_sent());
+
+        classic_cpu.write_reg(Register::A7, TEST_SP);
+        classic_bus.write_long(TEST_SP, classic_event);
+        classic_bus.write_word(TEST_SP + 4, u32::from(PPC_HIGH_LEVEL_EVENT_MASK) as u16);
+        classic_bus.write_word(TEST_SP + 6, 0xbeef);
+        assert!(classic
+            .dispatch_toolbox(true, 0x170, &mut classic_cpu, &mut classic_bus)
+            .unwrap()
+            .is_ok());
+        assert_eq!(classic_bus.read_word(TEST_SP + 6), 0);
+        assert_eq!(classic_bus.read_word(classic_event), 0);
+        assert!(context.event_queue().is_empty());
+
+        // Classic-first: reset only the process launch state, then make the
+        // native gateway poll after classic GetNextEvent consumed OAPP.
+        classic
+            .apple_event_launch_state
+            .reset_for_launch(true);
+        classic_cpu.write_reg(Register::A7, TEST_SP);
+        classic_bus.write_long(TEST_SP, classic_event);
+        classic_bus.write_word(TEST_SP + 4, u32::from(PPC_HIGH_LEVEL_EVENT_MASK) as u16);
+        classic_bus.write_word(TEST_SP + 6, 0);
+        assert!(classic
+            .dispatch_toolbox(true, 0x170, &mut classic_cpu, &mut classic_bus)
+            .unwrap()
+            .is_ok());
+        assert_eq!(classic_bus.read_word(TEST_SP + 6), 0xffff);
+        assert_eq!(classic_bus.read_word(classic_event), 23);
+        assert!(context.event_queue().is_empty());
+
+        native.cpu.gpr[3] = u32::from(PPC_HIGH_LEVEL_EVENT_MASK);
+        native.cpu.gpr[4] = native_event;
+        run_test_import(&mut native, PpcImportDispatcherTarget::GetNextEvent);
+        assert_eq!(native.cpu.gpr[3], 0);
+        assert_eq!(native.memory.read_u16_be(native_event), Some(0));
+        assert!(context.event_queue().is_empty());
+
+        assert!(!detached.is_high_level_event_aware());
+        assert!(!detached.is_open_application_event_sent());
+    }
+
+    #[test]
+    fn attached_event_launch_state_shares_eventavail_peek_without_duplicate_oapp() {
+        let (mut classic, mut classic_cpu, mut classic_bus) = setup_with_port();
+        let pef = synthetic_pef_with_import(b"EventAvail");
+        let mut native = load_pef_application(&pef).unwrap();
+        let mut context = ProcessContext::default();
+        classic.attach_process_context(&mut context);
+        native.attach_process_context(&mut context);
+        let low_memory = classic_bus
+            .shared_ram_region(0, 0x0010_0000)
+            .expect("classic adapter owns low memory");
+        context.attach_memory(0, low_memory, &mut native.memory);
+
+        let native_event = PPC_DATA_BASE + 0x3100;
+        native.memory.add_region(native_event, vec![0; 16]);
+        let classic_event = 0x0020_0000;
+        classic
+            .apple_event_launch_state
+            .reset_for_launch(true);
+
+        native.cpu.gpr[3] = u32::from(PPC_HIGH_LEVEL_EVENT_MASK);
+        native.cpu.gpr[4] = native_event;
+        run_test_import(&mut native, PpcImportDispatcherTarget::EventAvail);
+        assert_eq!(native.cpu.gpr[3], 1);
+        assert_eq!(context.event_queue().len(), 1);
+        assert_eq!(native.memory.read_u16_be(native_event), Some(23));
+
+        classic_cpu.write_reg(Register::A7, TEST_SP);
+        classic_bus.write_long(TEST_SP, classic_event);
+        classic_bus.write_word(TEST_SP + 4, u32::from(PPC_HIGH_LEVEL_EVENT_MASK) as u16);
+        classic_bus.write_word(TEST_SP + 6, 0);
+        assert!(classic
+            .dispatch_toolbox(true, 0x171, &mut classic_cpu, &mut classic_bus)
+            .unwrap()
+            .is_ok());
+        assert_eq!(classic_bus.read_word(TEST_SP + 6), 0xffff);
+        assert_eq!(classic_bus.read_word(classic_event), 23);
+        assert_eq!(context.event_queue().len(), 1);
+
+        native.cpu.gpr[3] = u32::from(PPC_HIGH_LEVEL_EVENT_MASK);
+        native.cpu.gpr[4] = native_event;
+        run_test_import(&mut native, PpcImportDispatcherTarget::EventAvail);
+        assert_eq!(native.cpu.gpr[3], 1);
+        assert_eq!(context.event_queue().len(), 1);
+        assert!(native
+            .apple_events
+            .apple_event_launch_state
+            .is_open_application_event_sent());
+    }
+
+    #[test]
+    fn attached_event_launch_state_requires_awareness_and_high_level_mask() {
+        let (mut classic, mut classic_cpu, mut classic_bus) = setup_with_port();
+        let pef = synthetic_pef_with_import(b"GetNextEvent");
+        let mut native = load_pef_application(&pef).unwrap();
+        let mut context = ProcessContext::default();
+        classic.attach_process_context(&mut context);
+        native.attach_process_context(&mut context);
+        let low_memory = classic_bus
+            .shared_ram_region(0, 0x0010_0000)
+            .expect("classic adapter owns low memory");
+        context.attach_memory(0, low_memory, &mut native.memory);
+
+        let native_event = PPC_DATA_BASE + 0x3200;
+        native.memory.add_region(native_event, vec![0; 16]);
+        let classic_event = 0x0020_0000;
+
+        classic
+            .apple_event_launch_state
+            .reset_for_launch(false);
+        native.cpu.gpr[3] = u32::from(PPC_HIGH_LEVEL_EVENT_MASK);
+        native.cpu.gpr[4] = native_event;
+        run_test_import(&mut native, PpcImportDispatcherTarget::GetNextEvent);
+        assert_eq!(native.cpu.gpr[3], 0);
+        assert!(!native
+            .apple_events
+            .apple_event_launch_state
+            .is_open_application_event_sent());
+        assert!(context.event_queue().is_empty());
+
+        classic
+            .apple_event_launch_state
+            .reset_for_launch(true);
+        native.cpu.gpr[3] = 0x0008;
+        native.cpu.gpr[4] = native_event;
+        run_test_import(&mut native, PpcImportDispatcherTarget::GetNextEvent);
+        assert_eq!(native.cpu.gpr[3], 0);
+        assert!(!native
+            .apple_events
+            .apple_event_launch_state
+            .is_open_application_event_sent());
+        assert!(context.event_queue().is_empty());
+
+        classic_cpu.write_reg(Register::A7, TEST_SP);
+        classic_bus.write_long(TEST_SP, classic_event);
+        classic_bus.write_word(TEST_SP + 4, 0x0008);
+        classic_bus.write_word(TEST_SP + 6, 0xbeef);
+        assert!(classic
+            .dispatch_toolbox(true, 0x170, &mut classic_cpu, &mut classic_bus)
+            .unwrap()
+            .is_ok());
+        assert_eq!(classic_bus.read_word(TEST_SP + 6), 0);
+        assert!(!classic
+            .apple_event_launch_state
+            .is_open_application_event_sent());
+        assert!(context.event_queue().is_empty());
     }
 
     #[test]
@@ -162081,7 +162270,10 @@ pub(crate) mod tests {
         );
         loaded.set_launched_app_path("Test App");
 
-        assert!(loaded.apple_events.application_high_level_event_aware);
+        assert!(loaded
+            .apple_events
+            .apple_event_launch_state
+            .is_high_level_event_aware());
     }
 
     #[test]
@@ -162122,7 +162314,10 @@ pub(crate) mod tests {
         assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_NO_ERR));
         assert_eq!(loaded.apple_events.handlers.len(), 1);
 
-        loaded.apple_events.application_high_level_event_aware = true;
+        loaded
+            .apple_events
+            .apple_event_launch_state
+            .set_high_level_event_aware(true);
         loaded.cpu.pc = loaded.entry_pc;
         loaded.cpu.lr = PPC_HALT_PC;
         loaded.imports[0].dispatcher_target = PpcImportDispatcherTarget::GetNextEvent;

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -1280,6 +1280,26 @@ pub(crate) type SharedProcessTextEditManager = SharedProcessValue<ProcessTextEdi
 /// Detached-by-default attachment handle for Dialog Manager `ParamText` slots.
 pub type SharedProcessDialogText = SharedProcessValue<[Vec<u8>; 4]>;
 
+/// Launch-time AppleEvent state owned by the emulated process rather than by
+/// either CPU gateway. The Event Manager's high-level-event awareness comes
+/// from the application's `SIZE` resource, while the one-shot bit prevents
+/// both attached gateways from manufacturing a second `kAEOpenApplication`.
+/// Inside Macintosh: Toolbox Essentials (1992), pp. 2-30--2-32 and 5-90.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct ProcessAppleEventLaunchState {
+    pub(crate) high_level_event_aware: bool,
+    pub(crate) open_application_event_sent: bool,
+}
+
+impl ProcessAppleEventLaunchState {
+    pub(crate) fn is_pristine(&self) -> bool {
+        *self == Self::default()
+    }
+}
+
+pub(crate) type SharedProcessAppleEventLaunchState =
+    SharedProcessValue<ProcessAppleEventLaunchState>;
+
 /// Canonical per-color-port arithmetic transfer colors. The guest-visible
 /// `CGrafPort.grafVars` record is the primary representation; this process
 /// index keeps the value live across adapters when a port is one of the
@@ -1494,6 +1514,67 @@ impl<T> SharedProcessValue<T> {
     #[cfg(test)]
     pub(crate) fn ptr_eq(&self, other: &Self) -> bool {
         Rc::ptr_eq(&self.0, &other.0)
+    }
+}
+
+impl SharedProcessValue<ProcessAppleEventLaunchState> {
+    /// Read the launch capability without returning a reference into the
+    /// process-owned `UnsafeCell`. A callback may enter the other ISA gateway
+    /// after this operation returns, so no borrow can cross that boundary.
+    pub(crate) fn is_high_level_event_aware(&self) -> bool {
+        // SAFETY: the runner serializes attached adapter access; this method
+        // copies the bit before returning and exposes no reference.
+        unsafe { (&*self.0.get()).high_level_event_aware }
+    }
+
+    /// Update the process launch capability while keeping the mutable access
+    /// scoped to this operation.
+    pub(crate) fn set_high_level_event_aware(&self, aware: bool) {
+        // SAFETY: see `is_high_level_event_aware`.
+        unsafe {
+            (&mut *self.0.get()).high_level_event_aware = aware;
+        }
+    }
+
+    /// Return whether the process-wide synthetic `kAEOpenApplication` has
+    /// already been claimed by either attached Event Manager gateway.
+    #[cfg(test)]
+    pub(crate) fn is_open_application_event_sent(&self) -> bool {
+        // SAFETY: see `is_high_level_event_aware`.
+        unsafe { (&*self.0.get()).open_application_event_sent }
+    }
+
+    /// Set the process-wide one-shot state for a test fixture.
+    pub(crate) fn set_open_application_event_sent(&self, sent: bool) {
+        // SAFETY: see `is_high_level_event_aware`.
+        unsafe {
+            (&mut *self.0.get()).open_application_event_sent = sent;
+        }
+    }
+
+    /// Start a new application launch with the capability parsed from its
+    /// `SIZE` resource and no previously delivered synthetic event.
+    pub(crate) fn reset_for_launch(&self, high_level_event_aware: bool) {
+        // SAFETY: see `is_high_level_event_aware`.
+        unsafe {
+            let state = &mut *self.0.get();
+            state.high_level_event_aware = high_level_event_aware;
+            state.open_application_event_sent = false;
+        }
+    }
+
+    /// Atomically claim the process-wide one-shot launch event. The caller
+    /// must still check its event mask before invoking this method.
+    pub(crate) fn claim_open_application_event(&self) -> bool {
+        // SAFETY: see `is_high_level_event_aware`.
+        unsafe {
+            let state = &mut *self.0.get();
+            if !state.high_level_event_aware || state.open_application_event_sent {
+                return false;
+            }
+            state.open_application_event_sent = true;
+            true
+        }
     }
 }
 
@@ -5683,6 +5764,7 @@ pub(crate) struct ProcessContext {
     pending_native_menu_selection: SharedNativeMenuSelection,
     guest_calls: SharedGuestCallStack,
     apple_event_handlers: SharedProcessAppleEventHandlers,
+    apple_event_launch_state: SharedProcessAppleEventLaunchState,
     file_system: SharedProcessFileSystem,
     sound_manager: SharedProcessSoundManager,
     timer_tasks: SharedProcessTimerTasks,
@@ -5718,6 +5800,7 @@ impl Default for ProcessContext {
             pending_native_menu_selection: SharedNativeMenuSelection::default(),
             guest_calls: SharedGuestCallStack::default(),
             apple_event_handlers: SharedProcessAppleEventHandlers::default(),
+            apple_event_launch_state: SharedProcessAppleEventLaunchState::default(),
             file_system: SharedProcessFileSystem::default(),
             sound_manager: SharedProcessSoundManager::default(),
             timer_tasks: SharedProcessTimerTasks::default(),
@@ -6121,6 +6204,24 @@ impl ProcessContext {
         adapter: &mut SharedProcessAppleEventHandlers,
     ) {
         adapter.attach_to(&self.apple_event_handlers);
+    }
+
+    pub(crate) fn attach_apple_event_launch_state(
+        &self,
+        adapter: &mut SharedProcessAppleEventLaunchState,
+    ) {
+        adapter.attach_copy_to(
+            &self.apple_event_launch_state,
+            ProcessAppleEventLaunchState::is_pristine,
+        );
+    }
+
+    pub(crate) fn reset_apple_event_launch_state_for_launch(
+        &self,
+        high_level_event_aware: bool,
+    ) {
+        self.apple_event_launch_state
+            .reset_for_launch(high_level_event_aware);
     }
 }
 
@@ -7975,6 +8076,28 @@ mod tests {
         assert_eq!(classic.len(), 1);
         assert_eq!(native.len(), 1);
         assert_eq!(detached.len(), 0);
+    }
+
+    #[test]
+    fn attached_apple_event_launch_state_shares_one_shot_claim_while_clones_detach() {
+        let context = ProcessContext::default();
+        let mut classic = SharedProcessAppleEventLaunchState::default();
+        let mut native = SharedProcessAppleEventLaunchState::default();
+        context.attach_apple_event_launch_state(&mut classic);
+        context.attach_apple_event_launch_state(&mut native);
+        let detached = native.clone();
+
+        classic.reset_for_launch(true);
+        assert!(native.is_high_level_event_aware());
+        assert!(classic.claim_open_application_event());
+        assert!(native.is_open_application_event_sent());
+        assert!(!native.claim_open_application_event());
+        assert!(!detached.is_high_level_event_aware());
+        assert!(!detached.is_open_application_event_sent());
+
+        native.reset_for_launch(false);
+        assert!(!classic.is_high_level_event_aware());
+        assert!(!classic.claim_open_application_event());
     }
 
     #[test]

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -3475,9 +3475,12 @@ impl FixtureRunner {
         use crate::memory::globals::addr;
         let ram_size = self.bus.ram_size();
 
-        self.dispatcher.application_high_level_event_aware = app
+        let high_level_event_aware = app
             .size_resource
             .is_some_and(ApplicationSizeResource::is_high_level_event_aware);
+        self.dispatcher
+            .apple_event_launch_state
+            .reset_for_launch(high_level_event_aware);
 
         // Classic Mac OS application code runs in supervisor mode with the
         // processor priority open to level-1 VBL interrupts. The m68k core
@@ -3877,6 +3880,22 @@ impl FixtureRunner {
 
     fn init_ppc_app(&mut self, mut ppc_app: PpcLoadedApp) {
         use crate::memory::globals::addr;
+
+        // A native application carries its parsed SIZE capability before it
+        // attaches to the runner-owned process state. Start this launch with
+        // that capability and a fresh process-wide OAPP claim so a prior
+        // application cannot suppress or duplicate delivery. Inside
+        // Macintosh: Toolbox Essentials (1992), pp. 2-30--2-32 and 5-90.
+        let high_level_event_aware = ppc_app
+            .apple_events
+            .apple_event_launch_state
+            .is_high_level_event_aware();
+        ppc_app
+            .apple_events
+            .apple_event_launch_state
+            .reset_for_launch(high_level_event_aware);
+        self.process_context
+            .reset_apple_event_launch_state_for_launch(high_level_event_aware);
 
         self.bus.detach_guest_address_space();
         self.adopt_ppc_process_memory_image(&mut ppc_app);
@@ -12573,7 +12592,10 @@ mod tests {
         let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
         let unaware_app = runner.load_app(&unaware_fork).expect("load unaware app");
         runner.init_app(&unaware_app);
-        assert!(!runner.dispatcher.application_high_level_event_aware);
+        assert!(!runner
+            .dispatcher
+            .apple_event_launch_state
+            .is_high_level_event_aware());
 
         let aware_size = size_resource_bytes(
             ApplicationSizeResource::HIGH_LEVEL_EVENT_AWARE,
@@ -12587,7 +12609,10 @@ mod tests {
         let aware_fork = ResourceFork::parse(&aware_fork_bytes).expect("parse aware app fork");
         let aware_app = runner.load_app(&aware_fork).expect("load aware app");
         runner.init_app(&aware_app);
-        assert!(runner.dispatcher.application_high_level_event_aware);
+        assert!(runner
+            .dispatcher
+            .apple_event_launch_state
+            .is_high_level_event_aware());
     }
 
     #[test]
@@ -20915,7 +20940,7 @@ mod tests {
             "the parked sleep keeps a write guard armed across the frontend boundary"
         );
 
-        runner.dispatcher.sent_open_app_event = true;
+        runner.dispatcher.set_sent_open_app_event_for_test(true);
         assert!(runner.try_resume_proven_idle_cycle(Some(110)));
         assert_eq!(runner.dispatcher.tick_count, 110);
         assert_eq!(runner.bus.read_long(sp), 100);
@@ -21555,7 +21580,7 @@ mod tests {
         runner.bus.write_word(flag_base + 48, 0);
         runner.bus.write_long(0x016A, 100);
         runner.dispatcher.tick_count = 100;
-        runner.dispatcher.sent_open_app_event = true;
+        runner.dispatcher.set_sent_open_app_event_for_test(true);
 
         let (_, running) = runner.run_steps_internal(1_000, Some(100), 0, true, false, false);
         assert!(running);
@@ -21583,7 +21608,7 @@ mod tests {
         runner.cpu.write_reg(Register::A7, sp);
         runner.bus.write_long(0x016A, 100);
         runner.dispatcher.tick_count = 100;
-        runner.dispatcher.sent_open_app_event = true;
+        runner.dispatcher.set_sent_open_app_event_for_test(true);
 
         runner.park_proven_idle_cycle(trap_pc, 103);
         assert!(!runner.try_resume_proven_idle_cycle(Some(110)));
@@ -23362,7 +23387,7 @@ mod tests {
         runner.cpu.write_reg(Register::A7, 0x007F_FFC0);
         runner.bus.write_long(0x016A, 0);
         runner.bus.write_word(result_ptr, 0);
-        runner.dispatcher.sent_open_app_event = true;
+        runner.dispatcher.set_sent_open_app_event_for_test(true);
         runner
             .dispatcher
             .write_event_record(&mut runner.bus, event_ptr, 0, 0, 0, 0, 0);
@@ -23404,7 +23429,7 @@ mod tests {
         let result_ptr = 0x0020_0020;
 
         runner.bus.write_word(result_ptr, 0);
-        runner.dispatcher.sent_open_app_event = true;
+        runner.dispatcher.set_sent_open_app_event_for_test(true);
         runner
             .dispatcher
             .write_event_record(&mut runner.bus, event_ptr, 0, 0, 0, 0, 0);
@@ -23441,7 +23466,7 @@ mod tests {
 
         runner.set_mouse_position(20, 25);
         runner.bus.write_word(result_ptr, 0);
-        runner.dispatcher.sent_open_app_event = true;
+        runner.dispatcher.set_sent_open_app_event_for_test(true);
         runner
             .dispatcher
             .write_event_record(&mut runner.bus, event_ptr, 0, 0, 0, 0, 0);
@@ -23488,7 +23513,7 @@ mod tests {
         runner.dispatcher.tick_count = 100;
         runner.tick_budget = 0;
         runner.bus.write_word(result_ptr, 0xFFFF);
-        runner.dispatcher.sent_open_app_event = true;
+        runner.dispatcher.set_sent_open_app_event_for_test(true);
         runner.dispatcher.write_event_record(
             &mut runner.bus,
             event_ptr,
@@ -23551,7 +23576,7 @@ mod tests {
         let interrupted_sp = 0x007F_FFC0;
 
         runner.bus.write_word(result_ptr, 0);
-        runner.dispatcher.sent_open_app_event = true;
+        runner.dispatcher.set_sent_open_app_event_for_test(true);
         runner
             .dispatcher
             .write_event_record(&mut runner.bus, event_ptr, 0, 0, 0, 0, 0);
@@ -23608,7 +23633,7 @@ mod tests {
         runner.cpu.write_reg(Register::PC, stale_pc);
         runner.cpu.write_reg(Register::A7, parked_sp);
         runner.bus.write_word(result_ptr, 0xA582);
-        runner.dispatcher.sent_open_app_event = true;
+        runner.dispatcher.set_sent_open_app_event_for_test(true);
         runner
             .dispatcher
             .write_event_record(&mut runner.bus, event_ptr, 0, 0, 0, 0, 0);

--- a/src/trap/dialog.rs
+++ b/src/trap/dialog.rs
@@ -27256,7 +27256,7 @@ mod tests {
                 ..DialogItem::default()
             }],
         );
-        disp.sent_open_app_event = true;
+        disp.set_sent_open_app_event_for_test(true);
     }
 
     fn seed_retained_modal_dialog(

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -18,7 +18,7 @@ use crate::process_context::{
     ProcessKeyRepeatState, ProcessLoadedResources, ProcessResourceFileMap,
     ProcessResourceManagerState, ProcessWorkingDirectory,
     ProcessVfsDirectory, ProcessVfsMetadata, ProcessVfsVolumeRecord,
-    SharedProcessAppleEventHandlers,
+    SharedProcessAppleEventHandlers, SharedProcessAppleEventLaunchState,
     SharedProcessControlManager, SharedProcessCursorState, SharedProcessDialogText,
     SharedProcessEventQueue, SharedProcessFileSystem, SharedProcessInputState,
     SharedProcessListManager, SharedProcessMemoryManager, SharedProcessMenuTracking,
@@ -1743,6 +1743,8 @@ pub struct TrapDispatcher {
     pub(crate) segment_map: HashMap<i16, u32>,
     /// Process-owned application and system AppleEvent dispatch tables.
     pub(crate) ae_handlers: SharedProcessAppleEventHandlers,
+    /// Process-owned launch awareness and one-shot synthetic OAPP state.
+    pub(crate) apple_event_launch_state: SharedProcessAppleEventLaunchState,
     /// Synthetic AppleEvent descriptors currently visible to guest
     /// handlers. Key is the guest address of the AEDesc record.
     pub(crate) ae_events: HashMap<u32, SyntheticAppleEvent>,
@@ -1878,8 +1880,8 @@ pub struct TrapDispatcher {
     pub(crate) saved_draw_old_regions: HashMap<u32, DrawOldState>,
     /// Whether the registered `kAEOpenApplication` handler has already
     /// been fired via an `AEProcessAppleEvent` dispatch. Distinct from
-    /// `sent_open_app_event` (which tracks the synthetic OAPP queued
-    /// for `WaitNextEvent` delivery): an app may call
+    /// the process launch state's one-shot bit (which tracks the synthetic
+    /// OAPP queued for `WaitNextEvent` delivery): an app may call
     /// `AEProcessAppleEvent` directly without ever pumping events
     /// through WNE, and vice versa, so the two state bits cannot
     /// share a flag.
@@ -2306,15 +2308,6 @@ pub struct TrapDispatcher {
     /// One-shot update events recovered after FlushEvents drops queue entries
     /// while the Window Manager update region remains dirty.
     pub(crate) flushed_update_events: VecDeque<QueuedEvent>,
-    /// Whether the synthetic kAEOpenApplication event has been delivered.
-    /// On a real Mac, the Finder sends this Apple Event at launch.
-    /// Macintosh Toolbox Essentials 1992, p. 5-90
-    pub(crate) sent_open_app_event: bool,
-    /// Whether the application's `'SIZE'` resource declares
-    /// `isHighLevelEventAware`. The Process Manager defaults this capability
-    /// to false when the resource or flag is absent.
-    /// Macintosh Toolbox Essentials 1992, pp. 2-30 to 2-32.
-    pub(crate) application_high_level_event_aware: bool,
     /// Full trap word currently being dispatched. Some OS traps share the
     /// low 8-bit trap number and require bit 8 to distinguish variants.
     pub(crate) current_trap_word: u16,
@@ -2864,6 +2857,7 @@ impl TrapDispatcher {
         context.attach_native_menu_selection(&mut self.pending_native_menu_selection);
         context.attach_guest_calls(&mut self.guest_calls);
         context.attach_apple_event_handlers(&mut self.ae_handlers);
+        context.attach_apple_event_launch_state(&mut self.apple_event_launch_state);
     }
 
     pub(crate) fn process_memory_manager(&self) -> SharedProcessMemoryManager {
@@ -3289,7 +3283,8 @@ impl TrapDispatcher {
     /// already delivered so the next GetNextEvent/WaitNextEvent
     /// returns a real null event instead of the boot-time oapp stub.
     pub fn set_sent_open_app_event_for_test(&mut self, sent: bool) {
-        self.sent_open_app_event = sent;
+        self.apple_event_launch_state
+            .set_open_application_event_sent(sent);
     }
 
     /// Test-only: set the screen mode (base, rowBytes, width, height, depth).
@@ -3762,6 +3757,7 @@ impl TrapDispatcher {
             dialogs_drawn_by_app: std::collections::HashSet::new(),
             segment_map: HashMap::new(),
             ae_handlers: SharedProcessAppleEventHandlers::default(),
+            apple_event_launch_state: SharedProcessAppleEventLaunchState::default(),
             ae_events: HashMap::new(),
             ae_descriptors: HashMap::new(),
             ae_descriptor_backing: HashMap::new(),
@@ -3945,8 +3941,6 @@ impl TrapDispatcher {
             pending_modal_dialog_mouse_up: false,
             pending_modal_dialog_mouse_down: None,
             flushed_update_events: VecDeque::new(),
-            sent_open_app_event: false,
-            application_high_level_event_aware: false,
             current_trap_word: 0,
             current_trap_operation: 0,
             current_trap_adapter: TrapAdapterId::Nonterminal,

--- a/src/trap/event.rs
+++ b/src/trap/event.rs
@@ -385,14 +385,12 @@ impl super::TrapDispatcher {
         // whose 'SIZE' resource declares isHighLevelEventAware. Applications
         // without that resource or flag default to false.
         // Macintosh Toolbox Essentials 1992, pp. 2-30 to 2-32 and 5-90.
-        if !self.application_high_level_event_aware
-            || self.sent_open_app_event
-            || (event_mask & Self::HIGH_LEVEL_EVENT_MASK) == 0
+        if (event_mask & Self::HIGH_LEVEL_EVENT_MASK) == 0
+            || !self.apple_event_launch_state.claim_open_application_event()
         {
             return;
         }
 
-        self.sent_open_app_event = true;
         self.event_queue.push_front(super::dispatch::QueuedEvent {
             what: Self::K_HIGH_LEVEL_EVENT,
             message: Self::K_CORE_EVENT_CLASS,
@@ -1409,7 +1407,7 @@ mod tests {
     #[test]
     fn held_key_generates_autokey_after_default_threshold() {
         let (mut disp, mut cpu, mut bus) = setup();
-        disp.sent_open_app_event = true;
+        disp.set_sent_open_app_event_for_test(true);
 
         disp.push_key_down(0x7D, 31); // Down Arrow
         let (what, message, _, _, _, has_event) =
@@ -1471,7 +1469,7 @@ mod tests {
     #[test]
     fn autokey_is_posted_when_ticks_advance_before_the_next_poll() {
         let (mut disp, mut cpu, mut bus) = setup();
-        disp.sent_open_app_event = true;
+        disp.set_sent_open_app_event_for_test(true);
 
         disp.push_key_down(0x00, b'a');
         let (_, _, _, _, _, has_event) = disp.dequeue_toolbox_event(&mut cpu, &mut bus, 0x0008);
@@ -1494,7 +1492,7 @@ mod tests {
     #[test]
     fn default_system_event_mask_suppresses_keyup_but_clears_keymap() {
         let (mut disp, mut cpu, mut bus) = setup();
-        disp.sent_open_app_event = true;
+        disp.set_sent_open_app_event_for_test(true);
 
         disp.push_key_down(0x24, 13);
         let (_, _, _, _, _, has_event) = disp.dequeue_toolbox_event(&mut cpu, &mut bus, 0x0008);
@@ -1543,7 +1541,7 @@ mod tests {
         // Event Manager emits one keyDown followed by timed autoKey records.
         // Inside Macintosh Volume I, I-246.
         let (mut disp, mut cpu, mut bus) = setup();
-        disp.sent_open_app_event = true;
+        disp.set_sent_open_app_event_for_test(true);
 
         disp.push_key_down(0x30, 9); // Tab
         let first_repeat_tick = disp.input_state.key_repeat.expect("Tab should arm autoKey").next_tick;
@@ -1567,7 +1565,7 @@ mod tests {
     #[test]
     fn event_avail_peeks_autokey_without_duplicating_it() {
         let (mut disp, mut cpu, mut bus) = setup();
-        disp.sent_open_app_event = true;
+        disp.set_sent_open_app_event_for_test(true);
 
         disp.push_key_down(0x7D, 31);
         let (_, _, _, _, _, has_event) = disp.dequeue_toolbox_event(&mut cpu, &mut bus, 0x0008);
@@ -1596,7 +1594,7 @@ mod tests {
     #[test]
     fn modifier_keys_update_keymap_without_generating_keyboard_events() {
         let (mut disp, mut cpu, mut bus) = setup();
-        disp.sent_open_app_event = true;
+        disp.set_sent_open_app_event_for_test(true);
 
         disp.push_key_down(0x38, 0); // Shift
         let (_, _, _, _, _, has_event) = disp.dequeue_toolbox_event(&mut cpu, &mut bus, 0x0008);
@@ -1621,7 +1619,7 @@ mod tests {
     #[test]
     fn caps_lock_latches_keymap_and_alpha_lock_until_second_press() {
         let (mut disp, mut cpu, mut bus) = setup();
-        disp.sent_open_app_event = true;
+        disp.set_sent_open_app_event_for_test(true);
 
         disp.push_key_down(0x39, 0);
         assert!(disp.key_is_down(0x39), "first press should latch Caps Lock");
@@ -1679,7 +1677,7 @@ mod tests {
     #[test]
     fn command_modifier_is_reported_on_following_character_event() {
         let (mut disp, mut cpu, mut bus) = setup();
-        disp.sent_open_app_event = true;
+        disp.set_sent_open_app_event_for_test(true);
 
         disp.push_key_down(0x37, 0); // Command
         disp.push_key_down(0x01, b's');

--- a/src/trap/menu.rs
+++ b/src/trap/menu.rs
@@ -10533,7 +10533,7 @@ mod tests {
     #[test]
     fn invalmenubar_defers_and_coalesces_one_draw_until_a_toolbox_event_scan() {
         let (mut disp, mut cpu, mut bus) = setup_with_port();
-        disp.sent_open_app_event = true;
+        disp.set_sent_open_app_event_for_test(true);
         disp.menu_bar_hidden = false;
         bus.write_word(crate::memory::globals::addr::MBAR_HEIGHT, 20);
         let (base, row_bytes, width, height, depth) = disp.get_screen_params();

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -17784,7 +17784,7 @@ mod tests {
     #[test]
     fn test_get_next_event_empty() {
         let (mut disp, mut cpu, mut bus) = setup();
-        disp.sent_open_app_event = true; // suppress synthetic oapp event
+        disp.set_sent_open_app_event_for_test(true); // suppress synthetic oapp event
         let sp = TEST_SP;
         // SP+0: event_ptr(4), SP+4: eventMask(2), SP+6: result(2)
         let event_ptr = 0x200000u32;
@@ -17805,7 +17805,7 @@ mod tests {
     #[test]
     fn test_get_next_event_with_event() {
         let (mut disp, mut cpu, mut bus) = setup();
-        disp.sent_open_app_event = true; // suppress synthetic oapp event
+        disp.set_sent_open_app_event_for_test(true); // suppress synthetic oapp event
         let sp = TEST_SP;
         let event_ptr = 0x200000u32;
         bus.write_long(sp, event_ptr);
@@ -17835,7 +17835,7 @@ mod tests {
     #[test]
     fn get_next_event_delivers_visible_window_update_after_flushevents_drops_queue_entry() {
         let (mut disp, mut cpu, mut bus) = setup();
-        disp.sent_open_app_event = true;
+        disp.set_sent_open_app_event_for_test(true);
 
         let bounds_rect_ptr = 0x300000u32;
         bus.write_word(bounds_rect_ptr, 40);
@@ -18135,7 +18135,7 @@ mod tests {
     #[test]
     fn test_get_next_event_mask_miss_returns_null_and_preserves_queue() {
         let (mut disp, mut cpu, mut bus) = setup();
-        disp.sent_open_app_event = true; // suppress synthetic oapp event
+        disp.set_sent_open_app_event_for_test(true); // suppress synthetic oapp event
         let sp = TEST_SP;
         let event_ptr = 0x200000u32;
         bus.write_long(sp, event_ptr);
@@ -18195,7 +18195,7 @@ mod tests {
         let (mut disp, mut cpu, mut bus) = setup();
         // Mark the synthetic kAEOpenApplication as already sent so this tests
         // the normal empty-queue path.
-        disp.sent_open_app_event = true;
+        disp.set_sent_open_app_event_for_test(true);
         let sp = TEST_SP;
         // SP+0: mouseRgn(4), SP+4: sleep(4), SP+8: event_ptr(4), SP+12: eventMask(2), SP+14: result(2)
         bus.write_long(sp, 0); // mouseRgn
@@ -18218,7 +18218,7 @@ mod tests {
     #[test]
     fn test_wait_next_event_zero_mask_takes_null_event_path() {
         let (mut disp, mut cpu, mut bus) = setup();
-        assert!(!disp.sent_open_app_event);
+        assert!(!disp.apple_event_launch_state.is_open_application_event_sent());
         let sp = TEST_SP;
         let event_ptr = 0x200000u32;
 
@@ -18236,14 +18236,14 @@ mod tests {
         assert_eq!(bus.read_word(sp + 14), 0);
         assert_eq!(cpu.read_reg(Register::A7), sp + 14);
         assert_eq!(bus.read_word(event_ptr), 0);
-        assert!(!disp.sent_open_app_event);
+        assert!(!disp.apple_event_launch_state.is_open_application_event_sent());
         assert_eq!(disp.pending_wait_sleep_ticks, 1);
     }
 
     #[test]
     fn wait_next_event_mouse_rgn_outside_returns_mouse_moved_os_event() {
         let (mut disp, mut cpu, mut bus) = setup();
-        disp.sent_open_app_event = true;
+        disp.set_sent_open_app_event_for_test(true);
         disp.input_state.mouse_pos = (50, 25);
         let sp = TEST_SP;
         let event_ptr = 0x200000u32;
@@ -18271,7 +18271,7 @@ mod tests {
     #[test]
     fn wait_next_event_mouse_rgn_inside_takes_null_sleep_path() {
         let (mut disp, mut cpu, mut bus) = setup();
-        disp.sent_open_app_event = true;
+        disp.set_sent_open_app_event_for_test(true);
         disp.input_state.mouse_pos = (20, 25);
         let sp = TEST_SP;
         let event_ptr = 0x200000u32;
@@ -18295,7 +18295,7 @@ mod tests {
     #[test]
     fn wait_next_event_empty_mouse_rgn_suppresses_mouse_moved_event() {
         let (mut disp, mut cpu, mut bus) = setup();
-        disp.sent_open_app_event = true;
+        disp.set_sent_open_app_event_for_test(true);
         disp.input_state.mouse_pos = (50, 25);
         let sp = TEST_SP;
         let event_ptr = 0x200000u32;
@@ -18319,7 +18319,7 @@ mod tests {
     #[test]
     fn wait_next_event_mouse_rgn_respects_event_mask() {
         let (mut disp, mut cpu, mut bus) = setup();
-        disp.sent_open_app_event = true;
+        disp.set_sent_open_app_event_for_test(true);
         disp.input_state.mouse_pos = (50, 25);
         let sp = TEST_SP;
         let event_ptr = 0x200000u32;
@@ -18344,8 +18344,8 @@ mod tests {
     #[test]
     fn test_wait_next_event_synthesizes_open_app() {
         let (mut disp, mut cpu, mut bus) = setup();
-        disp.application_high_level_event_aware = true;
-        assert!(!disp.sent_open_app_event);
+        disp.apple_event_launch_state.set_high_level_event_aware(true);
+        assert!(!disp.apple_event_launch_state.is_open_application_event_sent());
         let sp = TEST_SP;
         let event_ptr = 0x200000u32;
         bus.write_long(sp, 0); // mouseRgn
@@ -18368,7 +18368,7 @@ mod tests {
         assert_eq!(bus.read_word(event_ptr + 10), 0x6F61); // where.v
         assert_eq!(bus.read_word(event_ptr + 12), 0x7070); // where.h
                                                            // Flag should be set
-        assert!(disp.sent_open_app_event);
+        assert!(disp.apple_event_launch_state.is_open_application_event_sent());
 
         // Second call should NOT return synthetic event
         cpu.write_reg(Register::A7, sp);
@@ -18399,14 +18399,14 @@ mod tests {
         assert!(result.unwrap().is_ok());
         assert_eq!(bus.read_word(sp + 14), 0);
         assert_eq!(bus.read_word(event_ptr), 0);
-        assert!(!disp.sent_open_app_event);
+        assert!(!disp.apple_event_launch_state.is_open_application_event_sent());
     }
 
     // EventAvail ($A971) — with event (peeks, does not remove)
     #[test]
     fn test_event_avail_with_event() {
         let (mut disp, mut cpu, mut bus) = setup();
-        disp.sent_open_app_event = true; // suppress synthetic oapp event
+        disp.set_sent_open_app_event_for_test(true); // suppress synthetic oapp event
         let sp = TEST_SP;
         let event_ptr = 0x200000u32;
         // SP+0: event_ptr(4), SP+4: eventMask(2), SP+6: result(2)
@@ -18438,7 +18438,7 @@ mod tests {
     #[test]
     fn test_event_avail_empty() {
         let (mut disp, mut cpu, mut bus) = setup();
-        disp.sent_open_app_event = true; // suppress synthetic oapp event
+        disp.set_sent_open_app_event_for_test(true); // suppress synthetic oapp event
         let sp = TEST_SP;
         let event_ptr = 0x200000u32;
         bus.write_long(sp, event_ptr);
@@ -18461,7 +18461,7 @@ mod tests {
     #[test]
     fn test_event_avail_mask_miss_returns_null_and_preserves_queue() {
         let (mut disp, mut cpu, mut bus) = setup();
-        disp.sent_open_app_event = true; // suppress synthetic oapp event
+        disp.set_sent_open_app_event_for_test(true); // suppress synthetic oapp event
         let sp = TEST_SP;
         let event_ptr = 0x200000u32;
         bus.write_long(sp, event_ptr);
@@ -18491,7 +18491,7 @@ mod tests {
     #[test]
     fn test_event_avail_then_get_next_event_returns_same_event() {
         let (mut disp, mut cpu, mut bus) = setup();
-        disp.sent_open_app_event = true; // suppress synthetic oapp event
+        disp.set_sent_open_app_event_for_test(true); // suppress synthetic oapp event
         let sp = TEST_SP;
         let event_ptr = 0x200000u32;
         bus.write_long(sp, event_ptr);
@@ -18531,7 +18531,7 @@ mod tests {
     #[test]
     fn test_event_avail_synthesizes_open_app_without_consuming() {
         let (mut disp, mut cpu, mut bus) = setup();
-        disp.application_high_level_event_aware = true;
+        disp.apple_event_launch_state.set_high_level_event_aware(true);
         let sp = TEST_SP;
         let event_ptr = 0x200000u32;
         bus.write_long(sp, event_ptr);
@@ -18552,7 +18552,7 @@ mod tests {
     #[test]
     fn test_get_next_event_synthesizes_open_app() {
         let (mut disp, mut cpu, mut bus) = setup();
-        disp.application_high_level_event_aware = true;
+        disp.apple_event_launch_state.set_high_level_event_aware(true);
         let sp = TEST_SP;
         let event_ptr = 0x200000u32;
         bus.write_long(sp, event_ptr);


### PR DESCRIPTION
## Summary

- make high-level-event awareness and one-shot open-application delivery process-owned
- attach classic and native Event Manager gateways to the same launch state
- preserve adapter-local handlers, descriptors, pending dispatches, and continuation frames
- prevent duplicate launch delivery across native-first, classic-first, and EventAvail polling

## Root cause

The classic and native adapters independently tracked the application SIZE capability and whether the synthetic open-application event had been sent. Once both adapters shared one event queue, either gateway could consume its own one-shot flag while leaving the other gateway eligible to manufacture the event again.

## Validation

- `cargo test --locked --lib` (4,879 passed; 0 failed; 3 ignored)
- `cargo test --locked --lib attached_event_launch_state -- --nocapture`
- `cargo test --locked --lib apple_event -- --nocapture`
- `cargo check --all-features --all-targets --locked`
- `RUSTDOCFLAGS='-D warnings -D rustdoc::private_intra_doc_links' cargo doc --all-features --locked --no-deps --document-private-items`
- `git diff --check`

Closes #1322