### PR TITLE
refactor(events): make the process tick clock canonical

### DIFF
--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -84,7 +84,7 @@ use crate::process_context::{
     DEFAULT_QUICKDRAW_HILITE_COLOR, SharedProcessMenuTracking,
     SharedProcessMixedModeM68kState,
     SharedProcessQuickDrawHiliteColors, SharedProcessQuickDrawOpColors,
-    SharedProcessQuickDrawPixelStates,
+    SharedProcessQuickDrawPixelStates, SharedProcessTickState,
     SharedProcessTimerTasks, SharedProcessValue, SharedProcessVblTasks,
 };
 use crate::quickdraw::fonts::heuristics::{
@@ -3451,7 +3451,14 @@ pub struct PpcLoadedApp {
     pub stack_base: u32,
     pub stack_size: u32,
     pub stack_pointer: u32,
+    /// Guest-visible projection of the process-owned wrapping Macintosh tick
+    /// counter. Keep this field as a `u32` for loader/test compatibility; the
+    /// private `tick_state` is authoritative once the adapter is attached.
+    /// Inside Macintosh Volume I (1985), p. I-260; Volume II (1985),
+    /// pp. II-349--II-350.
     pub tick_count: u32,
+    pub(crate) tick_state: SharedProcessTickState,
+    pub(crate) last_projected_tick: u32,
     pub clock_cycles_per_tick: u32,
     pub clock_cycle_phase: u32,
     pub native_exception_handler: u32,
@@ -4035,6 +4042,13 @@ impl PpcLoadedApp {
         context.attach_file_system(&mut self.process_file_system);
         self.process_file_system.publish_native_vfs_catalogue();
         context.attach_sound_manager(&mut self.sound.manager);
+        // Preserve the old public `tick_count` field as an input projection
+        // at adapter boundaries, then make the process handle authoritative.
+        // A direct public write is intentional fixture/loader input; ordinary
+        // execution reads and publishes through `tick_state` below.
+        self.import_public_tick_projection();
+        context.attach_tick_state(&mut self.tick_state);
+        self.refresh_tick_projection();
         context.attach_callback_tasks(
             &mut self.timer_tasks,
             &mut self.vbl_tasks,
@@ -4180,11 +4194,40 @@ impl PpcLoadedApp {
     }
 
     pub fn set_tick_count(&mut self, tick_count: u32) {
-        self.tick_count = tick_count;
+        self.import_public_tick_projection();
+        self.tick_state.set_tick(tick_count);
+        self.refresh_tick_projection();
         self.callback_scheduling.current_subtick = self
             .callback_scheduling
             .current_subtick
             .max(u64::from(tick_count) * 1_000_000);
+    }
+
+    fn import_public_tick_projection(&mut self) {
+        if self.tick_count != self.last_projected_tick {
+            self.tick_state.set_tick(self.tick_count);
+            self.last_projected_tick = self.tick_count;
+        }
+    }
+
+    fn refresh_tick_projection(&mut self) -> u32 {
+        let tick = self.tick_state.current_tick();
+        self.tick_count = tick;
+        self.last_projected_tick = tick;
+        tick
+    }
+
+    fn current_tick(&mut self) -> u32 {
+        self.import_public_tick_projection();
+        self.refresh_tick_projection()
+    }
+
+    pub(crate) fn publish_tick(&mut self, candidate: u32) -> u32 {
+        self.import_public_tick_projection();
+        let tick = self.tick_state.publish_tick(candidate);
+        self.tick_count = tick;
+        self.last_projected_tick = tick;
+        tick
     }
 
     pub fn set_clock_cycle_timing(&mut self, cycles_per_tick: u32, cycle_phase: u32) {
@@ -6848,7 +6891,7 @@ impl PpcLoadedApp {
         }
         for tick_offset in 0..elapsed_ticks {
             let current_tick = start_tick.wrapping_add(tick_offset).wrapping_add(1);
-            self.tick_count = current_tick;
+            let current_tick = self.publish_tick(current_tick);
             self.callback_scheduling.current_subtick = u64::from(current_tick) * 1_000_000;
             loop {
                 if probes.len() >= max_callbacks {
@@ -6964,7 +7007,7 @@ impl PpcLoadedApp {
                 callback,
                 callback_entry: target.entry,
                 callback_rtoc: target.rtoc,
-                tick: self.tick_count,
+                tick: self.current_tick(),
                 cycles,
                 end_pc,
                 end_sp,
@@ -7035,7 +7078,10 @@ impl PpcLoadedApp {
             return probes;
         }
         for tick_offset in 0..elapsed_ticks {
-            self.tick_count = start_tick.wrapping_add(tick_offset).wrapping_add(1);
+            let current_tick = self.publish_tick(
+                start_tick.wrapping_add(tick_offset).wrapping_add(1),
+            );
+            self.callback_scheduling.current_subtick = u64::from(current_tick) * 1_000_000;
             let tasks = (*self.vbl_tasks).clone();
             for task in tasks {
                 if task.architecture != CallbackTaskArchitecture::PowerPc {
@@ -7153,7 +7199,7 @@ impl PpcLoadedApp {
                 callback,
                 callback_entry: target.entry,
                 callback_rtoc: target.rtoc,
-                tick: self.tick_count,
+                tick: self.current_tick(),
                 cycles,
                 end_pc,
                 end_sp,
@@ -7329,7 +7375,8 @@ impl PpcLoadedApp {
         let input = self.current_input_snapshot();
         let mut event_queue = std::mem::take(&mut self.event_queue);
         let process_memory_manager = process_memory_manager.native_mut();
-        let tick_count = self.tick_count;
+        self.current_tick();
+        let tick_state = self.tick_state.shared_handle();
         let clock_cycles_per_tick = self.clock_cycles_per_tick;
         let clock_cycle_phase = self.clock_cycle_phase;
         let mut process_file_system = self.process_file_system.shared_handle();
@@ -7503,8 +7550,14 @@ impl PpcLoadedApp {
                     return PpcImportAction::Halt;
                 }
                 last_import_index = Some(index);
+                // A Mixed Mode callback can advance process time while the
+                // native slice is suspended. Refresh the whole-tick baseline
+                // before every import so TickCount and EventRecord.when use
+                // the same canonical process clock while retaining this
+                // slice's native cycle phase.
+                let process_tick = tick_state.current_tick();
                 let mut import_tick_count = ppc_virtual_tick_count(
-                    tick_count,
+                    process_tick,
                     clock_cycles_per_tick,
                     clock_cycle_phase,
                     elapsed,
@@ -7660,7 +7713,7 @@ impl PpcLoadedApp {
                             cpu,
                             memory,
                             ppc_virtual_microseconds(
-                                tick_count,
+                                process_tick,
                                 clock_cycles_per_tick,
                                 clock_cycle_phase,
                                 elapsed,
@@ -7860,7 +7913,7 @@ impl PpcLoadedApp {
                     cpu,
                     memory,
                     ppc_virtual_microseconds(
-                        tick_count,
+                        process_tick,
                         clock_cycles_per_tick,
                         clock_cycle_phase,
                         elapsed,
@@ -8313,7 +8366,12 @@ impl PpcLoadedApp {
         };
         drop(fetch_observer);
 
-        self.tick_count = tick_count;
+        // `tick_count` is only the execution-slice baseline used to produce
+        // virtual PPC clock reads. Do not write it back here: a nested Mixed
+        // Mode callback may have advanced the process-owned clock while this
+        // slice was running, and restoring the stale baseline would regress
+        // both adapters. The runner publishes elapsed ticks at its boundary.
+        self.refresh_tick_projection();
         self.native_exception_handler = native_exception_handler.get();
         self.native_exception_stack = native_exception_stack;
         self.stdc_qsort_stack = stdc_qsort_stack;
@@ -13005,6 +13063,8 @@ fn load_pef_application_with_config_and_optional_system_reservation(
         stack_size,
         stack_pointer,
         tick_count: 0,
+        tick_state: SharedProcessTickState::default(),
+        last_projected_tick: 0,
         clock_cycles_per_tick: 1,
         clock_cycle_phase: 0,
         native_exception_handler: 0,

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -1265,6 +1265,12 @@ pub struct SharedProcessValue<T>(Rc<UnsafeCell<T>>);
 pub(crate) type SharedProcessResourceManager = SharedProcessValue<ProcessResourceManagerState>;
 pub(crate) type SharedProcessSoundManager = SharedProcessValue<SoundManager>;
 pub(crate) type SharedProcessCursorState = SharedProcessValue<ProcessCursorState>;
+/// Canonical wrapping Macintosh tick counter shared by both CPU adapters.
+///
+/// The low-memory `Ticks` global is only a guest-memory projection of this
+/// process value. Inside Macintosh Volume I (1985), p. I-260; Volume II
+/// (1985), pp. II-349--II-350.
+pub(crate) type SharedProcessTickState = SharedProcessValue<u32>;
 pub(crate) type SharedProcessEventQueue = SharedProcessValue<EventQueue>;
 pub(crate) type SharedProcessMenuTracking = SharedProcessValue<Option<ProcessMenuTrackingState>>;
 pub(crate) type SharedProcessWindowList = SharedProcessValue<Vec<u32>>;
@@ -1522,6 +1528,52 @@ impl<T> SharedProcessValue<T> {
     #[cfg(test)]
     pub(crate) fn ptr_eq(&self, other: &Self) -> bool {
         Rc::ptr_eq(&self.0, &other.0)
+    }
+}
+
+impl SharedProcessValue<u32> {
+    /// Read the process clock without exposing a reference into the
+    /// `UnsafeCell`-backed value. A Mixed Mode callback may enter the other
+    /// adapter after this operation returns.
+    pub(crate) fn current_tick(&self) -> u32 {
+        // SAFETY: attached adapters are serialized by the owning runner and
+        // this method returns a copied scalar rather than a reference.
+        unsafe { *self.0.get() }
+    }
+
+    /// Set the process clock for an explicit runner/launch synchronization.
+    /// Ordinary native slice teardown must use `publish_tick` so a stale
+    /// snapshot cannot regress a callback's newer value.
+    pub(crate) fn set_tick(&self, tick: u32) {
+        // SAFETY: see `current_tick`.
+        unsafe { *self.0.get() = tick }
+    }
+
+    /// Publish a candidate clock value without allowing an older native
+    /// snapshot to move process time backwards. Wrapping subtraction follows
+    /// the Event Manager's documented tick arithmetic: a candidate less than
+    /// half the u32 space ahead is newer, including MAX-to-zero wraparound.
+    /// Inside Macintosh Volume I (1985), p. I-260.
+    pub(crate) fn publish_tick(&self, candidate: u32) -> u32 {
+        // SAFETY: see `current_tick`.
+        unsafe {
+            let current = &mut *self.0.get();
+            let delta = candidate.wrapping_sub(*current);
+            if delta != 0 && delta < 0x8000_0000 {
+                *current = candidate;
+            }
+            *current
+        }
+    }
+
+    /// Advance process time by a wrapping number of ticks.
+    pub(crate) fn advance_ticks(&self, ticks: u32) -> u32 {
+        // SAFETY: see `current_tick`.
+        unsafe {
+            let current = &mut *self.0.get();
+            *current = current.wrapping_add(ticks);
+            *current
+        }
     }
 }
 
@@ -5794,6 +5846,7 @@ impl ProcessNativeMemoryManager {
 pub(crate) struct ProcessContext {
     memory: Vec<ProcessMemoryRegion>,
     memory_manager: SharedProcessMemoryManager,
+    tick_state: SharedProcessTickState,
     event_queue: SharedProcessEventQueue,
     input_state: SharedProcessInputState,
     menu_tracking: SharedProcessMenuTracking,
@@ -5831,6 +5884,7 @@ impl Default for ProcessContext {
         Self {
             memory: Vec::new(),
             memory_manager: SharedProcessMemoryManager::default(),
+            tick_state: SharedProcessTickState::default(),
             event_queue: SharedProcessEventQueue::default(),
             input_state: SharedProcessInputState::default(),
             menu_tracking: SharedProcessMenuTracking::default(),
@@ -5936,6 +5990,15 @@ impl ProcessContext {
 
     pub(crate) fn attach_sound_manager(&self, adapter: &mut SharedProcessSoundManager) {
         adapter.attach_to(&self.sound_manager, SoundManager::is_pristine);
+    }
+
+    /// Attach an ISA adapter to the process-wide wrapping Macintosh tick
+    /// counter. A nonzero detached adapter may seed a pristine process value;
+    /// two conflicting populated values are rejected before attachment.
+    /// Inside Macintosh Volume I (1985), p. I-260; Volume II (1985),
+    /// pp. II-349--II-350.
+    pub(crate) fn attach_tick_state(&self, adapter: &mut SharedProcessTickState) {
+        adapter.attach_copy_to(&self.tick_state, |tick| *tick == 0);
     }
 
     pub(crate) fn attach_callback_tasks(
@@ -8786,6 +8849,33 @@ mod tests {
         assert!(playback_snapshot.double_buffer_playbacks[0].active);
         assert!(playback_snapshot.double_buffer_playbacks[0].host_buffer_loaded);
         assert_eq!(playback_snapshot.pending_process_doublebacks.len(), 1);
+    }
+
+    #[test]
+    fn attached_tick_states_share_wrapping_clock_while_clones_detach() {
+        let context = ProcessContext::default();
+        let mut classic = SharedProcessTickState::from_value(41);
+        let mut native = SharedProcessTickState::default();
+
+        context.attach_tick_state(&mut classic);
+        context.attach_tick_state(&mut native);
+        let detached = native.clone();
+
+        assert!(classic.ptr_eq(&native));
+        assert_eq!(classic.current_tick(), 41);
+        native.advance_ticks(2);
+        assert_eq!(classic.current_tick(), 43);
+        assert_eq!(detached.current_tick(), 41);
+
+        // A stale native slice may publish its old snapshot after a nested
+        // callback has advanced the process clock. It must be ignored.
+        native.publish_tick(42);
+        assert_eq!(classic.current_tick(), 43);
+
+        // Wrapping subtraction recognizes MAX -> zero as forward progress.
+        native.set_tick(u32::MAX);
+        assert_eq!(native.publish_tick(0), 0);
+        assert_eq!(classic.current_tick(), 0);
     }
 
     #[test]

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -1888,7 +1888,7 @@ impl FixtureRunner {
     }
 
     pub fn guest_tick(&self) -> u32 {
-        self.bus.read_long(0x016A)
+        self.dispatcher.current_tick()
     }
 
     pub fn host_now(&self) -> Instant {
@@ -3280,7 +3280,7 @@ impl FixtureRunner {
         replacement.bus.write_long(addr::TICKS, launch_tick);
         replacement.bus.write_long(addr::TIME, launch_time);
         replacement.bus.write_long(addr::RND_SEED, launch_rnd_seed);
-        replacement.dispatcher.tick_count = launch_tick;
+        replacement.dispatcher.set_tick_count(launch_tick);
         if let Some(ppc_app) = replacement.ppc_app.as_mut() {
             ppc_app.set_tick_count(launch_tick);
         }
@@ -3530,7 +3530,7 @@ impl FixtureRunner {
                 DEFAULT_LAUNCH_TICKS.max(floor)
             });
         self.bus.write_long(addr::TICKS, launch_ticks);
-        self.dispatcher.tick_count = launch_ticks;
+        self.dispatcher.set_tick_count(launch_ticks);
         let time = self
             .app_start_time
             .unwrap_or_else(current_mac_epoch_seconds);
@@ -3920,7 +3920,7 @@ impl FixtureRunner {
         self.bus.write_long(addr::MEM_TOP, ram_size);
         let launch_ticks = self.launch_ticks_override.unwrap_or(0);
         self.bus.write_long(addr::TICKS, launch_ticks);
-        self.dispatcher.tick_count = launch_ticks;
+        self.dispatcher.set_tick_count(launch_ticks);
         ppc_app.set_tick_count(launch_ticks);
         let time = self
             .app_start_time
@@ -4318,11 +4318,11 @@ impl FixtureRunner {
         let target_tick = captured_tick.wrapping_add(1);
         match self.advance_until_tick(target_tick, tick_cap) {
             AdvanceResult::CapHit => {
-                self.bus.write_long(sp, self.dispatcher.tick_count);
+                self.bus.write_long(sp, self.dispatcher.current_tick());
                 true
             }
             AdvanceResult::Advanced => {
-                self.bus.write_long(sp, self.dispatcher.tick_count);
+                self.bus.write_long(sp, self.dispatcher.current_tick());
                 false
             }
             AdvanceResult::Interrupted | AdvanceResult::TooFar => false,
@@ -4407,11 +4407,11 @@ impl FixtureRunner {
         let target_tick = base_tick.wrapping_add(delay as u32);
         match self.advance_until_tick(target_tick, tick_cap) {
             AdvanceResult::CapHit => {
-                self.bus.write_long(sp, self.dispatcher.tick_count);
+                self.bus.write_long(sp, self.dispatcher.current_tick());
                 true
             }
             AdvanceResult::Advanced => {
-                self.bus.write_long(sp, self.dispatcher.tick_count);
+                self.bus.write_long(sp, self.dispatcher.current_tick());
                 false
             }
             AdvanceResult::Interrupted | AdvanceResult::TooFar => false,
@@ -4484,7 +4484,7 @@ impl FixtureRunner {
         self.idle_cycle_probe = None;
         self.idle_cycle_last_seen = None;
 
-        let tick = self.dispatcher.tick_count;
+        let tick = self.dispatcher.current_tick();
         self.idle_cycle_sleep = Some(ProvenIdleCycleSleep {
             trap_pc,
             wake_tick,
@@ -4511,7 +4511,11 @@ impl FixtureRunner {
         let memory_unchanged = self.bus.finish_write_probe_unchanged();
         let cpu_unchanged = sleep.cpu == CpuArchitecturalSnapshot::capture(&self.cpu.core);
         let tick_unchanged =
-            self.dispatcher.tick_count == sleep.tick && self.bus.read_long(0x016A) == sleep.tick;
+            self.dispatcher.current_tick() == sleep.tick
+                // The canonical process clock owns the value, while this
+                // second check verifies its low-memory guest projection did
+                // not diverge during the idle probe.
+                && self.bus.read_long(0x016A) == sleep.tick;
         let host_unchanged = sleep.host == IdleCycleHostSnapshot::capture(&self.dispatcher);
         let can_observe_events = self.active_interrupt_callback.is_none()
             && self.dispatcher.input_state.key_repeat.is_none()
@@ -4607,7 +4611,7 @@ impl FixtureRunner {
         wake_tick: u32,
         tick_cap: Option<u32>,
     ) -> bool {
-        let tick = self.dispatcher.tick_count;
+        let tick = self.dispatcher.current_tick();
         if self.idle_cycle_site_is_busy(trap_pc, tick) {
             // This site spent its probe budget (or overflowed a journal)
             // this tick: it is working between polls, not waiting.
@@ -4777,12 +4781,12 @@ impl FixtureRunner {
             // anchor across other permitted polling sites. A nested event
             // loop may alternate A → B → A; replacing the anchor at B would
             // prevent the complete A-to-A cycle from ever being observed.
-            if anchor_pc != trap_pc && anchor_tick == self.dispatcher.tick_count {
+            if anchor_pc != trap_pc && anchor_tick == self.dispatcher.current_tick() {
                 return false;
             }
         }
 
-        let wake_tick = self.dispatcher.tick_count.wrapping_add(1);
+        let wake_tick = self.dispatcher.current_tick().wrapping_add(1);
         self.try_exact_idle_cycle_fastfwd(trap_pc, wake_tick, tick_cap)
     }
 
@@ -4876,11 +4880,11 @@ impl FixtureRunner {
 
         match self.advance_until_tick(exit_tick, tick_cap) {
             AdvanceResult::CapHit => {
-                self.bus.write_long(sp, self.dispatcher.tick_count);
+                self.bus.write_long(sp, self.dispatcher.current_tick());
                 true
             }
             AdvanceResult::Advanced => {
-                self.bus.write_long(sp, self.dispatcher.tick_count);
+                self.bus.write_long(sp, self.dispatcher.current_tick());
                 false
             }
             AdvanceResult::Interrupted | AdvanceResult::TooFar => false,
@@ -4932,12 +4936,12 @@ impl FixtureRunner {
                 // Refresh it so the resumed comparison observes the same tick
                 // that a real busy loop would obtain on its next iteration.
                 let sp = self.cpu.core.a(7);
-                self.bus.write_long(sp, self.dispatcher.tick_count);
+                self.bus.write_long(sp, self.dispatcher.current_tick());
                 true
             }
             AdvanceResult::Advanced => {
                 let sp = self.cpu.core.a(7);
-                self.bus.write_long(sp, self.dispatcher.tick_count);
+                self.bus.write_long(sp, self.dispatcher.current_tick());
                 false
             }
             AdvanceResult::Interrupted | AdvanceResult::TooFar => false,
@@ -4993,7 +4997,7 @@ impl FixtureRunner {
 
         // Synthesise exit: Dn = final_tick - imm = Dm (by definition of
         // the fall-through condition), A7 += 4, PC past BHI.S.
-        let final_tick = self.dispatcher.tick_count;
+        let final_tick = self.dispatcher.current_tick();
         let sp = self.cpu.core.a(7);
         self.cpu.core.set_a(7, sp.wrapping_add(4));
         self.cpu.core.set_d(dn, final_tick.wrapping_sub(imm));
@@ -5077,7 +5081,7 @@ impl FixtureRunner {
 
         // Synthesise exit: Dn = final_tick, A7 += 4, PC past the branch.
         // body_size: MOVE.L (2) + CMP.L w/d16 (4) + Bcc.S (2) = 8 bytes.
-        let final_tick = self.dispatcher.tick_count;
+        let final_tick = self.dispatcher.current_tick();
         let sp = self.cpu.core.a(7);
         self.cpu.core.set_a(7, sp.wrapping_add(4));
         self.cpu.core.set_d(dn, final_tick);
@@ -5125,7 +5129,7 @@ impl FixtureRunner {
             AdvanceResult::Advanced => {}
         }
 
-        let final_tick = self.dispatcher.tick_count;
+        let final_tick = self.dispatcher.current_tick();
         let sp = self.cpu.core.a(7);
         self.cpu.core.set_a(7, sp.wrapping_add(4));
         self.cpu.core.set_d(dn, final_tick);
@@ -5139,14 +5143,14 @@ impl FixtureRunner {
     /// Shared helper: advance guest ticks until `target_tick` is
     /// reached.
     fn advance_until_tick(&mut self, target_tick: u32, tick_cap: Option<u32>) -> AdvanceResult {
-        let current_tick = self.dispatcher.tick_count;
+        let current_tick = self.dispatcher.current_tick();
         let ticks_to_advance = target_tick.wrapping_sub(current_tick);
         if ticks_to_advance > SPIN_FASTFWD_MAX_TICKS {
             return AdvanceResult::TooFar;
         }
         for _ in 0..ticks_to_advance {
             if let Some(cap) = tick_cap {
-                if self.bus.read_long(0x016A) >= cap {
+                if self.guest_tick() >= cap {
                     return AdvanceResult::CapHit;
                 }
             }
@@ -5538,7 +5542,7 @@ impl FixtureRunner {
                 crate::memory::bus::set_current_pc(pc);
             }
 
-            let trace_pc_range_hit = trace_pc_range_contains(pc, self.dispatcher.tick_count);
+            let trace_pc_range_hit = trace_pc_range_contains(pc, self.dispatcher.current_tick());
             if trace_pc_range_hit {
                 let sp = self.cpu.read_reg(Register::A7);
                 let a6 = self.cpu.read_reg(Register::A6);
@@ -5831,7 +5835,7 @@ impl FixtureRunner {
                                     && self.frozen_ticks.is_none()
                                     && tracking_refire_should_freeze_ticks(opcode)
                                 {
-                                    self.frozen_ticks = Some(self.bus.read_long(0x016A));
+                                    self.frozen_ticks = Some(self.guest_tick());
                                 }
                                 if yield_for_ui
                                     && self.frozen_ticks.is_some()
@@ -6092,6 +6096,7 @@ impl FixtureRunner {
                 self.halted_sp = Some(self.cpu.read_reg(Register::A7));
                 self.halted_d0 = Some(self.cpu.read_reg(Register::D0));
             }
+            self.dispatcher.refresh_tick_projection();
             if foreground {
                 self.ppc_app = Some(ppc_app);
             } else {
@@ -6103,7 +6108,7 @@ impl FixtureRunner {
             }
             return (mixed_steps, running);
         }
-        let ppc_start_tick = self.dispatcher.tick_count;
+        let ppc_start_tick = self.dispatcher.current_tick();
         let ppc_start_time = self.bus.read_long(crate::memory::globals::addr::TIME);
         let profile_ppc = ppc_profile_enabled();
         let profile_total_start = profile_ppc.then(Instant::now);
@@ -6159,7 +6164,7 @@ impl FixtureRunner {
             (Vec::new(), Vec::new())
         } else {
             self.advance_ticks_for_ppc_cycles(cycles, tick_cap);
-            let elapsed_ticks = self.dispatcher.tick_count.wrapping_sub(ppc_start_tick);
+            let elapsed_ticks = self.dispatcher.current_tick().wrapping_sub(ppc_start_tick);
             ppc_app.with_process_memory_manager(
                 |app, memory_manager| {
                     Self::fire_ppc_tick_callbacks(
@@ -6274,7 +6279,7 @@ impl FixtureRunner {
                     max_steps,
                     cycles,
                     total_instructions: self.total_instructions,
-                    tick: self.dispatcher.tick_count,
+                    tick: self.dispatcher.current_tick(),
                     pc,
                     lr: ppc_app.cpu.lr,
                     current_gworld: *ppc_app.current_gworld,
@@ -6358,6 +6363,7 @@ impl FixtureRunner {
             }
         }
 
+        self.dispatcher.refresh_tick_projection();
         if foreground {
             self.ppc_app = Some(ppc_app);
         } else {
@@ -6800,11 +6806,9 @@ impl FixtureRunner {
     }
 
     fn prepare_ppc_execution_clock(&self, ppc_app: &mut PpcLoadedApp) {
-        use crate::memory::globals::addr;
-
         // The guest-visible clock bytes are shared memory. Keep only the
         // CPU-local HLE timing base aligned with that canonical TickCount.
-        ppc_app.set_tick_count(self.bus.read_long(addr::TICKS));
+        ppc_app.set_tick_count(self.dispatcher.current_tick());
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -6827,11 +6831,12 @@ impl FixtureRunner {
         let mut timer_probes = Vec::new();
         let mut callback_time = start_time;
         for tick_offset in 0..elapsed_ticks {
-            let callback_tick = start_tick.wrapping_add(tick_offset).wrapping_add(1);
+            let callback_tick = ppc_app.publish_tick(
+                start_tick.wrapping_add(tick_offset).wrapping_add(1),
+            );
             if callback_tick.is_multiple_of(60) {
                 callback_time = callback_time.wrapping_add(1);
             }
-            ppc_app.set_tick_count(callback_tick);
             let _ = ppc_app.memory.write_u32_be(addr::TICKS, callback_tick);
             let _ = ppc_app.memory.write_u32_be(addr::TIME, callback_time);
             vbl_probes.extend(
@@ -7323,7 +7328,7 @@ impl FixtureRunner {
                 Self::queue_ppc_doubleback(
                     &mut ppc_app.sound.manager,
                     index,
-                    self.dispatcher.tick_count,
+                    self.dispatcher.current_tick(),
                     self.total_instructions,
                 );
                 continue;
@@ -7487,7 +7492,7 @@ impl FixtureRunner {
             Self::queue_ppc_doubleback(
                 &mut ppc_app.sound.manager,
                 index,
-                self.dispatcher.tick_count,
+                self.dispatcher.current_tick(),
                 self.total_instructions,
             );
             ppc_app.sound.manager.double_buffer_playbacks[index].current_buffer_index =
@@ -7748,9 +7753,9 @@ impl FixtureRunner {
                 channel: chan_ptr,
                 completion: callback_addr,
                 command,
-                tick: self.dispatcher.tick_count,
+                tick: self.dispatcher.current_tick(),
                 instruction_count: self.total_instructions,
-                scheduled_tick: self.dispatcher.tick_count,
+                scheduled_tick: self.dispatcher.current_tick(),
                 scheduled_instruction_count: self.total_instructions,
             };
             let probe = ppc_app.with_process_memory_manager(
@@ -8369,7 +8374,7 @@ impl FixtureRunner {
             self.tick_budget = 0;
             if self.frozen_ticks.is_none() {
                 if let Some(cap) = tick_cap {
-                    if self.bus.read_long(0x016A) >= cap {
+                    if self.guest_tick() >= cap {
                         return true;
                     }
                 }
@@ -8384,12 +8389,12 @@ impl FixtureRunner {
         let Some(cap) = tick_cap else {
             return max_steps;
         };
-        if self.frozen_ticks.is_some() || self.bus.read_long(0x016A) >= cap {
+        if self.frozen_ticks.is_some() || self.guest_tick() >= cap {
             return 0;
         }
 
         let mut budget = u64::try_from(max_steps).unwrap_or(u64::MAX);
-        let mut ticks_remaining = u64::from(cap.wrapping_sub(self.bus.read_long(0x016A)));
+        let mut ticks_remaining = u64::from(cap.wrapping_sub(self.guest_tick()));
         if ticks_remaining == 0 {
             return 0;
         }
@@ -8524,7 +8529,7 @@ impl FixtureRunner {
         self.tick_budget -= units;
         while self.tick_budget <= 0 && self.frozen_ticks.is_none() {
             if let Some(cap) = tick_cap {
-                if self.bus.read_long(0x016A) >= cap {
+                if self.guest_tick() >= cap {
                     return true;
                 }
             }
@@ -8534,7 +8539,7 @@ impl FixtureRunner {
                 return false;
             }
             if let Some(cap) = tick_cap {
-                if self.bus.read_long(0x016A) >= cap {
+                if self.guest_tick() >= cap {
                     return true;
                 }
             }
@@ -8548,9 +8553,10 @@ impl FixtureRunner {
         self.cancel_idle_cycle_detector();
         self.dispatcher
             .refresh_menu_bar_policy_from_guest(&self.bus);
-        let new_tick = self.bus.read_long(0x016A).wrapping_add(1);
+        let new_tick = self.dispatcher.advance_tick();
+        // Low-memory Ticks ($016A) is the guest projection of process time,
+        // not its owner. Inside Macintosh Volume I (1985), p. I-260.
         self.bus.write_long(0x016A, new_tick);
-        self.dispatcher.tick_count = new_tick;
         let sys_evt_mask = self
             .bus
             .read_word(crate::memory::globals::addr::SYS_EVT_MASK);
@@ -8766,7 +8772,7 @@ impl FixtureRunner {
         // if the time expires with no event pending, the app receives a null
         // event. Inside Macintosh: Processes 1994, p. 2-8.
         if let Some(cap) = tick_cap {
-            while self.dispatcher.pending_wait_sleep_ticks > 0 && self.bus.read_long(0x016A) < cap {
+            while self.dispatcher.pending_wait_sleep_ticks > 0 && self.guest_tick() < cap {
                 self.dispatcher.pending_wait_sleep_ticks -= 1;
                 self.advance_guest_tick();
                 self.tick_budget = self.instructions_per_tick as i32;
@@ -8778,7 +8784,7 @@ impl FixtureRunner {
             // Yield to the host if the frame tick cap was reached while the
             // process is still suspended; the next frame will continue draining
             // the remaining sleep without delivering another null event early.
-            if self.dispatcher.pending_wait_sleep_ticks > 0 && self.bus.read_long(0x016A) >= cap {
+            if self.dispatcher.pending_wait_sleep_ticks > 0 && self.guest_tick() >= cap {
                 return true;
             }
             self.dispatcher.pending_wait_next_event_return = None;
@@ -8840,7 +8846,7 @@ impl FixtureRunner {
         // In GUI mode with a tick_cap, yield if we reach the cap.
         while self.dispatcher.pending_delay_ticks > 0 {
             if let Some(cap) = tick_cap {
-                if self.bus.read_long(0x016A) >= cap {
+                if self.guest_tick() >= cap {
                     return true;
                 }
             }
@@ -8853,7 +8859,7 @@ impl FixtureRunner {
         }
 
         if self.dispatcher.pending_delay_ticks == 0 {
-            let final_ticks = self.bus.read_long(0x016A);
+            let final_ticks = self.guest_tick();
             self.cpu.write_reg(Register::D0, final_ticks);
         }
 
@@ -8866,7 +8872,7 @@ impl FixtureRunner {
         }
 
         if let Some(cap) = tick_cap {
-            if self.bus.read_long(0x016A) >= cap {
+            if self.guest_tick() >= cap {
                 return true;
             }
         }
@@ -8875,7 +8881,7 @@ impl FixtureRunner {
         self.tick_budget = self.instructions_per_tick as i32;
 
         tick_cap
-            .map(|cap| self.bus.read_long(0x016A) >= cap)
+            .map(|cap| self.guest_tick() >= cap)
             .unwrap_or(true)
     }
 
@@ -8885,7 +8891,7 @@ impl FixtureRunner {
             self.bus.write_long(0x016A, target_tick);
             // Keep `dispatcher.tick_count` in sync with $016A.
             // `advance_guest_tick` does this during ordinary advancement.
-            self.dispatcher.tick_count = target_tick;
+            self.dispatcher.set_tick_count(target_tick);
         }
     }
 
@@ -9673,7 +9679,7 @@ impl FixtureRunner {
                     .join(" ");
                 eprintln!(
                     "[SOUND-DB] fire-doubleback tick={} chan=${:08X} header=${:08X} idx={} buf=${:08X} frames={} flags_before=${:08X} callback=${:08X} sr=${:04X} first={}",
-                    self.bus.read_long(0x016A),
+                    self.guest_tick(),
                     cb.chan_ptr,
                     cb.header_ptr,
                     cb.exhausted_buffer_index,
@@ -10063,7 +10069,7 @@ impl FixtureRunner {
     fn dialog_filter_null_event_already_sent_this_tick(&self, dialog_ptr: u32) -> bool {
         self.dialog_filter_last_null_event_tick
             .is_some_and(|(sent_dialog, sent_tick)| {
-                sent_dialog == dialog_ptr && sent_tick == self.dispatcher.tick_count
+                sent_dialog == dialog_ptr && sent_tick == self.dispatcher.current_tick()
             })
     }
 
@@ -10076,7 +10082,7 @@ impl FixtureRunner {
             |(sent_dialog, sent_window, sent_tick)| {
                 sent_dialog == dialog_ptr
                     && sent_window == update_window
-                    && sent_tick == self.dispatcher.tick_count
+                    && sent_tick == self.dispatcher.current_tick()
             },
         )
     }
@@ -10190,7 +10196,7 @@ impl FixtureRunner {
         // Clear the filter result before each invocation.
         self.bus.write_word(result_addr, 0);
 
-        let ticks = self.bus.read_long(0x016A);
+        let ticks = self.guest_tick();
 
         // Consume the next actionable event from the queue, mirroring the real
         // Mac ModalDialog which calls GetNextEvent before invoking the filter.
@@ -10257,7 +10263,7 @@ impl FixtureRunner {
         } else {
             self.dialog_filter_last_null_event_tick = None;
         }
-        self.dispatcher.tick_count = ticks;
+        self.dispatcher.set_tick_count(ticks);
         self.dispatcher.write_event_record(
             &mut self.bus,
             evt,
@@ -11162,7 +11168,7 @@ mod tests {
     use crate::menu_manager::TrackedMenuPaneView;
     use crate::process_context::{
         PendingFileCompletion, ProcessFileSystemState, SharedProcessFileSystem,
-        SharedProcessValue,
+        SharedProcessTickState, SharedProcessValue,
     };
     use crate::sound::{
         DoubleBufferState, PendingDoubleBackCallback, PendingSoundCallback, PlaybackKind,
@@ -12141,6 +12147,39 @@ mod tests {
         let ppc_app = runner.ppc_app.as_mut().expect("PPC app installed");
         assert_eq!(ppc_app.tick_count, 42);
         assert_eq!(ppc_app.memory.read_u32_be(addr::TICKS), Some(42));
+    }
+
+    #[test]
+    fn process_tick_advance_overwrites_a_stale_low_memory_projection() {
+        use crate::memory::globals::addr;
+
+        let mut app = halted_ppc_app_with_sound(PpcSoundState::default());
+        app.ppc
+            .as_mut()
+            .expect("synthetic PPC app")
+            .memory
+            .add_region(PPC_HALT_PC, vec![0; 64 * 1024]);
+
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        runner.set_launch_state(41, 0x1234_5678, 0);
+        runner.init_app(&app);
+
+        // Ticks is an observable guest projection, not the scheduler's source
+        // of truth. A stale or guest-written cell must not make process time
+        // jump when the runner advances the canonical clock.
+        runner.bus.write_long(addr::TICKS, 9_000);
+        assert_eq!(runner.advance_guest_tick(), 42);
+        assert_eq!(runner.dispatcher.current_tick(), 42);
+        assert_eq!(runner.bus.read_long(addr::TICKS), 42);
+        assert_eq!(
+            runner
+                .ppc_app
+                .as_mut()
+                .expect("PPC app installed")
+                .memory
+                .read_u32_be(addr::TICKS),
+            Some(42)
+        );
     }
 
     #[test]
@@ -13626,6 +13665,8 @@ mod tests {
             stack_size: PPC_STACK_SIZE,
             stack_pointer: PPC_STACK_TOP - 64,
             tick_count: 0,
+            tick_state: SharedProcessTickState::default(),
+            last_projected_tick: 0,
             clock_cycles_per_tick: 1,
             clock_cycle_phase: 0,
             native_exception_handler: 0,
@@ -15984,6 +16025,8 @@ mod tests {
             stack_size: PPC_STACK_SIZE,
             stack_pointer: PPC_STACK_TOP - 64,
             tick_count: 0,
+            tick_state: SharedProcessTickState::default(),
+            last_projected_tick: 0,
             clock_cycles_per_tick: 1,
             clock_cycle_phase: 0,
             native_exception_handler: 0,
@@ -16835,6 +16878,8 @@ mod tests {
             stack_size: PPC_STACK_SIZE,
             stack_pointer: PPC_STACK_TOP - 64,
             tick_count: 0,
+            tick_state: SharedProcessTickState::default(),
+            last_projected_tick: 0,
             clock_cycles_per_tick: 1,
             clock_cycle_phase: 0,
             native_exception_handler: 0,
@@ -16990,6 +17035,8 @@ mod tests {
             stack_size: PPC_STACK_SIZE,
             stack_pointer: PPC_STACK_TOP - 64,
             tick_count: 0,
+            tick_state: SharedProcessTickState::default(),
+            last_projected_tick: 0,
             clock_cycles_per_tick: 1,
             clock_cycle_phase: 0,
             native_exception_handler: 0,
@@ -17377,6 +17424,8 @@ mod tests {
             stack_size: PPC_STACK_SIZE,
             stack_pointer: PPC_STACK_TOP - 64,
             tick_count: 0,
+            tick_state: SharedProcessTickState::default(),
+            last_projected_tick: 0,
             clock_cycles_per_tick: 1,
             clock_cycle_phase: 0,
             native_exception_handler: 0,
@@ -17658,6 +17707,8 @@ mod tests {
             stack_size: PPC_STACK_SIZE,
             stack_pointer: PPC_STACK_TOP - 64,
             tick_count: 0,
+            tick_state: SharedProcessTickState::default(),
+            last_projected_tick: 0,
             clock_cycles_per_tick: 1,
             clock_cycle_phase: 0,
             native_exception_handler: 0,

--- a/src/trap/control.rs
+++ b/src/trap/control.rs
@@ -3319,7 +3319,7 @@ impl super::TrapDispatcher {
                         return Some(Ok(()));
                     }
 
-                    let tick = self.tick_count;
+                    let tick = self.current_tick();
                     let callback_due = if let Some(tracking) = self.control_tracking.as_mut() {
                         tracking.scrollbar_idle_refires =
                             tracking.scrollbar_idle_refires.saturating_add(1);
@@ -3540,7 +3540,7 @@ impl super::TrapDispatcher {
                                                 stack_ptr: sp,
                                                 scrollbar_action_proc: action_proc,
                                                 scrollbar_part: part,
-                                                scrollbar_last_action_tick: self.tick_count,
+                                                scrollbar_last_action_tick: self.current_tick(),
                                                 scrollbar_idle_refires: 0,
                                                 scrollbar_callback_pending: true,
                                             });

--- a/src/trap/dialog.rs
+++ b/src/trap/dialog.rs
@@ -2304,7 +2304,7 @@ impl super::TrapDispatcher {
         bus.write_word(te_ptr + Self::TE_SEL_POINT_OFFSET + 2, dest_rect.1 as u16);
         bus.write_word(te_ptr + Self::TE_SEL_START_OFFSET, 0);
         bus.write_word(te_ptr + Self::TE_SEL_END_OFFSET, 0);
-        bus.write_long(te_ptr + Self::TE_CARET_TIME_OFFSET, self.tick_count);
+        bus.write_long(te_ptr + Self::TE_CARET_TIME_OFFSET, self.current_tick());
         bus.write_word(te_ptr + Self::TE_CARET_STATE_OFFSET, 0);
         bus.write_word(te_ptr + Self::TE_LENGTH_OFFSET, 0);
         bus.write_long(te_ptr + Self::TE_HTEXT_OFFSET, h_text);
@@ -2476,7 +2476,7 @@ impl super::TrapDispatcher {
         bus.write_word(te_ptr + Self::TE_SEL_POINT_OFFSET + 2, dest_rect.1 as u16);
         bus.write_word(te_ptr + Self::TE_SEL_START_OFFSET, 0);
         bus.write_word(te_ptr + Self::TE_SEL_END_OFFSET, 0);
-        bus.write_long(te_ptr + Self::TE_CARET_TIME_OFFSET, self.tick_count);
+        bus.write_long(te_ptr + Self::TE_CARET_TIME_OFFSET, self.current_tick());
         bus.write_word(te_ptr + Self::TE_CARET_STATE_OFFSET, 0);
         bus.write_word(te_ptr + Self::TE_JUST_OFFSET, 0);
         bus.write_word(te_ptr + Self::TE_LENGTH_OFFSET, 0);
@@ -2718,7 +2718,7 @@ impl super::TrapDispatcher {
         }
 
         let last_toggle = bus.read_long(te_ptr + Self::TE_CARET_TIME_OFFSET);
-        if self.tick_count.wrapping_sub(last_toggle) < Self::TE_CARET_BLINK_TICKS {
+        if self.current_tick().wrapping_sub(last_toggle) < Self::TE_CARET_BLINK_TICKS {
             return;
         }
 
@@ -2732,7 +2732,7 @@ impl super::TrapDispatcher {
             te_ptr + Self::TE_CARET_STATE_OFFSET,
             if caret_state == 0 { 1 } else { 0 },
         );
-        bus.write_long(te_ptr + Self::TE_CARET_TIME_OFFSET, self.tick_count);
+        bus.write_long(te_ptr + Self::TE_CARET_TIME_OFFSET, self.current_tick());
         self.draw_te_contents(cpu, bus, te_handle, true);
     }
 
@@ -5003,7 +5003,7 @@ impl super::TrapDispatcher {
         // activating an item must make that record active before later null
         // events call TEIdle for caret blinking.
         bus.write_word(te_ptr + Self::TE_ACTIVE_OFFSET, 1);
-        bus.write_long(te_ptr + Self::TE_CARET_TIME_OFFSET, self.tick_count);
+        bus.write_long(te_ptr + Self::TE_CARET_TIME_OFFSET, self.current_tick());
         bus.write_word(te_ptr + Self::TE_CARET_STATE_OFFSET, 0);
         self.draw_te_contents(cpu, bus, text_handle, true);
         true
@@ -15615,7 +15615,7 @@ impl super::TrapDispatcher {
                 let te_ptr = Self::te_record_ptr(bus, te_handle);
                 if te_ptr != 0 {
                     bus.write_word(te_ptr + Self::TE_ACTIVE_OFFSET, 1);
-                    bus.write_long(te_ptr + Self::TE_CARET_TIME_OFFSET, self.tick_count);
+                    bus.write_long(te_ptr + Self::TE_CARET_TIME_OFFSET, self.current_tick());
                     bus.write_word(te_ptr + Self::TE_CARET_STATE_OFFSET, 0);
                     self.draw_te_contents(cpu, bus, te_handle, true);
                 }

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -26,7 +26,7 @@ use crate::process_context::{
     SharedProcessQuickDrawHiliteColors, SharedProcessQuickDrawOpColors,
     SharedProcessQuickDrawPixelStates,
     SharedProcessScrapState, SharedProcessSoundManager, SharedProcessTextEditManager,
-    SharedProcessValue,
+    SharedProcessTickState, SharedProcessValue,
 };
 use crate::trace::{TraceEvent, TraceSink, TraceSource};
 use crate::ui_theme::{UiTheme, UiThemeId};
@@ -2091,8 +2091,14 @@ pub struct TrapDispatcher {
     pub(crate) outline_preferred: bool,
     /// Font Manager glyph-preservation preference (`SetPreserveGlyph` / `GetPreserveGlyph`).
     pub(crate) preserve_glyph: bool,
-    /// Simulated tick count
+    /// Guest-visible projection of the process-owned wrapping Macintosh tick
+    /// counter. The private `tick_state` is authoritative after process
+    /// attachment; this scalar remains for existing fixture/adapter callers.
+    /// Inside Macintosh Volume I (1985), p. I-260; Volume II (1985),
+    /// pp. II-349--II-350.
     pub(crate) tick_count: u32,
+    tick_state: SharedProcessTickState,
+    last_projected_tick: std::cell::Cell<u32>,
     /// Tick at which IdleUpdate last reset the Power Manager activity timer.
     /// Inside Macintosh: Devices (1994), p. 6-29.
     pub(crate) power_idle_last_update_tick: u32,
@@ -2818,6 +2824,9 @@ impl TrapDispatcher {
             .shared_handle();
         self.file_positions = self.process_file_system.files.positions();
         context.attach_sound_manager(&mut self.sound_manager);
+        self.import_public_tick_projection();
+        context.attach_tick_state(&mut self.tick_state);
+        self.refresh_tick_projection();
         context.attach_callback_tasks(
             &mut self.timer_tasks,
             &mut self.vbl_tasks,
@@ -3163,7 +3172,7 @@ impl TrapDispatcher {
         let safe_label = sanitize_gui_capture_label(label);
         let filename = format!(
             "{:06}_t{:06}_tr{:08}_{}.png",
-            frame, self.tick_count, self.trap_count, safe_label
+            frame, self.current_tick(), self.trap_count, safe_label
         );
         let path = dir.join(&filename);
         let mut rgba = crate::display::render_screen_with_gamma(
@@ -3203,7 +3212,7 @@ impl TrapDispatcher {
                 frame,
                 filename,
                 safe_label,
-                self.tick_count,
+                self.current_tick(),
                 self.trap_count,
                 self.game_trap_count,
                 self.current_trap_word,
@@ -3277,9 +3286,48 @@ impl TrapDispatcher {
     }
 
     /// Test-only: set the tick count.
+    /// Return the process-owned wrapping Macintosh tick counter.
+    pub(crate) fn current_tick(&self) -> u32 {
+        self.import_public_tick_projection();
+        self.tick_state.current_tick()
+    }
+
+    fn import_public_tick_projection(&self) {
+        if self.tick_count != self.last_projected_tick.get() {
+            self.tick_state.set_tick(self.tick_count);
+            self.last_projected_tick.set(self.tick_count);
+        }
+    }
+
+    pub(crate) fn refresh_tick_projection(&mut self) -> u32 {
+        let tick = self.tick_state.current_tick();
+        self.tick_count = tick;
+        self.last_projected_tick.set(tick);
+        tick
+    }
+
+    /// Set the process clock for an explicit runner/fixture synchronization.
+    /// Native slice teardown uses the process state's monotonic publication
+    /// rules instead of restoring a local snapshot.
+    pub(crate) fn set_tick_count(&mut self, tick: u32) {
+        self.tick_state.set_tick(tick);
+        self.tick_count = tick;
+        self.last_projected_tick.set(tick);
+    }
+
+    /// Advance the canonical process clock by one wrapping tick and refresh
+    /// its low-memory-facing scalar projection.
+    pub(crate) fn advance_tick(&mut self) -> u32 {
+        self.import_public_tick_projection();
+        let tick = self.tick_state.advance_ticks(1);
+        self.tick_count = tick;
+        self.last_projected_tick.set(tick);
+        tick
+    }
+
     /// Production code uses advance_guest_tick() to update tick_count.
     pub fn set_tick_count_for_test(&mut self, tick: u32) {
-        self.tick_count = tick;
+        self.set_tick_count(tick);
     }
 
     /// Test-only: mark the synthetic kAEOpenApplication event as
@@ -3505,6 +3553,7 @@ impl TrapDispatcher {
             if event == "copybits_screen" {
                 self.copybits_screen_secs.push(self.screen_event_count);
             }
+            let tick = self.current_tick();
             self.trace_sink
                 .as_mut()
                 .expect("trace_sink checked above")
@@ -3513,7 +3562,7 @@ impl TrapDispatcher {
                     self.screen_mode,
                     &self.device_clut,
                     self.screen_event_count,
-                    self.tick_count,
+                    tick,
                     self.instruction_count,
                 )
                 .map_err(Error::Trace)?;
@@ -3525,7 +3574,7 @@ impl TrapDispatcher {
             .source();
         let trace_event = TraceEvent {
             source,
-            tick: self.tick_count,
+            tick: self.current_tick(),
             instructions: self.instruction_count,
             pc,
             trap_count: self.trap_count,
@@ -3859,6 +3908,8 @@ impl TrapDispatcher {
             outline_preferred: false,
             preserve_glyph: false,
             tick_count: 0,
+            tick_state: SharedProcessTickState::default(),
+            last_projected_tick: std::cell::Cell::new(0),
             power_idle_last_update_tick: 0,
             power_idle_disable_count: 0,
             serial_port_a_powered: false,
@@ -5716,7 +5767,9 @@ impl TrapDispatcher {
             self.input_state.key_repeat = Some(ProcessKeyRepeatState {
                 key_code,
                 char_code,
-                next_tick: self.tick_count.wrapping_add(Self::AUTO_KEY_THRESHOLD_TICKS),
+                next_tick: self
+                    .current_tick()
+                    .wrapping_add(Self::AUTO_KEY_THRESHOLD_TICKS),
             });
         }
     }
@@ -7823,7 +7876,7 @@ impl TrapDispatcher {
                 "[FADE-TRACE] trap=${:04X} pc=${:08X} tick={} d0=${:08X} a0=${:08X}",
                 trap,
                 pc.wrapping_sub(2),
-                self.tick_count,
+                self.current_tick(),
                 cpu.read_reg(Register::D0),
                 cpu.read_reg(Register::A0),
             );
@@ -7838,7 +7891,7 @@ impl TrapDispatcher {
                 let sp = cpu.read_reg(Register::A7);
                 eprintln!(
                     "[TRACE-PC] trap=${:04X} pc=${:08X} tick={} sp=${:08X}",
-                    trap, trap_pc, self.tick_count, sp
+                    trap, trap_pc, self.current_tick(), sp
                 );
                 eprintln!(
                     "[TRACE-PC]   d0=${:08X} d1=${:08X} d2=${:08X} d3=${:08X} d4=${:08X} d5=${:08X} d6=${:08X} d7=${:08X}",
@@ -7906,10 +7959,10 @@ impl TrapDispatcher {
         // `SYSTEMLESS_TRACE_ATRAPS_WINDOW=LO-HI` logs trap+pc+tick for every
         // trap whose `tick_count` is in `[LO, HI]`.
         if let Some((lo, hi)) = trace_atraps_window() {
-            if self.tick_count >= lo && self.tick_count <= hi {
+            if self.current_tick() >= lo && self.current_tick() <= hi {
                 eprintln!(
                     "[ATRAP-WIN] tick={} trap=${:04X} pc=${:08X}",
-                    self.tick_count,
+                    self.current_tick(),
                     trap,
                     pc.wrapping_sub(2),
                 );
@@ -8299,6 +8352,7 @@ impl TrapDispatcher {
                 self.trap_time_ns[(trap & 0xFFF) as usize].saturating_add(ns);
         }
 
+        self.refresh_tick_projection();
         result
     }
 }

--- a/src/trap/event.rs
+++ b/src/trap/event.rs
@@ -308,7 +308,7 @@ impl super::TrapDispatcher {
         bus.write_word(ptr + 4, Self::EVQEL_QTYPE);
         bus.write_word(ptr + Self::EVQEL_WHAT_OFFSET, event.what);
         bus.write_long(ptr + Self::EVQEL_MESSAGE_OFFSET, event.message);
-        bus.write_long(ptr + Self::EVQEL_WHEN_OFFSET, self.tick_count);
+        bus.write_long(ptr + Self::EVQEL_WHEN_OFFSET, self.current_tick());
         bus.write_word(ptr + Self::EVQEL_WHERE_V_OFFSET, event.where_v as u16);
         bus.write_word(ptr + Self::EVQEL_WHERE_H_OFFSET, event.where_h as u16);
         bus.write_word(ptr + Self::EVQEL_MODIFIERS_OFFSET, event.modifiers);
@@ -374,7 +374,7 @@ impl super::TrapDispatcher {
         if std::env::var_os("SYSTEMLESS_TRACE_INVAL").is_some() {
             eprintln!(
                 "[INVAL] remember_flushed_update_event window=${:08X} tick={}",
-                event.message, self.tick_count
+                event.message, self.current_tick()
             );
         }
         self.flushed_update_events.push_back(event.clone());
@@ -419,12 +419,13 @@ impl super::TrapDispatcher {
             self.input_state.key_repeat = None;
             return;
         }
-        if !Self::tick_has_reached(self.tick_count, repeat.next_tick) {
+        if !Self::tick_has_reached(self.current_tick(), repeat.next_tick) {
             return;
         }
 
+        let tick = self.current_tick();
         if let Some(state) = self.input_state.key_repeat.as_mut() {
-            state.next_tick = self.tick_count.wrapping_add(Self::AUTO_KEY_RATE_TICKS);
+            state.next_tick = tick.wrapping_add(Self::AUTO_KEY_RATE_TICKS);
         }
 
         let message = ((repeat.key_code as u32) << 8) | (repeat.char_code as u32);
@@ -448,7 +449,7 @@ impl super::TrapDispatcher {
         &self,
         event_mask: u16,
     ) -> Option<super::dispatch::QueuedEvent> {
-        if self.pending_native_menu_event_tick == Some(self.tick_count) {
+        if self.pending_native_menu_event_tick == Some(self.current_tick()) {
             return None;
         }
         self.pending_native_menu_event
@@ -470,11 +471,11 @@ impl super::TrapDispatcher {
         event_mask: u16,
     ) -> Option<super::dispatch::QueuedEvent> {
         let event = self.peek_pending_native_menu_event(event_mask)?;
-        self.pending_native_menu_event_tick = Some(self.tick_count);
+        self.pending_native_menu_event_tick = Some(self.current_tick());
         if trace_input_enabled() || super::dispatch::trace_delivered_events_enabled() {
             eprintln!(
                 "[INPUT] present latched native-menu mouseDown where=({}, {}) mask=${:04X} tick={}",
-                event.where_v, event.where_h, event_mask, self.tick_count
+                event.where_v, event.where_h, event_mask, self.current_tick()
             );
         }
         Some(event)
@@ -725,7 +726,7 @@ impl super::TrapDispatcher {
         // Pack the 16-byte EventRecord into one big-endian buffer and issue
         // a single bus.write_bytes call (faster than 6 word/long writes for
         // hot paths like WaitNextEvent).
-        let when = self.tick_count;
+        let when = self.current_tick();
         let rec: [u8; 16] = [
             (what >> 8) as u8,
             what as u8,

--- a/src/trap/memory.rs
+++ b/src/trap/memory.rs
@@ -636,7 +636,7 @@ impl super::TrapDispatcher {
             let vbl_phase = bus.read_word(task_ptr + 12) as i16;
             eprintln!(
                 "[VBL] install tick={} task=${:08X} qType={} addr=${:08X} count={} phase={} slot={:?}",
-                self.tick_count, task_ptr, q_type, vbl_addr, vbl_count, vbl_phase, slot
+                self.current_tick(), task_ptr, q_type, vbl_addr, vbl_count, vbl_phase, slot
             );
         }
         if task_ptr == 0 || bus.read_word(task_ptr + 4) as i16 != 1 {
@@ -3234,8 +3234,8 @@ impl super::TrapDispatcher {
                 self.current_selector_operation = operation.map(|route| route.operation_id);
                 match raw_trap_route(self.current_trap_word).os_routine_variant {
                     OsRoutineVariant::PowerIdleUpdate => {
-                        self.power_idle_last_update_tick = self.tick_count;
-                        cpu.write_reg(Register::D0, self.tick_count);
+                        self.power_idle_last_update_tick = self.current_tick();
+                        cpu.write_reg(Register::D0, self.current_tick());
                     }
                     OsRoutineVariant::PowerIdleState => {
                         let selector = cpu.read_reg(Register::D0) as i32;

--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -826,7 +826,7 @@ impl super::TrapDispatcher {
                     eprintln!(
                         "[DIALOG-PORT] SetPort pc=${:08X} tick={} port=${:08X}",
                         cpu.read_reg(Register::PC).wrapping_sub(2),
-                        self.tick_count,
+                        self.current_tick(),
                         port
                     );
                 }
@@ -2672,7 +2672,7 @@ impl super::TrapDispatcher {
                         self.bg_color.0,
                         self.bg_color.1,
                         self.bg_color.2,
-                        self.tick_count
+                        self.current_tick()
                     );
                 }
                 if trace_eraserect_enabled() {
@@ -2765,7 +2765,7 @@ impl super::TrapDispatcher {
                         self.bg_color.0,
                         self.bg_color.1,
                         self.bg_color.2,
-                        self.tick_count,
+                        self.current_tick(),
                     );
                 }
                 self.draw_rect(cpu, bus, &r, ShapeOp::Fill(pat));
@@ -3163,13 +3163,13 @@ impl super::TrapDispatcher {
                 });
 
                 if trace_title_diag_enabled()
-                    && self.tick_count >= 68
-                    && self.tick_count <= 110
+                    && self.current_tick() >= 68
+                    && self.current_tick() <= 110
                     && dst_info.base == self.screen_mode.0
                 {
                     eprintln!(
                         "[TITLE-DIAG] CopyBits tick={} pc=${:08X} port=${:08X} srcBits=${:08X} dstBits=${:08X} srcBase=${:08X} dstBase=${:08X} srcRect=({},{}..{},{} ) dstRect=({},{}..{},{} ) mode={} srcCTab=${:08X} dstCTab=${:08X}",
-                        self.tick_count,
+                        self.current_tick(),
                         trap_pc,
                         *self.current_port,
                         src_bits_ptr,
@@ -3420,7 +3420,7 @@ impl super::TrapDispatcher {
                     let src_rb = src_info.row_bytes;
                     eprintln!(
                         "[OFFSCREEN-002EAD50] tick={} src_rect=({},{}..{},{}) rb={}",
-                        self.tick_count, src_top, src_left, src_bottom, src_right, src_rb,
+                        self.current_tick(), src_top, src_left, src_bottom, src_right, src_rb,
                     );
                     for row_y in [0i32, 1, 2, 3, 4, 5, 30, 53, 54, 55, 56, 57, 58] {
                         let mut sample = String::new();
@@ -3723,7 +3723,7 @@ impl super::TrapDispatcher {
                     let calling_pc = cpu.read_reg(Register::PC).wrapping_sub(2);
                     eprintln!(
                         "[COPYBITS] tick={} pc=${:08X} srcBase=${:08X} dstBase=${:08X} src={}bpp dst={}bpp mode={} src=({},{}..{},{} ) dst=({},{}..{},{} ) mask=${:08X} translate={} srcSeed={:?} dstSeed={:?}",
-                        self.tick_count,
+                        self.current_tick(),
                         calling_pc,
                         src_info.base,
                         dst_info.base,
@@ -4140,7 +4140,7 @@ impl super::TrapDispatcher {
                                             }) {
                                                 eprintln!(
                                                     "[COPYBITS-HUD] tick={} dx={} dy={} mode={} src_idx={} src_rgb=({:04X},{:04X},{:04X}) transparent=true bg_rgb=({:04X},{:04X},{:04X}) srcBase=${:08X} dstBase=${:08X} srcCTab=${:08X} dstCTab=${:08X} srcSeed={:?} dstSeed={:?}",
-                                                    self.tick_count,
+                                                    self.current_tick(),
                                                     dx,
                                                     dy,
                                                     mode_base,
@@ -4196,7 +4196,7 @@ impl super::TrapDispatcher {
                                             .unwrap_or([0, 0, 0]);
                                         eprintln!(
                                             "[COPYBITS-HUD] tick={} dx={} dy={} mode={} src_idx={} src_rgb=({:04X},{:04X},{:04X}) dst_idx={} dst_rgb=({:04X},{:04X},{:04X}) translate={} bg_rgb=({:04X},{:04X},{:04X}) srcBase=${:08X} dstBase=${:08X} srcCTab=${:08X} dstCTab=${:08X} srcSeed={:?} dstSeed={:?}",
-                                            self.tick_count,
+                                            self.current_tick(),
                                             dx,
                                             dy,
                                             mode_base,
@@ -4621,7 +4621,7 @@ impl super::TrapDispatcher {
                         self.fg_color.0,
                         self.fg_color.1,
                         self.fg_color.2,
-                        self.tick_count,
+                        self.current_tick(),
                     );
                 }
                 if trace_dialog_text_enabled() {
@@ -4655,7 +4655,7 @@ impl super::TrapDispatcher {
                         self.bg_color.0,
                         self.bg_color.1,
                         self.bg_color.2,
-                        self.tick_count
+                        self.current_tick()
                     );
                 }
                 if trace_dialog_text_enabled() {
@@ -4697,7 +4697,7 @@ impl super::TrapDispatcher {
                         *self.current_port,
                         color_ptr,
                         r, g, b,
-                        self.tick_count,
+                        self.current_tick(),
                     );
                 }
                 Ok(())
@@ -4725,7 +4725,7 @@ impl super::TrapDispatcher {
                 if trace_qd_colors_enabled() {
                     eprintln!(
                         "[QD-COLOR] RGBBackColor port=${:08X} ptr=${:08X} rgb=({:04X},{:04X},{:04X}) tick={}",
-                        *self.current_port, color_ptr, r, g, b, self.tick_count
+                        *self.current_port, color_ptr, r, g, b, self.current_tick()
                     );
                 }
                 Ok(())
@@ -5089,7 +5089,7 @@ impl super::TrapDispatcher {
                 if trace_palette_enabled() {
                     eprintln!(
                         "[PALETTE] NewPalette tick={} entries={} src_colors=${:08X} usage={} tolerance={}",
-                        self.tick_count, entries, src_colors, src_usage, src_tolerance
+                        self.current_tick(), entries, src_colors, src_usage, src_tolerance
                     );
                 }
                 let palette = self.create_palette_from_ctab(
@@ -5196,7 +5196,7 @@ impl super::TrapDispatcher {
                 if trace_palette_enabled() {
                     eprintln!(
                         "[PALETTE] ActivatePalette(trap) tick={} window=${:08X}",
-                        self.tick_count, window
+                        self.current_tick(), window
                     );
                 }
                 self.activate_associated_palette_for_window(bus, window);
@@ -5262,7 +5262,7 @@ impl super::TrapDispatcher {
                 if trace_palette_enabled() {
                     eprintln!(
                         "[PALETTE] GetPalette(trap) tick={} window=${:08X} -> handle=${:08X}",
-                        self.tick_count,
+                        self.current_tick(),
                         window,
                         self.window_palette_handle_exact(window)
                     );
@@ -5317,7 +5317,7 @@ impl super::TrapDispatcher {
                             self.fg_color.0,
                             self.fg_color.1,
                             self.fg_color.2,
-                            self.tick_count,
+                            self.current_tick(),
                         );
                     }
                 }
@@ -5366,7 +5366,7 @@ impl super::TrapDispatcher {
                             self.bg_color.0,
                             self.bg_color.1,
                             self.bg_color.2,
-                            self.tick_count,
+                            self.current_tick(),
                         );
                     }
                 }
@@ -8429,12 +8429,14 @@ impl super::TrapDispatcher {
                     );
 
                     let picture_info = self.loaded_handles.get(&pic_handle).copied();
-                    if trace_title_diag_enabled() && self.tick_count >= 80 && self.tick_count <= 110
+                    if trace_title_diag_enabled()
+                        && self.current_tick() >= 80
+                        && self.current_tick() <= 110
                     {
                         if let Some((_, res_type, res_id)) = picture_info {
                             eprintln!(
                                 "[TITLE-DIAG] DrawPicture tick={} port=${:08X} base=${:08X} handle=${:08X} type='{}' id={} rect=({},{}..{},{} )",
-                                self.tick_count,
+                                self.current_tick(),
                                 *self.current_port,
                                 port_base,
                                 pic_handle,
@@ -8448,7 +8450,7 @@ impl super::TrapDispatcher {
                         } else {
                             eprintln!(
                                 "[TITLE-DIAG] DrawPicture tick={} port=${:08X} base=${:08X} handle=${:08X} rect=({},{}..{},{} )",
-                                self.tick_count,
+                                self.current_tick(),
                                 *self.current_port,
                                 port_base,
                                 pic_handle,
@@ -8472,7 +8474,7 @@ impl super::TrapDispatcher {
                         if let Some(fetch) = recent_resource_ctable_fetch.as_ref() {
                             eprintln!(
                                 "[PALETTE] DrawPictureUsingFetchedCTable tick={} trap={} port=${:08X} ct_id={} picHandle=${:08X}",
-                                self.tick_count,
+                                self.current_tick(),
                                 self.trap_count,
                                 port,
                                 fetch.ct_id,
@@ -8507,7 +8509,7 @@ impl super::TrapDispatcher {
                                         *self.color_manager_clut = pict_clut_array;
                                         self.seeded_picture_palette = pict_clut_array;
                                         self.seeded_picture_palette_until_tick =
-                                            self.tick_count.saturating_add(48);
+                                            self.current_tick().saturating_add(48);
                                         self.sync_canonical_offscreen_ctabs_to_clut(
                                             bus,
                                             &pict_clut_array,
@@ -8652,7 +8654,7 @@ impl super::TrapDispatcher {
                             .unwrap_or(false);
                         eprintln!(
                             "[PALETTE] DrawPicture-seed-gate tick={} ok={} port_ps={} port_base=${:08X} screen_base=${:08X} port_rb={} screen_rb={} recent_fetch={} fetch_clut={} ctab_nonzero={} pict_clut={} picHandle=${:08X}",
-                            self.tick_count, ok, port_ps, port_base,
+                            self.current_tick(), ok, port_ps, port_base,
                             self.screen_mode.0, port_rb, self.screen_mode.1,
                             recent_resource_ctable_fetch.is_some(),
                             recent_resource_ctable_clut.is_some(),
@@ -8688,14 +8690,14 @@ impl super::TrapDispatcher {
                                             let pict0 = pict_clut_array[0];
                                             eprintln!(
                                             "[CM-WRITE] PictSeed@6097 tick={} cm[0]=({:04X},{:04X},{:04X}) <- pict[0]=({:04X},{:04X},{:04X})",
-                                            self.tick_count, cm_before[0], cm_before[1], cm_before[2], pict0[0], pict0[1], pict0[2]
+                                            self.current_tick(), cm_before[0], cm_before[1], cm_before[2], pict0[0], pict0[1], pict0[2]
                                         );
                                         }
                                         *self.device_clut = pict_clut_array;
                                         *self.color_manager_clut = pict_clut_array;
                                         self.seeded_picture_palette = pict_clut_array;
                                         self.seeded_picture_palette_until_tick =
-                                            self.tick_count.saturating_add(48);
+                                            self.current_tick().saturating_add(48);
                                         self.sync_canonical_offscreen_ctabs_to_clut(
                                             bus,
                                             &pict_clut_array,
@@ -8725,7 +8727,7 @@ impl super::TrapDispatcher {
                                         if trace_palette_enabled() {
                                             eprintln!(
                                             "[PALETTE] SeedFromPicture tick={} picHandle=${:08X} picPtr=${:08X} cm[0]=({:04X},{:04X},{:04X}) cm[1]=({:04X},{:04X},{:04X}) cm[16]=({:04X},{:04X},{:04X}) cm[42]=({:04X},{:04X},{:04X}) cm[128]=({:04X},{:04X},{:04X}) cm[255]=({:04X},{:04X},{:04X})",
-                                            self.tick_count,
+                                            self.current_tick(),
                                             pic_handle,
                                             pic_ptr,
                                             self.color_manager_clut[0][0],
@@ -8795,7 +8797,7 @@ impl super::TrapDispatcher {
                                     if trace_palette_enabled() {
                                         eprintln!(
                                             "[PALETTE] PreserveOffscreenPictureIndices tick={} port=${:08X} picHandle=${:08X} rgb16=({:04X},{:04X},{:04X}) rgb42=({:04X},{:04X},{:04X}) rgb128=({:04X},{:04X},{:04X})",
-                                            self.tick_count,
+                                            self.current_tick(),
                                             port,
                                             pic_handle,
                                             raw_pict_array[16][0],
@@ -8846,7 +8848,7 @@ impl super::TrapDispatcher {
                                     if trace_palette_enabled() {
                                         eprintln!(
                                             "[PALETTE] SeedOffscreenFromPicture tick={} port=${:08X} ctab=${:08X} picHandle=${:08X} rgb16=({:04X},{:04X},{:04X}) rgb42=({:04X},{:04X},{:04X}) rgb128=({:04X},{:04X},{:04X})",
-                                            self.tick_count,
+                                            self.current_tick(),
                                             port,
                                             port_ctab_handle,
                                             pic_handle,
@@ -9191,7 +9193,7 @@ impl super::TrapDispatcher {
                     if first_r == 0x0AAA {
                         eprintln!(
                             "[FADE-TRACE] SetEntries wrote 0AAA at tick={} pc=${:08X}",
-                            self.tick_count, trap_pc
+                            self.current_tick(), trap_pc
                         );
                         self.fade_trace_remaining = 30;
                     }
@@ -9989,7 +9991,7 @@ impl super::TrapDispatcher {
                             .unwrap_or(0);
                         eprintln!(
                             "[REGION] tick={} BitMapToRegion bmap=${:08X} rgn=${:08X} base=${:08X} rowBytes={} bounds=({},{}..{},{}) pixelSize={} wrote={} bbox={:?} size={}",
-                            self.tick_count,
+                            self.current_tick(),
                             bmap_ptr,
                             rgn_handle,
                             info.base,
@@ -10335,7 +10337,7 @@ impl super::TrapDispatcher {
                     if trace_region_ops_enabled() {
                         eprintln!(
                             "[REGION] tick={} SectRgn a=${:08X} bbox={:?} b=${:08X} bbox={:?} dst=${:08X} bbox={:?} size={}",
-                            self.tick_count,
+                            self.current_tick(),
                             src_a,
                             Self::region_bbox(bus, src_a),
                             src_b,
@@ -10370,7 +10372,7 @@ impl super::TrapDispatcher {
                     if trace_region_ops_enabled() {
                         eprintln!(
                             "[REGION] tick={} UnionRgn a=${:08X} bbox={:?} b=${:08X} bbox={:?} dst=${:08X} bbox={:?} size={}",
-                            self.tick_count,
+                            self.current_tick(),
                             src_a,
                             Self::region_bbox(bus, src_a),
                             src_b,
@@ -10405,7 +10407,7 @@ impl super::TrapDispatcher {
                     if trace_region_ops_enabled() {
                         eprintln!(
                             "[REGION] tick={} DiffRgn a=${:08X} bbox={:?} b=${:08X} bbox={:?} dst=${:08X} bbox={:?} size={}",
-                            self.tick_count,
+                            self.current_tick(),
                             src_a,
                             Self::region_bbox(bus, src_a),
                             src_b,
@@ -10440,7 +10442,7 @@ impl super::TrapDispatcher {
                     if trace_region_ops_enabled() {
                         eprintln!(
                             "[REGION] tick={} XorRgn a=${:08X} bbox={:?} b=${:08X} bbox={:?} dst=${:08X} bbox={:?} size={}",
-                            self.tick_count,
+                            self.current_tick(),
                             src_a,
                             Self::region_bbox(bus, src_a),
                             src_b,
@@ -10464,9 +10466,9 @@ impl super::TrapDispatcher {
                 let pt_h = bus.read_word(sp + 6) as i16;
                 let in_rgn = Self::region_contains_point(bus, rgn_handle, pt_v, pt_h);
                 if trace_region_ops_enabled() {
-                    eprintln!(
-                        "[REGION] tick={} PtInRgn pt=({}, {}) rgn=${:08X} bbox={:?} size={} -> {}",
-                        self.tick_count,
+                        eprintln!(
+                            "[REGION] tick={} PtInRgn pt=({}, {}) rgn=${:08X} bbox={:?} size={} -> {}",
+                        self.current_tick(),
                         pt_v,
                         pt_h,
                         rgn_handle,
@@ -10505,9 +10507,9 @@ impl super::TrapDispatcher {
                 let rect_ptr = bus.read_long(sp + 4);
                 let in_rgn = Self::rect_in_rgn(bus, rgn_handle, rect_ptr);
                 if trace_region_ops_enabled() {
-                    eprintln!(
-                        "[REGION] tick={} RectInRgn rect=({},{}..{},{}) rgn=${:08X} bbox={:?} size={} -> {}",
-                        self.tick_count,
+                        eprintln!(
+                            "[REGION] tick={} RectInRgn rect=({},{}..{},{}) rgn=${:08X} bbox={:?} size={} -> {}",
+                        self.current_tick(),
                         bus.read_word(rect_ptr) as i16,
                         bus.read_word(rect_ptr + 2) as i16,
                         bus.read_word(rect_ptr + 4) as i16,
@@ -17767,12 +17769,12 @@ impl super::TrapDispatcher {
         preserve_active_window: bool,
     ) -> u32 {
         if preserve_active_window
-            && self.tick_count < self.seeded_picture_palette_until_tick
+            && self.current_tick() < self.seeded_picture_palette_until_tick
             && !Self::uses_canonical_system_8bpp_clut(&self.seeded_picture_palette)
         {
             self.seeded_picture_palette_until_tick
         } else {
-            self.tick_count.saturating_add(extend_by_ticks)
+            self.current_tick().saturating_add(extend_by_ticks)
         }
     }
 
@@ -17781,12 +17783,12 @@ impl super::TrapDispatcher {
             ct_id,
             ctab_handle,
             port: *self.current_port,
-            tick: self.tick_count,
+            tick: self.current_tick(),
         });
         if trace_palette_enabled() {
             eprintln!(
                 "[PALETTE] RememberGetCTable tick={} trap={} port=${:08X} ct_id={} handle=${:08X}",
-                self.tick_count, self.trap_count, *self.current_port, ct_id, ctab_handle,
+                self.current_tick(), self.trap_count, *self.current_port, ct_id, ctab_handle,
             );
         }
     }
@@ -17799,7 +17801,7 @@ impl super::TrapDispatcher {
         port_ps: u16,
     ) -> Option<RecentColorTableFetch> {
         let recent = self.recent_resource_ctable_fetch?;
-        let stale = self.tick_count > recent.tick.saturating_add(1);
+        let stale = self.current_tick() > recent.tick.saturating_add(1);
         if stale {
             self.recent_resource_ctable_fetch = None;
             return None;
@@ -17845,7 +17847,7 @@ impl super::TrapDispatcher {
         if trace_palette_enabled() {
             eprintln!(
                 "[PALETTE] PublishFetchedCTableForOffscreenDrawPicture tick={} port=${:08X} ct_id={} entries={} ctab=${:08X} device[8]=({:04X},{:04X},{:04X}) device[9]=({:04X},{:04X},{:04X})",
-                self.tick_count,
+                self.current_tick(),
                 port,
                 fetch.ct_id,
                 entries,
@@ -17892,7 +17894,7 @@ impl super::TrapDispatcher {
             eprintln!(
                 "[PALETTE] {} tick={} picHandle=${:08X} picPtr=${:08X} scale={:.3} cm[0]=({:04X},{:04X},{:04X}) cm[1]=({:04X},{:04X},{:04X}) cm[16]=({:04X},{:04X},{:04X}) cm[42]=({:04X},{:04X},{:04X}) cm[128]=({:04X},{:04X},{:04X}) cm[255]=({:04X},{:04X},{:04X})",
                 event,
-                self.tick_count,
+                self.current_tick(),
                 pic_handle,
                 pic_ptr,
                 scale,
@@ -17946,7 +17948,7 @@ impl super::TrapDispatcher {
         if trace_ctab_seed_enabled() {
             eprintln!(
                 "[CTAB-SEED] tick={} next_ct_seed -> {}",
-                self.tick_count, seed,
+                self.current_tick(), seed,
             );
         }
         seed
@@ -17964,7 +17966,7 @@ impl super::TrapDispatcher {
         if trace_ctab_seed_enabled() {
             eprintln!(
                 "[CTAB-SEED-WRITE] tick={} label={} ctab_ptr=${:08X} seed={}",
-                self.tick_count, label, ctab_ptr, seed,
+                self.current_tick(), label, ctab_ptr, seed,
             );
         }
     }
@@ -18468,7 +18470,7 @@ impl super::TrapDispatcher {
             if trace_palette_enabled() {
                 eprintln!(
                     "[PALETTE] SyncOffscreenCtab tick={} port=${:08X} ctab=${:08X} rgb16=({:04X},{:04X},{:04X}) rgb42=({:04X},{:04X},{:04X}) rgb128=({:04X},{:04X},{:04X})",
-                    self.tick_count,
+                    self.current_tick(),
                     port,
                     ctab_handle,
                     clut[16][0],
@@ -18703,7 +18705,7 @@ impl super::TrapDispatcher {
     ) -> Option<[[u16; 3]; 256]> {
         if explicit_ctab_handle != 0
             || source_gdevice != self.main_gdevice_handle
-            || self.tick_count >= self.seeded_picture_palette_until_tick
+            || self.current_tick() >= self.seeded_picture_palette_until_tick
             || Self::uses_canonical_system_8bpp_clut(&self.seeded_picture_palette)
         {
             None
@@ -23530,7 +23532,7 @@ impl super::TrapDispatcher {
             {
                 eprintln!(
                     "[PALETTE] SetEntries tick={} start={} count={} table=${:08X} first=value:{} rgb=({:04X},{:04X},{:04X}) last=value:{} rgb=({:04X},{:04X},{:04X}) device[0]=({:04X},{:04X},{:04X}) device[1]=({:04X},{:04X},{:04X}) device[16]=({:04X},{:04X},{:04X}) device[42]=({:04X},{:04X},{:04X}) device[128]=({:04X},{:04X},{:04X}) device[255]=({:04X},{:04X},{:04X}) cm[0]=({:04X},{:04X},{:04X}) cm[1]=({:04X},{:04X},{:04X}) cm[16]=({:04X},{:04X},{:04X}) cm[42]=({:04X},{:04X},{:04X}) cm[128]=({:04X},{:04X},{:04X}) cm[255]=({:04X},{:04X},{:04X})",
-                    self.tick_count,
+                    self.current_tick(),
                     start,
                     count,
                     table_ptr,
@@ -23633,7 +23635,7 @@ impl super::TrapDispatcher {
         // Inside Macintosh Volume V, V-143.
         let preserve_seeded_picture_palette = self.set_entries_target_is_screen(bus)
             && incoming_default_palette
-            && self.tick_count < self.seeded_picture_palette_until_tick
+            && self.current_tick() < self.seeded_picture_palette_until_tick
             && !Self::uses_canonical_system_8bpp_clut(&self.seeded_picture_palette);
         if preserve_seeded_picture_palette && !strict_palette && !palette_as_game_wrote_enabled() {
             self.screen_palette_fade_active = true;
@@ -23657,11 +23659,11 @@ impl super::TrapDispatcher {
             // by ~4 points (old scene palette leaks into new scene's
             // canonical fade-ups). +64 is the safe maximum that
             // avoids cross-scene leakage.
-            self.seeded_picture_palette_until_tick = self.tick_count.saturating_add(64);
+            self.seeded_picture_palette_until_tick = self.current_tick().saturating_add(64);
             if trace_palette_enabled() {
                 eprintln!(
                     "[PALETTE] PreserveSeededPicture tick={} table=${:08X} until_tick={} device[0]=({:04X},{:04X},{:04X}) device[1]=({:04X},{:04X},{:04X}) device[42]=({:04X},{:04X},{:04X}) device[128]=({:04X},{:04X},{:04X}) device[255]=({:04X},{:04X},{:04X})",
-                    self.tick_count,
+                    self.current_tick(),
                     table_ptr,
                     self.seeded_picture_palette_until_tick,
                     self.device_clut[0][0],
@@ -23686,7 +23688,7 @@ impl super::TrapDispatcher {
                 let seed = self.seeded_picture_palette[0];
                 eprintln!(
                     "[CM-WRITE] PreserveSeeded@13177 tick={} cm[0]=({:04X},{:04X},{:04X}) <- seeded[0]=({:04X},{:04X},{:04X})",
-                    self.tick_count, cm_before[0], cm_before[1], cm_before[2], seed[0], seed[1], seed[2]
+                    self.current_tick(), cm_before[0], cm_before[1], cm_before[2], seed[0], seed[1], seed[2]
                 );
             }
             *self.color_manager_clut = self.seeded_picture_palette;
@@ -23752,14 +23754,14 @@ impl super::TrapDispatcher {
                 let dev0 = self.device_clut[0];
                 eprintln!(
                     "[CM-WRITE] PublishCm@13220 tick={} cm[0]=({:04X},{:04X},{:04X}) <- device[0]=({:04X},{:04X},{:04X})",
-                    self.tick_count, cm_before[0], cm_before[1], cm_before[2], dev0[0], dev0[1], dev0[2]
+                    self.current_tick(), cm_before[0], cm_before[1], cm_before[2], dev0[0], dev0[1], dev0[2]
                 );
             }
             *self.color_manager_clut = *self.device_clut;
             if trace_palette_enabled() {
                 eprintln!(
                     "[PALETTE] PublishCm tick={} — fresh full palette install cm[0]=({:04X},{:04X},{:04X}) cm[255]=({:04X},{:04X},{:04X})",
-                    self.tick_count,
+                    self.current_tick(),
                     self.color_manager_clut[0][0],
                     self.color_manager_clut[0][1],
                     self.color_manager_clut[0][2],

--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -1778,7 +1778,7 @@ impl super::TrapDispatcher {
                 if trace_getresource_enabled() {
                     eprintln!(
                         "[GETRESOURCE] tick={} type='{}' id={}",
-                        self.tick_count,
+                        self.current_tick(),
                         format_ostype(res_type),
                         res_id,
                     );

--- a/src/trap/shapes.rs
+++ b/src/trap/shapes.rs
@@ -432,7 +432,7 @@ impl super::TrapDispatcher {
                     r.right,
                     area,
                     *self.current_port,
-                    self.tick_count,
+                    self.current_tick(),
                 );
             }
         }
@@ -1365,7 +1365,7 @@ impl super::TrapDispatcher {
                         dst_right: r.right,
                     };
                     let candidate_area = i64::from(width) * i64::from(height);
-                    let current_area = if self.last_screen_frame_rect_tick == self.tick_count {
+                    let current_area = if self.last_screen_frame_rect_tick == self.current_tick() {
                         self.last_screen_frame_rect
                             .map(|current| {
                                 i64::from(current.dst_right.saturating_sub(current.dst_left))
@@ -1375,11 +1375,11 @@ impl super::TrapDispatcher {
                     } else {
                         0
                     };
-                    if self.last_screen_frame_rect_tick != self.tick_count
+                    if self.last_screen_frame_rect_tick != self.current_tick()
                         || candidate_area > current_area
                     {
                         self.last_screen_frame_rect = Some(candidate);
-                        self.last_screen_frame_rect_tick = self.tick_count;
+                        self.last_screen_frame_rect_tick = self.current_tick();
                     }
                 }
             }

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -4806,7 +4806,7 @@ impl super::TrapDispatcher {
     /// controller's MCIdle so playback is timeline-driven rather than jumping
     /// straight to the movie's end.
     fn advance_and_render_active_movies(&mut self, bus: &mut MacMemoryBus) {
-        let now = self.tick_count;
+        let now = self.current_tick();
         let movie_ptrs: Vec<u32> = self.movie_states.keys().copied().collect();
         for movie in movie_ptrs {
             let (finished, target_time, has_video) = {
@@ -5438,7 +5438,7 @@ impl super::TrapDispatcher {
             // TickCount ($A975): Returns tick count from low-memory global `$016A`
             (true, 0x175) => {
                 let sp = cpu.read_reg(Register::A7);
-                bus.write_long(sp, self.tick_count);
+                bus.write_long(sp, self.current_tick());
                 Ok(())
             }
 
@@ -10211,13 +10211,13 @@ impl super::TrapDispatcher {
                 if super::dispatch::trace_input_enabled() {
                     eprintln!(
                         "[INPUT] GetKeys tick={} pc=${:08X} ptr=${:08X} key_map={:02X?}",
-                        self.tick_count, trap_pc, keys_ptr, self.input_state.key_map
+                        self.current_tick(), trap_pc, keys_ptr, self.input_state.key_map
                     );
                 }
                 if trace_getkeys_nonzero_enabled() && self.input_state.key_map.iter().any(|&byte| byte != 0) {
                     eprintln!(
                         "[INPUT] GetKeys nonzero tick={} pc=${:08X} ptr=${:08X} key_map={:02X?}",
-                        self.tick_count, trap_pc, keys_ptr, self.input_state.key_map
+                        self.current_tick(), trap_pc, keys_ptr, self.input_state.key_map
                     );
                 }
                 if self.input_state.key_map.iter().any(|&byte| byte != 0) {
@@ -11583,6 +11583,7 @@ impl super::TrapDispatcher {
                         let mut double_click = false;
                         let mut draw_state = None;
                         let mut draw_cells = Vec::new();
+                        let tick = self.current_tick();
 
                         if let Some(state) = self.list_states.get_mut(&list_handle) {
                             let previous_selected = state.selected.clone();
@@ -11609,13 +11610,13 @@ impl super::TrapDispatcher {
                             if let Some(cell) = cell {
                                 state.selected.insert(cell);
                                 double_click = state.last_click == cell
-                                    && self.tick_count.saturating_sub(state.last_click_tick)
+                                    && tick.saturating_sub(state.last_click_tick)
                                         <= Self::LIST_DOUBLE_CLICK_TICKS;
                                 state.last_click = cell;
-                                state.last_click_tick = self.tick_count;
+                                state.last_click_tick = tick;
                             } else {
                                 state.last_click = Self::list_no_click_cell();
-                                state.last_click_tick = self.tick_count;
+                                state.last_click_tick = tick;
                             }
                             if state.draw_enabled {
                                 draw_cells = previous_selected
@@ -14127,7 +14128,7 @@ impl super::TrapDispatcher {
                         // Inside Macintosh: QuickTime 1993, pp. 2-111 to 2-112.
                         let sp = cpu.read_reg(Register::A7);
                         let movie = bus.read_long(sp);
-                        let now = self.tick_count;
+                        let now = self.current_tick();
                         let err = if let Some(state) = self.movie_states.get_mut(&movie) {
                             state.active = true;
                             state.rate = state.preferred_rate;
@@ -15757,13 +15758,14 @@ impl super::TrapDispatcher {
                         // block holds theMovie among its longs; find it by
                         // matching a known movie handle.
                         0x0017 => {
+                            let tick = self.current_tick();
                             for off in (4..4 + param_size).step_by(4) {
                                 let candidate = bus.read_long(sp + off);
                                 if self.movie_states.contains_key(&candidate) {
                                     self.movie_by_controller.insert(instance, candidate);
                                     if let Some(state) = self.movie_states.get_mut(&candidate) {
                                         state.active = true;
-                                        state.last_service_tick = Some(self.tick_count);
+                                        state.last_service_tick = Some(tick);
                                     }
                                     break;
                                 }
@@ -15772,6 +15774,7 @@ impl super::TrapDispatcher {
                         // MCDoAction(mc, action, params). Pascal push order puts
                         // params(long) at sp+4 and action(word) at sp+8.
                         0x0009 => {
+                            let tick = self.current_tick();
                             let action = bus.read_word(sp + 8);
                             let param = bus.read_long(sp + 4);
                             if let Some(&movie) = self.movie_by_controller.get(&instance) {
@@ -15782,7 +15785,7 @@ impl super::TrapDispatcher {
                                             let rate = param as i32;
                                             state.rate = if rate != 0 { rate } else { 0x0001_0000 };
                                             state.active = true;
-                                            state.last_service_tick = Some(self.tick_count);
+                                            state.last_service_tick = Some(tick);
                                         }
                                         // mcActionStop(2)/mcActionSetPlayRate not
                                         // separately tracked; stop clears the rate.

--- a/src/trap/window.rs
+++ b/src/trap/window.rs
@@ -2281,7 +2281,7 @@ impl super::TrapDispatcher {
             let rect = Self::region_handle_rect(bus, update_handle);
             eprintln!(
                 "[INVAL] BeginUpdate window=${:08X} update_handle=${:08X} update_rect_before={:?} tick={}",
-                window, update_handle, rect, self.tick_count
+                window, update_handle, rect, self.current_tick()
             );
         }
         let Some(update_rect) = self.window_update_rect(bus, window) else {
@@ -3155,7 +3155,7 @@ impl super::TrapDispatcher {
         if std::env::var_os("SYSTEMLESS_TRACE_INVAL").is_some() {
             eprintln!(
                 "[INVAL] queue_window_update_event window=${:08X} tick={}",
-                window_ptr, self.tick_count
+                window_ptr, self.current_tick()
             );
         }
         self.event_queue.push_back(QueuedEvent {
@@ -3205,7 +3205,7 @@ impl super::TrapDispatcher {
                 clipped_global.1,
                 clipped_global.2,
                 clipped_global.3,
-                self.tick_count
+                self.current_tick()
             );
         }
         self.queue_window_update_event(window_ptr);
@@ -4206,7 +4206,7 @@ impl super::TrapDispatcher {
                         requested_window,
                         the_window,
                         self.front_window,
-                        self.tick_count
+                        self.current_tick()
                     );
                 }
                 // A userItem ProcPtr is not a WindowPtr.
@@ -4297,7 +4297,7 @@ impl super::TrapDispatcher {
                         cpu.read_reg(Register::PC).wrapping_sub(2),
                         the_window,
                         self.front_window,
-                        self.tick_count
+                        self.current_tick()
                     );
                 }
                 // A userItem ProcPtr is not a WindowPtr. Treat ProcPtrs
@@ -5111,7 +5111,7 @@ impl super::TrapDispatcher {
                 if trace_inval_enabled() {
                     eprintln!(
                         "[INVAL] InvalRect tick={} port=${:08X} window=${:08X} front=${:08X}",
-                        self.tick_count, *self.current_port, target_window, self.front_window
+                        self.current_tick(), *self.current_port, target_window, self.front_window
                     );
                 }
                 if target_window != 0 && rect_ptr != 0 {


### PR DESCRIPTION
Closes #1324. Makes the wrapping Macintosh tick clock process-owned across 68K and PowerPC execution, keeps low-memory Ticks as a projection, prevents stale native slices from regressing time after nested callbacks, and preserves the existing public PpcLoadedApp tick_count field. Adds cross-ISA, projection, wraparound, and detached-clone coverage.