### PR TITLE
fix: restore desktop after moving windows

### DIFF
--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -52037,6 +52037,17 @@ fn ppc_validate_window_local_rect(
     }
 }
 
+fn ppc_standard_desktop_color(h: i32, v: i32) -> PpcRgbColor {
+    // Host menu-bar suppression changes only presentation and clipping; it
+    // does not replace the guest Window Manager's GrayRgn pattern with black.
+    // Macintosh Toolbox Essentials (1992), pp. 4-113--4-119.
+    if crate::window_manager::standard_desktop_pattern_is_ink(h, v) {
+        PPC_RGB_BLACK
+    } else {
+        PPC_RGB_WHITE
+    }
+}
+
 fn ppc_repaint_window_geometry_transition(
     memory: &mut PpcSectionMem,
     gworlds: &[PpcGWorldRecord],
@@ -52107,13 +52118,7 @@ fn ppc_restore_window_removal_exposure(
     if paint.0 < paint.2 && paint.1 < paint.3 {
         for v in i32::from(paint.0)..i32::from(paint.2) {
             for h in i32::from(paint.1)..i32::from(paint.3) {
-                let color = if host_menu_bar_hidden
-                    || crate::window_manager::standard_desktop_pattern_is_ink(h, v)
-                {
-                    PPC_RGB_BLACK
-                } else {
-                    PPC_RGB_WHITE
-                };
+                let color = ppc_standard_desktop_color(h, v);
                 let _ = ppc_quickdraw_write_pixel(memory, front_buffer, (h, v), color);
             }
         }
@@ -52872,13 +52877,7 @@ fn ppc_paint_behind(
             if let Some(front_buffer) = ppc_front_buffer_for_gworld(gworlds, PPC_MAIN_GWORLD) {
                 for v in i32::from(paint.0)..i32::from(paint.2) {
                     for h in i32::from(paint.1)..i32::from(paint.3) {
-                        let color = if host_menu_bar_hidden
-                            || crate::window_manager::standard_desktop_pattern_is_ink(h, v)
-                        {
-                            PPC_RGB_BLACK
-                        } else {
-                            PPC_RGB_WHITE
-                        };
+                        let color = ppc_standard_desktop_color(h, v);
                         let _ = ppc_quickdraw_write_pixel(memory, front_buffer, (h, v), color);
                     }
                 }
@@ -139681,7 +139680,7 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn ppc_paint_behind_hidden_menu_uses_solid_black_desktop() {
+    fn ppc_paint_behind_hidden_menu_uses_classic_desktop_pattern() {
         let pef = synthetic_pef_with_import(b"NewCWindow");
         let mut loaded = load_pef_application(&pef).unwrap();
         loaded.toolbox_startup.host_menu_bar_hidden = true;
@@ -139718,10 +139717,54 @@ pub(crate) mod tests {
         );
         let black = ppc_physical_screen_color_pixel(front, PPC_RGB_BLACK, &loaded.screen_clut)
             .unwrap();
+        let white = ppc_physical_screen_color_pixel(front, PPC_RGB_WHITE, &loaded.screen_clut)
+            .unwrap();
         assert_eq!(
-            ppc_quickdraw_read_pixel(&mut loaded.memory, front, (10, 10)),
+            ppc_quickdraw_read_pixel(&mut loaded.memory, front, (0, 0)),
             Some(black),
-            "hidden-menu desktop exposure must not retain the checkerboard",
+        );
+        assert_eq!(
+            ppc_quickdraw_read_pixel(&mut loaded.memory, front, (1, 0)),
+            Some(white),
+            "host menu suppression must not turn PaintBehind's desktop solid black",
+        );
+    }
+
+    #[test]
+    fn ppc_window_removal_exposure_uses_pattern_when_host_hides_menu_bar() {
+        let pef = synthetic_pef_with_import(b"NewCWindow");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let front = ppc_live_front_buffer_for_gworld(
+            &mut loaded.memory,
+            &loaded.gworlds,
+            PPC_MAIN_GWORLD,
+        )
+        .unwrap();
+        let mut event_queue = VecDeque::new();
+
+        ppc_restore_window_removal_exposure(
+            &mut loaded.memory,
+            &loaded.gworlds,
+            &[],
+            Some((0, 0, 2, 2)),
+            true,
+            &mut event_queue,
+            0,
+            PpcInputSnapshot::default(),
+        );
+
+        let black = ppc_physical_screen_color_pixel(front, PPC_RGB_BLACK, &loaded.screen_clut)
+            .unwrap();
+        let white = ppc_physical_screen_color_pixel(front, PPC_RGB_WHITE, &loaded.screen_clut)
+            .unwrap();
+        assert_eq!(
+            ppc_quickdraw_read_pixel(&mut loaded.memory, front, (0, 0)),
+            Some(black),
+        );
+        assert_eq!(
+            ppc_quickdraw_read_pixel(&mut loaded.memory, front, (1, 0)),
+            Some(white),
+            "moving or closing a window must restore GrayRgn even when its menu bar is hidden",
         );
     }
 

--- a/src/trap/window.rs
+++ b/src/trap/window.rs
@@ -1370,39 +1370,25 @@ impl super::TrapDispatcher {
     ) {
         let (screen_base, row_bytes, screen_width, screen_height, pixel_size) =
             self.get_screen_params();
-        if self.menu_bar_hidden || self.fullscreen_locked {
-            Self::fb_fill_rect(
-                bus,
-                screen_base,
-                row_bytes,
-                pixel_size,
-                screen_width,
-                screen_height,
-                top,
-                left,
-                bottom,
-                right,
-                true,
-            );
-        } else {
-            // SetDeskCPat defines the desktop as the Window Manager's
-            // patterned background. Systemless uses the standard QuickDraw
-            // gray pattern when app-style hosting exposes desktop areas.
-            // Inside Macintosh Volume V, V-210
-            Self::fb_fill_pattern_rect(
-                bus,
-                screen_base,
-                row_bytes,
-                pixel_size,
-                screen_width,
-                screen_height,
-                top,
-                left,
-                bottom,
-                right,
-                crate::window_manager::STANDARD_DESKTOP_PATTERN,
-            );
-        }
+        // GrayRgn and the desktop pattern are guest Window Manager state;
+        // hiding the guest menu bar is only a host presentation choice and
+        // does not turn a windowed application's desktop black. A genuine
+        // kiosk aperture is reapplied later by the dedicated stage compositor.
+        // Inside Macintosh Volume I (1985), pp. I-282 and I-289;
+        // Macintosh Toolbox Essentials (1992), pp. 4-113--4-119.
+        Self::fb_fill_pattern_rect(
+            bus,
+            screen_base,
+            row_bytes,
+            pixel_size,
+            screen_width,
+            screen_height,
+            top,
+            left,
+            bottom,
+            right,
+            crate::window_manager::STANDARD_DESKTOP_PATTERN,
+        );
     }
 
     fn erase_window_content_rect(
@@ -12128,13 +12114,13 @@ mod tests {
     }
 
     #[test]
-    fn move_window_restores_exposed_desktop_when_menu_bar_visible() {
+    fn move_window_restores_exposed_desktop_when_host_hides_menu_bar() {
         let (mut disp, mut cpu, mut bus) = setup();
         let screen_base = bus.alloc(800 * 600);
         bus.write_long(0x0824, screen_base);
         bus.write_word(crate::memory::globals::addr::MBAR_HEIGHT, 20);
         disp.screen_mode = (screen_base, 800, 800, 600, 8);
-        disp.menu_bar_hidden = false;
+        disp.menu_bar_hidden = true;
         super::super::TrapDispatcher::fb_fill_pattern_rect(
             &mut bus,
             screen_base,
@@ -12179,7 +12165,7 @@ mod tests {
         assert_eq!(
             bus.read_byte(old_content_probe),
             255,
-            "moving a visible window should restore the exposed old area to the desktop pattern"
+            "host menu suppression must not turn the exposed desktop black"
         );
         let new_content_probe = screen_base + 250 * 800 + 460;
         assert_eq!(


### PR DESCRIPTION
## Summary
- keep Window Manager desktop painting independent from host menu-bar visibility
- restore the classic GrayRgn pattern after 68K and PowerPC window movement, resizing, or closure
- preserve dedicated kiosk-stage rendering and add regressions for both CPU paths

## Validation
- `cargo test --locked move_window_restores_exposed_desktop_when_host_hides_menu_bar`
- `cargo test --locked ppc_paint_behind_hidden_menu_uses_classic_desktop_pattern`
- `cargo test --locked ppc_window_removal_exposure_uses_pattern_when_host_hides_menu_bar`
- `cargo test --locked --test toolbox_showcase`
- `cargo test --locked kiosk`
- `cargo check --locked --lib`
- `git diff --check`

Closes #1347