### PR TITLE
test: move trap patch fixtures onto guest tables

### DIFF
--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -2161,25 +2161,15 @@ pub struct TrapDispatcher {
     pub(crate) recording_picture: Option<(u32, i16, i16, i16, i16, Vec<u8>)>,
     /// Complete bitmap PICT captured by CopyBits during OpenPicture.
     pub(crate) recording_picture_bitmap: Option<Vec<u8>>,
-    /// Pre-initialization compatibility mapping from a canonical trap word to
-    /// a native 68K handler. SetTrapAddress keeps it available for focused
-    /// standalone tests and early startup before a process table exists. It
-    /// is cleared when a process table is activated and is ignored whenever
-    /// `trap_tables_materialized` is true; initialized runners dispatch
-    /// exclusively from writable guest cells. Native handlers execute as
-    /// simulated JSR targets, allowing CRT-installed LoadSeg, UnloadSeg, and
-    /// ExitToShell patches to relocate code normally.
-    //
-    // Deletion gate: migrate the remaining direct pre-initialization writers
-    // in runner/loader fixtures to an explicit process-table setup, then
-    // remove this field and the unmaterialized fallback together. Keeping the
-    // field until those callers move is intentional compatibility debt, not a
-    // second active-process authority.
+    /// Pre-initialization compatibility mapping for standalone dispatcher
+    /// callers that install handlers before a process table exists. Activation
+    /// clears it; initialized execution reads writable guest table cells.
+    /// Patch fixtures now initialize those cells and use the guest service.
+    // Deletion gate: establish the standalone process construction boundary,
+    // then remove this map and the unmaterialized fallback together.
     pub(crate) native_trap_table: TrapWordMap,
-    /// Whether the selected profile's two raw trap tables have been written
-    /// into guest low memory. Before application initialization, focused trap
-    /// unit tests retain the host-map fallback; afterwards the guest longs are
-    /// authoritative, including writes performed directly by native code.
+    /// Whether the selected profile's raw trap tables exist in guest memory.
+    /// Standalone dispatcher construction can still precede table activation.
     pub(crate) trap_tables_materialized: bool,
     /// Machine profile belonging to the currently installed process table.
     /// `None` means no application trap context is active.
@@ -8107,7 +8097,7 @@ mod tests {
     use super::*;
     use crate::cpu::{CpuOps, Register};
     use crate::trap::menu::test_tracked_menu_state;
-    use crate::trap::test_helpers::setup;
+    use crate::trap::test_helpers::{setup, setup_with_trap_tables};
     use std::collections::VecDeque;
 
     #[test]
@@ -9737,11 +9727,13 @@ mod tests {
 
     #[test]
     fn native_trap_dispatch_returns_past_the_a_line_opcode() {
-        let (mut dispatcher, mut cpu, mut bus) = setup();
+        let (mut dispatcher, mut cpu, mut bus) = setup_with_trap_tables();
         let trap_pc = 0x0020_0000u32;
         let handler_addr = 0x0021_0000u32;
         let sp = 0x003F_FF00u32;
-        dispatcher.native_trap_table.insert(0xA9F0, handler_addr);
+        dispatcher
+            .install_trap_address(&mut bus, 0xA9F0, handler_addr)
+            .unwrap();
         cpu.write_reg(Register::PC, trap_pc + 2);
         cpu.write_reg(Register::A7, sp);
 
@@ -9800,14 +9792,16 @@ mod tests {
         let return_pc = 0x0020_0002u32;
         let sp = 0x003F_FF00u32;
         for variant in 0u16..8 {
-            let (mut dispatcher, mut cpu, mut bus) = setup();
+            let (mut dispatcher, mut cpu, mut bus) = setup_with_trap_tables();
             let trap_word = 0xA039 | (variant << 8); // ReadDateTime variants
             let original_d1 = 0xD1D1_BEEF;
             let original_d2 = 0xD2D2_BEEF;
             let original_a0 = 0xA0A0_BEEF;
             let original_a1 = 0xA1A1_BEEF;
             let original_a2 = 0xA2A2_BEEF;
-            dispatcher.native_trap_table.insert(0xA039, handler_addr);
+            dispatcher
+                .install_trap_address(&mut bus, 0xA039, handler_addr)
+                .unwrap();
             cpu.write_reg(Register::PC, return_pc);
             cpu.write_reg(Register::A7, sp);
             cpu.write_reg(Register::D1, original_d1);
@@ -9866,7 +9860,7 @@ mod tests {
 
     #[test]
     fn saved_os_gateway_tail_uses_the_original_variant_dispatch_frame() {
-        let (mut dispatcher, mut cpu, mut bus) = setup();
+        let (mut dispatcher, mut cpu, mut bus) = setup_with_trap_tables();
         let gateway = dispatcher.get_or_create_os_trap_trampoline(&mut bus, 0xA01E);
         let handler = 0x0021_0000u32;
         let return_pc = 0x0020_0002u32;
@@ -9876,7 +9870,9 @@ mod tests {
         let original_d2 = 0xD2D2_BEEF;
         let original_a1 = 0xA1A1_BEEF;
         let original_a2 = 0xA2A2_BEEF;
-        dispatcher.native_trap_table.insert(0xA01E, handler);
+        dispatcher
+            .install_trap_address(&mut bus, 0xA01E, handler)
+            .unwrap();
         cpu.write_reg(Register::PC, return_pc);
         cpu.write_reg(Register::A7, sp);
         cpu.write_reg(Register::D0, 4);
@@ -9912,7 +9908,7 @@ mod tests {
 
     #[test]
     fn saved_os_gateway_subroutine_keeps_the_outer_dispatch_frame() {
-        let (mut dispatcher, mut cpu, mut bus) = setup();
+        let (mut dispatcher, mut cpu, mut bus) = setup_with_trap_tables();
         let gateway = dispatcher.get_or_create_os_trap_trampoline(&mut bus, 0xA039);
         let handler = 0x0021_0000u32;
         let patch_continuation = 0x0021_0100u32;
@@ -9924,7 +9920,9 @@ mod tests {
         let original_a0 = 0xA0A0_BEEF;
         let original_a1 = 0xA1A1_BEEF;
         let original_a2 = 0xA2A2_BEEF;
-        dispatcher.native_trap_table.insert(0xA039, handler);
+        dispatcher
+            .install_trap_address(&mut bus, 0xA039, handler)
+            .unwrap();
         bus.write_long(crate::memory::globals::addr::TIME, 0x1234_5678);
         cpu.write_reg(Register::PC, return_pc);
         cpu.write_reg(Register::A7, sp);
@@ -9987,12 +9985,14 @@ mod tests {
 
     #[test]
     fn native_auto_pop_trap_enters_patch_with_the_glue_callers_return_frame() {
-        let (mut dispatcher, mut cpu, mut bus) = setup();
+        let (mut dispatcher, mut cpu, mut bus) = setup_with_trap_tables();
         let trap_pc = 0x0020_0000u32;
         let handler_addr = 0x0021_0000u32;
         let caller_pc = 0x0022_0000u32;
         let sp = 0x003F_FF00u32;
-        dispatcher.native_trap_table.insert(0xA975, handler_addr);
+        dispatcher
+            .install_trap_address(&mut bus, 0xA975, handler_addr)
+            .unwrap();
         bus.write_long(sp, caller_pc);
         cpu.write_reg(Register::PC, trap_pc + 2);
         cpu.write_reg(Register::A7, sp);
@@ -10010,13 +10010,15 @@ mod tests {
 
     #[test]
     fn nested_same_native_trap_calls_retain_lifo_call_state() {
-        let (mut dispatcher, mut cpu, mut bus) = setup();
+        let (mut dispatcher, mut cpu, mut bus) = setup_with_trap_tables();
         let handler_addr = 0x0021_0000u32;
         let outer_return = 0x0020_0002u32;
         let inner_return = 0x0021_0102u32;
         let outer_sp = 0x003F_FF00u32;
         let inner_sp = 0x003F_FE00u32;
-        dispatcher.native_trap_table.insert(0xA9F0, handler_addr);
+        dispatcher
+            .install_trap_address(&mut bus, 0xA9F0, handler_addr)
+            .unwrap();
 
         cpu.write_reg(Register::PC, outer_return);
         cpu.write_reg(Register::A7, outer_sp);
@@ -10051,12 +10053,14 @@ mod tests {
 
     #[test]
     fn saved_tool_trap_gateway_bypasses_a_later_patch() {
-        let (mut dispatcher, mut cpu, mut bus) = setup();
+        let (mut dispatcher, mut cpu, mut bus) = setup_with_trap_tables();
         let gateway = dispatcher.get_or_create_tool_trap_trampoline(&mut bus, 0xA975);
         let caller_pc = 0x0021_0000u32;
         let sp = 0x003F_FF00u32;
         dispatcher.set_tick_count_for_test(&mut bus, 0x1234_5678);
-        dispatcher.native_trap_table.insert(0xA975, 0x0030_0000);
+        dispatcher
+            .install_trap_address(&mut bus, 0xA975, 0x0030_0000)
+            .unwrap();
         bus.write_long(sp, caller_pc);
         cpu.write_reg(Register::PC, 0x0020_0002);
         cpu.write_reg(Register::A7, sp);
@@ -10083,13 +10087,15 @@ mod tests {
 
     #[test]
     fn saved_os_trap_gateway_bypasses_a_later_patch() {
-        let (mut dispatcher, mut cpu, mut bus) = setup();
+        let (mut dispatcher, mut cpu, mut bus) = setup_with_trap_tables();
         let gateway = dispatcher.get_or_create_os_trap_trampoline(&mut bus, 0xA039);
         let sp = 0x003F_FF00u32;
         let output = 0x0020_0000u32;
         bus.write_long(crate::memory::globals::addr::TIME, 0x1234_5678);
         bus.write_long(sp, 0x0021_0000);
-        dispatcher.native_trap_table.insert(0xA039, 0x0030_0000);
+        dispatcher
+            .install_trap_address(&mut bus, 0xA039, 0x0030_0000)
+            .unwrap();
         cpu.write_reg(Register::PC, gateway + 2);
         cpu.write_reg(Register::A7, sp);
         cpu.write_reg(Register::A0, output);

--- a/src/trap/memory.rs
+++ b/src/trap/memory.rs
@@ -4557,7 +4557,7 @@ pub(crate) fn mac_roman_strip_diacriticals(ch: u8) -> u8 {
 
 #[cfg(test)]
 mod tests {
-    use super::super::test_helpers::{setup, MockCpu, TEST_SP};
+    use super::super::test_helpers::{setup, setup_with_trap_tables, MockCpu, TEST_SP};
     use crate::cpu::{CpuOps, Register};
     use crate::memory::globals::addr;
     use crate::memory::{GuestAddressSpace, MemoryBus};
@@ -7761,7 +7761,7 @@ mod tests {
 
     #[test]
     fn test_get_trap_address() {
-        let (mut dispatcher, mut cpu, mut bus) = setup();
+        let (mut dispatcher, mut cpu, mut bus) = setup_with_trap_tables();
         cpu.write_reg(Register::D0, 0x0044);
         let result = dispatcher.dispatch_memory(false, 0x46, &mut cpu, &mut bus);
         assert!(result.is_some(), "GetTrapAddress should be handled");
@@ -7784,7 +7784,7 @@ mod tests {
 
     #[test]
     fn restoring_an_os_trap_gateway_removes_the_installed_patch() {
-        let (mut dispatcher, mut cpu, mut bus) = setup();
+        let (mut dispatcher, mut cpu, mut bus) = setup_with_trap_tables();
         dispatcher.current_trap_word = 0xA346;
         cpu.write_reg(Register::D0, 0x39);
         dispatcher
@@ -7801,8 +7801,8 @@ mod tests {
             .expect("SetOSTrapAddress should be handled")
             .expect("SetOSTrapAddress should install a patch");
         assert_eq!(
-            dispatcher.native_trap_table.get(&0xA039),
-            Some(&0x0030_0000)
+            dispatcher.native_trap_handler(&bus, 0xA039),
+            Some(0x0030_0000)
         );
 
         cpu.write_reg(Register::A0, original);
@@ -7810,14 +7810,16 @@ mod tests {
             .dispatch_memory(false, 0x47, &mut cpu, &mut bus)
             .expect("SetOSTrapAddress should be handled")
             .expect("SetOSTrapAddress should restore the original");
-        assert!(dispatcher.native_trap_table.get(&0xA039).is_none());
+        assert!(dispatcher.native_trap_handler(&bus, 0xA039).is_none());
     }
 
     #[test]
     fn changing_a_trap_head_does_not_cancel_an_active_native_invocation() {
-        let (mut dispatcher, mut cpu, mut bus) = setup();
+        let (mut dispatcher, mut cpu, mut bus) = setup_with_trap_tables();
         let sp = 0x003F_FF00u32;
-        dispatcher.native_trap_table.insert(0xA039, 0x0030_0000);
+        dispatcher
+            .install_trap_address(&mut bus, 0xA039, 0x0030_0000)
+            .unwrap();
         cpu.write_reg(Register::PC, 0x0020_0002);
         cpu.write_reg(Register::A7, sp);
         dispatcher.dispatch(0xA039, &mut cpu, &mut bus).unwrap();
@@ -7839,8 +7841,8 @@ mod tests {
             .expect("SetOSTrapAddress should replace the table head");
 
         assert_eq!(
-            dispatcher.native_trap_table.get(&0xA039),
-            Some(&0x0031_0000)
+            dispatcher.native_trap_handler(&bus, 0xA039),
+            Some(0x0031_0000)
         );
         assert_eq!(
             dispatcher
@@ -7855,9 +7857,11 @@ mod tests {
 
     #[test]
     fn legacy_gettrapaddress_classifies_toolbox_trap_words_by_number() {
-        let (mut dispatcher, mut cpu, mut bus) = setup();
+        let (mut dispatcher, mut cpu, mut bus) = setup_with_trap_tables();
         dispatcher.current_trap_word = 0xA146;
-        dispatcher.native_trap_table.insert(0xA0A0, 0x0000_ADF2);
+        dispatcher
+            .install_trap_address(&mut bus, 0xA0A0, 0x0000_ADF2)
+            .unwrap();
         cpu.write_reg(Register::D0, 0xA9A0);
 
         let result = dispatcher.dispatch_memory(false, 0x46, &mut cpu, &mut bus);
@@ -7878,9 +7882,11 @@ mod tests {
 
     #[test]
     fn getostrapaddress_explicitly_uses_the_os_table() {
-        let (mut dispatcher, mut cpu, mut bus) = setup();
+        let (mut dispatcher, mut cpu, mut bus) = setup_with_trap_tables();
         dispatcher.current_trap_word = 0xA346;
-        dispatcher.native_trap_table.insert(0xA0A0, 0x0000_ADF2);
+        dispatcher
+            .install_trap_address(&mut bus, 0xA0A0, 0x0000_ADF2)
+            .unwrap();
         cpu.write_reg(Register::D0, 0xA9A0);
 
         let result = dispatcher.dispatch_memory(false, 0x46, &mut cpu, &mut bus);
@@ -7899,12 +7905,16 @@ mod tests {
         // bit 9 selects the new typed form, bit 10 then selects Toolbox, and
         // bit 8 independently controls A0 return handling. UI 3.4 Patches.h
         // lines 126--231 declares the new-OS and new-Tool entry points.
-        let (mut dispatcher, mut cpu, mut bus) = setup();
+        let (mut dispatcher, mut cpu, mut bus) = setup_with_trap_tables();
         let supplied_trap = 0xA9A0;
         let os_key = 0xA0A0;
         let tool_key = 0xA9A0;
-        dispatcher.native_trap_table.insert(os_key, 0x0030_0000);
-        dispatcher.native_trap_table.insert(tool_key, 0x0031_0000);
+        dispatcher
+            .install_trap_address(&mut bus, os_key, 0x0030_0000)
+            .unwrap();
+        dispatcher
+            .install_trap_address(&mut bus, tool_key, 0x0031_0000)
+            .unwrap();
 
         // Clear bit 8 from the declared getter words. The central route must
         // retain their table type even though the dispatcher later restores
@@ -7937,8 +7947,8 @@ mod tests {
                 .expect("typed trap setter should be handled")
                 .expect("typed trap setter should succeed");
             assert_eq!(
-                dispatcher.native_trap_table.get(&key),
-                Some(&handler),
+                dispatcher.native_trap_handler(&bus, key),
+                Some(handler),
                 "trap ${trap_word:04X}"
             );
         }
@@ -8065,7 +8075,7 @@ mod tests {
 
     #[test]
     fn test_set_trap_address() {
-        let (mut dispatcher, mut cpu, mut bus) = setup();
+        let (mut dispatcher, mut cpu, mut bus) = setup_with_trap_tables();
         // Set a native trap handler
         cpu.write_reg(Register::D0, 0x01FF);
         cpu.write_reg(Register::A0, 0x00400000); // handler address
@@ -8085,7 +8095,7 @@ mod tests {
 
     #[test]
     fn set_trap_address_does_not_promote_a_writable_signature_to_protected_code() {
-        let (mut dispatcher, mut cpu, mut bus) = setup();
+        let (mut dispatcher, mut cpu, mut bus) = setup_with_trap_tables();
         let handler = bus.alloc(4);
         bus.write_long(handler, COME_FROM_PATCH_SIGNATURE);
         bus.write_word(addr::DS_ERR_CODE, 0xBEEF);
@@ -8099,7 +8109,7 @@ mod tests {
 
         assert!(result.is_ok());
         assert_eq!(bus.read_word(addr::DS_ERR_CODE), 0xBEEF);
-        assert_eq!(dispatcher.native_trap_table.get(&0xA975), Some(&handler));
+        assert_eq!(dispatcher.native_trap_handler(&bus, 0xA975), Some(handler));
     }
 
     #[test]
@@ -8111,8 +8121,7 @@ mod tests {
         let installed = 0x0021_0000;
         let direct_guest_write = 0x0021_1000;
 
-        assert!(dispatcher.trap_tables_materialized);
-        assert_eq!(dispatcher.native_trap_table.get(&trap_word), None);
+        assert_eq!(dispatcher.native_trap_handler(&bus, trap_word), None);
 
         dispatcher.current_trap_word = 0xA047;
         cpu.write_reg(Register::D0, 0x0175);
@@ -8122,11 +8131,13 @@ mod tests {
             .expect("SetTrapAddress should be handled")
             .expect("SetTrapAddress should write the initialized table");
         assert_eq!(bus.read_long(table_entry), installed);
-        assert_eq!(dispatcher.native_trap_table.get(&trap_word), None);
+        assert_eq!(
+            dispatcher.native_trap_handler(&bus, trap_word),
+            Some(installed)
+        );
 
         // A guest/native store bypasses the setter and is immediately visible
-        // through the same 68K Trap Manager getter. This is the active
-        // guest-byte authority proof; the compatibility mirror is untouched.
+        // through the same 68K Trap Manager getter and dispatch lookup.
         bus.write_long(table_entry, direct_guest_write);
         dispatcher.current_trap_word = 0xA146;
         cpu.write_reg(Register::D0, 0x0175);
@@ -8135,13 +8146,18 @@ mod tests {
             .expect("GetTrapAddress should be handled")
             .expect("GetTrapAddress should read the guest table");
         assert_eq!(cpu.read_reg(Register::A0), direct_guest_write);
-        assert_eq!(dispatcher.native_trap_table.get(&trap_word), None);
+        assert_eq!(
+            dispatcher.native_trap_handler(&bus, trap_word),
+            Some(direct_guest_write)
+        );
     }
 
     #[test]
     fn nsettrapaddress_newtool_bare_trap_number_installs_canonical_tool_handler() {
-        let (mut dispatcher, mut cpu, mut bus) = setup();
+        let (mut dispatcher, mut cpu, mut bus) = setup_with_trap_tables();
         let handler_addr = 0x0040_0000;
+        let os_entry = super::super::dispatch::OS_TRAP_TABLE_BASE + 0xF4 * 4;
+        let original_os_entry = bus.read_long(os_entry);
 
         // `_SetTrapAddress newTool` accepts either an A-line instruction
         // or a bare trap number in D0. In either case the Toolbox table
@@ -8155,13 +8171,14 @@ mod tests {
         assert!(result.unwrap().is_ok(), "NSetTrapAddress should succeed");
 
         assert_eq!(
-            dispatcher.native_trap_table.get(&0xA9F4).copied(),
+            dispatcher.native_trap_handler(&bus, 0xA9F4),
             Some(handler_addr),
             "bare Toolbox trap numbers must install under their canonical A-line word"
         );
-        assert!(
-            dispatcher.native_trap_table.get(&0x01F4).is_none(),
-            "the raw bare trap number is not a dispatchable trap-table key"
+        assert_eq!(
+            bus.read_long(os_entry),
+            original_os_entry,
+            "a typed Toolbox setter must leave the corresponding OS slot untouched"
         );
     }
 
@@ -13513,7 +13530,7 @@ mod tests {
 
     #[test]
     fn gettooltrapaddress_trap_word_variant_returns_callable_trampoline() {
-        let (mut dispatcher, mut cpu, mut bus) = setup();
+        let (mut dispatcher, mut cpu, mut bus) = setup_with_trap_tables();
         let sp_before = cpu.read_reg(Register::A7);
         bus.write_long(sp_before, 0x1234_5678);
 

--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -8784,7 +8784,7 @@ impl super::TrapDispatcher {
 #[cfg(test)]
 mod tests {
     use super::super::dispatch::{LoadedResources, ResourceFileMap};
-    use super::super::test_helpers::{setup, TEST_SP};
+    use super::super::test_helpers::{setup, setup_with_trap_tables, TEST_SP};
     use super::QUICKTIME_NUM_VERSION_6_0_FINAL;
     use crate::cpu::{CpuOps, Register};
     use crate::memory::globals::addr;
@@ -12530,13 +12530,14 @@ mod tests {
 
     #[test]
     fn loadseg_auto_pop_old_trap_uses_original_mpw_caller_entry() {
-        let (mut disp, mut cpu, mut bus) = setup();
+        let (mut disp, mut cpu, mut bus) = setup_with_trap_tables();
 
         let seg_addr = 0x220000u32;
         bus.write_word(seg_addr, 0x0000);
         bus.write_word(seg_addr + 2, 0x0000);
         disp.register_segments(HashMap::from([(2i16, seg_addr)]));
-        disp.native_trap_table.insert(0xA9A0, 0x310000);
+        disp.install_trap_address(&mut bus, 0xA9A0, 0x310000)
+            .unwrap();
 
         let entry_addr = 0x240000u32;
         bus.write_word(entry_addr, 0x0010);
@@ -12581,7 +12582,7 @@ mod tests {
 
     #[test]
     fn loadseg_native_old_trap_recovers_the_recorded_original_call() {
-        let (mut disp, mut cpu, mut bus) = setup();
+        let (mut disp, mut cpu, mut bus) = setup_with_trap_tables();
         let preserved_d_regs = [
             0xD300_0003,
             0xD400_0004,
@@ -12636,7 +12637,8 @@ mod tests {
         // to recovery of the original A-line call.
         let handler = 0x300000u32;
         bus.write_word(handler, 0x4E71); // NOP
-        disp.native_trap_table.insert(0xA9F0, handler);
+        disp.install_trap_address(&mut bus, 0xA9F0, handler)
+            .unwrap();
         cpu.write_reg(Register::PC, entry_addr + 8);
         cpu.write_reg(Register::A7, TEST_SP);
         bus.write_word(TEST_SP, 2);
@@ -12707,7 +12709,7 @@ mod tests {
 
     #[test]
     fn loadseg_native_old_trap_restores_the_recorded_think_stack() {
-        let (mut disp, mut cpu, mut bus) = setup();
+        let (mut disp, mut cpu, mut bus) = setup_with_trap_tables();
         let seg_addr = 0x220000u32;
         bus.write_word(seg_addr, 0x0000);
         bus.write_word(seg_addr + 2, 0x0000);
@@ -12721,7 +12723,8 @@ mod tests {
 
         let handler = 0x300000u32;
         bus.write_word(handler, 0x4E71); // NOP
-        disp.native_trap_table.insert(0xA9F0, handler);
+        disp.install_trap_address(&mut bus, 0xA9F0, handler)
+            .unwrap();
         cpu.write_reg(Register::PC, entry_addr + 2);
         cpu.write_reg(Register::A7, TEST_SP);
         bus.write_word(TEST_SP, 0xBEEF);
@@ -12843,13 +12846,14 @@ mod tests {
 
     #[test]
     fn loadseg_defers_to_native_getresource_hook_when_installed() {
-        let (mut disp, mut cpu, mut bus) = setup();
+        let (mut disp, mut cpu, mut bus) = setup_with_trap_tables();
 
         let seg_addr = 0x230000u32;
         bus.write_word(seg_addr, 0x0000);
         bus.write_word(seg_addr + 2, 0x0000);
         disp.register_segments(HashMap::from([(1i16, seg_addr)]));
-        disp.native_trap_table.insert(0xA9A0, 0x300000);
+        disp.install_trap_address(&mut bus, 0xA9A0, 0x300000)
+            .unwrap();
 
         let island_addr = 0x240000u32;
         bus.write_word(island_addr, 0x0000);
@@ -13040,11 +13044,12 @@ mod tests {
 
     #[test]
     fn tool_trampoline_bypasses_later_native_trap_handler() {
-        let (mut disp, mut cpu, mut bus) = setup();
+        let (mut disp, mut cpu, mut bus) = setup_with_trap_tables();
         setup_resources(&mut disp, &mut bus, b"TEST", 7, &[0xAA, 0xBB]);
 
         let trampoline = disp.get_or_create_tool_trap_trampoline(&mut bus, 0xA9A0);
-        disp.native_trap_table.insert(0xA9A0, 0x300000);
+        disp.install_trap_address(&mut bus, 0xA9A0, 0x300000)
+            .unwrap();
 
         let return_pc = 0x12345678;
         bus.write_long(TEST_SP, return_pc);
@@ -13069,9 +13074,10 @@ mod tests {
 
     #[test]
     fn guest_auto_pop_old_trap_stub_bypasses_native_trap_handler() {
-        let (mut disp, mut cpu, mut bus) = setup();
+        let (mut disp, mut cpu, mut bus) = setup_with_trap_tables();
         setup_resources(&mut disp, &mut bus, b"TEST", 7, &[0xAA, 0xBB]);
-        disp.native_trap_table.insert(0xA9A0, 0x300000);
+        disp.install_trap_address(&mut bus, 0xA9A0, 0x300000)
+            .unwrap();
 
         let return_pc = 0x12345678;
         bus.write_word(TEST_SP, 7);

--- a/src/trap/test_helpers.rs
+++ b/src/trap/test_helpers.rs
@@ -124,6 +124,15 @@ pub fn setup() -> (TrapDispatcher, MockCpu, MacMemoryBus) {
     (dispatcher, cpu, bus)
 }
 
+/// Create a classic process environment with live writable trap tables.
+/// Patch fixtures use the same topology and setter as initialized runners.
+/// Inside Macintosh: Operating System Utilities (1994), pp. 8-4--8-6.
+pub fn setup_with_trap_tables() -> (TrapDispatcher, MockCpu, MacMemoryBus) {
+    let (mut dispatcher, cpu, mut bus) = setup();
+    dispatcher.materialize_trap_tables(&mut bus, super::dispatch::TrapTableProfile::M68k68040);
+    (dispatcher, cpu, bus)
+}
+
 /// Create a test environment and set up a basic GrafPort so drawing/port traps work.
 ///
 /// Returns (TrapDispatcher, MockCpu, MacMemoryBus) with a port at 0x181000


### PR DESCRIPTION
Trap patch regressions previously seeded or inspected the startup host map, bypassing the guest table service used by initialized execution. Twenty-four fixtures now start with live classic tables; all 29 direct map references in dispatcher, memory and resource tests are removed.

Patches use the existing guest Trap Manager setter. Assertions cover logical handlers, raw-cell visibility, default restoration, OS/Toolbox selection, active native calls, resource callbacks and writable signature lookalikes. Standalone production construction and removal of the compatibility map remain separate work.

Validation: 3,056 trap tests passed (three existing ignored tests); the production library check passed without warnings.

Closes #1486
