### PR TITLE
fix: preserve CFM connections when close publication fails

### DIFF
--- a/src/cfm.rs
+++ b/src/cfm.rs
@@ -172,6 +172,50 @@ pub struct CfmExport {
     pub address: u32,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum CfmCloseError {
+    InvalidIdPointer,
+    ConnectionNotFound,
+}
+
+impl CfmCloseError {
+    pub(crate) fn os_error(self) -> i16 {
+        match self {
+            Self::InvalidIdPointer => -50,
+            Self::ConnectionNotFound => -2801,
+        }
+    }
+}
+
+/// Commit the synchronous registry/output part of closing a connection.
+/// PowerPC System Software (1994), p. 3-23: CloseConnection takes a pointer
+/// to a ConnectionID. Retire the record only after publishing its invalidation.
+/// No guest execution may occur in `publish`; it must commit all outputs or none.
+/// Termination, fragment reference counting and storage release remain separate
+/// lifecycle work and are not implemented by this registry transaction.
+pub(crate) fn close_connection<M: CfmMemory>(
+    connections: &mut Vec<CfmConnection>,
+    memory: &mut M,
+    connection_id_address: u32,
+    publish: impl FnOnce(&mut M, &[(u32, &[u8])]) -> bool,
+) -> Result<(), CfmCloseError> {
+    if connection_id_address == 0 {
+        return Err(CfmCloseError::InvalidIdPointer);
+    }
+    let id = u32::from_be_bytes(
+        cfm_bytes(memory, connection_id_address).ok_or(CfmCloseError::InvalidIdPointer)?,
+    );
+    let index = connections
+        .iter()
+        .position(|connection| connection.id == id)
+        .ok_or(CfmCloseError::ConnectionNotFound)?;
+    if !publish(memory, &[(connection_id_address, &0u32.to_be_bytes())]) {
+        return Err(CfmCloseError::InvalidIdPointer);
+    }
+    connections.remove(index);
+    Ok(())
+}
+
 /// Export enumeration has no CPU or architectural return context.
 /// PowerPC System Software (1994), pp. 3-25–3-26: indices are one-based;
 /// symbol names are Pascal strings and symbol classes occupy one byte.
@@ -591,6 +635,95 @@ mod tests {
         let mut bytes = vec![0; 20];
         memory.read_bytes_into(OUTPUT, &mut bytes).unwrap();
         bytes
+    }
+
+    #[test]
+    fn close_publication_is_atomic_across_memory_views_and_retries() {
+        for classic in [false, true] {
+            for failure in 0..7 {
+                let mut memory = GuestAddressSpace::new();
+                memory.add_region(OUTPUT, vec![0xa5; 32]);
+                memory.write_bytes(OUTPUT, &7u32.to_be_bytes()).unwrap();
+                let pointer = match failure {
+                    0 => {
+                        memory.add_readonly_region(OUTPUT, 7u32.to_be_bytes().to_vec());
+                        OUTPUT
+                    }
+                    1 => {
+                        memory.add_readonly_region(OUTPUT + 3, vec![7]);
+                        OUTPUT
+                    }
+                    2 => OUTPUT + 30,
+                    3 => u32::MAX - 1,
+                    4 => 0,
+                    5 => {
+                        memory.write_bytes(OUTPUT, &99u32.to_be_bytes()).unwrap();
+                        OUTPUT
+                    }
+                    _ => OUTPUT,
+                };
+                let before = snapshot(&mut memory);
+                let mut connections = vec![connection(7), connection(8)];
+                let original = connections.clone();
+                let mut publish_called = false;
+                let result = if classic {
+                    let mut bus = MacMemoryBus::new(0x10000);
+                    bus.set_addressing_32_bit(true);
+                    bus.attach_guest_address_space(memory.shared_view());
+                    close_connection(&mut connections, &mut bus, pointer, |bus, writes| {
+                        publish_called = true;
+                        failure != 6 && bus.publish_cfm_outputs(writes)
+                    })
+                } else {
+                    close_connection(&mut connections, &mut memory, pointer, |memory, writes| {
+                        publish_called = true;
+                        failure != 6 && memory.publish_cfm_outputs(writes)
+                    })
+                };
+                assert_eq!(
+                    result,
+                    Err(if failure == 5 {
+                        CfmCloseError::ConnectionNotFound
+                    } else {
+                        CfmCloseError::InvalidIdPointer
+                    }),
+                    "classic={classic}, failure={failure}"
+                );
+                assert_eq!(publish_called, matches!(failure, 0 | 1 | 6));
+                assert_eq!(connections, original);
+                assert_eq!(snapshot(&mut memory), before);
+
+                memory.write_bytes(OUTPUT + 8, &7u32.to_be_bytes()).unwrap();
+                let result = if classic {
+                    let mut bus = MacMemoryBus::new(0x10000);
+                    bus.set_addressing_32_bit(true);
+                    bus.attach_guest_address_space(memory.shared_view());
+                    close_connection(
+                        &mut connections,
+                        &mut bus,
+                        OUTPUT + 8,
+                        CfmMemory::publish_cfm_outputs,
+                    )
+                } else {
+                    close_connection(
+                        &mut connections,
+                        &mut memory,
+                        OUTPUT + 8,
+                        CfmMemory::publish_cfm_outputs,
+                    )
+                };
+                assert_eq!(result, Ok(()));
+                assert_eq!(connections, vec![connection(8)]);
+                assert_eq!(
+                    cfm_bytes::<4>(&mut memory, OUTPUT + 8).map(u32::from_be_bytes),
+                    Some(0)
+                );
+                assert_eq!(
+                    cfm_bytes::<4>(&mut memory, OUTPUT + 12).map(u32::from_be_bytes),
+                    Some(0xa5a5_a5a5)
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -21068,9 +21068,17 @@ fn dispatch_supported_import(
                 result.err().map_or(0, |error| error.os_error()),
             )))
         }
-        PpcImportDispatcherTarget::CloseConnection => Some(PpcImportAction::Return(
-            ppc_i16_result(ppc_close_connection(cpu, memory, cfm_connections)),
-        )),
+        PpcImportDispatcherTarget::CloseConnection => {
+            let result = crate::cfm::close_connection(
+                cfm_connections,
+                memory,
+                cpu.gpr[3],
+                crate::cfm::CfmMemory::publish_cfm_outputs,
+            );
+            Some(PpcImportAction::Return(ppc_i16_result(
+                result.err().map_or(0, |error| error.os_error()),
+            )))
+        }
         PpcImportDispatcherTarget::GetMemFragment => Some(ppc_get_mem_fragment(
             cpu,
             &toolbox_startup.guest_calls,
@@ -51125,30 +51133,6 @@ fn ppc_get_shared_library(
         return action;
     }
     PpcImportAction::Return(ppc_complete_cfm_load(operation, 0, memory, cfm_connections))
-}
-
-fn ppc_close_connection(
-    cpu: &PpcCpu,
-    memory: &mut PpcSectionMem,
-    cfm_connections: &mut Vec<PpcCfmConnection>,
-) -> i16 {
-    // Inside Macintosh: PowerPC System Software (1994), p. 3-23:
-    // CloseConnection receives a pointer to a ConnectionID, invalidates that
-    // connection, and reports fragConnectionIDNotFound for an unknown ID.
-    let connection_id_ptr = cpu.gpr[3];
-    let Some(connection_id) = memory.read_u32_be(connection_id_ptr) else {
-        return PPC_PARAM_ERR;
-    };
-    let Some(index) = cfm_connections
-        .iter()
-        .position(|connection| connection.id == connection_id)
-    else {
-        return PPC_FRAG_CONNECTION_ID_NOT_FOUND;
-    };
-
-    cfm_connections.remove(index);
-    let _ = memory.write_u32_be(connection_id_ptr, 0);
-    PPC_NO_ERR
 }
 
 /// Borrowed native gateway staging; the process CFM service owns lookup policy.
@@ -113529,6 +113513,64 @@ pub(crate) mod tests {
         assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_FRAG_LIB_NOT_FOUND));
         assert!(loaded.cfm.as_ref().unwrap().connections.is_empty());
         assert_eq!(loaded.heap_cursor(), heap_before);
+    }
+
+    #[test]
+    fn close_connection_import_preserves_live_registry_on_protected_output_and_retries() {
+        for partial in [false, true] {
+            let mut loaded =
+                load_pef_application(&synthetic_pef_with_import(b"CloseConnection")).unwrap();
+            let pointer = PPC_HEAP_BASE + 0x1000;
+            loaded.memory.write_u32_be(pointer, 77).unwrap();
+            let connection = PpcCfmConnection {
+                id: 77,
+                library_name: "Library".to_string(),
+                main_addr: 0x1234,
+                init_addr: 0,
+                term_addr: 0,
+                exports: Vec::new(),
+            };
+            loaded.cfm.as_mut().unwrap().connections.push(connection);
+            loaded
+                .cfm
+                .as_mut()
+                .unwrap()
+                .connections
+                .push(PpcCfmConnection {
+                    id: 78,
+                    library_name: "Other".to_string(),
+                    main_addr: 0x5678,
+                    init_addr: 0,
+                    term_addr: 0,
+                    exports: Vec::new(),
+                });
+            if partial {
+                loaded.memory.add_readonly_region(pointer + 3, vec![77]);
+            } else {
+                loaded
+                    .memory
+                    .add_readonly_region(pointer, 77u32.to_be_bytes().to_vec());
+            }
+            let before = loaded.cfm.clone();
+            let entry = loaded.cpu.pc;
+            loaded.cpu.gpr[3] = pointer;
+            let probe = loaded.run_with_hle_imports(64);
+            assert_eq!(probe.unsupported_import_index, None);
+            assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_PARAM_ERR));
+            assert_eq!(loaded.cfm, before);
+            assert_eq!(loaded.memory.read_u32_be(pointer), Some(77));
+
+            loaded.memory.write_u32_be(pointer + 8, 77).unwrap();
+            loaded.cpu.pc = entry;
+            loaded.cpu.gpr[3] = pointer + 8;
+            let probe = loaded.run_with_hle_imports(64);
+            assert_eq!(probe.unsupported_import_index, None);
+            assert_eq!(loaded.cpu.gpr[3], 0);
+            assert_eq!(loaded.memory.read_u32_be(pointer + 8), Some(0));
+            let mut expected = before.unwrap();
+            expected.connections.remove(0);
+            assert_eq!(loaded.cfm.as_ref(), Some(&expected));
+        }
     }
 
     #[test]


