### PR TITLE
fix: commit thread results before retiring execution tasks

### DIFF
--- a/src/execution_kernel.rs
+++ b/src/execution_kernel.rs
@@ -51,7 +51,6 @@ pub(crate) enum ExecutionTaskState {
 pub(crate) enum ExecutionTaskEffect {
     Register(ExecutionTaskId),
     SwitchTo(ExecutionTaskId),
-    Retire(ExecutionTaskId),
 }
 
 /// A request type that identifies the task which owns its continuation.
@@ -365,6 +364,9 @@ pub(crate) enum ContinuationError {
     CommitRefused {
         call_id: CallId,
     },
+    TaskCommitRefused {
+        task: ExecutionTaskId,
+    },
     /// A request's embedded owner disagreed with the task supplied to submit.
     TaskMismatch {
         expected: ExecutionTaskId,
@@ -636,7 +638,6 @@ impl<R: Copy + TaskOwned, C: Copy> ContinuationStore<R, C> {
         match effect {
             ExecutionTaskEffect::Register(task) => self.register_task(task),
             ExecutionTaskEffect::SwitchTo(task) => self.switch_to_task(task),
-            ExecutionTaskEffect::Retire(task) => self.retire_task(task),
         }
     }
 
@@ -810,7 +811,20 @@ impl<R: Copy + TaskOwned, C: Copy> ContinuationStore<R, C> {
     /// A selected task is also refused, even when empty, because removing its
     /// stack would leave the task cursor dangling. Switch to a surviving task
     /// first, then call this method.
+    #[cfg(test)]
     pub(crate) fn retire_task(&self, task: ExecutionTaskId) -> Result<(), ContinuationError> {
+        self.retire_task_with(task, None, || true)
+    }
+
+    /// Validate retirement and optional replacement before committing external
+    /// result storage. The callback must be synchronous, non-reentrant and
+    /// leave external state unchanged on failure; it cannot execute guest code.
+    pub(crate) fn retire_task_with(
+        &self,
+        task: ExecutionTaskId,
+        successor: Option<ExecutionTaskId>,
+        commit: impl FnOnce() -> bool,
+    ) -> Result<(), ContinuationError> {
         let mut state = self.0.borrow_mut();
         let Some(stack) = state.stacks.get(&task) else {
             return Err(ContinuationError::TaskUnavailable { task });
@@ -830,13 +844,31 @@ impl<R: Copy + TaskOwned, C: Copy> ContinuationStore<R, C> {
             })
             .sum();
         let current = state.current_task == task;
-        if current || depth != 0 || contexts != 0 {
+        if (current && successor.is_none()) || depth != 0 || contexts != 0 {
             return Err(ContinuationError::RetirementRefused {
                 task,
                 depth,
                 contexts,
                 current,
             });
+        }
+        if let Some(next) = successor {
+            if !current
+                || next == task
+                || !state.stacks.contains_key(&next)
+                || state.task_states.get(&next) != Some(&ExecutionTaskState::Ready)
+                || state.critical_depth != 0
+            {
+                return Err(ContinuationError::TaskUnavailable { task: next });
+            }
+        }
+        if !commit() {
+            return Err(ContinuationError::TaskCommitRefused { task });
+        }
+        if let Some(next) = successor {
+            state.current_task = next;
+            state.task_states.insert(next, ExecutionTaskState::Running);
+            state.ready.retain(|queued| *queued != next);
         }
         state.stacks.remove(&task);
         state.retired_tasks.insert(task);
@@ -863,14 +895,17 @@ impl<R: Copy + TaskOwned, C: Copy> ContinuationStore<R, C> {
         self.task_depth(self.current_task())
     }
 
+    #[cfg(test)]
     pub(crate) fn len(&self) -> usize {
         self.0.borrow().stacks.values().map(Vec::len).sum()
     }
 
+    #[cfg(test)]
     pub(crate) fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
+    #[cfg(test)]
     pub(crate) fn task_is_empty(&self, task: ExecutionTaskId) -> bool {
         let state = self.0.borrow();
         state.stacks.get(&task).is_none_or(Vec::is_empty)

--- a/src/guest_call.rs
+++ b/src/guest_call.rs
@@ -473,15 +473,6 @@ impl SharedGuestCallStack {
         self.0.borrow().kernel.current_task()
     }
 
-    /// Whether `task` has no suspended guest-procedure continuations.
-    ///
-    /// A missing task has no continuations, which lets Thread Manager retire a
-    /// task that never crossed an ISA boundary without first creating an
-    /// otherwise empty stack entry.
-    pub(crate) fn task_is_empty(&self, task: ExecutionTaskId) -> bool {
-        self.0.borrow().kernel.task_is_empty(task)
-    }
-
     /// Select the continuation owner for subsequent guest execution.
     pub(crate) fn register_task(&self, task: ExecutionTaskId) -> bool {
         self.apply_task_effect(ExecutionTaskEffect::Register(task))
@@ -538,17 +529,36 @@ impl SharedGuestCallStack {
     /// Drop a retired task's empty continuation stack.
     ///
     /// A non-empty stack denotes suspended execution and cannot be discarded.
+    #[cfg(test)]
     pub(crate) fn remove_task(&self, task: ExecutionTaskId) -> bool {
         let mut tasks = self.0.borrow_mut();
-        if tasks
-            .kernel
-            .apply_task_effect(ExecutionTaskEffect::Retire(task))
-            .is_err()
-        {
+        if tasks.kernel.retire_task(task).is_err() {
             return false;
         }
         tasks.cooperative_contexts.remove(task);
         true
+    }
+
+    /// Commit result delivery and retirement while the execution owner keeps
+    /// both task identities and their adapter snapshots stable.
+    pub(crate) fn retire_cooperative_context(
+        &self,
+        task: ExecutionTaskId,
+        successor: Option<ExecutionTaskId>,
+        commit: impl FnOnce(&CooperativeThread) -> bool,
+    ) -> Option<(CooperativeThread, Option<CooperativeThread>)> {
+        let mut tasks = self.0.borrow_mut();
+        let finished = tasks.cooperative_contexts.get(task)?.clone();
+        let next = match successor {
+            Some(next) => Some(tasks.cooperative_contexts.get(next)?.clone()),
+            None => None,
+        };
+        tasks
+            .kernel
+            .retire_task_with(task, successor, || commit(&finished))
+            .ok()?;
+        tasks.cooperative_contexts.remove(task);
+        Some((finished, next))
     }
 
     pub(crate) fn cooperative_context(&self, task: ExecutionTaskId) -> Option<CooperativeThread> {
@@ -1329,6 +1339,11 @@ mod tests {
         ));
         assert!(calls.switch_to_task(ExecutionTaskId::APPLICATION));
         assert!(!calls.remove_task(worker));
+        assert!(calls
+            .retire_cooperative_context(worker, None, |_| {
+                panic!("pending continuations must reject retirement before result delivery")
+            })
+            .is_none());
         assert_eq!(calls.cooperative_context(worker), Some(context.clone()));
         let detached = calls.clone();
         let shared = calls.shared_handle();

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -1283,18 +1283,18 @@ impl super::TrapDispatcher {
         bus: &mut MacMemoryBus,
     ) -> bool {
         let task = ExecutionTaskId::from_thread_id(thread_id);
-        let finished = self.guest_calls.cooperative_context(task);
-        if !self.guest_calls.remove_task(task) {
+        let Some((finished, _)) =
+            self.guest_calls
+                .retire_cooperative_context(task, None, |saved| {
+                    saved.result_destination == 0
+                        || bus.try_write_long(saved.result_destination, result)
+                })
+        else {
             return false;
-        }
-        if let Some(finished) = finished {
-            if finished.result_destination != 0 {
-                bus.write_long(finished.result_destination, result);
-            }
-            if finished.stack_base != 0 {
-                self.cooperative_thread_pool
-                    .push((finished.stack_base, finished.stack_limit));
-            }
+        };
+        if finished.stack_base != 0 {
+            self.cooperative_thread_pool
+                .push((finished.stack_base, finished.stack_limit));
         }
         true
     }
@@ -1316,18 +1316,27 @@ impl super::TrapDispatcher {
         result: u32,
     ) -> bool {
         let finished = self.guest_calls.current_task();
-        if !self.guest_calls.task_is_empty(finished) {
-            return false;
-        }
-        // Select and validate the successor before releasing the outgoing
-        // snapshot or stack. A failed installation leaves the task retryable.
         let Some(next) = self.next_ready_cooperative_thread(0) else {
             return false;
         };
-        if !self.switch_to_cooperative_thread(cpu, next) {
+        let Some((saved, Some(successor))) = self.guest_calls.retire_cooperative_context(
+            finished,
+            Some(ExecutionTaskId::from_thread_id(next)),
+            |saved| {
+                saved.result_destination == 0
+                    || bus.try_write_long(saved.result_destination, result)
+            },
+        ) else {
             return false;
+        };
+        // The execution owner validated both contexts and committed the result.
+        // Installing this owned snapshot cannot yield or fail.
+        Self::install_cooperative_thread(cpu, &successor);
+        if saved.stack_base != 0 {
+            self.cooperative_thread_pool
+                .push((saved.stack_base, saved.stack_limit));
         }
-        self.retire_cooperative_thread(finished.thread_id(), result, bus)
+        true
     }
 
     /// Claim a pooled stack of at least `stack_size` bytes, or allocate a
@@ -27290,6 +27299,74 @@ mod tests {
                 .scheduling_state(ExecutionTaskId::APPLICATION),
             Some(ExecutionTaskState::Running)
         );
+    }
+
+    #[test]
+    fn thread_retirement_rejects_partial_result_writes_and_can_retry() {
+        for self_exit in [false, true] {
+            let (mut disp, mut cpu, mut bus) = setup();
+            let worker = ExecutionTaskId::from_thread_id(3);
+            let application = ExecutionTaskId::APPLICATION;
+            let result_slot = TEST_SP + 0x100;
+            bus.write_long(result_slot, 0x1234_5678);
+            bus.protect_readonly_code(result_slot + 2, 2);
+            assert!(disp.guest_calls.register_task(worker));
+            assert!(disp
+                .guest_calls
+                .set_scheduling_state(worker, ExecutionTaskState::Ready));
+            let mut saved = super::CooperativeThread::default();
+            saved.result_destination = result_slot;
+            saved.stack_base = 0x1000;
+            saved.stack_limit = 0x2000;
+            assert!(disp
+                .guest_calls
+                .save_cooperative_context(worker, saved.clone()));
+            let mut app = super::CooperativeThread::default();
+            app.pc = 0x4321;
+            app.a_regs[0] = 0x8765;
+            assert!(disp.guest_calls.save_cooperative_context(application, app));
+            if self_exit {
+                assert!(disp.guest_calls.switch_to_task(worker));
+            }
+            cpu.write_reg(Register::PC, 0x1234);
+            cpu.write_reg(Register::A0, 0xcafe_babe);
+            let current = disp.guest_calls.current_task();
+            let ready = disp.guest_calls.next_ready_task(None);
+            let retired = if self_exit {
+                disp.finish_cooperative_thread(&mut cpu, &mut bus)
+            } else {
+                disp.retire_cooperative_thread(worker.thread_id(), 0xcafe_babe, &mut bus)
+            };
+            assert!(!retired);
+            assert_eq!(disp.guest_calls.current_task(), current);
+            assert_eq!(disp.guest_calls.next_ready_task(None), ready);
+            assert_eq!(
+                disp.guest_calls.cooperative_context(worker),
+                Some(saved.clone())
+            );
+            assert_eq!(bus.read_long(result_slot), 0x1234_5678);
+            assert_eq!(cpu.read_reg(Register::PC), 0x1234);
+            assert_eq!(cpu.read_reg(Register::A0), 0xcafe_babe);
+            assert!(disp.cooperative_thread_pool.is_empty());
+
+            saved.result_destination = result_slot + 8;
+            assert!(disp.guest_calls.save_cooperative_context(worker, saved));
+            let retired = if self_exit {
+                disp.finish_cooperative_thread(&mut cpu, &mut bus)
+            } else {
+                disp.retire_cooperative_thread(worker.thread_id(), 0xcafe_babe, &mut bus)
+            };
+            assert!(retired);
+            assert_eq!(disp.guest_calls.current_task(), application);
+            assert!(disp.guest_calls.cooperative_context(worker).is_none());
+            assert_eq!(disp.guest_calls.scheduling_state(worker), None);
+            assert_eq!(bus.read_long(result_slot + 8), 0xcafe_babe);
+            assert_eq!(disp.cooperative_thread_pool, vec![(0x1000, 0x2000)]);
+            if self_exit {
+                assert_eq!(cpu.read_reg(Register::PC), 0x4321);
+                assert_eq!(cpu.read_reg(Register::A0), 0x8765);
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
Thread retirement could remove a task and recycle its stack even when its result pointer was unmapped or read-only. A self-exit could also switch to its successor before discovering a delivery failure.

Retirement now validates the task, pending continuations and optional successor under the execution owner before committing an atomic routed result write. A refused write preserves the task, queue and contexts. The adapter installs the validated successor and recycles the outgoing stack only after success. The synchronous commit callback cannot execute guest code or escape the operation.

Validation: 4,949 headless library tests passed, with three existing ignored tests; the headless library build passes without warnings. Regression coverage exercises partially protected result storage for both self-exit and disposal of another task, unchanged bytes/registers/scheduling after failure, successful retry, and refusal before result delivery when continuations remain pending. Ownership guardrails and all 14 failure-case fixtures pass.

Closes #1385. Advances #1366 and #1363 without closing them. Rebased onto master after prerequisite #1383 merged. Complete activation preflight, runnable engine ownership and native Thread Manager routes remain open.
