### PR TITLE
refactor: share CFM fragment layout and relocation planning

### DIFF
--- a/src/cfm.rs
+++ b/src/cfm.rs
@@ -1,6 +1,8 @@
 //! Semantic resumption of one CFM load across guest initialization.
 //! Inside Macintosh: PowerPC System Software (1994), pp. 3-15--3-18, 3-27.
 
+pub(crate) mod fragment;
+
 use crate::execution_kernel::GuestProcedureInvocation;
 use crate::guest_procedure::{
     GuestIsa, GuestProcedure, GuestProcedureMemory, GuestProcedureRepresentation,
@@ -285,6 +287,7 @@ pub(crate) enum CfmLoadError {
     InvalidOutputs,
     DescriptorChanged,
     CorruptFragment,
+    NoAddressSpace,
 }
 
 impl CfmLoadError {
@@ -293,6 +296,7 @@ impl CfmLoadError {
             Self::InitializationFailed => -2821,
             Self::ConnectionNotFound => -2801,
             Self::InvalidOutputs => -50,
+            Self::NoAddressSpace => -2810,
             Self::DescriptorChanged | Self::CorruptFragment => -2820,
         }
     }

--- a/src/cfm/fragment.rs
+++ b/src/cfm/fragment.rs
@@ -1,0 +1,514 @@
+//! Staged CFM section layout, relocation and metadata, without guest execution.
+//! PowerPC System Software (1994), pp. 1-25–1-26 and 3-21–3-22.
+
+use super::{CfmExport, CfmLoadError, CfmMemory};
+use crate::guest_procedure::GuestProcedureMemory;
+use crate::loader::pef::{
+    apply_pef_relocations_detailed, instantiate_pef_sections, parse_pef_exported_symbols,
+    parse_pef_header, parse_pef_loader_header, parse_pef_reloc_headers, parse_pef_sections,
+    pef_reloc_chunk_stream, PefRelocContext, SECTION_KIND_CODE, SECTION_KIND_EXECUTABLE_DATA,
+    SECTION_KIND_PATTERN_DATA, SECTION_KIND_UNPACKED_DATA,
+};
+
+/// Read precisely the PEF container extent, bounded by the logical resource
+/// when known. Grow only after each mapped read succeeds, never from an
+/// unchecked guest-declared packed size. PowerPC System Software, pp. 2-27–2-28.
+pub(crate) fn read_resource_fragment(
+    memory: &mut impl GuestProcedureMemory,
+    address: u32,
+    available: Option<u32>,
+) -> Option<Vec<u8>> {
+    fn extend(
+        memory: &mut impl GuestProcedureMemory,
+        address: u32,
+        available: Option<u32>,
+        bytes: &mut Vec<u8>,
+        length: u32,
+    ) -> Option<()> {
+        if available.is_some_and(|size| size < length) {
+            return None;
+        }
+        address.checked_add(length.checked_sub(1)?)?;
+        while bytes.len() < length as usize {
+            let byte = memory.procedure_read_u8(address + bytes.len() as u32)?;
+            bytes.push(byte);
+        }
+        Some(())
+    }
+    let mut bytes = Vec::new();
+    extend(memory, address, available, &mut bytes, 40)?;
+    let header = parse_pef_header(&bytes)?;
+    if header.architecture != *b"pwpc" || header.format_version != 1 {
+        return None;
+    }
+    let table_len = 40u32.checked_add(u32::from(header.section_count).checked_mul(28)?)?;
+    extend(memory, address, available, &mut bytes, table_len)?;
+    let mut length = table_len;
+    for section in parse_pef_sections(&bytes)? {
+        length = length.max(section.container_offset.checked_add(section.packed_size)?);
+    }
+    extend(memory, address, available, &mut bytes, length)?;
+    Some(bytes)
+}
+
+#[derive(Debug)]
+pub(crate) struct CfmSection {
+    pub(crate) index: usize,
+    pub(crate) section_kind: u8,
+    pub(crate) base: u32,
+    pub(crate) bytes: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CfmPreparedFragment {
+    pub(crate) main_addr: u32,
+    pub(crate) init_addr: u32,
+    pub(crate) term_addr: u32,
+    pub(crate) exports: Vec<CfmExport>,
+}
+
+/// A plan owns uncommitted bytes only. The process allocator must accept the
+/// cursor transition and atomic publication before import registrations escape.
+#[derive(Debug)]
+pub(crate) struct CfmFragmentPlan {
+    sections: Vec<CfmSection>,
+    next_heap_cursor: u32,
+    fragment: CfmPreparedFragment,
+}
+
+impl CfmFragmentPlan {
+    pub(crate) fn prepare(
+        fragment: &[u8],
+        import_addrs: &[u32],
+        heap_cursor: u32,
+        heap_limit: u32,
+        allocation_alignment: u32,
+        mut allocation_bounds: impl FnMut(u32, u32, u32) -> Option<(u32, u32)>,
+    ) -> Result<Self, CfmLoadError> {
+        let header = parse_pef_header(fragment).ok_or(CfmLoadError::CorruptFragment)?;
+        if header.architecture != *b"pwpc" || header.format_version != 1 {
+            return Err(CfmLoadError::CorruptFragment);
+        }
+        let loader = parse_pef_loader_header(fragment).ok_or(CfmLoadError::CorruptFragment)?;
+        if usize::try_from(loader.total_imported_symbol_count).ok() != Some(import_addrs.len()) {
+            return Err(CfmLoadError::CorruptFragment);
+        }
+        let instantiated =
+            instantiate_pef_sections(fragment).ok_or(CfmLoadError::CorruptFragment)?;
+        let mut sections = Vec::with_capacity(instantiated.len());
+        let mut cursor = heap_cursor;
+        for section in instantiated {
+            let alignment = if section.header.alignment < 31 {
+                1u32 << section.header.alignment
+            } else {
+                return Err(CfmLoadError::CorruptFragment);
+            };
+            let size =
+                u32::try_from(section.bytes.len()).map_err(|_| CfmLoadError::NoAddressSpace)?;
+            let (base, next) =
+                allocation_bounds(cursor, size, alignment).ok_or(CfmLoadError::NoAddressSpace)?;
+            if base < cursor
+                || base % alignment != 0
+                || base.checked_add(size) != Some(next)
+                || next >= heap_limit
+            {
+                return Err(CfmLoadError::NoAddressSpace);
+            }
+            sections.push(CfmSection {
+                index: section.index,
+                section_kind: section.header.section_kind,
+                base,
+                bytes: section.bytes,
+            });
+            cursor = next;
+        }
+        if !allocation_alignment.is_power_of_two() {
+            return Err(CfmLoadError::NoAddressSpace);
+        }
+        cursor = cursor
+            .checked_add(allocation_alignment - 1)
+            .map(|value| value & !(allocation_alignment - 1))
+            .filter(|value| *value < heap_limit)
+            .ok_or(CfmLoadError::NoAddressSpace)?;
+        let bases = section_bases(&sections);
+        let code_base = first_base_for_kind(&sections, SECTION_KIND_CODE)
+            .ok_or(CfmLoadError::CorruptFragment)?;
+        let data_base = first_data_base(&sections).unwrap_or(code_base);
+        let relocations = parse_pef_reloc_headers(fragment).ok_or(CfmLoadError::CorruptFragment)?;
+        for relocation in &relocations {
+            let stream = pef_reloc_chunk_stream(fragment, relocation)
+                .ok_or(CfmLoadError::CorruptFragment)?;
+            let section = sections
+                .iter_mut()
+                .find(|section| section.index == usize::from(relocation.section_index))
+                .ok_or(CfmLoadError::CorruptFragment)?;
+            let context = PefRelocContext {
+                code_base,
+                data_base,
+                section_bases: &bases,
+                import_addrs,
+            };
+            apply_pef_relocations_detailed(&mut section.bytes, stream, &context)
+                .map_err(|_| CfmLoadError::CorruptFragment)?;
+        }
+        let prepared = CfmPreparedFragment {
+            main_addr: fragment_special_tvector(
+                &sections,
+                loader.main_section,
+                loader.main_offset,
+            )?,
+            init_addr: fragment_special_tvector(
+                &sections,
+                loader.init_section,
+                loader.init_offset,
+            )?,
+            term_addr: fragment_special_tvector(
+                &sections,
+                loader.term_section,
+                loader.term_offset,
+            )?,
+            exports: resolve_fragment_exports(fragment, &sections, import_addrs)?,
+        };
+        Ok(Self {
+            sections,
+            next_heap_cursor: cursor,
+            fragment: prepared,
+        })
+    }
+
+    pub(crate) fn next_heap_cursor(&self) -> u32 {
+        self.next_heap_cursor
+    }
+
+    pub(crate) fn publish(&self, memory: &mut impl CfmMemory) -> bool {
+        let writes: Vec<_> = self
+            .sections
+            .iter()
+            .map(|section| (section.base, section.bytes.as_slice()))
+            .collect();
+        memory.publish_cfm_outputs(&writes)
+    }
+
+    pub(crate) fn into_fragment(self) -> CfmPreparedFragment {
+        self.fragment
+    }
+}
+
+pub(crate) fn section_bases(mapped: &[CfmSection]) -> Vec<Option<u32>> {
+    let mut bases = Vec::new();
+    for section in mapped {
+        if bases.len() <= section.index {
+            bases.resize(section.index + 1, None);
+        }
+        bases[section.index] = Some(section.base);
+    }
+    bases
+}
+
+pub(crate) fn first_base_for_kind(mapped: &[CfmSection], kind: u8) -> Option<u32> {
+    mapped
+        .iter()
+        .find(|section| section.section_kind == kind)
+        .map(|section| section.base)
+}
+
+pub(crate) fn first_data_base(mapped: &[CfmSection]) -> Option<u32> {
+    mapped
+        .iter()
+        .find(|section| {
+            matches!(
+                section.section_kind,
+                SECTION_KIND_UNPACKED_DATA
+                    | SECTION_KIND_PATTERN_DATA
+                    | SECTION_KIND_EXECUTABLE_DATA
+            )
+        })
+        .map(|section| section.base)
+}
+
+pub(crate) fn resolve_fragment_exports(
+    fragment: &[u8],
+    mapped_sections: &[CfmSection],
+    import_addrs: &[u32],
+) -> Result<Vec<CfmExport>, CfmLoadError> {
+    let loader = parse_pef_loader_header(fragment).ok_or(CfmLoadError::CorruptFragment)?;
+    let exported_symbols = if loader.exported_symbol_count == 0 {
+        Vec::new()
+    } else {
+        parse_pef_exported_symbols(fragment).ok_or(CfmLoadError::CorruptFragment)?
+    };
+    exported_symbols
+        .into_iter()
+        .map(|symbol| {
+            let address = match symbol.section_index {
+                section_index if section_index >= 0 => {
+                    let section_index = usize::try_from(section_index)
+                        .map_err(|_| CfmLoadError::CorruptFragment)?;
+                    let section = mapped_sections
+                        .iter()
+                        .find(|section| section.index == section_index)
+                        .ok_or(CfmLoadError::CorruptFragment)?;
+                    let offset = usize::try_from(symbol.symbol_value)
+                        .map_err(|_| CfmLoadError::CorruptFragment)?;
+                    if offset >= section.bytes.len() {
+                        return Err(CfmLoadError::CorruptFragment);
+                    }
+                    section
+                        .base
+                        .checked_add(symbol.symbol_value)
+                        .ok_or(CfmLoadError::NoAddressSpace)?
+                }
+                // Inside Macintosh: PowerPC System Software (1994),
+                // pp. 1-25--1-26: PEF uses -2 for an absolute export.
+                -2 => symbol.symbol_value,
+                // A re-export stores the imported-symbol index in the value
+                // field. Resolve only through the already checked local
+                // import address table; never index the raw fragment bytes.
+                -3 => {
+                    let import_index = usize::try_from(symbol.symbol_value)
+                        .map_err(|_| CfmLoadError::CorruptFragment)?;
+                    *import_addrs
+                        .get(import_index)
+                        .ok_or(CfmLoadError::CorruptFragment)?
+                }
+                _ => return Err(CfmLoadError::CorruptFragment),
+            };
+            Ok(CfmExport {
+                name: symbol.name,
+                class: symbol.class,
+                address,
+            })
+        })
+        .collect()
+}
+
+fn fragment_special_tvector(
+    mapped_sections: &[CfmSection],
+    section_index: i32,
+    offset: u32,
+) -> Result<u32, CfmLoadError> {
+    if section_index < 0 {
+        return Ok(0);
+    }
+    let section_index =
+        usize::try_from(section_index).map_err(|_| CfmLoadError::CorruptFragment)?;
+    let section = mapped_sections
+        .iter()
+        .find(|section| section.index == section_index)
+        .ok_or(CfmLoadError::CorruptFragment)?;
+    let offset_usize = usize::try_from(offset).map_err(|_| CfmLoadError::CorruptFragment)?;
+    if offset_usize
+        .checked_add(8)
+        .filter(|end| *end <= section.bytes.len())
+        .is_none()
+    {
+        return Err(CfmLoadError::CorruptFragment);
+    }
+    section
+        .base
+        .checked_add(offset)
+        .ok_or(CfmLoadError::NoAddressSpace)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::guest_procedure::GuestProcedureMemory;
+    use crate::loader::pef::tests::{
+        block_copy_section, run_reloc, synthetic_loader_with_reloc_header, synthetic_pef,
+    };
+    use crate::memory::{GuestAddressSpace, MacMemoryBus};
+
+    const HEAP: u32 = 0x0300_0000;
+    const IMPORT: u32 = 0x0200_0000;
+
+    fn fragment(chunks: &[u16]) -> Vec<u8> {
+        synthetic_pef(
+            synthetic_loader_with_reloc_header(chunks),
+            block_copy_section(&[0; 12]),
+            12,
+            12,
+        )
+    }
+
+    fn bounds(cursor: u32, size: u32, alignment: u32) -> Option<(u32, u32)> {
+        let base = cursor.checked_add(alignment - 1)? & !(alignment - 1);
+        Some((base, base.checked_add(size)?))
+    }
+
+    fn read(memory: &mut impl GuestProcedureMemory, address: u32, size: u32) -> Vec<Option<u8>> {
+        (0..size)
+            .map(|offset| memory.procedure_read_u8(address + offset))
+            .collect()
+    }
+
+    #[test]
+    fn resource_container_reads_respect_mapping_and_logical_extent_in_both_views() {
+        for fault in 0..7 {
+            let mut outcomes = Vec::new();
+            for classic in [false, true] {
+                let mut fragment = fragment(&[run_reloc(0x23, 1), run_reloc(0x25, 1)]);
+                if fault == 4 {
+                    fragment[8..12].copy_from_slice(b"m68k");
+                }
+                if fault == 5 {
+                    fragment[40 + 20..40 + 24].copy_from_slice(&u32::MAX.to_be_bytes());
+                }
+                let available = match fault {
+                    1 => Some(fragment.len() as u32 - 1),
+                    2 => Some(39),
+                    _ => None,
+                };
+                let address = if fault == 6 { u32::MAX - 30 } else { HEAP };
+                let mut memory = GuestAddressSpace::new();
+                let mapped = if fault == 3 {
+                    fragment[..fragment.len() - 1].to_vec()
+                } else {
+                    fragment.clone()
+                };
+                memory.add_region(HEAP, mapped);
+                let mut bus = MacMemoryBus::new(0x10000);
+                bus.set_addressing_32_bit(true);
+                bus.attach_guest_address_space(memory.shared_view());
+                let result = if classic {
+                    read_resource_fragment(&mut bus, address, available)
+                } else {
+                    read_resource_fragment(&mut memory, address, available)
+                };
+                assert_eq!(
+                    result,
+                    if fault == 0 { Some(fragment) } else { None },
+                    "fault {fault}"
+                );
+                outcomes.push(result);
+            }
+            assert_eq!(outcomes[0], outcomes[1]);
+        }
+    }
+
+    #[test]
+    fn relocated_plan_publishes_atomically_through_both_memory_views() {
+        let fragment = fragment(&[run_reloc(0x23, 1), run_reloc(0x25, 1)]);
+        let plan = CfmFragmentPlan::prepare(
+            &fragment,
+            &[IMPORT],
+            HEAP + 3,
+            HEAP + 256,
+            16,
+            |cursor, size, alignment| {
+                let (base, next) = bounds(cursor, size, alignment)?;
+                // The allocator reserves [HEAP + 32, HEAP + 64) for system code.
+                if base < HEAP + 64 && next > HEAP + 32 {
+                    bounds(HEAP + 64, size, alignment)
+                } else {
+                    Some((base, next))
+                }
+            },
+        )
+        .unwrap();
+        assert_eq!(plan.next_heap_cursor(), HEAP + 80);
+        assert_eq!(plan.fragment.main_addr, HEAP + 64);
+        assert_eq!((plan.fragment.init_addr, plan.fragment.term_addr), (0, 0));
+        assert!(plan.fragment.exports.is_empty());
+        for fault in 0..3 {
+            let mut outcomes = Vec::new();
+            for classic in [false, true] {
+                let mut memory = GuestAddressSpace::new();
+                memory.add_region(HEAP, vec![0xa5; if fault == 2 { 72 } else { 256 }]);
+                if fault == 1 {
+                    memory.add_readonly_region(HEAP + 72, vec![0xa5; 4]);
+                }
+                let before = read(&mut memory, HEAP, 256);
+                let mut bus = MacMemoryBus::new(0x10000);
+                bus.set_addressing_32_bit(true);
+                bus.attach_guest_address_space(memory.shared_view());
+                let published = if classic {
+                    plan.publish(&mut bus)
+                } else {
+                    plan.publish(&mut memory)
+                };
+                let after = read(&mut memory, HEAP, 256);
+                assert_eq!(published, fault == 0);
+                if published {
+                    let mut expected = vec![Some(0xa5); 256];
+                    expected[16..24].fill(Some(0));
+                    let relocated: Vec<_> = [HEAP + 16, HEAP + 64, IMPORT]
+                        .into_iter()
+                        .flat_map(u32::to_be_bytes)
+                        .map(Some)
+                        .collect();
+                    expected[64..76].copy_from_slice(&relocated);
+                    assert_eq!(after, expected);
+                } else {
+                    assert_eq!(after, before, "no section is published after a refusal");
+                }
+                if fault == 2 {
+                    memory.add_region(HEAP + 72, vec![0xa5; 184]);
+                    assert!(if classic {
+                        plan.publish(&mut bus)
+                    } else {
+                        plan.publish(&mut memory)
+                    });
+                    assert_eq!(memory.procedure_read_u32(HEAP + 72), Some(IMPORT));
+                }
+                outcomes.push((published, after));
+            }
+            assert_eq!(outcomes[0], outcomes[1]);
+        }
+    }
+
+    #[test]
+    fn fragment_planning_rejects_invalid_layout_relocations_and_metadata() {
+        for fault in 0..11 {
+            let mut fragment = fragment(&[run_reloc(0x23, 1), run_reloc(0x25, 1)]);
+            let mut imports = vec![IMPORT];
+            let mut allocation_alignment = 16;
+            match fault {
+                0 => fragment[40 + 26] = 31,
+                1 => fragment[0x80..0x84].copy_from_slice(&9u32.to_be_bytes()),
+                2 => fragment[0x84..0x88].copy_from_slice(&8u32.to_be_bytes()),
+                3 => fragment[0x80 + 52..0x80 + 56].copy_from_slice(&1u32.to_be_bytes()),
+                4 => imports.clear(),
+                5 => {
+                    let malformed = [run_reloc(0x23, 1), run_reloc(0x25, 2)];
+                    fragment = self::fragment(&malformed);
+                }
+                8 => allocation_alignment = 3,
+                9 => fragment[8..12].copy_from_slice(b"m68k"),
+                10 => fragment[12..16].copy_from_slice(&2u32.to_be_bytes()),
+                _ => {}
+            }
+            let result = CfmFragmentPlan::prepare(
+                &fragment,
+                &imports,
+                HEAP,
+                HEAP + 256,
+                allocation_alignment,
+                |cursor, size, alignment| {
+                    if fault == 6 {
+                        return None;
+                    }
+                    if fault == 7 {
+                        return Some((cursor - 1, cursor + size));
+                    }
+                    bounds(cursor, size, alignment)
+                },
+            );
+            assert_eq!(
+                result.err(),
+                Some(if matches!(fault, 6..=8) {
+                    CfmLoadError::NoAddressSpace
+                } else {
+                    CfmLoadError::CorruptFragment
+                }),
+                "fault {fault}"
+            );
+        }
+        let fragment = fragment(&[run_reloc(0x23, 1), run_reloc(0x25, 1)]);
+        assert_eq!(
+            CfmFragmentPlan::prepare(&fragment, &[IMPORT], u32::MAX - 7, u32::MAX, 16, bounds)
+                .err(),
+            Some(CfmLoadError::NoAddressSpace)
+        );
+    }
+}

--- a/src/loader/pef.rs
+++ b/src/loader/pef.rs
@@ -1402,7 +1402,7 @@ fn read_u32(data: &[u8], offset: usize) -> Option<u32> {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
 
     #[test]
@@ -2021,7 +2021,7 @@ mod tests {
         assert_eq!(err, PefRelocApplyError::SectionBaseUnavailable { index: 1 });
     }
 
-    fn synthetic_pef(
+    pub(crate) fn synthetic_pef(
         loader: Vec<u8>,
         pattern_section: Vec<u8>,
         pattern_unpacked_size: u32,
@@ -2097,7 +2097,7 @@ mod tests {
         bytes
     }
 
-    fn synthetic_loader_with_reloc_header(chunks: &[u16]) -> Vec<u8> {
+    pub(crate) fn synthetic_loader_with_reloc_header(chunks: &[u16]) -> Vec<u8> {
         let mut strings = Vec::new();
         let library_name_offset = push_c_string(&mut strings, b"InterfaceLib");
         let symbol_name_offset = push_c_string(&mut strings, b"Gestalt");
@@ -2214,7 +2214,7 @@ mod tests {
         bytes
     }
 
-    fn block_copy_section(bytes: &[u8]) -> Vec<u8> {
+    pub(crate) fn block_copy_section(bytes: &[u8]) -> Vec<u8> {
         assert!(bytes.len() < 32);
         let mut packed = vec![0x20 | bytes.len() as u8];
         packed.extend_from_slice(bytes);
@@ -2248,7 +2248,7 @@ mod tests {
         (u16::from(skip_count) << 6) | u16::from(reloc_count)
     }
 
-    fn run_reloc(dispatch: u8, run_length: u16) -> u16 {
+    pub(crate) fn run_reloc(dispatch: u8, run_length: u16) -> u16 {
         (u16::from(dispatch) << 9) | ((run_length - 1) & 0x01ff)
     }
 

--- a/src/loader/ppc/imports.rs
+++ b/src/loader/ppc/imports.rs
@@ -58,14 +58,6 @@ pub struct PpcCfmLibraryFragment {
     pub bytes: Vec<u8>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct PpcPreparedMemFragment {
-    pub(crate) main_addr: u32,
-    pub(crate) init_addr: u32,
-    pub(crate) term_addr: u32,
-    pub(crate) exports: Vec<PpcCfmExport>,
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct PpcInputSnapshot {
     pub key_map: [u8; 16],

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -5,16 +5,20 @@
 //! section bases, relocations, synthetic import TVectors, and an initial
 //! stack frame. It deliberately does not implement Toolbox imports yet.
 
+#[cfg(test)]
+use super::pef::SECTION_KIND_UNPACKED_DATA;
 use super::pef::{
-    apply_pef_relocations_detailed, instantiate_pef_sections, parse_pef_exported_symbols,
-    parse_pef_header, parse_pef_imported_symbols, parse_pef_loader_header, parse_pef_reloc_headers,
+    apply_pef_relocations_detailed, instantiate_pef_sections, parse_pef_header,
+    parse_pef_imported_symbols, parse_pef_loader_header, parse_pef_reloc_headers,
     parse_pef_sections, pef_reloc_chunk_stream, resolve_pef_imports, PefHeader, PefLoaderHeader,
     PefRelocApplyError, PefRelocContext, PefRelocHeader, PefResolvedImport, PefSection,
-    SECTION_KIND_CODE, SECTION_KIND_CONSTANT, SECTION_KIND_EXECUTABLE_DATA,
-    SECTION_KIND_PATTERN_DATA, SECTION_KIND_UNPACKED_DATA,
+    SECTION_KIND_CODE, SECTION_KIND_CONSTANT,
 };
 use super::ApplicationSizeResource;
 use crate::callback_manager::{CallbackTaskArchitecture, ProcessCallbackScheduling};
+use crate::cfm::fragment::{
+    first_base_for_kind, first_data_base, section_bases, CfmSection as MappedSection,
+};
 use crate::cfm::{
     CfmLoadId, CfmLoadOperation, CfmLoadOutputs, CfmOperation, CfmResourceCall,
     CfmResourcePreparation,
@@ -12503,14 +12507,6 @@ pub enum PpcLoadError {
     AddressOverflow,
 }
 
-#[derive(Debug)]
-struct MappedSection {
-    index: usize,
-    section_kind: u8,
-    base: u32,
-    bytes: Vec<u8>,
-}
-
 static PEF_DUMP_PATH: OnceLock<Option<std::path::PathBuf>> = OnceLock::new();
 
 fn pef_dump_path() -> Option<&'static std::path::Path> {
@@ -13330,38 +13326,6 @@ fn map_instantiated_sections(data: &[u8]) -> Result<Vec<MappedSection>, PpcLoadE
     }
 
     Ok(mapped)
-}
-
-fn section_bases(mapped: &[MappedSection]) -> Vec<Option<u32>> {
-    let mut bases = Vec::new();
-    for section in mapped {
-        if bases.len() <= section.index {
-            bases.resize(section.index + 1, None);
-        }
-        bases[section.index] = Some(section.base);
-    }
-    bases
-}
-
-fn first_base_for_kind(mapped: &[MappedSection], kind: u8) -> Option<u32> {
-    mapped
-        .iter()
-        .find(|section| section.section_kind == kind)
-        .map(|section| section.base)
-}
-
-fn first_data_base(mapped: &[MappedSection]) -> Option<u32> {
-    mapped
-        .iter()
-        .find(|section| {
-            matches!(
-                section.section_kind,
-                SECTION_KIND_UNPACKED_DATA
-                    | SECTION_KIND_PATTERN_DATA
-                    | SECTION_KIND_EXECUTABLE_DATA
-            )
-        })
-        .map(|section| section.base)
 }
 
 fn bind_imports(
@@ -44702,38 +44666,6 @@ fn ppc_install_legacy_call_universal_proc_arguments(cpu: &mut PpcCpu) {
     }
 }
 
-fn ppc_resource_fragment_bytes(
-    memory: &mut PpcSectionMem,
-    address: u32,
-    available: Option<u32>,
-) -> Option<Vec<u8>> {
-    if available.is_some_and(|size| size < 40) {
-        return None;
-    }
-    let header_bytes = ppc_memory_read_bytes(memory, address, 40)?;
-    let header = parse_pef_header(&header_bytes)?;
-    if header.architecture != *b"pwpc" || header.format_version != 1 {
-        return None;
-    }
-    let table_len = 40u32.checked_add(u32::from(header.section_count).checked_mul(28)?)?;
-    if available.is_some_and(|size| size < table_len) {
-        return None;
-    }
-    let table = ppc_memory_read_bytes(memory, address, table_len)?;
-    let mut length = table_len;
-    for section in parse_pef_sections(&table)? {
-        length = length.max(section.container_offset.checked_add(section.packed_size)?);
-    }
-    if available.is_some_and(|size| size < length) {
-        return None;
-    }
-    address.checked_add(length.checked_sub(1)?)?;
-    if !ppc_memory_can_read_bytes(memory, address, length) {
-        return None;
-    }
-    ppc_memory_read_bytes(memory, address, length)
-}
-
 fn ppc_invoke_prepared_resource(
     cpu: &mut PpcCpu,
     memory: &mut PpcSectionMem,
@@ -44838,8 +44770,12 @@ fn ppc_prepare_resource_call(
         } else {
             None
         };
-        let fragment = ppc_resource_fragment_bytes(memory, request.fragment_address, available)
-            .ok_or(PPC_FRAG_CORRUPT_ERR)?;
+        let fragment = crate::cfm::fragment::read_resource_fragment(
+            memory,
+            request.fragment_address,
+            available,
+        )
+        .ok_or(PPC_FRAG_CORRUPT_ERR)?;
         let id = *next_id;
         if id == 0 || id > PPC_CFM_MAIN_STUB_COUNT {
             return Err(PPC_FRAG_LIB_CONN_ERR);
@@ -51487,8 +51423,7 @@ fn ppc_prepare_mem_fragment(
     imports: &mut Vec<PpcImportBinding>,
     import_count: &mut u32,
     import_binding_indices: &mut Vec<Option<usize>>,
-) -> Result<PpcPreparedMemFragment, i16> {
-    let loader = parse_pef_loader_header(fragment).ok_or(PPC_FRAG_CORRUPT_ERR)?;
+) -> Result<crate::cfm::fragment::CfmPreparedFragment, i16> {
     let imported_symbols = parse_pef_imported_symbols(fragment).ok_or(PPC_FRAG_CORRUPT_ERR)?;
     let resolved_imports = resolve_pef_imports(fragment).ok_or(PPC_FRAG_CORRUPT_ERR)?;
     let local_import_count = u32::try_from(imported_symbols.len()).map_err(|_| PPC_FRAG_NO_MEM)?;
@@ -51499,93 +51434,28 @@ fn ppc_prepare_mem_fragment(
         return Err(PPC_FRAG_NO_MEM);
     }
 
-    let instantiated = instantiate_pef_sections(fragment).ok_or(PPC_FRAG_CORRUPT_ERR)?;
-    let mut mapped_sections = Vec::with_capacity(instantiated.len());
-    let mut next_heap_cursor = *heap_cursor;
-    for section in instantiated {
-        let alignment =
-            alignment_bytes(section.header.alignment).map_err(|_| PPC_FRAG_CORRUPT_ERR)?;
-        let size = u32::try_from(section.bytes.len()).map_err(|_| PPC_FRAG_NO_ADDR_SPACE)?;
-        let (base, next) = ppc_aligned_heap_allocation_bounds(
-            memory,
-            next_heap_cursor,
-            heap_limit,
-            size,
-            alignment,
-        )
-        .ok_or(PPC_FRAG_NO_ADDR_SPACE)?;
-        mapped_sections.push(MappedSection {
-            index: section.index,
-            section_kind: section.header.section_kind,
-            base,
-            bytes: section.bytes,
-        });
-        next_heap_cursor = next;
-    }
-    next_heap_cursor =
-        align_up(next_heap_cursor, PPC_HEAP_ALIGNMENT).map_err(|_| PPC_FRAG_NO_ADDR_SPACE)?;
-    if next_heap_cursor >= heap_limit {
-        return Err(PPC_FRAG_NO_ADDR_SPACE);
-    }
-
-    let section_bases = section_bases(&mapped_sections);
-    let code_base =
-        first_base_for_kind(&mapped_sections, SECTION_KIND_CODE).ok_or(PPC_FRAG_CORRUPT_ERR)?;
-    let data_base = first_data_base(&mapped_sections).unwrap_or(code_base);
     let new_bindings =
         bind_imports_at_base(resolved_imports, imported_symbols.len(), *import_count)
             .map_err(|_| PPC_FRAG_CORRUPT_ERR)?;
     let import_addrs =
         import_addresses(&new_bindings, imported_symbols.len()).map_err(|_| PPC_FRAG_NO_MEM)?;
 
-    let reloc_headers = parse_pef_reloc_headers(fragment).ok_or(PPC_FRAG_CORRUPT_ERR)?;
-    for reloc in &reloc_headers {
-        let stream = pef_reloc_chunk_stream(fragment, reloc).ok_or(PPC_FRAG_CORRUPT_ERR)?;
-        let mapped = mapped_sections
-            .iter_mut()
-            .find(|section| section.index == usize::from(reloc.section_index))
-            .ok_or(PPC_FRAG_CORRUPT_ERR)?;
-        let context = PefRelocContext {
-            code_base,
-            data_base,
-            section_bases: &section_bases,
-            import_addrs: &import_addrs,
-        };
-        apply_pef_relocations_detailed(&mut mapped.bytes, stream, &context)
-            .map_err(|_| PPC_FRAG_CORRUPT_ERR)?;
-    }
-
-    let main_addr =
-        ppc_fragment_special_tvector(&mapped_sections, loader.main_section, loader.main_offset)?;
-    let init_addr =
-        ppc_fragment_special_tvector(&mapped_sections, loader.init_section, loader.init_offset)?;
-    let term_addr =
-        ppc_fragment_special_tvector(&mapped_sections, loader.term_section, loader.term_offset)?;
-    let exports = ppc_resolve_fragment_exports(fragment, &mapped_sections, &import_addrs)?;
-
-    // Publish the complete relocated layout only after its process allocator
-    // and every destination accept it. No guest code or mapping changes occur
-    // between preflight and writes. PowerPC System Software, pp. 3-21–3-22.
-    let publish_sections = || {
-        for section in &mapped_sections {
-            let Ok(size) = u32::try_from(section.bytes.len()) else {
-                return false;
-            };
-            if !memory.preflight_writable_range(section.base, size) {
-                return false;
-            }
-        }
-        for section in &mapped_sections {
-            memory
-                .write_bytes(section.base, &section.bytes)
-                .expect("preflighted CFM section remains mapped and writable");
-        }
-        true
-    };
+    let plan = crate::cfm::fragment::CfmFragmentPlan::prepare(
+        fragment,
+        &import_addrs,
+        *heap_cursor,
+        heap_limit,
+        PPC_HEAP_ALIGNMENT,
+        |cursor, size, alignment| {
+            ppc_aligned_heap_allocation_bounds(memory, cursor, heap_limit, size, alignment)
+        },
+    )
+    .map_err(|error| error.os_error())?;
+    let next_heap_cursor = plan.next_heap_cursor();
     let committed = process_memory_manager.commit_native_heap_cursor_with(
         *heap_cursor,
         next_heap_cursor,
-        publish_sections,
+        || plan.publish(memory),
     );
     if !committed {
         return Err(PPC_FRAG_NO_ADDR_SPACE);
@@ -51594,93 +51464,7 @@ fn ppc_prepare_mem_fragment(
     imports.extend(new_bindings);
     *import_count = next_import_count;
     *import_binding_indices = ppc_import_binding_indices(imports, *import_count);
-    Ok(PpcPreparedMemFragment {
-        main_addr,
-        init_addr,
-        term_addr,
-        exports,
-    })
-}
-
-fn ppc_resolve_fragment_exports(
-    fragment: &[u8],
-    mapped_sections: &[MappedSection],
-    import_addrs: &[u32],
-) -> Result<Vec<PpcCfmExport>, i16> {
-    let loader = parse_pef_loader_header(fragment).ok_or(PPC_FRAG_CORRUPT_ERR)?;
-    let exported_symbols = if loader.exported_symbol_count == 0 {
-        Vec::new()
-    } else {
-        parse_pef_exported_symbols(fragment).ok_or(PPC_FRAG_CORRUPT_ERR)?
-    };
-    exported_symbols
-        .into_iter()
-        .map(|symbol| {
-            let address = match symbol.section_index {
-                section_index if section_index >= 0 => {
-                    let section_index =
-                        usize::try_from(section_index).map_err(|_| PPC_FRAG_CORRUPT_ERR)?;
-                    let section = mapped_sections
-                        .iter()
-                        .find(|section| section.index == section_index)
-                        .ok_or(PPC_FRAG_CORRUPT_ERR)?;
-                    let offset =
-                        usize::try_from(symbol.symbol_value).map_err(|_| PPC_FRAG_CORRUPT_ERR)?;
-                    if offset >= section.bytes.len() {
-                        return Err(PPC_FRAG_CORRUPT_ERR);
-                    }
-                    section
-                        .base
-                        .checked_add(symbol.symbol_value)
-                        .ok_or(PPC_FRAG_NO_ADDR_SPACE)?
-                }
-                // Inside Macintosh: PowerPC System Software (1994),
-                // pp. 1-25--1-26: PEF uses -2 for an absolute export.
-                -2 => symbol.symbol_value,
-                // A re-export stores the imported-symbol index in the value
-                // field. Resolve only through the already checked local
-                // import address table; never index the raw fragment bytes.
-                -3 => {
-                    let import_index =
-                        usize::try_from(symbol.symbol_value).map_err(|_| PPC_FRAG_CORRUPT_ERR)?;
-                    *import_addrs.get(import_index).ok_or(PPC_FRAG_CORRUPT_ERR)?
-                }
-                _ => return Err(PPC_FRAG_CORRUPT_ERR),
-            };
-            Ok(PpcCfmExport {
-                name: symbol.name,
-                class: symbol.class,
-                address,
-            })
-        })
-        .collect()
-}
-
-fn ppc_fragment_special_tvector(
-    mapped_sections: &[MappedSection],
-    section_index: i32,
-    offset: u32,
-) -> Result<u32, i16> {
-    if section_index < 0 {
-        return Ok(0);
-    }
-    let section_index = usize::try_from(section_index).map_err(|_| PPC_FRAG_CORRUPT_ERR)?;
-    let section = mapped_sections
-        .iter()
-        .find(|section| section.index == section_index)
-        .ok_or(PPC_FRAG_CORRUPT_ERR)?;
-    let offset_usize = usize::try_from(offset).map_err(|_| PPC_FRAG_CORRUPT_ERR)?;
-    if offset_usize
-        .checked_add(8)
-        .filter(|end| *end <= section.bytes.len())
-        .is_none()
-    {
-        return Err(PPC_FRAG_CORRUPT_ERR);
-    }
-    section
-        .base
-        .checked_add(offset)
-        .ok_or(PPC_FRAG_NO_ADDR_SPACE)
+    Ok(plan.into_fragment())
 }
 
 fn ppc_cfm_main_stub_addr(connection_id: u32) -> u32 {
@@ -113280,8 +113064,12 @@ pub(crate) mod tests {
             base: 0x0310_0000,
             bytes: vec![0; 8],
         }];
-        let exports =
-            ppc_resolve_fragment_exports(&fragment, &mapped, &[0xcafe_babe, 0xdead_beef]).unwrap();
+        let exports = crate::cfm::fragment::resolve_fragment_exports(
+            &fragment,
+            &mapped,
+            &[0xcafe_babe, 0xdead_beef],
+        )
+        .unwrap();
 
         assert_eq!(
             exports,
@@ -177453,14 +177241,14 @@ pub(crate) mod tests {
                 .memory
                 .write_bytes(fragment_address, &fragment)
                 .unwrap();
-            assert!(ppc_resource_fragment_bytes(
+            assert!(crate::cfm::fragment::read_resource_fragment(
                 &mut loaded.memory,
                 fragment_address,
                 Some(fragment.len() as u32 - 1)
             )
             .is_none());
             assert_eq!(
-                ppc_resource_fragment_bytes(
+                crate::cfm::fragment::read_resource_fragment(
                     &mut loaded.memory,
                     fragment_address,
                     Some(fragment.len() as u32)


### PR DESCRIPTION
Dynamic fragment preparation previously kept layout, relocation, special transition-vector selection and export resolution in the native execution loader. `CfmFragmentPlan` now stages those results without publishing guest bytes, allocator state or import registrations. The native edge supplies allocation bounds and import addresses, commits the allocator cursor together with atomic section publication, then registers imports.

The shared plan validates alignment, import-address count, allocation bounds, PEF architecture/version, relocations and metadata. `CfmSection` and `CfmPreparedFragment` replace native staging records. Resource-container extent reading is shared too: it respects logical resource bounds and grows the buffer only after mapped reads succeed, avoiding allocation from an unchecked packed size.

Validation: 5,049 full headless library tests passed (three existing ignored tests); production compilation is warning-free. New tests cover equivalent relocated bytes and protected/incomplete publication through both memory views, retry after missing storage is supplied, reserved allocation ranges, malformed plans and resource extents. Existing native preparation transaction/retry, real resource initialization and export resolution tests pass. PEF test builders are shared within tests to reuse the existing format fixtures.

This completes shared dynamic planning and publication policy. Native import registration and allocator orchestration, startup relocation, process composition, classic CFM routing and post-initialization rollback remain separate work.

Closes #1474
