### PR TITLE
feat: prepare accelerated resources for native universal calls

### DIFF
--- a/src/cfm.rs
+++ b/src/cfm.rs
@@ -12,6 +12,33 @@ pub(crate) struct CfmResourcePreparation {
     pub(crate) routine_flags: u16,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct CfmResourceCall {
+    pub(crate) task: crate::execution_kernel::ExecutionTaskId,
+    pub(crate) id: CfmLoadId,
+    pub(crate) preparation: CfmResourcePreparation,
+    pub(crate) descriptor_header: [u8; 12],
+    pub(crate) original_record: [u8; 20],
+    pub(crate) main_address: u32,
+    pub(crate) arguments: crate::execution_kernel::GuestArgumentValues,
+    pub(crate) caller_proc_info: u32,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum CfmOperation {
+    Load(CfmLoadOperation),
+    Resource(CfmResourceCall),
+}
+
+impl CfmOperation {
+    pub(crate) fn id(self) -> CfmLoadId {
+        match self {
+            Self::Load(load) => load.id,
+            Self::Resource(call) => call.id,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CfmConnection {
     pub id: u32,
@@ -27,6 +54,59 @@ pub struct CfmExport {
     pub name: String,
     pub class: u8,
     pub address: u32,
+}
+
+impl CfmResourceCall {
+    pub(crate) fn complete(
+        self,
+        initializer_result: u32,
+        connections: &mut Vec<CfmConnection>,
+        record: Option<[u8; 20]>,
+        write_outputs: impl FnOnce(&[(u32, &[u8])]) -> bool,
+    ) -> Result<Self, CfmLoadError> {
+        let request = self.preparation;
+        let result = (|| {
+            if initializer_result != 0 {
+                return Err(CfmLoadError::InitializationFailed);
+            }
+            if !connections
+                .iter()
+                .any(|connection| connection.id == self.id.0)
+            {
+                return Err(CfmLoadError::ConnectionNotFound);
+            }
+            let record = record.ok_or(CfmLoadError::InvalidOutputs)?;
+            if record != self.original_record
+                || record[5] != 1
+                || u32::from_be_bytes(record[0..4].try_into().unwrap()) != request.proc_info
+                || u16::from_be_bytes(record[6..8].try_into().unwrap()) != request.routine_flags
+                || request
+                    .descriptor
+                    .checked_add(u32::from_be_bytes(record[8..12].try_into().unwrap()))
+                    != Some(request.fragment_address)
+            {
+                return Err(CfmLoadError::DescriptorChanged);
+            }
+            let flags = (request.routine_flags & !3).to_be_bytes();
+            let target = self.main_address.to_be_bytes();
+            let flags_address = request
+                .record
+                .checked_add(6)
+                .ok_or(CfmLoadError::InvalidOutputs)?;
+            let target_address = request
+                .record
+                .checked_add(8)
+                .ok_or(CfmLoadError::InvalidOutputs)?;
+            if !write_outputs(&[(flags_address, &flags), (target_address, &target)]) {
+                return Err(CfmLoadError::InvalidOutputs);
+            }
+            Ok(self)
+        })();
+        if result.is_err() {
+            connections.retain(|connection| connection.id != self.id.0);
+        }
+        result
+    }
 }
 
 /// Load identities use the connection reserved for that load. The connection
@@ -71,6 +151,7 @@ pub(crate) enum CfmLoadError {
     InitializationFailed,
     ConnectionNotFound,
     InvalidOutputs,
+    DescriptorChanged,
 }
 
 impl CfmLoadError {
@@ -79,6 +160,7 @@ impl CfmLoadError {
             Self::InitializationFailed => -2821,
             Self::ConnectionNotFound => -2801,
             Self::InvalidOutputs => -50,
+            Self::DescriptorChanged => -2820,
         }
     }
 }
@@ -235,6 +317,71 @@ mod tests {
                     );
                     assert_eq!(connections.last(), Some(&connection(9)));
                 }
+            }
+        }
+    }
+
+    #[test]
+    fn prepared_resource_publication_is_atomic_and_rejects_changed_records_in_both_views() {
+        for classic in [false, true] {
+            for fault in 0..4 {
+                let mut record = [0u8; 20];
+                record[5] = 1;
+                record[6..8].copy_from_slice(&3u16.to_be_bytes());
+                record[8..12].copy_from_slice(&0x100u32.to_be_bytes());
+                let operation = CfmResourceCall {
+                    task: crate::execution_kernel::ExecutionTaskId::APPLICATION,
+                    id: CfmLoadId(7),
+                    preparation: CfmResourcePreparation {
+                        descriptor: OUTPUT - 12,
+                        record: OUTPUT,
+                        fragment_address: OUTPUT - 12 + 0x100,
+                        proc_info: 0,
+                        routine_flags: 3,
+                    },
+                    descriptor_header: [0; 12],
+                    original_record: record,
+                    main_address: 0x1234_5678,
+                    arguments: crate::execution_kernel::GuestArgumentValues::from_slice(&[])
+                        .unwrap(),
+                    caller_proc_info: 0,
+                };
+                if fault == 2 {
+                    record[19] = 1;
+                }
+                let mut memory = GuestAddressSpace::new();
+                memory.add_region(OUTPUT, record.to_vec());
+                if fault == 1 {
+                    memory.add_readonly_region(OUTPUT + 11, vec![record[11]]);
+                }
+                let mut bus = MacMemoryBus::new(0x10000);
+                bus.set_addressing_32_bit(true);
+                bus.attach_guest_address_space(memory.shared_view());
+                let mut connections = vec![connection(7), connection(9)];
+                let result = operation.complete(
+                    u32::from(fault == 3),
+                    &mut connections,
+                    Some(record),
+                    |writes| {
+                        if classic {
+                            bus.try_write_ranges_atomic(writes)
+                        } else {
+                            memory.try_write_ranges_atomic(writes)
+                        }
+                    },
+                );
+                assert_eq!(result.is_ok(), fault == 0);
+                if fault == 0 {
+                    record[6..8].copy_from_slice(&0u16.to_be_bytes());
+                    record[8..12].copy_from_slice(&operation.main_address.to_be_bytes());
+                }
+                assert_eq!(snapshot(&mut memory), record);
+                assert_eq!(bus.read_bytes(OUTPUT, 20), record);
+                assert_eq!(
+                    connections.iter().any(|connection| connection.id == 7),
+                    fault == 0
+                );
+                assert_eq!(connections.last(), Some(&connection(9)));
             }
         }
     }

--- a/src/execution_kernel.rs
+++ b/src/execution_kernel.rs
@@ -103,16 +103,18 @@ pub(crate) enum M68kResultSource {
     },
 }
 
