### PR TITLE
refactor: keep system trap identities with their code owner

### DIFF
--- a/src/memory/bus.rs
+++ b/src/memory/bus.rs
@@ -479,6 +479,8 @@ pub struct MacMemoryBus {
     synthetic_ptr: u32,
     /// Lower bound of the fixed reservation for future synthetic allocations.
     synthetic_floor: u32,
+    /// Stable trap defaults share the lifetime of their allocated system code.
+    trap_gateways: crate::trap::gateways::TrapSystemGateways,
     /// Guest writes cannot modify synthesized ROM-like instruction stubs.
     readonly_code_ranges: Vec<(u32, u32)>,
     /// Half-open bounding box over `readonly_code_ranges`, maintained on
@@ -1230,6 +1232,7 @@ impl MacMemoryBus {
             heap_allocator: SharedClassicHeapAllocator::default(),
             synthetic_ptr: screen_buffer_start,
             synthetic_floor,
+            trap_gateways: crate::trap::gateways::TrapSystemGateways::default(),
             readonly_code_ranges: Vec::new(),
             readonly_code_span: None,
             write_probe_original: None,
@@ -1323,6 +1326,7 @@ impl MacMemoryBus {
             heap_allocator: SharedClassicHeapAllocator::default(),
             synthetic_ptr: screen_buffer_start,
             synthetic_floor,
+            trap_gateways: crate::trap::gateways::TrapSystemGateways::default(),
             readonly_code_ranges: Vec::new(),
             readonly_code_span: None,
             write_probe_original: None,
@@ -1765,6 +1769,46 @@ impl MacMemoryBus {
 
     pub fn alloc(&mut self, size: u32) -> u32 {
         self.heap_allocator.allocate(size, 4, self.synthetic_floor)
+    }
+
+    pub(crate) fn system_trap_gateway(&self, word: u16) -> Option<u32> {
+        self.trap_gateways.get(word)
+    }
+
+    pub(crate) fn default_system_trap_gateway(
+        &self,
+        profile: crate::trap::gateways::TrapTableProfile,
+        word: u16,
+    ) -> Option<u32> {
+        self.trap_gateways.default_gateway(profile, word)
+    }
+
+    /// Publish through one synchronous owner operation. Publication only writes
+    /// owned storage and cannot execute guest code or reenter a manager; no
+    /// reference to the temporarily moved registry escapes this operation.
+    pub(crate) fn get_or_create_system_trap_gateway(&mut self, word: u16) -> u32 {
+        let mut gateways = std::mem::take(&mut self.trap_gateways);
+        let address = gateways.get_or_create(self, word);
+        self.trap_gateways = gateways;
+        address
+    }
+
+    /// Build an inactive process image using this allocation's system identities.
+    /// The shared constructor checks capacity before publication. Restore the
+    /// same registry on either success or refusal, without an attachment alias.
+    pub(crate) fn create_system_trap_table(
+        &mut self,
+        profile: crate::trap::gateways::TrapTableProfile,
+    ) -> Option<crate::trap::gateways::TrapTableImage> {
+        let mut gateways = std::mem::take(&mut self.trap_gateways);
+        let image = gateways.create_table(self, profile);
+        self.trap_gateways = gateways;
+        image
+    }
+
+    #[cfg(test)]
+    pub(crate) fn system_trap_gateways_are_empty(&self) -> bool {
+        self.trap_gateways.is_empty()
     }
 
     /// Preflight a synthetic code allocation without consuming storage.
@@ -2867,6 +2911,30 @@ impl crate::trap::gateways::TrapCodeMemory for MacMemoryBus {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn system_trap_code_lifetime_is_independent_between_memory_owners() {
+        let mut first = MacMemoryBus::new(4 * 1024 * 1024);
+        let mut second = MacMemoryBus::new(4 * 1024 * 1024);
+        second.alloc_synthetic(32);
+        let first_gateway = first.get_or_create_system_trap_gateway(0xA975);
+        let second_gateway = second.get_or_create_system_trap_gateway(0xA975);
+        assert_ne!(first_gateway, second_gateway);
+        first.write_readonly_code_word(first_gateway, 0);
+        assert_eq!(second.read_word(second_gateway), 0xAD75);
+        assert_eq!(
+            first.get_or_create_system_trap_gateway(0xAD75),
+            first_gateway
+        );
+        assert_eq!(first.read_word(first_gateway), 0xAD75);
+        drop(first);
+        assert_eq!(second.system_trap_gateway(0xA975), Some(second_gateway));
+        assert_eq!(
+            second.get_or_create_system_trap_gateway(0xAD75),
+            second_gateway
+        );
+        assert_eq!(second.read_word(second_gateway), 0xAD75);
+    }
 
     #[test]
     fn twenty_four_bit_mode_translates_scalar_and_bulk_accesses() {

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -4,7 +4,6 @@
 //! `impl TrapDispatcher` blocks with `dispatch_*` methods that return
 //! `Option<Result<()>>` — `Some` if the trap was handled, `None` to pass through.
 
-use super::gateways::TrapSystemGateways;
 pub(crate) use super::gateways::TrapTableProfile;
 #[cfg(test)]
 use super::gateways::{M68K_68040_COME_FROM_TRAPS, POWERPC_604_COME_FROM_TRAPS};
@@ -1395,9 +1394,6 @@ pub struct TrapDispatcher {
     /// MenuInfo.menuProc remains guest-visible and some applications invoke
     /// the procedure directly.
     pub(crate) system_mdef_cache: HashMap<i16, u32>,
-    /// System-generated default identities and profile construction. Patch
-    /// values remain exclusively in guest table cells and protected links.
-    pub(crate) trap_gateways: TrapSystemGateways,
     /// Protected callable nonterminal entry returned as the standard `StdPix`
     /// procedure by `SetStdCProcs`. QuickTime (1993), pp. 3-137--3-139 defines
     /// the distinct eight-argument routine; until that operation is complete,
@@ -3282,7 +3278,6 @@ impl TrapDispatcher {
             system_kmap_cache: HashMap::new(),
             system_wdef_cache: HashMap::new(),
             system_mdef_cache: HashMap::new(),
-            trap_gateways: TrapSystemGateways::default(),
             std_pix_gateway: 0,
             param_text: SharedProcessDialogText::default(),
             ui_theme_id: UiThemeId::ClassicSystem7,
@@ -6478,8 +6473,7 @@ impl TrapDispatcher {
         bus: &mut MacMemoryBus,
         trap_word: u16,
     ) -> u32 {
-        self.trap_gateways
-            .get_or_create(bus, 0xA800 | (trap_word & 0x03FF))
+        bus.get_or_create_system_trap_gateway(0xA800 | (trap_word & 0x03FF))
     }
 
     fn canonical_trap_word(trap_word: u16) -> u16 {
@@ -6491,9 +6485,8 @@ impl TrapDispatcher {
         raw_trap_route(trap_word).table_address
     }
 
-    fn default_trap_gateway(&self, trap_word: u16) -> Option<u32> {
-        self.trap_gateways
-            .default_gateway(self.trap_table_profile?, trap_word)
+    fn default_trap_gateway(&self, bus: &MacMemoryBus, trap_word: u16) -> Option<u32> {
+        bus.default_system_trap_gateway(self.trap_table_profile?, trap_word)
     }
 
     #[cfg(test)]
@@ -6510,9 +6503,8 @@ impl TrapDispatcher {
         bus: &mut MacMemoryBus,
         profile: TrapTableProfile,
     ) -> Result<TrapTableProcessContext> {
-        let image = self
-            .trap_gateways
-            .create_table(bus, profile)
+        let image = bus
+            .create_system_trap_table(profile)
             .ok_or(Error::TrapTableInitialization)?;
         Ok(TrapTableProcessContext {
             profile,
@@ -6671,7 +6663,7 @@ impl TrapDispatcher {
     pub(crate) fn native_trap_handler(&self, bus: &MacMemoryBus, trap_word: u16) -> Option<u32> {
         let canonical = Self::canonical_trap_word(trap_word);
         let logical = self.trap_table_address(bus, canonical)?;
-        (self.default_trap_gateway(canonical) != Some(logical)).then_some(logical)
+        (self.default_trap_gateway(bus, canonical) != Some(logical)).then_some(logical)
     }
 
     pub(crate) fn install_trap_address(
@@ -7387,9 +7379,8 @@ impl TrapDispatcher {
         let input_route = raw_trap_route(trap);
         let input_base_trap = input_route.canonical_word;
         let default_os_gateway_call = !input_route.is_toolbox
-            && self
-                .trap_gateways
-                .get(input_base_trap)
+            && bus
+                .system_trap_gateway(input_base_trap)
                 .is_some_and(|addr| pc == addr + 2);
         // A JMP to a saved OS gateway keeps the dispatcher's synthesized
         // return long at the top of the original argument stack. A JSR to the
@@ -7524,9 +7515,8 @@ impl TrapDispatcher {
             });
         let default_tool_gateway_call = is_tool
             && auto_pop
-            && (self
-                .trap_gateways
-                .get(base_trap)
+            && (bus
+                .system_trap_gateway(base_trap)
                 .is_some_and(|addr| pc == addr + 2)
                 || saved_tool_daisy_chain_call);
         let os_dispatch_frame = if is_tool {
@@ -7548,7 +7538,7 @@ impl TrapDispatcher {
             let handler_addr = self
                 .trap_table_address(bus, base_trap)
                 .ok_or(Error::TrapTableLookup(base_trap))?;
-            if self.default_trap_gateway(base_trap) != Some(handler_addr) {
+            if self.default_trap_gateway(bus, base_trap) != Some(handler_addr) {
                 // Simulate JSR to native handler: push return PC, jump to
                 // handler. For an auto-pop trap, the dispatcher's documented
                 // return target is the caller address removed from the glue
@@ -8142,7 +8132,7 @@ mod tests {
             dispatcher
                 .materialize_trap_tables(&mut bus, profile)
                 .expect("trap table construction requires writable cells and system storage");
-            let unimplemented = dispatcher.default_trap_gateway(0xAA6E).unwrap();
+            let unimplemented = dispatcher.default_trap_gateway(&bus, 0xAA6E).unwrap();
 
             for low_word in 0u16..0x1000 {
                 let word = 0xA000 | low_word;
@@ -8380,7 +8370,7 @@ mod tests {
     ) -> u32 {
         cpu.write_reg(Register::D0, 0xFFFF_0000 | u32::from(trap_word));
         let saved_gateway = dispatcher
-            .default_trap_gateway(getter)
+            .default_trap_gateway(bus, getter)
             .expect("materialized Trap Manager getter gateway");
         cpu.write_reg(Register::PC, saved_gateway + 2);
         dispatcher
@@ -8400,7 +8390,7 @@ mod tests {
         cpu.write_reg(Register::D0, 0xFFFF_0000 | u32::from(trap_word));
         cpu.write_reg(Register::A0, handler);
         let saved_gateway = dispatcher
-            .default_trap_gateway(setter)
+            .default_trap_gateway(bus, setter)
             .expect("materialized Trap Manager setter gateway");
         cpu.write_reg(Register::PC, saved_gateway + 2);
         dispatcher
@@ -8741,6 +8731,28 @@ mod tests {
     }
 
     #[test]
+    fn replacement_dispatcher_reuses_memory_owned_defaults_with_fresh_process_heads() {
+        let (mut first, _, mut bus) = setup();
+        first
+            .materialize_trap_tables(&mut bus, TrapTableProfile::M68k68040)
+            .unwrap();
+        let tick = first.trap_table_address(&bus, 0xA975).unwrap();
+        let protected_cell = raw_trap_route(0xA823).table_address;
+        let head = bus.read_long(protected_cell);
+        let vectors = [bus.read_long(0x28), bus.read_long(0x2c)];
+        let mut second = TrapDispatcher::new();
+        second
+            .materialize_trap_tables(&mut bus, TrapTableProfile::M68k68040)
+            .unwrap();
+        assert_eq!(second.trap_table_address(&bus, 0xA975), Some(tick));
+        assert_eq!(bus.read_word(tick), 0xAD75);
+        assert_ne!(bus.read_long(protected_cell), head);
+        assert_ne!([bus.read_long(0x28), bus.read_long(0x2c)], vectors);
+        bus.write_word(tick, 0xffff);
+        assert_eq!(bus.read_word(tick), 0xAD75);
+    }
+
+    #[test]
     fn profile_materialization_refuses_before_mutating_active_process() {
         for failure in 0..6 {
             let (mut dispatcher, _, mut bus) = setup();
@@ -8786,7 +8798,7 @@ mod tests {
             let code = bus.read_bytes(base, len as usize);
             let next = bus.synthetic_code_allocation_start(4);
             let defaults = dispatcher.trap_exception_vector_defaults;
-            let tick_default = dispatcher.trap_gateways.get(0xA975);
+            let tick_default = bus.system_trap_gateway(0xA975);
             assert!(matches!(
                 dispatcher.materialize_trap_tables(&mut bus, TrapTableProfile::PowerPc604),
                 Err(Error::TrapTableInitialization)
@@ -8799,7 +8811,7 @@ mod tests {
                 Some(TrapTableProfile::M68k68040)
             );
             assert_eq!(dispatcher.trap_exception_vector_defaults, defaults);
-            assert_eq!(dispatcher.trap_gateways.get(0xA975), tick_default);
+            assert_eq!(bus.system_trap_gateway(0xA975), tick_default);
             assert_eq!(dispatcher.current_trap_caller, Some(0x0020_1000));
             assert_eq!(bus.read_long(tick_cell), 0x1234_5678);
             let frames = &dispatcher.pending_native_trap_calls[&0xA975];
@@ -8883,7 +8895,7 @@ mod tests {
             assert_eq!(dispatcher.trap_table_profile, None);
             assert!(!dispatcher.aline_vector_is_default(&bus));
             assert!(!dispatcher.fline_vector_is_default(&bus));
-            assert!(dispatcher.trap_gateways.is_empty());
+            assert!(bus.system_trap_gateways_are_empty());
             if failure == 3 {
                 bus.detach_guest_address_space();
             } else {
@@ -8921,7 +8933,8 @@ mod tests {
         let (mut dispatcher, mut cpu, mut bus) = setup_with_trap_tables();
         let entry = TOOLBOX_TRAP_TABLE_BASE + 0x175 * 4;
         let default = dispatcher.trap_table_address(&bus, 0xA975).unwrap();
-        let head = TrapSystemGateways::create_come_from_head(&mut bus, default);
+        let head =
+            crate::trap::gateways::TrapSystemGateways::create_come_from_head(&mut bus, default);
         assert!(bus.try_write_protected_code_long(head + 4, head));
         bus.write_long(entry, head);
         let sp = cpu.read_reg(Register::A7);
@@ -9467,7 +9480,7 @@ mod tests {
         assert_eq!(bus.read_long(raw_entry), replacement);
         assert_eq!(
             bus.read_long(old_head + 4),
-            dispatcher.default_trap_gateway(trap_word).unwrap()
+            dispatcher.default_trap_gateway(&bus, trap_word).unwrap()
         );
     }
 
@@ -9778,7 +9791,7 @@ mod tests {
     #[test]
     fn saved_os_gateway_tail_uses_the_original_variant_dispatch_frame() {
         let (mut dispatcher, mut cpu, mut bus) = setup_with_trap_tables();
-        let gateway = dispatcher.trap_gateways.get_or_create(&mut bus, 0xA01E);
+        let gateway = bus.get_or_create_system_trap_gateway(0xA01E);
         let handler = 0x0021_0000u32;
         let return_pc = 0x0020_0002u32;
         let sp = 0x003F_FF00u32;
@@ -9826,7 +9839,7 @@ mod tests {
     #[test]
     fn saved_os_gateway_subroutine_keeps_the_outer_dispatch_frame() {
         let (mut dispatcher, mut cpu, mut bus) = setup_with_trap_tables();
-        let gateway = dispatcher.trap_gateways.get_or_create(&mut bus, 0xA039);
+        let gateway = bus.get_or_create_system_trap_gateway(0xA039);
         let handler = 0x0021_0000u32;
         let patch_continuation = 0x0021_0100u32;
         let return_pc = 0x0020_0002u32;
@@ -10005,7 +10018,7 @@ mod tests {
     #[test]
     fn saved_os_trap_gateway_bypasses_a_later_patch() {
         let (mut dispatcher, mut cpu, mut bus) = setup_with_trap_tables();
-        let gateway = dispatcher.trap_gateways.get_or_create(&mut bus, 0xA039);
+        let gateway = bus.get_or_create_system_trap_gateway(0xA039);
         let sp = 0x003F_FF00u32;
         let output = 0x0020_0000u32;
         bus.write_long(crate::memory::globals::addr::TIME, 0x1234_5678);

--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -21179,7 +21179,7 @@ impl super::TrapDispatcher {
             return None;
         }
         let bits_proc = bus.read_long(graf_procs + 32);
-        if bits_proc == 0 || self.trap_gateways.get(0xA8EB) == Some(bits_proc) {
+        if bits_proc == 0 || bus.system_trap_gateway(0xA8EB) == Some(bits_proc) {
             return None;
         }
         if let Some((active_proc, active_sp)) = self.bits_proc_reentry {
@@ -30859,11 +30859,11 @@ mod tests {
         ];
         for (i, trap) in TRAPS.into_iter().enumerate() {
             let gateway = bus.read_long(cprocs_ptr + (i as u32) * 4);
-            assert_eq!(d.trap_gateways.get(trap), Some(gateway));
+            assert_eq!(bus.system_trap_gateway(trap), Some(gateway));
             assert_eq!(bus.read_word(gateway), trap | 0x0400);
         }
         let std_pix = bus.read_long(cprocs_ptr + 14 * 4);
-        let unimplemented = d.trap_gateways.get(0xAA6E).unwrap();
+        let unimplemented = bus.system_trap_gateway(0xAA6E).unwrap();
         assert_eq!(std_pix, d.std_pix_gateway);
         assert_ne!(std_pix, unimplemented);
         assert_eq!(bus.read_word(std_pix), 0x4EF9);

--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -2674,9 +2674,8 @@ impl super::TrapDispatcher {
                 let pc = cpu.read_reg(Register::PC); // past A9F0
                 let a9f0_addr = pc.wrapping_sub(2);
 
-                let is_loadseg_trampoline = self
-                    .trap_gateways
-                    .get(0xA9F0)
+                let is_loadseg_trampoline = bus
+                    .system_trap_gateway(0xA9F0)
                     .is_some_and(|addr| addr == a9f0_addr);
 
                 let auto_pop_old_trap = (self.current_trap_word & 0x0400) != 0;


### PR DESCRIPTION
System trap default identities now live with their allocated, protected code on the memory owner. Previously the registry lived on TrapDispatcher, so replacing a dispatcher against the same memory allocated new identities while the original system code was still alive. A regression reproduced that address change.

The dispatcher, saved-default bypass, LoadSeg and QuickDraw now use bounded memory-owned lookup/publication operations. Replacing an adapter reuses defaults while profile construction still creates fresh process heads and exception vectors. Code publication remains synchronous with no guest execution, yielded effect or escaping registry reference. No new shared-handle family, native registry or public API is introduced.

Tests cover dispatcher replacement, stable protected defaults, fresh heads/vectors, independent memory lifetimes and canonical reuse. Existing capacity-refusal tests now verify the memory-owned registry; exhaustive profile, saved-default, LoadSeg and QuickDraw coverage remains in the library suite.

Closes #1500.

Validation: 5,078 headless library tests passed (three existing ignored). Production/downstream compilation is warning-free. An alternating, three-pair optimized (`ci-test`) saved-default workload comparison against the parent source measured identical 0.82s medians (baseline 0.85/0.82/0.82s; changed 0.82/0.82/0.83s). This is a bounded dispatch measurement, not a general game-performance claim. CI [33974127230](https://github.com/benletchford/systemless/actions/runs/33974127230) passed 5,087 library tests, 50 desktop tests, both showcases, builds, documentation, packaging and dependency licenses. Checkout `718bf2281` matches the PR source tree exactly. The two existing non-blocking Clippy errors remain; full-tree rustfmt exhausted memory, while changed hunks were formatted sequentially through stdin locally. Final unified process composition, standalone native default construction and imported patch routing remain separate open work.
