### PR TITLE
feat: share CFM symbol enumeration across classic and native calls

### DIFF
--- a/src/cfm.rs
+++ b/src/cfm.rs
@@ -1,4 +1,4 @@
-//! Semantic resumption of one CFM load across guest initialization.
+//! Process CFM records, export queries and resumable fragment operations.
 //! Inside Macintosh: PowerPC System Software (1994), pp. 3-15--3-18, 3-27.
 
 pub(crate) mod fragment;
@@ -170,6 +170,100 @@ pub struct CfmExport {
     pub name: String,
     pub class: u8,
     pub address: u32,
+}
+
+/// Export enumeration has no CPU or architectural return context.
+/// PowerPC System Software (1994), pp. 3-25–3-26: indices are one-based;
+/// symbol names are Pascal strings and symbol classes occupy one byte.
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum CfmSymbolQuery {
+    Count {
+        connection: u32,
+        count: u32,
+    },
+    Indexed {
+        connection: u32,
+        index: u32,
+        name: u32,
+        address: u32,
+        class: u32,
+    },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum CfmSymbolError {
+    ConnectionNotFound,
+    SymbolNotFound,
+    InvalidOutputs,
+}
+
+impl CfmSymbolError {
+    pub(crate) fn os_error(self) -> i16 {
+        match self {
+            Self::ConnectionNotFound => -2801,
+            Self::SymbolNotFound => -2802,
+            Self::InvalidOutputs => -50,
+        }
+    }
+}
+
+impl CfmSymbolQuery {
+    /// Publish all query outputs in one transaction. The ABI edge may include
+    /// its own result slot in that transaction without exposing it here.
+    pub(crate) fn complete(
+        self,
+        connections: &[CfmConnection],
+        mut publish: impl FnMut(&[(u32, &[u8])]) -> bool,
+    ) -> Result<(), CfmSymbolError> {
+        let id = match self {
+            Self::Count { connection, .. } | Self::Indexed { connection, .. } => connection,
+        };
+        let connection = connections
+            .iter()
+            .find(|connection| connection.id == id)
+            .ok_or(CfmSymbolError::ConnectionNotFound)?;
+        let writes: Vec<(u32, Vec<u8>)> = match self {
+            Self::Count { count, .. } => {
+                let size = i32::try_from(connection.exports.len())
+                    .map_err(|_| CfmSymbolError::InvalidOutputs)?;
+                vec![(count, size.to_be_bytes().to_vec())]
+            }
+            Self::Indexed {
+                index,
+                name,
+                address,
+                class,
+                ..
+            } => {
+                let export = index
+                    .checked_sub(1)
+                    .and_then(|index| connection.exports.get(index as usize))
+                    .ok_or(CfmSymbolError::SymbolNotFound)?;
+                let encoded = crate::mac_roman::encode_mac_roman_lossy(&export.name);
+                let encoded = &encoded[..encoded.len().min(255)];
+                let mut pascal = Vec::with_capacity(encoded.len() + 1);
+                pascal.push(encoded.len() as u8);
+                pascal.extend_from_slice(encoded);
+                vec![
+                    (name, pascal),
+                    (address, export.address.to_be_bytes().to_vec()),
+                    (class, vec![export.class]),
+                ]
+            }
+        };
+        if writes.iter().any(|(address, bytes)| {
+            *address == 0 || u64::from(*address) + bytes.len() as u64 > 1u64 << 32
+        }) {
+            return Err(CfmSymbolError::InvalidOutputs);
+        }
+        let writes: Vec<_> = writes
+            .iter()
+            .map(|(address, bytes)| (*address, bytes.as_slice()))
+            .collect();
+        publish(&writes)
+            .then_some(())
+            .ok_or(CfmSymbolError::InvalidOutputs)
+    }
 }
 
 /// One owned CFM registry. A standalone loader carries this as a seed;
@@ -417,6 +511,96 @@ mod tests {
         let mut bytes = vec![0; 20];
         memory.read_bytes_into(OUTPUT, &mut bytes).unwrap();
         bytes
+    }
+
+    #[test]
+    fn symbol_enumeration_is_atomic_and_equivalent_through_both_memory_views() {
+        for count in [false, true] {
+            for fault in 0..11 {
+                let mut outcomes = Vec::new();
+                for classic in [false, true] {
+                    let mut connection = connection(7);
+                    connection.exports = vec![CfmExport {
+                        name: "Café™".into(),
+                        class: 2,
+                        address: 0x1234_5678,
+                    }];
+                    if fault == 10 {
+                        connection.exports.clear();
+                    }
+                    let mut memory = GuestAddressSpace::new();
+                    memory.add_region(OUTPUT, vec![0xa5; 64]);
+                    if matches!(fault, 3..=5) {
+                        let protected = [OUTPUT, OUTPUT + 32, OUTPUT + 40][fault - 3];
+                        memory.add_readonly_region(protected, vec![0xa5]);
+                    }
+                    let pointer = match fault {
+                        6 => 0,
+                        7 => u32::MAX - 1,
+                        8 => OUTPUT + 62,
+                        _ => OUTPUT,
+                    };
+                    let id = if fault == 1 { 99 } else { 7 };
+                    let index = if fault == 2 {
+                        0
+                    } else if fault == 9 {
+                        u32::MAX
+                    } else {
+                        1
+                    };
+                    let query = if count {
+                        CfmSymbolQuery::Count {
+                            connection: id,
+                            count: pointer,
+                        }
+                    } else {
+                        CfmSymbolQuery::Indexed {
+                            connection: id,
+                            index,
+                            name: pointer,
+                            address: OUTPUT + 32,
+                            class: OUTPUT + 40,
+                        }
+                    };
+                    let mut bus = MacMemoryBus::new(0x10000);
+                    bus.set_addressing_32_bit(true);
+                    bus.attach_guest_address_space(memory.shared_view());
+                    let result = query.complete(&[connection], |writes| {
+                        if classic {
+                            bus.publish_cfm_outputs(writes)
+                        } else {
+                            memory.publish_cfm_outputs(writes)
+                        }
+                    });
+                    let bytes: Vec<_> = (0..64)
+                        .map(|offset| memory.procedure_read_u8(OUTPUT + offset).unwrap())
+                        .collect();
+                    let expected_error = match fault {
+                        1 => Some(CfmSymbolError::ConnectionNotFound),
+                        2 | 9 | 10 if !count => Some(CfmSymbolError::SymbolNotFound),
+                        3 | 6..=8 => Some(CfmSymbolError::InvalidOutputs),
+                        4 | 5 if !count => Some(CfmSymbolError::InvalidOutputs),
+                        _ => None,
+                    };
+                    assert_eq!(result.err(), expected_error, "count {count}, fault {fault}");
+                    let mut expected = vec![0xa5; 64];
+                    if expected_error.is_none() {
+                        if count {
+                            expected[..4].copy_from_slice(
+                                &(if fault == 10 { 0u32 } else { 1u32 }).to_be_bytes(),
+                            );
+                        } else {
+                            expected[..6].copy_from_slice(&[5, b'C', b'a', b'f', 0x8e, 0xaa]);
+                            expected[32..36].copy_from_slice(&0x1234_5678u32.to_be_bytes());
+                            expected[40] = 2;
+                        }
+                    }
+                    assert_eq!(bytes, expected);
+                    outcomes.push((result, bytes));
+                }
+                assert_eq!(outcomes[0], outcomes[1]);
+            }
+        }
     }
 
     #[test]

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -1088,6 +1088,8 @@ pub enum PpcImportDispatcherTarget {
     Gestalt,
     GetSharedLibrary,
     FindSymbol,
+    CountSymbols,
+    GetIndSymbol,
     CloseConnection,
     GetMemFragment,
     InitCursor,
@@ -14494,6 +14496,14 @@ fn dispatcher_target_for_import(
         ) => PpcImportDispatcherTarget::FindSymbol,
         (
             "InterfaceLib" | "CodeFragmentMgr" | "CarbonCore.vlib" | "CFMPriv_CarbonCore",
+            "CountSymbols",
+        ) => PpcImportDispatcherTarget::CountSymbols,
+        (
+            "InterfaceLib" | "CodeFragmentMgr" | "CarbonCore.vlib" | "CFMPriv_CarbonCore",
+            "GetIndSymbol",
+        ) => PpcImportDispatcherTarget::GetIndSymbol,
+        (
+            "InterfaceLib" | "CodeFragmentMgr" | "CarbonCore.vlib" | "CFMPriv_CarbonCore",
             "CloseConnection",
         ) => PpcImportDispatcherTarget::CloseConnection,
         ("InterfaceLib", "GetMemFragment") => PpcImportDispatcherTarget::GetMemFragment,
@@ -21013,6 +21023,30 @@ fn dispatch_supported_import(
             import_count,
             import_binding_indices,
         )),
+        PpcImportDispatcherTarget::CountSymbols | PpcImportDispatcherTarget::GetIndSymbol => {
+            // PowerPC System Software (1994), pp. 3-25–3-26. Only the ABI
+            // registers and return encoding belong in this adapter.
+            use crate::cfm::{CfmMemory, CfmSymbolQuery};
+            let query = if binding.dispatcher_target == PpcImportDispatcherTarget::CountSymbols {
+                CfmSymbolQuery::Count {
+                    connection: cpu.gpr[3],
+                    count: cpu.gpr[4],
+                }
+            } else {
+                CfmSymbolQuery::Indexed {
+                    connection: cpu.gpr[3],
+                    index: cpu.gpr[4],
+                    name: cpu.gpr[5],
+                    address: cpu.gpr[6],
+                    class: cpu.gpr[7],
+                }
+            };
+            let result =
+                query.complete(cfm_connections, |writes| memory.publish_cfm_outputs(writes));
+            Some(PpcImportAction::Return(ppc_i16_result(
+                result.err().map_or(0, |error| error.os_error()),
+            )))
+        }
         PpcImportDispatcherTarget::CloseConnection => Some(PpcImportAction::Return(
             ppc_i16_result(ppc_close_connection(cpu, memory, cfm_connections)),
         )),
@@ -113139,6 +113173,106 @@ pub(crate) mod tests {
             Some(PPC_CFM_MAIN_STUB_BASE)
         );
         assert_eq!(loaded.cfm.as_ref().unwrap().connections.len(), 1);
+    }
+
+    #[test]
+    fn cfm_symbol_enumeration_imports_route_aliases_and_preserve_failed_outputs() {
+        for library in [
+            "InterfaceLib",
+            "CodeFragmentMgr",
+            "CarbonCore.vlib",
+            "CFMPriv_CarbonCore",
+        ] {
+            for count in [false, true] {
+                let name = if count {
+                    "CountSymbols"
+                } else {
+                    "GetIndSymbol"
+                };
+                for fault in 0..4 {
+                    let mut loaded = load_pef_application(&synthetic_pef_with_library_import(
+                        library.as_bytes(),
+                        name.as_bytes(),
+                    ))
+                    .unwrap();
+                    const OUTPUT: u32 = PPC_HEAP_BASE + 0x100;
+                    loaded.memory.add_region(OUTPUT, vec![0xa5; 64]);
+                    loaded
+                        .cfm
+                        .as_mut()
+                        .unwrap()
+                        .connections
+                        .push(PpcCfmConnection {
+                            id: 7,
+                            library_name: "fixture".into(),
+                            main_addr: 0,
+                            init_addr: 0,
+                            term_addr: 0,
+                            exports: vec![PpcCfmExport {
+                                name: "Café™".into(),
+                                class: 2,
+                                address: 0x1234_5678,
+                            }],
+                        });
+                    loaded.cpu.gpr[3] = if fault == 1 { 99 } else { 7 };
+                    loaded.cpu.gpr[4] = if count {
+                        OUTPUT
+                    } else if fault == 2 {
+                        2
+                    } else {
+                        1
+                    };
+                    loaded.cpu.gpr[5] = OUTPUT;
+                    loaded.cpu.gpr[6] = OUTPUT + 32;
+                    loaded.cpu.gpr[7] = OUTPUT + 40;
+                    if fault == 3 {
+                        loaded
+                            .memory
+                            .add_readonly_region(OUTPUT + if count { 1 } else { 40 }, vec![0xa5]);
+                    }
+                    let probe = loaded.run_with_hle_imports(128);
+                    assert_eq!(probe.handled_import_count, 1, "{library} {name}");
+                    assert_eq!(probe.unsupported_import_index, None);
+                    let error: i16 = match fault {
+                        1 => -2801,
+                        2 if !count => -2802,
+                        3 => -50,
+                        _ => 0,
+                    };
+                    assert_eq!(loaded.cpu.gpr[3], error as i32 as u32);
+                    if error != 0 {
+                        assert!((0..64).all(|i| loaded.memory.read_u8(OUTPUT + i) == Some(0xa5)));
+                    } else if count {
+                        assert_eq!(loaded.memory.read_u32_be(OUTPUT), Some(1));
+                    } else {
+                        assert_eq!(loaded.memory.read_u32_be(OUTPUT + 32), Some(0x1234_5678));
+                        assert_eq!(loaded.memory.read_u8(OUTPUT + 40), Some(2));
+                    }
+                }
+            }
+        }
+    }
+
+    pub(crate) fn synthetic_pef_with_enumerable_exports() -> Vec<u8> {
+        let name = b"Caf\x8e\xaa";
+        let strings_offset = 56usize;
+        let hash_offset = strings_offset + name.len() + 1;
+        let key_offset = hash_offset + 4;
+        let symbol_offset = key_offset + 4;
+        let mut loader = vec![0; symbol_offset + 10];
+        write_i32(&mut loader, 0, -1);
+        write_i32(&mut loader, 8, -1);
+        write_i32(&mut loader, 16, -1);
+        write_u32(&mut loader, 40, strings_offset as u32);
+        write_u32(&mut loader, 44, hash_offset as u32);
+        write_u32(&mut loader, 52, 1);
+        loader[strings_offset..strings_offset + name.len()].copy_from_slice(name);
+        write_u32(&mut loader, hash_offset, 1 << 18);
+        write_u32(&mut loader, key_offset, (name.len() as u32) << 16);
+        write_u32(&mut loader, symbol_offset, 1 << 24); // data, string offset zero
+        write_u32(&mut loader, symbol_offset + 4, 0x1234_5678);
+        write_u16(&mut loader, symbol_offset + 8, (-2i16) as u16); // absolute export
+        synthetic_pef_with_loader_and_data(loader, &[0; 8])
     }
 
     #[test]

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -6194,6 +6194,10 @@ impl Default for ProcessContext {
 }
 
 impl ProcessContext {
+    pub(crate) fn cfm(&self) -> &crate::cfm::CfmState {
+        &self.cfm
+    }
+
     #[cfg(test)]
     pub(crate) fn cfm_mut(&mut self) -> &mut crate::cfm::CfmState {
         &mut self.cfm

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -6238,7 +6238,12 @@ impl FixtureRunner {
 
                     self.dispatcher.yield_for_ui = yield_for_ui;
                     let dispatch_result = self.dispatcher.with_process_state(|dispatcher| {
-                        dispatcher.dispatch(opcode, &mut self.m68k.cpu, &mut self.bus)
+                        dispatcher.dispatch_with_process_services(
+                            opcode,
+                            &mut self.m68k.cpu,
+                            &mut self.bus,
+                            self.process_context.cfm(),
+                        )
                     });
                     match dispatch_result {
                         Ok(()) => {
@@ -7018,7 +7023,12 @@ impl FixtureRunner {
                     }
                     let dispatch_err = self.dispatcher.with_process_state(|dispatcher| {
                         dispatcher
-                            .dispatch(opcode, &mut self.m68k.cpu, &mut self.bus)
+                            .dispatch_with_process_services(
+                                opcode,
+                                &mut self.m68k.cpu,
+                                &mut self.bus,
+                                self.process_context.cfm(),
+                            )
                             .is_err()
                     });
                     if dispatch_err {
@@ -10804,7 +10814,12 @@ impl FixtureRunner {
                         continue;
                     }
                     let dispatch_result = self.dispatcher.with_process_state(|dispatcher| {
-                        dispatcher.dispatch(opcode, &mut self.m68k.cpu, &mut self.bus)
+                        dispatcher.dispatch_with_process_services(
+                            opcode,
+                            &mut self.m68k.cpu,
+                            &mut self.bus,
+                            self.process_context.cfm(),
+                        )
                     });
                     match dispatch_result {
                         Ok(()) => {
@@ -11497,6 +11512,100 @@ mod tests {
             term_addr: 0,
             exports: vec![],
         }
+    }
+
+    #[test]
+    fn cfm_symbol_enumeration_observes_native_load_and_close_from_classic_execution() {
+        use crate::loader::ppc::tests::{
+            synthetic_pef_with_enumerable_exports, synthetic_pef_with_import,
+        };
+        const OUTPUT: u32 = PPC_HEAP_BASE + 0x1000;
+        const FRAGMENT: u32 = PPC_HEAP_BASE + 0x2000;
+        const CODE: u32 = 0x18000;
+        const STACK: u32 = 0x19000;
+        let fragment = synthetic_pef_with_enumerable_exports();
+        let mut native =
+            load_pef_application(&synthetic_pef_with_import(b"GetMemFragment")).unwrap();
+        native.memory.add_region(OUTPUT, vec![0xa5; 256]);
+        native.memory.add_region(FRAGMENT, fragment.clone());
+        native.cpu.gpr[3] = FRAGMENT;
+        native.cpu.gpr[4] = fragment.len() as u32;
+        native.cpu.gpr[5] = 0;
+        native.cpu.gpr[6] = 1;
+        native.cpu.gpr[7] = OUTPUT;
+        native.cpu.gpr[8] = OUTPUT + 4;
+        native.cpu.gpr[9] = OUTPUT + 8;
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        runner.init_ppc_companion(native);
+        let mut context = runner.native.take(NativeEngineRole::Companion).unwrap();
+        let native = context.adapter_mut();
+        let probe = runner.process_context.with_memory_and_cfm(|mm, cfm| {
+            native.run_with_process_services(128, false, false, mm, cfm)
+        });
+        assert_eq!(probe.unsupported_import_index, None);
+        assert_eq!(native.cpu.gpr[3], 0);
+        let id = native.memory.read_u32_be(OUTPUT).unwrap();
+        assert_ne!(id, 0xa5a5_a5a5);
+        assert_eq!(
+            runner.process_context.cfm().connections[0].exports[0].name,
+            "Café™"
+        );
+        assert!(runner.native.restore(context).is_ok());
+        for selector in [6u16, 7] {
+            runner.bus.write_word(CODE, 0x3f3c); // MOVE.W #selector,-(SP), Apple inline glue.
+            runner.bus.write_word(CODE + 2, selector);
+            runner.bus.write_word(CODE + 4, 0xaa5a);
+            runner.bus.write_word(CODE + 6, 0x60fe);
+            runner.m68k.cpu.write_reg(Register::PC, CODE);
+            runner.m68k.cpu.write_reg(Register::A7, STACK + 2);
+            runner.m68k.cpu.write_reg(Register::D0, 0xdead_beef);
+            if selector == 6 {
+                runner.bus.write_long(STACK + 2, OUTPUT + 16);
+                runner.bus.write_long(STACK + 6, id);
+            } else {
+                runner.bus.write_long(STACK + 2, OUTPUT + 64);
+                runner.bus.write_long(STACK + 6, OUTPUT + 60);
+                runner.bus.write_long(STACK + 10, OUTPUT + 32);
+                runner.bus.write_long(STACK + 14, 1);
+                runner.bus.write_long(STACK + 18, id);
+            }
+            let (steps, running) = runner.run_steps(8, None);
+            assert!(running && steps > 0);
+            assert_eq!(runner.m68k.cpu.read_reg(Register::D0), 0);
+            assert_eq!(
+                runner.m68k.cpu.read_reg(Register::A7),
+                STACK + if selector == 6 { 10 } else { 22 }
+            );
+        }
+        let mut context = runner.native.take(NativeEngineRole::Companion).unwrap();
+        let native = context.adapter_mut();
+        assert_eq!(native.memory.read_u32_be(OUTPUT + 16), Some(1));
+        assert_eq!(native.memory.read_u32_be(OUTPUT + 60), Some(0x1234_5678));
+        assert_eq!(native.memory.read_u8(OUTPUT + 64), Some(1));
+        assert_eq!(native.memory.read_u8(OUTPUT + 36), Some(0x8e));
+        native.imports[0].dispatcher_target = PpcImportDispatcherTarget::CloseConnection;
+        native.cpu.pc = native.entry_pc;
+        native.cpu.lr = PPC_HALT_PC;
+        native.cpu.gpr[3] = OUTPUT;
+        let probe = runner.process_context.with_memory_and_cfm(|mm, cfm| {
+            native.run_with_process_services(128, false, false, mm, cfm)
+        });
+        assert_eq!(probe.unsupported_import_index, None);
+        assert_eq!(native.cpu.gpr[3], 0);
+        assert!(runner.process_context.cfm().connections.is_empty());
+        assert!(runner.native.restore(context).is_ok());
+        runner.bus.write_word(CODE + 2, 6);
+        runner.m68k.cpu.write_reg(Register::PC, CODE);
+        runner.m68k.cpu.write_reg(Register::A7, STACK + 2);
+        runner.bus.write_long(STACK + 2, OUTPUT + 16);
+        runner.bus.write_long(STACK + 6, id);
+        let _ = runner.run_steps(8, None);
+        assert_eq!(runner.bus.read_word(STACK + 10) as i16, -2801);
+        assert_eq!(
+            runner.bus.read_long(OUTPUT + 16),
+            1,
+            "refused query preserves its previous output"
+        );
     }
 
     #[test]

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -7529,6 +7529,26 @@ impl TrapDispatcher {
         cpu: &mut C,
         bus: &mut MacMemoryBus,
     ) -> Result<()> {
+        self.dispatch_inner(trap, cpu, bus, None)
+    }
+
+    pub(crate) fn dispatch_with_process_services<C: CpuOps>(
+        &mut self,
+        trap: u16,
+        cpu: &mut C,
+        bus: &mut MacMemoryBus,
+        cfm: &crate::cfm::CfmState,
+    ) -> Result<()> {
+        self.dispatch_inner(trap, cpu, bus, Some(cfm))
+    }
+
+    fn dispatch_inner<C: CpuOps>(
+        &mut self,
+        trap: u16,
+        cpu: &mut C,
+        bus: &mut MacMemoryBus,
+        cfm: Option<&crate::cfm::CfmState>,
+    ) -> Result<()> {
         // Low-memory Ticks is guest-owned writable state. Import it at the
         // ABI boundary before any manager, trace, or diagnostic path observes
         // the process clock so a direct guest store cannot be shadowed by a
@@ -7970,7 +7990,7 @@ impl TrapDispatcher {
                     })
             })
             .or_else(|| {
-                self.dispatch_toolbox(is_tool, trap_num, cpu, bus)
+                self.dispatch_toolbox_with_process_services(is_tool, trap_num, cpu, bus, cfm)
                     .map(|result| {
                         selected_adapter = TrapAdapterId::Toolbox;
                         result

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -1039,6 +1039,69 @@ fn force_button_true_at_pc() -> Option<u32> {
     })
 }
 
+/// Classic ABI edge for the migrated CFM enumeration selectors.
+fn dispatch_cfm_symbols<C: CpuOps>(
+    cpu: &mut C,
+    bus: &mut MacMemoryBus,
+    cfm: Option<&crate::cfm::CfmState>,
+) -> Result<()> {
+    use crate::cfm::CfmSymbolQuery;
+    let sp = cpu.read_reg(Register::A7);
+    if sp.checked_add(1).is_none() || !bus.is_guest_address_mapped(sp, 2) {
+        cpu.write_reg(Register::D0, (-50i32) as u32);
+        return Ok(());
+    }
+    let selector = bus.read_word(sp);
+    let argument_bytes = match selector {
+        6 => 8,
+        7 => 20,
+        // Unmigrated selectors retain the legacy compatibility stub.
+        _ => return return_noerr(cpu),
+    };
+    let Some(cfm) = cfm else {
+        return Err(Error::UnimplementedTrap(0xAA5A));
+    };
+    let Some(result_slot) = sp.checked_add(2 + argument_bytes) else {
+        cpu.write_reg(Register::D0, (-50i32) as u32);
+        return Ok(());
+    };
+    if result_slot.checked_add(1).is_none()
+        || !bus.is_guest_address_mapped(sp, (2 + argument_bytes) as usize)
+        || !bus.is_guest_address_writable(result_slot, 2)
+    {
+        cpu.write_reg(Register::D0, (-50i32) as u32);
+        return Ok(());
+    }
+    let query = if selector == 6 {
+        CfmSymbolQuery::Count {
+            connection: bus.read_long(sp + 6),
+            count: bus.read_long(sp + 2),
+        }
+    } else {
+        CfmSymbolQuery::Indexed {
+            connection: bus.read_long(sp + 18),
+            index: bus.read_long(sp + 14),
+            name: bus.read_long(sp + 10),
+            address: bus.read_long(sp + 6),
+            class: bus.read_long(sp + 2),
+        }
+    };
+    let result = query.complete(&cfm.connections, |writes| {
+        let success = 0u16.to_be_bytes();
+        let mut writes = writes.to_vec();
+        writes.push((result_slot, &success));
+        bus.try_write_ranges_atomic(&writes)
+    });
+    let error = result.err().map_or(0, |error| error.os_error());
+    if error != 0 {
+        // All semantic outputs remain unchanged when their transaction fails.
+        let _ = bus.try_write_word(result_slot, error as u16);
+    }
+    cpu.write_reg(Register::A7, result_slot);
+    cpu.write_reg(Register::D0, error as i32 as u32);
+    Ok(())
+}
+
 impl super::TrapDispatcher {
     /// Whether `SystemTask` currently has periodic Desk Manager work to do.
     ///
@@ -4934,12 +4997,24 @@ impl super::TrapDispatcher {
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn dispatch_toolbox<C: CpuOps>(
         &mut self,
         is_tool: bool,
         trap_num: u16,
         cpu: &mut C,
         bus: &mut MacMemoryBus,
+    ) -> Option<Result<()>> {
+        self.dispatch_toolbox_with_process_services(is_tool, trap_num, cpu, bus, None)
+    }
+
+    pub(crate) fn dispatch_toolbox_with_process_services<C: CpuOps>(
+        &mut self,
+        is_tool: bool,
+        trap_num: u16,
+        cpu: &mut C,
+        bus: &mut MacMemoryBus,
+        cfm: Option<&crate::cfm::CfmState>,
     ) -> Option<Result<()>> {
         self.read_tick_count(bus);
         Some(match (is_tool, trap_num) {
@@ -11787,7 +11862,7 @@ impl super::TrapDispatcher {
                         | 0x0060
                         | 0x0064
                 ) {
-                    return self.dispatch_toolbox(true, 0x1E7, cpu, bus);
+                    return self.dispatch_toolbox_with_process_services(true, 0x1E7, cpu, bus, cfm);
                 }
                 match selector {
                     // PROCEDURE LActivate(act: BOOLEAN;
@@ -15970,34 +16045,15 @@ impl super::TrapDispatcher {
                 crate::mixed_mode::enter_m68k_routine_descriptor(cpu, bus, &self.guest_calls)
             }
 
-            // CodeFragmentDispatch ($AA5A) — Code Fragment Manager
-            // Inside Macintosh: PowerPC System Software 1994
-            // (PPC SS 1994 ch.6, Gestalt cite line 1770: "if you
-            // need to know whether the Code Fragment Manager is
-            // available, you can call the Gestalt function with the
-            // selector gestaltCFMAttr"; constant cite line 4736:
-            // `#define gestaltCFMAttr 'cfrg'`).
-            // The CFM resolves and connects PowerPC code fragments
-            // ('cfrg' resources) — the loader for PowerPC native
-            // executables and shared libraries (PEF format).
-            // Selector convention: D0 = routine number; routines
-            // include GetSharedLibrary, GetDiskFragment, FindSymbol,
-            // CountSymbols, GetIndSymbol, CloseConnection, etc.
-            // Gestalt: `gestaltCFMAttr = 'cfrg'`,
-            // `gestaltCFMPresent = 0` (response bit 0).
-            //
-            // HLE behaviour: D0=0 (noErr), all other registers
-            // preserved, stack untouched. Systemless is a 68K-only HLE
-            // — apps that probe Gestalt see 'cfrg' undefined and
-            // either fall back to the 68K code path or refuse to
-            // launch. PPC fat binaries with 68K-fork still execute
-            // because the loader picks the 68K fork when CFM is
-            // absent.
-            //
-            // Regression coverage:
-            //   src/trap/toolbox.rs::tests::codefragmentdispatch_*
-            // CodeFragmentDispatch (CFM) ($AA5A): PPC SS 1994 ch.6 1770. D0 selector. Gestalt 'cfrg' → gestaltCFMPresent=0. HLE: D0=0, registers + stack preserved (68K-only — fat binaries fall back to 68K fork).
-            (true, 0x25A) => return_noerr(cpu),
+            // CodeFragmentDispatch ($AA5A)
+            // Enumerates exports in a process CFM connection.
+            // OSErr CountSymbols(ConnectionID connID, long *symCount);
+            // OSErr GetIndSymbol(ConnectionID connID, long symIndex,
+            //                    Str255 symName, Ptr *symAddr, SymClass *symClass);
+            // PowerPC System Software (1994), pp. 3-25–3-26. Universal
+            // Interfaces 3.4, CodeFragments.h: $3F3C,$0006/$0007,$AA5A
+            // pushes a word selector before the Pascal argument frame.
+            (true, 0x25A) => dispatch_cfm_symbols(cpu, bus, cfm),
 
             // IconDispatch ($ABC9)
             // Dispatches Icon Utilities routines selected by the low word of D0.
@@ -16994,6 +17050,114 @@ mod tests {
             sp_before,
             "MethodDispatch should preserve the caller stack pointer"
         );
+    }
+
+    #[test]
+    fn cfm_symbol_enumeration_uses_stack_selectors_and_atomic_pascal_results() {
+        use crate::cfm::{CfmConnection, CfmExport, CfmState};
+        use crate::memory::GuestAddressSpace;
+        const STACK: u32 = 0x0100_0000;
+        const OUTPUT: u32 = STACK + 0x100;
+        let cfm = CfmState {
+            connections: vec![CfmConnection {
+                id: 7,
+                library_name: "fragment".into(),
+                main_addr: 0,
+                init_addr: 0,
+                term_addr: 0,
+                exports: vec![CfmExport {
+                    name: "Café™".into(),
+                    class: 1,
+                    address: 0x1234_5678,
+                }],
+            }],
+            ..Default::default()
+        };
+        for selector in [6, 7] {
+            for fault in 0..7 {
+                let (mut disp, mut cpu, mut bus) = setup();
+                let mut memory = GuestAddressSpace::new();
+                memory.add_region(STACK, vec![0xa5; 0x200]);
+                bus.set_addressing_32_bit(true);
+                bus.attach_guest_address_space(memory.shared_view());
+                let result_slot = STACK + if selector == 6 { 10 } else { 22 };
+                bus.write_word(STACK, selector);
+                if selector == 6 {
+                    bus.write_long(STACK + 2, OUTPUT);
+                    bus.write_long(STACK + 6, if fault == 1 { 99 } else { 7 });
+                } else {
+                    bus.write_long(STACK + 2, OUTPUT + 40);
+                    bus.write_long(STACK + 6, OUTPUT + 32);
+                    bus.write_long(STACK + 10, OUTPUT);
+                    bus.write_long(STACK + 14, if fault == 2 { 0 } else { 1 });
+                    bus.write_long(STACK + 18, if fault == 1 { 99 } else { 7 });
+                }
+                if fault == 3 {
+                    memory.add_readonly_region(OUTPUT, vec![0xa5]);
+                }
+                if fault == 4 {
+                    memory.add_readonly_region(result_slot, vec![0xa5; 2]);
+                }
+                let initial_sp = if fault == 5 { u32::MAX - 7 } else { STACK };
+                cpu.write_reg(Register::A7, initial_sp);
+                cpu.write_reg(Register::D0, 0xdead_beef); // D0 is not the selector.
+                cpu.write_reg(Register::D1, 0x1122_3344);
+                cpu.write_reg(Register::A0, 0x5566_7788);
+                let before: Vec<_> = (0..64).map(|i| bus.read_byte(OUTPUT + i)).collect();
+                let result = if fault == 6 {
+                    disp.dispatch(0xAA5A, &mut cpu, &mut bus)
+                } else {
+                    disp.dispatch_with_process_services(0xAA5A, &mut cpu, &mut bus, &cfm)
+                };
+                if fault == 6 {
+                    assert!(matches!(
+                        result,
+                        Err(crate::Error::UnimplementedTrap(0xAA5A))
+                    ));
+                    assert_eq!(cpu.read_reg(Register::A7), initial_sp);
+                    assert_eq!(cpu.read_reg(Register::D0), 0xdead_beef);
+                } else {
+                    assert!(result.is_ok());
+                    let error: i16 = match fault {
+                        1 => -2801,
+                        2 if selector == 7 => -2802,
+                        3..=5 => -50,
+                        _ => 0,
+                    };
+                    assert_eq!(cpu.read_reg(Register::D0), error as i32 as u32);
+                    assert_eq!(
+                        cpu.read_reg(Register::A7),
+                        if matches!(fault, 4 | 5) {
+                            initial_sp
+                        } else {
+                            result_slot
+                        }
+                    );
+                    if !matches!(fault, 4 | 5) {
+                        assert_eq!(bus.read_word(result_slot), error as u16);
+                    }
+                    if error == 0 {
+                        if selector == 6 {
+                            assert_eq!(bus.read_long(OUTPUT), 1);
+                        } else {
+                            assert_eq!(bus.read_byte(OUTPUT), 5);
+                            assert_eq!(bus.read_long(OUTPUT + 32), 0x1234_5678);
+                            assert_eq!(bus.read_byte(OUTPUT + 40), 1);
+                        }
+                    }
+                }
+                if matches!(fault, 1 | 3..=6) || (fault == 2 && selector == 7) {
+                    assert_eq!(
+                        (0..64)
+                            .map(|i| bus.read_byte(OUTPUT + i))
+                            .collect::<Vec<_>>(),
+                        before
+                    );
+                }
+                assert_eq!(cpu.read_reg(Register::D1), 0x1122_3344);
+                assert_eq!(cpu.read_reg(Register::A0), 0x5566_7788);
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
CountSymbols and GetIndSymbol now query the process CFM registry through both native imports and classic CodeFragmentDispatch. Previously the native entries were unsupported and the classic trap returned success without enumerating anything.

One CPU-independent query owns connection lookup, one-based indexing, Pascal MacRoman names and atomic output publication. The classic adapter reads the stack selector from Apple’s inline glue and commits its Pascal OSErr slot with the outputs. All runner classic execution routes receive the process service explicitly; standalone dispatch without that service refuses these selectors.

Validation: 5,056 headless library tests passed, with three existing ignored tests; production compilation passed without warnings. Focused tests cover both memory views, every existing native CFM library alias, empty exports, invalid IDs/indices, null/wrapping/incomplete/protected outputs, protected Pascal returns and register preservation. An executed 68K inline sequence observes exports loaded by native GetMemFragment and then observes removal by native CloseConnection, without copying a registry between adapters.

References: Inside Macintosh: PowerPC System Software (1994), pp. 3-25–3-26; Apple Universal Interfaces 3.4, CodeFragments.h selectors 6 and 7.

Other classic CFM selectors retain their existing compatibility path. Synthetic system-library bindings remain outside the loaded PEF export list; enumerating those namespaces belongs to the remaining import-service migration.

Closes #1478
