### PR TITLE
ci: publish native release archives for cargo binstall

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,0 +1,119 @@
+name: Release binaries
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: Existing release tag to build and attach binaries to
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing release tag to build and attach binaries to
+        required: true
+        type: string
+  pull_request:
+    paths:
+      - .github/workflows/release-binaries.yml
+      - .github/workflows/release-please.yml
+      - scripts/package-release.py
+      - Cargo.toml
+      - Cargo.lock
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Binary (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-22.04
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-22.04-arm
+          - target: x86_64-apple-darwin
+            os: macos-15-intel
+          - target: aarch64-apple-darwin
+            os: macos-14
+          - target: x86_64-pc-windows-msvc
+            os: windows-2022
+          - target: aarch64-pc-windows-msvc
+            os: windows-11-arm
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag || github.sha }}
+      # Fetch packaging tooling from the workflow revision, allowing manual
+      # backfills for release tags that predate this workflow.
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          path: release-tools
+          sparse-checkout: scripts/package-release.py
+          sparse-checkout-cone-mode: false
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Validate release tag against crate version
+        if: inputs.tag != ''
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          python - <<'PYTHON'
+          import os, tomllib
+          with open("Cargo.toml", "rb") as manifest:
+              version = tomllib.load(manifest)["package"]["version"]
+          assert os.environ["RELEASE_TAG"] == f"v{version}", "Release tag must match Cargo.toml"
+          PYTHON
+      - name: Install Linux audio dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libasound2-dev
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: release-${{ matrix.target }}
+      - name: Build release binary with default GUI and JIT features
+        run: cargo build --locked --release --bin systemless --target '${{ matrix.target }}'
+      - name: Package and smoke-test archive
+        run: python release-tools/scripts/package-release.py '${{ matrix.target }}'
+      - uses: actions/upload-artifact@v4
+        with:
+          name: systemless-${{ matrix.target }}
+          path: dist/*
+          if-no-files-found: error
+
+  upload:
+    needs: build
+    if: inputs.tag != '' && github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    concurrency:
+      group: release-binaries-${{ inputs.tag }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: systemless-*
+          merge-multiple: true
+          path: dist
+      - name: Attach archives and checksums to the existing release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          gh release view "$RELEASE_TAG"
+          gh release upload "$RELEASE_TAG" dist/* --clobber

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -13,13 +13,6 @@ on:
         description: Existing release tag to build and attach binaries to
         required: true
         type: string
-  pull_request:
-    paths:
-      - .github/workflows/release-binaries.yml
-      - .github/workflows/release-please.yml
-      - scripts/package-release.py
-      - Cargo.toml
-      - Cargo.lock
 
 permissions:
   contents: read

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,8 +17,19 @@ concurrency:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - id: release
+        uses: googleapis/release-please-action@v4
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  binaries:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    uses: ./.github/workflows/release-binaries.yml
+    with:
+      tag: ${{ needs.release-please.outputs.tag_name }}

--- a/README.md
+++ b/README.md
@@ -37,7 +37,18 @@ brew install benletchford/tap/systemless
 systemless path/to/app-or-game.sit
 ```
 
-Or install from crates.io:
+Install a prebuilt release with [cargo-binstall](https://github.com/cargo-bins/cargo-binstall):
+
+```sh
+cargo binstall systemless
+```
+
+Release archives and SHA-256 checksums are available on
+[GitHub Releases](https://github.com/benletchford/systemless/releases) for macOS,
+Linux (GNU), and Windows (MSVC), each on x86-64 and ARM64. Linux binaries require
+glibc 2.35 or newer and the ALSA runtime library (`libasound2` on Ubuntu 22.04).
+
+Or build and install from crates.io:
 
 ```sh
 cargo install systemless

--- a/scripts/package-release.py
+++ b/scripts/package-release.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Package a native release binary in cargo-binstall's default archive layout."""
+
+import hashlib
+import pathlib
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import tomllib
+import zipfile
+
+
+target = sys.argv[1]
+with open("Cargo.toml", "rb") as manifest:
+    version = tomllib.load(manifest)["package"]["version"]
+name = f"systemless-{target}-v{version}"
+windows = "windows" in target
+binary = "systemless.exe" if windows else "systemless"
+dist = pathlib.Path("dist")
+dist.mkdir(exist_ok=True)
+archive = dist / (name + (".zip" if windows else ".tgz"))
+
+with tempfile.TemporaryDirectory() as temporary:
+    root = pathlib.Path(temporary)
+    package = root / name
+    package.mkdir()
+    shutil.copy2(pathlib.Path("target") / target / "release" / binary, package)
+    for filename in ("LICENSE", "OFL.txt", "README.md"):
+        shutil.copy2(filename, package)
+    if windows:
+        with zipfile.ZipFile(archive, "w", zipfile.ZIP_DEFLATED) as output:
+            for path in sorted(package.iterdir()):
+                output.write(path, f"{name}/{path.name}")
+    else:
+        with tarfile.open(archive, "w:gz") as output:
+            output.add(package, arcname=name)
+    # Run the executable extracted from the archive to check both the package
+    # layout and native runtime dependencies without requiring a GUI display.
+    extracted = root / "extracted"
+    if windows:
+        with zipfile.ZipFile(archive) as source:
+            source.extractall(extracted)
+    else:
+        with tarfile.open(archive) as source:
+            source.extractall(extracted, filter="data")
+    subprocess.run([str(extracted / name / binary), "--help"], check=True)
+
+checksum = hashlib.file_digest(archive.open("rb"), "sha256").hexdigest()
+archive.with_name(archive.name + ".sha256").write_text(
+    f"{checksum}  {archive.name}\n", encoding="utf-8"
+)
+print(archive)


### PR DESCRIPTION
Releases currently have no native executables for cargo binstall. Invoke a reusable binary workflow directly when release-please creates a release, avoiding GITHUB_TOKEN release-event suppression. There are no push or pull-request triggers for the binary matrix; manual dispatch remains available for retries and backfills.

Build x86-64 and ARM64 archives for macOS, GNU Linux, and MSVC Windows with default GUI/JIT features. Smoke-test each extracted executable and attach archives plus SHA-256 checksums only after all six builds pass. Archive names and layout follow cargo-binstall defaults, including existing crate metadata. Validate the requested tag against Cargo.toml. Linux uses Ubuntu 22.04 for a glibc 2.35 baseline.

Validation: actionlint passes. A one-time six-platform validation run was started before removing the pull-request trigger; ordinary CI also runs on this PR.

Closes #1371