### PR TITLE
fix: preserve task scheduling invariants across thread switches

### DIFF
--- a/src/execution_kernel.rs
+++ b/src/execution_kernel.rs
@@ -11,7 +11,7 @@
 //! consume a different continuation.
 
 use std::cell::RefCell;
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::rc::Rc;
 
 use crate::guest_procedure::GuestIsa;
@@ -21,7 +21,7 @@ use crate::guest_procedure::GuestIsa;
 /// Thread Manager IDs are already stable and process-local, so cooperative
 /// tasks use their guest-visible ID directly. The application task is ID 2,
 /// matching `kApplicationThreadID` from Threads.h. Inside Macintosh:
-/// Processes (1994), pp. 4-4--4-6.
+/// Thread Manager (1999), pp. 47--48.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub(crate) struct ExecutionTaskId(u32);
 
@@ -35,6 +35,15 @@ impl ExecutionTaskId {
     pub(crate) const fn thread_id(self) -> u32 {
         self.0
     }
+}
+
+/// Scheduling state, independent of either engine's saved registers.
+/// Inside Macintosh: Thread Manager (1999), pp. 45, 67–70.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ExecutionTaskState {
+    Ready,
+    Stopped,
+    Running,
 }
 
 /// Task-lifecycle effect emitted by a process service.
@@ -416,6 +425,9 @@ struct StoreState<R: Copy, C: Copy> {
     stacks: HashMap<ExecutionTaskId, Vec<ContinuationState<R, C>>>,
     attached_contexts: HashMap<CallId, usize>,
     retired_tasks: HashSet<ExecutionTaskId>,
+    task_states: HashMap<ExecutionTaskId, ExecutionTaskState>,
+    ready: VecDeque<ExecutionTaskId>,
+    critical_depth: u32,
 }
 
 impl<R: Copy, C: Copy> Default for StoreState<R, C> {
@@ -426,6 +438,12 @@ impl<R: Copy, C: Copy> Default for StoreState<R, C> {
             stacks: HashMap::from([(ExecutionTaskId::APPLICATION, Vec::new())]),
             attached_contexts: HashMap::new(),
             retired_tasks: HashSet::new(),
+            task_states: HashMap::from([(
+                ExecutionTaskId::APPLICATION,
+                ExecutionTaskState::Running,
+            )]),
+            ready: VecDeque::new(),
+            critical_depth: 0,
         }
     }
 }
@@ -468,6 +486,7 @@ impl<R: Copy + TaskOwned, C: Copy> ContinuationStore<R, C> {
             return Err(ContinuationError::TaskUnavailable { task });
         }
         state.stacks.insert(task, Vec::new());
+        state.task_states.insert(task, ExecutionTaskState::Stopped);
         Ok(())
     }
 
@@ -477,8 +496,118 @@ impl<R: Copy + TaskOwned, C: Copy> ContinuationStore<R, C> {
         if !state.stacks.contains_key(&task) {
             return Err(ContinuationError::TaskUnavailable { task });
         }
+        if state.current_task != task {
+            if state.task_states.get(&task) != Some(&ExecutionTaskState::Ready) {
+                return Err(ContinuationError::TaskUnavailable { task });
+            }
+            if state.critical_depth != 0 {
+                return Err(ContinuationError::TaskUnavailable { task });
+            }
+            let previous = state.current_task;
+            if state.task_states.get(&previous) == Some(&ExecutionTaskState::Running) {
+                state
+                    .task_states
+                    .insert(previous, ExecutionTaskState::Ready);
+                if !state.ready.contains(&previous) {
+                    state.ready.push_back(previous);
+                }
+            }
+        }
+        state.ready.retain(|queued| *queued != task);
+        state.task_states.insert(task, ExecutionTaskState::Running);
         state.current_task = task;
         Ok(())
+    }
+
+    pub(crate) fn scheduling_state(&self, task: ExecutionTaskId) -> Option<ExecutionTaskState> {
+        self.0.borrow().task_states.get(&task).copied()
+    }
+
+    pub(crate) fn set_scheduling_state(
+        &self,
+        task: ExecutionTaskId,
+        requested: ExecutionTaskState,
+    ) -> bool {
+        self.change_scheduling_state(task, requested, false)
+    }
+
+    /// SetThreadStateEndCritical is one state transition, including failures.
+    /// Inside Macintosh: Thread Manager (1999), pp. 71--72.
+    pub(crate) fn set_state_ending_critical(
+        &self,
+        task: ExecutionTaskId,
+        requested: ExecutionTaskState,
+    ) -> bool {
+        self.change_scheduling_state(task, requested, true)
+    }
+
+    fn change_scheduling_state(
+        &self,
+        task: ExecutionTaskId,
+        requested: ExecutionTaskState,
+        end_critical: bool,
+    ) -> bool {
+        let mut state = self.0.borrow_mut();
+        let depth = if end_critical {
+            let Some(depth) = state.critical_depth.checked_sub(1) else {
+                return false;
+            };
+            depth
+        } else {
+            state.critical_depth
+        };
+        if !state.stacks.contains_key(&task)
+            || (requested == ExecutionTaskState::Running && task != state.current_task)
+            || (task == state.current_task
+                && requested != ExecutionTaskState::Running
+                && depth != 0)
+        {
+            return false;
+        }
+        state.critical_depth = depth;
+        state.ready.retain(|queued| *queued != task);
+        state.task_states.insert(task, requested);
+        if requested == ExecutionTaskState::Ready {
+            state.ready.push_back(task);
+        }
+        true
+    }
+
+    /// Selection is non-destructive: the adapter must first validate that it
+    /// can install the successor. Only the committed switch removes it.
+    pub(crate) fn next_ready_task(
+        &self,
+        suggested: Option<ExecutionTaskId>,
+    ) -> Option<ExecutionTaskId> {
+        let state = self.0.borrow();
+        if state.critical_depth != 0 {
+            return None;
+        }
+        let eligible = |task: ExecutionTaskId| {
+            task != state.current_task
+                && state.task_states.get(&task) == Some(&ExecutionTaskState::Ready)
+        };
+        suggested
+            .filter(|task| eligible(*task))
+            .or_else(|| state.ready.iter().copied().find(|task| eligible(*task)))
+    }
+
+    pub(crate) fn critical_depth(&self) -> u32 {
+        self.0.borrow().critical_depth
+    }
+
+    pub(crate) fn begin_critical(&self) {
+        let mut state = self.0.borrow_mut();
+        state.critical_depth = state.critical_depth.saturating_add(1);
+    }
+
+    pub(crate) fn end_critical(&self) -> bool {
+        let mut state = self.0.borrow_mut();
+        let Some(depth) = state.critical_depth.checked_sub(1) else {
+            return false;
+        };
+        state.critical_depth = depth;
+        true
     }
 
     pub(crate) fn apply_task_effect(
@@ -692,6 +821,8 @@ impl<R: Copy + TaskOwned, C: Copy> ContinuationStore<R, C> {
         }
         state.stacks.remove(&task);
         state.retired_tasks.insert(task);
+        state.task_states.remove(&task);
+        state.ready.retain(|queued| *queued != task);
         Ok(())
     }
 