+pub(crate) type PowerPcArguments = GuestArgumentValues;
+
 pub(crate) const MAX_POWERPC_GUEST_ARGUMENTS: usize = 13;
 
 /// Bounded, copyable native argument list carried by a semantic call request.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) struct PowerPcArguments {
+pub(crate) struct GuestArgumentValues {
     values: [u32; MAX_POWERPC_GUEST_ARGUMENTS],
     len: u8,
 }
 
-impl PowerPcArguments {
+impl GuestArgumentValues {
     pub(crate) fn from_slice(values: &[u32]) -> Option<Self> {
         if values.len() > MAX_POWERPC_GUEST_ARGUMENTS {
             return None;

--- a/src/guest_call.rs
+++ b/src/guest_call.rs
@@ -8,7 +8,7 @@
 //! while each adapter remains responsible for its architectural registers and
 //! ABI frame.
 
-use crate::cfm::{CfmLoadId, CfmLoadOperation};
+use crate::cfm::{CfmLoadId, CfmLoadOperation, CfmOperation};
 use crate::cpu::{CpuOps, M68kCpu, M68kExtendedContext, Register};
 #[cfg(test)]
 pub(crate) use crate::execution_kernel::MAX_POWERPC_GUEST_ARGUMENTS;
@@ -183,7 +183,7 @@ struct GuestCallFrame {
     target: GuestCallTarget,
     origin: GuestCallOrigin,
     native_scratch: Option<u32>,
-    cfm_load: Option<CfmLoadOperation>,
+    cfm_operation: Option<CfmOperation>,
     m68k_execution: Option<M68kExecution>,
     powerpc_execution: Option<PowerPcExecution>,
 }
@@ -319,7 +319,7 @@ impl GuestCallEffect {
                     result,
                 }),
                 native_scratch: None,
-                cfm_load: None,
+                cfm_operation: None,
                 m68k_execution: None,
                 powerpc_execution: None,
             }),
@@ -339,7 +339,7 @@ impl GuestCallEffect {
                     result,
                 }),
                 native_scratch: None,
-                cfm_load: None,
+                cfm_operation: None,
                 m68k_execution: None,
                 powerpc_execution: Some(PowerPcExecution {
                     arguments,
@@ -365,7 +365,7 @@ impl GuestCallEffect {
                     return_gpr3,
                 }),
                 native_scratch: None,
-                cfm_load: None,
+                cfm_operation: None,
                 m68k_execution: None,
                 powerpc_execution: None,
             }),
@@ -387,7 +387,7 @@ impl GuestCallEffect {
                     return_gpr3,
                 }),
                 native_scratch: None,
