### PR TITLE
ci: precompile optimized showcase tests for all variants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,24 +65,29 @@ jobs:
       - name: Run desktop tests
         run: cargo test --locked --bin systemless
 
+      # All four runtime configurations use this exact optimized executable.
+      # Keep ordinary library/desktop tests in the checked debug profile above.
+      - name: Compile optimized toolbox showcase tests
+        run: cargo test --locked --profile ci-test --test toolbox_showcase --no-run
+
       - name: Run toolbox showcase integration test (68k)
-        run: cargo test --test toolbox_showcase
+        run: cargo test --locked --profile ci-test --test toolbox_showcase
 
       - name: Run toolbox showcase integration test (PowerPC)
         env:
           SYSTEMLESS_PREFER_POWERPC: 1
-        run: cargo test --test toolbox_showcase
+        run: cargo test --locked --profile ci-test --test toolbox_showcase
 
       - name: Run toolbox showcase integration test (classic 68k)
         env:
           SYSTEMLESS_TOOLBOX_THEME: classic-system7
-        run: cargo test --locked --test toolbox_showcase
+        run: cargo test --locked --profile ci-test --test toolbox_showcase
 
       - name: Run toolbox showcase integration test (classic PowerPC)
         env:
           SYSTEMLESS_TOOLBOX_THEME: classic-system7
           SYSTEMLESS_PREFER_POWERPC: 1
-        run: cargo test --locked --test toolbox_showcase
+        run: cargo test --locked --profile ci-test --test toolbox_showcase
 
       - name: Upload failed showcase frames
         if: failure()

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,3 +112,13 @@ tempfile = "3"
 [profile.release]
 lto = "fat"
 codegen-units = 1
+
+# Execute emulator-heavy integration tests efficiently without production LTO
+# costs or dropping the runtime checks exercised by ordinary debug tests.
+[profile.ci-test]
+inherits = "dev"
+opt-level = 2
+debug = "line-tables-only"
+debug-assertions = true
+overflow-checks = true
+incremental = false


### PR DESCRIPTION
The four toolbox showcase variants spend most of their CI time running an unoptimized emulator, rather than recompiling. Add a dedicated `ci-test` profile with opt-level 2, line-table debugging, debug assertions and overflow checks enabled, and incremental compilation disabled. It inherits the development profile and does not use production fat LTO.

Compile the showcase explicitly once with `--no-run`, then run all four existing architecture/theme variants with exactly the same profile and features so Cargo reuses the executable. Ordinary library and desktop tests retain their debug settings; the release-only OS matrix and failure-frame uploads are unchanged.

This PR is stacked on #1427, which adds the fourth variant and fixes the existing sprite references. Only Cargo.toml and the CI workflow change here. All four variants pass in both profiles on ARM64 macOS, without updating any reference images. One paired execution run per variant, excluding compilation:

| Variant | Debug | Optimized |
| --- | ---: | ---: |
| Systemless 68k | 97.21 s | 7.35 s |
| Systemless PowerPC | 93.26 s | 3.68 s |
| Classic 68k | 80.38 s | 5.77 s |
| Classic PowerPC | 91.56 s | 3.65 s |
| Total | 362.41 s | 20.45 s |

That is a 17.7× execution speedup on this host. Build cost is separate; a subsequent identical `--no-run` invocation reused the compiled artifact in 0.23 seconds. Linux CI is running to validate the complete workflow and measure its initial optimized build separately. The variants remain sequential because the measured runtime gain does not justify adding parallel-runner setup yet.

Closes #1438
