### PR TITLE
fix: preflight shared trap construction before publication

### DIFF
--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -108117,10 +108117,12 @@ pub(crate) mod tests {
         let mut loaded = load_pef_application(&pef).unwrap();
         let mut bus = MacMemoryBus::new(8 * 1024 * 1024);
         let mut dispatcher = TrapDispatcher::new();
-        dispatcher.materialize_trap_tables(
-            &mut bus,
-            crate::trap::dispatch::TrapTableProfile::PowerPc604,
-        );
+        dispatcher
+            .materialize_trap_tables(
+                &mut bus,
+                crate::trap::dispatch::TrapTableProfile::PowerPc604,
+            )
+            .expect("trap table construction requires writable cells and system storage");
         let trap_word = 0xA823u16;
         let table_entry = ppc_raw_trap_table_entry(trap_word, true);
         let head = bus.read_long(table_entry);

--- a/src/memory/bus.rs
+++ b/src/memory/bus.rs
@@ -2840,6 +2840,17 @@ impl MemoryBus for MacMemoryBus {
 }
 
 impl crate::trap::gateways::TrapCodeMemory for MacMemoryBus {
+    fn trap_code_allocation_bucket(&self, size: u32) -> u32 {
+        Self::allocation_bucket_size(size)
+    }
+
+    fn can_allocate_trap_code(&self, size: u32) -> bool {
+        let table_end = crate::trap::manager::TOOLBOX_TRAP_TABLE_BASE
+            + u32::from(crate::trap::manager::TOOLBOX_TRAP_TABLE_SLOTS) * 4;
+        self.synthetic_code_allocation_start(size)
+            .is_some_and(|start| start >= table_end)
+    }
+
     fn publish_trap_code(&mut self, existing: Option<u32>, words: &[u16]) -> u32 {
         let size = words.len() as u32 * 2;
         let address = existing.unwrap_or_else(|| self.alloc_synthetic(size));

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -1990,7 +1990,9 @@ impl FixtureRunner {
         // Establish the writable tables and vector identities before any
         // guest patch or instruction can observe the process environment.
         // Inside Macintosh: Operating System Utilities (1994), pp. 8-4--8-6.
-        dispatcher.materialize_trap_tables(&mut bus, TrapTableProfile::M68k68040);
+        dispatcher
+            .materialize_trap_tables(&mut bus, TrapTableProfile::M68k68040)
+            .expect("trap table construction requires writable cells and system storage");
         Self {
             m68k: M68kExecution::new(&dispatcher.guest_calls),
             native: NativeExecution::default(),
@@ -4127,7 +4129,8 @@ impl FixtureRunner {
         // low memory. Materialize all 1,280 callable entries before installing
         // the adjacent QuickDraw vectors. IM:OSUtils 1994, pp. 8-4--8-6.
         self.dispatcher
-            .materialize_trap_tables(&mut self.bus, TrapTableProfile::M68k68040);
+            .materialize_trap_tables(&mut self.bus, TrapTableProfile::M68k68040)
+            .expect("trap table construction requires writable cells and system storage");
         // JHideCursor ($0800): argument-free QuickDraw cursor bottleneck.
         // Adapt a direct JSR to the existing A-line trap by removing the JSR
         // return address before dispatch and jumping back afterward.
@@ -4286,7 +4289,8 @@ impl FixtureRunner {
         let rnd_seed = self.launch_rnd_seed_override.unwrap_or(time);
         self.bus.write_long(addr::RND_SEED, rnd_seed);
         self.dispatcher
-            .materialize_trap_tables(&mut self.bus, TrapTableProfile::PowerPc604);
+            .materialize_trap_tables(&mut self.bus, TrapTableProfile::PowerPc604)
+            .expect("trap table construction requires writable cells and system storage");
         self.share_ppc_process_memory(&mut ppc_app);
         let detached_events = std::mem::take(&mut *ppc_app.event_queue);
         self.process_context

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -6509,16 +6509,19 @@ impl TrapDispatcher {
         &mut self,
         bus: &mut MacMemoryBus,
         profile: TrapTableProfile,
-    ) -> TrapTableProcessContext {
-        let image = self.trap_gateways.create_table(bus, profile);
-        TrapTableProcessContext {
+    ) -> Result<TrapTableProcessContext> {
+        let image = self
+            .trap_gateways
+            .create_table(bus, profile)
+            .ok_or(Error::TrapTableInitialization)?;
+        Ok(TrapTableProcessContext {
             profile,
             raw_entries: image.raw_entries,
             raw_exception_vectors: image.exception_vectors,
             default_exception_vectors: image.exception_vectors,
             pending_native_trap_calls: HashMap::new(),
             current_trap_caller: None,
-        }
+        })
     }
 
     /// Save the active application's trap context and restore another one.
@@ -6592,37 +6595,8 @@ impl TrapDispatcher {
         &mut self,
         bus: &mut MacMemoryBus,
         profile: TrapTableProfile,
-    ) {
-        let context = self.create_trap_table_process_context(bus, profile);
-        let _ = self.switch_trap_table_process_context(bus, context);
-    }
-
-    /// Establish the standalone classic Trap Manager environment before any
-    /// direct guest table patches. Ordinary dispatch also calls this on first
-    /// use. Repeated calls preserve the active profile, guest cells, exception
-    /// vectors and in-flight patch calls. Keep the dispatcher paired with the
-    /// same process bus; replacement memory requires a fresh dispatcher.
-    ///
-    /// Initialization requires writable table/vector cells and enough unused
-    /// process RAM for the protected gateways. It refuses unavailable storage
-    /// before allocating or changing guest bytes. Native application runners
-    /// establish their selected profile separately before attaching execution.
-    /// Inside Macintosh: Operating System Utilities (1994), pp. 8-4--8-9.
-    pub fn initialize_trap_tables(&mut self, bus: &mut MacMemoryBus) -> Result<()> {
-        if self.trap_table_profile.is_some() {
-            return Ok(());
-        }
-        let profile = TrapTableProfile::M68k68040;
-        let required = self
-            .trap_gateways
-            .required_bytes(profile, MacMemoryBus::allocation_bucket_size);
-        let table_end = TOOLBOX_TRAP_TABLE_BASE + u32::from(TOOLBOX_TRAP_TABLE_SLOTS) * 4;
-        let storage_available = bus
-            .synthetic_code_allocation_start(required)
-            .is_some_and(|start| start >= table_end);
-        if !storage_available
-            || !bus
-                .is_guest_address_writable(OS_TRAP_TABLE_BASE, usize::from(OS_TRAP_TABLE_SLOTS) * 4)
+    ) -> Result<()> {
+        if !bus.is_guest_address_writable(OS_TRAP_TABLE_BASE, usize::from(OS_TRAP_TABLE_SLOTS) * 4)
             || !bus.is_guest_address_writable(
                 TOOLBOX_TRAP_TABLE_BASE,
                 usize::from(TOOLBOX_TRAP_TABLE_SLOTS) * 4,
@@ -6631,8 +6605,20 @@ impl TrapDispatcher {
         {
             return Err(Error::TrapTableInitialization);
         }
-        self.materialize_trap_tables(bus, profile);
+        let context = self.create_trap_table_process_context(bus, profile)?;
+        let _ = self.switch_trap_table_process_context(bus, context);
         Ok(())
+    }
+
+    /// Establish standalone classic trap tables before lookup or patching.
+    /// Repeated initialization preserves active cells and in-flight calls.
+    /// Keep the dispatcher paired with its original code-memory owner.
+    /// Inside Macintosh: Operating System Utilities (1994), pp. 8-4--8-9.
+    pub fn initialize_trap_tables(&mut self, bus: &mut MacMemoryBus) -> Result<()> {
+        if self.trap_table_profile.is_some() {
+            return Ok(());
+        }
+        self.materialize_trap_tables(bus, TrapTableProfile::M68k68040)
     }
 
     /// Whether low-memory exception vector 10 still names this process's
@@ -8153,7 +8139,9 @@ mod tests {
     fn generated_profile_routes_cover_all_raw_words_and_live_table_cells() {
         for profile in [TrapTableProfile::M68k68040, TrapTableProfile::PowerPc604] {
             let (mut dispatcher, _cpu, mut bus) = setup();
-            dispatcher.materialize_trap_tables(&mut bus, profile);
+            dispatcher
+                .materialize_trap_tables(&mut bus, profile)
+                .expect("trap table construction requires writable cells and system storage");
             let unimplemented = dispatcher.default_trap_gateway(0xAA6E).unwrap();
 
             for low_word in 0u16..0x1000 {
@@ -8326,7 +8314,9 @@ mod tests {
                     0xA000 | slot
                 };
                 let (mut dispatcher, mut cpu, mut bus) = setup();
-                dispatcher.materialize_trap_tables(&mut bus, profile);
+                dispatcher
+                    .materialize_trap_tables(&mut bus, profile)
+                    .expect("trap table construction requires writable cells and system storage");
                 let saved_default = dispatcher.trap_table_address(&bus, canonical_word).unwrap();
                 let profile_route = profile.route(canonical_word);
                 let invoked_word = bus.read_word(saved_default);
@@ -8433,7 +8423,9 @@ mod tests {
 
         for profile in [TrapTableProfile::M68k68040, TrapTableProfile::PowerPc604] {
             let (mut dispatcher, mut cpu, mut bus) = setup();
-            dispatcher.materialize_trap_tables(&mut bus, profile);
+            dispatcher
+                .materialize_trap_tables(&mut bus, profile)
+                .expect("trap table construction requires writable cells and system storage");
 
             for table_index in 0..(OS_TRAP_TABLE_SLOTS + TOOLBOX_TRAP_TABLE_SLOTS) {
                 let is_toolbox = table_index >= OS_TRAP_TABLE_SLOTS;
@@ -8749,6 +8741,90 @@ mod tests {
     }
 
     #[test]
+    fn profile_materialization_refuses_before_mutating_active_process() {
+        for failure in 0..6 {
+            let (mut dispatcher, _, mut bus) = setup();
+            dispatcher
+                .materialize_trap_tables(&mut bus, TrapTableProfile::M68k68040)
+                .unwrap();
+            let tick_cell = raw_trap_route(0xA975).table_address;
+            bus.write_long(tick_cell, 0x1234_5678);
+            dispatcher.current_trap_caller = Some(0x0020_1000);
+            dispatcher.pending_native_trap_calls.insert(
+                0xA975,
+                vec![NativeTrapCallState {
+                    return_pc: 0x0020_2000,
+                    argument_sp: 0x003f_ff00,
+                    os_dispatch_frame: None,
+                    preserved_d_regs: [1; 5],
+                    preserved_a_regs: [2; 5],
+                }],
+            );
+            match failure {
+                0 => {
+                    while bus.synthetic_code_allocation_start(4).is_some() {
+                        bus.alloc_synthetic(4);
+                    }
+                }
+                1 => bus.protect_readonly_code(OS_TRAP_TABLE_BASE, 4),
+                2 => bus.protect_readonly_code(TOOLBOX_TRAP_TABLE_BASE, 4),
+                3 => bus.protect_readonly_code(0x28, 4),
+                4 | 5 => {
+                    let address = if failure == 4 {
+                        bus.synthetic_code_allocation_start(4).unwrap()
+                    } else {
+                        OS_TRAP_TABLE_BASE
+                    };
+                    let mut foreign = crate::memory::GuestAddressSpace::new();
+                    foreign.add_readonly_region(address, vec![0x55; 4]);
+                    bus.attach_guest_address_space(foreign.shared_view());
+                }
+                _ => unreachable!(),
+            }
+            let low_memory = bus.read_bytes(0, 0x2000);
+            let (base, len) = bus.synthetic_reservation_range().unwrap();
+            let code = bus.read_bytes(base, len as usize);
+            let next = bus.synthetic_code_allocation_start(4);
+            let defaults = dispatcher.trap_exception_vector_defaults;
+            let tick_default = dispatcher.trap_gateways.get(0xA975);
+            assert!(matches!(
+                dispatcher.materialize_trap_tables(&mut bus, TrapTableProfile::PowerPc604),
+                Err(Error::TrapTableInitialization)
+            ));
+            assert_eq!(bus.read_bytes(0, 0x2000), low_memory);
+            assert_eq!(bus.read_bytes(base, len as usize), code);
+            assert_eq!(bus.synthetic_code_allocation_start(4), next);
+            assert_eq!(
+                dispatcher.trap_table_profile,
+                Some(TrapTableProfile::M68k68040)
+            );
+            assert_eq!(dispatcher.trap_exception_vector_defaults, defaults);
+            assert_eq!(dispatcher.trap_gateways.get(0xA975), tick_default);
+            assert_eq!(dispatcher.current_trap_caller, Some(0x0020_1000));
+            assert_eq!(bus.read_long(tick_cell), 0x1234_5678);
+            let frames = &dispatcher.pending_native_trap_calls[&0xA975];
+            assert_eq!(frames.len(), 1);
+            assert_eq!(frames[0].return_pc, 0x0020_2000);
+            assert_eq!(frames[0].argument_sp, 0x003f_ff00);
+            assert_eq!(frames[0].preserved_d_regs, [1; 5]);
+            assert_eq!(frames[0].preserved_a_regs, [2; 5]);
+            if failure >= 4 {
+                bus.detach_guest_address_space();
+                dispatcher
+                    .materialize_trap_tables(&mut bus, TrapTableProfile::PowerPc604)
+                    .unwrap();
+                assert_eq!(
+                    dispatcher.trap_table_profile,
+                    Some(TrapTableProfile::PowerPc604)
+                );
+                assert_eq!(dispatcher.current_trap_caller, None);
+                assert!(dispatcher.pending_native_trap_calls.is_empty());
+                assert_ne!(bus.read_long(tick_cell), 0x1234_5678);
+            }
+        }
+    }
+
+    #[test]
     fn standalone_trap_initialization_refuses_unavailable_memory_atomically_and_retries() {
         for failure in 0..7 {
             let (mut dispatcher, mut cpu, _) = setup();
@@ -8917,7 +8993,9 @@ mod tests {
     #[test]
     fn materialized_trap_tables_contain_all_callable_profile_entries() {
         let (mut dispatcher, _cpu, mut bus) = setup();
-        dispatcher.materialize_trap_tables(&mut bus, TrapTableProfile::M68k68040);
+        dispatcher
+            .materialize_trap_tables(&mut bus, TrapTableProfile::M68k68040)
+            .expect("trap table construction requires writable cells and system storage");
 
         for slot in 0..OS_TRAP_TABLE_SLOTS {
             let trap_word = 0xA000 | slot;
@@ -8959,7 +9037,9 @@ mod tests {
     fn machine_profiles_generate_distinct_protected_exception_vector_defaults() {
         for profile in [TrapTableProfile::M68k68040, TrapTableProfile::PowerPc604] {
             let (mut dispatcher, _cpu, mut bus) = setup();
-            dispatcher.materialize_trap_tables(&mut bus, profile);
+            dispatcher
+                .materialize_trap_tables(&mut bus, profile)
+                .expect("trap table construction requires writable cells and system storage");
             let defaults = dispatcher.trap_exception_vector_defaults.unwrap();
 
             assert_ne!(defaults[0], defaults[1]);
@@ -8993,7 +9073,9 @@ mod tests {
             (TrapTableProfile::PowerPc604, POWERPC_604_COME_FROM_TRAPS),
         ] {
             let (mut dispatcher, _cpu, mut bus) = setup();
-            dispatcher.materialize_trap_tables(&mut bus, profile);
+            dispatcher
+                .materialize_trap_tables(&mut bus, profile)
+                .expect("trap table construction requires writable cells and system storage");
             let mut observed = Vec::new();
             for slot in 0..OS_TRAP_TABLE_SLOTS {
                 let word = 0xA000 | slot;
@@ -9025,7 +9107,9 @@ mod tests {
         let second_protected_patch = 0x0022_0000;
         let second_direct_patch = 0x0022_1000;
 
-        dispatcher.materialize_trap_tables(&mut bus, TrapTableProfile::M68k68040);
+        dispatcher
+            .materialize_trap_tables(&mut bus, TrapTableProfile::M68k68040)
+            .expect("trap table construction requires writable cells and system storage");
         let first_head = bus.read_long(protected_entry);
         let first_defaults = dispatcher.trap_exception_vector_defaults.unwrap();
         assert_eq!([bus.read_long(0x28), bus.read_long(0x2C)], first_defaults);
@@ -9047,8 +9131,9 @@ mod tests {
         );
         dispatcher.current_trap_caller = Some(0x0023_1000);
 
-        let fresh_second =
-            dispatcher.create_trap_table_process_context(&mut bus, TrapTableProfile::PowerPc604);
+        let fresh_second = dispatcher
+            .create_trap_table_process_context(&mut bus, TrapTableProfile::PowerPc604)
+            .unwrap();
         let first_context = dispatcher
             .switch_trap_table_process_context(&mut bus, fresh_second)
             .expect("first process context must be saved");
@@ -9138,7 +9223,9 @@ mod tests {
 
         for profile in [TrapTableProfile::M68k68040, TrapTableProfile::PowerPc604] {
             let (mut dispatcher, _cpu, mut bus) = setup();
-            dispatcher.materialize_trap_tables(&mut bus, profile);
+            dispatcher
+                .materialize_trap_tables(&mut bus, profile)
+                .expect("trap table construction requires writable cells and system storage");
             let unimplemented = dispatcher.trap_table_address(&bus, 0xAA6E).unwrap();
             let mut matching_slots = Vec::new();
 
@@ -9185,7 +9272,9 @@ mod tests {
         let aliases = [(0xA87D, 0xAA02), (0xAA08, 0xAA26)];
 
         let (mut dispatcher, _cpu, mut bus) = setup();
-        dispatcher.materialize_trap_tables(&mut bus, TrapTableProfile::M68k68040);
+        dispatcher
+            .materialize_trap_tables(&mut bus, TrapTableProfile::M68k68040)
+            .expect("trap table construction requires writable cells and system storage");
         for (target, alias) in aliases {
             assert_eq!(
                 dispatcher.trap_table_address(&bus, target),
@@ -9200,8 +9289,9 @@ mod tests {
             );
         }
 
-        let second =
-            dispatcher.create_trap_table_process_context(&mut bus, TrapTableProfile::PowerPc604);
+        let second = dispatcher
+            .create_trap_table_process_context(&mut bus, TrapTableProfile::PowerPc604)
+            .unwrap();
         let _first = dispatcher
             .switch_trap_table_process_context(&mut bus, second)
             .expect("68040 context must be saved");
@@ -9223,7 +9313,9 @@ mod tests {
     #[test]
     fn a_profile_default_alias_keeps_independent_patch_and_restore_state() {
         let (mut dispatcher, _cpu, mut bus) = setup();
-        dispatcher.materialize_trap_tables(&mut bus, TrapTableProfile::M68k68040);
+        dispatcher
+            .materialize_trap_tables(&mut bus, TrapTableProfile::M68k68040)
+            .expect("trap table construction requires writable cells and system storage");
 
         for (target, alias, patch) in [(0xA87D, 0xAA02, 0x0021_0000), (0xAA08, 0xAA26, 0x0021_1000)]
         {
@@ -9262,7 +9354,9 @@ mod tests {
         // address saved from $AA02 must therefore execute the shared $A87D
         // procedure and retain its one-CGrafPtr Pascal stack contract.
         let (mut dispatcher, mut cpu, mut bus) = setup();
-        dispatcher.materialize_trap_tables(&mut bus, TrapTableProfile::M68k68040);
+        dispatcher
+            .materialize_trap_tables(&mut bus, TrapTableProfile::M68k68040)
+            .expect("trap table construction requires writable cells and system storage");
         let gateway = dispatcher.trap_table_address(&bus, 0xAA02).unwrap();
         let return_pc = 0x0020_0000;
         let sp = 0x003F_FF00;
@@ -9286,7 +9380,9 @@ mod tests {
     #[test]
     fn trap_manager_mutates_hidden_successor_without_replacing_raw_head() {
         let (mut dispatcher, mut cpu, mut bus) = setup();
-        dispatcher.materialize_trap_tables(&mut bus, TrapTableProfile::M68k68040);
+        dispatcher
+            .materialize_trap_tables(&mut bus, TrapTableProfile::M68k68040)
+            .expect("trap table construction requires writable cells and system storage");
         let trap_word = 0xA078;
         let raw_entry = TrapDispatcher::raw_trap_table_entry(trap_word);
         let head = bus.read_long(raw_entry);
@@ -9314,7 +9410,9 @@ mod tests {
     #[test]
     fn trap_manager_mutates_the_last_exit_in_a_multi_head_chain() {
         let (mut dispatcher, mut cpu, mut bus) = setup();
-        dispatcher.materialize_trap_tables(&mut bus, TrapTableProfile::M68k68040);
+        dispatcher
+            .materialize_trap_tables(&mut bus, TrapTableProfile::M68k68040)
+            .expect("trap table construction requires writable cells and system storage");
         let trap_word = 0xA078;
         let raw_entry = TrapDispatcher::raw_trap_table_entry(trap_word);
         let first = bus.read_long(raw_entry);
@@ -9348,7 +9446,9 @@ mod tests {
     #[test]
     fn direct_raw_write_can_bypass_a_permanent_come_from_head() {
         let (mut dispatcher, mut cpu, mut bus) = setup();
-        dispatcher.materialize_trap_tables(&mut bus, TrapTableProfile::M68k68040);
+        dispatcher
+            .materialize_trap_tables(&mut bus, TrapTableProfile::M68k68040)
+            .expect("trap table construction requires writable cells and system storage");
         let trap_word = 0xAAFB;
         let raw_entry = TrapDispatcher::raw_trap_table_entry(trap_word);
         let old_head = bus.read_long(raw_entry);
@@ -9377,7 +9477,9 @@ mod tests {
         // Set/NSet installs the supplied address; no guest address range is a
         // host-only restoration token.
         let (mut dispatcher, _cpu, mut bus) = setup();
-        dispatcher.materialize_trap_tables(&mut bus, TrapTableProfile::M68k68040);
+        dispatcher
+            .materialize_trap_tables(&mut bus, TrapTableProfile::M68k68040)
+            .expect("trap table construction requires writable cells and system storage");
         let trap_word = 0xA004;
         let handler = 0x00F0_A004;
 
@@ -9398,7 +9500,9 @@ mod tests {
     #[test]
     fn nset_rejects_a_come_from_head_as_the_new_handler() {
         let (mut dispatcher, mut cpu, mut bus) = setup();
-        dispatcher.materialize_trap_tables(&mut bus, TrapTableProfile::M68k68040);
+        dispatcher
+            .materialize_trap_tables(&mut bus, TrapTableProfile::M68k68040)
+            .expect("trap table construction requires writable cells and system storage");
         let trap_word = 0xA078;
         let raw_entry = TrapDispatcher::raw_trap_table_entry(trap_word);
         let head = bus.read_long(raw_entry);
@@ -9416,7 +9520,9 @@ mod tests {
     #[test]
     fn direct_raw_table_write_is_authoritative_for_dispatch() {
         let (mut dispatcher, mut cpu, mut bus) = setup();
-        dispatcher.materialize_trap_tables(&mut bus, TrapTableProfile::M68k68040);
+        dispatcher
+            .materialize_trap_tables(&mut bus, TrapTableProfile::M68k68040)
+            .expect("trap table construction requires writable cells and system storage");
         let handler = 0x0021_0000;
         let return_pc = 0x0020_0002;
         let sp = 0x003F_FF00;
@@ -9435,7 +9541,9 @@ mod tests {
     #[test]
     fn trap_manager_apis_and_raw_table_long_stay_coherent() {
         let (mut dispatcher, mut cpu, mut bus) = setup();
-        dispatcher.materialize_trap_tables(&mut bus, TrapTableProfile::M68k68040);
+        dispatcher
+            .materialize_trap_tables(&mut bus, TrapTableProfile::M68k68040)
+            .expect("trap table construction requires writable cells and system storage");
         let entry_address = TOOLBOX_TRAP_TABLE_BASE + 0x175 * 4;
         let default = bus.read_long(entry_address);
         let handler = 0x0021_0000;

--- a/src/trap/gateways.rs
+++ b/src/trap/gateways.rs
@@ -86,12 +86,15 @@ impl TrapTableProfile {
     }
 }
 
-/// Bounded system-code publication supplied by the memory owner. Callers must
-/// preflight allocation and mapping before creating a table. `existing` names
+/// Bounded system-code publication supplied by the memory owner. Profile
+/// construction preflights its total allocation through this contract. Individual
+/// publication requires reserved capacity. `existing` names
 /// code already owned by this service in the same memory lifetime. Publication
 /// writes all words and makes new code read-only to ordinary guest stores.
 /// This interface does not own an allocator or authorize application writes.
 pub(crate) trait TrapCodeMemory {
+    fn trap_code_allocation_bucket(&self, size: u32) -> u32;
+    fn can_allocate_trap_code(&self, size: u32) -> bool;
     fn publish_trap_code(&mut self, existing: Option<u32>, words: &[u16]) -> u32;
 }
 
@@ -150,7 +153,11 @@ impl TrapSystemGateways {
     /// Required new storage using the memory owner's actual allocation bucket.
     /// Cached default identities cost no allocation; each process gets new
     /// protected heads and exception-vector gateways.
-    pub(crate) fn required_bytes(&self, profile: TrapTableProfile, bucket: fn(u32) -> u32) -> u32 {
+    pub(crate) fn required_bytes(
+        &self,
+        profile: TrapTableProfile,
+        bucket: impl Fn(u32) -> u32,
+    ) -> u32 {
         let mut words = HashSet::from([0xAA6E]);
         for word in Self::table_words() {
             let route = profile.route(word);
@@ -180,13 +187,19 @@ impl TrapSystemGateways {
     }
 
     /// Materialize profile defaults without constructing a manager adapter.
-    /// Code ownership and publication preflight belong to `memory`'s caller.
+    /// The memory owner preflights the entire allocation before any code,
+    /// identity or table image is published. Refusal leaves both owners intact.
     /// IM:OSUtils (1994), pp. 8-4--8-9, 8-25--8-31.
     pub(crate) fn create_table(
         &mut self,
         memory: &mut impl TrapCodeMemory,
         profile: TrapTableProfile,
-    ) -> TrapTableImage {
+    ) -> Option<TrapTableImage> {
+        let required =
+            self.required_bytes(profile, |size| memory.trap_code_allocation_bucket(size));
+        if !memory.can_allocate_trap_code(required) {
+            return None;
+        }
         let unimplemented = self.get_or_create(memory, 0xAA6E);
         let mut raw_entries =
             Vec::with_capacity(usize::from(OS_TRAP_TABLE_SLOTS + TOOLBOX_TRAP_TABLE_SLOTS));
@@ -209,10 +222,10 @@ impl TrapSystemGateways {
             memory.publish_trap_code(None, &[0x4E73]),
             memory.publish_trap_code(None, &[0x4E73]),
         ];
-        TrapTableImage {
+        Some(TrapTableImage {
             raw_entries,
             exception_vectors,
-        }
+        })
     }
 
     pub(crate) fn create_come_from_head(memory: &mut impl TrapCodeMemory, successor: u32) -> u32 {
@@ -237,11 +250,20 @@ mod tests {
 
     struct CodeMemory {
         next: u32,
+        limit: u32,
         bucket: fn(u32) -> u32,
         code: HashMap<u32, Vec<u16>>,
     }
 
     impl TrapCodeMemory for CodeMemory {
+        fn trap_code_allocation_bucket(&self, size: u32) -> u32 {
+            (self.bucket)(size)
+        }
+        fn can_allocate_trap_code(&self, size: u32) -> bool {
+            self.next
+                .checked_add(size)
+                .is_some_and(|end| end <= self.limit)
+        }
         fn publish_trap_code(&mut self, existing: Option<u32>, words: &[u16]) -> u32 {
             let address = existing.unwrap_or_else(|| {
                 let address = self.next;
@@ -266,6 +288,7 @@ mod tests {
             for profile in [TrapTableProfile::M68k68040, TrapTableProfile::PowerPc604] {
                 let mut memory = CodeMemory {
                     next: 0x10000,
+                    limit: u32::MAX,
                     bucket,
                     code: HashMap::new(),
                 };
@@ -275,7 +298,7 @@ mod tests {
                 let os = system.get_or_create(&mut memory, 0xA31E);
                 let before = memory.next;
                 let needed = system.required_bytes(profile, bucket);
-                let first = system.create_table(&mut memory, profile);
+                let first = system.create_table(&mut memory, profile).unwrap();
                 assert_eq!(memory.next - before, needed);
                 assert_eq!(first.raw_entries.len(), 1280);
                 assert_eq!(system.get(0xA975), Some(tick));
@@ -318,7 +341,7 @@ mod tests {
                 );
                 let before = memory.next;
                 let needed = system.required_bytes(profile, bucket);
-                let second = system.create_table(&mut memory, profile);
+                let second = system.create_table(&mut memory, profile).unwrap();
                 assert_eq!(memory.next - before, needed);
                 assert_eq!(
                     needed,
@@ -343,9 +366,40 @@ mod tests {
     }
 
     #[test]
+    fn profile_construction_refuses_capacity_before_publication_and_retries() {
+        for profile in [TrapTableProfile::M68k68040, TrapTableProfile::PowerPc604] {
+            for reused in [false, true] {
+                let mut memory = CodeMemory {
+                    next: 0x10000,
+                    limit: u32::MAX,
+                    bucket: eight,
+                    code: HashMap::new(),
+                };
+                let mut system = TrapSystemGateways::default();
+                if reused {
+                    system.create_table(&mut memory, profile).unwrap();
+                }
+                let before = memory.next;
+                let code = memory.code.clone();
+                let defaults = system.defaults.clone();
+                let required = system.required_bytes(profile, eight);
+                memory.limit = before + required - 1;
+                assert!(system.create_table(&mut memory, profile).is_none());
+                assert_eq!(memory.next, before);
+                assert_eq!(memory.code, code);
+                assert_eq!(system.defaults, defaults);
+                memory.limit += 1;
+                assert!(system.create_table(&mut memory, profile).is_some());
+                assert_eq!(memory.next, before + required);
+            }
+        }
+    }
+
+    #[test]
     fn saved_gateway_republication_uses_canonical_identity_without_allocating() {
         let mut memory = CodeMemory {
             next: 0x10000,
+            limit: u32::MAX,
             bucket: four,
             code: HashMap::new(),
         };

--- a/src/trap/memory.rs
+++ b/src/trap/memory.rs
@@ -7938,7 +7938,8 @@ mod tests {
     fn get_trap_address_does_not_misclassify_docking_dispatch_as_unimplemented() {
         let (mut dispatcher, mut cpu, mut bus) = setup();
         dispatcher
-            .materialize_trap_tables(&mut bus, crate::trap::dispatch::TrapTableProfile::M68k68040);
+            .materialize_trap_tables(&mut bus, crate::trap::dispatch::TrapTableProfile::M68k68040)
+            .expect("trap table construction requires writable cells and system storage");
 
         cpu.write_reg(Register::D0, 0xAA57);
         let result = dispatcher.dispatch_memory(false, 0x46, &mut cpu, &mut bus);
@@ -8095,7 +8096,9 @@ mod tests {
     #[test]
     fn initialized_68k_trap_manager_reads_and_writes_guest_table_bytes() {
         let (mut dispatcher, mut cpu, mut bus) = setup();
-        dispatcher.materialize_trap_tables(&mut bus, TrapTableProfile::M68k68040);
+        dispatcher
+            .materialize_trap_tables(&mut bus, TrapTableProfile::M68k68040)
+            .expect("trap table construction requires writable cells and system storage");
         let trap_word = 0xA975;
         let table_entry = TOOLBOX_TRAP_TABLE_BASE + 0x175 * 4;
         let installed = 0x0021_0000;

--- a/src/trap/test_helpers.rs
+++ b/src/trap/test_helpers.rs
@@ -129,7 +129,9 @@ pub fn setup() -> (TrapDispatcher, MockCpu, MacMemoryBus) {
 /// Inside Macintosh: Operating System Utilities (1994), pp. 8-4--8-6.
 pub fn setup_with_trap_tables() -> (TrapDispatcher, MockCpu, MacMemoryBus) {
     let (mut dispatcher, cpu, mut bus) = setup();
-    dispatcher.materialize_trap_tables(&mut bus, super::dispatch::TrapTableProfile::M68k68040);
+    dispatcher
+        .materialize_trap_tables(&mut bus, super::dispatch::TrapTableProfile::M68k68040)
+        .expect("trap table construction requires writable cells and system storage");
     (dispatcher, cpu, bus)
 }
 


### PR DESCRIPTION
Shared trap profile construction now checks the complete allocation before publishing code or default identities. Previously that check existed only in the standalone initializer, so direct profile construction could consume partial storage and publish invalid gateway addresses after exhaustion. The shared service uses the memory owner's actual allocation bucket and availability contract, including reuse of existing defaults.

Profile materialization also checks all table/vector destinations before creating or switching contexts and returns an explicit failure. Standalone initialization delegates to that path instead of carrying duplicate sizing logic. Existing infallible runner APIs explicitly stop if construction fails; whole-launch rollback is separate work, not claimed here.

Tests cover both profiles with cold/reused defaults, exact capacity boundaries, unchanged storage/registry on refusal and successful retry. Six active-profile failures cover exhausted storage, protected OS/Toolbox/vector cells and foreign code/table overlays, preserving guest/system bytes, allocator position, profile/vector identities and pending call frames. Removing an overlay permits retry. No public API changes.

Closes #1498.

Validation: 5,076 headless library tests passed (three existing ignored). The strengthened pending-call refusal regression passes, and production/downstream compilation is warning-free. CI [33972828959](https://github.com/benletchford/systemless/actions/runs/33972828959) passed 5,085 library tests, 50 desktop tests, both architecture showcases, builds, documentation, packaging and dependency licenses. Tested checkout `4bfd6cb02` has exactly the same source tree as the PR head. The two existing non-blocking Clippy errors remain; full-tree rustfmt exhausted memory. Changed hunks were formatted sequentially through stdin locally.
