### PR TITLE
fix: retain cooperative contexts through task retirement

### DIFF
--- a/src/execution_kernel.rs
+++ b/src/execution_kernel.rs
@@ -479,6 +479,25 @@ impl<R: Copy + TaskOwned, C: Copy> ContinuationStore<R, C> {
         self.0.borrow().current_task
     }
 
+    /// Construction-time adoption is safe only before this execution owner
+    /// has acquired any task, call identity, or scheduling history.
+    pub(crate) fn is_pristine(&self) -> bool {
+        let state = self.0.borrow();
+        state.current_task == ExecutionTaskId::APPLICATION
+            && state.next_call_id == 1
+            && state.stacks.len() == 1
+            && state
+                .stacks
+                .get(&ExecutionTaskId::APPLICATION)
+                .is_some_and(Vec::is_empty)
+            && state.attached_contexts.is_empty()
+            && state.retired_tasks.is_empty()
+            && state.task_states.get(&ExecutionTaskId::APPLICATION)
+                == Some(&ExecutionTaskState::Running)
+            && state.ready.is_empty()
+            && state.critical_depth == 0
+    }
+
     /// Register a new task exactly once for this process lifetime.
     pub(crate) fn register_task(&self, task: ExecutionTaskId) -> Result<(), ContinuationError> {
         let mut state = self.0.borrow_mut();
@@ -1018,21 +1037,12 @@ impl<T> Default for ExecutionTaskContextBank<T> {
 }
 
 impl<T> ExecutionTaskContextBank<T> {
-    #[cfg(test)]
     pub(crate) fn is_empty(&self) -> bool {
         self.by_task.is_empty()
     }
 
-    pub(crate) fn contains(&self, task: ExecutionTaskId) -> bool {
-        self.by_task.contains_key(&task)
-    }
-
     pub(crate) fn get(&self, task: ExecutionTaskId) -> Option<&T> {
         self.by_task.get(&task)
-    }
-
-    pub(crate) fn get_mut(&mut self, task: ExecutionTaskId) -> Option<&mut T> {
-        self.by_task.get_mut(&task)
     }
 
     pub(crate) fn insert(&mut self, task: ExecutionTaskId, context: T) -> Option<T> {

--- a/src/guest_call.rs
+++ b/src/guest_call.rs
@@ -16,12 +16,41 @@ pub(crate) use crate::execution_kernel::{
     M68kRegisterState, M68kResultSource, M68kResultTarget, M68kResume, PendingM68kExecution,
     PendingPowerPcExecution, PowerPcArguments, PowerPcReturnState,
 };
-use crate::execution_kernel::{ExecutionContextBank, ExecutionTaskEffect, ExecutionTaskState};
+use crate::execution_kernel::{
+    ExecutionContextBank, ExecutionTaskContextBank, ExecutionTaskEffect, ExecutionTaskState,
+};
 use crate::guest_procedure::GuestIsa;
 use ppc::{PpcCpu, PpcImportAction, PpcNativeReturnGpr3};
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
+
+/// Saved 68K state for one cooperative Thread Manager thread.
+///
+/// Cooperative switches occur only inside `_ThreadDispatch`, so the HLE can
+/// preserve the complete caller-visible register file without involving a
+/// host thread. New threads inherit the creator's register world (notably A5)
+/// and receive a private guest stack.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) struct CooperativeThread {
+    pub(crate) d_regs: [u32; 8],
+    pub(crate) a_regs: [u32; 8],
+    pub(crate) pc: u32,
+    pub(crate) ccr: u8,
+    /// `void **threadResult` the entry proc's return value is stored to.
+    pub(crate) result_destination: u32,
+    /// Lowest address of the private guest stack, or 0 for the
+    /// application thread, which keeps the process stack.
+    pub(crate) stack_base: u32,
+    /// Address one past the top of the private guest stack.
+    pub(crate) stack_limit: u32,
+    /// `SetThreadSwitcher` switch-in proc and its `switchProcParam`.
+    pub(crate) switch_in: (u32, u32),
+    /// `SetThreadSwitcher` switch-out proc and its `switchProcParam`.
+    pub(crate) switch_out: (u32, u32),
+    /// `SetThreadTerminator` proc and its `terminationProcParam`.
+    pub(crate) terminator: (u32, u32),
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct M68kCallOrigin {
@@ -336,6 +365,7 @@ struct ExecutionTaskCalls {
     kernel: ContinuationStore,
     frames: HashMap<CallId, GuestCallFrame>,
     powerpc_contexts: ExecutionContextBank<Box<PpcCpu>>,
+    cooperative_contexts: ExecutionTaskContextBank<CooperativeThread>,
 }
 
 impl Clone for ExecutionTaskCalls {
@@ -344,6 +374,7 @@ impl Clone for ExecutionTaskCalls {
             kernel: self.kernel.clone(),
             frames: self.frames.clone(),
             powerpc_contexts: self.powerpc_contexts.clone(),
+            cooperative_contexts: self.cooperative_contexts.clone(),
         }
     }
 }
@@ -353,6 +384,7 @@ impl PartialEq for ExecutionTaskCalls {
         self.kernel == other.kernel
             && self.frames == other.frames
             && self.powerpc_contexts.same_slots(&other.powerpc_contexts)
+            && self.cooperative_contexts == other.cooperative_contexts
     }
 }
 
@@ -364,13 +396,14 @@ impl Default for ExecutionTaskCalls {
             kernel: ContinuationStore::default(),
             frames: HashMap::new(),
             powerpc_contexts: ExecutionContextBank::default(),
+            cooperative_contexts: ExecutionTaskContextBank::default(),
         }
     }
 }
 
 impl ExecutionTaskCalls {
-    fn is_empty(&self) -> bool {
-        self.kernel.is_empty()
+    fn is_pristine(&self) -> bool {
+        self.kernel.is_pristine() && self.cooperative_contexts.is_empty()
     }
 }
 
@@ -398,8 +431,8 @@ impl Clone for SharedGuestCallStack {
 }
 
 impl SharedGuestCallStack {
-    fn all_tasks_idle(&self) -> bool {
-        self.0.borrow().is_empty()
+    pub(crate) fn is_pristine(&self) -> bool {
+        self.0.borrow().is_pristine()
     }
 
     pub(crate) fn shared_handle(&self) -> Self {
@@ -411,19 +444,19 @@ impl SharedGuestCallStack {
             return;
         }
         assert!(
-            self.all_tasks_idle() || process_calls.all_tasks_idle(),
-            "cannot attach two active guest-procedure continuation stacks"
+            self.is_pristine() || process_calls.is_pristine(),
+            "cannot attach two initialized execution owners"
         );
         let pending = std::mem::take(&mut *self.0.borrow_mut());
         self.0 = Rc::clone(&process_calls.0);
-        if !pending.is_empty() {
+        if !pending.is_pristine() {
             *self.0.borrow_mut() = pending;
         }
     }
 
     #[cfg(test)]
     pub(crate) fn is_empty(&self) -> bool {
-        self.all_tasks_idle()
+        self.0.borrow().kernel.is_empty()
     }
 
     pub(crate) fn depth(&self) -> usize {
@@ -498,7 +531,7 @@ impl SharedGuestCallStack {
         self.0.borrow().kernel.end_critical()
     }
 
-    pub(crate) fn apply_task_effect(&self, effect: ExecutionTaskEffect) -> bool {
+    fn apply_task_effect(&self, effect: ExecutionTaskEffect) -> bool {
         self.0.borrow().kernel.apply_task_effect(effect).is_ok()
     }
 
@@ -506,7 +539,35 @@ impl SharedGuestCallStack {
     ///
     /// A non-empty stack denotes suspended execution and cannot be discarded.
     pub(crate) fn remove_task(&self, task: ExecutionTaskId) -> bool {
-        self.apply_task_effect(ExecutionTaskEffect::Retire(task))
+        let mut tasks = self.0.borrow_mut();
+        if tasks
+            .kernel
+            .apply_task_effect(ExecutionTaskEffect::Retire(task))
+            .is_err()
+        {
+            return false;
+        }
+        tasks.cooperative_contexts.remove(task);
+        true
+    }
+
+    pub(crate) fn cooperative_context(&self, task: ExecutionTaskId) -> Option<CooperativeThread> {
+        self.0.borrow().cooperative_contexts.get(task).cloned()
+    }
+
+    /// Only registered tasks can retain adapter snapshots. No borrowed CPU
+    /// context escapes the execution owner across a guest call or task switch.
+    pub(crate) fn save_cooperative_context(
+        &self,
+        task: ExecutionTaskId,
+        context: CooperativeThread,
+    ) -> bool {
+        let mut tasks = self.0.borrow_mut();
+        if tasks.kernel.scheduling_state(task).is_none() {
+            return false;
+        }
+        tasks.cooperative_contexts.insert(task, context);
+        true
     }
 
     #[cfg(test)]
@@ -1219,6 +1280,69 @@ mod tests {
         assert!(detached.is_empty());
         assert!(shared.complete_m68k(0x2002, 0x3000));
         assert!(calls.is_empty());
+    }
+
+    #[test]
+    fn attachment_preserves_idle_task_snapshots_and_refuses_two_initialized_owners() {
+        let process = SharedGuestCallStack::default();
+        let mut adapter = SharedGuestCallStack::default();
+        let task = ExecutionTaskId::APPLICATION;
+        let mut context = CooperativeThread::default();
+        context.pc = 0x1234;
+        assert!(adapter.save_cooperative_context(task, context.clone()));
+        adapter.attach_to(&process);
+        assert_eq!(process.cooperative_context(task), Some(context.clone()));
+        let mut empty = SharedGuestCallStack::default();
+        empty.attach_to(&process);
+        assert_eq!(empty.cooperative_context(task), Some(context.clone()));
+        let mut other = SharedGuestCallStack::default();
+        let mut conflicting = context.clone();
+        conflicting.pc = 0x5678;
+        assert!(other.save_cooperative_context(task, conflicting.clone()));
+        assert!(std::panic::catch_unwind(std::panic::AssertUnwindSafe(
+            || other.attach_to(&process)
+        ))
+        .is_err());
+        assert_eq!(process.cooperative_context(task), Some(context));
+        assert_eq!(other.cooperative_context(task), Some(conflicting));
+    }
+
+    #[test]
+    fn cooperative_snapshots_share_live_ownership_but_clone_and_retire_with_the_task() {
+        let calls = SharedGuestCallStack::default();
+        let worker = ExecutionTaskId::from_thread_id(3);
+        let mut context = CooperativeThread::default();
+        context.d_regs[0] = 42;
+        assert!(!calls.save_cooperative_context(worker, context.clone()));
+        assert!(calls.register_task(worker));
+        assert!(calls.set_scheduling_state(worker, ExecutionTaskState::Ready));
+        assert!(calls.save_cooperative_context(worker, context.clone()));
+        assert!(calls.switch_to_task(worker));
+        assert!(calls.begin_m68k(
+            GuestCallTarget {
+                isa: GuestIsa::M68k,
+                entry: 0x1000,
+                rtoc: 0
+            },
+            0x2000,
+            0x3000
+        ));
+        assert!(calls.switch_to_task(ExecutionTaskId::APPLICATION));
+        assert!(!calls.remove_task(worker));
+        assert_eq!(calls.cooperative_context(worker), Some(context.clone()));
+        let detached = calls.clone();
+        let shared = calls.shared_handle();
+        context.d_regs[0] = 99;
+        assert!(calls.save_cooperative_context(worker, context.clone()));
+        assert_eq!(shared.cooperative_context(worker), Some(context.clone()));
+        assert_eq!(detached.cooperative_context(worker).unwrap().d_regs[0], 42);
+        assert!(calls.switch_to_task(worker));
+        assert!(calls.complete_m68k(0x2002, 0x3000));
+        assert!(calls.switch_to_task(ExecutionTaskId::APPLICATION));
+        assert!(calls.remove_task(worker));
+        assert!(shared.cooperative_context(worker).is_none());
+        assert!(!calls.save_cooperative_context(worker, context));
+        assert!(detached.cooperative_context(worker).is_some());
     }
 
     #[test]

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -7221,7 +7221,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "cannot attach two active guest-procedure continuation stacks")]
+    #[should_panic(expected = "cannot attach two initialized execution owners")]
     fn attaching_two_active_guest_call_stacks_is_always_rejected() {
         fn begin_call(calls: &SharedGuestCallStack, entry: u32) {
             calls.begin_m68k(

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -11513,6 +11513,7 @@ fn load_app_generic<M: MemoryBus>(
 mod tests {
     use super::*;
     use crate::audio::AudioBackend;
+    use crate::guest_call::CooperativeThread;
     use crate::loader::ppc::*;
     use crate::loader::{ApplicationSizeResource, Code0Header, LoadedApp};
     use crate::menu_manager::TrackedMenuPaneView;
@@ -11525,8 +11526,8 @@ mod tests {
         SndChannel, SndCommand, OUTPUT_RATE,
     };
     use crate::trap::dispatch::{
-        CooperativeThread, DialogItem, DialogTrackingState, LoadedResources,
-        PendingWaitNextEventReturn, QueuedEvent, ResourceFileMap, TimerTask, VblTask,
+        DialogItem, DialogTrackingState, LoadedResources, PendingWaitNextEventReturn, QueuedEvent,
+        ResourceFileMap, TimerTask, VblTask,
     };
     use ppc::{PpcCpu, PpcNativeReturnGpr3};
     use std::cell::RefCell;
@@ -15779,7 +15780,7 @@ mod tests {
             .dispatcher
             .guest_calls
             .register_task(ExecutionTaskId::from_thread_id(3)));
-        runner.dispatcher.cooperative_threads.insert(
+        runner.dispatcher.guest_calls.save_cooperative_context(
             ExecutionTaskId::from_thread_id(3),
             CooperativeThread {
                 d_regs: [0; 8],

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -17,7 +17,6 @@ use super::manager::{
 use super::types::UnderlineInfo;
 use crate::cpu::{CpuOps, Register};
 use crate::display::CursorImage;
-use crate::execution_kernel::ExecutionTaskContextBank;
 use crate::guest_call::SharedGuestCallStack;
 use crate::list_manager::ProcessListRecord;
 use crate::machine_profile::reference_machine_profile;
@@ -936,33 +935,6 @@ pub(crate) struct OsTrapDispatchFrame {
 /// covers the Toolbox call depth Systemless threads reach.
 pub(crate) const DEFAULT_COOPERATIVE_THREAD_STACK_SIZE: u32 = 32 * 1024;
 
-/// Saved 68K state for one cooperative Thread Manager thread.
-///
-/// Cooperative switches occur only inside `_ThreadDispatch`, so the HLE can
-/// preserve the complete caller-visible register file without involving a
-/// host thread. New threads inherit the creator's register world (notably A5)
-/// and receive a private guest stack.
-#[derive(Clone, Debug)]
-pub(crate) struct CooperativeThread {
-    pub(crate) d_regs: [u32; 8],
-    pub(crate) a_regs: [u32; 8],
-    pub(crate) pc: u32,
-    pub(crate) ccr: u8,
-    /// `void **threadResult` the entry proc's return value is stored to.
-    pub(crate) result_destination: u32,
-    /// Lowest address of the private guest stack, or 0 for the
-    /// application thread, which keeps the process stack.
-    pub(crate) stack_base: u32,
-    /// Address one past the top of the private guest stack.
-    pub(crate) stack_limit: u32,
-    /// `SetThreadSwitcher` switch-in proc and its `switchProcParam`.
-    pub(crate) switch_in: (u32, u32),
-    /// `SetThreadSwitcher` switch-out proc and its `switchProcParam`.
-    pub(crate) switch_out: (u32, u32),
-    /// `SetThreadTerminator` proc and its `terminationProcParam`.
-    pub(crate) terminator: (u32, u32),
-}
-
 /// In-flight AppleEvent handler call. Built by Pack8 routine 27
 /// (`AEProcessAppleEvent`) when it dispatches a registered handler;
 /// consumed by the trampoline trap when the handler `RTD`s back.
@@ -1515,8 +1487,6 @@ pub struct TrapDispatcher {
     /// on the zero-request local path is allowed before init in the baked
     /// fixture.
     pub(crate) ppc_initialized: bool,
-    /// Cooperative Thread Manager contexts keyed by their opaque ThreadID.
-    pub(crate) cooperative_threads: ExecutionTaskContextBank<CooperativeThread>,
     /// Next guest-visible ThreadID. IDs 1 and 2 are reserved by Threads.h.
     pub(crate) next_cooperative_thread_id: u32,
     /// Guest trampoline entered when a ThreadEntryProc returns.
@@ -3499,7 +3469,6 @@ impl TrapDispatcher {
             qddone_seen_ports: HashSet::new(),
             pict_info_ids: HashSet::new(),
             ppc_initialized: false,
-            cooperative_threads: ExecutionTaskContextBank::default(),
             next_cooperative_thread_id: 3,
             thread_return_trampoline: 0,
             cooperative_thread_scheduler: 0,

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -2,6 +2,7 @@
 
 use crate::cpu::{CpuOps, Register};
 use crate::execution_kernel::ExecutionTaskState;
+use crate::guest_call::CooperativeThread;
 use crate::guest_call::ExecutionTaskId;
 use crate::memory::globals::addr;
 use crate::memory::{MacMemoryBus, MemoryBus};
@@ -13,8 +14,8 @@ use std::sync::OnceLock;
 
 use super::dispatch::{
     raw_trap_route, selector_operation_route, AeCoercionHandler, AeDescriptor, AeObjectAccessor,
-    AePrivateHashTable, AeResolveLevel, AeResolveState, CooperativeThread, DialogItem,
-    EventProbeResult, EventRecordSnapshot, MovieState, OsRoutineVariant, SelectorOperationRoute,
+    AePrivateHashTable, AeResolveLevel, AeResolveState, DialogItem, EventProbeResult,
+    EventRecordSnapshot, MovieState, OsRoutineVariant, SelectorOperationRoute,
     StandardFileGetEntry, StandardFileGetTrackingState, StandardFilePutTrackingState,
     SyntheticAppleEvent,
 };
@@ -1195,24 +1196,25 @@ impl super::TrapDispatcher {
     /// `kApplicationThreadID` exists implicitly from launch, so
     /// `GetThreadState`, `SetThreadSwitcher` and friends must find it
     /// without a prior `NewThread`.
-    fn cooperative_thread_mut<C: CpuOps>(
+    fn cooperative_thread_snapshot<C: CpuOps>(
         &mut self,
         cpu: &C,
         thread_id: u32,
-    ) -> Option<&mut CooperativeThread> {
+    ) -> Option<CooperativeThread> {
         if thread_id == Self::APPLICATION_THREAD_ID
             && !self
-                .cooperative_threads
-                .contains(ExecutionTaskId::from_thread_id(Self::APPLICATION_THREAD_ID))
+                .guest_calls
+                .cooperative_context(ExecutionTaskId::from_thread_id(Self::APPLICATION_THREAD_ID))
+                .is_some()
         {
             let thread = Self::capture_cooperative_thread(cpu, 0);
-            self.cooperative_threads.insert(
+            self.guest_calls.save_cooperative_context(
                 ExecutionTaskId::from_thread_id(Self::APPLICATION_THREAD_ID),
                 thread,
             );
         }
-        self.cooperative_threads
-            .get_mut(ExecutionTaskId::from_thread_id(thread_id))
+        self.guest_calls
+            .cooperative_context(ExecutionTaskId::from_thread_id(thread_id))
     }
 
     /// Save the running thread's registers into its record without
@@ -1220,16 +1222,18 @@ impl super::TrapDispatcher {
     fn save_current_cooperative_thread<C: CpuOps>(&mut self, cpu: &C) {
         let current_id = self.guest_calls.current_task().thread_id();
         let saved = Self::capture_cooperative_thread(cpu, 0);
-        match self.cooperative_thread_mut(cpu, current_id) {
-            Some(thread) => {
+        match self.cooperative_thread_snapshot(cpu, current_id) {
+            Some(mut thread) => {
                 thread.d_regs = saved.d_regs;
                 thread.a_regs = saved.a_regs;
                 thread.pc = saved.pc;
                 thread.ccr = saved.ccr;
+                self.guest_calls
+                    .save_cooperative_context(ExecutionTaskId::from_thread_id(current_id), thread);
             }
             None => {
-                self.cooperative_threads
-                    .insert(ExecutionTaskId::from_thread_id(current_id), saved);
+                self.guest_calls
+                    .save_cooperative_context(ExecutionTaskId::from_thread_id(current_id), saved);
             }
         }
     }
@@ -1248,7 +1252,7 @@ impl super::TrapDispatcher {
     /// Validate the saved adapter context before committing the task switch.
     fn switch_to_cooperative_thread<C: CpuOps>(&mut self, cpu: &mut C, next_id: u32) -> bool {
         let task = ExecutionTaskId::from_thread_id(next_id);
-        let Some(next) = self.cooperative_threads.get(task).cloned() else {
+        let Some(next) = self.guest_calls.cooperative_context(task) else {
             return false;
         };
         if self.guest_calls.scheduling_state(task) != Some(ExecutionTaskState::Ready)
@@ -1279,23 +1283,11 @@ impl super::TrapDispatcher {
         bus: &mut MacMemoryBus,
     ) -> bool {
         let task = ExecutionTaskId::from_thread_id(thread_id);
-        // A continuation belongs to the task that created it. Disposing a
-        // different task while one of its calls is suspended would strand a
-        // parked CPU/context and make the next task switch ambiguous. Return
-        // the documented protocol error at the trap boundary instead of
-        // asserting on guest-controlled state.
-        if !self.guest_calls.task_is_empty(task) {
+        let finished = self.guest_calls.cooperative_context(task);
+        if !self.guest_calls.remove_task(task) {
             return false;
         }
-        if thread_id != self.guest_calls.current_task().thread_id()
-            && !self.guest_calls.remove_task(task)
-        {
-            return false;
-        }
-        if let Some(finished) = self
-            .cooperative_threads
-            .remove(ExecutionTaskId::from_thread_id(thread_id))
-        {
+        if let Some(finished) = finished {
             if finished.result_destination != 0 {
                 bus.write_long(finished.result_destination, result);
             }
@@ -1307,50 +1299,35 @@ impl super::TrapDispatcher {
         true
     }
 
-    /// Entered through the return trampoline when a `ThreadEntryProc`
-    /// returns. The proc's `void *` result arrives in A0, per the 68K
-    /// convention for a pointer-valued result.
+    /// ThreadEntryProc returns a pointer in A0 at the 68K ABI edge.
     fn finish_cooperative_thread<C: CpuOps>(
         &mut self,
         cpu: &mut C,
         bus: &mut MacMemoryBus,
     ) -> bool {
-        let finished_id = self.guest_calls.current_task().thread_id();
         let result = cpu.read_reg(Register::A0);
-        if !self.retire_cooperative_thread(finished_id, result, bus) {
+        self.finish_cooperative_thread_with_result(cpu, bus, result)
+    }
+
+    fn finish_cooperative_thread_with_result<C: CpuOps>(
+        &mut self,
+        cpu: &mut C,
+        bus: &mut MacMemoryBus,
+        result: u32,
+    ) -> bool {
+        let finished = self.guest_calls.current_task();
+        if !self.guest_calls.task_is_empty(finished) {
             return false;
         }
-
-        // The finished thread has no context left to return to, so a
-        // successor must be installed. The application thread always has a
-        // live saved context, so it is the backstop.
-        let next = self
-            .next_ready_cooperative_thread(0)
-            .filter(|next_id| *next_id != finished_id);
-        if let Some(next_id) = next {
-            if self.switch_to_cooperative_thread(cpu, next_id) {
-                return self
-                    .guest_calls
-                    .remove_task(ExecutionTaskId::from_thread_id(finished_id));
-            }
+        // Select and validate the successor before releasing the outgoing
+        // snapshot or stack. A failed installation leaves the task retryable.
+        let Some(next) = self.next_ready_cooperative_thread(0) else {
+            return false;
+        };
+        if !self.switch_to_cooperative_thread(cpu, next) {
+            return false;
         }
-        if let Some(application) = self
-            .cooperative_threads
-            .get(ExecutionTaskId::from_thread_id(Self::APPLICATION_THREAD_ID))
-            .cloned()
-        {
-            self.guest_calls
-                .switch_to_task(ExecutionTaskId::APPLICATION);
-            Self::install_cooperative_thread(cpu, &application);
-            self.cooperative_threads.insert(
-                ExecutionTaskId::from_thread_id(Self::APPLICATION_THREAD_ID),
-                application,
-            );
-            return self
-                .guest_calls
-                .remove_task(ExecutionTaskId::from_thread_id(finished_id));
-        }
-        false
+        self.retire_cooperative_thread(finished.thread_id(), result, bus)
     }
 
     /// Claim a pooled stack of at least `stack_size` bytes, or allocate a
@@ -16336,8 +16313,10 @@ impl super::TrapDispatcher {
                             thread.a_regs[7] = entry_sp;
                             thread.stack_base = stack_base;
                             thread.stack_limit = stack_limit;
-                            self.cooperative_threads
-                                .insert(ExecutionTaskId::from_thread_id(thread_id), thread);
+                            self.guest_calls.save_cooperative_context(
+                                ExecutionTaskId::from_thread_id(thread_id),
+                                thread,
+                            );
                             self.guest_calls.set_scheduling_state(
                                 ExecutionTaskId::from_thread_id(thread_id),
                                 if state == Self::THREAD_STATE_READY {
@@ -16419,7 +16398,7 @@ impl super::TrapDispatcher {
                         } else {
                             let running = thread == self.guest_calls.current_task().thread_id();
                             let current_sp = cpu.read_reg(Register::A7);
-                            match self.cooperative_thread_mut(cpu, thread) {
+                            match self.cooperative_thread_snapshot(cpu, thread) {
                                 None => Self::THREAD_NOT_FOUND_ERR,
                                 Some(record) => {
                                     // The application thread keeps the process
@@ -16448,19 +16427,19 @@ impl super::TrapDispatcher {
                         let thread_to_dump =
                             self.resolve_cooperative_thread_id(bus.read_long(sp + 6));
                         if !self
-                            .cooperative_threads
-                            .contains(ExecutionTaskId::from_thread_id(thread_to_dump))
+                            .guest_calls
+                            .cooperative_context(ExecutionTaskId::from_thread_id(thread_to_dump))
+                            .is_some()
                             && thread_to_dump != Self::APPLICATION_THREAD_ID
                         {
                             Self::THREAD_NOT_FOUND_ERR
                         } else if thread_to_dump == self.guest_calls.current_task().thread_id() {
                             // Threads.h allows a thread to dispose of itself;
                             // the call never returns to it.
-                            if !self.retire_cooperative_thread(thread_to_dump, thread_result, bus) {
-                                Self::THREAD_PROTOCOL_ERR
-                            } else {
-                                self.finish_cooperative_thread(cpu, bus);
+                            if self.finish_cooperative_thread_with_result(cpu, bus, thread_result) {
                                 return Some(Ok(()));
+                            } else {
+                                Self::THREAD_PROTOCOL_ERR
                             }
                         } else {
                             if self.retire_cooperative_thread(thread_to_dump, thread_result, bus) {
@@ -16578,14 +16557,18 @@ impl super::TrapDispatcher {
                         let switch_proc_param = bus.read_long(sp + 2);
                         let thread_switcher = bus.read_long(sp + 6);
                         let thread = self.resolve_cooperative_thread_id(bus.read_long(sp + 10));
-                        match self.cooperative_thread_mut(cpu, thread) {
+                        match self.cooperative_thread_snapshot(cpu, thread) {
                             None => Self::THREAD_NOT_FOUND_ERR,
-                            Some(record) => {
+                            Some(mut record) => {
                                 if switch_in {
                                     record.switch_in = (thread_switcher, switch_proc_param);
                                 } else {
                                     record.switch_out = (thread_switcher, switch_proc_param);
                                 }
+                                self.guest_calls.save_cooperative_context(
+                                    ExecutionTaskId::from_thread_id(thread),
+                                    record,
+                                );
                                 0
                             }
                         }
@@ -16596,10 +16579,14 @@ impl super::TrapDispatcher {
                         let termination_proc_param = bus.read_long(sp);
                         let thread_terminator = bus.read_long(sp + 4);
                         let thread = self.resolve_cooperative_thread_id(bus.read_long(sp + 8));
-                        match self.cooperative_thread_mut(cpu, thread) {
+                        match self.cooperative_thread_snapshot(cpu, thread) {
                             None => Self::THREAD_NOT_FOUND_ERR,
-                            Some(record) => {
+                            Some(mut record) => {
                                 record.terminator = (thread_terminator, termination_proc_param);
+                                self.guest_calls.save_cooperative_context(
+                                    ExecutionTaskId::from_thread_id(thread),
+                                    record,
+                                );
                                 0
                             }
                         }
@@ -27118,7 +27105,7 @@ mod tests {
         assert_eq!(cpu.read_reg(Register::D0) as i16, -50);
         assert_eq!(cpu.read_reg(Register::A7), sp + 28);
         assert_eq!(bus.read_long(thread_made), 0, "no ThreadID on failure");
-        assert!(disp.cooperative_threads.is_empty());
+        assert!(disp.guest_calls.is_pristine());
     }
 
     /// `kApplicationThreadID` exists implicitly from launch, so
@@ -27193,8 +27180,8 @@ mod tests {
         assert_eq!(cpu.read_reg(Register::A7), sp + 12);
 
         let thread = disp
-            .cooperative_threads
-            .get(ExecutionTaskId::from_thread_id(2))
+            .guest_calls
+            .cooperative_context(ExecutionTaskId::from_thread_id(2))
             .expect("the application thread record must exist");
         assert_eq!(thread.switch_in, (0x0003_0000, 0x1111_2222));
         assert_eq!(thread.switch_out, (0, 0), "switch-out stays unset");
@@ -27241,8 +27228,9 @@ mod tests {
         assert_eq!(cpu.read_reg(Register::D0), 0);
         assert_eq!(cpu.read_reg(Register::A7), sp + 10);
         assert!(!disp
-            .cooperative_threads
-            .contains(ExecutionTaskId::from_thread_id(new_id)));
+            .guest_calls
+            .cooperative_context(ExecutionTaskId::from_thread_id(new_id))
+            .is_some());
         assert!(
             disp.guest_calls
                 .scheduling_state(ExecutionTaskId::from_thread_id(new_id))
@@ -27312,6 +27300,33 @@ mod tests {
                 .scheduling_state(ExecutionTaskId::APPLICATION),
             Some(ExecutionTaskState::Running)
         );
+    }
+
+    #[test]
+    fn thread_exit_without_a_successor_context_keeps_the_task_stack_and_result() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let worker = ExecutionTaskId::from_thread_id(3);
+        let result_slot = TEST_SP + 0x100;
+        bus.write_long(result_slot, 0x1234_5678);
+        assert!(disp.guest_calls.register_task(worker));
+        assert!(disp
+            .guest_calls
+            .set_scheduling_state(worker, ExecutionTaskState::Ready));
+        let mut saved = super::CooperativeThread::default();
+        saved.result_destination = result_slot;
+        saved.stack_base = 0x1000;
+        saved.stack_limit = 0x2000;
+        assert!(disp
+            .guest_calls
+            .save_cooperative_context(worker, saved.clone()));
+        assert!(disp.guest_calls.switch_to_task(worker));
+        // The application is ready, but no adapter snapshot exists for it.
+        cpu.write_reg(Register::A0, 0xcafe_babe);
+        assert!(!disp.finish_cooperative_thread(&mut cpu, &mut bus));
+        assert_eq!(disp.guest_calls.current_task(), worker);
+        assert_eq!(disp.guest_calls.cooperative_context(worker), Some(saved));
+        assert_eq!(bus.read_long(result_slot), 0x1234_5678);
+        assert!(disp.cooperative_thread_pool.is_empty());
     }
 
     #[test]
@@ -27534,8 +27549,9 @@ mod tests {
 
         assert_eq!(disp.guest_calls.current_task().thread_id(), 2);
         assert!(!disp
-            .cooperative_threads
-            .contains(ExecutionTaskId::from_thread_id(3)));
+            .guest_calls
+            .cooperative_context(ExecutionTaskId::from_thread_id(3))
+            .is_some());
         assert_eq!(bus.read_long(thread_result), 0xCAFE_BABE);
         assert_eq!(cpu.read_reg(Register::PC), 0x000F_0000);
         assert_eq!(cpu.read_reg(Register::A7), app_sp + 4);


### PR DESCRIPTION
Cooperative thread snapshots now belong to the shared execution owner instead of `TrapDispatcher`. The adapter reads owned snapshots and explicitly saves register changes; task retirement removes the matching snapshot only after continuation checks succeed. A thread exit validates and installs a successor before releasing its old context or recycling its stack, so a missing successor context leaves the task and result intact for retry.

Attachment now distinguishes an untouched execution owner from one that merely has no pending calls. This prevents idle task snapshots, scheduling state and call-identity history from being discarded during adapter attachment. Two initialized owners are rejected before either is changed.

Validation: 4,947 headless library tests passed, with three existing ignored tests. Coverage includes task snapshot sharing versus detached clones, retirement with pending calls, rejection of stale context saves, failed exit without a successor context, attachment of idle owners and the real Thread Manager trap routes. Ownership guardrails and all 14 guardrail fixtures pass. The patch is rebased onto current master; all 45 focused execution, guest-call, Thread Manager and mixed-ISA task-switch tests passed on that tree.

Advances #1366 and #1363 without closing them. Runnable engine ownership, native Thread Manager entry coverage, complete transition preflight and semantic manager resumption remain open.
