### PR TITLE
fix: preserve window activation across toolbox calls

### DIFF
--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -1728,6 +1728,9 @@ pub struct TrapDispatcher {
     /// Total guest instructions retired so far.
     pub(crate) instruction_count: u64,
     /// Front window pointer
+    /// Keep activation independent of the shared WindowList's stacking order:
+    /// BringToFront does not activate, and an invisible frontmost NewWindow
+    /// can be active. Macintosh Toolbox Essentials (1992), pp. 4-76 and 4-90.
     pub(crate) front_window: u32,
     /// Pointer to the Window Manager port (`WMgrPort` low-memory global).
     /// Inside Macintosh Volume I, I-282.
@@ -1793,8 +1796,8 @@ pub struct TrapDispatcher {
     /// (`runner::idle_cycle_trap_is_journal_complete`).
     pub(crate) window_list: crate::process_context::SharedProcessWindowList,
     /// Whether `window_list` is the process-owned registry rather than a
-    /// standalone dispatcher fixture. Attached dispatchers derive the cached
-    /// front window even when the process list becomes empty.
+    /// standalone dispatcher fixture. The classic frame renderer leaves
+    /// native-owned windows in this shared list to the native renderer.
     pub(crate) process_window_list_attached: bool,
     /// Set once the game has entered fullscreen (window covers entire screen
     /// and MBarHeight was 0). While set, the menu bar is suppressed even if
@@ -7531,14 +7534,6 @@ impl TrapDispatcher {
         // the process clock so a direct guest store cannot be shadowed by a
         // stale host pacing snapshot.
         self.read_tick_count(bus);
-        if self.process_window_list_attached {
-            self.front_window = self
-                .window_list
-                .iter()
-                .copied()
-                .find(|window| bus.read_byte(window.wrapping_add(110)) != 0)
-                .unwrap_or(0);
-        }
         // Opt-in per-trap wall-clock timing.
         let timing_start = if trap_timing_enabled() {
             Some(std::time::Instant::now())

--- a/src/trap/window.rs
+++ b/src/trap/window.rs
@@ -6047,6 +6047,47 @@ mod tests {
     }
 
     #[test]
+    fn attached_window_list_preserves_activation_across_traps() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        disp.process_window_list_attached = true;
+        let active = bus.alloc(256);
+        let raised = bus.alloc(256);
+        *disp.window_list = vec![active, raised];
+        disp.front_window = active;
+        bus.write_byte(active + 110, 255);
+        bus.write_byte(active + 111, 255);
+        bus.write_byte(raised + 110, 255);
+        let sp = TEST_SP - 4;
+        cpu.write_reg(Register::A7, sp);
+        bus.write_long(sp, raised);
+        disp.dispatch(0xA920, &mut cpu, &mut bus).unwrap();
+        assert_eq!(disp.window_list[0], raised);
+
+        // Even an unrelated trap must not silently activate the raised window.
+        cpu.write_reg(Register::A7, sp);
+        disp.dispatch(0xA975, &mut cpu, &mut bus).unwrap();
+        assert_eq!(disp.front_window, active);
+        assert_eq!(bus.read_byte(raised + 111), 0);
+
+        cpu.write_reg(Register::A7, sp);
+        bus.write_long(sp, raised);
+        disp.dispatch(0xA91F, &mut cpu, &mut bus).unwrap();
+        assert_eq!(disp.front_window, raised);
+        assert_eq!(bus.read_byte(active + 111), 0);
+        assert_eq!(bus.read_byte(raised + 111), 255);
+        assert!(disp
+            .event_queue
+            .iter()
+            .any(|event| event.what == 8 && event.message == active && event.modifiers & 1 == 0));
+
+        // Invisible frontmost windows can be active too (NewWindow's ABI).
+        bus.write_byte(raised + 110, 0);
+        cpu.write_reg(Register::A7, sp);
+        disp.dispatch(0xA975, &mut cpu, &mut bus).unwrap();
+        assert_eq!(disp.front_window, raised);
+    }
+
+    #[test]
     fn layer_dispatch_is_layer_returns_false_and_consumes_its_pointer() {
         let (mut disp, mut cpu, mut bus) = setup();
         let sp = TEST_SP - 6;


### PR DESCRIPTION
SimFarm's floating toolbar could leave several document windows highlighted. After purchasing a tractor, clicking the exposed Buy window handled its buttons without bringing the window forward, so later category clicks reached the farm instead.

Trap dispatch was replacing the activation pointer with the first visible entry in the shared WindowList on every call. Preserve the Window Manager's activation state across calls: stacking order and activation differ after BringToFront and when a frontmost window is invisible. The regression exercises the full trap dispatcher, including a subsequent SelectWindow and its deactivation event.

Validation: 207 Window Manager regressions and classic Toolbox showcase on 68K and PowerPC passed; deterministic SimFarm purchase/category replay compared with BasiliskII.

Addresses the activation portion of #1463; remaining repaint work is tracked separately in #1465.