-                cfm_load: None,
+                cfm_operation: None,
                 m68k_execution: Some(M68kExecution {
                     entry: request.entry,
                     initial_sp: request.initial_sp,
@@ -441,7 +441,7 @@ impl PartialEq for GuestCallFrame {
         self.target == other.target
             && self.origin == other.origin
             && self.native_scratch == other.native_scratch
-            && self.cfm_load == other.cfm_load
+            && self.cfm_operation == other.cfm_operation
             && self.m68k_execution == other.m68k_execution
             && match (&self.powerpc_execution, &other.powerpc_execution) {
                 (None, None) => true,
@@ -2017,6 +2017,23 @@ impl SharedGuestCallStack {
         scratch: Option<u32>,
         cfm_load: Option<CfmLoadOperation>,
     ) -> bool {
+        self.activate_powerpc_effect_with_operation(
+            cpu,
+            memory,
+            effect,
+            scratch,
+            cfm_load.map(CfmOperation::Load),
+        )
+    }
+
+    pub(crate) fn activate_powerpc_effect_with_operation(
+        &self,
+        cpu: &mut PpcCpu,
+        memory: &mut GuestAddressSpace,
+        effect: GuestCallEffect,
+        scratch: Option<u32>,
+        cfm_operation: Option<CfmOperation>,
+    ) -> bool {
         let GuestCallEffect::CallGuest {
             request,
             continuation,
@@ -2058,7 +2075,7 @@ impl SharedGuestCallStack {
             .frames
             .get_mut(&call_id)
             .expect("submitted call has its manager continuation")
-            .cfm_load = cfm_load;
+            .cfm_operation = cfm_operation;
         // Submission just installed this task's pending top frame. This
         // synchronous transition cannot be displaced by another guest call.
         self.0
@@ -2135,18 +2152,42 @@ impl SharedGuestCallStack {
     }
 
     pub(crate) fn is_cfm_load_pending(&self, id: CfmLoadId) -> bool {
-        self.0
-            .borrow()
-            .frames
-            .values()
-            .any(|frame| frame.cfm_load.is_some_and(|operation| operation.id == id))
+        self.0.borrow().frames.values().any(|frame| {
+            frame
+                .cfm_operation
+                .is_some_and(|operation| operation.id() == id)
+        })
     }
 
+    pub(crate) fn is_resource_preparation_pending(&self, record: u32) -> bool {
+        self.0.borrow().frames.values().any(|frame| {
+            matches!(frame.cfm_operation,
+            Some(CfmOperation::Resource(call)) if call.preparation.record == record)
+        })
+    }
+
+    #[cfg(test)]
     pub(crate) fn complete_powerpc_resuming_load(
         &self,
         cpu: &mut PpcCpu,
         memory_manager: &mut ProcessNativeMemoryManager,
         mut resume: impl FnMut(CfmLoadOperation, u32) -> u32,
+    ) -> bool {
+        self.complete_powerpc_resuming_operation(cpu, memory_manager, |operation, result| {
+            match operation {
+                CfmOperation::Load(load) => resume(load, result),
+                CfmOperation::Resource(_) => {
+                    panic!("load-only fixture received resource operation")
+                }
+            }
+        })
+    }
+
+    pub(crate) fn complete_powerpc_resuming_operation(
+        &self,
+        cpu: &mut PpcCpu,
+        memory_manager: &mut ProcessNativeMemoryManager,
+        mut resume: impl FnMut(CfmOperation, u32) -> u32,
     ) -> bool {
         self.complete_powerpc_inner(cpu, Some(memory_manager), Some(&mut resume))
     }
@@ -2155,9 +2196,9 @@ impl SharedGuestCallStack {
         &self,
         cpu: &mut PpcCpu,
         memory_manager: Option<&mut ProcessNativeMemoryManager>,
-        resume: Option<&mut dyn FnMut(CfmLoadOperation, u32) -> u32>,
+        resume: Option<&mut dyn FnMut(CfmOperation, u32) -> u32>,
     ) -> bool {
-        let (task, call_id, origin, scratch, cfm_load) = {
+        let (task, call_id, origin, scratch, cfm_operation) = {
             let tasks = self.0.borrow();
             let task = tasks.kernel.current_task();
             let semantic = match tasks.kernel.peek(task) {
@@ -2184,7 +2225,7 @@ impl SharedGuestCallStack {
                     return false;
                 }
             }
-            if frame.cfm_load.is_some() && resume.is_none() {
+            if frame.cfm_operation.is_some() && resume.is_none() {
                 return false;
             }
             (
@@ -2192,7 +2233,7 @@ impl SharedGuestCallStack {
                 semantic.call_id(),
                 origin,
                 frame.native_scratch,
-                frame.cfm_load,
+                frame.cfm_operation,
             )
         };
         let mut tasks = self.0.borrow_mut();
@@ -2220,7 +2261,7 @@ impl SharedGuestCallStack {
                 .expect("scratch return requires its memory manager")
                 .release_native_scratch(scratch);
         }
-        if let Some(operation) = cfm_load {
+        if let Some(operation) = cfm_operation {
             cpu.gpr[3] =
                 resume.expect("CFM return requires its semantic consumer")(operation, cpu.gpr[3]);
         }

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -15,7 +15,10 @@ use super::pef::{
 };
 use super::ApplicationSizeResource;
 use crate::callback_manager::{CallbackTaskArchitecture, ProcessCallbackScheduling};
-use crate::cfm::{CfmLoadId, CfmLoadOperation, CfmLoadOutputs};
+use crate::cfm::{
+    CfmLoadId, CfmLoadOperation, CfmLoadOutputs, CfmOperation, CfmResourceCall,
+    CfmResourcePreparation,
+};
 use crate::event_queue::{
     EventProbeResult, EventQueue, EventQueueProbeSnapshot, EventRecordSnapshot, QueuedEvent,
 };
@@ -7603,13 +7606,40 @@ impl PpcLoadedApp {
                     return PpcImportAction::Yield(1);
                 }
                 if index == PPC_GUEST_CALL_RETURN_IMPORT_INDEX {
-                    if guest_calls.complete_powerpc_resuming_load(
+                    let mut resource_call = None;
+                    if guest_calls.complete_powerpc_resuming_operation(
                         cpu,
                         process_memory_manager,
-                        |operation, result| {
-                            ppc_complete_cfm_load(operation, result, memory, &mut cfm_connections)
+                        |operation, result| match operation {
+                            CfmOperation::Load(load) => {
+                                ppc_complete_cfm_load(load, result, memory, &mut cfm_connections)
+                            }
+                            CfmOperation::Resource(call) => match ppc_finish_resource_call(
+                                call,
+                                result,
+                                memory,
+                                &mut cfm_connections,
+                            ) {
+                                Ok(call) => {
+                                    resource_call = Some(call);
+                                    0
+                                }
+                                Err(error) => ppc_i16_result(error),
+                            },
                         },
                     ) {
+                        if let Some(call) = resource_call {
+                            if let Err(error) = ppc_invoke_prepared_resource(
+                                cpu,
+                                memory,
+                                &guest_calls,
+                                call,
+                                cpu.pc,
+                            ) {
+                                cpu.gpr[3] = ppc_i16_result(error);
+                            }
+                            return PpcImportAction::Continue;
+                        }
                         let native_heap = process_memory_manager
                             .native_heap_state()
                             .expect("native allocator registered during execution");
@@ -27344,15 +27374,44 @@ fn dispatch_supported_import(
             *last_mem_error = PPC_NO_ERR;
             Some(PpcImportAction::ReturnPreserve)
         }
-        PpcImportDispatcherTarget::CallUniversalProc => ppc_call_universal_proc(
-            cpu,
-            process_memory_manager,
-            memory,
-            heap_cursor,
-            heap_limit,
-            toolbox_startup,
-            GuestIsa::PowerPc,
-        ),
+        PpcImportDispatcherTarget::CallUniversalProc => {
+            let selector = ppc_call_universal_proc_selector(cpu, memory, cpu.gpr[4]).ok()?;
+            if let Some(crate::guest_procedure::GuestProcedureResolution::Prepare(request)) =
+                crate::guest_procedure::inspect_guest_procedure(
+                    memory,
+                    cpu.gpr[3],
+                    cpu.gpr[2],
+                    selector,
+                    GuestIsa::PowerPc,
+                    GuestIsa::PowerPc,
+                )
+            {
+                return Some(ppc_prepare_resource_call(
+                    cpu,
+                    memory,
+                    process_memory_manager,
+                    &toolbox_startup.guest_calls,
+                    heap_cursor,
+                    heap_limit,
+                    cfm_connections,
+                    next_cfm_connection_id,
+                    imports,
+                    import_count,
+                    import_binding_indices,
+                    request,
+                    selector,
+                ));
+            }
+            ppc_call_universal_proc(
+                cpu,
+                process_memory_manager,
+                memory,
+                heap_cursor,
+                heap_limit,
+                toolbox_startup,
+                GuestIsa::PowerPc,
+            )
+        }
         PpcImportDispatcherTarget::CallOSTrapUniversalProc => ppc_call_os_trap_universal_proc(
             cpu,
             process_memory_manager,
@@ -44643,6 +44702,294 @@ fn ppc_install_native_call_arguments(
 fn ppc_install_legacy_call_universal_proc_arguments(cpu: &mut PpcCpu) {
     for index in 0..PPC_CALL_UNIVERSAL_PROC_REGISTER_VARARGS {
         cpu.gpr[3 + index] = cpu.gpr[5 + index];
+    }
+}
+
+fn ppc_resource_fragment_bytes(
+    memory: &mut PpcSectionMem,
+    address: u32,
+    available: Option<u32>,
+) -> Option<Vec<u8>> {
+    if available.is_some_and(|size| size < 40) {
+        return None;
+    }
+    let header_bytes = ppc_memory_read_bytes(memory, address, 40)?;
+    let header = parse_pef_header(&header_bytes)?;
+    if header.architecture != *b"pwpc" || header.format_version != 1 {
+        return None;
+    }
+    let table_len = 40u32.checked_add(u32::from(header.section_count).checked_mul(28)?)?;
+    if available.is_some_and(|size| size < table_len) {
+        return None;
+    }
+    let table = ppc_memory_read_bytes(memory, address, table_len)?;
+    let mut length = table_len;
+    for section in parse_pef_sections(&table)? {
+        length = length.max(section.container_offset.checked_add(section.packed_size)?);
+    }
+    if available.is_some_and(|size| size < length) {
+        return None;
+    }
+    address.checked_add(length.checked_sub(1)?)?;
+    if !ppc_memory_can_read_bytes(memory, address, length) {
+        return None;
+    }
+    ppc_memory_read_bytes(memory, address, length)
+}
+
+fn ppc_finish_resource_call(
+    operation: CfmResourceCall,
+    result: u32,
+    memory: &mut PpcSectionMem,
+    connections: &mut Vec<PpcCfmConnection>,
+) -> Result<CfmResourceCall, i16> {
+    if result == 0
+        && !operation.main_address.checked_add(7).is_some_and(|_| {
+            memory
+                .read_u32_be(operation.main_address)
+                .is_some_and(|entry| entry != 0 && memory.read_u32_be(entry).is_some())
+                && memory.read_u32_be(operation.main_address + 4).is_some()
+        })
+    {
+        connections.retain(|connection| connection.id != operation.id.0);
+        return Err(PPC_FRAG_CORRUPT_ERR);
+    }
+    let request = operation.preparation;
+    let mut header = [0; 12];
+    let record = if memory
+        .read_bytes_into(request.descriptor, &mut header)
+        .is_some()
+        && header == operation.descriptor_header
+    {
+        let mut bytes = [0; 20];
+        memory
+            .read_bytes_into(request.record, &mut bytes)
+            .map(|_| bytes)
+    } else {
+        None
+    };
+    operation
+        .complete(result, connections, record, |writes| {
+            memory.try_write_ranges_atomic(writes)
+        })
+        .map_err(|error| error.os_error())
+}
+
+fn ppc_invoke_prepared_resource(
+    cpu: &mut PpcCpu,
+    memory: &mut PpcSectionMem,
+    calls: &SharedGuestCallStack,
+    operation: CfmResourceCall,
+    final_pc: u32,
+) -> Result<(), i16> {
+    let entry = memory
+        .read_u32_be(operation.main_address)
+        .ok_or(PPC_FRAG_CORRUPT_ERR)?;
+    let rtoc = memory
+        .read_u32_be(
+            operation
+                .main_address
+                .checked_add(4)
+                .ok_or(PPC_FRAG_CORRUPT_ERR)?,
+        )
+        .ok_or(PPC_FRAG_CORRUPT_ERR)?;
+    if entry == 0 || memory.read_u32_be(entry).is_none() {
+        return Err(PPC_FRAG_CORRUPT_ERR);
+    }
+    let effect = GuestCallEffect::call_guest(
+        GuestCallRequest::for_task(
+            operation.task,
+            GuestCallTarget {
+                isa: GuestIsa::PowerPc,
+                entry,
+                rtoc,
+            },
+        )
+        .with_powerpc_arguments(operation.arguments),
+        GuestCallContinuation::to_powerpc(
+            PPC_GUEST_CALL_RETURN_PC,
+            final_pc,
+            cpu.gpr[2],
+            ppc_call_universal_proc_return_gpr3(operation.caller_proc_info),
+        ),
+    );
+    if !calls.activate_powerpc_effect_with_operation(cpu, memory, effect, None, None) {
+        return Err(PPC_PARAM_ERR);
+    }
+    cpu.gpr[12] = operation.main_address;
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn ppc_prepare_resource_call(
+    cpu: &mut PpcCpu,
+    memory: &mut PpcSectionMem,
+    manager: &mut ProcessNativeMemoryManager,
+    calls: &SharedGuestCallStack,
+    heap_cursor: &mut u32,
+    heap_limit: u32,
+    connections: &mut Vec<PpcCfmConnection>,
+    next_id: &mut u32,
+    imports: &mut Vec<PpcImportBinding>,
+    import_count: &mut u32,
+    import_indices: &mut Vec<Option<usize>>,
+    request: CfmResourcePreparation,
+    selector: Option<u32>,
+) -> PpcImportAction {
+    let result = (|| {
+        if calls.is_resource_preparation_pending(request.record) {
+            return Err(PPC_FRAG_INIT_LOOP);
+        }
+        let mut descriptor_header = [0; 12];
+        let mut original_record = [0; 20];
+        memory
+            .read_bytes_into(request.descriptor, &mut descriptor_header)
+            .ok_or(PPC_FRAG_CORRUPT_ERR)?;
+        memory
+            .read_bytes_into(request.record, &mut original_record)
+            .ok_or(PPC_FRAG_CORRUPT_ERR)?;
+        let caller_proc_info = cpu.gpr[4];
+        let mut arguments = ppc_call_universal_proc_arguments(cpu, memory, caller_proc_info)
+            .map_err(|_| PPC_PARAM_ERR)?
+            .ok_or(PPC_PARAM_ERR)?;
+        if selector.is_some()
+            && request.routine_flags & PPC_ROUTINE_FLAG_DONT_PASS_SELECTOR != 0
+            && !arguments.is_empty()
+        {
+            arguments.remove(0);
+        }
+        let arguments = crate::execution_kernel::GuestArgumentValues::from_slice(&arguments)
+            .ok_or(PPC_PARAM_ERR)?;
+        let parameter_start = cpu.gpr[1].checked_add(24).ok_or(PPC_PARAM_ERR)?;
+        if !memory.preflight_writable_range(
+            parameter_start,
+            arguments.as_slice().len().max(8) as u32 * 4,
+        ) || !memory.preflight_writable_range(request.record + 6, 2)
+            || !memory.preflight_writable_range(request.record + 8, 4)
+        {
+            return Err(PPC_PARAM_ERR);
+        }
+        let available = if let Some(handle) = manager.handle_for_ptr(request.descriptor) {
+            let saved_error = manager
+                .native_heap_state()
+                .map(|heap| heap.last_mem_error)
+                .unwrap_or(0);
+            let size = manager.process_handle_size_from_master_pointer(handle, request.descriptor);
+            manager.set_native_mem_error(saved_error);
+            Some(
+                size.ok_or(PPC_FRAG_CORRUPT_ERR)?
+                    .checked_sub(
+                        request
+                            .fragment_address
+                            .checked_sub(request.descriptor)
+                            .ok_or(PPC_FRAG_CORRUPT_ERR)?,
+                    )
+                    .ok_or(PPC_FRAG_CORRUPT_ERR)?,
+            )
+        } else {
+            None
+        };
+        let fragment = ppc_resource_fragment_bytes(memory, request.fragment_address, available)
+            .ok_or(PPC_FRAG_CORRUPT_ERR)?;
+        let id = *next_id;
+        if id == 0 || id > PPC_CFM_MAIN_STUB_COUNT {
+            return Err(PPC_FRAG_LIB_CONN_ERR);
+        }
+        let prepared = ppc_prepare_mem_fragment(
+            &fragment,
+            manager,
+            memory,
+            heap_cursor,
+            heap_limit,
+            imports,
+            import_count,
+            import_indices,
+        )?;
+        if prepared.main_addr == 0 {
+            return Err(PPC_FRAG_CORRUPT_ERR);
+        }
+        *next_id = id + 1;
+        let name = format!("resource routine ${:08X}", request.record);
+        connections.push(PpcCfmConnection {
+            id,
+            library_name: name.clone(),
+            main_addr: prepared.main_addr,
+            init_addr: prepared.init_addr,
+            term_addr: prepared.term_addr,
+            exports: prepared.exports,
+        });
+        let operation = CfmResourceCall {
+            task: calls.current_task(),
+            id: CfmLoadId(id),
+            preparation: request,
+            descriptor_header,
+            original_record,
+            main_address: prepared.main_addr,
+            arguments,
+            caller_proc_info,
+        };
+        let activate = (|| {
+            if prepared.init_addr == 0 {
+                let operation = ppc_finish_resource_call(operation, 0, memory, connections)?;
+                return ppc_invoke_prepared_resource(cpu, memory, calls, operation, cpu.lr);
+            }
+            let block = ppc_create_mem_fragment_init_block(
+                Some(manager),
+                memory,
+                heap_cursor,
+                heap_limit,
+                id,
+                request.fragment_address,
+                fragment.len() as u32,
+                &name,
+            )?;
+            let target = prepared.init_addr.checked_add(7).and_then(|_| {
+                Some(GuestCallTarget {
+                    isa: GuestIsa::PowerPc,
+                    entry: memory.read_u32_be(prepared.init_addr)?,
+                    rtoc: memory.read_u32_be(prepared.init_addr + 4)?,
+                })
+            });
+            let activated = target.is_some_and(|target| {
+                if memory.read_u32_be(target.entry).is_none() {
+                    return false;
+                }
+                let effect = GuestCallEffect::call_guest(
+                    GuestCallRequest::for_task(calls.current_task(), target)
+                        .with_powerpc_arguments(
+                            crate::execution_kernel::GuestArgumentValues::from_slice(&[block])
+                                .unwrap(),
+                        ),
+                    GuestCallContinuation::to_powerpc(
+                        PPC_GUEST_CALL_RETURN_PC,
+                        cpu.lr,
+                        cpu.gpr[2],
+                        PpcNativeReturnGpr3::Preserve,
+                    ),
+                );
+                calls.activate_powerpc_effect_with_operation(
+                    cpu,
+                    memory,
+                    effect,
+                    Some(block),
+                    Some(CfmOperation::Resource(operation)),
+                )
+            });
+            if !activated {
+                manager.release_native_scratch(block);
+                return Err(PPC_FRAG_CORRUPT_ERR);
+            }
+            cpu.gpr[12] = prepared.init_addr;
+            Ok(())
+        })();
+        if activate.is_err() {
+            connections.retain(|connection| connection.id != id);
+        }
+        activate
+    })();
+    match result {
+        Ok(()) => PpcImportAction::Continue,
+        Err(error) => PpcImportAction::Return(ppc_i16_result(error)),
     }
 }
 
@@ -177120,6 +177467,205 @@ pub(crate) mod tests {
 
     pub(crate) fn synthetic_pef() -> Vec<u8> {
         synthetic_pef_with_import(b"TestImport")
+    }
+
+    #[test]
+    fn native_universal_proc_prepares_resources_runs_initializers_and_retries_failures() {
+        for initialization in [None, Some(0u16), Some(1u16)] {
+            let mut loader =
+                synthetic_loader_with_chunks(b"InterfaceLib", b"TestImport", &[run_reloc(0x23, 2)]);
+            if initialization.is_some() {
+                write_i32(&mut loader, 8, 1);
+                write_u32(&mut loader, 12, 8);
+            }
+            let mut data = vec![0; 16];
+            write_u32(&mut data, 8, 12);
+            let mut fragment = synthetic_pef_with_loader_and_data(loader, &data);
+            let code_offset = parse_pef_sections(&fragment).unwrap()[0].container_offset as usize;
+            for (index, word) in [
+                d_form_u(32, 11, 1, 56), // ninth argument
+                0x7c63_5a14,             // add r3,r3,r11
+                BLR,
+                d_form_u(14, 3, 0, initialization.unwrap_or(0)),
+                d_form_u(14, 4, 0, 0xBAD), // initializer clobbers argument registers
+                BLR,
+            ]
+            .into_iter()
+            .enumerate()
+            {
+                write_u32(&mut fragment, code_offset + index * 4, word);
+            }
+            let mut loaded =
+                load_pef_application(&synthetic_pef_with_import(b"CallUniversalProc")).unwrap();
+            let descriptor = PPC_HEAP_BASE + 0x1000;
+            let fragment_address = descriptor + 0x100;
+            loaded
+                .memory
+                .add_region(descriptor, vec![0; 0x100 + fragment.len()]);
+            loaded
+                .memory
+                .write_bytes(fragment_address, &fragment)
+                .unwrap();
+            assert!(ppc_resource_fragment_bytes(
+                &mut loaded.memory,
+                fragment_address,
+                Some(fragment.len() as u32 - 1)
+            )
+            .is_none());
+            assert_eq!(
+                ppc_resource_fragment_bytes(
+                    &mut loaded.memory,
+                    fragment_address,
+                    Some(fragment.len() as u32)
+                ),
+                Some(fragment.clone())
+            );
+            loaded.set_heap_cursor(descriptor + 0x100 + fragment.len() as u32 + 0x100);
+            loaded
+                .memory
+                .write_u16_be(descriptor, PPC_MIXED_MODE_TRAP)
+                .unwrap();
+            loaded
+                .memory
+                .write_u8(descriptor + 2, PPC_ROUTINE_DESCRIPTOR_VERSION)
+                .unwrap();
+            loaded.memory.write_u16_be(descriptor + 10, 0).unwrap();
+            let record = descriptor + PPC_ROUTINE_DESCRIPTOR_HEADER_SIZE;
+            let proc_info =
+                test_stack_proc_info(PPC_PROCINFO_SIZE_FOUR, &[PPC_PROCINFO_SIZE_FOUR; 9]);
+            assert!(ppc_write_routine_record(
+                &mut loaded.memory,
+                record,
+                proc_info,
+                PPC_ROUTINE_RECORD_POWERPC_ISA,
+                3,
+                0x100
+            ));
+            loaded.cpu.gpr[1] -= PPC_INITIAL_STACK_FRAME_SIZE;
+            let sp = loaded.cpu.gpr[1];
+            let caller_rtoc = loaded.cpu.gpr[2];
+            let first_id = loaded.next_cfm_connection_id;
+            let prepare_call = |loaded: &mut PpcLoadedApp| {
+                loaded.cpu.pc = loaded.entry_pc;
+                loaded.cpu.lr = PPC_HALT_PC;
+                loaded.cpu.gpr[2] = caller_rtoc;
+                loaded.cpu.gpr[3] = descriptor;
+                loaded.cpu.gpr[4] = proc_info;
+                for index in 0..9 {
+                    let value = (index as u32 + 1) * 0x10;
+                    if index < 6 {
+                        loaded.cpu.gpr[5 + index] = value;
+                    } else {
+                        let slot = ppc_parameter_area_slot_addr(
+                            sp,
+                            PPC_CALL_UNIVERSAL_PROC_FIXED_WORD_PARAMETERS + index,
+                        )
+                        .unwrap();
+                        loaded.memory.write_u32_be(slot, value).unwrap();
+                    }
+                }
+            };
+            prepare_call(&mut loaded);
+            if initialization.is_some() {
+                for _ in 0..16 {
+                    if loaded.guest_calls.is_resource_preparation_pending(record) {
+                        break;
+                    }
+                    let slice = loaded.run_with_hle_imports(1);
+                    assert_eq!(slice.unsupported_import_index, None);
+                }
+                assert!(loaded.guest_calls.is_resource_preparation_pending(record));
+                assert_eq!(loaded.memory.read_u16_be(record + 6), Some(3));
+                let request = match crate::guest_procedure::inspect_guest_procedure(
+                    &mut loaded.memory,
+                    descriptor,
+                    caller_rtoc,
+                    None,
+                    GuestIsa::PowerPc,
+                    GuestIsa::PowerPc,
+                )
+                .unwrap()
+                {
+                    crate::guest_procedure::GuestProcedureResolution::Prepare(request) => request,
+                    _ => panic!("initializing resource became callable"),
+                };
+                let mut recursive_cpu = loaded.cpu.clone();
+                let before_cpu = recursive_cpu.clone();
+                let mut cursor = loaded.heap_cursor();
+                let mut binding_indices =
+                    ppc_import_binding_indices(&loaded.imports, loaded.import_count);
+                let mut manager = loaded.process_memory_manager.0.borrow_mut();
+                let limit = manager.native_heap_state().unwrap().heap_limit;
+                assert_eq!(
+                    ppc_prepare_resource_call(
+                        &mut recursive_cpu,
+                        &mut loaded.memory,
+                        &mut manager,
+                        &loaded.guest_calls,
+                        &mut cursor,
+                        limit,
+                        &mut loaded.cfm_connections,
+                        &mut loaded.next_cfm_connection_id,
+                        &mut loaded.imports,
+                        &mut loaded.import_count,
+                        &mut binding_indices,
+                        request,
+                        None
+                    ),
+                    PpcImportAction::Return(ppc_i16_result(PPC_FRAG_INIT_LOOP))
+                );
+                assert_eq!(recursive_cpu.gpr, before_cpu.gpr);
+                assert_eq!(recursive_cpu.pc, before_cpu.pc);
+                assert!(loaded.guest_calls.is_resource_preparation_pending(record));
+            }
+            let result = loaded.run_with_hle_imports(128);
+            assert_eq!(result.unsupported_import_index, None);
+            assert!(matches!(
+                result.result,
+                PpcRunResult::Halted {
+                    pc: PPC_HALT_PC,
+                    ..
+                }
+            ));
+            assert_eq!(loaded.cpu.gpr[2], caller_rtoc);
+            assert_eq!(loaded.cpu.gpr[1], sp);
+            assert!(loaded.guest_calls.is_empty());
+            if initialization == Some(1) {
+                assert_eq!(
+                    loaded.cpu.gpr[3],
+                    ppc_i16_result(PPC_FRAG_USER_INIT_PROC_ERR)
+                );
+                assert_eq!(loaded.memory.read_u16_be(record + 6), Some(3));
+                assert_eq!(loaded.memory.read_u32_be(record + 8), Some(0x100));
+                assert!(!loaded
+                    .cfm_connections
+                    .iter()
+                    .any(|connection| connection.id == first_id));
+                loaded
+                    .memory
+                    .write_u32_be(
+                        fragment_address + code_offset as u32 + 12,
+                        d_form_u(14, 3, 0, 0),
+                    )
+                    .unwrap();
+                prepare_call(&mut loaded);
+                let retry = loaded.run_with_hle_imports(128);
+                assert_eq!(retry.unsupported_import_index, None);
+                assert!(loaded.next_cfm_connection_id > first_id + 1);
+            }
+            assert_eq!(loaded.cpu.gpr[3], 0xA0);
+            assert_eq!(loaded.memory.read_u16_be(record + 6), Some(0));
+            let prepared_target = loaded.memory.read_u32_be(record + 8).unwrap();
+            assert_ne!(prepared_target, 0x100);
+            let cursor = loaded.heap_cursor();
+            let next = loaded.next_cfm_connection_id;
+            prepare_call(&mut loaded);
+            let again = loaded.run_with_hle_imports(128);
+            assert_eq!(again.unsupported_import_index, None);
+            assert_eq!(loaded.cpu.gpr[3], 0xA0);
+            assert_eq!(loaded.next_cfm_connection_id, next);
+            assert_eq!(loaded.heap_cursor(), cursor);
+        }
     }
 
     fn synthetic_pef_with_initializer() -> Vec<u8> {

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -5958,7 +5958,6 @@ impl ProcessNativeMemoryManager {
         self.native_allocator_dirty = true;
     }
 
-    #[cfg(test)]
     pub(crate) fn handle_for_ptr(&self, ptr: u32) -> Option<u32> {
         self.ptr_to_handle.get(&ptr)
     }


### PR DESCRIPTION
Native CallUniversalProc previously refused accelerated resources requiring CFM preparation. It now prepares the selected fragment, runs its initializer when present, and invokes the target with the saved logical arguments and caller return convention.

A typed resource operation retains the initiating task, descriptor snapshot and arguments across initialization. Successful initialization atomically replaces the relative container reference with the prepared transition vector. Recursive preparation refuses without consuming the outer operation. Failed initialization removes its connection and preserves the original descriptor for retry; changed/protected descriptors refuse publication. Handle-backed container reads respect the resource allocation size.

Real native-runner tests cover no initializer, successful and failed initialization, fresh-ID retry, recursive refusal during initialization, nine arguments including stack arguments, caller TOC/SP restoration and repeated calls without additional preparation. Paired memory-view tests cover atomic publication and failure preservation. Full validation: 5,034 headless library tests passed, 3 ignored; production test-support check passed without warnings.

Classic entry, other callback producers, full resource lifetime, section/import rollback and process-owned composition remain follow-up work.

Depends on #1458. Closes #1459.
