### PR TITLE
fix: restore Odyssey profile creation and picture colors

### DIFF
--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -5820,6 +5820,112 @@ impl TrapDispatcher {
         }
     }
 
+    // Inside Macintosh: Files (1992), pp. 2-81–2-83: an HFS file
+    // reference number is 2 + 94*n, an offset into the FCB buffer.
+    // Resource Manager access paths share that namespace with data forks.
+    fn allocate_resource_file_fcb(
+        &mut self,
+        bus: &mut MacMemoryBus,
+        path: &str,
+        writable: bool,
+    ) -> std::result::Result<u16, i16> {
+        use crate::memory::globals::addr;
+        const FCB_SIZE: u16 = 94;
+        const MAX_FCBS: u16 = 342;
+        let old_buffer = bus.read_long(addr::FCB_S_PTR);
+        let old_size = if old_buffer == 0 {
+            0
+        } else {
+            bus.read_word(old_buffer)
+        };
+        let refnum = (0..MAX_FCBS)
+            .map(|index| 2 + FCB_SIZE * index)
+            .find(|refnum| {
+                *refnum != bus.read_word(addr::CUR_APREF_NUM)
+                    && !self.open_files.contains_key(refnum)
+                    && !self.synthetic_drivers.contains_key(refnum)
+                    && !self
+                        .resources
+                        .as_ref()
+                        .is_some_and(|r| r.files.contains_key(refnum))
+                    && (*refnum >= old_size || bus.read_long(old_buffer + *refnum as u32) == 0)
+            })
+            .ok_or(-42i16)?; // tmfoErr
+        let required = refnum + FCB_SIZE;
+        let buffer = if required > old_size {
+            let new_buffer = bus.alloc(required as u32);
+            if new_buffer == 0 {
+                return Err(-108); // memFullErr
+            }
+            bus.fill_bytes(new_buffer, required as u32, 0);
+            if old_buffer != 0 {
+                let previous = bus.read_bytes(old_buffer, old_size as usize);
+                bus.write_bytes(new_buffer, &previous);
+            }
+            bus.write_word(new_buffer, required);
+            bus.write_long(addr::FCB_S_PTR, new_buffer);
+            if old_buffer != 0 {
+                bus.free(old_buffer);
+            }
+            new_buffer
+        } else {
+            old_buffer
+        };
+        bus.write_word(addr::FS_FCB_LEN, FCB_SIZE);
+
+        // Files 1992, pp. 2-79–2-83: fcbVPtr identifies the volume's VCB;
+        // vcbVRefNum is the signed word at byte 78 of that record.
+        let volume_ref = self
+            .vfs_volume_for_path(path)
+            .map(|volume| volume.ref_num)
+            .unwrap_or(BOOT_VOLUME_REF_NUM);
+        let mut vcb = bus.read_long(addr::VCB_Q_HDR + 2);
+        while vcb != 0 && bus.read_word(vcb + 78) != volume_ref as u16 {
+            vcb = bus.read_long(vcb);
+        }
+        if vcb == 0 {
+            vcb = bus.alloc(178);
+            if vcb == 0 {
+                return Err(-108);
+            }
+            bus.fill_bytes(vcb, 178, 0);
+            bus.write_word(vcb + 8, 0x4244);
+            bus.write_word(vcb + 78, volume_ref as u16);
+            let volume_name = self
+                .vfs_volume_for_ref_num(volume_ref)
+                .map(|volume| volume.name.as_str())
+                .unwrap_or(BOOT_VOLUME_NAME);
+            Self::write_pstring(
+                bus,
+                vcb + 44,
+                &volume_name.chars().take(27).collect::<String>(),
+            );
+            let tail = bus.read_long(addr::VCB_Q_HDR + 6);
+            if tail == 0 {
+                bus.write_long(addr::VCB_Q_HDR + 2, vcb);
+            } else {
+                bus.write_long(tail, vcb);
+            }
+            bus.write_long(addr::VCB_Q_HDR + 6, vcb);
+        }
+        let metadata = self
+            .vfs_file_metadata(path)
+            .expect("existing resource file");
+        let len = self.vfs_rsrc.get(path).map_or(0, |data| data.len() as u32);
+        let fcb = buffer + refnum as u32;
+        bus.fill_bytes(fcb, FCB_SIZE as u32, 0);
+        bus.write_long(fcb, metadata.file_id);
+        bus.write_word(fcb + 4, 0x0200 | if writable { 0x0100 } else { 0 });
+        bus.write_long(fcb + 8, len);
+        bus.write_long(fcb + 12, len);
+        bus.write_long(fcb + 20, vcb);
+        bus.write_long(fcb + 50, metadata.file_type);
+        bus.write_long(fcb + 58, metadata.parent_dir_id);
+        let name = Self::hfs_name_from_vfs_component(Self::vfs_basename(path));
+        Self::write_pstring(bus, fcb + 62, &name.chars().take(31).collect::<String>());
+        Ok(refnum)
+    }
+
     /// Allocate a new loaded resource-file slot for the given VFS key.
     ///
     /// The caller is responsible for resolving duplicates before calling
