### PR TITLE
fix: isolate menu definition callback workspaces

### DIFF
--- a/src/execution_m68k.rs
+++ b/src/execution_m68k.rs
@@ -246,6 +246,7 @@ impl M68kExecution {
         memory: &mut PpcSectionMem,
         native: &mut ppc::PpcCpu,
         pending: crate::guest_call::PendingM68kExecution,
+        manager: &mut crate::process_context::ProcessNativeMemoryManager,
     ) -> bool {
         use crate::guest_call::M68kResultSource;
 
@@ -281,11 +282,13 @@ impl M68kExecution {
                 value
             }
         };
-        self.calls.complete_m68k_for_powerpc(
+        self.calls.complete_m68k_operation_for_powerpc(
             pending.return_pc,
             self.cpu.read_reg(Register::A7),
             result,
             native,
+            memory,
+            manager,
         )
     }
 

--- a/src/guest_call.rs
+++ b/src/guest_call.rs
@@ -231,12 +231,18 @@ enum GuestCallOrigin {
     PowerPc(PowerPcCallOrigin),
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum ManagerContinuation {
+    Cfm(CfmOperation),
+    Menu(crate::menu_manager::MenuDefinitionOperation),
+}
+
 #[derive(Clone, Debug)]
 struct GuestCallFrame {
     target: GuestCallTarget,
     origin: GuestCallOrigin,
     native_scratch: Option<u32>,
-    cfm_operation: Option<CfmOperation>,
+    operation: Option<ManagerContinuation>,
     m68k_execution: Option<M68kExecution>,
     powerpc_execution: Option<PowerPcExecution>,
 }
@@ -372,7 +378,7 @@ impl GuestCallEffect {
                     result,
                 }),
                 native_scratch: None,
-                cfm_operation: None,
+                operation: None,
                 m68k_execution: None,
                 powerpc_execution: None,
             }),
@@ -392,7 +398,7 @@ impl GuestCallEffect {
                     result,
                 }),
                 native_scratch: None,
-                cfm_operation: None,
+                operation: None,
                 m68k_execution: None,
                 powerpc_execution: Some(PowerPcExecution {
                     arguments,
@@ -418,7 +424,7 @@ impl GuestCallEffect {
                     return_gpr3,
                 }),
                 native_scratch: None,
-                cfm_operation: None,
+                operation: None,
                 m68k_execution: None,
                 powerpc_execution: None,
             }),
@@ -440,7 +446,7 @@ impl GuestCallEffect {
                     return_gpr3,
                 }),
                 native_scratch: None,
