### PR TITLE
fix: return abandoned native contexts to their execution owner

### DIFF
--- a/src/execution_native.rs
+++ b/src/execution_native.rs
@@ -4,6 +4,7 @@
 //! checkout, so the execution coordinator can suspend native work while a
 //! classic callback runs without borrowing the engine bank recursively.
 
+use std::cell::OnceCell;
 use std::rc::Rc;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -15,7 +16,7 @@ pub(crate) enum NativeEngineRole {
 enum NativeSlot<T> {
     Empty,
     Installed(T),
-    CheckedOut,
+    CheckedOut(Rc<OnceCell<T>>),
 }
 
 pub(crate) struct NativeExecution<T> {
@@ -30,12 +31,51 @@ pub(crate) struct NativeExecution<T> {
 pub(crate) struct NativeContext<T> {
     identity: Rc<()>,
     role: NativeEngineRole,
-    adapter: T,
+    adapter: Option<T>,
+    return_slot: Rc<OnceCell<T>>,
 }
 
 impl<T> NativeContext<T> {
     pub(crate) fn adapter_mut(&mut self) -> &mut T {
-        &mut self.adapter
+        self.adapter.as_mut().expect("context retains its adapter")
+    }
+}
+
+// The cell is a return channel, not another engine authority. Only the unique
+// context can fill it; the slot remains unavailable until custody is returned.
+impl<T> Drop for NativeContext<T> {
+    fn drop(&mut self) {
+        if let Some(adapter) = self.adapter.take() {
+            let result = self.return_slot.set(adapter);
+            debug_assert!(result.is_ok(), "native context returned more than once");
+        }
+    }
+}
+
+impl<T> NativeSlot<T> {
+    fn installed(&self) -> Option<&T> {
+        match self {
+            Self::Installed(adapter) => Some(adapter),
+            Self::CheckedOut(return_slot) => return_slot.get(),
+            Self::Empty => None,
+        }
+    }
+
+    fn checked_out(&self) -> bool {
+        matches!(self, Self::CheckedOut(return_slot) if return_slot.get().is_none())
+    }
+
+    fn reclaim(&mut self) {
+        if matches!(self, Self::CheckedOut(return_slot) if return_slot.get().is_some()) {
+            let Self::CheckedOut(return_slot) = std::mem::replace(self, Self::Empty) else {
+                unreachable!("returned slot was validated")
+            };
+            // Drop has released the context's reference before another owner
+            // operation can run. No guest or manager code can access this cell.
+            let cell = Rc::try_unwrap(return_slot)
+                .unwrap_or_else(|_| panic!("returned context still owns its slot"));
+            *self = Self::Installed(cell.into_inner().expect("returned adapter"));
+        }
     }
 }
 
@@ -67,20 +107,18 @@ impl<T> NativeExecution<T> {
 
     pub(crate) fn availability(&self) -> crate::execution_kernel::NativeAvailability {
         crate::execution_kernel::NativeAvailability {
-            application: matches!(self.application, NativeSlot::Installed(_)),
-            companion: matches!(self.companion, NativeSlot::Installed(_)),
+            application: self.application.installed().is_some(),
+            companion: self.companion.installed().is_some(),
             staged_companion: self.staged.is_some() && matches!(self.companion, NativeSlot::Empty),
         }
     }
 
     pub(crate) fn application(&self) -> Option<&T> {
-        match &self.application {
-            NativeSlot::Installed(adapter) => Some(adapter),
-            _ => None,
-        }
+        self.application.installed()
     }
 
     pub(crate) fn application_mut(&mut self) -> Option<&mut T> {
+        self.application.reclaim();
         match &mut self.application {
             NativeSlot::Installed(adapter) => Some(adapter),
             _ => None,
@@ -89,10 +127,7 @@ impl<T> NativeExecution<T> {
 
     #[cfg(test)]
     pub(crate) fn companion(&self) -> Option<&T> {
-        match &self.companion {
-            NativeSlot::Installed(adapter) => Some(adapter),
-            _ => None,
-        }
+        self.companion.installed()
     }
 
     pub(crate) fn install(&mut self, role: NativeEngineRole, adapter: T) -> Result<(), T> {
@@ -104,34 +139,40 @@ impl<T> NativeExecution<T> {
     }
 
     pub(crate) fn take(&mut self, role: NativeEngineRole) -> Option<NativeContext<T>> {
+        self.slot_mut(role).reclaim();
         if !matches!(self.slot(role), NativeSlot::Installed(_)) {
             return None;
         }
-        let NativeSlot::Installed(adapter) =
-            std::mem::replace(self.slot_mut(role), NativeSlot::CheckedOut)
-        else {
+        let return_slot = Rc::new(OnceCell::new());
+        let NativeSlot::Installed(adapter) = std::mem::replace(
+            self.slot_mut(role),
+            NativeSlot::CheckedOut(Rc::clone(&return_slot)),
+        ) else {
             unreachable!("installed slot was validated before checkout")
         };
         Some(NativeContext {
             identity: Rc::clone(&self.identity),
             role,
-            adapter,
+            adapter: Some(adapter),
+            return_slot,
         })
     }
 
     pub(crate) fn restore(&mut self, context: NativeContext<T>) -> Result<(), NativeContext<T>> {
         if !Rc::ptr_eq(&self.identity, &context.identity)
-            || !matches!(self.slot(context.role), NativeSlot::CheckedOut)
+            || !matches!(self.slot(context.role), NativeSlot::CheckedOut(slot)
+                if Rc::ptr_eq(slot, &context.return_slot) && slot.get().is_none())
         {
             return Err(context);
         }
-        *self.slot_mut(context.role) = NativeSlot::Installed(context.adapter);
+        let role = context.role;
+        drop(context);
+        self.slot_mut(role).reclaim();
         Ok(())
     }
 
     pub(crate) fn can_relaunch(&self) -> bool {
-        !matches!(self.application, NativeSlot::CheckedOut)
-            && !matches!(self.companion, NativeSlot::CheckedOut)
+        !self.application.checked_out() && !self.companion.checked_out()
     }
 
     /// Preserve a staged companion for a classic launch, but discard it when
@@ -172,6 +213,81 @@ impl<T> NativeExecution<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn abandoned_context_returns_mutated_adapter_for_another_checkout() {
+        let mut owner = NativeExecution::default();
+        for role in [NativeEngineRole::Application, NativeEngineRole::Companion] {
+            assert!(owner.install(role, vec![1, 2]).is_ok());
+            let mut context = owner.take(role).unwrap();
+            context.adapter_mut().push(3);
+            assert!(!owner.can_relaunch());
+            assert!(owner.take(role).is_none());
+            drop(context);
+            assert!(owner.can_relaunch());
+            let availability = owner.availability();
+            assert!(match role {
+                NativeEngineRole::Application => availability.application,
+                NativeEngineRole::Companion => availability.companion,
+            });
+            // A returned context is occupied, even before the next checkout.
+            assert_eq!(owner.install(role, vec![99]), Err(vec![99]));
+            let mut next = owner.take(role).unwrap();
+            assert_eq!(next.adapter_mut(), &[1, 2, 3]);
+            next.adapter_mut().push(4);
+            assert!(owner.restore(next).is_ok());
+        }
+        assert_eq!(owner.application().unwrap(), &[1, 2, 3, 4]);
+        assert_eq!(owner.companion().unwrap(), &[1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn unwind_returns_native_custody_without_rolling_back_adapter_progress() {
+        use std::panic::{catch_unwind, AssertUnwindSafe};
+        let mut owner = NativeExecution::default();
+        assert!(owner
+            .install(NativeEngineRole::Application, vec![10])
+            .is_ok());
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            let mut context = owner.take(NativeEngineRole::Application).unwrap();
+            context.adapter_mut().push(20);
+            panic!("interrupted coordinator");
+        }));
+        assert!(result.is_err());
+        assert_eq!(owner.application().unwrap(), &[10, 20]);
+        owner.application_mut().unwrap().push(30);
+        assert_eq!(owner.application().unwrap(), &[10, 20, 30]);
+        assert!(owner.reset_for_launch(false));
+        assert!(owner.application().is_none());
+    }
+
+    #[test]
+    fn rejected_restore_and_owner_drop_release_each_adapter_once() {
+        use std::cell::Cell;
+        struct Adapter(Rc<Cell<usize>>);
+        impl Drop for Adapter {
+            fn drop(&mut self) {
+                self.0.set(self.0.get() + 1);
+            }
+        }
+        let drops = Rc::new(Cell::new(0));
+        let mut owner = NativeExecution::default();
+        let mut other = NativeExecution::default();
+        assert!(owner
+            .install(NativeEngineRole::Application, Adapter(Rc::clone(&drops)))
+            .is_ok());
+        let context = owner.take(NativeEngineRole::Application).unwrap();
+        let context = other.restore(context).err().unwrap();
+        drop(context);
+        assert_eq!(drops.get(), 0);
+        assert!(owner.application().is_some());
+        assert!(other.application().is_none());
+        let context = owner.take(NativeEngineRole::Application).unwrap();
+        drop(owner);
+        assert_eq!(drops.get(), 0);
+        drop(context);
+        assert_eq!(drops.get(), 1);
+    }
 
     #[test]
     fn native_contexts_restore_to_their_original_owner_and_role() {


### PR DESCRIPTION
An early return or panic after native checkout dropped the adapter while leaving its execution slot permanently checked out. Subsequent stepping and relaunch could not recover it.

Each unique native context now retains a one-shot return slot. Dropping the context returns the adapter automatically; the owner can inspect it, reclaim it for another checkout, or reset it. Explicit restoration validates the owner, role and exact return slot. Rejected restoration still returns to the original owner when dropped. No bank borrow spans guest execution, and the adapter is never cloned.

Recovery preserves the adapter’s latest state. It does not roll back interrupted guest operations or establish that they can safely resume. Native task register contexts remain separate work under #1366.

Validation: 4,966 headless library tests passed, three existing tests ignored; the production test-support build is warning-free. Focused regressions cover both roles, mutation followed by drop and checkout, unwind, wrong-owner rejection, and exactly-once destruction when the owner drops first.

Closes #1400. Advances #1366 and #1363 without closing them.

Stacked on #1399.

Integration validation on the current public base, including the dependent execution PRs: 4,970 headless library tests passed with three existing ignored tests, and the production test-support build is warning-free. The upstream TextEdit inspection helper now accesses the native execution owner.
