### PR TITLE
feat: share CFM symbol lookup across classic and native calls

### DIFF
--- a/src/cfm.rs
+++ b/src/cfm.rs
@@ -195,6 +195,7 @@ pub(crate) enum CfmSymbolError {
     ConnectionNotFound,
     SymbolNotFound,
     InvalidOutputs,
+    NoAddressSpace,
 }
 
 impl CfmSymbolError {
@@ -203,6 +204,7 @@ impl CfmSymbolError {
             Self::ConnectionNotFound => -2801,
             Self::SymbolNotFound => -2802,
             Self::InvalidOutputs => -50,
+            Self::NoAddressSpace => -2810,
         }
     }
 }
@@ -263,6 +265,84 @@ impl CfmSymbolQuery {
         publish(&writes)
             .then_some(())
             .ok_or(CfmSymbolError::InvalidOutputs)
+    }
+}
+
+/// An ABI edge may stage a callable gateway, but may not register it until
+/// the CFM service has published every guest output. Providers are bounded
+/// borrows for one synchronous operation; dropping one discards its staging.
+pub(crate) trait CfmSymbolBindings {
+    fn prepare(&mut self, library: &str, symbol: &str) -> Result<(u32, u8), CfmSymbolError>;
+    fn commit(&mut self);
+}
+
+/// FindSymbol's logical arguments, without caller registers or return slots.
+/// PowerPC System Software (1994), pp. 3-24–3-25.
+pub(crate) struct CfmFindSymbol {
+    pub(crate) connection: u32,
+    pub(crate) name: u32,
+    pub(crate) address: u32,
+    pub(crate) class: u32,
+}
+
+impl CfmFindSymbol {
+    pub(crate) fn complete<M: GuestProcedureMemory>(
+        self,
+        connections: &[CfmConnection],
+        memory: &mut M,
+        mut bindings: Option<&mut dyn CfmSymbolBindings>,
+        mut publish: impl FnMut(&mut M, &[(u32, &[u8])]) -> bool,
+    ) -> Result<(), CfmSymbolError> {
+        let connection = connections
+            .iter()
+            .find(|connection| connection.id == self.connection)
+            .ok_or(CfmSymbolError::ConnectionNotFound)?;
+        if self.name == 0
+            || self.address == 0
+            || self.class == 0
+            || self.address.checked_add(3).is_none()
+        {
+            return Err(CfmSymbolError::InvalidOutputs);
+        }
+        let length = memory
+            .procedure_read_u8(self.name)
+            .ok_or(CfmSymbolError::InvalidOutputs)?;
+        let mut name = Vec::with_capacity(usize::from(length));
+        for offset in 1..=u32::from(length) {
+            let address = self
+                .name
+                .checked_add(offset)
+                .ok_or(CfmSymbolError::InvalidOutputs)?;
+            name.push(
+                memory
+                    .procedure_read_u8(address)
+                    .ok_or(CfmSymbolError::InvalidOutputs)?,
+            );
+        }
+        let name = crate::mac_roman::decode_mac_roman(&name);
+        let (address, class, used_binding) =
+            if let Some(export) = connection.exports.iter().find(|export| export.name == name) {
+                (export.address, export.class, false)
+            } else {
+                let provider = bindings
+                    .as_deref_mut()
+                    .ok_or(CfmSymbolError::SymbolNotFound)?;
+                let (address, class) = provider.prepare(&connection.library_name, &name)?;
+                (address, class, true)
+            };
+        if !publish(
+            memory,
+            &[
+                (self.address, &address.to_be_bytes()),
+                (self.class, &[class]),
+            ],
+        ) {
+            return Err(CfmSymbolError::InvalidOutputs);
+        }
+        if used_binding {
+            bindings.expect("a binding was prepared").commit();
+        }
+        Ok(())
     }
 }
 
