### PR TITLE
fix: preflight native arguments before changing caller state

### DIFF
--- a/src/guest_call.rs
+++ b/src/guest_call.rs
@@ -39,6 +39,59 @@ pub(crate) fn restore_powerpc_context(cpu: &mut PpcCpu, context: PpcCpu) {
     cpu.set_time_base(time_base);
 }
 
+/// Exclusive, synchronous preparation of the PowerPC word-argument ABI.
+/// No guest execution or mapping change may intervene before installation.
+struct PreparedPowerPcCallArguments<'a> {
+    cpu: &'a mut PpcCpu,
+    memory: &'a mut GuestAddressSpace,
+    values: &'a [u32],
+    parameter_start: u32,
+}
+
+impl<'a> PreparedPowerPcCallArguments<'a> {
+    fn prepare(
+        cpu: &'a mut PpcCpu,
+        memory: &'a mut GuestAddressSpace,
+        values: &'a [u32],
+    ) -> Option<Self> {
+        // Inside Macintosh: PowerPC System Software (1994), pp. 1-45--1-50:
+        // parameter words follow the 24-byte linkage area. Keep the existing
+        // eight-word minimum so native variable-argument callees can spill r3--r10.
+        let parameter_start = cpu.gpr[1].checked_add(24)?;
+        let parameter_len = u32::try_from(values.len().max(8)).ok()?.checked_mul(4)?;
+        if !memory.preflight_writable_range(parameter_start, parameter_len) {
+            return None;
+        }
+        Some(Self {
+            cpu,
+            memory,
+            values,
+            parameter_start,
+        })
+    }
+
+    fn install(self) {
+        for slot in 0..self.values.len().max(8) {
+            let value = self.values.get(slot).copied().unwrap_or(0);
+            self.memory
+                .write_u32_be(self.parameter_start + slot as u32 * 4, value)
+                .expect("preflighted native parameter area remains writable");
+            if slot < 8 {
+                self.cpu.gpr[3 + slot] = value;
+            }
+        }
+    }
+}
+
+pub(crate) fn install_powerpc_call_arguments(
+    cpu: &mut PpcCpu,
+    memory: &mut GuestAddressSpace,
+    values: &[u32],
+) -> Option<()> {
+    PreparedPowerPcCallArguments::prepare(cpu, memory, values)?.install();
+    Some(())
+}
+
 /// Saved 68K state for one cooperative Thread Manager thread.
 ///
 /// The execution owner preserves the caller-visible register file across
