### PR TITLE
fix: preserve classic thread status and floating-point state

### DIFF
--- a/src/cpu/mod.rs
+++ b/src/cpu/mod.rs
@@ -49,6 +49,27 @@ pub enum StepResult {
     Fline(u16),
 }
 
+/// Classic task state beyond the integer registers exposed by [`CpuOps`].
+///
+/// Inside Macintosh: Thread Manager (1999), p. 15, Table 1-1 requires the
+/// full SR, floating-point registers and FPU frame. Raw extended-precision
+/// values preserve NaN payloads and values that cannot round-trip through f64.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct M68kExtendedContext {
+    /// Full status register, including CCR and stack-bank selection.
+    pub sr: u16,
+    /// FP0 through FP7 in the backend's exact 80-bit representation.
+    pub fpr: [m68k::fpu::FloatX80; 8],
+    /// Floating-point control register.
+    pub fpcr: u32,
+    /// Floating-point status register.
+    pub fpsr: u32,
+    /// Floating-point instruction address register.
+    pub fpiar: u32,
+    /// Distinguishes the backend's null and idle FSAVE frames.
+    pub fpu_just_reset: bool,
+}
+
 /// Register interface used by the trap dispatcher.
 ///
 /// Keeping handlers generic over this subset lets them operate on both the
@@ -65,6 +86,17 @@ pub trait CpuOps {
     ///
     /// The low five bits are X(4), N(3), Z(2), V(1), and C(0).
     fn set_ccr(&mut self, ccr: u8);
+
+    /// Capture additional architectural task state when this adapter has it.
+    /// Register-only adapters retain their existing integer/CCR behavior.
+    fn capture_extended_context(&self) -> Option<M68kExtendedContext> {
+        None
+    }
+
+    /// Restore state captured by this adapter before installing A7: restoring
+    /// SR can change the selected stack bank. Register-only adapters have no
+    /// additional state; backends returning `Some` must implement this method.
+    fn restore_extended_context(&mut self, _context: &M68kExtendedContext) {}
 }
 
 /// Systemless wrapper around [`m68k::CpuCore`].
@@ -224,6 +256,26 @@ impl CpuOps for M68kCpu {
     #[inline]
     fn set_ccr(&mut self, ccr: u8) {
         self.core.set_ccr(ccr);
+    }
+
+    fn capture_extended_context(&self) -> Option<M68kExtendedContext> {
+        Some(M68kExtendedContext {
+            sr: self.core.get_sr(),
+            fpr: self.core.fpr,
+            fpcr: self.core.fpcr,
+            fpsr: self.core.fpsr,
+            fpiar: self.core.fpiar,
+            fpu_just_reset: self.core.fpu_just_reset,
+        })
+    }
+
+    fn restore_extended_context(&mut self, context: &M68kExtendedContext) {
+        self.core.set_sr(context.sr);
+        self.core.fpr = context.fpr;
+        self.core.fpcr = context.fpcr;
+        self.core.fpsr = context.fpsr;
+        self.core.fpiar = context.fpiar;
+        self.core.fpu_just_reset = context.fpu_just_reset;
     }
 }
 