@@ -1127,6 +1258,86 @@ mod tests {
     }
 
     #[test]
+    fn scheduler_selection_is_stable_until_a_switch_and_stopped_tasks_are_removed() {
+        let store = Store::default();
+        let app = ExecutionTaskId::APPLICATION;
+        let first = ExecutionTaskId::from_thread_id(3);
+        let second = ExecutionTaskId::from_thread_id(4);
+        for task in [first, second] {
+            store.register_task(task).unwrap();
+            assert!(store.set_scheduling_state(task, ExecutionTaskState::Ready));
+        }
+        assert_eq!(store.next_ready_task(None), Some(first));
+        let before = store.clone();
+        assert_eq!(store.next_ready_task(Some(second)), Some(second));
+        assert_eq!(
+            store, before,
+            "selection must not consume a context the adapter may reject"
+        );
+        assert!(!store.set_scheduling_state(first, ExecutionTaskState::Running));
+        assert_eq!(store, before);
+        assert!(store.set_scheduling_state(first, ExecutionTaskState::Stopped));
+        assert_eq!(store.next_ready_task(Some(first)), Some(second));
+        store.switch_to_task(second).unwrap();
+        assert_eq!(
+            store.scheduling_state(second),
+            Some(ExecutionTaskState::Running)
+        );
+        assert_eq!(store.scheduling_state(app), Some(ExecutionTaskState::Ready));
+        assert_eq!(store.next_ready_task(None), Some(app));
+        store.retire_task(first).unwrap();
+        assert!(!store.set_scheduling_state(first, ExecutionTaskState::Ready));
+        assert_eq!(store.next_ready_task(None), Some(app));
+    }
+
+    #[test]
+    fn combined_state_and_critical_exit_rejects_without_partial_unmasking() {
+        let store = Store::default();
+        let app = ExecutionTaskId::APPLICATION;
+        store.begin_critical();
+        let before = store.clone();
+        assert!(!store.set_state_ending_critical(
+            ExecutionTaskId::from_thread_id(999),
+            ExecutionTaskState::Ready
+        ));
+        assert_eq!(store, before);
+        store.begin_critical();
+        let nested = store.clone();
+        assert!(!store.set_state_ending_critical(app, ExecutionTaskState::Stopped));
+        assert_eq!(store, nested);
+        assert!(store.end_critical());
+        assert!(store.set_state_ending_critical(app, ExecutionTaskState::Stopped));
+        assert_eq!(store.critical_depth(), 0);
+        assert_eq!(
+            store.scheduling_state(app),
+            Some(ExecutionTaskState::Stopped)
+        );
+    }
+
+    #[test]
+    fn nested_critical_sections_keep_task_cursor_and_schedule_unchanged() {
+        let store = Store::default();
+        let app = ExecutionTaskId::APPLICATION;
+        let worker = ExecutionTaskId::from_thread_id(3);
+        store.register_task(worker).unwrap();
+        assert!(store.set_scheduling_state(worker, ExecutionTaskState::Ready));
+        assert!(store.set_scheduling_state(worker, ExecutionTaskState::Ready));
+        store.begin_critical();
+        store.begin_critical();
+        let before = store.clone();
+        assert_eq!(store.next_ready_task(Some(worker)), None);
+        assert!(store.switch_to_task(worker).is_err());
+        assert!(!store.set_scheduling_state(app, ExecutionTaskState::Stopped));
+        assert_eq!(store, before);
+        assert!(store.end_critical());
+        assert_eq!(store.next_ready_task(None), None);
+        assert!(store.end_critical());
+        assert_eq!(store.next_ready_task(None), Some(worker));
+        assert!(!store.end_critical());
+        assert_eq!(store.critical_depth(), 0);
+    }
+
+    #[test]
     fn task_ids_cannot_be_created_by_submission_or_resurrected_after_retirement() {
         let store = Store::default();
         let worker = ExecutionTaskId::from_thread_id(77);
@@ -1135,6 +1346,7 @@ mod tests {
         assert!(store.submit(worker, request(worker, 0x1000), 0).is_err());
         assert_eq!(store, snapshot);
         store.register_task(worker).unwrap();
+        assert!(store.set_scheduling_state(worker, ExecutionTaskState::Ready));
         assert!(store.register_task(worker).is_err());
         store.retire_task(worker).unwrap();
         let retired = store.clone();
@@ -1266,6 +1478,7 @@ mod tests {
         let application = ExecutionTaskId::APPLICATION;
         let worker = ExecutionTaskId::from_thread_id(7);
         store.register_task(worker).unwrap();
+        assert!(store.set_scheduling_state(worker, ExecutionTaskState::Ready));
         let app_call = submit(&store, application, 0x1000);
         let worker_call = submit(&store, worker, 0x3000);
 
@@ -1290,6 +1503,7 @@ mod tests {
         let application = ExecutionTaskId::APPLICATION;
         let worker = ExecutionTaskId::from_thread_id(9);
         store.register_task(worker).unwrap();
+        assert!(store.set_scheduling_state(worker, ExecutionTaskState::Ready));
 
         assert_eq!(
             store.submit(application, request(worker, 0x1000), 0x1001),
@@ -1343,6 +1557,7 @@ mod tests {
         let application = ExecutionTaskId::APPLICATION;
         let worker = ExecutionTaskId::from_thread_id(11);
         store.register_task(worker).unwrap();
+        assert!(store.set_scheduling_state(worker, ExecutionTaskState::Ready));
         let call_id = submit(&store, application, 0x1000);
         let before = store.clone();
         assert!(matches!(
@@ -1398,6 +1613,7 @@ mod tests {
         let application = ExecutionTaskId::APPLICATION;
         let worker = ExecutionTaskId::from_thread_id(13);
         store.register_task(worker).unwrap();
+        assert!(store.set_scheduling_state(worker, ExecutionTaskState::Ready));
         let application_call = submit(&store, application, 0x1000);
         let worker_call = submit(&store, worker, 0x2000);
         let mut contexts = ExecutionContextBank::default();

--- a/src/guest_call.rs
+++ b/src/guest_call.rs
@@ -16,7 +16,7 @@ pub(crate) use crate::execution_kernel::{
     M68kRegisterState, M68kResultSource, M68kResultTarget, M68kResume, PendingM68kExecution,
     PendingPowerPcExecution, PowerPcArguments, PowerPcReturnState,
 };
-use crate::execution_kernel::{ExecutionContextBank, ExecutionTaskEffect};
+use crate::execution_kernel::{ExecutionContextBank, ExecutionTaskEffect, ExecutionTaskState};
 use crate::guest_procedure::GuestIsa;
 use ppc::{PpcCpu, PpcImportAction, PpcNativeReturnGpr3};
 use std::cell::RefCell;
@@ -456,6 +456,46 @@ impl SharedGuestCallStack {
 
     pub(crate) fn switch_to_task(&self, task: ExecutionTaskId) -> bool {
         self.apply_task_effect(ExecutionTaskEffect::SwitchTo(task))
+    }
+
+    pub(crate) fn scheduling_state(&self, task: ExecutionTaskId) -> Option<ExecutionTaskState> {
+        self.0.borrow().kernel.scheduling_state(task)
+    }
+
+    pub(crate) fn set_scheduling_state(
+        &self,
+        task: ExecutionTaskId,
+        state: ExecutionTaskState,
+    ) -> bool {
+        self.0.borrow().kernel.set_scheduling_state(task, state)
+    }
+
+    pub(crate) fn set_state_ending_critical(
+        &self,
+        task: ExecutionTaskId,
+        state: ExecutionTaskState,
+    ) -> bool {
+        self.0
+            .borrow()
+            .kernel
+            .set_state_ending_critical(task, state)
+    }
+
+    pub(crate) fn next_ready_task(
+        &self,
+        suggested: Option<ExecutionTaskId>,
+    ) -> Option<ExecutionTaskId> {
+        self.0.borrow().kernel.next_ready_task(suggested)
+    }
+
+    pub(crate) fn critical_depth(&self) -> u32 {
+        self.0.borrow().kernel.critical_depth()
+    }
+    pub(crate) fn begin_critical(&self) {
+        self.0.borrow().kernel.begin_critical();
+    }
+    pub(crate) fn end_critical(&self) -> bool {
+        self.0.borrow().kernel.end_critical()
     }
 
     pub(crate) fn apply_task_effect(&self, effect: ExecutionTaskEffect) -> bool {
@@ -1196,6 +1236,10 @@ mod tests {
             GuestCallContinuation::to_m68k(0x2000, 0x3000, None),
         );
         assert!(calls.register_task(ExecutionTaskId::from_thread_id(7)));
+        assert!(calls.set_scheduling_state(
+            ExecutionTaskId::from_thread_id(7),
+            ExecutionTaskState::Ready
+        ));
         assert!(calls.switch_to_task(ExecutionTaskId::from_thread_id(7)));
         let before = calls.clone();
         assert!(!calls.push_effect(effect));
@@ -1220,6 +1264,7 @@ mod tests {
 
         let worker = ExecutionTaskId::from_thread_id(7);
         assert!(calls.register_task(worker));
+        assert!(calls.set_scheduling_state(worker, ExecutionTaskState::Ready));
         calls.switch_to_task(worker);
         assert_eq!(calls.depth(), 0);
         calls.begin_m68k(
@@ -1246,6 +1291,7 @@ mod tests {
         let calls = SharedGuestCallStack::default();
         let worker = ExecutionTaskId::from_thread_id(7);
         assert!(calls.register_task(worker));
+        assert!(calls.set_scheduling_state(worker, ExecutionTaskState::Ready));
         calls.switch_to_task(worker);
         calls.begin_m68k(
             GuestCallTarget {

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -14015,10 +14015,7 @@ mod tests {
         let systemless = UiThemeId::SystemlessDefault.provider();
 
         assert_eq!(runner.ui_theme_id(), UiThemeId::ClassicSystem7);
-        assert_eq!(
-            runner.dispatcher().ui_theme_id(),
-            UiThemeId::ClassicSystem7
-        );
+        assert_eq!(runner.dispatcher().ui_theme_id(), UiThemeId::ClassicSystem7);
         assert_eq!(runner.ui_theme().id(), UiThemeId::ClassicSystem7);
         assert!(runner.uses_classic_guest_metrics());
         assert_eq!(runner.ui_theme().menu_metrics(), systemless.menu_metrics());
@@ -14036,10 +14033,7 @@ mod tests {
         runner.set_ui_theme(UiThemeId::ClassicSystem7);
 
         assert_eq!(runner.ui_theme_id(), UiThemeId::ClassicSystem7);
-        assert_eq!(
-            runner.dispatcher().ui_theme_id(),
-            UiThemeId::ClassicSystem7
-        );
+        assert_eq!(runner.dispatcher().ui_theme_id(), UiThemeId::ClassicSystem7);
         assert!(runner.uses_classic_guest_metrics());
     }
 
@@ -15792,7 +15786,6 @@ mod tests {
                 a_regs: [0, 0, 0, 0, 0, 0, 0, WORKER_SP],
                 pc: WORKER_ENTRY,
                 ccr: 0,
-                state: 0,
                 result_destination: 0,
                 stack_base: WORKER_STACK,
                 stack_limit: WORKER_STACK + 0x40,
@@ -15801,7 +15794,10 @@ mod tests {
                 terminator: (0, 0),
             },
         );
-        runner.dispatcher.cooperative_thread_ready.push_back(3);
+        assert!(runner.dispatcher.guest_calls.set_scheduling_state(
+            ExecutionTaskId::from_thread_id(3),
+            crate::execution_kernel::ExecutionTaskState::Ready
+        ));
 
         let (_, running) = runner.run_steps(128, None);
         assert!(running);

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -948,8 +948,6 @@ pub(crate) struct CooperativeThread {
     pub(crate) a_regs: [u32; 8],
     pub(crate) pc: u32,
     pub(crate) ccr: u8,
-    /// `ThreadState` from Threads.h: 0 ready, 1 stopped, 2 running.
-    pub(crate) state: u16,
     /// `void **threadResult` the entry proc's return value is stored to.
     pub(crate) result_destination: u32,
     /// Lowest address of the private guest stack, or 0 for the
@@ -1517,14 +1515,8 @@ pub struct TrapDispatcher {
     /// on the zero-request local path is allowed before init in the baked
     /// fixture.
     pub(crate) ppc_initialized: bool,
-    /// Nesting depth for the guest's critical sections. Systemless runs the
-    /// HLE on one host thread, so Thread Manager critical sections collapse
-    /// to a single dispatcher-wide counter.
-    pub(crate) thread_critical_nesting: u32,
     /// Cooperative Thread Manager contexts keyed by their opaque ThreadID.
     pub(crate) cooperative_threads: ExecutionTaskContextBank<CooperativeThread>,
-    /// Round-robin queue of ready cooperative threads.
-    pub(crate) cooperative_thread_ready: VecDeque<u32>,
     /// Next guest-visible ThreadID. IDs 1 and 2 are reserved by Threads.h.
     pub(crate) next_cooperative_thread_id: u32,
     /// Guest trampoline entered when a ThreadEntryProc returns.
@@ -3507,9 +3499,7 @@ impl TrapDispatcher {
             qddone_seen_ports: HashSet::new(),
             pict_info_ids: HashSet::new(),
             ppc_initialized: false,
-            thread_critical_nesting: 0,
             cooperative_threads: ExecutionTaskContextBank::default(),
-            cooperative_thread_ready: VecDeque::new(),
             next_cooperative_thread_id: 3,
             thread_return_trampoline: 0,
             cooperative_thread_scheduler: 0,

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -1,6 +1,7 @@
 //! Toolbox Utility trap handlers (events, Random, Sound, misc).
 
 use crate::cpu::{CpuOps, Register};
+use crate::execution_kernel::ExecutionTaskState;
 use crate::guest_call::ExecutionTaskId;
 use crate::memory::globals::addr;
 use crate::memory::{MacMemoryBus, MemoryBus};
@@ -1101,7 +1102,6 @@ impl super::TrapDispatcher {
 
     fn capture_cooperative_thread<C: CpuOps>(
         cpu: &C,
-        state: u16,
         result_destination: u32,
     ) -> CooperativeThread {
         let d_regs = [
@@ -1129,7 +1129,6 @@ impl super::TrapDispatcher {
             a_regs,
             pc: cpu.read_reg(Register::PC),
             ccr: cpu.get_ccr(),
-            state,
             result_destination,
             stack_base: 0,
             stack_limit: 0,
@@ -1206,13 +1205,7 @@ impl super::TrapDispatcher {
                 .cooperative_threads
                 .contains(ExecutionTaskId::from_thread_id(Self::APPLICATION_THREAD_ID))
         {
-            let state =
-                if self.guest_calls.current_task().thread_id() == Self::APPLICATION_THREAD_ID {
-                    Self::THREAD_STATE_RUNNING
-                } else {
-                    Self::THREAD_STATE_READY
-                };
-            let thread = Self::capture_cooperative_thread(cpu, state, 0);
+            let thread = Self::capture_cooperative_thread(cpu, 0);
             self.cooperative_threads.insert(
                 ExecutionTaskId::from_thread_id(Self::APPLICATION_THREAD_ID),
                 thread,
@@ -1226,7 +1219,7 @@ impl super::TrapDispatcher {
     /// changing its scheduling state.
     fn save_current_cooperative_thread<C: CpuOps>(&mut self, cpu: &C) {
         let current_id = self.guest_calls.current_task().thread_id();
-        let saved = Self::capture_cooperative_thread(cpu, Self::THREAD_STATE_RUNNING, 0);
+        let saved = Self::capture_cooperative_thread(cpu, 0);
         match self.cooperative_thread_mut(cpu, current_id) {
             Some(thread) => {
                 thread.d_regs = saved.d_regs;
@@ -1245,106 +1238,36 @@ impl super::TrapDispatcher {
     /// ready thread, matching `YieldToThread`; otherwise the ready queue
     /// runs round-robin, as the stock 68K scheduler does.
     fn next_ready_cooperative_thread(&mut self, suggested_thread: u32) -> Option<u32> {
-        let current_id = self.guest_calls.current_task().thread_id();
-        if suggested_thread > 1 && suggested_thread != current_id {
-            if let Some(position) = self
-                .cooperative_thread_ready
-                .iter()
-                .position(|thread_id| *thread_id == suggested_thread)
-            {
-                return self.cooperative_thread_ready.remove(position);
-            }
-        }
-        for _ in 0..self.cooperative_thread_ready.len() {
-            let candidate = self.cooperative_thread_ready.pop_front()?;
-            if candidate == current_id {
-                self.cooperative_thread_ready.push_back(candidate);
-                continue;
-            }
-            let ready = self
-                .cooperative_threads
-                .get(ExecutionTaskId::from_thread_id(candidate))
-                .is_some_and(|thread| thread.state == Self::THREAD_STATE_READY);
-            if ready {
-                return Some(candidate);
-            }
-        }
-        None
+        self.guest_calls
+            .next_ready_task(
+                (suggested_thread > 1).then(|| ExecutionTaskId::from_thread_id(suggested_thread)),
+            )
+            .map(ExecutionTaskId::thread_id)
     }
 
-    /// Install `next_id` as the running thread. The caller has already
-    /// saved and re-queued the outgoing context.
+    /// Validate the saved adapter context before committing the task switch.
     fn switch_to_cooperative_thread<C: CpuOps>(&mut self, cpu: &mut C, next_id: u32) -> bool {
-        let Some(mut next) = self
-            .cooperative_threads
-            .get(ExecutionTaskId::from_thread_id(next_id))
-            .cloned()
-        else {
+        let task = ExecutionTaskId::from_thread_id(next_id);
+        let Some(next) = self.cooperative_threads.get(task).cloned() else {
             return false;
         };
-        if next.state != Self::THREAD_STATE_READY {
-            self.cooperative_thread_ready.push_back(next_id);
-            return false;
-        }
-        next.state = Self::THREAD_STATE_RUNNING;
-        if !self
-            .guest_calls
-            .switch_to_task(ExecutionTaskId::from_thread_id(next_id))
+        if self.guest_calls.scheduling_state(task) != Some(ExecutionTaskState::Ready)
+            || !self.guest_calls.switch_to_task(task)
         {
             return false;
         }
         Self::install_cooperative_thread(cpu, &next);
-        self.cooperative_threads
-            .insert(ExecutionTaskId::from_thread_id(next_id), next);
         true
     }
 
-    /// `YieldToThread` and `YieldToAnyThread`. A yield inside a critical
-    /// section is a no-op: Threads.h documents `ThreadBeginCritical` as
-    /// suppressing scheduling until the matching end.
+    /// Scheduling policy lives with the task cursor; this adapter only saves
+    /// and installs registers. Inside Macintosh: Thread Manager (1999), pp. 65–70.
     fn yield_cooperative_thread<C: CpuOps>(&mut self, cpu: &mut C, suggested_thread: u32) {
-        if self.thread_critical_nesting != 0 || self.cooperative_thread_ready.is_empty() {
-            return;
-        }
-
-        let current_id = self.guest_calls.current_task().thread_id();
-        self.save_current_cooperative_thread(cpu);
-        if let Some(thread) = self
-            .cooperative_threads
-            .get_mut(ExecutionTaskId::from_thread_id(current_id))
-        {
-            if thread.state == Self::THREAD_STATE_RUNNING {
-                thread.state = Self::THREAD_STATE_READY;
-            }
-        }
-        let requeue = self
-            .cooperative_threads
-            .get(ExecutionTaskId::from_thread_id(current_id))
-            .is_some_and(|thread| thread.state == Self::THREAD_STATE_READY)
-            && !self.cooperative_thread_ready.contains(&current_id);
-        if requeue {
-            self.cooperative_thread_ready.push_back(current_id);
-        }
-
-        let restore_running = |dispatcher: &mut Self| {
-            if let Some(thread) = dispatcher
-                .cooperative_threads
-                .get_mut(ExecutionTaskId::from_thread_id(current_id))
-            {
-                thread.state = Self::THREAD_STATE_RUNNING;
-            }
-            dispatcher
-                .cooperative_thread_ready
-                .retain(|thread_id| *thread_id != current_id);
-        };
-
         let Some(next_id) = self.next_ready_cooperative_thread(suggested_thread) else {
-            restore_running(self);
             return;
         };
-        if !self.switch_to_cooperative_thread(cpu, next_id) {
-            restore_running(self);
-        }
+        self.save_current_cooperative_thread(cpu);
+        self.switch_to_cooperative_thread(cpu, next_id);
     }
 
     /// Retire `thread_id`, storing its entry-proc result and returning its
@@ -1381,8 +1304,6 @@ impl super::TrapDispatcher {
                     .push((finished.stack_base, finished.stack_limit));
             }
         }
-        self.cooperative_thread_ready
-            .retain(|queued| *queued != thread_id);
         true
     }
 
@@ -1413,14 +1334,11 @@ impl super::TrapDispatcher {
                     .remove_task(ExecutionTaskId::from_thread_id(finished_id));
             }
         }
-        if let Some(mut application) = self
+        if let Some(application) = self
             .cooperative_threads
             .get(ExecutionTaskId::from_thread_id(Self::APPLICATION_THREAD_ID))
             .cloned()
         {
-            self.cooperative_thread_ready
-                .retain(|queued| *queued != Self::APPLICATION_THREAD_ID);
-            application.state = Self::THREAD_STATE_RUNNING;
             self.guest_calls
                 .switch_to_task(ExecutionTaskId::APPLICATION);
             Self::install_cooperative_thread(cpu, &application);
@@ -16413,16 +16331,21 @@ impl super::TrapDispatcher {
                                 Self::THREAD_STATE_READY
                             };
                             let mut thread =
-                                Self::capture_cooperative_thread(cpu, state, result_destination);
+                                Self::capture_cooperative_thread(cpu, result_destination);
                             thread.pc = thread_entry;
                             thread.a_regs[7] = entry_sp;
                             thread.stack_base = stack_base;
                             thread.stack_limit = stack_limit;
                             self.cooperative_threads
                                 .insert(ExecutionTaskId::from_thread_id(thread_id), thread);
-                            if state == Self::THREAD_STATE_READY {
-                                self.cooperative_thread_ready.push_back(thread_id);
-                            }
+                            self.guest_calls.set_scheduling_state(
+                                ExecutionTaskId::from_thread_id(thread_id),
+                                if state == Self::THREAD_STATE_READY {
+                                    ExecutionTaskState::Ready
+                                } else {
+                                    ExecutionTaskState::Stopped
+                                },
+                            );
                             bus.write_long(thread_made, thread_id);
                             0
                         }
@@ -16557,10 +16480,23 @@ impl super::TrapDispatcher {
                         if thread_state == 0 {
                             -50
                         } else {
-                            match self.cooperative_thread_mut(cpu, thread_to_get) {
-                                Some(thread) => {
-                                    let state = thread.state;
-                                    bus.write_word(thread_state, state);
+                            match self
+                                .guest_calls
+                                .scheduling_state(ExecutionTaskId::from_thread_id(thread_to_get))
+                            {
+                                Some(state) => {
+                                    bus.write_word(
+                                        thread_state,
+                                        match state {
+                                            ExecutionTaskState::Ready => Self::THREAD_STATE_READY,
+                                            ExecutionTaskState::Stopped => {
+                                                Self::THREAD_STATE_STOPPED
+                                            }
+                                            ExecutionTaskState::Running => {
+                                                Self::THREAD_STATE_RUNNING
+                                            }
+                                        },
+                                    );
                                     0
                                 }
                                 None => Self::THREAD_NOT_FOUND_ERR,
@@ -16575,71 +16511,58 @@ impl super::TrapDispatcher {
                         let new_state = bus.read_word(sp + 4);
                         let thread_to_set =
                             self.resolve_cooperative_thread_id(bus.read_long(sp + 6));
-                        if selector == 0x0512 {
-                            self.thread_critical_nesting =
-                                self.thread_critical_nesting.saturating_sub(1);
-                        }
-                        match self.cooperative_thread_mut(cpu, thread_to_set) {
-                            None => Self::THREAD_NOT_FOUND_ERR,
-                            Some(thread) => {
-                                let was_running = thread.state == Self::THREAD_STATE_RUNNING;
-                                thread.state = new_state;
-                                self.cooperative_thread_ready
-                                    .retain(|queued| *queued != thread_to_set);
-                                if new_state == Self::THREAD_STATE_READY {
-                                    self.cooperative_thread_ready.push_back(thread_to_set);
-                                }
-                                // Stopping the running thread has to hand the
-                                // CPU to someone else immediately.
-                                if was_running && new_state != Self::THREAD_STATE_RUNNING {
-                                    bus.write_word(sp + 10, 0);
-                                    cpu.write_reg(Register::A7, sp + 10);
-                                    cpu.write_reg(Register::D0, 0);
-                                    self.save_current_cooperative_thread(cpu);
-                                    if let Some(next_id) =
-                                        self.next_ready_cooperative_thread(suggested_thread)
-                                    {
-                                        if self.switch_to_cooperative_thread(cpu, next_id) {
-                                            return Some(Ok(()));
-                                        }
-                                    }
-                                    // No runnable successor was available (or
-                                    // the suggested one was no longer ready).
-                                    // Keep the installed context and its task
-                                    // owner coherent rather than labelling a
-                                    // still-running CPU as stopped.
-                                    if let Some(current) = self
-                                        .cooperative_threads
-                                        .get_mut(ExecutionTaskId::from_thread_id(thread_to_set))
-                                    {
-                                        current.state = Self::THREAD_STATE_RUNNING;
-                                    }
-                                    self.cooperative_thread_ready
-                                        .retain(|thread_id| *thread_id != thread_to_set);
-                                    self.guest_calls.switch_to_task(
-                                        ExecutionTaskId::from_thread_id(thread_to_set),
-                                    );
-                                    bus.write_word(sp + 10, 0);
-                                    cpu.write_reg(Register::A7, sp + 10);
-                                    cpu.write_reg(Register::D0, 0);
+                        let task = ExecutionTaskId::from_thread_id(thread_to_set);
+                        let requested = match new_state {
+                            Self::THREAD_STATE_READY => Some(ExecutionTaskState::Ready),
+                            Self::THREAD_STATE_STOPPED => Some(ExecutionTaskState::Stopped),
+                            Self::THREAD_STATE_RUNNING => Some(ExecutionTaskState::Running),
+                            _ => None,
+                        };
+                        if self.guest_calls.scheduling_state(task).is_none() {
+                            Self::THREAD_NOT_FOUND_ERR
+                        } else if !requested.is_some_and(|state| {
+                            if selector == 0x0512 {
+                                self.guest_calls.set_state_ending_critical(task, state)
+                            } else {
+                                self.guest_calls.set_scheduling_state(task, state)
+                            }
+                        }) {
+                            Self::THREAD_PROTOCOL_ERR
+                        } else if task == self.guest_calls.current_task()
+                            && new_state != Self::THREAD_STATE_RUNNING
+                        {
+                            // Save the ABI return before installing a different engine context.
+                            bus.write_word(sp + 10, 0);
+                            cpu.write_reg(Register::A7, sp + 10);
+                            cpu.write_reg(Register::D0, 0);
+                            self.save_current_cooperative_thread(cpu);
+                            if let Some(next_id) =
+                                self.next_ready_cooperative_thread(suggested_thread)
+                            {
+                                if self.switch_to_cooperative_thread(cpu, next_id) {
                                     return Some(Ok(()));
                                 }
-                                0
                             }
+                            self.guest_calls
+                                .set_scheduling_state(task, ExecutionTaskState::Running);
+                            return Some(Ok(()));
+                        } else {
+                            0
                         }
                     }
                     // SetThreadReadyGivenTaskRef(threadTRef, threadToSet)
                     0x0410 => {
-                        let thread_to_set = self.resolve_cooperative_thread_id(bus.read_long(sp));
-                        match self.cooperative_thread_mut(cpu, thread_to_set) {
+                        let task = ExecutionTaskId::from_thread_id(
+                            self.resolve_cooperative_thread_id(bus.read_long(sp)),
+                        );
+                        match self.guest_calls.scheduling_state(task) {
                             None => Self::THREAD_NOT_FOUND_ERR,
-                            Some(thread) => {
-                                if thread.state == Self::THREAD_STATE_STOPPED {
-                                    thread.state = Self::THREAD_STATE_READY;
-                                    self.cooperative_thread_ready.push_back(thread_to_set);
-                                }
+                            Some(ExecutionTaskState::Stopped) => {
+                                self.guest_calls
+                                    .set_scheduling_state(task, ExecutionTaskState::Ready);
                                 0
                             }
+                            Some(_) => 0,
                         }
                     }
                     // SetThreadScheduler(threadScheduler)
@@ -16699,13 +16622,12 @@ impl super::TrapDispatcher {
                         }
                     }
                     0x000B => {
-                        self.thread_critical_nesting =
-                            self.thread_critical_nesting.saturating_add(1);
+                        self.guest_calls.begin_critical();
                         0
                     }
-                    0x000C if self.thread_critical_nesting == 0 => Self::THREAD_PROTOCOL_ERR,
+                    0x000C if self.guest_calls.critical_depth() == 0 => Self::THREAD_PROTOCOL_ERR,
                     0x000C => {
-                        self.thread_critical_nesting -= 1;
+                        self.guest_calls.end_critical();
                         0
                     }
                     _ => -50,
@@ -17015,7 +16937,7 @@ mod tests {
         STANDARD_FILE_GET_VOLUME_RECT,
     };
     use crate::cpu::{CpuOps, Register};
-    use crate::execution_kernel::ExecutionTaskId;
+    use crate::execution_kernel::{ExecutionTaskId, ExecutionTaskState};
     use crate::memory::globals::addr;
     use crate::memory::MacMemoryBus;
     use crate::memory::MemoryBus;
@@ -27156,7 +27078,7 @@ mod tests {
         assert_eq!(cpu.read_reg(Register::D0), 0);
         assert_eq!(cpu.read_reg(Register::A7), sp);
         assert_eq!(bus.read_word(sp), 0);
-        assert_eq!(disp.thread_critical_nesting, 1);
+        assert_eq!(disp.guest_calls.critical_depth(), 1);
 
         cpu.write_reg(Register::D0, 0x0000_000C);
         let end = disp.dispatch_toolbox(true, 0x3F2, &mut cpu, &mut bus);
@@ -27168,7 +27090,7 @@ mod tests {
         assert_eq!(cpu.read_reg(Register::D0), 0);
         assert_eq!(cpu.read_reg(Register::A7), sp);
         assert_eq!(bus.read_word(sp), 0);
-        assert_eq!(disp.thread_critical_nesting, 0);
+        assert_eq!(disp.guest_calls.critical_depth(), 0);
     }
 
     /// `kPreemptiveThread` has no 68K implementation, so `NewThread` must
@@ -27301,7 +27223,11 @@ mod tests {
             .expect("NewThread handled")
             .expect("NewThread returns");
         let new_id = bus.read_long(thread_made);
-        assert!(disp.cooperative_thread_ready.contains(&new_id));
+        assert!(
+            disp.guest_calls
+                .scheduling_state(ExecutionTaskId::from_thread_id(new_id))
+                == Some(ExecutionTaskState::Ready)
+        );
 
         // DisposeThread(threadToDump, threadResult, recycleThread)
         cpu.write_reg(Register::A7, sp);
@@ -27317,7 +27243,11 @@ mod tests {
         assert!(!disp
             .cooperative_threads
             .contains(ExecutionTaskId::from_thread_id(new_id)));
-        assert!(!disp.cooperative_thread_ready.contains(&new_id));
+        assert!(
+            disp.guest_calls
+                .scheduling_state(ExecutionTaskId::from_thread_id(new_id))
+                != Some(ExecutionTaskState::Ready)
+        );
         assert_eq!(disp.cooperative_thread_pool.len(), 1);
 
         // GetFreeThreadCount(threadStyle, freeCount)
@@ -27363,6 +27293,28 @@ mod tests {
     }
 
     #[test]
+    fn threaddispatch_invalid_state_does_not_partially_end_a_critical_section() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        disp.guest_calls.begin_critical();
+        cpu.write_reg(Register::A7, TEST_SP);
+        bus.write_long(TEST_SP, 0);
+        bus.write_word(TEST_SP + 4, 99);
+        bus.write_long(TEST_SP + 6, 1);
+        cpu.write_reg(Register::D0, 0x0512);
+        disp.dispatch_toolbox(true, 0x3F2, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+        assert_eq!(cpu.read_reg(Register::D0) as i16, -619);
+        assert_eq!(bus.read_word(TEST_SP + 10), (-619_i16) as u16);
+        assert_eq!(disp.guest_calls.critical_depth(), 1);
+        assert_eq!(
+            disp.guest_calls
+                .scheduling_state(ExecutionTaskId::APPLICATION),
+            Some(ExecutionTaskState::Running)
+        );
+    }
+
+    #[test]
     fn threaddispatch_endcritical_underflow_returns_thread_protocol_err() {
         let (mut disp, mut cpu, mut bus) = setup();
         let sp = TEST_SP;
@@ -27379,7 +27331,7 @@ mod tests {
         assert_eq!(cpu.read_reg(Register::D0) as i16, -619);
         assert_eq!(cpu.read_reg(Register::A7), sp);
         assert_eq!(bus.read_word(sp), (-619i16) as u16);
-        assert_eq!(disp.thread_critical_nesting, 0);
+        assert_eq!(disp.guest_calls.critical_depth(), 0);
     }
 
     #[test]
@@ -27401,7 +27353,7 @@ mod tests {
         assert_eq!(cpu.read_reg(Register::A1), 0x5555_6666);
         assert_eq!(cpu.read_reg(Register::A7), sp);
         assert_eq!(bus.read_word(sp), (-50i16) as u16);
-        assert_eq!(disp.thread_critical_nesting, 0);
+        assert_eq!(disp.guest_calls.critical_depth(), 0);
     }
 
     #[test]


### PR DESCRIPTION
Cooperative thread switches previously coordinated a kernel task cursor with a dispatcher-owned ready queue, mutable thread-state fields and a critical-section counter. The execution store now owns all four. The 68K adapter saves and installs registers, while task selection, ready/stopped transitions, critical-section checks and retirement cleanup use the same scheduling authority.

Successor selection leaves the queue unchanged until the adapter can install its context. Stopped tasks cannot be selected, and a rejected switch preserves the cursor and queue. `SetThreadStateEndCritical` validates its state change and critical-section exit together, so an invalid request cannot partially enable scheduling.

Validation: the headless library suite passed 4,944 tests with three existing ignored tests, including the real Thread Manager routes and nested cross-ISA task switching. New tests cover selection without consumption, stopped/retired tasks, nested critical sections and rejected combined state/critical-section changes. Local ownership guardrails and all 14 guardrail fixtures pass.

Advances #1366 and #1363 without closing them. Cooperative register snapshots, runnable engine lifetimes, native Thread Manager entry coverage and manager resumption still require migration. Existing handling when no successor can be installed remains unchanged.
