### PR TITLE
fix: route guest execution by task and pending call ownership

### DIFF
--- a/src/execution_kernel.rs
+++ b/src/execution_kernel.rs
@@ -46,6 +46,25 @@ pub(crate) enum ExecutionTaskState {
     Running,
 }
 
+/// Available native coordinator contexts, observed without borrowing a CPU.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct NativeAvailability {
+    pub(crate) application: bool,
+    pub(crate) companion: bool,
+    pub(crate) staged_companion: bool,
+}
+
+/// Which execution coordinator can advance the selected task. A native
+/// session can itself advance a classic callback before resuming native code.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ExecutionRoute {
+    Classic,
+    NativeApplication,
+    NativeCompanion,
+    PrepareCompanion,
+    Blocked,
+}
+
 /// Task-lifecycle effect emitted by a process service.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum ExecutionTaskEffect {
@@ -428,6 +447,7 @@ struct StoreState<R: Copy, C: Copy> {
     attached_contexts: HashMap<CallId, usize>,
     retired_tasks: HashSet<ExecutionTaskId>,
     task_states: HashMap<ExecutionTaskId, ExecutionTaskState>,
+    task_entry_isas: HashMap<ExecutionTaskId, GuestIsa>,
     ready: VecDeque<ExecutionTaskId>,
     critical_depth: u32,
 }
@@ -444,6 +464,7 @@ impl<R: Copy, C: Copy> Default for StoreState<R, C> {
                 ExecutionTaskId::APPLICATION,
                 ExecutionTaskState::Running,
             )]),
+            task_entry_isas: HashMap::new(),
             ready: VecDeque::new(),
             critical_depth: 0,
         }
@@ -494,6 +515,7 @@ impl<R: Copy + TaskOwned, C: Copy> ContinuationStore<R, C> {
                 .is_some_and(Vec::is_empty)
             && state.attached_contexts.is_empty()
             && state.retired_tasks.is_empty()
+            && state.task_entry_isas.is_empty()
             && state.task_states.get(&ExecutionTaskId::APPLICATION)
                 == Some(&ExecutionTaskState::Running)
             && state.ready.is_empty()
@@ -508,6 +530,7 @@ impl<R: Copy + TaskOwned, C: Copy> ContinuationStore<R, C> {
         }
         state.stacks.insert(task, Vec::new());
         state.task_states.insert(task, ExecutionTaskState::Stopped);
+        state.task_entry_isas.insert(task, GuestIsa::M68k);
         Ok(())
     }
 
@@ -538,6 +561,36 @@ impl<R: Copy + TaskOwned, C: Copy> ContinuationStore<R, C> {
         state.task_states.insert(task, ExecutionTaskState::Running);
         state.current_task = task;
         Ok(())
+    }
+
+    /// Initial application binding may accompany adopted pending calls. Once
+    /// bound, an entry architecture changes only when that task has no calls.
+    pub(crate) fn bind_task_entry_isa(&self, task: ExecutionTaskId, isa: GuestIsa) -> bool {
+        let mut state = self.0.borrow_mut();
+        let Some(stack) = state.stacks.get(&task) else {
+            return false;
+        };
+        if state
+            .task_entry_isas
+            .get(&task)
+            .is_some_and(|old| *old != isa)
+            && !stack.is_empty()
+        {
+            return false;
+        }
+        state.task_entry_isas.insert(task, isa);
+        true
+    }
+
+    pub(crate) fn task_entry_isa(&self, task: ExecutionTaskId) -> Option<GuestIsa> {
+        let state = self.0.borrow();
+        state.stacks.contains_key(&task).then(|| {
+            state
+                .task_entry_isas
+                .get(&task)
+                .copied()
+                .unwrap_or(GuestIsa::M68k)
+        })
     }
 
     pub(crate) fn scheduling_state(&self, task: ExecutionTaskId) -> Option<ExecutionTaskState> {
@@ -874,6 +927,7 @@ impl<R: Copy + TaskOwned, C: Copy> ContinuationStore<R, C> {
         state.stacks.remove(&task);
         state.retired_tasks.insert(task);
         state.task_states.remove(&task);
+        state.task_entry_isas.remove(&task);
         state.ready.retain(|queued| *queued != task);
         Ok(())
     }
@@ -1378,6 +1432,21 @@ mod tests {
         assert_eq!(store.next_ready_task(None), Some(worker));
         assert!(!store.end_critical());
         assert_eq!(store.critical_depth(), 0);
+    }
+
+    #[test]
+    fn task_entry_architecture_retires_with_its_task() {
+        let store = Store::default();
+        let worker = ExecutionTaskId::from_thread_id(9);
+        assert_eq!(store.task_entry_isa(worker), None);
+        assert!(!store.bind_task_entry_isa(worker, GuestIsa::PowerPc));
+        store.register_task(worker).unwrap();
+        assert_eq!(store.task_entry_isa(worker), Some(GuestIsa::M68k));
+        assert!(store.bind_task_entry_isa(worker, GuestIsa::PowerPc));
+        assert_eq!(store.task_entry_isa(worker), Some(GuestIsa::PowerPc));
+        store.retire_task(worker).unwrap();
+        assert_eq!(store.task_entry_isa(worker), None);
+        assert!(!store.bind_task_entry_isa(worker, GuestIsa::M68k));
     }
 
     #[test]

--- a/src/execution_native.rs
+++ b/src/execution_native.rs
@@ -65,6 +65,14 @@ impl<T> NativeExecution<T> {
         }
     }
 
