### PR TITLE
fix: exclude visual oracle assets from crate uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,19 @@ jobs:
       - name: Package dry-run
         run: cargo publish --locked --dry-run
 
+      - name: Check crates.io upload size
+        run: |
+          python3 - <<'PYTHON'
+          import pathlib, tomllib
+          with open("Cargo.toml", "rb") as manifest:
+              package = tomllib.load(manifest)["package"]
+          archive = pathlib.Path("target/package") / f"{package['name']}-{package['version']}.crate"
+          size = archive.stat().st_size
+          limit = 10 * 1024 * 1024
+          print(f"Crate upload: {size:,} bytes (limit {limit:,})")
+          assert size <= limit, "Crate exceeds the crates.io upload limit"
+          PYTHON
+
   lint:
     name: fmt & clippy (non-blocking)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,8 +117,8 @@ jobs:
           rm metadata.json
 
       # Catch packaging/metadata problems before a release ever runs.
-      - name: Package dry-run
-        run: cargo publish --locked --dry-run
+      - name: Package and verify crate
+        run: cargo package --locked
 
       - name: Check crates.io upload size
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,18 @@ documentation = "https://docs.rs/systemless"
 # `cargo run` (no `--bin`) routes to the GUI runner for local checkouts.
 default-run = "systemless"
 autobins = false
+# Ship runtime sources and documentation, not the repository's visual oracle
+# suite. The native PCM fixtures are embedded by library unit tests.
+include = [
+    "/Cargo.toml",
+    "/Cargo.lock",
+    "/src/**",
+    "/*.md",
+    "/LICENSE",
+    "/OFL.txt",
+    "/.github/assets/**",
+    "/tests/toolbox-showcase/reference/native-audio/*.u8",
+]
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }


### PR DESCRIPTION
The v0.34.0 upload fails with HTTP 413 because the compressed crate is 14.4 MiB, exceeding crates.io’s 10 MiB limit. Visual oracle references account for roughly 25 MiB of the uncompressed package.

Explicitly include runtime sources, top-level documentation and licenses, README images, and native PCM fixtures needed by library unit tests. The showcase integration suite remains in the repository and CI but is excluded from the published package. Add a CI check for the compressed upload limit after the package dry-run.

Validation: actionlint passes; cargo package reduces the archive to 4.3 MiB and verifies the packaged build. Publishing v0.34.0 can be retried after this lands because the rejected upload did not reserve the version.

Closes #1417