--- a/src/execution_m68k.rs
+++ b/src/execution_m68k.rs
@@ -23,14 +23,7 @@ impl M68kExecution {
 
     pub(crate) fn apply_task_handoff(&mut self) {
         if let Some(context) = self.calls.take_classic_task_handoff() {
-            for (index, value) in context.d_regs.into_iter().enumerate() {
-                self.cpu.core.set_d(index, value);
-            }
-            for (index, value) in context.a_regs.into_iter().enumerate() {
-                self.cpu.core.set_a(index, value);
-            }
-            self.cpu.write_reg(Register::PC, context.pc);
-            self.cpu.core.set_ccr(context.ccr);
+            context.install(&mut self.cpu);
         }
     }
 
@@ -406,6 +399,82 @@ mod tests {
     use super::*;
     use crate::guest_call::GuestCallTarget;
     use crate::guest_procedure::GuestIsa;
+
+    #[test]
+    fn native_task_handoff_restores_classic_status_fpu_and_frame_state() {
+        use crate::cpu::{CpuOps, StepResult};
+        use crate::guest_call::{CooperativeThread, ExecutionTaskId, ThreadStorage};
+        use crate::memory::{MacMemoryBus, MemoryBus};
+
+        for just_reset in [false, true] {
+            let calls = SharedGuestCallStack::default();
+            calls.start_native_engine();
+            assert!(calls.bind_task_entry_isa(ExecutionTaskId::APPLICATION, GuestIsa::PowerPc));
+            let mut engine = M68kExecution::new(&calls);
+            engine.cpu.core.set_sr(0x250a);
+            engine.cpu.core.fpr = std::array::from_fn(|i| m68k::fpu::FloatX80 {
+                mantissa: 0x8000_0000_0000_0021 + i as u64,
+                sign_exp: 0xffff,
+            });
+            engine.cpu.core.fpcr = 0x20;
+            engine.cpu.core.fpsr = 0x0800_0000;
+            engine.cpu.core.fpiar = 0x0010_1000;
+            engine.cpu.core.fpu_just_reset = just_reset;
+            engine.cpu.write_reg(Register::PC, 0x0010_0000);
+            engine.cpu.write_reg(Register::A0, 0x0010_2000);
+            engine.cpu.write_reg(Register::A7, 0x0010_8000);
+            let mut saved = CooperativeThread::capture(&engine.cpu);
+            // A result may update CCR after the extended snapshot was taken.
+            saved.ccr = 0x11;
+            let worker = calls
+                .create_classic_thread(
+                    saved.clone(),
+                    ThreadStorage {
+                        stack_base: 0x0010_4000,
+                        stack_limit: 0x0010_9000,
+                        ..Default::default()
+                    },
+                    false,
+                    |_| true,
+                )
+                .unwrap();
+
+            engine.cpu.core.set_sr(0);
+            engine.cpu.core.fpr.fill(Default::default());
+            engine.cpu.core.fpcr = 0;
+            engine.cpu.core.fpsr = 0;
+            engine.cpu.core.fpiar = 0;
+            engine.cpu.core.fpu_just_reset = !just_reset;
+            engine.cpu.write_reg(Register::A7, 0x0010_3000);
+            let untouched = CooperativeThread::capture(&engine.cpu);
+            let mut native = ppc::PpcCpu::new();
+            native.lr = 0x1234;
+            assert_eq!(
+                calls.yield_native_thread(&mut native, worker.thread_id()),
+                Ok(true)
+            );
+            assert_eq!(CooperativeThread::capture(&engine.cpu), untouched);
+            assert!(calls.has_classic_task_handoff());
+            engine.apply_task_handoff();
+            assert!(!calls.has_classic_task_handoff());
+            assert_eq!(engine.cpu.core.get_sr(), 0x2511);
+            assert_eq!(engine.cpu.core.a(7), saved.a_regs[7]);
+            let mut expected = saved.extended.unwrap();
+            expected.sr = 0x2511;
+            assert_eq!(engine.cpu.capture_extended_context(), Some(expected));
+
+            // Check the frame through a guest FSAVE instruction, not just
+            // the implementation's null/idle bookkeeping bit.
+            let mut bus = MacMemoryBus::new(0x400000);
+            bus.write_word(0x0010_0000, 0xf310); // FSAVE (A0)
+            bus.write_long(0x0010_2000, 0xdead_beef);
+            assert!(matches!(engine.cpu.step(&mut bus), StepResult::Ok));
+            assert_eq!(bus.read_long(0x0010_2000) == 0, just_reset);
+            let after = CooperativeThread::capture(&engine.cpu);
+            engine.apply_task_handoff();
+            assert_eq!(CooperativeThread::capture(&engine.cpu), after);
+        }
+    }
 
     #[test]
     fn relaunch_waits_for_the_bound_process_calls_to_finish() {

--- a/src/guest_call.rs
+++ b/src/guest_call.rs
@@ -8,7 +8,7 @@
 //! while each adapter remains responsible for its architectural registers and
 //! ABI frame.
 
-use crate::cpu::M68kCpu;
+use crate::cpu::{CpuOps, M68kCpu, M68kExtendedContext, Register};
 #[cfg(test)]
 pub(crate) use crate::execution_kernel::MAX_POWERPC_GUEST_ARGUMENTS;
 pub(crate) use crate::execution_kernel::{
@@ -38,22 +38,102 @@ pub(crate) fn restore_powerpc_context(cpu: &mut PpcCpu, context: PpcCpu) {
 
 /// Saved 68K state for one cooperative Thread Manager thread.
 ///
-/// Cooperative switches occur only inside `_ThreadDispatch`, so the HLE can
-/// preserve the complete caller-visible register file without involving a
-/// host thread. New threads inherit the creator's register world (notably A5)
-/// and receive a private guest stack.
+/// The execution owner preserves the caller-visible register file across
+/// classic switches and native task handoffs without involving a host thread.
+/// New threads inherit the creator's register world (notably A5) and receive
+/// a private guest stack.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub(crate) struct CooperativeThread {
     pub(crate) d_regs: [u32; 8],
     pub(crate) a_regs: [u32; 8],
     pub(crate) pc: u32,
     pub(crate) ccr: u8,
+    pub(crate) extended: Option<M68kExtendedContext>,
     /// `SetThreadSwitcher` switch-in proc and its `switchProcParam`.
     pub(crate) switch_in: (u32, u32),
     /// `SetThreadSwitcher` switch-out proc and its `switchProcParam`.
     pub(crate) switch_out: (u32, u32),
     /// `SetThreadTerminator` proc and its `terminationProcParam`.
     pub(crate) terminator: (u32, u32),
+}
+
+impl CooperativeThread {
+    pub(crate) fn capture<C: CpuOps>(cpu: &C) -> CooperativeThread {
+        let d_regs = [
+            cpu.read_reg(Register::D0),
+            cpu.read_reg(Register::D1),
+            cpu.read_reg(Register::D2),
+            cpu.read_reg(Register::D3),
+            cpu.read_reg(Register::D4),
+            cpu.read_reg(Register::D5),
+            cpu.read_reg(Register::D6),
+            cpu.read_reg(Register::D7),
+        ];
+        let a_regs = [
+            cpu.read_reg(Register::A0),
+            cpu.read_reg(Register::A1),
+            cpu.read_reg(Register::A2),
+            cpu.read_reg(Register::A3),
+            cpu.read_reg(Register::A4),
+            cpu.read_reg(Register::A5),
+            cpu.read_reg(Register::A6),
+            cpu.read_reg(Register::A7),
+        ];
+        CooperativeThread {
+            d_regs,
+            a_regs,
+            pc: cpu.read_reg(Register::PC),
+            ccr: cpu.get_ccr(),
+            extended: cpu.capture_extended_context(),
+            switch_in: (0, 0),
+            switch_out: (0, 0),
+            terminator: (0, 0),
+        }
+    }
+
+    pub(crate) fn save_registers<C: CpuOps>(&mut self, cpu: &C) {
+        *self = Self {
+            switch_in: self.switch_in,
+            switch_out: self.switch_out,
+            terminator: self.terminator,
+            ..Self::capture(cpu)
+        };
+    }
+
+    pub(crate) fn install<C: CpuOps>(&self, cpu: &mut C) {
+        if let Some(context) = &self.extended {
+            cpu.restore_extended_context(context);
+        }
+        let d_registers = [
+            Register::D0,
+            Register::D1,
+            Register::D2,
+            Register::D3,
+            Register::D4,
+            Register::D5,
+            Register::D6,
+            Register::D7,
+        ];
+        let a_registers = [
+            Register::A0,
+            Register::A1,
+            Register::A2,
+            Register::A3,
+            Register::A4,
+            Register::A5,
+            Register::A6,
+            Register::A7,
+        ];
+        for (register, value) in d_registers.into_iter().zip(self.d_regs) {
+            cpu.write_reg(register, value);
+        }
+        for (register, value) in a_registers.into_iter().zip(self.a_regs) {
+            cpu.write_reg(register, value);
+        }
+        cpu.write_reg(Register::PC, self.pc);
+        // ABI results may update CCR after the extended snapshot was captured.
+        cpu.set_ccr(self.ccr);
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -16226,6 +16226,7 @@ mod tests {
                         a_regs: [0, 0, 0, 0, 0, 0, 0, WORKER_SP],
                         pc: WORKER_ENTRY,
                         ccr: 0,
+                        extended: None,
                         switch_in: (0, 0),
                         switch_out: (0, 0),
                         terminator: (0, 0),

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -1096,69 +1096,6 @@ impl super::TrapDispatcher {
     const THREAD_NOT_FOUND_ERR: i16 = crate::thread_manager::THREAD_NOT_FOUND_ERR;
     const THREAD_PROTOCOL_ERR: i16 = crate::thread_manager::THREAD_PROTOCOL_ERR;
 
-    fn capture_cooperative_thread<C: CpuOps>(cpu: &C) -> CooperativeThread {
-        let d_regs = [
-            cpu.read_reg(Register::D0),
-            cpu.read_reg(Register::D1),
-            cpu.read_reg(Register::D2),
-            cpu.read_reg(Register::D3),
-            cpu.read_reg(Register::D4),
-            cpu.read_reg(Register::D5),
-            cpu.read_reg(Register::D6),
-            cpu.read_reg(Register::D7),
-        ];
-        let a_regs = [
-            cpu.read_reg(Register::A0),
-            cpu.read_reg(Register::A1),
-            cpu.read_reg(Register::A2),
-            cpu.read_reg(Register::A3),
-            cpu.read_reg(Register::A4),
-            cpu.read_reg(Register::A5),
-            cpu.read_reg(Register::A6),
-            cpu.read_reg(Register::A7),
-        ];
-        CooperativeThread {
-            d_regs,
-            a_regs,
-            pc: cpu.read_reg(Register::PC),
-            ccr: cpu.get_ccr(),
-            switch_in: (0, 0),
-            switch_out: (0, 0),
-            terminator: (0, 0),
-        }
-    }
-
-    fn install_cooperative_thread<C: CpuOps>(cpu: &mut C, thread: &CooperativeThread) {
-        let d_registers = [
-            Register::D0,
-            Register::D1,
-            Register::D2,
-            Register::D3,
-            Register::D4,
-            Register::D5,
-            Register::D6,
-            Register::D7,
-        ];
-        let a_registers = [
-            Register::A0,
-            Register::A1,
-            Register::A2,
-            Register::A3,
-            Register::A4,
-            Register::A5,
-            Register::A6,
-            Register::A7,
-        ];
-        for (register, value) in d_registers.into_iter().zip(thread.d_regs) {
-            cpu.write_reg(register, value);
-        }
-        for (register, value) in a_registers.into_iter().zip(thread.a_regs) {
-            cpu.write_reg(register, value);
-        }
-        cpu.write_reg(Register::PC, thread.pc);
-        cpu.set_ccr(thread.ccr);
-    }
-
     fn thread_return_trampoline(&mut self, bus: &mut MacMemoryBus) -> u32 {
         if self.thread_return_trampoline == 0 {
             let trampoline = bus.alloc(8);
@@ -1196,7 +1133,7 @@ impl super::TrapDispatcher {
                 .cooperative_context(ExecutionTaskId::from_thread_id(Self::APPLICATION_THREAD_ID))
                 .is_some()
         {
-            let thread = Self::capture_cooperative_thread(cpu);
+            let thread = CooperativeThread::capture(cpu);
             self.guest_calls.save_cooperative_context(
                 ExecutionTaskId::from_thread_id(Self::APPLICATION_THREAD_ID),
                 thread,
@@ -1210,21 +1147,12 @@ impl super::TrapDispatcher {
     /// changing its scheduling state.
     fn save_current_cooperative_thread<C: CpuOps>(&mut self, cpu: &C) {
         let current_id = self.guest_calls.current_task().thread_id();
-        let saved = Self::capture_cooperative_thread(cpu);
-        match self.cooperative_thread_snapshot(cpu, current_id) {
-            Some(mut thread) => {
-                thread.d_regs = saved.d_regs;
-                thread.a_regs = saved.a_regs;
-                thread.pc = saved.pc;
-                thread.ccr = saved.ccr;
-                self.guest_calls
-                    .save_cooperative_context(ExecutionTaskId::from_thread_id(current_id), thread);
-            }
-            None => {
-                self.guest_calls
-                    .save_cooperative_context(ExecutionTaskId::from_thread_id(current_id), saved);
-            }
-        }
+        let mut thread = self
+            .cooperative_thread_snapshot(cpu, current_id)
+            .unwrap_or_default();
+        thread.save_registers(cpu);
+        self.guest_calls
+            .save_cooperative_context(ExecutionTaskId::from_thread_id(current_id), thread);
     }
 
     /// Pick the next ready thread. `suggested_thread` wins when it names a
@@ -1245,7 +1173,7 @@ impl super::TrapDispatcher {
             return false;
         };
         if let Some(next) = next {
-            Self::install_cooperative_thread(cpu, &next);
+            next.install(cpu);
         }
         true
     }
@@ -1326,7 +1254,7 @@ impl super::TrapDispatcher {
         // The execution owner validated both contexts and committed the result.
         // Installing this owned snapshot cannot yield or fail.
         if let Some(successor) = successor {
-            Self::install_cooperative_thread(cpu, &successor);
+            successor.install(cpu);
         }
         if !recycle && saved.stack_base != 0 {
             if saved.managed_pointer {
@@ -16296,7 +16224,7 @@ impl super::TrapDispatcher {
                                 }
                                 return Err(-50);
                             }
-                            let mut thread = Self::capture_cooperative_thread(cpu);
+                            let mut thread = CooperativeThread::capture(cpu);
                             thread.pc = thread_entry;
                             thread.a_regs[7] = entry_sp;
                             let mut frame = [0u8; 8];
@@ -16519,15 +16447,11 @@ impl super::TrapDispatcher {
                         let state = bus.read_word(sp + 4);
                         let thread = bus.read_long(sp + 6);
                         let current = self.guest_calls.current_task();
-                        let saved = Self::capture_cooperative_thread(cpu);
                         let mut outgoing = self
                             .guest_calls
                             .cooperative_context(current)
-                            .unwrap_or_else(|| saved.clone());
-                        outgoing.d_regs = saved.d_regs;
-                        outgoing.a_regs = saved.a_regs;
-                        outgoing.pc = saved.pc;
-                        outgoing.ccr = saved.ccr;
+                            .unwrap_or_default();
+                        outgoing.save_registers(cpu);
                         outgoing.d_regs[0] = 0;
                         outgoing.a_regs[7] = sp + 10;
                         match self.guest_calls.set_classic_thread_state(
@@ -16544,7 +16468,7 @@ impl super::TrapDispatcher {
                                 if switched {
                                     if let Some(next) = self.guest_calls.take_classic_task_handoff()
                                     {
-                                        Self::install_cooperative_thread(cpu, &next);
+                                        next.install(cpu);
                                     }
                                 }
                                 return Some(Ok(()));
@@ -27908,7 +27832,23 @@ mod tests {
 
     #[test]
     fn threaddispatch_yield_to_any_thread_roundtrips_complete_68k_contexts() {
-        let (mut disp, mut cpu, mut bus) = setup();
+        let (mut disp, _, mut bus) = setup();
+        let mut cpu = crate::cpu::M68kCpu::new();
+        cpu.core.set_sr(0x3010);
+        cpu.core.fpr = std::array::from_fn(|i| m68k::fpu::FloatX80 {
+            mantissa: 0x8000_0000_0000_0001 + i as u64,
+            sign_exp: 0x7fff,
+        });
+        cpu.core.fpcr = 0x1234;
+        cpu.core.fpsr = 0x5678;
+        cpu.core.fpiar = 0x0010_2340;
+        let initial_fpu = (
+            cpu.core.fpr,
+            cpu.core.fpcr,
+            cpu.core.fpsr,
+            cpu.core.fpiar,
+            cpu.core.fpu_just_reset,
+        );
         let new_sp = TEST_SP;
         let thread_made = bus.alloc(4);
         let entry = 0x0012_3456;
@@ -27931,6 +27871,20 @@ mod tests {
 
         let app_sp = new_sp + 28;
         let app_pc = 0x000F_0000;
+        cpu.core.set_sr(0x851b);
+        cpu.write_reg(Register::A7, app_sp);
+        cpu.core.fpr.reverse();
+        cpu.core.fpcr = 0x4321;
+        cpu.core.fpsr = 0x8765;
+        cpu.core.fpiar = 0x0010_9870;
+        cpu.core.fpu_just_reset = false;
+        let app_fpu = (
+            cpu.core.fpr,
+            cpu.core.fpcr,
+            cpu.core.fpsr,
+            cpu.core.fpiar,
+            cpu.core.fpu_just_reset,
+        );
         cpu.write_reg(Register::PC, app_pc);
         cpu.write_reg(Register::D3, 0xCAFE_BABE);
         disp.guest_calls.begin_m68k(
@@ -27964,6 +27918,17 @@ mod tests {
             0x000D_1000,
             cpu.read_reg(Register::A7),
         );
+        assert_eq!(cpu.core.get_sr() & 0xff00, 0x3000);
+        assert_eq!(
+            (
+                cpu.core.fpr,
+                cpu.core.fpcr,
+                cpu.core.fpsr,
+                cpu.core.fpiar,
+                cpu.core.fpu_just_reset
+            ),
+            initial_fpu
+        );
         assert_eq!(cpu.read_reg(Register::PC), entry);
         assert_eq!(cpu.read_reg(Register::A5), 0x00AA_5500);
         let thread_sp = cpu.read_reg(Register::A7);
@@ -27991,10 +27956,60 @@ mod tests {
             1,
             "the suspended worker continuation must remain task-local"
         );
+        assert_eq!(cpu.core.get_sr(), 0x851b);
+        assert_eq!(
+            (
+                cpu.core.fpr,
+                cpu.core.fpcr,
+                cpu.core.fpsr,
+                cpu.core.fpiar,
+                cpu.core.fpu_just_reset
+            ),
+            app_fpu
+        );
         assert_eq!(cpu.read_reg(Register::PC), app_pc);
         assert_eq!(cpu.read_reg(Register::A7), app_sp + 4);
         assert_eq!(cpu.read_reg(Register::D3), 0xCAFE_BABE);
         assert_eq!(bus.read_word(app_sp + 4), 0);
+
+        // SetThreadState has a separate ABI path for saving the outgoing task.
+        // Refresh every register while preserving its registered hooks.
+        let app = ExecutionTaskId::from_thread_id(2);
+        let mut saved = disp.guest_calls.cooperative_context(app).unwrap();
+        saved.switch_in = (0x1000, 1);
+        saved.switch_out = (0x2000, 2);
+        saved.terminator = (0x3000, 3);
+        assert!(disp.guest_calls.save_cooperative_context(app, saved));
+        cpu.core.set_sr(0x3209);
+        cpu.core.fpr.rotate_left(1);
+        cpu.core.fpcr = 0x40;
+        cpu.core.fpsr = 0x80;
+        cpu.core.fpiar = 0x0012_1000;
+        cpu.core.fpu_just_reset = true;
+        let latest = cpu.capture_extended_context();
+        cpu.write_reg(Register::A7, app_sp);
+        bus.write_long(app_sp, 3);
+        bus.write_word(app_sp + 4, 0); // ready
+        bus.write_long(app_sp + 6, 1); // current thread
+        cpu.write_reg(Register::D0, 0x0508);
+        disp.dispatch_toolbox(true, 0x3F2, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+        assert_eq!(disp.guest_calls.current_task().thread_id(), 3);
+        let worker_sp = cpu.read_reg(Register::A7) - 8;
+        cpu.write_reg(Register::A7, worker_sp);
+        bus.write_long(worker_sp, 2);
+        cpu.write_reg(Register::D0, 0x0205);
+        disp.dispatch_toolbox(true, 0x3F2, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+        assert_eq!(disp.guest_calls.current_task(), app);
+        assert_eq!(cpu.capture_extended_context(), latest);
+        assert_eq!(cpu.read_reg(Register::A7), app_sp + 10);
+        let saved = disp.guest_calls.cooperative_context(app).unwrap();
+        assert_eq!(saved.switch_in, (0x1000, 1));
+        assert_eq!(saved.switch_out, (0x2000, 2));
+        assert_eq!(saved.terminator, (0x3000, 3));
     }
 
     #[test]


### PR DESCRIPTION
Classic cooperative thread switches restored only CCR, so a worker could inherit the outgoing thread’s status bits and floating-point state. Snapshots now preserve full SR, raw FP0–FP7, FPCR/FPSR/FPIAR and the backend’s null/idle FPU frame state.

Capture, register refresh and installation are shared by classic yield, SetThreadState and native-to-classic task handoffs. Refresh retains registered thread hooks. Installation restores SR before A7 to respect stack banking and applies the latest ABI CCR last. Existing register-only CpuOps implementations retain their behavior through default extension methods.

The strengthened production-CPU yield regression failed on the old SR restoration. It now covers user/master stack banks, raw NaN payloads, floating-point control registers, SetThreadState and hook preservation. A separate native handoff regression executes guest FSAVE after restoring both null and idle contexts.

Validation: 5,012 headless library tests passed, three existing tests ignored; the production library check is warning-free. Architecture guardrails and all 20 guardrail fixtures passed.

Reference: [Inside Macintosh: Thread Manager, p. 15, Table 1-1](https://leopard-adc.pepas.com/documentation/macos8/pdf/ThreadManager.pdf).

Depends on #1425. Callback ownership, delivery policy and the broader runtime migration remain open.

Closes #1429.
