### PR TITLE
refactor: publish native generated code with system provenance

### DIFF
--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -3920,11 +3920,11 @@ impl PpcLoadedApp {
             return false;
         }
 
-        fn ordinary_overlaps(memory: &mut PpcSectionMem, start: u64, end: u64) -> bool {
+        fn mapped_overlaps(memory: &mut PpcSectionMem, start: u64, end: u64) -> bool {
             if start >= end {
                 return false;
             }
-            memory.ordinary_mapping_overlaps(
+            memory.mapping_overlaps(
                 u32::try_from(start).expect("nonempty guest range starts below 2^32"),
                 u32::try_from(end - start).expect("subrange fits reservation length"),
             )
@@ -3937,8 +3937,8 @@ impl PpcLoadedApp {
         let future_end = u64::from(self.heap_limit());
         let before_end = end.min(future_start);
         let after_start = start.max(future_end);
-        if ordinary_overlaps(&mut self.memory, start, before_end)
-            || ordinary_overlaps(&mut self.memory, after_start, end)
+        if mapped_overlaps(&mut self.memory, start, before_end)
+            || mapped_overlaps(&mut self.memory, after_start, end)
         {
             return false;
         }
@@ -13074,20 +13074,26 @@ fn load_pef_application_with_config_and_optional_system_reservation(
     }
     // Keep a bounded pool of synthetic import slots mapped from launch so
     // GetMemFragment can bind imports while the CPU is already running.
-    memory.add_readonly_region(
-        PPC_IMPORT_TVECTOR_BASE,
-        import_tvector_bytes(PPC_IMPORT_SLOT_COUNT as usize),
-    );
-    memory.add_readonly_region(
-        PPC_IMPORT_TRAP_BASE,
-        import_trap_bytes(PPC_IMPORT_SLOT_COUNT as usize),
-    );
+    memory
+        .publish_system_code(
+            PPC_IMPORT_TVECTOR_BASE,
+            import_tvector_bytes(PPC_IMPORT_SLOT_COUNT as usize),
+        )
+        .ok_or(PpcLoadError::AddressOverflow)?;
+    memory
+        .publish_system_code(
+            PPC_IMPORT_TRAP_BASE,
+            import_trap_bytes(PPC_IMPORT_SLOT_COUNT as usize),
+        )
+        .ok_or(PpcLoadError::AddressOverflow)?;
     memory.add_region(PPC_IMPORT_DATA_BASE, vec![0; PPC_IMPORT_DATA_SIZE]);
     ppc_seed_import_data(&mut memory);
-    memory.add_readonly_region(
-        PPC_CFM_MAIN_STUB_BASE,
-        import_trap_bytes(PPC_CFM_MAIN_STUB_COUNT as usize),
-    );
+    memory
+        .publish_system_code(
+            PPC_CFM_MAIN_STUB_BASE,
+            import_trap_bytes(PPC_CFM_MAIN_STUB_COUNT as usize),
+        )
+        .ok_or(PpcLoadError::AddressOverflow)?;
     memory.add_region(PPC_MAIN_GWORLD, vec![0u8; 256]);
     memory.add_region(PPC_MAIN_GDEVICE, vec![0u8; 256]);
     memory.add_region(PPC_MAIN_GDEVICE_RECORD, vec![0u8; 256]);
@@ -13159,10 +13165,12 @@ fn load_pef_application_with_config_and_optional_system_reservation(
     memory.add_region(PPC_DSP_CONTEXT, vec![0u8; PPC_QA_OBJECTS_SIZE]);
     ppc_seed_qa_rave_objects(&mut memory);
     if init_tvector.is_some() {
-        memory.add_readonly_region(
-            PPC_APPLICATION_INIT_RETURN_PC,
-            ppc_application_init_return_trampoline(entry_pc, rtoc),
-        );
+        memory
+            .publish_system_code(
+                PPC_APPLICATION_INIT_RETURN_PC,
+                ppc_application_init_return_trampoline(entry_pc, rtoc),
+            )
+            .ok_or(PpcLoadError::AddressOverflow)?;
     }
     let mut gworlds = vec![
         ppc_seed_main_gworld(&mut memory),
@@ -13178,7 +13186,7 @@ fn load_pef_application_with_config_and_optional_system_reservation(
         let reservation_end = reservation_start + u64::from(len);
         let overlaps_stack =
             reservation_start < u64::from(PPC_STACK_TOP) && u64::from(stack_base) < reservation_end;
-        if overlaps_stack || memory.ordinary_mapping_overlaps(base, len) {
+        if overlaps_stack || memory.mapping_overlaps(base, len) {
             return Err(PpcLoadError::AddressOverflow);
         }
     }
@@ -108424,6 +108432,38 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn native_generated_code_uses_owned_system_provenance() {
+        let mut loaded = load_pef_application(&synthetic_pef_with_initializer()).unwrap();
+        for base in [
+            PPC_IMPORT_TVECTOR_BASE,
+            PPC_IMPORT_TRAP_BASE,
+            PPC_CFM_MAIN_STUB_BASE,
+            PPC_APPLICATION_INIT_RETURN_PC,
+        ] {
+            let word = loaded.memory.read_u32_be(base).unwrap();
+            assert!(loaded
+                .memory
+                .shared_view()
+                .is_shared_readonly_range(base, 4));
+            assert!(!loaded.prepare_shared_system_reservation(base, 4));
+            assert_eq!(loaded.memory.write_u32_be(base, word ^ u32::MAX), None);
+            loaded.memory.add_region(base, vec![0xff; 4]);
+            assert_eq!(loaded.memory.read_u32_be(base), Some(word));
+            let mut detached = loaded.memory.clone();
+            assert_eq!(
+                detached.write_shared_system_u32_be(base, word ^ u32::MAX),
+                Some(())
+            );
+            assert_eq!(detached.read_u32_be(base), Some(word ^ u32::MAX));
+            assert_eq!(loaded.memory.read_u32_be(base), Some(word));
+        }
+        assert!(!loaded
+            .memory
+            .shared_view()
+            .is_shared_readonly_range(PPC_CODE_BASE, 4));
+    }
+
+    #[test]
     fn ppc_loader_rejects_system_reservation_layout_collisions() {
         fn reservation_at(base: u32) -> (MacMemoryBus, (u32, u32)) {
             let bus = MacMemoryBus::new((base + 0x0009_0000) as usize);
@@ -108440,7 +108480,13 @@ pub(crate) mod tests {
         )
         .expect("the 8 MiB runner reservation occupies a native-layout gap");
 
-        for base in [PPC_CODE_BASE, PPC_MAIN_GWORLD] {
+        for base in [
+            PPC_CODE_BASE,
+            PPC_MAIN_GWORLD,
+            PPC_IMPORT_TVECTOR_BASE,
+            PPC_IMPORT_TRAP_BASE,
+            PPC_CFM_MAIN_STUB_BASE,
+        ] {
             let (_bus, reservation) = reservation_at(base);
             assert_eq!(
                 load_pef_application_with_config_and_system_reservation(

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -164506,10 +164506,7 @@ pub(crate) mod tests {
             .expect("classic adapter owns low memory");
         context.attach_memory(0, low_memory, &mut native.memory);
         let ram_end = classic_bus.ram_size();
-        for (base, end) in native
-            .memory
-            .ordinary_mapping_holes(0x0010_0000, ram_end)
-        {
+        for (base, end) in native.memory.mapping_holes(0x0010_0000, ram_end) {
             let memory = classic_bus
                 .shared_ram_region(base, end - base)
                 .expect("classic adapter owns the native mapping hole");
@@ -167746,10 +167743,7 @@ pub(crate) mod tests {
             .shared_ram_region(0, low_memory_end)
             .expect("classic adapter owns low memory");
         context.attach_memory(0, low_memory, &mut native.memory);
-        for (base, end) in native
-            .memory
-            .ordinary_mapping_holes(low_memory_end, ram_end)
-        {
+        for (base, end) in native.memory.mapping_holes(low_memory_end, ram_end) {
             let memory = classic_bus
                 .shared_ram_region(base, end - base)
                 .expect("classic adapter owns the native mapping hole");

--- a/src/memory/address_space.rs
+++ b/src/memory/address_space.rs
@@ -57,7 +57,7 @@ struct GuestAddressSpaceState {
     shared_regions: Vec<SharedRegionMapping>,
     /// Derived envelope of nonempty shared mappings; extended on every insert
     /// and copied with detached snapshots. It only rejects impossible hits.
-    shared_bounds: Option<(u64, u64)>,
+    shared_bounds: std::ops::Range<u64>,
     readonly_allocation_exclusions: Vec<(u32, u32)>,
 }
 
@@ -66,18 +66,19 @@ impl GuestAddressSpaceState {
         if mapping.region.len() != 0 {
             let start = u64::from(mapping.base);
             let end = start.saturating_add(mapping.region.len() as u64);
-            self.shared_bounds = Some(match self.shared_bounds {
-                Some((old_start, old_end)) => (old_start.min(start), old_end.max(end)),
-                None => (start, end),
-            });
+            if self.shared_bounds.is_empty() {
+                self.shared_bounds = start..end;
+            } else {
+                self.shared_bounds.start = self.shared_bounds.start.min(start);
+                self.shared_bounds.end = self.shared_bounds.end.max(end);
+            }
         }
         self.shared_regions.push(mapping);
     }
 
     #[inline]
     fn may_overlap_shared(&self, start: u64, end: u64) -> bool {
-        self.shared_bounds
-            .is_some_and(|(low, high)| start < high && low < end)
+        start < self.shared_bounds.end && self.shared_bounds.start < end
     }
 
     #[inline]
@@ -768,7 +769,7 @@ impl Clone for GuestAddressSpace {
         Self(Rc::new(UnsafeCell::new(GuestAddressSpaceState {
             regions: state.regions.clone(),
             ordinary_regions: state.ordinary_regions.clone(),
-            shared_bounds: state.shared_bounds,
+            shared_bounds: state.shared_bounds.clone(),
             shared_regions: state
                 .shared_regions
                 .iter()
@@ -863,22 +864,19 @@ impl GuestAddressSpace {
         Some(())
     }
 
-    /// Return the disjoint holes not occupied by ordinary sparse mappings in
+    /// Return the disjoint holes not occupied by ordinary or shared mappings in
     /// the supplied half-open range.
-    pub(crate) fn ordinary_mapping_holes(&self, start: u32, end: u32) -> Vec<(u32, u32)> {
+    pub(crate) fn mapping_holes(&self, start: u32, end: u32) -> Vec<(u32, u32)> {
         if start >= end {
             return Vec::new();
         }
 
-        let mut occupied = self
-            .state()
-            .ordinary_regions
-            .iter()
-            .filter_map(|mapping| {
-                let mapping_start = u64::from(mapping.base).max(u64::from(start));
-                let mapping_end = u64::from(mapping.base)
-                    .saturating_add(mapping.len as u64)
-                    .min(u64::from(end));
+        let state = self.state();
+        let mut occupied = ordinary_ranges(state)
+            .chain(shared_ranges(state))
+            .filter_map(|(base, limit)| {
+                let mapping_start = base.max(u64::from(start));
+                let mapping_end = limit.min(u64::from(end));
                 (mapping_start < mapping_end).then_some((mapping_start, mapping_end))
             })
             .collect::<Vec<_>>();
@@ -898,22 +896,15 @@ impl GuestAddressSpace {
         holes
     }
 
-    /// Return the disjoint occupied spans of ordinary sparse mappings.
-    ///
-    /// Shared flat-RAM overlays are intentionally not subtracted: callers
-    /// use these spans to keep process allocators away from the native PEF
-    /// layout before those overlays are installed. Inside Macintosh: Memory
-    /// (1992), pp. 2-19--2-21.
-    pub(crate) fn ordinary_mapping_ranges(&self) -> Vec<(u32, u32)> {
-        let mut ranges = self
-            .state()
-            .ordinary_regions
-            .iter()
-            .filter_map(|mapping| {
-                let end = u64::from(mapping.base).checked_add(mapping.len as u64)?;
-                (u64::from(mapping.base) < end)
-                    .then_some((mapping.base, u32::try_from(end).ok()?))
-            })
+    /// Return the disjoint occupied spans of ordinary and shared mappings.
+    /// Callers reserve these spans before adding process RAM overlays so that
+    /// the classic heap cannot select native PEF or generated system code.
+    /// Inside Macintosh: Memory (1992), pp. 2-19--2-21.
+    pub(crate) fn mapping_ranges(&self) -> Vec<(u32, u32)> {
+        let state = self.state();
+        let mut ranges = ordinary_ranges(state)
+            .chain(shared_ranges(state))
+            .filter_map(|(base, end)| Some((u32::try_from(base).ok()?, u32::try_from(end).ok()?)))
             .collect::<Vec<_>>();
         ranges.sort_unstable_by_key(|&(base, _)| base);
 
@@ -1874,18 +1865,45 @@ mod tests {
     }
 
     #[test]
-    fn ordinary_mapping_holes_track_writable_and_readonly_regions() {
+    fn mapping_holes_preserve_owned_system_code_and_shared_ram() {
+        let mut memory = GuestAddressSpace::new();
+        memory.add_region(0x1200, vec![0; 0x100]);
+        memory
+            .publish_system_code(0x1400, vec![0x5a; 0x100])
+            .unwrap();
+        let mut bus = MacMemoryBus::new(0x1000);
+        // SAFETY: both adapters are accessed serially in this test.
+        unsafe { memory.add_shared_region(0x1600, bus.shared_ram_region(0, 0x100).unwrap()) };
+        for view in [&memory, &memory.clone()] {
+            assert_eq!(
+                view.mapping_ranges(),
+                vec![(0x1200, 0x1300), (0x1400, 0x1500), (0x1600, 0x1700)]
+            );
+            assert_eq!(
+                view.mapping_holes(0x1000, 0x1800),
+                vec![
+                    (0x1000, 0x1200),
+                    (0x1300, 0x1400),
+                    (0x1500, 0x1600),
+                    (0x1700, 0x1800)
+                ]
+            );
+        }
+    }
+
+    #[test]
+    fn mapping_holes_track_writable_and_readonly_regions() {
         let mut memory = GuestAddressSpace::new();
         memory.add_region(0x1200, vec![0; 0x100]);
         memory.add_readonly_region(0x1400, vec![0; 0x200]);
         memory.add_region(0x1500, vec![0; 0x200]);
 
         assert_eq!(
-            memory.ordinary_mapping_holes(0x1000, 0x1800),
+            memory.mapping_holes(0x1000, 0x1800),
             vec![(0x1000, 0x1200), (0x1300, 0x1400), (0x1700, 0x1800)]
         );
         assert_eq!(
-            memory.ordinary_mapping_ranges(),
+            memory.mapping_ranges(),
             vec![(0x1200, 0x1300), (0x1400, 0x1700)]
         );
         assert!(memory.ordinary_mapping_overlaps(0x1280, 0x100));
@@ -1893,11 +1911,11 @@ mod tests {
 
         let detached = memory.clone();
         assert_eq!(
-            detached.ordinary_mapping_holes(0x1000, 0x1800),
+            detached.mapping_holes(0x1000, 0x1800),
             vec![(0x1000, 0x1200), (0x1300, 0x1400), (0x1700, 0x1800)]
         );
         assert_eq!(
-            detached.ordinary_mapping_ranges(),
+            detached.mapping_ranges(),
             vec![(0x1200, 0x1300), (0x1400, 0x1700)]
         );
     }

--- a/src/memory/address_space.rs
+++ b/src/memory/address_space.rs
@@ -55,7 +55,35 @@ struct GuestAddressSpaceState {
     regions: PpcSectionMem,
     ordinary_regions: Vec<OrdinaryRegionMapping>,
     shared_regions: Vec<SharedRegionMapping>,
+    /// Derived envelope of nonempty shared mappings; extended on every insert
+    /// and copied with detached snapshots. It only rejects impossible hits.
+    shared_bounds: Option<(u64, u64)>,
     readonly_allocation_exclusions: Vec<(u32, u32)>,
+}
+
+impl GuestAddressSpaceState {
+    fn push_shared_mapping(&mut self, mapping: SharedRegionMapping) {
+        if mapping.region.len() != 0 {
+            let start = u64::from(mapping.base);
+            let end = start.saturating_add(mapping.region.len() as u64);
+            self.shared_bounds = Some(match self.shared_bounds {
+                Some((old_start, old_end)) => (old_start.min(start), old_end.max(end)),
+                None => (start, end),
+            });
+        }
+        self.shared_regions.push(mapping);
+    }
+
+    #[inline]
+    fn may_overlap_shared(&self, start: u64, end: u64) -> bool {
+        self.shared_bounds
+            .is_some_and(|(low, high)| start < high && low < end)
+    }
+
+    #[inline]
+    fn overlaps_shared(&self, start: u64, end: u64) -> bool {
+        self.may_overlap_shared(start, end) && ranges_overlap(start, end, shared_ranges(self))
+    }
 }
 
 #[derive(Debug, Default)]
@@ -87,6 +115,9 @@ fn shared_mapping_at(
     state: &GuestAddressSpaceState,
     address: u32,
 ) -> Option<(&SharedRegionMapping, usize)> {
+    if !state.may_overlap_shared(u64::from(address), u64::from(address) + 1) {
+        return None;
+    }
     state.shared_regions.iter().rev().find_map(|mapping| {
         let offset = usize::try_from(address.checked_sub(mapping.base)?).ok()?;
         (offset < mapping.region.len()).then_some((mapping, offset))
@@ -289,7 +320,7 @@ fn route_range_state(
     };
     let start = u64::from(address);
 
-    let shared_overlap = ranges_overlap(start, end, shared_ranges(state));
+    let shared_overlap = state.overlaps_shared(start, end);
     if shared_overlap {
         if ranges_cover_shared(state, start, end) {
             return shared_range_route(state, start, end);
@@ -429,7 +460,7 @@ fn read_routed_u16_state(
     flat_limit: Option<u32>,
 ) -> Option<u16> {
     let end = range_end(address, 2)?;
-    if !ranges_overlap(u64::from(address), end, shared_ranges(state)) {
+    if !state.overlaps_shared(u64::from(address), end) {
         return PpcMemory::read_u16_be(&mut state.regions, address);
     }
     let hi = read_routed_u8_state(state, address, flat_limit)?;
@@ -444,7 +475,7 @@ fn read_routed_u32_state(
     flat_limit: Option<u32>,
 ) -> Option<u32> {
     let end = range_end(address, 4)?;
-    if !ranges_overlap(u64::from(address), end, shared_ranges(state)) {
+    if !state.overlaps_shared(u64::from(address), end) {
         return PpcMemory::read_u32_be(&mut state.regions, address);
     }
     let b0 = read_routed_u8_state(state, address, flat_limit)?;
@@ -483,7 +514,7 @@ fn write_routed_u16_state(
     flat_limit: Option<u32>,
 ) -> Option<()> {
     let end = range_end(address, 2)?;
-    if !ranges_overlap(u64::from(address), end, shared_ranges(state)) {
+    if !state.overlaps_shared(u64::from(address), end) {
         return PpcMemory::write_u16_be(&mut state.regions, address, value);
     }
     let bytes = value.to_be_bytes();
@@ -508,7 +539,7 @@ fn write_routed_u32_state(
     flat_limit: Option<u32>,
 ) -> Option<()> {
     let end = range_end(address, 4)?;
-    if !ranges_overlap(u64::from(address), end, shared_ranges(state)) {
+    if !state.overlaps_shared(u64::from(address), end) {
         return PpcMemory::write_u32_be(&mut state.regions, address, value);
     }
     let bytes = value.to_be_bytes();
@@ -737,6 +768,7 @@ impl Clone for GuestAddressSpace {
         Self(Rc::new(UnsafeCell::new(GuestAddressSpaceState {
             regions: state.regions.clone(),
             ordinary_regions: state.ordinary_regions.clone(),
+            shared_bounds: state.shared_bounds,
             shared_regions: state
                 .shared_regions
                 .iter()
@@ -813,6 +845,22 @@ impl GuestAddressSpace {
             len: bytes.len(),
         });
         state.regions.add_readonly_region(base, bytes);
+    }
+
+    /// Publish runtime-generated code with system provenance in owned storage.
+    /// Application code remains an ordinary mapping; it cannot acquire this
+    /// provenance by presenting matching bytes. Existing mappings and empty or
+    /// wrapping ranges are refused before changing the address space.
+    pub(crate) fn publish_system_code(&mut self, base: u32, bytes: Vec<u8>) -> Option<()> {
+        let len = u32::try_from(bytes.len()).ok()?;
+        if len == 0 || range_end(base, bytes.len()).is_none() || self.mapping_overlaps(base, len) {
+            return None;
+        }
+        let region = SharedRamRegion::from_owned_bytes(bytes);
+        // SAFETY: this new allocation has no external accessor. Subsequent
+        // views use the existing serialized address-space access contract.
+        unsafe { self.add_shared_readonly_region(base, region) };
+        Some(())
     }
 
     /// Return the disjoint holes not occupied by ordinary sparse mappings in
@@ -893,7 +941,7 @@ impl GuestAddressSpace {
     /// serializes all access. No source-bus slice or fast-memory window may be
     /// used while this address space mutates the shared allocation.
     pub(crate) unsafe fn add_shared_region(&mut self, base: u32, region: SharedRamRegion) {
-        self.state_mut().shared_regions.push(SharedRegionMapping {
+        self.state_mut().push_shared_mapping(SharedRegionMapping {
             base,
             region,
             writable: true,
@@ -917,7 +965,7 @@ impl GuestAddressSpace {
                     (excluded_base, excluded_len) != (base, len)
                 });
         }
-        state.shared_regions.push(SharedRegionMapping {
+        state.push_shared_mapping(SharedRegionMapping {
             base,
             region,
             writable: false,
@@ -960,6 +1008,20 @@ impl GuestAddressSpace {
             let mapping_end = mapping_start.saturating_add(mapping.len as u64);
             start < mapping_end && mapping_start < end
         })
+    }
+
+    /// Whether any ordinary or shared backing occupies the requested range.
+    /// Allocation exclusions alone are reservations, not published mappings.
+    pub(crate) fn mapping_overlaps(&self, base: u32, len: u32) -> bool {
+        if len == 0 || u64::from(base) + u64::from(len) > (1u64 << 32) {
+            return false;
+        }
+        self.ordinary_mapping_overlaps(base, len)
+            || self.state().shared_regions.iter().any(|mapping| {
+                let start = u64::from(mapping.base);
+                let end = start + mapping.region.len() as u64;
+                u64::from(base) < end && start < u64::from(base) + u64::from(len)
+            })
     }
 
     /// Write a big-endian long through a shared mapping regardless of its
@@ -1468,6 +1530,94 @@ mod tests {
     use crate::memory::{MacMemoryBus, MemoryBus};
     use m68k::{AddressBus, CpuCore, StepResult};
     use ppc::{PpcCpu, PpcMemory, PpcRunResult};
+
+    #[test]
+    fn shared_mapping_bounds_follow_insertions_and_detached_views() {
+        let mut memory = GuestAddressSpace::new();
+        let view = memory.shared_view();
+        assert_eq!(memory.read_u32_be(0x8000), None);
+        memory.publish_system_code(0x8000, vec![0x88; 4]).unwrap();
+        assert_eq!(memory.read_u32_be(0x8000), Some(0x8888_8888));
+        assert_eq!(memory.read_u32_be(0x1000), None);
+        let mut bus = MacMemoryBus::new(0x10000);
+        MemoryBus::write_long(&mut bus, 0, 0x1111_1111);
+        let region = bus.shared_ram_region(0, 4).unwrap();
+        // SAFETY: all source and address-space accesses are serialized here.
+        unsafe { memory.add_shared_region(0x1000, region) };
+        assert_eq!(memory.read_u32_be(0x1000), Some(0x1111_1111));
+        assert!(!view.is_shared_readonly_range(0x1000, 4));
+        assert!(view.is_shared_readonly_range(0x8000, 4));
+        assert_eq!(memory.read_u32_be(0x4000), None, "holes remain unmapped");
+        let mut detached = memory.clone();
+        assert_eq!(detached.read_u32_be(0x1000), Some(0x1111_1111));
+        assert_eq!(detached.read_u32_be(0x8000), Some(0x8888_8888));
+        memory.publish_system_code(0x9000, vec![0x99; 4]).unwrap();
+        detached.publish_system_code(0x0800, vec![0x08; 4]).unwrap();
+        assert_eq!(memory.read_u32_be(0x9000), Some(0x9999_9999));
+        assert_eq!(detached.read_u32_be(0x9000), None);
+        assert_eq!(memory.read_u32_be(0x0800), None);
+        assert_eq!(detached.read_u32_be(0x0800), Some(0x0808_0808));
+    }
+
+    #[test]
+    fn owned_system_code_preserves_provenance_and_detached_snapshot_independence() {
+        let mut memory = GuestAddressSpace::new();
+        memory
+            .publish_system_code(0x1000, vec![0x60, 0x06, 0x4e, 0xf9, 0, 0, 0x20, 0])
+            .unwrap();
+        let view = memory.shared_view();
+        assert!(view.is_shared_readonly_range(0x1000, 8));
+        assert_eq!(memory.write_u32_be(0x1004, 0x3000), None);
+        memory.add_region(0x1000, vec![0xff; 8]);
+        assert_eq!(memory.read_u32_be(0x1000), Some(0x6006_4ef9));
+        assert!(view.is_shared_readonly_range(0x1000, 8));
+        let mut detached = memory.clone();
+        assert!(detached.shared_view().is_shared_readonly_range(0x1000, 8));
+        assert_eq!(
+            detached.write_shared_system_u32_be(0x1004, 0x4000),
+            Some(())
+        );
+        assert_eq!(detached.read_u32_be(0x1004), Some(0x4000));
+        assert_eq!(memory.read_u32_be(0x1004), Some(0x2000));
+        assert_eq!(memory.write_shared_system_u32_be(0x1004, 0x5000), Some(()));
+        assert_eq!(detached.read_u32_be(0x1004), Some(0x4000));
+        memory.add_readonly_region(0x2000, vec![0x60, 0x06, 0x4e, 0xf9]);
+        assert!(!view.is_shared_readonly_range(0x2000, 4));
+        assert_eq!(memory.write_shared_system_u32_be(0x2000, 0), None);
+    }
+
+    #[test]
+    fn system_code_publication_refuses_invalid_or_occupied_ranges_atomically() {
+        let mut memory = GuestAddressSpace::new();
+        memory.add_region(0x1000, vec![0x11; 4]);
+        memory.add_readonly_region(0x2000, vec![0x22; 4]);
+        memory.publish_system_code(0x3000, vec![0x33; 4]).unwrap();
+        let mut bus = MacMemoryBus::new(0x10000);
+        let region = bus.shared_ram_region(0, 4).unwrap();
+        // SAFETY: the test serializes both memory owners.
+        unsafe { memory.add_shared_region(0x4000, region) };
+        for (base, size) in [
+            (0, 0),
+            (u32::MAX - 1, 4),
+            (0x1000, 4),
+            (0x1ffe, 4),
+            (0x3002, 4),
+            (0x3ffe, 4),
+        ] {
+            let count = memory.region_count();
+            assert_eq!(memory.publish_system_code(base, vec![0x77; size]), None);
+            assert_eq!(memory.region_count(), count);
+            assert_eq!(memory.read_u32_be(0x1000), Some(0x1111_1111));
+            assert_eq!(memory.read_u32_be(0x2000), Some(0x2222_2222));
+            assert_eq!(memory.read_u32_be(0x3000), Some(0x3333_3333));
+            assert_eq!(memory.read_u32_be(0x4000), Some(0));
+        }
+        // The last four bytes are valid; only a range beyond 2^32 wraps.
+        memory
+            .publish_system_code(u32::MAX - 3, vec![0x55; 4])
+            .unwrap();
+        assert_eq!(memory.read_u32_be(u32::MAX - 3), Some(0x5555_5555));
+    }
 
     #[test]
     fn both_cpu_backends_execute_against_immediately_shared_bytes() {

--- a/src/memory/bus.rs
+++ b/src/memory/bus.rs
@@ -596,7 +596,7 @@ fn protected_ranges_overlap(ranges: &[(u32, u32)], address: u64, end: u64) -> bo
 /// of the tick.
 pub(crate) const WRITE_PROBE_MAX_ENTRIES: usize = 4096;
 
-/// Stable shared ownership of the runner's flat RAM allocation.
+/// Stable shared ownership of flat RAM or runtime-generated system code.
 ///
 /// `FixtureRunner` serializes access to its 68k bus and native application
 /// behind `&mut self`. A mapped [`SharedRamRegion`] can therefore expose the
@@ -626,7 +626,7 @@ impl SharedRam {
     }
 }
 
-/// A stable subrange of runner RAM mapped into another CPU bus.
+/// A stable subrange of runtime-owned RAM mapped into an address space.
 #[derive(Clone)]
 pub(crate) struct SharedRamRegion {
     ram: SharedRam,
@@ -644,6 +644,17 @@ impl std::fmt::Debug for SharedRamRegion {
 }
 
 impl SharedRamRegion {
+    /// Own a complete fixed allocation without constructing a classic bus.
+    /// Access still follows the same serialized shared-region contract.
+    pub(crate) fn from_owned_bytes(bytes: Vec<u8>) -> Self {
+        let len = bytes.len();
+        Self {
+            ram: SharedRam(Rc::new(UnsafeCell::new(bytes.into_boxed_slice()))),
+            offset: 0,
+            len,
+        }
+    }
+
     pub(crate) fn len(&self) -> usize {
         self.len
     }
@@ -705,13 +716,7 @@ impl SharedRamRegion {
     }
 
     pub(crate) fn detached_clone(&self) -> Self {
-        let bytes = self.snapshot();
-        let ram = SharedRam(Rc::new(UnsafeCell::new(bytes.into_boxed_slice())));
-        Self {
-            len: ram.len(),
-            ram,
-            offset: 0,
-        }
+        Self::from_owned_bytes(self.snapshot())
     }
 }
 

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -4358,7 +4358,7 @@ impl FixtureRunner {
         // Macintosh: Memory (1992), pp. 2-19--2-21.
         let classic_heap_floor = APP_HEAP_FLOOR;
         let classic_heap_limit = self.bus.classic_heap_limit();
-        for (mapping_start, mapping_end) in ppc_app.memory.ordinary_mapping_ranges() {
+        for (mapping_start, mapping_end) in ppc_app.memory.mapping_ranges() {
             let start = mapping_start.max(classic_heap_floor);
             let end = mapping_end.min(classic_heap_limit);
             if start < end {
@@ -4366,16 +4366,23 @@ impl FixtureRunner {
             }
         }
 
+        // Check the native layout before our own RAM overlays occupy its holes.
+        let system_reservation =
+            self.bus
+                .shared_synthetic_reservation()
+                .filter(|(base, region)| {
+                    let len = u32::try_from(region.len())
+                        .expect("synthetic reservation fits guest address");
+                    ppc_app.prepare_shared_system_reservation(*base, len)
+                });
+
         let process_low_memory = self
             .bus
             .shared_ram_region(0, low_memory_end)
             .expect("FixtureRunner owns the complete process low-memory range");
         self.process_context
             .attach_memory(0, process_low_memory, &mut ppc_app.memory);
-        for (base, end) in ppc_app
-            .memory
-            .ordinary_mapping_holes(low_memory_end, ram_end)
-        {
+        for (base, end) in ppc_app.memory.mapping_holes(low_memory_end, ram_end) {
             let len = end - base;
             let process_memory = self
                 .bus
@@ -4384,17 +4391,9 @@ impl FixtureRunner {
             self.process_context
                 .attach_memory(base, process_memory, &mut ppc_app.memory);
         }
-        let Some((base, region)) = self.bus.shared_synthetic_reservation() else {
+        let Some((base, region)) = system_reservation else {
             return;
         };
-        let len = u32::try_from(region.len()).expect("synthetic reservation fits guest address");
-        if !ppc_app.prepare_shared_system_reservation(base, len) {
-            // Low-level public PEF loading does not know which runner will
-            // eventually own the app. If that late pairing would overlay
-            // already-mapped native state, preserve the native layout rather
-            // than silently replacing it with system bytes.
-            return;
-        }
         // SAFETY: the same serialized ownership contract applies, while the
         // read-only mapping preserves the ROM-like protection enforced by the
         // 68k bus for trap gateways and permanent come-from heads.
@@ -15123,6 +15122,54 @@ mod tests {
             .close_resource_file_refnum(&mut runner.bus, 5));
         assert_eq!(runner.dispatcher.current_resource_refnum(), 9);
         assert_eq!(runner.bus.read_word(0x0A5A), 9);
+    }
+
+    #[test]
+    fn native_system_code_survives_large_process_ram_attachment() {
+        use crate::loader::ppc::tests::synthetic_pef_with_import;
+
+        let mut native = load_pef_application(&synthetic_pef_with_import(b"TickCount")).unwrap();
+        let pools = [
+            PPC_IMPORT_TVECTOR_BASE,
+            PPC_IMPORT_TRAP_BASE,
+            PPC_CFM_MAIN_STUB_BASE,
+        ];
+        let words = pools.map(|base| native.memory.read_u32_be(base).unwrap());
+        // Call the imported transition vector, as compiled PEF glue does.
+        // Inside Macintosh: PowerPC System Software (1994), pp. 1-27--1-28.
+        let code = [
+            0x3d80_0000 | (PPC_IMPORT_TVECTOR_BASE >> 16), // lis r12, vector@h
+            0x618c_0000 | (PPC_IMPORT_TVECTOR_BASE & 0xffff), // ori r12,r12,vector@l
+            0x800c_0000,                                   // lwz r0,0(r12)
+            0x804c_0004,                                   // lwz r2,4(r12)
+            0x7c09_03a6,                                   // mtctr r0
+            0x4e80_0420,                                   // bctr
+        ];
+        const ENTRY: u32 = 0x0180_0000;
+        native
+            .memory
+            .add_readonly_region(ENTRY, code.into_iter().flat_map(u32::to_be_bytes).collect());
+        native.entry_pc = ENTRY;
+        native.cpu.pc = ENTRY;
+        native.cpu.lr = native.halt_pc;
+        let mut runner = FixtureRunner::new(64 * 1024 * 1024, FixtureRunnerConfig::default());
+        let (reservation_base, _) = runner.bus.synthetic_reservation_range().unwrap();
+        runner.set_launch_state(17, 1, 0);
+        runner.init_app(&LoadedApp::from_ppc(native));
+        let native = runner.native.application_mut().unwrap();
+        for (base, word) in pools.into_iter().zip(words) {
+            assert_eq!(native.memory.read_u32_be(base), Some(word));
+            assert!(native.memory.is_shared_readonly_address(base));
+            assert_eq!(native.memory.write_u32_be(base, 0), None);
+        }
+        assert!(native.memory.is_shared_readonly_address(reservation_base));
+        assert_eq!(native.memory.write_u8(reservation_base, 0xff), None);
+        let (steps, running) = runner.run_steps(64, None);
+        assert!(steps >= 6);
+        assert!(!running);
+        let native = runner.native.application_mut().unwrap();
+        assert_eq!(native.cpu.pc, native.halt_pc);
+        assert_eq!(native.cpu.gpr[3], 17);
     }
 
     #[test]


### PR DESCRIPTION
Native-generated import vectors, import stubs, CFM entry stubs and initializer return code now use checked, owned system-code publication. The address-space owner consumes their bytes into the existing shared RAM storage, preserving runtime provenance and guest write protection without constructing a classic bus. Application PEF sections retain ordinary mapping semantics. Reservation checks include both ordinary and system mappings so they cannot overwrite the generated pools.

Publication refuses empty, wrapping and occupied ranges before changing mappings. Tests cover ordinary overlay attempts, privileged writes, detached snapshot independence, final-address boundaries, writable/read-only collisions and real native loader pools. A derived shared-mapping envelope avoids scanning the support pools for unrelated memory accesses; insertion updates and detached-view behavior are tested, and positive routing decisions still use the existing precedence rules.

Runner attachment now includes system mappings when reserving classic heap spans and filling RAM holes. It preflights the synthetic reservation before adding its own RAM overlays. The initial CI run exposed erased import vectors at startup; the fix passes the PowerPC showcase locally and adds a 64 MB runner regression that executes an imported transition vector and verifies protected code and late reservation attachment.

This provides the storage boundary for native trap construction. It does not initialize standalone trap tables or fix imported patch execution (#1491, #1490).

Closes #1494.

Validation: 5,072 headless library tests passed (three existing ignored), and production/downstream compilation is warning-free. CI [33970875000](https://github.com/benletchford/systemless/actions/runs/33970875000) tested checkout `8f8e9c388`, whose source tree matches this PR head: 5,081 library tests, 50 desktop tests, both architecture showcases, builds, documentation, packaging and licenses passed. The two existing non-blocking Clippy errors remain; the non-blocking full-tree formatter exhausted memory. Changed source hunks were formatted sequentially through stdin locally.

An alternating, three-pair optimized window workload comparison against master measured 4.54s baseline versus 4.68s changed medians (about 3.1% slower; baseline samples 4.53/4.54/4.57s, changed 4.66/4.68/4.69s). This is a measured cost of the protected mapping boundary on that workload, not evidence of performance parity or a general game benchmark.
