### PR TITLE
fix: distinguish system-code ISA from mapping protection

### DIFF
--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -13076,12 +13076,14 @@ fn load_pef_application_with_config_and_optional_system_reservation(
     // GetMemFragment can bind imports while the CPU is already running.
     memory
         .publish_system_code(
+            GuestIsa::PowerPc,
             PPC_IMPORT_TVECTOR_BASE,
             import_tvector_bytes(PPC_IMPORT_SLOT_COUNT as usize),
         )
         .ok_or(PpcLoadError::AddressOverflow)?;
     memory
         .publish_system_code(
+            GuestIsa::PowerPc,
             PPC_IMPORT_TRAP_BASE,
             import_trap_bytes(PPC_IMPORT_SLOT_COUNT as usize),
         )
@@ -13090,6 +13092,7 @@ fn load_pef_application_with_config_and_optional_system_reservation(
     ppc_seed_import_data(&mut memory);
     memory
         .publish_system_code(
+            GuestIsa::PowerPc,
             PPC_CFM_MAIN_STUB_BASE,
             import_trap_bytes(PPC_CFM_MAIN_STUB_COUNT as usize),
         )
@@ -13167,6 +13170,7 @@ fn load_pef_application_with_config_and_optional_system_reservation(
     if init_tvector.is_some() {
         memory
             .publish_system_code(
+                GuestIsa::PowerPc,
                 PPC_APPLICATION_INIT_RETURN_PC,
                 ppc_application_init_return_trampoline(entry_pc, rtoc),
             )
@@ -45054,14 +45058,11 @@ fn ppc_call_universal_proc(
         // changed an interrupt mask, so consuming the saved token is a no-op.
         return Some(PpcImportAction::ReturnPreserve);
     }
-    // InterfaceLib may return a direct 680x0 system gateway as a UniversalProcPtr.
-    // The runner maps that system-owned synthetic reservation read-only, which
-    // supplies the architecture information that a bare pointer does not carry.
-    let raw_isa = if memory.is_shared_readonly_address(proc_ptr) {
-        GuestIsa::M68k
-    } else {
-        raw_isa
-    };
+    // System owners identify native transition vectors and direct 680x0
+    // gateways explicitly; read-only storage alone cannot select an ISA.
+    // Inside Macintosh: PowerPC System Software (1994), pp. 1-27--1-28,
+    // 2-42--2-43.
+    let raw_isa = memory.system_code_isa(proc_ptr).unwrap_or(raw_isa);
     let target = resolve_guest_procedure(
         memory,
         proc_ptr,
@@ -108150,9 +108151,11 @@ pub(crate) mod tests {
         let (synthetic_base, synthetic) = bus.shared_synthetic_reservation().unwrap();
         // SAFETY: this focused fixture serializes the two adapters.
         unsafe {
-            loaded
-                .memory
-                .add_shared_readonly_region(synthetic_base, synthetic)
+            loaded.memory.add_shared_readonly_region(
+                Some(GuestIsa::M68k),
+                synthetic_base,
+                synthetic,
+            )
         };
         let ds_err = bus
             .shared_ram_region(crate::memory::globals::addr::DS_ERR_CODE, 2)
@@ -108273,7 +108276,7 @@ pub(crate) mod tests {
         bus.write_byte(reservation_base, 0x5a);
         // SAFETY: this focused fixture serializes the two adapters.
         unsafe {
-            memory.add_shared_readonly_region(reservation_base, reservation);
+            memory.add_shared_readonly_region(Some(GuestIsa::M68k), reservation_base, reservation);
         }
 
         let mut heap_cursor = local_base;
@@ -108368,12 +108371,15 @@ pub(crate) mod tests {
         unsafe {
             installed
                 .memory
-                .add_shared_readonly_region(shared_base, shared)
+                .add_shared_readonly_region(Some(GuestIsa::M68k), shared_base, shared)
         };
         assert!(!installed
             .memory
             .has_readonly_allocation_exclusion(reservation.0, reservation.1));
-        assert!(installed.memory.is_shared_readonly_address(reservation.0));
+        assert!(installed
+            .memory
+            .shared_view()
+            .is_shared_readonly_range(reservation.0, 1));
         assert_eq!(installed.memory.write_u8(reservation.0, 0xff), None);
         assert_eq!(bus.read_byte(reservation_base), 0x5a);
     }
@@ -108441,6 +108447,7 @@ pub(crate) mod tests {
             PPC_APPLICATION_INIT_RETURN_PC,
         ] {
             let word = loaded.memory.read_u32_be(base).unwrap();
+            assert_eq!(loaded.memory.system_code_isa(base), Some(GuestIsa::PowerPc));
             assert!(loaded
                 .memory
                 .shared_view()

--- a/src/memory/address_space.rs
+++ b/src/memory/address_space.rs
@@ -5,6 +5,7 @@
 //! read-only regions, and instruction-cache behavior required by native PEF
 //! applications.
 
+use crate::guest_procedure::GuestIsa;
 use m68k::core::memory::{BusFault, BusFaultKind};
 use m68k::AddressBus;
 use ppc::{PpcMemory, PpcSectionMem, PpcSectionMemSpan};
@@ -18,6 +19,7 @@ struct SharedRegionMapping {
     base: u32,
     region: SharedRamRegion,
     writable: bool,
+    code_isa: Option<GuestIsa>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -777,6 +779,7 @@ impl Clone for GuestAddressSpace {
                     base: mapping.base,
                     region: mapping.region.detached_clone(),
                     writable: mapping.writable,
+                    code_isa: mapping.code_isa,
                 })
                 .collect(),
             readonly_allocation_exclusions: state.readonly_allocation_exclusions.clone(),
@@ -852,7 +855,12 @@ impl GuestAddressSpace {
     /// Application code remains an ordinary mapping; it cannot acquire this
     /// provenance by presenting matching bytes. Existing mappings and empty or
     /// wrapping ranges are refused before changing the address space.
-    pub(crate) fn publish_system_code(&mut self, base: u32, bytes: Vec<u8>) -> Option<()> {
+    pub(crate) fn publish_system_code(
+        &mut self,
+        isa: GuestIsa,
+        base: u32,
+        bytes: Vec<u8>,
+    ) -> Option<()> {
         let len = u32::try_from(bytes.len()).ok()?;
         if len == 0 || range_end(base, bytes.len()).is_none() || self.mapping_overlaps(base, len) {
             return None;
@@ -860,7 +868,7 @@ impl GuestAddressSpace {
         let region = SharedRamRegion::from_owned_bytes(bytes);
         // SAFETY: this new allocation has no external accessor. Subsequent
         // views use the existing serialized address-space access contract.
-        unsafe { self.add_shared_readonly_region(base, region) };
+        unsafe { self.add_shared_readonly_region(Some(isa), base, region) };
         Some(())
     }
 
@@ -936,18 +944,26 @@ impl GuestAddressSpace {
             base,
             region,
             writable: true,
+            code_isa: None,
         });
     }
 
     /// Overlay runner-owned system code without allowing ordinary guest
-    /// writes. Trap Manager uses the privileged writer below when it must
+    /// writes. `code_isa` identifies code and its transition vectors only when
+    /// the publishing owner supplies that identity; generic protected data uses
+    /// `None`. Trap Manager uses the privileged writer below when it must
     /// update the protected exit of a permanent come-from head.
     ///
     /// # Safety
     ///
     /// The ownership and serialization requirements are the same as for
     /// [`Self::add_shared_region`].
-    pub(crate) unsafe fn add_shared_readonly_region(&mut self, base: u32, region: SharedRamRegion) {
+    pub(crate) unsafe fn add_shared_readonly_region(
+        &mut self,
+        code_isa: Option<GuestIsa>,
+        base: u32,
+        region: SharedRamRegion,
+    ) {
         let state = self.state_mut();
         if let Ok(len) = u32::try_from(region.len()) {
             state
@@ -960,6 +976,7 @@ impl GuestAddressSpace {
             base,
             region,
             writable: false,
+            code_isa,
         });
     }
 
@@ -1032,9 +1049,12 @@ impl GuestAddressSpace {
         Some(())
     }
 
-    pub(crate) fn is_shared_readonly_address(&self, address: u32) -> bool {
+    /// ISA supplied by the owner of the selected system mapping. Protection
+    /// alone does not identify an instruction set, and ordinary mappings never
+    /// acquire this metadata by presenting matching bytes.
+    pub(crate) fn system_code_isa(&self, address: u32) -> Option<GuestIsa> {
         self.locate_shared_mapping(address)
-            .is_some_and(|(mapping, _)| !mapping.writable)
+            .and_then(|(mapping, _)| mapping.code_isa)
     }
 
     /// Return the highest end address among staged allocation exclusions or
@@ -1517,17 +1537,51 @@ impl AddressBus for GuestAddressSpace {
 
 #[cfg(test)]
 mod tests {
-    use super::GuestAddressSpace;
+    use super::{GuestAddressSpace, GuestIsa};
     use crate::memory::{MacMemoryBus, MemoryBus};
     use m68k::{AddressBus, CpuCore, StepResult};
     use ppc::{PpcCpu, PpcMemory, PpcRunResult};
+
+    #[test]
+    fn system_code_isa_follows_mapping_owner_and_detached_lifetime() {
+        let mut memory = GuestAddressSpace::new();
+        memory
+            .publish_system_code(GuestIsa::PowerPc, 0x1000, vec![0x60, 0x06, 0x4e, 0xf9])
+            .unwrap();
+        memory.add_readonly_region(0x2000, vec![0x60, 0x06, 0x4e, 0xf9]);
+        let mut bus = MacMemoryBus::new(0x1000);
+        // SAFETY: all source-bus and mapped-view access is serialized here.
+        unsafe {
+            memory.add_shared_readonly_region(None, 0x3000, bus.shared_ram_region(0, 4).unwrap());
+            memory.add_shared_readonly_region(
+                Some(GuestIsa::M68k),
+                0x4000,
+                bus.shared_ram_region(4, 4).unwrap(),
+            );
+        }
+        memory.add_region(0x1000, vec![0; 4]);
+        assert_eq!(memory.system_code_isa(0x1000), Some(GuestIsa::PowerPc));
+        assert_eq!(memory.system_code_isa(0x2000), None);
+        assert_eq!(memory.system_code_isa(0x3000), None);
+        assert_eq!(memory.system_code_isa(0x4000), Some(GuestIsa::M68k));
+        assert_eq!(memory.system_code_isa(0x5000), None);
+        let detached = memory.clone();
+        // A newer shared writable mapping wins and carries no code identity.
+        unsafe { memory.add_shared_region(0x1000, bus.shared_ram_region(8, 4).unwrap()) };
+        assert_eq!(memory.system_code_isa(0x1000), None);
+        assert_eq!(detached.system_code_isa(0x1000), Some(GuestIsa::PowerPc));
+        assert_eq!(detached.system_code_isa(0x3000), None);
+        assert_eq!(detached.system_code_isa(0x4000), Some(GuestIsa::M68k));
+    }
 
     #[test]
     fn shared_mapping_bounds_follow_insertions_and_detached_views() {
         let mut memory = GuestAddressSpace::new();
         let view = memory.shared_view();
         assert_eq!(memory.read_u32_be(0x8000), None);
-        memory.publish_system_code(0x8000, vec![0x88; 4]).unwrap();
+        memory
+            .publish_system_code(GuestIsa::M68k, 0x8000, vec![0x88; 4])
+            .unwrap();
         assert_eq!(memory.read_u32_be(0x8000), Some(0x8888_8888));
         assert_eq!(memory.read_u32_be(0x1000), None);
         let mut bus = MacMemoryBus::new(0x10000);
@@ -1542,8 +1596,12 @@ mod tests {
         let mut detached = memory.clone();
         assert_eq!(detached.read_u32_be(0x1000), Some(0x1111_1111));
         assert_eq!(detached.read_u32_be(0x8000), Some(0x8888_8888));
-        memory.publish_system_code(0x9000, vec![0x99; 4]).unwrap();
-        detached.publish_system_code(0x0800, vec![0x08; 4]).unwrap();
+        memory
+            .publish_system_code(GuestIsa::M68k, 0x9000, vec![0x99; 4])
+            .unwrap();
+        detached
+            .publish_system_code(GuestIsa::M68k, 0x0800, vec![0x08; 4])
+            .unwrap();
         assert_eq!(memory.read_u32_be(0x9000), Some(0x9999_9999));
         assert_eq!(detached.read_u32_be(0x9000), None);
         assert_eq!(memory.read_u32_be(0x0800), None);
@@ -1554,7 +1612,11 @@ mod tests {
     fn owned_system_code_preserves_provenance_and_detached_snapshot_independence() {
         let mut memory = GuestAddressSpace::new();
         memory
-            .publish_system_code(0x1000, vec![0x60, 0x06, 0x4e, 0xf9, 0, 0, 0x20, 0])
+            .publish_system_code(
+                GuestIsa::M68k,
+                0x1000,
+                vec![0x60, 0x06, 0x4e, 0xf9, 0, 0, 0x20, 0],
+            )
             .unwrap();
         let view = memory.shared_view();
         assert!(view.is_shared_readonly_range(0x1000, 8));
@@ -1582,7 +1644,9 @@ mod tests {
         let mut memory = GuestAddressSpace::new();
         memory.add_region(0x1000, vec![0x11; 4]);
         memory.add_readonly_region(0x2000, vec![0x22; 4]);
-        memory.publish_system_code(0x3000, vec![0x33; 4]).unwrap();
+        memory
+            .publish_system_code(GuestIsa::M68k, 0x3000, vec![0x33; 4])
+            .unwrap();
         let mut bus = MacMemoryBus::new(0x10000);
         let region = bus.shared_ram_region(0, 4).unwrap();
         // SAFETY: the test serializes both memory owners.
@@ -1596,7 +1660,10 @@ mod tests {
             (0x3ffe, 4),
         ] {
             let count = memory.region_count();
-            assert_eq!(memory.publish_system_code(base, vec![0x77; size]), None);
+            assert_eq!(
+                memory.publish_system_code(GuestIsa::M68k, base, vec![0x77; size]),
+                None
+            );
             assert_eq!(memory.region_count(), count);
             assert_eq!(memory.read_u32_be(0x1000), Some(0x1111_1111));
             assert_eq!(memory.read_u32_be(0x2000), Some(0x2222_2222));
@@ -1605,7 +1672,7 @@ mod tests {
         }
         // The last four bytes are valid; only a range beyond 2^32 wraps.
         memory
-            .publish_system_code(u32::MAX - 3, vec![0x55; 4])
+            .publish_system_code(GuestIsa::M68k, u32::MAX - 3, vec![0x55; 4])
             .unwrap();
         assert_eq!(memory.read_u32_be(u32::MAX - 3), Some(0x5555_5555));
     }
@@ -1869,7 +1936,7 @@ mod tests {
         let mut memory = GuestAddressSpace::new();
         memory.add_region(0x1200, vec![0; 0x100]);
         memory
-            .publish_system_code(0x1400, vec![0x5a; 0x100])
+            .publish_system_code(GuestIsa::M68k, 0x1400, vec![0x5a; 0x100])
             .unwrap();
         let mut bus = MacMemoryBus::new(0x1000);
         // SAFETY: both adapters are accessed serially in this test.

--- a/src/memory/bus.rs
+++ b/src/memory/bus.rs
@@ -3844,7 +3844,7 @@ mod tests {
             .expect("read-only alias");
         // SAFETY: access remains serialized as above.
         unsafe {
-            memory.add_shared_readonly_region(ALIAS + 4, readonly);
+            memory.add_shared_readonly_region(None, ALIAS + 4, readonly);
         }
         let before = bus.read_byte(ALIAS + 4);
         bus.write_byte(ALIAS + 4, before ^ 0xff);

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -8,6 +8,7 @@ use crate::execution_kernel::ExecutionRoute;
 use crate::execution_m68k::M68kExecution;
 use crate::execution_native::{NativeEngineRole, NativeExecution};
 use crate::guest_call::ExecutionTaskId;
+use crate::guest_procedure::GuestIsa;
 use crate::loader::ppc::{
     PpcDrawSprocketTraceEntry, PpcFrontBuffer, PpcGWorldRecord, PpcHleImportTraceEntry,
     PpcImportBinding, PpcImportDispatcherTarget, PpcInputSnapshot,
@@ -4398,7 +4399,9 @@ impl FixtureRunner {
         // read-only mapping preserves the ROM-like protection enforced by the
         // 68k bus for trap gateways and permanent come-from heads.
         unsafe {
-            ppc_app.memory.add_shared_readonly_region(base, region);
+            ppc_app
+                .memory
+                .add_shared_readonly_region(Some(GuestIsa::M68k), base, region);
         }
     }
 
@@ -15125,6 +15128,49 @@ mod tests {
     }
 
     #[test]
+    fn universal_proc_preserves_native_isa_for_protected_transition_vectors() {
+        use crate::loader::ppc::tests::synthetic_pef_with_import;
+
+        const VECTOR: u32 = 0x0180_0000;
+        const ENTRY: u32 = VECTOR + 8;
+        const RESULT: u32 = 0x1234_5678;
+        for installed in [false, true] {
+            for protected in [false, true] {
+                let mut native =
+                    load_pef_application(&synthetic_pef_with_import(b"CallUniversalProc")).unwrap();
+                let words = [ENTRY, PPC_DATA_BASE, 0x3c60_1234, 0x6063_5678, 0x4e80_0020];
+                let bytes = words.into_iter().flat_map(u32::to_be_bytes).collect();
+                if protected {
+                    native
+                        .memory
+                        .publish_system_code(GuestIsa::PowerPc, VECTOR, bytes)
+                        .unwrap();
+                } else {
+                    native.memory.add_readonly_region(VECTOR, bytes);
+                }
+                native.cpu.gpr[3] = VECTOR;
+                native.cpu.gpr[4] = 0x30; // Pascal, no arguments, long result.
+                if installed {
+                    let mut runner =
+                        FixtureRunner::new(64 * 1024 * 1024, FixtureRunnerConfig::default());
+                    runner.init_app(&LoadedApp::from_ppc(native));
+                    let (_, running) = runner.run_steps(128, None);
+                    assert!(!running, "installed protected={protected}");
+                    assert_eq!(runner.native.application_mut().unwrap().cpu.gpr[3], RESULT);
+                } else {
+                    let probe = native.run_with_hle_imports(128);
+                    assert_eq!(probe.unsupported_import_index, None);
+                    assert_eq!(native.cpu.pc, native.halt_pc);
+                    assert_eq!(
+                        native.cpu.gpr[3], RESULT,
+                        "standalone protected={protected}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
     fn native_system_code_survives_large_process_ram_attachment() {
         use crate::loader::ppc::tests::synthetic_pef_with_import;
 
@@ -15159,10 +15205,13 @@ mod tests {
         let native = runner.native.application_mut().unwrap();
         for (base, word) in pools.into_iter().zip(words) {
             assert_eq!(native.memory.read_u32_be(base), Some(word));
-            assert!(native.memory.is_shared_readonly_address(base));
+            assert!(native.memory.shared_view().is_shared_readonly_range(base, 1));
             assert_eq!(native.memory.write_u32_be(base, 0), None);
         }
-        assert!(native.memory.is_shared_readonly_address(reservation_base));
+        assert!(native
+            .memory
+            .shared_view()
+            .is_shared_readonly_range(reservation_base, 1));
         assert_eq!(native.memory.write_u8(reservation_base, 0xff), None);
         let (steps, running) = runner.run_steps(64, None);
         assert!(steps >= 6);


### PR DESCRIPTION
CallUniversalProc inferred direct 68K code from any protected mapping. Native-generated transition vectors now use protected system storage too, so an unwrapped native vector could be sent toward the wrong execution engine. A regression reproduced the failure with the actual CallUniversalProc import; the same bytes in an ordinary read-only mapping worked.

System-code publishers now provide explicit optional ISA metadata on mappings. Native support pools are marked PowerPC, the classic system reservation is marked M68k, and generic protected data is unclassified. Mixed Mode uses this identity while retaining each API's raw-pointer convention for unclassified pointers and the existing descriptor resolver. Metadata follows mapping precedence and independent detached snapshots. The obsolete protection-only query is removed.

Tests cover native vector calls in all four ordinary/protected and standalone/runner combinations, mapping lookalikes, generic read-only data, writable overlays, detached snapshots and all four actual native support pools. No public API changes.

Closes #1496.

Validation: 5,074 headless library tests passed (three existing ignored); final focused checks passed five system-code tests and 29 universal-procedure tests. Production and downstream builds are warning-free. CI [33971822525](https://github.com/benletchford/systemless/actions/runs/33971822525) passed on checkout `adea7aee0`, whose tree exactly matches the PR head: 5,083 library tests, 50 desktop tests, both architecture showcases, builds, documentation, packaging and dependency licenses. The two existing non-blocking Clippy errors remain; the full-tree formatter exhausted memory. Changed source hunks were formatted sequentially through stdin locally.
