### PR TITLE
refactor!: move runner CFM ownership into the process context

### DIFF
--- a/src/cfm.rs
+++ b/src/cfm.rs
@@ -172,6 +172,39 @@ pub struct CfmExport {
     pub address: u32,
 }
 
+/// One owned CFM registry. A standalone loader carries this as a seed;
+/// process installation moves it, rather than cloning an adapter projection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CfmState {
+    pub connections: Vec<CfmConnection>,
+    pub library_fragments: Vec<CfmLibraryFragment>,
+    pub next_connection_id: u32,
+}
+
+impl Default for CfmState {
+    fn default() -> Self {
+        Self {
+            connections: Vec::new(),
+            library_fragments: Vec::new(),
+            next_connection_id: 1,
+        }
+    }
+}
+
+impl CfmState {
+    pub(crate) fn is_pristine(&self) -> bool {
+        self.connections.is_empty()
+            && self.library_fragments.is_empty()
+            && self.next_connection_id == 1
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CfmLibraryFragment {
+    pub name: String,
+    pub bytes: Vec<u8>,
+}
+
 impl CfmResourceCall {
     pub(crate) fn complete(
         self,

--- a/src/loader/ppc/imports.rs
+++ b/src/loader/ppc/imports.rs
@@ -50,13 +50,10 @@ pub struct PpcHleRunProbe {
     pub fetch_histogram: Option<PpcFetchHistogram>,
 }
 
-pub use crate::cfm::{CfmConnection as PpcCfmConnection, CfmExport as PpcCfmExport};
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PpcCfmLibraryFragment {
-    pub name: String,
-    pub bytes: Vec<u8>,
-}
+pub use crate::cfm::{
+    CfmConnection as PpcCfmConnection, CfmExport as PpcCfmExport,
+    CfmLibraryFragment as PpcCfmLibraryFragment, CfmState as PpcCfmState,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct PpcInputSnapshot {

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -3493,9 +3493,9 @@ pub struct PpcLoadedApp {
     pub(crate) stdc_qsort_stack: Vec<PpcQsortState>,
     pub(crate) dialog_callback_stack: Vec<PpcDialogCallbackState>,
     pub(crate) apple_events: PpcAppleEventState,
-    pub cfm_connections: Vec<PpcCfmConnection>,
-    pub cfm_library_fragments: Vec<PpcCfmLibraryFragment>,
-    pub next_cfm_connection_id: u32,
+    /// Standalone CFM seed; None after a runner moves it into its process.
+    /// Installed execution must receive the process service explicitly.
+    pub cfm: Option<PpcCfmState>,
     pub(crate) controls: SharedProcessControlManager,
     pub aliases: Vec<PpcAliasRecord>,
     pub gworlds: Vec<PpcGWorldRecord>,
@@ -4134,12 +4134,14 @@ impl PpcLoadedApp {
     }
 
     /// Run one native operation with every process manager continuously attached.
+    #[cfg(test)]
     pub(crate) fn with_process_state<R>(&mut self, f: impl FnOnce(&mut Self) -> R) -> R {
         f(self)
     }
 
     /// Run one native operation with the continuously attached process Memory
     /// Manager as its sole allocator owner.
+    #[cfg(test)]
     pub(crate) fn with_process_memory_manager<R>(
         &mut self,
         f: impl FnOnce(&mut Self, &mut ProcessMemoryManager) -> R,
@@ -6726,25 +6728,143 @@ impl PpcLoadedApp {
         Some(alphas)
     }
 
+    fn assert_cfm_execution_owner(&self, process_cfm: Option<&PpcCfmState>) {
+        assert!(
+            process_cfm.is_some() || self.cfm.is_some(),
+            "installed native execution requires process CFM services"
+        );
+        assert!(
+            process_cfm.is_none() || self.cfm.is_none(),
+            "move the standalone CFM seed before using process services"
+        );
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn run_with_process_services(
+        &mut self,
+        max_cycles: u64,
+        trace_imports: bool,
+        trace_fetches: bool,
+        memory_manager: &mut ProcessMemoryManager,
+        cfm: &mut PpcCfmState,
+    ) -> PpcHleRunProbe {
+        self.run_with_hle_imports_with_trace(
+            max_cycles,
+            trace_imports,
+            trace_fetches,
+            Some(memory_manager),
+            Some(cfm),
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn run_sound_completion_callback_with_process_services(
+        &mut self,
+        completion: PpcSoundCompletionRecord,
+        max_cycles: u64,
+        trace_imports: bool,
+        trace_fetches: bool,
+        memory_manager: &mut ProcessMemoryManager,
+        cfm: &mut PpcCfmState,
+    ) -> PpcSoundCompletionCallProbe {
+        self.run_sound_completion_callback_inner(
+            completion,
+            max_cycles,
+            trace_imports,
+            trace_fetches,
+            Some(memory_manager),
+            Some(cfm),
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn fire_timer_tasks_for_ticks_with_process_services(
+        &mut self,
+        start_tick: u32,
+        elapsed_ticks: u32,
+        max_callbacks: usize,
+        max_cycles: u64,
+        trace_imports: bool,
+        trace_fetches: bool,
+        memory_manager: &mut ProcessMemoryManager,
+        cfm: &mut PpcCfmState,
+    ) -> Vec<PpcTimerCallbackProbe> {
+        self.fire_timer_tasks_for_ticks_inner(
+            start_tick,
+            elapsed_ticks,
+            max_callbacks,
+            max_cycles,
+            trace_imports,
+            trace_fetches,
+            Some(memory_manager),
+            Some(cfm),
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn fire_vbl_tasks_for_ticks_with_process_services(
+        &mut self,
+        start_tick: u32,
+        elapsed_ticks: u32,
+        max_callbacks: usize,
+        max_cycles: u64,
+        trace_imports: bool,
+        trace_fetches: bool,
+        memory_manager: &mut ProcessMemoryManager,
+        cfm: &mut PpcCfmState,
+    ) -> Vec<PpcVblCallbackProbe> {
+        self.fire_vbl_tasks_for_ticks_inner(
+            start_tick,
+            elapsed_ticks,
+            max_callbacks,
+            max_cycles,
+            trace_imports,
+            trace_fetches,
+            Some(memory_manager),
+            Some(cfm),
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn run_sound_doubleback_callback_with_process_services(
+        &mut self,
+        doubleback: PpcSoundDoubleBackRecord,
+        max_cycles: u64,
+        trace_imports: bool,
+        trace_fetches: bool,
+        memory_manager: &mut ProcessMemoryManager,
+        cfm: &mut PpcCfmState,
+    ) -> PpcSoundCompletionCallProbe {
+        self.run_sound_doubleback_callback_inner(
+            doubleback,
+            max_cycles,
+            trace_imports,
+            trace_fetches,
+            Some(memory_manager),
+            Some(cfm),
+        )
+    }
+
     pub fn run_with_hle_imports(&mut self, max_cycles: u64) -> PpcHleRunProbe {
-        self.run_with_hle_imports_with_trace(max_cycles, false, false, None)
+        self.run_with_hle_imports_with_trace(max_cycles, false, false, None, None)
     }
 
     pub fn run_with_hle_import_trace(&mut self, max_cycles: u64) -> PpcHleRunProbe {
-        self.run_with_hle_imports_with_trace(max_cycles, true, false, None)
+        self.run_with_hle_imports_with_trace(max_cycles, true, false, None, None)
     }
 
     pub fn run_with_hle_import_fetch_histogram(&mut self, max_cycles: u64) -> PpcHleRunProbe {
-        self.run_with_hle_imports_with_trace(max_cycles, false, true, None)
+        self.run_with_hle_imports_with_trace(max_cycles, false, true, None, None)
     }
 
     pub fn run_with_hle_import_trace_and_fetch_histogram(
         &mut self,
         max_cycles: u64,
     ) -> PpcHleRunProbe {
-        self.run_with_hle_imports_with_trace(max_cycles, true, true, None)
+        self.run_with_hle_imports_with_trace(max_cycles, true, true, None, None)
     }
 
+    #[cfg(test)]
     pub(crate) fn run_with_process_memory_manager(
         &mut self,
         max_cycles: u64,
@@ -6757,6 +6877,7 @@ impl PpcLoadedApp {
             trace_imports,
             trace_fetches,
             Some(memory_manager),
+            None,
         )
     }
 
@@ -6773,23 +6894,7 @@ impl PpcLoadedApp {
             trace_imports,
             trace_fetches,
             None,
-        )
-    }
-
-    pub(crate) fn run_sound_completion_callback_with_process_memory_manager(
-        &mut self,
-        completion: PpcSoundCompletionRecord,
-        max_cycles: u64,
-        trace_imports: bool,
-        trace_fetches: bool,
-        memory_manager: &mut ProcessMemoryManager,
-    ) -> PpcSoundCompletionCallProbe {
-        self.run_sound_completion_callback_inner(
-            completion,
-            max_cycles,
-            trace_imports,
-            trace_fetches,
-            Some(memory_manager),
+            None,
         )
     }
 
@@ -6852,7 +6957,9 @@ impl PpcLoadedApp {
         trace_imports: bool,
         trace_fetches: bool,
         process_memory_manager: Option<&mut ProcessMemoryManager>,
+        mut process_cfm: Option<&mut PpcCfmState>,
     ) -> PpcSoundCompletionCallProbe {
+        self.assert_cfm_execution_owner(process_cfm.as_deref());
         let saved_cpu = self.cpu.clone();
         let default_rtoc = if saved_cpu.gpr[2] != 0 {
             saved_cpu.gpr[2]
@@ -6902,6 +7009,7 @@ impl PpcLoadedApp {
                 trace_imports,
                 trace_fetches,
                 process_memory_manager,
+                process_cfm.as_deref_mut(),
             )
         } else {
             self.interrupt_callback_stack_fault()
@@ -6952,28 +7060,7 @@ impl PpcLoadedApp {
             trace_imports,
             trace_fetches,
             None,
-        )
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    pub(crate) fn fire_timer_tasks_for_ticks_with_process_memory_manager(
-        &mut self,
-        start_tick: u32,
-        elapsed_ticks: u32,
-        max_callbacks: usize,
-        max_cycles: u64,
-        trace_imports: bool,
-        trace_fetches: bool,
-        memory_manager: &mut ProcessMemoryManager,
-    ) -> Vec<PpcTimerCallbackProbe> {
-        self.fire_timer_tasks_for_ticks_inner(
-            start_tick,
-            elapsed_ticks,
-            max_callbacks,
-            max_cycles,
-            trace_imports,
-            trace_fetches,
-            Some(memory_manager),
+            None,
         )
     }
 
@@ -6987,7 +7074,9 @@ impl PpcLoadedApp {
         trace_imports: bool,
         trace_fetches: bool,
         mut process_memory_manager: Option<&mut ProcessMemoryManager>,
+        mut process_cfm: Option<&mut PpcCfmState>,
     ) -> Vec<PpcTimerCallbackProbe> {
+        self.assert_cfm_execution_owner(process_cfm.as_deref());
         let mut probes = Vec::new();
         if elapsed_ticks == 0 || self.timer_tasks.is_empty() || max_callbacks == 0 {
             return probes;
@@ -7032,6 +7121,7 @@ impl PpcLoadedApp {
                         trace_imports,
                         trace_fetches,
                         process_memory_manager.as_deref_mut(),
+                        process_cfm.as_deref_mut(),
                     ));
                 }
             }
@@ -7047,7 +7137,9 @@ impl PpcLoadedApp {
         trace_imports: bool,
         trace_fetches: bool,
         process_memory_manager: Option<&mut ProcessMemoryManager>,
+        mut process_cfm: Option<&mut PpcCfmState>,
     ) -> PpcTimerCallbackProbe {
+        self.assert_cfm_execution_owner(process_cfm.as_deref());
         let saved_cpu = self.cpu.clone();
         let saved_current_resource_refnum = self.current_resource_refnum();
         let default_rtoc = if saved_cpu.gpr[2] != 0 {
@@ -7076,6 +7168,7 @@ impl PpcLoadedApp {
                 trace_imports,
                 trace_fetches,
                 process_memory_manager,
+                process_cfm.as_deref_mut(),
             )
         } else {
             self.interrupt_callback_stack_fault()
@@ -7123,30 +7216,10 @@ impl PpcLoadedApp {
             trace_imports,
             trace_fetches,
             None,
+            None,
         )
     }
 
-    #[allow(clippy::too_many_arguments)]
-    pub(crate) fn fire_vbl_tasks_for_ticks_with_process_memory_manager(
-        &mut self,
-        start_tick: u32,
-        elapsed_ticks: u32,
-        max_callbacks: usize,
-        max_cycles: u64,
-        trace_imports: bool,
-        trace_fetches: bool,
-        memory_manager: &mut ProcessMemoryManager,
-    ) -> Vec<PpcVblCallbackProbe> {
-        self.fire_vbl_tasks_for_ticks_inner(
-            start_tick,
-            elapsed_ticks,
-            max_callbacks,
-            max_cycles,
-            trace_imports,
-            trace_fetches,
-            Some(memory_manager),
-        )
-    }
 
     #[allow(clippy::too_many_arguments)]
     fn fire_vbl_tasks_for_ticks_inner(
@@ -7158,7 +7231,9 @@ impl PpcLoadedApp {
         trace_imports: bool,
         trace_fetches: bool,
         mut process_memory_manager: Option<&mut ProcessMemoryManager>,
+        mut process_cfm: Option<&mut PpcCfmState>,
     ) -> Vec<PpcVblCallbackProbe> {
+        self.assert_cfm_execution_owner(process_cfm.as_deref());
         let mut probes = Vec::new();
         if elapsed_ticks == 0 || self.vbl_tasks.is_empty() || max_callbacks == 0 {
             return probes;
@@ -7198,6 +7273,7 @@ impl PpcLoadedApp {
                     trace_imports,
                     trace_fetches,
                     process_memory_manager.as_deref_mut(),
+                    process_cfm.as_deref_mut(),
                 ));
                 // Inside Macintosh: Processes (1994), pp. 4-7–4-8: a VBL
                 // task must reset vblCount from its callback or the Vertical
@@ -7220,7 +7296,9 @@ impl PpcLoadedApp {
         trace_imports: bool,
         trace_fetches: bool,
         process_memory_manager: Option<&mut ProcessMemoryManager>,
+        mut process_cfm: Option<&mut PpcCfmState>,
     ) -> PpcVblCallbackProbe {
+        self.assert_cfm_execution_owner(process_cfm.as_deref());
         let saved_cpu = self.cpu.clone();
         let saved_current_resource_refnum = self.current_resource_refnum();
         let default_rtoc = if saved_cpu.gpr[2] != 0 {
@@ -7251,6 +7329,7 @@ impl PpcLoadedApp {
                 trace_imports,
                 trace_fetches,
                 process_memory_manager,
+                process_cfm.as_deref_mut(),
             )
         } else {
             self.interrupt_callback_stack_fault()
@@ -7294,23 +7373,7 @@ impl PpcLoadedApp {
             trace_imports,
             trace_fetches,
             None,
-        )
-    }
-
-    pub(crate) fn run_sound_doubleback_callback_with_process_memory_manager(
-        &mut self,
-        doubleback: PpcSoundDoubleBackRecord,
-        max_cycles: u64,
-        trace_imports: bool,
-        trace_fetches: bool,
-        memory_manager: &mut ProcessMemoryManager,
-    ) -> PpcSoundCompletionCallProbe {
-        self.run_sound_doubleback_callback_inner(
-            doubleback,
-            max_cycles,
-            trace_imports,
-            trace_fetches,
-            Some(memory_manager),
+            None,
         )
     }
 
@@ -7321,7 +7384,9 @@ impl PpcLoadedApp {
         trace_imports: bool,
         trace_fetches: bool,
         process_memory_manager: Option<&mut ProcessMemoryManager>,
+        mut process_cfm: Option<&mut PpcCfmState>,
     ) -> PpcSoundCompletionCallProbe {
+        self.assert_cfm_execution_owner(process_cfm.as_deref());
         let saved_cpu = self.cpu.clone();
         let default_rtoc = if saved_cpu.gpr[2] != 0 {
             saved_cpu.gpr[2]
@@ -7352,6 +7417,7 @@ impl PpcLoadedApp {
                 trace_imports,
                 trace_fetches,
                 process_memory_manager,
+                process_cfm.as_deref_mut(),
             )
         } else {
             self.interrupt_callback_stack_fault()
@@ -7391,7 +7457,9 @@ impl PpcLoadedApp {
         trace_imports: bool,
         trace_fetches: bool,
         process_memory_manager: Option<&mut ProcessMemoryManager>,
+        mut process_cfm: Option<&mut PpcCfmState>,
     ) -> PpcHleRunProbe {
+        self.assert_cfm_execution_owner(process_cfm.as_deref());
         // Wakeup selects and prepares a saved context before any native step.
         self.guest_calls.resume_ready_task();
         if !self.guest_calls.current_task_is_running()
@@ -7463,9 +7531,21 @@ impl PpcLoadedApp {
         let mut stdc_qsort_stack = std::mem::take(&mut self.stdc_qsort_stack);
         let mut dialog_callback_stack = std::mem::take(&mut self.dialog_callback_stack);
         let mut apple_events = std::mem::take(&mut self.apple_events);
-        let mut cfm_connections = std::mem::take(&mut self.cfm_connections);
-        let mut cfm_library_fragments = std::mem::take(&mut self.cfm_library_fragments);
-        let mut next_cfm_connection_id = self.next_cfm_connection_id;
+        let mut standalone_cfm = if process_cfm.is_none() {
+            self.cfm.take()
+        } else {
+            None
+        };
+        let cfm = if let Some(cfm) = process_cfm.as_deref_mut() {
+            cfm
+        } else {
+            standalone_cfm.as_mut().expect("standalone CFM seed exists")
+        };
+        let (mut cfm_connections, mut cfm_library_fragments, mut next_cfm_connection_id) = (
+            &mut cfm.connections,
+            &mut cfm.library_fragments,
+            &mut cfm.next_connection_id,
+        );
         let mut controls = std::mem::take(&mut self.controls);
         let mut aliases = std::mem::take(&mut self.aliases);
         let mut gworlds = std::mem::take(&mut self.gworlds);
@@ -8505,9 +8585,7 @@ impl PpcLoadedApp {
         self.stdc_qsort_stack = stdc_qsort_stack;
         self.dialog_callback_stack = dialog_callback_stack;
         self.apple_events = apple_events;
-        self.cfm_connections = cfm_connections;
-        self.cfm_library_fragments = cfm_library_fragments;
-        self.next_cfm_connection_id = next_cfm_connection_id;
+        self.cfm = standalone_cfm;
         self.imports = imports;
         self.import_count = import_count;
         self.controls = controls;
@@ -8637,7 +8715,10 @@ impl PpcLoadedApp {
     }
 
     pub fn seed_cfm_library_fragments(&mut self, fragments: Vec<PpcCfmLibraryFragment>) {
-        self.cfm_library_fragments = fragments;
+        self.cfm
+            .as_mut()
+            .expect("seed CFM libraries before process installation")
+            .library_fragments = fragments;
     }
 
     pub fn seed_vfs_files_and_resources(
@@ -13210,9 +13291,11 @@ fn load_pef_application_with_config_and_optional_system_reservation(
         stdc_qsort_stack: Vec::new(),
         dialog_callback_stack: Vec::new(),
         apple_events: PpcAppleEventState::default(),
-        cfm_connections,
-        cfm_library_fragments: Vec::new(),
-        next_cfm_connection_id,
+        cfm: Some(PpcCfmState {
+            connections: cfm_connections,
+            library_fragments: Vec::new(),
+            next_connection_id: next_cfm_connection_id,
+        }),
         controls: SharedProcessControlManager::default(),
         aliases: Vec::new(),
         gworlds,
@@ -103549,8 +103632,11 @@ pub(crate) mod tests {
         assert_eq!(loaded.last_mem_error(), 0);
         assert_eq!(*loaded.process_file_system.current_resource_file, 0);
         assert_eq!(loaded.test_resource_error(), 0);
-        assert_eq!(loaded.cfm_connections.len(), 0);
-        assert_eq!(loaded.next_cfm_connection_id, PPC_FIRST_CFM_CONNECTION_ID);
+        assert_eq!(loaded.cfm.as_ref().unwrap().connections.len(), 0);
+        assert_eq!(
+            loaded.cfm.as_ref().unwrap().next_connection_id,
+            PPC_FIRST_CFM_CONNECTION_ID
+        );
         assert_eq!(test_handle_records!(loaded).len(), 0);
         assert_eq!(loaded.gworlds.len(), 2);
         assert_eq!(loaded.gworlds[0].port, PPC_MAIN_GWORLD);
@@ -113026,7 +113112,7 @@ pub(crate) mod tests {
             Some(PPC_CFM_MAIN_STUB_BASE)
         );
         assert_eq!(loaded.memory.read_u8(err_name_ptr), Some(0));
-        assert_eq!(loaded.cfm_connections.len(), 1);
+        assert_eq!(loaded.cfm.as_ref().unwrap().connections.len(), 1);
 
         loaded.cpu.pc = loaded.entry_pc;
         loaded.cpu.lr = PPC_HALT_PC;
@@ -113052,7 +113138,7 @@ pub(crate) mod tests {
             loaded.memory.read_u32_be(main_addr_ptr),
             Some(PPC_CFM_MAIN_STUB_BASE)
         );
-        assert_eq!(loaded.cfm_connections.len(), 1);
+        assert_eq!(loaded.cfm.as_ref().unwrap().connections.len(), 1);
     }
 
     #[test]
@@ -113114,7 +113200,7 @@ pub(crate) mod tests {
 
         assert_eq!(probe.unsupported_import_index, None);
         assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_FRAG_LIB_NOT_FOUND));
-        assert!(loaded.cfm_connections.is_empty());
+        assert!(loaded.cfm.as_ref().unwrap().connections.is_empty());
     }
 
     #[test]
@@ -113135,7 +113221,7 @@ pub(crate) mod tests {
 
         assert_eq!(probe.unsupported_import_index, None);
         assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_FRAG_ARCH_ERR));
-        assert!(loaded.cfm_connections.is_empty());
+        assert!(loaded.cfm.as_ref().unwrap().connections.is_empty());
     }
 
     #[test]
@@ -113161,7 +113247,7 @@ pub(crate) mod tests {
 
         assert_eq!(probe.unsupported_import_index, None);
         assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_FRAG_LIB_NOT_FOUND));
-        assert!(loaded.cfm_connections.is_empty());
+        assert!(loaded.cfm.as_ref().unwrap().connections.is_empty());
         assert_eq!(loaded.heap_cursor(), heap_before);
     }
 
@@ -113175,18 +113261,23 @@ pub(crate) mod tests {
         let address_ptr = scratch + 32;
         let class_ptr = scratch + 36;
         write_ppc_pstring(&mut loaded.memory, symbol_ptr, b"RealExport");
-        loaded.cfm_connections.push(PpcCfmConnection {
-            id: 77,
-            library_name: "RealLibrary".to_string(),
-            main_addr: 0,
-            init_addr: 0,
-            term_addr: 0,
-            exports: vec![PpcCfmExport {
-                name: "RealExport".to_string(),
-                class: 1,
-                address: 0x0312_3456,
-            }],
-        });
+        loaded
+            .cfm
+            .as_mut()
+            .unwrap()
+            .connections
+            .push(PpcCfmConnection {
+                id: 77,
+                library_name: "RealLibrary".to_string(),
+                main_addr: 0,
+                init_addr: 0,
+                term_addr: 0,
+                exports: vec![PpcCfmExport {
+                    name: "RealExport".to_string(),
+                    class: 1,
+                    address: 0x0312_3456,
+                }],
+            });
         loaded.cpu.gpr[3] = 77;
         loaded.cpu.gpr[4] = symbol_ptr;
         loaded.cpu.gpr[5] = address_ptr;
@@ -113198,7 +113289,7 @@ pub(crate) mod tests {
         let action = ppc_find_symbol(
             &loaded.cpu,
             &mut loaded.memory,
-            &loaded.cfm_connections,
+            &loaded.cfm.as_ref().unwrap().connections,
             &mut loaded.imports,
             &mut loaded.import_count,
             &mut import_binding_indices,
@@ -113219,14 +113310,19 @@ pub(crate) mod tests {
         let symbol_ptr = scratch;
         let address_ptr = scratch + 32;
         let class_ptr = scratch + 36;
-        loaded.cfm_connections.push(PpcCfmConnection {
-            id: 78,
-            library_name: "StdCLib".to_string(),
-            main_addr: 0,
-            init_addr: 0,
-            term_addr: 0,
-            exports: Vec::new(),
-        });
+        loaded
+            .cfm
+            .as_mut()
+            .unwrap()
+            .connections
+            .push(PpcCfmConnection {
+                id: 78,
+                library_name: "StdCLib".to_string(),
+                main_addr: 0,
+                init_addr: 0,
+                term_addr: 0,
+                exports: Vec::new(),
+            });
         loaded.cpu.gpr[3] = 78;
         loaded.cpu.gpr[4] = symbol_ptr;
         loaded.cpu.gpr[5] = address_ptr;
@@ -113244,7 +113340,7 @@ pub(crate) mod tests {
             let action = ppc_find_symbol(
                 &loaded.cpu,
                 &mut loaded.memory,
-                &loaded.cfm_connections,
+                &loaded.cfm.as_ref().unwrap().connections,
                 &mut loaded.imports,
                 &mut loaded.import_count,
                 &mut import_binding_indices,
@@ -175763,13 +175859,13 @@ pub(crate) mod tests {
         match kind {
             0 => {
                 loaded
-                    .run_timer_callback(OUTPUT, VECTOR, 64, false, false, None)
+                    .run_timer_callback(OUTPUT, VECTOR, 64, false, false, None, None)
                     .invocation
                     .result
             }
             1 => {
                 loaded
-                    .run_vbl_callback(OUTPUT, VECTOR, 64, false, false, None)
+                    .run_vbl_callback(OUTPUT, VECTOR, 64, false, false, None, None)
                     .invocation
                     .result
             }
@@ -177279,7 +177375,7 @@ pub(crate) mod tests {
             loaded.cpu.gpr[1] -= PPC_INITIAL_STACK_FRAME_SIZE;
             let sp = loaded.cpu.gpr[1];
             let caller_rtoc = loaded.cpu.gpr[2];
-            let first_id = loaded.next_cfm_connection_id;
+            let first_id = loaded.cfm.as_ref().unwrap().next_connection_id;
             let prepare_call = |loaded: &mut PpcLoadedApp| {
                 loaded.cpu.pc = loaded.entry_pc;
                 loaded.cpu.lr = PPC_HALT_PC;
@@ -177331,6 +177427,7 @@ pub(crate) mod tests {
                     ppc_import_binding_indices(&loaded.imports, loaded.import_count);
                 let mut manager = loaded.process_memory_manager.0.borrow_mut();
                 let limit = manager.native_heap_state().unwrap().heap_limit;
+                let cfm = loaded.cfm.as_mut().unwrap();
                 assert_eq!(
                     ppc_prepare_resource_call(
                         &mut recursive_cpu,
@@ -177339,8 +177436,8 @@ pub(crate) mod tests {
                         &loaded.guest_calls,
                         &mut cursor,
                         limit,
-                        &mut loaded.cfm_connections,
-                        &mut loaded.next_cfm_connection_id,
+                        &mut cfm.connections,
+                        &mut cfm.next_connection_id,
                         &mut loaded.imports,
                         &mut loaded.import_count,
                         &mut binding_indices,
@@ -177373,7 +177470,10 @@ pub(crate) mod tests {
                 assert_eq!(loaded.memory.read_u16_be(record + 6), Some(3));
                 assert_eq!(loaded.memory.read_u32_be(record + 8), Some(0x100));
                 assert!(!loaded
-                    .cfm_connections
+                    .cfm
+                    .as_ref()
+                    .unwrap()
+                    .connections
                     .iter()
                     .any(|connection| connection.id == first_id));
                 loaded
@@ -177386,19 +177486,19 @@ pub(crate) mod tests {
                 prepare_call(&mut loaded);
                 let retry = loaded.run_with_hle_imports(128);
                 assert_eq!(retry.unsupported_import_index, None);
-                assert!(loaded.next_cfm_connection_id > first_id + 1);
+                assert!(loaded.cfm.as_ref().unwrap().next_connection_id > first_id + 1);
             }
             assert_eq!(loaded.cpu.gpr[3], 0xA0);
             assert_eq!(loaded.memory.read_u16_be(record + 6), Some(0));
             let prepared_target = loaded.memory.read_u32_be(record + 8).unwrap();
             assert_ne!(prepared_target, 0x100);
             let cursor = loaded.heap_cursor();
-            let next = loaded.next_cfm_connection_id;
+            let next = loaded.cfm.as_ref().unwrap().next_connection_id;
             prepare_call(&mut loaded);
             let again = loaded.run_with_hle_imports(128);
             assert_eq!(again.unsupported_import_index, None);
             assert_eq!(loaded.cpu.gpr[3], 0xA0);
-            assert_eq!(loaded.next_cfm_connection_id, next);
+            assert_eq!(loaded.cfm.as_ref().unwrap().next_connection_id, next);
             assert_eq!(loaded.heap_cursor(), cursor);
         }
     }
@@ -178303,7 +178403,7 @@ pub(crate) mod tests {
         }
     }
 
-    fn synthetic_pef_with_import(symbol_name: &[u8]) -> Vec<u8> {
+    pub(crate) fn synthetic_pef_with_import(symbol_name: &[u8]) -> Vec<u8> {
         synthetic_pef_with_library_import(b"InterfaceLib", symbol_name)
     }
 

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -6116,6 +6116,7 @@ impl ProcessNativeMemoryManager {
 /// its mutable borrow.
 #[derive(Debug)]
 pub(crate) struct ProcessContext {
+    cfm: crate::cfm::CfmState,
     memory: Vec<ProcessMemoryRegion>,
     memory_manager: SharedProcessMemoryManager,
     tick_state: SharedProcessTickState,
@@ -6154,6 +6155,7 @@ pub(crate) struct ProcessContext {
 impl Default for ProcessContext {
     fn default() -> Self {
         Self {
+            cfm: crate::cfm::CfmState::default(),
             memory: Vec::new(),
             memory_manager: SharedProcessMemoryManager::default(),
             tick_state: SharedProcessTickState::default(),
@@ -6192,6 +6194,39 @@ impl Default for ProcessContext {
 }
 
 impl ProcessContext {
+    #[cfg(test)]
+    pub(crate) fn cfm_mut(&mut self) -> &mut crate::cfm::CfmState {
+        &mut self.cfm
+    }
+
+    pub(crate) fn can_install_cfm_seed(&self, seed: &Option<crate::cfm::CfmState>) -> bool {
+        seed.as_ref()
+            .is_some_and(|seed| self.cfm.is_pristine() || seed.is_pristine())
+    }
+
+    pub(crate) fn install_cfm_seed(&mut self, seed: &mut Option<crate::cfm::CfmState>) -> bool {
+        if !self.can_install_cfm_seed(seed) {
+            return false;
+        }
+        let seed = seed.take().expect("CFM installation was preflighted");
+        if self.cfm.is_pristine() {
+            self.cfm = seed;
+        }
+        true
+    }
+
+    pub(crate) fn reset_cfm_for_launch(&mut self) {
+        self.cfm = crate::cfm::CfmState::default();
+    }
+
+    pub(crate) fn with_memory_and_cfm<R>(
+        &mut self,
+        f: impl FnOnce(&mut ProcessMemoryManager, &mut crate::cfm::CfmState) -> R,
+    ) -> R {
+        let mut memory = self.memory_manager.borrow_mut();
+        f(&mut memory, &mut self.cfm)
+    }
+
     pub(crate) fn with_file_system(file_system: SharedProcessFileSystem) -> Self {
         Self {
             file_system,
@@ -6618,6 +6653,44 @@ mod tests {
     use crate::guest_procedure::GuestIsa;
     use crate::memory::{MacMemoryBus, MemoryBus};
     use ppc::PpcMemory;
+
+    #[test]
+    fn cfm_seed_installation_moves_one_owner_and_refuses_conflicts() {
+        let mut context = ProcessContext::default();
+        let mut seed = Some(crate::cfm::CfmState {
+            connections: vec![crate::cfm::CfmConnection {
+                id: 7,
+                library_name: "seed".into(),
+                main_addr: 0x2000,
+                init_addr: 0,
+                term_addr: 0,
+                exports: vec![],
+            }],
+            library_fragments: vec![crate::cfm::CfmLibraryFragment {
+                name: "library".into(),
+                bytes: vec![1, 2],
+            }],
+            next_connection_id: 8,
+        });
+        let expected = seed.clone().unwrap();
+        assert!(context.install_cfm_seed(&mut seed));
+        assert!(seed.is_none());
+        assert_eq!(context.cfm, expected);
+        assert!(!context.install_cfm_seed(&mut seed));
+        assert_eq!(context.cfm, expected);
+        let mut conflict = Some(expected.clone());
+        assert!(!context.install_cfm_seed(&mut conflict));
+        assert_eq!(conflict, Some(expected.clone()));
+        assert_eq!(context.cfm, expected);
+        let mut empty = Some(crate::cfm::CfmState::default());
+        assert!(context.install_cfm_seed(&mut empty));
+        assert!(empty.is_none());
+        assert_eq!(context.cfm, expected);
+        context.with_memory_and_cfm(|_, cfm| cfm.next_connection_id = 9);
+        assert_eq!(context.cfm.next_connection_id, 9);
+        context.reset_cfm_for_launch();
+        assert!(context.cfm.is_pristine());
+    }
 
     fn native_heap_state(heap_cursor: u32, heap_limit: u32) -> ProcessNativeHeapState {
         ProcessNativeHeapState {

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -3788,7 +3788,12 @@ impl FixtureRunner {
             self.m68k.can_relaunch() && self.native.can_relaunch(),
             "cannot relaunch with parked execution contexts"
         );
+        assert!(
+            app.ppc.as_ref().is_none_or(|native| native.cfm.is_some()),
+            "native relaunch requires an uninstalled CFM seed"
+        );
         assert!(self.native.reset_for_launch(app.ppc.is_some()));
+        self.process_context.reset_cfm_for_launch();
         if let Some(ppc_app) = app.ppc.clone() {
             self.init_ppc_app(ppc_app);
             return;
@@ -4202,8 +4207,16 @@ impl FixtureRunner {
     }
 
     fn init_ppc_companion(&mut self, mut ppc_companion: PpcLoadedApp) {
+        assert!(
+            self.process_context
+                .can_install_cfm_seed(&ppc_companion.cfm),
+            "CFM seed conflicts with the process registry"
+        );
         self.share_ppc_process_memory(&mut ppc_companion);
         ppc_companion.attach_process_context(&mut self.process_context);
+        assert!(self
+            .process_context
+            .install_cfm_seed(&mut ppc_companion.cfm));
         self.bus
             .attach_guest_address_space(ppc_companion.memory.shared_view());
         self.native
@@ -4212,6 +4225,10 @@ impl FixtureRunner {
     }
 
     fn init_ppc_app(&mut self, mut ppc_app: PpcLoadedApp) {
+        assert!(
+            self.process_context.can_install_cfm_seed(&ppc_app.cfm),
+            "CFM seed conflicts with the process registry"
+        );
         use crate::memory::globals::addr;
 
         // A native application carries its parsed SIZE capability before it
@@ -4268,6 +4285,7 @@ impl FixtureRunner {
             .event_queue_mut()
             .merge(detached_events);
         ppc_app.attach_process_context(&mut self.process_context);
+        assert!(self.process_context.install_cfm_seed(&mut ppc_app.cfm));
         if let Some(time_base) = self.launch_ppc_time_base_override {
             ppc_app.cpu.set_time_base(time_base);
         }
@@ -6579,18 +6597,20 @@ impl FixtureRunner {
                     self.dispatcher.guest_calls.current_task().thread_id(),
                 ) == ppc_task;
             let (vbl_probes, timer_probes) = if native_callbacks_allowed {
-                ppc_app.with_process_memory_manager(|app, memory_manager| {
-                    Self::fire_ppc_tick_callbacks(
-                        app,
-                        memory_manager,
-                        tick_advance.baseline_tick,
-                        ppc_start_time,
-                        tick_advance.elapsed_ticks,
-                        u64::from(cycles_per_tick),
-                        false,
-                        false,
-                    )
-                })
+                self.process_context
+                    .with_memory_and_cfm(|memory_manager, cfm| {
+                        Self::fire_ppc_tick_callbacks(
+                            &mut ppc_app,
+                            memory_manager,
+                            cfm,
+                            tick_advance.baseline_tick,
+                            ppc_start_time,
+                            tick_advance.elapsed_ticks,
+                            u64::from(cycles_per_tick),
+                            false,
+                            false,
+                        )
+                    })
             } else {
                 (Vec::new(), Vec::new())
             };
@@ -6639,14 +6659,17 @@ impl FixtureRunner {
         let trace_ppc_imports = record_ppc_imports || trace_ppc_import_hist;
         let trace_ppc_fetches = trace_ppc_fetch_counts_enabled();
         let profile_run_start = profile_ppc.then(Instant::now);
-        let probe = ppc_app.with_process_memory_manager(|app, memory_manager| {
-            app.run_with_process_memory_manager(
-                ppc_max_steps as u64,
-                trace_ppc_imports,
-                trace_ppc_fetches,
-                memory_manager,
-            )
-        });
+        let probe = self
+            .process_context
+            .with_memory_and_cfm(|memory_manager, cfm| {
+                ppc_app.run_with_process_services(
+                    ppc_max_steps as u64,
+                    trace_ppc_imports,
+                    trace_ppc_fetches,
+                    memory_manager,
+                    cfm,
+                )
+            });
         let profile_run_us = elapsed_profile_micros(profile_run_start);
         let ppc_cycles = ppc_run_result_cycles(probe.result);
         let resumed_m68k = self.resume_m68k_after_powerpc(&mut ppc_app);
@@ -6690,18 +6713,20 @@ impl FixtureRunner {
                     self.dispatcher.guest_calls.current_task().thread_id(),
                 ) == ppc_task;
             if native_callbacks_allowed {
-                ppc_app.with_process_memory_manager(|app, memory_manager| {
-                    Self::fire_ppc_tick_callbacks(
-                        app,
-                        memory_manager,
-                        tick_advance.baseline_tick,
-                        ppc_start_time,
-                        tick_advance.elapsed_ticks,
-                        u64::from(cycles_per_tick),
-                        trace_ppc_imports,
-                        trace_ppc_fetches,
-                    )
-                })
+                self.process_context
+                    .with_memory_and_cfm(|memory_manager, cfm| {
+                        Self::fire_ppc_tick_callbacks(
+                            &mut ppc_app,
+                            memory_manager,
+                            cfm,
+                            tick_advance.baseline_tick,
+                            ppc_start_time,
+                            tick_advance.elapsed_ticks,
+                            u64::from(cycles_per_tick),
+                            trace_ppc_imports,
+                            trace_ppc_fetches,
+                        )
+                    })
             } else {
                 (Vec::new(), Vec::new())
             }
@@ -7055,6 +7080,7 @@ impl FixtureRunner {
     fn fire_ppc_tick_callbacks(
         ppc_app: &mut PpcLoadedApp,
         memory_manager: &mut ProcessMemoryManager,
+        cfm: &mut crate::cfm::CfmState,
         baseline_tick: u32,
         start_time: u32,
         elapsed_ticks: u32,
@@ -7078,28 +7104,26 @@ impl FixtureRunner {
             }
             let _ = ppc_app.memory.write_u32_be(addr::TICKS, callback_tick);
             let _ = ppc_app.memory.write_u32_be(addr::TIME, callback_time);
-            vbl_probes.extend(
-                ppc_app.fire_vbl_tasks_for_ticks_with_process_memory_manager(
-                    callback_tick.wrapping_sub(1),
-                    1,
-                    usize::MAX,
-                    max_cycles,
-                    trace_imports,
-                    trace_fetches,
-                    memory_manager,
-                ),
-            );
-            timer_probes.extend(
-                ppc_app.fire_timer_tasks_for_ticks_with_process_memory_manager(
-                    callback_tick.wrapping_sub(1),
-                    1,
-                    usize::MAX,
-                    max_cycles,
-                    trace_imports,
-                    trace_fetches,
-                    memory_manager,
-                ),
-            );
+            vbl_probes.extend(ppc_app.fire_vbl_tasks_for_ticks_with_process_services(
+                callback_tick.wrapping_sub(1),
+                1,
+                usize::MAX,
+                max_cycles,
+                trace_imports,
+                trace_fetches,
+                memory_manager,
+                cfm,
+            ));
+            timer_probes.extend(ppc_app.fire_timer_tasks_for_ticks_with_process_services(
+                callback_tick.wrapping_sub(1),
+                1,
+                usize::MAX,
+                max_cycles,
+                trace_imports,
+                trace_fetches,
+                memory_manager,
+                cfm,
+            ));
         }
         (vbl_probes, timer_probes)
     }
@@ -7800,15 +7824,18 @@ impl FixtureRunner {
                 .pending_process_doublebacks
                 .remove(index);
             let resume_pc = ppc_app.cpu.pc;
-            let probe = ppc_app.with_process_memory_manager(|app, memory_manager| {
-                app.run_sound_doubleback_callback_with_process_memory_manager(
-                    doubleback,
-                    PPC_SOUND_COMPLETION_CALLBACK_MAX_CYCLES,
-                    trace_ppc_imports,
-                    trace_ppc_fetches,
-                    memory_manager,
-                )
-            });
+            let probe = self
+                .process_context
+                .with_memory_and_cfm(|memory_manager, cfm| {
+                    ppc_app.run_sound_doubleback_callback_with_process_services(
+                        doubleback,
+                        PPC_SOUND_COMPLETION_CALLBACK_MAX_CYCLES,
+                        trace_ppc_imports,
+                        trace_ppc_fetches,
+                        memory_manager,
+                        cfm,
+                    )
+                });
             let invocation = probe.invocation;
             if trace_sound_runner_enabled() {
                 eprintln!(
@@ -8006,15 +8033,18 @@ impl FixtureRunner {
                 scheduled_tick: self.guest_tick(),
                 scheduled_instruction_count: self.total_instructions,
             };
-            let probe = ppc_app.with_process_memory_manager(|app, memory_manager| {
-                app.run_sound_completion_callback_with_process_memory_manager(
-                    completion,
-                    PPC_SOUND_COMPLETION_CALLBACK_MAX_CYCLES,
-                    trace_ppc_imports,
-                    trace_ppc_fetches,
-                    memory_manager,
-                )
-            });
+            let probe = self
+                .process_context
+                .with_memory_and_cfm(|memory_manager, cfm| {
+                    ppc_app.run_sound_completion_callback_with_process_services(
+                        completion,
+                        PPC_SOUND_COMPLETION_CALLBACK_MAX_CYCLES,
+                        trace_ppc_imports,
+                        trace_ppc_fetches,
+                        memory_manager,
+                        cfm,
+                    )
+                });
             let invocation = probe.invocation;
             if record_ppc_imports {
                 self.record_ppc_import_trace(&probe.import_trace);
@@ -11458,6 +11488,229 @@ mod tests {
     use std::collections::{HashMap, VecDeque};
     use std::rc::Rc;
 
+    fn cfm_test_connection(id: u32) -> crate::cfm::CfmConnection {
+        crate::cfm::CfmConnection {
+            id,
+            library_name: format!("existing-{id}"),
+            main_addr: 0,
+            init_addr: 0,
+            term_addr: 0,
+            exports: vec![],
+        }
+    }
+
+    #[test]
+    fn runner_cfm_owns_native_connections_ids_and_library_seeds() {
+        let mut app = halted_ppc_app_with_sound(PpcSoundState::default());
+        let mut native = load_pef_application(
+            &crate::loader::ppc::tests::synthetic_pef_with_import(b"GetSharedLibrary"),
+        )
+        .unwrap();
+        const OUTPUT: u32 = PPC_HEAP_BASE + 0x200;
+        native.memory.add_region(OUTPUT, vec![0; 128]);
+        native
+            .memory
+            .write_bytes(OUTPUT, b"\x0cInterfaceLib")
+            .unwrap();
+        native.cpu.gpr[3] = OUTPUT;
+        native.cpu.gpr[4] = u32::from_be_bytes(*b"pwpc");
+        native.cpu.gpr[5] = 1;
+        native.cpu.gpr[6] = OUTPUT + 64;
+        native.cpu.gpr[7] = OUTPUT + 68;
+        native.cpu.gpr[8] = OUTPUT + 72;
+        native
+            .cfm
+            .as_mut()
+            .unwrap()
+            .connections
+            .push(cfm_test_connection(3));
+        native.cfm.as_mut().unwrap().next_connection_id = 7;
+        native.seed_cfm_library_fragments(vec![PpcCfmLibraryFragment {
+            name: "seeded library".into(),
+            bytes: vec![1, 2, 3],
+        }]);
+        app.ppc = Some(native);
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        runner.init_app(&app);
+        assert!(runner.native.application().unwrap().cfm.is_none());
+        assert_eq!(runner.process_context.cfm_mut().next_connection_id, 7);
+        runner.run_steps(128, None);
+        assert_eq!(runner.bus.read_long(OUTPUT + 64), 7);
+        assert_eq!(runner.process_context.cfm_mut().next_connection_id, 8);
+        assert_eq!(
+            runner
+                .process_context
+                .cfm_mut()
+                .connections
+                .iter()
+                .map(|c| c.id)
+                .collect::<Vec<_>>(),
+            vec![3, 7]
+        );
+        assert_eq!(
+            runner.process_context.cfm_mut().library_fragments[0].bytes,
+            vec![1, 2, 3]
+        );
+        let registry = runner.process_context.cfm_mut().clone();
+        let native = runner.native.application_mut().unwrap();
+        assert!(native.cfm.is_none());
+        let before_cpu = native.cpu.clone();
+        let refused = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            native.run_with_hle_imports(64)
+        }));
+        assert!(refused.is_err());
+        assert_eq!(native.cpu.gpr, before_cpu.gpr);
+        assert_eq!(native.cpu.pc, before_cpu.pc);
+        assert_eq!(*runner.process_context.cfm_mut(), registry);
+        // The caller's launch blueprint remains an independent, unchanged seed.
+        assert_eq!(
+            app.ppc
+                .as_ref()
+                .unwrap()
+                .cfm
+                .as_ref()
+                .unwrap()
+                .next_connection_id,
+            7
+        );
+        runner.init_app(&app);
+        assert_eq!(runner.process_context.cfm_mut().next_connection_id, 7);
+        assert_eq!(runner.process_context.cfm_mut().connections.len(), 1);
+    }
+
+    #[test]
+    fn runner_cfm_is_used_by_timer_vbl_and_sound_callback_entries() {
+        use crate::callback_manager::{CallbackTaskArchitecture, ProcessTimerTask, ProcessVblTask};
+        const OUTPUT: u32 = PPC_HEAP_BASE + 0x200;
+        for callback_kind in 0..4 {
+            let mut app = halted_ppc_app_with_sound(PpcSoundState::default());
+            let mut native = load_pef_application(
+                &crate::loader::ppc::tests::synthetic_pef_with_import(b"CloseConnection"),
+            )
+            .unwrap();
+            native.memory.add_region(OUTPUT, vec![0; 64]);
+            native.memory.write_u32_be(OUTPUT, 3).unwrap();
+            let callback = native.imports[0].address;
+            native.cfm.as_mut().unwrap().connections =
+                vec![cfm_test_connection(3), cfm_test_connection(9)];
+            native.cfm.as_mut().unwrap().next_connection_id = 10;
+            app.ppc = Some(native);
+            let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+            runner.init_app(&app);
+            let native = runner.native.application_mut().unwrap();
+            let saved_cpu = native.cpu.clone();
+            runner
+                .process_context
+                .with_memory_and_cfm(|memory_manager, cfm| match callback_kind {
+                    0 => {
+                        native.timer_tasks.push(ProcessTimerTask {
+                            task_ptr: OUTPUT,
+                            architecture: CallbackTaskArchitecture::PowerPc,
+                            extended: false,
+                            callback,
+                            active: true,
+                            fire_at_tick: 1,
+                            fire_at_subtick: 0,
+                            last_fired_tick: None,
+                        });
+                        let probes = native.fire_timer_tasks_for_ticks_with_process_services(
+                            0,
+                            1,
+                            1,
+                            64,
+                            false,
+                            false,
+                            memory_manager,
+                            cfm,
+                        );
+                        assert_eq!(probes.len(), 1);
+                        assert_eq!(probes[0].invocation.unsupported_import_index, None);
+                    }
+                    1 => {
+                        native.memory.write_u32_be(OUTPUT + 6, callback).unwrap();
+                        native.memory.write_u16_be(OUTPUT + 10, 1).unwrap();
+                        native.vbl_tasks.push(ProcessVblTask {
+                            task_ptr: OUTPUT,
+                            architecture: CallbackTaskArchitecture::PowerPc,
+                            slot: None,
+                            pending: false,
+                        });
+                        let probes = native.fire_vbl_tasks_for_ticks_with_process_services(
+                            0,
+                            1,
+                            1,
+                            64,
+                            false,
+                            false,
+                            memory_manager,
+                            cfm,
+                        );
+                        assert_eq!(probes.len(), 1);
+                        assert_eq!(probes[0].invocation.unsupported_import_index, None);
+                    }
+                    2 => {
+                        let probe = native.run_sound_completion_callback_with_process_services(
+                            PpcSoundCompletionRecord {
+                                file_playback_index: 0,
+                                channel: OUTPUT,
+                                completion: callback,
+                                command: None,
+                                tick: 0,
+                                instruction_count: 0,
+                                scheduled_tick: 0,
+                                scheduled_instruction_count: 0,
+                            },
+                            64,
+                            false,
+                            false,
+                            memory_manager,
+                            cfm,
+                        );
+                        assert_eq!(probe.invocation.unsupported_import_index, None);
+                    }
+                    _ => {
+                        let probe = native.run_sound_doubleback_callback_with_process_services(
+                            PpcSoundDoubleBackRecord {
+                                architecture: CallbackTaskArchitecture::PowerPc,
+                                channel: OUTPUT,
+                                header: 0,
+                                exhausted_buffer: 0,
+                                exhausted_buffer_index: 0,
+                                callback,
+                                tick: 0,
+                                instruction_count: 0,
+                            },
+                            64,
+                            false,
+                            false,
+                            memory_manager,
+                            cfm,
+                        );
+                        assert_eq!(probe.invocation.unsupported_import_index, None);
+                    }
+                });
+            assert!(native.cfm.is_none());
+            assert_eq!(native.cpu.gpr, saved_cpu.gpr);
+            assert_eq!(native.cpu.pc, saved_cpu.pc);
+            assert_eq!(
+                runner.bus.read_long(OUTPUT),
+                0,
+                "callback kind {callback_kind}"
+            );
+            assert_eq!(
+                runner
+                    .process_context
+                    .cfm_mut()
+                    .connections
+                    .iter()
+                    .map(|c| c.id)
+                    .collect::<Vec<_>>(),
+                vec![9]
+            );
+            assert_eq!(runner.process_context.cfm_mut().next_connection_id, 10);
+        }
+    }
+
     #[test]
     fn os_trap_address_gateway_executes_and_returns_through_the_68k_cpu() {
         use crate::memory::globals::addr;
@@ -12778,8 +13031,11 @@ mod tests {
         runner.bus.write_long(addr::TICKS, third);
         ppc_app.cpu.pc = PPC_IMPORT_TRAP_BASE;
         ppc_app.cpu.lr = PPC_HALT_PC;
-        let mut memory_manager = runner.process_context.memory_manager_mut();
-        let probe = ppc_app.run_with_process_memory_manager(64, false, false, &mut memory_manager);
+        let probe = runner
+            .process_context
+            .with_memory_and_cfm(|memory_manager, cfm| {
+                ppc_app.run_with_process_services(64, false, false, memory_manager, cfm)
+            });
         assert_eq!(probe.handled_import_count, 1);
         assert_eq!(probe.unsupported_import_index, None);
         assert_eq!(ppc_app.cpu.gpr[3], third);
@@ -12933,17 +13189,21 @@ mod tests {
             });
         }
 
-        let mut memory_manager = runner.process_context.memory_manager_mut();
-        let (vbl, timer) = FixtureRunner::fire_ppc_tick_callbacks(
-            &mut ppc_app,
-            &mut memory_manager,
-            41,
-            0x1020_3040,
-            2,
-            64,
-            false,
-            false,
-        );
+        let (vbl, timer) = runner
+            .process_context
+            .with_memory_and_cfm(|memory_manager, cfm| {
+                FixtureRunner::fire_ppc_tick_callbacks(
+                    &mut ppc_app,
+                    memory_manager,
+                    cfm,
+                    41,
+                    0x1020_3040,
+                    2,
+                    64,
+                    false,
+                    false,
+                )
+            });
 
         assert_eq!(vbl.len(), 2);
         assert!(timer.is_empty());
@@ -14304,9 +14564,7 @@ mod tests {
             stdc_qsort_stack: Vec::new(),
             dialog_callback_stack: Vec::new(),
             apple_events: Default::default(),
-            cfm_connections: Vec::new(),
-            cfm_library_fragments: Vec::new(),
-            next_cfm_connection_id: 1,
+            cfm: Some(crate::cfm::CfmState::default()),
             controls: Default::default(),
             screen_clut: SharedProcessValue::from_value(TrapDispatcher::standard_mac_8bpp_clut()),
             device_gamma: SharedProcessValue::from_value(crate::display::default_display_gamma()),
@@ -14768,7 +15026,11 @@ mod tests {
         native.cpu.pc = native.entry_pc;
         native.cpu.lr = PPC_HALT_PC;
         native.imports[0].dispatcher_target = PpcImportDispatcherTarget::MenuChoice;
-        let probe = native.run_with_hle_imports(64);
+        let probe = runner
+            .process_context
+            .with_memory_and_cfm(|memory_manager, cfm| {
+                native.run_with_process_services(64, false, false, memory_manager, cfm)
+            });
         assert_eq!(probe.handled_import_count, 1);
         assert_eq!(probe.unsupported_import_index, None);
         assert_eq!(native.cpu.gpr[3], raw_choice);
@@ -17846,9 +18108,7 @@ mod tests {
             stdc_qsort_stack: Vec::new(),
             dialog_callback_stack: Vec::new(),
             apple_events: Default::default(),
-            cfm_connections: Vec::new(),
-            cfm_library_fragments: Vec::new(),
-            next_cfm_connection_id: 1,
+            cfm: Some(crate::cfm::CfmState::default()),
             controls: Default::default(),
             screen_clut: SharedProcessValue::from_value(TrapDispatcher::standard_mac_8bpp_clut()),
             device_gamma: SharedProcessValue::from_value(crate::display::default_display_gamma()),
@@ -18707,9 +18967,7 @@ mod tests {
             stdc_qsort_stack: Vec::new(),
             dialog_callback_stack: Vec::new(),
             apple_events: Default::default(),
-            cfm_connections: Vec::new(),
-            cfm_library_fragments: Vec::new(),
-            next_cfm_connection_id: 1,
+            cfm: Some(crate::cfm::CfmState::default()),
             controls: Default::default(),
             screen_clut: SharedProcessValue::from_value(TrapDispatcher::standard_mac_8bpp_clut()),
             device_gamma: SharedProcessValue::from_value(crate::display::default_display_gamma()),
@@ -18862,9 +19120,7 @@ mod tests {
             stdc_qsort_stack: Vec::new(),
             dialog_callback_stack: Vec::new(),
             apple_events: Default::default(),
-            cfm_connections: Vec::new(),
-            cfm_library_fragments: Vec::new(),
-            next_cfm_connection_id: 1,
+            cfm: Some(crate::cfm::CfmState::default()),
             controls: Default::default(),
             screen_clut: SharedProcessValue::from_value(TrapDispatcher::standard_mac_8bpp_clut()),
             device_gamma: SharedProcessValue::from_value(crate::display::default_display_gamma()),
@@ -19246,9 +19502,7 @@ mod tests {
             stdc_qsort_stack: Vec::new(),
             dialog_callback_stack: Vec::new(),
             apple_events: Default::default(),
-            cfm_connections: Vec::new(),
-            cfm_library_fragments: Vec::new(),
-            next_cfm_connection_id: 1,
+            cfm: Some(crate::cfm::CfmState::default()),
             controls: Default::default(),
             screen_clut: SharedProcessValue::from_value(TrapDispatcher::standard_mac_8bpp_clut()),
             device_gamma: SharedProcessValue::from_value(crate::display::default_display_gamma()),
@@ -19533,9 +19787,7 @@ mod tests {
             stdc_qsort_stack: Vec::new(),
             dialog_callback_stack: Vec::new(),
             apple_events: Default::default(),
-            cfm_connections: Vec::new(),
-            cfm_library_fragments: Vec::new(),
-            next_cfm_connection_id: 1,
+            cfm: Some(crate::cfm::CfmState::default()),
             controls: Default::default(),
             screen_clut: SharedProcessValue::from_value(TrapDispatcher::standard_mac_8bpp_clut()),
             device_gamma: SharedProcessValue::from_value(crate::display::default_display_gamma()),


### PR DESCRIPTION
Runner CFM connections, library seeds and connection IDs previously lived on the native adapter. The process context now owns that registry directly: installation moves the standalone seed, and normal execution plus Time, VBL and sound callback entries borrow the same process service. Conflicting seeds and attempts to execute an installed adapter without its service are rejected before execution changes.

Public API migration: `PpcLoadedApp::{cfm_connections, cfm_library_fragments, next_cfm_connection_id}` become `cfm: Option<PpcCfmState>` with `connections`, `library_fragments` and `next_connection_id`. The option is populated for standalone construction and empty after runner installation. Seed libraries before installation using the existing seeding method. Existing connection/export/library type names remain available.

Validation: 5,052 headless library tests passed, with three existing ignored tests; production compilation passed without warnings. New tests exercise real GetSharedLibrary and CloseConnection mutations, all four callback entry types, seed transfer and collision refusal, relaunch reset and missing-service refusal. Existing mixed-ISA and initializer/retry tests remain green.

This establishes runner ownership. Legacy standalone attachment still retains a seed; classic CFM dispatch, native import/preparation orchestration and complete cancellation/teardown remain separate work.

Closes #1476
