### PR TITLE
feat: play QuickTime piano music tracks

### DIFF
--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -4489,7 +4489,8 @@ impl FixtureRunner {
                 .map(|samples| samples.max(1).min(remaining_samples))
                 .unwrap_or(remaining_samples);
 
-            let samples = self.dispatcher.sound_manager.mix_frame_stereo(chunk);
+            let mut samples = self.dispatcher.sound_manager.mix_frame_stereo(chunk);
+            self.dispatcher.mix_movie_music(&mut samples, chunk);
             if samples.is_empty() {
                 self.queue_host_silence_audio(remaining_samples);
                 self.dispatcher

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -2151,6 +2151,9 @@ pub(crate) struct MovieState {
     pub active: bool,
     /// Parsed video track (sample tables + codec), if the movie carries one.
     pub media: Option<super::movie_media::VideoTrack>,
+    pub music: Option<Vec<super::movie_media::MusicNote>>,
+    pub audio_time: f64,
+    pub time_base_flags: u32,
     /// The movie's data-fork bytes; `media` sample offsets index into this.
     pub data_fork: Vec<u8>,
     /// Lazily-created Cinepak decoder, retained so inter frames composite on
@@ -2188,6 +2191,9 @@ impl MovieState {
             time_scale: time_scale.max(1),
             active: true,
             media: None,
+            music: None,
+            audio_time: 0.0,
+            time_base_flags: 0,
             data_fork: Vec::new(),
             decoder: None,
             rle_decoder: None,

--- a/src/trap/movie_media.rs
+++ b/src/trap/movie_media.rs
@@ -387,6 +387,203 @@ fn parse_inline_clut(id: &[u8], depth: u16) -> Option<Vec<[u8; 3]>> {
     Some(table)
 }
 
+/// A note in QuickTime music media, expressed in seconds and MIDI units.
+#[derive(Clone, Debug)]
+pub(crate) struct MusicNote {
+    pub start: f64,
+    pub duration: f64,
+    pub pitch: f64,
+    pub velocity: f64,
+    pub part: u16,
+}
+
+/// Decode the note events in a music track. Event bit layouts are specified
+/// by Apple's QuickTimeMusic.h (Universal Interfaces), Music Media Events.
+/// Samples use the media time scale; rest events advance the event cursor,
+/// while note durations do not delay the following event (polyphony).
+pub(crate) fn parse_music_track(moov: &[u8], data: &[u8]) -> Option<Vec<MusicNote>> {
+    let inner = find_atom(moov, b"moov").unwrap_or(moov);
+    let mut result = None;
+    for_each_atom(inner, |kind, trak| {
+        if kind != b"trak" || result.is_some() {
+            return;
+        }
+        let Some(mdia) = find_atom(trak, b"mdia") else {
+            return;
+        };
+        let Some(hdlr) = find_atom(mdia, b"hdlr") else {
+            return;
+        };
+        if hdlr.get(8..12) != Some(b"musi") {
+            return;
+        }
+        let Some(mdhd) = find_atom(mdia, b"mdhd") else {
+            return;
+        };
+        let scale = be32(mdhd, if mdhd.first() == Some(&1) { 20 } else { 12 });
+        if scale == 0 {
+            return;
+        }
+        let Some(stbl) = find_atom(mdia, b"minf").and_then(|m| find_atom(m, b"stbl")) else {
+            return;
+        };
+        let Some(stsd) = find_atom(stbl, b"stsd") else {
+            return;
+        };
+        if stsd.get(12..16) != Some(b"musi") {
+            return;
+        }
+        let Some(sz) = find_atom(stbl, b"stsz") else {
+            return;
+        };
+        let count = be32(sz, 8) as usize;
+        // Bound every table by its actual bytes before using the common
+        // expansion helpers. Malformed media must not allocate by file counts.
+        if count > data.len() / 4 || (be32(sz, 4) == 0 && count > sz.len().saturating_sub(12) / 4) {
+            return;
+        }
+        for (name, width) in [(b"stsc", 12), (b"stco", 4), (b"stts", 8)] {
+            let Some(table) = find_atom(stbl, name) else {
+                return;
+            };
+            if be32(table, 4) as usize > table.len().saturating_sub(8) / width {
+                return;
+            }
+        }
+        let (sample_size, sample_count, sizes) = parse_stsz(sz);
+        let tables = SampleTables {
+            stsc: parse_stsc(find_atom(stbl, b"stsc").unwrap()),
+            chunks: parse_stco(find_atom(stbl, b"stco").unwrap()),
+            stts: parse_stts(find_atom(stbl, b"stts").unwrap()),
+            stss: Vec::new(),
+            sample_size,
+            sample_count,
+            sizes,
+        };
+        if tables.stts.iter().map(|&(n, _)| u64::from(n)).sum::<u64>() != count as u64 {
+            return;
+        }
+        if tables.stsc.iter().any(|&(first, n, _)| {
+            first == 0 || first as usize > tables.chunks.len() || n as usize > count
+        }) {
+            return;
+        }
+        let mut notes = Vec::new();
+        let mut sustain_changes = Vec::new();
+        for sample in expand_samples(&tables) {
+            let Some(end) = sample.offset.checked_add(sample.size) else {
+                return;
+            };
+            let Some(bytes) = data.get(sample.offset..end) else {
+                return;
+            };
+            let mut time = sample.start_time as f64 / scale as f64;
+            let mut off = 0;
+            while off + 4 <= bytes.len() {
+                let word = be32(bytes, off);
+                let length = match word >> 30 {
+                    0 | 1 => 1,
+                    2 => 2,
+                    _ => (word & 0xffff) as usize,
+                };
+                if length == 0 || length > (bytes.len() - off) / 4 {
+                    return;
+                }
+                let part = ((word >> 24) & 31) as u16;
+                match word >> 29 {
+                    0 => time += (word & 0xffffff) as f64 / scale as f64,
+                    1 => notes.push(MusicNote {
+                        start: time,
+                        duration: (word & 2047) as f64 / scale as f64,
+                        pitch: ((word >> 18) & 63) as f64 + 32.0,
+                        velocity: ((word >> 11) & 127) as f64 / 127.0,
+                        part,
+                    }),
+                    2 if (word >> 16) & 255 == 64 => {
+                        let down = word & 0xffff >= 64 * 256;
+                        sustain_changes.push((part, time, down));
+                    }
+                    _ if word >> 28 == 9 => {
+                        let next = be32(bytes, off + 4);
+                        notes.push(MusicNote {
+                            start: time,
+                            duration: (next & 0x3fffff) as f64 / scale as f64,
+                            pitch: (word & 0xffff) as f64,
+                            velocity: ((next >> 22) & 127) as f64 / 127.0,
+                            part: ((word >> 16) & 4095) as u16,
+                        });
+                    }
+                    _ => {}
+                }
+                off += length * 4;
+            }
+        }
+        // The sustain pedal holds released notes until the next pedal-up.
+        for note in &mut notes {
+            let end = note.start + note.duration;
+            let down = sustain_changes
+                .iter()
+                .rev()
+                .find(|&&(p, t, _)| p == note.part && t <= end)
+                .is_some_and(|&(_, _, down)| down);
+            if down {
+                if let Some(&(_, up, _)) = sustain_changes
+                    .iter()
+                    .find(|&&(p, t, down)| p == note.part && t > end && !down)
+                {
+                    note.duration = up - note.start;
+                }
+            }
+        }
+        notes.sort_by(|a, b| a.start.total_cmp(&b.start));
+        result = Some(notes);
+    });
+    result
+}
+
+/// Deterministic polyphonic piano synthesis. The oscillators and decaying
+/// partials are generated here; no proprietary QuickTime instrument samples
+/// are copied. This is an approximation of the instrument timbre.
+pub(crate) fn mix_music_notes(
+    notes: &[MusicNote],
+    start: f64,
+    rate: f64,
+    volume: f64,
+    output: &mut [u8],
+) {
+    let step = rate / crate::sound::OUTPUT_RATE as f64;
+    let finish = start + output.len() as f64 / 2.0 * step;
+    for note in notes {
+        if note.start > finish {
+            break;
+        }
+        if note.start + note.duration + 0.18 < start || note.velocity == 0.0 {
+            continue;
+        }
+        let frequency = 440.0 * 2.0f64.powf((note.pitch - 69.0) / 12.0);
+        for (i, frame) in output.chunks_exact_mut(2).enumerate() {
+            let age = start + i as f64 * step - note.start;
+            if age < 0.0 || age > note.duration + 0.18 {
+                continue;
+            }
+            let release = if age > note.duration {
+                (1.0 - (age - note.duration) / 0.18).max(0.0)
+            } else {
+                1.0
+            };
+            let envelope = (age / 0.004).min(1.0) * (-age / 2.8).exp() * release;
+            let phase = std::f64::consts::TAU * frequency * age;
+            let wave = phase.sin()
+                + 0.35 * (2.0 * phase).sin() * (-age * 1.5).exp()
+                + 0.15 * (3.0 * phase).sin() * (-age * 3.0).exp();
+            let sample = (wave * envelope * note.velocity * volume * 22.0) as i32;
+            for channel in frame {
+                *channel = (*channel as i32 + sample).clamp(0, 255) as u8;
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -397,6 +594,99 @@ mod tests {
         v.extend_from_slice(t);
         v.extend_from_slice(body);
         v
+    }
+
+    fn music_movie(events: &[u32]) -> (Vec<u8>, Vec<u8>) {
+        let data: Vec<u8> = events.iter().flat_map(|w| w.to_be_bytes()).collect();
+        let mut mdhd = vec![0; 24];
+        mdhd[12..16].copy_from_slice(&600u32.to_be_bytes());
+        let mut handler = vec![0; 24];
+        handler[8..12].copy_from_slice(b"musi");
+        let mut description = vec![0; 28];
+        description[4..8].copy_from_slice(&1u32.to_be_bytes());
+        description[8..12].copy_from_slice(&20u32.to_be_bytes());
+        description[12..16].copy_from_slice(b"musi");
+        let words = |values: &[u32]| {
+            values
+                .iter()
+                .flat_map(|w| w.to_be_bytes())
+                .collect::<Vec<_>>()
+        };
+        let stbl = [
+            atom(b"stsd", &description),
+            atom(b"stsc", &words(&[0, 1, 1, 1, 1])),
+            atom(b"stco", &words(&[0, 1, 0])),
+            atom(b"stsz", &words(&[0, 0, 1, data.len() as u32])),
+            atom(b"stts", &words(&[0, 1, 1, 600])),
+        ]
+        .concat();
+        let mdia = [
+            atom(b"mdhd", &mdhd),
+            atom(b"hdlr", &handler),
+            atom(b"minf", &atom(b"stbl", &stbl)),
+        ]
+        .concat();
+        (atom(b"moov", &atom(b"trak", &atom(b"mdia", &mdia))), data)
+    }
+
+    #[test]
+    fn music_events_preserve_polyphony_pitch_duration_and_sustain() {
+        let note = 0x20000000 | ((60 - 32) << 18) | (100 << 11) | 60;
+        let (moov, data) = music_movie(&[
+            600,
+            0x40407f00,
+            note,
+            0x90000045,
+            (100 << 22) | 120,
+            180,
+            0x40400000,
+        ]);
+        let notes = parse_music_track(&moov, &data).unwrap();
+        assert_eq!(notes.len(), 2);
+        assert_eq!(notes[0].start, 1.0);
+        assert_eq!(notes[1].start, 1.0);
+        assert_eq!(notes[0].pitch, 60.0);
+        assert_eq!(notes[1].pitch, 69.0);
+        assert!((notes[0].duration - 0.3).abs() < 1e-9);
+        assert!((notes[1].duration - 0.3).abs() < 1e-9);
+    }
+
+    #[test]
+    fn music_rejects_truncated_events_and_out_of_file_sample_offsets() {
+        let (moov, data) = music_movie(&[0x90000045]);
+        assert!(parse_music_track(&moov, &data).is_none());
+        let (mut moov, data) = music_movie(&[600, 0x20001020]);
+        let pos = moov.windows(4).position(|s| s == b"stco").unwrap();
+        moov[pos + 12..pos + 16].copy_from_slice(&u32::MAX.to_be_bytes());
+        assert!(parse_music_track(&moov, &data).is_none());
+    }
+
+    #[test]
+    fn music_synthesis_obeys_rest_release_and_volume() {
+        let notes = vec![MusicNote {
+            start: 1.0,
+            duration: 0.25,
+            pitch: 69.0,
+            velocity: 0.8,
+            part: 0,
+        }];
+        let mut silence = vec![128; 2205 * 2];
+        mix_music_notes(&notes, 0.0, 1.0, 1.0, &mut silence);
+        assert!(silence.iter().all(|&v| v == 128));
+        let mut audible = silence.clone();
+        mix_music_notes(&notes, 1.0, 1.0, 1.0, &mut audible);
+        assert!(audible.iter().filter(|&&v| v != 128).count() > 3000);
+        let mut muted = silence.clone();
+        mix_music_notes(&notes, 1.0, 1.0, 0.0, &mut muted);
+        assert_eq!(muted, silence);
+        mix_music_notes(&notes, 1.5, 1.0, 1.0, &mut silence);
+        assert_eq!(muted, silence);
+        let mut whole = vec![128; 4410];
+        mix_music_notes(&notes, 1.0, 1.0, 1.0, &mut whole);
+        let mut split = vec![128; 4410];
+        mix_music_notes(&notes, 1.0, 1.0, 1.0, &mut split[..2200]);
+        mix_music_notes(&notes, 1.0 + 1100.0 / 22050.0, 1.0, 1.0, &mut split[2200..]);
+        assert_eq!(whole, split);
     }
 
     #[test]

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -4730,6 +4730,52 @@ impl super::TrapDispatcher {
         }
     }
 
+    pub(crate) fn mix_movie_music(&mut self, output: &mut Vec<u8>, frames: usize) {
+        for state in self.movie_states.values_mut() {
+            if super::dispatch::trace_quicktime_enabled() {
+                static MIX_TRACE: std::sync::atomic::AtomicU32 =
+                    std::sync::atomic::AtomicU32::new(0);
+                if MIX_TRACE.fetch_add(1, std::sync::atomic::Ordering::Relaxed) < 8 {
+                    eprintln!("[QUICKTIME] music mix active={} rate={} time={} audio={} duration={} notes={}", state.active, state.rate, state.current_time, state.audio_time, state.duration, state.music.as_ref().map_or(0, Vec::len));
+                }
+            }
+            if !state.active || state.rate <= 0 {
+                continue;
+            }
+            let Some(notes) = state.music.as_ref() else {
+                continue;
+            };
+            output.resize(frames * 2, 128);
+            let rate = state.rate as f64 / 65536.0;
+            let duration = state.duration as f64 / state.time_scale as f64;
+            let mut rendered = 0;
+            while rendered < frames {
+                if state.audio_time >= duration {
+                    if state.time_base_flags & 1 == 0 {
+                        break;
+                    }
+                    state.audio_time %= duration;
+                }
+                let until_end = ((duration - state.audio_time) * crate::sound::OUTPUT_RATE as f64
+                    / rate)
+                    .ceil() as usize;
+                let count = until_end.max(1).min(frames - rendered);
+                super::movie_media::mix_music_notes(
+                    notes,
+                    state.audio_time,
+                    rate,
+                    state.volume.max(0) as f64 / 256.0,
+                    &mut output[rendered * 2..(rendered + count) * 2],
+                );
+                state.audio_time += count as f64 * rate / crate::sound::OUTPUT_RATE as f64;
+                rendered += count;
+            }
+            if state.time_base_flags & 1 != 0 {
+                state.audio_time %= duration;
+            }
+        }
+    }
+
     /// Advance the clock of every active, playing movie by the real guest
     /// time elapsed since it was last serviced, then decode and blit the frame
     /// due at the new movie time. Called from MoviesTask and the movie
@@ -4759,8 +4805,12 @@ impl super::TrapDispatcher {
                 let mut new_time = state.current_time as i64 + advance;
                 let mut finished = false;
                 if new_time >= state.duration as i64 {
-                    new_time = state.duration as i64;
-                    finished = true;
+                    if state.time_base_flags & 1 != 0 {
+                        new_time %= state.duration.max(1) as i64;
+                    } else {
+                        new_time = state.duration as i64;
+                        finished = true;
+                    }
                 }
                 state.current_time = new_time.clamp(0, state.duration as i64) as i32;
                 let has_video = state.media.as_ref().is_some_and(|m| {
@@ -13987,6 +14037,8 @@ impl super::TrapDispatcher {
                             duration,
                             time_scale,
                         );
+                        movie_state.music =
+                            super::movie_media::parse_music_track(&movie_data, &data_fork);
                         movie_state.media = media;
                         movie_state.data_fork = data_fork;
                         self.movie_states.insert(movie, movie_state);
@@ -14019,6 +14071,99 @@ impl super::TrapDispatcher {
                         cpu.write_reg(Register::A7, sp + 20);
                         cpu.write_reg(Register::D0, 0);
                         record_movie_error(self, 0);
+                        Ok(())
+                    }
+                    0x0012 => {
+                        // GetMovieTimeBase ($AAAA selector $0012)
+                        // Returns the movie-owned time base.
+                        // pascal TimeBase GetMovieTimeBase(Movie movie);
+                        // Inside Macintosh: QuickTime 1993, p. 2-190.
+                        let sp = cpu.read_reg(Register::A7);
+                        let movie = bus.read_long(sp);
+                        let valid = self.movie_states.contains_key(&movie);
+                        bus.write_long(sp + 4, if valid { movie } else { 0 });
+                        cpu.write_reg(Register::A7, sp + 4);
+                        record_movie_error(self, if valid { 0 } else { QUICKTIME_INVALID_MOVIE });
+                        Ok(())
+                    }
+                    0x00B2 => {
+                        // SetTimeBaseFlags ($AAAA selector $00B2)
+                        // Sets playback control flags, including loopTimeBase.
+                        // pascal void SetTimeBaseFlags(TimeBase tb, long flags);
+                        // Inside Macintosh: QuickTime 1993, pp. 2-331–2-332.
+                        let sp = cpu.read_reg(Register::A7);
+                        let flags = bus.read_long(sp);
+                        let time_base = bus.read_long(sp + 4);
+                        if let Some(state) = self.movie_states.get_mut(&time_base) {
+                            state.time_base_flags = flags;
+                        }
+                        cpu.write_reg(Register::A7, sp + 8);
+                        Ok(())
+                    }
+                    0x01B3 => {
+                        // NewMovieFromDataFork ($AAAA selector $01B3)
+                        // Loads a movie atom at an offset in an open data fork.
+                        // pascal OSErr NewMovieFromDataFork(Movie *movie, short refNum,
+                        //   long offset, short flags, Boolean *changed);
+                        // Inside Macintosh: QuickTime 1993, pp. 2-109–2-110.
+                        let sp = cpu.read_reg(Register::A7);
+                        let changed = bus.read_long(sp);
+                        let flags = bus.read_word(sp + 4);
+                        let offset = bus.read_long(sp + 6) as usize;
+                        let refnum = bus.read_word(sp + 10);
+                        let out = bus.read_long(sp + 12);
+                        let data = self
+                            .open_files
+                            .get(&refnum)
+                            .and_then(|name| self.vfs_data_fork_bytes(name));
+                        let mut error: i16 = -51;
+                        if out != 0 {
+                            bus.write_long(out, 0);
+                        }
+                        if let Some(data) = data {
+                            error = -2002;
+                            let atom = data.get(offset..).and_then(|rest| {
+                                let size = rest
+                                    .get(..4)
+                                    .map(|n| u32::from_be_bytes(n.try_into().unwrap()) as usize)?;
+                                if size < 8 || rest.get(4..8) != Some(b"moov") {
+                                    return None;
+                                }
+                                rest.get(..size)
+                            });
+                            if let Some(atom) = atom {
+                                let (rect, duration, scale) = quicktime_movie_metadata(atom);
+                                let mut state =
+                                    MovieState::new(refnum, -1, flags, rect, duration, scale);
+                                state.media = super::movie_media::parse_video_track(atom);
+                                state.music = super::movie_media::parse_music_track(atom, &data);
+                                state.active = flags & 1 != 0;
+                                if super::dispatch::trace_quicktime_enabled() {
+                                    eprintln!("[QUICKTIME] NewMovieFromDataFork offset={} duration={} scale={} notes={}",
+                                                    offset, duration, scale, state.music.as_ref().map_or(0, Vec::len));
+                                }
+                                state.data_fork = data;
+                                let movie = bus.alloc(16);
+                                if movie == 0 {
+                                    error = -108;
+                                } else if out == 0 {
+                                    bus.free(movie);
+                                    error = -50;
+                                } else {
+                                    bus.write_long(movie, u32::from_be_bytes(*b"MooV"));
+                                    self.movie_states.insert(movie, state);
+                                    bus.write_long(out, movie);
+                                    if changed != 0 {
+                                        bus.write_byte(changed, 0);
+                                    }
+                                    error = 0;
+                                }
+                            }
+                        }
+                        bus.write_word(sp + 16, error as u16);
+                        cpu.write_reg(Register::A7, sp + 16);
+                        cpu.write_reg(Register::D0, error as u32);
+                        record_movie_error(self, error);
                         Ok(())
                     }
                     0x0187 => {
@@ -14106,6 +14251,7 @@ impl super::TrapDispatcher {
                         let err = if let Some(state) = self.movie_states.get_mut(&movie) {
                             state.preferred_rate = rate;
                             state.current_time = time.clamp(0, state.duration);
+                            state.audio_time = state.current_time as f64 / state.time_scale as f64;
                             0
                         } else {
                             QUICKTIME_INVALID_MOVIE
@@ -14169,6 +14315,7 @@ impl super::TrapDispatcher {
                         let err = if let Some(state) = self.movie_states.get_mut(&movie) {
                             state.active = true;
                             state.rate = state.preferred_rate;
+                            state.audio_time = state.current_time as f64 / state.time_scale as f64;
                             // Begin the playback clock now so MoviesTask advances
                             // by real elapsed time from this point.
                             state.last_service_tick = Some(now);
@@ -14209,6 +14356,7 @@ impl super::TrapDispatcher {
                         let movie = bus.read_long(sp);
                         let err = if let Some(state) = self.movie_states.get_mut(&movie) {
                             state.current_time = 0;
+                            state.audio_time = 0.0;
                             0
                         } else {
                             QUICKTIME_INVALID_MOVIE
@@ -15758,8 +15906,9 @@ impl super::TrapDispatcher {
             // version (>=3 supports automatic version control,
             // unregister, icon families).
             //
-            // HLE behaviour: provides one synthetic QuickTime movie
-            // controller component (`'play'`) and opaque instances for
+            // HLE behaviour: provides a synthetic QuickTime movie controller
+            // (`'play'`) plus software-instrument discovery for music media,
+            // and opaque movie-controller instances for
             // FindNextComponent/OpenComponent/CloseComponent. Component
             // calls consume selector + instance + arguments and return a
             // zero ComponentResult in the caller's four-byte result slot.
@@ -15767,6 +15916,7 @@ impl super::TrapDispatcher {
             (true, 0x02A) => {
                 const MOVIE_CONTROLLER_COMPONENT: u32 = u32::from_be_bytes(*b"play");
                 const SYNTHETIC_MOVIE_CONTROLLER: u32 = 0x00C0_0001;
+                const SOFTWARE_INSTRUMENT: u32 = 0x00C0_0002;
 
                 let d0 = cpu.read_reg(Register::D0);
                 let operation = component_dispatch_operation_route(self.current_trap_word, d0);
@@ -15864,9 +16014,16 @@ impl super::TrapDispatcher {
                         } else {
                             bus.read_long(description)
                         };
+                        let instrument_matches = (component_type == 0
+                            || component_type == u32::from_be_bytes(*b"inst"))
+                            && (description == 0
+                                || ([0, u32::from_be_bytes(*b"ss  ")]
+                                    .contains(&bus.read_long(description + 4))
+                                    && [0, u32::from_be_bytes(*b"appl")]
+                                        .contains(&bus.read_long(description + 8))));
                         let count = u32::from(
                             component_type == 0 || component_type == MOVIE_CONTROLLER_COMPONENT,
-                        );
+                        ) + u32::from(instrument_matches);
                         bus.write_long(sp + 4, count);
                         cpu.write_reg(Register::A7, sp + 4);
                         cpu.write_reg(Register::D0, count);
@@ -15884,6 +16041,18 @@ impl super::TrapDispatcher {
                             && (component_type == 0 || component_type == MOVIE_CONTROLLER_COMPONENT)
                         {
                             SYNTHETIC_MOVIE_CONTROLLER
+                        } else if (previous == 0 || previous == SYNTHETIC_MOVIE_CONTROLLER)
+                            && (component_type == 0
+                                || component_type == u32::from_be_bytes(*b"inst"))
+                            && (description == 0
+                                || ([0, u32::from_be_bytes(*b"ss  ")]
+                                    .contains(&bus.read_long(description + 4))
+                                    && [0, u32::from_be_bytes(*b"appl")]
+                                        .contains(&bus.read_long(description + 8))))
+                        {
+                            // QuickTime Music Architecture: the instrument
+                            // component advertises the Movie Toolbox's synth.
+                            SOFTWARE_INSTRUMENT
                         } else {
                             0
                         };
@@ -26303,7 +26472,7 @@ mod tests {
             disp.current_selector_operation,
             Some("selector-operation:_ComponentDispatch:0x0003:d0-moveq-immediate:8")
         );
-        assert_eq!(bus.read_long(sp + 4), 1);
+        assert_eq!(bus.read_long(sp + 4), 2);
         assert_eq!(cpu.read_reg(Register::A7), sp + 4);
 
         disp.current_trap_word = 0xA92A;
@@ -26314,7 +26483,7 @@ mod tests {
         let result = disp.dispatch_toolbox(true, 0x02A, &mut cpu, &mut bus);
         assert!(result.expect("ComponentDispatch arm").is_ok());
         assert_eq!(disp.current_selector_operation, None);
-        assert_eq!(bus.read_long(sp + 4), 1);
+        assert_eq!(bus.read_long(sp + 4), 2);
     }
 
     #[test]
@@ -34483,6 +34652,95 @@ mod tests {
         );
         assert_eq!(bus.read_word(sp), (-43i16) as u16);
         assert_eq!(cpu.read_reg(Register::D0), (-43i16) as u32);
+    }
+
+    #[test]
+    fn movie_data_fork_loader_checks_offsets_and_pascal_stack() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let mut mvhd = vec![0; 100];
+        mvhd[12..16].copy_from_slice(&600u32.to_be_bytes());
+        mvhd[16..20].copy_from_slice(&1200u32.to_be_bytes());
+        let mut file = vec![0x77; 32];
+        file.extend(quicktime_atom(*b"moov", &quicktime_atom(*b"mvhd", &mvhd)));
+        disp.vfs.insert("score".to_string(), file);
+        disp.open_files.insert(128, "score".to_string());
+        for (offset, expected) in [(32, 0i16), (0, -2002), (u32::MAX, -2002)] {
+            cpu.write_reg(Register::A7, TEST_SP);
+            cpu.write_reg(Register::D0, 0x01B3);
+            bus.write_long(TEST_SP, 0x300010);
+            bus.write_word(TEST_SP + 4, 1);
+            bus.write_long(TEST_SP + 6, offset);
+            bus.write_word(TEST_SP + 10, 128);
+            bus.write_long(TEST_SP + 12, 0x300000);
+            bus.write_long(TEST_SP + 18, 0xCAFE_BABE);
+            disp.dispatch_toolbox(true, 0x2AA, &mut cpu, &mut bus)
+                .unwrap()
+                .unwrap();
+            assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 16);
+            assert_eq!(bus.read_word(TEST_SP + 16) as i16, expected);
+            assert_eq!(bus.read_long(TEST_SP + 18), 0xCAFE_BABE);
+            if expected == 0 {
+                let movie = bus.read_long(0x300000);
+                assert_eq!(disp.movie_states[&movie].duration, 1200);
+                assert_eq!(disp.movie_states[&movie].time_scale, 600);
+                assert_eq!(bus.read_byte(0x300010), 0);
+            } else {
+                assert_eq!(bus.read_long(0x300000), 0);
+            }
+        }
+    }
+
+    #[test]
+    fn movie_music_controls_stop_mute_seek_and_loop() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let movie = 0x300100;
+        let mut state = super::MovieState::new(0, -1, 1, (0, 0, 0, 0), 600, 600);
+        state.music = Some(vec![super::super::movie_media::MusicNote {
+            start: 0.0,
+            duration: 0.8,
+            pitch: 60.0,
+            velocity: 1.0,
+            part: 0,
+        }]);
+        disp.movie_states.insert(movie, state);
+        let call = |disp: &mut TrapDispatcher,
+                    cpu: &mut MockCpu,
+                    bus: &mut MacMemoryBus,
+                    selector: u32| {
+            cpu.write_reg(Register::A7, TEST_SP);
+            cpu.write_reg(Register::D0, selector);
+            disp.dispatch_toolbox(true, 0x2AA, cpu, bus)
+                .unwrap()
+                .unwrap();
+        };
+        bus.write_long(TEST_SP, movie);
+        call(&mut disp, &mut cpu, &mut bus, 0x0012);
+        assert_eq!(bus.read_long(TEST_SP + 4), movie);
+        bus.write_long(TEST_SP, 1);
+        bus.write_long(TEST_SP + 4, movie);
+        call(&mut disp, &mut cpu, &mut bus, 0x00B2);
+        assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 8);
+        bus.write_long(TEST_SP, movie);
+        call(&mut disp, &mut cpu, &mut bus, 0x000B);
+        let mut output = Vec::new();
+        disp.mix_movie_music(&mut output, 2205);
+        assert!(output.iter().any(|&b| b != 128));
+        bus.write_word(TEST_SP, 0);
+        bus.write_long(TEST_SP + 2, movie);
+        call(&mut disp, &mut cpu, &mut bus, 0x002F);
+        output.clear();
+        disp.mix_movie_music(&mut output, 2205);
+        assert!(output.iter().all(|&b| b == 128));
+        bus.write_long(TEST_SP, movie);
+        call(&mut disp, &mut cpu, &mut bus, 0x000D);
+        assert_eq!(disp.movie_states[&movie].audio_time, 0.0);
+        disp.mix_movie_music(&mut Vec::new(), 22050 + 2205);
+        assert!((disp.movie_states[&movie].audio_time - 0.1).abs() < 1e-9);
+        bus.write_long(TEST_SP, movie);
+        call(&mut disp, &mut cpu, &mut bus, 0x000C);
+        output.clear();
+        disp.mix_movie_music(&mut output, 2205);
+        assert!(output.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Odyssey disables music when it cannot find the software instrument component. Its score also relies on NewMovieFromDataFork and movie time-base looping, which were missing.

This adds the data-fork loader with offset and Pascal-stack validation, software-instrument discovery, QuickTime note-track decoding, and polyphonic piano synthesis through the regular audio mixer. Playback honors note timing, overlapping notes, sustain, volume, stop/restart and looping. The piano is procedural; this does not include Apple's instrument samples or a complete General MIDI instrument bank.

Validated all 18 score atoms locally. The live gameplay music probe captured 28,880 non-silent samples; a separate attack probe with music switched off captured 24,071 non-silent samples. Decoder, malformed-input, loader, playback-control and audio-capture regressions pass. The integrated rendering/audio tree passed 5,095 library tests. Clippy encountered the existing mut_from_ref error in src/memory/address_space.rs:569.

Stacked on #1515. Closes #1514. Related to #1506.