+    pub(crate) fn availability(&self) -> crate::execution_kernel::NativeAvailability {
+        crate::execution_kernel::NativeAvailability {
+            application: matches!(self.application, NativeSlot::Installed(_)),
+            companion: matches!(self.companion, NativeSlot::Installed(_)),
+            staged_companion: self.staged.is_some() && matches!(self.companion, NativeSlot::Empty),
+        }
+    }
+
     pub(crate) fn application(&self) -> Option<&T> {
         match &self.application {
             NativeSlot::Installed(adapter) => Some(adapter),
@@ -79,6 +87,7 @@ impl<T> NativeExecution<T> {
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn companion(&self) -> Option<&T> {
         match &self.companion {
             NativeSlot::Installed(adapter) => Some(adapter),
@@ -147,6 +156,7 @@ impl<T> NativeExecution<T> {
         Ok(())
     }
 
+    #[cfg(test)]
     pub(crate) fn has_staged_companion(&self) -> bool {
         self.staged.is_some()
     }

--- a/src/guest_call.rs
+++ b/src/guest_call.rs
@@ -17,7 +17,8 @@ pub(crate) use crate::execution_kernel::{
     PendingPowerPcExecution, PowerPcArguments, PowerPcReturnState,
 };
 use crate::execution_kernel::{
-    ExecutionContextBank, ExecutionTaskContextBank, ExecutionTaskEffect, ExecutionTaskState,
+    ExecutionContextBank, ExecutionRoute, ExecutionTaskContextBank, ExecutionTaskEffect,
+    ExecutionTaskState, NativeAvailability,
 };
 use crate::guest_procedure::GuestIsa;
 use ppc::{PpcCpu, PpcImportAction, PpcNativeReturnGpr3};
@@ -479,6 +480,34 @@ impl SharedGuestCallStack {
 
     pub(crate) fn switch_to_task(&self, task: ExecutionTaskId) -> bool {
         self.apply_task_effect(ExecutionTaskEffect::SwitchTo(task))
+    }
+
+    pub(crate) fn bind_task_entry_isa(&self, task: ExecutionTaskId, isa: GuestIsa) -> bool {
+        self.0.borrow().kernel.bind_task_entry_isa(task, isa)
+    }
+
+    /// Select work using task ownership, never the numeric application ID.
+    /// Availability is a current observation; no engine or manager is borrowed.
+    pub(crate) fn execution_route(&self, native: NativeAvailability) -> ExecutionRoute {
+        let task = self.current_task();
+        if self.scheduling_state(task) != Some(ExecutionTaskState::Running) {
+            return ExecutionRoute::Blocked;
+        }
+        let entry = self.0.borrow().kernel.task_entry_isa(task);
+        let native_call = self.has_powerpc_from_m68k();
+        if entry == Some(GuestIsa::PowerPc) || native_call || self.has_m68k_execution() {
+            if native.application {
+                ExecutionRoute::NativeApplication
+            } else if native.companion {
+                ExecutionRoute::NativeCompanion
+            } else if native.staged_companion && native_call {
+                ExecutionRoute::PrepareCompanion
+            } else {
+                ExecutionRoute::Blocked
+            }
+        } else {
+            ExecutionRoute::Classic
+        }
     }
 
     pub(crate) fn scheduling_state(&self, task: ExecutionTaskId) -> Option<ExecutionTaskState> {
@@ -1268,6 +1297,62 @@ mod tests {
         )
         .into_ppc_import_action()
         .expect("native PowerPC request should adapt to CallNative")
+    }
+
+    #[test]
+    fn execution_routes_follow_task_entry_and_pending_work_without_consuming_it() {
+        let calls = SharedGuestCallStack::default();
+        let application = NativeAvailability {
+            application: true,
+            ..Default::default()
+        };
+        assert_eq!(calls.execution_route(application), ExecutionRoute::Classic);
+        assert!(calls.bind_task_entry_isa(ExecutionTaskId::APPLICATION, GuestIsa::PowerPc));
+        assert_eq!(
+            calls.execution_route(application),
+            ExecutionRoute::NativeApplication
+        );
+        let worker = ExecutionTaskId::from_thread_id(7);
+        assert!(calls.register_task(worker));
+        assert!(calls.set_scheduling_state(worker, ExecutionTaskState::Ready));
+        assert!(calls.switch_to_task(worker));
+        assert_eq!(calls.execution_route(application), ExecutionRoute::Classic);
+        assert!(calls.begin_m68k_to_powerpc(
+            GuestCallTarget {
+                isa: GuestIsa::PowerPc,
+                entry: 0x1000,
+                rtoc: 0
+            },
+            PowerPcArguments::from_slice(&[]).unwrap(),
+            0x2000,
+            0x3000,
+            None
+        ));
+        let before = calls.clone();
+        assert!(!calls.bind_task_entry_isa(worker, GuestIsa::PowerPc));
+        for (availability, expected) in [
+            (application, ExecutionRoute::NativeApplication),
+            (
+                NativeAvailability {
+                    companion: true,
+                    ..Default::default()
+                },
+                ExecutionRoute::NativeCompanion,
+            ),
+            (
+                NativeAvailability {
+                    staged_companion: true,
+                    ..Default::default()
+                },
+                ExecutionRoute::PrepareCompanion,
+            ),
+            (NativeAvailability::default(), ExecutionRoute::Blocked),
+        ] {
+            assert_eq!(calls.execution_route(availability), expected);
+            assert_eq!(calls, before);
+        }
+        assert!(calls.set_scheduling_state(worker, ExecutionTaskState::Stopped));
+        assert_eq!(calls.execution_route(application), ExecutionRoute::Blocked);
     }
 
     #[test]

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -4,6 +4,7 @@ use crate::callback_manager::CallbackTaskArchitecture;
 use crate::cpu::{M68kCpu, Register, StepResult};
 use crate::debug_overlay::{DebugOverlayFrameStats, DebugOverlaySnapshot};
 use crate::event_queue::{EventManagerSnapshot, EventRecordSnapshot};
+use crate::execution_kernel::ExecutionRoute;
 use crate::execution_m68k::M68kExecution;
 use crate::execution_native::{NativeEngineRole, NativeExecution};
 use crate::guest_call::ExecutionTaskId;
@@ -3764,6 +3765,10 @@ impl FixtureRunner {
             return;
         }
 
+        assert!(self.dispatcher.guest_calls.bind_task_entry_isa(
+            ExecutionTaskId::APPLICATION,
+            crate::guest_procedure::GuestIsa::M68k
+        ));
         self.bus.detach_guest_address_space();
 
         use crate::memory::globals::addr;
@@ -4278,6 +4283,10 @@ impl FixtureRunner {
         self.m68k.cpu.write_reg(Register::PC, 0);
         self.bus
             .attach_guest_address_space(ppc_app.memory.shared_view());
+        assert!(self.dispatcher.guest_calls.bind_task_entry_isa(
+            ExecutionTaskId::APPLICATION,
+            crate::guest_procedure::GuestIsa::PowerPc
+        ));
         self.native
             .install(NativeEngineRole::Application, ppc_app)
             .unwrap_or_else(|_| panic!("native engine slot is occupied"));
@@ -5468,17 +5477,15 @@ impl FixtureRunner {
         sound_work_only: bool,
         finish_frame: bool,
     ) -> (usize, bool) {
-        // The native application owns the foreground task. A cooperative
-        // Thread Manager switch can leave that native continuation suspended
-        // while a 68K worker runs; route the worker through the classic CPU
-        // until the application task is selected again. Otherwise the runner
-        // would execute the PPC caller after the switch and consume the wrong
-        // task's continuation.
-        let current_task =
-            ExecutionTaskId::from_thread_id(self.dispatcher.guest_calls.current_task().thread_id());
-        let native_foreground_task =
-            self.native.application().is_some() && current_task == ExecutionTaskId::APPLICATION;
-        if native_foreground_task {
+        let route = self
+            .dispatcher
+            .guest_calls
+            .execution_route(self.native.availability());
+        if route == ExecutionRoute::Blocked {
+            return (0, !self.halted);
+        }
+        let session_task = self.dispatcher.guest_calls.current_task();
+        if route == ExecutionRoute::NativeApplication {
             if yield_for_ui {
                 return self.run_ppc_steps(
                     max_steps,
@@ -5500,22 +5507,25 @@ impl FixtureRunner {
                 if steps == 0 {
                     break;
                 }
-                // A 68K callback may yield to a cooperative worker while
-                // this native slice is suspended. The native adapter still
-                // contains the application continuation, but the installed
-                // CPU now belongs to the selected worker; stop the native
-                // loop before it can execute that continuation on the wrong
-                // task.
-                if ExecutionTaskId::from_thread_id(
-                    self.dispatcher.guest_calls.current_task().thread_id(),
-                ) != ExecutionTaskId::APPLICATION
+                // A callback may select another task, or a worker's native
+                // call may finish and expose classic work. Re-arbitrate before
+                // another native batch can consume the retained application CPU.
+                if self.dispatcher.guest_calls.current_task() != session_task
+                    || self
+                        .dispatcher
+                        .guest_calls
+                        .execution_route(self.native.availability())
+                        != route
                 {
                     break;
                 }
             }
-            if ExecutionTaskId::from_thread_id(
-                self.dispatcher.guest_calls.current_task().thread_id(),
-            ) != ExecutionTaskId::APPLICATION
+            if self.dispatcher.guest_calls.current_task() != session_task
+                || self
+                    .dispatcher
+                    .guest_calls
+                    .execution_route(self.native.availability())
+                    != route
             {
                 if finish_frame {
                     self.sync_ppc_deferred_host_state();
@@ -5534,21 +5544,17 @@ impl FixtureRunner {
             return (count, running);
         }
 
-        if self.native.companion().is_none()
-            && self.native.has_staged_companion()
-            && self.dispatcher.guest_calls.has_powerpc_from_m68k()
-        {
+        if route == ExecutionRoute::PrepareCompanion {
             let companion = self
                 .native
                 .take_staged_companion()
-                .expect("checked staged native companion");
+                .expect("selected staged native companion");
             self.init_ppc_companion(companion);
         }
-        if self.native.companion().is_some_and(|companion| {
-            companion.guest_calls.pending_powerpc_from_m68k().is_some()
-                || companion.guest_calls.has_powerpc_from_m68k()
-                || companion.guest_calls.has_m68k_execution()
-        }) {
+        if matches!(
+            route,
+            ExecutionRoute::NativeCompanion | ExecutionRoute::PrepareCompanion
+        ) {
             return self.run_ppc_steps(
                 max_steps,
                 tick_cap,
@@ -6335,17 +6341,12 @@ impl FixtureRunner {
             }
 
             self.dispatcher.instruction_count = self.total_instructions;
-            let ppc_callback_ready = self
-                .native
-                .application()
-                .is_some_and(|app| app.guest_calls.has_m68k_execution())
-                || self.native.companion().is_some_and(|companion| {
-                    companion.guest_calls.has_powerpc_from_m68k()
-                        || companion.guest_calls.has_m68k_execution()
-                })
-                || (self.native.has_staged_companion()
-                    && self.dispatcher.guest_calls.has_powerpc_from_m68k());
-            if ppc_callback_ready {
+            if self
+                .dispatcher
+                .guest_calls
+                .execution_route(self.native.availability())
+                != ExecutionRoute::Classic
+            {
                 break;
             }
         }
@@ -15376,6 +15377,70 @@ mod tests {
         let ppc_app = runner.native.application().expect("PPC app retained");
         assert_eq!(ppc_app.cpu.pc, PPC_CODE_BASE);
         assert_eq!(ppc_app.cpu.gpr[3], u32::from(TRAP));
+    }
+
+    #[test]
+    fn classic_worker_uses_native_application_engine_and_stops_at_its_return() {
+        use crate::execution_kernel::ExecutionTaskState;
+        use crate::guest_call::{GuestCallTarget, M68kResultTarget, PowerPcArguments};
+        use crate::guest_procedure::GuestIsa;
+        const ENTRY: u32 = PPC_CODE_BASE + 0x1000;
+        const CLASSIC_RETURN: u32 = 0x0304_0000;
+        const CLASSIC_SP: u32 = 0x0304_1080;
+        let mut app = halted_ppc_app_with_sound(PpcSoundState::default());
+        let native = app.ppc.as_mut().unwrap();
+        native
+            .memory
+            .add_region(PPC_STACK_BASE, vec![0; PPC_STACK_SIZE as usize]);
+        native.memory.add_region(
+            ENTRY,
+            [0x3860_002au32, 0x4e80_0020]
+                .into_iter()
+                .flat_map(u32::to_be_bytes)
+                .collect(),
+        );
+        native.memory.add_region(CLASSIC_RETURN, vec![0x60, 0xfe]);
+        native.memory.add_region(CLASSIC_SP - 0x80, vec![0; 0x100]);
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        runner.init_app(&app);
+        let native_pc = runner.native.application().unwrap().cpu.pc;
+        let calls = runner.dispatcher.guest_calls.shared_handle();
+        let worker = ExecutionTaskId::from_thread_id(3);
+        assert!(calls.register_task(worker));
+        assert!(calls.set_scheduling_state(worker, ExecutionTaskState::Ready));
+        assert!(calls.switch_to_task(worker));
+        runner.m68k.cpu.write_reg(Register::PC, CLASSIC_RETURN);
+        runner.m68k.cpu.write_reg(Register::A7, CLASSIC_SP);
+        assert!(calls.begin_m68k_to_powerpc(
+            GuestCallTarget {
+                isa: GuestIsa::PowerPc,
+                entry: ENTRY,
+                rtoc: 0
+            },
+            PowerPcArguments::from_slice(&[]).unwrap(),
+            CLASSIC_RETURN,
+            CLASSIC_SP,
+            Some(M68kResultTarget::Data { index: 0, size: 4 })
+        ));
+        let (steps, running) = runner.run_steps(64, None);
+        assert!(steps > 0);
+        assert!(
+            running,
+            "coalescing must not continue into the suspended application's halt"
+        );
+        assert!(
+            calls.is_empty(),
+            "the worker's native call must execute without a companion"
+        );
+        assert_eq!(calls.current_task(), worker);
+        assert_eq!(runner.m68k.cpu.read_reg(Register::D0), 42);
+        assert_eq!(runner.m68k.cpu.read_reg(Register::PC), CLASSIC_RETURN);
+        assert_eq!(runner.m68k.cpu.read_reg(Register::A7), CLASSIC_SP);
+        assert_eq!(runner.native.application().unwrap().cpu.pc, native_pc);
+        assert_eq!(
+            calls.execution_route(runner.native.availability()),
+            ExecutionRoute::Classic
+        );
     }
 
     #[test]


### PR DESCRIPTION
A classic cooperative worker in a native application could submit a PPC call but never execute it: the runner selected the native application engine only for the application task, while the worker fallback required a companion engine.

Execution now chooses its coordinator from the selected task’s entry architecture, scheduling state, pending calls and available engines. Initial dispatch, post-trap handoff and native batch coalescing share this decision. A worker can execute through the application engine, then stop at its classic return without advancing the suspended application. Missing engines leave pending work intact.

Task entry architecture retires with the task; changing it while calls are pending is rejected. Native task register contexts and the remaining native Thread Manager lifecycle routes remain separate work under #1366.

Validation: 4,963 headless library tests passed, three existing tests ignored; the production test-support build passed without warnings. The real-instruction regression calls a PPC routine from a classic worker and verifies D0, PC, SP, task identity and the suspended native PC. Route tests cover installed, staged and missing engines, stopped tasks, unchanged pending calls and retired task metadata. 

Closes #1396. Advances #1366 and #1363 without closing them.

Based on master after #1394 merged.

Integration validation after rebasing onto the merged native owner and upstream sound-conversion change, including the dependent execution PRs: 4,993 library tests passed with three existing ignored tests. The production library check is warning-free and all 20 ownership guardrails pass.
