### PR TITLE
feat: execute native cooperative threads through the process task owner

### DIFF
--- a/src/cpu/mod.rs
+++ b/src/cpu/mod.rs
@@ -72,6 +72,7 @@ pub trait CpuOps {
 /// Construction selects the CPU type from
 /// [`crate::machine_profile::REFERENCE_MACHINE_PROFILE`]. Callers with a
 /// specialized embedding may subsequently reconfigure the public core.
+#[derive(Debug)]
 pub struct M68kCpu {
     /// Complete m68k CPU state and execution API.
     ///

--- a/src/execution_kernel.rs
+++ b/src/execution_kernel.rs
@@ -1297,6 +1297,47 @@ impl<T> ExecutionContextBank<T> {
         Ok(())
     }
 
+    /// Attach both sides of an ISA transition under one validated call token.
+    /// Refusal leaves the installed caller and both banks unchanged.
+    pub(crate) fn park_pair_while_activating<R: Copy + TaskOwned, C: Copy, U: Default>(
+        &mut self,
+        caller_bank: &mut ExecutionContextBank<U>,
+        kernel: &ContinuationStore<R, C>,
+        task: ExecutionTaskId,
+        call_id: CallId,
+        context: T,
+        caller: &mut U,
+    ) -> Result<(), (ContinuationError, T)> {
+        let mut state = kernel.0.borrow_mut();
+        if let Err(error) = ContinuationStore::validate_transition(
+            &state,
+            task,
+            call_id,
+            ContinuationPhase::Pending,
+        ) {
+            return Err((error, context));
+        }
+        if self.contains(task, call_id) || caller_bank.contains(task, call_id) {
+            return Err((
+                ContinuationError::ContextAttached { call_id, count: 1 },
+                context,
+            ));
+        }
+        let replacement = U::default();
+        state
+            .stacks
+            .get_mut(&task)
+            .and_then(|stack| stack.last_mut())
+            .expect("validated activation")
+            .phase = ContinuationPhase::Active;
+        *state.attached_contexts.entry(call_id).or_default() += 2;
+        self.by_call.insert((task, call_id), context);
+        caller_bank
+            .by_call
+            .insert((task, call_id), std::mem::replace(caller, replacement));
+        Ok(())
+    }
+
     pub(crate) fn park_while_activating<R: Copy + TaskOwned, C: Copy>(
         &mut self,
         kernel: &ContinuationStore<R, C>,

--- a/src/execution_kernel.rs
+++ b/src/execution_kernel.rs
@@ -528,12 +528,24 @@ impl<R: Copy + TaskOwned, C: Copy> ContinuationStore<R, C> {
     /// Allocate from the same monotonic namespace used by explicit registration.
     /// Exhaustion never wraps into aliases, the application task or retired IDs.
     pub(crate) fn create_task(&self) -> Result<ExecutionTaskId, ContinuationError> {
+        self.create_task_with(|_| true)
+    }
+
+    /// The synchronous commit must not reenter this owner or change state on
+    /// failure. Publish guest output only after preparation, before registration.
+    pub(crate) fn create_task_with(
+        &self,
+        commit: impl FnOnce(ExecutionTaskId) -> bool,
+    ) -> Result<ExecutionTaskId, ContinuationError> {
         let id = self
             .0
             .borrow()
             .next_task_id
             .ok_or(ContinuationError::TaskIdsExhausted)?;
         let task = ExecutionTaskId::from_thread_id(id);
+        if !commit(task) {
+            return Err(ContinuationError::TaskCommitRefused { task });
+        }
         self.register_task(task)?;
         Ok(task)
     }
@@ -615,6 +627,14 @@ impl<R: Copy + TaskOwned, C: Copy> ContinuationStore<R, C> {
         })
     }
 
+    pub(crate) fn has_live_workers(&self) -> bool {
+        self.0
+            .borrow()
+            .task_states
+            .keys()
+            .any(|task| *task != ExecutionTaskId::APPLICATION)
+    }
+
     pub(crate) fn scheduling_state(&self, task: ExecutionTaskId) -> Option<ExecutionTaskState> {
         self.0.borrow().task_states.get(&task).copied()
     }
@@ -688,7 +708,6 @@ impl<R: Copy + TaskOwned, C: Copy> ContinuationStore<R, C> {
             .or_else(|| state.ready.iter().copied().find(|task| eligible(*task)))
     }
 
-    #[cfg(test)]
     pub(crate) fn critical_depth(&self) -> u32 {
         self.0.borrow().critical_depth
     }
@@ -1146,6 +1165,14 @@ impl<T> Default for ExecutionTaskContextBank<T> {
 }
 
 impl<T> ExecutionTaskContextBank<T> {
+    pub(crate) fn same_tasks<U>(&self, other: &ExecutionTaskContextBank<U>) -> bool {
+        self.by_task.len() == other.by_task.len()
+            && self
+                .by_task
+                .keys()
+                .all(|task| other.by_task.contains_key(task))
+    }
+
     pub(crate) fn is_empty(&self) -> bool {
         self.by_task.is_empty()
     }
@@ -1453,6 +1480,15 @@ mod tests {
         assert_eq!(store.next_ready_task(None), Some(worker));
         assert!(!store.end_critical());
         assert_eq!(store.critical_depth(), 0);
+    }
+
+    #[test]
+    fn refused_task_creation_does_not_consume_identity_or_publish_state() {
+        let store = Store::default();
+        let before = store.clone();
+        assert!(store.create_task_with(|_| false).is_err());
+        assert_eq!(store, before);
+        assert_eq!(store.create_task().unwrap().thread_id(), 3);
     }
 
     #[test]

--- a/src/execution_kernel.rs
+++ b/src/execution_kernel.rs
@@ -643,6 +643,7 @@ impl<R: Copy + TaskOwned, C: Copy> ContinuationStore<R, C> {
 
     /// SetThreadStateEndCritical is one state transition, including failures.
     /// Inside Macintosh: Thread Manager (1999), pp. 71--72.
+    #[cfg(test)]
     pub(crate) fn set_state_ending_critical(
         &self,
         task: ExecutionTaskId,
@@ -683,14 +684,94 @@ impl<R: Copy + TaskOwned, C: Copy> ContinuationStore<R, C> {
         true
     }
 
+    /// Validate state, critical depth and successor before the adapter commits
+    /// its return. The callback is synchronous and must not reenter this store.
+    /// Inside Macintosh: Thread Manager (1999), pp. 67–72.
+    pub(crate) fn change_thread_state_with(
+        &self,
+        task: ExecutionTaskId,
+        requested: ExecutionTaskState,
+        suggested: Option<ExecutionTaskId>,
+        end_critical: bool,
+        commit: impl FnOnce(Option<ExecutionTaskId>) -> bool,
+    ) -> Option<Option<ExecutionTaskId>> {
+        let mut state = self.0.borrow_mut();
+        let depth = if end_critical {
+            state.critical_depth.checked_sub(1)?
+        } else {
+            state.critical_depth
+        };
+        if !state.stacks.contains_key(&task)
+            || (requested == ExecutionTaskState::Running && task != state.current_task)
+        {
+            return None;
+        }
+        let switching = task == state.current_task && requested != ExecutionTaskState::Running;
+        if switching && depth != 0 {
+            return None;
+        }
+        let successor = if switching {
+            let eligible = |candidate: ExecutionTaskId| {
+                candidate != task
+                    && state.task_states.get(&candidate) == Some(&ExecutionTaskState::Ready)
+            };
+            let next = suggested
+                .filter(|candidate| eligible(*candidate))
+                .or_else(|| {
+                    state
+                        .ready
+                        .iter()
+                        .copied()
+                        .find(|candidate| eligible(*candidate))
+                });
+            // A ready caller can resume itself. A stopped caller requires a
+            // runnable successor; do not report a successful stop while running it.
+            if next.is_none() && requested == ExecutionTaskState::Stopped {
+                return None;
+            }
+            next
+        } else {
+            None
+        };
+        if !commit(successor) {
+            return None;
+        }
+        state.critical_depth = depth;
+        state.ready.retain(|queued| *queued != task);
+        let final_state = if switching && successor.is_none() {
+            ExecutionTaskState::Running
+        } else {
+            requested
+        };
+        state.task_states.insert(task, final_state);
+        if final_state == ExecutionTaskState::Ready {
+            state.ready.push_back(task);
+        }
+        if let Some(next) = successor {
+            state.ready.retain(|queued| *queued != next);
+            state.task_states.insert(next, ExecutionTaskState::Running);
+            state.current_task = next;
+        }
+        Some(successor)
+    }
+
     /// Selection is non-destructive: the adapter must first validate that it
     /// can install the successor. Only the committed switch removes it.
     pub(crate) fn next_ready_task(
         &self,
         suggested: Option<ExecutionTaskId>,
     ) -> Option<ExecutionTaskId> {
+        self.next_ready_task_after_critical(suggested, false)
+    }
+
+    pub(crate) fn next_ready_task_after_critical(
+        &self,
+        suggested: Option<ExecutionTaskId>,
+        end_critical: bool,
+    ) -> Option<ExecutionTaskId> {
         let state = self.0.borrow();
-        if state.critical_depth != 0 {
+        let depth = state.critical_depth.checked_sub(u32::from(end_critical))?;
+        if depth != 0 {
             return None;
         }
         let eligible = |task: ExecutionTaskId| {

--- a/src/execution_kernel.rs
+++ b/src/execution_kernel.rs
@@ -1408,8 +1408,31 @@ impl<T> ExecutionContextBank<T> {
     where
         T: Default,
     {
+        self.activate_parking_caller_with_context::<R, C, ()>(
+            kernel, task, call_id, caller, installed, None,
+        )
+    }
+
+    pub(crate) fn activate_parking_caller_with_context<R: Copy + TaskOwned, C: Copy, U>(
+        &mut self,
+        kernel: &ContinuationStore<R, C>,
+        task: ExecutionTaskId,
+        call_id: CallId,
+        caller: Option<CallId>,
+        installed: &mut T,
+        companion: Option<(&mut ExecutionContextBank<U>, U)>,
+    ) -> Result<(), ContinuationError>
+    where
+        T: Default,
+    {
         let mut state = kernel.0.borrow_mut();
         ContinuationStore::validate_transition(&state, task, call_id, ContinuationPhase::Pending)?;
+        if companion
+            .as_ref()
+            .is_some_and(|(bank, _)| bank.contains(task, call_id))
+        {
+            return Err(ContinuationError::ContextAttached { call_id, count: 1 });
+        }
         if let Some(caller) = caller {
             ContinuationStore::validate_context_owner(&state, task, caller)?;
             if caller == call_id {
@@ -1427,6 +1450,10 @@ impl<T> ExecutionContextBank<T> {
                     .insert((task, caller), std::mem::take(installed));
                 *state.attached_contexts.entry(caller).or_default() += 1;
             }
+        }
+        if let Some((bank, context)) = companion {
+            bank.by_call.insert((task, call_id), context);
+            *state.attached_contexts.entry(call_id).or_default() += 1;
         }
         state
             .stacks

--- a/src/execution_kernel.rs
+++ b/src/execution_kernel.rs
@@ -521,6 +521,7 @@ impl<R: Copy + TaskOwned, C: Copy> ContinuationStore<R, C> {
 
     /// Allocate from the same monotonic namespace used by explicit registration.
     /// Exhaustion never wraps into aliases, the application task or retired IDs.
+    #[cfg(test)]
     pub(crate) fn create_task(&self) -> Result<ExecutionTaskId, ContinuationError> {
         self.create_task_with(|_| true)
     }

--- a/src/execution_kernel.rs
+++ b/src/execution_kernel.rs
@@ -65,12 +65,6 @@ pub(crate) enum ExecutionRoute {
     Blocked,
 }
 
-/// Task-lifecycle effect emitted by a process service.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum ExecutionTaskEffect {
-    SwitchTo(ExecutionTaskId),
-}
-
 /// A request type that identifies the task which owns its continuation.
 ///
 /// The kernel does not know the request's ABI or payload. Each semantic edge
@@ -724,15 +718,6 @@ impl<R: Copy + TaskOwned, C: Copy> ContinuationStore<R, C> {
         };
         state.critical_depth = depth;
         true
-    }
-
-    pub(crate) fn apply_task_effect(
-        &self,
-        effect: ExecutionTaskEffect,
-    ) -> Result<(), ContinuationError> {
-        match effect {
-            ExecutionTaskEffect::SwitchTo(task) => self.switch_to_task(task),
-        }
     }
 
     /// Submit a continuation to `task` and allocate its explicit call ID.

--- a/src/execution_kernel.rs
+++ b/src/execution_kernel.rs
@@ -724,11 +724,6 @@ impl<R: Copy + TaskOwned, C: Copy> ContinuationStore<R, C> {
                         .copied()
                         .find(|candidate| eligible(*candidate))
                 });
-            // A ready caller can resume itself. A stopped caller requires a
-            // runnable successor; do not report a successful stop while running it.
-            if next.is_none() && requested == ExecutionTaskState::Stopped {
-                return None;
-            }
             next
         } else {
             None
@@ -738,11 +733,12 @@ impl<R: Copy + TaskOwned, C: Copy> ContinuationStore<R, C> {
         }
         state.critical_depth = depth;
         state.ready.retain(|queued| *queued != task);
-        let final_state = if switching && successor.is_none() {
-            ExecutionTaskState::Running
-        } else {
-            requested
-        };
+        let final_state =
+            if switching && successor.is_none() && requested == ExecutionTaskState::Ready {
+                ExecutionTaskState::Running
+            } else {
+                requested
+            };
         state.task_states.insert(task, final_state);
         if final_state == ExecutionTaskState::Ready {
             state.ready.push_back(task);

--- a/src/execution_m68k.rs
+++ b/src/execution_m68k.rs
@@ -39,7 +39,8 @@ impl M68kExecution {
 
     /// A launch cannot discard contexts still associated with live calls.
     pub(crate) fn can_relaunch(&self) -> bool {
-        self.parked.is_empty()
+        self.calls.current_task_is_running()
+            && self.parked.is_empty()
             && self.calls.is_empty()
             && !self.calls.has_live_workers()
             && !self.calls.has_pending_task_handoff()

--- a/src/execution_m68k.rs
+++ b/src/execution_m68k.rs
@@ -4,14 +4,12 @@
 //! must move with their context. The task store remains the process authority.
 
 use crate::cpu::{M68kCpu, Register};
-use crate::execution_kernel::ExecutionContextBank;
 use crate::guest_call::{PendingM68kExecution, SharedGuestCallStack};
 use crate::memory::GuestAddressSpace as PpcSectionMem;
 use ppc::PpcMemory;
 
 pub(crate) struct M68kExecution {
     pub(crate) cpu: M68kCpu,
-    pub(crate) parked: ExecutionContextBank<M68kCpu>,
     calls: SharedGuestCallStack,
 }
 
@@ -19,7 +17,6 @@ impl M68kExecution {
     pub(crate) fn new(calls: &SharedGuestCallStack) -> Self {
         Self {
             cpu: M68kCpu::new(),
-            parked: ExecutionContextBank::default(),
             calls: calls.shared_handle(),
         }
     }
@@ -40,7 +37,7 @@ impl M68kExecution {
     /// A launch cannot discard contexts still associated with live calls.
     pub(crate) fn can_relaunch(&self) -> bool {
         self.calls.current_task_is_running()
-            && self.parked.is_empty()
+            && !self.calls.has_parked_m68k_contexts()
             && self.calls.is_empty()
             && !self.calls.has_live_workers()
             && !self.calls.has_pending_task_handoff()
@@ -51,9 +48,7 @@ impl M68kExecution {
         if let Some(active) = self.calls.active_m68k() {
             return Some(active);
         }
-        let pending = self
-            .calls
-            .activate_m68k_parking(&mut self.parked, &mut self.cpu)?;
+        let pending = self.calls.activate_m68k_parking(&mut self.cpu)?;
         for (index, value) in pending.registers.data.into_iter().enumerate() {
             self.cpu.core.set_d(index, value);
         }
@@ -67,18 +62,15 @@ impl M68kExecution {
 
     /// Apply a completed native result to its actual caller, then restore it.
     pub(crate) fn resume_after_powerpc(&mut self, memory: &mut PpcSectionMem) -> bool {
-        let Some(parked) = self
-            .calls
-            .commit_m68k_resume(&mut self.parked, |resume, parked| {
-                let cpu = parked.unwrap_or(&mut self.cpu);
-                if !Self::apply_m68k_resume_result(cpu, memory, resume) {
-                    return false;
-                }
-                cpu.write_reg(Register::PC, resume.return_pc);
-                cpu.write_reg(Register::A7, resume.final_sp);
-                true
-            })
-        else {
+        let Some(parked) = self.calls.commit_m68k_resume(|resume, parked| {
+            let cpu = parked.unwrap_or(&mut self.cpu);
+            if !Self::apply_m68k_resume_result(cpu, memory, resume) {
+                return false;
+            }
+            cpu.write_reg(Register::PC, resume.return_pc);
+            cpu.write_reg(Register::A7, resume.final_sp);
+            true
+        }) else {
             return false;
         };
         if let Some(parked) = parked {

--- a/src/execution_m68k.rs
+++ b/src/execution_m68k.rs
@@ -44,11 +44,14 @@ impl M68kExecution {
     }
 
     /// Validate and park the outgoing context before installing the callback.
-    pub(crate) fn activate_pending(&mut self) -> Option<PendingM68kExecution> {
+    pub(crate) fn activate_pending(
+        &mut self,
+        native: &ppc::PpcCpu,
+    ) -> Option<PendingM68kExecution> {
         if let Some(active) = self.calls.active_m68k() {
             return Some(active);
         }
-        let pending = self.calls.activate_m68k_parking(&mut self.cpu)?;
+        let pending = self.calls.activate_m68k_parking(&mut self.cpu, native)?;
         for (index, value) in pending.registers.data.into_iter().enumerate() {
             self.cpu.core.set_d(index, value);
         }

--- a/src/execution_m68k.rs
+++ b/src/execution_m68k.rs
@@ -24,9 +24,25 @@ impl M68kExecution {
         }
     }
 
+    pub(crate) fn apply_task_handoff(&mut self) {
+        if let Some(context) = self.calls.take_classic_task_handoff() {
+            for (index, value) in context.d_regs.into_iter().enumerate() {
+                self.cpu.core.set_d(index, value);
+            }
+            for (index, value) in context.a_regs.into_iter().enumerate() {
+                self.cpu.core.set_a(index, value);
+            }
+            self.cpu.write_reg(Register::PC, context.pc);
+            self.cpu.core.set_ccr(context.ccr);
+        }
+    }
+
     /// A launch cannot discard contexts still associated with live calls.
     pub(crate) fn can_relaunch(&self) -> bool {
-        self.parked.is_empty() && self.calls.is_empty() && !self.calls.has_live_workers()
+        self.parked.is_empty()
+            && self.calls.is_empty()
+            && !self.calls.has_live_workers()
+            && !self.calls.has_pending_task_handoff()
     }
 
     /// Validate and park the outgoing context before installing the callback.

--- a/src/execution_m68k.rs
+++ b/src/execution_m68k.rs
@@ -26,7 +26,7 @@ impl M68kExecution {
 
     /// A launch cannot discard contexts still associated with live calls.
     pub(crate) fn can_relaunch(&self) -> bool {
-        self.parked.is_empty() && self.calls.is_empty()
+        self.parked.is_empty() && self.calls.is_empty() && !self.calls.has_live_workers()
     }
 
     /// Validate and park the outgoing context before installing the callback.

--- a/src/guest_call.rs
+++ b/src/guest_call.rs
@@ -936,16 +936,28 @@ impl SharedGuestCallStack {
         );
     }
 
+    #[cfg(test)]
     pub(crate) fn classic_thread_pool_count(&self, minimum_size: u32) -> usize {
+        self.thread_pool_count(GuestIsa::M68k, minimum_size)
+    }
+
+    pub(crate) fn thread_pool_count(&self, isa: GuestIsa, minimum_size: u32) -> usize {
         self.0
             .borrow()
             .thread_pool
             .iter()
-            .filter(|(isa, storage)| {
-                *isa == GuestIsa::M68k
+            .filter(|(entry_isa, storage)| {
+                *entry_isa == isa
                     && storage.stack_limit.saturating_sub(storage.stack_base) >= minimum_size
             })
             .count()
+    }
+
+    pub(crate) fn publish_thread_pool(&self, isa: GuestIsa, storage: Vec<ThreadStorage>) {
+        self.0
+            .borrow_mut()
+            .thread_pool
+            .extend(storage.into_iter().map(|storage| (isa, storage)));
     }
 
     pub(crate) fn switch_from_classic(

--- a/src/guest_call.rs
+++ b/src/guest_call.rs
@@ -486,6 +486,64 @@ impl ExecutionTaskCalls {
         }
     }
 
+    fn change_thread_state(
+        &mut self,
+        thread: u32,
+        new_state: u16,
+        suggested: u32,
+        end_critical: bool,
+        commit: impl FnOnce() -> bool,
+    ) -> Result<Option<(ExecutionTaskId, TaskResumeContext)>, i16> {
+        use crate::thread_manager::{THREAD_NOT_FOUND_ERR, THREAD_PROTOCOL_ERR};
+        let task = if thread <= 1 {
+            self.kernel.current_task()
+        } else {
+            ExecutionTaskId::from_thread_id(thread)
+        };
+        if self.kernel.scheduling_state(task).is_none() {
+            return Err(THREAD_NOT_FOUND_ERR);
+        }
+        let requested = match new_state {
+            0 => ExecutionTaskState::Ready,
+            1 => ExecutionTaskState::Stopped,
+            2 => ExecutionTaskState::Running,
+            _ => return Err(THREAD_PROTOCOL_ERR),
+        };
+        if self.handoff.is_some() {
+            return Err(THREAD_PROTOCOL_ERR);
+        }
+        // Capture only the selected candidate before the kernel's atomic commit.
+        let candidate = self
+            .kernel
+            .next_ready_task_after_critical(
+                (suggested > 1).then(|| ExecutionTaskId::from_thread_id(suggested)),
+                end_critical,
+            )
+            .and_then(|next| self.saved_context(next).map(|context| (next, context)));
+        let mut successor = None;
+        self.kernel
+            .change_thread_state_with(
+                task,
+                requested,
+                (suggested > 1).then(|| ExecutionTaskId::from_thread_id(suggested)),
+                end_critical,
+                |next| {
+                    if let Some(next) = next {
+                        let Some((task, context)) = candidate else {
+                            return false;
+                        };
+                        if task != next {
+                            return false;
+                        }
+                        successor = Some((next, context));
+                    }
+                    commit()
+                },
+            )
+            .ok_or(THREAD_PROTOCOL_ERR)?;
+        Ok(successor)
+    }
+
     fn save_native_cpu(&mut self, task: ExecutionTaskId, cpu: &PpcCpu) {
         if self.kernel.scheduling_state(task).is_none() {
             return;
@@ -649,17 +707,6 @@ impl SharedGuestCallStack {
         state: ExecutionTaskState,
     ) -> bool {
         self.0.borrow().kernel.set_scheduling_state(task, state)
-    }
-
-    pub(crate) fn set_state_ending_critical(
-        &self,
-        task: ExecutionTaskId,
-        state: ExecutionTaskState,
-    ) -> bool {
-        self.0
-            .borrow()
-            .kernel
-            .set_state_ending_critical(task, state)
     }
 
     pub(crate) fn next_ready_task(
@@ -849,6 +896,52 @@ impl SharedGuestCallStack {
                 .set_scheduling_state(task, ExecutionTaskState::Ready));
         }
         Some(task)
+    }
+
+    pub(crate) fn set_native_thread_state(
+        &self,
+        cpu: &mut PpcCpu,
+        thread: u32,
+        new_state: u16,
+        suggested: u32,
+        end_critical: bool,
+    ) -> Result<bool, i16> {
+        let mut tasks = self.0.borrow_mut();
+        let current = tasks.kernel.current_task();
+        let successor =
+            tasks.change_thread_state(thread, new_state, suggested, end_critical, || true)?;
+        let Some((next, context)) = successor else {
+            return Ok(false);
+        };
+        let mut outgoing = cpu.clone();
+        outgoing.pc = outgoing.lr;
+        outgoing.gpr[3] = 0;
+        tasks.save_native_cpu(current, &outgoing);
+        *cpu = outgoing;
+        tasks.native_cpu_task = Some(current);
+        tasks.install_native_successor(next, context, cpu);
+        Ok(true)
+    }
+
+    pub(crate) fn set_classic_thread_state(
+        &self,
+        thread: u32,
+        new_state: u16,
+        suggested: u32,
+        end_critical: bool,
+        outgoing: CooperativeThread,
+        commit: impl FnOnce() -> bool,
+    ) -> Result<bool, i16> {
+        let mut tasks = self.0.borrow_mut();
+        let current = tasks.kernel.current_task();
+        let successor =
+            tasks.change_thread_state(thread, new_state, suggested, end_critical, commit)?;
+        let Some((next, context)) = successor else {
+            return Ok(false);
+        };
+        tasks.cooperative_contexts.insert(current, outgoing);
+        tasks.handoff = Some((next, context));
+        Ok(true)
     }
 
     /// Native ABI edge supplies the live CPU; the owner validates the next

--- a/src/guest_call.rs
+++ b/src/guest_call.rs
@@ -1032,6 +1032,25 @@ impl SharedGuestCallStack {
         tasks.native_cpu_task = Some(tasks.kernel.current_task());
     }
 
+    /// Select bounds for the installed native engine, which can still belong
+    /// to a suspended task while a classic task owns the scheduling cursor.
+    pub(crate) fn native_stack_bounds(
+        &self,
+        application_base: u32,
+        application_limit: u32,
+    ) -> Option<(u32, u32)> {
+        let tasks = self.0.borrow();
+        if let Some(task) = tasks.native_cpu_task {
+            if task != ExecutionTaskId::APPLICATION
+                && tasks.kernel.task_entry_isa(task) == Some(GuestIsa::PowerPc)
+            {
+                let storage = tasks.thread_storage.get(task)?;
+                return Some((storage.stack_base, storage.stack_limit));
+            }
+        }
+        Some((application_base, application_limit))
+    }
+
     pub(crate) fn has_classic_task_handoff(&self) -> bool {
         matches!(
             self.0.borrow().handoff,

--- a/src/guest_call.rs
+++ b/src/guest_call.rs
@@ -17,8 +17,8 @@ pub(crate) use crate::execution_kernel::{
     PendingPowerPcExecution, PowerPcArguments, PowerPcReturnState,
 };
 use crate::execution_kernel::{
-    ExecutionContextBank, ExecutionRoute, ExecutionTaskContextBank, ExecutionTaskEffect,
-    ExecutionTaskState, NativeAvailability,
+    ExecutionContextBank, ExecutionRoute, ExecutionTaskContextBank, ExecutionTaskState,
+    NativeAvailability,
 };
 use crate::guest_procedure::GuestIsa;
 use ppc::{PpcCpu, PpcImportAction, PpcNativeReturnGpr3};
@@ -368,6 +368,21 @@ pub(crate) struct NativeThreadContext {
     pub(crate) stack_base: u32,
 }
 
+#[derive(Clone, Debug)]
+enum TaskResumeContext {
+    Classic(CooperativeThread),
+    Native(Box<PpcCpu>),
+}
+
+impl TaskResumeContext {
+    fn isa(&self) -> GuestIsa {
+        match self {
+            Self::Classic(_) => GuestIsa::M68k,
+            Self::Native(_) => GuestIsa::PowerPc,
+        }
+    }
+}
+
 #[derive(Debug)]
 struct ExecutionTaskCalls {
     /// Authoritative task/order/phase state. The frame map below is only the
@@ -377,6 +392,8 @@ struct ExecutionTaskCalls {
     powerpc_contexts: ExecutionContextBank<Box<PpcCpu>>,
     cooperative_contexts: ExecutionTaskContextBank<CooperativeThread>,
     native_threads: ExecutionTaskContextBank<NativeThreadContext>,
+    native_cpu_task: Option<ExecutionTaskId>,
+    handoff: Option<(ExecutionTaskId, TaskResumeContext)>,
 }
 
 impl Clone for ExecutionTaskCalls {
@@ -387,6 +404,8 @@ impl Clone for ExecutionTaskCalls {
             powerpc_contexts: self.powerpc_contexts.clone(),
             cooperative_contexts: self.cooperative_contexts.clone(),
             native_threads: self.native_threads.clone(),
+            native_cpu_task: self.native_cpu_task,
+            handoff: self.handoff.clone(),
         }
     }
 }
@@ -398,6 +417,15 @@ impl PartialEq for ExecutionTaskCalls {
             && self.powerpc_contexts.same_slots(&other.powerpc_contexts)
             && self.cooperative_contexts == other.cooperative_contexts
             && self.native_threads.same_tasks(&other.native_threads)
+            && self.native_cpu_task == other.native_cpu_task
+            && self
+                .handoff
+                .as_ref()
+                .map(|(task, context)| (*task, context.isa()))
+                == other
+                    .handoff
+                    .as_ref()
+                    .map(|(task, context)| (*task, context.isa()))
     }
 }
 
@@ -411,15 +439,95 @@ impl Default for ExecutionTaskCalls {
             powerpc_contexts: ExecutionContextBank::default(),
             cooperative_contexts: ExecutionTaskContextBank::default(),
             native_threads: ExecutionTaskContextBank::default(),
+            native_cpu_task: None,
+            handoff: None,
         }
     }
 }
 
 impl ExecutionTaskCalls {
+    fn saved_context(&self, task: ExecutionTaskId) -> Option<TaskResumeContext> {
+        let isa = self
+            .kernel
+            .peek(task)
+            .and_then(|call| {
+                let frame = self.frames.get(&call.call_id())?;
+                Some(
+                    if call.phase() == crate::execution_kernel::ContinuationPhase::Active {
+                        frame.target.isa
+                    } else {
+                        match frame.origin {
+                            GuestCallOrigin::M68k(_) => GuestIsa::M68k,
+                            GuestCallOrigin::PowerPc(_) => GuestIsa::PowerPc,
+                        }
+                    },
+                )
+            })
+            .unwrap_or_else(|| {
+                if self.kernel.task_entry_isa(task) == Some(GuestIsa::PowerPc)
+                    || (self.native_threads.get(task).is_some()
+                        && self.cooperative_contexts.get(task).is_none())
+                {
+                    GuestIsa::PowerPc
+                } else {
+                    GuestIsa::M68k
+                }
+            });
+        match isa {
+            GuestIsa::M68k => self
+                .cooperative_contexts
+                .get(task)
+                .cloned()
+                .map(TaskResumeContext::Classic),
+            GuestIsa::PowerPc => self
+                .native_threads
+                .get(task)
+                .map(|saved| TaskResumeContext::Native(saved.cpu.clone())),
+        }
+    }
+
+    fn save_native_cpu(&mut self, task: ExecutionTaskId, cpu: &PpcCpu) {
+        if self.kernel.scheduling_state(task).is_none() {
+            return;
+        }
+        let mut context = self
+            .native_threads
+            .get(task)
+            .cloned()
+            .unwrap_or(NativeThreadContext {
+                cpu: Box::new(cpu.clone()),
+                result_destination: 0,
+                stack_base: 0,
+            });
+        context.cpu = Box::new(cpu.clone());
+        self.native_threads.insert(task, context);
+    }
+
+    fn install_native_successor(
+        &mut self,
+        task: ExecutionTaskId,
+        context: TaskResumeContext,
+        cpu: &mut PpcCpu,
+    ) {
+        match context {
+            TaskResumeContext::Classic(context) => {
+                self.handoff = Some((task, TaskResumeContext::Classic(context)));
+            }
+            TaskResumeContext::Native(next) => {
+                let time_base = cpu.time_base().max(next.time_base());
+                *cpu = *next;
+                cpu.set_time_base(time_base);
+                self.native_cpu_task = Some(task);
+            }
+        }
+    }
+
     fn is_pristine(&self) -> bool {
         self.kernel.is_pristine()
             && self.cooperative_contexts.is_empty()
             && self.native_threads.is_empty()
+            && self.native_cpu_task.is_none()
+            && self.handoff.is_none()
     }
 }
 
@@ -494,8 +602,9 @@ impl SharedGuestCallStack {
         self.0.borrow().kernel.register_task(task).is_ok()
     }
 
+    #[cfg(test)]
     pub(crate) fn switch_to_task(&self, task: ExecutionTaskId) -> bool {
-        self.apply_task_effect(ExecutionTaskEffect::SwitchTo(task))
+        self.0.borrow().kernel.switch_to_task(task).is_ok()
     }
 
     pub(crate) fn create_task(&self) -> Option<ExecutionTaskId> {
@@ -571,10 +680,6 @@ impl SharedGuestCallStack {
         self.0.borrow().kernel.end_critical()
     }
 
-    fn apply_task_effect(&self, effect: ExecutionTaskEffect) -> bool {
-        self.0.borrow().kernel.apply_task_effect(effect).is_ok()
-    }
-
     /// Drop a retired task's empty continuation stack.
     ///
     /// A non-empty stack denotes suspended execution and cannot be discarded.
@@ -600,12 +705,12 @@ impl SharedGuestCallStack {
         let mut tasks = self.0.borrow_mut();
         // Native stack/result ownership cannot be retired through the classic
         // projection. Mixed-ISA disposal must use the owning task record.
-        if tasks.native_threads.get(task).is_some() {
+        if tasks.kernel.task_entry_isa(task) == Some(GuestIsa::PowerPc) || tasks.handoff.is_some() {
             return None;
         }
         let finished = tasks.cooperative_contexts.get(task)?.clone();
         let next = match successor {
-            Some(next) => Some(tasks.cooperative_contexts.get(next)?.clone()),
+            Some(next) => Some((next, tasks.saved_context(next)?)),
             None => None,
         };
         tasks
@@ -614,7 +719,114 @@ impl SharedGuestCallStack {
             .ok()?;
         tasks.cooperative_contexts.remove(task);
         tasks.native_threads.remove(task);
-        Some((finished, next))
+        let classic = match next {
+            Some((_, TaskResumeContext::Classic(context))) => Some(context),
+            Some((next, context)) => {
+                tasks.handoff = Some((next, context));
+                None
+            }
+            None => None,
+        };
+        Some((finished, classic))
+    }
+
+    pub(crate) fn switch_from_classic(
+        &self,
+        next: ExecutionTaskId,
+    ) -> Option<Option<CooperativeThread>> {
+        let mut tasks = self.0.borrow_mut();
+        if tasks.handoff.is_some() {
+            return None;
+        }
+        let context = tasks.saved_context(next)?;
+        tasks.kernel.switch_to_task(next).ok()?;
+        match context {
+            TaskResumeContext::Classic(context) => Some(Some(context)),
+            context => {
+                tasks.handoff = Some((next, context));
+                Some(None)
+            }
+        }
+    }
+
+    pub(crate) fn take_classic_task_handoff(&self) -> Option<CooperativeThread> {
+        let mut tasks = self.0.borrow_mut();
+        let Some((task, TaskResumeContext::Classic(_))) = tasks.handoff.as_ref() else {
+            return None;
+        };
+        if *task != tasks.kernel.current_task() {
+            return None;
+        }
+        match tasks.handoff.take()? {
+            (_, TaskResumeContext::Classic(context)) => Some(context),
+            _ => unreachable!(),
+        }
+    }
+
+    pub(crate) fn start_native_engine(&self) {
+        let mut tasks = self.0.borrow_mut();
+        assert!(
+            tasks.handoff.is_none(),
+            "cannot launch across a pending task handoff"
+        );
+        tasks.native_cpu_task = Some(tasks.kernel.current_task());
+    }
+
+    pub(crate) fn has_classic_task_handoff(&self) -> bool {
+        matches!(
+            self.0.borrow().handoff,
+            Some((_, TaskResumeContext::Classic(_)))
+        )
+    }
+
+    /// Preserve the previous native owner before replacing its engine. A
+    /// classic task may execute while this native CPU is suspended in a callback.
+    pub(crate) fn prepare_native_task(&self, cpu: &mut PpcCpu) -> bool {
+        let mut tasks = self.0.borrow_mut();
+        let current = tasks.kernel.current_task();
+        if tasks.kernel.scheduling_state(current) != Some(ExecutionTaskState::Running) {
+            return false;
+        }
+        if tasks
+            .handoff
+            .as_ref()
+            .is_some_and(|(task, _)| *task != current)
+        {
+            return false;
+        }
+        if matches!(tasks.handoff, Some((_, TaskResumeContext::Classic(_)))) {
+            return false;
+        }
+        let pending_native = matches!(tasks.handoff, Some((_, TaskResumeContext::Native(_))));
+        let next = if pending_native {
+            match tasks.handoff.take().unwrap().1 {
+                TaskResumeContext::Native(cpu) => Some(cpu),
+                _ => unreachable!(),
+            }
+        } else if tasks.native_cpu_task != Some(current) {
+            tasks
+                .native_threads
+                .get(current)
+                .map(|context| context.cpu.clone())
+        } else {
+            None
+        };
+        if tasks.native_cpu_task != Some(current) {
+            if let Some(previous) = tasks.native_cpu_task {
+                tasks.save_native_cpu(previous, cpu);
+            }
+        }
+        if let Some(next) = next {
+            let time_base = cpu.time_base().max(next.time_base());
+            *cpu = *next;
+            cpu.set_time_base(time_base);
+        }
+        tasks.native_cpu_task = Some(current);
+        true
+    }
+
+    pub(crate) fn has_pending_task_handoff(&self) -> bool {
+        self.0.borrow().handoff.is_some()
     }
 
     pub(crate) fn has_live_workers(&self) -> bool {
@@ -648,7 +860,7 @@ impl SharedGuestCallStack {
     ) -> Result<bool, i16> {
         use crate::thread_manager::THREAD_PROTOCOL_ERR;
         let mut tasks = self.0.borrow_mut();
-        if tasks.kernel.critical_depth() != 0 {
+        if tasks.kernel.critical_depth() != 0 || tasks.handoff.is_some() {
             return Err(THREAD_PROTOCOL_ERR);
         }
         let current = tasks.kernel.current_task();
@@ -658,33 +870,18 @@ impl SharedGuestCallStack {
         else {
             return Ok(false);
         };
-        let next_cpu = tasks
-            .native_threads
-            .get(next)
-            .ok_or(THREAD_PROTOCOL_ERR)?
-            .cpu
-            .clone();
+        let next_context = tasks.saved_context(next).ok_or(THREAD_PROTOCOL_ERR)?;
         let mut outgoing = cpu.clone();
         outgoing.pc = outgoing.lr;
         outgoing.gpr[3] = 0;
-        let mut saved = tasks
-            .native_threads
-            .get(current)
-            .cloned()
-            .unwrap_or(NativeThreadContext {
-                cpu: Box::new(outgoing.clone()),
-                result_destination: 0,
-                stack_base: 0,
-            });
-        saved.cpu = Box::new(outgoing);
         tasks
             .kernel
             .switch_to_task(next)
             .map_err(|_| THREAD_PROTOCOL_ERR)?;
-        tasks.native_threads.insert(current, saved);
-        let time_base = cpu.time_base().max(next_cpu.time_base());
-        *cpu = *next_cpu;
-        cpu.set_time_base(time_base);
+        tasks.save_native_cpu(current, &outgoing);
+        *cpu = outgoing;
+        tasks.native_cpu_task = Some(current);
+        tasks.install_native_successor(next, next_context, cpu);
         Ok(true)
     }
 
@@ -695,10 +892,18 @@ impl SharedGuestCallStack {
         commit: impl FnOnce(&NativeThreadContext) -> bool,
     ) -> Option<NativeThreadContext> {
         let mut tasks = self.0.borrow_mut();
+        if tasks.handoff.is_some() {
+            return None;
+        }
+        if tasks.kernel.task_entry_isa(task) == Some(GuestIsa::M68k)
+            && tasks.cooperative_contexts.get(task).is_some()
+        {
+            return None;
+        }
         let finished = tasks.native_threads.get(task)?.clone();
         let successor = if task == tasks.kernel.current_task() {
             let next = tasks.kernel.next_ready_task(None)?;
-            Some((next, tasks.native_threads.get(next)?.cpu.clone()))
+            Some((next, tasks.saved_context(next)?))
         } else {
             None
         };
@@ -710,10 +915,9 @@ impl SharedGuestCallStack {
             .ok()?;
         tasks.native_threads.remove(task);
         tasks.cooperative_contexts.remove(task);
-        if let Some((_, next_cpu)) = successor {
-            let time_base = cpu.time_base().max(next_cpu.time_base());
-            *cpu = *next_cpu;
-            cpu.set_time_base(time_base);
+        if let Some((next, context)) = successor {
+            tasks.native_cpu_task = None;
+            tasks.install_native_successor(next, context, cpu);
         }
         Some(finished)
     }
@@ -1425,6 +1629,54 @@ mod tests {
         )
         .into_ppc_import_action()
         .expect("native PowerPC request should adapt to CallNative")
+    }
+
+    #[test]
+    fn native_retirement_hands_off_to_classic_without_losing_the_native_caller() {
+        let calls = SharedGuestCallStack::default();
+        let mut cpu = PpcCpu::new();
+        cpu.pc = 0x1234;
+        cpu.gpr[20] = 0x1122_3344;
+        calls.start_native_engine();
+        assert!(calls.bind_task_entry_isa(ExecutionTaskId::APPLICATION, GuestIsa::PowerPc));
+        let classic = calls.create_task().unwrap();
+        let mut context = CooperativeThread::default();
+        context.pc = 0x5678;
+        assert!(calls.save_cooperative_context(classic, context));
+        assert!(calls.set_scheduling_state(classic, ExecutionTaskState::Ready));
+        let native = calls
+            .create_native_thread(
+                NativeThreadContext {
+                    cpu: Box::new(PpcCpu::new()),
+                    result_destination: 0,
+                    stack_base: 0,
+                },
+                false,
+                |_| true,
+            )
+            .unwrap();
+        assert!(calls.switch_to_task(native));
+        assert!(calls.prepare_native_task(&mut cpu));
+        assert!(calls
+            .retire_native_thread(native, &mut cpu, |_| true)
+            .is_some());
+        assert_eq!(calls.current_task(), classic);
+        assert!(calls.has_classic_task_handoff());
+        let blocked_pc = cpu.pc;
+        assert!(!calls.prepare_native_task(&mut cpu));
+        assert_eq!(cpu.pc, blocked_pc);
+        assert!(calls
+            .switch_from_classic(ExecutionTaskId::APPLICATION)
+            .is_none());
+        assert_eq!(calls.take_classic_task_handoff().unwrap().pc, 0x5678);
+        assert!(calls
+            .switch_from_classic(ExecutionTaskId::APPLICATION)
+            .unwrap()
+            .is_none());
+        assert!(calls.prepare_native_task(&mut cpu));
+        assert_eq!(cpu.pc, 0x1234);
+        assert_eq!(cpu.gpr[20], 0x1122_3344);
+        assert!(!calls.has_pending_task_handoff());
     }
 
     #[test]

--- a/src/guest_call.rs
+++ b/src/guest_call.rs
@@ -366,7 +366,7 @@ pub(crate) struct ThreadStorage {
     pub(crate) stack_base: u32,
     pub(crate) stack_limit: u32,
     /// Managed pointers are released through the process Memory Manager;
-    /// reserved guest stacks return to the execution owner's classic pool.
+    /// reserved guest stacks use the classic allocator when not recycled.
     pub(crate) managed_pointer: bool,
 }
 
@@ -395,7 +395,7 @@ struct ExecutionTaskCalls {
     cooperative_contexts: ExecutionTaskContextBank<CooperativeThread>,
     native_threads: ExecutionTaskContextBank<NativeThreadContext>,
     thread_storage: ExecutionTaskContextBank<ThreadStorage>,
-    classic_thread_pool: Vec<(u32, u32)>,
+    thread_pool: Vec<(GuestIsa, ThreadStorage)>,
     native_cpu_task: Option<ExecutionTaskId>,
     handoff: Option<(ExecutionTaskId, TaskResumeContext)>,
 }
@@ -409,7 +409,7 @@ impl Clone for ExecutionTaskCalls {
             cooperative_contexts: self.cooperative_contexts.clone(),
             native_threads: self.native_threads.clone(),
             thread_storage: self.thread_storage.clone(),
-            classic_thread_pool: self.classic_thread_pool.clone(),
+            thread_pool: self.thread_pool.clone(),
             native_cpu_task: self.native_cpu_task,
             handoff: self.handoff.clone(),
         }
@@ -424,7 +424,7 @@ impl PartialEq for ExecutionTaskCalls {
             && self.cooperative_contexts == other.cooperative_contexts
             && self.native_threads.same_tasks(&other.native_threads)
             && self.thread_storage == other.thread_storage
-            && self.classic_thread_pool == other.classic_thread_pool
+            && self.thread_pool == other.thread_pool
             && self.native_cpu_task == other.native_cpu_task
             && self
                 .handoff
@@ -448,7 +448,7 @@ impl Default for ExecutionTaskCalls {
             cooperative_contexts: ExecutionTaskContextBank::default(),
             native_threads: ExecutionTaskContextBank::default(),
             thread_storage: ExecutionTaskContextBank::default(),
-            classic_thread_pool: Vec::new(),
+            thread_pool: Vec::new(),
             native_cpu_task: None,
             handoff: None,
         }
@@ -585,8 +585,14 @@ impl ExecutionTaskCalls {
         &mut self,
         task: ExecutionTaskId,
         successor: Option<ExecutionTaskId>,
+        recycle: bool,
         commit: impl FnOnce(&ThreadStorage) -> bool,
     ) -> Option<(ThreadStorage, Option<(ExecutionTaskId, TaskResumeContext)>)> {
+        // Thread Manager (1999), p. 60: DisposeThread may never retire
+        // the application thread, even while a worker is running.
+        if task == ExecutionTaskId::APPLICATION {
+            return None;
+        }
         if self.handoff.is_some() {
             return None;
         }
@@ -595,6 +601,11 @@ impl ExecutionTaskCalls {
             return None;
         }
         let storage = self.thread_storage.get(task).copied().unwrap_or_default();
+        let pooled_isa = if recycle && storage.stack_base != 0 {
+            Some(self.kernel.task_entry_isa(task)?)
+        } else {
+            None
+        };
         let next = match successor {
             Some(next) => Some((next, self.saved_context(next)?)),
             None => None,
@@ -605,9 +616,14 @@ impl ExecutionTaskCalls {
         self.cooperative_contexts.remove(task);
         self.native_threads.remove(task);
         self.thread_storage.remove(task);
-        if storage.stack_base != 0 && !storage.managed_pointer {
-            self.classic_thread_pool
-                .push((storage.stack_base, storage.stack_limit));
+        if let Some(isa) = pooled_isa {
+            self.thread_pool.push((
+                isa,
+                ThreadStorage {
+                    result_destination: 0,
+                    ..storage
+                },
+            ));
         }
         if self.native_cpu_task == Some(task) {
             self.native_cpu_task = None;
@@ -654,7 +670,7 @@ impl ExecutionTaskCalls {
             && self.cooperative_contexts.is_empty()
             && self.native_threads.is_empty()
             && self.thread_storage.is_empty()
-            && self.classic_thread_pool.is_empty()
+            && self.thread_pool.is_empty()
             && self.native_cpu_task.is_none()
             && self.handoff.is_none()
     }
@@ -820,10 +836,11 @@ impl SharedGuestCallStack {
         &self,
         task: ExecutionTaskId,
         successor: Option<ExecutionTaskId>,
+        recycle: bool,
         commit: impl FnOnce(&ThreadStorage) -> bool,
     ) -> Option<(ThreadStorage, Option<CooperativeThread>)> {
         let mut tasks = self.0.borrow_mut();
-        let (finished, next) = tasks.retire_thread(task, successor, commit)?;
+        let (finished, next) = tasks.retire_thread(task, successor, recycle, commit)?;
         let classic = match next {
             Some((_, TaskResumeContext::Classic(context))) => Some(context),
             Some((next, context)) => {
@@ -856,45 +873,78 @@ impl SharedGuestCallStack {
         self.request_classic_thread_stack(size, 2).ok().flatten()
     }
 
-    /// Select storage without publishing a task. Thread Manager (1999),
-    /// pp. 48, 57–58: opt-in pool use, best fit, exact match and -617 refusal.
     pub(crate) fn request_classic_thread_stack(
         &self,
         size: u32,
         options: u32,
     ) -> Result<Option<(u32, u32)>, i16> {
+        self.request_thread_stack(GuestIsa::M68k, size, options)
+            .map(|storage| storage.map(|storage| (storage.stack_base, storage.stack_limit)))
+    }
+
+    /// Select storage without publishing a task. Thread Manager (1999),
+    /// pp. 48, 57–58: same-ISA pool use, best fit, exact match and -617 refusal.
+    pub(crate) fn request_thread_stack(
+        &self,
+        isa: GuestIsa,
+        size: u32,
+        options: u32,
+    ) -> Result<Option<ThreadStorage>, i16> {
         if options & 2 == 0 {
             return Ok(None);
         }
         let mut tasks = self.0.borrow_mut();
         let index = tasks
-            .classic_thread_pool
+            .thread_pool
             .iter()
             .enumerate()
-            .filter_map(|(index, &(base, limit))| {
-                let available = limit.checked_sub(base)?;
-                (base != 0 && available >= size && (options & 16 == 0 || available == size))
+            .filter_map(|(index, (entry_isa, storage))| {
+                let available = storage.stack_limit.checked_sub(storage.stack_base)?;
+                (*entry_isa == isa
+                    && storage.stack_base != 0
+                    && available >= size
+                    && (options & 16 == 0 || available == size))
                     .then_some((index, available))
             })
             .min_by_key(|&(_, available)| available)
             .map(|(index, _)| index);
         match index {
-            Some(index) => Ok(Some(tasks.classic_thread_pool.swap_remove(index))),
+            Some(index) => Ok(Some(tasks.thread_pool.swap_remove(index).1)),
             None if options & 4 != 0 => Ok(None),
             None => Err(-617),
         }
     }
 
+    pub(crate) fn recycle_thread_stack(&self, isa: GuestIsa, storage: ThreadStorage) {
+        self.0.borrow_mut().thread_pool.push((
+            isa,
+            ThreadStorage {
+                result_destination: 0,
+                ..storage
+            },
+        ));
+    }
+
     pub(crate) fn recycle_classic_thread_stack(&self, stack: (u32, u32)) {
-        self.0.borrow_mut().classic_thread_pool.push(stack);
+        self.recycle_thread_stack(
+            GuestIsa::M68k,
+            ThreadStorage {
+                stack_base: stack.0,
+                stack_limit: stack.1,
+                ..ThreadStorage::default()
+            },
+        );
     }
 
     pub(crate) fn classic_thread_pool_count(&self, minimum_size: u32) -> usize {
         self.0
             .borrow()
-            .classic_thread_pool
+            .thread_pool
             .iter()
-            .filter(|(base, limit)| limit.saturating_sub(*base) >= minimum_size)
+            .filter(|(isa, storage)| {
+                *isa == GuestIsa::M68k
+                    && storage.stack_limit.saturating_sub(storage.stack_base) >= minimum_size
+            })
             .count()
     }
 
@@ -1153,6 +1203,7 @@ impl SharedGuestCallStack {
         &self,
         task: ExecutionTaskId,
         cpu: &mut PpcCpu,
+        recycle: bool,
         commit: impl FnOnce(&ThreadStorage) -> bool,
     ) -> Option<ThreadStorage> {
         let mut tasks = self.0.borrow_mut();
@@ -1161,7 +1212,7 @@ impl SharedGuestCallStack {
         } else {
             None
         };
-        let (finished, successor) = tasks.retire_thread(task, successor, commit)?;
+        let (finished, successor) = tasks.retire_thread(task, successor, recycle, commit)?;
         if let Some((next, context)) = successor {
             tasks.install_native_successor(next, context, cpu);
         }
@@ -1878,6 +1929,122 @@ mod tests {
     }
 
     #[test]
+    fn thread_disposal_refuses_the_application_before_committing_either_abi_result() {
+        let calls = SharedGuestCallStack::default();
+        assert!(calls
+            .save_cooperative_context(ExecutionTaskId::APPLICATION, CooperativeThread::default()));
+        let worker = calls
+            .create_classic_thread(
+                CooperativeThread::default(),
+                ThreadStorage::default(),
+                false,
+                |_| true,
+            )
+            .unwrap();
+        for recycle in [false, true] {
+            assert!(calls
+                .retire_cooperative_context(
+                    ExecutionTaskId::APPLICATION,
+                    Some(worker),
+                    recycle,
+                    |_| panic!("application disposal must not write its result")
+                )
+                .is_none());
+            assert!(calls
+                .retire_native_thread(
+                    ExecutionTaskId::APPLICATION,
+                    &mut PpcCpu::new(),
+                    recycle,
+                    |_| panic!("application disposal must not write its result")
+                )
+                .is_none());
+            assert_eq!(calls.current_task(), ExecutionTaskId::APPLICATION);
+            assert_eq!(calls.next_ready_task(None), Some(worker));
+        }
+        assert!(calls.switch_to_task(worker));
+        assert!(calls
+            .retire_cooperative_context(ExecutionTaskId::APPLICATION, None, false, |_| panic!(
+                "a worker must not dispose its application"
+            ))
+            .is_none());
+        assert_eq!(calls.current_task(), worker);
+        assert!(calls
+            .cooperative_context(ExecutionTaskId::APPLICATION)
+            .is_some());
+    }
+
+    #[test]
+    fn thread_recycled_storage_retains_entry_isa_and_is_unavailable_until_retirement_commits() {
+        let calls = SharedGuestCallStack::default();
+        let classic_storage = ThreadStorage {
+            result_destination: 0x8000,
+            stack_base: 0x1000,
+            stack_limit: 0x1800,
+            managed_pointer: false,
+        };
+        let classic = calls
+            .create_classic_thread(CooperativeThread::default(), classic_storage, true, |_| {
+                true
+            })
+            .unwrap();
+        let native = calls
+            .create_native_thread(
+                NativeThreadContext {
+                    cpu: Box::new(PpcCpu::new()),
+                },
+                ThreadStorage {
+                    stack_base: 0x2000,
+                    stack_limit: 0x3000,
+                    managed_pointer: true,
+                    ..classic_storage
+                },
+                true,
+                |_| true,
+            )
+            .unwrap();
+        assert!(calls
+            .retire_cooperative_context(classic, None, true, |_| false)
+            .is_none());
+        assert_eq!(
+            calls.request_thread_stack(GuestIsa::M68k, 1024, 2),
+            Err(-617)
+        );
+        assert_eq!(calls.thread_storage(classic), Some(classic_storage));
+        assert!(calls
+            .retire_cooperative_context(classic, None, true, |_| true)
+            .is_some());
+        assert_eq!(
+            calls.request_thread_stack(GuestIsa::PowerPc, 1024, 2),
+            Err(-617)
+        );
+        assert!(calls
+            .retire_native_thread(native, &mut PpcCpu::new(), true, |_| true)
+            .is_some());
+        assert_eq!(
+            calls.request_thread_stack(GuestIsa::PowerPc, 1024, 2 | 16),
+            Err(-617)
+        );
+        let pooled_native = calls
+            .request_thread_stack(GuestIsa::PowerPc, 4096, 2 | 16)
+            .unwrap()
+            .unwrap();
+        assert_eq!(pooled_native.stack_base, 0x2000);
+        assert!(pooled_native.managed_pointer);
+        assert_eq!(pooled_native.result_destination, 0);
+        let pooled_classic = calls
+            .request_thread_stack(GuestIsa::M68k, 1024, 2)
+            .unwrap()
+            .unwrap();
+        assert_eq!(pooled_classic.stack_base, classic_storage.stack_base);
+        assert!(!pooled_classic.managed_pointer);
+        assert_eq!(pooled_classic.result_destination, 0);
+        assert_eq!(
+            calls.request_thread_stack(GuestIsa::M68k, 1024, 2),
+            Err(-617)
+        );
+    }
+
+    #[test]
     fn native_retirement_hands_off_to_classic_without_losing_the_native_caller() {
         let calls = SharedGuestCallStack::default();
         let mut cpu = PpcCpu::new();
@@ -1908,7 +2075,7 @@ mod tests {
         assert!(calls.switch_to_task(native));
         assert!(calls.prepare_native_task(&mut cpu));
         assert!(calls
-            .retire_native_thread(native, &mut cpu, |_| true)
+            .retire_native_thread(native, &mut cpu, false, |_| true)
             .is_some());
         assert_eq!(calls.current_task(), classic);
         assert!(calls.has_classic_task_handoff());
@@ -2107,7 +2274,7 @@ mod tests {
         assert!(calls.switch_to_task(ExecutionTaskId::APPLICATION));
         assert!(!calls.remove_task(worker));
         assert!(calls
-            .retire_cooperative_context(worker, None, |_| {
+            .retire_cooperative_context(worker, None, false, |_| {
                 panic!("pending continuations must reject retirement before result delivery")
             })
             .is_none());

--- a/src/guest_call.rs
+++ b/src/guest_call.rs
@@ -359,6 +359,15 @@ impl PartialEq for GuestCallFrame {
 
 impl Eq for GuestCallFrame {}
 
+/// Full native engine state is retained, including the CPU's private import
+/// continuations. The active CPU remains with its engine between task switches.
+#[derive(Clone, Debug)]
+pub(crate) struct NativeThreadContext {
+    pub(crate) cpu: Box<PpcCpu>,
+    pub(crate) result_destination: u32,
+    pub(crate) stack_base: u32,
+}
+
 #[derive(Debug)]
 struct ExecutionTaskCalls {
     /// Authoritative task/order/phase state. The frame map below is only the
@@ -367,6 +376,7 @@ struct ExecutionTaskCalls {
     frames: HashMap<CallId, GuestCallFrame>,
     powerpc_contexts: ExecutionContextBank<Box<PpcCpu>>,
     cooperative_contexts: ExecutionTaskContextBank<CooperativeThread>,
+    native_threads: ExecutionTaskContextBank<NativeThreadContext>,
 }
 
 impl Clone for ExecutionTaskCalls {
@@ -376,6 +386,7 @@ impl Clone for ExecutionTaskCalls {
             frames: self.frames.clone(),
             powerpc_contexts: self.powerpc_contexts.clone(),
             cooperative_contexts: self.cooperative_contexts.clone(),
+            native_threads: self.native_threads.clone(),
         }
     }
 }
@@ -386,6 +397,7 @@ impl PartialEq for ExecutionTaskCalls {
             && self.frames == other.frames
             && self.powerpc_contexts.same_slots(&other.powerpc_contexts)
             && self.cooperative_contexts == other.cooperative_contexts
+            && self.native_threads.same_tasks(&other.native_threads)
     }
 }
 
@@ -398,13 +410,16 @@ impl Default for ExecutionTaskCalls {
             frames: HashMap::new(),
             powerpc_contexts: ExecutionContextBank::default(),
             cooperative_contexts: ExecutionTaskContextBank::default(),
+            native_threads: ExecutionTaskContextBank::default(),
         }
     }
 }
 
 impl ExecutionTaskCalls {
     fn is_pristine(&self) -> bool {
-        self.kernel.is_pristine() && self.cooperative_contexts.is_empty()
+        self.kernel.is_pristine()
+            && self.cooperative_contexts.is_empty()
+            && self.native_threads.is_empty()
     }
 }
 
@@ -570,6 +585,7 @@ impl SharedGuestCallStack {
             return false;
         }
         tasks.cooperative_contexts.remove(task);
+        tasks.native_threads.remove(task);
         true
     }
 
@@ -582,6 +598,11 @@ impl SharedGuestCallStack {
         commit: impl FnOnce(&CooperativeThread) -> bool,
     ) -> Option<(CooperativeThread, Option<CooperativeThread>)> {
         let mut tasks = self.0.borrow_mut();
+        // Native stack/result ownership cannot be retired through the classic
+        // projection. Mixed-ISA disposal must use the owning task record.
+        if tasks.native_threads.get(task).is_some() {
+            return None;
+        }
         let finished = tasks.cooperative_contexts.get(task)?.clone();
         let next = match successor {
             Some(next) => Some(tasks.cooperative_contexts.get(next)?.clone()),
@@ -592,7 +613,109 @@ impl SharedGuestCallStack {
             .retire_task_with(task, successor, || commit(&finished))
             .ok()?;
         tasks.cooperative_contexts.remove(task);
+        tasks.native_threads.remove(task);
         Some((finished, next))
+    }
+
+    pub(crate) fn has_live_workers(&self) -> bool {
+        self.0.borrow().kernel.has_live_workers()
+    }
+
+    pub(crate) fn create_native_thread(
+        &self,
+        context: NativeThreadContext,
+        suspended: bool,
+        commit: impl FnOnce(ExecutionTaskId) -> bool,
+    ) -> Option<ExecutionTaskId> {
+        let mut tasks = self.0.borrow_mut();
+        let task = tasks.kernel.create_task_with(commit).ok()?;
+        tasks.kernel.bind_task_entry_isa(task, GuestIsa::PowerPc);
+        tasks.native_threads.insert(task, context);
+        if !suspended {
+            assert!(tasks
+                .kernel
+                .set_scheduling_state(task, ExecutionTaskState::Ready));
+        }
+        Some(task)
+    }
+
+    /// Native ABI edge supplies the live CPU; the owner validates the next
+    /// snapshot before saving the return and committing the selected task.
+    pub(crate) fn yield_native_thread(
+        &self,
+        cpu: &mut PpcCpu,
+        suggested: u32,
+    ) -> Result<bool, i16> {
+        use crate::thread_manager::THREAD_PROTOCOL_ERR;
+        let mut tasks = self.0.borrow_mut();
+        if tasks.kernel.critical_depth() != 0 {
+            return Err(THREAD_PROTOCOL_ERR);
+        }
+        let current = tasks.kernel.current_task();
+        let Some(next) = tasks
+            .kernel
+            .next_ready_task((suggested > 1).then(|| ExecutionTaskId::from_thread_id(suggested)))
+        else {
+            return Ok(false);
+        };
+        let next_cpu = tasks
+            .native_threads
+            .get(next)
+            .ok_or(THREAD_PROTOCOL_ERR)?
+            .cpu
+            .clone();
+        let mut outgoing = cpu.clone();
+        outgoing.pc = outgoing.lr;
+        outgoing.gpr[3] = 0;
+        let mut saved = tasks
+            .native_threads
+            .get(current)
+            .cloned()
+            .unwrap_or(NativeThreadContext {
+                cpu: Box::new(outgoing.clone()),
+                result_destination: 0,
+                stack_base: 0,
+            });
+        saved.cpu = Box::new(outgoing);
+        tasks
+            .kernel
+            .switch_to_task(next)
+            .map_err(|_| THREAD_PROTOCOL_ERR)?;
+        tasks.native_threads.insert(current, saved);
+        let time_base = cpu.time_base().max(next_cpu.time_base());
+        *cpu = *next_cpu;
+        cpu.set_time_base(time_base);
+        Ok(true)
+    }
+
+    pub(crate) fn retire_native_thread(
+        &self,
+        task: ExecutionTaskId,
+        cpu: &mut PpcCpu,
+        commit: impl FnOnce(&NativeThreadContext) -> bool,
+    ) -> Option<NativeThreadContext> {
+        let mut tasks = self.0.borrow_mut();
+        let finished = tasks.native_threads.get(task)?.clone();
+        let successor = if task == tasks.kernel.current_task() {
+            let next = tasks.kernel.next_ready_task(None)?;
+            Some((next, tasks.native_threads.get(next)?.cpu.clone()))
+        } else {
+            None
+        };
+        tasks
+            .kernel
+            .retire_task_with(task, successor.as_ref().map(|(task, _)| *task), || {
+                commit(&finished)
+            })
+            .ok()?;
+        tasks.native_threads.remove(task);
+        tasks.cooperative_contexts.remove(task);
+        if let Some((_, next_cpu)) = successor {
+            let time_base = cpu.time_base().max(next_cpu.time_base());
+            *cpu = *next_cpu;
+            cpu.set_time_base(time_base);
+        }
+        Some(finished)
     }
 
     pub(crate) fn cooperative_context(&self, task: ExecutionTaskId) -> Option<CooperativeThread> {
@@ -1302,6 +1425,54 @@ mod tests {
         )
         .into_ppc_import_action()
         .expect("native PowerPC request should adapt to CallNative")
+    }
+
+    #[test]
+    fn native_yield_preflights_context_and_critical_state_before_saving_return() {
+        let calls = SharedGuestCallStack::default();
+        let mut cpu = PpcCpu::new();
+        cpu.pc = 0x1234;
+        cpu.lr = 0x4560;
+        cpu.gpr[3] = 99;
+        let worker = calls
+            .create_native_thread(
+                NativeThreadContext {
+                    cpu: Box::new(PpcCpu::new()),
+                    result_destination: 0,
+                    stack_base: 0,
+                },
+                false,
+                |_| true,
+            )
+            .unwrap();
+        calls.begin_critical();
+        assert_eq!(
+            calls.yield_native_thread(&mut cpu, worker.thread_id()),
+            Err(-619)
+        );
+        assert_eq!(cpu.pc, 0x1234);
+        assert_eq!(cpu.gpr[3], 99);
+        assert_eq!(calls.current_task(), ExecutionTaskId::APPLICATION);
+        assert!(calls.end_critical());
+        let classic = calls.create_task().unwrap();
+        assert!(calls.set_scheduling_state(classic, ExecutionTaskState::Ready));
+        assert_eq!(
+            calls.yield_native_thread(&mut cpu, classic.thread_id()),
+            Err(-619)
+        );
+        assert_eq!(cpu.pc, 0x1234);
+        assert_eq!(cpu.gpr[3], 99);
+        assert_eq!(calls.current_task(), ExecutionTaskId::APPLICATION);
+        assert!(calls
+            .yield_native_thread(&mut cpu, worker.thread_id())
+            .unwrap());
+        assert_eq!(calls.current_task(), worker);
+        cpu.lr = 0x9000;
+        assert!(calls
+            .yield_native_thread(&mut cpu, ExecutionTaskId::APPLICATION.thread_id())
+            .unwrap());
+        assert_eq!(cpu.pc, 0x4560);
+        assert_eq!(cpu.gpr[3], 0);
     }
 
     #[test]

--- a/src/guest_call.rs
+++ b/src/guest_call.rs
@@ -1403,9 +1403,9 @@ impl SharedGuestCallStack {
         ))
     }
 
-    /// Park a native caller and retain the emulated 68k execution interval
-    /// that will satisfy it. The caller's PowerPC registers remain in its CPU
-    /// context; only the documented return state is applied at completion.
+    /// Prepare the emulated 68K interval for a native caller. Activation
+    /// retains its complete native context; completion restores that context
+    /// before applying the documented return state.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn begin_powerpc_to_m68k(
         &self,
@@ -1696,16 +1696,23 @@ impl SharedGuestCallStack {
     /// Return the top cross-ISA 68k interval and mark its CPU context active.
     #[cfg(test)]
     pub(crate) fn activate_m68k(&self) -> Option<PendingM68kExecution> {
-        self.activate_m68k_in_bank(&mut ExecutionContextBank::<()>::default(), &mut (), None)
+        self.activate_m68k_in_bank(
+            &mut ExecutionContextBank::<()>::default(),
+            &mut (),
+            None,
+            None,
+        )
     }
 
     pub(crate) fn activate_m68k_parking(
         &self,
         installed: &mut M68kCpu,
+        native: &PpcCpu,
     ) -> Option<PendingM68kExecution> {
         let caller = self.suspended_m68k_context_owner().map(|(_, call)| call);
         let bank = self.classic_contexts();
-        let pending = self.activate_m68k_in_bank(&mut bank.borrow_mut(), installed, caller);
+        let pending =
+            self.activate_m68k_in_bank(&mut bank.borrow_mut(), installed, caller, Some(native));
         pending
     }
 
@@ -1714,6 +1721,7 @@ impl SharedGuestCallStack {
         bank: &mut ExecutionContextBank<T>,
         installed: &mut T,
         caller: Option<CallId>,
+        native: Option<&PpcCpu>,
     ) -> Option<PendingM68kExecution> {
         let (task, call_id, pending, started) = {
             let tasks = self.0.borrow();
@@ -1735,8 +1743,21 @@ impl SharedGuestCallStack {
             return Some(pending);
         }
         let mut tasks = self.0.borrow_mut();
-        bank.activate_parking_caller(&tasks.kernel, task, call_id, caller, installed)
+        if let Some(native) = native {
+            let kernel = tasks.kernel.shared_handle();
+            bank.activate_parking_caller_with_context(
+                &kernel,
+                task,
+                call_id,
+                caller,
+                installed,
+                Some((&mut tasks.powerpc_contexts, Box::new(native.clone()))),
+            )
             .ok()?;
+        } else {
+            bank.activate_parking_caller(&tasks.kernel, task, call_id, caller, installed)
+                .ok()?;
+        }
         let frame = tasks
             .frames
             .get_mut(&call_id)
@@ -1896,9 +1917,27 @@ impl SharedGuestCallStack {
             (task, semantic.call_id(), origin)
         };
         let mut tasks = self.0.borrow_mut();
-        if tasks.kernel.complete(task, call_id, result).is_err() {
+        let native = if tasks.powerpc_contexts.contains(task, call_id) {
+            let kernel = tasks.kernel.shared_handle();
+            let Ok((context, _)) = tasks
+                .powerpc_contexts
+                .take_while_completing(&kernel, task, call_id, result)
+            else {
+                return false;
+            };
+            Some(context)
+        } else {
+            #[cfg(not(test))]
             return false;
-        }
+            #[cfg(test)]
+            {
+                // Register-only unit fixtures have no native engine to retain.
+                if tasks.kernel.complete(task, call_id, result).is_err() {
+                    return false;
+                }
+                None
+            }
+        };
         let _ = tasks
             .kernel
             .retire(task, call_id)
@@ -1907,6 +1946,11 @@ impl SharedGuestCallStack {
             .frames
             .remove(&call_id)
             .expect("semantic continuation must have an adapter frame");
+        if let Some(native) = native {
+            let time_base = cpu.time_base().max(native.time_base());
+            *cpu = *native;
+            cpu.set_time_base(time_base);
+        }
         if let Some(result) = result {
             cpu.gpr[3] = result;
         }
@@ -2883,6 +2927,88 @@ mod tests {
         assert!(calls.complete_m68k_for_powerpc(0x4000, 0x3004, None, &mut cpu));
         assert_eq!((cpu.pc, cpu.lr, cpu.gpr[2]), (0x5000, 0x5000, 0x6000));
         assert!(calls.is_empty());
+    }
+
+    #[test]
+    fn classic_callback_activation_retains_native_context_until_a_valid_return() {
+        for occupied in [false, true] {
+            let calls = SharedGuestCallStack::default();
+            assert!(calls.begin_powerpc_to_m68k(
+                GuestCallTarget {
+                    isa: GuestIsa::M68k,
+                    entry: 0x2000,
+                    rtoc: 0
+                },
+                0x2000,
+                0x3000,
+                0x4000,
+                0x3004,
+                M68kRegisterState::default(),
+                Some(M68kResultSource::Data(0)),
+                0x5000,
+                0x6000,
+                PpcNativeReturnGpr3::Preserve
+            ));
+            let (call, _) = calls.top_frame().unwrap();
+            let mut native = PpcCpu::new();
+            native.gpr[1] = 0x9000;
+            native.gpr[20] = 0xabcdef;
+            native.fpr[20] = 0x400921fb54442d18;
+            native.cr = 0x12345678;
+            native.set_time_base(7);
+            if occupied {
+                let kernel = calls.0.borrow().kernel.shared_handle();
+                assert!(calls
+                    .0
+                    .borrow_mut()
+                    .powerpc_contexts
+                    .park(
+                        &kernel,
+                        ExecutionTaskId::APPLICATION,
+                        call,
+                        Box::new(native.clone())
+                    )
+                    .is_ok());
+            }
+            let mut classic = M68kCpu::new();
+            classic.core.set_d(6, 0x7777);
+            let activated = calls.activate_m68k_parking(&mut classic, &native);
+            if occupied {
+                assert!(activated.is_none());
+                assert_eq!(classic.core.d(6), 0x7777);
+                assert!(calls.active_m68k().is_none());
+                continue;
+            }
+            assert!(activated.is_some());
+            assert!(calls
+                .0
+                .borrow()
+                .powerpc_contexts
+                .contains(ExecutionTaskId::APPLICATION, call));
+            native.gpr[1] = 0x1111;
+            native.gpr[20] = 0;
+            native.fpr[20] = 0;
+            native.cr = 0;
+            native.set_time_base(44);
+            assert!(!calls.complete_m68k_for_powerpc(0x4000, 0x3000, Some(42), &mut native));
+            assert_eq!(native.gpr[1], 0x1111);
+            assert!(calls
+                .0
+                .borrow()
+                .powerpc_contexts
+                .contains(ExecutionTaskId::APPLICATION, call));
+            assert!(calls.complete_m68k_for_powerpc(0x4000, 0x3004, Some(42), &mut native));
+            assert_eq!(
+                (native.gpr[1], native.gpr[2], native.gpr[3]),
+                (0x9000, 0x6000, 42)
+            );
+            assert_eq!(native.gpr[20], 0xabcdef);
+            assert_eq!(native.fpr[20], 0x400921fb54442d18);
+            assert_eq!(native.cr, 0x12345678);
+            assert_eq!(native.time_base(), 44);
+            assert!(calls.0.borrow().powerpc_contexts.is_empty());
+            assert!(calls.is_empty());
+        }
     }
 
     #[test]

--- a/src/guest_call.rs
+++ b/src/guest_call.rs
@@ -1449,9 +1449,28 @@ impl SharedGuestCallStack {
         )
     }
 
+    #[cfg(test)]
     pub(crate) fn activate_powerpc_from_m68k(
         &self,
         cpu: &mut PpcCpu,
+        return_pc: u32,
+    ) -> Option<PendingPowerPcExecution> {
+        self.activate_powerpc_transition(cpu, None, return_pc)
+    }
+
+    pub(crate) fn activate_powerpc_with_classic_caller(
+        &self,
+        cpu: &mut PpcCpu,
+        caller: &mut M68kCpu,
+        return_pc: u32,
+    ) -> Option<PendingPowerPcExecution> {
+        self.activate_powerpc_transition(cpu, Some(caller), return_pc)
+    }
+
+    fn activate_powerpc_transition(
+        &self,
+        cpu: &mut PpcCpu,
+        caller: Option<&mut M68kCpu>,
         return_pc: u32,
     ) -> Option<PendingPowerPcExecution> {
         let (task, call_id, target, arguments) = {
@@ -1470,10 +1489,25 @@ impl SharedGuestCallStack {
         };
         let mut tasks = self.0.borrow_mut();
         let kernel = tasks.kernel.shared_handle();
-        tasks
-            .powerpc_contexts
-            .park_while_activating(&kernel, task, call_id, Box::new(cpu.clone()))
-            .ok()?;
+        if let Some(caller) = caller {
+            let bank = Rc::clone(&tasks.m68k_contexts);
+            tasks
+                .powerpc_contexts
+                .park_pair_while_activating(
+                    &mut bank.borrow_mut(),
+                    &kernel,
+                    task,
+                    call_id,
+                    Box::new(cpu.clone()),
+                    caller,
+                )
+                .ok()?;
+        } else {
+            tasks
+                .powerpc_contexts
+                .park_while_activating(&kernel, task, call_id, Box::new(cpu.clone()))
+                .ok()?;
+        }
         let frame = tasks
             .frames
             .get_mut(&call_id)
@@ -2570,6 +2604,81 @@ mod tests {
         assert!(calls.complete_powerpc(&mut cpu));
         assert_eq!(cpu.pc, 0x2000);
         assert!(calls.is_empty());
+    }
+
+    #[test]
+    fn initial_native_transition_owns_its_classic_caller_and_refuses_duplicate_contexts() {
+        for occupied in [false, true] {
+            let calls = SharedGuestCallStack::default();
+            assert!(calls.begin_m68k_to_powerpc(
+                GuestCallTarget {
+                    isa: GuestIsa::PowerPc,
+                    entry: 0x1000,
+                    rtoc: 0x2000
+                },
+                PowerPcArguments::from_slice(&[]).unwrap(),
+                0x3000,
+                0x4000,
+                None
+            ));
+            let (call, _) = calls.top_frame().unwrap();
+            let bank = calls.m68k_context_bank();
+            if occupied {
+                assert!(calls
+                    .park_context(
+                        &mut bank.borrow_mut(),
+                        ExecutionTaskId::APPLICATION,
+                        call,
+                        M68kCpu::new()
+                    )
+                    .is_ok());
+            }
+            let mut classic = M68kCpu::new();
+            classic.core.set_a(7, 0x9876);
+            classic.core.set_d(6, 0xabcdef);
+            let mut native = PpcCpu::new();
+            native.pc = 0x5000;
+            native.gpr[3] = 99;
+            let activated =
+                calls.activate_powerpc_with_classic_caller(&mut native, &mut classic, RETURN_PC);
+            if occupied {
+                assert!(activated.is_none());
+                assert_eq!(classic.core.a(7), 0x9876);
+                assert_eq!(classic.core.d(6), 0xabcdef);
+                assert_eq!(native.pc, 0x5000);
+                assert_eq!(native.gpr[3], 99);
+                assert!(calls.pending_powerpc_from_m68k().is_some());
+                assert!(calls.0.borrow().powerpc_contexts.is_empty());
+                assert_eq!(bank.borrow().len(), 1);
+                continue;
+            }
+            assert!(activated.is_some());
+            assert!(bank.borrow().contains(ExecutionTaskId::APPLICATION, call));
+            assert!(calls
+                .0
+                .borrow()
+                .powerpc_contexts
+                .contains(ExecutionTaskId::APPLICATION, call));
+            classic.core.set_a(7, 0x1111);
+            assert!(calls
+                .activate_powerpc_with_classic_caller(&mut native, &mut classic, RETURN_PC)
+                .is_none());
+            assert_eq!(classic.core.a(7), 0x1111);
+            native.pc = RETURN_PC;
+            assert!(calls.complete_powerpc_for_m68k(&mut native));
+            let restored = calls
+                .commit_m68k_resume(|_, context| {
+                    let context = context.expect("the initial classic caller must be parked");
+                    assert_eq!(context.core.a(7), 0x9876);
+                    assert_eq!(context.core.d(6), 0xabcdef);
+                    true
+                })
+                .unwrap()
+                .unwrap();
+            assert_eq!(restored.core.a(7), 0x9876);
+            assert!(bank.borrow().is_empty());
+            assert!(calls.is_empty());
+        }
     }
 
     #[test]

--- a/src/guest_call.rs
+++ b/src/guest_call.rs
@@ -38,13 +38,6 @@ pub(crate) struct CooperativeThread {
     pub(crate) a_regs: [u32; 8],
     pub(crate) pc: u32,
     pub(crate) ccr: u8,
-    /// `void **threadResult` the entry proc's return value is stored to.
-    pub(crate) result_destination: u32,
-    /// Lowest address of the private guest stack, or 0 for the
-    /// application thread, which keeps the process stack.
-    pub(crate) stack_base: u32,
-    /// Address one past the top of the private guest stack.
-    pub(crate) stack_limit: u32,
     /// `SetThreadSwitcher` switch-in proc and its `switchProcParam`.
     pub(crate) switch_in: (u32, u32),
     /// `SetThreadSwitcher` switch-out proc and its `switchProcParam`.
@@ -364,8 +357,17 @@ impl Eq for GuestCallFrame {}
 #[derive(Clone, Debug)]
 pub(crate) struct NativeThreadContext {
     pub(crate) cpu: Box<PpcCpu>,
+}
+
+/// Process-owned storage provenance is independent of a task's current ISA.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct ThreadStorage {
     pub(crate) result_destination: u32,
     pub(crate) stack_base: u32,
+    pub(crate) stack_limit: u32,
+    /// Managed pointers are released through the process Memory Manager;
+    /// reserved guest stacks return to the execution owner's classic pool.
+    pub(crate) managed_pointer: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -392,6 +394,8 @@ struct ExecutionTaskCalls {
     powerpc_contexts: ExecutionContextBank<Box<PpcCpu>>,
     cooperative_contexts: ExecutionTaskContextBank<CooperativeThread>,
     native_threads: ExecutionTaskContextBank<NativeThreadContext>,
+    thread_storage: ExecutionTaskContextBank<ThreadStorage>,
+    classic_thread_pool: Vec<(u32, u32)>,
     native_cpu_task: Option<ExecutionTaskId>,
     handoff: Option<(ExecutionTaskId, TaskResumeContext)>,
 }
@@ -404,6 +408,8 @@ impl Clone for ExecutionTaskCalls {
             powerpc_contexts: self.powerpc_contexts.clone(),
             cooperative_contexts: self.cooperative_contexts.clone(),
             native_threads: self.native_threads.clone(),
+            thread_storage: self.thread_storage.clone(),
+            classic_thread_pool: self.classic_thread_pool.clone(),
             native_cpu_task: self.native_cpu_task,
             handoff: self.handoff.clone(),
         }
@@ -417,6 +423,8 @@ impl PartialEq for ExecutionTaskCalls {
             && self.powerpc_contexts.same_slots(&other.powerpc_contexts)
             && self.cooperative_contexts == other.cooperative_contexts
             && self.native_threads.same_tasks(&other.native_threads)
+            && self.thread_storage == other.thread_storage
+            && self.classic_thread_pool == other.classic_thread_pool
             && self.native_cpu_task == other.native_cpu_task
             && self
                 .handoff
@@ -439,6 +447,8 @@ impl Default for ExecutionTaskCalls {
             powerpc_contexts: ExecutionContextBank::default(),
             cooperative_contexts: ExecutionTaskContextBank::default(),
             native_threads: ExecutionTaskContextBank::default(),
+            thread_storage: ExecutionTaskContextBank::default(),
+            classic_thread_pool: Vec::new(),
             native_cpu_task: None,
             handoff: None,
         }
@@ -544,6 +554,40 @@ impl ExecutionTaskCalls {
         Ok(successor)
     }
 
+    fn retire_thread(
+        &mut self,
+        task: ExecutionTaskId,
+        successor: Option<ExecutionTaskId>,
+        commit: impl FnOnce(&ThreadStorage) -> bool,
+    ) -> Option<(ThreadStorage, Option<(ExecutionTaskId, TaskResumeContext)>)> {
+        if self.handoff.is_some() {
+            return None;
+        }
+        if self.cooperative_contexts.get(task).is_none() && self.native_threads.get(task).is_none()
+        {
+            return None;
+        }
+        let storage = self.thread_storage.get(task).copied().unwrap_or_default();
+        let next = match successor {
+            Some(next) => Some((next, self.saved_context(next)?)),
+            None => None,
+        };
+        self.kernel
+            .retire_task_with(task, successor, || commit(&storage))
+            .ok()?;
+        self.cooperative_contexts.remove(task);
+        self.native_threads.remove(task);
+        self.thread_storage.remove(task);
+        if storage.stack_base != 0 && !storage.managed_pointer {
+            self.classic_thread_pool
+                .push((storage.stack_base, storage.stack_limit));
+        }
+        if self.native_cpu_task == Some(task) {
+            self.native_cpu_task = None;
+        }
+        Some((storage, next))
+    }
+
     fn save_native_cpu(&mut self, task: ExecutionTaskId, cpu: &PpcCpu) {
         if self.kernel.scheduling_state(task).is_none() {
             return;
@@ -554,8 +598,6 @@ impl ExecutionTaskCalls {
             .cloned()
             .unwrap_or(NativeThreadContext {
                 cpu: Box::new(cpu.clone()),
-                result_destination: 0,
-                stack_base: 0,
             });
         context.cpu = Box::new(cpu.clone());
         self.native_threads.insert(task, context);
@@ -584,6 +626,8 @@ impl ExecutionTaskCalls {
         self.kernel.is_pristine()
             && self.cooperative_contexts.is_empty()
             && self.native_threads.is_empty()
+            && self.thread_storage.is_empty()
+            && self.classic_thread_pool.is_empty()
             && self.native_cpu_task.is_none()
             && self.handoff.is_none()
     }
@@ -738,6 +782,7 @@ impl SharedGuestCallStack {
         }
         tasks.cooperative_contexts.remove(task);
         tasks.native_threads.remove(task);
+        tasks.thread_storage.remove(task);
         true
     }
 
@@ -747,25 +792,10 @@ impl SharedGuestCallStack {
         &self,
         task: ExecutionTaskId,
         successor: Option<ExecutionTaskId>,
-        commit: impl FnOnce(&CooperativeThread) -> bool,
-    ) -> Option<(CooperativeThread, Option<CooperativeThread>)> {
+        commit: impl FnOnce(&ThreadStorage) -> bool,
+    ) -> Option<(ThreadStorage, Option<CooperativeThread>)> {
         let mut tasks = self.0.borrow_mut();
-        // Native stack/result ownership cannot be retired through the classic
-        // projection. Mixed-ISA disposal must use the owning task record.
-        if tasks.kernel.task_entry_isa(task) == Some(GuestIsa::PowerPc) || tasks.handoff.is_some() {
-            return None;
-        }
-        let finished = tasks.cooperative_contexts.get(task)?.clone();
-        let next = match successor {
-            Some(next) => Some((next, tasks.saved_context(next)?)),
-            None => None,
-        };
-        tasks
-            .kernel
-            .retire_task_with(task, successor, || commit(&finished))
-            .ok()?;
-        tasks.cooperative_contexts.remove(task);
-        tasks.native_threads.remove(task);
+        let (finished, next) = tasks.retire_thread(task, successor, commit)?;
         let classic = match next {
             Some((_, TaskResumeContext::Classic(context))) => Some(context),
             Some((next, context)) => {
@@ -775,6 +805,43 @@ impl SharedGuestCallStack {
             None => None,
         };
         Some((finished, classic))
+    }
+
+    pub(crate) fn thread_storage(&self, task: ExecutionTaskId) -> Option<ThreadStorage> {
+        let tasks = self.0.borrow();
+        tasks.kernel.scheduling_state(task)?;
+        Some(tasks.thread_storage.get(task).copied().unwrap_or_default())
+    }
+
+    pub(crate) fn set_thread_storage(&self, task: ExecutionTaskId, storage: ThreadStorage) -> bool {
+        let mut tasks = self.0.borrow_mut();
+        if tasks.kernel.scheduling_state(task).is_none() {
+            return false;
+        }
+        tasks.thread_storage.insert(task, storage);
+        true
+    }
+
+    pub(crate) fn take_classic_thread_stack(&self, size: u32) -> Option<(u32, u32)> {
+        let mut tasks = self.0.borrow_mut();
+        let index = tasks
+            .classic_thread_pool
+            .iter()
+            .position(|(base, limit)| limit.saturating_sub(*base) >= size)?;
+        Some(tasks.classic_thread_pool.swap_remove(index))
+    }
+
+    pub(crate) fn recycle_classic_thread_stack(&self, stack: (u32, u32)) {
+        self.0.borrow_mut().classic_thread_pool.push(stack);
+    }
+
+    pub(crate) fn classic_thread_pool_count(&self, minimum_size: u32) -> usize {
+        self.0
+            .borrow()
+            .classic_thread_pool
+            .iter()
+            .filter(|(base, limit)| limit.saturating_sub(*base) >= minimum_size)
+            .count()
     }
 
     pub(crate) fn switch_from_classic(
@@ -883,6 +950,7 @@ impl SharedGuestCallStack {
     pub(crate) fn create_native_thread(
         &self,
         context: NativeThreadContext,
+        storage: ThreadStorage,
         suspended: bool,
         commit: impl FnOnce(ExecutionTaskId) -> bool,
     ) -> Option<ExecutionTaskId> {
@@ -890,6 +958,7 @@ impl SharedGuestCallStack {
         let task = tasks.kernel.create_task_with(commit).ok()?;
         tasks.kernel.bind_task_entry_isa(task, GuestIsa::PowerPc);
         tasks.native_threads.insert(task, context);
+        tasks.thread_storage.insert(task, storage);
         if !suspended {
             assert!(tasks
                 .kernel
@@ -1020,34 +1089,16 @@ impl SharedGuestCallStack {
         &self,
         task: ExecutionTaskId,
         cpu: &mut PpcCpu,
-        commit: impl FnOnce(&NativeThreadContext) -> bool,
-    ) -> Option<NativeThreadContext> {
+        commit: impl FnOnce(&ThreadStorage) -> bool,
+    ) -> Option<ThreadStorage> {
         let mut tasks = self.0.borrow_mut();
-        if tasks.handoff.is_some() {
-            return None;
-        }
-        if tasks.kernel.task_entry_isa(task) == Some(GuestIsa::M68k)
-            && tasks.cooperative_contexts.get(task).is_some()
-        {
-            return None;
-        }
-        let finished = tasks.native_threads.get(task)?.clone();
         let successor = if task == tasks.kernel.current_task() {
-            let next = tasks.kernel.next_ready_task(None)?;
-            Some((next, tasks.saved_context(next)?))
+            Some(tasks.kernel.next_ready_task(None)?)
         } else {
             None
         };
-        tasks
-            .kernel
-            .retire_task_with(task, successor.as_ref().map(|(task, _)| *task), || {
-                commit(&finished)
-            })
-            .ok()?;
-        tasks.native_threads.remove(task);
-        tasks.cooperative_contexts.remove(task);
+        let (finished, successor) = tasks.retire_thread(task, successor, commit)?;
         if let Some((next, context)) = successor {
-            tasks.native_cpu_task = None;
             tasks.install_native_successor(next, context, cpu);
         }
         Some(finished)
@@ -1779,8 +1830,12 @@ mod tests {
             .create_native_thread(
                 NativeThreadContext {
                     cpu: Box::new(PpcCpu::new()),
+                },
+                crate::guest_call::ThreadStorage {
                     result_destination: 0,
                     stack_base: 0,
+                    stack_limit: 0,
+                    managed_pointer: true,
                 },
                 false,
                 |_| true,
@@ -1821,8 +1876,12 @@ mod tests {
             .create_native_thread(
                 NativeThreadContext {
                     cpu: Box::new(PpcCpu::new()),
+                },
+                crate::guest_call::ThreadStorage {
                     result_destination: 0,
                     stack_base: 0,
+                    stack_limit: 0,
+                    managed_pointer: true,
                 },
                 false,
                 |_| true,

--- a/src/guest_call.rs
+++ b/src/guest_call.rs
@@ -851,13 +851,38 @@ impl SharedGuestCallStack {
         true
     }
 
+    #[cfg(test)]
     pub(crate) fn take_classic_thread_stack(&self, size: u32) -> Option<(u32, u32)> {
+        self.request_classic_thread_stack(size, 2).ok().flatten()
+    }
+
+    /// Select storage without publishing a task. Thread Manager (1999),
+    /// pp. 48, 57–58: opt-in pool use, best fit, exact match and -617 refusal.
+    pub(crate) fn request_classic_thread_stack(
+        &self,
+        size: u32,
+        options: u32,
+    ) -> Result<Option<(u32, u32)>, i16> {
+        if options & 2 == 0 {
+            return Ok(None);
+        }
         let mut tasks = self.0.borrow_mut();
         let index = tasks
             .classic_thread_pool
             .iter()
-            .position(|(base, limit)| limit.saturating_sub(*base) >= size)?;
-        Some(tasks.classic_thread_pool.swap_remove(index))
+            .enumerate()
+            .filter_map(|(index, &(base, limit))| {
+                let available = limit.checked_sub(base)?;
+                (base != 0 && available >= size && (options & 16 == 0 || available == size))
+                    .then_some((index, available))
+            })
+            .min_by_key(|&(_, available)| available)
+            .map(|(index, _)| index);
+        match index {
+            Some(index) => Ok(Some(tasks.classic_thread_pool.swap_remove(index))),
+            None if options & 4 != 0 => Ok(None),
+            None => Err(-617),
+        }
     }
 
     pub(crate) fn recycle_classic_thread_stack(&self, stack: (u32, u32)) {

--- a/src/guest_call.rs
+++ b/src/guest_call.rs
@@ -554,6 +554,33 @@ impl ExecutionTaskCalls {
         Ok(successor)
     }
 
+    fn create_thread(
+        &mut self,
+        context: TaskResumeContext,
+        storage: ThreadStorage,
+        suspended: bool,
+        commit: impl FnOnce(ExecutionTaskId) -> bool,
+    ) -> Option<ExecutionTaskId> {
+        let task = self.kernel.create_task_with(commit).ok()?;
+        self.kernel.bind_task_entry_isa(task, context.isa());
+        match context {
+            TaskResumeContext::Classic(context) => {
+                self.cooperative_contexts.insert(task, context);
+            }
+            TaskResumeContext::Native(cpu) => {
+                self.native_threads
+                    .insert(task, NativeThreadContext { cpu });
+            }
+        }
+        self.thread_storage.insert(task, storage);
+        if !suspended {
+            assert!(self
+                .kernel
+                .set_scheduling_state(task, ExecutionTaskState::Ready));
+        }
+        Some(task)
+    }
+
     fn retire_thread(
         &mut self,
         task: ExecutionTaskId,
@@ -709,6 +736,7 @@ impl SharedGuestCallStack {
         self.0.borrow().kernel.switch_to_task(task).is_ok()
     }
 
+    #[cfg(test)]
     pub(crate) fn create_task(&self) -> Option<ExecutionTaskId> {
         self.0.borrow().kernel.create_task().ok()
     }
@@ -813,6 +841,7 @@ impl SharedGuestCallStack {
         Some(tasks.thread_storage.get(task).copied().unwrap_or_default())
     }
 
+    #[cfg(test)]
     pub(crate) fn set_thread_storage(&self, task: ExecutionTaskId, storage: ThreadStorage) -> bool {
         let mut tasks = self.0.borrow_mut();
         if tasks.kernel.scheduling_state(task).is_none() {
@@ -947,6 +976,21 @@ impl SharedGuestCallStack {
         self.0.borrow().kernel.has_live_workers()
     }
 
+    pub(crate) fn create_classic_thread(
+        &self,
+        context: CooperativeThread,
+        storage: ThreadStorage,
+        suspended: bool,
+        commit: impl FnOnce(ExecutionTaskId) -> bool,
+    ) -> Option<ExecutionTaskId> {
+        self.0.borrow_mut().create_thread(
+            TaskResumeContext::Classic(context),
+            storage,
+            suspended,
+            commit,
+        )
+    }
+
     pub(crate) fn create_native_thread(
         &self,
         context: NativeThreadContext,
@@ -954,17 +998,12 @@ impl SharedGuestCallStack {
         suspended: bool,
         commit: impl FnOnce(ExecutionTaskId) -> bool,
     ) -> Option<ExecutionTaskId> {
-        let mut tasks = self.0.borrow_mut();
-        let task = tasks.kernel.create_task_with(commit).ok()?;
-        tasks.kernel.bind_task_entry_isa(task, GuestIsa::PowerPc);
-        tasks.native_threads.insert(task, context);
-        tasks.thread_storage.insert(task, storage);
-        if !suspended {
-            assert!(tasks
-                .kernel
-                .set_scheduling_state(task, ExecutionTaskState::Ready));
-        }
-        Some(task)
+        self.0.borrow_mut().create_thread(
+            TaskResumeContext::Native(context.cpu),
+            storage,
+            suspended,
+            commit,
+        )
     }
 
     /// Scheduling resumes only after a wake operation marks a task ready and

--- a/src/guest_call.rs
+++ b/src/guest_call.rs
@@ -898,6 +898,38 @@ impl SharedGuestCallStack {
         Some(task)
     }
 
+    /// Scheduling resumes only after a wake operation marks a task ready and
+    /// its saved engine context can be installed. A stopped cursor owns no work.
+    pub(crate) fn resume_ready_task(&self) -> bool {
+        let mut tasks = self.0.borrow_mut();
+        if tasks.handoff.is_some() || tasks.kernel.critical_depth() != 0 {
+            return false;
+        }
+        let current = tasks.kernel.current_task();
+        let next = match tasks.kernel.scheduling_state(current) {
+            Some(ExecutionTaskState::Running) => return false,
+            Some(ExecutionTaskState::Ready) => current,
+            _ => match tasks.kernel.next_ready_task(None) {
+                Some(next) => next,
+                None => return false,
+            },
+        };
+        let Some(context) = tasks.saved_context(next) else {
+            return false;
+        };
+        if tasks.kernel.switch_to_task(next).is_err() {
+            return false;
+        }
+        tasks.handoff = Some((next, context));
+        true
+    }
+
+    pub(crate) fn current_task_is_running(&self) -> bool {
+        let tasks = self.0.borrow();
+        tasks.kernel.scheduling_state(tasks.kernel.current_task())
+            == Some(ExecutionTaskState::Running)
+    }
+
     pub(crate) fn set_native_thread_state(
         &self,
         cpu: &mut PpcCpu,
@@ -910,16 +942,20 @@ impl SharedGuestCallStack {
         let current = tasks.kernel.current_task();
         let successor =
             tasks.change_thread_state(thread, new_state, suggested, end_critical, || true)?;
-        let Some((next, context)) = successor else {
+        if successor.is_none()
+            && tasks.kernel.scheduling_state(current) != Some(ExecutionTaskState::Stopped)
+        {
             return Ok(false);
-        };
+        }
         let mut outgoing = cpu.clone();
         outgoing.pc = outgoing.lr;
         outgoing.gpr[3] = 0;
         tasks.save_native_cpu(current, &outgoing);
         *cpu = outgoing;
         tasks.native_cpu_task = Some(current);
-        tasks.install_native_successor(next, context, cpu);
+        if let Some((next, context)) = successor {
+            tasks.install_native_successor(next, context, cpu);
+        }
         Ok(true)
     }
 
@@ -936,11 +972,13 @@ impl SharedGuestCallStack {
         let current = tasks.kernel.current_task();
         let successor =
             tasks.change_thread_state(thread, new_state, suggested, end_critical, commit)?;
-        let Some((next, context)) = successor else {
+        if successor.is_none()
+            && tasks.kernel.scheduling_state(current) != Some(ExecutionTaskState::Stopped)
+        {
             return Ok(false);
-        };
+        }
         tasks.cooperative_contexts.insert(current, outgoing);
-        tasks.handoff = Some((next, context));
+        tasks.handoff = successor;
         Ok(true)
     }
 

--- a/src/guest_call.rs
+++ b/src/guest_call.rs
@@ -8,6 +8,7 @@
 //! while each adapter remains responsible for its architectural registers and
 //! ABI frame.
 
+use crate::cpu::M68kCpu;
 #[cfg(test)]
 pub(crate) use crate::execution_kernel::MAX_POWERPC_GUEST_ARGUMENTS;
 pub(crate) use crate::execution_kernel::{
@@ -392,6 +393,7 @@ struct ExecutionTaskCalls {
     kernel: ContinuationStore,
     frames: HashMap<CallId, GuestCallFrame>,
     powerpc_contexts: ExecutionContextBank<Box<PpcCpu>>,
+    m68k_contexts: Rc<RefCell<ExecutionContextBank<M68kCpu>>>,
     cooperative_contexts: ExecutionTaskContextBank<CooperativeThread>,
     native_threads: ExecutionTaskContextBank<NativeThreadContext>,
     thread_storage: ExecutionTaskContextBank<ThreadStorage>,
@@ -402,10 +404,15 @@ struct ExecutionTaskCalls {
 
 impl Clone for ExecutionTaskCalls {
     fn clone(&self) -> Self {
+        assert!(
+            self.m68k_contexts.borrow().is_empty(),
+            "cannot clone an execution owner while a non-cloneable 68K engine is parked"
+        );
         Self {
             kernel: self.kernel.clone(),
             frames: self.frames.clone(),
             powerpc_contexts: self.powerpc_contexts.clone(),
+            m68k_contexts: Rc::new(RefCell::new(ExecutionContextBank::default())),
             cooperative_contexts: self.cooperative_contexts.clone(),
             native_threads: self.native_threads.clone(),
             thread_storage: self.thread_storage.clone(),
@@ -421,6 +428,10 @@ impl PartialEq for ExecutionTaskCalls {
         self.kernel == other.kernel
             && self.frames == other.frames
             && self.powerpc_contexts.same_slots(&other.powerpc_contexts)
+            && self
+                .m68k_contexts
+                .borrow()
+                .same_slots(&other.m68k_contexts.borrow())
             && self.cooperative_contexts == other.cooperative_contexts
             && self.native_threads.same_tasks(&other.native_threads)
             && self.thread_storage == other.thread_storage
@@ -445,6 +456,7 @@ impl Default for ExecutionTaskCalls {
             kernel: ContinuationStore::default(),
             frames: HashMap::new(),
             powerpc_contexts: ExecutionContextBank::default(),
+            m68k_contexts: Rc::new(RefCell::new(ExecutionContextBank::default())),
             cooperative_contexts: ExecutionTaskContextBank::default(),
             native_threads: ExecutionTaskContextBank::default(),
             thread_storage: ExecutionTaskContextBank::default(),
@@ -667,6 +679,7 @@ impl ExecutionTaskCalls {
 
     fn is_pristine(&self) -> bool {
         self.kernel.is_pristine()
+            && self.m68k_contexts.borrow().is_empty()
             && self.cooperative_contexts.is_empty()
             && self.native_threads.is_empty()
             && self.thread_storage.is_empty()
@@ -681,7 +694,8 @@ impl ExecutionTaskCalls {
 /// Both CPU adapters share this owner, but every Thread Manager task has an
 /// independent LIFO stack. Switching tasks changes which stack subsequent
 /// Mixed Mode operations address; it cannot expose another task's suspended
-/// call. Ordinary `Clone` still creates an independent process snapshot.
+/// call. Ordinary `Clone` creates an independent process snapshot only when
+/// no non-cloneable 68K engine is parked; `shared_handle` preserves custody.
 #[derive(Debug, Default)]
 pub(crate) struct SharedGuestCallStack(Rc<RefCell<ExecutionTaskCalls>>);
 
@@ -737,6 +751,22 @@ impl SharedGuestCallStack {
     /// parked contexts with the same cooperative task.  The task owner itself
     /// remains process-wide; this is a view of its current cursor, not a second
     /// owner.  Inside Macintosh: Processes (1994), pp. 4-4--4-6.
+    /// Borrowing this process-owned bank never spans guest execution. Each
+    /// transition selects the bank from its execution owner instead of keeping
+    /// a separate bank handle on the CPU adapter.
+    fn classic_contexts(&self) -> Rc<RefCell<ExecutionContextBank<M68kCpu>>> {
+        Rc::clone(&self.0.borrow().m68k_contexts)
+    }
+
+    pub(crate) fn has_parked_m68k_contexts(&self) -> bool {
+        !self.classic_contexts().borrow().is_empty()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn m68k_context_bank(&self) -> Rc<RefCell<ExecutionContextBank<M68kCpu>>> {
+        self.classic_contexts()
+    }
+
     pub(crate) fn current_task(&self) -> ExecutionTaskId {
         self.0.borrow().kernel.current_task()
     }
@@ -1598,11 +1628,12 @@ impl SharedGuestCallStack {
     /// Commit the ABI result and restore the exact caller under one validated
     /// retirement boundary. The adapter closure must leave state unchanged
     /// when it rejects a result and must not execute guest code.
-    pub(crate) fn commit_m68k_resume<T>(
+    pub(crate) fn commit_m68k_resume(
         &self,
-        bank: &mut ExecutionContextBank<T>,
-        apply: impl FnOnce(M68kResume, Option<&mut T>) -> bool,
-    ) -> Option<Option<T>> {
+        apply: impl FnOnce(M68kResume, Option<&mut M68kCpu>) -> bool,
+    ) -> Option<Option<M68kCpu>> {
+        let bank = self.classic_contexts();
+        let mut bank = bank.borrow_mut();
         let resume = self.peek_m68k_resume()?;
         let (task, call_id) = self.pending_m68k_resume_owner()?;
         let mut tasks = self.0.borrow_mut();
@@ -1634,13 +1665,14 @@ impl SharedGuestCallStack {
         self.activate_m68k_in_bank(&mut ExecutionContextBank::<()>::default(), &mut (), None)
     }
 
-    pub(crate) fn activate_m68k_parking<T: Default>(
+    pub(crate) fn activate_m68k_parking(
         &self,
-        bank: &mut ExecutionContextBank<T>,
-        installed: &mut T,
+        installed: &mut M68kCpu,
     ) -> Option<PendingM68kExecution> {
         let caller = self.suspended_m68k_context_owner().map(|(_, call)| call);
-        self.activate_m68k_in_bank(bank, installed, caller)
+        let bank = self.classic_contexts();
+        let pending = self.activate_m68k_in_bank(&mut bank.borrow_mut(), installed, caller);
+        pending
     }
 
     fn activate_m68k_in_bank<T: Default>(
@@ -1938,6 +1970,51 @@ mod tests {
         )
         .into_ppc_import_action()
         .expect("native PowerPC request should adapt to CallNative")
+    }
+
+    #[test]
+    fn classic_parked_engines_follow_the_process_owner_and_refuse_snapshot_duplication() {
+        let calls = SharedGuestCallStack::default();
+        assert!(calls.begin_m68k(
+            GuestCallTarget {
+                isa: GuestIsa::M68k,
+                entry: 0x1000,
+                rtoc: 0
+            },
+            0x2000,
+            0x3000
+        ));
+        let (call, _) = calls.top_frame().unwrap();
+        let bank = calls.m68k_context_bank();
+        let mut cpu = M68kCpu::new();
+        cpu.core.set_a(7, 0x7654);
+        cpu.core.set_d(6, 0xabcdef);
+        assert!(calls
+            .park_context(
+                &mut bank.borrow_mut(),
+                ExecutionTaskId::APPLICATION,
+                call,
+                cpu
+            )
+            .is_ok());
+        let shared = calls.shared_handle();
+        assert!(Rc::ptr_eq(&bank, &shared.m68k_context_bank()));
+        assert!(std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| calls.clone())).is_err());
+        assert!(bank.borrow().contains(ExecutionTaskId::APPLICATION, call));
+        let mut adopting = SharedGuestCallStack::default();
+        adopting.attach_to(&calls);
+        assert!(Rc::ptr_eq(&bank, &adopting.m68k_context_bank()));
+        assert!(!adopting.is_pristine());
+        let restored = bank
+            .borrow_mut()
+            .take(&calls.0.borrow().kernel, ExecutionTaskId::APPLICATION, call)
+            .unwrap();
+        assert_eq!(restored.core.a(7), 0x7654);
+        assert_eq!(restored.core.d(6), 0xabcdef);
+        assert!(adopting.m68k_context_bank().borrow().is_empty());
+        let snapshot = calls.clone();
+        assert!(!Rc::ptr_eq(&bank, &snapshot.m68k_context_bank()));
+        assert_eq!(calls, snapshot);
     }
 
     #[test]

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -4159,7 +4159,14 @@ impl PpcLoadedApp {
         let frame_size = required.max(PPC_INITIAL_STACK_FRAME_SIZE).checked_add(15)? & !15;
         let caller_sp = self.cpu.gpr[1];
         let callback_sp = caller_sp.checked_sub(frame_size)? & !15;
-        if callback_sp < self.stack_base
+        // PowerPC System Software, 1-44–1-49: linkage and parameter areas
+        // belong to the caller's grow-down stack, including worker stacks.
+        let (stack_base, stack_limit) = self.guest_calls.native_stack_bounds(
+            self.stack_base,
+            self.stack_base.checked_add(self.stack_size)?,
+        )?;
+        if callback_sp < stack_base
+            || caller_sp > stack_limit
             || !ppc_memory_can_write_bytes(&mut self.memory, callback_sp, frame_size)
             || !ppc_zero_guest_bytes(&mut self.memory, callback_sp, frame_size)
         {
@@ -108863,6 +108870,84 @@ pub(crate) mod tests {
             Some(callback_rtoc)
         );
         assert!(loaded.guest_calls.is_empty());
+    }
+
+    #[test]
+    fn reverse_mixed_mode_activation_uses_the_native_worker_stack_and_retries_overflow() {
+        use crate::guest_call::{ExecutionTaskId, GuestCallTarget, PowerPcArguments};
+        const MADE: u32 = PPC_DATA_BASE + 0x2000;
+        let mut loaded = load_pef_application(&synthetic_pef_with_import(b"NewThread")).unwrap();
+        loaded.memory.add_region(MADE, vec![0; 4]);
+        loaded.cpu.gpr[3] = 1;
+        loaded.cpu.gpr[4] = PPC_CODE_BASE;
+        loaded.cpu.gpr[5] = 17;
+        loaded.cpu.gpr[6] = 4096;
+        loaded.cpu.gpr[7] = 0;
+        loaded.cpu.gpr[8] = 0;
+        loaded.cpu.gpr[9] = MADE;
+        loaded.run_with_hle_imports(64);
+        assert_eq!(loaded.cpu.gpr[3], 0);
+        let worker = ExecutionTaskId::from_thread_id(loaded.memory.read_u32_be(MADE).unwrap());
+        assert!(loaded
+            .guest_calls
+            .yield_native_thread(&mut loaded.cpu, worker.thread_id())
+            .unwrap());
+        let storage = loaded.guest_calls.thread_storage(worker).unwrap();
+        let worker_sp = loaded.cpu.gpr[1];
+        assert!(worker_sp < loaded.stack_base);
+        assert!(loaded
+            .guest_calls
+            .switch_to_task(ExecutionTaskId::APPLICATION));
+        assert_eq!(
+            loaded
+                .guest_calls
+                .native_stack_bounds(loaded.stack_base, PPC_STACK_TOP),
+            Some((storage.stack_base, storage.stack_limit))
+        );
+        assert!(loaded.guest_calls.switch_to_task(worker));
+        assert!(loaded.guest_calls.begin_m68k_to_powerpc(
+            GuestCallTarget {
+                isa: GuestIsa::PowerPc,
+                entry: PPC_CODE_BASE + 0x1000,
+                rtoc: PPC_DATA_BASE,
+            },
+            PowerPcArguments::from_slice(&[42]).unwrap(),
+            0x0010_0000,
+            0x0010_1000,
+            None,
+        ));
+        let mut classic = crate::cpu::M68kCpu::new();
+        classic.write_reg(crate::cpu::Register::PC, 0x0010_0000);
+        loaded
+            .memory
+            .add_region(storage.stack_base - 64, vec![0; 64]);
+        // Both surrounding addresses are mapped. Mapping
+        // alone must not permit a frame outside this worker's allocation.
+        for invalid_sp in [storage.stack_base + 16, storage.stack_limit + 16] {
+            loaded.cpu.gpr[1] = invalid_sp;
+            let before = loaded.cpu.clone();
+            let sentinel = invalid_sp - 64;
+            loaded.memory.write_u32_be(sentinel, 0xface_cafe).unwrap();
+            assert!(loaded.activate_powerpc_from_m68k(&mut classic).is_none());
+            assert_eq!(loaded.cpu.gpr, before.gpr);
+            assert_eq!(loaded.cpu.pc, before.pc);
+            assert_eq!(loaded.cpu.lr, before.lr);
+            assert_eq!(loaded.cpu.cr, before.cr);
+            assert_eq!(loaded.cpu.fpr, before.fpr);
+            assert_eq!(classic.read_reg(crate::cpu::Register::PC), 0x0010_0000);
+            assert_eq!(loaded.memory.read_u32_be(sentinel), Some(0xface_cafe));
+            assert!(loaded.guest_calls.pending_powerpc_from_m68k().is_some());
+            assert!(!loaded.guest_calls.has_parked_m68k_contexts());
+        }
+        loaded.cpu.gpr[1] = worker_sp;
+        loaded.activate_powerpc_from_m68k(&mut classic).unwrap();
+        let callback_sp = loaded.cpu.gpr[1];
+        assert!(callback_sp >= storage.stack_base && callback_sp < worker_sp);
+        assert_eq!(callback_sp & 15, 0);
+        assert_eq!(loaded.memory.read_u32_be(callback_sp), Some(worker_sp));
+        assert_eq!(loaded.cpu.gpr[3], 42);
+        assert_eq!(loaded.cpu.pc, PPC_CODE_BASE + 0x1000);
+        assert!(loaded.guest_calls.has_parked_m68k_contexts());
     }
 
     #[test]

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -4144,7 +4144,10 @@ impl PpcLoadedApp {
     /// Park the current native context and enter a PowerPC routine selected by
     /// a 68k RoutineDescriptor. The new ABI frame protects the parked caller's
     /// linkage and parameter areas while the shared continuation owns return.
-    pub(crate) fn activate_powerpc_from_m68k(&mut self) -> Option<()> {
+    pub(crate) fn activate_powerpc_from_m68k(
+        &mut self,
+        caller: &mut crate::cpu::M68kCpu,
+    ) -> Option<()> {
         let pending = self.guest_calls.pending_powerpc_from_m68k()?;
         let parameter_slots = pending
             .arguments
@@ -4171,9 +4174,11 @@ impl PpcLoadedApp {
         self.memory
             .write_u32_be(callback_sp + PPC_LINKAGE_SAVED_RTOC_OFFSET, self.cpu.gpr[2])?;
 
-        let pending = self
-            .guest_calls
-            .activate_powerpc_from_m68k(&mut self.cpu, PPC_GUEST_CALL_RETURN_PC)?;
+        let pending = self.guest_calls.activate_powerpc_with_classic_caller(
+            &mut self.cpu,
+            caller,
+            PPC_GUEST_CALL_RETURN_PC,
+        )?;
         self.cpu.gpr[1] = callback_sp;
         self.cpu.pc = pending.target.entry;
         self.cpu.lr = PPC_GUEST_CALL_RETURN_PC;
@@ -108881,7 +108886,9 @@ pub(crate) mod tests {
             None,
         ));
 
-        loaded.activate_powerpc_from_m68k().unwrap();
+        loaded
+            .activate_powerpc_from_m68k(&mut crate::cpu::M68kCpu::new())
+            .unwrap();
 
         let callback_sp = loaded.cpu.gpr[1];
         assert!(callback_sp < caller.gpr[1]);

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -285,9 +285,11 @@ const PPC_CLOSED_RESOURCE_REF_NUM: i16 = i16::MIN;
 const PPC_PICT_INFO_SIZE: u32 = 104;
 const PPC_CFM_MAIN_STUB_COUNT: u32 = 256;
 const PPC_IMPORT_CAPACITY: u32 = 4096;
-// The final mapped trap is reserved for process-owned guest-call returns and
+// The final mapped traps are reserved for guest-call and thread returns and
 // does not reduce the 4,096 application/CFM binding capacity.
-const PPC_IMPORT_SLOT_COUNT: u32 = PPC_IMPORT_CAPACITY + 1;
+const PPC_IMPORT_SLOT_COUNT: u32 = PPC_IMPORT_CAPACITY + 2;
+const PPC_THREAD_RETURN_IMPORT_INDEX: u32 = PPC_IMPORT_CAPACITY + 1;
+const PPC_THREAD_RETURN_PC: u32 = PPC_IMPORT_TRAP_BASE + PPC_THREAD_RETURN_IMPORT_INDEX * 4;
 const PPC_GUEST_CALL_RETURN_IMPORT_INDEX: u32 = PPC_IMPORT_CAPACITY;
 const PPC_FIRST_CFM_CONNECTION_ID: u32 = 1;
 const PPC_CFM_FIND_LIB: u32 = 2;
@@ -1632,6 +1634,10 @@ pub enum PpcImportDispatcherTarget {
     GetCurrentThread,
     GetThreadState,
     ThreadBeginCritical,
+    NewThread,
+    YieldToThread,
+    YieldToAnyThread,
+    DisposeThread,
     ThreadEndCritical,
     GetCurrentProcess,
     WakeUpProcess,
@@ -7553,6 +7559,22 @@ impl PpcLoadedApp {
         let result = {
             type Mem = PpcSectionMem;
             let mut handle_import = |elapsed, index, cpu: &mut PpcCpu, memory: &mut Mem| {
+                if index == PPC_THREAD_RETURN_IMPORT_INDEX {
+                    // ThreadEntryProc returns its result in R3. Retire only
+                    // after validating the successor and result destination.
+                    // Inside Macintosh: Thread Manager (1999), pp. 59–60.
+                    let task = guest_calls.current_task();
+                    let result = cpu.gpr[3];
+                    let _ = ppc_retire_native_thread(
+                        &guest_calls,
+                        cpu,
+                        memory,
+                        process_memory_manager,
+                        task,
+                        result,
+                    );
+                    return PpcImportAction::Yield(1);
+                }
                 if index == PPC_GUEST_CALL_RETURN_IMPORT_INDEX {
                     if guest_calls.complete_powerpc(cpu) {
                         let native_heap = process_memory_manager
@@ -14992,6 +15014,10 @@ fn dispatcher_target_for_import(
             PpcImportDispatcherTarget::GetCurrentThread
         }
         ("InterfaceLib", "GetThreadState") => PpcImportDispatcherTarget::GetThreadState,
+        ("InterfaceLib", "NewThread") => PpcImportDispatcherTarget::NewThread,
+        ("InterfaceLib", "YieldToThread") => PpcImportDispatcherTarget::YieldToThread,
+        ("InterfaceLib", "YieldToAnyThread") => PpcImportDispatcherTarget::YieldToAnyThread,
+        ("InterfaceLib", "DisposeThread") => PpcImportDispatcherTarget::DisposeThread,
         ("InterfaceLib", "ThreadBeginCritical") => PpcImportDispatcherTarget::ThreadBeginCritical,
         ("InterfaceLib", "ThreadEndCritical") => PpcImportDispatcherTarget::ThreadEndCritical,
         ("InterfaceLib", "GetCurrentProcess" | "GetFrontProcess") => {
@@ -24153,6 +24179,135 @@ fn dispatch_supported_import(
                 }
             };
             Some(PpcImportAction::Return(ppc_i16_result(result)))
+        }
+        PpcImportDispatcherTarget::NewThread => {
+            // OSErr NewThread(ThreadStyle, ThreadEntryUPP, void *, Size,
+            //                 ThreadOptions, void **, ThreadID *);
+            // Inside Macintosh: Thread Manager (1999), pp. 55–58.
+            let style = cpu.gpr[3];
+            let entry = cpu.gpr[4];
+            let param = cpu.gpr[5];
+            let size = if cpu.gpr[6] == 0 {
+                crate::thread_manager::DEFAULT_COOPERATIVE_THREAD_STACK_SIZE
+            } else {
+                cpu.gpr[6]
+            };
+            let options = cpu.gpr[7];
+            let result_destination = cpu.gpr[8];
+            let made = cpu.gpr[9];
+            let target = ppc_resolve_callback_target(memory, entry, cpu.gpr[2], None);
+            if style != 1
+                || size < 256
+                || size > i32::MAX as u32
+                || made == 0
+                || !ppc_memory_can_write_bytes(memory, made, 4)
+                || target.is_none()
+            {
+                return Some(PpcImportAction::Return(ppc_i16_result(PPC_PARAM_ERR)));
+            }
+            let target = target.unwrap();
+            let stack = process_memory_manager.new_native_ptr(memory, size, true);
+            ppc_apply_process_native_allocator(
+                process_memory_manager,
+                memory,
+                heap_cursor,
+                last_mem_error,
+            );
+            if stack == 0 {
+                return Some(PpcImportAction::Return(ppc_i16_result(PPC_MEM_FULL_ERR)));
+            }
+            let Some(top) = stack.checked_add(size) else {
+                process_memory_manager.dispose_native_ptr(stack);
+                return Some(PpcImportAction::Return(ppc_i16_result(PPC_MEM_FULL_ERR)));
+            };
+            let mut thread_cpu = PpcCpu::new();
+            thread_cpu.alignment_policy = cpu.alignment_policy;
+            thread_cpu.msr = cpu.msr;
+            thread_cpu.pc = target.entry;
+            thread_cpu.lr = PPC_THREAD_RETURN_PC;
+            thread_cpu.gpr[1] = (top & !15) - PPC_INITIAL_STACK_FRAME_SIZE;
+            thread_cpu.gpr[2] = target.rtoc;
+            thread_cpu.gpr[3] = param;
+            let created = toolbox_startup.guest_calls.create_native_thread(
+                crate::guest_call::NativeThreadContext {
+                    cpu: Box::new(thread_cpu),
+                    result_destination,
+                    stack_base: stack,
+                },
+                options & 1 != 0,
+                |task| memory.write_u32_be(made, task.thread_id()).is_some(),
+            );
+            if created.is_none() {
+                process_memory_manager.dispose_native_ptr(stack);
+            }
+            ppc_apply_process_native_allocator(
+                process_memory_manager,
+                memory,
+                heap_cursor,
+                last_mem_error,
+            );
+            Some(PpcImportAction::Return(ppc_i16_result(
+                if created.is_some() {
+                    PPC_NO_ERR
+                } else {
+                    PPC_MEM_FULL_ERR
+                },
+            )))
+        }
+        PpcImportDispatcherTarget::YieldToThread | PpcImportDispatcherTarget::YieldToAnyThread => {
+            // OSErr YieldToThread(ThreadID); OSErr YieldToAnyThread(void);
+            // Inside Macintosh: Thread Manager (1999), pp. 64–66.
+            let suggested = if binding.dispatcher_target == PpcImportDispatcherTarget::YieldToThread
+            {
+                cpu.gpr[3]
+            } else {
+                0
+            };
+            Some(
+                match toolbox_startup
+                    .guest_calls
+                    .yield_native_thread(cpu, suggested)
+                {
+                    Ok(true) => PpcImportAction::Yield(1),
+                    Ok(false) => PpcImportAction::Return(0),
+                    Err(error) => PpcImportAction::Return(ppc_i16_result(error)),
+                },
+            )
+        }
+        PpcImportDispatcherTarget::DisposeThread => {
+            // OSErr DisposeThread(ThreadID, void *, Boolean);
+            // Inside Macintosh: Thread Manager (1999), pp. 59–60.
+            let calls = &toolbox_startup.guest_calls;
+            let task = crate::guest_call::ExecutionTaskId::from_thread_id(
+                crate::thread_manager::ThreadManager::new(calls).resolve_thread(cpu.gpr[3]),
+            );
+            if calls.scheduling_state(task).is_none() {
+                return Some(PpcImportAction::Return(ppc_i16_result(
+                    crate::thread_manager::THREAD_NOT_FOUND_ERR,
+                )));
+            }
+            let current = task == calls.current_task();
+            let result = cpu.gpr[4];
+            Some(
+                if ppc_retire_native_thread(
+                    calls,
+                    cpu,
+                    memory,
+                    process_memory_manager,
+                    task,
+                    result,
+                ) {
+                    if current {
+                        PpcImportAction::Yield(1)
+                    } else {
+                        PpcImportAction::Return(0)
+                    }
+                } else {
+                    PpcImportAction::Return(ppc_i16_result(
+                        crate::thread_manager::THREAD_PROTOCOL_ERR,
+                    ))
+                },
+            )
         }
         PpcImportDispatcherTarget::ThreadBeginCritical => {
             Some(PpcImportAction::Return(ppc_i16_result(
@@ -90412,6 +90567,28 @@ fn ppc_restore_native_exception(
     }
     cpu.fpscr = memory.read_u32_be(context.fpu_image + 256)?;
     frame_is_valid.then_some(())
+}
+
+fn ppc_retire_native_thread(
+    calls: &crate::guest_call::SharedGuestCallStack,
+    cpu: &mut PpcCpu,
+    memory: &mut PpcSectionMem,
+    manager: &mut ProcessNativeMemoryManager,
+    task: crate::guest_call::ExecutionTaskId,
+    result: u32,
+) -> bool {
+    let Some(finished) = calls.retire_native_thread(task, cpu, |context| {
+        context.result_destination == 0
+            || memory
+                .write_u32_be(context.result_destination, result)
+                .is_some()
+    }) else {
+        return false;
+    };
+    if finished.stack_base != 0 {
+        manager.dispose_native_ptr(finished.stack_base);
+    }
+    true
 }
 
 fn ppc_resolve_callback_target(
@@ -167346,6 +167523,72 @@ pub(crate) mod tests {
             ppc_memory_read_bytes(&mut loaded.memory, text_ptr, 5),
             Some(vec![b'A', b'Z', 0x83, b'!', b'q'])
         );
+    }
+
+    #[test]
+    fn native_thread_entry_returns_to_its_creator_and_retries_result_delivery() {
+        use crate::guest_call::ExecutionTaskId;
+        const ENTRY: u32 = PPC_CODE_BASE + 0x2000;
+        const MADE: u32 = PPC_DATA_BASE + 0x2000;
+        const RESULT: u32 = PPC_DATA_BASE + 0x3000;
+        let mut loaded = load_pef_application(&synthetic_pef_with_import(b"NewThread")).unwrap();
+        loaded.memory.add_region(
+            ENTRY,
+            [0x3860_002au32, BLR]
+                .into_iter()
+                .flat_map(u32::to_be_bytes)
+                .collect(),
+        );
+        loaded.memory.add_region(MADE, vec![0; 4]);
+        loaded.cpu.gpr[3] = 1;
+        loaded.cpu.gpr[4] = ENTRY;
+        loaded.cpu.gpr[5] = 17;
+        loaded.cpu.gpr[6] = 4096;
+        loaded.cpu.gpr[7] = 0;
+        loaded.cpu.gpr[8] = RESULT; // deliberately unmapped until return retry
+        loaded.cpu.gpr[9] = MADE;
+        loaded.cpu.gpr[20] = 0x1234_5678;
+        loaded.cpu.fpr[20] = 0x4009_21fb_5444_2d18;
+        loaded.cpu.cr = 0x1357_2468;
+        let probe = loaded.run_with_hle_imports(64);
+        assert_eq!(probe.unsupported_import_index, None);
+        assert_eq!(loaded.cpu.gpr[3], 0);
+        let worker = ExecutionTaskId::from_thread_id(loaded.memory.read_u32_be(MADE).unwrap());
+        assert_eq!(worker.thread_id(), 3);
+        let mut yielding = loaded.imports[0].clone();
+        yielding.symbol_index = 1;
+        yielding.symbol_name = "YieldToAnyThread".into();
+        yielding.dispatcher_target =
+            dispatcher_target_for_import("InterfaceLib", "YieldToAnyThread");
+        yielding.trap_pc = PPC_IMPORT_TRAP_BASE + 4;
+        loaded.imports.push(yielding);
+        loaded.import_count = 2;
+        loaded.cpu.pc = PPC_IMPORT_TRAP_BASE + 4;
+        loaded.cpu.lr = PPC_HALT_PC;
+        let creator = loaded.cpu.clone();
+        loaded.run_with_hle_imports(64);
+        assert_eq!(loaded.guest_calls.current_task(), worker);
+        assert_eq!(loaded.cpu.pc, ENTRY);
+        assert_eq!(loaded.cpu.gpr[3], 17);
+        loaded.run_with_hle_imports(64);
+        assert_eq!(loaded.guest_calls.current_task(), worker);
+        assert_eq!(loaded.cpu.pc, PPC_THREAD_RETURN_PC);
+        assert_eq!(loaded.cpu.gpr[3], 42);
+        loaded.memory.add_region(RESULT, vec![0; 4]);
+        loaded.run_with_hle_imports(64);
+        assert_eq!(
+            loaded.guest_calls.current_task(),
+            ExecutionTaskId::APPLICATION
+        );
+        assert_eq!(loaded.guest_calls.scheduling_state(worker), None);
+        assert_eq!(loaded.memory.read_u32_be(RESULT), Some(42));
+        assert_eq!(loaded.cpu.pc, PPC_HALT_PC);
+        assert_eq!(loaded.cpu.gpr[20], creator.gpr[20]);
+        assert_eq!(loaded.cpu.gpr[1], creator.gpr[1]);
+        assert_eq!(loaded.cpu.gpr[2], creator.gpr[2]);
+        assert_eq!(loaded.cpu.fpr, creator.fpr);
+        assert_eq!(loaded.cpu.cr, creator.cr);
+        assert!(loaded.cpu.time_base() >= creator.time_base());
     }
 
     #[test]

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -24302,6 +24302,9 @@ fn dispatch_supported_import(
                 || !ppc_memory_can_write_bytes(memory, made, 4)
                 || target.is_none()
             {
+                if made != 0 {
+                    let _ = memory.write_u32_be(made, 0);
+                }
                 return Some(PpcImportAction::Return(ppc_i16_result(PPC_PARAM_ERR)));
             }
             let target = target.unwrap();
@@ -24313,10 +24316,12 @@ fn dispatch_supported_import(
                 last_mem_error,
             );
             if stack == 0 {
+                let _ = memory.write_u32_be(made, 0);
                 return Some(PpcImportAction::Return(ppc_i16_result(PPC_MEM_FULL_ERR)));
             }
             let Some(top) = stack.checked_add(size) else {
                 process_memory_manager.dispose_native_ptr(stack);
+                let _ = memory.write_u32_be(made, 0);
                 return Some(PpcImportAction::Return(ppc_i16_result(PPC_MEM_FULL_ERR)));
             };
             let mut thread_cpu = PpcCpu::new();
@@ -24342,6 +24347,7 @@ fn dispatch_supported_import(
             );
             if created.is_none() {
                 process_memory_manager.dispose_native_ptr(stack);
+                let _ = memory.write_u32_be(made, 0);
             }
             ppc_apply_process_native_allocator(
                 process_memory_manager,
@@ -167626,6 +167632,27 @@ pub(crate) mod tests {
             ppc_memory_read_bytes(&mut loaded.memory, text_ptr, 5),
             Some(vec![b'A', b'Z', 0x83, b'!', b'q'])
         );
+    }
+
+    #[test]
+    fn native_thread_creation_clears_the_output_on_failure_without_publishing_a_task() {
+        let mut loaded = load_pef_application(&synthetic_pef_with_import(b"NewThread")).unwrap();
+        let made = PPC_DATA_BASE + 0x1000;
+        loaded.memory.add_region(made, vec![0xaa; 4]);
+        loaded.cpu.gpr[3] = 2;
+        loaded.cpu.gpr[4] = loaded.entry_pc;
+        loaded.cpu.gpr[6] = 1024;
+        loaded.cpu.gpr[9] = made;
+        assert_eq!(loaded.run_with_hle_imports(64).handled_import_count, 1);
+        assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_PARAM_ERR));
+        assert_eq!(loaded.memory.read_u32_be(made), Some(0));
+        assert!(!loaded.guest_calls.has_live_workers());
+        loaded.cpu.pc = loaded.entry_pc;
+        loaded.cpu.lr = PPC_HALT_PC;
+        loaded.cpu.gpr[3] = 1;
+        assert_eq!(loaded.run_with_hle_imports(64).handled_import_count, 1);
+        assert_eq!(loaded.cpu.gpr[3], 0);
+        assert_eq!(loaded.memory.read_u32_be(made), Some(3));
     }
 
     #[test]

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -1633,6 +1633,9 @@ pub enum PpcImportDispatcherTarget {
     UpperText,
     GetCurrentThread,
     GetThreadState,
+    GetThreadCurrentTaskRef,
+    GetThreadStateGivenTaskRef,
+    SetThreadReadyGivenTaskRef,
     SetThreadState,
     SetThreadStateEndCritical,
     ThreadBeginCritical,
@@ -7379,9 +7382,10 @@ impl PpcLoadedApp {
         trace_fetches: bool,
         process_memory_manager: Option<&mut ProcessMemoryManager>,
     ) -> PpcHleRunProbe {
-        // A standalone native adapter must not advance a suspended native CPU
-        // while its process is handing execution to a classic engine.
-        if self.guest_calls.has_classic_task_handoff()
+        // Wakeup selects and prepares a saved context before any native step.
+        self.guest_calls.resume_ready_task();
+        if !self.guest_calls.current_task_is_running()
+            || self.guest_calls.has_classic_task_handoff()
             || (self.guest_calls.has_pending_task_handoff()
                 && !self.guest_calls.prepare_native_task(&mut self.cpu))
         {
@@ -15031,6 +15035,15 @@ fn dispatcher_target_for_import(
         ("InterfaceLib", "UpperText") => PpcImportDispatcherTarget::UpperText,
         ("InterfaceLib", "GetCurrentThread" | "MacGetCurrentThread") => {
             PpcImportDispatcherTarget::GetCurrentThread
+        }
+        ("InterfaceLib", "GetThreadCurrentTaskRef") => {
+            PpcImportDispatcherTarget::GetThreadCurrentTaskRef
+        }
+        ("InterfaceLib", "GetThreadStateGivenTaskRef") => {
+            PpcImportDispatcherTarget::GetThreadStateGivenTaskRef
+        }
+        ("InterfaceLib", "SetThreadReadyGivenTaskRef") => {
+            PpcImportDispatcherTarget::SetThreadReadyGivenTaskRef
         }
         ("InterfaceLib", "GetThreadState") => PpcImportDispatcherTarget::GetThreadState,
         ("InterfaceLib", "SetThreadState") => PpcImportDispatcherTarget::SetThreadState,
@@ -24201,6 +24214,42 @@ fn dispatch_supported_import(
                     Err(error) => error,
                 }
             };
+            Some(PpcImportAction::Return(ppc_i16_result(result)))
+        }
+        PpcImportDispatcherTarget::GetThreadCurrentTaskRef => {
+            // OSErr GetThreadCurrentTaskRef(ThreadTaskRef *reference);
+            // Inside Macintosh: Thread Manager (1999), p. 73.
+            let reference = crate::thread_manager::ThreadManager::new(&toolbox_startup.guest_calls)
+                .task_reference();
+            let result = if cpu.gpr[3] != 0 && memory.write_u32_be(cpu.gpr[3], reference).is_some()
+            {
+                0
+            } else {
+                PPC_PARAM_ERR
+            };
+            Some(PpcImportAction::Return(ppc_i16_result(result)))
+        }
+        PpcImportDispatcherTarget::GetThreadStateGivenTaskRef => {
+            // OSErr GetThreadStateGivenTaskRef(ThreadTaskRef, ThreadID, ThreadState *);
+            // Inside Macintosh: Thread Manager (1999), pp. 74–75.
+            let result = if cpu.gpr[5] == 0 {
+                PPC_PARAM_ERR
+            } else {
+                match crate::thread_manager::ThreadManager::new(&toolbox_startup.guest_calls)
+                    .state_given_task(cpu.gpr[3], cpu.gpr[4])
+                {
+                    Ok(state) if memory.write_u16_be(cpu.gpr[5], state).is_some() => 0,
+                    Ok(_) => PPC_PARAM_ERR,
+                    Err(error) => error,
+                }
+            };
+            Some(PpcImportAction::Return(ppc_i16_result(result)))
+        }
+        PpcImportDispatcherTarget::SetThreadReadyGivenTaskRef => {
+            // OSErr SetThreadReadyGivenTaskRef(ThreadTaskRef reference, ThreadID thread);
+            // Inside Macintosh: Thread Manager (1999), pp. 75–76.
+            let result = crate::thread_manager::ThreadManager::new(&toolbox_startup.guest_calls)
+                .ready_given_task(cpu.gpr[3], cpu.gpr[4]);
             Some(PpcImportAction::Return(ppc_i16_result(result)))
         }
         PpcImportDispatcherTarget::SetThreadState
@@ -167639,6 +167688,86 @@ pub(crate) mod tests {
         assert_eq!(loaded.cpu.fpr, creator.fpr);
         assert_eq!(loaded.cpu.cr, creator.cr);
         assert!(loaded.cpu.time_base() >= creator.time_base());
+    }
+
+    #[test]
+    fn standalone_native_thread_stays_stopped_until_ready() {
+        let mut loaded =
+            load_pef_application(&synthetic_pef_with_import(b"SetThreadStateEndCritical")).unwrap();
+        loaded.guest_calls.begin_critical();
+        loaded.cpu.gpr[3] = 1;
+        loaded.cpu.gpr[4] = 1;
+        loaded.cpu.gpr[5] = 0;
+        assert_eq!(loaded.run_with_hle_imports(64).handled_import_count, 1);
+        assert!(!loaded.guest_calls.current_task_is_running());
+        let pc = loaded.cpu.pc;
+        let time = loaded.cpu.time_base();
+        for _ in 0..3 {
+            let probe = loaded.run_with_hle_imports(64);
+            assert_eq!(probe.result, PpcRunResult::CycleLimit { cycles: 0 });
+            assert_eq!(probe.handled_import_count, 0);
+            assert_eq!(loaded.cpu.pc, pc);
+            assert_eq!(loaded.cpu.time_base(), time);
+        }
+        let manager = crate::thread_manager::ThreadManager::new(&loaded.guest_calls);
+        assert_eq!(manager.ready_given_task(manager.task_reference(), 2), 0);
+        loaded.run_with_hle_imports(64);
+        assert_eq!(loaded.cpu.pc, PPC_HALT_PC);
+        assert_eq!(loaded.cpu.gpr[3], 0);
+    }
+
+    #[test]
+    fn native_thread_task_reference_routes_share_state_and_validate_requests() {
+        use crate::guest_call::ExecutionTaskId;
+        let mut loaded =
+            load_pef_application(&synthetic_pef_with_import(b"SetThreadReadyGivenTaskRef"))
+                .unwrap();
+        let worker = ExecutionTaskId::from_thread_id(3);
+        assert!(loaded.guest_calls.register_task(worker));
+        for (reference, thread, result) in [
+            (99, 3, -619),
+            (2, 99, -618),
+            (2, 3, 0),
+            (2, 3, -619),
+            (2, 2, -619),
+        ] {
+            loaded.cpu.pc = loaded.entry_pc;
+            loaded.cpu.lr = PPC_HALT_PC;
+            loaded.cpu.gpr[3] = reference;
+            loaded.cpu.gpr[4] = thread;
+            assert_eq!(loaded.run_with_hle_imports(64).handled_import_count, 1);
+            assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(result));
+            assert_eq!(
+                loaded.guest_calls.current_task(),
+                ExecutionTaskId::APPLICATION
+            );
+        }
+        let mut query =
+            load_pef_application(&synthetic_pef_with_import(b"GetThreadStateGivenTaskRef"))
+                .unwrap();
+        query.guest_calls = loaded.guest_calls.shared_handle();
+        let out = PPC_DATA_BASE + 0x1000;
+        query.memory.add_region(out, vec![0xaa; 4]);
+        for (reference, thread, result, state) in
+            [(2, 3, 0, 0), (99, 3, -619, 0xaaaa), (2, 99, -618, 0xaaaa)]
+        {
+            query.cpu.pc = query.entry_pc;
+            query.cpu.lr = PPC_HALT_PC;
+            query.cpu.gpr[3] = reference;
+            query.cpu.gpr[4] = thread;
+            query.cpu.gpr[5] = out;
+            query.memory.write_u32_be(out, 0xaaaaaaaa).unwrap();
+            assert_eq!(query.run_with_hle_imports(64).handled_import_count, 1);
+            assert_eq!(query.cpu.gpr[3], ppc_i16_result(result));
+            assert_eq!(query.memory.read_u16_be(out), Some(state));
+            assert_eq!(query.memory.read_u16_be(out + 2), Some(0xaaaa));
+        }
+        let mut reference =
+            load_pef_application(&synthetic_pef_with_import(b"GetThreadCurrentTaskRef")).unwrap();
+        reference.memory.add_region(out, vec![0; 4]);
+        reference.cpu.gpr[3] = out;
+        assert_eq!(reference.run_with_hle_imports(64).handled_import_count, 1);
+        assert_eq!(reference.memory.read_u32_be(out), Some(2));
     }
 
     #[test]

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -1633,6 +1633,8 @@ pub enum PpcImportDispatcherTarget {
     UpperText,
     GetCurrentThread,
     GetThreadState,
+    SetThreadState,
+    SetThreadStateEndCritical,
     ThreadBeginCritical,
     NewThread,
     YieldToThread,
@@ -15031,6 +15033,10 @@ fn dispatcher_target_for_import(
             PpcImportDispatcherTarget::GetCurrentThread
         }
         ("InterfaceLib", "GetThreadState") => PpcImportDispatcherTarget::GetThreadState,
+        ("InterfaceLib", "SetThreadState") => PpcImportDispatcherTarget::SetThreadState,
+        ("InterfaceLib", "SetThreadStateEndCritical") => {
+            PpcImportDispatcherTarget::SetThreadStateEndCritical
+        }
         ("InterfaceLib", "NewThread") => PpcImportDispatcherTarget::NewThread,
         ("InterfaceLib", "YieldToThread") => PpcImportDispatcherTarget::YieldToThread,
         ("InterfaceLib", "YieldToAnyThread") => PpcImportDispatcherTarget::YieldToAnyThread,
@@ -24196,6 +24202,33 @@ fn dispatch_supported_import(
                 }
             };
             Some(PpcImportAction::Return(ppc_i16_result(result)))
+        }
+        PpcImportDispatcherTarget::SetThreadState
+        | PpcImportDispatcherTarget::SetThreadStateEndCritical => {
+            // SetThreadState / SetThreadStateEndCritical
+            // Set state and optionally exit a critical section atomically.
+            // OSErr (ThreadID thread, ThreadState state, ThreadID suggested);
+            // Inside Macintosh: Thread Manager (1999), pp. 67–72.
+            let thread = cpu.gpr[3];
+            let state = cpu.gpr[4] as u16;
+            let suggested = cpu.gpr[5];
+            let end_critical = matches!(
+                binding.dispatcher_target,
+                PpcImportDispatcherTarget::SetThreadStateEndCritical
+            );
+            Some(
+                match toolbox_startup.guest_calls.set_native_thread_state(
+                    cpu,
+                    thread,
+                    state,
+                    suggested,
+                    end_critical,
+                ) {
+                    Ok(true) => PpcImportAction::Yield(1),
+                    Ok(false) => PpcImportAction::Return(0),
+                    Err(error) => PpcImportAction::Return(ppc_i16_result(error)),
+                },
+            )
         }
         PpcImportDispatcherTarget::NewThread => {
             // OSErr NewThread(ThreadStyle, ThreadEntryUPP, void *, Size,
@@ -167606,6 +167639,131 @@ pub(crate) mod tests {
         assert_eq!(loaded.cpu.fpr, creator.fpr);
         assert_eq!(loaded.cpu.cr, creator.cr);
         assert!(loaded.cpu.time_base() >= creator.time_base());
+    }
+
+    #[test]
+    fn native_thread_state_stop_wake_and_resume_preserves_the_caller() {
+        use crate::execution_kernel::ExecutionTaskState;
+        use crate::guest_call::{ExecutionTaskId, NativeThreadContext};
+        for end_critical in [false, true] {
+            let symbol = if end_critical {
+                b"SetThreadStateEndCritical".as_slice()
+            } else {
+                b"SetThreadState".as_slice()
+            };
+            let mut loaded = load_pef_application(&synthetic_pef_with_import(symbol)).unwrap();
+            let code = PPC_DATA_BASE + 0x1000;
+            loaded.memory.add_region(
+                code,
+                [0x3a800055_u32, 0x4e800020]
+                    .into_iter()
+                    .flat_map(u32::to_be_bytes)
+                    .collect(),
+            );
+            let mut worker_cpu = loaded.cpu.clone();
+            worker_cpu.pc = code;
+            worker_cpu.lr = PPC_HALT_PC;
+            worker_cpu.gpr[20] = 0;
+            let worker = loaded
+                .guest_calls
+                .create_native_thread(
+                    NativeThreadContext {
+                        cpu: Box::new(worker_cpu),
+                        result_destination: 0,
+                        stack_base: 0,
+                    },
+                    false,
+                    |_| true,
+                )
+                .unwrap();
+            loaded.cpu.gpr[20] = 0x12345678;
+            loaded.cpu.gpr[3] = 1;
+            loaded.cpu.gpr[4] = 1;
+            loaded.cpu.gpr[5] = worker.thread_id();
+            loaded.cpu.lr = PPC_HALT_PC;
+            if end_critical {
+                loaded.guest_calls.begin_critical();
+            }
+            assert_eq!(loaded.run_with_hle_imports(64).handled_import_count, 1);
+            assert_eq!(loaded.guest_calls.current_task(), worker);
+            assert_eq!(
+                loaded
+                    .guest_calls
+                    .scheduling_state(ExecutionTaskId::APPLICATION),
+                Some(ExecutionTaskState::Stopped)
+            );
+            assert_eq!(loaded.guest_calls.critical_depth(), 0);
+            loaded.run_with_hle_imports(64);
+            assert_eq!(loaded.cpu.gpr[20], 0x55);
+            // Wake the creator without switching away from the worker.
+            loaded.cpu.pc = loaded.entry_pc;
+            loaded.cpu.lr = PPC_HALT_PC;
+            loaded.cpu.gpr[3] = ExecutionTaskId::APPLICATION.thread_id();
+            loaded.cpu.gpr[4] = 0;
+            loaded.cpu.gpr[5] = 0;
+            if end_critical {
+                loaded.guest_calls.begin_critical();
+            }
+            assert_eq!(loaded.run_with_hle_imports(64).handled_import_count, 1);
+            assert_eq!(loaded.guest_calls.current_task(), worker);
+            assert_eq!(
+                loaded
+                    .guest_calls
+                    .scheduling_state(ExecutionTaskId::APPLICATION),
+                Some(ExecutionTaskState::Ready)
+            );
+            // Stopping the worker resumes the creator's successful ABI return.
+            loaded.cpu.pc = loaded.entry_pc;
+            loaded.cpu.lr = PPC_HALT_PC;
+            loaded.cpu.gpr[3] = 1;
+            loaded.cpu.gpr[4] = 1;
+            loaded.cpu.gpr[5] = ExecutionTaskId::APPLICATION.thread_id();
+            if end_critical {
+                loaded.guest_calls.begin_critical();
+            }
+            assert_eq!(loaded.run_with_hle_imports(64).handled_import_count, 1);
+            assert_eq!(
+                loaded.guest_calls.current_task(),
+                ExecutionTaskId::APPLICATION
+            );
+            assert_eq!(loaded.cpu.gpr[3], 0);
+            assert_eq!(loaded.cpu.gpr[20], 0x12345678);
+            assert_eq!(loaded.cpu.pc, loaded.entry_pc + 16);
+            loaded.run_with_hle_imports(64);
+            assert_eq!(loaded.cpu.pc, PPC_HALT_PC);
+            assert_eq!(
+                loaded.guest_calls.scheduling_state(worker),
+                Some(ExecutionTaskState::Stopped)
+            );
+        }
+    }
+
+    #[test]
+    fn native_thread_state_refusal_preserves_critical_depth_and_contexts() {
+        use crate::execution_kernel::ExecutionTaskState;
+        use crate::guest_call::ExecutionTaskId;
+        let mut loaded =
+            load_pef_application(&synthetic_pef_with_import(b"SetThreadStateEndCritical")).unwrap();
+        let worker = ExecutionTaskId::from_thread_id(3);
+        assert!(loaded.guest_calls.register_task(worker));
+        assert!(loaded
+            .guest_calls
+            .set_scheduling_state(worker, ExecutionTaskState::Ready));
+        loaded.guest_calls.begin_critical();
+        // The ready identity has no saved execution context. Do not partially
+        // end critical or stop the caller when successor preparation refuses.
+        for (thread, state, error) in [(1, 1, -619), (99, 0, -618), (1, 99, -619), (3, 2, -619)] {
+            loaded.cpu.pc = loaded.entry_pc;
+            loaded.cpu.lr = PPC_HALT_PC;
+            loaded.cpu.gpr[3] = thread;
+            loaded.cpu.gpr[4] = state;
+            loaded.cpu.gpr[5] = 3;
+            let before = loaded.guest_calls.clone();
+            assert_eq!(loaded.run_with_hle_imports(64).handled_import_count, 1);
+            assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(error));
+            assert_eq!(loaded.guest_calls, before);
+            assert_eq!(loaded.guest_calls.critical_depth(), 1);
+        }
     }
 
     #[test]

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -7595,6 +7595,7 @@ impl PpcLoadedApp {
                         process_memory_manager,
                         task,
                         result,
+                        false,
                     );
                     return PpcImportAction::Yield(1);
                 }
@@ -24308,7 +24309,21 @@ fn dispatch_supported_import(
                 return Some(PpcImportAction::Return(ppc_i16_result(PPC_PARAM_ERR)));
             }
             let target = target.unwrap();
-            let stack = process_memory_manager.new_native_ptr(memory, size, true);
+            let pooled = match toolbox_startup.guest_calls.request_thread_stack(
+                GuestIsa::PowerPc,
+                size,
+                options,
+            ) {
+                Ok(pooled) => pooled,
+                Err(error) => {
+                    let _ = memory.write_u32_be(made, 0);
+                    return Some(PpcImportAction::Return(ppc_i16_result(error)));
+                }
+            };
+            let stack = pooled.map_or_else(
+                || process_memory_manager.new_native_ptr(memory, size, true),
+                |storage| storage.stack_base,
+            );
             ppc_apply_process_native_allocator(
                 process_memory_manager,
                 memory,
@@ -24319,7 +24334,10 @@ fn dispatch_supported_import(
                 let _ = memory.write_u32_be(made, 0);
                 return Some(PpcImportAction::Return(ppc_i16_result(PPC_MEM_FULL_ERR)));
             }
-            let Some(top) = stack.checked_add(size) else {
+            let Some(top) = pooled
+                .map(|storage| storage.stack_limit)
+                .or_else(|| stack.checked_add(size))
+            else {
                 process_memory_manager.dispose_native_ptr(stack);
                 let _ = memory.write_u32_be(made, 0);
                 return Some(PpcImportAction::Return(ppc_i16_result(PPC_MEM_FULL_ERR)));
@@ -24346,7 +24364,13 @@ fn dispatch_supported_import(
                 |task| memory.write_u32_be(made, task.thread_id()).is_some(),
             );
             if created.is_none() {
-                process_memory_manager.dispose_native_ptr(stack);
+                if let Some(storage) = pooled {
+                    toolbox_startup
+                        .guest_calls
+                        .recycle_thread_stack(GuestIsa::PowerPc, storage);
+                } else {
+                    process_memory_manager.dispose_native_ptr(stack);
+                }
                 let _ = memory.write_u32_be(made, 0);
             }
             ppc_apply_process_native_allocator(
@@ -24397,6 +24421,7 @@ fn dispatch_supported_import(
             }
             let current = task == calls.current_task();
             let result = cpu.gpr[4];
+            let recycle = cpu.gpr[5] as u8 != 0;
             Some(
                 if ppc_retire_native_thread(
                     calls,
@@ -24405,6 +24430,7 @@ fn dispatch_supported_import(
                     process_memory_manager,
                     task,
                     result,
+                    recycle,
                 ) {
                     if current {
                         PpcImportAction::Yield(1)
@@ -90685,8 +90711,9 @@ fn ppc_retire_native_thread(
     manager: &mut ProcessNativeMemoryManager,
     task: crate::guest_call::ExecutionTaskId,
     result: u32,
+    recycle: bool,
 ) -> bool {
-    let Some(finished) = calls.retire_native_thread(task, cpu, |context| {
+    let Some(finished) = calls.retire_native_thread(task, cpu, recycle, |context| {
         context.result_destination == 0
             || memory
                 .write_u32_be(context.result_destination, result)
@@ -90694,8 +90721,12 @@ fn ppc_retire_native_thread(
     }) else {
         return false;
     };
-    if finished.stack_base != 0 && finished.managed_pointer {
-        manager.dispose_native_ptr(finished.stack_base);
+    if !recycle && finished.stack_base != 0 {
+        if finished.managed_pointer {
+            manager.dispose_native_ptr(finished.stack_base);
+        } else {
+            manager.dispose_classic_ptr_from_native_import(finished.stack_base);
+        }
     }
     true
 }
@@ -167650,6 +167681,15 @@ pub(crate) mod tests {
         loaded.cpu.pc = loaded.entry_pc;
         loaded.cpu.lr = PPC_HALT_PC;
         loaded.cpu.gpr[3] = 1;
+        loaded.cpu.gpr[7] = 2; // kUsePremadeThread, with an empty pool
+        assert_eq!(loaded.run_with_hle_imports(64).handled_import_count, 1);
+        assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(-617));
+        assert_eq!(loaded.memory.read_u32_be(made), Some(0));
+        assert!(!loaded.guest_calls.has_live_workers());
+        loaded.cpu.pc = loaded.entry_pc;
+        loaded.cpu.lr = PPC_HALT_PC;
+        loaded.cpu.gpr[3] = 1;
+        loaded.cpu.gpr[7] = 2 | 4; // kCreateIfNeeded preserves the unconsumed ID
         assert_eq!(loaded.run_with_hle_imports(64).handled_import_count, 1);
         assert_eq!(loaded.cpu.gpr[3], 0);
         assert_eq!(loaded.memory.read_u32_be(made), Some(3));

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -24330,8 +24330,12 @@ fn dispatch_supported_import(
             let created = toolbox_startup.guest_calls.create_native_thread(
                 crate::guest_call::NativeThreadContext {
                     cpu: Box::new(thread_cpu),
+                },
+                crate::guest_call::ThreadStorage {
                     result_destination,
                     stack_base: stack,
+                    stack_limit: top,
+                    managed_pointer: true,
                 },
                 options & 1 != 0,
                 |task| memory.write_u32_be(made, task.thread_id()).is_some(),
@@ -90684,7 +90688,7 @@ fn ppc_retire_native_thread(
     }) else {
         return false;
     };
-    if finished.stack_base != 0 {
+    if finished.stack_base != 0 && finished.managed_pointer {
         manager.dispose_native_ptr(finished.stack_base);
     }
     true
@@ -167798,8 +167802,12 @@ pub(crate) mod tests {
                 .create_native_thread(
                     NativeThreadContext {
                         cpu: Box::new(worker_cpu),
+                    },
+                    crate::guest_call::ThreadStorage {
                         result_destination: 0,
                         stack_base: 0,
+                        stack_limit: 0,
+                        managed_pointer: true,
                     },
                     false,
                     |_| true,

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -7377,6 +7377,23 @@ impl PpcLoadedApp {
         trace_fetches: bool,
         process_memory_manager: Option<&mut ProcessMemoryManager>,
     ) -> PpcHleRunProbe {
+        // A standalone native adapter must not advance a suspended native CPU
+        // while its process is handing execution to a classic engine.
+        if self.guest_calls.has_classic_task_handoff()
+            || (self.guest_calls.has_pending_task_handoff()
+                && !self.guest_calls.prepare_native_task(&mut self.cpu))
+        {
+            return PpcHleRunProbe {
+                result: PpcRunResult::CycleLimit { cycles: 0 },
+                handled_import_count: 0,
+                last_import_index: None,
+                unsupported_import_index: None,
+                import_trace: Vec::new(),
+                draw_sprocket_trace: Vec::new(),
+                input_sprocket_trace: Vec::new(),
+                fetch_histogram: None,
+            };
+        }
         let standalone_memory_manager = process_memory_manager
             .is_none()
             .then(|| self.process_memory_manager.0.clone());

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -1640,6 +1640,10 @@ pub enum PpcImportDispatcherTarget {
     SetThreadStateEndCritical,
     ThreadBeginCritical,
     NewThread,
+    CreateThreadPool,
+    GetFreeThreadCount,
+    GetSpecificFreeThreadCount,
+    GetDefaultThreadStackSize,
     YieldToThread,
     YieldToAnyThread,
     DisposeThread,
@@ -15051,6 +15055,14 @@ fn dispatcher_target_for_import(
         ("InterfaceLib", "SetThreadStateEndCritical") => {
             PpcImportDispatcherTarget::SetThreadStateEndCritical
         }
+        ("InterfaceLib", "CreateThreadPool") => PpcImportDispatcherTarget::CreateThreadPool,
+        ("InterfaceLib", "GetFreeThreadCount") => PpcImportDispatcherTarget::GetFreeThreadCount,
+        ("InterfaceLib", "GetSpecificFreeThreadCount") => {
+            PpcImportDispatcherTarget::GetSpecificFreeThreadCount
+        }
+        ("InterfaceLib", "GetDefaultThreadStackSize") => {
+            PpcImportDispatcherTarget::GetDefaultThreadStackSize
+        }
         ("InterfaceLib", "NewThread") => PpcImportDispatcherTarget::NewThread,
         ("InterfaceLib", "YieldToThread") => PpcImportDispatcherTarget::YieldToThread,
         ("InterfaceLib", "YieldToAnyThread") => PpcImportDispatcherTarget::YieldToAnyThread,
@@ -24279,6 +24291,84 @@ fn dispatch_supported_import(
                     Err(error) => PpcImportAction::Return(ppc_i16_result(error)),
                 },
             )
+        }
+        PpcImportDispatcherTarget::CreateThreadPool => {
+            // OSErr CreateThreadPool(ThreadStyle, short, Size);
+            // Thread Manager (1999), pp. 50–51: all allocations or none.
+            let manager = crate::thread_manager::ThreadManager::new(&toolbox_startup.guest_calls);
+            let result = manager.create_pool(
+                GuestIsa::PowerPc,
+                cpu.gpr[3],
+                cpu.gpr[4] as i16,
+                cpu.gpr[5],
+                |size| {
+                    let base = process_memory_manager.new_native_ptr(memory, size, true);
+                    (base != 0).then_some(crate::guest_call::ThreadStorage {
+                        stack_base: base,
+                        stack_limit: base.saturating_add(size),
+                        managed_pointer: true,
+                        ..Default::default()
+                    })
+                },
+            );
+            let error = match result {
+                Ok(()) => 0,
+                Err((error, storage)) => {
+                    for stack in storage {
+                        process_memory_manager.dispose_native_ptr(stack.stack_base);
+                    }
+                    error
+                }
+            };
+            ppc_apply_process_native_allocator(
+                process_memory_manager,
+                memory,
+                heap_cursor,
+                last_mem_error,
+            );
+            Some(PpcImportAction::Return(ppc_i16_result(error)))
+        }
+        PpcImportDispatcherTarget::GetFreeThreadCount
+        | PpcImportDispatcherTarget::GetSpecificFreeThreadCount
+        | PpcImportDispatcherTarget::GetDefaultThreadStackSize => {
+            // OSErr GetFreeThreadCount(ThreadStyle, short *);
+            // OSErr GetSpecificFreeThreadCount(ThreadStyle, Size, short *);
+            // OSErr GetDefaultThreadStackSize(ThreadStyle, Size *);
+            // Thread Manager (1999), pp. 52–55.
+            let specific =
+                binding.dispatcher_target == PpcImportDispatcherTarget::GetSpecificFreeThreadCount;
+            let default_size =
+                binding.dispatcher_target == PpcImportDispatcherTarget::GetDefaultThreadStackSize;
+            let output = if specific { cpu.gpr[5] } else { cpu.gpr[4] };
+            let manager = crate::thread_manager::ThreadManager::new(&toolbox_startup.guest_calls);
+            let value = if default_size {
+                crate::thread_manager::ThreadManager::stack_size(GuestIsa::PowerPc, cpu.gpr[3], 0)
+            } else {
+                manager
+                    .free_count(
+                        GuestIsa::PowerPc,
+                        cpu.gpr[3],
+                        if specific { cpu.gpr[4] } else { 0 },
+                    )
+                    .map(u32::from)
+            };
+            let result = match value {
+                Err(error) => error,
+                Ok(value) if output != 0 => {
+                    let written = if default_size {
+                        memory.write_u32_be(output, value)
+                    } else {
+                        memory.write_u16_be(output, value as u16)
+                    };
+                    if written.is_some() {
+                        0
+                    } else {
+                        PPC_PARAM_ERR
+                    }
+                }
+                Ok(_) => PPC_PARAM_ERR,
+            };
+            Some(PpcImportAction::Return(ppc_i16_result(result)))
         }
         PpcImportDispatcherTarget::NewThread => {
             // OSErr NewThread(ThreadStyle, ThreadEntryUPP, void *, Size,
@@ -167663,6 +167753,69 @@ pub(crate) mod tests {
             ppc_memory_read_bytes(&mut loaded.memory, text_ptr, 5),
             Some(vec![b'A', b'Z', 0x83, b'!', b'q'])
         );
+    }
+
+    #[test]
+    fn native_thread_pool_imports_create_query_validate_and_supply_new_threads() {
+        let mut loaded =
+            load_pef_application(&synthetic_pef_with_import(b"CreateThreadPool")).unwrap();
+        let output = PPC_DATA_BASE + 0x5000;
+        loaded.memory.add_region(output, vec![0xaa; 4]);
+        let invoke = |loaded: &mut PpcLoadedApp, name: &str, args: [u32; 3]| {
+            loaded.imports[0].symbol_name = name.into();
+            loaded.imports[0].dispatcher_target =
+                dispatcher_target_for_import("InterfaceLib", name);
+            loaded.cpu.pc = loaded.entry_pc;
+            loaded.cpu.lr = PPC_HALT_PC;
+            loaded.cpu.gpr[3..6].copy_from_slice(&args);
+            let result = loaded.run_with_hle_imports(64);
+            assert_eq!(result.unsupported_import_index, None);
+            assert_eq!(result.handled_import_count, 1);
+            loaded.cpu.gpr[3] as i16
+        };
+        assert_eq!(invoke(&mut loaded, "CreateThreadPool", [1, 3, 1024]), 0);
+        assert_eq!(invoke(&mut loaded, "CreateThreadPool", [1, 1, 2048]), 0);
+        assert_eq!(invoke(&mut loaded, "GetFreeThreadCount", [1, output, 0]), 0);
+        assert_eq!(loaded.memory.read_u32_be(output), Some(0x0004aaaa));
+        assert_eq!(
+            invoke(&mut loaded, "GetSpecificFreeThreadCount", [1, 1536, output]),
+            0
+        );
+        assert_eq!(loaded.memory.read_u32_be(output), Some(0x0001aaaa));
+        assert_eq!(
+            invoke(&mut loaded, "GetFreeThreadCount", [0, output, 0]),
+            -50
+        );
+        assert_eq!(loaded.memory.read_u32_be(output), Some(0x0001aaaa));
+        assert_eq!(
+            invoke(&mut loaded, "GetFreeThreadCount", [1, output + 3, 0]),
+            -50
+        );
+        assert_eq!(loaded.memory.read_u32_be(output), Some(0x0001aaaa));
+        assert_eq!(
+            invoke(&mut loaded, "CreateThreadPool", [1, 0xffff, 1024]),
+            -50
+        );
+        assert_eq!(
+            invoke(&mut loaded, "CreateThreadPool", [1, 1, u32::MAX]),
+            -50
+        );
+        assert_eq!(
+            invoke(&mut loaded, "GetDefaultThreadStackSize", [1, output, 0]),
+            0
+        );
+        assert_eq!(loaded.memory.read_u32_be(output), Some(32 * 1024));
+        // Pool creation assigns no task IDs; the first premade NewThread does.
+        loaded.cpu.gpr[6] = 1024;
+        loaded.cpu.gpr[7] = 1 | 2 | 16;
+        loaded.cpu.gpr[8] = 0;
+        loaded.cpu.gpr[9] = output;
+        let entry = loaded.entry_pc;
+        assert_eq!(invoke(&mut loaded, "NewThread", [1, entry, 0x1234]), 0);
+        assert_eq!(loaded.memory.read_u32_be(output), Some(3));
+        assert_eq!(invoke(&mut loaded, "GetFreeThreadCount", [1, output, 0]), 0);
+        assert_eq!(loaded.memory.read_u16_be(output), Some(3));
+        assert_eq!(loaded.guest_calls.thread_pool_count(GuestIsa::M68k, 0), 0);
     }
 
     #[test]

--- a/src/memory/bus.rs
+++ b/src/memory/bus.rs
@@ -1420,7 +1420,7 @@ impl MacMemoryBus {
     /// This is the atomic preflight for routed bulk copies: a mixed flat /
     /// sparse span may be valid, while any hole or read-only byte rejects the
     /// operation before the first destination byte changes.
-    fn is_guest_address_writable(&self, address: u32, len: usize) -> bool {
+    pub(crate) fn is_guest_address_writable(&self, address: u32, len: usize) -> bool {
         (0..len).all(|offset| {
             let guest_address = address.wrapping_add(offset as u32);
             let translated = self.translate_guest_address(guest_address);
@@ -1450,6 +1450,37 @@ impl MacMemoryBus {
     /// Commit a 16-bit ABI result only when all routed bytes accept writes.
     pub(crate) fn try_write_word(&mut self, address: u32, value: u16) -> bool {
         self.try_write_bytes_atomic(address, &value.to_be_bytes())
+    }
+
+    /// Commit a prepared operation's discontiguous outputs together. No guest
+    /// code or mapping mutation may run between preflight and these writes.
+    pub(crate) fn try_write_ranges_atomic(&mut self, writes: &[(u32, &[u8])]) -> bool {
+        if writes
+            .iter()
+            .any(|(address, bytes)| !self.is_guest_address_writable(*address, bytes.len()))
+        {
+            return false;
+        }
+        let originals: Vec<Vec<u8>> = writes
+            .iter()
+            .map(|(address, bytes)| {
+                (0..bytes.len())
+                    .map(|offset| self.read_byte(address.wrapping_add(offset as u32)))
+                    .collect()
+            })
+            .collect();
+        for (index, (address, bytes)) in writes.iter().enumerate() {
+            if !self.try_write_bytes_atomic(*address, bytes) {
+                for ((address, _), original) in
+                    writes[..index].iter().zip(&originals[..index]).rev()
+                {
+                    let restored = self.try_write_bytes_atomic(*address, original);
+                    debug_assert!(restored);
+                }
+                return false;
+            }
+        }
+        true
     }
 
     /// Read one guest longword only when all four routed bytes are mapped.
@@ -3699,6 +3730,20 @@ mod tests {
                 "in-RAM tail of straddling fill_zeros"
             );
         }
+    }
+
+    #[test]
+    fn prepared_discontiguous_writes_refuse_before_changing_any_destination() {
+        let mut bus = MacMemoryBus::new(64 * 1024);
+        bus.write_long(0x2000, 0x11223344);
+        bus.write_long(0x3000, 0x55667788);
+        bus.protect_readonly_code(0x3002, 2);
+        assert!(!bus.try_write_ranges_atomic(&[(0x2000, &[1, 2, 3, 4]), (0x3000, &[5, 6, 7, 8])]));
+        assert_eq!(bus.read_long(0x2000), 0x11223344);
+        assert_eq!(bus.read_long(0x3000), 0x55667788);
+        assert!(bus.try_write_ranges_atomic(&[(0x2000, &[1, 2, 3, 4]), (0x3000, &[5, 6])]));
+        assert_eq!(bus.read_long(0x2000), 0x01020304);
+        assert_eq!(bus.read_long(0x3000), 0x05067788);
     }
 
     #[test]

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -5602,6 +5602,7 @@ impl FixtureRunner {
         sound_work_only: bool,
         finish_frame: bool,
     ) -> (usize, bool) {
+        self.dispatcher.guest_calls.resume_ready_task();
         self.m68k.apply_task_handoff();
         let route = self
             .dispatcher
@@ -6573,7 +6574,8 @@ impl FixtureRunner {
             // the native caller is parked. Do not deliver the native
             // application's VBL/Time Manager work against that successor's
             // task; the callback phase is retried once its owner is selected.
-            let native_callbacks_allowed = ppc_app.guest_calls.current_task() == ppc_task
+            let native_callbacks_allowed = ppc_app.guest_calls.current_task_is_running()
+                && ppc_app.guest_calls.current_task() == ppc_task
                 && ExecutionTaskId::from_thread_id(
                     self.dispatcher.guest_calls.current_task().thread_id(),
                 ) == ppc_task;
@@ -6683,7 +6685,8 @@ impl FixtureRunner {
             (Vec::new(), Vec::new())
         } else {
             let tick_advance = self.advance_ticks_for_ppc_cycles(cycles, tick_cap);
-            let native_callbacks_allowed = ppc_app.guest_calls.current_task() == ppc_task
+            let native_callbacks_allowed = ppc_app.guest_calls.current_task_is_running()
+                && ppc_app.guest_calls.current_task() == ppc_task
                 && ExecutionTaskId::from_thread_id(
                     self.dispatcher.guest_calls.current_task().thread_id(),
                 ) == ppc_task;
@@ -6934,7 +6937,9 @@ impl FixtureRunner {
         // task and the continuation captured above must remain suspended until
         // its owner is scheduled again. Continuing here would execute the old
         // callback against the new task's registers and stack.
-        if ppc_app.guest_calls.current_task() != task {
+        if ppc_app.guest_calls.current_task() != task
+            || !ppc_app.guest_calls.current_task_is_running()
+        {
             return Some((0, true));
         }
 
@@ -6996,7 +7001,9 @@ impl FixtureRunner {
                         running = false;
                         break;
                     }
-                    if ppc_app.guest_calls.current_task() != task {
+                    if ppc_app.guest_calls.current_task() != task
+                        || !ppc_app.guest_calls.current_task_is_running()
+                    {
                         // The trap switched cooperative tasks. Preserve the active
                         // frame and let the outer scheduler run the newly selected
                         // task; only this task may resume the captured continuation.
@@ -15522,6 +15529,100 @@ mod tests {
         let ppc_app = runner.native.application().expect("PPC app retained");
         assert_eq!(ppc_app.cpu.pc, PPC_CODE_BASE);
         assert_eq!(ppc_app.cpu.gpr[3], u32::from(TRAP));
+    }
+
+    #[test]
+    fn stopped_last_thread_waits_for_a_task_reference_wakeup() {
+        use crate::cpu::CpuOps;
+        use crate::execution_kernel::ExecutionTaskState;
+        use crate::trap::test_helpers::{setup, TEST_SP};
+        const CLASSIC_PC: u32 = 0x4000;
+        const CLASSIC_SP: u32 = 0x5000;
+        for native in [false, true] {
+            let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+            if native {
+                let mut app = halted_ppc_app_with_sound(PpcSoundState::default());
+                let loaded = app.ppc.as_mut().unwrap();
+                loaded.entry_pc = PPC_IMPORT_TRAP_BASE;
+                loaded.cpu.pc = PPC_IMPORT_TRAP_BASE;
+                loaded.memory.add_region(PPC_IMPORT_TRAP_BASE, vec![0; 4]);
+                loaded.memory.add_region(
+                    PPC_CODE_BASE,
+                    [0x3a800055_u32, 0x48000000]
+                        .into_iter()
+                        .flat_map(u32::to_be_bytes)
+                        .collect(),
+                );
+                let mut binding = test_ppc_import_binding(0, "InterfaceLib", "SetThreadState");
+                binding.dispatcher_target = PpcImportDispatcherTarget::SetThreadState;
+                binding.trap_pc = PPC_IMPORT_TRAP_BASE;
+                loaded.import_count = 1;
+                loaded.imports.push(binding);
+                runner.init_app(&app);
+                let cpu = &mut runner.native.application_mut().unwrap().cpu;
+                cpu.lr = PPC_CODE_BASE;
+                cpu.gpr[3] = 1;
+                cpu.gpr[4] = 1;
+                cpu.gpr[5] = 0;
+                cpu.gpr[20] = 0;
+            } else {
+                for (i, word) in [0x303cu16, 0x0508, 0xabf2, 0x7c55, 0x60fe]
+                    .into_iter()
+                    .enumerate()
+                {
+                    runner.bus.write_word(CLASSIC_PC + i as u32 * 2, word);
+                }
+                runner.bus.write_long(CLASSIC_SP, 0);
+                runner.bus.write_word(CLASSIC_SP + 4, 1);
+                runner.bus.write_long(CLASSIC_SP + 6, 1);
+                runner.m68k.cpu.write_reg(Register::PC, CLASSIC_PC);
+                runner.m68k.cpu.write_reg(Register::A7, CLASSIC_SP);
+                runner.m68k.cpu.write_reg(Register::D6, 0);
+            }
+            let calls = runner.dispatcher.guest_calls.shared_handle();
+            let (steps, running) = runner.run_steps(32, None);
+            assert!(steps > 0 && running);
+            assert_eq!(
+                calls.scheduling_state(ExecutionTaskId::APPLICATION),
+                Some(ExecutionTaskState::Stopped)
+            );
+            assert!(!runner.m68k.can_relaunch());
+            for _ in 0..3 {
+                assert_eq!(runner.run_steps(32, None), (0, true));
+            }
+            if native {
+                let cpu = &runner.native.application().unwrap().cpu;
+                assert_eq!(cpu.pc, PPC_CODE_BASE);
+                assert_eq!(cpu.gpr[20], 0);
+            } else {
+                assert_eq!(runner.m68k.cpu.read_reg(Register::PC), CLASSIC_PC + 6);
+                assert_eq!(runner.m68k.cpu.read_reg(Register::D6), 0);
+                assert_eq!(runner.m68k.cpu.read_reg(Register::A7), CLASSIC_SP + 10);
+            }
+            // An interrupt/completion edge may mark the stopped thread ready;
+            // the wake call must not execute or replace the suspended CPU.
+            let (mut wake, mut cpu, mut bus) = setup();
+            wake.guest_calls = calls.shared_handle();
+            bus.write_long(TEST_SP, ExecutionTaskId::APPLICATION.thread_id());
+            bus.write_long(TEST_SP + 4, 2);
+            cpu.write_reg(Register::D0, 0x0410);
+            wake.dispatch_toolbox(true, 0x3f2, &mut cpu, &mut bus)
+                .unwrap()
+                .unwrap();
+            assert_eq!(cpu.read_reg(Register::D0), 0);
+            assert_eq!(
+                calls.scheduling_state(ExecutionTaskId::APPLICATION),
+                Some(ExecutionTaskState::Ready)
+            );
+            let (steps, running) = runner.run_steps(32, None);
+            assert!(steps > 0 && running);
+            assert!(calls.current_task_is_running());
+            if native {
+                assert_eq!(runner.native.application().unwrap().cpu.gpr[20], 0x55);
+            } else {
+                assert_eq!(runner.m68k.cpu.read_reg(Register::D6), 0x55);
+            }
+        }
     }
 
     #[test]

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -16558,6 +16558,23 @@ mod tests {
         assert!(calls.complete_m68k(0x2002, 0x3000));
         runner.init_app(&app);
         assert!(runner.m68k.can_relaunch());
+        let worker = calls
+            .create_native_thread(
+                crate::guest_call::NativeThreadContext {
+                    cpu: Box::new(PpcCpu::new()),
+                    result_destination: 0,
+                    stack_base: 0,
+                },
+                true,
+                |_| true,
+            )
+            .unwrap();
+        let native_pc = runner.native.application().unwrap().cpu.pc;
+        let rejected =
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| runner.init_app(&app)));
+        assert!(rejected.is_err());
+        assert_eq!(runner.native.application().unwrap().cpu.pc, native_pc);
+        assert!(calls.scheduling_state(worker).is_some());
     }
 
     #[test]

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -6932,7 +6932,7 @@ impl FixtureRunner {
             return Some((0, true));
         }
         let task = ppc_app.guest_calls.current_task();
-        let pending = self.m68k.activate_pending()?;
+        let pending = self.m68k.activate_pending(&ppc_app.cpu)?;
 
         // Thread Manager calls are allowed to yield while guest callback code
         // is running. Once that happens, `self.m68k.cpu` belongs to the successor

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -16238,14 +16238,16 @@ mod tests {
             assert!(running);
             assert_eq!(runner.dispatcher.guest_calls.current_task().thread_id(), 3);
             assert_eq!(
-            runner.m68k.parked.task_len(ExecutionTaskId::APPLICATION),
+            runner.dispatcher.guest_calls.m68k_context_bank().borrow().task_len(ExecutionTaskId::APPLICATION),
             1,
             "the application-owned nested 68K context must stay parked while its callback yields"
         );
             assert_eq!(
                 runner
-                    .m68k
-                    .parked
+                    .dispatcher
+                    .guest_calls
+                    .m68k_context_bank()
+                    .borrow()
                     .task_len(ExecutionTaskId::from_thread_id(3)),
                 0,
                 "the worker must not consume the application's parked context"
@@ -16256,7 +16258,12 @@ mod tests {
             assert_eq!(runner.dispatcher.guest_calls.current_task().thread_id(), 2);
             if !native_worker {
                 assert_eq!(
-                    runner.m68k.parked.task_len(ExecutionTaskId::APPLICATION),
+                    runner
+                        .dispatcher
+                        .guest_calls
+                        .m68k_context_bank()
+                        .borrow()
+                        .task_len(ExecutionTaskId::APPLICATION),
                     1,
                     "returning from the worker must leave the nested application context parked"
                 );
@@ -16268,7 +16275,12 @@ mod tests {
             }
             assert_eq!(runner.dispatcher.guest_calls.current_task().thread_id(), 2);
             assert!(runner.dispatcher.guest_calls.is_empty());
-            assert!(runner.m68k.parked.is_empty());
+            assert!(runner
+                .dispatcher
+                .guest_calls
+                .m68k_context_bank()
+                .borrow()
+                .is_empty());
             let ppc_app = runner.native.application().expect("PPC app retained");
             assert_eq!(ppc_app.cpu.pc, PPC_CODE_BASE);
             // The outer routine has a void ProcInfo, so its internal callback's
@@ -16468,17 +16480,36 @@ mod tests {
                 runner.m68k.cpu.read_reg(Register::PC),
                 runner.m68k.cpu.read_reg(Register::A7),
                 runner.dispatcher.guest_calls.len(),
-                runner.m68k.parked.len(),
+                runner.dispatcher.guest_calls.m68k_context_bank().borrow().len(),
                 runner.native.application()
                     .map_or(0, |ppc_app| ppc_app.cpu.pc),
             );
-            maximum_parked = maximum_parked.max(runner.m68k.parked.len());
-            if !runner.m68k.parked.is_empty()
+            maximum_parked = maximum_parked.max(
+                runner
+                    .dispatcher
+                    .guest_calls
+                    .m68k_context_bank()
+                    .borrow()
+                    .len(),
+            );
+            if !runner
+                .dispatcher
+                .guest_calls
+                .m68k_context_bank()
+                .borrow()
+                .is_empty()
                 && runner.m68k.cpu.read_reg(Register::PC) == M68K_INNER + 6
             {
                 inner_entries += 1;
             }
-            if !checked_wrong_boundary && !runner.m68k.parked.is_empty() {
+            if !checked_wrong_boundary
+                && !runner
+                    .dispatcher
+                    .guest_calls
+                    .m68k_context_bank()
+                    .borrow()
+                    .is_empty()
+            {
                 let frame_count = runner.dispatcher.guest_calls.len();
                 let mut native_context = runner
                     .native
@@ -16486,7 +16517,15 @@ mod tests {
                     .expect("PPC app");
                 let mut ppc_app = native_context.adapter_mut();
                 assert!(!runner.resume_m68k_after_powerpc(&mut ppc_app));
-                assert_eq!(runner.m68k.parked.len(), 1);
+                assert_eq!(
+                    runner
+                        .dispatcher
+                        .guest_calls
+                        .m68k_context_bank()
+                        .borrow()
+                        .len(),
+                    1
+                );
                 assert_eq!(ppc_app.guest_calls.len(), frame_count);
                 runner
                     .native
@@ -16502,7 +16541,12 @@ mod tests {
         assert!(checked_wrong_boundary);
         assert_eq!(inner_entries, 2);
         assert_eq!(maximum_parked, 1);
-        assert!(runner.m68k.parked.is_empty());
+        assert!(runner
+            .dispatcher
+            .guest_calls
+            .m68k_context_bank()
+            .borrow()
+            .is_empty());
         assert!(runner.dispatcher.guest_calls.is_empty());
         assert_eq!(runner.m68k.cpu.core.d(6), OUTER_D6);
         let ppc_app = runner.native.application_mut().expect("PPC app retained");
@@ -17091,7 +17135,11 @@ mod tests {
             assert!(ppc_app
                 .guest_calls
                 .park_context(
-                    &mut runner.m68k.parked,
+                    &mut runner
+                        .dispatcher
+                        .guest_calls
+                        .m68k_context_bank()
+                        .borrow_mut(),
                     task,
                     call_id,
                     std::mem::take(&mut runner.m68k.cpu),
@@ -17113,7 +17161,12 @@ mod tests {
             assert_eq!(runner.m68k.cpu.read_reg(Register::PC), RETURN_PC);
             assert_eq!(runner.m68k.cpu.read_reg(Register::A7), FINAL_SP);
             assert!(ppc_app.guest_calls.is_empty());
-            assert!(runner.m68k.parked.is_empty());
+            assert!(runner
+                .dispatcher
+                .guest_calls
+                .m68k_context_bank()
+                .borrow()
+                .is_empty());
         }
     }
 
@@ -17169,28 +17222,64 @@ mod tests {
         assert!(ppc_app
             .guest_calls
             .park_context(
-                &mut runner.m68k.parked,
+                &mut runner
+                    .dispatcher
+                    .guest_calls
+                    .m68k_context_bank()
+                    .borrow_mut(),
                 task,
                 call_id,
                 std::mem::take(&mut runner.m68k.cpu),
             )
             .is_ok());
-        assert_eq!(runner.m68k.parked.task_len(task), 1);
+        assert_eq!(
+            runner
+                .dispatcher
+                .guest_calls
+                .m68k_context_bank()
+                .borrow()
+                .task_len(task),
+            1
+        );
         assert!(ppc_app.guest_calls.peek_m68k_resume().is_some());
 
         assert!(!runner.resume_m68k_after_powerpc(&mut ppc_app));
-        assert_eq!(runner.m68k.parked.task_len(task), 1);
+        assert_eq!(
+            runner
+                .dispatcher
+                .guest_calls
+                .m68k_context_bank()
+                .borrow()
+                .task_len(task),
+            1
+        );
         assert!(ppc_app.guest_calls.peek_m68k_resume().is_some());
 
         ppc_app.memory.add_readonly_region(RESULT, vec![0xaa; 4]);
         assert!(!runner.resume_m68k_after_powerpc(&mut ppc_app));
         assert_eq!(ppc_app.memory.read_u32_be(RESULT), Some(0xaaaa_aaaa));
-        assert_eq!(runner.m68k.parked.task_len(task), 1);
+        assert_eq!(
+            runner
+                .dispatcher
+                .guest_calls
+                .m68k_context_bank()
+                .borrow()
+                .task_len(task),
+            1
+        );
         assert!(ppc_app.guest_calls.peek_m68k_resume().is_some());
 
         ppc_app.memory.add_region(RESULT, vec![0; 4]);
         assert!(runner.resume_m68k_after_powerpc(&mut ppc_app));
-        assert_eq!(runner.m68k.parked.task_len(task), 0);
+        assert_eq!(
+            runner
+                .dispatcher
+                .guest_calls
+                .m68k_context_bank()
+                .borrow()
+                .task_len(task),
+            0
+        );
         assert!(ppc_app.guest_calls.peek_m68k_resume().is_none());
         assert_eq!(ppc_app.memory.read_u32_be(RESULT), Some(RESULT_VALUE));
         assert_eq!(runner.m68k.cpu.core.d(0), PARKED_D0);

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -15532,6 +15532,130 @@ mod tests {
     }
 
     #[test]
+    fn opposite_abi_thread_disposal_preserves_stack_provenance_and_retries_results() {
+        const FRAME: u32 = 0x6000;
+        const MADE: u32 = 0x7000;
+        const RESULT: u32 = 0x7100;
+        for native_worker in [false, true] {
+            let mut app = halted_ppc_app_with_sound(PpcSoundState::default());
+            let loaded = app.ppc.as_mut().unwrap();
+            loaded.entry_pc = PPC_IMPORT_TRAP_BASE;
+            loaded.cpu.pc = PPC_IMPORT_TRAP_BASE;
+            loaded.memory.add_region(PPC_IMPORT_TRAP_BASE, vec![0; 4]);
+            let name = if native_worker {
+                "NewThread"
+            } else {
+                "DisposeThread"
+            };
+            let mut binding = test_ppc_import_binding(0, "InterfaceLib", name);
+            binding.dispatcher_target = if native_worker {
+                PpcImportDispatcherTarget::NewThread
+            } else {
+                PpcImportDispatcherTarget::DisposeThread
+            };
+            binding.trap_pc = PPC_IMPORT_TRAP_BASE;
+            loaded.import_count = 1;
+            loaded.imports.push(binding);
+            let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+            runner.init_app(&app);
+            if native_worker {
+                let cpu = &mut runner.native.application_mut().unwrap().cpu;
+                cpu.lr = PPC_CODE_BASE;
+                cpu.gpr[3] = 1;
+                cpu.gpr[4] = PPC_CODE_BASE;
+                cpu.gpr[5] = 0;
+                cpu.gpr[6] = 1024;
+                cpu.gpr[7] = 1;
+                cpu.gpr[8] = RESULT;
+                cpu.gpr[9] = MADE;
+                assert!(runner.run_steps(32, None).1);
+            } else {
+                runner.m68k.cpu.write_reg(Register::A7, FRAME);
+                runner.m68k.cpu.write_reg(Register::D0, 0x0e03);
+                for (offset, value) in [
+                    (0, MADE),
+                    (4, RESULT),
+                    (8, 1),
+                    (12, 1024),
+                    (16, 0),
+                    (20, 0x8000),
+                    (24, 1),
+                ] {
+                    runner.bus.write_long(FRAME + offset, value);
+                }
+                runner
+                    .dispatcher
+                    .dispatch_toolbox(true, 0x3f2, &mut runner.m68k.cpu, &mut runner.bus)
+                    .unwrap()
+                    .unwrap();
+                assert_eq!(runner.m68k.cpu.read_reg(Register::D0), 0);
+            }
+            let calls = runner.dispatcher.guest_calls.shared_handle();
+            let worker = ExecutionTaskId::from_thread_id(runner.bus.read_long(MADE));
+            assert_eq!(worker.thread_id(), 3);
+            let mut storage = calls.thread_storage(worker).unwrap();
+            assert_eq!(storage.managed_pointer, native_worker);
+            assert_ne!(storage.stack_base, 0);
+            runner.bus.write_long(RESULT, 0x12345678);
+            storage.result_destination = u32::MAX - 1;
+            assert!(calls.set_thread_storage(worker, storage));
+            for (attempt, expected) in [(0, -619_i16), (1, 0), (2, -618)] {
+                if attempt == 1 {
+                    storage.result_destination = RESULT;
+                    assert!(calls.set_thread_storage(worker, storage));
+                }
+                if native_worker {
+                    runner.m68k.cpu.write_reg(Register::A7, FRAME);
+                    runner.m68k.cpu.write_reg(Register::D0, 0x0504);
+                    runner.bus.write_word(FRAME, 0);
+                    runner.bus.write_long(FRAME + 2, 0xcafebabe);
+                    runner.bus.write_long(FRAME + 6, worker.thread_id());
+                    runner
+                        .dispatcher
+                        .dispatch_toolbox(true, 0x3f2, &mut runner.m68k.cpu, &mut runner.bus)
+                        .unwrap()
+                        .unwrap();
+                    assert_eq!(runner.m68k.cpu.read_reg(Register::D0) as i16, expected);
+                } else {
+                    let cpu = &mut runner.native.application_mut().unwrap().cpu;
+                    cpu.pc = PPC_IMPORT_TRAP_BASE;
+                    cpu.lr = PPC_CODE_BASE;
+                    cpu.gpr[3] = worker.thread_id();
+                    cpu.gpr[4] = 0xcafebabe;
+                    cpu.gpr[5] = 0;
+                    assert!(runner.run_steps(32, None).1);
+                    assert_eq!(
+                        runner.native.application().unwrap().cpu.gpr[3] as i16,
+                        expected
+                    );
+                }
+                assert_eq!(calls.current_task(), ExecutionTaskId::APPLICATION);
+                assert_eq!(calls.thread_storage(worker).is_some(), attempt == 0);
+                assert_eq!(
+                    runner.bus.read_long(RESULT),
+                    if attempt == 0 { 0x12345678 } else { 0xcafebabe }
+                );
+                if native_worker {
+                    let manager = runner.dispatcher.process_memory_manager();
+                    let live = manager
+                        .borrow_mut()
+                        .native_mut()
+                        .native_ptr_records()
+                        .iter()
+                        .any(|record| record.ptr == storage.stack_base);
+                    assert_eq!(live, attempt == 0);
+                    assert_eq!(calls.classic_thread_pool_count(0), 0);
+                } else {
+                    assert_eq!(
+                        calls.classic_thread_pool_count(0),
+                        usize::from(attempt != 0)
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
     fn stopped_last_thread_waits_for_a_task_reference_wakeup() {
         use crate::cpu::CpuOps;
         use crate::execution_kernel::ExecutionTaskState;
@@ -15677,7 +15801,13 @@ mod tests {
             context.pc = CLASSIC_ENTRY;
             context.a_regs[0] = 0x5566_7788;
             context.a_regs[7] = CLASSIC_SP;
-            context.result_destination = RESULT;
+            assert!(calls.set_thread_storage(
+                worker,
+                crate::guest_call::ThreadStorage {
+                    result_destination: RESULT,
+                    ..Default::default()
+                }
+            ));
             assert!(calls.save_cooperative_context(worker, context));
             assert!(calls.set_scheduling_state(worker, ExecutionTaskState::Ready));
             let (_, running) = runner.run_steps(64, None);
@@ -16000,10 +16130,12 @@ mod tests {
                     .dispatcher
                     .guest_calls
                     .create_native_thread(
-                        crate::guest_call::NativeThreadContext {
-                            cpu: Box::new(cpu),
+                        crate::guest_call::NativeThreadContext { cpu: Box::new(cpu) },
+                        crate::guest_call::ThreadStorage {
                             result_destination: 0,
                             stack_base: 0,
+                            stack_limit: 0,
+                            managed_pointer: true,
                         },
                         true,
                         |_| true,
@@ -16015,6 +16147,14 @@ mod tests {
                     .dispatcher
                     .guest_calls
                     .register_task(ExecutionTaskId::from_thread_id(3)));
+                assert!(runner.dispatcher.guest_calls.set_thread_storage(
+                    ExecutionTaskId::from_thread_id(3),
+                    crate::guest_call::ThreadStorage {
+                        stack_base: WORKER_STACK,
+                        stack_limit: WORKER_STACK + 0x40,
+                        ..Default::default()
+                    }
+                ));
                 runner.dispatcher.guest_calls.save_cooperative_context(
                     ExecutionTaskId::from_thread_id(3),
                     CooperativeThread {
@@ -16022,9 +16162,6 @@ mod tests {
                         a_regs: [0, 0, 0, 0, 0, 0, 0, WORKER_SP],
                         pc: WORKER_ENTRY,
                         ccr: 0,
-                        result_destination: 0,
-                        stack_base: WORKER_STACK,
-                        stack_limit: WORKER_STACK + 0x40,
                         switch_in: (0, 0),
                         switch_out: (0, 0),
                         terminator: (0, 0),
@@ -16793,8 +16930,12 @@ mod tests {
             .create_native_thread(
                 crate::guest_call::NativeThreadContext {
                     cpu: Box::new(PpcCpu::new()),
+                },
+                crate::guest_call::ThreadStorage {
                     result_destination: 0,
                     stack_base: 0,
+                    stack_limit: 0,
+                    managed_pointer: true,
                 },
                 true,
                 |_| true,

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -4320,6 +4320,7 @@ impl FixtureRunner {
             crate::guest_procedure::GuestIsa::PowerPc
         ));
         ppc_app.set_ui_theme(self.config.ui_theme);
+        ppc_app.guest_calls.start_native_engine();
         self.native
             .install(NativeEngineRole::Application, ppc_app)
             .unwrap_or_else(|_| panic!("native engine slot is occupied"));
@@ -5601,6 +5602,7 @@ impl FixtureRunner {
         sound_work_only: bool,
         finish_frame: bool,
     ) -> (usize, bool) {
+        self.m68k.apply_task_handoff();
         let route = self
             .dispatcher
             .guest_calls
@@ -6533,6 +6535,9 @@ impl FixtureRunner {
         let mut ppc_app = native_context.adapter_mut();
 
         ppc_app.set_ui_theme(self.config.ui_theme);
+        if !ppc_app.guest_calls.prepare_native_task(&mut ppc_app.cpu) {
+            return (0, !self.halted);
+        }
         ppc_app.toolbox_startup.host_menu_bar_hidden = self.dispatcher.menu_bar_hidden;
         self.prepare_ppc_execution_clock(&mut ppc_app);
         let cycles_per_tick = self.instructions_per_tick.max(1);
@@ -6914,6 +6919,13 @@ impl FixtureRunner {
         ppc_app: &mut PpcLoadedApp,
         max_steps: usize,
     ) -> Option<(usize, bool)> {
+        self.m68k.apply_task_handoff();
+        if !ppc_app.guest_calls.has_m68k_execution() {
+            return None;
+        }
+        if !ppc_app.guest_calls.prepare_native_task(&mut ppc_app.cpu) {
+            return Some((0, true));
+        }
         let task = ppc_app.guest_calls.current_task();
         let pending = self.m68k.activate_pending()?;
 
@@ -15513,6 +15525,86 @@ mod tests {
     }
 
     #[test]
+    fn native_yield_roundtrips_classic_worker_yield_and_retirement() {
+        use crate::execution_kernel::ExecutionTaskState;
+        use crate::guest_call::CooperativeThread;
+        const CLASSIC_ENTRY: u32 = 0x0305_0000;
+        const CLASSIC_SP: u32 = 0x0305_1100;
+        const RESULT: u32 = 0x0305_2000;
+        for retire in [false, true] {
+            let mut app = halted_ppc_app_with_sound(PpcSoundState::default());
+            let native = app.ppc.as_mut().unwrap();
+            native.cpu.pc = PPC_IMPORT_TRAP_BASE;
+            native.entry_pc = PPC_IMPORT_TRAP_BASE;
+            native.cpu.lr = PPC_CODE_BASE;
+            native.cpu.gpr[20] = 0x1122_3344;
+            native.cpu.fpr[20] = 0x4009_21fb_5444_2d18;
+            native.cpu.cr = 0x1357_2468;
+            native.memory.add_region(PPC_IMPORT_TRAP_BASE, vec![0; 4]);
+            native
+                .memory
+                .add_region(PPC_STACK_BASE, vec![0; PPC_STACK_SIZE as usize]);
+            native.memory.add_region(
+                CLASSIC_ENTRY,
+                [
+                    0x7c55u16,
+                    0x303c,
+                    if retire { 0xfffe } else { 0x0205 },
+                    0xabf2,
+                    0x60fe,
+                ]
+                .into_iter()
+                .flat_map(u16::to_be_bytes)
+                .collect(),
+            );
+            native.memory.add_region(CLASSIC_SP, vec![0; 16]);
+            native.memory.write_u32_be(CLASSIC_SP, 2).unwrap();
+            native.memory.add_region(RESULT, vec![0; 4]);
+            let mut binding = test_ppc_import_binding(0, "InterfaceLib", "YieldToAnyThread");
+            binding.dispatcher_target = PpcImportDispatcherTarget::YieldToAnyThread;
+            binding.trap_pc = PPC_IMPORT_TRAP_BASE;
+            native.import_count = 1;
+            native.imports.push(binding);
+            let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+            runner.init_app(&app);
+            // Launch installs its entry return convention; use a live continuation
+            // that loops after the yield so it cannot halt the test's process.
+            runner.native.application_mut().unwrap().cpu.lr = PPC_CODE_BASE;
+            let calls = runner.dispatcher.guest_calls.shared_handle();
+            let worker = calls.create_task().unwrap();
+            let mut context = CooperativeThread::default();
+            context.pc = CLASSIC_ENTRY;
+            context.a_regs[0] = 0x5566_7788;
+            context.a_regs[7] = CLASSIC_SP;
+            context.result_destination = RESULT;
+            assert!(calls.save_cooperative_context(worker, context));
+            assert!(calls.set_scheduling_state(worker, ExecutionTaskState::Ready));
+            let (_, running) = runner.run_steps(64, None);
+            assert!(running);
+            assert_eq!(calls.current_task(), worker);
+            assert_eq!(runner.m68k.cpu.read_reg(Register::PC), CLASSIC_ENTRY);
+            let (_, running) = runner.run_steps(64, None);
+            assert!(running);
+            assert_eq!(calls.current_task(), ExecutionTaskId::APPLICATION);
+            assert_eq!(runner.m68k.cpu.read_reg(Register::D6), 0x55);
+            assert!(calls.has_pending_task_handoff());
+            assert!(!runner.m68k.can_relaunch());
+            if retire {
+                assert_eq!(calls.scheduling_state(worker), None);
+                assert_eq!(runner.bus.read_long(RESULT), 0x5566_7788);
+            }
+            let (_, running) = runner.run_steps(64, None);
+            assert!(running);
+            assert!(!calls.has_pending_task_handoff());
+            let native = runner.native.application().unwrap();
+            assert_eq!(native.cpu.pc, PPC_CODE_BASE);
+            assert_eq!(native.cpu.gpr[20], 0x1122_3344);
+            assert_eq!(native.cpu.fpr[20], 0x4009_21fb_5444_2d18);
+            assert_eq!(native.cpu.cr, 0x1357_2468);
+        }
+    }
+
+    #[test]
     fn classic_worker_uses_native_application_engine_and_stops_at_its_return() {
         use crate::execution_kernel::ExecutionTaskState;
         use crate::guest_call::{GuestCallTarget, M68kResultTarget, PowerPcArguments};
@@ -15578,274 +15670,312 @@ mod tests {
 
     #[test]
     fn nested_cross_isa_callback_survives_a_cooperative_task_switch() {
-        use crate::guest_procedure::{
-            ROUTINE_DESCRIPTOR_HEADER_SIZE, ROUTINE_DESCRIPTOR_MIXED_MODE_TRAP,
-            ROUTINE_DESCRIPTOR_VERSION, ROUTINE_FLAG_USE_NATIVE_ISA, ROUTINE_RECORD_FLAGS_OFFSET,
-            ROUTINE_RECORD_ISA_OFFSET, ROUTINE_RECORD_M68K_ISA, ROUTINE_RECORD_POWERPC_ISA,
-            ROUTINE_RECORD_PROC_DESCRIPTOR_OFFSET,
-        };
-        use crate::mixed_mode::proc_info;
+        for native_worker in [false, true] {
+            use crate::guest_procedure::{
+                ROUTINE_DESCRIPTOR_HEADER_SIZE, ROUTINE_DESCRIPTOR_MIXED_MODE_TRAP,
+                ROUTINE_DESCRIPTOR_VERSION, ROUTINE_FLAG_USE_NATIVE_ISA,
+                ROUTINE_RECORD_FLAGS_OFFSET, ROUTINE_RECORD_ISA_OFFSET, ROUTINE_RECORD_M68K_ISA,
+                ROUTINE_RECORD_POWERPC_ISA, ROUTINE_RECORD_PROC_DESCRIPTOR_OFFSET,
+            };
+            use crate::mixed_mode::proc_info;
 
-        const OUTER_ENTRY: u32 = 0x0301_0000;
-        const OUTER_DESCRIPTOR: u32 = 0x0301_0100;
-        const OUTER_TVECTOR: u32 = 0x0301_0200;
-        const PPC_CALLBACK: u32 = PPC_CODE_BASE + 0x1000;
-        const CALLBACK_RTOC: u32 = 0x0301_0300;
-        const INNER_DESCRIPTOR: u32 = 0x0301_0400;
-        const INNER_ENTRY: u32 = 0x0301_0500;
-        const STACK_BASE: u32 = 0x0302_0000;
-        const INITIAL_SP: u32 = STACK_BASE + 0x80;
-        const OUTER_RETURN: u32 = 0x0302_0110;
-        const WORKER_ENTRY: u32 = 0x0303_0000;
-        const WORKER_STACK: u32 = 0x0303_1000;
-        const WORKER_SP: u32 = WORKER_STACK + 0x10;
-        const ARGUMENT: u32 = 0x1020_3040;
+            const OUTER_ENTRY: u32 = 0x0301_0000;
+            const OUTER_DESCRIPTOR: u32 = 0x0301_0100;
+            const OUTER_TVECTOR: u32 = 0x0301_0200;
+            const PPC_CALLBACK: u32 = PPC_CODE_BASE + 0x1000;
+            const CALLBACK_RTOC: u32 = 0x0301_0300;
+            const INNER_DESCRIPTOR: u32 = 0x0301_0400;
+            const INNER_ENTRY: u32 = 0x0301_0500;
+            const STACK_BASE: u32 = 0x0302_0000;
+            const INITIAL_SP: u32 = STACK_BASE + 0x80;
+            const OUTER_RETURN: u32 = 0x0302_0110;
+            const WORKER_ENTRY: u32 = 0x0303_0000;
+            const WORKER_STACK: u32 = 0x0303_1000;
+            const WORKER_SP: u32 = WORKER_STACK + 0x10;
+            const ARGUMENT: u32 = 0x1020_3040;
 
-        let mut app = halted_ppc_app_with_sound(PpcSoundState::default());
-        let ppc_app = app.ppc.as_mut().expect("PPC app");
-        ppc_app
-            .memory
-            .add_region(PPC_STACK_BASE, vec![0; PPC_STACK_SIZE as usize]);
-        ppc_app.memory.add_region(
-            OUTER_ENTRY,
-            [
-                0x4ef9,
-                (OUTER_DESCRIPTOR >> 16) as u16,
-                OUTER_DESCRIPTOR as u16,
-            ]
-            .into_iter()
-            .flat_map(u16::to_be_bytes)
-            .collect(),
-        );
-        ppc_app.memory.add_region(
-            INNER_ENTRY,
-            [
-                0x303c, 0x0205, // MOVE.W #YieldToAnyThread,D0
-                0xabf2, // ThreadDispatch
-                0x598f, // SUBQ.L #4,SP (undo the selector frame pop)
-                0x4e75, // RTS through the PPC Mixed Mode gateway
-            ]
-            .into_iter()
-            .flat_map(u16::to_be_bytes)
-            .collect(),
-        );
-        ppc_app.memory.add_region(
-            WORKER_ENTRY,
-            [
-                0x303c, 0x0205, // MOVE.W #YieldToAnyThread,D0
-                0xabf2, // ThreadDispatch back to the application task
-                0x60fe, // BRA.S -2 if no successor is currently runnable
-            ]
-            .into_iter()
-            .flat_map(u16::to_be_bytes)
-            .collect(),
-        );
-        ppc_app.memory.add_region(OUTER_DESCRIPTOR, vec![0; 0x100]);
-        ppc_app.memory.add_region(INNER_DESCRIPTOR, vec![0; 0x100]);
-        ppc_app.memory.add_region(OUTER_TVECTOR, vec![0; 8]);
-        ppc_app.memory.add_region(STACK_BASE, vec![0; 0x200]);
-        ppc_app.memory.add_region(WORKER_STACK, vec![0; 0x40]);
-
-        // A Pascal native-to-68K call owns one return long followed by its
-        // argument. The descriptor consumes both, so the completion boundary
-        // is exactly eight bytes above the initial stack pointer.
-        ppc_app
-            .memory
-            .write_u32_be(INITIAL_SP, OUTER_RETURN)
-            .unwrap();
-        ppc_app
-            .memory
-            .write_u32_be(INITIAL_SP + 4, ARGUMENT)
-            .unwrap();
-        ppc_app.memory.write_u32_be(WORKER_SP, 0).unwrap();
-
-        let proc_info = proc_info::PASCAL_STACK_BASED
-            | (proc_info::SIZE_FOUR << proc_info::STACK_PARAMETER_PHASE);
-        ppc_app
-            .memory
-            .write_u16_be(OUTER_DESCRIPTOR, ROUTINE_DESCRIPTOR_MIXED_MODE_TRAP)
-            .unwrap();
-        ppc_app
-            .memory
-            .write_u8(OUTER_DESCRIPTOR + 2, ROUTINE_DESCRIPTOR_VERSION)
-            .unwrap();
-        ppc_app
-            .memory
-            .write_u16_be(OUTER_DESCRIPTOR + 10, 0)
-            .unwrap();
-        let outer_record = OUTER_DESCRIPTOR + ROUTINE_DESCRIPTOR_HEADER_SIZE;
-        ppc_app
-            .memory
-            .write_u32_be(outer_record, proc_info)
-            .unwrap();
-        ppc_app
-            .memory
-            .write_u8(
-                outer_record + ROUTINE_RECORD_ISA_OFFSET,
-                ROUTINE_RECORD_POWERPC_ISA,
-            )
-            .unwrap();
-        ppc_app
-            .memory
-            .write_u16_be(
-                outer_record + ROUTINE_RECORD_FLAGS_OFFSET,
-                ROUTINE_FLAG_USE_NATIVE_ISA,
-            )
-            .unwrap();
-        ppc_app
-            .memory
-            .write_u32_be(
-                outer_record + ROUTINE_RECORD_PROC_DESCRIPTOR_OFFSET,
-                OUTER_TVECTOR,
-            )
-            .unwrap();
-        ppc_app
-            .memory
-            .write_u32_be(OUTER_TVECTOR, PPC_CALLBACK)
-            .unwrap();
-        ppc_app
-            .memory
-            .write_u32_be(OUTER_TVECTOR + 4, CALLBACK_RTOC)
-            .unwrap();
-
-        let inner_proc_info = proc_info::PASCAL_STACK_BASED;
-        ppc_app
-            .memory
-            .write_u16_be(INNER_DESCRIPTOR, ROUTINE_DESCRIPTOR_MIXED_MODE_TRAP)
-            .unwrap();
-        ppc_app
-            .memory
-            .write_u8(INNER_DESCRIPTOR + 2, ROUTINE_DESCRIPTOR_VERSION)
-            .unwrap();
-        ppc_app
-            .memory
-            .write_u16_be(INNER_DESCRIPTOR + 10, 0)
-            .unwrap();
-        let inner_record = INNER_DESCRIPTOR + ROUTINE_DESCRIPTOR_HEADER_SIZE;
-        ppc_app
-            .memory
-            .write_u32_be(inner_record, inner_proc_info)
-            .unwrap();
-        ppc_app
-            .memory
-            .write_u8(
-                inner_record + ROUTINE_RECORD_ISA_OFFSET,
-                ROUTINE_RECORD_M68K_ISA,
-            )
-            .unwrap();
-        ppc_app
-            .memory
-            .write_u32_be(
-                inner_record + ROUTINE_RECORD_PROC_DESCRIPTOR_OFFSET,
-                INNER_ENTRY,
-            )
-            .unwrap();
-
-        let callback_words = [
-            0x7fe8_02a6, // MFLR R31
-            0x3c60_0000 | (INNER_DESCRIPTOR >> 16),
-            0x6063_0000 | (INNER_DESCRIPTOR & 0xffff),
-            0x3c80_0000, // LIS R4,0 (void ProcInfo)
-            0x6084_0000, // ORI R4,R4,0
-            0x38a0_0000, // LI R5,0 (unused for a void signature)
-            ppc_test_relative_branch(PPC_CALLBACK + 6 * 4, PPC_IMPORT_TRAP_BASE) | 1,
-            0x7fe8_03a6, // MTLR R31
-            0x3863_0007, // ADDI R3,R3,7
-            0x4e80_0020, // BLR
-        ];
-        ppc_app.memory.add_region(
-            PPC_CALLBACK,
-            callback_words
+            let mut app = halted_ppc_app_with_sound(PpcSoundState::default());
+            let ppc_app = app.ppc.as_mut().expect("PPC app");
+            ppc_app
+                .memory
+                .add_region(PPC_STACK_BASE, vec![0; PPC_STACK_SIZE as usize]);
+            ppc_app.memory.add_region(
+                OUTER_ENTRY,
+                [
+                    0x4ef9,
+                    (OUTER_DESCRIPTOR >> 16) as u16,
+                    OUTER_DESCRIPTOR as u16,
+                ]
                 .into_iter()
-                .flat_map(u32::to_be_bytes)
+                .flat_map(u16::to_be_bytes)
                 .collect(),
-        );
-        let mut call_universal_proc =
-            test_ppc_import_binding(0, "InterfaceLib", "CallUniversalProc");
-        call_universal_proc.trap_pc = PPC_IMPORT_TRAP_BASE;
-        call_universal_proc.dispatcher_target = PpcImportDispatcherTarget::CallUniversalProc;
-        ppc_app.import_count = 1;
-        ppc_app.imports = vec![call_universal_proc];
+            );
+            ppc_app.memory.add_region(
+                INNER_ENTRY,
+                [
+                    0x303c, 0x0205, // MOVE.W #YieldToAnyThread,D0
+                    0xabf2, // ThreadDispatch
+                    0x598f, // SUBQ.L #4,SP (undo the selector frame pop)
+                    0x4e75, // RTS through the PPC Mixed Mode gateway
+                ]
+                .into_iter()
+                .flat_map(u16::to_be_bytes)
+                .collect(),
+            );
+            ppc_app.memory.add_region(
+                WORKER_ENTRY,
+                [
+                    0x303c, 0x0205, // MOVE.W #YieldToAnyThread,D0
+                    0xabf2, // ThreadDispatch back to the application task
+                    0x60fe, // BRA.S -2 if no successor is currently runnable
+                ]
+                .into_iter()
+                .flat_map(u16::to_be_bytes)
+                .collect(),
+            );
+            ppc_app.memory.add_region(OUTER_DESCRIPTOR, vec![0; 0x100]);
+            ppc_app.memory.add_region(INNER_DESCRIPTOR, vec![0; 0x100]);
+            ppc_app.memory.add_region(OUTER_TVECTOR, vec![0; 8]);
+            ppc_app.memory.add_region(STACK_BASE, vec![0; 0x200]);
+            ppc_app.memory.add_region(WORKER_STACK, vec![0; 0x40]);
 
-        assert!(ppc_app.guest_calls.begin_powerpc_to_m68k(
-            crate::guest_call::GuestCallTarget {
-                isa: crate::guest_procedure::GuestIsa::M68k,
-                entry: OUTER_ENTRY,
-                rtoc: 0,
-            },
-            OUTER_ENTRY,
-            INITIAL_SP,
-            OUTER_RETURN,
-            INITIAL_SP + 8,
-            crate::guest_call::M68kRegisterState::default(),
-            None,
-            PPC_CODE_BASE,
-            0,
-            PpcNativeReturnGpr3::Preserve,
-        ));
+            // A Pascal native-to-68K call owns one return long followed by its
+            // argument. The descriptor consumes both, so the completion boundary
+            // is exactly eight bytes above the initial stack pointer.
+            ppc_app
+                .memory
+                .write_u32_be(INITIAL_SP, OUTER_RETURN)
+                .unwrap();
+            ppc_app
+                .memory
+                .write_u32_be(INITIAL_SP + 4, ARGUMENT)
+                .unwrap();
+            ppc_app.memory.write_u32_be(WORKER_SP, 0).unwrap();
 
-        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
-        runner.init_app(&app);
-        assert!(runner
-            .dispatcher
-            .guest_calls
-            .register_task(ExecutionTaskId::from_thread_id(3)));
-        runner.dispatcher.guest_calls.save_cooperative_context(
-            ExecutionTaskId::from_thread_id(3),
-            CooperativeThread {
-                d_regs: [0; 8],
-                a_regs: [0, 0, 0, 0, 0, 0, 0, WORKER_SP],
-                pc: WORKER_ENTRY,
-                ccr: 0,
-                result_destination: 0,
-                stack_base: WORKER_STACK,
-                stack_limit: WORKER_STACK + 0x40,
-                switch_in: (0, 0),
-                switch_out: (0, 0),
-                terminator: (0, 0),
-            },
-        );
-        assert!(runner.dispatcher.guest_calls.set_scheduling_state(
-            ExecutionTaskId::from_thread_id(3),
-            crate::execution_kernel::ExecutionTaskState::Ready
-        ));
+            let proc_info = proc_info::PASCAL_STACK_BASED
+                | (proc_info::SIZE_FOUR << proc_info::STACK_PARAMETER_PHASE);
+            ppc_app
+                .memory
+                .write_u16_be(OUTER_DESCRIPTOR, ROUTINE_DESCRIPTOR_MIXED_MODE_TRAP)
+                .unwrap();
+            ppc_app
+                .memory
+                .write_u8(OUTER_DESCRIPTOR + 2, ROUTINE_DESCRIPTOR_VERSION)
+                .unwrap();
+            ppc_app
+                .memory
+                .write_u16_be(OUTER_DESCRIPTOR + 10, 0)
+                .unwrap();
+            let outer_record = OUTER_DESCRIPTOR + ROUTINE_DESCRIPTOR_HEADER_SIZE;
+            ppc_app
+                .memory
+                .write_u32_be(outer_record, proc_info)
+                .unwrap();
+            ppc_app
+                .memory
+                .write_u8(
+                    outer_record + ROUTINE_RECORD_ISA_OFFSET,
+                    ROUTINE_RECORD_POWERPC_ISA,
+                )
+                .unwrap();
+            ppc_app
+                .memory
+                .write_u16_be(
+                    outer_record + ROUTINE_RECORD_FLAGS_OFFSET,
+                    ROUTINE_FLAG_USE_NATIVE_ISA,
+                )
+                .unwrap();
+            ppc_app
+                .memory
+                .write_u32_be(
+                    outer_record + ROUTINE_RECORD_PROC_DESCRIPTOR_OFFSET,
+                    OUTER_TVECTOR,
+                )
+                .unwrap();
+            ppc_app
+                .memory
+                .write_u32_be(OUTER_TVECTOR, PPC_CALLBACK)
+                .unwrap();
+            ppc_app
+                .memory
+                .write_u32_be(OUTER_TVECTOR + 4, CALLBACK_RTOC)
+                .unwrap();
 
-        let (_, running) = runner.run_steps(128, None);
-        assert!(running);
-        assert_eq!(runner.dispatcher.guest_calls.current_task().thread_id(), 3);
-        assert_eq!(
+            let inner_proc_info = proc_info::PASCAL_STACK_BASED;
+            ppc_app
+                .memory
+                .write_u16_be(INNER_DESCRIPTOR, ROUTINE_DESCRIPTOR_MIXED_MODE_TRAP)
+                .unwrap();
+            ppc_app
+                .memory
+                .write_u8(INNER_DESCRIPTOR + 2, ROUTINE_DESCRIPTOR_VERSION)
+                .unwrap();
+            ppc_app
+                .memory
+                .write_u16_be(INNER_DESCRIPTOR + 10, 0)
+                .unwrap();
+            let inner_record = INNER_DESCRIPTOR + ROUTINE_DESCRIPTOR_HEADER_SIZE;
+            ppc_app
+                .memory
+                .write_u32_be(inner_record, inner_proc_info)
+                .unwrap();
+            ppc_app
+                .memory
+                .write_u8(
+                    inner_record + ROUTINE_RECORD_ISA_OFFSET,
+                    ROUTINE_RECORD_M68K_ISA,
+                )
+                .unwrap();
+            ppc_app
+                .memory
+                .write_u32_be(
+                    inner_record + ROUTINE_RECORD_PROC_DESCRIPTOR_OFFSET,
+                    INNER_ENTRY,
+                )
+                .unwrap();
+
+            let callback_words = [
+                0x7fe8_02a6, // MFLR R31
+                0x3c60_0000 | (INNER_DESCRIPTOR >> 16),
+                0x6063_0000 | (INNER_DESCRIPTOR & 0xffff),
+                0x3c80_0000, // LIS R4,0 (void ProcInfo)
+                0x6084_0000, // ORI R4,R4,0
+                0x38a0_0000, // LI R5,0 (unused for a void signature)
+                ppc_test_relative_branch(PPC_CALLBACK + 6 * 4, PPC_IMPORT_TRAP_BASE) | 1,
+                0x7fe8_03a6, // MTLR R31
+                0x3863_0007, // ADDI R3,R3,7
+                0x4e80_0020, // BLR
+            ];
+            ppc_app.memory.add_region(
+                PPC_CALLBACK,
+                callback_words
+                    .into_iter()
+                    .flat_map(u32::to_be_bytes)
+                    .collect(),
+            );
+            let mut call_universal_proc =
+                test_ppc_import_binding(0, "InterfaceLib", "CallUniversalProc");
+            call_universal_proc.trap_pc = PPC_IMPORT_TRAP_BASE;
+            call_universal_proc.dispatcher_target = PpcImportDispatcherTarget::CallUniversalProc;
+            ppc_app.import_count = 1;
+            ppc_app.imports = vec![call_universal_proc];
+            if native_worker {
+                let mut yielding = test_ppc_import_binding(1, "InterfaceLib", "YieldToThread");
+                yielding.dispatcher_target = PpcImportDispatcherTarget::YieldToThread;
+                yielding.trap_pc = PPC_IMPORT_TRAP_BASE + 4;
+                ppc_app
+                    .memory
+                    .add_region(PPC_IMPORT_TRAP_BASE + 4, vec![0; 4]);
+                ppc_app.imports.push(yielding);
+                ppc_app.import_count = 2;
+            }
+
+            assert!(ppc_app.guest_calls.begin_powerpc_to_m68k(
+                crate::guest_call::GuestCallTarget {
+                    isa: crate::guest_procedure::GuestIsa::M68k,
+                    entry: OUTER_ENTRY,
+                    rtoc: 0,
+                },
+                OUTER_ENTRY,
+                INITIAL_SP,
+                OUTER_RETURN,
+                INITIAL_SP + 8,
+                crate::guest_call::M68kRegisterState::default(),
+                None,
+                PPC_CODE_BASE,
+                0,
+                PpcNativeReturnGpr3::Preserve,
+            ));
+
+            let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+            runner.init_app(&app);
+            if native_worker {
+                let mut cpu = PpcCpu::new();
+                cpu.pc = PPC_IMPORT_TRAP_BASE + 4;
+                cpu.lr = PPC_CODE_BASE;
+                cpu.gpr[1] = WORKER_SP;
+                cpu.gpr[3] = ExecutionTaskId::APPLICATION.thread_id();
+                let task = runner
+                    .dispatcher
+                    .guest_calls
+                    .create_native_thread(
+                        crate::guest_call::NativeThreadContext {
+                            cpu: Box::new(cpu),
+                            result_destination: 0,
+                            stack_base: 0,
+                        },
+                        true,
+                        |_| true,
+                    )
+                    .unwrap();
+                assert_eq!(task.thread_id(), 3);
+            } else {
+                assert!(runner
+                    .dispatcher
+                    .guest_calls
+                    .register_task(ExecutionTaskId::from_thread_id(3)));
+                runner.dispatcher.guest_calls.save_cooperative_context(
+                    ExecutionTaskId::from_thread_id(3),
+                    CooperativeThread {
+                        d_regs: [0; 8],
+                        a_regs: [0, 0, 0, 0, 0, 0, 0, WORKER_SP],
+                        pc: WORKER_ENTRY,
+                        ccr: 0,
+                        result_destination: 0,
+                        stack_base: WORKER_STACK,
+                        stack_limit: WORKER_STACK + 0x40,
+                        switch_in: (0, 0),
+                        switch_out: (0, 0),
+                        terminator: (0, 0),
+                    },
+                );
+            }
+            assert!(runner.dispatcher.guest_calls.set_scheduling_state(
+                ExecutionTaskId::from_thread_id(3),
+                crate::execution_kernel::ExecutionTaskState::Ready
+            ));
+
+            let (_, running) = runner.run_steps(128, None);
+            assert!(running);
+            assert_eq!(runner.dispatcher.guest_calls.current_task().thread_id(), 3);
+            assert_eq!(
             runner.m68k.parked.task_len(ExecutionTaskId::APPLICATION),
             1,
             "the application-owned nested 68K context must stay parked while its callback yields"
         );
-        assert_eq!(
-            runner
-                .m68k
-                .parked
-                .task_len(ExecutionTaskId::from_thread_id(3)),
-            0,
-            "the worker must not consume the application's parked context"
-        );
+            assert_eq!(
+                runner
+                    .m68k
+                    .parked
+                    .task_len(ExecutionTaskId::from_thread_id(3)),
+                0,
+                "the worker must not consume the application's parked context"
+            );
 
-        let (_, running) = runner.run_steps(128, None);
-        assert!(running);
-        assert_eq!(runner.dispatcher.guest_calls.current_task().thread_id(), 2);
-        assert_eq!(
-            runner.m68k.parked.task_len(ExecutionTaskId::APPLICATION),
-            1,
-            "returning from the worker must leave the nested application context parked"
-        );
+            let (_, running) = runner.run_steps(128, None);
+            assert!(running);
+            assert_eq!(runner.dispatcher.guest_calls.current_task().thread_id(), 2);
+            if !native_worker {
+                assert_eq!(
+                    runner.m68k.parked.task_len(ExecutionTaskId::APPLICATION),
+                    1,
+                    "returning from the worker must leave the nested application context parked"
+                );
+            }
 
-        let (_, running) = runner.run_steps(128, None);
-        assert!(running);
-        assert_eq!(runner.dispatcher.guest_calls.current_task().thread_id(), 2);
-        assert!(runner.dispatcher.guest_calls.is_empty());
-        assert!(runner.m68k.parked.is_empty());
-        let ppc_app = runner.native.application().expect("PPC app retained");
-        assert_eq!(ppc_app.cpu.pc, PPC_CODE_BASE);
-        // The outer routine has a void ProcInfo, so its internal callback's
-        // transient R3 value must not leak into the parked native caller.
-        assert_eq!(ppc_app.cpu.gpr[3], 0);
+            if !runner.dispatcher.guest_calls.is_empty() {
+                let (_, running) = runner.run_steps(128, None);
+                assert!(running);
+            }
+            assert_eq!(runner.dispatcher.guest_calls.current_task().thread_id(), 2);
+            assert!(runner.dispatcher.guest_calls.is_empty());
+            assert!(runner.m68k.parked.is_empty());
+            let ppc_app = runner.native.application().expect("PPC app retained");
+            assert_eq!(ppc_app.cpu.pc, PPC_CODE_BASE);
+            // The outer routine has a void ProcInfo, so its internal callback's
+            // transient R3 value must not leak into the parked native caller.
+            assert_eq!(ppc_app.cpu.gpr[3], 0);
+        }
     }
 
     #[test]

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -6549,7 +6549,9 @@ impl FixtureRunner {
             cycles_per_tick.saturating_sub(remaining_cycles),
         );
         if ppc_app.guest_calls.pending_powerpc_from_m68k().is_some()
-            && ppc_app.activate_powerpc_from_m68k().is_none()
+            && ppc_app
+                .activate_powerpc_from_m68k(&mut self.m68k.cpu)
+                .is_none()
         {
             self.halted = true;
             self.halted_pc = Some(self.m68k.cpu.read_reg(Register::PC));

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -15536,7 +15536,8 @@ mod tests {
         const FRAME: u32 = 0x6000;
         const MADE: u32 = 0x7000;
         const RESULT: u32 = 0x7100;
-        for native_worker in [false, true] {
+        for (native_worker, recycle) in [(false, false), (false, true), (true, false), (true, true)]
+        {
             let mut app = halted_ppc_app_with_sound(PpcSoundState::default());
             let loaded = app.ppc.as_mut().unwrap();
             loaded.entry_pc = PPC_IMPORT_TRAP_BASE;
@@ -15607,7 +15608,9 @@ mod tests {
                 if native_worker {
                     runner.m68k.cpu.write_reg(Register::A7, FRAME);
                     runner.m68k.cpu.write_reg(Register::D0, 0x0504);
-                    runner.bus.write_word(FRAME, 0);
+                    runner
+                        .bus
+                        .write_word(FRAME, if recycle { 0x0100 } else { 0 });
                     runner.bus.write_long(FRAME + 2, 0xcafebabe);
                     runner.bus.write_long(FRAME + 6, worker.thread_id());
                     runner
@@ -15622,7 +15625,7 @@ mod tests {
                     cpu.lr = PPC_CODE_BASE;
                     cpu.gpr[3] = worker.thread_id();
                     cpu.gpr[4] = 0xcafebabe;
-                    cpu.gpr[5] = 0;
+                    cpu.gpr[5] = u32::from(recycle);
                     assert!(runner.run_steps(32, None).1);
                     assert_eq!(
                         runner.native.application().unwrap().cpu.gpr[3] as i16,
@@ -15643,14 +15646,72 @@ mod tests {
                         .native_ptr_records()
                         .iter()
                         .any(|record| record.ptr == storage.stack_base);
-                    assert_eq!(live, attempt == 0);
+                    assert_eq!(live, attempt == 0 || recycle);
                     assert_eq!(calls.classic_thread_pool_count(0), 0);
                 } else {
                     assert_eq!(
+                        runner.bus.get_alloc_size(storage.stack_base).is_some(),
+                        attempt == 0 || recycle
+                    );
+                    assert_eq!(
                         calls.classic_thread_pool_count(0),
-                        usize::from(attempt != 0)
+                        usize::from(attempt != 0 && recycle)
                     );
                 }
+            }
+            // Request the recycled stack through its original ABI. A released
+            // stack is unavailable, while recycled storage keeps its allocation
+            // and acquires a fresh identity and result destination.
+            if native_worker {
+                let cpu = &mut runner.native.application_mut().unwrap().cpu;
+                cpu.pc = PPC_IMPORT_TRAP_BASE;
+                cpu.lr = PPC_CODE_BASE;
+                cpu.gpr[3] = 1;
+                cpu.gpr[4] = PPC_CODE_BASE;
+                cpu.gpr[5] = 0xabcdef;
+                cpu.gpr[6] = 1024;
+                cpu.gpr[7] = 1 | 2 | 16;
+                cpu.gpr[8] = RESULT + 4;
+                cpu.gpr[9] = MADE;
+                assert!(runner.run_steps(32, None).1);
+                assert_eq!(
+                    runner.native.application().unwrap().cpu.gpr[3] as i16,
+                    if recycle { 0 } else { -617 }
+                );
+            } else {
+                runner.m68k.cpu.write_reg(Register::A7, FRAME);
+                runner.m68k.cpu.write_reg(Register::D0, 0x0e03);
+                for (offset, value) in [
+                    (0, MADE),
+                    (4, RESULT + 4),
+                    (8, 1 | 2 | 16),
+                    (12, 1024),
+                    (16, 0xabcdef),
+                    (20, 0x8000),
+                    (24, 1),
+                ] {
+                    runner.bus.write_long(FRAME + offset, value);
+                }
+                runner
+                    .dispatcher
+                    .dispatch_toolbox(true, 0x3f2, &mut runner.m68k.cpu, &mut runner.bus)
+                    .unwrap()
+                    .unwrap();
+                assert_eq!(
+                    runner.m68k.cpu.read_reg(Register::D0) as i16,
+                    if recycle { 0 } else { -617 }
+                );
+            }
+            assert_eq!(runner.bus.read_long(MADE), if recycle { 4 } else { 0 });
+            if recycle {
+                let reused = calls
+                    .thread_storage(ExecutionTaskId::from_thread_id(4))
+                    .unwrap();
+                assert_eq!(reused.stack_base, storage.stack_base);
+                assert_eq!(reused.stack_limit, storage.stack_limit);
+                assert_eq!(reused.managed_pointer, native_worker);
+                assert_eq!(reused.result_destination, RESULT + 4);
+                assert!(calls.thread_storage(worker).is_none());
             }
         }
     }

--- a/src/thread_manager.rs
+++ b/src/thread_manager.rs
@@ -6,6 +6,8 @@
 use crate::execution_kernel::ExecutionTaskState;
 use crate::guest_call::{ExecutionTaskId, SharedGuestCallStack};
 
+pub(crate) const DEFAULT_COOPERATIVE_THREAD_STACK_SIZE: u32 = 32 * 1024;
+
 // Inside Macintosh: Thread Manager (1999), p. 101.
 pub(crate) const THREAD_NOT_FOUND_ERR: i16 = -618;
 pub(crate) const THREAD_PROTOCOL_ERR: i16 = -619;

--- a/src/thread_manager.rs
+++ b/src/thread_manager.rs
@@ -4,7 +4,8 @@
 //! creates no task registry, snapshots, or independent scheduling state.
 
 use crate::execution_kernel::ExecutionTaskState;
-use crate::guest_call::{ExecutionTaskId, SharedGuestCallStack};
+use crate::guest_call::{ExecutionTaskId, SharedGuestCallStack, ThreadStorage};
+use crate::guest_procedure::GuestIsa;
 
 pub(crate) const DEFAULT_COOPERATIVE_THREAD_STACK_SIZE: u32 = 32 * 1024;
 
@@ -19,6 +20,69 @@ pub(crate) struct ThreadManager<'a> {
 impl<'a> ThreadManager<'a> {
     pub(crate) fn new(execution: &'a SharedGuestCallStack) -> Self {
         Self { execution }
+    }
+
+    // Thread Manager (1999), pp. 50–55. Size is a signed Macintosh Size;
+    // stack minima reflect the corresponding adapter's initial ABI frame.
+    pub(crate) fn stack_size(isa: GuestIsa, style: u32, requested: u32) -> Result<u32, i16> {
+        let size = if requested == 0 {
+            DEFAULT_COOPERATIVE_THREAD_STACK_SIZE
+        } else {
+            requested
+        };
+        let minimum = match isa {
+            GuestIsa::M68k => 8,
+            GuestIsa::PowerPc => 256,
+        };
+        if style != 1 || size < minimum || size > i32::MAX as u32 {
+            Err(-50)
+        } else {
+            Ok(size)
+        }
+    }
+
+    /// Prepare every allocation before publishing any pool entry. On failure,
+    /// return all reserved storage to the ABI allocator for rollback.
+    /// Thread Manager (1999), p. 51 requires all-or-none pool creation.
+    pub(crate) fn create_pool(
+        &self,
+        isa: GuestIsa,
+        style: u32,
+        count: i16,
+        requested: u32,
+        mut allocate: impl FnMut(u32) -> Option<ThreadStorage>,
+    ) -> Result<(), (i16, Vec<ThreadStorage>)> {
+        let size = Self::stack_size(isa, style, requested).map_err(|error| (error, Vec::new()))?;
+        if count < 0 {
+            return Err((-50, Vec::new()));
+        }
+        let mut prepared = Vec::new();
+        for _ in 0..count {
+            let Some(mut storage) = allocate(size) else {
+                return Err((-108, prepared));
+            };
+            storage.result_destination = 0;
+            prepared.push(storage);
+            if storage.stack_base == 0
+                || storage.stack_limit.checked_sub(storage.stack_base) != Some(size)
+            {
+                return Err((-108, prepared));
+            }
+        }
+        self.execution.publish_thread_pool(isa, prepared);
+        Ok(())
+    }
+
+    pub(crate) fn free_count(
+        &self,
+        isa: GuestIsa,
+        style: u32,
+        minimum_size: u32,
+    ) -> Result<u16, i16> {
+        if style != 1 || minimum_size > i32::MAX as u32 {
+            return Err(-50);
+        }
+        u16::try_from(self.execution.thread_pool_count(isa, minimum_size)).map_err(|_| -617)
     }
 
     // MacGetCurrentThread / GetCurrentThread, Thread Manager (1999), p. 62.
@@ -93,6 +157,55 @@ impl<'a> ThreadManager<'a> {
             0
         } else {
             THREAD_PROTOCOL_ERR
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn thread_pool_preparation_preserves_existing_entries_and_returns_every_reserved_stack() {
+        for isa in [GuestIsa::M68k, GuestIsa::PowerPc] {
+            let execution = SharedGuestCallStack::default();
+            let manager = ThreadManager::new(&execution);
+            let storage = |base| ThreadStorage {
+                stack_base: base,
+                stack_limit: base + 1024,
+                result_destination: 42,
+                managed_pointer: isa == GuestIsa::PowerPc,
+            };
+            manager
+                .create_pool(isa, 1, 1, 1024, |_| Some(storage(0x1000)))
+                .unwrap();
+            let mut allocations = 0;
+            let failure = manager
+                .create_pool(isa, 1, 3, 1024, |_| {
+                    allocations += 1;
+                    if allocations == 3 {
+                        None
+                    } else {
+                        Some(storage(0x2000 + allocations * 1024))
+                    }
+                })
+                .unwrap_err();
+            assert_eq!(failure.0, -108);
+            assert_eq!(failure.1.len(), 2);
+            assert!(failure.1.iter().all(|stack| stack.result_destination == 0));
+            assert_eq!(manager.free_count(isa, 1, 0), Ok(1));
+            assert_eq!(manager.free_count(isa, 1, 2048), Ok(0));
+            assert!(manager
+                .create_pool(isa, 0, 1, 1024, |_| panic!(
+                    "invalid style must not allocate"
+                ))
+                .is_err());
+            assert!(manager
+                .create_pool(isa, 1, -1, 1024, |_| panic!(
+                    "negative count must not allocate"
+                ))
+                .is_err());
+            assert_eq!(execution.create_task().unwrap().thread_id(), 3);
         }
     }
 }

--- a/src/thread_manager.rs
+++ b/src/thread_manager.rs
@@ -46,6 +46,42 @@ impl<'a> ThreadManager<'a> {
             .ok_or(THREAD_NOT_FOUND_ERR)
     }
 
+    // Thread task references identify the process, not an execution thread.
+    // The current runtime hosts one process per service. Preserve the existing
+    // process-local opaque token while process construction is migrated.
+    // Inside Macintosh: Thread Manager (1999), pp. 46, 73–76.
+    pub(crate) fn task_reference(&self) -> u32 {
+        ExecutionTaskId::APPLICATION.thread_id()
+    }
+
+    pub(crate) fn state_given_task(&self, reference: u32, thread: u32) -> Result<u16, i16> {
+        if reference != self.task_reference() {
+            return Err(THREAD_PROTOCOL_ERR);
+        }
+        self.state(thread)
+    }
+
+    pub(crate) fn ready_given_task(&self, reference: u32, thread: u32) -> i16 {
+        if reference != self.task_reference() {
+            return THREAD_PROTOCOL_ERR;
+        }
+        let task = ExecutionTaskId::from_thread_id(self.resolve_thread(thread));
+        match self.execution.scheduling_state(task) {
+            None => THREAD_NOT_FOUND_ERR,
+            Some(ExecutionTaskState::Stopped) => {
+                if self
+                    .execution
+                    .set_scheduling_state(task, ExecutionTaskState::Ready)
+                {
+                    0
+                } else {
+                    THREAD_PROTOCOL_ERR
+                }
+            }
+            Some(_) => THREAD_PROTOCOL_ERR,
+        }
+    }
+
     // ThreadBeginCritical / ThreadEndCritical, Thread Manager (1999), pp. 69–70.
     pub(crate) fn begin_critical(&self) -> i16 {
         self.execution.begin_critical();

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -934,7 +934,7 @@ pub(crate) struct OsTrapDispatchFrame {
 /// and the size reported by `GetDefaultThreadStackSize`. The 68K Thread
 /// Manager's own default is a small multiple of a page; 32K comfortably
 /// covers the Toolbox call depth Systemless threads reach.
-pub(crate) const DEFAULT_COOPERATIVE_THREAD_STACK_SIZE: u32 = 32 * 1024;
+pub(crate) use crate::thread_manager::DEFAULT_COOPERATIVE_THREAD_STACK_SIZE;
 
 /// In-flight AppleEvent handler call. Built by Pack8 routine 27
 /// (`AEProcessAppleEvent`) when it dispatches a registered handler;

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -930,12 +930,6 @@ pub(crate) struct OsTrapDispatchFrame {
     a2: u32,
 }
 
-/// Stack size handed to a cooperative thread when `NewThread` is passed 0
-/// and the size reported by `GetDefaultThreadStackSize`. The 68K Thread
-/// Manager's own default is a small multiple of a page; 32K comfortably
-/// covers the Toolbox call depth Systemless threads reach.
-pub(crate) use crate::thread_manager::DEFAULT_COOPERATIVE_THREAD_STACK_SIZE;
-
 /// In-flight AppleEvent handler call. Built by Pack8 routine 27
 /// (`AEProcessAppleEvent`) when it dispatches a registered handler;
 /// consumed by the trampoline trap when the handler `RTD`s back.
@@ -1494,7 +1488,6 @@ pub struct TrapDispatcher {
     pub(crate) cooperative_thread_scheduler: u32,
     /// Default cooperative stack size reported by
     /// `GetDefaultThreadStackSize` and used when `NewThread` is passed 0.
-    pub(crate) cooperative_thread_stack_size: u32,
     /// Synthetic Component Manager instances opened for HLE-provided
     /// components such as the QuickTime movie controller.
     pub(crate) synthetic_component_instances: HashSet<u32>,
@@ -3467,7 +3460,6 @@ impl TrapDispatcher {
             ppc_initialized: false,
             thread_return_trampoline: 0,
             cooperative_thread_scheduler: 0,
-            cooperative_thread_stack_size: DEFAULT_COOPERATIVE_THREAD_STACK_SIZE,
             synthetic_component_instances: HashSet::new(),
             next_synthetic_component_instance: 0x00C1_0001,
             saved_draw_old_regions: HashMap::new(),

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -1495,9 +1495,6 @@ pub struct TrapDispatcher {
     /// Default cooperative stack size reported by
     /// `GetDefaultThreadStackSize` and used when `NewThread` is passed 0.
     pub(crate) cooperative_thread_stack_size: u32,
-    /// Cooperative stacks banked by `CreateThreadPool` and recycled by
-    /// `DisposeThread`, reused by `NewThread` before allocating.
-    pub(crate) cooperative_thread_pool: Vec<(u32, u32)>,
     /// Synthetic Component Manager instances opened for HLE-provided
     /// components such as the QuickTime movie controller.
     pub(crate) synthetic_component_instances: HashSet<u32>,
@@ -3471,7 +3468,6 @@ impl TrapDispatcher {
             thread_return_trampoline: 0,
             cooperative_thread_scheduler: 0,
             cooperative_thread_stack_size: DEFAULT_COOPERATIVE_THREAD_STACK_SIZE,
-            cooperative_thread_pool: Vec::new(),
             synthetic_component_instances: HashSet::new(),
             next_synthetic_component_instance: 0x00C1_0001,
             saved_draw_old_regions: HashMap::new(),

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -16431,7 +16431,13 @@ impl super::TrapDispatcher {
                         if thread_state == 0 {
                             -50
                         } else {
-                            match ThreadManager::new(&self.guest_calls).state(thread_to_get) {
+                            let manager = ThreadManager::new(&self.guest_calls);
+                            let state = if selector == 0x060F {
+                                manager.state_given_task(bus.read_long(sp + 8), thread_to_get)
+                            } else {
+                                manager.state(thread_to_get)
+                            };
+                            match state {
                                 Ok(state) if bus.try_write_word(thread_state, state) => 0,
                                 Ok(_) => -50,
                                 Err(error) => error,
@@ -16480,21 +16486,12 @@ impl super::TrapDispatcher {
                             Err(error) => error,
                         }
                     }
-                    // SetThreadReadyGivenTaskRef(threadTRef, threadToSet)
-                    0x0410 => {
-                        let task = ExecutionTaskId::from_thread_id(
-                            self.resolve_cooperative_thread_id(bus.read_long(sp)),
-                        );
-                        match self.guest_calls.scheduling_state(task) {
-                            None => Self::THREAD_NOT_FOUND_ERR,
-                            Some(ExecutionTaskState::Stopped) => {
-                                self.guest_calls
-                                    .set_scheduling_state(task, ExecutionTaskState::Ready);
-                                0
-                            }
-                            Some(_) => 0,
-                        }
-                    }
+                    // SetThreadReadyGivenTaskRef (0xA3F2)
+                    // Mark a stopped thread ready without switching during the call.
+                    // OSErr (ThreadTaskRef threadTRef, ThreadID threadToSet);
+                    // Inside Macintosh: Thread Manager (1999), pp. 75–76.
+                    0x0410 => ThreadManager::new(&self.guest_calls)
+                        .ready_given_task(bus.read_long(sp + 4), bus.read_long(sp)),
                     // SetThreadScheduler(threadScheduler)
                     0x0209 => {
                         self.cooperative_thread_scheduler = bus.read_long(sp);
@@ -16555,8 +16552,12 @@ impl super::TrapDispatcher {
                         if thread_t_ref == 0 {
                             -50
                         } else {
-                            bus.write_long(thread_t_ref, Self::APPLICATION_THREAD_ID);
-                            0
+                            let reference = ThreadManager::new(&self.guest_calls).task_reference();
+                            if bus.try_write_long(thread_t_ref, reference) {
+                                0
+                            } else {
+                                -50
+                            }
                         }
                     }
                     0x000B => ThreadManager::new(&self.guest_calls).begin_critical(),

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -1332,20 +1332,6 @@ impl super::TrapDispatcher {
         true
     }
 
-    /// Claim a pooled stack of at least `stack_size` bytes, or allocate a
-    /// fresh one. Returns `(base, limit)`.
-    fn acquire_cooperative_thread_stack(
-        &mut self,
-        bus: &mut MacMemoryBus,
-        stack_size: u32,
-    ) -> (u32, u32) {
-        if let Some(stack) = self.guest_calls.take_classic_thread_stack(stack_size) {
-            return stack;
-        }
-        let base = bus.alloc(stack_size);
-        (base, base.wrapping_add(stack_size))
-    }
-
     fn apple_event_handler_for(
         &self,
         event_class: u32,
@@ -16264,11 +16250,22 @@ impl super::TrapDispatcher {
                             if trampoline == 0 {
                                 return Err(-108);
                             }
-                            let (base, limit) = self.acquire_cooperative_thread_stack(bus, size);
+                            let pooled = self
+                                .guest_calls
+                                .request_classic_thread_stack(size, options)?;
+                            let (base, limit) = pooled.unwrap_or_else(|| {
+                                let base = bus.alloc(size);
+                                (base, base.saturating_add(size))
+                            });
                             let fail_stack = base == 0 || limit < base || limit - base < 8;
                             if fail_stack {
                                 if base != 0 {
-                                    self.guest_calls.recycle_classic_thread_stack((base, limit));
+                                    if pooled.is_some() {
+                                        self.guest_calls
+                                            .recycle_classic_thread_stack((base, limit));
+                                    } else {
+                                        bus.free(base);
+                                    }
                                 }
                                 return Err(-108);
                             }
@@ -16284,7 +16281,11 @@ impl super::TrapDispatcher {
                                 || overlap(result_slot, 2, entry_sp, 8)
                                 || overlap(thread_made, 4, result_slot, 2)
                             {
-                                self.guest_calls.recycle_classic_thread_stack((base, limit));
+                                if pooled.is_some() {
+                                    self.guest_calls.recycle_classic_thread_stack((base, limit));
+                                } else {
+                                    bus.free(base);
+                                }
                                 return Err(-50);
                             }
                             let mut thread = Self::capture_cooperative_thread(cpu);
@@ -16311,7 +16312,11 @@ impl super::TrapDispatcher {
                                 },
                             );
                             if made.is_none() {
-                                self.guest_calls.recycle_classic_thread_stack((base, limit));
+                                if pooled.is_some() {
+                                    self.guest_calls.recycle_classic_thread_stack((base, limit));
+                                } else {
+                                    bus.free(base);
+                                }
                                 return Err(-108);
                             }
                             Ok(())
@@ -27553,6 +27558,80 @@ mod tests {
     }
 
     #[test]
+    fn classic_newthread_obeys_pool_options_without_consuming_ids_on_refusal() {
+        // Thread Manager (1999), pp. 48, 57–58.
+        for (options, requested, expected_size, expected_error) in [
+            (0, 1024, 1024, 0),
+            (2, 1024, 1024, 0),
+            (2, 1200, 2048, 0),
+            (2 | 16, 1200, 0, -617),
+            (2 | 16 | 4, 1200, 1200, 0),
+            (2, 8192, 0, -617),
+            (2 | 4, 8192, 8192, 0),
+        ] {
+            let (mut disp, mut cpu, mut bus) = setup();
+            let made = TEST_SP + 0x100;
+            let mut pooled = Vec::new();
+            // Deliberately put larger stacks first to distinguish best fit
+            // from first fit, including an exact match at the end.
+            for size in [4096, 2048, 1024] {
+                let base = bus.alloc(size);
+                pooled.push((base, size));
+                disp.guest_calls
+                    .recycle_classic_thread_stack((base, base + size));
+            }
+            for (offset, value) in [
+                (0, made),
+                (4, 0),
+                (8, options | 1),
+                (12, requested),
+                (16, 0xcafebabe),
+                (20, 0x10000),
+                (24, 1),
+            ] {
+                bus.write_long(TEST_SP + offset, value);
+            }
+            bus.write_long(made, u32::MAX);
+            cpu.write_reg(Register::D0, 0x0e03);
+            disp.dispatch_toolbox(true, 0x3f2, &mut cpu, &mut bus)
+                .unwrap()
+                .unwrap();
+            assert_eq!(cpu.read_reg(Register::D0) as i16, expected_error);
+            if expected_error != 0 {
+                assert_eq!(bus.read_long(made), 0);
+                assert!(!disp.guest_calls.has_live_workers());
+                assert_eq!(disp.guest_calls.classic_thread_pool_count(0), 3);
+                // A fresh request retries successfully using the unconsumed ID.
+                cpu.write_reg(Register::A7, TEST_SP);
+                cpu.write_reg(Register::D0, 0x0e03);
+                bus.write_long(TEST_SP + 8, 1);
+                disp.dispatch_toolbox(true, 0x3f2, &mut cpu, &mut bus)
+                    .unwrap()
+                    .unwrap();
+                assert_eq!(cpu.read_reg(Register::D0), 0);
+                assert_eq!(bus.read_long(made), 3);
+                continue;
+            }
+            let task = ExecutionTaskId::from_thread_id(bus.read_long(made));
+            let storage = disp.guest_calls.thread_storage(task).unwrap();
+            assert_eq!(storage.stack_limit - storage.stack_base, expected_size);
+            let selected = pooled.iter().find(|&&(base, _)| base == storage.stack_base);
+            let should_reuse = options & 2 != 0 && expected_size != 1200 && expected_size != 8192;
+            assert_eq!(selected.is_some(), should_reuse);
+            assert_eq!(
+                disp.guest_calls.classic_thread_pool_count(0),
+                if should_reuse { 2 } else { 3 }
+            );
+            assert_eq!(
+                disp.guest_calls.scheduling_state(task),
+                Some(ExecutionTaskState::Stopped)
+            );
+            let context = disp.guest_calls.cooperative_context(task).unwrap();
+            assert_eq!(bus.read_long(context.a_regs[7] + 4), 0xcafebabe);
+        }
+    }
+
+    #[test]
     fn classic_thread_creation_refuses_bad_outputs_and_stacks_without_consuming_an_id() {
         for fault in 0..4 {
             let (mut disp, mut cpu, mut bus) = setup();
@@ -27567,7 +27646,7 @@ mod tests {
             for (offset, value) in [
                 (0, made),
                 (4, 0),
-                (8, 1),
+                (8, 1 | 2 | 4),
                 (12, if fault == 2 { 4 } else { 1024 }),
                 (16, 0xcafebabe),
                 (20, 0x10000),
@@ -27603,7 +27682,7 @@ mod tests {
             for (offset, value) in [
                 (0, retry_made),
                 (4, 0),
-                (8, 1),
+                (8, 1 | 2 | 4),
                 (12, 1024),
                 (16, 0xcafebabe),
                 (20, 0x10000),

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -1097,7 +1097,6 @@ impl super::TrapDispatcher {
     /// `ThreadState` values from Threads.h.
     const THREAD_STATE_READY: u16 = 0;
     const THREAD_STATE_STOPPED: u16 = 1;
-    const THREAD_STATE_RUNNING: u16 = 2;
     /// `threadNotFoundErr` and `threadProtocolErr` from Errors.h.
     const THREAD_NOT_FOUND_ERR: i16 = crate::thread_manager::THREAD_NOT_FOUND_ERR;
     const THREAD_PROTOCOL_ERR: i16 = crate::thread_manager::THREAD_PROTOCOL_ERR;
@@ -16439,51 +16438,46 @@ impl super::TrapDispatcher {
                             }
                         }
                     }
-                    // SetThreadState(threadToSet, newState, suggestedThread),
-                    // and SetThreadStateEndCritical, which additionally
-                    // performs the ThreadEndCritical the caller owes.
+                    // SetThreadState / SetThreadStateEndCritical (0xA3F2)
+                    // Set state and optionally exit a critical section atomically.
+                    // OSErr (ThreadID thread, ThreadState state, ThreadID suggested);
+                    // Inside Macintosh: Thread Manager (1999), pp. 67–72.
                     0x0508 | 0x0512 => {
-                        let suggested_thread = bus.read_long(sp);
-                        let new_state = bus.read_word(sp + 4);
-                        let thread_to_set =
-                            self.resolve_cooperative_thread_id(bus.read_long(sp + 6));
-                        let task = ExecutionTaskId::from_thread_id(thread_to_set);
-                        let requested = match new_state {
-                            Self::THREAD_STATE_READY => Some(ExecutionTaskState::Ready),
-                            Self::THREAD_STATE_STOPPED => Some(ExecutionTaskState::Stopped),
-                            Self::THREAD_STATE_RUNNING => Some(ExecutionTaskState::Running),
-                            _ => None,
-                        };
-                        if self.guest_calls.scheduling_state(task).is_none() {
-                            Self::THREAD_NOT_FOUND_ERR
-                        } else if !requested.is_some_and(|state| {
-                            if selector == 0x0512 {
-                                self.guest_calls.set_state_ending_critical(task, state)
-                            } else {
-                                self.guest_calls.set_scheduling_state(task, state)
-                            }
-                        }) {
-                            Self::THREAD_PROTOCOL_ERR
-                        } else if task == self.guest_calls.current_task()
-                            && new_state != Self::THREAD_STATE_RUNNING
-                        {
-                            // Save the ABI return before installing a different engine context.
-                            bus.write_word(sp + 10, 0);
-                            cpu.write_reg(Register::A7, sp + 10);
-                            cpu.write_reg(Register::D0, 0);
-                            self.save_current_cooperative_thread(cpu);
-                            if let Some(next_id) =
-                                self.next_ready_cooperative_thread(suggested_thread)
-                            {
-                                if self.switch_to_cooperative_thread(cpu, next_id) {
-                                    return Some(Ok(()));
+                        let suggested = bus.read_long(sp);
+                        let state = bus.read_word(sp + 4);
+                        let thread = bus.read_long(sp + 6);
+                        let current = self.guest_calls.current_task();
+                        let saved = Self::capture_cooperative_thread(cpu, 0);
+                        let mut outgoing = self
+                            .guest_calls
+                            .cooperative_context(current)
+                            .unwrap_or_else(|| saved.clone());
+                        outgoing.d_regs = saved.d_regs;
+                        outgoing.a_regs = saved.a_regs;
+                        outgoing.pc = saved.pc;
+                        outgoing.ccr = saved.ccr;
+                        outgoing.d_regs[0] = 0;
+                        outgoing.a_regs[7] = sp + 10;
+                        match self.guest_calls.set_classic_thread_state(
+                            thread,
+                            state,
+                            suggested,
+                            selector == 0x0512,
+                            outgoing,
+                            || bus.try_write_word(sp + 10, 0),
+                        ) {
+                            Ok(switched) => {
+                                cpu.write_reg(Register::A7, sp + 10);
+                                cpu.write_reg(Register::D0, 0);
+                                if switched {
+                                    if let Some(next) = self.guest_calls.take_classic_task_handoff()
+                                    {
+                                        Self::install_cooperative_thread(cpu, &next);
+                                    }
                                 }
+                                return Some(Ok(()));
                             }
-                            self.guest_calls
-                                .set_scheduling_state(task, ExecutionTaskState::Running);
-                            return Some(Ok(()));
-                        } else {
-                            0
+                            Err(error) => error,
                         }
                     }
                     // SetThreadReadyGivenTaskRef(threadTRef, threadToSet)
@@ -27285,6 +27279,39 @@ mod tests {
                 .scheduling_state(ExecutionTaskId::APPLICATION),
             Some(ExecutionTaskState::Running)
         );
+    }
+
+    #[test]
+    fn thread_state_preflights_successor_and_return_write_before_ending_critical() {
+        for missing_context in [true, false] {
+            let (mut disp, mut cpu, mut bus) = setup();
+            let worker = ExecutionTaskId::from_thread_id(3);
+            assert!(disp.guest_calls.register_task(worker));
+            assert!(disp
+                .guest_calls
+                .set_scheduling_state(worker, ExecutionTaskState::Ready));
+            if !missing_context {
+                assert!(disp
+                    .guest_calls
+                    .save_cooperative_context(worker, super::CooperativeThread::default()));
+            }
+            disp.guest_calls.begin_critical();
+            bus.write_long(TEST_SP, 3);
+            bus.write_word(TEST_SP + 4, 1);
+            bus.write_long(TEST_SP + 6, 1);
+            bus.write_word(TEST_SP + 10, 0x1234);
+            if !missing_context {
+                bus.protect_readonly_code(TEST_SP + 11, 1);
+            }
+            cpu.write_reg(Register::D0, 0x0512);
+            let before = disp.guest_calls.clone();
+            disp.dispatch_toolbox(true, 0x3f2, &mut cpu, &mut bus)
+                .unwrap()
+                .unwrap();
+            assert_eq!(cpu.read_reg(Register::D0) as i16, -619);
+            assert_eq!(disp.guest_calls, before);
+            assert_eq!(disp.guest_calls.critical_depth(), 1);
+        }
     }
 
     #[test]

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -1261,29 +1261,33 @@ impl super::TrapDispatcher {
         self.switch_to_cooperative_thread(cpu, next_id);
     }
 
-    /// Retire `thread_id`, storing its entry-proc result and returning its
-    /// stack to the pool so `NewThread` can recycle it.
+    /// Retire a task and release its storage unless explicitly recycled.
     fn retire_cooperative_thread(
         &mut self,
         thread_id: u32,
         result: u32,
         bus: &mut MacMemoryBus,
+        recycle: bool,
     ) -> bool {
         let task = ExecutionTaskId::from_thread_id(thread_id);
         let Some((finished, _)) =
             self.guest_calls
-                .retire_cooperative_context(task, None, |saved| {
+                .retire_cooperative_context(task, None, recycle, |saved| {
                     saved.result_destination == 0
                         || bus.try_write_long(saved.result_destination, result)
                 })
         else {
             return false;
         };
-        if finished.stack_base != 0 && finished.managed_pointer {
-            self.process_memory_manager()
-                .borrow_mut()
-                .native_mut()
-                .dispose_native_ptr(finished.stack_base);
+        if !recycle && finished.stack_base != 0 {
+            if finished.managed_pointer {
+                self.process_memory_manager()
+                    .borrow_mut()
+                    .native_mut()
+                    .dispose_native_ptr(finished.stack_base);
+            } else {
+                bus.free(finished.stack_base);
+            }
         }
         true
     }
@@ -1295,7 +1299,7 @@ impl super::TrapDispatcher {
         bus: &mut MacMemoryBus,
     ) -> bool {
         let result = cpu.read_reg(Register::A0);
-        self.finish_cooperative_thread_with_result(cpu, bus, result)
+        self.finish_cooperative_thread_with_result(cpu, bus, result, false)
     }
 
     fn finish_cooperative_thread_with_result<C: CpuOps>(
@@ -1303,6 +1307,7 @@ impl super::TrapDispatcher {
         cpu: &mut C,
         bus: &mut MacMemoryBus,
         result: u32,
+        recycle: bool,
     ) -> bool {
         let finished = self.guest_calls.current_task();
         let Some(next) = self.next_ready_cooperative_thread(0) else {
@@ -1311,6 +1316,7 @@ impl super::TrapDispatcher {
         let Some((saved, successor)) = self.guest_calls.retire_cooperative_context(
             finished,
             Some(ExecutionTaskId::from_thread_id(next)),
+            recycle,
             |saved| {
                 saved.result_destination == 0
                     || bus.try_write_long(saved.result_destination, result)
@@ -1323,11 +1329,15 @@ impl super::TrapDispatcher {
         if let Some(successor) = successor {
             Self::install_cooperative_thread(cpu, &successor);
         }
-        if saved.stack_base != 0 && saved.managed_pointer {
-            self.process_memory_manager()
-                .borrow_mut()
-                .native_mut()
-                .dispose_native_ptr(saved.stack_base);
+        if !recycle && saved.stack_base != 0 {
+            if saved.managed_pointer {
+                self.process_memory_manager()
+                    .borrow_mut()
+                    .native_mut()
+                    .dispose_native_ptr(saved.stack_base);
+            } else {
+                bus.free(saved.stack_base);
+            }
         }
         true
     }
@@ -16431,6 +16441,9 @@ impl super::TrapDispatcher {
                     }
                     // DisposeThread(threadToDump, threadResult, recycleThread)
                     0x0504 => {
+                        // Pascal Boolean occupies the high byte of its stack word.
+                        // Thread Manager (1999), pp. 59–60.
+                        let recycle = bus.read_byte(sp) != 0;
                         let thread_result = bus.read_long(sp + 2);
                         let thread_to_dump =
                             self.resolve_cooperative_thread_id(bus.read_long(sp + 6));
@@ -16444,13 +16457,23 @@ impl super::TrapDispatcher {
                         } else if thread_to_dump == self.guest_calls.current_task().thread_id() {
                             // Threads.h allows a thread to dispose of itself;
                             // the call never returns to it.
-                            if self.finish_cooperative_thread_with_result(cpu, bus, thread_result) {
+                            if self.finish_cooperative_thread_with_result(
+                                cpu,
+                                bus,
+                                thread_result,
+                                recycle,
+                            ) {
                                 return Some(Ok(()));
                             } else {
                                 Self::THREAD_PROTOCOL_ERR
                             }
                         } else {
-                            if self.retire_cooperative_thread(thread_to_dump, thread_result, bus) {
+                            if self.retire_cooperative_thread(
+                                thread_to_dump,
+                                thread_result,
+                                bus,
+                                recycle,
+                            ) {
                                 0
                             } else {
                                 Self::THREAD_PROTOCOL_ERR
@@ -27415,7 +27438,7 @@ mod tests {
             let retired = if self_exit {
                 disp.finish_cooperative_thread(&mut cpu, &mut bus)
             } else {
-                disp.retire_cooperative_thread(worker.thread_id(), 0xcafe_babe, &mut bus)
+                disp.retire_cooperative_thread(worker.thread_id(), 0xcafe_babe, &mut bus, false)
             };
             assert!(!retired);
             assert_eq!(disp.guest_calls.current_task(), current);
@@ -27434,17 +27457,14 @@ mod tests {
             let retired = if self_exit {
                 disp.finish_cooperative_thread(&mut cpu, &mut bus)
             } else {
-                disp.retire_cooperative_thread(worker.thread_id(), 0xcafe_babe, &mut bus)
+                disp.retire_cooperative_thread(worker.thread_id(), 0xcafe_babe, &mut bus, false)
             };
             assert!(retired);
             assert_eq!(disp.guest_calls.current_task(), application);
             assert!(disp.guest_calls.cooperative_context(worker).is_none());
             assert_eq!(disp.guest_calls.scheduling_state(worker), None);
             assert_eq!(bus.read_long(result_slot + 8), 0xcafe_babe);
-            assert_eq!(
-                disp.guest_calls.take_classic_thread_stack(0),
-                Some((0x1000, 0x2000))
-            );
+            assert_eq!(disp.guest_calls.classic_thread_pool_count(0), 0);
             if self_exit {
                 assert_eq!(cpu.read_reg(Register::PC), 0x4321);
                 assert_eq!(cpu.read_reg(Register::A0), 0x8765);

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -657,7 +657,7 @@ const STANDARD_FILE_GET_DESKTOP_RECT: (i16, i16, i16, i16) = (66, 258, 87, 338);
 const STANDARD_FILE_GET_SEPARATOR_RECT: (i16, i16, i16, i16) = (98, 258, 99, 338);
 const STANDARD_FILE_GET_CANCEL_RECT: (i16, i16, i16, i16) = (110, 258, 131, 338);
 const STANDARD_FILE_GET_OPEN_RECT: (i16, i16, i16, i16) = (138, 258, 159, 338);
-const DEFAULT_COOPERATIVE_THREAD_STACK_SIZE: u32 = 32 * 1024;
+use crate::thread_manager::DEFAULT_COOPERATIVE_THREAD_STACK_SIZE;
 
 #[inline]
 fn return_noerr_and_pop<C: CpuOps>(cpu: &mut C, bytes: u32) -> Result<()> {
@@ -16190,7 +16190,6 @@ impl super::TrapDispatcher {
                 let sp = cpu.read_reg(Register::A7);
                 // Threads.h option and style bits.
                 const K_NEW_SUSPEND: u32 = 1 << 0;
-                const K_PREEMPTIVE_THREAD: u32 = 1 << 1;
 
                 let result = match selector {
                     0xFFFE => {
@@ -16239,11 +16238,11 @@ impl super::TrapDispatcher {
                         // pp. 56–58: threadMade is kNoThreadID on failure.
                         let result = (|| -> std::result::Result<(), i16> {
                             let result_slot = sp.checked_add(28).ok_or(-50_i16)?;
-                            let size = if stack_size == 0 {
-                                self.cooperative_thread_stack_size
-                            } else {
-                                stack_size
-                            };
+                            let size = ThreadManager::stack_size(
+                                crate::guest_procedure::GuestIsa::M68k,
+                                thread_style,
+                                stack_size,
+                            )?;
                             if thread_made == 0
                                 || thread_entry == 0
                                 || thread_entry & 1 != 0
@@ -16342,65 +16341,79 @@ impl super::TrapDispatcher {
                         }
                     }
                     // CreateThreadPool(threadStyle, numToCreate, stackSize)
+                    // Thread Manager (1999), pp. 50–51: publish all or none.
                     0x0501 => {
                         let stack_size = bus.read_long(sp);
                         let count = bus.read_word(sp + 4) as i16;
-                        let thread_style = bus.read_long(sp + 6);
-                        if thread_style & K_PREEMPTIVE_THREAD != 0 {
-                            -50
+                        let style = bus.read_long(sp + 6);
+                        let result = if !sp
+                            .checked_add(10)
+                            .is_some_and(|slot| bus.is_guest_address_writable(slot, 2))
+                        {
+                            Err((-50, Vec::new()))
                         } else {
-                            let stack_size = if stack_size == 0 {
-                                self.cooperative_thread_stack_size
-                            } else {
-                                stack_size
-                            };
-                            for _ in 0..count.max(0) {
-                                let base = bus.alloc(stack_size);
-                                self.guest_calls.recycle_classic_thread_stack((
-                                    base,
-                                    base.wrapping_add(stack_size),
-                                ));
+                            ThreadManager::new(&self.guest_calls).create_pool(
+                                crate::guest_procedure::GuestIsa::M68k,
+                                style,
+                                count,
+                                stack_size,
+                                |size| {
+                                    let base = bus.alloc(size);
+                                    (base != 0).then_some(crate::guest_call::ThreadStorage {
+                                        stack_base: base,
+                                        stack_limit: base.saturating_add(size),
+                                        ..Default::default()
+                                    })
+                                },
+                            )
+                        };
+                        match result {
+                            Ok(()) => 0,
+                            Err((error, storage)) => {
+                                for stack in storage {
+                                    bus.free(stack.stack_base);
+                                }
+                                error
                             }
-                            0
                         }
                     }
-                    // GetFreeThreadCount(threadStyle, freeCount)
-                    0x0402 => {
-                        let free_count = bus.read_long(sp);
-                        let thread_style = bus.read_long(sp + 4);
-                        if free_count == 0 || thread_style & K_PREEMPTIVE_THREAD != 0 {
-                            -50
+                    // GetFreeThreadCount / GetSpecificFreeThreadCount /
+                    // GetDefaultThreadStackSize. Thread Manager (1999), pp. 52–55.
+                    0x0402 | 0x0615 | 0x0413 => {
+                        let output = bus.read_long(sp);
+                        let specific = selector == 0x0615;
+                        let style = bus.read_long(sp + if specific { 8 } else { 4 });
+                        let manager = ThreadManager::new(&self.guest_calls);
+                        let value = if selector == 0x0413 {
+                            ThreadManager::stack_size(
+                                crate::guest_procedure::GuestIsa::M68k,
+                                style,
+                                0,
+                            )
                         } else {
-                            bus.write_word(
-                                free_count,
-                                self.guest_calls.classic_thread_pool_count(0) as u16,
-                            );
-                            0
-                        }
-                    }
-                    // GetSpecificFreeThreadCount(threadStyle, stackSize,
-                    //                            freeCount)
-                    0x0615 => {
-                        let free_count = bus.read_long(sp);
-                        let stack_size = bus.read_long(sp + 4);
-                        let thread_style = bus.read_long(sp + 8);
-                        if free_count == 0 || thread_style & K_PREEMPTIVE_THREAD != 0 {
-                            -50
-                        } else {
-                            let matching = self.guest_calls.classic_thread_pool_count(stack_size);
-                            bus.write_word(free_count, matching as u16);
-                            0
-                        }
-                    }
-                    // GetDefaultThreadStackSize(threadStyle, stackSize)
-                    0x0413 => {
-                        let stack_size = bus.read_long(sp);
-                        let thread_style = bus.read_long(sp + 4);
-                        if stack_size == 0 || thread_style & K_PREEMPTIVE_THREAD != 0 {
-                            -50
-                        } else {
-                            bus.write_long(stack_size, self.cooperative_thread_stack_size);
-                            0
+                            manager
+                                .free_count(
+                                    crate::guest_procedure::GuestIsa::M68k,
+                                    style,
+                                    if specific { bus.read_long(sp + 4) } else { 0 },
+                                )
+                                .map(u32::from)
+                        };
+                        match value {
+                            Err(error) => error,
+                            Ok(value) if output != 0 => {
+                                let written = if selector == 0x0413 {
+                                    bus.try_write_long(output, value)
+                                } else {
+                                    bus.try_write_word(output, value as u16)
+                                };
+                                if written {
+                                    0
+                                } else {
+                                    -50
+                                }
+                            }
+                            Ok(_) => -50,
                         }
                     }
                     // ThreadCurrentStackSpace(thread, freeStack)
@@ -27272,6 +27285,50 @@ mod tests {
 
     /// `GetDefaultThreadStackSize` reports the size `NewThread` uses when
     /// passed 0, and refuses the preemptive style.
+    #[test]
+    fn thread_pool_creation_refuses_a_protected_pascal_result_before_allocating() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let before = bus.heap_bump_ptr();
+        bus.write_long(TEST_SP, 1024);
+        bus.write_word(TEST_SP + 4, 2);
+        bus.write_long(TEST_SP + 6, 1);
+        bus.protect_readonly_code(TEST_SP + 11, 1);
+        cpu.write_reg(Register::D0, 0x0501);
+        disp.dispatch_toolbox(true, 0x3f2, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+        assert_eq!(cpu.read_reg(Register::D0) as i16, -50);
+        assert_eq!(disp.guest_calls.classic_thread_pool_count(0), 0);
+        assert_eq!(bus.heap_bump_ptr(), before);
+    }
+
+    #[test]
+    fn thread_pool_allocation_failure_rolls_back_and_retries_without_publishing_entries() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let base = bus.classic_heap_limit() - 1028;
+        bus.reserve_heap_until(base);
+        for (count, expected) in [(2, -108_i16), (1, 0)] {
+            cpu.write_reg(Register::A7, TEST_SP);
+            cpu.write_reg(Register::D0, 0x0501);
+            bus.write_long(TEST_SP, 1024);
+            bus.write_word(TEST_SP + 4, count);
+            bus.write_long(TEST_SP + 6, 1);
+            disp.dispatch_toolbox(true, 0x3f2, &mut cpu, &mut bus)
+                .unwrap()
+                .unwrap();
+            assert_eq!(cpu.read_reg(Register::D0) as i16, expected);
+            assert_eq!(
+                disp.guest_calls.classic_thread_pool_count(0),
+                usize::from(expected == 0)
+            );
+            assert_eq!(
+                bus.get_alloc_size(base),
+                if expected == 0 { Some(1024) } else { None }
+            );
+        }
+        assert_eq!(disp.guest_calls.create_task().unwrap().thread_id(), 3);
+    }
+
     #[test]
     fn thread_pool_creation_adds_distinct_stacks_to_the_execution_owner() {
         let (mut disp, mut cpu, mut bus) = setup();

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -1,7 +1,6 @@
 //! Toolbox Utility trap handlers (events, Random, Sound, misc).
 
 use crate::cpu::{CpuOps, Register};
-use crate::execution_kernel::ExecutionTaskState;
 use crate::guest_call::CooperativeThread;
 use crate::guest_call::ExecutionTaskId;
 use crate::memory::globals::addr;
@@ -1094,9 +1093,6 @@ impl super::TrapDispatcher {
     /// `kApplicationThreadID` from Threads.h — the thread the process
     /// launches on, which owns the process stack rather than a pooled one.
     const APPLICATION_THREAD_ID: u32 = 2;
-    /// `ThreadState` values from Threads.h.
-    const THREAD_STATE_READY: u16 = 0;
-    const THREAD_STATE_STOPPED: u16 = 1;
     /// `threadNotFoundErr` and `threadProtocolErr` from Errors.h.
     const THREAD_NOT_FOUND_ERR: i16 = crate::thread_manager::THREAD_NOT_FOUND_ERR;
     const THREAD_PROTOCOL_ERR: i16 = crate::thread_manager::THREAD_PROTOCOL_ERR;
@@ -1167,10 +1163,14 @@ impl super::TrapDispatcher {
     fn thread_return_trampoline(&mut self, bus: &mut MacMemoryBus) -> u32 {
         if self.thread_return_trampoline == 0 {
             let trampoline = bus.alloc(8);
-            bus.write_word(trampoline, 0x303C); // MOVE.W #$FFFE,D0
-            bus.write_word(trampoline + 2, 0xFFFE);
-            bus.write_word(trampoline + 4, 0xABF2); // _ThreadDispatch
-            bus.write_word(trampoline + 6, 0x4E75); // defensive RTS
+            let code = [0x303Cu16, 0xFFFE, 0xABF2, 0x4E75]
+                .into_iter()
+                .flat_map(u16::to_be_bytes)
+                .collect::<Vec<_>>();
+            if trampoline == 0 || !bus.try_write_ranges_atomic(&[(trampoline, &code)]) {
+                bus.free(trampoline);
+                return 0;
+            }
             self.thread_return_trampoline = trampoline;
         }
         self.thread_return_trampoline
@@ -16238,67 +16238,92 @@ impl super::TrapDispatcher {
                         let thread_entry = bus.read_long(sp + 20);
                         let thread_style = bus.read_long(sp + 24);
 
-                        if thread_made == 0
-                            || thread_entry == 0
-                            || thread_style & K_PREEMPTIVE_THREAD != 0
-                        {
-                            if thread_made != 0 {
-                                bus.write_long(thread_made, 0);
-                            }
-                            -50
-                        } else if let Some(task) = self.guest_calls.create_task() {
-                            let thread_id = task.thread_id();
-
-                            let stack_size = if stack_size == 0 {
+                        // NewThread publishes no identity until its ABI frame and
+                        // output destinations are committed. Thread Manager (1999),
+                        // pp. 56–58: threadMade is kNoThreadID on failure.
+                        let result = (|| -> std::result::Result<(), i16> {
+                            let result_slot = sp.checked_add(28).ok_or(-50_i16)?;
+                            let size = if stack_size == 0 {
                                 self.cooperative_thread_stack_size
                             } else {
                                 stack_size
                             };
-                            let (stack_base, stack_limit) =
-                                self.acquire_cooperative_thread_stack(bus, stack_size);
-
-                            // Seed the private stack as though the entry proc
-                            // had been called by the trampoline: return
-                            // address, then its single Pascal argument.
-                            let return_trampoline = self.thread_return_trampoline(bus);
-                            let entry_sp = stack_limit.wrapping_sub(8);
-                            bus.write_long(entry_sp, return_trampoline);
-                            bus.write_long(entry_sp + 4, thread_param);
-
-                            let state = if options & K_NEW_SUSPEND != 0 {
-                                Self::THREAD_STATE_STOPPED
-                            } else {
-                                Self::THREAD_STATE_READY
-                            };
+                            if thread_made == 0
+                                || thread_entry == 0
+                                || thread_entry & 1 != 0
+                                || thread_style != 1
+                                || size < 8
+                                || size > i32::MAX as u32
+                                || !bus.is_guest_address_mapped(thread_entry, 2)
+                                || !bus.is_guest_address_writable(thread_made, 4)
+                                || !bus.is_guest_address_writable(result_slot, 2)
+                            {
+                                return Err(-50);
+                            }
+                            let trampoline = self.thread_return_trampoline(bus);
+                            if trampoline == 0 {
+                                return Err(-108);
+                            }
+                            let (base, limit) = self.acquire_cooperative_thread_stack(bus, size);
+                            let fail_stack = base == 0 || limit < base || limit - base < 8;
+                            if fail_stack {
+                                if base != 0 {
+                                    self.guest_calls.recycle_classic_thread_stack((base, limit));
+                                }
+                                return Err(-108);
+                            }
+                            let entry_sp = (limit - 8) & !1;
+                            let overlap =
+                                |address: u32, length: u32, other: u32, other_length: u32| {
+                                    u64::from(address) < u64::from(other) + u64::from(other_length)
+                                        && u64::from(other) < u64::from(address) + u64::from(length)
+                                };
+                            if entry_sp < base
+                                || !bus.is_guest_address_writable(entry_sp, 8)
+                                || overlap(thread_made, 4, entry_sp, 8)
+                                || overlap(result_slot, 2, entry_sp, 8)
+                                || overlap(thread_made, 4, result_slot, 2)
+                            {
+                                self.guest_calls.recycle_classic_thread_stack((base, limit));
+                                return Err(-50);
+                            }
                             let mut thread = Self::capture_cooperative_thread(cpu);
                             thread.pc = thread_entry;
                             thread.a_regs[7] = entry_sp;
-                            self.guest_calls.set_thread_storage(
-                                task,
+                            let mut frame = [0u8; 8];
+                            frame[..4].copy_from_slice(&trampoline.to_be_bytes());
+                            frame[4..].copy_from_slice(&thread_param.to_be_bytes());
+                            let made = self.guest_calls.create_classic_thread(
+                                thread,
                                 crate::guest_call::ThreadStorage {
                                     result_destination,
-                                    stack_base,
-                                    stack_limit,
+                                    stack_base: base,
+                                    stack_limit: limit,
                                     managed_pointer: false,
                                 },
-                            );
-                            self.guest_calls.save_cooperative_context(
-                                ExecutionTaskId::from_thread_id(thread_id),
-                                thread,
-                            );
-                            self.guest_calls.set_scheduling_state(
-                                ExecutionTaskId::from_thread_id(thread_id),
-                                if state == Self::THREAD_STATE_READY {
-                                    ExecutionTaskState::Ready
-                                } else {
-                                    ExecutionTaskState::Stopped
+                                options & K_NEW_SUSPEND != 0,
+                                |task| {
+                                    bus.try_write_ranges_atomic(&[
+                                        (entry_sp, &frame),
+                                        (thread_made, &task.thread_id().to_be_bytes()),
+                                        (result_slot, &0u16.to_be_bytes()),
+                                    ])
                                 },
                             );
-                            bus.write_long(thread_made, thread_id);
-                            0
-                        } else {
-                            bus.write_long(thread_made, 0);
-                            -108
+                            if made.is_none() {
+                                self.guest_calls.recycle_classic_thread_stack((base, limit));
+                                return Err(-108);
+                            }
+                            Ok(())
+                        })();
+                        match result {
+                            Ok(()) => 0,
+                            Err(error) => {
+                                if thread_made != 0 {
+                                    let _ = bus.try_write_long(thread_made, 0);
+                                }
+                                error
+                            }
                         }
                     }
                     // CreateThreadPool(threadStyle, numToCreate, stackSize)
@@ -27524,6 +27549,84 @@ mod tests {
                 .is_some());
             // Another creator shares the owner's namespace between classic calls.
             assert_eq!(process.create_task().unwrap().thread_id(), expected + 1);
+        }
+    }
+
+    #[test]
+    fn classic_thread_creation_refuses_bad_outputs_and_stacks_without_consuming_an_id() {
+        for fault in 0..4 {
+            let (mut disp, mut cpu, mut bus) = setup();
+            let made = TEST_SP + 0x100;
+            let stack = bus.alloc(1024);
+            disp.guest_calls
+                .recycle_classic_thread_stack((stack, stack + 1024));
+            bus.write_long(stack + 1016, 0x11223344);
+            bus.write_long(stack + 1020, 0x55667788);
+            let stack_bytes = (bus.read_long(stack + 1016), bus.read_long(stack + 1020));
+            bus.write_long(made, 0xaaaaaaaa);
+            for (offset, value) in [
+                (0, made),
+                (4, 0),
+                (8, 1),
+                (12, if fault == 2 { 4 } else { 1024 }),
+                (16, 0xcafebabe),
+                (20, 0x10000),
+                (24, 1),
+            ] {
+                bus.write_long(TEST_SP + offset, value);
+            }
+            match fault {
+                0 => bus.protect_readonly_code(made + 2, 2),
+                1 => bus.protect_readonly_code(stack + 1022, 2),
+                3 => bus.protect_readonly_code(TEST_SP + 29, 1),
+                _ => {}
+            }
+            cpu.write_reg(Register::D0, 0x0e03);
+            disp.dispatch_toolbox(true, 0x3f2, &mut cpu, &mut bus)
+                .unwrap()
+                .unwrap();
+            assert_eq!(cpu.read_reg(Register::D0) as i16, -50);
+            assert_eq!(bus.read_long(made), if fault == 0 { 0xaaaaaaaa } else { 0 });
+            assert_eq!(disp.guest_calls.classic_thread_pool_count(0), 1);
+            assert!(!disp.guest_calls.has_live_workers());
+            assert_eq!(
+                (bus.read_long(stack + 1016), bus.read_long(stack + 1020)),
+                stack_bytes
+            );
+            // Retry with a valid output, return frame, size and stack. If the
+            // pool stack itself is protected, reserve another stack for retry.
+            let retry_sp = TEST_SP + 0x200;
+            let retry_made = TEST_SP + 0x300;
+            if fault == 1 {
+                disp.guest_calls.take_classic_thread_stack(1024);
+            }
+            for (offset, value) in [
+                (0, retry_made),
+                (4, 0),
+                (8, 1),
+                (12, 1024),
+                (16, 0xcafebabe),
+                (20, 0x10000),
+                (24, 1),
+            ] {
+                bus.write_long(retry_sp + offset, value);
+            }
+            cpu.write_reg(Register::A7, retry_sp);
+            cpu.write_reg(Register::D0, 0x0e03);
+            disp.dispatch_toolbox(true, 0x3f2, &mut cpu, &mut bus)
+                .unwrap()
+                .unwrap();
+            assert_eq!(cpu.read_reg(Register::D0), 0);
+            assert_eq!(bus.read_long(retry_made), 3);
+            let worker = disp
+                .guest_calls
+                .cooperative_context(ExecutionTaskId::from_thread_id(3))
+                .unwrap();
+            assert_eq!(bus.read_long(worker.a_regs[7] + 4), 0xcafebabe);
+            assert_eq!(
+                bus.read_long(worker.a_regs[7]),
+                disp.thread_return_trampoline
+            );
         }
     }
 

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -1101,10 +1101,7 @@ impl super::TrapDispatcher {
     const THREAD_NOT_FOUND_ERR: i16 = crate::thread_manager::THREAD_NOT_FOUND_ERR;
     const THREAD_PROTOCOL_ERR: i16 = crate::thread_manager::THREAD_PROTOCOL_ERR;
 
-    fn capture_cooperative_thread<C: CpuOps>(
-        cpu: &C,
-        result_destination: u32,
-    ) -> CooperativeThread {
+    fn capture_cooperative_thread<C: CpuOps>(cpu: &C) -> CooperativeThread {
         let d_regs = [
             cpu.read_reg(Register::D0),
             cpu.read_reg(Register::D1),
@@ -1130,9 +1127,6 @@ impl super::TrapDispatcher {
             a_regs,
             pc: cpu.read_reg(Register::PC),
             ccr: cpu.get_ccr(),
-            result_destination,
-            stack_base: 0,
-            stack_limit: 0,
             switch_in: (0, 0),
             switch_out: (0, 0),
             terminator: (0, 0),
@@ -1203,7 +1197,7 @@ impl super::TrapDispatcher {
                 .cooperative_context(ExecutionTaskId::from_thread_id(Self::APPLICATION_THREAD_ID))
                 .is_some()
         {
-            let thread = Self::capture_cooperative_thread(cpu, 0);
+            let thread = Self::capture_cooperative_thread(cpu);
             self.guest_calls.save_cooperative_context(
                 ExecutionTaskId::from_thread_id(Self::APPLICATION_THREAD_ID),
                 thread,
@@ -1217,7 +1211,7 @@ impl super::TrapDispatcher {
     /// changing its scheduling state.
     fn save_current_cooperative_thread<C: CpuOps>(&mut self, cpu: &C) {
         let current_id = self.guest_calls.current_task().thread_id();
-        let saved = Self::capture_cooperative_thread(cpu, 0);
+        let saved = Self::capture_cooperative_thread(cpu);
         match self.cooperative_thread_snapshot(cpu, current_id) {
             Some(mut thread) => {
                 thread.d_regs = saved.d_regs;
@@ -1285,9 +1279,11 @@ impl super::TrapDispatcher {
         else {
             return false;
         };
-        if finished.stack_base != 0 {
-            self.cooperative_thread_pool
-                .push((finished.stack_base, finished.stack_limit));
+        if finished.stack_base != 0 && finished.managed_pointer {
+            self.process_memory_manager()
+                .borrow_mut()
+                .native_mut()
+                .dispose_native_ptr(finished.stack_base);
         }
         true
     }
@@ -1327,9 +1323,11 @@ impl super::TrapDispatcher {
         if let Some(successor) = successor {
             Self::install_cooperative_thread(cpu, &successor);
         }
-        if saved.stack_base != 0 {
-            self.cooperative_thread_pool
-                .push((saved.stack_base, saved.stack_limit));
+        if saved.stack_base != 0 && saved.managed_pointer {
+            self.process_memory_manager()
+                .borrow_mut()
+                .native_mut()
+                .dispose_native_ptr(saved.stack_base);
         }
         true
     }
@@ -1341,12 +1339,8 @@ impl super::TrapDispatcher {
         bus: &mut MacMemoryBus,
         stack_size: u32,
     ) -> (u32, u32) {
-        if let Some(position) = self
-            .cooperative_thread_pool
-            .iter()
-            .position(|(base, limit)| limit.saturating_sub(*base) >= stack_size)
-        {
-            return self.cooperative_thread_pool.swap_remove(position);
+        if let Some(stack) = self.guest_calls.take_classic_thread_stack(stack_size) {
+            return stack;
         }
         let base = bus.alloc(stack_size);
         (base, base.wrapping_add(stack_size))
@@ -16276,12 +16270,18 @@ impl super::TrapDispatcher {
                             } else {
                                 Self::THREAD_STATE_READY
                             };
-                            let mut thread =
-                                Self::capture_cooperative_thread(cpu, result_destination);
+                            let mut thread = Self::capture_cooperative_thread(cpu);
                             thread.pc = thread_entry;
                             thread.a_regs[7] = entry_sp;
-                            thread.stack_base = stack_base;
-                            thread.stack_limit = stack_limit;
+                            self.guest_calls.set_thread_storage(
+                                task,
+                                crate::guest_call::ThreadStorage {
+                                    result_destination,
+                                    stack_base,
+                                    stack_limit,
+                                    managed_pointer: false,
+                                },
+                            );
                             self.guest_calls.save_cooperative_context(
                                 ExecutionTaskId::from_thread_id(thread_id),
                                 thread,
@@ -16315,8 +16315,11 @@ impl super::TrapDispatcher {
                                 stack_size
                             };
                             for _ in 0..count.max(0) {
-                                let stack = self.acquire_cooperative_thread_stack(bus, stack_size);
-                                self.cooperative_thread_pool.push(stack);
+                                let base = bus.alloc(stack_size);
+                                self.guest_calls.recycle_classic_thread_stack((
+                                    base,
+                                    base.wrapping_add(stack_size),
+                                ));
                             }
                             0
                         }
@@ -16328,7 +16331,10 @@ impl super::TrapDispatcher {
                         if free_count == 0 || thread_style & K_PREEMPTIVE_THREAD != 0 {
                             -50
                         } else {
-                            bus.write_word(free_count, self.cooperative_thread_pool.len() as u16);
+                            bus.write_word(
+                                free_count,
+                                self.guest_calls.classic_thread_pool_count(0) as u16,
+                            );
                             0
                         }
                     }
@@ -16341,11 +16347,7 @@ impl super::TrapDispatcher {
                         if free_count == 0 || thread_style & K_PREEMPTIVE_THREAD != 0 {
                             -50
                         } else {
-                            let matching = self
-                                .cooperative_thread_pool
-                                .iter()
-                                .filter(|(base, limit)| limit.saturating_sub(*base) >= stack_size)
-                                .count();
+                            let matching = self.guest_calls.classic_thread_pool_count(stack_size);
                             bus.write_word(free_count, matching as u16);
                             0
                         }
@@ -16377,7 +16379,11 @@ impl super::TrapDispatcher {
                                     // stack, whose base this record does not
                                     // track, so report the default size rather
                                     // than a bogus multi-megabyte figure.
-                                    let free = if record.stack_base == 0 {
+                                    let storage = self
+                                        .guest_calls
+                                        .thread_storage(ExecutionTaskId::from_thread_id(thread))
+                                        .unwrap_or_default();
+                                    let free = if storage.stack_base == 0 {
                                         DEFAULT_COOPERATIVE_THREAD_STACK_SIZE
                                     } else {
                                         let stack_pointer = if running {
@@ -16385,7 +16391,7 @@ impl super::TrapDispatcher {
                                         } else {
                                             record.a_regs[7]
                                         };
-                                        stack_pointer.saturating_sub(record.stack_base)
+                                        stack_pointer.saturating_sub(storage.stack_base)
                                     };
                                     bus.write_long(free_stack, free);
                                     0
@@ -16400,7 +16406,7 @@ impl super::TrapDispatcher {
                             self.resolve_cooperative_thread_id(bus.read_long(sp + 6));
                         if !self
                             .guest_calls
-                            .cooperative_context(ExecutionTaskId::from_thread_id(thread_to_dump))
+                            .thread_storage(ExecutionTaskId::from_thread_id(thread_to_dump))
                             .is_some()
                             && thread_to_dump != Self::APPLICATION_THREAD_ID
                         {
@@ -16453,7 +16459,7 @@ impl super::TrapDispatcher {
                         let state = bus.read_word(sp + 4);
                         let thread = bus.read_long(sp + 6);
                         let current = self.guest_calls.current_task();
-                        let saved = Self::capture_cooperative_thread(cpu, 0);
+                        let saved = Self::capture_cooperative_thread(cpu);
                         let mut outgoing = self
                             .guest_calls
                             .cooperative_context(current)
@@ -27196,7 +27202,7 @@ mod tests {
                 .scheduling_state(ExecutionTaskId::from_thread_id(new_id))
                 != Some(ExecutionTaskState::Ready)
         );
-        assert_eq!(disp.cooperative_thread_pool.len(), 1);
+        assert_eq!(disp.guest_calls.classic_thread_pool_count(0), 1);
 
         // GetFreeThreadCount(threadStyle, freeCount)
         let out = TEST_SP + 0x420;
@@ -27213,6 +27219,32 @@ mod tests {
 
     /// `GetDefaultThreadStackSize` reports the size `NewThread` uses when
     /// passed 0, and refuses the preemptive style.
+    #[test]
+    fn thread_pool_creation_adds_distinct_stacks_to_the_execution_owner() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        for expected_count in [3, 6] {
+            cpu.write_reg(Register::A7, TEST_SP);
+            cpu.write_reg(Register::D0, 0x0501);
+            bus.write_long(TEST_SP, 1024);
+            bus.write_word(TEST_SP + 4, 3);
+            bus.write_long(TEST_SP + 6, 1);
+            disp.dispatch_toolbox(true, 0x3f2, &mut cpu, &mut bus)
+                .unwrap()
+                .unwrap();
+            assert_eq!(cpu.read_reg(Register::D0), 0);
+            assert_eq!(
+                disp.guest_calls.classic_thread_pool_count(1024),
+                expected_count
+            );
+        }
+        let mut stacks = Vec::new();
+        while let Some(stack) = disp.guest_calls.take_classic_thread_stack(1024) {
+            assert!(!stacks.contains(&stack));
+            stacks.push(stack);
+        }
+        assert_eq!(stacks.len(), 6);
+    }
+
     #[test]
     fn threaddispatch_default_stack_size_is_reported_and_refuses_preemptive() {
         let (mut disp, mut cpu, mut bus) = setup();
@@ -27328,10 +27360,14 @@ mod tests {
             assert!(disp
                 .guest_calls
                 .set_scheduling_state(worker, ExecutionTaskState::Ready));
-            let mut saved = super::CooperativeThread::default();
-            saved.result_destination = result_slot;
-            saved.stack_base = 0x1000;
-            saved.stack_limit = 0x2000;
+            let saved = super::CooperativeThread::default();
+            let mut storage = crate::guest_call::ThreadStorage {
+                result_destination: result_slot,
+                stack_base: 0x1000,
+                stack_limit: 0x2000,
+                managed_pointer: false,
+            };
+            assert!(disp.guest_calls.set_thread_storage(worker, storage));
             assert!(disp
                 .guest_calls
                 .save_cooperative_context(worker, saved.clone()));
@@ -27361,10 +27397,10 @@ mod tests {
             assert_eq!(bus.read_long(result_slot), 0x1234_5678);
             assert_eq!(cpu.read_reg(Register::PC), 0x1234);
             assert_eq!(cpu.read_reg(Register::A0), 0xcafe_babe);
-            assert!(disp.cooperative_thread_pool.is_empty());
+            assert!(disp.guest_calls.classic_thread_pool_count(0) == 0);
 
-            saved.result_destination = result_slot + 8;
-            assert!(disp.guest_calls.save_cooperative_context(worker, saved));
+            storage.result_destination = result_slot + 8;
+            assert!(disp.guest_calls.set_thread_storage(worker, storage));
             let retired = if self_exit {
                 disp.finish_cooperative_thread(&mut cpu, &mut bus)
             } else {
@@ -27375,7 +27411,10 @@ mod tests {
             assert!(disp.guest_calls.cooperative_context(worker).is_none());
             assert_eq!(disp.guest_calls.scheduling_state(worker), None);
             assert_eq!(bus.read_long(result_slot + 8), 0xcafe_babe);
-            assert_eq!(disp.cooperative_thread_pool, vec![(0x1000, 0x2000)]);
+            assert_eq!(
+                disp.guest_calls.take_classic_thread_stack(0),
+                Some((0x1000, 0x2000))
+            );
             if self_exit {
                 assert_eq!(cpu.read_reg(Register::PC), 0x4321);
                 assert_eq!(cpu.read_reg(Register::A0), 0x8765);
@@ -27393,10 +27432,16 @@ mod tests {
         assert!(disp
             .guest_calls
             .set_scheduling_state(worker, ExecutionTaskState::Ready));
-        let mut saved = super::CooperativeThread::default();
-        saved.result_destination = result_slot;
-        saved.stack_base = 0x1000;
-        saved.stack_limit = 0x2000;
+        let saved = super::CooperativeThread::default();
+        assert!(disp.guest_calls.set_thread_storage(
+            worker,
+            crate::guest_call::ThreadStorage {
+                result_destination: result_slot,
+                stack_base: 0x1000,
+                stack_limit: 0x2000,
+                managed_pointer: false
+            }
+        ));
         assert!(disp
             .guest_calls
             .save_cooperative_context(worker, saved.clone()));
@@ -27407,7 +27452,7 @@ mod tests {
         assert_eq!(disp.guest_calls.current_task(), worker);
         assert_eq!(disp.guest_calls.cooperative_context(worker), Some(saved));
         assert_eq!(bus.read_long(result_slot), 0x1234_5678);
-        assert!(disp.cooperative_thread_pool.is_empty());
+        assert!(disp.guest_calls.classic_thread_pool_count(0) == 0);
     }
 
     #[test]

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -1249,15 +1249,12 @@ impl super::TrapDispatcher {
     /// Validate the saved adapter context before committing the task switch.
     fn switch_to_cooperative_thread<C: CpuOps>(&mut self, cpu: &mut C, next_id: u32) -> bool {
         let task = ExecutionTaskId::from_thread_id(next_id);
-        let Some(next) = self.guest_calls.cooperative_context(task) else {
+        let Some(next) = self.guest_calls.switch_from_classic(task) else {
             return false;
         };
-        if self.guest_calls.scheduling_state(task) != Some(ExecutionTaskState::Ready)
-            || !self.guest_calls.switch_to_task(task)
-        {
-            return false;
+        if let Some(next) = next {
+            Self::install_cooperative_thread(cpu, &next);
         }
-        Self::install_cooperative_thread(cpu, &next);
         true
     }
 
@@ -1316,7 +1313,7 @@ impl super::TrapDispatcher {
         let Some(next) = self.next_ready_cooperative_thread(0) else {
             return false;
         };
-        let Some((saved, Some(successor))) = self.guest_calls.retire_cooperative_context(
+        let Some((saved, successor)) = self.guest_calls.retire_cooperative_context(
             finished,
             Some(ExecutionTaskId::from_thread_id(next)),
             |saved| {
@@ -1328,7 +1325,9 @@ impl super::TrapDispatcher {
         };
         // The execution owner validated both contexts and committed the result.
         // Installing this owned snapshot cannot yield or fail.
-        Self::install_cooperative_thread(cpu, &successor);
+        if let Some(successor) = successor {
+            Self::install_cooperative_thread(cpu, &successor);
+        }
         if saved.stack_base != 0 {
             self.cooperative_thread_pool
                 .push((saved.stack_base, saved.stack_limit));


### PR DESCRIPTION
Native Thread Manager had queries but no creation, yield or entry-return path. This change adds native NewThread, YieldToThread/YieldToAnyThread and DisposeThread imports over task-owned PPC snapshots. Entry return uses a reserved import distinct from application halt. Result delivery and retirement commit together; a missing result mapping leaves the returning thread available for retry. Relaunch refuses live workers or pending handoffs even if they have no pending calls.

NewThread prepares a process-allocated ABI stack and publishes the ID through the execution owner; a refused publication consumes no ID. Contexts retain complete PPC CPUs and preserve a monotonic time base. Classic and native creation share the default stack constant.

For cross-ISA task switches, the execution owner retains the validated successor snapshot until the matching engine installs it. It tracks the native CPU's task separately from the selected task, preserving a suspended native caller while classic code runs. Native yield can hand off to classic workers; classic yield/retirement can hand back to native execution; native retirement can select a classic successor. A standalone native adapter cannot step through a pending classic handoff.

SetThreadState and SetThreadStateEndCritical now use the same execution-owned transaction from native imports and classic ThreadDispatch. Successor context and classic success-return placement are validated before changing state, ready order or critical depth. The old classic fallback could partially end a critical section and then silently resume the caller after successor preparation failed. Refused transitions now preserve the execution owner.

Stopping the last runnable thread now suspends its saved ABI return context. Repeated runner or standalone native steps execute no guest instructions until a task-reference wake request marks a thread ready; scheduling then validates and installs its context. Relaunch refuses the suspended operation. Both ABIs now share GetThreadCurrentTaskRef, GetThreadStateGivenTaskRef and SetThreadReadyGivenTaskRef semantics, including invalid-reference and invalid-state errors.

Thread result destinations and stack allocation provenance now belong to one execution-owned storage bank, separate from the CPU snapshots. Both disposal edges share a retirement transaction, so classic code can dispose native workers and native code can dispose classic workers. Result-write refusal preserves the task and stack for retry. Both disposal adapters now honor recycleThread: recycled stacks retain their allocation in one ISA-tagged owner pool; unrecycled stacks return to their original allocator. Implicit entry return does not recycle. The dispatcher no longer owns that pool. CreateThreadPool now adds distinct stacks instead of repeatedly acquiring and recycling the same one.

Classic and native creation now use one owner transaction. Classic preparation validates entry alignment/mapping, stack frame space and protected or overlapping outputs, then commits the stack frame, thread ID and successful return together. Failed creation consumes no task identity; borrowed storage returns to its pool and fresh classic storage is freed. Both ABI failures clear writable threadMade outputs as documented. Bare task allocation and direct storage setters are test-only.

Classic NewThread now opts into premade storage only when requested. The execution owner selects the smallest fitting stack, enforces exact-match requests and honors fresh-allocation fallback. A missing premade match returns -617 and clears threadMade without consuming an ID. Integration cases verify actual storage provenance, suspended state, argument delivery and successful retry after refusal. Native NewThread now uses this same selection service.

Recycling commits with result delivery and task retirement. Refused writes preserve the live task and allocation; repeated disposal cannot duplicate pool entries or free storage twice. Cross-ABI integration tests exercise both recycle choices, actual allocation retention/release and reuse with a fresh identity and result destination. Owner tests verify ISA isolation and cleared stale results. Both disposal edges also refuse the main application thread before committing results, as required by Thread Manager (1999), p. 60.

CreateThreadPool, GetFreeThreadCount, GetSpecificFreeThreadCount and GetDefaultThreadStackSize now have native imports and classic routes over the same operation service. Pool creation validates and prepares the entire allocation batch before publication; failure releases every reserved stack. Classic creation preflights its Pascal result slot, and both query adapters refuse incomplete output writes. Counts include stacks at least as large as the request, as documented. The dispatcher no longer stores a duplicate default stack size.

Tests cover classic heap exhaustion after one allocation, rollback and retry, protected result slots, native partial output writes, size-filtered counts, defaults and premade-thread consumption without early ID allocation.

Parked 68K engines now live in the shared execution owner alongside native contexts. Classic activation and result commit select that bank internally; production callers cannot supply an alternate bank. The 68K engine wrapper retains only its live CPU and execution handle. Nested/task-switch/result-retry tests now inspect the process bank, and new coverage verifies shared/adopted bank identity and preserved registers.

68K engines remain non-cloneable. Cloning an execution snapshot while a 68K engine is parked now refuses before copying state; shared handles retain the bank. Empty-bank snapshots remain detached. Stack-space query work exposed this ownership prerequisite, but complete ThreadCurrentStackSpace routing and main-thread/mixed-call stack resolution are still unfinished.

Initial 68K→PowerPC activation now parks the classic caller immediately, alongside the native coordinator, under the same call ID. The CPU-independent paired-bank primitive validates the pending token and both slots before changing custody. Occupied or repeated activation preserves both CPUs and banks. The production path requires the classic caller; the old coordinator-only route is test-only. A direct-transition regression checks immediate retention and original stack/register restoration, with existing nested/task-switch/retry coverage retained.

Classic callback activation now retains the complete native caller under its task/call token. The shared activation primitive validates the companion bank and enclosing classic context before changing ownership or phase. Completion restores that native context before applying the callback result and return policy, preserving a monotonic time base. Missing native context refuses production completion; the no-engine path remains only in register-level unit fixtures. New coverage checks occupied-slot refusal, invalid-return retry, native SP/GPR/FPR/CR restoration and elapsed time.

Reverse mixed-mode activation now validates native worker frames against the installed engine owner’s thread storage rather than the application stack boundary. Both lower and upper allocation violations refuse before memory or continuation changes. A real NewThread import regression checks worker entry, engine-owner selection independently of the scheduling cursor, mapped boundary refusal and successful retry. Other callback frame builders and complete stack-space queries remain unfinished.

Validation: 5,004 full headless library tests with test-support passed, three existing tests ignored; both final focused activation tests passed and the final production check is warning-free. All 20 guardrail fixtures and final source ownership checks passed. Tests execute PPC entry/return, native yield and state-changing imports, real 68K worker code, and nested cross-ISA callbacks with either worker architecture. Stop/wake/resume tests verify the native caller's import-stub return and registers; refusal cases cover missing contexts, invalid states and protected classic return slots. Runner tests stop and wake both ISAs through a shared classic completion edge; standalone native tests also verify unchanged PC/time base while stopped. These tests do not establish automatic interrupt delivery during process idle. Opposite-ABI creation/disposal regressions verify result retry and exactly-once allocator/pool cleanup. Source ownership checks and all 20 guardrail fixtures pass; named field guards reject storage fields reappearing in either CPU snapshot.

Remaining follow-up scope: Complete entry-address/ABI validation, remaining native entries such as stack-space queries, switch/termination hooks, remaining native Thread Manager entries, automatic timer/completion execution while all application threads are stopped, and full preparation gates are unfinished. These tests prove the listed paths, not completion of the Thread Manager contract.

Advances #1407, #1366 and #1363; none is closed. Based on master after #1404 merged.




Entry-contract clarification: Thread Manager (1999), p. 58 requires same-ISA entry addresses and excludes routine descriptors for NewThread. Earlier descriptions of mixed-ISA NewThread creation as a historical API gap were too broad. Mixed-ISA callbacks and task-context preservation remain required and tested independently.

