### PR TITLE
feat: share thread stack-space queries across CPU adapters

### DIFF
--- a/src/execution_kernel.rs
+++ b/src/execution_kernel.rs
@@ -622,6 +622,12 @@ impl<R: Copy + TaskOwned, C: Copy> ContinuationStore<R, C> {
         })
     }
 
+    /// Unlike legacy execution routing, observations must distinguish an
+    /// explicitly bound ISA from the historical implicit classic default.
+    pub(crate) fn bound_task_entry_isa(&self, task: ExecutionTaskId) -> Option<GuestIsa> {
+        self.0.borrow().task_entry_isas.get(&task).copied()
+    }
+
     pub(crate) fn has_live_workers(&self) -> bool {
         self.0
             .borrow()
@@ -1254,6 +1260,10 @@ impl<T> ExecutionTaskContextBank<T> {
 }
 
 impl<T> ExecutionContextBank<T> {
+    pub(crate) fn get(&self, task: ExecutionTaskId, call_id: CallId) -> Option<&T> {
+        self.by_call.get(&(task, call_id))
+    }
+
     pub(crate) fn contains(&self, task: ExecutionTaskId, call_id: CallId) -> bool {
         self.by_call.contains_key(&(task, call_id))
     }

--- a/src/guest_call.rs
+++ b/src/guest_call.rs
@@ -378,6 +378,13 @@ enum TaskResumeContext {
 }
 
 impl TaskResumeContext {
+    fn stack_pointer(&self) -> u32 {
+        match self {
+            Self::Classic(context) => context.a_regs[7],
+            Self::Native(cpu) => cpu.gpr[1],
+        }
+    }
+
     fn isa(&self) -> GuestIsa {
         match self {
             Self::Classic(_) => GuestIsa::M68k,
@@ -886,6 +893,88 @@ impl SharedGuestCallStack {
         let tasks = self.0.borrow();
         tasks.kernel.scheduling_state(task)?;
         Some(tasks.thread_storage.get(task).copied().unwrap_or_default())
+    }
+
+    /// Observe the thread's original stack without exposing a parked engine.
+    /// Classic reentry uses a bridge stack; the oldest parked classic caller
+    /// remains the owner of the thread allocation. Native reentry continues
+    /// on its native stack, so prefer its live or suspended active context.
+    pub(crate) fn thread_stack_pointer(
+        &self,
+        task: ExecutionTaskId,
+        live_isa: GuestIsa,
+        live_sp: u32,
+    ) -> Option<(GuestIsa, u32)> {
+        let tasks = self.0.borrow();
+        tasks.kernel.scheduling_state(task)?;
+        let calls = tasks.kernel.task_states(task);
+        let entry = tasks.kernel.bound_task_entry_isa(task).or_else(|| {
+            if task != ExecutionTaskId::APPLICATION {
+                return None;
+            }
+            // Detached legacy adapters may lack launch metadata. Observe the
+            // oldest call or a unique saved engine without initializing them
+            // as a side effect of an otherwise read-only query.
+            if let Some(call) = calls.first() {
+                return Some(match tasks.frames.get(&call.call_id())?.origin {
+                    GuestCallOrigin::M68k(_) => GuestIsa::M68k,
+                    GuestCallOrigin::PowerPc(_) => GuestIsa::PowerPc,
+                });
+            }
+            match (
+                tasks.cooperative_contexts.get(task),
+                tasks.native_threads.get(task),
+            ) {
+                (Some(_), None) => Some(GuestIsa::M68k),
+                (None, Some(_)) => Some(GuestIsa::PowerPc),
+                (None, None) if task == tasks.kernel.current_task() => Some(live_isa),
+                _ => None,
+            }
+        })?;
+        if entry == GuestIsa::M68k {
+            let bank = tasks.m68k_contexts.borrow();
+            for call in &calls {
+                if matches!(
+                    tasks.frames.get(&call.call_id())?.origin,
+                    GuestCallOrigin::M68k(_)
+                ) {
+                    if let Some(cpu) = bank.get(task, call.call_id()) {
+                        return Some((entry, cpu.core.a(7)));
+                    }
+                    if call.phase() != ContinuationPhase::Pending {
+                        return None;
+                    }
+                }
+            }
+        }
+        if let Some((owner, context)) = &tasks.handoff {
+            if *owner == task && context.isa() == entry {
+                return Some((entry, context.stack_pointer()));
+            }
+        }
+        if task == tasks.kernel.current_task() && live_isa == entry {
+            return Some((entry, live_sp));
+        }
+        if task != tasks.kernel.current_task() {
+            if let Some(context) = tasks.saved_context(task) {
+                if context.isa() == entry {
+                    return Some((entry, context.stack_pointer()));
+                }
+            }
+        }
+        if entry == GuestIsa::PowerPc {
+            for call in calls.iter().rev() {
+                if matches!(
+                    tasks.frames.get(&call.call_id())?.origin,
+                    GuestCallOrigin::PowerPc(_)
+                ) {
+                    if let Some(cpu) = tasks.powerpc_contexts.get(task, call.call_id()) {
+                        return Some((entry, cpu.gpr[1]));
+                    }
+                }
+            }
+        }
+        None
     }
 
     #[cfg(test)]
@@ -2801,6 +2890,91 @@ mod tests {
         assert_eq!((resume.return_pc, resume.final_sp), (0x3000, 0x4000));
         assert_eq!(resume.powerpc.gpr3, 0x1234_5678);
         assert!(calls.is_empty());
+    }
+
+    #[test]
+    fn thread_stack_space_uses_original_callers_through_nested_isa_transitions() {
+        use crate::thread_manager::ThreadManager;
+        for entry in [GuestIsa::M68k, GuestIsa::PowerPc] {
+            let calls = SharedGuestCallStack::default();
+            assert!(calls.bind_task_entry_isa(ExecutionTaskId::APPLICATION, entry));
+            let mut classic = M68kCpu::new();
+            classic.core.set_a(7, 0x9000);
+            let mut native = PpcCpu::new();
+            native.gpr[1] = 0x9000;
+            let enter_native =
+                |calls: &SharedGuestCallStack, classic: &mut M68kCpu, native: &mut PpcCpu| {
+                    assert!(calls.begin_m68k_to_powerpc(
+                        GuestCallTarget {
+                            isa: GuestIsa::PowerPc,
+                            entry: 0x1000,
+                            rtoc: 0x2000
+                        },
+                        PowerPcArguments::from_slice(&[]).unwrap(),
+                        0x3000,
+                        0x6004,
+                        None
+                    ));
+                    calls
+                        .activate_powerpc_with_classic_caller(native, classic, RETURN_PC)
+                        .unwrap();
+                };
+            let enter_classic =
+                |calls: &SharedGuestCallStack, classic: &mut M68kCpu, native: &PpcCpu| {
+                    assert!(calls.begin_powerpc_to_m68k(
+                        GuestCallTarget {
+                            isa: GuestIsa::M68k,
+                            entry: 0x5000,
+                            rtoc: 0
+                        },
+                        0x5000,
+                        0x6000,
+                        0x7000,
+                        0x6004,
+                        M68kRegisterState::default(),
+                        None,
+                        0x8000,
+                        0x2000,
+                        PpcNativeReturnGpr3::Preserve
+                    ));
+                    calls.activate_m68k_parking(classic, native).unwrap();
+                    classic.core.set_a(7, 0x6000);
+                };
+            if entry == GuestIsa::M68k {
+                enter_native(&calls, &mut classic, &mut native);
+            }
+            enter_classic(&calls, &mut classic, &native);
+            let manager = ThreadManager::new(&calls);
+            assert_eq!(
+                manager.stack_space(1, GuestIsa::M68k, 0x6000, |_| 0x8000),
+                Ok(0x1000)
+            );
+            enter_native(&calls, &mut classic, &mut native);
+            native.gpr[1] = 0x8800;
+            let expected = if entry == GuestIsa::M68k {
+                0x1000
+            } else {
+                0x800
+            };
+            assert_eq!(
+                manager.stack_space(1, GuestIsa::PowerPc, native.gpr[1], |_| 0x8000),
+                Ok(expected)
+            );
+            enter_classic(&calls, &mut classic, &native);
+            let depth = calls.len();
+            assert_eq!(
+                manager.stack_space(1, GuestIsa::M68k, 0x6000, |_| 0x8000),
+                Ok(expected)
+            );
+            let other = calls.create_task().unwrap();
+            assert!(calls.set_scheduling_state(other, ExecutionTaskState::Ready));
+            assert!(calls.switch_to_task(other));
+            assert_eq!(
+                manager.stack_space(2, GuestIsa::M68k, 0x1234, |_| 0x8000),
+                Ok(expected)
+            );
+            assert_eq!(calls.len(), depth);
+        }
     }
 
     #[test]

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -1644,6 +1644,7 @@ pub enum PpcImportDispatcherTarget {
     GetFreeThreadCount,
     GetSpecificFreeThreadCount,
     GetDefaultThreadStackSize,
+    ThreadCurrentStackSpace,
     YieldToThread,
     YieldToAnyThread,
     DisposeThread,
@@ -15059,6 +15060,9 @@ fn dispatcher_target_for_import(
         ("InterfaceLib", "GetDefaultThreadStackSize") => {
             PpcImportDispatcherTarget::GetDefaultThreadStackSize
         }
+        ("InterfaceLib", "ThreadCurrentStackSpace") => {
+            PpcImportDispatcherTarget::ThreadCurrentStackSpace
+        }
         ("InterfaceLib", "NewThread") => PpcImportDispatcherTarget::NewThread,
         ("InterfaceLib", "YieldToThread") => PpcImportDispatcherTarget::YieldToThread,
         ("InterfaceLib", "YieldToAnyThread") => PpcImportDispatcherTarget::YieldToAnyThread,
@@ -24362,6 +24366,28 @@ fn dispatch_supported_import(
                         PPC_PARAM_ERR
                     }
                 }
+                Ok(_) => PPC_PARAM_ERR,
+            };
+            Some(PpcImportAction::Return(ppc_i16_result(result)))
+        }
+        PpcImportDispatcherTarget::ThreadCurrentStackSpace => {
+            // OSErr ThreadCurrentStackSpace(ThreadID, unsigned long *);
+            // Thread Manager (1999), pp. 17–18 and 61.
+            let output = cpu.gpr[4];
+            let manager = crate::thread_manager::ThreadManager::new(&toolbox_startup.guest_calls);
+            let result = match manager.stack_space(
+                cpu.gpr[3],
+                GuestIsa::PowerPc,
+                cpu.gpr[1],
+                |isa| match isa {
+                    GuestIsa::M68k => memory
+                        .read_u32_be(crate::memory::globals::addr::APPL_LIMIT)
+                        .unwrap_or(0),
+                    GuestIsa::PowerPc => process_memory_manager.application_heap_limit(heap_limit),
+                },
+            ) {
+                Err(error) => error,
+                Ok(value) if output != 0 && memory.write_u32_be(output, value).is_some() => 0,
                 Ok(_) => PPC_PARAM_ERR,
             };
             Some(PpcImportAction::Return(ppc_i16_result(result)))
@@ -167829,6 +167855,152 @@ pub(crate) mod tests {
             ppc_memory_read_bytes(&mut loaded.memory, text_ptr, 5),
             Some(vec![b'A', b'Z', 0x83, b'!', b'q'])
         );
+    }
+
+    #[test]
+    fn native_stack_space_import_uses_the_parked_classic_application_limit() {
+        use crate::guest_call::{ExecutionTaskId, GuestCallTarget, PowerPcArguments};
+        const OUTPUT: u32 = PPC_DATA_BASE + 0x5000;
+        let mut loaded =
+            load_pef_application(&synthetic_pef_with_import(b"ThreadCurrentStackSpace")).unwrap();
+        loaded.memory.add_region(0, vec![0; 0x200]);
+        loaded
+            .memory
+            .write_u32_be(crate::memory::globals::addr::APPL_LIMIT, 0x8000)
+            .unwrap();
+        loaded.memory.add_region(OUTPUT, vec![0; 4]);
+        assert!(loaded.application_heap_limit() > 0x9000);
+        assert!(loaded
+            .guest_calls
+            .bind_task_entry_isa(ExecutionTaskId::APPLICATION, GuestIsa::M68k));
+        let mut classic = crate::cpu::M68kCpu::new();
+        classic.core.set_a(7, 0x9000);
+        assert!(loaded.guest_calls.begin_m68k_to_powerpc(
+            GuestCallTarget {
+                isa: GuestIsa::PowerPc,
+                entry: loaded.entry_pc,
+                rtoc: loaded.rtoc
+            },
+            PowerPcArguments::from_slice(&[1, OUTPUT]).unwrap(),
+            0x1000,
+            0x9004,
+            None
+        ));
+        loaded.activate_powerpc_from_m68k(&mut classic).unwrap();
+        let probe = loaded.run_with_hle_imports(64);
+        assert_eq!(probe.handled_import_count, 1);
+        assert_eq!(probe.unsupported_import_index, None);
+        assert_eq!(loaded.memory.read_u32_be(OUTPUT), Some(0x1000));
+    }
+
+    #[test]
+    fn native_thread_stack_space_queries_current_suspended_and_classic_threads() {
+        use crate::guest_call::{CooperativeThread, ExecutionTaskId, ThreadStorage};
+        const OUTPUT: u32 = PPC_DATA_BASE + 0x5000;
+        const MADE: u32 = OUTPUT + 8;
+        const PARTIAL: u32 = OUTPUT + 0x1000;
+        let mut loaded =
+            load_pef_application(&synthetic_pef_with_import(b"ThreadCurrentStackSpace")).unwrap();
+        loaded.memory.add_region(OUTPUT, vec![0xaa; 16]);
+        loaded.memory.add_region(PARTIAL, vec![0x5a; 3]);
+        let query = |loaded: &mut PpcLoadedApp, thread: u32, output: u32| {
+            loaded.imports[0].dispatcher_target =
+                dispatcher_target_for_import("InterfaceLib", "ThreadCurrentStackSpace");
+            loaded.cpu.pc = loaded.entry_pc;
+            loaded.cpu.lr = PPC_HALT_PC;
+            loaded.cpu.gpr[3] = thread;
+            loaded.cpu.gpr[4] = output;
+            let probe = loaded.run_with_hle_imports(64);
+            assert_eq!(probe.handled_import_count, 1);
+            assert_eq!(probe.unsupported_import_index, None);
+            loaded.cpu.gpr[3] as i16
+        };
+        let main_sp = loaded.cpu.gpr[1];
+        for alias in [0, 1, 2] {
+            assert_eq!(query(&mut loaded, alias, OUTPUT), 0);
+            assert_eq!(
+                loaded.memory.read_u32_be(OUTPUT),
+                Some(main_sp - loaded.application_heap_limit())
+            );
+        }
+        let limit = loaded.application_heap_limit() - 0x400;
+        loaded.imports[0].dispatcher_target =
+            dispatcher_target_for_import("InterfaceLib", "SetApplLimit");
+        loaded.cpu.pc = loaded.entry_pc;
+        loaded.cpu.lr = PPC_HALT_PC;
+        loaded.cpu.gpr[3] = limit;
+        loaded.run_with_hle_imports(64);
+        assert_eq!(loaded.application_heap_limit(), limit);
+        assert_eq!(query(&mut loaded, 1, OUTPUT), 0);
+        assert_eq!(loaded.memory.read_u32_be(OUTPUT), Some(main_sp - limit));
+
+        loaded.imports[0].dispatcher_target =
+            dispatcher_target_for_import("InterfaceLib", "NewThread");
+        loaded.cpu.pc = loaded.entry_pc;
+        loaded.cpu.lr = PPC_HALT_PC;
+        loaded.cpu.gpr[3..10].copy_from_slice(&[1, PPC_CODE_BASE, 0, 4096, 0, 0, MADE]);
+        loaded.run_with_hle_imports(64);
+        assert_eq!(loaded.cpu.gpr[3], 0);
+        let worker = ExecutionTaskId::from_thread_id(loaded.memory.read_u32_be(MADE).unwrap());
+        assert_eq!(query(&mut loaded, worker.thread_id(), OUTPUT), 0);
+        assert_eq!(loaded.memory.read_u32_be(OUTPUT), Some(4096 - 64));
+        let mut classic = CooperativeThread::default();
+        classic.a_regs[7] = 0x9300;
+        let classic = loaded
+            .guest_calls
+            .create_classic_thread(
+                classic,
+                ThreadStorage {
+                    stack_base: 0x9000,
+                    stack_limit: 0xa000,
+                    ..Default::default()
+                },
+                true,
+                |_| true,
+            )
+            .unwrap();
+        assert_eq!(query(&mut loaded, classic.thread_id(), OUTPUT), 0);
+        assert_eq!(loaded.memory.read_u32_be(OUTPUT), Some(0x300));
+        assert!(loaded
+            .guest_calls
+            .yield_native_thread(&mut loaded.cpu, worker.thread_id())
+            .unwrap());
+        let worker_sp = loaded.cpu.gpr[1];
+        let storage = loaded.guest_calls.thread_storage(worker).unwrap();
+        assert_eq!(query(&mut loaded, 1, OUTPUT), 0);
+        assert_eq!(
+            loaded.memory.read_u32_be(OUTPUT),
+            Some(worker_sp - storage.stack_base)
+        );
+        assert_eq!(query(&mut loaded, 2, OUTPUT), 0);
+        assert_eq!(loaded.memory.read_u32_be(OUTPUT), Some(main_sp - limit));
+        assert_eq!(
+            crate::thread_manager::ThreadManager::new(&loaded.guest_calls).stack_space(
+                2,
+                GuestIsa::M68k,
+                0x1234,
+                |isa| {
+                    assert_eq!(isa, GuestIsa::PowerPc);
+                    limit
+                },
+            ),
+            Ok(main_sp - limit),
+        );
+        loaded.cpu.gpr[1] = storage.stack_base - 4;
+        assert_eq!(query(&mut loaded, 1, OUTPUT), 0);
+        assert_eq!(loaded.memory.read_u32_be(OUTPUT), Some(0));
+        loaded.cpu.gpr[1] = storage.stack_limit + 4;
+        assert_eq!(query(&mut loaded, 1, OUTPUT), -619);
+        loaded.cpu.gpr[1] = worker_sp;
+        assert_eq!(query(&mut loaded, 0xdead, OUTPUT), -618);
+        assert_eq!(loaded.memory.read_u32_be(OUTPUT), Some(0));
+        assert_eq!(query(&mut loaded, 1, PARTIAL), -50);
+        assert_eq!(
+            ppc_memory_read_bytes(&mut loaded.memory, PARTIAL, 3),
+            Some(vec![0x5a; 3])
+        );
+        assert_eq!(query(&mut loaded, 1, 0), -50);
+        assert_eq!(loaded.guest_calls.current_task(), worker);
     }
 
     #[test]

--- a/src/thread_manager.rs
+++ b/src/thread_manager.rs
@@ -90,6 +90,42 @@ impl<'a> ThreadManager<'a> {
         self.execution.current_task().thread_id()
     }
 
+    // Thread Manager (1999), pp. 17–18 and 61: workers have private
+    // allocations; the main thread uses the expandable application stack.
+    pub(crate) fn stack_space(
+        &self,
+        thread: u32,
+        live_isa: GuestIsa,
+        live_sp: u32,
+        application_limit: impl FnOnce(GuestIsa) -> u32,
+    ) -> Result<u32, i16> {
+        let task = ExecutionTaskId::from_thread_id(self.resolve_thread(thread));
+        let storage = self
+            .execution
+            .thread_storage(task)
+            .ok_or(THREAD_NOT_FOUND_ERR)?;
+        let (isa, sp) = self
+            .execution
+            .thread_stack_pointer(task, live_isa, live_sp)
+            .ok_or(THREAD_PROTOCOL_ERR)?;
+        let base = if task == ExecutionTaskId::APPLICATION {
+            let application_limit = application_limit(isa);
+            if application_limit == 0 {
+                return Err(THREAD_PROTOCOL_ERR);
+            }
+            application_limit
+        } else {
+            if storage.stack_base == 0
+                || storage.stack_limit < storage.stack_base
+                || sp > storage.stack_limit
+            {
+                return Err(THREAD_PROTOCOL_ERR);
+            }
+            storage.stack_base
+        };
+        Ok(sp.saturating_sub(base))
+    }
+
     pub(crate) fn resolve_thread(&self, thread: u32) -> u32 {
         if thread <= 1 {
             self.current_thread()

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -657,7 +657,6 @@ const STANDARD_FILE_GET_DESKTOP_RECT: (i16, i16, i16, i16) = (66, 258, 87, 338);
 const STANDARD_FILE_GET_SEPARATOR_RECT: (i16, i16, i16, i16) = (98, 258, 99, 338);
 const STANDARD_FILE_GET_CANCEL_RECT: (i16, i16, i16, i16) = (110, 258, 131, 338);
 const STANDARD_FILE_GET_OPEN_RECT: (i16, i16, i16, i16) = (138, 258, 159, 338);
-use crate::thread_manager::DEFAULT_COOPERATIVE_THREAD_STACK_SIZE;
 
 #[inline]
 fn return_noerr_and_pop<C: CpuOps>(cpu: &mut C, bytes: u32) -> Result<()> {
@@ -16416,40 +16415,35 @@ impl super::TrapDispatcher {
                             Ok(_) => -50,
                         }
                     }
-                    // ThreadCurrentStackSpace(thread, freeStack)
+                    // ThreadCurrentStackSpace ($ABF2, selector $0414)
+                    // Returns available stack bytes for the specified thread.
+                    // FUNCTION ThreadCurrentStackSpace(thread: ThreadID; VAR freeStack: LONGINT): OSErr;
+                    // Thread Manager (1999), pp. 17–18 and 61.
                     0x0414 => {
-                        let free_stack = bus.read_long(sp);
-                        let thread = self.resolve_cooperative_thread_id(bus.read_long(sp + 4));
-                        if free_stack == 0 {
-                            -50
-                        } else {
-                            let running = thread == self.guest_calls.current_task().thread_id();
-                            let current_sp = cpu.read_reg(Register::A7);
-                            match self.cooperative_thread_snapshot(cpu, thread) {
-                                None => Self::THREAD_NOT_FOUND_ERR,
-                                Some(record) => {
-                                    // The application thread keeps the process
-                                    // stack, whose base this record does not
-                                    // track, so report the default size rather
-                                    // than a bogus multi-megabyte figure.
-                                    let storage = self
-                                        .guest_calls
-                                        .thread_storage(ExecutionTaskId::from_thread_id(thread))
-                                        .unwrap_or_default();
-                                    let free = if storage.stack_base == 0 {
-                                        DEFAULT_COOPERATIVE_THREAD_STACK_SIZE
-                                    } else {
-                                        let stack_pointer = if running {
-                                            current_sp
-                                        } else {
-                                            record.a_regs[7]
-                                        };
-                                        stack_pointer.saturating_sub(storage.stack_base)
-                                    };
-                                    bus.write_long(free_stack, free);
-                                    0
-                                }
-                            }
+                        let output = bus.read_long(sp);
+                        let classic_limit = bus.read_long(crate::memory::globals::addr::APPL_LIMIT);
+                        let native_limit = {
+                            let memory_manager = self.process_memory_manager();
+                            let memory_manager = memory_manager.borrow();
+                            memory_manager.application_heap_limit(
+                                memory_manager
+                                    .native_heap_state()
+                                    .map_or(0, |heap| heap.heap_limit),
+                            )
+                        };
+                        let manager = crate::thread_manager::ThreadManager::new(&self.guest_calls);
+                        match manager.stack_space(
+                            bus.read_long(sp + 4),
+                            crate::guest_procedure::GuestIsa::M68k,
+                            cpu.read_reg(Register::A7),
+                            |isa| match isa {
+                                crate::guest_procedure::GuestIsa::M68k => classic_limit,
+                                crate::guest_procedure::GuestIsa::PowerPc => native_limit,
+                            },
+                        ) {
+                            Err(error) => error,
+                            Ok(value) if output != 0 && bus.try_write_long(output, value) => 0,
+                            Ok(_) => -50,
                         }
                     }
                     // DisposeThread(threadToDump, threadResult, recycleThread)
@@ -27383,14 +27377,111 @@ mod tests {
     }
 
     #[test]
+    fn classic_stack_space_query_uses_the_parked_native_application_limit() {
+        use crate::guest_call::{GuestCallTarget, M68kRegisterState};
+        use crate::guest_procedure::GuestIsa;
+        let (mut disp, mut cpu, mut bus) = setup();
+        let output = TEST_SP + 0x400;
+        bus.write_long(crate::memory::globals::addr::APPL_LIMIT, 0x1000);
+        disp.process_memory_manager()
+            .borrow_mut()
+            .set_application_heap_limit(0x8000);
+        // A detached legacy owner has no entry metadata; the retained
+        // outer native call still identifies its original stack.
+        let mut native = ppc::PpcCpu::new();
+        native.gpr[1] = 0x9000;
+        let mut classic = crate::cpu::M68kCpu::new();
+        assert!(disp.guest_calls.begin_powerpc_to_m68k(
+            GuestCallTarget {
+                isa: GuestIsa::M68k,
+                entry: 0x5000,
+                rtoc: 0
+            },
+            0x5000,
+            TEST_SP,
+            0x7000,
+            TEST_SP + 4,
+            M68kRegisterState::default(),
+            None,
+            0x8000,
+            0x2000,
+            crate::guest_call::GuestCallReturnPolicy::Preserve
+        ));
+        disp.guest_calls
+            .activate_m68k_parking(&mut classic, &native)
+            .unwrap();
+        cpu.write_reg(Register::A7, TEST_SP);
+        cpu.write_reg(Register::D0, 0x0414);
+        bus.write_long(TEST_SP, output);
+        bus.write_long(TEST_SP + 4, 1);
+        disp.dispatch_toolbox(true, 0x3f2, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+        assert_eq!(cpu.read_reg(Register::D0), 0);
+        assert_eq!(bus.read_long(output), 0x1000);
+    }
+
+    #[test]
+    fn threaddispatch_stack_space_tracks_application_limit_and_native_workers() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let output = TEST_SP + 0x400;
+        let invoke = |disp: &mut TrapDispatcher,
+                      cpu: &mut MockCpu,
+                      bus: &mut crate::memory::MacMemoryBus,
+                      thread: u32| {
+            cpu.write_reg(Register::A7, TEST_SP);
+            cpu.write_reg(Register::D0, 0x0414);
+            bus.write_long(TEST_SP, output);
+            bus.write_long(TEST_SP + 4, thread);
+            disp.dispatch_toolbox(true, 0x3f2, cpu, bus)
+                .unwrap()
+                .unwrap();
+            cpu.read_reg(Register::D0) as i16
+        };
+        for (alias, available) in [(0, 0x1200), (1, 0x800), (2, 0x400)] {
+            bus.write_long(
+                crate::memory::globals::addr::APPL_LIMIT,
+                TEST_SP - available,
+            );
+            assert_eq!(invoke(&mut disp, &mut cpu, &mut bus, alias), 0);
+            assert_eq!(bus.read_long(output), available);
+        }
+        bus.write_long(crate::memory::globals::addr::APPL_LIMIT, 0);
+        assert_eq!(invoke(&mut disp, &mut cpu, &mut bus, 1), -619);
+        assert_eq!(bus.read_long(output), 0x400);
+        let mut native = ppc::PpcCpu::new();
+        native.gpr[1] = 0x8700;
+        let worker = disp
+            .guest_calls
+            .create_native_thread(
+                crate::guest_call::NativeThreadContext {
+                    cpu: Box::new(native),
+                },
+                crate::guest_call::ThreadStorage {
+                    stack_base: 0x8000,
+                    stack_limit: 0x9000,
+                    ..Default::default()
+                },
+                true,
+                |_| true,
+            )
+            .unwrap();
+        assert_eq!(invoke(&mut disp, &mut cpu, &mut bus, worker.thread_id()), 0);
+        assert_eq!(bus.read_long(output), 0x700);
+        assert_eq!(invoke(&mut disp, &mut cpu, &mut bus, 0xdead), -618);
+        assert_eq!(bus.read_long(output), 0x700);
+    }
+
+    #[test]
     fn threaddispatch_queries_reject_protected_output_without_partial_writes() {
-        for selector in [0x0206, 0x0407] {
+        for selector in [0x0206, 0x0407, 0x0414] {
             let (mut disp, mut cpu, mut bus) = setup();
+            bus.write_long(crate::memory::globals::addr::APPL_LIMIT, TEST_SP - 0x1000);
             let out = TEST_SP + 0x100;
             bus.write_long(out, 0xaabb_ccdd);
             bus.protect_readonly_code(out + 1, 1);
             bus.write_long(TEST_SP, out);
-            if selector == 0x0407 {
+            if selector != 0x0206 {
                 bus.write_long(TEST_SP + 4, 1);
             }
             cpu.write_reg(Register::D0, selector);


### PR DESCRIPTION
ThreadCurrentStackSpace previously had no native import route. Classic dispatch only inspected classic snapshots, returned a fixed 32 KiB for the application thread, and could partially write the output.

Both ABIs now use a shared Thread Manager query. The execution owner selects the thread’s live, saved or parked original-stack pointer; workers use their existing allocation bounds. Main-thread queries choose the limit for the original entry ISA, avoiding the companion’s different allocation boundary. Legacy standalone owners infer missing entry metadata from an existing call or a unique saved context without being initialized as a query side effect. The generic context bank exposes only a read-only lookup; no new stack registry or adapter-owned manager state is added.

Both output adapters reject incomplete writes. Unknown IDs return -618; unavailable provenance or an invalid worker stack pointer returns -619. Exhausted known stacks report zero. Tests cover current aliases, suspended opposite-ISA workers, native NewThread and SetApplLimit imports, nested ISA transitions while running and suspended, divergent application limits through both API edges, and protected/partial output destinations.

Validation: 5,010 full headless library tests passed with three existing ignored tests; the production check is warning-free. All 20 guardrail fixtures and final source checks passed. Five focused stack-space regressions also pass.

Advances #1415, #1407 and #1366; none is closed. Legacy direct callbacks without a registered or parked original context still refuse this query and require the remaining callback-ownership migration. Prerequisites #1414 and #1408 are merged; this PR is rebased onto master for landing.
