### PR TITLE
fix: share CopyBits row transfers across CPU routes

### DIFF
--- a/src/copy_bits.rs
+++ b/src/copy_bits.rs
@@ -1,0 +1,378 @@
+//! Shared byte-aligned, unscaled srcCopy transfers.
+//! Imaging With QuickDraw (1994), pp. 3-112–3-117 and 4-27–4-28.
+//! ABI decoding, port/mask resolution and picture recording stay at the callers
+//! until their corresponding operation families migrate.
+
+use crate::memory::{GuestAddressSpace, MacMemoryBus, MemoryBus};
+
+pub(crate) trait CopyBitsMemory {
+    fn read_copy_row(&mut self, address: u32, bytes: &mut [u8]) -> Option<()>;
+    fn write_copy_row(&mut self, address: u32, bytes: &[u8]) -> Option<()>;
+}
+
+impl CopyBitsMemory for GuestAddressSpace {
+    fn read_copy_row(&mut self, address: u32, bytes: &mut [u8]) -> Option<()> {
+        self.read_bytes_into(address, bytes)
+    }
+
+    fn write_copy_row(&mut self, address: u32, bytes: &[u8]) -> Option<()> {
+        self.write_bytes(address, bytes)
+    }
+}
+
+impl CopyBitsMemory for MacMemoryBus {
+    fn read_copy_row(&mut self, address: u32, bytes: &mut [u8]) -> Option<()> {
+        if !self.is_guest_address_mapped(address, bytes.len()) {
+            return None;
+        }
+        self.read_bytes_into(address, bytes);
+        Some(())
+    }
+
+    fn write_copy_row(&mut self, address: u32, bytes: &[u8]) -> Option<()> {
+        if !self.is_guest_address_writable(address, bytes.len()) {
+            return None;
+        }
+        // The exclusive view remains held; no guest execution or mapping
+        // mutation intervenes between the range check and the bulk write.
+        self.write_bytes(address, bytes);
+        Some(())
+    }
+}
+
+/// Bounds and rectangles are [top, left, bottom, right] in guest coordinates.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct BytePixmap {
+    pub(crate) base: u32,
+    pub(crate) row_bytes: u32,
+    pub(crate) depth: u32,
+    pub(crate) bounds: [i32; 4],
+}
+
+impl BytePixmap {
+    fn row_address(self, x: i32, y: i32, len: usize) -> Option<u32> {
+        let [top, left, bottom, right] = self.bounds;
+        if x < left || x >= right || y < top || y >= bottom {
+            return None;
+        }
+        let x_bytes = u32::try_from(x.checked_sub(left)?)
+            .ok()?
+            .checked_mul(self.depth / 8)?;
+        let len = u32::try_from(len).ok()?;
+        if x_bytes.checked_add(len)? > self.row_bytes {
+            return None;
+        }
+        let y_bytes = u32::try_from(y.checked_sub(top)?)
+            .ok()?
+            .checked_mul(self.row_bytes)?;
+        let address = self.base.checked_add(y_bytes)?.checked_add(x_bytes)?;
+        if u64::from(address) + u64::from(len) > 1u64 << 32 {
+            return None;
+        }
+        Some(address)
+    }
+}
+
+/// One synchronous transfer, consumed before any guest callback can run.
+pub(crate) struct RowCopy<'a> {
+    pub(crate) source: BytePixmap,
+    pub(crate) destination: BytePixmap,
+    pub(crate) source_rect: [i32; 4],
+    pub(crate) destination_rect: [i32; 4],
+    pub(crate) clip: [i32; 4],
+    pub(crate) palette: Option<&'a [u8; 256]>,
+}
+
+impl RowCopy<'_> {
+    /// Snapshot all source rows before writing, including across different
+    /// addresses that alias the same backing. Geometry/read failures write
+    /// nothing. A destination failure preserves that row but may follow rows
+    /// already committed; this does not promise rectangle-wide atomicity.
+    pub(crate) fn execute(self, memory: &mut impl CopyBitsMemory) -> Option<()> {
+        let depth = self.source.depth;
+        if depth != self.destination.depth
+            || !matches!(depth, 8 | 16 | 24 | 32)
+            || (self.palette.is_some() && depth != 8)
+        {
+            return None;
+        }
+        let [st, sl, sb, sr] = self.source_rect;
+        let [dt, dl, db, dr] = self.destination_rect;
+        let width = sr.checked_sub(sl)?;
+        let height = sb.checked_sub(st)?;
+        if width <= 0
+            || height <= 0
+            || dr.checked_sub(dl)? != width
+            || db.checked_sub(dt)? != height
+        {
+            return None;
+        }
+        let x_delta = sl.checked_sub(dl)?;
+        let y_delta = st.checked_sub(dt)?;
+        let [sbt, sbl, sbb, sbr] = self.source.bounds;
+        let [dbt, dbl, dbb, dbr] = self.destination.bounds;
+        let [ct, cl, cb, cr] = self.clip;
+        let top = dt.max(dbt).max(ct).max(sbt.checked_sub(y_delta)?);
+        let left = dl.max(dbl).max(cl).max(sbl.checked_sub(x_delta)?);
+        let bottom = db.min(dbb).min(cb).min(sbb.checked_sub(y_delta)?);
+        let right = dr.min(dbr).min(cr).min(sbr.checked_sub(x_delta)?);
+        if top >= bottom || left >= right {
+            return None;
+        }
+        let row_len = usize::try_from(right.checked_sub(left)?)
+            .ok()?
+            .checked_mul((depth / 8) as usize)?;
+        let count = usize::try_from(bottom.checked_sub(top)?).ok()?;
+        let mut addresses = Vec::with_capacity(count);
+        // Check every row's arithmetic before allocating or reading pixels.
+        for y in top..bottom {
+            addresses.push((
+                self.source.row_address(
+                    left.checked_add(x_delta)?,
+                    y.checked_add(y_delta)?,
+                    row_len,
+                )?,
+                self.destination.row_address(left, y, row_len)?,
+            ));
+        }
+        let mut pixels = vec![0; count.checked_mul(row_len)?];
+        for ((source, _), row) in addresses.iter().zip(pixels.chunks_exact_mut(row_len)) {
+            memory.read_copy_row(*source, row)?;
+            if let Some(palette) = self.palette {
+                for pixel in row {
+                    *pixel = palette[usize::from(*pixel)];
+                }
+            }
+        }
+        for ((_, destination), row) in addresses.iter().zip(pixels.chunks_exact(row_len)) {
+            memory.write_copy_row(*destination, row)?;
+        }
+        Some(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SOURCE: u32 = 0x0100_0000;
+    const DESTINATION: u32 = 0x0200_0000;
+
+    fn run(memory: &mut GuestAddressSpace, classic: bool, copy: RowCopy<'_>) -> Option<()> {
+        if classic {
+            let mut bus = MacMemoryBus::new(0x10000);
+            bus.set_addressing_32_bit(true);
+            bus.attach_guest_address_space(memory.shared_view());
+            copy.execute(&mut bus)
+        } else {
+            copy.execute(memory)
+        }
+    }
+
+    fn pixmap(base: u32, row_bytes: u32, depth: u32, bounds: [i32; 4]) -> BytePixmap {
+        BytePixmap {
+            base,
+            row_bytes,
+            depth,
+            bounds,
+        }
+    }
+
+    #[test]
+    fn clipped_offset_rows_preserve_padding_in_both_memory_views() {
+        for classic in [false, true] {
+            for depth in [8, 16, 24, 32] {
+                let bytes = depth / 8;
+                let stride = 4 * bytes + 3;
+                let mut memory = GuestAddressSpace::new();
+                let source: Vec<u8> = (0..stride * 3).map(|n| n as u8).collect();
+                memory.add_region(SOURCE, source.clone());
+                memory.add_region(DESTINATION, vec![0xAA; (stride * 3) as usize]);
+                let copy = RowCopy {
+                    source: pixmap(SOURCE, stride, depth, [-2, -3, 1, 1]),
+                    destination: pixmap(DESTINATION, stride, depth, [10, 20, 13, 24]),
+                    source_rect: [-3, -4, 1, 1],
+                    destination_rect: [9, 19, 13, 24],
+                    clip: [11, 21, 13, 23],
+                    palette: None,
+                };
+                assert_eq!(run(&mut memory, classic, copy), Some(()));
+                let mut expected = vec![0xAA; (stride * 3) as usize];
+                for row in 1..3 {
+                    let start = (row * stride + bytes) as usize;
+                    let end = start + (2 * bytes) as usize;
+                    expected[start..end].copy_from_slice(&source[start..end]);
+                }
+                let mut actual = vec![0; expected.len()];
+                memory.read_bytes_into(DESTINATION, &mut actual).unwrap();
+                assert_eq!(actual, expected, "classic={classic}, depth={depth}");
+            }
+        }
+    }
+
+    #[test]
+    fn overlapping_rows_snapshot_before_palette_mapping_and_writes() {
+        for classic in [false, true] {
+            for downward in [false, true] {
+                let mut memory = GuestAddressSpace::new();
+                memory.add_region(SOURCE, (0..16).collect());
+                let palette = std::array::from_fn(|n| 255 - n as u8);
+                let (source, destination) = if downward {
+                    (SOURCE, SOURCE + 4)
+                } else {
+                    (SOURCE + 4, SOURCE)
+                };
+                assert_eq!(
+                    run(
+                        &mut memory,
+                        classic,
+                        RowCopy {
+                            source: pixmap(source, 4, 8, [0, 0, 3, 3]),
+                            destination: pixmap(destination, 4, 8, [0, 0, 3, 3]),
+                            source_rect: [0, 0, 3, 3],
+                            destination_rect: [0, 0, 3, 3],
+                            clip: [0, 0, 3, 3],
+                            palette: Some(&palette),
+                        }
+                    ),
+                    Some(())
+                );
+                let mut expected: Vec<u8> = (0..16).collect();
+                for row in 0..3 {
+                    for x in 0..3 {
+                        expected[(destination - SOURCE) as usize + row * 4 + x] =
+                            255 - ((source - SOURCE) as usize + row * 4 + x) as u8;
+                    }
+                }
+                let mut actual = vec![0; 16];
+                memory.read_bytes_into(SOURCE, &mut actual).unwrap();
+                assert_eq!(actual, expected);
+            }
+        }
+    }
+
+    #[test]
+    fn distinct_guest_aliases_snapshot_the_same_backing() {
+        for classic in [false, true] {
+            let mut memory = GuestAddressSpace::new();
+            let backing = crate::memory::bus::SharedRamRegion::from_owned_bytes((0..16).collect());
+            // SAFETY: this test accesses both aliases serially through one
+            // operation; no borrowed byte slices survive a memory call.
+            unsafe {
+                memory.add_shared_region(SOURCE, backing.clone());
+                memory.add_shared_region(DESTINATION, backing);
+            }
+            assert_eq!(
+                run(
+                    &mut memory,
+                    classic,
+                    RowCopy {
+                        source: pixmap(SOURCE, 4, 8, [0, 0, 3, 3]),
+                        destination: pixmap(DESTINATION + 4, 4, 8, [0, 0, 3, 3]),
+                        source_rect: [0, 0, 3, 3],
+                        destination_rect: [0, 0, 3, 3],
+                        clip: [0, 0, 3, 3],
+                        palette: None,
+                    }
+                ),
+                Some(())
+            );
+            let mut actual = [0; 16];
+            memory.read_bytes_into(SOURCE, &mut actual).unwrap();
+            assert_eq!(actual, [0, 1, 2, 3, 0, 1, 2, 7, 4, 5, 6, 11, 8, 9, 10, 15]);
+        }
+    }
+
+    #[test]
+    fn overflowing_geometry_is_rejected_before_memory_access() {
+        struct NoAccess;
+        impl CopyBitsMemory for NoAccess {
+            fn read_copy_row(&mut self, _: u32, _: &mut [u8]) -> Option<()> {
+                panic!("invalid geometry reached source memory");
+            }
+            fn write_copy_row(&mut self, _: u32, _: &[u8]) -> Option<()> {
+                panic!("invalid geometry reached destination memory");
+            }
+        }
+        for (base, stride, bounds, rect) in [
+            (u32::MAX - 1, 4, [0, 0, 2, 4], [0, 0, 2, 4]),
+            (SOURCE, u32::MAX, [0, 0, 3, 4], [0, 0, 3, 4]),
+            (
+                SOURCE,
+                4,
+                [0, i32::MIN, 1, i32::MAX],
+                [0, i32::MIN, 1, i32::MAX],
+            ),
+        ] {
+            assert_eq!(
+                RowCopy {
+                    source: pixmap(base, stride, 8, bounds),
+                    destination: pixmap(DESTINATION, stride, 8, bounds),
+                    source_rect: rect,
+                    destination_rect: rect,
+                    clip: rect,
+                    palette: None,
+                }
+                .execute(&mut NoAccess),
+                None
+            );
+        }
+    }
+
+    #[test]
+    fn source_hole_or_invalid_stride_never_writes_destination() {
+        for classic in [false, true] {
+            for bad_stride in [false, true] {
+                let mut memory = GuestAddressSpace::new();
+                memory.add_region(SOURCE, vec![7; if bad_stride { 8 } else { 4 }]);
+                memory.add_region(DESTINATION, vec![0xAA; 8]);
+                assert_eq!(
+                    run(
+                        &mut memory,
+                        classic,
+                        RowCopy {
+                            source: pixmap(SOURCE, if bad_stride { 3 } else { 4 }, 8, [0, 0, 2, 4]),
+                            destination: pixmap(DESTINATION, 4, 8, [0, 0, 2, 4]),
+                            source_rect: [0, 0, 2, 4],
+                            destination_rect: [0, 0, 2, 4],
+                            clip: [0, 0, 2, 4],
+                            palette: None,
+                        }
+                    ),
+                    None
+                );
+                let mut actual = [0; 8];
+                memory.read_bytes_into(DESTINATION, &mut actual).unwrap();
+                assert_eq!(actual, [0xAA; 8]);
+            }
+        }
+    }
+
+    #[test]
+    fn protected_later_row_preserves_that_row_after_prior_row_commits() {
+        for classic in [false, true] {
+            let mut memory = GuestAddressSpace::new();
+            memory.add_region(SOURCE, vec![7; 8]);
+            memory.add_region(DESTINATION, vec![0xAA; 8]);
+            memory.add_readonly_region(DESTINATION + 6, vec![0xAA]);
+            assert_eq!(
+                run(
+                    &mut memory,
+                    classic,
+                    RowCopy {
+                        source: pixmap(SOURCE, 4, 8, [0, 0, 2, 4]),
+                        destination: pixmap(DESTINATION, 4, 8, [0, 0, 2, 4]),
+                        source_rect: [0, 0, 2, 4],
+                        destination_rect: [0, 0, 2, 4],
+                        clip: [0, 0, 2, 4],
+                        palette: None,
+                    }
+                ),
+                None
+            );
+            let mut actual = [0; 8];
+            memory.read_bytes_into(DESTINATION, &mut actual).unwrap();
+            assert_eq!(actual, [7, 7, 7, 7, 0xAA, 0xAA, 0xAA, 0xAA]);
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,7 @@ pub use event_queue::{
     EventManagerSnapshot, EventProbeResult, EventQueueProbeSnapshot, EventRecordSnapshot,
 };
 mod cfm;
+mod copy_bits;
 mod execution_kernel;
 mod execution_m68k;
 mod execution_native;

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -57611,33 +57611,6 @@ fn ppc_resolve_pixmap_bits(
         .or_else(|| ppc_read_pixmap_handle_bits(memory, pixmap_or_handle))
 }
 
-fn ppc_pixmap_pixel_addr(bits: PpcPixMapBits, x: i32, y: i32) -> Option<u32> {
-    let bytes_per_pixel = match bits.depth {
-        8 => 1,
-        16 => 2,
-        _ => return None,
-    };
-    if x < i32::from(bits.left)
-        || x >= i32::from(bits.right)
-        || y < i32::from(bits.top)
-        || y >= i32::from(bits.bottom)
-    {
-        return None;
-    }
-    let x_offset = u32::try_from(x - i32::from(bits.left)).ok()?;
-    let y_offset = u32::try_from(y - i32::from(bits.top)).ok()?;
-    if x_offset >= bits.width || y_offset >= bits.height {
-        return None;
-    }
-    let pixel_offset = x_offset.checked_mul(bytes_per_pixel)?;
-    if pixel_offset.checked_add(bytes_per_pixel)? > bits.row_bytes {
-        return None;
-    }
-    bits.base_addr
-        .checked_add(y_offset.checked_mul(bits.row_bytes)?)?
-        .checked_add(pixel_offset)
-}
-
 fn ppc_read_pixmap_raw_pixel(
     memory: &mut PpcSectionMem,
     bits: PpcPixMapBits,
@@ -58396,38 +58369,28 @@ fn ppc_copy_bits(
             && src_width == dst_width
             && src_height == dst_height
         {
-            let x_delta = i32::from(src_left) - i32::from(dst_left);
-            let y_delta = i32::from(src_top) - i32::from(dst_top);
-            let copy_left = copy_left.max(i32::from(src_bits.left) - x_delta);
-            let copy_top = copy_top.max(i32::from(src_bits.top) - y_delta);
-            let copy_right = copy_right.min(i32::from(src_bits.right) - x_delta);
-            let copy_bottom = copy_bottom.min(i32::from(src_bits.bottom) - y_delta);
-            if copy_left >= copy_right || copy_top >= copy_bottom {
-                reason = "clipped-empty";
-                return None;
+            use crate::copy_bits::{BytePixmap, RowCopy};
+            return RowCopy {
+                source: BytePixmap {
+                    base: src_bits.base_addr,
+                    row_bytes: src_bits.row_bytes,
+                    depth: src_bits.depth,
+                    bounds: [src_bits.top, src_bits.left, src_bits.bottom, src_bits.right]
+                        .map(i32::from),
+                },
+                destination: BytePixmap {
+                    base: dst_bits.base_addr,
+                    row_bytes: dst_bits.row_bytes,
+                    depth: dst_bits.depth,
+                    bounds: [dst_bits.top, dst_bits.left, dst_bits.bottom, dst_bits.right]
+                        .map(i32::from),
+                },
+                source_rect: [src_top, src_left, src_bottom, src_right].map(i32::from),
+                destination_rect: [dst_top, dst_left, dst_bottom, dst_right].map(i32::from),
+                clip: [copy_top, copy_left, copy_bottom, copy_right],
+                palette: palette_map.as_ref(),
             }
-            let bytes_per_pixel = src_bits.depth / 8;
-            let copy_width = u32::try_from(copy_right - copy_left).ok()?;
-            let row_len = usize::try_from(copy_width.checked_mul(bytes_per_pixel)?).ok()?;
-            let mut rows = Vec::with_capacity(usize::try_from(copy_bottom - copy_top).ok()?);
-            for dst_y in copy_top..copy_bottom {
-                let src_y = i32::from(src_top) + (dst_y - i32::from(dst_top));
-                let src_x = i32::from(src_left) + (copy_left - i32::from(dst_left));
-                let src_addr = ppc_pixmap_pixel_addr(src_bits, src_x, src_y)?;
-                let dst_addr = ppc_pixmap_pixel_addr(dst_bits, copy_left, dst_y)?;
-                let mut row = vec![0; row_len];
-                memory.read_bytes_into(src_addr, &mut row)?;
-                if let Some(palette_map) = palette_map.as_ref() {
-                    for pixel in &mut row {
-                        *pixel = palette_map[usize::from(*pixel)];
-                    }
-                }
-                rows.push((dst_addr, row));
-            }
-            for (dst_addr, row) in rows {
-                memory.write_bytes(dst_addr, &row)?;
-            }
-            return Some(());
+            .execute(memory);
         }
 
         let transparent_back_pixel = match src_bits.depth {
@@ -150176,6 +150139,38 @@ pub(crate) mod tests {
             .gworlds
             .iter()
             .any(|record| record.port == second_port && record.pixmap_handle == second_pmh));
+    }
+
+    #[test]
+    fn hle_import_runner_copybits_overlapping_rows_preserve_padding() {
+        let mut loaded = load_pef_application(&synthetic_pef_with_import(b"CopyBits")).unwrap();
+        let pixels = PPC_HEAP_BASE + 0x10000;
+        let src_pixmap = pixels + 0x100;
+        let dst_pixmap = pixels + 0x200;
+        let rect = pixels + 0x300;
+        loaded.memory.add_region(pixels, vec![0; 0x400]);
+        loaded
+            .memory
+            .write_bytes(
+                pixels,
+                &[1, 2, 3, 90, 4, 5, 6, 91, 7, 8, 9, 92, 10, 11, 12, 93],
+            )
+            .unwrap();
+        ppc_write_pixmap(&mut loaded.memory, src_pixmap, pixels, 4, 0, 0, 3, 4, 8).unwrap();
+        ppc_write_pixmap(&mut loaded.memory, dst_pixmap, pixels + 4, 4, 0, 0, 3, 4, 8).unwrap();
+        ppc_write_rect(&mut loaded.memory, rect, 0, 0, 3, 3).unwrap();
+        loaded.cpu.gpr[3] = src_pixmap;
+        loaded.cpu.gpr[4] = dst_pixmap;
+        loaded.cpu.gpr[5] = rect;
+        loaded.cpu.gpr[6] = rect;
+        loaded.cpu.gpr[7] = 0;
+        loaded.cpu.gpr[8] = 0;
+        let probe = loaded.run_with_hle_imports(64);
+        assert_eq!(probe.handled_import_count, 1);
+        assert_eq!(probe.unsupported_import_index, None);
+        let mut actual = [0; 16];
+        loaded.memory.read_bytes_into(pixels, &mut actual).unwrap();
+        assert_eq!(actual, [1, 2, 3, 90, 1, 2, 3, 91, 4, 5, 6, 92, 7, 8, 9, 93]);
     }
 
     #[test]

--- a/src/memory/bus.rs
+++ b/src/memory/bus.rs
@@ -1430,6 +1430,16 @@ impl MacMemoryBus {
     /// sparse span may be valid, while any hole or read-only byte rejects the
     /// operation before the first destination byte changes.
     pub(crate) fn is_guest_address_writable(&self, address: u32, len: usize) -> bool {
+        if len == 0 {
+            return true;
+        }
+        // A complete flat route needs one protection-range check. Keep bulk
+        // drawing on the bulk path rather than checking every pixel byte.
+        if self.route(address, len) == GuestMemoryRoute::Flat {
+            return u32::try_from(len).ok().is_some_and(|len| {
+                !self.readonly_code_overlaps(self.translate_guest_address(address), len)
+            });
+        }
         (0..len).all(|offset| {
             let guest_address = address.wrapping_add(offset as u32);
             let translated = self.translate_guest_address(guest_address);
@@ -3953,6 +3963,18 @@ mod tests {
 
         bus.set_addressing_32_bit(false);
         assert!(bus.is_guest_address_mapped(0x00ff_ffff, 2));
+    }
+
+    #[test]
+    fn writable_range_preflight_preserves_empty_ranges_and_flat_protection() {
+        let mut bus = MacMemoryBus::new(0x10000);
+        bus.protect_readonly_code(0x3000, 4);
+        assert!(bus.is_guest_address_writable(0x3001, 0));
+        assert!(bus.is_guest_address_writable(u32::MAX, 0));
+        assert!(!bus.is_guest_address_writable(0x3001, 1));
+        assert!(!bus.is_guest_address_writable(0x2FFF, 2));
+        assert!(bus.is_guest_address_writable(0x2FFE, 2));
+        assert!(bus.is_guest_address_writable(0x3004, 2));
     }
 
     #[test]

--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -3597,46 +3597,14 @@ impl super::TrapDispatcher {
                 ));
                 let (copy_fg_rgb, copy_bg_rgb) = self.copy_bits_port_draw_colors(bus, port);
 
-                // Identity-blit fast path: when nothing in the inner loop
-                // transforms the pixel, replace per-pixel read+write with
-                // one bus.read_bytes + bus.write_bytes per row.
-                //
-                // Conditions (all must hold):
-                //   - mode_base == 0 (plain srcCopy, no transparency,
-                //     colorization, or hilite mode)
-                //   - no_scaling (src and dst dimensions match)
-                //   - palette_translation is None (no CTab remap)
-                //   - matching byte-aligned pixel sizes (8/16/24/32)
-                //   - src and dst rects fully inside their bitmap bounds
-                //   - src.base != dst.base (in-place may need direction-
-                //     aware copy; defer to per-pixel path for safety)
-                //   - no probe/trace flag wants per-pixel observability
-                //
-                // Region clipping is handled by the precomputed clip_t/l/b/r
-                // (intersection with the port's visRgn, clipRgn, and
-                // mask_rgn bboxes plus dst bitmap bounds). Regions are
-                // modeled as bounding rectangles, so within the clip rect
-                // there are no holes — bulk-copying clip_t..clip_b ×
-                // clip_l..clip_r is correct even when handles are non-zero.
-                //
-                // Imaging With QuickDraw 1994, p. 7-25 (CopyBits modes).
-                let src_inside_bounds = src_top >= src_info.bounds_top
-                    && src_bottom <= src_info.bounds_bottom
-                    && src_left >= src_info.bounds_left
-                    && src_right <= src_info.bounds_right;
-                let dst_inside_bounds = dst_top >= dst_info.bounds_top
-                    && dst_bottom <= dst_info.bounds_bottom
-                    && dst_left >= dst_info.bounds_left
-                    && dst_right <= dst_info.bounds_right;
+                // Rectangular, byte-aligned srcCopy uses the common transfer
+                // operation. It snapshots the source before any destination
+                // write, including overlapping or differently mapped aliases.
+                // Port/region resolution and picture/screen effects remain here.
                 let pixel_size_ok = src_info.pixel_size == dst_info.pixel_size
-                    && src_info.pixel_size >= 8
-                    && src_info.pixel_size.is_multiple_of(8);
+                    && matches!(src_info.pixel_size, 8 | 16 | 24 | 32);
                 let identity_blit = mode_base == 0
                     && no_scaling
-                    && palette_translation.is_none()
-                    && src_inside_bounds
-                    && dst_inside_bounds
-                    && src_info.base != dst_info.base
                     && pixel_size_ok
                     && !Self::region_is_complex(bus, vis_rgn_handle)
                     && !Self::region_is_complex(bus, clip_rgn_handle)
@@ -3647,28 +3615,38 @@ impl super::TrapDispatcher {
                     && !trace_menu_redraw_enabled()
                     && trace_probes.is_empty();
                 if identity_blit {
-                    let bytes_per_pixel = src_info.pixel_size / 8;
-                    let row_byte_count = ((clip_r as i32 - clip_l as i32) as u32) * bytes_per_pixel;
-                    let src_x_offset_bytes = ((i32::from(src_left) + i32::from(clip_l)
-                        - i32::from(dst_left)
-                        - i32::from(src_info.bounds_left))
-                        as u32)
-                        * bytes_per_pixel;
-                    let dst_x_offset_bytes = ((i32::from(clip_l) - i32::from(dst_info.bounds_left))
-                        as u32)
-                        * bytes_per_pixel;
-                    for dy in clip_t..clip_b {
-                        let rel_y = i32::from(dy) - i32::from(dst_top);
-                        let src_y_off =
-                            ((i32::from(src_top) + rel_y) - i32::from(src_info.bounds_top)) as u32;
-                        let dst_y_off = (i32::from(dy) - i32::from(dst_info.bounds_top)) as u32;
-                        let src_addr =
-                            src_info.base + src_y_off * src_info.row_bytes + src_x_offset_bytes;
-                        let dst_addr =
-                            dst_info.base + dst_y_off * dst_info.row_bytes + dst_x_offset_bytes;
-                        let src_row = bus.read_bytes(src_addr, row_byte_count as usize);
-                        bus.write_bytes(dst_addr, &src_row);
+                    use crate::copy_bits::{BytePixmap, RowCopy};
+                    let _ = RowCopy {
+                        source: BytePixmap {
+                            base: src_info.base,
+                            row_bytes: src_info.row_bytes,
+                            depth: src_info.pixel_size,
+                            bounds: [
+                                src_info.bounds_top,
+                                src_info.bounds_left,
+                                src_info.bounds_bottom,
+                                src_info.bounds_right,
+                            ]
+                            .map(i32::from),
+                        },
+                        destination: BytePixmap {
+                            base: dst_info.base,
+                            row_bytes: dst_info.row_bytes,
+                            depth: dst_info.pixel_size,
+                            bounds: [
+                                dst_info.bounds_top,
+                                dst_info.bounds_left,
+                                dst_info.bounds_bottom,
+                                dst_info.bounds_right,
+                            ]
+                            .map(i32::from),
+                        },
+                        source_rect: [src_top, src_left, src_bottom, src_right].map(i32::from),
+                        destination_rect: [dst_top, dst_left, dst_bottom, dst_right].map(i32::from),
+                        clip: [clip_t, clip_l, clip_b, clip_r].map(i32::from),
+                        palette: palette_translation,
                     }
+                    .execute(bus);
                     if let Some(rect) = screen_copybits_rect {
                         self.fill_kiosk_letterbox_for_copybits(bus, rect);
                         self.refresh_dialog_saved_pixels_after_screen_draw(
@@ -35899,6 +35877,39 @@ mod tests {
                 assert_eq!(bus.read_byte(dst_base), expected, "{pixel_size}bpp srcXor");
             }
         }
+    }
+
+    #[test]
+    fn copy_bits_overlapping_different_bases_preserves_source_rows() {
+        let (mut d, mut cpu, mut bus) = setup_with_port();
+        let src_pixmap = 0x300100;
+        let dst_pixmap = 0x300200;
+        let pixels = 0x301000;
+        let src_rect = 0x302000;
+        let dst_rect = 0x302010;
+        write_pixmap_8(&mut bus, src_pixmap, pixels, 4, 3, 0);
+        write_pixmap_8(&mut bus, dst_pixmap, pixels + 4, 4, 3, 0);
+        bus.write_bytes(
+            pixels,
+            &[1, 2, 3, 90, 4, 5, 6, 91, 7, 8, 9, 92, 10, 11, 12, 93],
+        );
+        write_rect(&mut bus, src_rect, 0, 0, 3, 3);
+        write_rect(&mut bus, dst_rect, 0, 0, 3, 3);
+        cpu.write_reg(Register::A7, TEST_SP);
+        bus.write_long(TEST_SP, 0);
+        bus.write_word(TEST_SP + 4, 0);
+        bus.write_long(TEST_SP + 6, dst_rect);
+        bus.write_long(TEST_SP + 10, src_rect);
+        bus.write_long(TEST_SP + 14, dst_pixmap);
+        bus.write_long(TEST_SP + 18, src_pixmap);
+        assert!(d
+            .dispatch_quickdraw(true, 0x0EC, &mut cpu, &mut bus)
+            .unwrap()
+            .is_ok());
+        assert_eq!(
+            bus.read_bytes(pixels, 16),
+            vec![1, 2, 3, 90, 1, 2, 3, 91, 4, 5, 6, 92, 7, 8, 9, 93]
+        );
     }
 
     fn write_pixmap_8(


### PR DESCRIPTION
Classic CopyBits copied each source row immediately, so a destination starting one row into the source repeated the first row instead of preserving the original image. Both the classic trap and native import now execute one checked, byte-aligned, unscaled srcCopy operation for their eligible rectangular transfers. It clips coordinates, optionally translates indexed pixels, snapshots all source rows (including guest aliases), and publishes complete rows. The two adapter row loops and the obsolete native address helper are removed.

Geometry and source-read failures leave the destination untouched. A failed destination row is preserved, while previous rows may already have committed. Packed/scaled transfers, other modes, complex regions, and callback/picture/palette-policy convergence remain outside this bounded migration.

Validation: 5,092 headless library tests pass, with three existing ignored. Paired memory-view coverage exercises 8/16/24/32-bit clipping and padding, palette translation, overlap, distinct aliases, invalid strides, overflow, source holes and protected destinations. Matching classic trap and native import regressions pass; restoring the old classic loop makes its overlap regression fail. A flat-range regression preserves empty writes inside protected code while refusing nonempty overlaps. Changed Rust hunks were formatted sequentially.

Optimized alternating classic-trap measurements (three runs per executable, four warm samples per size) show median time per copy falling from 1.62 to 1.21 microseconds for 32×32 and from 6.16 to 4.10 microseconds for 256×128. The old executable reproduces the overlap failure and the final executable passes it. This is bounded offscreen-copy evidence, not a general emulator performance claim.

The existing non-blocking lint job still reports full-tree rustfmt memory exhaustion and the baseline Clippy `mut_from_ref` and `erasing_op` errors.

Closes #1507
