### PR TITLE
refactor: activate CFM initializers through task-owned effects

### DIFF
--- a/src/guest_call.rs
+++ b/src/guest_call.rs
@@ -22,7 +22,8 @@ use crate::execution_kernel::{
     NativeAvailability,
 };
 use crate::guest_procedure::GuestIsa;
-use ppc::{PpcCpu, PpcImportAction, PpcNativeReturnGpr3};
+use crate::memory::GuestAddressSpace;
+use ppc::{PpcCpu, PpcImportAction, PpcMemory, PpcNativeReturnGpr3};
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
@@ -340,7 +341,7 @@ impl GuestCallEffect {
             }),
             (
                 GuestIsa::PowerPc,
-                GuestCallArguments::None,
+                GuestCallArguments::None | GuestCallArguments::PowerPc(_),
                 GuestCallContinuation::ReturnToPowerPc {
                     return_pc,
                     final_pc,
@@ -1979,6 +1980,68 @@ impl SharedGuestCallStack {
             .is_some_and(|(_, frame)| frame.m68k_execution.is_some())
     }
 
+    /// Activate a native call without discarding its task or logical arguments.
+    /// The entire parameter area must be writable before any call state or
+    /// architectural state changes. No guest execution intervenes in commit.
+    pub(crate) fn activate_powerpc_effect(
+        &self,
+        cpu: &mut PpcCpu,
+        memory: &mut GuestAddressSpace,
+        effect: GuestCallEffect,
+    ) -> bool {
+        let GuestCallEffect::CallGuest {
+            request,
+            continuation,
+        } = effect;
+        let GuestCallContinuation::ReturnToPowerPc { return_pc, .. } = continuation else {
+            return false;
+        };
+        let GuestCallArguments::PowerPc(arguments) = request.arguments else {
+            return false;
+        };
+        if request.task != self.current_task()
+            || request.target.isa != GuestIsa::PowerPc
+            || request.target.entry == 0
+        {
+            return false;
+        }
+        // Inside Macintosh: PowerPC System Software (1994), pp. 1-45--1-50:
+        // the parameter area follows the 24-byte linkage area and reserves
+        // at least eight words, corresponding to r3 through r10.
+        let Some(parameter_start) = cpu.gpr[1].checked_add(24) else {
+            return false;
+        };
+        let values = arguments.as_slice();
+        let parameter_len = values.len().max(8) as u32 * 4;
+        if !memory.preflight_writable_range(parameter_start, parameter_len) {
+            return false;
+        }
+        let Some(call_id) = self.submit_effect(effect) else {
+            return false;
+        };
+        // Submission just installed this task's pending top frame. This
+        // synchronous transition cannot be displaced by another guest call.
+        self.0
+            .borrow()
+            .kernel
+            .activate(request.task, call_id)
+            .expect("newly submitted native call remains pending");
+        cpu.gpr[3..11].fill(0);
+        for slot in 0..values.len().max(8) {
+            let value = values.get(slot).copied().unwrap_or(0);
+            memory
+                .write_u32_be(parameter_start + slot as u32 * 4, value)
+                .expect("preflighted native parameter area remains writable");
+            if slot < 8 {
+                cpu.gpr[3 + slot] = value;
+            }
+        }
+        cpu.pc = request.target.entry;
+        cpu.gpr[2] = request.target.rtoc;
+        cpu.lr = return_pc;
+        true
+    }
+
     /// Move the continuation embedded in a CPU action into the process stack
     /// and arrange the next native PowerPC context directly.
     pub(crate) fn externalize_powerpc_action(
@@ -2760,6 +2823,92 @@ mod tests {
         assert_eq!(process_calls.len(), 1);
         assert!(adapter_calls.complete_m68k(0x2002, 0x3000));
         assert!(process_calls.is_empty());
+    }
+
+    #[test]
+    fn native_effect_preflights_all_arguments_and_preserves_nested_calls_on_refusal() {
+        for failure in 0..5 {
+            let calls = SharedGuestCallStack::default();
+            let worker = calls.create_task().unwrap();
+            assert!(calls.set_scheduling_state(worker, ExecutionTaskState::Ready));
+            assert!(calls.switch_to_task(worker));
+            let mut cpu = PpcCpu::new();
+            calls.externalize_powerpc_action(
+                &mut cpu,
+                native_action(0x1000, 0x2000, PpcNativeReturnGpr3::Preserve),
+            );
+            cpu.gpr[1] = if failure == 3 { u32::MAX - 8 } else { 0x8000 };
+            cpu.gpr[3..11].fill(0xfeed);
+            let arguments = PowerPcArguments::from_slice(&[1, 2, 3, 4, 5, 6, 7, 8, 9]).unwrap();
+            let mut request = GuestCallRequest::for_task(
+                worker,
+                GuestCallTarget {
+                    isa: GuestIsa::PowerPc,
+                    entry: 0x3000,
+                    rtoc: 0x3100,
+                },
+            )
+            .with_powerpc_arguments(arguments);
+            if failure == 2 {
+                request.task = ExecutionTaskId::APPLICATION;
+            }
+            if failure == 4 {
+                request.target.entry = 0;
+            }
+            let continuation = GuestCallContinuation::to_powerpc(
+                RETURN_PC,
+                cpu.pc,
+                cpu.gpr[2],
+                PpcNativeReturnGpr3::Mask(0xff),
+            );
+            let effect = GuestCallEffect::call_guest(request, continuation);
+            let mut memory = GuestAddressSpace::new();
+            memory.add_region(0x8018, vec![0xa5; 32]);
+            if failure == 1 {
+                memory.add_readonly_region(0x8038, vec![0xa5; 4]);
+            } else if failure != 0 {
+                memory.add_region(0x8038, vec![0xa5; 4]);
+            }
+            let before = calls.clone();
+            let registers = cpu.gpr;
+            let control = (cpu.pc, cpu.lr);
+            assert!(
+                !calls.activate_powerpc_effect(&mut cpu, &mut memory, effect),
+                "case {failure}"
+            );
+            assert_eq!(calls, before);
+            assert_eq!(cpu.gpr, registers);
+            assert_eq!((cpu.pc, cpu.lr), control);
+            for offset in 0..32 {
+                assert_eq!(memory.read_u8(0x8018 + offset), Some(0xa5));
+            }
+
+            // Retry under the same worker, retaining the outer continuation.
+            let mut memory = GuestAddressSpace::new();
+            memory.add_region(0x8000, vec![0xa5; 128]);
+            cpu.gpr[1] = 0x8000;
+            request.task = worker;
+            request.target.entry = 0x3000;
+            assert!(calls.activate_powerpc_effect(
+                &mut cpu,
+                &mut memory,
+                GuestCallEffect::call_guest(request, continuation)
+            ));
+            assert_eq!(&cpu.gpr[3..11], &[1, 2, 3, 4, 5, 6, 7, 8]);
+            assert_eq!(memory.read_u32_be(0x8038), Some(9));
+            assert_eq!((cpu.pc, cpu.lr, cpu.gpr[2]), (0x3000, RETURN_PC, 0x3100));
+            assert_eq!(calls.task_depth(worker), 2);
+            assert_eq!(calls.task_depth(ExecutionTaskId::APPLICATION), 0);
+            cpu.pc = RETURN_PC;
+            cpu.gpr[3] = 0x1234;
+            assert!(calls.complete_powerpc(&mut cpu));
+            assert_eq!((cpu.pc, cpu.gpr[2], cpu.gpr[3]), (0x1000, 0x1100, 0x34));
+            assert_eq!(calls.task_depth(worker), 1);
+            cpu.pc = RETURN_PC;
+            assert!(calls.complete_powerpc(&mut cpu));
+            assert_eq!(cpu.pc, 0x2000);
+            assert!(calls.is_empty());
+        }
     }
 
     #[test]

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -20911,6 +20911,7 @@ fn dispatch_supported_import(
         ))),
         PpcImportDispatcherTarget::GetSharedLibrary => Some(ppc_get_shared_library(
             cpu,
+            &toolbox_startup.guest_calls,
             process_memory_manager,
             memory,
             heap_cursor,
@@ -20935,6 +20936,7 @@ fn dispatch_supported_import(
         )),
         PpcImportDispatcherTarget::GetMemFragment => Some(ppc_get_mem_fragment(
             cpu,
+            &toolbox_startup.guest_calls,
             process_memory_manager,
             memory,
             heap_cursor,
@@ -50595,6 +50597,7 @@ fn ppc_gestalt_response(selector: u32) -> Option<(u32, i16)> {
 
 fn ppc_get_shared_library(
     cpu: &mut PpcCpu,
+    guest_calls: &SharedGuestCallStack,
     process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
@@ -50746,38 +50749,9 @@ fn ppc_get_shared_library(
         return return_error(PPC_PARAM_ERR);
     }
     let Some((init_addr, init_block)) = initialization else {
-        return return_error(PPC_NO_ERR);
+        return PpcImportAction::Return(ppc_i16_result(PPC_NO_ERR));
     };
-    let (Some(entry), Some(rtoc)) = (
-        memory.read_u32_be(init_addr),
-        memory.read_u32_be(init_addr.wrapping_add(4)),
-    ) else {
-        return return_error(PPC_FRAG_CORRUPT_ERR);
-    };
-    if entry == 0 || ppc_install_native_call_arguments(cpu, memory, &[init_block]).is_none() {
-        return return_error(PPC_FRAG_CORRUPT_ERR);
-    }
-    let final_pc = cpu.lr;
-    let restore_rtoc = cpu.gpr[2];
-    cpu.gpr[12] = init_addr;
-    GuestCallEffect::call_guest(
-        GuestCallRequest::new(GuestCallTarget {
-            isa: GuestIsa::PowerPc,
-            entry,
-            rtoc,
-        }),
-        GuestCallContinuation::to_powerpc(
-            PPC_GUEST_CALL_RETURN_PC,
-            final_pc,
-            restore_rtoc,
-            PpcNativeReturnGpr3::ZeroOrSet {
-                zero: ppc_i16_result(PPC_NO_ERR),
-                nonzero: ppc_i16_result(PPC_FRAG_USER_INIT_PROC_ERR),
-            },
-        ),
-    )
-    .into_ppc_import_action()
-    .expect("validated CFM initialization target must be native PowerPC")
+    ppc_activate_cfm_initializer(cpu, memory, guest_calls, init_addr, init_block)
 }
 
 fn ppc_close_connection(
@@ -50896,6 +50870,7 @@ fn ppc_find_symbol(
 
 fn ppc_get_mem_fragment(
     cpu: &mut PpcCpu,
+    guest_calls: &SharedGuestCallStack,
     process_memory_manager: &mut ProcessNativeMemoryManager,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
@@ -51042,36 +51017,46 @@ fn ppc_get_mem_fragment(
     let Some((init_addr, init_block)) = initialization else {
         return PpcImportAction::Return(ppc_i16_result(PPC_NO_ERR));
     };
-    let Some(entry) = memory.read_u32_be(init_addr) else {
-        return PpcImportAction::Return(ppc_i16_result(PPC_FRAG_CORRUPT_ERR));
-    };
-    let Some(rtoc) = memory.read_u32_be(init_addr.wrapping_add(4)) else {
-        return PpcImportAction::Return(ppc_i16_result(PPC_FRAG_CORRUPT_ERR));
-    };
-    if entry == 0 || ppc_install_native_call_arguments(cpu, memory, &[init_block]).is_none() {
-        return PpcImportAction::Return(ppc_i16_result(PPC_FRAG_CORRUPT_ERR));
-    }
-    let final_pc = cpu.lr;
-    let restore_rtoc = cpu.gpr[2];
-    cpu.gpr[12] = init_addr;
-    GuestCallEffect::call_guest(
-        GuestCallRequest::new(GuestCallTarget {
+    ppc_activate_cfm_initializer(cpu, memory, guest_calls, init_addr, init_block)
+}
+
+fn ppc_activate_cfm_initializer(
+    cpu: &mut PpcCpu,
+    memory: &mut PpcSectionMem,
+    guest_calls: &SharedGuestCallStack,
+    init_addr: u32,
+    init_block: u32,
+) -> PpcImportAction {
+    let target = init_addr.checked_add(7).and_then(|_| {
+        Some(GuestCallTarget {
             isa: GuestIsa::PowerPc,
-            entry,
-            rtoc,
-        }),
+            entry: memory.read_u32_be(init_addr)?,
+            rtoc: memory.read_u32_be(init_addr + 4)?,
+        })
+    });
+    let Some(target) = target else {
+        return PpcImportAction::Return(ppc_i16_result(PPC_FRAG_CORRUPT_ERR));
+    };
+    let effect = GuestCallEffect::call_guest(
+        GuestCallRequest::for_task(guest_calls.current_task(), target).with_powerpc_arguments(
+            crate::guest_call::PowerPcArguments::from_slice(&[init_block])
+                .expect("one initializer argument fits the native ABI"),
+        ),
         GuestCallContinuation::to_powerpc(
             PPC_GUEST_CALL_RETURN_PC,
-            final_pc,
-            restore_rtoc,
+            cpu.lr,
+            cpu.gpr[2],
             PpcNativeReturnGpr3::ZeroOrSet {
                 zero: ppc_i16_result(PPC_NO_ERR),
                 nonzero: ppc_i16_result(PPC_FRAG_USER_INIT_PROC_ERR),
             },
         ),
-    )
-    .into_ppc_import_action()
-    .expect("validated CFM initialization target must be native PowerPC")
+    );
+    if !guest_calls.activate_powerpc_effect(cpu, memory, effect) {
+        return PpcImportAction::Return(ppc_i16_result(PPC_FRAG_CORRUPT_ERR));
+    }
+    cpu.gpr[12] = init_addr;
+    PpcImportAction::Continue
 }
 
 fn ppc_create_mem_fragment_init_block(
@@ -112363,6 +112348,62 @@ pub(crate) mod tests {
         let unchanged = loaded.run_with_hle_imports(64);
         assert_eq!(unchanged.unsupported_import_index, None);
         assert_eq!(loaded.cpu.gpr[3], first_handler);
+    }
+
+    #[test]
+    fn cfm_initializer_effect_executes_and_returns_to_its_worker() {
+        use crate::execution_kernel::ExecutionTaskState;
+        for result in [0u16, 0xffff] {
+            let calls = SharedGuestCallStack::default();
+            let worker = calls.create_task().unwrap();
+            assert!(calls.set_scheduling_state(worker, ExecutionTaskState::Ready));
+            assert!(calls.switch_to_task(worker));
+            let mut memory = PpcSectionMem::new();
+            memory.add_region(
+                0x1000,
+                [0x3860_0000 | u32::from(result), 0x4e80_0020]
+                    .into_iter()
+                    .flat_map(u32::to_be_bytes)
+                    .collect(),
+            );
+            memory.add_region(
+                0x2000,
+                [0x1000u32, 0x2100]
+                    .into_iter()
+                    .flat_map(u32::to_be_bytes)
+                    .collect(),
+            );
+            memory.add_region(0x8000, vec![0xa5; 128]);
+            let mut cpu = PpcCpu::new();
+            cpu.gpr[1] = 0x8000;
+            cpu.gpr[2] = 0x2200;
+            cpu.lr = 0x4000;
+            assert_eq!(
+                ppc_activate_cfm_initializer(&mut cpu, &mut memory, &calls, 0x2000, 0x5000,),
+                PpcImportAction::Continue
+            );
+            assert_eq!((cpu.gpr[3], cpu.gpr[12]), (0x5000, 0x2000));
+            assert_eq!(calls.current_task(), worker);
+            assert_eq!(calls.task_depth(worker), 1);
+            assert_eq!(
+                cpu.run_with_imports(&mut memory, 2, 0, 0xff00_0000, 0, |_, _, _| {
+                    PpcImportAction::Halt
+                }),
+                PpcRunResult::CycleLimit { cycles: 2 }
+            );
+            assert_eq!(cpu.pc, PPC_GUEST_CALL_RETURN_PC);
+            assert!(calls.complete_powerpc(&mut cpu));
+            assert_eq!((cpu.pc, cpu.lr, cpu.gpr[2]), (0x4000, 0x4000, 0x2200));
+            assert_eq!(
+                cpu.gpr[3],
+                ppc_i16_result(if result == 0 {
+                    PPC_NO_ERR
+                } else {
+                    PPC_FRAG_USER_INIT_PROC_ERR
+                })
+            );
+            assert!(calls.is_empty());
+        }
     }
 
     #[test]


### PR DESCRIPTION
GetMemFragment and GetSharedLibrary initializer calls now preserve explicit task identity and logical arguments through direct execution-owner activation. Previously they wrote native argument registers and slots first, converted the request into an import action, then reconstructed a task-stamped continuation at dispatch. A later unwritable slot could leave earlier arguments changed on refusal.

The execution ABI edge preflights the complete parameter area before installing the continuation or changing CPU state. Both CFM entry points share checked transition-vector decoding and retain their existing initializer result policy. The two effect/action round trips are removed.

Validation: 5,021 headless library tests passed, three ignored; production test-support check passed without warnings. A nested worker regression covers partial/read-only mappings, wrapping addresses, stale task identity and zero entry, followed by successful retry and LIFO return. A CFM test executes real PPC initializer instructions under a worker for both success and error results.

Prerequisite #1437 is merged; this patch is rebased unchanged onto master for landing. Typed manager operations, automatic accelerated-resource preparation and initializer/connection lifetimes remain separate migration work.

Closes #1440