@@ -511,6 +591,124 @@ mod tests {
         let mut bytes = vec![0; 20];
         memory.read_bytes_into(OUTPUT, &mut bytes).unwrap();
         bytes
+    }
+
+    #[test]
+    fn find_symbol_shares_lookup_and_commits_bindings_only_after_atomic_publication() {
+        #[derive(Default)]
+        struct Bindings {
+            prepared: usize,
+            committed: usize,
+        }
+        impl CfmSymbolBindings for Bindings {
+            fn prepare(
+                &mut self,
+                library: &str,
+                symbol: &str,
+            ) -> Result<(u32, u8), CfmSymbolError> {
+                self.prepared += 1;
+                assert_eq!(library, "library-7");
+                if symbol != "Café™" {
+                    return Err(CfmSymbolError::SymbolNotFound);
+                }
+                Ok((0x1234_5678, 2))
+            }
+            fn commit(&mut self) {
+                self.committed += 1;
+            }
+        }
+        const NAME: u32 = OUTPUT + 0x100;
+        for dynamic in [false, true] {
+            for fault in 0..14 {
+                let mut outcomes = Vec::new();
+                for classic in [false, true] {
+                    let mut connection = connection(7);
+                    if !dynamic {
+                        connection.exports.push(CfmExport {
+                            name: "Café™".into(),
+                            class: 2,
+                            address: 0x1234_5678,
+                        });
+                    }
+                    let mut memory = GuestAddressSpace::new();
+                    memory.add_region(OUTPUT, vec![0xa5; if fault == 8 { 2 } else { 16 }]);
+                    let name = if fault == 2 {
+                        vec![5, b'c', b'a', b'f', 0x8e, 0xaa]
+                    } else {
+                        vec![5, b'C', b'a', b'f', 0x8e, 0xaa]
+                    };
+                    memory.add_region(NAME, if fault == 3 { name[..4].to_vec() } else { name });
+                    if fault == 5 {
+                        memory.add_region(u32::MAX, vec![2]);
+                    }
+                    if fault == 10 {
+                        memory.add_readonly_region(OUTPUT + 1, vec![0xa5]);
+                    }
+                    if fault == 11 {
+                        memory.add_readonly_region(OUTPUT + 8, vec![0xa5]);
+                    }
+                    let mut bus = MacMemoryBus::new(0x10000);
+                    bus.set_addressing_32_bit(true);
+                    bus.attach_guest_address_space(memory.shared_view());
+                    let request = CfmFindSymbol {
+                        connection: if fault == 1 { 99 } else { 7 },
+                        name: match fault {
+                            4 => 0,
+                            5 => u32::MAX,
+                            _ => NAME,
+                        },
+                        address: match fault {
+                            6 => 0,
+                            7 => u32::MAX - 1,
+                            _ => OUTPUT,
+                        },
+                        class: match fault {
+                            9 => 0,
+                            13 => OUTPUT + 0x1000,
+                            _ => OUTPUT + 8,
+                        },
+                    };
+                    let mut bindings = Bindings::default();
+                    let provider = if fault == 12 {
+                        None
+                    } else {
+                        Some(&mut bindings as &mut dyn CfmSymbolBindings)
+                    };
+                    let before: Vec<_> = (0..16)
+                        .map(|i| memory.procedure_read_u8(OUTPUT + i))
+                        .collect();
+                    let result = if classic {
+                        request.complete(&[connection], &mut bus, provider, |memory, writes| {
+                            memory.publish_cfm_outputs(writes)
+                        })
+                    } else {
+                        request.complete(&[connection], &mut memory, provider, |memory, writes| {
+                            memory.publish_cfm_outputs(writes)
+                        })
+                    };
+                    let expected = match fault {
+                        1 => Some(CfmSymbolError::ConnectionNotFound),
+                        2 => Some(CfmSymbolError::SymbolNotFound),
+                        12 if dynamic => Some(CfmSymbolError::SymbolNotFound),
+                        3..=11 | 13 => Some(CfmSymbolError::InvalidOutputs),
+                        _ => None,
+                    };
+                    assert_eq!(result.err(), expected, "dynamic {dynamic}, fault {fault}");
+                    let bytes: Vec<_> = (0..16)
+                        .map(|i| memory.procedure_read_u8(OUTPUT + i))
+                        .collect();
+                    assert_eq!(bindings.committed, usize::from(dynamic && result.is_ok()));
+                    if result.is_err() {
+                        assert_eq!(bytes, before);
+                    } else {
+                        assert_eq!(memory.procedure_read_u32(OUTPUT), Some(0x1234_5678));
+                        assert_eq!(memory.procedure_read_u8(OUTPUT + 8), Some(2));
+                    }
+                    outcomes.push((result, bytes, bindings.prepared, bindings.committed));
+                }
+                assert_eq!(outcomes[0], outcomes[1]);
+            }
+        }
     }
 
     #[test]

