### PR TITLE
refactor: allocate thread identities in the execution owner

### DIFF
--- a/src/execution_kernel.rs
+++ b/src/execution_kernel.rs
@@ -68,7 +68,6 @@ pub(crate) enum ExecutionRoute {
 /// Task-lifecycle effect emitted by a process service.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum ExecutionTaskEffect {
-    Register(ExecutionTaskId),
     SwitchTo(ExecutionTaskId),
 }
 
@@ -376,6 +375,7 @@ impl<R: Copy, C: Copy> ContinuationState<R, C> {
 /// Why a transactional continuation operation was refused.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum ContinuationError {
+    TaskIdsExhausted,
     TaskUnavailable {
         task: ExecutionTaskId,
     },
@@ -443,6 +443,7 @@ pub(crate) struct ContinuationStore<R: Copy, C: Copy>(Rc<RefCell<StoreState<R, C
 struct StoreState<R: Copy, C: Copy> {
     current_task: ExecutionTaskId,
     next_call_id: u64,
+    next_task_id: Option<u32>,
     stacks: HashMap<ExecutionTaskId, Vec<ContinuationState<R, C>>>,
     attached_contexts: HashMap<CallId, usize>,
     retired_tasks: HashSet<ExecutionTaskId>,
@@ -457,6 +458,7 @@ impl<R: Copy, C: Copy> Default for StoreState<R, C> {
         Self {
             current_task: ExecutionTaskId::APPLICATION,
             next_call_id: 1,
+            next_task_id: Some(3),
             stacks: HashMap::from([(ExecutionTaskId::APPLICATION, Vec::new())]),
             attached_contexts: HashMap::new(),
             retired_tasks: HashSet::new(),
@@ -508,6 +510,7 @@ impl<R: Copy + TaskOwned, C: Copy> ContinuationStore<R, C> {
         let state = self.0.borrow();
         state.current_task == ExecutionTaskId::APPLICATION
             && state.next_call_id == 1
+            && state.next_task_id == Some(3)
             && state.stacks.len() == 1
             && state
                 .stacks
@@ -522,6 +525,19 @@ impl<R: Copy + TaskOwned, C: Copy> ContinuationStore<R, C> {
             && state.critical_depth == 0
     }
 
+    /// Allocate from the same monotonic namespace used by explicit registration.
+    /// Exhaustion never wraps into aliases, the application task or retired IDs.
+    pub(crate) fn create_task(&self) -> Result<ExecutionTaskId, ContinuationError> {
+        let id = self
+            .0
+            .borrow()
+            .next_task_id
+            .ok_or(ContinuationError::TaskIdsExhausted)?;
+        let task = ExecutionTaskId::from_thread_id(id);
+        self.register_task(task)?;
+        Ok(task)
+    }
+
     /// Register a new task exactly once for this process lifetime.
     pub(crate) fn register_task(&self, task: ExecutionTaskId) -> Result<(), ContinuationError> {
         let mut state = self.0.borrow_mut();
@@ -531,6 +547,12 @@ impl<R: Copy + TaskOwned, C: Copy> ContinuationStore<R, C> {
         state.stacks.insert(task, Vec::new());
         state.task_states.insert(task, ExecutionTaskState::Stopped);
         state.task_entry_isas.insert(task, GuestIsa::M68k);
+        if state
+            .next_task_id
+            .is_some_and(|next| task.thread_id() >= next)
+        {
+            state.next_task_id = task.thread_id().checked_add(1);
+        }
         Ok(())
     }
 
@@ -690,7 +712,6 @@ impl<R: Copy + TaskOwned, C: Copy> ContinuationStore<R, C> {
         effect: ExecutionTaskEffect,
     ) -> Result<(), ContinuationError> {
         match effect {
-            ExecutionTaskEffect::Register(task) => self.register_task(task),
             ExecutionTaskEffect::SwitchTo(task) => self.switch_to_task(task),
         }
     }
@@ -1432,6 +1453,47 @@ mod tests {
         assert_eq!(store.next_ready_task(None), Some(worker));
         assert!(!store.end_critical());
         assert_eq!(store.critical_depth(), 0);
+    }
+
+    #[test]
+    fn task_allocation_shares_registration_and_never_reuses_retired_ids() {
+        let store = Store::default();
+        let first = store.create_task().unwrap();
+        assert_eq!(first.thread_id(), 3);
+        let imported = ExecutionTaskId::from_thread_id(40);
+        store.register_task(imported).unwrap();
+        store.retire_task(imported).unwrap();
+        store.retire_task(first).unwrap();
+        let next = store.create_task().unwrap();
+        assert_eq!(next.thread_id(), 41);
+        assert_eq!(
+            store.scheduling_state(next),
+            Some(ExecutionTaskState::Stopped)
+        );
+        assert_eq!(store.task_entry_isa(next), Some(GuestIsa::M68k));
+        assert!(!store.is_pristine());
+    }
+
+    #[test]
+    fn exhausted_task_namespace_is_unchanged_and_does_not_wrap() {
+        let store = Store::default();
+        store
+            .register_task(ExecutionTaskId::from_thread_id(u32::MAX - 1))
+            .unwrap();
+        assert_eq!(store.create_task().unwrap().thread_id(), u32::MAX);
+        let before = store.clone();
+        assert_eq!(
+            store.create_task(),
+            Err(ContinuationError::TaskIdsExhausted)
+        );
+        assert_eq!(store, before);
+        store
+            .retire_task(ExecutionTaskId::from_thread_id(u32::MAX))
+            .unwrap();
+        assert_eq!(
+            store.create_task(),
+            Err(ContinuationError::TaskIdsExhausted)
+        );
     }
 
     #[test]

--- a/src/guest_call.rs
+++ b/src/guest_call.rs
@@ -473,13 +473,18 @@ impl SharedGuestCallStack {
         self.0.borrow().kernel.current_task()
     }
 
-    /// Select the continuation owner for subsequent guest execution.
+    /// Fixtures may import an explicit identity into the owner's namespace.
+    #[cfg(test)]
     pub(crate) fn register_task(&self, task: ExecutionTaskId) -> bool {
-        self.apply_task_effect(ExecutionTaskEffect::Register(task))
+        self.0.borrow().kernel.register_task(task).is_ok()
     }
 
     pub(crate) fn switch_to_task(&self, task: ExecutionTaskId) -> bool {
         self.apply_task_effect(ExecutionTaskEffect::SwitchTo(task))
+    }
+
+    pub(crate) fn create_task(&self) -> Option<ExecutionTaskId> {
+        self.0.borrow().kernel.create_task().ok()
     }
 
     pub(crate) fn bind_task_entry_isa(&self, task: ExecutionTaskId, isa: GuestIsa) -> bool {

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -1488,8 +1488,6 @@ pub struct TrapDispatcher {
     /// on the zero-request local path is allowed before init in the baked
     /// fixture.
     pub(crate) ppc_initialized: bool,
-    /// Next guest-visible ThreadID. IDs 1 and 2 are reserved by Threads.h.
-    pub(crate) next_cooperative_thread_id: u32,
     /// Guest trampoline entered when a ThreadEntryProc returns.
     pub(crate) thread_return_trampoline: u32,
     /// Custom `ThreadSchedulerProcPtr` installed by `SetThreadScheduler`.
@@ -3470,7 +3468,6 @@ impl TrapDispatcher {
             qddone_seen_ports: HashSet::new(),
             pict_info_ids: HashSet::new(),
             ppc_initialized: false,
-            next_cooperative_thread_id: 3,
             thread_return_trampoline: 0,
             cooperative_thread_scheduler: 0,
             cooperative_thread_stack_size: DEFAULT_COOPERATIVE_THREAD_STACK_SIZE,

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -16254,18 +16254,8 @@ impl super::TrapDispatcher {
                                 bus.write_long(thread_made, 0);
                             }
                             -50
-                        } else if !self
-                            .guest_calls
-                            .register_task(ExecutionTaskId::from_thread_id(
-                                self.next_cooperative_thread_id,
-                            ))
-                        {
-                            bus.write_long(thread_made, 0);
-                            -108
-                        } else {
-                            let thread_id = self.next_cooperative_thread_id;
-                            self.next_cooperative_thread_id =
-                                self.next_cooperative_thread_id.saturating_add(1);
+                        } else if let Some(task) = self.guest_calls.create_task() {
+                            let thread_id = task.thread_id();
 
                             let stack_size = if stack_size == 0 {
                                 self.cooperative_thread_stack_size
@@ -16308,6 +16298,9 @@ impl super::TrapDispatcher {
                             );
                             bus.write_long(thread_made, thread_id);
                             0
+                        } else {
+                            bus.write_long(thread_made, 0);
+                            -108
                         }
                     }
                     // CreateThreadPool(threadStyle, numToCreate, stackSize)
@@ -24240,7 +24233,10 @@ mod tests {
             bus.write_word(sp, 0x002C);
             bus.write_long(sp + 2, list_handle);
             bus.write_word(sp + 6, if draw { 0x0100 } else { 0 });
-            assert!(disp.dispatch_toolbox(true, 0x1E7, &mut cpu, &mut bus).unwrap().is_ok());
+            assert!(disp
+                .dispatch_toolbox(true, 0x1E7, &mut cpu, &mut bus)
+                .unwrap()
+                .is_ok());
             assert_eq!(bus.read_byte(v_scroll_ptr + 16), 255);
             assert_eq!(disp.list_states[&list_handle].draw_enabled, draw);
         }
@@ -27427,6 +27423,36 @@ mod tests {
         assert_eq!(cpu.read_reg(Register::A7), sp);
         assert_eq!(bus.read_word(sp), (-50i16) as u16);
         assert_eq!(disp.guest_calls.critical_depth(), 0);
+    }
+
+    #[test]
+    fn threaddispatch_newthread_uses_the_adopted_execution_namespace() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let process = crate::guest_call::SharedGuestCallStack::default();
+        assert!(process.register_task(ExecutionTaskId::from_thread_id(40)));
+        disp.guest_calls.attach_to(&process);
+        let thread_made = bus.alloc(4);
+        for expected in [41, 43] {
+            cpu.write_reg(Register::A7, TEST_SP);
+            bus.write_long(TEST_SP, thread_made);
+            bus.write_long(TEST_SP + 4, 0);
+            bus.write_long(TEST_SP + 8, 1); // kNewSuspend
+            bus.write_long(TEST_SP + 12, 4096);
+            bus.write_long(TEST_SP + 16, 0);
+            bus.write_long(TEST_SP + 20, 0x0004_2000);
+            bus.write_long(TEST_SP + 24, 1);
+            cpu.write_reg(Register::D0, 0x0E03);
+            disp.dispatch_toolbox(true, 0x3F2, &mut cpu, &mut bus)
+                .unwrap()
+                .unwrap();
+            assert_eq!(cpu.read_reg(Register::D0), 0);
+            assert_eq!(bus.read_long(thread_made), expected);
+            assert!(process
+                .cooperative_context(ExecutionTaskId::from_thread_id(expected))
+                .is_some());
+            // Another creator shares the owner's namespace between classic calls.
+            assert_eq!(process.create_task().unwrap().thread_id(), expected + 1);
+        }
     }
 
     #[test]


### PR DESCRIPTION
Classic NewThread chose IDs with a dispatcher counter while the process execution owner held the task registry. Adopting a registry or interleaving another creator could collide with that counter and make thread creation fail.

The execution store now allocates task IDs from one monotonic namespace. Explicit registration advances it, retirement cannot recycle an ID, and exhaustion returns an error without wrapping or changing state. Classic NewThread uses this service; the dispatcher counter and obsolete explicit-registration effect are removed. Caller-supplied registration remains only as fixture support at the execution facade.

Validation: 4,969 headless library tests passed, three existing tests ignored. After the final cleanup, 32 focused task tests and the classic adopted-registry regression passed; the production test-support build is warning-free. Tests cover interleaved creators, imported IDs, retirement and namespace exhaustion.

Closes #1403. Advances #1366 and #1363 without closing them. Native task register contexts and native NewThread/yield/disposal imports remain outstanding; this establishes their shared identity allocator.

Stacked on #1402.

Integration validation on the current public base, including the dependent execution PRs: 4,970 headless library tests passed with three existing ignored tests, and the production test-support build is warning-free. The upstream TextEdit inspection helper now accesses the native execution owner.
