### PR TITLE
perf(trap): look up trap table addresses without copying or scanning the protected-code ranges

### DIFF
--- a/src/memory/bus.rs
+++ b/src/memory/bus.rs
@@ -543,26 +543,47 @@ fn protected_code_covers_long(addressing_32_bit: bool, ranges: &[(u32, u32)], ad
     } else {
         address & 0x00FF_FFFF
     };
-    let end = (u64::from(translated) + 4).min(1u64 << 32);
-    if end != u64::from(translated) + 4 {
-        return false;
+    let end = u64::from(translated) + 4;
+    end <= (1u64 << 32) && protected_ranges_cover(ranges, u64::from(translated), end)
+}
+
+/// Insert `[start, end)` into a list kept sorted by start with no overlapping
+/// or touching entries, merging as needed. Every materialized trap slot
+/// registers a range (trampoline, gateway, come-from head), so the list
+/// grows to about a thousand entries and every trap dispatch queries it.
+fn insert_protected_range(ranges: &mut Vec<(u32, u32)>, start: u32, end: u32) {
+    let mut lo = ranges.partition_point(|&(s, _)| s < start);
+    if lo > 0 && ranges[lo - 1].1 >= start {
+        lo -= 1;
     }
-    let mut cursor = u64::from(translated);
-    while cursor < end {
-        let mut covered_end = cursor;
-        for &(start, stop) in ranges {
-            let start = u64::from(start);
-            let stop = u64::from(stop);
-            if start <= cursor && cursor < stop {
-                covered_end = covered_end.max(stop.min(end));
-            }
-        }
-        if covered_end == cursor {
-            return false;
-        }
-        cursor = covered_end;
+    let mut merged = (start, end);
+    let mut hi = lo;
+    while hi < ranges.len() && ranges[hi].0 <= merged.1 {
+        merged.0 = merged.0.min(ranges[hi].0);
+        merged.1 = merged.1.max(ranges[hi].1);
+        hi += 1;
     }
-    true
+    ranges.splice(lo..hi, [merged]);
+}
+
+/// Whether `[address, end)` lies entirely inside the protected ranges. With
+/// sorted, merged ranges that is true exactly when the last range starting
+/// at or before `address` reaches `end`.
+#[inline]
+fn protected_ranges_cover(ranges: &[(u32, u32)], address: u64, end: u64) -> bool {
+    if end <= address {
+        return true;
+    }
+    let i = ranges.partition_point(|&(s, _)| u64::from(s) <= address);
+    i > 0 && u64::from(ranges[i - 1].1) >= end
+}
+
+/// Whether any byte of `[address, end)` is protected: among the ranges that
+/// start before `end`, the last one has the largest stop.
+#[inline]
+fn protected_ranges_overlap(ranges: &[(u32, u32)], address: u64, end: u64) -> bool {
+    let i = ranges.partition_point(|&(s, _)| u64::from(s) < end);
+    i > 0 && u64::from(ranges[i - 1].1) > address
 }
 
 /// An exact-state probe journals the words an idle cycle writes: a spilled
@@ -1725,7 +1746,7 @@ impl MacMemoryBus {
             let Some(end) = address.checked_add(len) else {
                 return;
             };
-            self.readonly_code_ranges.push((address, end));
+            insert_protected_range(&mut self.readonly_code_ranges, address, end);
             self.readonly_code_span = Some(match self.readonly_code_span {
                 Some((lo, hi)) => (lo.min(address), hi.max(end)),
                 None => (address, end),
@@ -1753,20 +1774,8 @@ impl MacMemoryBus {
         let Some(end) = end else {
             return false;
         };
-        let mut cursor = u64::from(address);
-        while cursor < end {
-            let mut covered_end = cursor;
-            for &(start, stop) in &self.readonly_code_ranges {
-                let start = u64::from(start);
-                let stop = u64::from(stop);
-                if start <= cursor && cursor < stop {
-                    covered_end = covered_end.max(stop.min(end));
-                }
-            }
-            if covered_end == cursor {
-                return false;
-            }
-            cursor = covered_end;
+        if !protected_ranges_cover(&self.readonly_code_ranges, u64::from(address), end) {
+            return false;
         }
         true
     }
@@ -1818,9 +1827,7 @@ impl MacMemoryBus {
         if end <= span_start as u64 || address as u64 >= span_end as u64 {
             return false;
         }
-        self.readonly_code_ranges
-            .iter()
-            .any(|&(start, stop)| (start as u64) < end && (stop as u64) > address as u64)
+        protected_ranges_overlap(&self.readonly_code_ranges, address as u64, end)
     }
 
     /// Allocate memory from the heap with a stronger start-address alignment.
@@ -3446,6 +3453,53 @@ mod tests {
             "byte before write_bytes window"
         );
         assert_eq!(bus.read_byte(0x13E8), 0xCC, "byte after write_bytes window");
+    }
+
+    #[test]
+    fn protected_ranges_merge_on_insert_and_answer_like_the_union() {
+        let mut ranges = Vec::new();
+        for &(start, end) in &[
+            (0x2000u32, 0x2002u32),
+            (0x1000, 0x1004),
+            (0x2002, 0x2010), // touches the first: merged
+            (0x1002, 0x1003), // inside the second: absorbed
+            (0x0FF0, 0x1001), // overlaps the second from below: merged
+            (0x3000, 0x3004),
+        ] {
+            insert_protected_range(&mut ranges, start, end);
+        }
+        assert_eq!(ranges, vec![(0x0FF0, 0x1004), (0x2000, 0x2010), (0x3000, 0x3004)]);
+
+        let union = |address: u64, end: u64| -> bool {
+            (address..end).all(|byte| {
+                ranges
+                    .iter()
+                    .any(|&(s, e)| u64::from(s) <= byte && byte < u64::from(e))
+            })
+        };
+        let any = |address: u64, end: u64| -> bool {
+            (address..end).any(|byte| {
+                ranges
+                    .iter()
+                    .any(|&(s, e)| u64::from(s) <= byte && byte < u64::from(e))
+            })
+        };
+        for start in (0x0FE0u64..0x3010).step_by(1) {
+            for len in [1u64, 2, 3, 4, 8, 17] {
+                let end = start + len;
+                assert_eq!(
+                    protected_ranges_cover(&ranges, start, end),
+                    union(start, end),
+                    "cover [{start:#x}, {end:#x})"
+                );
+                assert_eq!(
+                    protected_ranges_overlap(&ranges, start, end),
+                    any(start, end),
+                    "overlap [{start:#x}, {end:#x})"
+                );
+            }
+        }
+        assert!(protected_ranges_cover(&ranges, 0x2004, 0x2004), "an empty range is covered");
     }
 
     #[test]

--- a/src/memory/bus.rs
+++ b/src/memory/bus.rs
@@ -529,32 +529,40 @@ pub(crate) struct ProtectedCodeOwnership {
 impl ProtectedCodeOwnership {
     #[inline]
     pub(crate) fn contains(&self, address: u32) -> bool {
-        let translated = if self.addressing_32_bit {
-            address
-        } else {
-            address & 0x00FF_FFFF
-        };
-        let end = (u64::from(translated) + 4).min(1u64 << 32);
-        if end != u64::from(translated) + 4 {
+        protected_code_covers_long(self.addressing_32_bit, &self.ranges, address)
+    }
+}
+
+/// Whether the longword at `address` lies entirely inside protected code
+/// (`ranges` are half-open `(start, stop)` translated addresses). Shared by
+/// the ownership snapshot and the bus's borrowed check so both answer alike.
+#[inline]
+fn protected_code_covers_long(addressing_32_bit: bool, ranges: &[(u32, u32)], address: u32) -> bool {
+    let translated = if addressing_32_bit {
+        address
+    } else {
+        address & 0x00FF_FFFF
+    };
+    let end = (u64::from(translated) + 4).min(1u64 << 32);
+    if end != u64::from(translated) + 4 {
+        return false;
+    }
+    let mut cursor = u64::from(translated);
+    while cursor < end {
+        let mut covered_end = cursor;
+        for &(start, stop) in ranges {
+            let start = u64::from(start);
+            let stop = u64::from(stop);
+            if start <= cursor && cursor < stop {
+                covered_end = covered_end.max(stop.min(end));
+            }
+        }
+        if covered_end == cursor {
             return false;
         }
-        let mut cursor = u64::from(translated);
-        while cursor < end {
-            let mut covered_end = cursor;
-            for &(start, stop) in &self.ranges {
-                let start = u64::from(start);
-                let stop = u64::from(stop);
-                if start <= cursor && cursor < stop {
-                    covered_end = covered_end.max(stop.min(end));
-                }
-            }
-            if covered_end == cursor {
-                return false;
-            }
-            cursor = covered_end;
-        }
-        true
+        cursor = covered_end;
     }
+    true
 }
 
 /// An exact-state probe journals the words an idle cycle writes: a spilled
@@ -1771,6 +1779,14 @@ impl MacMemoryBus {
             addressing_32_bit: self.addressing_32_bit,
             ranges: self.readonly_code_ranges.clone(),
         }
+    }
+
+    /// The snapshot's `contains`, answered from the live ranges without
+    /// copying them. For callers that hold the bus immutably for the whole
+    /// Trap Manager call, such as every trap dispatch's table lookup.
+    #[inline]
+    pub(crate) fn protected_code_contains(&self, address: u32) -> bool {
+        protected_code_covers_long(self.addressing_32_bit, &self.readonly_code_ranges, address)
     }
 
     /// Privileged, status-bearing longword write for a known system-owned

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -6912,7 +6912,9 @@ impl TrapDispatcher {
         } else {
             TrapTableKind::OperatingSystem
         };
-        let protected_code = bus.protected_code_ownership();
+        // The bus is borrowed immutably for the whole lookup, so the
+        // protected-code check reads the live ranges; snapshotting them here
+        // copied a Vec on every trap dispatch.
         TrapManager::get_address_with_provenance(
             canonical,
             kind,
@@ -6923,7 +6925,7 @@ impl TrapDispatcher {
                 TrapManagerMemoryOp::WriteLong { .. }
                 | TrapManagerMemoryOp::WriteProtectedLong { .. } => None,
             },
-            move |address| protected_code.contains(address),
+            |address| bus.protected_code_contains(address),
         )
     }
 


### PR DESCRIPTION
## Summary

Two fixes to the per-dispatch trap-table lookup that #1364 introduced, keeping its provenance check intact:

1. `trap_table_address` snapshotted the bus's protected-code ownership on every trap dispatch, cloning the `readonly_code_ranges` `Vec` so the check closure could outlive an immutable borrow it did not need (the whole lookup holds the bus immutably). It now answers the check from the live ranges through a borrowed accessor; the snapshot stays for `install_trap_address`, whose memory closure needs the mutable bus.
2. The protected-code range list is queried by `is_protected_head` on every hop of every trap-table chain walk, by `readonly_code_contains` on protected writes, and by `readonly_code_overlaps` on every guest write. Every materialized trap slot registers a range (trampoline, gateway, come-from head), so the list holds on the order of a thousand entries and each query was a linear scan. The list is now kept sorted by start with overlapping and touching entries merged on insert, and all three queries are one binary search. Answers are unchanged: coverage of a contiguous interval by the union of ranges is coverage by the single merged range containing its start, and the last range starting before an interval's end has the largest stop. A unit test checks merged insertion and compares both queries against a brute-force union over every interval in a synthetic layout.

## Why

Re-baselining perf work against current `master` showed it executing several times the host work of a tree based on 3c63ca4. Bisect (3 in Three headless replay, 200 M guest instructions, single runs): 5d87791 = 105.9 B host instructions, eef89a3 (#1364) = 268.0 B, 305027d (#1362) = 308.6 B, 83af901 = 308.5 B. A `sample` profile of `master` (with #1220 rebased on it, so the single-step effect is excluded) put `trap_table_address` at 22% of self time with another 6% in the `memmove` under it.

## Measurements

Paired hardware counters on the headless replay (`--max-instructions`, scripted input where the game needs it), both arms interleaved, identical guest instructions, ticks and framebuffer hash on every pair; the medians of the pair ratios:

| step | 3 in Three, 200 M: instructions / CPU time | SimCity 2000, 400 M: instructions / CPU time |
|---|---|---|
| no clone (fix 1) vs rebased #1220 | −3.9% (5/5) / per-step CPU time to follow in a comment | −1.8% (5/5) / to follow |
| sorted ranges (fix 2 here) on top of the chrome and routing fixes | **−47.7%** (5/5) / to follow | **−20.3%** (5/5) / to follow |
| all four fixes together vs rebased #1220 | **−60.7%** instructions, **−53.0%** CPU time (35.4 s → 16.6 s), 5/5 | **−39.1%** instructions, **−30.8%** CPU time (18.6 s → 12.9 s), 5/5 |

Absolute, 3 in Three: 246.7 B → 128.9 B host instructions for the second step. Cycles and CPU time moved the same direction but the machine was loaded during these runs, so the instruction counts are the numbers to trust.

Together with the routing fast path and the themed-chrome cache (separate PRs), 3 in Three goes from 308.5 B on `master` to 128.9 B; the pre-#1364 tree is 105.9 B.

Measured on builds based on c40588f, the `master` of the day; the branch is rebased onto d30234c, whose seven commits do not touch these paths.

The per-step instruction counts above were measured while the machine was loaded (cycles and CPU time were noise); the combined row was re-measured with the machine idle, and per-step CPU times from the same idle rerun follow in a comment.

Related fixes for the same regression: #1419 (trap-table lookup), #1420 (routing fast path), #1421 (themed chrome cache); #1220 removes the single-step mode they were measured on top of.

## Tests

`cargo test`: the new unit test plus the existing suite; one failure, `step_frame_forces_render_after_same_tick_foreground_progress`, fails identically on untouched `master` (c40588f) here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UqCuD9vsGeeij5DdYt3vcK