--- a/src/execution_native.rs
+++ b/src/execution_native.rs
@@ -118,8 +118,12 @@ impl<T> NativeExecution<T> {
     }
 
     pub(crate) fn application_mut(&mut self) -> Option<&mut T> {
-        self.application.reclaim();
-        match &mut self.application {
+        self.adapter_mut(NativeEngineRole::Application)
+    }
+
+    pub(crate) fn adapter_mut(&mut self, role: NativeEngineRole) -> Option<&mut T> {
+        self.slot_mut(role).reclaim();
+        match self.slot_mut(role) {
             NativeSlot::Installed(adapter) => Some(adapter),
             _ => None,
         }

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -3644,6 +3644,15 @@ fn ppc_set_current_resource_refnum(
 }
 
 impl PpcLoadedApp {
+    pub(crate) fn cfm_symbol_bindings(&mut self) -> PpcCfmSymbolBindings<'_> {
+        PpcCfmSymbolBindings {
+            imports: &mut self.imports,
+            import_count: &mut self.import_count,
+            indices: None,
+            pending: None,
+        }
+    }
+
     #[cfg(test)]
     fn set_test_resource_error(&mut self, error: i16) {
         let _ = self
@@ -51159,6 +51168,78 @@ fn ppc_close_connection(
     PPC_NO_ERR
 }
 
+/// Borrowed native gateway staging; the process CFM service owns lookup policy.
+pub(crate) struct PpcCfmSymbolBindings<'a> {
+    imports: &'a mut Vec<PpcImportBinding>,
+    import_count: &'a mut u32,
+    indices: Option<&'a mut Vec<Option<usize>>>,
+    pending: Option<PpcImportBinding>,
+}
+
+impl crate::cfm::CfmSymbolBindings for PpcCfmSymbolBindings<'_> {
+    fn prepare(
+        &mut self,
+        library: &str,
+        symbol: &str,
+    ) -> Result<(u32, u8), crate::cfm::CfmSymbolError> {
+        use crate::cfm::CfmSymbolError;
+        self.pending = None;
+        if !ppc_is_explicit_hle_cfm_library(library) {
+            return Err(CfmSymbolError::SymbolNotFound);
+        }
+        if let Some(address) = import_data_address_for(library, symbol) {
+            return Ok((address, 1));
+        }
+        if let Some(binding) = self.imports.iter().find(|binding| {
+            binding.library_name == library
+                && binding.symbol_name == symbol
+                && binding.class == 2
+                && binding.dispatcher_target != PpcImportDispatcherTarget::Unsupported
+        }) {
+            return Ok((binding.address, binding.class));
+        }
+        let target = dispatcher_target_for_import(library, symbol);
+        if target == PpcImportDispatcherTarget::Unsupported
+            || *self.import_count >= PPC_IMPORT_CAPACITY
+        {
+            return Err(CfmSymbolError::SymbolNotFound);
+        }
+        let symbol_index = *self.import_count;
+        let address =
+            import_address_for(symbol_index, 2).map_err(|_| CfmSymbolError::NoAddressSpace)?;
+        let trap_pc = import_trap_pc(symbol_index).map_err(|_| CfmSymbolError::NoAddressSpace)?;
+        self.pending = Some(PpcImportBinding {
+            library_index: u32::MAX,
+            symbol_index,
+            library_name: library.into(),
+            symbol_name: symbol.into(),
+            class: 2,
+            weak: false,
+            address,
+            tvector_address: Some(address),
+            trap_pc,
+            dispatcher_target: target,
+        });
+        Ok((address, 2))
+    }
+
+    fn commit(&mut self) {
+        let Some(binding) = self.pending.take() else {
+            return;
+        };
+        let symbol_index = binding.symbol_index as usize;
+        let binding_index = self.imports.len();
+        self.imports.push(binding);
+        if let Some(indices) = self.indices.as_deref_mut() {
+            if indices.len() <= symbol_index {
+                indices.resize(symbol_index + 1, None);
+            }
+            indices[symbol_index] = Some(binding_index);
+        }
+        *self.import_count += 1;
+    }
+}
+
 fn ppc_find_symbol(
     cpu: &PpcCpu,
     memory: &mut PpcSectionMem,
@@ -51167,86 +51248,30 @@ fn ppc_find_symbol(
     import_count: &mut u32,
     import_binding_indices: &mut Vec<Option<usize>>,
 ) -> PpcImportAction {
-    // Inside Macintosh: PowerPC System Software (1994), pp. 3-24--3-25.
-    let connection_id = cpu.gpr[3];
-    let symbol_name_ptr = cpu.gpr[4];
-    let symbol_addr_ptr = cpu.gpr[5];
-    let symbol_class_ptr = cpu.gpr[6];
-    let Some(connection) = cfm_connections
-        .iter()
-        .find(|connection| connection.id == connection_id)
-    else {
-        return PpcImportAction::Return(ppc_i16_result(PPC_FRAG_CONNECTION_ID_NOT_FOUND));
+    use crate::cfm::{CfmFindSymbol, CfmMemory};
+    // PowerPC System Software (1994), pp. 3-24–3-25: decode the native ABI
+    // here; shared CFM owns validation, export selection and publication.
+    let request = CfmFindSymbol {
+        connection: cpu.gpr[3],
+        name: cpu.gpr[4],
+        address: cpu.gpr[5],
+        class: cpu.gpr[6],
     };
-    let Some(symbol_name) =
-        ppc_read_pstring_bytes(memory, symbol_name_ptr).map(|name| decode_mac_roman(&name))
-    else {
-        return PpcImportAction::Return(ppc_i16_result(PPC_PARAM_ERR));
+    let mut bindings = PpcCfmSymbolBindings {
+        imports,
+        import_count,
+        indices: Some(import_binding_indices),
+        pending: None,
     };
-    if let Some(export) = connection
-        .exports
-        .iter()
-        .find(|export| export.name == symbol_name)
-    {
-        if memory
-            .write_u32_be(symbol_addr_ptr, export.address)
-            .is_none()
-            || memory.write_u8(symbol_class_ptr, export.class).is_none()
-        {
-            return PpcImportAction::Return(ppc_i16_result(PPC_PARAM_ERR));
-        }
-        return PpcImportAction::Return(ppc_i16_result(PPC_NO_ERR));
-    }
-    if !ppc_is_explicit_hle_cfm_library(&connection.library_name) {
-        return PpcImportAction::Return(ppc_i16_result(PPC_FRAG_SYMBOL_NOT_FOUND));
-    }
-    if let Some(address) = import_data_address_for(&connection.library_name, &symbol_name) {
-        if memory.write_u32_be(symbol_addr_ptr, address).is_none()
-            || memory.write_u8(symbol_class_ptr, 1).is_none()
-        {
-            return PpcImportAction::Return(ppc_i16_result(PPC_PARAM_ERR));
-        }
-        return PpcImportAction::Return(ppc_i16_result(PPC_NO_ERR));
-    }
-    let target = dispatcher_target_for_import(&connection.library_name, &symbol_name);
-    if target == PpcImportDispatcherTarget::Unsupported || *import_count >= PPC_IMPORT_CAPACITY {
-        return PpcImportAction::Return(ppc_i16_result(PPC_FRAG_SYMBOL_NOT_FOUND));
-    }
-
-    let symbol_index = *import_count;
-    let address = match import_address_for(symbol_index, 2) {
-        Ok(address) => address,
-        Err(_) => return PpcImportAction::Return(ppc_i16_result(PPC_FRAG_NO_ADDR_SPACE)),
-    };
-    let trap_pc = match import_trap_pc(symbol_index) {
-        Ok(address) => address,
-        Err(_) => return PpcImportAction::Return(ppc_i16_result(PPC_FRAG_NO_ADDR_SPACE)),
-    };
-    let binding_index = imports.len();
-    imports.push(PpcImportBinding {
-        library_index: u32::MAX,
-        symbol_index,
-        library_name: connection.library_name.clone(),
-        symbol_name,
-        class: 2,
-        weak: false,
-        address,
-        tvector_address: Some(address),
-        trap_pc,
-        dispatcher_target: target,
-    });
-    if import_binding_indices.len() <= symbol_index as usize {
-        import_binding_indices.resize(symbol_index as usize + 1, None);
-    }
-    import_binding_indices[symbol_index as usize] = Some(binding_index);
-    *import_count += 1;
-
-    if memory.write_u32_be(symbol_addr_ptr, address).is_none()
-        || memory.write_u8(symbol_class_ptr, 2).is_none()
-    {
-        return PpcImportAction::Return(ppc_i16_result(PPC_PARAM_ERR));
-    }
-    PpcImportAction::Return(ppc_i16_result(PPC_NO_ERR))
+    let result = request.complete(
+        cfm_connections,
+        memory,
+        Some(&mut bindings),
+        |memory, writes| memory.publish_cfm_outputs(writes),
+    );
+    PpcImportAction::Return(ppc_i16_result(
+        result.err().map_or(0, |error| error.os_error()),
+    ))
 }
 
 fn ppc_get_mem_fragment(
@@ -113433,6 +113458,105 @@ pub(crate) mod tests {
         assert_eq!(loaded.memory.read_u32_be(address_ptr), Some(0x0312_3456));
         assert_eq!(loaded.memory.read_u8(class_ptr), Some(1));
         assert_eq!(loaded.imports.len(), import_len_before);
+    }
+
+    #[test]
+    fn find_symbol_import_refuses_partial_outputs_retries_and_reuses_callable_bindings() {
+        const OUTPUT: u32 = PPC_HEAP_BASE + 0x100;
+        for dynamic in [false, true] {
+            let mut loaded =
+                load_pef_application(&synthetic_pef_with_import(b"FindSymbol")).unwrap();
+            loaded.memory.add_region(OUTPUT, vec![0xa5; 128]);
+            loaded.memory.add_readonly_region(OUTPUT + 8, vec![0xa5]);
+            let symbol = if dynamic {
+                b"TickCount".as_slice()
+            } else {
+                b"RealExport".as_slice()
+            };
+            write_ppc_pstring(&mut loaded.memory, OUTPUT + 32, symbol);
+            loaded
+                .cfm
+                .as_mut()
+                .unwrap()
+                .connections
+                .push(PpcCfmConnection {
+                    id: 7,
+                    library_name: if dynamic {
+                        "InterfaceLib"
+                    } else {
+                        "RealLibrary"
+                    }
+                    .into(),
+                    main_addr: 0,
+                    init_addr: 0,
+                    term_addr: 0,
+                    exports: if dynamic {
+                        vec![]
+                    } else {
+                        vec![PpcCfmExport {
+                            name: "RealExport".into(),
+                            class: 1,
+                            address: 0x1234_5678,
+                        }]
+                    },
+                });
+            let original_count = loaded.import_count;
+            let original_len = loaded.imports.len();
+            let mut returned = None;
+            for attempt in 0..3 {
+                loaded.cpu.pc = loaded.entry_pc;
+                loaded.cpu.lr = PPC_HALT_PC;
+                loaded.cpu.gpr[3] = 7;
+                loaded.cpu.gpr[4] = OUTPUT + 32;
+                loaded.cpu.gpr[5] = OUTPUT;
+                loaded.cpu.gpr[6] = OUTPUT + if attempt == 0 { 8 } else { 9 };
+                let probe = loaded.run_with_hle_imports(128);
+                assert_eq!(probe.handled_import_count, 1);
+                assert_eq!(probe.unsupported_import_index, None);
+                if attempt == 0 {
+                    assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_PARAM_ERR));
+                    assert_eq!(loaded.memory.read_u32_be(OUTPUT), Some(0xa5a5_a5a5));
+                    assert_eq!(loaded.import_count, original_count);
+                    assert_eq!(loaded.imports.len(), original_len);
+                } else {
+                    assert_eq!(loaded.cpu.gpr[3], 0);
+                    let address = loaded.memory.read_u32_be(OUTPUT).unwrap();
+                    if let Some(previous) = returned {
+                        assert_eq!(address, previous);
+                    }
+                    returned = Some(address);
+                    assert_eq!(loaded.import_count, original_count + u32::from(dynamic));
+                    assert_eq!(loaded.imports.len(), original_len + usize::from(dynamic));
+                }
+            }
+            if dynamic {
+                let vector = returned.unwrap();
+                loaded
+                    .memory
+                    .write_u32_be(crate::memory::globals::addr::TICKS, 0x1234)
+                    .unwrap();
+                loaded.cpu.pc = loaded.memory.read_u32_be(vector).unwrap();
+                loaded.cpu.gpr[2] = loaded.memory.read_u32_be(vector + 4).unwrap();
+                loaded.cpu.lr = PPC_HALT_PC;
+                let probe = loaded.run_with_hle_imports(64);
+                assert_eq!(probe.handled_import_count, 1);
+                assert_eq!(loaded.cpu.gpr[3], 0x1234);
+                // An existing symbol remains available when the gateway pool is full.
+                loaded.import_count = PPC_IMPORT_CAPACITY;
+                let mut bindings = loaded.cfm_symbol_bindings();
+                assert_eq!(
+                    crate::cfm::CfmSymbolBindings::prepare(
+                        &mut bindings,
+                        "InterfaceLib",
+                        "TickCount"
+                    ),
+                    Ok((vector, 2))
+                );
+                crate::cfm::CfmSymbolBindings::commit(&mut bindings);
+                assert_eq!(loaded.import_count, PPC_IMPORT_CAPACITY);
+                assert_eq!(loaded.imports.len(), original_len + 1);
+            }
+        }
     }
 
     #[test]

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -5608,6 +5608,27 @@ impl FixtureRunner {
         AdvanceResult::Advanced
     }
 
+    fn dispatch_classic_with_process_services(&mut self, opcode: u16) -> Result<()> {
+        let role = if self.native.availability().application {
+            NativeEngineRole::Application
+        } else {
+            NativeEngineRole::Companion
+        };
+        let mut bindings = self
+            .native
+            .adapter_mut(role)
+            .map(PpcLoadedApp::cfm_symbol_bindings);
+        self.dispatcher.dispatch_with_process_services(
+            opcode,
+            &mut self.m68k.cpu,
+            &mut self.bus,
+            self.process_context.cfm(),
+            bindings
+                .as_mut()
+                .map(|bindings| bindings as &mut dyn crate::cfm::CfmSymbolBindings),
+        )
+    }
+
     fn run_steps_internal(
         &mut self,
         max_steps: usize,
@@ -6237,14 +6258,7 @@ impl FixtureRunner {
                     }
 
                     self.dispatcher.yield_for_ui = yield_for_ui;
-                    let dispatch_result = self.dispatcher.with_process_state(|dispatcher| {
-                        dispatcher.dispatch_with_process_services(
-                            opcode,
-                            &mut self.m68k.cpu,
-                            &mut self.bus,
-                            self.process_context.cfm(),
-                        )
-                    });
+                    let dispatch_result = self.dispatch_classic_with_process_services(opcode);
                     match dispatch_result {
                         Ok(()) => {
                             let null_event = self.note_idle_cycle_trap_result(opcode);
@@ -7021,16 +7035,18 @@ impl FixtureRunner {
                         self.m68k.cpu.core.take_aline_exception(&mut self.bus);
                         continue;
                     }
-                    let dispatch_err = self.dispatcher.with_process_state(|dispatcher| {
-                        dispatcher
+                    let dispatch_err = {
+                        let mut bindings = ppc_app.cfm_symbol_bindings();
+                        self.dispatcher
                             .dispatch_with_process_services(
                                 opcode,
                                 &mut self.m68k.cpu,
                                 &mut self.bus,
                                 self.process_context.cfm(),
+                                Some(&mut bindings),
                             )
                             .is_err()
-                    });
+                    };
                     if dispatch_err {
                         running = false;
                         break;
@@ -10813,14 +10829,7 @@ impl FixtureRunner {
                         count += 1;
                         continue;
                     }
-                    let dispatch_result = self.dispatcher.with_process_state(|dispatcher| {
-                        dispatcher.dispatch_with_process_services(
-                            opcode,
-                            &mut self.m68k.cpu,
-                            &mut self.bus,
-                            self.process_context.cfm(),
-                        )
-                    });
+                    let dispatch_result = self.dispatch_classic_with_process_services(opcode);
                     match dispatch_result {
                         Ok(()) => {
                             // Smart PC Advance:
@@ -11515,6 +11524,159 @@ mod tests {
     }
 
     #[test]
+    fn find_symbol_classic_lookup_stages_native_bindings_and_returns_callable_identity() {
+        use crate::loader::ppc::tests::synthetic_pef_with_import;
+        const OUTPUT: u32 = PPC_HEAP_BASE + 0x1000;
+        const CODE: u32 = 0x18000;
+        const STACK: u32 = 0x19000;
+        let mut native =
+            load_pef_application(&synthetic_pef_with_import(b"GetSharedLibrary")).unwrap();
+        native.memory.add_region(OUTPUT, vec![0xa5; 256]);
+        native
+            .memory
+            .write_bytes(OUTPUT + 32, b"\x0cInterfaceLib")
+            .unwrap();
+        native.cpu.gpr[3] = OUTPUT + 32;
+        native.cpu.gpr[4] = u32::from_be_bytes(*b"pwpc");
+        native.cpu.gpr[5] = 1;
+        native.cpu.gpr[6] = OUTPUT;
+        native.cpu.gpr[7] = OUTPUT + 4;
+        native.cpu.gpr[8] = OUTPUT + 8;
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        runner.init_ppc_companion(native);
+        let mut context = runner.native.take(NativeEngineRole::Companion).unwrap();
+        let native = context.adapter_mut();
+        let probe = runner.process_context.with_memory_and_cfm(|mm, cfm| {
+            native.run_with_process_services(128, false, false, mm, cfm)
+        });
+        assert_eq!(probe.unsupported_import_index, None);
+        assert_eq!(native.cpu.gpr[3], 0);
+        let id = native.memory.read_u32_be(OUTPUT).unwrap();
+        let initial_count = native.import_count;
+        native
+            .memory
+            .write_bytes(OUTPUT + 32, b"\x09TickCount")
+            .unwrap();
+        native.memory.add_readonly_region(OUTPUT + 64, vec![0xa5]);
+        assert!(runner.native.restore(context).is_ok());
+        for attempt in 0..3 {
+            for (offset, word) in [0x3f3c, 5, 0xaa5a, 0x60fe].into_iter().enumerate() {
+                runner.bus.write_word(CODE + offset as u32 * 2, word);
+            }
+            runner
+                .bus
+                .write_long(STACK + 2, OUTPUT + if attempt == 0 { 64 } else { 65 });
+            runner.bus.write_long(STACK + 6, OUTPUT + 60);
+            runner.bus.write_long(STACK + 10, OUTPUT + 32);
+            runner.bus.write_long(STACK + 14, id);
+            runner.m68k.cpu.write_reg(Register::PC, CODE);
+            runner.m68k.cpu.write_reg(Register::A7, STACK + 2);
+            runner.m68k.cpu.write_reg(Register::D0, 0xdead_beef);
+            let (steps, running) = runner.run_steps(8, None);
+            assert!(running && steps > 0);
+            assert_eq!(runner.m68k.cpu.read_reg(Register::A7), STACK + 18);
+            assert_eq!(
+                runner.bus.read_word(STACK + 18) as i16,
+                if attempt == 0 { -50 } else { 0 }
+            );
+            let native = runner.native.companion().unwrap();
+            assert_eq!(native.import_count, initial_count + u32::from(attempt != 0));
+            if attempt == 0 {
+                assert_eq!(runner.bus.read_long(OUTPUT + 60), 0xa5a5_a5a5);
+            } else {
+                assert_eq!(runner.bus.read_byte(OUTPUT + 65), 2);
+            }
+        }
+        let address = runner.bus.read_long(OUTPUT + 60);
+        runner
+            .bus
+            .write_long(crate::memory::globals::addr::TICKS, 0x2345);
+        let mut context = runner.native.take(NativeEngineRole::Companion).unwrap();
+        let native = context.adapter_mut();
+        native.cpu.pc = native.memory.read_u32_be(address).unwrap();
+        native.cpu.gpr[2] = native.memory.read_u32_be(address + 4).unwrap();
+        native.cpu.lr = PPC_HALT_PC;
+        let probe = runner.process_context.with_memory_and_cfm(|mm, cfm| {
+            native.run_with_process_services(64, false, false, mm, cfm)
+        });
+        assert_eq!(probe.handled_import_count, 1);
+        assert_eq!(native.cpu.gpr[3], 0x2345);
+        native.imports[0].dispatcher_target = PpcImportDispatcherTarget::FindSymbol;
+        native.cpu.pc = native.entry_pc;
+        native.cpu.lr = PPC_HALT_PC;
+        native.cpu.gpr[3] = id;
+        native.cpu.gpr[4] = OUTPUT + 32;
+        native.cpu.gpr[5] = OUTPUT + 80;
+        native.cpu.gpr[6] = OUTPUT + 84;
+        let probe = runner.process_context.with_memory_and_cfm(|mm, cfm| {
+            native.run_with_process_services(64, false, false, mm, cfm)
+        });
+        assert_eq!(probe.handled_import_count, 1);
+        assert_eq!(native.cpu.gpr[3], 0);
+        assert_eq!(native.memory.read_u32_be(OUTPUT + 80), Some(address));
+        assert_eq!(native.import_count, initial_count + 1);
+    }
+
+    #[test]
+    fn find_symbol_during_native_to_classic_callback_borrows_the_checked_out_adapter() {
+        use crate::guest_call::{GuestCallTarget, M68kRegisterState, M68kResultSource};
+        use crate::guest_procedure::GuestIsa;
+        use ppc::PpcNativeReturnGpr3;
+        const CALLBACK: u32 = 0x18000;
+        const STACK: u32 = 0x19000;
+        const RETURN: u32 = 0x1a000;
+        const OUTPUT: u32 = 0x1b000;
+        let mut app = halted_ppc_app_with_sound(PpcSoundState::default());
+        let native = app.ppc.as_mut().unwrap();
+        let mut connection = cfm_test_connection(7);
+        connection.library_name = "InterfaceLib".into();
+        native.cfm.as_mut().unwrap().connections = vec![connection];
+        native.memory.add_region(CALLBACK, vec![0; 0x4000]);
+        native
+            .memory
+            .write_bytes(OUTPUT + 32, b"\x09TickCount")
+            .unwrap();
+        let mut words = vec![0x3f3c, 0]; // Pascal result slot.
+        for argument in [7, OUTPUT + 32, OUTPUT, OUTPUT + 4] {
+            words.extend([0x2f3c, (argument >> 16) as u16, argument as u16]);
+        }
+        words.extend([0x3f3c, 5, 0xaa5a, 0x548f, 0x4e75]);
+        for (i, word) in words.into_iter().enumerate() {
+            native
+                .memory
+                .write_u16_be(CALLBACK + i as u32 * 2, word)
+                .unwrap();
+        }
+        native.memory.write_u32_be(STACK, RETURN).unwrap();
+        assert!(native.guest_calls.begin_powerpc_to_m68k(
+            GuestCallTarget {
+                isa: GuestIsa::M68k,
+                entry: CALLBACK,
+                rtoc: 0
+            },
+            CALLBACK,
+            STACK,
+            RETURN,
+            STACK + 4,
+            M68kRegisterState::default(),
+            Some(M68kResultSource::Data(0)),
+            PPC_CODE_BASE,
+            0,
+            PpcNativeReturnGpr3::Preserve,
+        ));
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        runner.init_app(&app);
+        let (steps, _) = runner.run_steps(64, None);
+        assert!(steps > 0);
+        assert!(runner.dispatcher.guest_calls.is_empty());
+        assert_eq!(runner.bus.read_byte(OUTPUT + 4), 2);
+        let native = runner.native.application().unwrap();
+        assert_eq!(native.imports.len(), 1);
+        assert_eq!(native.imports[0].symbol_name, "TickCount");
+        assert_eq!(runner.bus.read_long(OUTPUT), native.imports[0].address);
+    }
+
+    #[test]
     fn cfm_symbol_enumeration_observes_native_load_and_close_from_classic_execution() {
         use crate::loader::ppc::tests::{
             synthetic_pef_with_enumerable_exports, synthetic_pef_with_import,
@@ -11551,7 +11713,7 @@ mod tests {
             "Café™"
         );
         assert!(runner.native.restore(context).is_ok());
-        for selector in [6u16, 7] {
+        for selector in [5u16, 6, 7] {
             runner.bus.write_word(CODE, 0x3f3c); // MOVE.W #selector,-(SP), Apple inline glue.
             runner.bus.write_word(CODE + 2, selector);
             runner.bus.write_word(CODE + 4, 0xaa5a);
@@ -11559,7 +11721,15 @@ mod tests {
             runner.m68k.cpu.write_reg(Register::PC, CODE);
             runner.m68k.cpu.write_reg(Register::A7, STACK + 2);
             runner.m68k.cpu.write_reg(Register::D0, 0xdead_beef);
-            if selector == 6 {
+            if selector == 5 {
+                for (i, byte) in b"\x05Caf\x8e\xaa".iter().enumerate() {
+                    runner.bus.write_byte(OUTPUT + 96 + i as u32, *byte);
+                }
+                runner.bus.write_long(STACK + 2, OUTPUT + 64);
+                runner.bus.write_long(STACK + 6, OUTPUT + 60);
+                runner.bus.write_long(STACK + 10, OUTPUT + 96);
+                runner.bus.write_long(STACK + 14, id);
+            } else if selector == 6 {
                 runner.bus.write_long(STACK + 2, OUTPUT + 16);
                 runner.bus.write_long(STACK + 6, id);
             } else {
@@ -11574,7 +11744,12 @@ mod tests {
             assert_eq!(runner.m68k.cpu.read_reg(Register::D0), 0);
             assert_eq!(
                 runner.m68k.cpu.read_reg(Register::A7),
-                STACK + if selector == 6 { 10 } else { 22 }
+                STACK
+                    + match selector {
+                        5 => 18,
+                        6 => 10,
+                        _ => 22,
+                    }
             );
         }
         let mut context = runner.native.take(NativeEngineRole::Companion).unwrap();

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -7529,7 +7529,7 @@ impl TrapDispatcher {
         cpu: &mut C,
         bus: &mut MacMemoryBus,
     ) -> Result<()> {
-        self.dispatch_inner(trap, cpu, bus, None)
+        self.dispatch_inner(trap, cpu, bus, None, None)
     }
 
     pub(crate) fn dispatch_with_process_services<C: CpuOps>(
@@ -7538,8 +7538,9 @@ impl TrapDispatcher {
         cpu: &mut C,
         bus: &mut MacMemoryBus,
         cfm: &crate::cfm::CfmState,
+        bindings: Option<&mut dyn crate::cfm::CfmSymbolBindings>,
     ) -> Result<()> {
-        self.dispatch_inner(trap, cpu, bus, Some(cfm))
+        self.dispatch_inner(trap, cpu, bus, Some(cfm), bindings)
     }
 
     fn dispatch_inner<C: CpuOps>(
@@ -7548,6 +7549,7 @@ impl TrapDispatcher {
         cpu: &mut C,
         bus: &mut MacMemoryBus,
         cfm: Option<&crate::cfm::CfmState>,
+        bindings: Option<&mut dyn crate::cfm::CfmSymbolBindings>,
     ) -> Result<()> {
         // Low-memory Ticks is guest-owned writable state. Import it at the
         // ABI boundary before any manager, trace, or diagnostic path observes
@@ -7990,11 +7992,13 @@ impl TrapDispatcher {
                     })
             })
             .or_else(|| {
-                self.dispatch_toolbox_with_process_services(is_tool, trap_num, cpu, bus, cfm)
-                    .map(|result| {
-                        selected_adapter = TrapAdapterId::Toolbox;
-                        result
-                    })
+                self.dispatch_toolbox_with_process_services(
+                    is_tool, trap_num, cpu, bus, cfm, bindings,
+                )
+                .map(|result| {
+                    selected_adapter = TrapAdapterId::Toolbox;
+                    result
+                })
             })
             .or_else(|| {
                 self.dispatch_sane(is_tool, trap_num, cpu, bus)

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -1039,11 +1039,12 @@ fn force_button_true_at_pc() -> Option<u32> {
     })
 }
 
-/// Classic ABI edge for the migrated CFM enumeration selectors.
+/// Classic ABI edge for the migrated CFM symbol-query selectors.
 fn dispatch_cfm_symbols<C: CpuOps>(
     cpu: &mut C,
     bus: &mut MacMemoryBus,
     cfm: Option<&crate::cfm::CfmState>,
+    bindings: Option<&mut dyn crate::cfm::CfmSymbolBindings>,
 ) -> Result<()> {
     use crate::cfm::CfmSymbolQuery;
     let sp = cpu.read_reg(Register::A7);
@@ -1053,6 +1054,7 @@ fn dispatch_cfm_symbols<C: CpuOps>(
     }
     let selector = bus.read_word(sp);
     let argument_bytes = match selector {
+        5 => 16,
         6 => 8,
         7 => 20,
         // Unmigrated selectors retain the legacy compatibility stub.
@@ -1072,26 +1074,37 @@ fn dispatch_cfm_symbols<C: CpuOps>(
         cpu.write_reg(Register::D0, (-50i32) as u32);
         return Ok(());
     }
-    let query = if selector == 6 {
-        CfmSymbolQuery::Count {
-            connection: bus.read_long(sp + 6),
-            count: bus.read_long(sp + 2),
-        }
-    } else {
-        CfmSymbolQuery::Indexed {
-            connection: bus.read_long(sp + 18),
-            index: bus.read_long(sp + 14),
-            name: bus.read_long(sp + 10),
-            address: bus.read_long(sp + 6),
-            class: bus.read_long(sp + 2),
-        }
-    };
-    let result = query.complete(&cfm.connections, |writes| {
+    let publish = |bus: &mut MacMemoryBus, writes: &[(u32, &[u8])]| {
         let success = 0u16.to_be_bytes();
         let mut writes = writes.to_vec();
         writes.push((result_slot, &success));
         bus.try_write_ranges_atomic(&writes)
-    });
+    };
+    let result = if selector == 5 {
+        crate::cfm::CfmFindSymbol {
+            connection: bus.read_long(sp + 14),
+            name: bus.read_long(sp + 10),
+            address: bus.read_long(sp + 6),
+            class: bus.read_long(sp + 2),
+        }
+        .complete(&cfm.connections, bus, bindings, publish)
+    } else {
+        let query = if selector == 6 {
+            CfmSymbolQuery::Count {
+                connection: bus.read_long(sp + 6),
+                count: bus.read_long(sp + 2),
+            }
+        } else {
+            CfmSymbolQuery::Indexed {
+                connection: bus.read_long(sp + 18),
+                index: bus.read_long(sp + 14),
+                name: bus.read_long(sp + 10),
+                address: bus.read_long(sp + 6),
+                class: bus.read_long(sp + 2),
+            }
+        };
+        query.complete(&cfm.connections, |writes| publish(bus, writes))
+    };
     let error = result.err().map_or(0, |error| error.os_error());
     if error != 0 {
         // All semantic outputs remain unchanged when their transaction fails.
@@ -5005,7 +5018,7 @@ impl super::TrapDispatcher {
         cpu: &mut C,
         bus: &mut MacMemoryBus,
     ) -> Option<Result<()>> {
-        self.dispatch_toolbox_with_process_services(is_tool, trap_num, cpu, bus, None)
+        self.dispatch_toolbox_with_process_services(is_tool, trap_num, cpu, bus, None, None)
     }
 
     pub(crate) fn dispatch_toolbox_with_process_services<C: CpuOps>(
@@ -5015,6 +5028,7 @@ impl super::TrapDispatcher {
         cpu: &mut C,
         bus: &mut MacMemoryBus,
         cfm: Option<&crate::cfm::CfmState>,
+        bindings: Option<&mut dyn crate::cfm::CfmSymbolBindings>,
     ) -> Option<Result<()>> {
         self.read_tick_count(bus);
         Some(match (is_tool, trap_num) {
@@ -11862,7 +11876,9 @@ impl super::TrapDispatcher {
                         | 0x0060
                         | 0x0064
                 ) {
-                    return self.dispatch_toolbox_with_process_services(true, 0x1E7, cpu, bus, cfm);
+                    return self.dispatch_toolbox_with_process_services(
+                        true, 0x1E7, cpu, bus, cfm, bindings,
+                    );
                 }
                 match selector {
                     // PROCEDURE LActivate(act: BOOLEAN;
@@ -16046,14 +16062,16 @@ impl super::TrapDispatcher {
             }
 
             // CodeFragmentDispatch ($AA5A)
-            // Enumerates exports in a process CFM connection.
+            // Finds and enumerates exports in a process CFM connection.
+            // OSErr FindSymbol(ConnectionID connID, Str255 symName,
+            //                  Ptr *symAddr, SymClass *symClass);
             // OSErr CountSymbols(ConnectionID connID, long *symCount);
             // OSErr GetIndSymbol(ConnectionID connID, long symIndex,
             //                    Str255 symName, Ptr *symAddr, SymClass *symClass);
-            // PowerPC System Software (1994), pp. 3-25–3-26. Universal
-            // Interfaces 3.4, CodeFragments.h: $3F3C,$0006/$0007,$AA5A
+            // PowerPC System Software (1994), pp. 3-24–3-26. Universal
+            // Interfaces 3.4, CodeFragments.h: $3F3C,$0005/$0006/$0007,$AA5A
             // pushes a word selector before the Pascal argument frame.
-            (true, 0x25A) => dispatch_cfm_symbols(cpu, bus, cfm),
+            (true, 0x25A) => dispatch_cfm_symbols(cpu, bus, cfm, bindings),
 
             // IconDispatch ($ABC9)
             // Dispatches Icon Utilities routines selected by the low word of D0.
@@ -17073,16 +17091,34 @@ mod tests {
             }],
             ..Default::default()
         };
-        for selector in [6, 7] {
+        for selector in [5, 6, 7] {
             for fault in 0..7 {
                 let (mut disp, mut cpu, mut bus) = setup();
                 let mut memory = GuestAddressSpace::new();
                 memory.add_region(STACK, vec![0xa5; 0x200]);
                 bus.set_addressing_32_bit(true);
                 bus.attach_guest_address_space(memory.shared_view());
-                let result_slot = STACK + if selector == 6 { 10 } else { 22 };
+                let result_slot = STACK
+                    + match selector {
+                        5 => 18,
+                        6 => 10,
+                        _ => 22,
+                    };
                 bus.write_word(STACK, selector);
-                if selector == 6 {
+                if selector == 5 {
+                    let name = if fault == 2 {
+                        b"\x01x".as_slice()
+                    } else {
+                        b"\x05Caf\x8e\xaa".as_slice()
+                    };
+                    for (i, byte) in name.iter().enumerate() {
+                        bus.write_byte(OUTPUT + 48 + i as u32, *byte);
+                    }
+                    bus.write_long(STACK + 2, OUTPUT + 40);
+                    bus.write_long(STACK + 6, OUTPUT + 32);
+                    bus.write_long(STACK + 10, OUTPUT + 48);
+                    bus.write_long(STACK + 14, if fault == 1 { 99 } else { 7 });
+                } else if selector == 6 {
                     bus.write_long(STACK + 2, OUTPUT);
                     bus.write_long(STACK + 6, if fault == 1 { 99 } else { 7 });
                 } else {
@@ -17093,7 +17129,10 @@ mod tests {
                     bus.write_long(STACK + 18, if fault == 1 { 99 } else { 7 });
                 }
                 if fault == 3 {
-                    memory.add_readonly_region(OUTPUT, vec![0xa5]);
+                    memory.add_readonly_region(
+                        OUTPUT + if selector == 5 { 32 } else { 0 },
+                        vec![0xa5],
+                    );
                 }
                 if fault == 4 {
                     memory.add_readonly_region(result_slot, vec![0xa5; 2]);
@@ -17107,7 +17146,7 @@ mod tests {
                 let result = if fault == 6 {
                     disp.dispatch(0xAA5A, &mut cpu, &mut bus)
                 } else {
-                    disp.dispatch_with_process_services(0xAA5A, &mut cpu, &mut bus, &cfm)
+                    disp.dispatch_with_process_services(0xAA5A, &mut cpu, &mut bus, &cfm, None)
                 };
                 if fault == 6 {
                     assert!(matches!(
@@ -17120,7 +17159,7 @@ mod tests {
                     assert!(result.is_ok());
                     let error: i16 = match fault {
                         1 => -2801,
-                        2 if selector == 7 => -2802,
+                        2 if selector != 6 => -2802,
                         3..=5 => -50,
                         _ => 0,
                     };
@@ -17140,13 +17179,15 @@ mod tests {
                         if selector == 6 {
                             assert_eq!(bus.read_long(OUTPUT), 1);
                         } else {
-                            assert_eq!(bus.read_byte(OUTPUT), 5);
+                            if selector == 7 {
+                                assert_eq!(bus.read_byte(OUTPUT), 5);
+                            }
                             assert_eq!(bus.read_long(OUTPUT + 32), 0x1234_5678);
                             assert_eq!(bus.read_byte(OUTPUT + 40), 1);
                         }
                     }
                 }
-                if matches!(fault, 1 | 3..=6) || (fault == 2 && selector == 7) {
+                if matches!(fault, 1 | 3..=6) || (fault == 2 && selector != 6) {
                     assert_eq!(
                         (0..64)
                             .map(|i| bus.read_byte(OUTPUT + i))


### PR DESCRIPTION
FindSymbol now uses the same process CFM lookup service from native imports and classic CodeFragmentDispatch selector 5. Previously the classic route returned success without looking up a symbol, while the native route could write one output and register a new binding before discovering that another output was unwritable.

The shared service validates the connection and mapped Pascal MacRoman name, selects a real PEF export or requests a native gateway, and publishes address/class atomically. A bounded gateway provider commits a new binding only after that publication succeeds. Classic publication includes its Pascal result slot. Repeated lookup reuses the existing callable address, including when new gateway capacity is exhausted.

Classic normal and single-step dispatch borrow the installed adapter provider. During a native-to-classic callback, dispatch uses the already checked-out adapter. No new persistent manager fields or shared handles are introduced.

Validation: 5,060 headless library tests passed, with three existing ignored tests; production compilation passed without warnings. Tests cover paired memory views, malformed names and IDs, partial/protected outputs without binding leaks, retry, repeated lookup, static data, real PEF exports, classic result-slot protection and register preservation. Returned lazy code addresses are actually executed, and a native-to-classic callback resolves through the retained adapter.

References: Inside Macintosh: PowerPC System Software (1994), pp. 3-24–3-25; Apple Universal Interfaces 3.4, CodeFragments.h inline selector 5.

Complete synthetic export enumeration, import ownership, classic fragment loading/closing and teardown remain separate work.

Closes #1480