@@ -5833,7 +5939,13 @@ impl TrapDispatcher {
         wants_write: bool,
     ) -> u16 {
         let rsrc_data = self.vfs_rsrc.get(vfs_key).unwrap().clone();
-        let refnum = self.allocate_process_file_refnum();
+        let refnum = match self.allocate_resource_file_fcb(bus, vfs_key, wants_write) {
+            Ok(refnum) => refnum,
+            Err(error) => {
+                bus.write_word(0x0A60, error as u16);
+                return u16::MAX;
+            }
+        };
         if let Some(fork) = ResourceFork::parse(&rsrc_data) {
             self.merge_resources_from_fork(&fork, bus, refnum);
         } else {
@@ -5844,6 +5956,7 @@ impl TrapDispatcher {
             self.write_refnums.insert(refnum);
         }
         self.set_current_resource_refnum(bus, refnum);
+        bus.write_word(0x0A60, 0);
         refnum
     }
 
@@ -5961,6 +6074,10 @@ impl TrapDispatcher {
         }
 
         self.write_refnums.remove(&refnum);
+        let fcb_buffer = bus.read_long(crate::memory::globals::addr::FCB_S_PTR);
+        if fcb_buffer != 0 && refnum % 94 == 2 && refnum + 94 <= bus.read_word(fcb_buffer) {
+            bus.fill_bytes(fcb_buffer + refnum as u32, 94, 0);
+        }
         bus.write_word(0x0A5A, self.current_resource_refnum());
 
         if trace_resfile_enabled() {

--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -17098,6 +17098,11 @@ impl super::TrapDispatcher {
             return;
         }
 
+        // Activating a palette can assign its colors to different device
+        // indices than the source ColorTable. DrawPicture must then match
+        // against the destination table, not a preceding GetCTable result.
+        // Imaging With QuickDraw (1994), pp. 3-117, 7-44.
+        self.recent_resource_ctable_fetch = None;
         let palette_entries = usize::from(Self::palette_entry_count(bus, palette_handle)).min(256);
         let current_clut = *self.device_clut;
         // Palette activation changes only the cells claimed by this palette.
@@ -39488,6 +39493,41 @@ mod tests {
         assert_ne!(d.device_clut, before);
         assert_eq!(d.device_clut[0], [0x1234, 0x5678, 0x9ABC]);
         assert_eq!(d.color_manager_clut[0], [0x1234, 0x5678, 0x9ABC]);
+    }
+
+    #[test]
+    fn activatepalette_discards_fetched_table_before_picture_color_matching() {
+        let (mut d, mut cpu, mut bus) = setup();
+        let window = 0x0020_4110;
+        let palette = d.create_palette_from_ctab(&mut bus, 1, 0, super::PM_TOLERANT, 0);
+        let palette_ptr = TrapDispatcher::palette_ptr(&bus, palette);
+        let rgb = [0x1234, 0x5678, 0x9ABC];
+        TrapDispatcher::write_palette_color_info(
+            &mut bus,
+            palette_ptr,
+            0,
+            rgb,
+            super::PM_TOLERANT,
+            0,
+        );
+        d.set_window_palette_association(window, palette, 0);
+        d.front_window = window;
+        *d.current_port = window;
+        d.remember_recent_resource_ctable_fetch(250, 0x0020_4500);
+        bus.write_long(TEST_SP, window);
+        d.dispatch_quickdraw(true, 0x294, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+
+        let device_index = d.palette_device_indices[&(palette, 0)];
+        assert_ne!(
+            device_index, 0,
+            "tolerant color must not replace the white endpoint"
+        );
+        assert_eq!(d.color_manager_clut[device_index as usize], rgb);
+        assert!(d
+            .take_recent_drawpicture_resource_ctable_fetch(window, 0, 0, 8)
+            .is_none());
     }
 
     #[test]

--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -7203,7 +7203,6 @@ impl super::TrapDispatcher {
                                 self.open_resource_file_from_vfs_key(bus, &vfs_key, wants_write);
                             bus.write_word(sp + 6, refnum);
                             cpu.write_reg(Register::D0, refnum as u32);
-                            bus.write_word(0x0A60, 0); // ResErr = noErr
                         } else {
                             // FSpOpenResFile failure semantics:
                             // - If the file exists but has no resource fork, return
@@ -8043,7 +8042,7 @@ impl super::TrapDispatcher {
         decode_mac_roman(&bus.read_pstring(name_ptr))
     }
 
-    fn write_pstring(bus: &mut MacMemoryBus, ptr: u32, value: &str) {
+    pub(crate) fn write_pstring(bus: &mut MacMemoryBus, ptr: u32, value: &str) {
         if ptr == 0 {
             return;
         }
@@ -14043,7 +14042,7 @@ mod tests {
         let new_sp = cpu.read_reg(Register::A7);
         assert_eq!(new_sp, TEST_SP + 6);
         let refnum = bus.read_word(new_sp);
-        assert!(refnum >= 100);
+        assert_eq!(refnum % 94, 2, "resource refnum is an HFS FCB offset");
         assert_eq!(cpu.read_reg(Register::D0), refnum as u32);
         assert_eq!(bus.read_word(0x0A60), 0);
         assert_eq!(bus.read_word(0x0A5A), refnum);

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -6375,7 +6375,6 @@ impl super::TrapDispatcher {
                                 self.open_resource_file_from_vfs_key(bus, &vfs_key, wants_write);
                             bus.write_word(sp + 8, refnum);
                             cpu.write_reg(Register::D0, refnum as u32);
-                            bus.write_word(0x0A60, 0); // ResErr = noErr
                             cpu.write_reg(Register::A7, sp + 8);
                             return Some(Ok(()));
                         }
@@ -6400,7 +6399,6 @@ impl super::TrapDispatcher {
                     let refnum = self.open_resource_file_from_vfs_key(bus, &vfs_key, wants_write);
                     bus.write_word(sp + 8, refnum);
                     cpu.write_reg(Register::D0, refnum as u32);
-                    bus.write_word(0x0A60, 0); // ResErr = noErr
                 } else {
                     eprintln!("[TRAP] OpenRFPerm: \"{}\" not found in vfs_rsrc", name);
                     bus.write_word(sp + 8, (-1i16) as u16);
@@ -9467,7 +9465,6 @@ impl super::TrapDispatcher {
                     }
                     let refnum = self.open_resource_file_from_vfs_key(bus, &vfs_key, wants_write);
                     bus.write_word(sp + 12, refnum);
-                    bus.write_word(0x0A60, 0); // ResErr = noErr
                 } else {
                     bus.write_word(sp + 12, (-1i16) as u16);
                     bus.write_word(0x0A60, (-43i16) as u16); // fnfErr
@@ -9596,7 +9593,6 @@ impl super::TrapDispatcher {
                         let refnum = self.open_resource_file_from_vfs_key(bus, &vfs_key, false);
                         bus.write_word(sp + 4, refnum);
                         cpu.write_reg(Register::D0, refnum as u32);
-                        bus.write_word(0x0A60, 0); // ResErr = noErr
                         cpu.write_reg(Register::A7, sp + 4);
                         return Some(Ok(()));
                     }
@@ -13832,6 +13828,14 @@ impl super::TrapDispatcher {
                             return Some(Ok(()));
                         };
 
+                        if refnum == u16::MAX {
+                            let error = bus.read_word(0x0A60) as i16;
+                            record_movie_error(self, error);
+                            bus.write_word(sp + 10, error as u16);
+                            cpu.write_reg(Register::A7, sp + 10);
+                            cpu.write_reg(Register::D0, error as i32 as u32);
+                            return Some(Ok(()));
+                        }
                         if ref_num_ptr != 0 {
                             bus.write_word(ref_num_ptr, refnum);
                         }
@@ -22449,6 +22453,81 @@ mod tests {
         assert_eq!(disp.current_resource_refnum(), refnum);
         assert_eq!(disp.resource_file_name(refnum), Some("Shapes"));
         assert_eq!(cpu.read_reg(Register::A7), sp + 4);
+    }
+
+    #[test]
+    fn open_res_file_publishes_a_valid_fcb_and_preserves_other_access_paths() {
+        use crate::memory::globals::addr;
+        let (mut disp, mut cpu, mut bus) = setup();
+        let original_buffer = bus.alloc(96);
+        bus.fill_bytes(original_buffer, 96, 0);
+        bus.write_word(original_buffer, 96);
+        bus.write_long(original_buffer + 2, 1234);
+        bus.write_long(addr::FCB_S_PTR, original_buffer);
+        bus.write_word(addr::FS_FCB_LEN, 94);
+        bus.write_word(addr::CUR_APREF_NUM, 2);
+        disp.open_files.insert(96, "Other Data".to_string());
+        disp.vfs_rsrc.insert("Profiles/Player".to_string(), vec![]);
+        disp.set_vfs_entry_metadata("Profiles/Player", *b"SAVE", *b"TEST", 0);
+        let metadata = disp.vfs_file_metadata("Profiles/Player").unwrap();
+        let name_ptr = 0x200250;
+        bus.write_pstring(name_ptr, b"Profiles:Player");
+        bus.write_long(TEST_SP, name_ptr);
+
+        disp.dispatch_toolbox(true, 0x197, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+        let refnum = bus.read_word(TEST_SP + 4);
+        let buffer = bus.read_long(addr::FCB_S_PTR);
+        // Files 1992, 2-81–2-83: these are the same direct FCB/VCB
+        // lookups used by classic runtime libraries to recover a volume.
+        assert_eq!(refnum, 190, "skip application and data-fork access paths");
+        assert_eq!(refnum % bus.read_word(addr::FS_FCB_LEN), 2);
+        assert!(refnum + 94 <= bus.read_word(buffer));
+        assert_eq!(bus.read_long(buffer + 2), 1234);
+        let fcb = buffer + refnum as u32;
+        assert_eq!(bus.read_long(fcb), metadata.file_id);
+        assert_eq!(bus.read_word(fcb + 4), 0x0200);
+        assert_eq!(bus.read_long(fcb + 50), u32::from_be_bytes(*b"SAVE"));
+        assert_eq!(bus.read_long(fcb + 58), metadata.parent_dir_id);
+        assert_eq!(bus.read_pstring(fcb + 62), b"Player");
+        let vcb = bus.read_long(fcb + 20);
+        assert_ne!(vcb, 0);
+        assert_eq!(bus.read_word(vcb + 78) as i16, -1);
+
+        bus.write_word(TEST_SP, refnum);
+        cpu.write_reg(Register::A7, TEST_SP);
+        disp.dispatch_toolbox(true, 0x19A, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+        assert_eq!(bus.read_bytes(fcb, 94), vec![0; 94]);
+        assert_eq!(bus.read_long(buffer + 2), 1234);
+        bus.write_long(TEST_SP, name_ptr);
+        cpu.write_reg(Register::A7, TEST_SP);
+        disp.dispatch_toolbox(true, 0x197, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+        assert_eq!(bus.read_word(TEST_SP + 4), refnum, "reuse a closed FCB");
+    }
+
+    #[test]
+    fn open_res_file_reports_exhausted_fcb_table_without_changing_current_file() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        disp.vfs_rsrc.insert("Player".to_string(), vec![]);
+        for index in 0..342 {
+            disp.open_files
+                .insert(2 + 94 * index, "Occupied".to_string());
+        }
+        let current = disp.current_resource_refnum();
+        bus.write_pstring(0x200250, b"Player");
+        bus.write_long(TEST_SP, 0x200250);
+        disp.dispatch_toolbox(true, 0x197, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+        assert_eq!(bus.read_word(TEST_SP + 4) as i16, -1);
+        assert_eq!(bus.read_word(0x0A60) as i16, -42);
+        assert_eq!(disp.current_resource_refnum(), current);
+        assert_eq!(disp.refnum_for_resource_file_name("Player"), None);
     }
 
     // Inside Macintosh Volume I (1985), p. I-115: reopening an already-open


### PR DESCRIPTION
Odyssey’s new-character Save action previously opened the profile’s resource fork and immediately displayed “Sorry, Odyssey Internal Memory Error.” Its runtime validates the returned reference number and reads the volume through the guest FCB table. Resource-file opens now allocate valid HFS FCB offsets, publish the file and volume records, preserve existing entries when the table grows, and clear entries on close. Allocation failures remain visible through ResError.

The welcome artwork also used incorrect colors because DrawPicture reused a preceding GetCTable result after Palette Manager had assigned the palette’s colors to different device indices. Palette activation now invalidates that stale lookup, so picture drawing matches colors against the active destination table.

Validation:
- 5,086 library tests passed; 3 ignored (`cargo test --lib --no-default-features --features test-support --profile ci-test`). New regressions cover direct FCB/VCB lookup, collision avoidance, growth, close/reuse, table exhaustion, and palette activation before picture drawing.
- Reproduced the reported error using the creator’s freeware Odyssey 1.1 archive, then replayed New Game → character confirmation → Save → introduction → beach gameplay locally. Both final gameplay pixel assertions passed.
- Compared the welcome artwork with a BasiliskII capture: 99.9% of artwork pixels match exactly.

Partially addresses #1506. Music remains unsupported: Odyssey requires the Apple QuickTime software instrument component (`inst` / `ss  ` / `appl`), which is not implemented, and consequently disables Music Volume. Leave the issue open for that work. No game-specific runtime conditions or archive modifications are introduced.