@@ -2050,17 +2103,11 @@ impl SharedGuestCallStack {
         {
             return false;
         }
-        // Inside Macintosh: PowerPC System Software (1994), pp. 1-45--1-50:
-        // the parameter area follows the 24-byte linkage area and reserves
-        // at least eight words, corresponding to r3 through r10.
-        let Some(parameter_start) = cpu.gpr[1].checked_add(24) else {
+        let Some(prepared) =
+            PreparedPowerPcCallArguments::prepare(cpu, memory, arguments.as_slice())
+        else {
             return false;
         };
-        let values = arguments.as_slice();
-        let parameter_len = values.len().max(8) as u32 * 4;
-        if !memory.preflight_writable_range(parameter_start, parameter_len) {
-            return false;
-        }
         let Some(call_id) = self.submit_effect(effect) else {
             return false;
         };
@@ -2083,16 +2130,7 @@ impl SharedGuestCallStack {
             .kernel
             .activate(request.task, call_id)
             .expect("newly submitted native call remains pending");
-        cpu.gpr[3..11].fill(0);
-        for slot in 0..values.len().max(8) {
-            let value = values.get(slot).copied().unwrap_or(0);
-            memory
-                .write_u32_be(parameter_start + slot as u32 * 4, value)
-                .expect("preflighted native parameter area remains writable");
-            if slot < 8 {
-                cpu.gpr[3 + slot] = value;
-            }
-        }
+        prepared.install();
         cpu.pc = request.target.entry;
         cpu.gpr[2] = request.target.rtoc;
         cpu.lr = return_pc;
@@ -2972,6 +3010,34 @@ mod tests {
         assert_eq!(process_calls.len(), 1);
         assert!(adapter_calls.complete_m68k(0x2002, 0x3000));
         assert!(process_calls.is_empty());
+    }
+
+    #[test]
+    fn native_arguments_preserve_word_layout_for_empty_short_and_spilled_calls() {
+        for count in [0usize, 1, 8, 9, 16] {
+            let mut cpu = PpcCpu::new();
+            cpu.gpr.fill(0xfeed_beef);
+            cpu.gpr[1] = 0x8000;
+            let before = cpu.gpr;
+            let mut memory = GuestAddressSpace::new();
+            memory.add_region(0x8000, vec![0xa5; 128]);
+            let values: Vec<_> = (0..count as u32).map(|i| 0x1234_0000 + i).collect();
+            assert!(install_powerpc_call_arguments(&mut cpu, &mut memory, &values).is_some());
+            assert_eq!(&cpu.gpr[..3], &before[..3]);
+            assert_eq!(&cpu.gpr[11..], &before[11..]);
+            for slot in 0..count.max(8) {
+                let expected = values.get(slot).copied().unwrap_or(0);
+                assert_eq!(memory.read_u32_be(0x8018 + slot as u32 * 4), Some(expected));
+                if slot < 8 {
+                    assert_eq!(cpu.gpr[3 + slot], expected);
+                }
+            }
+            assert_eq!(memory.read_u32_be(0x8014), Some(0xa5a5_a5a5));
+            assert_eq!(
+                memory.read_u32_be(0x8018 + count.max(8) as u32 * 4),
+                Some(0xa5a5_a5a5)
+            );
+        }
     }
 
     #[test]

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -27,8 +27,8 @@ use crate::event_queue::{
     EventProbeResult, EventQueue, EventQueueProbeSnapshot, EventRecordSnapshot, QueuedEvent,
 };
 use crate::guest_call::{
-    format_ppc_import_action, GuestCallContinuation, GuestCallEffect, GuestCallRequest,
-    GuestCallTarget, SharedGuestCallStack,
+    format_ppc_import_action, install_powerpc_call_arguments, GuestCallContinuation,
+    GuestCallEffect, GuestCallRequest, GuestCallTarget, SharedGuestCallStack,
 };
 use crate::guest_procedure::{
     resolve_guest_procedure, GuestIsa, GuestProcedure,
@@ -4213,7 +4213,7 @@ impl PpcLoadedApp {
         self.cpu.pc = pending.target.entry;
         self.cpu.lr = PPC_GUEST_CALL_RETURN_PC;
         self.cpu.gpr[2] = pending.target.rtoc;
-        ppc_install_native_call_arguments(
+        install_powerpc_call_arguments(
             &mut self.cpu,
             &mut self.memory,
             pending.arguments.as_slice(),
@@ -7009,7 +7009,7 @@ impl PpcLoadedApp {
                 self.memory.write_u32_be(command_ptr + 4, command.param2)?;
                 Some(command_ptr)
             });
-            let _ = ppc_install_native_call_arguments(
+            let _ = install_powerpc_call_arguments(
                 &mut self.cpu,
                 &mut self.memory,
                 &[completion.channel, command_ptr.unwrap_or(0)],
@@ -7173,7 +7173,7 @@ impl PpcLoadedApp {
             // Inside Macintosh: Processes (1994), pp. 3-21--3-22: the Time
             // Manager passes the expired TMTask record to its callback. Mixed
             // Mode marshals that pointer into the native PowerPC argument area.
-            let _ = ppc_install_native_call_arguments(&mut self.cpu, &mut self.memory, &[task_ptr]);
+            let _ = install_powerpc_call_arguments(&mut self.cpu, &mut self.memory, &[task_ptr]);
             self.run_with_hle_imports_with_trace(
                 max_cycles,
                 trace_imports,
@@ -7334,7 +7334,7 @@ impl PpcLoadedApp {
             // reset vblCount. Inside Macintosh: PowerPC System Software (1994),
             // pp. 2-32–2-33 documents the register-based routine convention that
             // Mixed Mode uses to marshal that four-byte A0 parameter to native PPC.
-            let _ = ppc_install_native_call_arguments(&mut self.cpu, &mut self.memory, &[task_ptr]);
+            let _ = install_powerpc_call_arguments(&mut self.cpu, &mut self.memory, &[task_ptr]);
             self.run_with_hle_imports_with_trace(
                 max_cycles,
                 trace_imports,
@@ -7417,7 +7417,7 @@ impl PpcLoadedApp {
             self.cpu.lr = self.halt_pc;
             self.cpu.gpr[1] = callback_sp;
             self.cpu.gpr[2] = target.rtoc;
-            let _ = ppc_install_native_call_arguments(
+            let _ = install_powerpc_call_arguments(
                 &mut self.cpu,
                 &mut self.memory,
                 &[doubleback.channel, doubleback.exhausted_buffer],
@@ -31697,7 +31697,7 @@ fn ppc_qsort_compare_next(
         .base
         .checked_add(state.index.checked_mul(state.width)?)?;
     let right = left.checked_add(state.width)?;
-    ppc_install_native_call_arguments(cpu, memory, &[left, right])?;
+    install_powerpc_call_arguments(cpu, memory, &[left, right])?;
     GuestCallEffect::call_guest(
         GuestCallRequest::new(GuestCallTarget {
             isa: GuestIsa::PowerPc,
@@ -44772,32 +44772,6 @@ fn ppc_parameter_area_slot_addr(sp: u32, slot: usize) -> Option<u32> {
     sp.checked_add(offset)
 }
 
-fn ppc_install_native_call_arguments(
-    cpu: &mut PpcCpu,
-    memory: &mut PpcSectionMem,
-    args: &[u32],
-) -> Option<()> {
-    for index in 0..PPC_NATIVE_PARAMETER_GPR_COUNT {
-        cpu.gpr[3 + index] = 0;
-    }
-    for (index, value) in args.iter().copied().enumerate() {
-        if index < PPC_NATIVE_PARAMETER_GPR_COUNT {
-            cpu.gpr[3 + index] = value;
-        }
-    }
-    let parameter_slots = args.len().max(PPC_NATIVE_PARAMETER_GPR_COUNT);
-    for index in 0..parameter_slots {
-        let value = if index < PPC_NATIVE_PARAMETER_GPR_COUNT {
-            cpu.gpr[3 + index]
-        } else {
-            args[index]
-        };
-        let addr = ppc_parameter_area_slot_addr(cpu.gpr[1], index)?;
-        memory.write_u32_be(addr, value)?;
-    }
-    Some(())
-}
-
 fn ppc_install_legacy_call_universal_proc_arguments(cpu: &mut PpcCpu) {
     for index in 0..PPC_CALL_UNIVERSAL_PROC_REGISTER_VARARGS {
         cpu.gpr[3 + index] = cpu.gpr[5 + index];
@@ -45090,7 +45064,7 @@ fn ppc_call_universal_proc(
                     {
                         args.remove(0);
                     }
-                    ppc_install_native_call_arguments(cpu, memory, &args)?
+                    install_powerpc_call_arguments(cpu, memory, &args)?
                 }
                 None => ppc_install_legacy_call_universal_proc_arguments(cpu),
             }
@@ -64563,7 +64537,7 @@ fn ppc_process_apple_event(
         || reply_handle == 0
         || !ppc_write_ae_desc(memory, descriptors, PPC_CORE_EVENT_CLASS, event_handle)
         || !ppc_write_ae_desc(memory, descriptors + 8, PPC_CORE_EVENT_CLASS, reply_handle)
-        || ppc_install_native_call_arguments(
+        || install_powerpc_call_arguments(
             cpu,
             memory,
             &[descriptors, descriptors + 8, handler.refcon],
@@ -68267,7 +68241,7 @@ fn ppc_next_dialog_callback(
         let dialog = state.dialog;
         let restore_rtoc = state.restore_rtoc;
         state.next_callback += 1;
-        if ppc_install_native_call_arguments(cpu, memory, &[dialog, item_number]).is_none() {
+        if install_powerpc_call_arguments(cpu, memory, &[dialog, item_number]).is_none() {
             continue;
         }
         return GuestCallEffect::call_guest(
@@ -69634,7 +69608,7 @@ fn ppc_dispatch_legacy_control(
             let restore_rtoc = cpu.gpr[2];
             let final_pc = cpu.lr;
             let target = ppc_resolve_callback_target(memory, action_proc, restore_rtoc, None)?;
-            ppc_install_native_call_arguments(cpu, memory, &[cpu.gpr[3], part as u16 as u32])?;
+            install_powerpc_call_arguments(cpu, memory, &[cpu.gpr[3], part as u16 as u32])?;
             Some(
                 GuestCallEffect::call_guest(
                     GuestCallRequest::new(GuestCallTarget {
@@ -72561,7 +72535,7 @@ fn ppc_dm_get_indexed_display_mode_values(
     let restore_rtoc = cpu.gpr[2];
     let final_pc = cpu.lr;
     let target = ppc_resolve_callback_target(memory, callback, restore_rtoc, None)?;
-    ppc_install_native_call_arguments(
+    install_powerpc_call_arguments(
         cpu,
         memory,
         &[user_data, item_index, list + PPC_DM_MODE_LIST_ENTRY_OFFSET],
@@ -76467,7 +76441,7 @@ fn ppc_dispatch_native_menu_definition_with_return(
     let call = invocation.call(scratch);
     match target.isa {
         GuestIsa::PowerPc => {
-            ppc_install_native_call_arguments(cpu, memory, &call.native_arguments())?;
+            install_powerpc_call_arguments(cpu, memory, &call.native_arguments())?;
             Some(
                 GuestCallEffect::call_guest(
                     GuestCallRequest::new(GuestCallTarget {
@@ -84901,7 +84875,7 @@ fn ppc_standard_file_filter_next_action(
     } else {
         vec![state.filter_pb]
     };
-    ppc_install_native_call_arguments(cpu, memory, &arguments)?;
+    install_powerpc_call_arguments(cpu, memory, &arguments)?;
     Some(
         GuestCallEffect::call_guest(
             GuestCallRequest::new(GuestCallTarget {
@@ -91048,7 +91022,7 @@ fn ppc_begin_native_exception(
     cpu.lr = PPC_HALT_PC;
     cpu.gpr[1] = callback_sp;
     cpu.gpr[2] = rtoc;
-    ppc_install_native_call_arguments(cpu, memory, &[information])?;
+    install_powerpc_call_arguments(cpu, memory, &[information])?;
 
     Some(PpcNativeExceptionContext {
         cause,
@@ -110011,6 +109985,98 @@ pub(crate) mod tests {
             Some((first + second).to_bits())
         );
         assert_eq!(f64::from_bits(loaded.cpu.fpr[1]), first + second);
+    }
+
+    #[test]
+    fn native_arguments_refuse_without_partial_register_or_stack_writes() {
+        for failure in 0..5 {
+            let mut cpu = PpcCpu::new();
+            cpu.gpr.fill(0xfeed_beef);
+            cpu.gpr[1] = match failure {
+                3 => u32::MAX - 8,
+                4 => u32::MAX - 39,
+                _ => 0x8000,
+            };
+            cpu.pc = 0x1234;
+            cpu.lr = 0x5678;
+            let mut memory = PpcSectionMem::new();
+            memory.add_region(0x8018, vec![0xa5; 32]);
+            match failure {
+                1 => memory.add_readonly_region(0x8038, vec![0xa5; 4]),
+                2 => {
+                    memory.add_region(0x8038, vec![0xa5; 4]);
+                    memory.add_readonly_region(0x803a, vec![0xa5; 1]);
+                }
+                _ => {}
+            }
+            let registers = cpu.gpr;
+            let arguments = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+            assert!(install_powerpc_call_arguments(&mut cpu, &mut memory, &arguments).is_none());
+            assert_eq!(cpu.gpr, registers, "failure {failure}");
+            assert_eq!((cpu.pc, cpu.lr), (0x1234, 0x5678));
+            for offset in 0..32 {
+                assert_eq!(memory.read_u8(0x8018 + offset), Some(0xa5));
+            }
+
+            // Retry across independently mapped words, including a spilled argument.
+            let mut memory = PpcSectionMem::new();
+            for slot in 0..9 {
+                memory.add_region(0x8018 + slot * 4, vec![0xa5; 4]);
+            }
+            cpu.gpr[1] = 0x8000;
+            assert!(install_powerpc_call_arguments(&mut cpu, &mut memory, &arguments).is_some());
+            assert_eq!(&cpu.gpr[3..11], &arguments[..8]);
+            for (slot, value) in arguments.iter().enumerate() {
+                assert_eq!(memory.read_u32_be(0x8018 + slot as u32 * 4), Some(*value));
+            }
+            assert_eq!((cpu.pc, cpu.lr), (0x1234, 0x5678));
+        }
+    }
+
+    #[test]
+    fn hle_import_runner_call_universal_proc_preserves_arguments_on_stack_refusal() {
+        for traced in [false, true] {
+            let pef = synthetic_pef_with_import(b"CallUniversalProc");
+            let mut loaded = load_pef_application(&pef).unwrap();
+            let descriptor = PPC_HEAP_BASE + 0x1000;
+            let callback_rtoc = PPC_HEAP_BASE + 0x3000;
+            let proc_info = test_stack_proc_info(PPC_PROCINFO_SIZE_FOUR, &[PPC_PROCINFO_SIZE_FOUR]);
+            install_test_powerpc_callback(
+                &mut loaded,
+                descriptor,
+                descriptor + 0x80,
+                PPC_HEAP_BASE + 0x2000,
+                callback_rtoc,
+                proc_info,
+                &[d_form_u(36, 3, 2, 0), BLR],
+            );
+            let start_pc = loaded.cpu.pc;
+            let sp = loaded.cpu.gpr[1];
+            loaded.memory.write_bytes(sp + 24, &[0xa5; 32]).unwrap();
+            loaded.memory.add_readonly_region(sp + 52, vec![0xa5; 4]);
+            loaded.cpu.gpr[3] = descriptor;
+            loaded.cpu.gpr[4] = proc_info;
+            loaded.cpu.gpr[5] = 0x1234_5678;
+            let registers = loaded.cpu.gpr[3..11].to_vec();
+            let calls = loaded.guest_calls.clone();
+            let probe = loaded.run_with_hle_imports_with_trace(64, traced, false, None, None);
+            assert_eq!(probe.unsupported_import_index, Some(0));
+            assert_eq!(&loaded.cpu.gpr[3..11], registers.as_slice());
+            assert_eq!(loaded.guest_calls, calls);
+            for offset in 0..32 {
+                assert_eq!(loaded.memory.read_u8(sp + 24 + offset), Some(0xa5));
+            }
+            assert_eq!(loaded.memory.read_u32_be(callback_rtoc), Some(0));
+
+            // The same import and arguments can run after moving to a writable frame.
+            loaded.cpu.pc = start_pc;
+            loaded.cpu.gpr[1] = PPC_HEAP_BASE + 0x4000;
+            let probe = loaded.run_with_hle_imports_with_trace(64, traced, false, None, None);
+            assert_eq!(probe.unsupported_import_index, None);
+            assert_eq!(loaded.cpu.gpr[3], 0x1234_5678);
+            assert_eq!(loaded.memory.read_u32_be(callback_rtoc), Some(0x1234_5678));
+            assert!(loaded.guest_calls.is_empty());
+        }
     }
 
     #[test]


### PR DESCRIPTION
Native CallUniversalProc and callback preparation could overwrite r3–r10 and earlier stack words before refusing a missing, protected or wrapping parameter destination. The caller was left corrupted even though the callee never started.

Use one checked PowerPC word-argument preparation operation for all fourteen native invocation sites and execution-owned effect activation. It preflights the complete parameter area before publication, preserves the existing eight-word zero padding and spilled arguments, and is consumed before guest execution. The duplicate native installer is removed. This covers argument publication; caller-specific manager state, allocation rollback and signature-free legacy register shifting retain their existing behavior.

Validation:
- The new direct refusal regression fails on the old installer and passes with the change; missing/protected/partial tails, both address overflow forms and split-mapping retry are covered.
- Actual fast and traced CallUniversalProc imports refuse unchanged, do not enter the callback, and successfully retry with a writable frame.
- Zero/one/eight/nine/sixteen-word layouts and adjacent sentinels are verified; existing nested activation and callback tests pass.
- All 5,081 headless library tests passed, with three existing ignored tests; production compilation is warning-free.
- Changed Rust hunks formatted sequentially through stdin. CI run [33975800514](https://github.com/benletchford/systemless/actions/runs/33975800514) passed 5,090 library tests (three existing ignored), 50 desktop tests, both architecture showcases, builds, documentation, packaging and licenses. Tested checkout `051bf1a41203d13ba27a44b95978cab564656f23` exactly matches the published source. The existing non-blocking `mut_from_ref`/`erasing_op` Clippy errors and full-tree formatter memory exhaustion remain.

Reference: Inside Macintosh: PowerPC System Software (1994), pp. 1-45–1-50.

Closes #1502