### PR DESCRIPTION
CloseConnection removed its live registry record before trying to clear the caller-owned ID, discarded write failure and returned success. A protected ID therefore retained a stale value after its connection had been lost.

Move synchronous ID validation, atomic output publication and record removal into the process CFM service. The native adapter only decodes the argument and encodes the error. Null, wrapping and incomplete ID pointers are rejected; unknown IDs and failed output publication preserve the registry. Remove the native close helper. No persistent state is added.

Validation:
- An actual-import regression fails on the old implementation. Full/partial protection now preserves the complete registry and caller ID; retry with a writable ID succeeds and preserves unrelated connections.
- Service tests cover both memory views, invalid inputs, unknown IDs, explicit publication refusal and retry.
- 5,083 headless library tests passed (three existing ignored); 32 final focused tests passed and production compilation is warning-free.
- Changed hunks formatted sequentially through stdin. CI [33977438972](https://github.com/benletchford/systemless/actions/runs/33977438972) passed 5,092 library tests (three existing ignored), 50 desktop tests, both architecture showcases, builds, documentation, packaging and licenses. Tested checkout `8d71b3e5e` exactly matches the published source. Existing non-blocking Clippy errors (`mut_from_ref`, `erasing_op`) and full-tree rustfmt memory exhaustion remain.

This fixes synchronous publication only. The classic close selector, termination routines, fragment/dependency reference counts, storage release and exit teardown remain separate work; the paired memory tests do not claim classic dispatch coverage.

Reference: Inside Macintosh: PowerPC System Software (1994), pp. 3-23–3-24.

Closes #1504
