### PR TITLE
fix: preserve task-owned callers across mixed mode transitions

### DIFF
--- a/src/execution_kernel.rs
+++ b/src/execution_kernel.rs
@@ -11,8 +11,10 @@
 //! consume a different continuation.
 
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
+
+use crate::guest_procedure::GuestIsa;
 
 /// Stable execution-task identity used by the continuation owner.
 ///
@@ -29,6 +31,18 @@ impl ExecutionTaskId {
     pub(crate) const fn from_thread_id(thread_id: u32) -> Self {
         Self(thread_id)
     }
+
+    pub(crate) const fn thread_id(self) -> u32 {
+        self.0
+    }
+}
+
+/// Task-lifecycle effect emitted by a process service.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ExecutionTaskEffect {
+    Register(ExecutionTaskId),
+    SwitchTo(ExecutionTaskId),
+    Retire(ExecutionTaskId),
 }
 
 /// A request type that identifies the task which owns its continuation.
@@ -38,6 +52,247 @@ impl ExecutionTaskId {
 /// task metadata instead of rewriting it.
 pub(crate) trait TaskOwned {
     fn task(&self) -> ExecutionTaskId;
+}
+
+/// Architecture-neutral destination of one guest procedure invocation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct GuestCallTarget {
+    pub(crate) isa: GuestIsa,
+    pub(crate) entry: u32,
+    pub(crate) rtoc: u32,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct M68kRegisterState {
+    pub(crate) data: [u32; 8],
+    pub(crate) address: [u32; 7],
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum M68kResultSource {
+    Data(u8),
+    Address(u8),
+    Memory {
+        address: u32,
+        size: u8,
+    },
+    SpecialCase {
+        selector: u8,
+        arguments: PowerPcArguments,
+        stack_result: Option<u32>,
+    },
+}
+
+pub(crate) const MAX_POWERPC_GUEST_ARGUMENTS: usize = 13;
+
+/// Bounded, copyable native argument list carried by a semantic call request.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct PowerPcArguments {
+    values: [u32; MAX_POWERPC_GUEST_ARGUMENTS],
+    len: u8,
+}
+
+impl PowerPcArguments {
+    pub(crate) fn from_slice(values: &[u32]) -> Option<Self> {
+        if values.len() > MAX_POWERPC_GUEST_ARGUMENTS {
+            return None;
+        }
+        let mut arguments = Self {
+            values: [0; MAX_POWERPC_GUEST_ARGUMENTS],
+            len: u8::try_from(values.len()).ok()?,
+        };
+        arguments.values[..values.len()].copy_from_slice(values);
+        Some(arguments)
+    }
+
+    pub(crate) fn as_slice(&self) -> &[u32] {
+        &self.values[..usize::from(self.len)]
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum M68kResultTarget {
+    Data { index: u8, size: u8 },
+    Address { index: u8, size: u8 },
+    Ccr { mask: u8 },
+    Memory { address: u32, size: u8 },
+    SpecialCase { selector: u8, scratch: u32 },
+}
+
+/// Architecture-neutral policy for placing a guest callback's result in the
+/// caller's result slot.
+///
+/// The architecture adapter translates this policy to its ABI vocabulary.
+/// Inside Macintosh: PowerPC System Software (1994), pp. 2-12--2-16.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum GuestCallReturnPolicy {
+    Preserve,
+    Mask(u32),
+    Set(u32),
+    ZeroOrSet { zero: u32, nonzero: u32 },
+    CrBit(u8),
+    XerCa,
+    XerOv,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct PowerPcReturnState {
+    pub(crate) gpr3: u32,
+}
+
+/// The architecture-neutral payload supplied to a guest call.
+///
+/// A call into native PowerPC code receives its values through the PPC ABI
+/// registers/parameter area, while a call into 68K code needs the emulated
+/// stack/register interval. Both are represented here so the process-owned
+/// continuation stack does not have to infer an ABI from a CPU action.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct M68kCallRequest {
+    pub(crate) entry: u32,
+    pub(crate) initial_sp: u32,
+    pub(crate) final_sp: u32,
+    pub(crate) registers: M68kRegisterState,
+    pub(crate) result: Option<M68kResultSource>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum GuestCallArguments {
+    None,
+    PowerPc(PowerPcArguments),
+    M68k(M68kCallRequest),
+}
+
+/// One architecture-neutral guest procedure request.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct GuestCallRequest {
+    pub(crate) task: ExecutionTaskId,
+    pub(crate) target: GuestCallTarget,
+    pub(crate) arguments: GuestCallArguments,
+}
+
+impl GuestCallRequest {
+    pub(crate) fn new(target: GuestCallTarget) -> Self {
+        Self::for_task(ExecutionTaskId::APPLICATION, target)
+    }
+
+    pub(crate) fn for_task(task: ExecutionTaskId, target: GuestCallTarget) -> Self {
+        Self {
+            task,
+            target,
+            arguments: GuestCallArguments::None,
+        }
+    }
+
+    pub(crate) fn with_powerpc_arguments(mut self, arguments: PowerPcArguments) -> Self {
+        self.arguments = GuestCallArguments::PowerPc(arguments);
+        self
+    }
+
+    pub(crate) fn with_m68k_request(mut self, request: M68kCallRequest) -> Self {
+        self.arguments = GuestCallArguments::M68k(request);
+        self
+    }
+}
+
+impl TaskOwned for GuestCallRequest {
+    fn task(&self) -> ExecutionTaskId {
+        self.task
+    }
+}
+
+/// Typed resumption metadata for one guest call.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum GuestCallContinuation {
+    ReturnToM68k {
+        return_pc: u32,
+        final_sp: u32,
+        result: Option<M68kResultTarget>,
+    },
+    ReturnToPowerPc {
+        return_pc: u32,
+        final_pc: u32,
+        restore_rtoc: u32,
+        return_gpr3: GuestCallReturnPolicy,
+    },
+}
+
+impl GuestCallContinuation {
+    pub(crate) const fn to_m68k(
+        return_pc: u32,
+        final_sp: u32,
+        result: Option<M68kResultTarget>,
+    ) -> Self {
+        Self::ReturnToM68k {
+            return_pc,
+            final_sp,
+            result,
+        }
+    }
+
+    pub(crate) fn to_powerpc(
+        return_pc: u32,
+        final_pc: u32,
+        restore_rtoc: u32,
+        return_gpr3: impl Into<GuestCallReturnPolicy>,
+    ) -> Self {
+        Self::ReturnToPowerPc {
+            return_pc,
+            final_pc,
+            restore_rtoc,
+            return_gpr3: return_gpr3.into(),
+        }
+    }
+}
+
+/// Semantic guest-execution effect emitted by either ABI edge.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum GuestCallEffect {
+    CallGuest {
+        request: GuestCallRequest,
+        continuation: GuestCallContinuation,
+    },
+}
+
+impl GuestCallEffect {
+    pub(crate) const fn call_guest(
+        request: GuestCallRequest,
+        continuation: GuestCallContinuation,
+    ) -> Self {
+        Self::CallGuest {
+            request,
+            continuation,
+        }
+    }
+
+    pub(crate) fn request(self) -> GuestCallRequest {
+        match self {
+            Self::CallGuest { request, .. } => request,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct PendingPowerPcExecution {
+    pub(crate) target: GuestCallTarget,
+    pub(crate) arguments: PowerPcArguments,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct PendingM68kExecution {
+    pub(crate) entry: u32,
+    pub(crate) initial_sp: u32,
+    pub(crate) return_pc: u32,
+    pub(crate) final_sp: u32,
+    pub(crate) registers: M68kRegisterState,
+    pub(crate) result: Option<M68kResultSource>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct M68kResume {
+    pub(crate) return_pc: u32,
+    pub(crate) final_sp: u32,
+    pub(crate) result: Option<M68kResultTarget>,
+    pub(crate) powerpc: PowerPcReturnState,
 }
 
 /// Opaque, monotonically allocated identity for one submitted continuation.
@@ -94,6 +349,13 @@ impl<R: Copy, C: Copy> ContinuationState<R, C> {
 /// Why a transactional continuation operation was refused.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum ContinuationError {
+    TaskUnavailable {
+        task: ExecutionTaskId,
+    },
+    /// The adapter rejected its prepared return without changing live state.
+    CommitRefused {
+        call_id: CallId,
+    },
     /// A request's embedded owner disagreed with the task supplied to submit.
     TaskMismatch {
         expected: ExecutionTaskId,
@@ -119,10 +381,18 @@ pub(crate) enum ContinuationError {
         actual: ContinuationPhase,
         expected: ContinuationPhase,
     },
+    /// A concrete adapter context is still parked against the call. The
+    /// context must be restored before the semantic continuation can leave
+    /// the kernel.
+    ContextAttached {
+        call_id: CallId,
+        count: usize,
+    },
     /// A task with suspended continuations cannot be retired.
     RetirementRefused {
         task: ExecutionTaskId,
         depth: usize,
+        contexts: usize,
         current: bool,
     },
     /// The monotonic ID namespace is exhausted. This is practically
@@ -144,6 +414,8 @@ struct StoreState<R: Copy, C: Copy> {
     current_task: ExecutionTaskId,
     next_call_id: u64,
     stacks: HashMap<ExecutionTaskId, Vec<ContinuationState<R, C>>>,
+    attached_contexts: HashMap<CallId, usize>,
+    retired_tasks: HashSet<ExecutionTaskId>,
 }
 
 impl<R: Copy, C: Copy> Default for StoreState<R, C> {
@@ -152,6 +424,8 @@ impl<R: Copy, C: Copy> Default for StoreState<R, C> {
             current_task: ExecutionTaskId::APPLICATION,
             next_call_id: 1,
             stacks: HashMap::from([(ExecutionTaskId::APPLICATION, Vec::new())]),
+            attached_contexts: HashMap::new(),
+            retired_tasks: HashSet::new(),
         }
     }
 }
@@ -178,7 +452,6 @@ impl<R: Copy + Eq, C: Copy + Eq> Eq for ContinuationStore<R, C> {}
 
 impl<R: Copy + TaskOwned, C: Copy> ContinuationStore<R, C> {
     /// Return a handle sharing this store's live state.
-    #[cfg(test)]
     pub(crate) fn shared_handle(&self) -> Self {
         Self(Rc::clone(&self.0))
     }
@@ -188,12 +461,35 @@ impl<R: Copy + TaskOwned, C: Copy> ContinuationStore<R, C> {
         self.0.borrow().current_task
     }
 
-    /// Select the task subsequent activation, completion, and retirement may
-    /// consume. Selecting a task creates an empty stack if necessary.
-    pub(crate) fn switch_to_task(&self, task: ExecutionTaskId) {
+    /// Register a new task exactly once for this process lifetime.
+    pub(crate) fn register_task(&self, task: ExecutionTaskId) -> Result<(), ContinuationError> {
         let mut state = self.0.borrow_mut();
-        state.stacks.entry(task).or_default();
+        if state.stacks.contains_key(&task) || state.retired_tasks.contains(&task) {
+            return Err(ContinuationError::TaskUnavailable { task });
+        }
+        state.stacks.insert(task, Vec::new());
+        Ok(())
+    }
+
+    /// Select an existing task without manufacturing or resurrecting it.
+    pub(crate) fn switch_to_task(&self, task: ExecutionTaskId) -> Result<(), ContinuationError> {
+        let mut state = self.0.borrow_mut();
+        if !state.stacks.contains_key(&task) {
+            return Err(ContinuationError::TaskUnavailable { task });
+        }
         state.current_task = task;
+        Ok(())
+    }
+
+    pub(crate) fn apply_task_effect(
+        &self,
+        effect: ExecutionTaskEffect,
+    ) -> Result<(), ContinuationError> {
+        match effect {
+            ExecutionTaskEffect::Register(task) => self.register_task(task),
+            ExecutionTaskEffect::SwitchTo(task) => self.switch_to_task(task),
+            ExecutionTaskEffect::Retire(task) => self.retire_task(task),
+        }
     }
 
     /// Submit a continuation to `task` and allocate its explicit call ID.
@@ -214,6 +510,9 @@ impl<R: Copy + TaskOwned, C: Copy> ContinuationStore<R, C> {
                 actual: task,
             });
         }
+        if !state.stacks.contains_key(&task) {
+            return Err(ContinuationError::TaskUnavailable { task });
+        }
         let Some(next_call_id) = state.next_call_id.checked_add(1) else {
             return Err(ContinuationError::CallIdExhausted);
         };
@@ -221,8 +520,8 @@ impl<R: Copy + TaskOwned, C: Copy> ContinuationStore<R, C> {
         state.next_call_id = next_call_id;
         state
             .stacks
-            .entry(task)
-            .or_default()
+            .get_mut(&task)
+            .expect("registered task")
             .push(ContinuationState {
                 call_id,
                 task,
@@ -252,6 +551,24 @@ impl<R: Copy + TaskOwned, C: Copy> ContinuationStore<R, C> {
         Ok(*frame)
     }
 
+    fn activate_attaching_context(
+        &self,
+        task: ExecutionTaskId,
+        call_id: CallId,
+    ) -> Result<ContinuationState<R, C>, ContinuationError> {
+        let mut state = self.0.borrow_mut();
+        Self::validate_transition(&state, task, call_id, ContinuationPhase::Pending)?;
+        let frame = state
+            .stacks
+            .get_mut(&task)
+            .and_then(|stack| stack.last_mut())
+            .expect("validated continuation must remain present");
+        frame.phase = ContinuationPhase::Active;
+        let frame = *frame;
+        *state.attached_contexts.entry(call_id).or_default() += 1;
+        Ok(frame)
+    }
+
     /// Complete the active top continuation with an optional neutral result.
     /// The result is retained until [`Self::retire`] consumes the frame.
     pub(crate) fn complete(
@@ -272,6 +589,33 @@ impl<R: Copy + TaskOwned, C: Copy> ContinuationStore<R, C> {
         Ok(*frame)
     }
 
+    fn complete_detaching_context(
+        &self,
+        task: ExecutionTaskId,
+        call_id: CallId,
+        result: Option<u32>,
+    ) -> Result<ContinuationState<R, C>, ContinuationError> {
+        let mut state = self.0.borrow_mut();
+        Self::validate_transition(&state, task, call_id, ContinuationPhase::Active)?;
+        let Some(context_count) = state.attached_contexts.get(&call_id).copied() else {
+            return Err(ContinuationError::ContextAttached { call_id, count: 0 });
+        };
+        let frame = state
+            .stacks
+            .get_mut(&task)
+            .and_then(|stack| stack.last_mut())
+            .expect("validated continuation must remain present");
+        frame.phase = ContinuationPhase::Completed;
+        frame.result = result;
+        let frame = *frame;
+        if context_count == 1 {
+            state.attached_contexts.remove(&call_id);
+        } else {
+            state.attached_contexts.insert(call_id, context_count - 1);
+        }
+        Ok(frame)
+    }
+
     /// Retire a completed top continuation after validating its exact ID.
     ///
     /// Retirement is separate from completion so a scheduler can observe the
@@ -283,6 +627,9 @@ impl<R: Copy + TaskOwned, C: Copy> ContinuationStore<R, C> {
     ) -> Result<ContinuationState<R, C>, ContinuationError> {
         let mut state = self.0.borrow_mut();
         Self::validate_transition(&state, task, call_id, ContinuationPhase::Completed)?;
+        if let Some(count) = state.attached_contexts.get(&call_id).copied() {
+            return Err(ContinuationError::ContextAttached { call_id, count });
+        }
         Ok(state
             .stacks
             .get_mut(&task)
@@ -300,6 +647,9 @@ impl<R: Copy + TaskOwned, C: Copy> ContinuationStore<R, C> {
     ) -> Result<ContinuationState<R, C>, ContinuationError> {
         let mut state = self.0.borrow_mut();
         Self::validate_transition(&state, task, call_id, ContinuationPhase::Pending)?;
+        if let Some(count) = state.attached_contexts.get(&call_id).copied() {
+            return Err(ContinuationError::ContextAttached { call_id, count });
+        }
         Ok(state
             .stacks
             .get_mut(&task)
@@ -314,16 +664,34 @@ impl<R: Copy + TaskOwned, C: Copy> ContinuationStore<R, C> {
     /// first, then call this method.
     pub(crate) fn retire_task(&self, task: ExecutionTaskId) -> Result<(), ContinuationError> {
         let mut state = self.0.borrow_mut();
-        let depth = state.stacks.get(&task).map_or(0, Vec::len);
+        let Some(stack) = state.stacks.get(&task) else {
+            return Err(ContinuationError::TaskUnavailable { task });
+        };
+        let depth = stack.len();
+        let contexts = state
+            .stacks
+            .get(&task)
+            .into_iter()
+            .flatten()
+            .map(|continuation| {
+                state
+                    .attached_contexts
+                    .get(&continuation.call_id)
+                    .copied()
+                    .unwrap_or(0)
+            })
+            .sum();
         let current = state.current_task == task;
-        if current || depth != 0 {
+        if current || depth != 0 || contexts != 0 {
             return Err(ContinuationError::RetirementRefused {
                 task,
                 depth,
+                contexts,
                 current,
             });
         }
         state.stacks.remove(&task);
+        state.retired_tasks.insert(task);
         Ok(())
     }
 
@@ -354,7 +722,8 @@ impl<R: Copy + TaskOwned, C: Copy> ContinuationStore<R, C> {
     }
 
     pub(crate) fn task_is_empty(&self, task: ExecutionTaskId) -> bool {
-        self.task_depth(task) == 0
+        let state = self.0.borrow();
+        state.stacks.get(&task).is_none_or(Vec::is_empty)
     }
 
     /// Snapshot one task's stack in bottom-to-top order. The semantic layer
@@ -366,6 +735,67 @@ impl<R: Copy + TaskOwned, C: Copy> ContinuationStore<R, C> {
             .stacks
             .get(&task)
             .map_or_else(Vec::new, |stack| stack.clone())
+    }
+
+    #[cfg(test)]
+    fn attach_context(
+        &self,
+        task: ExecutionTaskId,
+        call_id: CallId,
+    ) -> Result<(), ContinuationError> {
+        let mut state = self.0.borrow_mut();
+        Self::validate_context_owner(&state, task, call_id)?;
+        *state.attached_contexts.entry(call_id).or_default() += 1;
+        Ok(())
+    }
+
+    #[cfg(test)]
+    fn detach_context(
+        &self,
+        task: ExecutionTaskId,
+        call_id: CallId,
+    ) -> Result<(), ContinuationError> {
+        let mut state = self.0.borrow_mut();
+        Self::validate_context_owner(&state, task, call_id)?;
+        let Some(count) = state.attached_contexts.get_mut(&call_id) else {
+            return Err(ContinuationError::ContextAttached { call_id, count: 0 });
+        };
+        *count -= 1;
+        if *count == 0 {
+            state.attached_contexts.remove(&call_id);
+        }
+        Ok(())
+    }
+
+    fn validate_context_owner(
+        state: &StoreState<R, C>,
+        task: ExecutionTaskId,
+        call_id: CallId,
+    ) -> Result<(), ContinuationError> {
+        let Some(owner) = Self::owner_of(state, call_id) else {
+            return Err(ContinuationError::CallIdMismatch {
+                task,
+                expected: state
+                    .stacks
+                    .get(&task)
+                    .and_then(|stack| stack.last())
+                    .map(|frame| frame.call_id()),
+                actual: call_id,
+            });
+        };
+        if owner != task {
+            return Err(ContinuationError::TaskMismatch {
+                expected: owner,
+                actual: task,
+            });
+        }
+        if state.current_task != task {
+            return Err(ContinuationError::TaskNotCurrent {
+                current: state.current_task,
+                requested: task,
+            });
+        }
+        Ok(())
     }
 
     fn validate_transition(
@@ -420,6 +850,256 @@ impl<R: Copy + TaskOwned, C: Copy> ContinuationStore<R, C> {
     }
 }
 
+/// Concrete adapter state parked against an exact semantic continuation.
+///
+/// The bank is generic so the execution kernel remains CPU-free. It owns the
+/// `(task, call)` association and registers every parked value with the
+/// continuation store, while an ISA adapter supplies the concrete context.
+/// Mixed Mode switch frames preserve nonvolatile state until the matching
+/// return crosses the mode boundary; they are linked in exact LIFO order.
+/// Inside Macintosh: PowerPC System Software (1994), pp. 2-9--2-13.
+#[derive(Clone, Debug)]
+pub(crate) struct ExecutionContextBank<T> {
+    by_call: HashMap<(ExecutionTaskId, CallId), T>,
+}
+
+/// Process-task snapshots keyed by the same stable identities as
+/// continuations and parked ISA contexts.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ExecutionTaskContextBank<T> {
+    by_task: HashMap<ExecutionTaskId, T>,
+}
+
+impl<T> Default for ExecutionContextBank<T> {
+    fn default() -> Self {
+        Self {
+            by_call: HashMap::new(),
+        }
+    }
+}
+
+impl<T> Default for ExecutionTaskContextBank<T> {
+    fn default() -> Self {
+        Self {
+            by_task: HashMap::new(),
+        }
+    }
+}
+
+impl<T> ExecutionTaskContextBank<T> {
+    #[cfg(test)]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.by_task.is_empty()
+    }
+
+    pub(crate) fn contains(&self, task: ExecutionTaskId) -> bool {
+        self.by_task.contains_key(&task)
+    }
+
+    pub(crate) fn get(&self, task: ExecutionTaskId) -> Option<&T> {
+        self.by_task.get(&task)
+    }
+
+    pub(crate) fn get_mut(&mut self, task: ExecutionTaskId) -> Option<&mut T> {
+        self.by_task.get_mut(&task)
+    }
+
+    pub(crate) fn insert(&mut self, task: ExecutionTaskId, context: T) -> Option<T> {
+        self.by_task.insert(task, context)
+    }
+
+    pub(crate) fn remove(&mut self, task: ExecutionTaskId) -> Option<T> {
+        self.by_task.remove(&task)
+    }
+}
+
+impl<T> ExecutionContextBank<T> {
+    pub(crate) fn contains(&self, task: ExecutionTaskId, call_id: CallId) -> bool {
+        self.by_call.contains_key(&(task, call_id))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
+        self.by_call.len()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.by_call.is_empty()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn task_len(&self, task: ExecutionTaskId) -> usize {
+        self.by_call
+            .keys()
+            .filter(|(owner, _)| *owner == task)
+            .count()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn park<R: Copy + TaskOwned, C: Copy>(
+        &mut self,
+        kernel: &ContinuationStore<R, C>,
+        task: ExecutionTaskId,
+        call_id: CallId,
+        context: T,
+    ) -> Result<(), (ContinuationError, T)> {
+        if self.contains(task, call_id) {
+            return Err((
+                ContinuationError::ContextAttached { call_id, count: 1 },
+                context,
+            ));
+        }
+        if let Err(error) = kernel.attach_context(task, call_id) {
+            return Err((error, context));
+        }
+        let replaced = self.by_call.insert((task, call_id), context);
+        debug_assert!(replaced.is_none());
+        Ok(())
+    }
+
+    pub(crate) fn park_while_activating<R: Copy + TaskOwned, C: Copy>(
+        &mut self,
+        kernel: &ContinuationStore<R, C>,
+        task: ExecutionTaskId,
+        call_id: CallId,
+        context: T,
+    ) -> Result<ContinuationState<R, C>, (ContinuationError, T)> {
+        if self.contains(task, call_id) {
+            return Err((
+                ContinuationError::ContextAttached { call_id, count: 1 },
+                context,
+            ));
+        }
+        let semantic = match kernel.activate_attaching_context(task, call_id) {
+            Ok(semantic) => semantic,
+            Err(error) => return Err((error, context)),
+        };
+        let replaced = self.by_call.insert((task, call_id), context);
+        debug_assert!(replaced.is_none());
+        Ok(semantic)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn take<R: Copy + TaskOwned, C: Copy>(
+        &mut self,
+        kernel: &ContinuationStore<R, C>,
+        task: ExecutionTaskId,
+        call_id: CallId,
+    ) -> Result<T, ContinuationError> {
+        if !self.contains(task, call_id) {
+            return Err(ContinuationError::ContextAttached { call_id, count: 0 });
+        }
+        kernel.detach_context(task, call_id)?;
+        Ok(self
+            .by_call
+            .remove(&(task, call_id))
+            .expect("validated context must remain parked"))
+    }
+
+    pub(crate) fn take_while_completing<R: Copy + TaskOwned, C: Copy>(
+        &mut self,
+        kernel: &ContinuationStore<R, C>,
+        task: ExecutionTaskId,
+        call_id: CallId,
+        result: Option<u32>,
+    ) -> Result<(T, ContinuationState<R, C>), ContinuationError> {
+        if !self.contains(task, call_id) {
+            return Err(ContinuationError::ContextAttached { call_id, count: 0 });
+        }
+        let semantic = kernel.complete_detaching_context(task, call_id, result)?;
+        let context = self
+            .by_call
+            .remove(&(task, call_id))
+            .expect("validated context must remain parked");
+        Ok((context, semantic))
+    }
+
+    /// Park the enclosing caller and activate its nested call as one change.
+    /// All identity/phase checks precede replacement of the installed engine.
+    pub(crate) fn activate_parking_caller<R: Copy + TaskOwned, C: Copy>(
+        &mut self,
+        kernel: &ContinuationStore<R, C>,
+        task: ExecutionTaskId,
+        call_id: CallId,
+        caller: Option<CallId>,
+        installed: &mut T,
+    ) -> Result<(), ContinuationError>
+    where
+        T: Default,
+    {
+        let mut state = kernel.0.borrow_mut();
+        ContinuationStore::validate_transition(&state, task, call_id, ContinuationPhase::Pending)?;
+        if let Some(caller) = caller {
+            ContinuationStore::validate_context_owner(&state, task, caller)?;
+            if caller == call_id {
+                return Err(ContinuationError::CallIdMismatch {
+                    task,
+                    expected: None,
+                    actual: caller,
+                });
+            }
+            if self.contains(task, caller) {
+                // Sibling callbacks reuse the enclosing caller's saved state.
+                *installed = T::default();
+            } else {
+                self.by_call
+                    .insert((task, caller), std::mem::take(installed));
+                *state.attached_contexts.entry(caller).or_default() += 1;
+            }
+        }
+        state
+            .stacks
+            .get_mut(&task)
+            .and_then(|stack| stack.last_mut())
+            .expect("validated continuation")
+            .phase = ContinuationPhase::Active;
+        Ok(())
+    }
+
+    /// Validate the complete return boundary before allowing adapter writes.
+    /// The closure must validate all fallible ABI work before mutating state;
+    /// it cannot execute guest code or reenter this store. Once it succeeds,
+    /// removal of the exact context and continuation cannot fail.
+    pub(crate) fn retire_with_context<R: Copy + TaskOwned, C: Copy>(
+        &mut self,
+        kernel: &ContinuationStore<R, C>,
+        task: ExecutionTaskId,
+        call_id: CallId,
+        apply: impl FnOnce(Option<&mut T>) -> bool,
+    ) -> Result<Option<T>, ContinuationError> {
+        let mut state = kernel.0.borrow_mut();
+        ContinuationStore::validate_transition(
+            &state,
+            task,
+            call_id,
+            ContinuationPhase::Completed,
+        )?;
+        let expected = usize::from(self.contains(task, call_id));
+        let attached = state.attached_contexts.get(&call_id).copied().unwrap_or(0);
+        if attached != expected {
+            return Err(ContinuationError::ContextAttached {
+                call_id,
+                count: attached,
+            });
+        }
+        if !apply(self.by_call.get_mut(&(task, call_id))) {
+            return Err(ContinuationError::CommitRefused { call_id });
+        }
+        state.attached_contexts.remove(&call_id);
+        state.stacks.get_mut(&task).expect("validated task").pop();
+        Ok(self.by_call.remove(&(task, call_id)))
+    }
+
+    pub(crate) fn same_slots<U>(&self, other: &ExecutionContextBank<U>) -> bool {
+        self.by_call.len() == other.by_call.len()
+            && self
+                .by_call
+                .keys()
+                .all(|key| other.by_call.contains_key(key))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -444,6 +1124,100 @@ mod tests {
 
     fn submit(store: &Store, task: ExecutionTaskId, entry: u32) -> CallId {
         store.submit(task, request(task, entry), entry + 1).unwrap()
+    }
+
+    #[test]
+    fn task_ids_cannot_be_created_by_submission_or_resurrected_after_retirement() {
+        let store = Store::default();
+        let worker = ExecutionTaskId::from_thread_id(77);
+        let snapshot = store.clone();
+        assert!(store.switch_to_task(worker).is_err());
+        assert!(store.submit(worker, request(worker, 0x1000), 0).is_err());
+        assert_eq!(store, snapshot);
+        store.register_task(worker).unwrap();
+        assert!(store.register_task(worker).is_err());
+        store.retire_task(worker).unwrap();
+        let retired = store.clone();
+        assert!(store.register_task(worker).is_err());
+        assert!(store.switch_to_task(worker).is_err());
+        assert!(store.submit(worker, request(worker, 0x1000), 0).is_err());
+        assert!(store.retire_task(worker).is_err());
+        assert_eq!(store, retired);
+    }
+
+    #[test]
+    fn nested_activation_validates_before_replacing_the_installed_caller() {
+        let store = Store::default();
+        let task = ExecutionTaskId::APPLICATION;
+        let outer = submit(&store, task, 0x1000);
+        store.activate(task, outer).unwrap();
+        let inner = submit(&store, task, 0x2000);
+        let mut bank = ExecutionContextBank::default();
+        let mut installed = 42_u32;
+        let before = store.clone();
+        assert!(bank
+            .activate_parking_caller(&store, task, inner, Some(inner), &mut installed)
+            .is_err());
+        assert_eq!(installed, 42);
+        assert_eq!(store, before);
+        assert!(bank.is_empty());
+        bank.activate_parking_caller(&store, task, inner, Some(outer), &mut installed)
+            .unwrap();
+        assert_eq!(installed, 0);
+        assert_eq!(store.peek(task).unwrap().phase(), ContinuationPhase::Active);
+        installed = 99;
+        assert!(bank
+            .activate_parking_caller(&store, task, inner, Some(outer), &mut installed)
+            .is_err());
+        assert_eq!(installed, 99);
+        store.complete(task, inner, None).unwrap();
+        store.retire(task, inner).unwrap();
+        store.complete(task, outer, None).unwrap();
+        assert_eq!(
+            bank.retire_with_context(&store, task, outer, |_| true),
+            Ok(Some(42))
+        );
+    }
+
+    #[test]
+    fn return_commit_validates_contexts_before_adapter_writes_and_retries() {
+        let store = Store::default();
+        let task = ExecutionTaskId::APPLICATION;
+        let call = submit(&store, task, 0x1000);
+        let mut bank = ExecutionContextBank::default();
+        bank.park(&store, task, call, 42_u32).unwrap();
+        // Pending calls cannot expose the parked caller to result writes.
+        assert!(bank
+            .retire_with_context(&store, task, call, |_| panic!("not completed"))
+            .is_err());
+        store.activate(task, call).unwrap();
+        store.complete(task, call, Some(7)).unwrap();
+        let snapshot = store.clone();
+        let mut wrong_bank = ExecutionContextBank::<u32>::default();
+        assert!(wrong_bank
+            .retire_with_context(&store, task, call, |_| panic!("missing context"))
+            .is_err());
+        assert_eq!(store, snapshot);
+        assert_eq!(
+            bank.retire_with_context(&store, task, call, |context| {
+                assert_eq!(context.as_deref(), Some(&42));
+                false
+            }),
+            Err(ContinuationError::CommitRefused { call_id: call })
+        );
+        assert_eq!(store, snapshot);
+        assert_eq!(
+            bank.retire_with_context(&store, task, call, |context| {
+                *context.unwrap() = 7;
+                true
+            }),
+            Ok(Some(7))
+        );
+        assert!(store.is_empty());
+        assert!(bank.is_empty());
+        assert!(bank
+            .retire_with_context(&store, task, call, |_| panic!("stale return"))
+            .is_err());
     }
 
     #[test]
@@ -491,16 +1265,17 @@ mod tests {
         let store = Store::default();
         let application = ExecutionTaskId::APPLICATION;
         let worker = ExecutionTaskId::from_thread_id(7);
+        store.register_task(worker).unwrap();
         let app_call = submit(&store, application, 0x1000);
         let worker_call = submit(&store, worker, 0x3000);
 
-        store.switch_to_task(worker);
+        store.switch_to_task(worker).unwrap();
         assert_eq!(store.depth(), 1);
         store.activate(worker, worker_call).unwrap();
         store.complete(worker, worker_call, None).unwrap();
         store.retire(worker, worker_call).unwrap();
 
-        store.switch_to_task(application);
+        store.switch_to_task(application).unwrap();
         assert_eq!(store.depth(), 1);
         assert_eq!(store.peek(application).unwrap().call_id(), app_call);
         store.activate(application, app_call).unwrap();
@@ -514,6 +1289,7 @@ mod tests {
         let store = Store::default();
         let application = ExecutionTaskId::APPLICATION;
         let worker = ExecutionTaskId::from_thread_id(9);
+        store.register_task(worker).unwrap();
 
         assert_eq!(
             store.submit(application, request(worker, 0x1000), 0x1001),
@@ -566,6 +1342,7 @@ mod tests {
         let store = Store::default();
         let application = ExecutionTaskId::APPLICATION;
         let worker = ExecutionTaskId::from_thread_id(11);
+        store.register_task(worker).unwrap();
         let call_id = submit(&store, application, 0x1000);
         let before = store.clone();
         assert!(matches!(
@@ -573,28 +1350,30 @@ mod tests {
             Err(ContinuationError::RetirementRefused {
                 task,
                 depth: 1,
+                contexts: 0,
                 current: true,
             }) if task == application
         ));
         assert_eq!(store, before);
 
-        store.switch_to_task(worker);
+        store.switch_to_task(worker).unwrap();
         let before = store.clone();
         assert!(matches!(
             store.retire_task(application),
             Err(ContinuationError::RetirementRefused {
                 task,
                 depth: 1,
+                contexts: 0,
                 current: false,
             }) if task == application
         ));
         assert_eq!(store, before);
 
-        store.switch_to_task(application);
+        store.switch_to_task(application).unwrap();
         store.activate(application, call_id).unwrap();
         store.complete(application, call_id, None).unwrap();
         store.retire(application, call_id).unwrap();
-        store.switch_to_task(worker);
+        store.switch_to_task(worker).unwrap();
         assert_eq!(store.retire_task(application), Ok(()));
         assert!(store.task_is_empty(application));
     }
@@ -611,5 +1390,58 @@ mod tests {
         assert_eq!(shared.peek(task).unwrap().call_id(), call_id);
         shared.activate(task, call_id).unwrap();
         assert_eq!(store.peek(task).unwrap().phase(), ContinuationPhase::Active);
+    }
+
+    #[test]
+    fn concrete_contexts_are_keyed_by_exact_task_and_call() {
+        let store = Store::default();
+        let application = ExecutionTaskId::APPLICATION;
+        let worker = ExecutionTaskId::from_thread_id(13);
+        store.register_task(worker).unwrap();
+        let application_call = submit(&store, application, 0x1000);
+        let worker_call = submit(&store, worker, 0x2000);
+        let mut contexts = ExecutionContextBank::default();
+
+        assert_eq!(
+            contexts.park(&store, application, application_call, 0xaaaa),
+            Ok(())
+        );
+        assert_eq!(contexts.len(), 1);
+        assert_eq!(contexts.task_len(application), 1);
+        assert_eq!(contexts.task_len(worker), 0);
+
+        store.switch_to_task(worker).unwrap();
+        assert_eq!(contexts.park(&store, worker, worker_call, 0xbbbb), Ok(()));
+        assert_eq!(contexts.len(), 2);
+        assert_eq!(contexts.task_len(application), 1);
+        assert_eq!(contexts.task_len(worker), 1);
+        assert_eq!(contexts.take(&store, worker, worker_call), Ok(0xbbbb));
+        assert!(!contexts.contains(worker, worker_call));
+
+        store.switch_to_task(application).unwrap();
+        assert_eq!(
+            contexts.take(&store, application, application_call),
+            Ok(0xaaaa)
+        );
+        assert!(contexts.is_empty());
+    }
+
+    #[test]
+    fn attached_context_blocks_call_retirement_until_exact_restore() {
+        let store = Store::default();
+        let task = ExecutionTaskId::APPLICATION;
+        let call_id = submit(&store, task, 0x1000);
+        store.activate(task, call_id).unwrap();
+        let mut contexts = ExecutionContextBank::default();
+        contexts.park(&store, task, call_id, 7).unwrap();
+        store.complete(task, call_id, None).unwrap();
+
+        assert_eq!(
+            store.retire(task, call_id),
+            Err(ContinuationError::ContextAttached { call_id, count: 1 })
+        );
+        assert_eq!(contexts.take(&store, task, call_id), Ok(7));
+        assert_eq!(store.retire(task, call_id).unwrap().call_id(), call_id);
+        assert!(store.is_empty());
     }
 }

--- a/src/guest_call.rs
+++ b/src/guest_call.rs
@@ -8,25 +8,20 @@
 //! while each adapter remains responsible for its architectural registers and
 //! ABI frame.
 
-use crate::execution_kernel::TaskOwned;
+#[cfg(test)]
+pub(crate) use crate::execution_kernel::MAX_POWERPC_GUEST_ARGUMENTS;
+pub(crate) use crate::execution_kernel::{
+    CallId, ContinuationPhase, ExecutionTaskId, GuestCallArguments, GuestCallContinuation,
+    GuestCallEffect, GuestCallRequest, GuestCallReturnPolicy, GuestCallTarget, M68kCallRequest,
+    M68kRegisterState, M68kResultSource, M68kResultTarget, M68kResume, PendingM68kExecution,
+    PendingPowerPcExecution, PowerPcArguments, PowerPcReturnState,
+};
+use crate::execution_kernel::{ExecutionContextBank, ExecutionTaskEffect};
 use crate::guest_procedure::GuestIsa;
 use ppc::{PpcCpu, PpcImportAction, PpcNativeReturnGpr3};
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
-
-// Compatibility exports for the first execution-kernel slice. The new
-// semantic IDs/phases/store are CPU-free; the legacy value objects and
-// SharedGuestCallStack below remain here temporarily because its parking and
-// resume methods still carry concrete PowerPC context.
-pub(crate) use crate::execution_kernel::{CallId, ContinuationPhase, ExecutionTaskId};
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) struct GuestCallTarget {
-    pub(crate) isa: GuestIsa,
-    pub(crate) entry: u32,
-    pub(crate) rtoc: u32,
-}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct M68kCallOrigin {
@@ -58,7 +53,6 @@ struct M68kExecution {
 struct PowerPcExecution {
     arguments: PowerPcArguments,
     return_pc: Option<u32>,
-    parked_cpu: Option<Box<PpcCpu>>,
     completed: Option<PowerPcReturnState>,
 }
 
@@ -74,90 +68,6 @@ struct GuestCallFrame {
     origin: GuestCallOrigin,
     m68k_execution: Option<M68kExecution>,
     powerpc_execution: Option<PowerPcExecution>,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) struct PendingM68kExecution {
-    pub(crate) entry: u32,
-    pub(crate) initial_sp: u32,
-    pub(crate) return_pc: u32,
-    pub(crate) final_sp: u32,
-    pub(crate) registers: M68kRegisterState,
-    pub(crate) result: Option<M68kResultSource>,
-}
-
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub(crate) struct M68kRegisterState {
-    pub(crate) data: [u32; 8],
-    pub(crate) address: [u32; 7],
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum M68kResultSource {
-    Data(u8),
-    Address(u8),
-    Memory {
-        address: u32,
-        size: u8,
-    },
-    SpecialCase {
-        selector: u8,
-        arguments: PowerPcArguments,
-        stack_result: Option<u32>,
-    },
-}
-
-pub(crate) const MAX_POWERPC_GUEST_ARGUMENTS: usize = 13;
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) struct PowerPcArguments {
-    values: [u32; MAX_POWERPC_GUEST_ARGUMENTS],
-    len: u8,
-}
-
-impl PowerPcArguments {
-    pub(crate) fn from_slice(values: &[u32]) -> Option<Self> {
-        if values.len() > MAX_POWERPC_GUEST_ARGUMENTS {
-            return None;
-        }
-        let mut arguments = Self {
-            values: [0; MAX_POWERPC_GUEST_ARGUMENTS],
-            len: u8::try_from(values.len()).ok()?,
-        };
-        arguments.values[..values.len()].copy_from_slice(values);
-        Some(arguments)
-    }
-
-    pub(crate) fn as_slice(&self) -> &[u32] {
-        &self.values[..usize::from(self.len)]
-    }
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum M68kResultTarget {
-    Data { index: u8, size: u8 },
-    Address { index: u8, size: u8 },
-    Ccr { mask: u8 },
-    Memory { address: u32, size: u8 },
-    SpecialCase { selector: u8, scratch: u32 },
-}
-
-/// Architecture-neutral policy for placing a guest callback's result in the
-/// caller's result slot.
-///
-/// The PowerPC CPU exposes the same choices through `PpcNativeReturnGpr3`, but
-/// that is an ABI detail. Keeping the policy here lets a 68K or PowerPC edge
-/// describe the same continuation without constructing a CPU action. Inside
-/// Macintosh: PowerPC System Software (1994), pp. 2-12--2-16.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum GuestCallReturnPolicy {
-    Preserve,
-    Mask(u32),
-    Set(u32),
-    ZeroOrSet { zero: u32, nonzero: u32 },
-    CrBit(u8),
-    XerCa,
-    XerOv,
 }
 
 impl From<PpcNativeReturnGpr3> for GuestCallReturnPolicy {
@@ -188,187 +98,13 @@ impl From<GuestCallReturnPolicy> for PpcNativeReturnGpr3 {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) struct PowerPcReturnState {
-    pub(crate) gpr3: u32,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) struct PendingPowerPcExecution {
-    pub(crate) target: GuestCallTarget,
-    pub(crate) arguments: PowerPcArguments,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) struct M68kResume {
-    pub(crate) return_pc: u32,
-    pub(crate) final_sp: u32,
-    pub(crate) result: Option<M68kResultTarget>,
-    pub(crate) powerpc: PowerPcReturnState,
-}
-
-/// The architecture-neutral payload supplied to a guest call.
-///
-/// A call into native PowerPC code receives its values through the PPC ABI
-/// registers/parameter area, while a call into 68K code needs the emulated
-/// stack/register interval. Both are represented here so the process-owned
-/// continuation stack does not have to infer an ABI from a CPU action.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) struct M68kCallRequest {
-    pub(crate) entry: u32,
-    pub(crate) initial_sp: u32,
-    pub(crate) final_sp: u32,
-    pub(crate) registers: M68kRegisterState,
-    pub(crate) result: Option<M68kResultSource>,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum GuestCallArguments {
-    None,
-    PowerPc(PowerPcArguments),
-    M68k(M68kCallRequest),
-}
-
-/// One architecture-neutral guest procedure request.
-///
-/// `task` identifies the process execution task that owns the eventual
-/// continuation. ABI adapters may construct a request before the stack's
-/// current task is known; `SharedGuestCallStack::push_effect` stamps its
-/// current task at the scheduling boundary.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) struct GuestCallRequest {
-    pub(crate) task: ExecutionTaskId,
-    pub(crate) target: GuestCallTarget,
-    pub(crate) arguments: GuestCallArguments,
-}
-
-impl GuestCallRequest {
-    pub(crate) fn new(target: GuestCallTarget) -> Self {
-        Self::for_task(ExecutionTaskId::APPLICATION, target)
-    }
-
-    pub(crate) fn for_task(task: ExecutionTaskId, target: GuestCallTarget) -> Self {
-        Self {
-            task,
-            target,
-            arguments: GuestCallArguments::None,
-        }
-    }
-
-    pub(crate) fn with_powerpc_arguments(mut self, arguments: PowerPcArguments) -> Self {
-        self.arguments = GuestCallArguments::PowerPc(arguments);
-        self
-    }
-
-    pub(crate) fn with_m68k_request(mut self, request: M68kCallRequest) -> Self {
-        self.arguments = GuestCallArguments::M68k(request);
-        self
-    }
-
-    fn with_task(mut self, task: ExecutionTaskId) -> Self {
-        self.task = task;
-        self
-    }
-}
-
-impl TaskOwned for GuestCallRequest {
-    fn task(&self) -> ExecutionTaskId {
-        self.task
-    }
-}
-
-/// Typed resumption metadata for one guest call.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum GuestCallContinuation {
-    ReturnToM68k {
-        return_pc: u32,
-        final_sp: u32,
-        result: Option<M68kResultTarget>,
-    },
-    ReturnToPowerPc {
-        return_pc: u32,
-        final_pc: u32,
-        restore_rtoc: u32,
-        return_gpr3: GuestCallReturnPolicy,
-    },
-}
-
-impl GuestCallContinuation {
-    pub(crate) const fn to_m68k(
-        return_pc: u32,
-        final_sp: u32,
-        result: Option<M68kResultTarget>,
-    ) -> Self {
-        Self::ReturnToM68k {
-            return_pc,
-            final_sp,
-            result,
-        }
-    }
-
-    pub(crate) fn to_powerpc(
-        return_pc: u32,
-        final_pc: u32,
-        restore_rtoc: u32,
-        return_gpr3: impl Into<GuestCallReturnPolicy>,
-    ) -> Self {
-        Self::ReturnToPowerPc {
-            return_pc,
-            final_pc,
-            restore_rtoc,
-            return_gpr3: return_gpr3.into(),
-        }
-    }
-}
-
 /// Compatibility aliases for the CPU-free semantic store. The concrete frame
 /// map below remains responsible for parked CPU contexts until the runner is
 /// migrated to consume continuation effects directly.
 pub(crate) type ContinuationStore =
     crate::execution_kernel::ContinuationStore<GuestCallRequest, GuestCallContinuation>;
 
-/// Semantic guest-execution effect emitted by either ABI edge.
-///
-/// `PpcImportAction` is deliberately produced/consumed only by the adapter
-/// methods below. Managers and Mixed Mode code exchange this effect instead
-/// of constructing an architecture-specific native-call action.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum GuestCallEffect {
-    CallGuest {
-        request: GuestCallRequest,
-        continuation: GuestCallContinuation,
-    },
-}
-
 impl GuestCallEffect {
-    pub(crate) const fn call_guest(
-        request: GuestCallRequest,
-        continuation: GuestCallContinuation,
-    ) -> Self {
-        Self::CallGuest {
-            request,
-            continuation,
-        }
-    }
-
-    fn with_task(self, task: ExecutionTaskId) -> Self {
-        match self {
-            Self::CallGuest {
-                request,
-                continuation,
-            } => Self::CallGuest {
-                request: request.with_task(task),
-                continuation,
-            },
-        }
-    }
-
-    pub(crate) fn request(self) -> GuestCallRequest {
-        match self {
-            Self::CallGuest { request, .. } => request,
-        }
-    }
-
     /// Convert the semantic effect to the PPC CPU's import ABI.
     ///
     /// Only a native PowerPC target can be represented by `CallNative`; a
@@ -404,7 +140,15 @@ impl GuestCallEffect {
     }
 
     /// Decode the PPC ABI adapter action back into its neutral effect.
+    #[cfg(test)]
     pub(crate) fn from_ppc_import_action(action: PpcImportAction) -> Option<Self> {
+        Self::from_ppc_import_action_for_task(ExecutionTaskId::APPLICATION, action)
+    }
+
+    pub(crate) fn from_ppc_import_action_for_task(
+        task: ExecutionTaskId,
+        action: PpcImportAction,
+    ) -> Option<Self> {
         let PpcImportAction::CallNative {
             entry,
             rtoc,
@@ -417,11 +161,14 @@ impl GuestCallEffect {
             return None;
         };
         Some(Self::call_guest(
-            GuestCallRequest::new(GuestCallTarget {
-                isa: GuestIsa::PowerPc,
-                entry,
-                rtoc,
-            }),
+            GuestCallRequest::for_task(
+                task,
+                GuestCallTarget {
+                    isa: GuestIsa::PowerPc,
+                    entry,
+                    rtoc,
+                },
+            ),
             GuestCallContinuation::to_powerpc(
                 return_pc,
                 final_pc,
@@ -475,7 +222,6 @@ impl GuestCallEffect {
                 powerpc_execution: Some(PowerPcExecution {
                     arguments,
                     return_pc: None,
-                    parked_cpu: None,
                     completed: None,
                 }),
             }),
@@ -574,7 +320,6 @@ impl PartialEq for GuestCallFrame {
                 (Some(left), Some(right)) => {
                     left.arguments == right.arguments
                         && left.return_pc == right.return_pc
-                        && left.parked_cpu.is_some() == right.parked_cpu.is_some()
                         && left.completed == right.completed
                 }
                 _ => false,
@@ -584,19 +329,41 @@ impl PartialEq for GuestCallFrame {
 
 impl Eq for GuestCallFrame {}
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Debug)]
 struct ExecutionTaskCalls {
     /// Authoritative task/order/phase state. The frame map below is only the
     /// temporary CPU-adapter projection keyed by this store's CallId.
     kernel: ContinuationStore,
     frames: HashMap<CallId, GuestCallFrame>,
+    powerpc_contexts: ExecutionContextBank<Box<PpcCpu>>,
 }
+
+impl Clone for ExecutionTaskCalls {
+    fn clone(&self) -> Self {
+        Self {
+            kernel: self.kernel.clone(),
+            frames: self.frames.clone(),
+            powerpc_contexts: self.powerpc_contexts.clone(),
+        }
+    }
+}
+
+impl PartialEq for ExecutionTaskCalls {
+    fn eq(&self, other: &Self) -> bool {
+        self.kernel == other.kernel
+            && self.frames == other.frames
+            && self.powerpc_contexts.same_slots(&other.powerpc_contexts)
+    }
+}
+
+impl Eq for ExecutionTaskCalls {}
 
 impl Default for ExecutionTaskCalls {
     fn default() -> Self {
         Self {
             kernel: ContinuationStore::default(),
             frames: HashMap::new(),
+            powerpc_contexts: ExecutionContextBank::default(),
         }
     }
 }
@@ -683,19 +450,23 @@ impl SharedGuestCallStack {
     }
 
     /// Select the continuation owner for subsequent guest execution.
-    pub(crate) fn switch_to_task(&self, task: ExecutionTaskId) {
-        self.0.borrow().kernel.switch_to_task(task);
+    pub(crate) fn register_task(&self, task: ExecutionTaskId) -> bool {
+        self.apply_task_effect(ExecutionTaskEffect::Register(task))
+    }
+
+    pub(crate) fn switch_to_task(&self, task: ExecutionTaskId) -> bool {
+        self.apply_task_effect(ExecutionTaskEffect::SwitchTo(task))
+    }
+
+    pub(crate) fn apply_task_effect(&self, effect: ExecutionTaskEffect) -> bool {
+        self.0.borrow().kernel.apply_task_effect(effect).is_ok()
     }
 
     /// Drop a retired task's empty continuation stack.
     ///
     /// A non-empty stack denotes suspended execution and cannot be discarded.
     pub(crate) fn remove_task(&self, task: ExecutionTaskId) -> bool {
-        let tasks = self.0.borrow_mut();
-        if tasks.kernel.retire_task(task).is_err() {
-            return false;
-        }
-        true
+        self.apply_task_effect(ExecutionTaskEffect::Retire(task))
     }
 
     #[cfg(test)]
@@ -708,6 +479,60 @@ impl SharedGuestCallStack {
         self.0.borrow().kernel.task_depth(task)
     }
 
+    /// Park concrete adapter state against an exact live continuation.
+    #[cfg(test)]
+    pub(crate) fn park_context<T>(
+        &self,
+        bank: &mut ExecutionContextBank<T>,
+        task: ExecutionTaskId,
+        call_id: CallId,
+        context: T,
+    ) -> Result<(), T> {
+        let tasks = self.0.borrow();
+        bank.park(&tasks.kernel, task, call_id, context)
+            .map_err(|(_, context)| context)
+    }
+
+    /// Return the active 68K-origin switch frame below the top 68K callback.
+    ///
+    /// This exact identity replaces the runner's old nesting-depth inference.
+    /// A repeated sibling callback sees the same owner token and reuses its
+    /// already parked caller; a deeper callback sees the newer token.
+    pub(crate) fn suspended_m68k_context_owner(&self) -> Option<(ExecutionTaskId, CallId)> {
+        let tasks = self.0.borrow();
+        let task = tasks.kernel.current_task();
+        tasks
+            .kernel
+            .task_states(task)
+            .into_iter()
+            .rev()
+            .filter_map(|semantic| {
+                let frame = tasks.frames.get(&semantic.call_id())?;
+                let execution = frame.powerpc_execution.as_ref()?;
+                (matches!(frame.origin, GuestCallOrigin::M68k(_))
+                    && execution.return_pc.is_some()
+                    && execution.completed.is_none())
+                .then_some((task, semantic.call_id()))
+            })
+            .next()
+    }
+
+    /// Return the exact continuation whose completed native result is ready
+    /// to resume a 68K caller.
+    pub(crate) fn pending_m68k_resume_owner(&self) -> Option<(ExecutionTaskId, CallId)> {
+        let tasks = self.0.borrow();
+        let task = tasks.kernel.current_task();
+        let semantic = tasks.kernel.peek(task)?;
+        let frame = tasks.frames.get(&semantic.call_id())?;
+        (matches!(frame.origin, GuestCallOrigin::M68k(_))
+            && frame
+                .powerpc_execution
+                .as_ref()
+                .and_then(|execution| execution.completed)
+                .is_some())
+        .then_some((task, semantic.call_id()))
+    }
+
     fn top_frame(&self) -> Option<(CallId, GuestCallFrame)> {
         let tasks = self.0.borrow();
         let task = tasks.kernel.current_task();
@@ -717,7 +542,6 @@ impl SharedGuestCallStack {
     }
 
     fn submit_effect(&self, effect: GuestCallEffect) -> Option<CallId> {
-        let effect = effect.with_task(self.current_task());
         let GuestCallEffect::CallGuest {
             request,
             continuation,
@@ -744,7 +568,7 @@ impl SharedGuestCallStack {
     ) -> bool {
         debug_assert_eq!(target.isa, GuestIsa::M68k);
         self.push_effect(GuestCallEffect::call_guest(
-            GuestCallRequest::new(target),
+            GuestCallRequest::for_task(self.current_task(), target),
             GuestCallContinuation::to_m68k(return_pc, final_sp, None),
         ))
     }
@@ -762,7 +586,8 @@ impl SharedGuestCallStack {
         }
         debug_assert_eq!(target.isa, GuestIsa::PowerPc);
         self.push_effect(GuestCallEffect::call_guest(
-            GuestCallRequest::new(target).with_powerpc_arguments(arguments),
+            GuestCallRequest::for_task(self.current_task(), target)
+                .with_powerpc_arguments(arguments),
             GuestCallContinuation::to_m68k(return_pc, final_sp, result),
         ))
     }
@@ -786,13 +611,15 @@ impl SharedGuestCallStack {
     ) -> bool {
         debug_assert_eq!(target.isa, GuestIsa::M68k);
         self.push_effect(GuestCallEffect::call_guest(
-            GuestCallRequest::new(target).with_m68k_request(M68kCallRequest {
-                entry,
-                initial_sp,
-                final_sp,
-                registers,
-                result,
-            }),
+            GuestCallRequest::for_task(self.current_task(), target).with_m68k_request(
+                M68kCallRequest {
+                    entry,
+                    initial_sp,
+                    final_sp,
+                    registers,
+                    result,
+                },
+            ),
             GuestCallContinuation::to_powerpc(return_pc, final_pc, restore_rtoc, return_gpr3),
         ))
     }
@@ -831,7 +658,11 @@ impl SharedGuestCallStack {
             (task, semantic.call_id(), frame.target, execution.arguments)
         };
         let mut tasks = self.0.borrow_mut();
-        tasks.kernel.activate(task, call_id).ok()?;
+        let kernel = tasks.kernel.shared_handle();
+        tasks
+            .powerpc_contexts
+            .park_while_activating(&kernel, task, call_id, Box::new(cpu.clone()))
+            .ok()?;
         let frame = tasks
             .frames
             .get_mut(&call_id)
@@ -840,7 +671,6 @@ impl SharedGuestCallStack {
             .powerpc_execution
             .as_mut()
             .expect("validated PowerPC transition must have an execution payload");
-        execution.parked_cpu = Some(Box::new(cpu.clone()));
         execution.return_pc = Some(return_pc);
         Some(PendingPowerPcExecution { target, arguments })
     }
@@ -858,6 +688,7 @@ impl SharedGuestCallStack {
     /// Mode links switch frames in LIFO order and preserves the emulated 68k
     /// context across every mode switch. Inside Macintosh: PowerPC System
     /// Software (1994), pp. 2-9--2-13.
+    #[cfg(test)]
     pub(crate) fn suspended_m68k_context_depth(&self) -> usize {
         let tasks = self.0.borrow();
         let task = tasks.kernel.current_task();
@@ -877,7 +708,7 @@ impl SharedGuestCallStack {
     }
 
     pub(crate) fn complete_powerpc_for_m68k(&self, cpu: &mut PpcCpu) -> bool {
-        let (task, call_id, parked_cpu) = {
+        let (task, call_id) = {
             let tasks = self.0.borrow();
             let task = tasks.kernel.current_task();
             let semantic = match tasks.kernel.peek(task) {
@@ -897,21 +728,22 @@ impl SharedGuestCallStack {
             if execution.completed.is_some() || execution.return_pc != Some(cpu.pc) {
                 return false;
             }
-            let Some(parked_cpu) = execution.parked_cpu.as_ref() else {
+            if !tasks.powerpc_contexts.contains(task, semantic.call_id()) {
                 return false;
-            };
-            (task, semantic.call_id(), parked_cpu.clone())
+            }
+            (task, semantic.call_id())
         };
         let result = PowerPcReturnState { gpr3: cpu.gpr[3] };
         let elapsed_time_base = cpu.time_base();
         let mut tasks = self.0.borrow_mut();
-        if tasks
-            .kernel
-            .complete(task, call_id, Some(result.gpr3))
-            .is_err()
-        {
+        let kernel = tasks.kernel.shared_handle();
+        let Ok((parked_cpu, _)) =
+            tasks
+                .powerpc_contexts
+                .take_while_completing(&kernel, task, call_id, Some(result.gpr3))
+        else {
             return false;
-        }
+        };
         let frame = tasks
             .frames
             .get_mut(&call_id)
@@ -920,7 +752,6 @@ impl SharedGuestCallStack {
             .powerpc_execution
             .as_mut()
             .expect("validated PowerPC transition must have an execution payload");
-        execution.parked_cpu.take();
         execution.completed = Some(result);
         *cpu = *parked_cpu;
         cpu.set_time_base(elapsed_time_base);
@@ -954,6 +785,7 @@ impl SharedGuestCallStack {
     /// Retire the completed 68K-origin continuation after its result has been
     /// applied by the runner. No architectural state is changed here, so a
     /// failed result application can leave the frame available for retry.
+    #[cfg(test)]
     pub(crate) fn retire_m68k_resume(&self) -> bool {
         let (task, call_id) = {
             let tasks = self.0.borrow();
@@ -982,6 +814,29 @@ impl SharedGuestCallStack {
         tasks.frames.remove(&call_id).is_some()
     }
 
+    /// Commit the ABI result and restore the exact caller under one validated
+    /// retirement boundary. The adapter closure must leave state unchanged
+    /// when it rejects a result and must not execute guest code.
+    pub(crate) fn commit_m68k_resume<T>(
+        &self,
+        bank: &mut ExecutionContextBank<T>,
+        apply: impl FnOnce(M68kResume, Option<&mut T>) -> bool,
+    ) -> Option<Option<T>> {
+        let resume = self.peek_m68k_resume()?;
+        let (task, call_id) = self.pending_m68k_resume_owner()?;
+        let mut tasks = self.0.borrow_mut();
+        let context = bank
+            .retire_with_context(&tasks.kernel, task, call_id, |context| {
+                apply(resume, context)
+            })
+            .ok()?;
+        tasks
+            .frames
+            .remove(&call_id)
+            .expect("validated resume frame");
+        Some(context)
+    }
+
     /// Take and retire a completed 68K-origin continuation.
     ///
     /// New runner code should prefer [`Self::peek_m68k_resume`] followed by
@@ -993,7 +848,26 @@ impl SharedGuestCallStack {
     }
 
     /// Return the top cross-ISA 68k interval and mark its CPU context active.
+    #[cfg(test)]
     pub(crate) fn activate_m68k(&self) -> Option<PendingM68kExecution> {
+        self.activate_m68k_in_bank(&mut ExecutionContextBank::<()>::default(), &mut (), None)
+    }
+
+    pub(crate) fn activate_m68k_parking<T: Default>(
+        &self,
+        bank: &mut ExecutionContextBank<T>,
+        installed: &mut T,
+    ) -> Option<PendingM68kExecution> {
+        let caller = self.suspended_m68k_context_owner().map(|(_, call)| call);
+        self.activate_m68k_in_bank(bank, installed, caller)
+    }
+
+    fn activate_m68k_in_bank<T: Default>(
+        &self,
+        bank: &mut ExecutionContextBank<T>,
+        installed: &mut T,
+        caller: Option<CallId>,
+    ) -> Option<PendingM68kExecution> {
         let (task, call_id, pending, started) = {
             let tasks = self.0.borrow();
             let task = tasks.kernel.current_task();
@@ -1014,7 +888,8 @@ impl SharedGuestCallStack {
             return Some(pending);
         }
         let mut tasks = self.0.borrow_mut();
-        tasks.kernel.activate(task, call_id).ok()?;
+        bank.activate_parking_caller(&tasks.kernel, task, call_id, caller, installed)
+            .ok()?;
         let frame = tasks
             .frames
             .get_mut(&call_id)
@@ -1052,7 +927,9 @@ impl SharedGuestCallStack {
         cpu: &mut PpcCpu,
         action: PpcImportAction,
     ) -> PpcImportAction {
-        let Some(effect) = GuestCallEffect::from_ppc_import_action(action) else {
+        let Some(effect) =
+            GuestCallEffect::from_ppc_import_action_for_task(self.current_task(), action)
+        else {
             return action;
         };
         let Some(call_id) = self.submit_effect(effect) else {
@@ -1305,6 +1182,30 @@ mod tests {
     }
 
     #[test]
+    fn stale_effect_task_is_rejected_without_rewriting_or_allocating_a_call() {
+        let calls = SharedGuestCallStack::default();
+        let effect = GuestCallEffect::call_guest(
+            GuestCallRequest::for_task(
+                ExecutionTaskId::APPLICATION,
+                GuestCallTarget {
+                    isa: GuestIsa::M68k,
+                    entry: 0x1000,
+                    rtoc: 0,
+                },
+            ),
+            GuestCallContinuation::to_m68k(0x2000, 0x3000, None),
+        );
+        assert!(calls.register_task(ExecutionTaskId::from_thread_id(7)));
+        assert!(calls.switch_to_task(ExecutionTaskId::from_thread_id(7)));
+        let before = calls.clone();
+        assert!(!calls.push_effect(effect));
+        assert_eq!(calls, before);
+        calls.switch_to_task(ExecutionTaskId::APPLICATION);
+        assert!(calls.push_effect(effect));
+        assert!(calls.complete_m68k(0x2002, 0x3000));
+    }
+
+    #[test]
     fn execution_tasks_keep_independent_continuation_stacks() {
         let calls = SharedGuestCallStack::default();
         calls.begin_m68k(
@@ -1318,6 +1219,7 @@ mod tests {
         );
 
         let worker = ExecutionTaskId::from_thread_id(7);
+        assert!(calls.register_task(worker));
         calls.switch_to_task(worker);
         assert_eq!(calls.depth(), 0);
         calls.begin_m68k(
@@ -1343,6 +1245,7 @@ mod tests {
     fn global_stack_queries_include_suspended_tasks() {
         let calls = SharedGuestCallStack::default();
         let worker = ExecutionTaskId::from_thread_id(7);
+        assert!(calls.register_task(worker));
         calls.switch_to_task(worker);
         calls.begin_m68k(
             GuestCallTarget {

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -4,6 +4,7 @@ use crate::callback_manager::CallbackTaskArchitecture;
 use crate::cpu::{M68kCpu, Register, StepResult};
 use crate::debug_overlay::{DebugOverlayFrameStats, DebugOverlaySnapshot};
 use crate::event_queue::{EventManagerSnapshot, EventRecordSnapshot};
+use crate::execution_kernel::ExecutionContextBank;
 use crate::guest_call::ExecutionTaskId;
 use crate::loader::ppc::{
     PpcDrawSprocketTraceEntry, PpcFrontBuffer, PpcGWorldRecord, PpcHleImportTraceEntry,
@@ -338,17 +339,6 @@ const HFS_VCB_SIZE: u32 = 178;
 // that do substantially more work than a normal foreground interpreter batch.
 const PPC_SOUND_COMPLETION_CALLBACK_MAX_CYCLES: u64 = 250_000;
 
-/// Architecture-specific 68K contexts suspended by a cross-ISA callback.
-///
-/// A context is owned by the execution task whose continuation suspended it.
-/// Keeping the task key next to the parked CPU prevents a callback on one
-/// cooperative Thread Manager task from consuming another task's caller when
-/// the tasks yield while nested Mixed Mode work is in flight.
-#[derive(Default)]
-struct ParkedM68kContexts {
-    by_task: HashMap<ExecutionTaskId, Vec<M68kCpu>>,
-}
-
 /// Result of charging one native execution slice against the runner's host
 /// cycle clock.
 ///
@@ -363,41 +353,6 @@ struct PpcCycleAdvanceResult {
     baseline_tick: u32,
     /// Number of VBL boundaries crossed by the host cycle budget.
     elapsed_ticks: u32,
-}
-
-impl ParkedM68kContexts {
-    fn clear(&mut self) {
-        self.by_task.clear();
-    }
-
-    #[cfg(test)]
-    fn is_empty(&self) -> bool {
-        self.by_task.values().all(Vec::is_empty)
-    }
-
-    /// Total number of contexts, retaining the old diagnostic meaning of
-    /// `FixtureRunner::parked_m68k_cpus.len()`.
-    #[cfg(test)]
-    fn len(&self) -> usize {
-        self.by_task.values().map(Vec::len).sum()
-    }
-
-    fn task_len(&self, task: ExecutionTaskId) -> usize {
-        self.by_task.get(&task).map_or(0, Vec::len)
-    }
-
-    fn push(&mut self, task: ExecutionTaskId, cpu: M68kCpu) {
-        self.by_task.entry(task).or_default().push(cpu);
-    }
-
-    fn pop(&mut self, task: ExecutionTaskId) -> Option<M68kCpu> {
-        let contexts = self.by_task.get_mut(&task)?;
-        let context = contexts.pop();
-        if contexts.is_empty() {
-            self.by_task.remove(&task);
-        }
-        context
-    }
 }
 
 fn trace_dialog_filter_enabled() -> bool {
@@ -1672,7 +1627,7 @@ pub struct FixtureRunner {
     cpu: M68kCpu,
     /// Complete 68K CPU contexts parked by nested Mixed Mode switch frames,
     /// owned by the execution task that suspended each context.
-    parked_m68k_cpus: ParkedM68kContexts,
+    parked_m68k_cpus: ExecutionContextBank<M68kCpu>,
     ppc_app: Option<PpcLoadedApp>,
     /// Native execution adapter retained by a classic foreground process.
     /// It runs only while the process guest-call stack contains a pending
@@ -1940,7 +1895,7 @@ impl FixtureRunner {
         let dialog_callback_scratch_base = bus.alloc_synthetic(DIALOG_CALLBACK_SCRATCH_SIZE);
         Self {
             cpu: M68kCpu::new(),
-            parked_m68k_cpus: ParkedM68kContexts::default(),
+            parked_m68k_cpus: ExecutionContextBank::default(),
             ppc_app: None,
             ppc_companion: None,
             staged_ppc_companion: None,
@@ -2049,8 +2004,7 @@ impl FixtureRunner {
     }
 
     pub fn guest_tick(&self) -> u32 {
-        self.bus
-            .read_long(crate::memory::globals::addr::TICKS)
+        self.bus.read_long(crate::memory::globals::addr::TICKS)
     }
 
     /// Test-only: seed the guest-owned low-memory clock. Production clock
@@ -2068,10 +2022,7 @@ impl FixtureRunner {
     /// rendered pixels or 68K/PPC-specific EventRecord offsets.
     pub fn event_manager_snapshot(&self) -> EventManagerSnapshot {
         let queue = self.process_context.event_queue();
-        let ppc_state = self
-            .ppc_app
-            .as_ref()
-            .map(|app| &app.toolbox_startup);
+        let ppc_state = self.ppc_app.as_ref().map(|app| &app.toolbox_startup);
         let last_record: Option<EventRecordSnapshot> = self
             .dispatcher
             .debug_last_event_record
@@ -2081,18 +2032,17 @@ impl FixtureRunner {
             || self.dispatcher.debug_event_queue_probe.clone(),
             |state| state.event_queue_probe.clone(),
         );
-        let button_result = ppc_state.map_or(
-            self.dispatcher.debug_last_button_result,
-            |state| state.last_button_result,
-        );
-        let still_down_result = ppc_state.map_or(
-            self.dispatcher.debug_last_still_down_result,
-            |state| state.last_still_down_result,
-        );
-        let wait_mouse_up_result = ppc_state.map_or(
-            self.dispatcher.debug_last_wait_mouse_up_result,
-            |state| state.last_wait_mouse_up_result,
-        );
+        let button_result = ppc_state.map_or(self.dispatcher.debug_last_button_result, |state| {
+            state.last_button_result
+        });
+        let still_down_result = ppc_state
+            .map_or(self.dispatcher.debug_last_still_down_result, |state| {
+                state.last_still_down_result
+            });
+        let wait_mouse_up_result = ppc_state
+            .map_or(self.dispatcher.debug_last_wait_mouse_up_result, |state| {
+                state.last_wait_mouse_up_result
+            });
         EventManagerSnapshot {
             last_record,
             queue_probe,
@@ -2226,9 +2176,10 @@ impl FixtureRunner {
 
     /// Number of live guest windows, independent of the active CPU adapter.
     pub fn window_count(&mut self) -> usize {
-        self.ppc_app
-            .as_mut()
-            .map_or_else(|| self.dispatcher.window_count(), PpcLoadedApp::window_count)
+        self.ppc_app.as_mut().map_or_else(
+            || self.dispatcher.window_count(),
+            PpcLoadedApp::window_count,
+        )
     }
 
     /// Return the live Window Manager stack in front-to-back order.
@@ -2713,10 +2664,9 @@ impl FixtureRunner {
     }
 
     fn redraw_chrome(&mut self) {
-        self.dispatcher
-            .with_process_state(|dispatcher| {
-                dispatcher.redraw_chrome(&mut self.bus);
-            });
+        self.dispatcher.with_process_state(|dispatcher| {
+            dispatcher.redraw_chrome(&mut self.bus);
+        });
     }
 
     /// Enable or disable arrow-key-to-numpad remapping.
@@ -2946,10 +2896,9 @@ impl FixtureRunner {
     pub fn push_key_down(&mut self, mac_key: u8, char_code: u8) {
         let (key, char_code) = self.remap_key(mac_key, char_code);
         self.dispatcher.read_tick_count(&self.bus);
-        self.dispatcher
-            .with_process_state(|d| {
-                d.push_key_down(key, char_code);
-            });
+        self.dispatcher.with_process_state(|d| {
+            d.push_key_down(key, char_code);
+        });
         self.sync_key_map_lowmem();
         self.wake_pending_wait_next_event_if_input_available();
         self.wake_foreground_after_input();
@@ -2962,10 +2911,9 @@ impl FixtureRunner {
         let sys_evt_mask = self
             .bus
             .read_word(crate::memory::globals::addr::SYS_EVT_MASK);
-        self.dispatcher
-            .with_process_state(|d| {
-                d.push_key_up_with_system_event_mask(sys_evt_mask, key, char_code);
-            });
+        self.dispatcher.with_process_state(|d| {
+            d.push_key_up_with_system_event_mask(sys_evt_mask, key, char_code);
+        });
         self.sync_key_map_lowmem();
         self.wake_pending_wait_next_event_if_input_available();
         self.wake_foreground_after_input();
@@ -3063,8 +3011,7 @@ impl FixtureRunner {
                     architecture: CallbackTaskArchitecture::PowerPc,
                     ..
                 }
-                |
-                crate::sound::PendingSoundCallback::FileCompletion {
+                | crate::sound::PendingSoundCallback::FileCompletion {
                     architecture: CallbackTaskArchitecture::PowerPc,
                     ..
                 } => self.ppc_app.is_some(),
@@ -3301,7 +3248,12 @@ impl FixtureRunner {
 
     fn vfs_file_stat_for_path(&mut self, path: &str) -> Option<VfsFileStat> {
         let metadata = self.dispatcher.vfs_file_metadata(path)?;
-        let data_len = self.dispatcher.vfs.get(path).map(|bytes| bytes.len()).unwrap_or(0);
+        let data_len = self
+            .dispatcher
+            .vfs
+            .get(path)
+            .map(|bytes| bytes.len())
+            .unwrap_or(0);
         let resource_len = self
             .dispatcher
             .vfs_rsrc
@@ -3353,7 +3305,8 @@ impl FixtureRunner {
         // direct-loaded image. Reserve the image itself, plus the zone header,
         // without throwing that lower partition space away.
         // Inside Macintosh: Memory (1992), pp. 1-7 to 1-9 and 2-19.
-        self.process_context.reserve_classic_heap(APP_ZONE_HEADER_SIZE);
+        self.process_context
+            .reserve_classic_heap(APP_ZONE_HEADER_SIZE);
         self.process_context
             .reserve_classic_heap_range(image_start, heap_start);
         self.dispatcher.load_resources(fork, &mut self.bus);
@@ -3704,7 +3657,7 @@ impl FixtureRunner {
     /// Think C runtimes, e.g. Koji / Munchies) sees `CurStackBase` =
     /// 0 and spins forever in the globals-decompression loop.
     pub fn init_app(&mut self, app: &LoadedApp) {
-        self.parked_m68k_cpus.clear();
+        self.parked_m68k_cpus = ExecutionContextBank::default();
         self.ppc_companion = None;
         if let Some(ppc_app) = app.ppc.clone() {
             self.staged_ppc_companion = None;
@@ -3771,7 +3724,7 @@ impl FixtureRunner {
             .launch_ticks_override
             .map_or(DEFAULT_LAUNCH_TICKS, |floor| {
                 DEFAULT_LAUNCH_TICKS.max(floor)
-        });
+            });
         self.bus.write_long(addr::TICKS, launch_ticks);
         self.dispatcher.read_tick_count(&self.bus);
         let time = self
@@ -4194,8 +4147,7 @@ impl FixtureRunner {
 
         let gdh = self.dispatcher.ensure_main_gdevice(&mut self.bus);
         self.bus.write_long(0x8A4, gdh);
-        self.bus
-            .write_long(0xCC8, *self.dispatcher.current_gdevice);
+        self.bus.write_long(0xCC8, *self.dispatcher.current_gdevice);
         self.bus.write_long(0x8A8, gdh);
         if let Some(front_buffer) = ppc_app.presented_front_buffer() {
             self.ensure_ppc_host_screen_mode(front_buffer);
@@ -4240,8 +4192,7 @@ impl FixtureRunner {
             let start = mapping_start.max(classic_heap_floor);
             let end = mapping_end.min(classic_heap_limit);
             if start < end {
-                self.process_context
-                    .reserve_classic_heap_range(start, end);
+                self.process_context.reserve_classic_heap_range(start, end);
             }
         }
 
@@ -4752,8 +4703,7 @@ impl FixtureRunner {
 
         let memory_unchanged = self.bus.finish_write_probe_unchanged();
         let cpu_unchanged = sleep.cpu == CpuArchitecturalSnapshot::capture(&self.cpu.core);
-        let tick_unchanged =
-            self.guest_tick() == sleep.tick
+        let tick_unchanged = self.guest_tick() == sleep.tick
                 // The canonical process clock owns the value, while this
                 // second check verifies its low-memory guest projection did
                 // not diverge during the idle probe.
@@ -5419,9 +5369,10 @@ impl FixtureRunner {
         // until the application task is selected again. Otherwise the runner
         // would execute the PPC caller after the switch and consume the wrong
         // task's continuation.
-        let current_task = ExecutionTaskId::from_thread_id(self.dispatcher.current_cooperative_thread);
-        let native_foreground_task = self.ppc_app.is_some()
-            && current_task == ExecutionTaskId::APPLICATION;
+        let current_task =
+            ExecutionTaskId::from_thread_id(self.dispatcher.guest_calls.current_task().thread_id());
+        let native_foreground_task =
+            self.ppc_app.is_some() && current_task == ExecutionTaskId::APPLICATION;
         if native_foreground_task {
             if yield_for_ui {
                 return self.run_ppc_steps(
@@ -5450,14 +5401,16 @@ impl FixtureRunner {
                 // CPU now belongs to the selected worker; stop the native
                 // loop before it can execute that continuation on the wrong
                 // task.
-                if ExecutionTaskId::from_thread_id(self.dispatcher.current_cooperative_thread)
-                    != ExecutionTaskId::APPLICATION
+                if ExecutionTaskId::from_thread_id(
+                    self.dispatcher.guest_calls.current_task().thread_id(),
+                ) != ExecutionTaskId::APPLICATION
                 {
                     break;
                 }
             }
-            if ExecutionTaskId::from_thread_id(self.dispatcher.current_cooperative_thread)
-                != ExecutionTaskId::APPLICATION
+            if ExecutionTaskId::from_thread_id(
+                self.dispatcher.guest_calls.current_task().thread_id(),
+            ) != ExecutionTaskId::APPLICATION
             {
                 if finish_frame {
                     self.sync_ppc_deferred_host_state();
@@ -6022,9 +5975,9 @@ impl FixtureRunner {
                     }
 
                     self.dispatcher.yield_for_ui = yield_for_ui;
-                    let dispatch_result = self.dispatcher.with_process_state(
-                        |dispatcher| dispatcher.dispatch(opcode, &mut self.cpu, &mut self.bus),
-                    );
+                    let dispatch_result = self.dispatcher.with_process_state(|dispatcher| {
+                        dispatcher.dispatch(opcode, &mut self.cpu, &mut self.bus)
+                    });
                     match dispatch_result {
                         Ok(()) => {
                             let null_event = self.note_idle_cycle_trap_result(opcode);
@@ -6376,26 +6329,23 @@ impl FixtureRunner {
             // the native caller is parked. Do not deliver the native
             // application's VBL/Time Manager work against that successor's
             // task; the callback phase is retried once its owner is selected.
-            let native_callbacks_allowed =
-                ppc_app.guest_calls.current_task() == ppc_task
-                    && ExecutionTaskId::from_thread_id(
-                        self.dispatcher.current_cooperative_thread,
-                    ) == ppc_task;
+            let native_callbacks_allowed = ppc_app.guest_calls.current_task() == ppc_task
+                && ExecutionTaskId::from_thread_id(
+                    self.dispatcher.guest_calls.current_task().thread_id(),
+                ) == ppc_task;
             let (vbl_probes, timer_probes) = if native_callbacks_allowed {
-                ppc_app.with_process_memory_manager(
-                    |app, memory_manager| {
-                        Self::fire_ppc_tick_callbacks(
-                            app,
-                            memory_manager,
-                            tick_advance.baseline_tick,
-                            ppc_start_time,
-                            tick_advance.elapsed_ticks,
-                            u64::from(cycles_per_tick),
-                            false,
-                            false,
-                        )
-                    },
-                )
+                ppc_app.with_process_memory_manager(|app, memory_manager| {
+                    Self::fire_ppc_tick_callbacks(
+                        app,
+                        memory_manager,
+                        tick_advance.baseline_tick,
+                        ppc_start_time,
+                        tick_advance.elapsed_ticks,
+                        u64::from(cycles_per_tick),
+                        false,
+                        false,
+                    )
+                })
             } else {
                 (Vec::new(), Vec::new())
             };
@@ -6446,16 +6396,14 @@ impl FixtureRunner {
         let trace_ppc_imports = record_ppc_imports || trace_ppc_import_hist;
         let trace_ppc_fetches = trace_ppc_fetch_counts_enabled();
         let profile_run_start = profile_ppc.then(Instant::now);
-        let probe = ppc_app.with_process_memory_manager(
-            |app, memory_manager| {
-                app.run_with_process_memory_manager(
-                    ppc_max_steps as u64,
-                    trace_ppc_imports,
-                    trace_ppc_fetches,
-                    memory_manager,
-                )
-            },
-        );
+        let probe = ppc_app.with_process_memory_manager(|app, memory_manager| {
+            app.run_with_process_memory_manager(
+                ppc_max_steps as u64,
+                trace_ppc_imports,
+                trace_ppc_fetches,
+                memory_manager,
+            )
+        });
         let profile_run_us = elapsed_profile_micros(profile_run_start);
         let ppc_cycles = ppc_run_result_cycles(probe.result);
         let resumed_m68k = self.resume_m68k_after_powerpc(&mut ppc_app);
@@ -6493,26 +6441,23 @@ impl FixtureRunner {
             (Vec::new(), Vec::new())
         } else {
             let tick_advance = self.advance_ticks_for_ppc_cycles(cycles, tick_cap);
-            let native_callbacks_allowed =
-                ppc_app.guest_calls.current_task() == ppc_task
-                    && ExecutionTaskId::from_thread_id(
-                        self.dispatcher.current_cooperative_thread,
-                    ) == ppc_task;
+            let native_callbacks_allowed = ppc_app.guest_calls.current_task() == ppc_task
+                && ExecutionTaskId::from_thread_id(
+                    self.dispatcher.guest_calls.current_task().thread_id(),
+                ) == ppc_task;
             if native_callbacks_allowed {
-                ppc_app.with_process_memory_manager(
-                    |app, memory_manager| {
-                        Self::fire_ppc_tick_callbacks(
-                            app,
-                            memory_manager,
-                            tick_advance.baseline_tick,
-                            ppc_start_time,
-                            tick_advance.elapsed_ticks,
-                            u64::from(cycles_per_tick),
-                            trace_ppc_imports,
-                            trace_ppc_fetches,
-                        )
-                    },
-                )
+                ppc_app.with_process_memory_manager(|app, memory_manager| {
+                    Self::fire_ppc_tick_callbacks(
+                        app,
+                        memory_manager,
+                        tick_advance.baseline_tick,
+                        ppc_start_time,
+                        tick_advance.elapsed_ticks,
+                        u64::from(cycles_per_tick),
+                        trace_ppc_imports,
+                        trace_ppc_fetches,
+                    )
+                })
             } else {
                 (Vec::new(), Vec::new())
             }
@@ -6736,26 +6681,12 @@ impl FixtureRunner {
     ) -> Option<(usize, bool)> {
         let task = ppc_app.guest_calls.current_task();
         let active = ppc_app.guest_calls.active_m68k();
-        let pending = active.or_else(|| ppc_app.guest_calls.activate_m68k())?;
+        let pending = active.or_else(|| {
+            ppc_app
+                .guest_calls
+                .activate_m68k_parking(&mut self.parked_m68k_cpus, &mut self.cpu)
+        })?;
         if active.is_none() {
-            let suspended_depth = ppc_app.guest_calls.suspended_m68k_context_depth();
-            if suspended_depth > 0 {
-                match self.parked_m68k_cpus.task_len(task) {
-                    parked if parked == suspended_depth => {
-                        // A sibling PowerPC-to-68k call at this depth replaces
-                        // the completed nested context, while its caller stays
-                        // parked in the existing stack entry.
-                        self.cpu = M68kCpu::new();
-                    }
-                    parked if parked.checked_add(1) == Some(suspended_depth) => {
-                        // The first PowerPC-to-68k call at this depth parks the
-                        // live classic caller before installing a fresh context.
-                        let parked = std::mem::take(&mut self.cpu);
-                        self.parked_m68k_cpus.push(task, parked);
-                    }
-                    _ => return Some((0, false)),
-                }
-            }
             for (index, value) in pending.registers.data.into_iter().enumerate() {
                 self.cpu.core.set_d(index, value);
             }
@@ -6819,13 +6750,11 @@ impl FixtureRunner {
                         self.cpu.core.take_aline_exception(&mut self.bus);
                         continue;
                     }
-                    let dispatch_err = self.dispatcher.with_process_state(
-                        |dispatcher| {
-                            dispatcher
-                                .dispatch(opcode, &mut self.cpu, &mut self.bus)
-                                .is_err()
-                        },
-                    );
+                    let dispatch_err = self.dispatcher.with_process_state(|dispatcher| {
+                        dispatcher
+                            .dispatch(opcode, &mut self.cpu, &mut self.bus)
+                            .is_err()
+                    });
                     if dispatch_err {
                         running = false;
                         break;
@@ -6859,42 +6788,55 @@ impl FixtureRunner {
     }
 
     fn resume_m68k_after_powerpc(&mut self, ppc_app: &mut PpcLoadedApp) -> bool {
-        use crate::guest_call::M68kResultTarget;
-
-        let task = ppc_app.guest_calls.current_task();
-        let suspended_depth = ppc_app.guest_calls.suspended_m68k_context_depth();
-        let restore_parked = if suspended_depth == 0 {
-            false
-        } else {
-            match self.parked_m68k_cpus.task_len(task) {
-                parked if parked == suspended_depth => true,
-                parked if parked.checked_add(1) == Some(suspended_depth) => false,
-                _ => return false,
-            }
-        };
-        // Result placement can fail when a classic result slot is unmapped,
-        // read-only, or malformed. Inspect the completed continuation first;
-        // retirement and parked-context removal happen only after the result
-        // has been accepted, so the same completion remains retryable.
-        let Some(resume) = ppc_app.guest_calls.peek_m68k_resume() else {
+        let calls = ppc_app.guest_calls.shared_handle();
+        let Some(parked) =
+            calls.commit_m68k_resume(&mut self.parked_m68k_cpus, |resume, parked| {
+                let cpu = parked.unwrap_or(&mut self.cpu);
+                if !Self::apply_m68k_resume_result(cpu, &mut ppc_app.memory, resume) {
+                    return false;
+                }
+                cpu.write_reg(Register::PC, resume.return_pc);
+                cpu.write_reg(Register::A7, resume.final_sp);
+                true
+            })
+        else {
             return false;
         };
+        if let Some(parked) = parked {
+            self.cpu = parked;
+        }
+        // A native RoutineDescriptor can be the head of a raw A-line patch.
+        // Mixed Mode resumes at the synthesized JSR continuation directly,
+        // so retire that Trap Manager frame before the next 68k instruction.
+        self.dispatcher
+            .retire_returned_native_trap_call(&mut self.cpu);
+        true
+    }
+
+    fn apply_m68k_resume_result(
+        cpu: &mut M68kCpu,
+        memory: &mut PpcSectionMem,
+        resume: crate::guest_call::M68kResume,
+    ) -> bool {
+        use crate::guest_call::M68kResultTarget;
+
         let mask_value = |value: u32, size: u8| match size {
             1 => Some(value & 0xff),
             2 => Some(value & 0xffff),
             4 => Some(value),
             _ => None,
         };
-        let result_applied = match resume.result {
+        match resume.result {
             None => true,
-            Some(M68kResultTarget::Data { index, size }) => mask_value(resume.powerpc.gpr3, size)
-                .is_some_and(|value| {
-                    self.cpu.core.set_d(usize::from(index), value);
-                    true
-                }),
-            Some(M68kResultTarget::Address { index, size }) => {
+            Some(M68kResultTarget::Data { index, size }) if index < 8 => {
                 mask_value(resume.powerpc.gpr3, size).is_some_and(|value| {
-                    self.cpu.core.set_a(usize::from(index), value);
+                    cpu.core.set_d(usize::from(index), value);
+                    true
+                })
+            }
+            Some(M68kResultTarget::Address { index, size }) if index < 8 => {
+                mask_value(resume.powerpc.gpr3, size).is_some_and(|value| {
+                    cpu.core.set_a(usize::from(index), value);
                     true
                 })
             }
@@ -6904,45 +6846,34 @@ impl FixtureRunner {
                 // including a CCR bit. Inside Macintosh: PowerPC System
                 // Software (1994), pp. 2-10--2-12.
                 let set = resume.powerpc.gpr3 != 0;
-                let ccr = (self.cpu.core.get_ccr() & !mask) | if set { mask } else { 0 };
-                self.cpu.core.set_ccr(ccr);
+                let ccr = (cpu.core.get_ccr() & !mask) | if set { mask } else { 0 };
+                cpu.core.set_ccr(ccr);
                 true
             }
             Some(M68kResultTarget::Memory { address, size }) => {
                 mask_value(resume.powerpc.gpr3, size).is_some_and(|value| match size {
-                    1 => ppc_app.memory.write_u8(address, value as u8).is_some(),
-                    2 => ppc_app.memory.write_u16_be(address, value as u16).is_some(),
-                    4 => ppc_app.memory.write_u32_be(address, value).is_some(),
+                    1 => memory.write_u8(address, value as u8).is_some(),
+                    2 => memory.write_u16_be(address, value as u16).is_some(),
+                    4 => memory.write_u32_be(address, value).is_some(),
                     _ => false,
                 })
             }
             Some(M68kResultTarget::SpecialCase { selector, scratch }) => {
-                self.apply_m68k_special_case_result(ppc_app, selector, scratch, resume.powerpc.gpr3)
+                Self::apply_m68k_special_case_result(
+                    cpu,
+                    memory,
+                    selector,
+                    scratch,
+                    resume.powerpc.gpr3,
+                )
             }
-        };
-        if !result_applied {
-            return false;
+            _ => false,
         }
-        if !ppc_app.guest_calls.retire_m68k_resume() {
-            return false;
-        }
-        if restore_parked {
-            self.cpu = self.parked_m68k_cpus.pop(task)
-                .expect("depth proves a parked 68k CPU context");
-        }
-        self.cpu.write_reg(Register::PC, resume.return_pc);
-        self.cpu.write_reg(Register::A7, resume.final_sp);
-        // A native RoutineDescriptor can be the head of a raw A-line patch.
-        // Mixed Mode resumes at the synthesized JSR continuation directly,
-        // so retire that Trap Manager frame before the next 68k instruction.
-        self.dispatcher
-            .retire_returned_native_trap_call(&mut self.cpu);
-        true
     }
 
     fn apply_m68k_special_case_result(
-        &mut self,
-        ppc_app: &mut PpcLoadedApp,
+        cpu: &mut M68kCpu,
+        memory: &mut PpcSectionMem,
         selector: u8,
         scratch: u32,
         native_result: u32,
@@ -6962,69 +6893,86 @@ impl FixtureRunner {
             special_case::EOL_HOOK
             | special_case::PROTOCOL_HANDLER
             | special_case::SOCKET_LISTENER => {
-                set_z(&mut self.cpu, native_result & 0xff != 0);
+                set_z(cpu, native_result & 0xff != 0);
                 true
             }
             special_case::WIDTH_HOOK | special_case::NWIDTH_HOOK => {
-                set_data_word(&mut self.cpu, 1, native_result);
+                set_data_word(cpu, 1, native_result);
                 true
             }
             special_case::HIT_TEST_HOOK => {
-                let Some(pixel_width) = ppc_app.memory.read_u16_be(scratch) else {
+                let Some(pixel_width) = memory.read_u16_be(scratch) else {
                     return false;
                 };
-                let Some(char_offset) = ppc_app.memory.read_u16_be(scratch + 2) else {
+                let Some(char_offset) = scratch
+                    .checked_add(2)
+                    .and_then(|address| memory.read_u16_be(address))
+                else {
                     return false;
                 };
-                let Some(pixel_in_char) = ppc_app.memory.read_u8(scratch + 4) else {
+                let Some(pixel_in_char) = scratch
+                    .checked_add(4)
+                    .and_then(|address| memory.read_u8(address))
+                else {
                     return false;
                 };
-                self.cpu
-                    .core
+                cpu.core
                     .set_d(0, ((native_result & 0xff) << 16) | u32::from(pixel_width));
-                set_data_word(&mut self.cpu, 1, u32::from(char_offset));
-                set_data_word(&mut self.cpu, 2, u32::from(pixel_in_char));
+                set_data_word(cpu, 1, u32::from(char_offset));
+                set_data_word(cpu, 2, u32::from(pixel_in_char));
                 true
             }
             special_case::TE_FIND_WORD => {
-                let Some(word_start) = ppc_app.memory.read_u16_be(scratch) else {
+                let Some(word_start) = memory.read_u16_be(scratch) else {
                     return false;
                 };
-                let Some(word_end) = ppc_app.memory.read_u16_be(scratch + 2) else {
+                let Some(word_end) = scratch
+                    .checked_add(2)
+                    .and_then(|address| memory.read_u16_be(address))
+                else {
                     return false;
                 };
-                set_data_word(&mut self.cpu, 0, u32::from(word_start));
-                set_data_word(&mut self.cpu, 1, u32::from(word_end));
+                set_data_word(cpu, 0, u32::from(word_start));
+                set_data_word(cpu, 1, u32::from(word_end));
                 true
             }
             special_case::TE_RECALC => {
-                let Some(line_start) = ppc_app.memory.read_u16_be(scratch) else {
+                let Some(line_start) = memory.read_u16_be(scratch) else {
                     return false;
                 };
-                let Some(first_char) = ppc_app.memory.read_u16_be(scratch + 2) else {
+                let Some(first_char) = scratch
+                    .checked_add(2)
+                    .and_then(|address| memory.read_u16_be(address))
+                else {
                     return false;
                 };
-                let Some(last_char) = ppc_app.memory.read_u16_be(scratch + 4) else {
+                let Some(last_char) = scratch
+                    .checked_add(4)
+                    .and_then(|address| memory.read_u16_be(address))
+                else {
                     return false;
                 };
-                set_data_word(&mut self.cpu, 2, u32::from(line_start));
-                set_data_word(&mut self.cpu, 3, u32::from(first_char));
-                set_data_word(&mut self.cpu, 4, u32::from(last_char));
+                set_data_word(cpu, 2, u32::from(line_start));
+                set_data_word(cpu, 3, u32::from(first_char));
+                set_data_word(cpu, 4, u32::from(last_char));
                 true
             }
             special_case::TE_DO_TEXT => {
-                let Some(current_graf_port) = ppc_app.memory.read_u32_be(scratch) else {
+                let Some(current_graf_port) = memory.read_u32_be(scratch) else {
                     return false;
                 };
-                let Some(char_position) = ppc_app.memory.read_u16_be(scratch + 4) else {
+                let Some(char_position) = scratch
+                    .checked_add(4)
+                    .and_then(|address| memory.read_u16_be(address))
+                else {
                     return false;
                 };
-                self.cpu.core.set_a(0, current_graf_port);
-                set_data_word(&mut self.cpu, 0, u32::from(char_position));
+                cpu.core.set_a(0, current_graf_port);
+                set_data_word(cpu, 0, u32::from(char_position));
                 true
             }
             special_case::MBAR_HOOK => {
-                set_data_word(&mut self.cpu, 0, native_result);
+                set_data_word(cpu, 0, native_result);
                 true
             }
             _ => false,
@@ -7107,6 +7055,12 @@ impl FixtureRunner {
                 Ok(Some(self.cpu.core.d(1) & 0xffff))
             }
             special_case::HIT_TEST_HOOK => {
+                if ![(arguments[6], 2), (arguments[7], 2), (arguments[8], 1)]
+                    .into_iter()
+                    .all(|(address, size)| ppc_app.memory.preflight_writable_range(address, size))
+                {
+                    return Err(());
+                }
                 ppc_app
                     .memory
                     .write_u16_be(arguments[6], self.cpu.core.d(0) as u16)
@@ -7122,6 +7076,12 @@ impl FixtureRunner {
                 Ok(Some((self.cpu.core.d(0) >> 16) & 0xff))
             }
             special_case::TE_FIND_WORD => {
+                if ![(arguments[4], 2), (arguments[5], 2)]
+                    .into_iter()
+                    .all(|(address, size)| ppc_app.memory.preflight_writable_range(address, size))
+                {
+                    return Err(());
+                }
                 ppc_app
                     .memory
                     .write_u16_be(arguments[4], self.cpu.core.d(0) as u16)
@@ -7133,6 +7093,13 @@ impl FixtureRunner {
                 Ok(None)
             }
             special_case::TE_RECALC => {
+                if !arguments[2..5]
+                    .iter()
+                    .copied()
+                    .all(|address| ppc_app.memory.preflight_writable_range(address, 2))
+                {
+                    return Err(());
+                }
                 for (argument, register) in arguments[2..5].iter().copied().zip(2..=4) {
                     ppc_app
                         .memory
@@ -7142,6 +7109,12 @@ impl FixtureRunner {
                 Ok(None)
             }
             special_case::TE_DO_TEXT => {
+                if ![(arguments[4], 4), (arguments[5], 2)]
+                    .into_iter()
+                    .all(|(address, size)| ppc_app.memory.preflight_writable_range(address, size))
+                {
+                    return Err(());
+                }
                 ppc_app
                     .memory
                     .write_u32_be(arguments[4], self.cpu.core.a(0))
@@ -7157,6 +7130,9 @@ impl FixtureRunner {
                     .memory
                     .read_u16_be(stack_result.ok_or(())?)
                     .ok_or(())?;
+                if !ppc_app.memory.preflight_writable_range(arguments[1], 1) {
+                    return Err(());
+                }
                 ppc_app
                     .memory
                     .write_u8(arguments[1], result as u8)
@@ -7197,9 +7173,8 @@ impl FixtureRunner {
         let mut timer_probes = Vec::new();
         let mut callback_time = start_time;
         for tick_offset in 0..elapsed_ticks {
-            let callback_tick = ppc_app.publish_host_epoch_tick(
-                baseline_tick.wrapping_add(tick_offset).wrapping_add(1),
-            );
+            let callback_tick = ppc_app
+                .publish_host_epoch_tick(baseline_tick.wrapping_add(tick_offset).wrapping_add(1));
             if callback_tick.is_multiple_of(60) {
                 callback_time = callback_time.wrapping_add(1);
             }
@@ -7917,17 +7892,15 @@ impl FixtureRunner {
                 .pending_process_doublebacks
                 .remove(index);
             let resume_pc = ppc_app.cpu.pc;
-            let probe = ppc_app.with_process_memory_manager(
-                |app, memory_manager| {
-                    app.run_sound_doubleback_callback_with_process_memory_manager(
-                        doubleback,
-                        PPC_SOUND_COMPLETION_CALLBACK_MAX_CYCLES,
-                        trace_ppc_imports,
-                        trace_ppc_fetches,
-                        memory_manager,
-                    )
-                },
-            );
+            let probe = ppc_app.with_process_memory_manager(|app, memory_manager| {
+                app.run_sound_doubleback_callback_with_process_memory_manager(
+                    doubleback,
+                    PPC_SOUND_COMPLETION_CALLBACK_MAX_CYCLES,
+                    trace_ppc_imports,
+                    trace_ppc_fetches,
+                    memory_manager,
+                )
+            });
             let invocation = probe.invocation;
             if trace_sound_runner_enabled() {
                 eprintln!(
@@ -7964,17 +7937,15 @@ impl FixtureRunner {
             self.prepare_ppc_execution_clock(&mut ppc_app);
 
             let buffer_bit = 1u8 << (doubleback.exhausted_buffer_index.min(1) as u8);
-            if let Some(playback) =
-                ppc_app
-                    .sound
-                    .manager
-                    .double_buffer_playbacks
-                    .iter_mut()
-                    .rev()
-                    .find(|playback| {
-                        playback.channel == doubleback.channel
-                            && playback.header == doubleback.header
-                    })
+            if let Some(playback) = ppc_app
+                .sound
+                .manager
+                .double_buffer_playbacks
+                .iter_mut()
+                .rev()
+                .find(|playback| {
+                    playback.channel == doubleback.channel && playback.header == doubleback.header
+                })
             {
                 playback.callback_pending_mask &= !buffer_bit;
             }
@@ -8124,17 +8095,15 @@ impl FixtureRunner {
                 scheduled_tick: self.guest_tick(),
                 scheduled_instruction_count: self.total_instructions,
             };
-            let probe = ppc_app.with_process_memory_manager(
-                |app, memory_manager| {
-                    app.run_sound_completion_callback_with_process_memory_manager(
-                        completion,
-                        PPC_SOUND_COMPLETION_CALLBACK_MAX_CYCLES,
-                        trace_ppc_imports,
-                        trace_ppc_fetches,
-                        memory_manager,
-                    )
-                },
-            );
+            let probe = ppc_app.with_process_memory_manager(|app, memory_manager| {
+                app.run_sound_completion_callback_with_process_memory_manager(
+                    completion,
+                    PPC_SOUND_COMPLETION_CALLBACK_MAX_CYCLES,
+                    trace_ppc_imports,
+                    trace_ppc_fetches,
+                    memory_manager,
+                )
+            });
             let invocation = probe.invocation;
             if record_ppc_imports {
                 self.record_ppc_import_trace(&probe.import_trace);
@@ -8942,10 +8911,9 @@ impl FixtureRunner {
         let sys_evt_mask = self
             .bus
             .read_word(crate::memory::globals::addr::SYS_EVT_MASK);
-        self.dispatcher
-            .with_process_state(|d| {
-                d.post_auto_key_if_due(sys_evt_mask);
-            });
+        self.dispatcher.with_process_state(|d| {
+            d.post_auto_key_if_due(sys_evt_mask);
+        });
 
         // Sync MBState ($0172) from the internal button state.
         // On real hardware the VBL interrupt handler reads the ADB mouse
@@ -8960,11 +8928,9 @@ impl FixtureRunner {
         // to 0x80 even when no GetNextEvent ever drains the queue —
         // critical for polling-only games (Bonkheads-Deluxe class titles)
         // that would otherwise see the button as "held forever".
-        let has_pending_unmatched_down =
-            self.dispatcher
-                .with_process_state(|d| {
-                    d.has_unmatched_queued_mouse_down()
-                });
+        let has_pending_unmatched_down = self
+            .dispatcher
+            .with_process_state(|d| d.has_unmatched_queued_mouse_down());
         let pressed = self.dispatcher.input_state.mouse_button || has_pending_unmatched_down;
         let mb_state: u8 = if pressed { 0x00 } else { 0x80 };
         self.bus.write_byte(0x0172, mb_state);
@@ -9028,11 +8994,17 @@ impl FixtureRunner {
             }
         }
 
-        let (mut what, mut message, mut when, mut where_v, mut where_h, mut modifiers, mut has_event) = self
-            .dispatcher
-            .with_process_state(|dispatcher| {
-                dispatcher.dequeue_toolbox_event(&mut self.cpu, &mut self.bus, pending.event_mask)
-            });
+        let (
+            mut what,
+            mut message,
+            mut when,
+            mut where_v,
+            mut where_h,
+            mut modifiers,
+            mut has_event,
+        ) = self.dispatcher.with_process_state(|dispatcher| {
+            dispatcher.dequeue_toolbox_event(&mut self.cpu, &mut self.bus, pending.event_mask)
+        });
         if !has_event {
             if let Some(event) = self.dispatcher.mouse_moved_event_for_region(
                 &self.bus,
@@ -9264,9 +9236,7 @@ impl FixtureRunner {
         self.advance_guest_tick();
         self.tick_budget = self.instructions_per_tick as i32;
 
-        tick_cap
-            .map(|cap| self.guest_tick() >= cap)
-            .unwrap_or(true)
+        tick_cap.map(|cap| self.guest_tick() >= cap).unwrap_or(true)
     }
 
     fn unfreeze_ticks_to(&mut self, target_tick: Option<u32>) {
@@ -9388,12 +9358,9 @@ impl FixtureRunner {
                         == CallbackTaskArchitecture::M68k
             })
             .or_else(|| {
-                self.dispatcher
-                    .vbl_tasks
-                    .iter()
-                    .position(|task| {
-                        task.architecture == CallbackTaskArchitecture::M68k && task.pending
-                    })
+                self.dispatcher.vbl_tasks.iter().position(|task| {
+                    task.architecture == CallbackTaskArchitecture::M68k && task.pending
+                })
             });
         let due_task = due_index.map(|index| {
             let task = &mut self.dispatcher.vbl_tasks[index];
@@ -9919,11 +9886,10 @@ impl FixtureRunner {
                     crate::sound::PendingSoundCallback::Command {
                         architecture: CallbackTaskArchitecture::M68k,
                         ..
+                    } | crate::sound::PendingSoundCallback::FileCompletion {
+                        architecture: CallbackTaskArchitecture::M68k,
+                        ..
                     }
-                        | crate::sound::PendingSoundCallback::FileCompletion {
-                            architecture: CallbackTaskArchitecture::M68k,
-                            ..
-                        }
                 )
             });
         let Some(callback_index) = callback_index else {
@@ -10883,9 +10849,9 @@ impl FixtureRunner {
                         count += 1;
                         continue;
                     }
-                    let dispatch_result = self.dispatcher.with_process_state(
-                        |dispatcher| dispatcher.dispatch(opcode, &mut self.cpu, &mut self.bus),
-                    );
+                    let dispatch_result = self.dispatcher.with_process_state(|dispatcher| {
+                        dispatcher.dispatch(opcode, &mut self.cpu, &mut self.bus)
+                    });
                     match dispatch_result {
                         Ok(()) => {
                             // Smart PC Advance:
@@ -12214,7 +12180,8 @@ mod tests {
             "fresh app launch should see a realistic nonzero post-boot TickCount"
         );
         assert_eq!(
-            runner.guest_tick(), DEFAULT_LAUNCH_TICKS,
+            runner.guest_tick(),
+            DEFAULT_LAUNCH_TICKS,
             "TickCount fast path must stay in sync with low-memory Ticks"
         );
     }
@@ -12274,7 +12241,12 @@ mod tests {
         assert_eq!(runner.guest_tick(), 4321);
         assert_eq!(runner.bus.read_long(addr::RND_SEED), 0x7654_3210);
         let ppc_app = runner.ppc_app.as_mut().expect("PPC app installed");
-        assert_eq!(ppc_app.memory.read_u32_be(crate::memory::globals::addr::TICKS), Some(4321));
+        assert_eq!(
+            ppc_app
+                .memory
+                .read_u32_be(crate::memory::globals::addr::TICKS),
+            Some(4321)
+        );
         assert_eq!(ppc_app.memory.read_u32_be(addr::TICKS), Some(4321));
         assert_eq!(
             ppc_app.memory.read_u32_be(addr::RND_SEED),
@@ -12368,7 +12340,12 @@ mod tests {
         assert_eq!(runner.guest_tick(), 0);
         assert_eq!(runner.bus.read_long(addr::RND_SEED), 0x1020_3040);
         let ppc_app = runner.ppc_app.as_mut().expect("PPC app installed");
-        assert_eq!(ppc_app.memory.read_u32_be(crate::memory::globals::addr::TICKS), Some(0));
+        assert_eq!(
+            ppc_app
+                .memory
+                .read_u32_be(crate::memory::globals::addr::TICKS),
+            Some(0)
+        );
         assert_eq!(ppc_app.memory.read_u32_be(addr::TICKS), Some(0));
         assert_eq!(ppc_app.memory.read_u32_be(addr::TIME), Some(0x1020_3040));
         assert_eq!(
@@ -12504,7 +12481,10 @@ mod tests {
         assert_eq!(&*ppc_app.window_list, &[0x1000, 0x2000]);
         ppc_app.window_list.insert(0, 0x3000);
         assert_eq!(&*runner.dispatcher.window_list, &[0x3000, 0x1000, 0x2000]);
-        runner.dispatcher.window_list.retain(|window| *window != 0x1000);
+        runner
+            .dispatcher
+            .window_list
+            .retain(|window| *window != 0x1000);
         assert_eq!(&*ppc_app.window_list, &[0x3000, 0x2000]);
         assert_eq!(&*detached, &[0x1000, 0x2000]);
     }
@@ -12535,7 +12515,12 @@ mod tests {
         assert_eq!(runner.bus.read_long(addr::TICKS), 42);
         assert_eq!(runner.guest_tick(), 42);
         let ppc_app = runner.ppc_app.as_mut().expect("PPC app installed");
-        assert_eq!(ppc_app.memory.read_u32_be(crate::memory::globals::addr::TICKS), Some(42));
+        assert_eq!(
+            ppc_app
+                .memory
+                .read_u32_be(crate::memory::globals::addr::TICKS),
+            Some(42)
+        );
         assert_eq!(ppc_app.memory.read_u32_be(addr::TICKS), Some(42));
     }
 
@@ -12670,8 +12655,8 @@ mod tests {
                 CALLBACK,
                 [
                     0x3880_BEEFu32, // li r4,$BEEF
-                    0xB083_000E,     // sth r4,14(r3): callback marker
-                    0x4E80_0020,     // blr
+                    0xB083_000E,    // sth r4,14(r3): callback marker
+                    0x4E80_0020,    // blr
                 ]
                 .into_iter()
                 .flat_map(u32::to_be_bytes)
@@ -12747,9 +12732,9 @@ mod tests {
                 CALLBACK,
                 [
                     0x3880_016Au32, // li r4,$016A
-                    0x80A4_0000,     // lwz r5,0(r4): read guest Ticks
-                    0x90A3_0010,     // stw r5,16(r3): record on task
-                    0x4E80_0020,     // blr
+                    0x80A4_0000,    // lwz r5,0(r4): read guest Ticks
+                    0x90A3_0010,    // stw r5,16(r3): record on task
+                    0x4E80_0020,    // blr
                 ]
                 .into_iter()
                 .flat_map(u32::to_be_bytes)
@@ -12822,9 +12807,10 @@ mod tests {
         runner.cpu.write_reg(Register::A7, sp);
         let first = 0x1020_3040;
         runner.bus.write_long(addr::TICKS, first);
-        let first_result = runner
-            .dispatcher
-            .dispatch_toolbox(true, 0x175, &mut runner.cpu, &mut runner.bus);
+        let first_result =
+            runner
+                .dispatcher
+                .dispatch_toolbox(true, 0x175, &mut runner.cpu, &mut runner.bus);
         assert!(first_result.is_some_and(|result| result.is_ok()));
         assert_eq!(runner.bus.read_long(sp), first);
 
@@ -12840,9 +12826,10 @@ mod tests {
             .write_u32_be(addr::TICKS, second)
             .expect("shared Ticks write");
         runner.cpu.write_reg(Register::A7, sp);
-        let second_result = runner
-            .dispatcher
-            .dispatch_toolbox(true, 0x175, &mut runner.cpu, &mut runner.bus);
+        let second_result =
+            runner
+                .dispatcher
+                .dispatch_toolbox(true, 0x175, &mut runner.cpu, &mut runner.bus);
         assert!(second_result.is_some_and(|result| result.is_ok()));
         assert_eq!(runner.bus.read_long(sp), second);
 
@@ -12851,12 +12838,7 @@ mod tests {
         ppc_app.cpu.pc = PPC_IMPORT_TRAP_BASE;
         ppc_app.cpu.lr = PPC_HALT_PC;
         let mut memory_manager = runner.process_context.memory_manager_mut();
-        let probe = ppc_app.run_with_process_memory_manager(
-            64,
-            false,
-            false,
-            &mut memory_manager,
-        );
+        let probe = ppc_app.run_with_process_memory_manager(64, false, false, &mut memory_manager);
         assert_eq!(probe.handled_import_count, 1);
         assert_eq!(probe.unsupported_import_index, None);
         assert_eq!(ppc_app.cpu.gpr[3], third);
@@ -14374,12 +14356,8 @@ mod tests {
             cfm_library_fragments: Vec::new(),
             next_cfm_connection_id: 1,
             controls: Default::default(),
-            screen_clut: SharedProcessValue::from_value(
-                TrapDispatcher::standard_mac_8bpp_clut(),
-            ),
-            device_gamma: SharedProcessValue::from_value(
-                crate::display::default_display_gamma(),
-            ),
+            screen_clut: SharedProcessValue::from_value(TrapDispatcher::standard_mac_8bpp_clut()),
+            device_gamma: SharedProcessValue::from_value(crate::display::default_display_gamma()),
             device_gamma_explicit: SharedProcessValue::from_value(false),
             process_quickdraw_port_state_attached: false,
             color_manager_clut: SharedProcessValue::from_value(
@@ -14387,7 +14365,8 @@ mod tests {
             ),
             aliases: Vec::new(),
             gworlds: Vec::new(),
-            gworld_pixel_states: crate::process_context::SharedProcessQuickDrawPixelStates::default(),
+            gworld_pixel_states: crate::process_context::SharedProcessQuickDrawPixelStates::default(
+            ),
             q3_objects: Vec::new(),
             q3_object_refs: Vec::new(),
             next_q3_object: 0,
@@ -14527,19 +14506,13 @@ mod tests {
                 .sound
                 .manager
                 .ptr_eq(&runner.dispatcher.sound_manager));
-            ppc_app
-                .sound
-                .manager
-                .register_channel(
-                    0x0050_1000,
-                    false,
-                    0x0012_3456,
-                    CallbackTaskArchitecture::M68k,
-                );
-            ppc_app
-                .sound
-                .manager
-                .set_default_output_volume(0x0000_8000);
+            ppc_app.sound.manager.register_channel(
+                0x0050_1000,
+                false,
+                0x0012_3456,
+                CallbackTaskArchitecture::M68k,
+            );
+            ppc_app.sound.manager.set_default_output_volume(0x0000_8000);
         }
 
         let classic_channel = runner
@@ -14551,7 +14524,10 @@ mod tests {
             .expect("native channel visible to classic adapter");
         assert_eq!(classic_channel.callback_addr, 0x0012_3456);
         classic_channel.set_volume(0x0000_4000);
-        runner.dispatcher.sound_manager.set_sys_beep_volume(0x0000_2000);
+        runner
+            .dispatcher
+            .sound_manager
+            .set_sys_beep_volume(0x0000_2000);
 
         let ppc_app = runner.ppc_app.as_ref().expect("PPC app");
         assert_eq!(ppc_app.sound.manager.default_output_volume(), 0x0000_8000);
@@ -15596,29 +15572,6 @@ mod tests {
     }
 
     #[test]
-    fn parked_m68k_contexts_remain_owned_by_their_execution_task() {
-        let application = ExecutionTaskId::APPLICATION;
-        let worker = ExecutionTaskId::from_thread_id(3);
-        let mut parked = ParkedM68kContexts::default();
-
-        parked.push(application, M68kCpu::new());
-        parked.push(worker, M68kCpu::new());
-        parked.push(application, M68kCpu::new());
-
-        assert_eq!(parked.len(), 3);
-        assert_eq!(parked.task_len(application), 2);
-        assert_eq!(parked.task_len(worker), 1);
-        assert!(parked.pop(worker).is_some());
-        assert_eq!(parked.task_len(worker), 0);
-        assert_eq!(parked.task_len(application), 2);
-        assert_eq!(parked.len(), 2);
-        assert!(parked.pop(worker).is_none());
-        assert!(parked.pop(application).is_some());
-        assert!(parked.pop(application).is_some());
-        assert!(parked.is_empty());
-    }
-
-    #[test]
     fn nested_cross_isa_callback_survives_a_cooperative_task_switch() {
         use crate::guest_procedure::{
             ROUTINE_DESCRIPTOR_HEADER_SIZE, ROUTINE_DESCRIPTOR_MIXED_MODE_TRAP,
@@ -15650,10 +15603,14 @@ mod tests {
             .add_region(PPC_STACK_BASE, vec![0; PPC_STACK_SIZE as usize]);
         ppc_app.memory.add_region(
             OUTER_ENTRY,
-            [0x4ef9, (OUTER_DESCRIPTOR >> 16) as u16, OUTER_DESCRIPTOR as u16]
-                .into_iter()
-                .flat_map(u16::to_be_bytes)
-                .collect(),
+            [
+                0x4ef9,
+                (OUTER_DESCRIPTOR >> 16) as u16,
+                OUTER_DESCRIPTOR as u16,
+            ]
+            .into_iter()
+            .flat_map(u16::to_be_bytes)
+            .collect(),
         );
         ppc_app.memory.add_region(
             INNER_ENTRY,
@@ -15707,16 +15664,28 @@ mod tests {
             .memory
             .write_u8(OUTER_DESCRIPTOR + 2, ROUTINE_DESCRIPTOR_VERSION)
             .unwrap();
-        ppc_app.memory.write_u16_be(OUTER_DESCRIPTOR + 10, 0).unwrap();
-        let outer_record = OUTER_DESCRIPTOR + ROUTINE_DESCRIPTOR_HEADER_SIZE;
-        ppc_app.memory.write_u32_be(outer_record, proc_info).unwrap();
         ppc_app
             .memory
-            .write_u8(outer_record + ROUTINE_RECORD_ISA_OFFSET, ROUTINE_RECORD_POWERPC_ISA)
+            .write_u16_be(OUTER_DESCRIPTOR + 10, 0)
+            .unwrap();
+        let outer_record = OUTER_DESCRIPTOR + ROUTINE_DESCRIPTOR_HEADER_SIZE;
+        ppc_app
+            .memory
+            .write_u32_be(outer_record, proc_info)
             .unwrap();
         ppc_app
             .memory
-            .write_u16_be(outer_record + ROUTINE_RECORD_FLAGS_OFFSET, ROUTINE_FLAG_USE_NATIVE_ISA)
+            .write_u8(
+                outer_record + ROUTINE_RECORD_ISA_OFFSET,
+                ROUTINE_RECORD_POWERPC_ISA,
+            )
+            .unwrap();
+        ppc_app
+            .memory
+            .write_u16_be(
+                outer_record + ROUTINE_RECORD_FLAGS_OFFSET,
+                ROUTINE_FLAG_USE_NATIVE_ISA,
+            )
             .unwrap();
         ppc_app
             .memory
@@ -15743,7 +15712,10 @@ mod tests {
             .memory
             .write_u8(INNER_DESCRIPTOR + 2, ROUTINE_DESCRIPTOR_VERSION)
             .unwrap();
-        ppc_app.memory.write_u16_be(INNER_DESCRIPTOR + 10, 0).unwrap();
+        ppc_app
+            .memory
+            .write_u16_be(INNER_DESCRIPTOR + 10, 0)
+            .unwrap();
         let inner_record = INNER_DESCRIPTOR + ROUTINE_DESCRIPTOR_HEADER_SIZE;
         ppc_app
             .memory
@@ -15751,7 +15723,10 @@ mod tests {
             .unwrap();
         ppc_app
             .memory
-            .write_u8(inner_record + ROUTINE_RECORD_ISA_OFFSET, ROUTINE_RECORD_M68K_ISA)
+            .write_u8(
+                inner_record + ROUTINE_RECORD_ISA_OFFSET,
+                ROUTINE_RECORD_M68K_ISA,
+            )
             .unwrap();
         ppc_app
             .memory
@@ -15780,7 +15755,8 @@ mod tests {
                 .flat_map(u32::to_be_bytes)
                 .collect(),
         );
-        let mut call_universal_proc = test_ppc_import_binding(0, "InterfaceLib", "CallUniversalProc");
+        let mut call_universal_proc =
+            test_ppc_import_binding(0, "InterfaceLib", "CallUniversalProc");
         call_universal_proc.trap_pc = PPC_IMPORT_TRAP_BASE;
         call_universal_proc.dispatcher_target = PpcImportDispatcherTarget::CallUniversalProc;
         ppc_app.import_count = 1;
@@ -15805,8 +15781,12 @@ mod tests {
 
         let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
         runner.init_app(&app);
+        assert!(runner
+            .dispatcher
+            .guest_calls
+            .register_task(ExecutionTaskId::from_thread_id(3)));
         runner.dispatcher.cooperative_threads.insert(
-            3,
+            ExecutionTaskId::from_thread_id(3),
             CooperativeThread {
                 d_regs: [0; 8],
                 a_regs: [0, 0, 0, 0, 0, 0, 0, WORKER_SP],
@@ -15825,7 +15805,7 @@ mod tests {
 
         let (_, running) = runner.run_steps(128, None);
         assert!(running);
-        assert_eq!(runner.dispatcher.current_cooperative_thread, 3);
+        assert_eq!(runner.dispatcher.guest_calls.current_task().thread_id(), 3);
         assert_eq!(
             runner
                 .parked_m68k_cpus
@@ -15843,7 +15823,7 @@ mod tests {
 
         let (_, running) = runner.run_steps(128, None);
         assert!(running);
-        assert_eq!(runner.dispatcher.current_cooperative_thread, 2);
+        assert_eq!(runner.dispatcher.guest_calls.current_task().thread_id(), 2);
         assert_eq!(
             runner
                 .parked_m68k_cpus
@@ -15854,7 +15834,7 @@ mod tests {
 
         let (_, running) = runner.run_steps(128, None);
         assert!(running);
-        assert_eq!(runner.dispatcher.current_cooperative_thread, 2);
+        assert_eq!(runner.dispatcher.guest_calls.current_task().thread_id(), 2);
         assert!(runner.dispatcher.guest_calls.is_empty());
         assert!(runner.parked_m68k_cpus.is_empty());
         let ppc_app = runner.ppc_app.as_ref().expect("PPC app retained");
@@ -16151,15 +16131,17 @@ mod tests {
             special_case::PROTOCOL_HANDLER,
             special_case::SOCKET_LISTENER,
         ] {
-            assert!(runner.apply_m68k_special_case_result(
-                &mut ppc_app,
+            assert!(FixtureRunner::apply_m68k_special_case_result(
+                &mut runner.cpu,
+                &mut ppc_app.memory,
                 u8::try_from(selector).unwrap(),
                 SCRATCH,
                 1,
             ));
             assert_eq!(runner.cpu.core.get_ccr(), 0x17);
-            assert!(runner.apply_m68k_special_case_result(
-                &mut ppc_app,
+            assert!(FixtureRunner::apply_m68k_special_case_result(
+                &mut runner.cpu,
+                &mut ppc_app.memory,
                 u8::try_from(selector).unwrap(),
                 SCRATCH,
                 0,
@@ -16169,8 +16151,9 @@ mod tests {
 
         runner.cpu.core.set_d(1, 0xaaaa_0000);
         for selector in [special_case::WIDTH_HOOK, special_case::NWIDTH_HOOK] {
-            assert!(runner.apply_m68k_special_case_result(
-                &mut ppc_app,
+            assert!(FixtureRunner::apply_m68k_special_case_result(
+                &mut runner.cpu,
+                &mut ppc_app.memory,
                 u8::try_from(selector).unwrap(),
                 SCRATCH,
                 0x1234_5678,
@@ -16183,8 +16166,9 @@ mod tests {
         ppc_app.memory.write_u16_be(SCRATCH, 0x1111).unwrap();
         ppc_app.memory.write_u16_be(SCRATCH + 2, 0x2222).unwrap();
         ppc_app.memory.write_u8(SCRATCH + 4, 1).unwrap();
-        assert!(runner.apply_m68k_special_case_result(
-            &mut ppc_app,
+        assert!(FixtureRunner::apply_m68k_special_case_result(
+            &mut runner.cpu,
+            &mut ppc_app.memory,
             u8::try_from(special_case::HIT_TEST_HOOK).unwrap(),
             SCRATCH,
             1,
@@ -16197,8 +16181,9 @@ mod tests {
         runner.cpu.core.set_d(1, 0xbbbb_0000);
         ppc_app.memory.write_u16_be(SCRATCH, 0x3333).unwrap();
         ppc_app.memory.write_u16_be(SCRATCH + 2, 0x4444).unwrap();
-        assert!(runner.apply_m68k_special_case_result(
-            &mut ppc_app,
+        assert!(FixtureRunner::apply_m68k_special_case_result(
+            &mut runner.cpu,
+            &mut ppc_app.memory,
             u8::try_from(special_case::TE_FIND_WORD).unwrap(),
             SCRATCH,
             0,
@@ -16215,8 +16200,9 @@ mod tests {
         runner.cpu.core.set_d(2, 0xaaaa_0000);
         runner.cpu.core.set_d(3, 0xbbbb_0000);
         runner.cpu.core.set_d(4, 0xcccc_0000);
-        assert!(runner.apply_m68k_special_case_result(
-            &mut ppc_app,
+        assert!(FixtureRunner::apply_m68k_special_case_result(
+            &mut runner.cpu,
+            &mut ppc_app.memory,
             u8::try_from(special_case::TE_RECALC).unwrap(),
             SCRATCH,
             0,
@@ -16228,8 +16214,9 @@ mod tests {
         ppc_app.memory.write_u32_be(SCRATCH, 0xcafe_babe).unwrap();
         ppc_app.memory.write_u16_be(SCRATCH + 4, 0x8888).unwrap();
         runner.cpu.core.set_d(0, 0xdddd_0000);
-        assert!(runner.apply_m68k_special_case_result(
-            &mut ppc_app,
+        assert!(FixtureRunner::apply_m68k_special_case_result(
+            &mut runner.cpu,
+            &mut ppc_app.memory,
             u8::try_from(special_case::TE_DO_TEXT).unwrap(),
             SCRATCH,
             0,
@@ -16238,14 +16225,21 @@ mod tests {
         assert_eq!(runner.cpu.core.d(0), 0xdddd_8888);
 
         runner.cpu.core.set_d(0, 0xeeee_0000);
-        assert!(runner.apply_m68k_special_case_result(
-            &mut ppc_app,
+        assert!(FixtureRunner::apply_m68k_special_case_result(
+            &mut runner.cpu,
+            &mut ppc_app.memory,
             u8::try_from(special_case::MBAR_HOOK).unwrap(),
             SCRATCH,
             0x1234_9999,
         ));
         assert_eq!(runner.cpu.core.d(0), 0xeeee_9999);
-        assert!(!runner.apply_m68k_special_case_result(&mut ppc_app, 13, SCRATCH, 0));
+        assert!(!FixtureRunner::apply_m68k_special_case_result(
+            &mut runner.cpu,
+            &mut ppc_app.memory,
+            13,
+            SCRATCH,
+            0
+        ));
         runner.ppc_app = Some(ppc_app);
     }
 
@@ -16411,6 +16405,22 @@ mod tests {
         );
         assert_eq!(ppc_app.memory.read_u8(SCRATCH + 26), Some(1));
 
+        // The callback writes multiple output locations as one ABI result.
+        // A bad later destination must not leave an earlier output changed.
+        ppc_app.memory.write_u16_be(SCRATCH + 30, 0xaaaa).unwrap();
+        runner.cpu.core.set_d(0, 0x1111);
+        runner.cpu.core.set_d(1, 0x2222);
+        assert_eq!(
+            runner.complete_m68k_special_case_result(
+                &mut ppc_app,
+                u8::try_from(special_case::TE_FIND_WORD).unwrap(),
+                arguments(&[0, 0, 0, 0, SCRATCH + 30, 0x0500_0000]),
+                None,
+            ),
+            Err(()),
+        );
+        assert_eq!(ppc_app.memory.read_u16_be(SCRATCH + 30), Some(0xaaaa));
+
         runner.cpu.core.set_d(0, 0xaaaa_abcd);
         assert_eq!(
             runner.complete_m68k_special_case_result(
@@ -16484,6 +16494,110 @@ mod tests {
     }
 
     #[test]
+    fn malformed_m68k_return_shapes_leave_registers_unchanged() {
+        use crate::guest_call::{M68kResultTarget, M68kResume, PowerPcReturnState};
+        let mut cpu = M68kCpu::new();
+        let mut memory = PpcSectionMem::new();
+        cpu.core.set_d(0, 0xabcd_1234);
+        cpu.core.set_a(0, 0x1234_abcd);
+        cpu.core.set_ccr(0x15);
+        for target in [
+            M68kResultTarget::Data { index: 8, size: 4 },
+            M68kResultTarget::Address { index: 8, size: 4 },
+            M68kResultTarget::Data { index: 0, size: 3 },
+            M68kResultTarget::SpecialCase {
+                selector: crate::mixed_mode::special_case::TE_FIND_WORD as u8,
+                scratch: u32::MAX,
+            },
+        ] {
+            assert!(!FixtureRunner::apply_m68k_resume_result(
+                &mut cpu,
+                &mut memory,
+                M68kResume {
+                    return_pc: 0x1000,
+                    final_sp: 0x2000,
+                    result: Some(target),
+                    powerpc: PowerPcReturnState { gpr3: 42 },
+                }
+            ));
+            assert_eq!(cpu.core.d(0), 0xabcd_1234);
+            assert_eq!(cpu.core.a(0), 0x1234_abcd);
+            assert_eq!(cpu.core.get_ccr(), 0x15);
+        }
+    }
+
+    #[test]
+    fn parked_m68k_caller_receives_native_register_and_ccr_results() {
+        use crate::guest_call::M68kResultTarget;
+        use crate::mixed_mode::special_case;
+
+        const RETURN_PC: u32 = 0x0306_5000;
+        const FINAL_SP: u32 = 0x0306_6000;
+        for target in [
+            M68kResultTarget::Data { index: 2, size: 4 },
+            M68kResultTarget::Address { index: 3, size: 4 },
+            M68kResultTarget::Ccr { mask: 4 },
+            M68kResultTarget::SpecialCase {
+                selector: special_case::WIDTH_HOOK as u8,
+                scratch: 0,
+            },
+        ] {
+            let app = halted_ppc_app_with_sound(PpcSoundState::default());
+            let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+            runner.init_app(&app);
+            let mut ppc_app = runner.ppc_app.take().unwrap();
+            assert!(ppc_app.guest_calls.begin_m68k_to_powerpc(
+                crate::guest_call::GuestCallTarget {
+                    isa: crate::guest_procedure::GuestIsa::PowerPc,
+                    entry: PPC_CODE_BASE,
+                    rtoc: 0,
+                },
+                crate::guest_call::PowerPcArguments::from_slice(&[]).unwrap(),
+                RETURN_PC,
+                FINAL_SP,
+                Some(target),
+            ));
+            ppc_app
+                .guest_calls
+                .activate_powerpc_from_m68k(&mut ppc_app.cpu, RETURN_PC)
+                .unwrap();
+            ppc_app.cpu.pc = RETURN_PC;
+            ppc_app.cpu.gpr[3] = 0x1234_5678;
+            assert!(ppc_app
+                .guest_calls
+                .complete_powerpc_for_m68k(&mut ppc_app.cpu));
+            let (task, call_id) = ppc_app.guest_calls.pending_m68k_resume_owner().unwrap();
+            runner.cpu.core.set_d(1, 0xabcd_0000);
+            runner.cpu.core.set_d(7, 0xcafe_babe);
+            runner.cpu.core.set_ccr(0x11);
+            assert!(ppc_app
+                .guest_calls
+                .park_context(
+                    &mut runner.parked_m68k_cpus,
+                    task,
+                    call_id,
+                    std::mem::take(&mut runner.cpu),
+                )
+                .is_ok());
+            assert!(runner.resume_m68k_after_powerpc(&mut ppc_app), "{target:?}");
+            match target {
+                M68kResultTarget::Data { .. } => assert_eq!(runner.cpu.core.d(2), 0x1234_5678),
+                M68kResultTarget::Address { .. } => assert_eq!(runner.cpu.core.a(3), 0x1234_5678),
+                M68kResultTarget::Ccr { .. } => assert_eq!(runner.cpu.core.get_ccr(), 0x15),
+                M68kResultTarget::SpecialCase { .. } => {
+                    assert_eq!(runner.cpu.core.d(1), 0xabcd_5678)
+                }
+                _ => unreachable!(),
+            }
+            assert_eq!(runner.cpu.core.d(7), 0xcafe_babe);
+            assert_eq!(runner.cpu.read_reg(Register::PC), RETURN_PC);
+            assert_eq!(runner.cpu.read_reg(Register::A7), FINAL_SP);
+            assert!(ppc_app.guest_calls.is_empty());
+            assert!(runner.parked_m68k_cpus.is_empty());
+        }
+    }
+
+    #[test]
     fn failed_m68k_result_application_keeps_resume_and_parked_context_retryable() {
         use crate::guest_call::M68kResultTarget;
 
@@ -16523,13 +16637,30 @@ mod tests {
 
         // Model the caller parked by a nested native-to-68K transition. The
         // failed write must not consume either this context or its completion.
-        let task = ppc_app.guest_calls.current_task();
+        let (task, call_id) = ppc_app
+            .guest_calls
+            .pending_m68k_resume_owner()
+            .expect("completed continuation owner");
         runner.cpu.core.set_d(0, PARKED_D0);
-        runner.parked_m68k_cpus.push(task, std::mem::take(&mut runner.cpu));
+        assert!(ppc_app
+            .guest_calls
+            .park_context(
+                &mut runner.parked_m68k_cpus,
+                task,
+                call_id,
+                std::mem::take(&mut runner.cpu),
+            )
+            .is_ok());
         assert_eq!(runner.parked_m68k_cpus.task_len(task), 1);
         assert!(ppc_app.guest_calls.peek_m68k_resume().is_some());
 
         assert!(!runner.resume_m68k_after_powerpc(&mut ppc_app));
+        assert_eq!(runner.parked_m68k_cpus.task_len(task), 1);
+        assert!(ppc_app.guest_calls.peek_m68k_resume().is_some());
+
+        ppc_app.memory.add_readonly_region(RESULT, vec![0xaa; 4]);
+        assert!(!runner.resume_m68k_after_powerpc(&mut ppc_app));
+        assert_eq!(ppc_app.memory.read_u32_be(RESULT), Some(0xaaaa_aaaa));
         assert_eq!(runner.parked_m68k_cpus.task_len(task), 1);
         assert!(ppc_app.guest_calls.peek_m68k_resume().is_some());
 
@@ -16772,21 +16903,9 @@ mod tests {
     #[test]
     fn ppc_sound_completions_preserve_centered_viewport_event_coordinates() {
         let mut sound = PpcSoundState::default();
-        queue_ppc_sound_completion(
-            &mut sound,
-            0x0300_1000,
-            PPC_SOUND_GET_EVENT_CALLBACK,
-        );
-        queue_ppc_sound_completion(
-            &mut sound,
-            0x0300_1000,
-            PPC_SOUND_POST_EVENT_CALLBACK,
-        );
-        queue_ppc_sound_completion(
-            &mut sound,
-            0x0300_1000,
-            PPC_SOUND_SET_EVENT_MASK_CALLBACK,
-        );
+        queue_ppc_sound_completion(&mut sound, 0x0300_1000, PPC_SOUND_GET_EVENT_CALLBACK);
+        queue_ppc_sound_completion(&mut sound, 0x0300_1000, PPC_SOUND_POST_EVENT_CALLBACK);
+        queue_ppc_sound_completion(&mut sound, 0x0300_1000, PPC_SOUND_SET_EVENT_MASK_CALLBACK);
         let app = halted_ppc_app_with_sound(sound);
 
         assert_ppc_sound_event_boundary(app, FixtureRunner::fire_pending_ppc_sound_completions);
@@ -17073,7 +17192,12 @@ mod tests {
         assert_eq!(runner.bus.read_long(addr::TICKS), 43);
         assert_eq!(runner.guest_tick(), 43);
         let ppc_app = runner.ppc_app.as_mut().expect("PPC app");
-        assert_eq!(ppc_app.memory.read_u32_be(crate::memory::globals::addr::TICKS), Some(43));
+        assert_eq!(
+            ppc_app
+                .memory
+                .read_u32_be(crate::memory::globals::addr::TICKS),
+            Some(43)
+        );
         assert_eq!(ppc_app.memory.read_u32_be(addr::TICKS), Some(43));
         assert_eq!(ppc_app.sound.completion_invocations.len(), 2);
         assert_eq!(ppc_app.sound.completion_invocations[1].end_r3, 42);
@@ -17108,12 +17232,8 @@ mod tests {
             cfm_library_fragments: Vec::new(),
             next_cfm_connection_id: 1,
             controls: Default::default(),
-            screen_clut: SharedProcessValue::from_value(
-                TrapDispatcher::standard_mac_8bpp_clut(),
-            ),
-            device_gamma: SharedProcessValue::from_value(
-                crate::display::default_display_gamma(),
-            ),
+            screen_clut: SharedProcessValue::from_value(TrapDispatcher::standard_mac_8bpp_clut()),
+            device_gamma: SharedProcessValue::from_value(crate::display::default_display_gamma()),
             device_gamma_explicit: SharedProcessValue::from_value(false),
             process_quickdraw_port_state_attached: false,
             color_manager_clut: SharedProcessValue::from_value(
@@ -17121,7 +17241,8 @@ mod tests {
             ),
             aliases: Vec::new(),
             gworlds: Vec::new(),
-            gworld_pixel_states: crate::process_context::SharedProcessQuickDrawPixelStates::default(),
+            gworld_pixel_states: crate::process_context::SharedProcessQuickDrawPixelStates::default(
+            ),
             q3_objects: Vec::new(),
             q3_object_refs: Vec::new(),
             next_q3_object: 0,
@@ -17164,61 +17285,61 @@ mod tests {
             callback_scheduling: Default::default(),
             process_file_system: SharedProcessFileSystem::from_state(
                 ProcessFileSystemState {
-                files: Default::default(),
-                stdio_streams: ppc_initial_stdio_streams(),
-                vfs_volumes: crate::process_context::SharedProcessValue::default(),
-                vfs_directories: crate::process_context::SharedProcessValue::from_value(vec![PpcVfsDirectory {
-                    dir_id: 18,
-                    parent_dir_id: 17,
-                    path: "System Folder/Preferences/Test App Saves".to_string(),
-                    creator: u32::from_be_bytes(*b"Nano"),
-                    file_type: u32::from_be_bytes(*b"dir "),
-                    finder_flags: 0x0080,
-                    dirty: true,
-                }]),
-                next_vfs_dir_id: crate::process_context::SharedProcessValue::from_value(18),
-                default_dir_id: crate::process_context::SharedProcessValue::from_value(2),
-                vfs_files: vec![PpcVfsFileRecord {
-                    path: "System Folder/Preferences/Test App Prefs".to_string(),
-                    data: (b"prefs".to_vec()).into(),
-                    creator: u32::from_be_bytes(*b"Nano"),
-                    file_type: u32::from_be_bytes(*b"pref"),
-                    finder_flags: 0x0200,
-                    dirty: true,
-                }]
-                .into(),
-                deleted_vfs_file_paths: vec![
-                    "System Folder/Preferences/Old Prefs".to_string(),
-                ],
-                resource_manager: Default::default(),
-                next_file_ref_num: 128,
-                ..ProcessFileSystemState::default()
-            }
-            .with_resources(
-                Vec::new(),
-                vec![PpcVfsResourceFileRecord {
-                    path: "System Folder/Preferences/Test App HighScores".to_string(),
-                    creator: u32::from_be_bytes(*b"Nano"),
-                    file_type: u32::from_be_bytes(*b"pref"),
-                    finder_flags: 0x0400,
-                    resource_len: 0,
-                    raw_data: None,
-                    map_attrs: 0,
-                    dirty: true,
-                }],
-                vec![PpcVfsResourceRecord {
-                    ref_num: 128,
-                    path: "System Folder/Preferences/Test App HighScores".to_string(),
-                    res_type: u32::from_be_bytes(*b"pref"),
-                    res_id: 200,
-                    name: b"Scores".to_vec(),
-                    data: b"score".to_vec(),
-                    raw_data: None,
-                    raw_attrs: None,
-                    attrs: 0,
-                    handle: 0,
-                }],
-            ),
+                    files: Default::default(),
+                    stdio_streams: ppc_initial_stdio_streams(),
+                    vfs_volumes: crate::process_context::SharedProcessValue::default(),
+                    vfs_directories: crate::process_context::SharedProcessValue::from_value(vec![
+                        PpcVfsDirectory {
+                            dir_id: 18,
+                            parent_dir_id: 17,
+                            path: "System Folder/Preferences/Test App Saves".to_string(),
+                            creator: u32::from_be_bytes(*b"Nano"),
+                            file_type: u32::from_be_bytes(*b"dir "),
+                            finder_flags: 0x0080,
+                            dirty: true,
+                        },
+                    ]),
+                    next_vfs_dir_id: crate::process_context::SharedProcessValue::from_value(18),
+                    default_dir_id: crate::process_context::SharedProcessValue::from_value(2),
+                    vfs_files: vec![PpcVfsFileRecord {
+                        path: "System Folder/Preferences/Test App Prefs".to_string(),
+                        data: (b"prefs".to_vec()).into(),
+                        creator: u32::from_be_bytes(*b"Nano"),
+                        file_type: u32::from_be_bytes(*b"pref"),
+                        finder_flags: 0x0200,
+                        dirty: true,
+                    }]
+                    .into(),
+                    deleted_vfs_file_paths: vec!["System Folder/Preferences/Old Prefs".to_string()],
+                    resource_manager: Default::default(),
+                    next_file_ref_num: 128,
+                    ..ProcessFileSystemState::default()
+                }
+                .with_resources(
+                    Vec::new(),
+                    vec![PpcVfsResourceFileRecord {
+                        path: "System Folder/Preferences/Test App HighScores".to_string(),
+                        creator: u32::from_be_bytes(*b"Nano"),
+                        file_type: u32::from_be_bytes(*b"pref"),
+                        finder_flags: 0x0400,
+                        resource_len: 0,
+                        raw_data: None,
+                        map_attrs: 0,
+                        dirty: true,
+                    }],
+                    vec![PpcVfsResourceRecord {
+                        ref_num: 128,
+                        path: "System Folder/Preferences/Test App HighScores".to_string(),
+                        res_type: u32::from_be_bytes(*b"pref"),
+                        res_id: 200,
+                        name: b"Scores".to_vec(),
+                        data: b"score".to_vec(),
+                        raw_data: None,
+                        raw_attrs: None,
+                        attrs: 0,
+                        handle: 0,
+                    }],
+                ),
             ),
             current_gworld: SharedProcessValue::from_value(PPC_MAIN_GWORLD),
             current_gdevice: SharedProcessValue::from_value(PPC_MAIN_GDEVICE),
@@ -17364,9 +17485,7 @@ mod tests {
             .dispatcher()
             .vfs_directories
             .iter()
-            .find(|directory| {
-                directory.path == "System Folder/Preferences/Test App Saves"
-            })
+            .find(|directory| directory.path == "System Folder/Preferences/Test App Saves")
             .expect("dirty PPC directory should remain in the shared catalogue");
         assert_eq!(
             TrapDispatcher::vfs_basename(&saves_directory.path),
@@ -17827,10 +17946,7 @@ mod tests {
         assert!(ppc_app.sound.manager.pending_sound_callbacks.is_empty());
 
         assert_eq!(
-            runner
-                .dispatcher
-                .sound_manager
-                .toggle_file_paused(channel),
+            runner.dispatcher.sound_manager.toggle_file_paused(channel),
             Some(false)
         );
         runner.mix_host_audio(samples.len());
@@ -17959,12 +18075,8 @@ mod tests {
             cfm_library_fragments: Vec::new(),
             next_cfm_connection_id: 1,
             controls: Default::default(),
-            screen_clut: SharedProcessValue::from_value(
-                TrapDispatcher::standard_mac_8bpp_clut(),
-            ),
-            device_gamma: SharedProcessValue::from_value(
-                crate::display::default_display_gamma(),
-            ),
+            screen_clut: SharedProcessValue::from_value(TrapDispatcher::standard_mac_8bpp_clut()),
+            device_gamma: SharedProcessValue::from_value(crate::display::default_display_gamma()),
             device_gamma_explicit: SharedProcessValue::from_value(false),
             process_quickdraw_port_state_attached: false,
             color_manager_clut: SharedProcessValue::from_value(
@@ -17972,7 +18084,8 @@ mod tests {
             ),
             aliases: Vec::new(),
             gworlds: Vec::new(),
-            gworld_pixel_states: crate::process_context::SharedProcessQuickDrawPixelStates::default(),
+            gworld_pixel_states: crate::process_context::SharedProcessQuickDrawPixelStates::default(
+            ),
             q3_objects: Vec::new(),
             q3_object_refs: Vec::new(),
             next_q3_object: 0,
@@ -18114,12 +18227,8 @@ mod tests {
             cfm_library_fragments: Vec::new(),
             next_cfm_connection_id: 1,
             controls: Default::default(),
-            screen_clut: SharedProcessValue::from_value(
-                TrapDispatcher::standard_mac_8bpp_clut(),
-            ),
-            device_gamma: SharedProcessValue::from_value(
-                crate::display::default_display_gamma(),
-            ),
+            screen_clut: SharedProcessValue::from_value(TrapDispatcher::standard_mac_8bpp_clut()),
+            device_gamma: SharedProcessValue::from_value(crate::display::default_display_gamma()),
             device_gamma_explicit: SharedProcessValue::from_value(false),
             process_quickdraw_port_state_attached: false,
             color_manager_clut: SharedProcessValue::from_value(
@@ -18127,7 +18236,8 @@ mod tests {
             ),
             aliases: Vec::new(),
             gworlds: Vec::new(),
-            gworld_pixel_states: crate::process_context::SharedProcessQuickDrawPixelStates::default(),
+            gworld_pixel_states: crate::process_context::SharedProcessQuickDrawPixelStates::default(
+            ),
             q3_objects: Vec::new(),
             q3_object_refs: Vec::new(),
             next_q3_object: 0,
@@ -18501,12 +18611,8 @@ mod tests {
             cfm_library_fragments: Vec::new(),
             next_cfm_connection_id: 1,
             controls: Default::default(),
-            screen_clut: SharedProcessValue::from_value(
-                TrapDispatcher::standard_mac_8bpp_clut(),
-            ),
-            device_gamma: SharedProcessValue::from_value(
-                crate::display::default_display_gamma(),
-            ),
+            screen_clut: SharedProcessValue::from_value(TrapDispatcher::standard_mac_8bpp_clut()),
+            device_gamma: SharedProcessValue::from_value(crate::display::default_display_gamma()),
             device_gamma_explicit: SharedProcessValue::from_value(false),
             process_quickdraw_port_state_attached: false,
             color_manager_clut: SharedProcessValue::from_value(
@@ -18541,7 +18647,8 @@ mod tests {
                     pixels_no_purge: false,
                 },
             ],
-            gworld_pixel_states: crate::process_context::SharedProcessQuickDrawPixelStates::default(),
+            gworld_pixel_states: crate::process_context::SharedProcessQuickDrawPixelStates::default(
+            ),
             q3_objects: Vec::new(),
             q3_object_refs: Vec::new(),
             next_q3_object: 0,
@@ -18782,12 +18889,8 @@ mod tests {
             cfm_library_fragments: Vec::new(),
             next_cfm_connection_id: 1,
             controls: Default::default(),
-            screen_clut: SharedProcessValue::from_value(
-                TrapDispatcher::standard_mac_8bpp_clut(),
-            ),
-            device_gamma: SharedProcessValue::from_value(
-                crate::display::default_display_gamma(),
-            ),
+            screen_clut: SharedProcessValue::from_value(TrapDispatcher::standard_mac_8bpp_clut()),
+            device_gamma: SharedProcessValue::from_value(crate::display::default_display_gamma()),
             device_gamma_explicit: SharedProcessValue::from_value(false),
             process_quickdraw_port_state_attached: false,
             color_manager_clut: SharedProcessValue::from_value(
@@ -18807,7 +18910,8 @@ mod tests {
                 pixels_locked: false,
                 pixels_no_purge: false,
             }],
-            gworld_pixel_states: crate::process_context::SharedProcessQuickDrawPixelStates::default(),
+            gworld_pixel_states: crate::process_context::SharedProcessQuickDrawPixelStates::default(
+            ),
             q3_objects: Vec::new(),
             q3_object_refs: Vec::new(),
             next_q3_object: 0,
@@ -22111,7 +22215,8 @@ mod tests {
             assert!(runner.bus.fast_mem_window().is_some());
         }
         assert_eq!(
-            runner.guest_tick(), 100,
+            runner.guest_tick(),
+            100,
             "a busy site is never fast-forwarded"
         );
 

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -4,11 +4,6 @@
 //! `impl TrapDispatcher` blocks with `dispatch_*` methods that return
 //! `Option<Result<()>>` — `Some` if the trap was handled, `None` to pass through.
 
-use super::types::UnderlineInfo;
-use super::manager::{
-    TrapManager, TrapManagerMemoryOp, TrapManagerMemoryResult, TrapManagerSetError,
-    TrapTableKind,
-};
 pub(crate) use super::manager::{
     raw_trap_route, OsRoutineVariant, RawTrapRoute, OS_TRAP_TABLE_BASE, OS_TRAP_TABLE_SLOTS,
     TOOLBOX_TRAP_TABLE_BASE, TOOLBOX_TRAP_TABLE_SLOTS,
@@ -16,8 +11,13 @@ pub(crate) use super::manager::{
 #[cfg(test)]
 #[cfg(test)]
 use super::manager::{resolve_trap_table_target, TrapTableTarget, COME_FROM_PATCH_SIGNATURE};
+use super::manager::{
+    TrapManager, TrapManagerMemoryOp, TrapManagerMemoryResult, TrapManagerSetError, TrapTableKind,
+};
+use super::types::UnderlineInfo;
 use crate::cpu::{CpuOps, Register};
 use crate::display::CursorImage;
+use crate::execution_kernel::ExecutionTaskContextBank;
 use crate::guest_call::SharedGuestCallStack;
 use crate::list_manager::ProcessListRecord;
 use crate::machine_profile::reference_machine_profile;
@@ -25,19 +25,17 @@ use crate::managers::resource::ResourceFork;
 use crate::memory::{MacMemoryBus, MemoryBus};
 use crate::menu_manager::{ProcessMenuTrackingState, SharedNativeMenuSelection};
 use crate::process_context::{
-    PendingFileCompletion, ProcessContext, ProcessForkMap,
-    ProcessKeyRepeatState, ProcessLoadedResources, ProcessResourceFileMap,
-    ProcessResourceManagerState, ProcessWorkingDirectory,
-    ProcessVfsDirectory, ProcessVfsMetadata, ProcessVfsVolumeRecord,
+    PendingFileCompletion, ProcessContext, ProcessForkMap, ProcessKeyRepeatState,
+    ProcessLoadedResources, ProcessResourceFileMap, ProcessResourceManagerState,
+    ProcessVfsDirectory, ProcessVfsMetadata, ProcessVfsVolumeRecord, ProcessWorkingDirectory,
     SharedProcessAppleEventHandlers, SharedProcessAppleEventLaunchState,
     SharedProcessControlManager, SharedProcessCursorState, SharedProcessDialogText,
     SharedProcessEventQueue, SharedProcessFileSystem, SharedProcessInputState,
     SharedProcessListManager, SharedProcessMemoryManager, SharedProcessMenuTracking,
-    SharedProcessOpenFilePositions, SharedProcessOpenFiles,
-    SharedProcessQuickDrawHiliteColors, SharedProcessQuickDrawOpColors,
-    SharedProcessQuickDrawPixelStates,
-    SharedProcessScrapState, SharedProcessSoundManager, SharedProcessTextEditManager,
-    SharedProcessTickState, SharedProcessValue,
+    SharedProcessOpenFilePositions, SharedProcessOpenFiles, SharedProcessQuickDrawHiliteColors,
+    SharedProcessQuickDrawOpColors, SharedProcessQuickDrawPixelStates, SharedProcessScrapState,
+    SharedProcessSoundManager, SharedProcessTextEditManager, SharedProcessTickState,
+    SharedProcessValue,
 };
 use crate::trace::{TraceEvent, TraceSink, TraceSource};
 use crate::ui_theme::{UiTheme, UiThemeId};
@@ -1208,7 +1206,6 @@ impl TrapWordMap {
     }
 }
 
-
 /// Rust adapter identities allowed for one canonical A-line operation row.
 /// `Nonterminal` is a declared registry state, distinct from an accidental
 /// omission: its gateway remains callable and reports the exact raw word until
@@ -1525,11 +1522,9 @@ pub struct TrapDispatcher {
     /// to a single dispatcher-wide counter.
     pub(crate) thread_critical_nesting: u32,
     /// Cooperative Thread Manager contexts keyed by their opaque ThreadID.
-    pub(crate) cooperative_threads: HashMap<u32, CooperativeThread>,
+    pub(crate) cooperative_threads: ExecutionTaskContextBank<CooperativeThread>,
     /// Round-robin queue of ready cooperative threads.
     pub(crate) cooperative_thread_ready: VecDeque<u32>,
-    /// ThreadID whose register context is currently installed in the CPU.
-    pub(crate) current_cooperative_thread: u32,
     /// Next guest-visible ThreadID. IDs 1 and 2 are reserved by Threads.h.
     pub(crate) next_cooperative_thread_id: u32,
     /// Guest trampoline entered when a ThreadEntryProc returns.
@@ -1653,8 +1648,7 @@ pub struct TrapDispatcher {
     /// Read-only disk-image volumes mounted alongside the synthetic boot volume.
     pub(crate) vfs_volumes: SharedProcessValue<Vec<VfsVolume>>,
     /// Open working directories keyed by working directory reference number.
-    pub(crate) working_directories:
-        SharedProcessValue<HashMap<i16, WorkingDirectory>>,
+    pub(crate) working_directories: SharedProcessValue<HashMap<i16, WorkingDirectory>>,
     /// Open file table: refnum -> filename
     pub(crate) open_files: SharedProcessOpenFiles,
     /// Synthetic Device Manager drivers opened by name via PBOpen/OpenDriver.
@@ -2478,8 +2472,7 @@ impl TrapDispatcher {
     pub(crate) fn attach_process_context(&mut self, context: &mut ProcessContext) {
         let mut memory_manager = None;
         context.attach_memory_manager(&mut memory_manager);
-        let memory_manager =
-            memory_manager.expect("process context supplies a Memory Manager");
+        let memory_manager = memory_manager.expect("process context supplies a Memory Manager");
         if let Some(attached) = &self.process_memory_manager {
             assert!(
                 attached.ptr_eq(&memory_manager),
@@ -2493,14 +2486,9 @@ impl TrapDispatcher {
         context.attach_file_system(&mut self.process_file_system);
         self.open_files = self.process_file_system.files.shared_handle();
         self.write_refnums = self.process_file_system.writable_refnums.shared_handle();
-        self.pending_file_completions = self
-            .process_file_system
-            .pending_completions
-            .shared_handle();
-        self.working_directories = self
-            .process_file_system
-            .working_directories
-            .shared_handle();
+        self.pending_file_completions =
+            self.process_file_system.pending_completions.shared_handle();
+        self.working_directories = self.process_file_system.working_directories.shared_handle();
         self.next_working_dir_refnum = self
             .process_file_system
             .next_working_directory_ref_num
@@ -2640,9 +2628,12 @@ impl TrapDispatcher {
         bytes: &[u8],
     ) -> bool {
         let memory_manager = self.process_memory_manager();
-        let result = memory_manager
-            .borrow_mut()
-            .replace_native_handle_bytes(bus, handle, expected_ptr, bytes);
+        let result = memory_manager.borrow_mut().replace_native_handle_bytes(
+            bus,
+            handle,
+            expected_ptr,
+            bytes,
+        );
         match result {
             Ok((old_ptr, new_ptr)) => {
                 self.untrack_handle_ptr(old_ptr);
@@ -2651,10 +2642,7 @@ impl TrapDispatcher {
                 true
             }
             Err(error) => {
-                bus.write_word(
-                    crate::memory::globals::addr::MEM_ERR,
-                    error as u16,
-                );
+                bus.write_word(crate::memory::globals::addr::MEM_ERR, error as u16);
                 false
             }
         }
@@ -2862,7 +2850,10 @@ impl TrapDispatcher {
         let safe_label = sanitize_gui_capture_label(label);
         let filename = format!(
             "{:06}_t{:06}_tr{:08}_{}.png",
-            frame, self.current_tick(), self.trap_count, safe_label
+            frame,
+            self.current_tick(),
+            self.trap_count,
+            safe_label
         );
         let path = dir.join(&filename);
         let mut rgba = crate::display::render_screen_with_gamma(
@@ -3338,7 +3329,8 @@ impl TrapDispatcher {
 
     pub(crate) fn input_trace_state_fields(&self) -> String {
         let key_map = if self.input_state.key_map.iter().any(|&byte| byte != 0) {
-            self.input_state.key_map
+            self.input_state
+                .key_map
                 .iter()
                 .map(|byte| format!("{byte:02X}"))
                 .collect::<Vec<_>>()
@@ -3468,9 +3460,7 @@ impl TrapDispatcher {
             .application_working_directory_ref_num
             .shared_handle();
         let vfs_volumes = process_file_system.vfs_volumes.shared_handle();
-        let next_vfs_volume_ref_num = process_file_system
-            .next_vfs_volume_ref_num
-            .shared_handle();
+        let next_vfs_volume_ref_num = process_file_system.next_vfs_volume_ref_num.shared_handle();
         let vfs_directories = process_file_system.vfs_directories.shared_handle();
         let file_positions = process_file_system.files.positions();
 
@@ -3518,9 +3508,8 @@ impl TrapDispatcher {
             pict_info_ids: HashSet::new(),
             ppc_initialized: false,
             thread_critical_nesting: 0,
-            cooperative_threads: HashMap::new(),
+            cooperative_threads: ExecutionTaskContextBank::default(),
             cooperative_thread_ready: VecDeque::new(),
-            current_cooperative_thread: 2,
             next_cooperative_thread_id: 3,
             thread_return_trampoline: 0,
             cooperative_thread_scheduler: 0,
@@ -4724,7 +4713,8 @@ impl TrapDispatcher {
 
     pub(crate) fn remove_vfs_entry_from_process(&mut self, name: &str) {
         let normalized = Self::normalize_vfs_path(name);
-        self.process_file_system.remove_classic_vfs_path(&normalized);
+        self.process_file_system
+            .remove_classic_vfs_path(&normalized);
     }
 
     pub fn remove_vfs_path(&mut self, name: &str) -> bool {
@@ -4771,7 +4761,8 @@ impl TrapDispatcher {
             removed = true;
         }
 
-        self.process_file_system.remove_classic_vfs_path(&normalized);
+        self.process_file_system
+            .remove_classic_vfs_path(&normalized);
 
         removed
     }
@@ -4822,11 +4813,7 @@ impl TrapDispatcher {
         if vref == Self::boot_volume_ref_num() {
             return vref;
         }
-        if self
-            .vfs_volumes
-            .iter()
-            .any(|volume| volume.ref_num == vref)
-        {
+        if self.vfs_volumes.iter().any(|volume| volume.ref_num == vref) {
             return vref;
         }
         if let Some(working_directory) = self.working_directories.get(&vref) {
@@ -5347,7 +5334,8 @@ impl TrapDispatcher {
     /// Coordinates are in Mac screen space (0,0 = top-left of screen).
     pub fn set_mouse_position(&mut self, v: i16, h: i16) {
         self.input_state.mouse_pos = (v, h);
-        self.adb.note_mouse_state(self.input_state.mouse_pos, self.input_state.mouse_button);
+        self.adb
+            .note_mouse_state(self.input_state.mouse_pos, self.input_state.mouse_button);
     }
 
     pub(crate) fn has_unmatched_queued_mouse_down(&self) -> bool {
@@ -5366,7 +5354,8 @@ impl TrapDispatcher {
     pub fn push_mouse_down(&mut self, v: i16, h: i16) {
         self.input_state.mouse_button = true;
         self.input_state.mouse_pos = (v, h);
-        self.adb.note_mouse_state(self.input_state.mouse_pos, self.input_state.mouse_button);
+        self.adb
+            .note_mouse_state(self.input_state.mouse_pos, self.input_state.mouse_button);
         let modifiers = self.current_event_modifiers();
         let tick = self.current_tick();
         self.event_queue.push_back(QueuedEvent {
@@ -5387,7 +5376,8 @@ impl TrapDispatcher {
     pub fn push_mouse_up(&mut self, v: i16, h: i16) {
         self.input_state.mouse_pos = (v, h);
         self.input_state.mouse_button = false;
-        self.adb.note_mouse_state(self.input_state.mouse_pos, self.input_state.mouse_button);
+        self.adb
+            .note_mouse_state(self.input_state.mouse_pos, self.input_state.mouse_button);
         // The classic mouse has one button, so the first physical release
         // after a ModalDialog-owned press is its matching mouseUp. Consume it
         // at injection time so event masks or FlushEvents cannot leave stale
@@ -5597,7 +5587,10 @@ impl TrapDispatcher {
     /// `TrapDispatcher::new()` seeds the default arrow). Used by
     /// tests to observe SetCursor's bitmap-storage effect.
     pub fn cursor_data(&self) -> Option<([u8; 32], [u8; 32], i16, i16)> {
-        self.cursor_state.image.as_ref().map(CursorImage::mono_parts)
+        self.cursor_state
+            .image
+            .as_ref()
+            .map(CursorImage::mono_parts)
     }
 
     /// Get the current mouse position.
@@ -7622,7 +7615,10 @@ impl TrapDispatcher {
                 let sp = cpu.read_reg(Register::A7);
                 eprintln!(
                     "[TRACE-PC] trap=${:04X} pc=${:08X} tick={} sp=${:08X}",
-                    trap, trap_pc, self.current_tick(), sp
+                    trap,
+                    trap_pc,
+                    self.current_tick(),
+                    sp
                 );
                 eprintln!(
                     "[TRACE-PC]   d0=${:08X} d1=${:08X} d2=${:08X} d3=${:08X} d4=${:08X} d5=${:08X} d6=${:08X} d7=${:08X}",
@@ -11028,7 +11024,10 @@ mod tests {
             .ptr_eq(&second.pending_file_completions));
 
         first.pending_file_completions.push_back(completion);
-        assert_eq!(second.pending_file_completions.pop_front(), Some(completion));
+        assert_eq!(
+            second.pending_file_completions.pop_front(),
+            Some(completion)
+        );
         assert!(first.pending_file_completions.is_empty());
     }
 
@@ -11036,7 +11035,9 @@ mod tests {
     fn attached_menu_tracking_mutates_process_context_immediately() {
         let mut dispatcher = TrapDispatcher::new();
         let mut context = ProcessContext::default();
-        context.set_menu_tracking(Some(crate::menu_manager::test_process_menu_tracking(0x1234)));
+        context.set_menu_tracking(Some(crate::menu_manager::test_process_menu_tracking(
+            0x1234,
+        )));
         dispatcher.attach_process_context(&mut context);
 
         assert_eq!(
@@ -11051,14 +11052,19 @@ mod tests {
                 .map(|t| (t.menu_handle, t.highlighted_item)),
             Some((0x1234, 5))
         );
-        assert_eq!(dispatcher.menu_tracking.as_ref().unwrap().highlighted_item, 5);
+        assert_eq!(
+            dispatcher.menu_tracking.as_ref().unwrap().highlighted_item,
+            5
+        );
     }
 
     #[test]
     fn attached_menu_tracking_remains_shared_through_panic() {
         let mut dispatcher = TrapDispatcher::new();
         let mut context = ProcessContext::default();
-        context.set_menu_tracking(Some(crate::menu_manager::test_process_menu_tracking(0x5678)));
+        context.set_menu_tracking(Some(crate::menu_manager::test_process_menu_tracking(
+            0x5678,
+        )));
         dispatcher.attach_process_context(&mut context);
 
         let panic_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -11073,14 +11079,19 @@ mod tests {
                 .map(|t| (t.menu_handle, t.highlighted_item)),
             Some((0x5678, 9))
         );
-        assert_eq!(dispatcher.menu_tracking.as_ref().unwrap().highlighted_item, 9);
+        assert_eq!(
+            dispatcher.menu_tracking.as_ref().unwrap().highlighted_item,
+            9
+        );
     }
 
     #[test]
     fn attached_process_state_remains_canonical_through_panic() {
         let mut dispatcher = TrapDispatcher::new();
         let mut context = ProcessContext::default();
-        context.set_menu_tracking(Some(crate::menu_manager::test_process_menu_tracking(0x9abc)));
+        context.set_menu_tracking(Some(crate::menu_manager::test_process_menu_tracking(
+            0x9abc,
+        )));
         dispatcher.attach_process_context(&mut context);
         let memory_manager = context.memory_manager_handle().clone();
 
@@ -11106,16 +11117,11 @@ mod tests {
             context.event_queue().front().map(|event| event.message),
             Some(0x3333)
         );
-        assert_eq!(
-            memory_manager.borrow().handle_for_ptr(0x4444),
-            Some(0x5555)
-        );
+        assert_eq!(memory_manager.borrow().handle_for_ptr(0x4444), Some(0x5555));
         assert_eq!(memory_manager.borrow().handle_state(0x5555), 0xc0);
         assert_eq!(dispatcher.handle_for_ptr(0x4444), Some(0x5555));
         assert_eq!(dispatcher.handle_state_bits(0x5555), Some(0xc0));
-        memory_manager
-            .borrow_mut()
-            .track_handle_ptr(0x6666, 0x7777);
+        memory_manager.borrow_mut().track_handle_ptr(0x6666, 0x7777);
         assert_eq!(dispatcher.handle_for_ptr(0x6666), Some(0x7777));
         assert_eq!(
             context
@@ -11124,7 +11130,10 @@ mod tests {
             Some((0x9abc, 7))
         );
         assert_eq!(dispatcher.event_queue.len(), 1);
-        assert_eq!(dispatcher.menu_tracking.as_ref().unwrap().highlighted_item, 7);
+        assert_eq!(
+            dispatcher.menu_tracking.as_ref().unwrap().highlighted_item,
+            7
+        );
         assert!(dispatcher
             .process_memory_manager
             .as_ref()

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -12,10 +12,10 @@ use std::sync::OnceLock;
 
 use super::dispatch::{
     raw_trap_route, selector_operation_route, AeCoercionHandler, AeDescriptor, AeObjectAccessor,
-    AePrivateHashTable, AeResolveLevel, AeResolveState, CooperativeThread, DialogItem, MovieState,
-    EventProbeResult, EventRecordSnapshot, OsRoutineVariant, SelectorOperationRoute,
-    StandardFileGetEntry, StandardFileGetTrackingState,
-    StandardFilePutTrackingState, SyntheticAppleEvent,
+    AePrivateHashTable, AeResolveLevel, AeResolveState, CooperativeThread, DialogItem,
+    EventProbeResult, EventRecordSnapshot, MovieState, OsRoutineVariant, SelectorOperationRoute,
+    StandardFileGetEntry, StandardFileGetTrackingState, StandardFilePutTrackingState,
+    SyntheticAppleEvent,
 };
 use super::types::{decode_mac_roman, encode_mac_roman_lossy, Rect, ShapeOp};
 
@@ -1186,7 +1186,7 @@ impl super::TrapDispatcher {
     /// `kNoThreadID` (0) both name the running thread, per Threads.h.
     fn resolve_cooperative_thread_id(&self, thread_id: u32) -> u32 {
         if thread_id == 0 || thread_id == 1 {
-            self.current_cooperative_thread
+            self.guest_calls.current_task().thread_id()
         } else {
             thread_id
         }
@@ -1204,24 +1204,28 @@ impl super::TrapDispatcher {
         if thread_id == Self::APPLICATION_THREAD_ID
             && !self
                 .cooperative_threads
-                .contains_key(&Self::APPLICATION_THREAD_ID)
+                .contains(ExecutionTaskId::from_thread_id(Self::APPLICATION_THREAD_ID))
         {
-            let state = if self.current_cooperative_thread == Self::APPLICATION_THREAD_ID {
-                Self::THREAD_STATE_RUNNING
-            } else {
-                Self::THREAD_STATE_READY
-            };
+            let state =
+                if self.guest_calls.current_task().thread_id() == Self::APPLICATION_THREAD_ID {
+                    Self::THREAD_STATE_RUNNING
+                } else {
+                    Self::THREAD_STATE_READY
+                };
             let thread = Self::capture_cooperative_thread(cpu, state, 0);
-            self.cooperative_threads
-                .insert(Self::APPLICATION_THREAD_ID, thread);
+            self.cooperative_threads.insert(
+                ExecutionTaskId::from_thread_id(Self::APPLICATION_THREAD_ID),
+                thread,
+            );
         }
-        self.cooperative_threads.get_mut(&thread_id)
+        self.cooperative_threads
+            .get_mut(ExecutionTaskId::from_thread_id(thread_id))
     }
 
     /// Save the running thread's registers into its record without
     /// changing its scheduling state.
     fn save_current_cooperative_thread<C: CpuOps>(&mut self, cpu: &C) {
-        let current_id = self.current_cooperative_thread;
+        let current_id = self.guest_calls.current_task().thread_id();
         let saved = Self::capture_cooperative_thread(cpu, Self::THREAD_STATE_RUNNING, 0);
         match self.cooperative_thread_mut(cpu, current_id) {
             Some(thread) => {
@@ -1231,7 +1235,8 @@ impl super::TrapDispatcher {
                 thread.ccr = saved.ccr;
             }
             None => {
-                self.cooperative_threads.insert(current_id, saved);
+                self.cooperative_threads
+                    .insert(ExecutionTaskId::from_thread_id(current_id), saved);
             }
         }
     }
@@ -1240,7 +1245,7 @@ impl super::TrapDispatcher {
     /// ready thread, matching `YieldToThread`; otherwise the ready queue
     /// runs round-robin, as the stock 68K scheduler does.
     fn next_ready_cooperative_thread(&mut self, suggested_thread: u32) -> Option<u32> {
-        let current_id = self.current_cooperative_thread;
+        let current_id = self.guest_calls.current_task().thread_id();
         if suggested_thread > 1 && suggested_thread != current_id {
             if let Some(position) = self
                 .cooperative_thread_ready
@@ -1258,7 +1263,7 @@ impl super::TrapDispatcher {
             }
             let ready = self
                 .cooperative_threads
-                .get(&candidate)
+                .get(ExecutionTaskId::from_thread_id(candidate))
                 .is_some_and(|thread| thread.state == Self::THREAD_STATE_READY);
             if ready {
                 return Some(candidate);
@@ -1270,7 +1275,11 @@ impl super::TrapDispatcher {
     /// Install `next_id` as the running thread. The caller has already
     /// saved and re-queued the outgoing context.
     fn switch_to_cooperative_thread<C: CpuOps>(&mut self, cpu: &mut C, next_id: u32) -> bool {
-        let Some(mut next) = self.cooperative_threads.get(&next_id).cloned() else {
+        let Some(mut next) = self
+            .cooperative_threads
+            .get(ExecutionTaskId::from_thread_id(next_id))
+            .cloned()
+        else {
             return false;
         };
         if next.state != Self::THREAD_STATE_READY {
@@ -1278,11 +1287,15 @@ impl super::TrapDispatcher {
             return false;
         }
         next.state = Self::THREAD_STATE_RUNNING;
-        self.guest_calls
-            .switch_to_task(ExecutionTaskId::from_thread_id(next_id));
+        if !self
+            .guest_calls
+            .switch_to_task(ExecutionTaskId::from_thread_id(next_id))
+        {
+            return false;
+        }
         Self::install_cooperative_thread(cpu, &next);
-        self.cooperative_threads.insert(next_id, next);
-        self.current_cooperative_thread = next_id;
+        self.cooperative_threads
+            .insert(ExecutionTaskId::from_thread_id(next_id), next);
         true
     }
 
@@ -1294,16 +1307,19 @@ impl super::TrapDispatcher {
             return;
         }
 
-        let current_id = self.current_cooperative_thread;
+        let current_id = self.guest_calls.current_task().thread_id();
         self.save_current_cooperative_thread(cpu);
-        if let Some(thread) = self.cooperative_threads.get_mut(&current_id) {
+        if let Some(thread) = self
+            .cooperative_threads
+            .get_mut(ExecutionTaskId::from_thread_id(current_id))
+        {
             if thread.state == Self::THREAD_STATE_RUNNING {
                 thread.state = Self::THREAD_STATE_READY;
             }
         }
         let requeue = self
             .cooperative_threads
-            .get(&current_id)
+            .get(ExecutionTaskId::from_thread_id(current_id))
             .is_some_and(|thread| thread.state == Self::THREAD_STATE_READY)
             && !self.cooperative_thread_ready.contains(&current_id);
         if requeue {
@@ -1311,7 +1327,10 @@ impl super::TrapDispatcher {
         }
 
         let restore_running = |dispatcher: &mut Self| {
-            if let Some(thread) = dispatcher.cooperative_threads.get_mut(&current_id) {
+            if let Some(thread) = dispatcher
+                .cooperative_threads
+                .get_mut(ExecutionTaskId::from_thread_id(current_id))
+            {
                 thread.state = Self::THREAD_STATE_RUNNING;
             }
             dispatcher
@@ -1345,12 +1364,15 @@ impl super::TrapDispatcher {
         if !self.guest_calls.task_is_empty(task) {
             return false;
         }
-        if thread_id != self.current_cooperative_thread
+        if thread_id != self.guest_calls.current_task().thread_id()
             && !self.guest_calls.remove_task(task)
         {
             return false;
         }
-        if let Some(finished) = self.cooperative_threads.remove(&thread_id) {
+        if let Some(finished) = self
+            .cooperative_threads
+            .remove(ExecutionTaskId::from_thread_id(thread_id))
+        {
             if finished.result_destination != 0 {
                 bus.write_long(finished.result_destination, result);
             }
@@ -1372,7 +1394,7 @@ impl super::TrapDispatcher {
         cpu: &mut C,
         bus: &mut MacMemoryBus,
     ) -> bool {
-        let finished_id = self.current_cooperative_thread;
+        let finished_id = self.guest_calls.current_task().thread_id();
         let result = cpu.read_reg(Register::A0);
         if !self.retire_cooperative_thread(finished_id, result, bus) {
             return false;
@@ -1393,7 +1415,7 @@ impl super::TrapDispatcher {
         }
         if let Some(mut application) = self
             .cooperative_threads
-            .get(&Self::APPLICATION_THREAD_ID)
+            .get(ExecutionTaskId::from_thread_id(Self::APPLICATION_THREAD_ID))
             .cloned()
         {
             self.cooperative_thread_ready
@@ -1402,9 +1424,10 @@ impl super::TrapDispatcher {
             self.guest_calls
                 .switch_to_task(ExecutionTaskId::APPLICATION);
             Self::install_cooperative_thread(cpu, &application);
-            self.cooperative_threads
-                .insert(Self::APPLICATION_THREAD_ID, application);
-            self.current_cooperative_thread = Self::APPLICATION_THREAD_ID;
+            self.cooperative_threads.insert(
+                ExecutionTaskId::from_thread_id(Self::APPLICATION_THREAD_ID),
+                application,
+            );
             return self
                 .guest_calls
                 .remove_task(ExecutionTaskId::from_thread_id(finished_id));
@@ -3456,7 +3479,8 @@ impl super::TrapDispatcher {
     }
 
     fn serialized_scrap_size(&self) -> u32 {
-        self.scrap.entries
+        self.scrap
+            .entries
             .iter()
             .map(|(_, data)| {
                 let padded = (data.len() as u32 + 1) & !1;
@@ -5191,8 +5215,15 @@ impl super::TrapDispatcher {
                 // Finder delivers kAEOpenApplication as a queued high-level
                 // event at launch. Make it visible through the normal toolbox
                 // event APIs instead of special-casing WaitNextEvent only.
-                let (mut what, mut message, mut when, mut where_v, mut where_h, mut modifiers, mut has_event) =
-                    self.dequeue_toolbox_event(cpu, bus, event_mask);
+                let (
+                    mut what,
+                    mut message,
+                    mut when,
+                    mut where_v,
+                    mut where_h,
+                    mut modifiers,
+                    mut has_event,
+                ) = self.dequeue_toolbox_event(cpu, bus, event_mask);
 
                 if !has_event {
                     if let Some(event) =
@@ -6720,9 +6751,7 @@ impl super::TrapDispatcher {
                     // re-seed from vfs_rsrc here, the writes are lost.
                     let refnum = self.allocate_process_file_refnum();
                     let rsrc_key = format!("__rsrc__{}", vfs_key);
-                    self.vfs
-                        .entry(rsrc_key.clone())
-                        .or_insert(rsrc_data.into());
+                    self.vfs.entry(rsrc_key.clone()).or_insert(rsrc_data.into());
                     self.open_files.insert(refnum, rsrc_key);
                     self.file_positions.insert(refnum, 0);
                     bus.write_word(pb + 24, refnum);
@@ -8274,9 +8303,7 @@ impl super::TrapDispatcher {
                             bus.read_word(event_record + 14)
                         );
                     }
-                    if let Some(handler) =
-                        self.apple_event_handler_for(oapp_class, oapp_id)
-                    {
+                    if let Some(handler) = self.apple_event_handler_for(oapp_class, oapp_id) {
                         let handler_ptr = handler.procedure.original_pointer;
                         let refcon = handler.refcon;
                         // Lazily allocate the trampoline on first use.
@@ -8369,9 +8396,7 @@ impl super::TrapDispatcher {
                             }
                             crate::guest_procedure::GuestIsa::PowerPc => {
                                 let arguments = crate::guest_call::PowerPcArguments::from_slice(&[
-                                    event_desc,
-                                    reply_desc,
-                                    refcon,
+                                    event_desc, reply_desc, refcon,
                                 ])
                                 .expect("AppleEvent handler has three arguments");
                                 let started = self.guest_calls.begin_m68k_to_powerpc(
@@ -8488,9 +8513,7 @@ impl super::TrapDispatcher {
                                 crate::guest_procedure::GuestIsa::PowerPc => {
                                     let arguments =
                                         crate::guest_call::PowerPcArguments::from_slice(&[
-                                            event_desc,
-                                            reply_desc,
-                                            refcon,
+                                            event_desc, reply_desc, refcon,
                                         ])
                                         .expect("AppleEvent handler has three arguments");
                                     if !self.guest_calls.begin_m68k_to_powerpc(
@@ -10246,13 +10269,21 @@ impl super::TrapDispatcher {
                 if super::dispatch::trace_input_enabled() {
                     eprintln!(
                         "[INPUT] GetKeys tick={} pc=${:08X} ptr=${:08X} key_map={:02X?}",
-                        self.current_tick(), trap_pc, keys_ptr, self.input_state.key_map
+                        self.current_tick(),
+                        trap_pc,
+                        keys_ptr,
+                        self.input_state.key_map
                     );
                 }
-                if trace_getkeys_nonzero_enabled() && self.input_state.key_map.iter().any(|&byte| byte != 0) {
+                if trace_getkeys_nonzero_enabled()
+                    && self.input_state.key_map.iter().any(|&byte| byte != 0)
+                {
                     eprintln!(
                         "[INPUT] GetKeys nonzero tick={} pc=${:08X} ptr=${:08X} key_map={:02X?}",
-                        self.current_tick(), trap_pc, keys_ptr, self.input_state.key_map
+                        self.current_tick(),
+                        trap_pc,
+                        keys_ptr,
+                        self.input_state.key_map
                     );
                 }
                 if self.input_state.key_map.iter().any(|&byte| byte != 0) {
@@ -11740,21 +11771,23 @@ impl super::TrapDispatcher {
                         let list_handle = bus.read_long(sp + 2);
                         let d_rows = bus.read_word(sp + 6) as i16;
                         let d_cols = bus.read_word(sp + 8) as i16;
-                        let should_draw = if let Some(state) = self.list_states.get_mut(&list_handle) {
-                            Self::set_list_visible_origin(
-                                state,
-                                state.visible.0.saturating_add(d_rows),
-                                state.visible.1.saturating_add(d_cols),
-                            );
-                            Self::sync_list_state_to_guest(bus, list_handle, state);
-                            state.draw_enabled
-                        } else {
-                            false
-                        };
+                        let should_draw =
+                            if let Some(state) = self.list_states.get_mut(&list_handle) {
+                                Self::set_list_visible_origin(
+                                    state,
+                                    state.visible.0.saturating_add(d_rows),
+                                    state.visible.1.saturating_add(d_cols),
+                                );
+                                Self::sync_list_state_to_guest(bus, list_handle, state);
+                                state.draw_enabled
+                            } else {
+                                false
+                            };
                         if should_draw {
                             self.draw_list_scrollbars(cpu, bus, list_handle);
                             if let Some(state) = self.list_states.get(&list_handle).cloned() {
-                                if self.draw_list_with_ldef(cpu, bus, list_handle, &state, None, 10) {
+                                if self.draw_list_with_ldef(cpu, bus, list_handle, &state, None, 10)
+                                {
                                     return Some(Ok(()));
                                 }
                                 self.draw_list_fallback(cpu, bus, &state, None);
@@ -11769,25 +11802,27 @@ impl super::TrapDispatcher {
                         let list_handle = bus.read_long(sp + 2);
                         let height = bus.read_word(sp + 6) as i16;
                         let width = bus.read_word(sp + 8) as i16;
-                        let should_draw = if let Some(state) = self.list_states.get_mut(&list_handle) {
-                            let old_origin = (state.visible.0, state.visible.1);
-                            state.view_rect.2 = state.view_rect.0.saturating_add(height.max(0));
-                            state.view_rect.3 = state.view_rect.1.saturating_add(width.max(0));
-                            state.visible = Self::compute_list_visible_rect(
-                                state.view_rect,
-                                state.data_bounds,
-                                state.cell_size,
-                            );
-                            Self::set_list_visible_origin(state, old_origin.0, old_origin.1);
-                            Self::sync_list_state_to_guest(bus, list_handle, state);
-                            state.draw_enabled
-                        } else {
-                            false
-                        };
+                        let should_draw =
+                            if let Some(state) = self.list_states.get_mut(&list_handle) {
+                                let old_origin = (state.visible.0, state.visible.1);
+                                state.view_rect.2 = state.view_rect.0.saturating_add(height.max(0));
+                                state.view_rect.3 = state.view_rect.1.saturating_add(width.max(0));
+                                state.visible = Self::compute_list_visible_rect(
+                                    state.view_rect,
+                                    state.data_bounds,
+                                    state.cell_size,
+                                );
+                                Self::set_list_visible_origin(state, old_origin.0, old_origin.1);
+                                Self::sync_list_state_to_guest(bus, list_handle, state);
+                                state.draw_enabled
+                            } else {
+                                false
+                            };
                         if should_draw {
                             self.draw_list_scrollbars(cpu, bus, list_handle);
                             if let Some(state) = self.list_states.get(&list_handle).cloned() {
-                                if self.draw_list_with_ldef(cpu, bus, list_handle, &state, None, 10) {
+                                if self.draw_list_with_ldef(cpu, bus, list_handle, &state, None, 10)
+                                {
                                     return Some(Ok(()));
                                 }
                                 self.draw_list_fallback(cpu, bus, &state, None);
@@ -11805,11 +11840,17 @@ impl super::TrapDispatcher {
                         let list_handle = bus.read_long(sp + 2);
                         let act = Self::stack_bool_slot(bus, sp + 6);
                         let list_ptr = Self::list_record_ptr(bus, list_handle);
-                        let should_draw = if let Some(state) = self.list_states.get_mut(&list_handle) {
+                        let should_draw = if let Some(state) =
+                            self.list_states.get_mut(&list_handle)
+                        {
                             state.active = act;
                             if list_ptr != 0 {
-                                bus.write_byte(list_ptr + Self::LIST_ACTIVE_OFFSET, if act { 1 } else { 0 });
-                                for offset in [Self::LIST_VSCROLL_OFFSET, Self::LIST_HSCROLL_OFFSET] {
+                                bus.write_byte(
+                                    list_ptr + Self::LIST_ACTIVE_OFFSET,
+                                    if act { 1 } else { 0 },
+                                );
+                                for offset in [Self::LIST_VSCROLL_OFFSET, Self::LIST_HSCROLL_OFFSET]
+                                {
                                     let control_handle = bus.read_long(list_ptr + offset);
                                     let control = if control_handle != 0 {
                                         bus.read_long(control_handle)
@@ -11831,7 +11872,8 @@ impl super::TrapDispatcher {
                         if should_draw {
                             self.draw_list_scrollbars(cpu, bus, list_handle);
                             if let Some(state) = self.list_states.get(&list_handle).cloned() {
-                                if self.draw_list_with_ldef(cpu, bus, list_handle, &state, None, 8) {
+                                if self.draw_list_with_ldef(cpu, bus, list_handle, &state, None, 8)
+                                {
                                     return Some(Ok(()));
                                 }
                                 self.draw_list_fallback(cpu, bus, &state, None);
@@ -16244,7 +16286,7 @@ impl super::TrapDispatcher {
                     0 => return_noerr_and_pop(cpu, pop_bytes),
                     _ => return_error_and_pop(cpu, pop_bytes, -50),
                 }
-            },
+            }
 
             // ThreadDispatch ($ABF2) — cooperative Thread Manager
             // Inside Macintosh: Thread Manager (1999), pp. 1-56 to 1-58:
@@ -16310,7 +16352,10 @@ impl super::TrapDispatcher {
                         if current_thread == 0 {
                             -50
                         } else {
-                            bus.write_long(current_thread, self.current_cooperative_thread);
+                            bus.write_long(
+                                current_thread,
+                                self.guest_calls.current_task().thread_id(),
+                            );
                             0
                         }
                     }
@@ -16333,6 +16378,14 @@ impl super::TrapDispatcher {
                                 bus.write_long(thread_made, 0);
                             }
                             -50
+                        } else if !self
+                            .guest_calls
+                            .register_task(ExecutionTaskId::from_thread_id(
+                                self.next_cooperative_thread_id,
+                            ))
+                        {
+                            bus.write_long(thread_made, 0);
+                            -108
                         } else {
                             let thread_id = self.next_cooperative_thread_id;
                             self.next_cooperative_thread_id =
@@ -16365,7 +16418,8 @@ impl super::TrapDispatcher {
                             thread.a_regs[7] = entry_sp;
                             thread.stack_base = stack_base;
                             thread.stack_limit = stack_limit;
-                            self.cooperative_threads.insert(thread_id, thread);
+                            self.cooperative_threads
+                                .insert(ExecutionTaskId::from_thread_id(thread_id), thread);
                             if state == Self::THREAD_STATE_READY {
                                 self.cooperative_thread_ready.push_back(thread_id);
                             }
@@ -16440,7 +16494,7 @@ impl super::TrapDispatcher {
                         if free_stack == 0 {
                             -50
                         } else {
-                            let running = thread == self.current_cooperative_thread;
+                            let running = thread == self.guest_calls.current_task().thread_id();
                             let current_sp = cpu.read_reg(Register::A7);
                             match self.cooperative_thread_mut(cpu, thread) {
                                 None => Self::THREAD_NOT_FOUND_ERR,
@@ -16470,15 +16524,16 @@ impl super::TrapDispatcher {
                         let thread_result = bus.read_long(sp + 2);
                         let thread_to_dump =
                             self.resolve_cooperative_thread_id(bus.read_long(sp + 6));
-                        if !self.cooperative_threads.contains_key(&thread_to_dump)
+                        if !self
+                            .cooperative_threads
+                            .contains(ExecutionTaskId::from_thread_id(thread_to_dump))
                             && thread_to_dump != Self::APPLICATION_THREAD_ID
                         {
                             Self::THREAD_NOT_FOUND_ERR
-                        } else if thread_to_dump == self.current_cooperative_thread {
+                        } else if thread_to_dump == self.guest_calls.current_task().thread_id() {
                             // Threads.h allows a thread to dispose of itself;
                             // the call never returns to it.
-                            if !self.retire_cooperative_thread(thread_to_dump, thread_result, bus)
-                            {
+                            if !self.retire_cooperative_thread(thread_to_dump, thread_result, bus) {
                                 Self::THREAD_PROTOCOL_ERR
                             } else {
                                 self.finish_cooperative_thread(cpu, bus);
@@ -16553,8 +16608,9 @@ impl super::TrapDispatcher {
                                     // Keep the installed context and its task
                                     // owner coherent rather than labelling a
                                     // still-running CPU as stopped.
-                                    if let Some(current) =
-                                        self.cooperative_threads.get_mut(&thread_to_set)
+                                    if let Some(current) = self
+                                        .cooperative_threads
+                                        .get_mut(ExecutionTaskId::from_thread_id(thread_to_set))
                                     {
                                         current.state = Self::THREAD_STATE_RUNNING;
                                     }
@@ -16661,7 +16717,7 @@ impl super::TrapDispatcher {
                 } else {
                     return_error_and_pop(cpu, argument_bytes, result)
                 }
-            },
+            }
 
             // _TranslationDispatch (0xABFC)
             // Dispatches Translation Manager routines selected by D0.
@@ -16673,7 +16729,7 @@ impl super::TrapDispatcher {
                     translation_dispatch_operation_route(self.current_trap_word, selector);
                 self.current_selector_operation = operation.map(|route| route.operation_id);
                 return_error_and_pop(cpu, 4, -50)
-            },
+            }
 
             _ => return None,
         })
@@ -16959,6 +17015,7 @@ mod tests {
         STANDARD_FILE_GET_VOLUME_RECT,
     };
     use crate::cpu::{CpuOps, Register};
+    use crate::execution_kernel::ExecutionTaskId;
     use crate::memory::globals::addr;
     use crate::memory::MacMemoryBus;
     use crate::memory::MemoryBus;
@@ -17561,9 +17618,8 @@ mod tests {
         assert_eq!(bus.read_word(sp + 6), 0xCAFE);
 
         // Wrong trap form clears stale identity
-        disp.current_selector_operation = Some(
-            "selector-operation:_Pack15:0x0800:d0-low-word-immediate:16",
-        );
+        disp.current_selector_operation =
+            Some("selector-operation:_Pack15:0x0800:d0-low-word-immediate:16");
         disp.current_trap_word = 0xA931;
         cpu.write_reg(Register::A7, sp);
         cpu.write_reg(Register::D0, 0x0800);
@@ -18364,7 +18420,9 @@ mod tests {
     #[test]
     fn test_wait_next_event_zero_mask_takes_null_event_path() {
         let (mut disp, mut cpu, mut bus) = setup();
-        assert!(!disp.apple_event_launch_state.is_open_application_event_sent());
+        assert!(!disp
+            .apple_event_launch_state
+            .is_open_application_event_sent());
         let sp = TEST_SP;
         let event_ptr = 0x200000u32;
 
@@ -18382,7 +18440,9 @@ mod tests {
         assert_eq!(bus.read_word(sp + 14), 0);
         assert_eq!(cpu.read_reg(Register::A7), sp + 14);
         assert_eq!(bus.read_word(event_ptr), 0);
-        assert!(!disp.apple_event_launch_state.is_open_application_event_sent());
+        assert!(!disp
+            .apple_event_launch_state
+            .is_open_application_event_sent());
         assert_eq!(disp.pending_wait_sleep_ticks, 1);
     }
 
@@ -18490,8 +18550,11 @@ mod tests {
     #[test]
     fn test_wait_next_event_synthesizes_open_app() {
         let (mut disp, mut cpu, mut bus) = setup();
-        disp.apple_event_launch_state.set_high_level_event_aware(true);
-        assert!(!disp.apple_event_launch_state.is_open_application_event_sent());
+        disp.apple_event_launch_state
+            .set_high_level_event_aware(true);
+        assert!(!disp
+            .apple_event_launch_state
+            .is_open_application_event_sent());
         let sp = TEST_SP;
         let event_ptr = 0x200000u32;
         bus.write_long(sp, 0); // mouseRgn
@@ -18514,7 +18577,9 @@ mod tests {
         assert_eq!(bus.read_word(event_ptr + 10), 0x6F61); // where.v
         assert_eq!(bus.read_word(event_ptr + 12), 0x7070); // where.h
                                                            // Flag should be set
-        assert!(disp.apple_event_launch_state.is_open_application_event_sent());
+        assert!(disp
+            .apple_event_launch_state
+            .is_open_application_event_sent());
 
         // Second call should NOT return synthetic event
         cpu.write_reg(Register::A7, sp);
@@ -18545,7 +18610,9 @@ mod tests {
         assert!(result.unwrap().is_ok());
         assert_eq!(bus.read_word(sp + 14), 0);
         assert_eq!(bus.read_word(event_ptr), 0);
-        assert!(!disp.apple_event_launch_state.is_open_application_event_sent());
+        assert!(!disp
+            .apple_event_launch_state
+            .is_open_application_event_sent());
     }
 
     // EventAvail ($A971) — with event (peeks, does not remove)
@@ -18680,7 +18747,8 @@ mod tests {
     #[test]
     fn test_event_avail_synthesizes_open_app_without_consuming() {
         let (mut disp, mut cpu, mut bus) = setup();
-        disp.apple_event_launch_state.set_high_level_event_aware(true);
+        disp.apple_event_launch_state
+            .set_high_level_event_aware(true);
         let sp = TEST_SP;
         let event_ptr = 0x200000u32;
         bus.write_long(sp, event_ptr);
@@ -18701,7 +18769,8 @@ mod tests {
     #[test]
     fn test_get_next_event_synthesizes_open_app() {
         let (mut disp, mut cpu, mut bus) = setup();
-        disp.apple_event_launch_state.set_high_level_event_aware(true);
+        disp.apple_event_launch_state
+            .set_high_level_event_aware(true);
         let sp = TEST_SP;
         let event_ptr = 0x200000u32;
         bus.write_long(sp, event_ptr);
@@ -21040,10 +21109,7 @@ mod tests {
         assert_eq!(cpu.read_reg(Register::D0), 0x89AB_CDEF);
         assert_eq!(cpu.read_reg(Register::A7), sp_before);
         assert_eq!(bus.read_word(0x0936), 1);
-        assert_eq!(
-            disp.launched_app_path(),
-            Some("LaunchTargets/NoSuchApp")
-        );
+        assert_eq!(disp.launched_app_path(), Some("LaunchTargets/NoSuchApp"));
         assert!(
             disp.take_pending_launch_application(false, true).is_none(),
             "a missing legacy target must not be queued"
@@ -21091,10 +21157,7 @@ mod tests {
         assert_eq!(bus.read_long(launch_pb + 28), 0);
         assert_eq!(bus.read_long(launch_pb + 32), 0);
         assert_eq!(bus.read_long(launch_pb + 36), 0);
-        assert_eq!(
-            disp.launched_app_path(),
-            Some("LaunchTargets/NoSuchApp")
-        );
+        assert_eq!(disp.launched_app_path(), Some("LaunchTargets/NoSuchApp"));
         assert_eq!(*disp.default_dir_id, target_dir_id);
         assert_ne!(disp.app_wd_refnum, 0);
     }
@@ -21140,10 +21203,7 @@ mod tests {
         assert_eq!(bus.read_long(launch_pb + 28), 0);
         assert_eq!(bus.read_long(launch_pb + 32), 0);
         assert_eq!(bus.read_long(launch_pb + 36), 0);
-        assert_eq!(
-            disp.launched_app_path(),
-            Some("LaunchTargets/NoSuchApp")
-        );
+        assert_eq!(disp.launched_app_path(), Some("LaunchTargets/NoSuchApp"));
         assert_eq!(*disp.default_dir_id, target_dir_id);
         assert_ne!(disp.app_wd_refnum, 0);
     }
@@ -21333,10 +21393,7 @@ mod tests {
         assert_eq!(cpu.read_reg(Register::D0), 0x1234_5678);
         assert_eq!(cpu.read_reg(Register::A7), sp_before);
         assert_eq!(bus.read_word(0x0936), 0x0001);
-        assert_eq!(
-            disp.launched_app_path(),
-            Some("ChainTargets/NoSuchApp")
-        );
+        assert_eq!(disp.launched_app_path(), Some("ChainTargets/NoSuchApp"));
         assert_eq!(*disp.default_dir_id, target_dir_id);
         assert_ne!(disp.app_wd_refnum, 0);
     }
@@ -23677,7 +23734,10 @@ mod tests {
         bus.write_long(sp, window_ptr);
         let result = disp.dispatch_toolbox(true, 0x104, &mut cpu, &mut bus);
         assert!(result.is_some(), "active DrawGrowIcon should be handled");
-        assert!(result.unwrap().is_ok(), "active DrawGrowIcon should succeed");
+        assert!(
+            result.unwrap().is_ok(),
+            "active DrawGrowIcon should succeed"
+        );
         assert!(
             read_screen_pixel_1bpp(&bus, screen_base, row_bytes, 87, 68),
             "active document window should draw the longest diagonal grip"
@@ -24300,7 +24360,11 @@ mod tests {
         assert_ne!(v_scroll_handle, 0);
         let v_scroll_ptr = bus.read_long(v_scroll_handle);
         assert_eq!(bus.read_byte(list_ptr + 37), 1, "initial lActive must be 1");
-        assert_eq!(bus.read_byte(v_scroll_ptr + 17), 0, "initial contrlHilite must be 0");
+        assert_eq!(
+            bus.read_byte(v_scroll_ptr + 17),
+            0,
+            "initial contrlHilite must be 0"
+        );
 
         // Call LActivate(FALSE, list)
         cpu.write_reg(Register::A7, sp);
@@ -24310,8 +24374,16 @@ mod tests {
         let result = disp.dispatch_toolbox(true, 0x1E7, &mut cpu, &mut bus);
         assert!(result.unwrap().is_ok());
         assert_eq!(cpu.read_reg(Register::A7), sp + 8);
-        assert_eq!(bus.read_byte(list_ptr + 37), 0, "lActive must be 0 when deactivated");
-        assert_eq!(bus.read_byte(v_scroll_ptr + 17), 255, "scrollbar contrlHilite must be 255 when deactivated");
+        assert_eq!(
+            bus.read_byte(list_ptr + 37),
+            0,
+            "lActive must be 0 when deactivated"
+        );
+        assert_eq!(
+            bus.read_byte(v_scroll_ptr + 17),
+            255,
+            "scrollbar contrlHilite must be 255 when deactivated"
+        );
 
         // Call LActivate(TRUE, list)
         cpu.write_reg(Register::A7, sp);
@@ -24321,8 +24393,16 @@ mod tests {
         let result = disp.dispatch_toolbox(true, 0x1E7, &mut cpu, &mut bus);
         assert!(result.unwrap().is_ok());
         assert_eq!(cpu.read_reg(Register::A7), sp + 8);
-        assert_eq!(bus.read_byte(list_ptr + 37), 1, "lActive must be 1 when reactivated");
-        assert_eq!(bus.read_byte(v_scroll_ptr + 17), 0, "scrollbar contrlHilite must be 0 when reactivated");
+        assert_eq!(
+            bus.read_byte(list_ptr + 37),
+            1,
+            "lActive must be 1 when reactivated"
+        );
+        assert_eq!(
+            bus.read_byte(v_scroll_ptr + 17),
+            0,
+            "scrollbar contrlHilite must be 0 when reactivated"
+        );
     }
 
     #[test]
@@ -27192,7 +27272,7 @@ mod tests {
 
         let thread = disp
             .cooperative_threads
-            .get(&2)
+            .get(ExecutionTaskId::from_thread_id(2))
             .expect("the application thread record must exist");
         assert_eq!(thread.switch_in, (0x0003_0000, 0x1111_2222));
         assert_eq!(thread.switch_out, (0, 0), "switch-out stays unset");
@@ -27234,7 +27314,9 @@ mod tests {
             .expect("DisposeThread returns");
         assert_eq!(cpu.read_reg(Register::D0), 0);
         assert_eq!(cpu.read_reg(Register::A7), sp + 10);
-        assert!(!disp.cooperative_threads.contains_key(&new_id));
+        assert!(!disp
+            .cooperative_threads
+            .contains(ExecutionTaskId::from_thread_id(new_id)));
         assert!(!disp.cooperative_thread_ready.contains(&new_id));
         assert_eq!(disp.cooperative_thread_pool.len(), 1);
 
@@ -27394,7 +27476,7 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        assert_eq!(disp.current_cooperative_thread, 3);
+        assert_eq!(disp.guest_calls.current_task().thread_id(), 3);
         assert_eq!(
             disp.guest_calls.depth(),
             0,
@@ -27424,7 +27506,7 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        assert_eq!(disp.current_cooperative_thread, 2);
+        assert_eq!(disp.guest_calls.current_task().thread_id(), 2);
         assert_eq!(
             disp.guest_calls.depth(),
             1,
@@ -27498,8 +27580,10 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        assert_eq!(disp.current_cooperative_thread, 2);
-        assert!(!disp.cooperative_threads.contains_key(&3));
+        assert_eq!(disp.guest_calls.current_task().thread_id(), 2);
+        assert!(!disp
+            .cooperative_threads
+            .contains(ExecutionTaskId::from_thread_id(3)));
         assert_eq!(bus.read_long(thread_result), 0xCAFE_BABE);
         assert_eq!(cpu.read_reg(Register::PC), 0x000F_0000);
         assert_eq!(cpu.read_reg(Register::A7), app_sp + 4);
@@ -34406,7 +34490,7 @@ mod tests {
         disp.current_trap_word = 0xA82D;
         cpu.write_reg(Register::A7, sp);
         cpu.write_reg(Register::D0, 0xABCD_0A02); // NewSection ($0A02, 20 arg bytes)
-        // Pascal entry order: sectionH*, mode, ID, kind, document, container.
+                                                  // Pascal entry order: sectionH*, mode, ID, kind, document, container.
         bus.write_long(sp, out_section_handle);
         bus.write_word(sp + 4, 0);
         bus.write_long(sp + 6, 42);
@@ -34519,7 +34603,9 @@ mod tests {
             assert_eq!(route.routine_name, routine_name);
             assert_eq!(
                 route.operation_id,
-                format!("selector-operation:_TranslationDispatch:0x{selector:04X}:d0-moveq-immediate:8")
+                format!(
+                    "selector-operation:_TranslationDispatch:0x{selector:04X}:d0-moveq-immediate:8"
+                )
             );
         }
 


### PR DESCRIPTION
Mixed Mode returns can lose register and CCR results when a nested callback has parked the 68K caller: result placement updates the installed callback CPU, then restoring the caller overwrites it. Returns now validate the exact task, call phase and attached contexts, apply the result to the actual caller, and retire the context and continuation together. Invalid result destinations retain the return for retry.

Generic context banks replace production depth inference for parked 68K and PPC state. Nested activation validates before replacing the installed engine. Tasks must register explicitly, retired task IDs cannot be resurrected, and submitted effects retain their original task identity. The execution cursor replaces the dispatcher's separate current-thread field.

Validation:
- Headless library suite: 4,933 passed, three existing ignored tests.
- Library suite with test support: 4,947 passed, three existing ignored tests; the subsequently added malformed-return test and read-only retry assertion passed in the headless suite.
- Headless library check passes without warnings.
- Exact runtime guardrails and all 14 guardrail fixtures pass.
- Both 68K and PPC Toolbox Showcase modes passed against existing reference images before the rebase. The rebased tree passes the headless build and local guardrails.

This advances #1366 and #1363; both remain open. Ready scheduling, cooperative context storage, runnable engine lifetimes, native Thread Manager entry coverage and semantic manager effects still require migration. Development documentation and scripts are excluded from this runtime PR.
