### PR TITLE
perf(bus): decide flat guest accesses inline when no foreign address space is attached

### DIFF
--- a/src/memory/bus.rs
+++ b/src/memory/bus.rs
@@ -1316,16 +1316,27 @@ impl MacMemoryBus {
     /// range as `Flat` and retains its write probes, protection checks, and
     /// direct slice paths. A shared mapping that is outside this bus's RAM is
     /// left as `Shared` and is serviced through the attached view.
+    ///
+    /// Every bus read and write starts here, so the common case, no foreign
+    /// address space attached, is decided inline from the translated address
+    /// and the RAM size; only an attached space pays the out-of-line router.
     #[inline]
     fn route(&self, address: u32, len: usize) -> GuestMemoryRoute {
         // The neutral router receives the translated start plus a length, but
         // 24-bit mode wraps at $0100_0000.  A range crossing that boundary is
         // necessarily mixed and must use the byte-wise bus path even when
         // the backing RAM itself is larger than 16 MiB.
-        if self.range_translates_contiguously(address, len).is_none() {
+        let Some(translated) = self.range_translates_contiguously(address, len) else {
             return GuestMemoryRoute::Mixed;
+        };
+        if self.foreign_address_space.is_none() {
+            return flat_memory_route(translated, len, self.ram_size);
         }
-        let translated = self.translate_guest_address(address);
+        self.route_through_foreign_space(translated, len)
+    }
+
+    #[inline(never)]
+    fn route_through_foreign_space(&self, translated: u32, len: usize) -> GuestMemoryRoute {
         let Some(memory) = self.foreign_address_space.as_ref() else {
             return flat_memory_route(translated, len, self.ram_size);
         };


### PR DESCRIPTION
## Summary

`MacMemoryBus::route` runs on every bus read and write. Since #1364 it has been an out-of-line call that recomputes the address translation and consults the foreign address space before reaching the flat-RAM answer that the 68k-only configuration always takes; it carried `#[inline]` but LLVM declined it. This keeps the same decision order but splits the function: a small inline wrapper answers the common case from the translated address and the RAM size, and only an attached foreign space pays the out-of-line router.

## Why

Part of the host-work regression found while re-baselining against `master` (see #1364 comment): `route` was 6.5% of self time on a 3 in Three replay.

## Measurements

Measured together with the themed-chrome cache PR (the two were built as one step), paired hardware counters on the headless replay against a tree carrying rebased #1220 and the trap-table fix, identical ticks and framebuffer hash on every pair:

| workload | instructions / CPU time |
|---|---|
| 3 in Three, 200 M | **−17.8%** (5/5) / per-step CPU time to follow in a comment |
| SimCity 2000, 400 M | **−14.6%** (5/5) / to follow |

All four regression fixes together vs rebased #1220: **−60.7%** instructions, **−53.0%** CPU time (35.4 s → 16.6 s), 5/5 on 3 in Three, **−39.1%** instructions, **−30.8%** CPU time (18.6 s → 12.9 s), 5/5 on SimCity 2000.

Measured on builds based on c40588f, the `master` of the day; the branch is rebased onto d30234c, whose seven commits do not touch these paths.

The per-step instruction counts above were measured while the machine was loaded (cycles and CPU time were noise); the combined row was re-measured with the machine idle, and per-step CPU times from the same idle rerun follow in a comment.

Related fixes for the same regression: #1419 (trap-table lookup), #1420 (routing fast path), #1421 (themed chrome cache); #1220 removes the single-step mode they were measured on top of.

## Tests

`cargo test`; see the trap-table PR for the one pre-existing failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UqCuD9vsGeeij5DdYt3vcK
