### PR TITLE
feat: share thread queries and critical sections across native imports

### DIFF
--- a/src/execution_kernel.rs
+++ b/src/execution_kernel.rs
@@ -613,6 +613,7 @@ impl<R: Copy + TaskOwned, C: Copy> ContinuationStore<R, C> {
             .or_else(|| state.ready.iter().copied().find(|task| eligible(*task)))
     }
 
+    #[cfg(test)]
     pub(crate) fn critical_depth(&self) -> u32 {
         self.0.borrow().critical_depth
     }

--- a/src/guest_call.rs
+++ b/src/guest_call.rs
@@ -512,6 +512,7 @@ impl SharedGuestCallStack {
         self.0.borrow().kernel.next_ready_task(suggested)
     }
 
+    #[cfg(test)]
     pub(crate) fn critical_depth(&self) -> u32 {
         self.0.borrow().kernel.critical_depth()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,7 @@ pub mod runner;
 pub mod scripted_traces;
 pub mod sound;
 mod text_edit;
+mod thread_manager;
 pub mod trace;
 pub mod trap;
 mod ui_art;

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -1626,6 +1626,10 @@ pub enum PpcImportDispatcherTarget {
     P2CStr,
     C2PStr,
     UpperText,
+    GetCurrentThread,
+    GetThreadState,
+    ThreadBeginCritical,
+    ThreadEndCritical,
     GetCurrentProcess,
     WakeUpProcess,
     SameProcess,
@@ -14944,6 +14948,12 @@ fn dispatcher_target_for_import(
             PpcImportDispatcherTarget::C2PStr
         }
         ("InterfaceLib", "UpperText") => PpcImportDispatcherTarget::UpperText,
+        ("InterfaceLib", "GetCurrentThread" | "MacGetCurrentThread") => {
+            PpcImportDispatcherTarget::GetCurrentThread
+        }
+        ("InterfaceLib", "GetThreadState") => PpcImportDispatcherTarget::GetThreadState,
+        ("InterfaceLib", "ThreadBeginCritical") => PpcImportDispatcherTarget::ThreadBeginCritical,
+        ("InterfaceLib", "ThreadEndCritical") => PpcImportDispatcherTarget::ThreadEndCritical,
         ("InterfaceLib", "GetCurrentProcess" | "GetFrontProcess") => {
             PpcImportDispatcherTarget::GetCurrentProcess
         }
@@ -23972,6 +23982,46 @@ fn dispatch_supported_import(
                 }
             }
             Some(PpcImportAction::ReturnPreserve)
+        }
+        PpcImportDispatcherTarget::GetCurrentThread => {
+            // OSErr GetCurrentThread(ThreadID *currentThreadID);
+            // Inside Macintosh: Thread Manager (1999), p. 62.
+            let id = crate::thread_manager::ThreadManager::new(&toolbox_startup.guest_calls)
+                .current_thread();
+            let result = if cpu.gpr[3] != 0 && memory.write_u32_be(cpu.gpr[3], id).is_some() {
+                PPC_NO_ERR
+            } else {
+                PPC_PARAM_ERR
+            };
+            Some(PpcImportAction::Return(ppc_i16_result(result)))
+        }
+        PpcImportDispatcherTarget::GetThreadState => {
+            // OSErr GetThreadState(ThreadID thread, ThreadState *state);
+            // Inside Macintosh: Thread Manager (1999), pp. 45, 63.
+            let result = if cpu.gpr[4] == 0 {
+                PPC_PARAM_ERR
+            } else {
+                match crate::thread_manager::ThreadManager::new(&toolbox_startup.guest_calls)
+                    .state(cpu.gpr[3])
+                {
+                    Ok(state) if memory.write_u16_be(cpu.gpr[4], state).is_some() => PPC_NO_ERR,
+                    Ok(_) => PPC_PARAM_ERR,
+                    Err(error) => error,
+                }
+            };
+            Some(PpcImportAction::Return(ppc_i16_result(result)))
+        }
+        PpcImportDispatcherTarget::ThreadBeginCritical => {
+            Some(PpcImportAction::Return(ppc_i16_result(
+                crate::thread_manager::ThreadManager::new(&toolbox_startup.guest_calls)
+                    .begin_critical(),
+            )))
+        }
+        PpcImportDispatcherTarget::ThreadEndCritical => {
+            Some(PpcImportAction::Return(ppc_i16_result(
+                crate::thread_manager::ThreadManager::new(&toolbox_startup.guest_calls)
+                    .end_critical(),
+            )))
         }
         PpcImportDispatcherTarget::GetCurrentProcess => Some(PpcImportAction::Return(
             ppc_i16_result(ppc_get_current_process(cpu, memory)),
@@ -166573,6 +166623,130 @@ pub(crate) mod tests {
             ppc_memory_read_bytes(&mut loaded.memory, text_ptr, 5),
             Some(vec![b'A', b'Z', 0x83, b'!', b'q'])
         );
+    }
+
+    #[test]
+    fn hle_import_runner_thread_queries_observe_classic_task_state() {
+        use crate::cpu::{CpuOps, Register};
+        use crate::guest_call::ExecutionTaskId;
+        use crate::trap::test_helpers::{setup, TEST_SP};
+        let (mut classic, mut cpu, mut bus) = setup();
+        let worker = ExecutionTaskId::from_thread_id(3);
+        assert!(classic.guest_calls.register_task(worker));
+        // SetThreadState(worker, ready, kNoThreadID) at the classic ABI edge.
+        bus.write_long(TEST_SP, 0);
+        bus.write_word(TEST_SP + 4, 0);
+        bus.write_long(TEST_SP + 6, worker.thread_id());
+        cpu.write_reg(Register::D0, 0x0508);
+        classic
+            .dispatch_toolbox(true, 0x3f2, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+        assert_eq!(cpu.read_reg(Register::D0), 0);
+        let mut loaded =
+            load_pef_application(&synthetic_pef_with_import(b"GetThreadState")).unwrap();
+        loaded.guest_calls = classic.guest_calls.shared_handle();
+        let out = PPC_DATA_BASE + 0x1000;
+        loaded.memory.add_region(out, vec![0xaa; 4]);
+        for (thread, expected_result, expected_state) in [(3, 0, 0), (1, 0, 2), (99, -618, 0xaaaa)]
+        {
+            loaded.cpu.pc = loaded.entry_pc;
+            loaded.cpu.lr = PPC_HALT_PC;
+            loaded.cpu.gpr[3] = thread;
+            loaded.cpu.gpr[4] = out;
+            loaded.memory.write_u32_be(out, 0xaaaa_aaaa).unwrap();
+            let probe = loaded.run_with_hle_imports(64);
+            assert_eq!(probe.handled_import_count, 1);
+            assert_eq!(probe.unsupported_import_index, None);
+            assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(expected_result));
+            assert_eq!(loaded.memory.read_u16_be(out), Some(expected_state));
+            assert_eq!(loaded.memory.read_u16_be(out + 2), Some(0xaaaa));
+        }
+        // The classic unknown-thread route returns the same error and leaves output intact.
+        cpu.write_reg(Register::A7, TEST_SP);
+        cpu.write_reg(Register::D0, 0x0407);
+        bus.write_long(TEST_SP, TEST_SP + 0x100);
+        bus.write_long(TEST_SP + 4, 99);
+        bus.write_word(TEST_SP + 0x100, 0xaaaa);
+        classic
+            .dispatch_toolbox(true, 0x3f2, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+        assert_eq!(cpu.read_reg(Register::D0) as i16, -618);
+        assert_eq!(bus.read_word(TEST_SP + 0x100), 0xaaaa);
+    }
+
+    #[test]
+    fn hle_import_runner_thread_outputs_reject_partial_mappings() {
+        for symbol in [
+            b"GetCurrentThread".as_slice(),
+            b"MacGetCurrentThread".as_slice(),
+            b"GetThreadState".as_slice(),
+        ] {
+            let mut loaded = load_pef_application(&synthetic_pef_with_import(symbol)).unwrap();
+            let out = PPC_DATA_BASE + 0x1000;
+            loaded.memory.add_region(out, vec![0xaa]);
+            let state_query = symbol == b"GetThreadState";
+            loaded.cpu.gpr[3] = if state_query { 1 } else { out };
+            loaded.cpu.gpr[4] = out;
+            let probe = loaded.run_with_hle_imports(64);
+            assert_eq!(probe.handled_import_count, 1);
+            assert_eq!(probe.unsupported_import_index, None);
+            assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_PARAM_ERR));
+            assert_eq!(loaded.memory.read_u8(out), Some(0xaa));
+
+            loaded.memory.add_region(out, vec![0xaa; 4]);
+            loaded.cpu.pc = loaded.entry_pc;
+            loaded.cpu.lr = PPC_HALT_PC;
+            loaded.cpu.gpr[3] = if state_query { 1 } else { out };
+            loaded.cpu.gpr[4] = out;
+            assert_eq!(loaded.run_with_hle_imports(64).handled_import_count, 1);
+            assert_eq!(loaded.cpu.gpr[3], 0);
+            if state_query {
+                assert_eq!(loaded.memory.read_u32_be(out), Some(0x0002_aaaa));
+            } else {
+                assert_eq!(loaded.memory.read_u32_be(out), Some(2));
+            }
+        }
+    }
+
+    #[test]
+    fn hle_import_runner_thread_critical_sections_cross_both_abi_edges() {
+        use crate::cpu::{CpuOps, Register};
+        use crate::trap::test_helpers::{setup, TEST_SP};
+        let (mut classic, mut cpu, mut bus) = setup();
+        cpu.write_reg(Register::D0, 0x000b);
+        classic
+            .dispatch_toolbox(true, 0x3f2, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+        assert_eq!(classic.guest_calls.critical_depth(), 1);
+        let mut end =
+            load_pef_application(&synthetic_pef_with_import(b"ThreadEndCritical")).unwrap();
+        end.guest_calls = classic.guest_calls.shared_handle();
+        assert_eq!(end.run_with_hle_imports(64).handled_import_count, 1);
+        assert_eq!(end.cpu.gpr[3], 0);
+        assert_eq!(classic.guest_calls.critical_depth(), 0);
+        end.cpu.pc = end.entry_pc;
+        end.cpu.lr = PPC_HALT_PC;
+        assert_eq!(end.run_with_hle_imports(64).handled_import_count, 1);
+        assert_eq!(end.cpu.gpr[3], ppc_i16_result(-619));
+        assert_eq!(classic.guest_calls.critical_depth(), 0);
+
+        let mut begin =
+            load_pef_application(&synthetic_pef_with_import(b"ThreadBeginCritical")).unwrap();
+        begin.guest_calls = classic.guest_calls.shared_handle();
+        assert_eq!(begin.run_with_hle_imports(64).handled_import_count, 1);
+        assert_eq!(begin.cpu.gpr[3], 0);
+        assert_eq!(classic.guest_calls.critical_depth(), 1);
+        cpu.write_reg(Register::D0, 0x000c);
+        cpu.write_reg(Register::A7, TEST_SP);
+        classic
+            .dispatch_toolbox(true, 0x3f2, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+        assert_eq!(cpu.read_reg(Register::D0), 0);
+        assert_eq!(classic.guest_calls.critical_depth(), 0);
     }
 
     #[test]

--- a/src/memory/bus.rs
+++ b/src/memory/bus.rs
@@ -1407,6 +1407,11 @@ impl MacMemoryBus {
         self.try_write_bytes_atomic(address, &value.to_be_bytes())
     }
 
+    /// Commit a 16-bit ABI result only when all routed bytes accept writes.
+    pub(crate) fn try_write_word(&mut self, address: u32, value: u16) -> bool {
+        self.try_write_bytes_atomic(address, &value.to_be_bytes())
+    }
+
     /// Read one guest longword only when all four routed bytes are mapped.
     /// `MemoryBus::read_long` preserves the classic unmapped-zero behavior,
     /// which is useful to emulated code but cannot distinguish a missing Trap

--- a/src/thread_manager.rs
+++ b/src/thread_manager.rs
@@ -1,0 +1,60 @@
+//! Thread Manager operations over the process execution owner.
+//!
+//! ABI adapters retain output-pointer and register handling. This service
+//! creates no task registry, snapshots, or independent scheduling state.
+
+use crate::execution_kernel::ExecutionTaskState;
+use crate::guest_call::{ExecutionTaskId, SharedGuestCallStack};
+
+// Inside Macintosh: Thread Manager (1999), p. 101.
+pub(crate) const THREAD_NOT_FOUND_ERR: i16 = -618;
+pub(crate) const THREAD_PROTOCOL_ERR: i16 = -619;
+
+pub(crate) struct ThreadManager<'a> {
+    execution: &'a SharedGuestCallStack,
+}
+
+impl<'a> ThreadManager<'a> {
+    pub(crate) fn new(execution: &'a SharedGuestCallStack) -> Self {
+        Self { execution }
+    }
+
+    // MacGetCurrentThread / GetCurrentThread, Thread Manager (1999), p. 62.
+    pub(crate) fn current_thread(&self) -> u32 {
+        self.execution.current_task().thread_id()
+    }
+
+    pub(crate) fn resolve_thread(&self, thread: u32) -> u32 {
+        if thread <= 1 {
+            self.current_thread()
+        } else {
+            thread
+        }
+    }
+
+    // GetThreadState, Thread Manager (1999), pp. 45, 63.
+    pub(crate) fn state(&self, thread: u32) -> Result<u16, i16> {
+        self.execution
+            .scheduling_state(ExecutionTaskId::from_thread_id(self.resolve_thread(thread)))
+            .map(|state| match state {
+                ExecutionTaskState::Ready => 0,
+                ExecutionTaskState::Stopped => 1,
+                ExecutionTaskState::Running => 2,
+            })
+            .ok_or(THREAD_NOT_FOUND_ERR)
+    }
+
+    // ThreadBeginCritical / ThreadEndCritical, Thread Manager (1999), pp. 69–70.
+    pub(crate) fn begin_critical(&self) -> i16 {
+        self.execution.begin_critical();
+        0
+    }
+
+    pub(crate) fn end_critical(&self) -> i16 {
+        if self.execution.end_critical() {
+            0
+        } else {
+            THREAD_PROTOCOL_ERR
+        }
+    }
+}

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -8,6 +8,7 @@ use crate::memory::globals::addr;
 use crate::memory::{MacMemoryBus, MemoryBus};
 use crate::quickdraw::fonts::get_font_face_scaled;
 use crate::quickdraw::text::{get_font_metrics, get_glyph};
+use crate::thread_manager::ThreadManager;
 use crate::{Error, Result};
 use std::collections::HashMap;
 use std::sync::OnceLock;
@@ -1098,8 +1099,8 @@ impl super::TrapDispatcher {
     const THREAD_STATE_STOPPED: u16 = 1;
     const THREAD_STATE_RUNNING: u16 = 2;
     /// `threadNotFoundErr` and `threadProtocolErr` from Errors.h.
-    const THREAD_NOT_FOUND_ERR: i16 = -617;
-    const THREAD_PROTOCOL_ERR: i16 = -619;
+    const THREAD_NOT_FOUND_ERR: i16 = crate::thread_manager::THREAD_NOT_FOUND_ERR;
+    const THREAD_PROTOCOL_ERR: i16 = crate::thread_manager::THREAD_PROTOCOL_ERR;
 
     fn capture_cooperative_thread<C: CpuOps>(
         cpu: &C,
@@ -1185,11 +1186,7 @@ impl super::TrapDispatcher {
     /// Resolve a guest-supplied ThreadID. `kCurrentThreadID` (1) and
     /// `kNoThreadID` (0) both name the running thread, per Threads.h.
     fn resolve_cooperative_thread_id(&self, thread_id: u32) -> u32 {
-        if thread_id == 0 || thread_id == 1 {
-            self.guest_calls.current_task().thread_id()
-        } else {
-            thread_id
-        }
+        ThreadManager::new(&self.guest_calls).resolve_thread(thread_id)
     }
 
     /// Materialise the record for the thread the process launched on.
@@ -16231,14 +16228,11 @@ impl super::TrapDispatcher {
                     // GetCurrentThread(currentThreadID)
                     0x0206 => {
                         let current_thread = bus.read_long(sp);
-                        if current_thread == 0 {
-                            -50
-                        } else {
-                            bus.write_long(
-                                current_thread,
-                                self.guest_calls.current_task().thread_id(),
-                            );
+                        let id = ThreadManager::new(&self.guest_calls).current_thread();
+                        if current_thread != 0 && bus.try_write_long(current_thread, id) {
                             0
+                        } else {
+                            -50
                         }
                     }
                     // NewThread(threadStyle, threadEntry, threadParam,
@@ -16446,26 +16440,10 @@ impl super::TrapDispatcher {
                         if thread_state == 0 {
                             -50
                         } else {
-                            match self
-                                .guest_calls
-                                .scheduling_state(ExecutionTaskId::from_thread_id(thread_to_get))
-                            {
-                                Some(state) => {
-                                    bus.write_word(
-                                        thread_state,
-                                        match state {
-                                            ExecutionTaskState::Ready => Self::THREAD_STATE_READY,
-                                            ExecutionTaskState::Stopped => {
-                                                Self::THREAD_STATE_STOPPED
-                                            }
-                                            ExecutionTaskState::Running => {
-                                                Self::THREAD_STATE_RUNNING
-                                            }
-                                        },
-                                    );
-                                    0
-                                }
-                                None => Self::THREAD_NOT_FOUND_ERR,
+                            match ThreadManager::new(&self.guest_calls).state(thread_to_get) {
+                                Ok(state) if bus.try_write_word(thread_state, state) => 0,
+                                Ok(_) => -50,
+                                Err(error) => error,
                             }
                         }
                     }
@@ -16595,15 +16573,8 @@ impl super::TrapDispatcher {
                             0
                         }
                     }
-                    0x000B => {
-                        self.guest_calls.begin_critical();
-                        0
-                    }
-                    0x000C if self.guest_calls.critical_depth() == 0 => Self::THREAD_PROTOCOL_ERR,
-                    0x000C => {
-                        self.guest_calls.end_critical();
-                        0
-                    }
+                    0x000B => ThreadManager::new(&self.guest_calls).begin_critical(),
+                    0x000C => ThreadManager::new(&self.guest_calls).end_critical(),
                     _ => -50,
                 };
                 let argument_bytes = (selector >> 8) * 2;
@@ -27277,6 +27248,26 @@ mod tests {
             .expect("GetDefaultThreadStackSize handled")
             .expect("GetDefaultThreadStackSize returns");
         assert_eq!(cpu.read_reg(Register::D0) as i16, -50);
+    }
+
+    #[test]
+    fn threaddispatch_queries_reject_protected_output_without_partial_writes() {
+        for selector in [0x0206, 0x0407] {
+            let (mut disp, mut cpu, mut bus) = setup();
+            let out = TEST_SP + 0x100;
+            bus.write_long(out, 0xaabb_ccdd);
+            bus.protect_readonly_code(out + 1, 1);
+            bus.write_long(TEST_SP, out);
+            if selector == 0x0407 {
+                bus.write_long(TEST_SP + 4, 1);
+            }
+            cpu.write_reg(Register::D0, selector);
+            disp.dispatch_toolbox(true, 0x3f2, &mut cpu, &mut bus)
+                .unwrap()
+                .unwrap();
+            assert_eq!(cpu.read_reg(Register::D0) as i16, -50);
+            assert_eq!(bus.read_long(out), 0xaabb_ccdd);
+        }
     }
 
     #[test]


### PR DESCRIPTION
InterfaceLib lacked Thread Manager entry points even though classic ThreadDispatch already managed shared tasks. GetCurrentThread (including MacGetCurrentThread), GetThreadState, ThreadBeginCritical and ThreadEndCritical now use the same operation service as their classic selectors. The service borrows the existing execution owner and adds no task registry or attachment family.

Both adapters preserve output widths and reject inaccessible or partially writable query destinations without changing the existing bytes. Unknown threads return the documented threadNotFoundErr (-618), correcting the classic path’s -617 value.

Validation: 4,953 headless library tests passed with three existing ignored tests before rebase; the headless build was warning-free, and ownership guardrails plus all 14 failure-case fixtures passed. Three synthetic PEF tests exercise import resolution, classic-to-native state visibility, critical sections entered and exited across both ABI edges, error results and output widths. A classic trap regression covers protected output storage. All 21 focused thread tests and the guardrails passed on the rebased tree, which also includes upstream List Manager changes.

Closes #1389. Advances #1366 and #1363 without closing them. Rebased onto master after #1387 merged. The rebased runtime content is unchanged. Native NewThread, yield, disposal, task-reference operations and execution-engine lifetime ownership remain open.