-                cfm_operation: None,
+                operation: None,
                 m68k_execution: Some(M68kExecution {
                     entry: request.entry,
                     initial_sp: request.initial_sp,
@@ -494,7 +500,7 @@ impl PartialEq for GuestCallFrame {
         self.target == other.target
             && self.origin == other.origin
             && self.native_scratch == other.native_scratch
-            && self.cfm_operation == other.cfm_operation
+            && self.operation == other.operation
             && self.m68k_execution == other.m68k_execution
             && match (&self.powerpc_execution, &other.powerpc_execution) {
                 (None, None) => true,
@@ -1696,6 +1702,28 @@ impl SharedGuestCallStack {
         ))
     }
 
+    /// Adopt prepared emulated ABI storage into one exact task-owned call.
+    pub(crate) fn begin_m68k_operation(
+        &self,
+        effect: GuestCallEffect,
+        scratch: u32,
+        operation: ManagerContinuation,
+    ) -> bool {
+        if effect.request().task != self.current_task()
+            || effect.request().target.isa != GuestIsa::M68k
+        {
+            return false;
+        }
+        let Some(id) = self.submit_effect(effect) else {
+            return false;
+        };
+        let mut tasks = self.0.borrow_mut();
+        let frame = tasks.frames.get_mut(&id).expect("new call owns its frame");
+        frame.native_scratch = Some(scratch);
+        frame.operation = Some(operation);
+        true
+    }
+
     pub(crate) fn pending_powerpc_from_m68k(&self) -> Option<PendingPowerPcExecution> {
         let (_, frame) = self.top_frame()?;
         let GuestCallOrigin::M68k(_) = frame.origin else {
@@ -2075,7 +2103,7 @@ impl SharedGuestCallStack {
             memory,
             effect,
             scratch,
-            cfm_load.map(CfmOperation::Load),
+            cfm_load.map(|load| ManagerContinuation::Cfm(CfmOperation::Load(load))),
         )
     }
 
@@ -2085,7 +2113,7 @@ impl SharedGuestCallStack {
         memory: &mut GuestAddressSpace,
         effect: GuestCallEffect,
         scratch: Option<u32>,
-        cfm_operation: Option<CfmOperation>,
+        operation: Option<ManagerContinuation>,
     ) -> bool {
         let GuestCallEffect::CallGuest {
             request,
@@ -2122,7 +2150,7 @@ impl SharedGuestCallStack {
             .frames
             .get_mut(&call_id)
             .expect("submitted call has its manager continuation")
-            .cfm_operation = cfm_operation;
+            .operation = operation;
         // Submission just installed this task's pending top frame. This
         // synchronous transition cannot be displaced by another guest call.
         self.0
@@ -2191,16 +2219,16 @@ impl SharedGuestCallStack {
 
     pub(crate) fn is_cfm_load_pending(&self, id: CfmLoadId) -> bool {
         self.0.borrow().frames.values().any(|frame| {
-            frame
-                .cfm_operation
-                .is_some_and(|operation| operation.id() == id)
+            frame.operation.as_ref().is_some_and(
+                |operation| matches!(operation, ManagerContinuation::Cfm(cfm) if cfm.id() == id),
+            )
         })
     }
 
     pub(crate) fn is_resource_preparation_pending(&self, record: u32) -> bool {
         self.0.borrow().frames.values().any(|frame| {
-            matches!(frame.cfm_operation,
-            Some(CfmOperation::Resource(call)) if call.preparation.record == record)
+            matches!(frame.operation.as_ref(),
+            Some(ManagerContinuation::Cfm(CfmOperation::Resource(call))) if call.preparation.record == record)
         })
     }
 
@@ -2213,8 +2241,8 @@ impl SharedGuestCallStack {
     ) -> bool {
         self.complete_powerpc_resuming_operation(cpu, memory_manager, |operation, result| {
             match operation {
-                CfmOperation::Load(load) => resume(load, result),
-                CfmOperation::Resource(_) => {
+                ManagerContinuation::Cfm(CfmOperation::Load(load)) => resume(load, result),
+                _ => {
                     panic!("load-only fixture received resource operation")
                 }
             }
@@ -2225,7 +2253,7 @@ impl SharedGuestCallStack {
         &self,
         cpu: &mut PpcCpu,
         memory_manager: &mut ProcessNativeMemoryManager,
-        mut resume: impl FnMut(CfmOperation, u32) -> u32,
+        mut resume: impl FnMut(ManagerContinuation, u32) -> u32,
     ) -> bool {
         self.complete_powerpc_inner(cpu, Some(memory_manager), Some(&mut resume))
     }
@@ -2234,9 +2262,9 @@ impl SharedGuestCallStack {
         &self,
         cpu: &mut PpcCpu,
         memory_manager: Option<&mut ProcessNativeMemoryManager>,
-        resume: Option<&mut dyn FnMut(CfmOperation, u32) -> u32>,
+        resume: Option<&mut dyn FnMut(ManagerContinuation, u32) -> u32>,
     ) -> bool {
-        let (task, call_id, origin, scratch, cfm_operation) = {
+        let (task, call_id, origin, scratch, operation) = {
             let tasks = self.0.borrow();
             let task = tasks.kernel.current_task();
             let semantic = match tasks.kernel.peek(task) {
@@ -2263,7 +2291,7 @@ impl SharedGuestCallStack {
                     return false;
                 }
             }
-            if frame.cfm_operation.is_some() && resume.is_none() {
+            if frame.operation.is_some() && resume.is_none() {
                 return false;
             }
             (
@@ -2271,7 +2299,7 @@ impl SharedGuestCallStack {
                 semantic.call_id(),
                 origin,
                 frame.native_scratch,
-                frame.cfm_operation,
+                frame.operation.clone(),
             )
         };
         let mut tasks = self.0.borrow_mut();
@@ -2294,20 +2322,21 @@ impl SharedGuestCallStack {
         // service resumes. The enclosing frame stays live, and no execution
         // store borrow may span the semantic consumer.
         drop(tasks);
+        if let Some(operation) = operation {
+            cpu.gpr[3] =
+                resume.expect("manager return requires its semantic consumer")(operation, cpu.gpr[3]);
+        }
         if let Some(scratch) = scratch {
             memory_manager
                 .expect("scratch return requires its memory manager")
                 .release_native_scratch(scratch);
-        }
-        if let Some(operation) = cfm_operation {
-            cpu.gpr[3] =
-                resume.expect("CFM return requires its semantic consumer")(operation, cpu.gpr[3]);
         }
         Self::apply_powerpc_return(cpu, origin);
         true
     }
 
     /// Complete an emulated 68k interval for its parked native caller.
+    #[cfg(test)]
     pub(crate) fn complete_m68k_for_powerpc(
         &self,
         post_call_pc: u32,
@@ -2315,7 +2344,36 @@ impl SharedGuestCallStack {
         result: Option<u32>,
         cpu: &mut PpcCpu,
     ) -> bool {
-        let (task, call_id, origin) = {
+        self.complete_m68k_for_powerpc_inner(post_call_pc, final_sp, result, cpu, None)
+    }
+
+    pub(crate) fn complete_m68k_operation_for_powerpc(
+        &self,
+        post_call_pc: u32,
+        final_sp: u32,
+        result: Option<u32>,
+        cpu: &mut PpcCpu,
+        memory: &mut GuestAddressSpace,
+        manager: &mut ProcessNativeMemoryManager,
+    ) -> bool {
+        self.complete_m68k_for_powerpc_inner(
+            post_call_pc,
+            final_sp,
+            result,
+            cpu,
+            Some((memory, manager)),
+        )
+    }
+
+    fn complete_m68k_for_powerpc_inner(
+        &self,
+        post_call_pc: u32,
+        final_sp: u32,
+        result: Option<u32>,
+        cpu: &mut PpcCpu,
+        services: Option<(&mut GuestAddressSpace, &mut ProcessNativeMemoryManager)>,
+    ) -> bool {
+        let (task, call_id, origin, scratch, operation) = {
             let tasks = self.0.borrow();
             let task = tasks.kernel.current_task();
             let semantic = match tasks.kernel.peek(task) {
@@ -2355,7 +2413,29 @@ impl SharedGuestCallStack {
             {
                 return false;
             }
-            (task, semantic.call_id(), origin)
+            if (frame.native_scratch.is_some() || frame.operation.is_some()) && services.is_none() {
+                return false;
+            }
+            if let Some(scratch) = frame.native_scratch {
+                if !services.as_ref().is_some_and(|(_, manager)| {
+                    manager
+                        .native_ptr_records()
+                        .iter()
+                        .any(|record| record.ptr == scratch)
+                }) {
+                    return false;
+                }
+            }
+            if matches!(frame.operation, Some(ManagerContinuation::Cfm(_))) {
+                return false;
+            }
+            (
+                task,
+                semantic.call_id(),
+                origin,
+                frame.native_scratch,
+                frame.operation.clone(),
+            )
         };
         let mut tasks = self.0.borrow_mut();
         let native = if tasks.powerpc_contexts.contains(task, call_id) {
@@ -2387,6 +2467,15 @@ impl SharedGuestCallStack {
             .frames
             .remove(&call_id)
             .expect("semantic continuation must have an adapter frame");
+        drop(tasks);
+        if let Some((memory, manager)) = services {
+            if let Some(ManagerContinuation::Menu(operation)) = operation {
+                operation.complete(memory);
+            }
+            if let Some(scratch) = scratch {
+                manager.release_native_scratch(scratch);
+            }
+        }
         if let Some(native) = native {
             restore_powerpc_context(cpu, *native);
         }

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -3045,8 +3045,6 @@ pub struct PpcToolboxStartupState {
     /// PowerPC call frame parked while `PopUpMenuSelect` yields.
     /// This is adapter state, not part of the shared Menu Manager session.
     popup_menu_call: Option<PpcPopUpMenuCall>,
-    /// Reused guest storage for the by-reference MDEF rectangle and item.
-    menu_def_scratch: u32,
     /// Process-owned 68k switch marker/gateway and compatibility stack used
     /// whenever native PowerPC enters classic code through Mixed Mode.
     mixed_mode_m68k: SharedProcessMixedModeM68kState,
@@ -3124,7 +3122,6 @@ impl Default for PpcToolboxStartupState {
             menu_select_call: None,
             menu_definition_saved_gworld: None,
             popup_menu_call: None,
-            menu_def_scratch: 0,
             mixed_mode_m68k: SharedProcessMixedModeM68kState::default(),
             guest_calls: SharedGuestCallStack::default(),
             go_away_tracking: None,
@@ -7706,18 +7703,22 @@ impl PpcLoadedApp {
                         cpu,
                         process_memory_manager,
                         |operation, result| match operation {
-                            CfmOperation::Load(load) => {
-                                ppc_complete_cfm_load(load, result, memory, &mut cfm_connections)
+                            crate::guest_call::ManagerContinuation::Menu(operation) => {
+                                operation.complete(memory);
+                                result
                             }
-                            CfmOperation::Resource(call) => {
-                                match call.complete(result, &mut cfm_connections, memory) {
-                                    Ok(call) => {
-                                        resource_call = Some(call);
-                                        0
-                                    }
-                                    Err(error) => ppc_i16_result(error.os_error()),
+                            crate::guest_call::ManagerContinuation::Cfm(CfmOperation::Load(
+                                load,
+                            )) => ppc_complete_cfm_load(load, result, memory, &mut cfm_connections),
+                            crate::guest_call::ManagerContinuation::Cfm(
+                                CfmOperation::Resource(call),
+                            ) => match call.complete(result, &mut cfm_connections, memory) {
+                                Ok(call) => {
+                                    resource_call = Some(call);
+                                    0
                                 }
-                            }
+                                Err(error) => ppc_i16_result(error.os_error()),
+                            },
                         },
                     ) {
                         if let Some(call) = resource_call {
@@ -17322,7 +17323,6 @@ fn dispatch_supported_import(
                 );
                 if let Some(invocation) = toolbox_startup
                     .active_menu_definition()
-                    .copied()
                     .and_then(MenuDefinitionTracking::pending_invocation)
                 {
                     toolbox_startup.menu_select_call = Some(PpcMenuSelectCall {
@@ -44979,7 +44979,9 @@ fn ppc_prepare_resource_call(
                     memory,
                     effect,
                     Some(block),
-                    Some(CfmOperation::Resource(operation)),
+                    Some(crate::guest_call::ManagerContinuation::Cfm(
+                        CfmOperation::Resource(operation),
+                    )),
                 )
             });
             if !activated {
@@ -76360,99 +76362,112 @@ fn ppc_dispatch_native_menu_definition_with_return(
     mut process_memory_manager: Option<&mut ProcessNativeMemoryManager>,
     memory: &mut PpcSectionMem,
     heap_cursor: &mut u32,
-    heap_limit: u32,
+    _heap_limit: u32,
     resources: &[PpcVfsResourceRecord],
     toolbox_startup: &mut PpcToolboxStartupState,
     invocation: MenuDefinitionInvocation,
     final_pc: u32,
     return_gpr3: PpcNativeReturnGpr3,
 ) -> Option<PpcImportAction> {
-    let menu_handle = invocation.menu_handle;
-    let target = ppc_menu_definition_target(cpu, memory, resources, menu_handle)?;
-    if toolbox_startup.menu_def_scratch == 0 {
-        toolbox_startup.menu_def_scratch = if let Some(memory_manager) =
-            process_memory_manager.as_deref_mut()
-        {
-            ppc_process_heap_alloc(memory_manager, memory, heap_cursor, 10, true)
-        } else {
-            ppc_heap_alloc(memory, heap_cursor, heap_limit, 10, true)
-        };
-    }
-    let scratch = toolbox_startup.menu_def_scratch;
+    let target = ppc_menu_definition_target(cpu, memory, resources, invocation.menu_handle)?;
+    let manager = process_memory_manager.as_deref_mut()?;
+    // The emulated callback owns its wrapper and stack as well as its
+    // by-reference arguments. Nested calls must not reuse a live gateway.
+    let workspace_size = match target.isa {
+        GuestIsa::PowerPc => 10,
+        GuestIsa::M68k => PPC_MIXED_MODE_M68K_STACK_SIZE + 80,
+    };
+    let scratch = manager.new_native_scratch(memory, workspace_size);
     if scratch == 0 {
         return None;
     }
-    for (offset, byte) in invocation.scratch_bytes().into_iter().enumerate() {
-        memory.write_u8(scratch + offset as u32, byte)?;
+    if let Some(heap) = manager.native_heap_state() {
+        *heap_cursor = heap.heap_cursor;
     }
-    let call = invocation.call(scratch);
-    match target.isa {
-        GuestIsa::PowerPc => {
-            install_powerpc_call_arguments(cpu, memory, &call.native_arguments())?;
-            Some(
-                GuestCallEffect::call_guest(
-                    GuestCallRequest::new(GuestCallTarget {
-                        isa: GuestIsa::PowerPc,
-                        entry: target.entry,
-                        rtoc: target.rtoc,
-                    }),
+    let completion = crate::menu_manager::MenuDefinitionCompletion::pending();
+    let operation = crate::menu_manager::MenuDefinitionOperation {
+        scratch,
+        completion: completion.clone(),
+    };
+    let prepared = (|| {
+        memory.write_bytes(scratch, &invocation.scratch_bytes())?;
+        let call = invocation.call(scratch);
+        match target.isa {
+            GuestIsa::PowerPc => {
+                let effect = GuestCallEffect::call_guest(
+                    GuestCallRequest::for_task(
+                        toolbox_startup.guest_calls.current_task(),
+                        GuestCallTarget {
+                            isa: target.isa,
+                            entry: target.entry,
+                            rtoc: target.rtoc,
+                        },
+                    )
+                    .with_powerpc_arguments(
+                        crate::guest_call::PowerPcArguments::from_slice(&call.native_arguments())?,
+                    ),
                     GuestCallContinuation::to_powerpc(
                         PPC_GUEST_CALL_RETURN_PC,
                         final_pc,
                         cpu.gpr[2],
                         return_gpr3,
                     ),
-                )
-                .into_ppc_import_action()?,
-            )
+                );
+                toolbox_startup
+                    .guest_calls
+                    .activate_powerpc_effect_with_operation(
+                        cpu,
+                        memory,
+                        effect,
+                        Some(scratch),
+                        Some(crate::guest_call::ManagerContinuation::Menu(operation)),
+                    )
+                    .then_some(PpcImportAction::Continue)
+            }
+            GuestIsa::M68k => ppc_begin_m68k_menu_definition(
+                cpu,
+                memory,
+                toolbox_startup,
+                target,
+                call,
+                final_pc,
+                return_gpr3,
+                operation,
+            ),
         }
-        GuestIsa::M68k => ppc_begin_m68k_menu_definition(
-            cpu,
-            process_memory_manager.as_deref_mut(),
-            memory,
-            heap_cursor,
-            heap_limit,
-            toolbox_startup,
-            target,
-            call,
-            final_pc,
-            return_gpr3,
-        ),
+    })();
+    if prepared.is_none() {
+        manager.release_native_scratch(scratch);
+        return None;
     }
+    if let Some(definition) = toolbox_startup.active_menu_definition_mut() {
+        definition.bind_completion(invocation, completion);
+    }
+    prepared
 }
-
-const MDEF_PASCAL_PROC_INFO: u32 = 0x0000_ff80;
 
 #[allow(clippy::too_many_arguments)]
 fn ppc_begin_m68k_menu_definition(
     cpu: &PpcCpu,
-    process_memory_manager: Option<&mut ProcessNativeMemoryManager>,
     memory: &mut PpcSectionMem,
-    heap_cursor: &mut u32,
-    heap_limit: u32,
     startup: &mut PpcToolboxStartupState,
     target: GuestProcedure,
     call: crate::menu_manager::MenuDefinitionCall,
     final_pc: u32,
     return_gpr3: PpcNativeReturnGpr3,
+    operation: crate::menu_manager::MenuDefinitionOperation,
 ) -> Option<PpcImportAction> {
     // `MyMenuDef` is a no-result Pascal stack routine with parameter sizes
     // 2, 4, 4, 4, and 4 bytes. The Mixed Mode ProcInfo encoding is therefore
     // $0000FF80. Macintosh Toolbox Essentials (1992), pp. 3-148--3-151;
     // Inside Macintosh: PowerPC System Software (1994), pp. 2-12--2-16.
-    if target.proc_info != 0 && target.proc_info != MDEF_PASCAL_PROC_INFO {
+    if target.proc_info != 0 && target.proc_info != MenuDefinitionInvocation::PASCAL_PROC_INFO {
         return None;
     }
-    let (gateway, stack_top) = ppc_mixed_mode_m68k_storage(
-        process_memory_manager,
-        memory,
-        heap_cursor,
-        heap_limit,
-        &mut startup.mixed_mode_m68k,
-    )?;
-    if stack_top < 4 {
-        return None;
-    }
+    let gateway = operation.scratch.checked_add(16)?;
+    let stack_top = operation
+        .scratch
+        .checked_add(PPC_MIXED_MODE_M68K_STACK_SIZE + 80)?;
 
     let return_slot = stack_top - 4;
     let saved_register_sp = return_slot - 32;
@@ -76482,25 +76497,30 @@ fn ppc_begin_m68k_menu_definition(
     write_word(memory, 48, 0x4e75)?; // RTS
     memory.write_u32_be(return_slot, return_pc)?;
 
-    if !startup.guest_calls.begin_powerpc_to_m68k(
-        crate::guest_call::GuestCallTarget {
-            isa: target.isa,
-            entry: target.entry,
-            rtoc: target.rtoc,
-        },
-        gateway,
-        return_slot,
-        return_pc,
-        stack_top,
-        {
-            let mut registers = crate::guest_call::M68kRegisterState::default();
-            registers.address[5] = PPC_DATA_BASE;
-            registers
-        },
-        None,
-        final_pc,
-        cpu.gpr[2],
-        return_gpr3,
+    let mut registers = crate::guest_call::M68kRegisterState::default();
+    registers.address[5] = PPC_DATA_BASE;
+    let effect = GuestCallEffect::call_guest(
+        GuestCallRequest::for_task(
+            startup.guest_calls.current_task(),
+            GuestCallTarget {
+                isa: target.isa,
+                entry: target.entry,
+                rtoc: target.rtoc,
+            },
+        )
+        .with_m68k_request(crate::guest_call::M68kCallRequest {
+            entry: gateway,
+            initial_sp: return_slot,
+            final_sp: stack_top,
+            registers,
+            result: None,
+        }),
+        GuestCallContinuation::to_powerpc(return_pc, final_pc, cpu.gpr[2], return_gpr3),
+    );
+    if !startup.guest_calls.begin_m68k_operation(
+        effect,
+        operation.scratch,
+        crate::guest_call::ManagerContinuation::Menu(operation),
     ) {
         return None;
     }
@@ -76693,7 +76713,6 @@ fn ppc_begin_custom_popup_menu_tracking(
     ppc_prepare_menu_definition_port(startup, current_gworld, current_gdevice);
     let invocation = startup
         .active_menu_definition()
-        .copied()
         .and_then(MenuDefinitionTracking::pending_invocation)?;
     let action = ppc_dispatch_native_menu_definition(
         cpu,
@@ -76735,17 +76754,28 @@ fn ppc_continue_custom_popup_menu_tracking(
         ppc_restore_menu_definition_port(startup, current_gworld, current_gdevice);
         return PpcImportAction::Return(0);
     };
-    let scratch = startup.menu_def_scratch;
-    let completed = startup.active_menu_definition_mut().and_then(|definition| {
-        (definition.pending_invocation().is_some() && scratch != 0)
-            .then(|| {
-                let bytes = std::array::from_fn(|offset| {
-                    memory.read_u8(scratch + offset as u32).unwrap_or(0)
-                });
-                definition.complete_pending(MenuDefinitionInvocation::decode_result(bytes))
-            })
-            .flatten()
-    });
+    let completed = match startup
+        .active_menu_definition_mut()
+        .map(MenuDefinitionTracking::complete_callback)
+        .transpose()
+    {
+        Ok(completed) => completed.flatten(),
+        Err(()) => {
+            if let Some(state) = startup.menu_tracking.take() {
+                if ppc_live_front_buffer_for_gworld(memory, gworlds, PPC_MAIN_GWORLD)
+                    .map(MenuTrackingSurface::from)
+                    == state.front_buffer
+                {
+                    ppc_restore_menu_tracking(memory, state.front_buffer, &state);
+                }
+            }
+            startup.clear_active_menu_definition();
+            startup.popup_menu_call = None;
+            ppc_restore_menu_definition_port(startup, current_gworld, current_gdevice);
+            cpu.lr = call.return_address;
+            return PpcImportAction::Return(0);
+        }
+    };
 
     if startup
         .menu_tracking
@@ -76782,7 +76812,6 @@ fn ppc_continue_custom_popup_menu_tracking(
             .flash(remaining & 1 == 0);
         let invocation = startup
             .active_menu_definition()
-            .copied()
             .and_then(MenuDefinitionTracking::pending_invocation)
             .unwrap();
         if let Some(action) = ppc_dispatch_native_menu_definition(
@@ -76808,7 +76837,7 @@ fn ppc_continue_custom_popup_menu_tracking(
             cpu.lr = call.return_address;
             return PpcImportAction::Return(0);
         };
-        let definition = *startup.active_menu_definition().unwrap();
+        let definition = startup.active_menu_definition().unwrap().clone();
         let (top, left, bottom, right) = definition.menu_rect();
         let Some(mut state) = ppc_begin_tracked_menu_with_appearances(
             memory,
@@ -76851,7 +76880,6 @@ fn ppc_continue_custom_popup_menu_tracking(
         startup.active_menu_definition_mut().unwrap().draw();
         let invocation = startup
             .active_menu_definition()
-            .copied()
             .and_then(MenuDefinitionTracking::pending_invocation)
             .unwrap();
         if let Some(action) = ppc_dispatch_native_menu_definition(
@@ -76888,7 +76916,7 @@ fn ppc_continue_custom_popup_menu_tracking(
             }
         } else if input.mouse_button {
             return PpcImportAction::Yield(u64::MAX);
-        } else if let Some(definition) = startup.active_menu_definition().copied() {
+        } else if let Some(definition) = startup.active_menu_definition().cloned() {
             let item = definition.which_item();
             let menu_id = memory
                 .read_u32_be(definition.menu_handle())
@@ -78440,7 +78468,6 @@ fn ppc_begin_custom_menu_bar_tracking(
     ppc_prepare_menu_definition_port(startup, current_gworld, current_gdevice);
     let invocation = startup
         .active_menu_definition()
-        .copied()
         .and_then(MenuDefinitionTracking::pending_invocation)?;
     let action = ppc_dispatch_native_menu_definition(
         cpu,
@@ -78496,19 +78523,29 @@ fn ppc_continue_custom_menu_bar_tracking(
         ppc_restore_menu_definition_port(startup, current_gworld, current_gdevice);
         return PpcImportAction::Return(0);
     };
-    let scratch = startup.menu_def_scratch;
     let Some(definition) = startup.active_menu_definition_mut() else {
         cpu.lr = call.return_address;
         startup.menu_select_call = None;
         ppc_restore_menu_definition_port(startup, current_gworld, current_gdevice);
         return PpcImportAction::Return(0);
     };
-    let completed = if definition.pending_invocation().is_some() && scratch != 0 {
-        let bytes =
-            std::array::from_fn(|offset| memory.read_u8(scratch + offset as u32).unwrap_or(0));
-        definition.complete_pending(MenuDefinitionInvocation::decode_result(bytes))
-    } else {
-        None
+    let completed = match definition.complete_callback() {
+        Ok(completed) => completed,
+        Err(()) => {
+            if let Some(state) = startup.menu_tracking.take() {
+                if ppc_live_front_buffer_for_gworld(memory, gworlds, PPC_MAIN_GWORLD)
+                    .map(MenuTrackingSurface::from)
+                    == state.front_buffer
+                {
+                    ppc_restore_menu_tracking(memory, state.front_buffer, &state);
+                }
+            }
+            startup.clear_active_menu_definition();
+            startup.menu_select_call = None;
+            ppc_restore_menu_definition_port(startup, current_gworld, current_gdevice);
+            cpu.lr = call.return_address;
+            return PpcImportAction::Return(0);
+        }
     };
 
     if completed == Some(MenuDefinitionMessage::Choose) {
@@ -78552,7 +78589,6 @@ fn ppc_continue_custom_menu_bar_tracking(
                 }
                 if let Some(invocation) = startup
                     .active_menu_definition()
-                    .copied()
                     .and_then(MenuDefinitionTracking::pending_invocation)
                 {
                     if let Some(action) = ppc_dispatch_native_menu_definition(
@@ -78619,7 +78655,6 @@ fn ppc_continue_custom_menu_bar_tracking(
             .flash(remaining & 1 == 0);
         let invocation = startup
             .active_menu_definition()
-            .copied()
             .and_then(MenuDefinitionTracking::pending_invocation)
             .unwrap();
         if let Some(action) = ppc_dispatch_native_menu_definition(
@@ -78685,7 +78720,7 @@ fn ppc_continue_custom_menu_bar_tracking(
         return PpcImportAction::Yield(u64::MAX);
     }
 
-    let definition = *startup.active_menu_definition().unwrap();
+    let definition = startup.active_menu_definition().unwrap().clone();
     let item = definition.which_item();
     let menu_handle = definition.menu_handle();
     let menu_id = memory
@@ -91451,11 +91486,13 @@ pub(crate) mod tests {
                     panic!("special-case result selector {selector} requires the shared runner")
                 }
             };
-            assert!(loaded.guest_calls.complete_m68k_for_powerpc(
+            assert!(loaded.guest_calls.complete_m68k_operation_for_powerpc(
                 cpu.pc,
                 cpu.a(7),
                 result,
                 &mut loaded.cpu,
+                &mut loaded.memory,
+                loaded.process_memory_manager.0.borrow_mut().native_mut(),
             ));
 
             if loaded.cpu.pc >= loaded.import_trap_base
@@ -94040,8 +94077,169 @@ pub(crate) mod tests {
 
         assert_eq!(loaded.memory.read_u16_be(menu_ptr + 2), Some(123));
         assert_eq!(loaded.memory.read_u16_be(menu_ptr + 4), Some(45));
-        assert_ne!(loaded.toolbox_startup.menu_def_scratch, 0);
+        assert!(loaded
+            .process_memory_manager
+            .0
+            .borrow()
+            .native_ptr_records()
+            .iter()
+            .all(|record| record.ptr != loaded.cpu.gpr[5]));
         assert!(loaded.guest_calls.is_empty());
+    }
+
+    #[test]
+    fn nested_native_mdef_preserves_outer_by_reference_arguments() {
+        let mut loaded = load_pef_application(&synthetic_pef_with_import(b"CalcMenuSize")).unwrap();
+        let outer = install_test_menu(&mut loaded, PPC_DATA_BASE + 0x1000, 140, b"Outer", b"A");
+        let inner = install_test_menu(&mut loaded, PPC_DATA_BASE + 0x2000, 141, b"Inner", b"B");
+        let marker = PPC_DATA_BASE + 0x7800;
+        loaded.memory.add_region(marker, vec![0; 4]);
+        let outer_code = [
+            0x9421_ffa0, // stwu r1,-96(r1)
+            0x7c08_02a6, // mflr r0
+            0x9001_0064, // stw r0,100(r1)
+            0x90a1_0038, // stw r5,56(r1): retain outer menuRect pointer
+            0x3920_1122, // li r9,0x1122
+            0xb125_0000, // sth r9,0(r5)
+            0x3c60_0000 | (inner >> 16),
+            0x6063_0000 | (inner & 0xffff),
+            0x3d80_0000 | (PPC_IMPORT_TRAP_BASE >> 16),
+            0x618c_0000 | (PPC_IMPORT_TRAP_BASE & 0xffff),
+            0x7d89_03a6, // mtctr r12
+            0x4e80_0421, // bctrl: nested CalcMenuSize
+            0x80a1_0038, // lwz r5,56(r1)
+            0xa125_0000, // lhz r9,0(r5)
+            0x3d40_0000 | (marker >> 16),
+            0x614a_0000 | (marker & 0xffff),
+            0x912a_0000, // stw r9,0(r10)
+            0x8001_0064, // lwz r0,100(r1)
+            0x7c08_03a6, // mtlr r0
+            0x3821_0060, // addi r1,r1,96
+            BLR,
+        ];
+        let inner_code = [0x3920_3344, 0xb125_0000, BLR];
+        for (index, menu, code) in [
+            (0, outer, outer_code.as_slice()),
+            (1, inner, inner_code.as_slice()),
+        ] {
+            let storage = PPC_DATA_BASE + 0x7000 + index * 0x400;
+            loaded.memory.add_region(storage, vec![0; 4]);
+            install_test_powerpc_callback(
+                &mut loaded,
+                storage + 0x100,
+                storage + 0x180,
+                PPC_CODE_BASE + 0x4000 + index * 0x100,
+                0,
+                0x0000_ff80,
+                code,
+            );
+            loaded
+                .memory
+                .write_u32_be(storage, storage + 0x100)
+                .unwrap();
+            let record = loaded.memory.read_u32_be(menu).unwrap();
+            loaded.memory.write_u32_be(record + 6, storage).unwrap();
+        }
+        loaded.cpu.pc = loaded.entry_pc;
+        loaded.cpu.lr = PPC_HALT_PC;
+        loaded.cpu.gpr[3] = outer;
+        let probe = loaded.run_with_hle_imports(256);
+        assert_eq!(probe.unsupported_import_index, None);
+        assert_eq!(probe.handled_import_count, 2);
+        assert_eq!(loaded.cpu.pc, PPC_HALT_PC);
+        assert!(loaded.guest_calls.is_empty());
+        assert_eq!(
+            loaded.memory.read_u32_be(marker),
+            Some(0x1122),
+            "nested MDEF scratch must not alias its caller"
+        );
+    }
+
+    #[test]
+    fn nested_classic_mdef_adapters_keep_live_workspaces_disjoint() {
+        let mut loaded = load_pef_application(&synthetic_pef_with_import(b"CalcMenuSize")).unwrap();
+        let menu = install_test_menu(&mut loaded, PPC_DATA_BASE + 0x1000, 140, b"Custom", b"A");
+        let handle = PPC_DATA_BASE + 0x7000;
+        let descriptor = handle + 0x100;
+        loaded.memory.add_region(handle, vec![0; 4]);
+        install_test_m68k_callback(
+            &mut loaded,
+            descriptor,
+            PPC_CODE_BASE + 0x4000,
+            MenuDefinitionInvocation::PASCAL_PROC_INFO,
+            0,
+            &[0x4e74, 18],
+        );
+        loaded.memory.write_u32_be(handle, descriptor).unwrap();
+        let record = loaded.memory.read_u32_be(menu).unwrap();
+        loaded.memory.write_u32_be(record + 6, handle).unwrap();
+        let manager_handle = loaded.process_memory_manager.0.clone();
+        let mut manager = manager_handle.borrow_mut();
+        let initial_count = manager.native_ptr_records().len();
+        let heap = manager.native_heap_state().unwrap();
+        let mut cursor = heap.heap_cursor;
+        let invocation = MenuDefinitionInvocation {
+            message: crate::menu_manager::MenuDefinitionMessage::Size,
+            menu_handle: menu,
+            menu_rect: (1, 2, 3, 4),
+            hit_point: 0,
+            which_item: 0,
+        };
+        let mut intervals = Vec::new();
+        for index in 0..2 {
+            let action = ppc_dispatch_native_menu_definition(
+                &mut loaded.cpu,
+                Some(manager.native_mut()),
+                &mut loaded.memory,
+                &mut cursor,
+                heap.heap_limit,
+                &loaded.process_file_system.vfs_resources,
+                &mut loaded.toolbox_startup,
+                invocation,
+                PPC_HALT_PC,
+            )
+            .unwrap();
+            assert!(matches!(action, PpcImportAction::Halt));
+            let pending = loaded.toolbox_startup.guest_calls.activate_m68k().unwrap();
+            loaded
+                .memory
+                .write_u32_be(pending.initial_sp - 100, 0x1122 + index)
+                .unwrap();
+            intervals.push(pending);
+        }
+        let outer = intervals[0];
+        let inner = intervals[1];
+        assert_ne!(outer.entry, inner.entry);
+        assert!(outer.final_sp <= inner.entry || inner.final_sp <= outer.entry);
+        assert_eq!(
+            loaded.memory.read_u32_be(outer.initial_sp - 100),
+            Some(0x1122)
+        );
+        assert_eq!(
+            loaded.memory.read_u32_be(inner.initial_sp - 100),
+            Some(0x1123)
+        );
+        assert_eq!(manager.native_ptr_records().len(), initial_count + 2);
+        for (index, pending) in intervals.into_iter().rev().enumerate() {
+            assert!(loaded
+                .toolbox_startup
+                .guest_calls
+                .complete_m68k_operation_for_powerpc(
+                    pending.return_pc,
+                    pending.final_sp,
+                    None,
+                    &mut loaded.cpu,
+                    &mut loaded.memory,
+                    manager.native_mut(),
+                ));
+            assert_eq!(
+                manager.native_ptr_records().len(),
+                initial_count + 1 - index
+            );
+        }
+        assert!(loaded.toolbox_startup.guest_calls.is_empty());
+        assert_eq!(loaded.toolbox_startup.mixed_mode_m68k.gateway, 0);
+        assert_eq!(loaded.toolbox_startup.mixed_mode_m68k.stack_top, 0);
     }
 
     #[test]
@@ -94094,12 +94292,16 @@ pub(crate) mod tests {
             which_item: 4,
         };
         let final_pc = 0x1234_5678;
+        let manager_handle = loaded.process_memory_manager.0.clone();
+        let mut manager = manager_handle.borrow_mut();
+        let heap = manager.native_heap_state().unwrap();
+        let mut cursor = heap.heap_cursor;
         let action = ppc_dispatch_native_menu_definition(
             &mut loaded.cpu,
-            None,
+            Some(manager.native_mut()),
             &mut loaded.memory,
-            test_heap_cursor!(loaded),
-            test_heap_limit!(loaded),
+            &mut cursor,
+            heap.heap_limit,
             &loaded.process_file_system.vfs_resources,
             &mut loaded.toolbox_startup,
             invocation,
@@ -94107,22 +94309,11 @@ pub(crate) mod tests {
         )
         .expect("native custom MDEF should be callable");
 
-        let GuestCallEffect::CallGuest {
-            request,
-            continuation:
-                GuestCallContinuation::ReturnToPowerPc {
-                    final_pc: actual_final_pc,
-                    ..
-                },
-        } = GuestCallEffect::from_ppc_import_action(action)
-            .expect("native custom MDEF should produce a guest-call effect")
-        else {
-            panic!("native custom MDEF returned an unsupported guest-call effect");
-        };
-        assert_eq!(request.target.entry, callback_entry);
-        assert_eq!(request.target.rtoc, callback_rtoc);
-        assert_eq!(actual_final_pc, final_pc);
-        let scratch = loaded.toolbox_startup.menu_def_scratch;
+        assert!(matches!(action, PpcImportAction::Continue));
+        assert_eq!(loaded.cpu.pc, callback_entry);
+        assert_eq!(loaded.cpu.gpr[2], callback_rtoc);
+        assert_eq!(loaded.toolbox_startup.guest_calls.len(), 1);
+        let scratch = loaded.cpu.gpr[5];
         assert_eq!(
             ppc_memory_read_bytes(&mut loaded.memory, scratch, 10),
             Some(invocation.scratch_bytes().to_vec())
@@ -94131,6 +94322,26 @@ pub(crate) mod tests {
             &loaded.cpu.gpr[3..8],
             &[1, menu, scratch, invocation.hit_point, scratch + 8,]
         );
+        loaded.cpu.pc = PPC_GUEST_CALL_RETURN_PC;
+        assert!(loaded
+            .toolbox_startup
+            .guest_calls
+            .complete_powerpc_resuming_operation(
+                &mut loaded.cpu,
+                manager.native_mut(),
+                |operation, result| {
+                    let crate::guest_call::ManagerContinuation::Menu(operation) = operation else {
+                        panic!("MDEF continuation");
+                    };
+                    operation.complete(&mut loaded.memory);
+                    result
+                },
+            ));
+        assert_eq!(loaded.cpu.pc, final_pc);
+        assert!(manager
+            .native_ptr_records()
+            .iter()
+            .all(|record| record.ptr != scratch));
     }
 
     #[test]
@@ -101661,7 +101872,13 @@ pub(crate) mod tests {
         let menu = loaded.memory.read_u32_be(menu_handle).unwrap();
         assert_eq!(loaded.memory.read_u16_be(menu + 2), Some(123));
         assert_eq!(loaded.memory.read_u16_be(menu + 4), Some(45));
-        assert_ne!(loaded.toolbox_startup.menu_def_scratch, 0);
+        assert!(loaded
+            .process_memory_manager
+            .0
+            .borrow()
+            .native_ptr_records()
+            .iter()
+            .all(|record| record.ptr != loaded.cpu.gpr[5]));
     }
 
     #[test]
@@ -101709,8 +101926,8 @@ pub(crate) mod tests {
         assert_eq!(loaded.memory.read_u16_be(menu + 2), Some(123));
         assert_eq!(loaded.memory.read_u16_be(menu + 4), Some(45));
         assert!(loaded.guest_calls.is_empty());
-        assert_ne!(loaded.toolbox_startup.mixed_mode_m68k.gateway, 0);
-        assert_ne!(loaded.toolbox_startup.mixed_mode_m68k.stack_top, 0);
+        assert_eq!(loaded.toolbox_startup.mixed_mode_m68k.gateway, 0);
+        assert_eq!(loaded.toolbox_startup.mixed_mode_m68k.stack_top, 0);
     }
 
     #[test]

--- a/src/menu_manager.rs
+++ b/src/menu_manager.rs
@@ -190,6 +190,10 @@ impl<Handle: Copy> MenuBarBuild<Handle> {
 }
 
 impl MenuDefinitionInvocation {
+    /// MyMenuDef is Pascal, has no result, and takes 2/4/4/4/4-byte parameters.
+    /// PowerPC System Software (1994), pp. 2-12--2-16.
+    pub(crate) const PASCAL_PROC_INFO: u32 = 0x0000_ff80;
+
     pub(crate) fn size(menu_handle: u32) -> Self {
         Self {
             message: MenuDefinitionMessage::Size,
@@ -232,19 +236,80 @@ impl MenuDefinitionInvocation {
     }
 }
 
+/// A single-use completion channel for one logical MDEF invocation.
+/// Cloning retains identity; it never duplicates a pending callback.
+#[derive(Clone, Debug)]
+pub(crate) struct MenuDefinitionCompletion(Rc<RefCell<MenuDefinitionCompletionState>>);
+
+#[derive(Debug)]
+enum MenuDefinitionCompletionState {
+    Pending,
+    Ready(Result<MenuDefinitionResult, ()>),
+    Consumed,
+}
+
+impl PartialEq for MenuDefinitionCompletion {
+    fn eq(&self, other: &Self) -> bool {
+        Rc::ptr_eq(&self.0, &other.0)
+    }
+}
+impl Eq for MenuDefinitionCompletion {}
+
+impl MenuDefinitionCompletion {
+    pub(crate) fn pending() -> Self {
+        Self(Rc::new(RefCell::new(
+            MenuDefinitionCompletionState::Pending,
+        )))
+    }
+    pub(crate) fn take(&self) -> Option<Result<MenuDefinitionResult, ()>> {
+        let mut state = self.0.borrow_mut();
+        match std::mem::replace(&mut *state, MenuDefinitionCompletionState::Consumed) {
+            MenuDefinitionCompletionState::Ready(result) => Some(result),
+            MenuDefinitionCompletionState::Pending => {
+                *state = MenuDefinitionCompletionState::Pending;
+                None
+            }
+            MenuDefinitionCompletionState::Consumed => None,
+        }
+    }
+}
+
+/// Execution owns this operation and its allocation until the exact callback
+/// returns. Copy results before releasing guest storage or running more code.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct MenuDefinitionOperation {
+    pub(crate) scratch: u32,
+    pub(crate) completion: MenuDefinitionCompletion,
+}
+
+impl MenuDefinitionOperation {
+    pub(crate) fn complete(self, memory: &mut crate::memory::GuestAddressSpace) {
+        let mut bytes = [0; 10];
+        let result = memory
+            .read_bytes_into(self.scratch, &mut bytes)
+            .map(|()| MenuDefinitionInvocation::decode_result(bytes))
+            .ok_or(());
+        let mut state = self.completion.0.borrow_mut();
+        if matches!(*state, MenuDefinitionCompletionState::Pending) {
+            *state = MenuDefinitionCompletionState::Ready(result);
+        }
+    }
+}
+
 /// Architecture-neutral continuation for an application-defined MDEF.
 ///
 /// The Menu Manager owns the current rectangle, previous item, and callback
 /// ordering. CPU adapters only execute `pending_invocation` and return its
 /// two by-reference results. Macintosh Toolbox Essentials (1992),
 /// pp. 3-87--3-91 and 3-148--3-151.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct MenuDefinitionTracking {
     menu_handle: u32,
     menu_rect: (i16, i16, i16, i16),
     which_item: i16,
     last_hit_point: Option<u32>,
     pending_invocation: Option<MenuDefinitionInvocation>,
+    completion: Option<MenuDefinitionCompletion>,
 }
 
 impl MenuDefinitionTracking {
@@ -254,6 +319,7 @@ impl MenuDefinitionTracking {
             menu_rect,
             which_item: 0,
             last_hit_point: None,
+            completion: None,
             pending_invocation: Some(MenuDefinitionInvocation {
                 message: MenuDefinitionMessage::Draw,
                 menu_handle,
@@ -270,6 +336,7 @@ impl MenuDefinitionTracking {
             menu_rect: (0, 0, 0, 0),
             which_item,
             last_hit_point: None,
+            completion: None,
             pending_invocation: Some(MenuDefinitionInvocation {
                 message: MenuDefinitionMessage::PopUp,
                 menu_handle,
@@ -280,8 +347,30 @@ impl MenuDefinitionTracking {
         }
     }
 
-    pub(crate) fn pending_invocation(self) -> Option<MenuDefinitionInvocation> {
+    pub(crate) fn pending_invocation(&self) -> Option<MenuDefinitionInvocation> {
         self.pending_invocation
+    }
+
+    pub(crate) fn bind_completion(
+        &mut self,
+        invocation: MenuDefinitionInvocation,
+        completion: MenuDefinitionCompletion,
+    ) {
+        if self.pending_invocation == Some(invocation) {
+            self.completion = Some(completion);
+        }
+    }
+
+    pub(crate) fn complete_callback(&mut self) -> Result<Option<MenuDefinitionMessage>, ()> {
+        let Some(result) = self
+            .completion
+            .as_ref()
+            .and_then(MenuDefinitionCompletion::take)
+        else {
+            return Ok(None);
+        };
+        self.completion = None;
+        Ok(self.complete_pending(result?))
     }
 
     pub(crate) fn complete_pending(
@@ -289,6 +378,7 @@ impl MenuDefinitionTracking {
         result: MenuDefinitionResult,
     ) -> Option<MenuDefinitionMessage> {
         let completed = self.pending_invocation.take()?;
+        self.completion = None;
         self.menu_rect = result.menu_rect;
         self.which_item = result.which_item;
         Some(completed.message)
@@ -359,15 +449,15 @@ impl MenuDefinitionTracking {
         Some(invocation)
     }
 
-    pub(crate) fn which_item(self) -> i16 {
+    pub(crate) fn which_item(&self) -> i16 {
         self.which_item
     }
 
-    pub(crate) fn menu_handle(self) -> u32 {
+    pub(crate) fn menu_handle(&self) -> u32 {
         self.menu_handle
     }
 
-    pub(crate) fn menu_rect(self) -> (i16, i16, i16, i16) {
+    pub(crate) fn menu_rect(&self) -> (i16, i16, i16, i16) {
         self.menu_rect
     }
 }
@@ -3551,6 +3641,63 @@ mod tests {
     use super::*;
 
     #[test]
+    fn mdef_completion_is_single_use_even_when_its_operation_is_cloned() {
+        let mut memory = crate::memory::GuestAddressSpace::new();
+        let invocation = MenuDefinitionInvocation {
+            message: MenuDefinitionMessage::Choose,
+            menu_handle: 0x100,
+            menu_rect: (1, 2, 3, 4),
+            hit_point: 0,
+            which_item: 2,
+        };
+        memory.add_region(0x1000, invocation.scratch_bytes().to_vec());
+        let completion = MenuDefinitionCompletion::pending();
+        let operation = MenuDefinitionOperation {
+            scratch: 0x1000,
+            completion: completion.clone(),
+        };
+        assert_eq!(completion.take(), None);
+        operation.clone().complete(&mut memory);
+        memory.write_bytes(0x1000, &[0; 10]).unwrap();
+        operation.clone().complete(&mut memory);
+        assert_eq!(
+            completion.take(),
+            Some(Ok(MenuDefinitionInvocation::decode_result(
+                invocation.scratch_bytes()
+            )))
+        );
+        operation.complete(&mut memory);
+        assert_eq!(completion.take(), None);
+    }
+
+    #[test]
+    fn mdef_failed_result_is_delivered_once_without_consuming_another_receipt() {
+        let mut memory = crate::memory::GuestAddressSpace::new();
+        let failed = MenuDefinitionCompletion::pending();
+        let other = MenuDefinitionCompletion::pending();
+        assert_ne!(failed, other);
+        assert_eq!(failed, failed.clone());
+        MenuDefinitionOperation {
+            scratch: 0x1000,
+            completion: failed.clone(),
+        }
+        .complete(&mut memory);
+        assert_eq!(failed.take(), Some(Err(())));
+        assert_eq!(failed.take(), None);
+        assert_eq!(other.take(), None);
+        memory.add_region(0x1000, vec![0; 10]);
+        MenuDefinitionOperation {
+            scratch: 0x1000,
+            completion: other.clone(),
+        }
+        .complete(&mut memory);
+        assert_eq!(
+            other.take(),
+            Some(Ok(MenuDefinitionInvocation::decode_result([0; 10])))
+        );
+    }
+
+    #[test]
     fn cloned_menu_tracking_state_is_a_detached_runtime_snapshot() {
         let live = Some(test_process_menu_tracking(0x0012_3456));
 
@@ -5175,7 +5322,7 @@ mod tests {
             menu_rect: (20, 80, 52, 152),
             which_item: 3,
         });
-        classic.submenus[0].definition = Some(classic_definition);
+        classic.submenus[0].definition = Some(classic_definition.clone());
         assert_eq!(classic.selection(|_, _| false), Some((1, 3)));
         let closed = classic.close_submenus_from(0);
         assert!(classic.active_definition().is_none());
@@ -5187,7 +5334,7 @@ mod tests {
             menu_rect: (20, 80, 52, 152),
             which_item: 3,
         });
-        powerpc.submenus[0].definition = Some(powerpc_definition);
+        powerpc.submenus[0].definition = Some(powerpc_definition.clone());
         assert_eq!(powerpc.selection(|_, _| false), Some((0x2000, 3)));
         let closed = powerpc.close_submenus_from(0);
         assert!(powerpc.active_definition().is_none());

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -7002,9 +7002,10 @@ impl FixtureRunner {
         if self.m68k.cpu.read_reg(Register::PC) == pending.return_pc
             && self.m68k.cpu.read_reg(Register::A7) == pending.final_sp
         {
-            let completed =
+            let completed = self.process_context.with_memory_and_cfm(|manager, _| {
                 self.m68k
-                    .complete_pending(&mut ppc_app.memory, &mut ppc_app.cpu, pending);
+                    .complete_pending(&mut ppc_app.memory, &mut ppc_app.cpu, pending, manager)
+            });
             return Some((0, completed));
         }
         if max_steps == 0 {
@@ -7016,9 +7017,14 @@ impl FixtureRunner {
         let mut watch_buf = Vec::with_capacity(4);
         while executed < max_steps {
             if self.m68k.cpu.read_reg(Register::PC) == pending.return_pc {
-                running =
-                    self.m68k
-                        .complete_pending(&mut ppc_app.memory, &mut ppc_app.cpu, pending);
+                running = self.process_context.with_memory_and_cfm(|manager, _| {
+                    self.m68k.complete_pending(
+                        &mut ppc_app.memory,
+                        &mut ppc_app.cpu,
+                        pending,
+                        manager,
+                    )
+                });
                 break;
             }
             let batch_max = u32::try_from(max_steps - executed).unwrap_or(u32::MAX);
@@ -7038,9 +7044,14 @@ impl FixtureRunner {
             match batch.exit {
                 BatchExit::BudgetExhausted => break,
                 BatchExit::WatchedPc { pc } if pc == pending.return_pc => {
-                    running =
-                        self.m68k
-                            .complete_pending(&mut ppc_app.memory, &mut ppc_app.cpu, pending);
+                    running = self.process_context.with_memory_and_cfm(|manager, _| {
+                        self.m68k.complete_pending(
+                            &mut ppc_app.memory,
+                            &mut ppc_app.cpu,
+                            pending,
+                            manager,
+                        )
+                    });
                     break;
                 }
                 BatchExit::AlineTrap { opcode } => {
@@ -15939,6 +15950,213 @@ mod tests {
         assert_eq!(ppc_app.memory.read_u32_be(ppc_app.cpu.gpr[1]), Some(0));
     }
 
+    struct ClassicPowerPcMdefFixture {
+        runner: FixtureRunner,
+        menu: u32,
+        record: u32,
+        marker: u32,
+        entry: u32,
+        stack: u32,
+    }
+
+    fn classic_powerpc_mdef_fixture() -> ClassicPowerPcMdefFixture {
+        use crate::guest_procedure::{
+            ROUTINE_DESCRIPTOR_HEADER_SIZE, ROUTINE_DESCRIPTOR_MIXED_MODE_TRAP,
+            ROUTINE_DESCRIPTOR_VERSION, ROUTINE_FLAG_USE_NATIVE_ISA, ROUTINE_RECORD_FLAGS_OFFSET,
+            ROUTINE_RECORD_ISA_OFFSET, ROUTINE_RECORD_POWERPC_ISA,
+            ROUTINE_RECORD_PROC_DESCRIPTOR_OFFSET,
+        };
+        const MENU: u32 = 0x0030_0000;
+        const RECORD: u32 = MENU + 0x100;
+        const MDEF: u32 = MENU + 0x200;
+        const DESCRIPTOR: u32 = MENU + 0x300;
+        const TVECTOR: u32 = MENU + 0x400;
+        const MARKER: u32 = MENU + 0x500;
+        const ENTRY: u32 = MENU + 0x600;
+        const STACK: u32 = 0x0070_0000;
+        const CALLBACK: u32 = PPC_CODE_BASE + 0x1000;
+        let mut native = halted_ppc_app_with_sound(PpcSoundState::default())
+            .ppc
+            .take()
+            .unwrap();
+        native
+            .memory
+            .add_region(PPC_STACK_BASE, vec![0; PPC_STACK_SIZE as usize]);
+        native.memory.add_region(
+            CALLBACK,
+            [
+                0x8124_0000u32, // lwz r9,0(r4): live MenuHandle
+                0x3940_01b0,    // li r10,432
+                0xb149_0002,    // sth r10,menuWidth(r9)
+                0x3940_007b,    // li r10,123
+                0xb149_0004,    // sth r10,menuHeight(r9)
+                0x3d20_0000 | (MARKER >> 16),
+                0x6129_0000 | (MARKER & 0xffff),
+                0x8149_0000, // lwz r10,0(r9)
+                0x394a_0001, // addi r10,r10,1
+                0x9149_0000, // stw r10,0(r9)
+                0x3940_0002, // li r10,2
+                0xb147_0000, // sth r10,0(r7): chosen item
+                0x4e80_0020, // blr
+            ]
+            .into_iter()
+            .flat_map(u32::to_be_bytes)
+            .collect(),
+        );
+        let classic = LoadedApp {
+            ppc: None,
+            code0_header: Code0Header {
+                above_a5: 0,
+                below_a5: 0x2000,
+                jump_table_size: 0,
+                jump_table_offset: 0,
+            },
+            a5_base: 0x0040_0000,
+            jump_table: Vec::new(),
+            segment_bases: HashMap::new(),
+            loaded_image_end: 0,
+            initial_sp: 0x007f_ffc0,
+            size_resource: None,
+        };
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        runner.stage_ppc_companion(native);
+        runner.init_app(&classic);
+        runner.bus.write_long(MENU, RECORD);
+        runner.bus.write_word(RECORD, 140);
+        runner.bus.write_long(RECORD + 6, MDEF);
+        runner.bus.write_long(RECORD + 10, u32::MAX);
+        runner.bus.write_long(MDEF, DESCRIPTOR);
+        runner
+            .bus
+            .write_word(DESCRIPTOR, ROUTINE_DESCRIPTOR_MIXED_MODE_TRAP);
+        runner
+            .bus
+            .write_byte(DESCRIPTOR + 2, ROUTINE_DESCRIPTOR_VERSION);
+        runner.bus.write_word(DESCRIPTOR + 10, 0);
+        let routine = DESCRIPTOR + ROUTINE_DESCRIPTOR_HEADER_SIZE;
+        runner.bus.write_long(routine, 0x0000_ff80);
+        runner.bus.write_byte(
+            routine + ROUTINE_RECORD_ISA_OFFSET,
+            ROUTINE_RECORD_POWERPC_ISA,
+        );
+        runner.bus.write_word(
+            routine + ROUTINE_RECORD_FLAGS_OFFSET,
+            ROUTINE_FLAG_USE_NATIVE_ISA,
+        );
+        runner
+            .bus
+            .write_long(routine + ROUTINE_RECORD_PROC_DESCRIPTOR_OFFSET, TVECTOR);
+        runner.bus.write_long(TVECTOR, CALLBACK);
+        runner.bus.write_long(TVECTOR + 4, 0);
+        runner.bus.write_word(ENTRY, 0xA948); // CalcMenuSize
+        runner.bus.write_word(ENTRY + 2, 0x60fe); // park after the call
+        runner.bus.write_long(STACK, MENU);
+        runner.m68k.cpu.write_reg(Register::PC, ENTRY);
+        runner.m68k.cpu.write_reg(Register::A7, STACK);
+        ClassicPowerPcMdefFixture {
+            runner,
+            menu: MENU,
+            record: RECORD,
+            marker: MARKER,
+            entry: ENTRY,
+            stack: STACK,
+        }
+    }
+
+    #[test]
+    fn classic_calc_menu_size_executes_powerpc_mdef_and_resumes_once() {
+        let ClassicPowerPcMdefFixture {
+            mut runner,
+            record,
+            marker,
+            entry,
+            stack,
+            ..
+        } = classic_powerpc_mdef_fixture();
+        for _ in 0..8 {
+            let (_, running) = runner.run_steps(128, None);
+            assert!(running);
+        }
+        assert_eq!(
+            runner.bus.read_long(marker),
+            1,
+            "PowerPC MDEF must run exactly once"
+        );
+        assert_eq!(runner.bus.read_word(record + 2), 432);
+        assert_eq!(runner.bus.read_word(record + 4), 123);
+        assert_eq!(runner.m68k.cpu.read_reg(Register::A7), stack + 4);
+        assert_eq!(runner.m68k.cpu.read_reg(Register::PC), entry + 2);
+        assert!(runner.dispatcher.guest_calls.is_empty());
+    }
+
+    #[test]
+    fn classic_menu_select_retains_powerpc_mdef_until_mouse_release() {
+        use crate::memory::globals::addr;
+        let ClassicPowerPcMdefFixture {
+            mut runner,
+            menu,
+            record,
+            marker,
+            entry,
+            stack,
+        } = classic_powerpc_mdef_fixture();
+        runner.dispatcher.menu_bar_hidden = false;
+        runner.bus.write_word(addr::MBAR_HEIGHT, 20);
+        runner.bus.write_word(addr::MENU_FLASH, 0);
+        runner.bus.write_word(record + 2, 80);
+        runner.bus.write_word(record + 4, 32);
+        runner.bus.write_bytes(
+            record + 14,
+            b"\x06Custom\x01A\x00\x00\x00\x00\x01B\x00\x00\x00\x00\x00",
+        );
+        runner.bus.write_word(stack, 0);
+        runner.bus.write_long(stack + 2, menu);
+        runner
+            .dispatcher
+            .dispatch_menu(true, 0x135, &mut runner.m68k.cpu, &mut runner.bus)
+            .unwrap()
+            .unwrap();
+        runner.dispatcher.draw_menu_bar_to_fb(&mut runner.bus);
+        let original_port = *runner.dispatcher.current_port;
+        runner.bus.write_word(entry, 0xA93D);
+        runner.bus.write_word(stack, 10);
+        runner.bus.write_word(stack + 2, 16);
+        runner.bus.write_long(stack + 4, 0);
+        runner.m68k.cpu.write_reg(Register::A7, stack);
+        runner.push_canonical_mouse_down(10, 16);
+        for _ in 0..8 {
+            assert!(runner.run_steps(128, None).1);
+        }
+        let rect = runner
+            .process_context
+            .menu_tracking()
+            .expect("classic tracking remains active")
+            .dropdown_rect();
+        assert!(
+            runner.bus.read_long(marker) > 0,
+            "PowerPC draw callback ran"
+        );
+        let (v, h) = (rect.0 + 24, rect.1 + 16);
+        runner.dispatcher.set_mouse_position(v, h);
+        for _ in 0..8 {
+            assert!(runner.run_steps(128, None).1);
+        }
+        runner.push_canonical_mouse_up(v, h);
+        for _ in 0..16 {
+            assert!(runner.run_steps(128, None).1);
+            if runner.process_context.menu_tracking().is_none()
+                && runner.dispatcher.guest_calls.is_empty()
+            {
+                break;
+            }
+        }
+        assert!(runner.process_context.menu_tracking().is_none());
+        assert!(runner.dispatcher.guest_calls.is_empty());
+        assert_eq!(runner.bus.read_long(stack + 4), (140 << 16) | 2);
+        assert_eq!(runner.m68k.cpu.read_reg(Register::A7), stack + 4);
+        assert_eq!(*runner.dispatcher.current_port, original_port);
+    }
+
     #[test]
     fn standalone_classic_process_enters_powerpc_routine_descriptor_and_resumes_once() {
         use crate::guest_procedure::{
@@ -17670,8 +17888,13 @@ mod tests {
         runner.m68k.cpu.write_reg(Register::A7, pending.final_sp);
 
         assert!(runner
-            .m68k
-            .complete_pending(&mut ppc_app.memory, &mut ppc_app.cpu, pending));
+            .process_context
+            .with_memory_and_cfm(|manager, _| runner.m68k.complete_pending(
+                &mut ppc_app.memory,
+                &mut ppc_app.cpu,
+                pending,
+                manager
+            )));
         assert_eq!(ppc_app.cpu.gpr[3], NATIVE_R3);
         assert!(ppc_app.guest_calls.is_empty());
     }

--- a/src/trap/menu.rs
+++ b/src/trap/menu.rs
@@ -490,10 +490,22 @@ impl super::TrapDispatcher {
         else {
             return false;
         };
-        if procedure.isa != GuestIsa::M68k || procedure.entry >= bus.ram_size() {
+        let proc_addr = match (procedure.isa, procedure.representation) {
+            (GuestIsa::M68k, _) => procedure.entry,
+            (
+                GuestIsa::PowerPc,
+                crate::guest_procedure::GuestProcedureRepresentation::RoutineDescriptor {
+                    descriptor,
+                    ..
+                },
+            ) if procedure.proc_info == SharedMenuDefinitionInvocation::PASCAL_PROC_INFO => {
+                descriptor
+            }
+            _ => return false,
+        };
+        if !bus.is_guest_address_mapped(proc_addr, 2) {
             return false;
         }
-        let proc_addr = procedure.entry;
 
         // MDEFs are Pascal procedures with five arguments. The definition
         // procedure owns menuWidth/menuHeight for mSizeMsg, so the HLE only
@@ -537,9 +549,11 @@ impl super::TrapDispatcher {
         if return_pc != cpu.read_reg(Register::PC) {
             self.guest_calls.begin_m68k(
                 GuestCallTarget {
-                    isa: procedure.isa,
-                    entry: procedure.entry,
-                    rtoc: procedure.rtoc,
+                    // The Pascal wrapper runs on 68K; a descriptor then
+                    // submits its actual ISA transition through Mixed Mode.
+                    isa: GuestIsa::M68k,
+                    entry: proc_addr,
+                    rtoc: 0,
                 },
                 return_pc,
                 final_sp,
@@ -558,7 +572,6 @@ impl super::TrapDispatcher {
         let trampoline = self.menu_def_trampoline;
         if self
             .active_menu_definition()
-            .copied()
             .and_then(SharedMenuDefinitionTracking::pending_invocation)
             .is_none()
             || trampoline == 0
@@ -587,7 +600,6 @@ impl super::TrapDispatcher {
     ) -> bool {
         let invocation = self
             .active_menu_definition()
-            .copied()
             .and_then(SharedMenuDefinitionTracking::pending_invocation);
         invocation
             .is_some_and(|invocation| self.arm_menu_definition_to(cpu, bus, invocation, return_pc))
@@ -2253,7 +2265,7 @@ impl super::TrapDispatcher {
                         }
 
                         if !self.menu_tracking_button_down(bus) {
-                            let definition = *self.active_menu_definition().unwrap();
+                            let definition = self.active_menu_definition().unwrap().clone();
                             let item = definition.which_item();
                             let menu_handle = definition.menu_handle();
                             let menu_id = bus.read_long(menu_handle);
@@ -2660,7 +2672,7 @@ impl super::TrapDispatcher {
                             return Some(Ok(()));
                         }
                         if !self.menu_tracking_button_down(bus) {
-                            let definition = *self.active_menu_definition().unwrap();
+                            let definition = self.active_menu_definition().unwrap().clone();
                             let item = definition.which_item();
                             let menu_ptr = bus.read_long(definition.menu_handle());
                             let result = if item > 0 && menu_ptr != 0 {


### PR DESCRIPTION
Nested custom menu definitions could overwrite their caller's by-reference arguments because the native adapter reused one scratch block. Native-to-68K MDEFs also reused a wrapper and compatibility stack while earlier callbacks could still be live. Classic callers rejected valid PowerPC-only MDEF routine descriptors.

Give each native-origin MDEF an allocation owned by its exact guest-call frame, including the wrapper and stack for emulated callbacks. Capture the result through a single-use Menu Manager completion before releasing storage. Extend the existing typed CFM completion boundary to carry menu completions, and let classic callers enter valid PowerPC MDEF descriptors through Mixed Mode.

Validation covers an actual nested PowerPC callback retaining its outer arguments, disjoint live emulated workspaces and their retirement, actual classic-to-PowerPC sizing and tracking, existing native-to-classic DisableItem/AppendMenu behavior, and single-use success/error delivery. The full headless library suite with JIT enabled passes 5,092 tests with three existing ignored. Public CI is required before merging.

Progress toward #1512; this does not close it. Shared MenuSelect policy, classic wrapper ownership, task/teardown coverage, retained port/build state, and removal of the remaining menu-specific resume paths are still outstanding.
