### PR TITLE
fix: share stack-local menu callbacks and retire menu-bar sizing

### DIFF
--- a/src/execution_m68k.rs
+++ b/src/execution_m68k.rs
@@ -8,6 +8,64 @@ use crate::guest_call::{PendingM68kExecution, SharedGuestCallStack};
 use crate::memory::GuestAddressSpace as PpcSectionMem;
 use ppc::PpcMemory;
 
+/// Stack-local Pascal MDEF lowering shared by classic and native callers.
+/// Code lives above the callback SP, so nested calls cannot overwrite it.
+/// Macintosh Toolbox Essentials (1992), pp. 3-148--3-151.
+pub(crate) struct M68kMenuDefinitionFrame {
+    pub(crate) entry: u32,
+    pub(crate) image: [u8; 60],
+}
+
+impl M68kMenuDefinitionFrame {
+    pub(crate) const RESERVATION: u32 = 80;
+    pub(crate) const STACK_PREFIX: u32 = 54;
+
+    pub(crate) fn new(
+        call: crate::menu_manager::MenuDefinitionCall,
+        target: u32,
+        return_pc: u32,
+        final_sp: u32,
+    ) -> Option<Self> {
+        let entry = final_sp.checked_sub(Self::RESERVATION)?;
+        entry.checked_sub(Self::STACK_PREFIX)?;
+        if entry & 1 != 0 {
+            return None;
+        }
+        let mut image = [0; 60];
+        for (offset, value) in [
+            (0, 0x48e7u16),
+            (2, 0xf0f0), // MOVEM D0-D3/A0-A3,-(SP)
+            (4, 0x3f3c),
+            (6, call.message as i16 as u16),
+            (8, 0x2f3c),
+            (14, 0x2f3c),
+            (20, 0x2f3c),
+            (26, 0x2f3c),
+            (32, 0x4eb9), // JSR target
+            (38, 0x2e7c), // restore saved-register SP
+            (44, 0x4cdf),
+            (46, 0x0f0f),
+            (48, 0x2e7c), // restore caller SP
+            (54, 0x4ef9), // JMP return_pc
+        ] {
+            image[offset..offset + 2].copy_from_slice(&value.to_be_bytes());
+        }
+        for (offset, value) in [
+            (10, call.menu_handle),
+            (16, call.menu_rect),
+            (22, call.hit_point),
+            (28, call.which_item),
+            (34, target),
+            (40, entry - 32),
+            (50, final_sp),
+            (56, return_pc),
+        ] {
+            image[offset..offset + 4].copy_from_slice(&value.to_be_bytes());
+        }
+        Some(Self { entry, image })
+    }
+}
+
 pub(crate) struct M68kExecution {
     pub(crate) cpu: M68kCpu,
     calls: SharedGuestCallStack,

--- a/src/execution_m68k.rs
+++ b/src/execution_m68k.rs
@@ -18,13 +18,13 @@ pub(crate) struct M68kMenuDefinitionFrame {
 
 impl M68kMenuDefinitionFrame {
     pub(crate) const RESERVATION: u32 = 80;
-    pub(crate) const STACK_PREFIX: u32 = 54;
+    pub(crate) const STACK_PREFIX: u32 = 58;
 
     pub(crate) fn new(
         call: crate::menu_manager::MenuDefinitionCall,
         target: u32,
-        return_pc: u32,
         final_sp: u32,
+        release_stack: bool,
     ) -> Option<Self> {
         let entry = final_sp.checked_sub(Self::RESERVATION)?;
         entry.checked_sub(Self::STACK_PREFIX)?;
@@ -45,8 +45,10 @@ impl M68kMenuDefinitionFrame {
             (38, 0x2e7c), // restore saved-register SP
             (44, 0x4cdf),
             (46, 0x0f0f),
-            (48, 0x2e7c), // restore caller SP
-            (54, 0x4ef9), // JMP return_pc
+            // RTD changes PC and SP in one instruction. An interrupt must
+            // never see SP above code which the foreground will still fetch.
+            (48, 0x4e74),
+            (50, if release_stack { Self::RESERVATION as u16 } else { 0 }),
         ] {
             image[offset..offset + 2].copy_from_slice(&value.to_be_bytes());
         }
@@ -56,13 +58,44 @@ impl M68kMenuDefinitionFrame {
             (22, call.hit_point),
             (28, call.which_item),
             (34, target),
-            (40, entry - 32),
-            (50, final_sp),
-            (56, return_pc),
+            (40, entry - 36),
         ] {
             image[offset..offset + 4].copy_from_slice(&value.to_be_bytes());
         }
         Some(Self { entry, image })
+    }
+}
+
+/// Consume a manager result while its stack reservation is still live, then
+/// restore the caller ABI before trap/vector lookup can invoke more guest code.
+pub(crate) fn complete_classic_manager_return<C: crate::cpu::CpuOps>(
+    calls: &SharedGuestCallStack,
+    cpu: &mut C,
+    bus: &crate::memory::MacMemoryBus,
+) -> bool {
+    use crate::memory::MemoryBus;
+    let restored_sp = calls.complete_m68k_with_operation(
+        cpu.read_reg(Register::PC),
+        cpu.read_reg(Register::A7),
+        |operation| {
+            let crate::guest_call::ManagerContinuation::Menu(operation) = operation else {
+                panic!("classic manager return has no completion consumer");
+            };
+            let result = if bus.is_guest_address_mapped(operation.scratch, 10) {
+                <[u8; 10]>::try_from(bus.read_bytes(operation.scratch, 10))
+                    .map(crate::menu_manager::MenuDefinitionInvocation::decode_result)
+                    .map_err(|_| ())
+            } else {
+                Err(())
+            };
+            operation.complete_result(result);
+        },
+    );
+    if let Some(sp) = restored_sp {
+        cpu.write_reg(Register::A7, sp);
+        true
+    } else {
+        false
     }
 }
 
@@ -77,6 +110,10 @@ impl M68kExecution {
             cpu: M68kCpu::new(),
             calls: calls.shared_handle(),
         }
+    }
+
+    pub(crate) fn complete_manager_return(&mut self, bus: &crate::memory::MacMemoryBus) -> bool {
+        complete_classic_manager_return(&self.calls, &mut self.cpu, bus)
     }
 
     pub(crate) fn apply_task_handoff(&mut self) {

--- a/src/guest_call.rs
+++ b/src/guest_call.rs
@@ -1638,17 +1638,39 @@ impl SharedGuestCallStack {
         self.submit_effect(effect).is_some()
     }
 
+    #[cfg(test)]
     pub(crate) fn begin_m68k(
         &self,
         target: GuestCallTarget,
         return_pc: u32,
         final_sp: u32,
     ) -> bool {
-        debug_assert_eq!(target.isa, GuestIsa::M68k);
-        self.push_effect(GuestCallEffect::call_guest(
+        self.begin_m68k_with_operation(target, return_pc, final_sp, None)
+    }
+
+    pub(crate) fn begin_m68k_with_operation(
+        &self,
+        target: GuestCallTarget,
+        return_pc: u32,
+        final_sp: u32,
+        operation: Option<ManagerContinuation>,
+    ) -> bool {
+        if target.isa != GuestIsa::M68k {
+            return false;
+        }
+        let Some(id) = self.submit_effect(GuestCallEffect::call_guest(
             GuestCallRequest::for_task(self.current_task(), target),
             GuestCallContinuation::to_m68k(return_pc, final_sp, None),
-        ))
+        )) else {
+            return false;
+        };
+        self.0
+            .borrow_mut()
+            .frames
+            .get_mut(&id)
+            .expect("submitted classic call")
+            .operation = operation;
+        true
     }
 
     pub(crate) fn begin_m68k_to_powerpc(
@@ -2507,7 +2529,17 @@ impl SharedGuestCallStack {
 
     /// Complete the top classic frame only after its trampoline restored the
     /// exact caller PC and stack pointer. A native frame remains untouched.
+    #[cfg(test)]
     pub(crate) fn complete_m68k(&self, post_trap_pc: u32, final_sp: u32) -> bool {
+        self.complete_m68k_with_operation(post_trap_pc, final_sp, |_| panic!("unhandled manager completion"))
+    }
+
+    pub(crate) fn complete_m68k_with_operation(
+        &self,
+        post_trap_pc: u32,
+        final_sp: u32,
+        mut resume: impl FnMut(ManagerContinuation),
+    ) -> bool {
         let (task, call_id) = {
             let tasks = self.0.borrow();
             let task = tasks.kernel.current_task();
@@ -2545,10 +2577,14 @@ impl SharedGuestCallStack {
             .kernel
             .retire(task, call_id)
             .expect("completed 68k continuation must retire transactionally");
-        tasks
+        let frame = tasks
             .frames
             .remove(&call_id)
             .expect("semantic continuation must have an adapter frame");
+        drop(tasks);
+        if let Some(operation) = frame.operation {
+            resume(operation);
+        }
         true
     }
 }

--- a/src/guest_call.rs
+++ b/src/guest_call.rs
@@ -196,6 +196,8 @@ impl CooperativeThread {
 struct M68kCallOrigin {
     return_pc: u32,
     final_sp: u32,
+    /// Keep callback storage above SP until execution captures its result.
+    parked_sp: Option<u32>,
     result: Option<M68kResultTarget>,
 }
 
@@ -375,6 +377,7 @@ impl GuestCallEffect {
                 origin: GuestCallOrigin::M68k(M68kCallOrigin {
                     return_pc,
                     final_sp,
+                    parked_sp: None,
                     result,
                 }),
                 native_scratch: None,
@@ -395,6 +398,7 @@ impl GuestCallEffect {
                 origin: GuestCallOrigin::M68k(M68kCallOrigin {
                     return_pc,
                     final_sp,
+                    parked_sp: None,
                     result,
                 }),
                 native_scratch: None,
@@ -1645,7 +1649,7 @@ impl SharedGuestCallStack {
         return_pc: u32,
         final_sp: u32,
     ) -> bool {
-        self.begin_m68k_with_operation(target, return_pc, final_sp, None)
+        self.begin_m68k_with_operation(target, return_pc, final_sp, None, None)
     }
 
     pub(crate) fn begin_m68k_with_operation(
@@ -1653,6 +1657,7 @@ impl SharedGuestCallStack {
         target: GuestCallTarget,
         return_pc: u32,
         final_sp: u32,
+        parked_sp: Option<u32>,
         operation: Option<ManagerContinuation>,
     ) -> bool {
         if target.isa != GuestIsa::M68k {
@@ -1664,12 +1669,13 @@ impl SharedGuestCallStack {
         )) else {
             return false;
         };
-        self.0
-            .borrow_mut()
-            .frames
-            .get_mut(&id)
-            .expect("submitted classic call")
-            .operation = operation;
+        let mut tasks = self.0.borrow_mut();
+        let frame = tasks.frames.get_mut(&id).expect("submitted classic call");
+        let GuestCallOrigin::M68k(origin) = &mut frame.origin else {
+            unreachable!()
+        };
+        origin.parked_sp = parked_sp;
+        frame.operation = operation;
         true
     }
 
@@ -2531,7 +2537,7 @@ impl SharedGuestCallStack {
     /// exact caller PC and stack pointer. A native frame remains untouched.
     #[cfg(test)]
     pub(crate) fn complete_m68k(&self, post_trap_pc: u32, final_sp: u32) -> bool {
-        self.complete_m68k_with_operation(post_trap_pc, final_sp, |_| panic!("unhandled manager completion"))
+        self.complete_m68k_with_operation(post_trap_pc, final_sp, |_| panic!("unhandled manager completion")).is_some()
     }
 
     pub(crate) fn complete_m68k_with_operation(
@@ -2539,27 +2545,26 @@ impl SharedGuestCallStack {
         post_trap_pc: u32,
         final_sp: u32,
         mut resume: impl FnMut(ManagerContinuation),
-    ) -> bool {
-        let (task, call_id) = {
+    ) -> Option<u32> {
+        let (task, call_id, caller_sp) = {
             let tasks = self.0.borrow();
             let task = tasks.kernel.current_task();
             let Some(semantic) = tasks.kernel.peek(task) else {
-                return false;
+                return None;
             };
             let Some(frame) = tasks.frames.get(&semantic.call_id()) else {
-                return false;
+                return None;
+            };
+            let GuestCallOrigin::M68k(origin) = frame.origin else {
+                return None;
             };
             if frame.target.isa != GuestIsa::M68k
-                || !matches!(
-                    frame.origin,
-                    GuestCallOrigin::M68k(origin)
-                        if origin.return_pc.wrapping_add(2) == post_trap_pc
-                            && origin.final_sp == final_sp
-                )
+                || origin.return_pc.wrapping_add(2) != post_trap_pc
+                || origin.parked_sp.unwrap_or(origin.final_sp) != final_sp
             {
-                return false;
+                return None;
             }
-            (task, semantic.call_id())
+            (task, semantic.call_id(), origin.final_sp)
         };
         let mut tasks = self.0.borrow_mut();
         let phase = tasks
@@ -2568,10 +2573,10 @@ impl SharedGuestCallStack {
             .expect("semantic continuation must have an adapter frame")
             .phase();
         if phase == ContinuationPhase::Pending && tasks.kernel.activate(task, call_id).is_err() {
-            return false;
+            return None;
         }
         if tasks.kernel.complete(task, call_id, None).is_err() {
-            return false;
+            return None;
         }
         let _ = tasks
             .kernel
@@ -2585,7 +2590,7 @@ impl SharedGuestCallStack {
         if let Some(operation) = frame.operation {
             resume(operation);
         }
-        true
+        Some(caller_sp)
     }
 }
 

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -76375,7 +76375,7 @@ fn ppc_dispatch_native_menu_definition_with_return(
     // by-reference arguments. Nested calls must not reuse a live gateway.
     let workspace_size = match target.isa {
         GuestIsa::PowerPc => 10,
-        GuestIsa::M68k => PPC_MIXED_MODE_M68K_STACK_SIZE + 80,
+        GuestIsa::M68k => PPC_MIXED_MODE_M68K_STACK_SIZE + 96,
     };
     let scratch = manager.new_native_scratch(memory, workspace_size);
     if scratch == 0 {
@@ -76441,7 +76441,14 @@ fn ppc_dispatch_native_menu_definition_with_return(
         return None;
     }
     if let Some(definition) = toolbox_startup.active_menu_definition_mut() {
-        definition.bind_completion(invocation, completion);
+        definition.bind_completion(invocation, completion.clone());
+    }
+    if invocation.message == MenuDefinitionMessage::Size {
+        if let Some(pending) = toolbox_startup.pending_menu_bar_build.as_mut() {
+            pending
+                .build
+                .bind_completion(invocation.menu_handle, completion);
+        }
     }
     prepared
 }
@@ -76464,38 +76471,12 @@ fn ppc_begin_m68k_menu_definition(
     if target.proc_info != 0 && target.proc_info != MenuDefinitionInvocation::PASCAL_PROC_INFO {
         return None;
     }
-    let gateway = operation.scratch.checked_add(16)?;
     let stack_top = operation
         .scratch
-        .checked_add(PPC_MIXED_MODE_M68K_STACK_SIZE + 80)?;
-
-    let return_slot = stack_top - 4;
-    let saved_register_sp = return_slot - 32;
-    let return_pc = gateway + PPC_MIXED_MODE_M68K_RETURN_OFFSET;
-    let write_word = |memory: &mut PpcSectionMem, offset: u32, value: u16| {
-        memory.write_u16_be(gateway + offset, value)
-    };
-    write_word(memory, 0, 0x48e7)?; // MOVEM.L D0-D3/A0-A3,-(SP)
-    write_word(memory, 2, 0xf0f0)?;
-    write_word(memory, 4, 0x3f3c)?; // MOVE.W #message,-(SP)
-    write_word(memory, 6, call.message as i16 as u16)?;
-    for (offset, value) in [
-        (8, call.menu_handle),
-        (14, call.menu_rect),
-        (20, call.hit_point),
-        (26, call.which_item),
-    ] {
-        write_word(memory, offset, 0x2f3c)?; // MOVE.L #value,-(SP)
-        memory.write_u32_be(gateway + offset + 2, value)?;
-    }
-    write_word(memory, 32, 0x4eb9)?; // JSR abs.L
-    memory.write_u32_be(gateway + 34, target.entry)?;
-    write_word(memory, 38, 0x2e7c)?; // MOVEA.L #savedRegisters,A7
-    memory.write_u32_be(gateway + 40, saved_register_sp)?;
-    write_word(memory, 44, 0x4cdf)?; // MOVEM.L (SP)+,D0-D3/A0-A3
-    write_word(memory, 46, 0x0f0f)?;
-    write_word(memory, 48, 0x4e75)?; // RTS
-    memory.write_u32_be(return_slot, return_pc)?;
+        .checked_add(PPC_MIXED_MODE_M68K_STACK_SIZE + 96)?;
+    let return_pc = PPC_GUEST_CALL_RETURN_PC;
+    let frame = crate::execution_m68k::M68kMenuDefinitionFrame::new(call, target.entry, return_pc, stack_top)?;
+    memory.write_bytes(frame.entry, &frame.image)?;
 
     let mut registers = crate::guest_call::M68kRegisterState::default();
     registers.address[5] = PPC_DATA_BASE;
@@ -76509,8 +76490,8 @@ fn ppc_begin_m68k_menu_definition(
             },
         )
         .with_m68k_request(crate::guest_call::M68kCallRequest {
-            entry: gateway,
-            initial_sp: return_slot,
+            entry: frame.entry,
+            initial_sp: frame.entry,
             final_sp: stack_top,
             registers,
             result: None,

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -76475,8 +76475,10 @@ fn ppc_begin_m68k_menu_definition(
         .scratch
         .checked_add(PPC_MIXED_MODE_M68K_STACK_SIZE + 96)?;
     let return_pc = PPC_GUEST_CALL_RETURN_PC;
-    let frame = crate::execution_m68k::M68kMenuDefinitionFrame::new(call, target.entry, return_pc, stack_top)?;
+    let frame =
+        crate::execution_m68k::M68kMenuDefinitionFrame::new(call, target.entry, stack_top, false)?;
     memory.write_bytes(frame.entry, &frame.image)?;
+    memory.write_u32_be(frame.entry - 4, return_pc)?;
 
     let mut registers = crate::guest_call::M68kRegisterState::default();
     registers.address[5] = PPC_DATA_BASE;
@@ -76491,8 +76493,8 @@ fn ppc_begin_m68k_menu_definition(
         )
         .with_m68k_request(crate::guest_call::M68kCallRequest {
             entry: frame.entry,
-            initial_sp: frame.entry,
-            final_sp: stack_top,
+            initial_sp: frame.entry - 4,
+            final_sp: frame.entry,
             registers,
             result: None,
         }),

--- a/src/menu_manager.rs
+++ b/src/menu_manager.rs
@@ -168,18 +168,38 @@ pub(crate) struct MenuBarBuild<Handle> {
     result_handle: Option<Handle>,
     menu_handles: Vec<Handle>,
     next_menu: usize,
+    completion: Option<MenuDefinitionCompletion>,
 }
 
-impl<Handle: Copy> MenuBarBuild<Handle> {
+impl<Handle: Copy + PartialEq> MenuBarBuild<Handle> {
     pub(crate) fn new(result_handle: Handle, menu_handles: Vec<Handle>) -> Self {
         Self {
             result_handle: Some(result_handle),
             menu_handles,
             next_menu: 0,
+            completion: None,
+        }
+    }
+
+    pub(crate) fn bind_completion(&mut self, handle: Handle, completion: MenuDefinitionCompletion) {
+        if self.completion.is_none()
+            && self
+                .next_menu
+                .checked_sub(1)
+                .and_then(|index| self.menu_handles.get(index))
+                == Some(&handle)
+        {
+            self.completion = Some(completion);
         }
     }
 
     pub(crate) fn next_step(&mut self) -> Option<MenuBarBuildStep<Handle>> {
+        if let Some(completion) = self.completion.as_ref() {
+            // mSizeMsg publishes dimensions in the live menu record, not its
+            // rectangle/item arguments. The receipt gates callback retirement.
+            let _ = completion.take()?;
+            self.completion = None;
+        }
         if let Some(handle) = self.menu_handles.get(self.next_menu).copied() {
             self.next_menu += 1;
             Some(MenuBarBuildStep::Size(handle))
@@ -289,6 +309,10 @@ impl MenuDefinitionOperation {
             .read_bytes_into(self.scratch, &mut bytes)
             .map(|()| MenuDefinitionInvocation::decode_result(bytes))
             .ok_or(());
+        self.complete_result(result);
+    }
+
+    pub(crate) fn complete_result(self, result: Result<MenuDefinitionResult, ()>) {
         let mut state = self.completion.0.borrow_mut();
         if matches!(*state, MenuDefinitionCompletionState::Pending) {
             *state = MenuDefinitionCompletionState::Ready(result);
@@ -3767,6 +3791,23 @@ mod tests {
         );
         assert_eq!(MenuDefinitionMessage::Draw as i16, 0);
         assert_eq!(MenuDefinitionMessage::PopUp as i16, 3);
+    }
+
+    #[test]
+    fn menu_bar_build_waits_for_its_own_callback_before_advancing() {
+        let mut build = MenuBarBuild::new(1u32, vec![2, 3]);
+        assert_eq!(build.next_step(), Some(MenuBarBuildStep::Size(2)));
+        let completion = MenuDefinitionCompletion::pending();
+        build.bind_completion(2, completion.clone());
+        assert_eq!(build.next_step(), None);
+        let nested = MenuDefinitionCompletion::pending();
+        build.bind_completion(2, nested.clone());
+        MenuDefinitionOperation { scratch: 0, completion: nested }.complete_result(Ok(MenuDefinitionInvocation::decode_result([0; 10])));
+        assert_eq!(build.next_step(), None, "nested receipt must not release the outer build");
+        MenuDefinitionOperation { scratch: 0, completion }.complete_result(Ok(MenuDefinitionInvocation::decode_result([0; 10])));
+        assert_eq!(build.next_step(), Some(MenuBarBuildStep::Size(3)));
+        assert_eq!(build.next_step(), Some(MenuBarBuildStep::Complete(1)));
+        assert_eq!(build.next_step(), None);
     }
 
     #[test]

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -16065,6 +16065,48 @@ mod tests {
     }
 
     #[test]
+    fn nested_classic_mdef_preserves_its_wrapper_arguments_and_caller_stack() {
+        let ClassicPowerPcMdefFixture { mut runner, menu, record, marker, entry, stack } = classic_powerpc_mdef_fixture();
+        let inner = menu + 0x1000;
+        let inner_record = inner + 0x100;
+        let inner_handle = inner + 0x200;
+        let outer_code = menu + 0x2000;
+        let inner_code = outer_code + 0x200;
+        let outer_handle = runner.bus.read_long(record + 6);
+        runner.bus.write_long(outer_handle, outer_code);
+        runner.bus.write_long(inner, inner_record);
+        runner.bus.write_word(inner_record, 141);
+        runner.bus.write_long(inner_record + 6, inner_handle);
+        runner.bus.write_long(inner_record + 10, u32::MAX);
+        runner.bus.write_long(inner_handle, inner_code);
+        for (address, words) in [
+            (outer_code, vec![
+                0x206f, 12, // MOVEA.L menuRect(SP),A0
+                0x30bc, 0x1122, // MOVE.W #$1122,(A0)
+                0x2f08, // retain outer rectangle pointer
+                0x2f3c, (inner >> 16) as u16, inner as u16,
+                0xa948, // nested CalcMenuSize
+                0x205f, // restore outer pointer
+                0x33d0, (marker >> 16) as u16, marker as u16,
+                0x4e74, 18, // RTD #18
+            ]),
+            (inner_code, vec![0x206f, 12, 0x30bc, 0x3344, 0x4e74, 18]),
+        ] {
+            for (index, word) in words.into_iter().enumerate() {
+                runner.bus.write_word(address + index as u32 * 2, word);
+            }
+        }
+        for _ in 0..8 {
+            let (_, running) = runner.run_steps(128, None);
+            assert!(running);
+        }
+        assert_eq!(runner.bus.read_word(marker), 0x1122);
+        assert_eq!(runner.m68k.cpu.read_reg(Register::A7), stack + 4);
+        assert_eq!(runner.m68k.cpu.read_reg(Register::PC), entry + 2);
+        assert!(runner.dispatcher.guest_calls.is_empty());
+    }
+
+    #[test]
     fn classic_calc_menu_size_executes_powerpc_mdef_and_resumes_once() {
         let ClassicPowerPcMdefFixture {
             mut runner,

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -6228,6 +6228,7 @@ impl FixtureRunner {
                     return (count, false);
                 }
                 BatchExit::AlineTrap { opcode } => {
+                    self.m68k.complete_manager_return(&self.bus);
                     // Accounting (count/ticks) happened via `executed`
                     // above. The batch may have retired instructions before
                     // the trap, so the loop-top `pc` is stale; the trap
@@ -7056,6 +7057,7 @@ impl FixtureRunner {
                     break;
                 }
                 BatchExit::AlineTrap { opcode } => {
+                    self.m68k.complete_manager_return(&self.bus);
                     if !self.dispatcher.aline_vector_is_default(&self.bus) {
                         self.m68k.cpu.core.take_aline_exception(&mut self.bus);
                         continue;
@@ -16106,6 +16108,66 @@ mod tests {
         assert!(runner.dispatcher.guest_calls.is_empty());
     }
 
+    fn fire_menu_test_timer(runner: &mut FixtureRunner, menu: u32, marker: u32) {
+        let timer = menu + 0x3000;
+        for (index, word) in [0x33fc, 1, ((marker + 4) >> 16) as u16, (marker + 4) as u16, 0x4e75].into_iter().enumerate() {
+            runner.bus.write_word(timer + index as u32 * 2, word);
+        }
+        runner.dispatcher.timer_tasks.push(TimerTask {
+            task_ptr: timer + 0x100,
+            architecture: CallbackTaskArchitecture::M68k,
+            extended: false,
+            callback: timer,
+            active: true,
+            fire_at_tick: 1,
+            fire_at_subtick: 1_000_000,
+            last_fired_tick: None,
+        });
+        runner.fire_timer_tasks(1);
+    }
+
+    #[test]
+    fn timer_at_classic_mdef_return_preserves_callback_code_and_stack() {
+        let ClassicPowerPcMdefFixture {
+            mut runner,
+            menu,
+            marker,
+            entry,
+            stack,
+            ..
+        } = classic_powerpc_mdef_fixture();
+        let frame = stack + 4 - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION;
+        let mut reached_return = false;
+        for _ in 0..512 {
+            let return_instruction = if runner.bus.read_word(frame + 48) == 0x4e74 {
+                frame + 48
+            } else {
+                frame + 54
+            };
+            if runner.m68k.cpu.read_reg(Register::PC) == return_instruction {
+                reached_return = true;
+                break;
+            }
+            let (_, running) = runner.run_steps(1, None);
+            assert!(running);
+        }
+        assert!(
+            reached_return,
+            "callback must reach its final return instruction"
+        );
+        fire_menu_test_timer(&mut runner, menu, marker);
+        assert!(runner.active_interrupt_callback.is_some());
+        for _ in 0..8 {
+            let (_, running) = runner.run_steps(128, None);
+            assert!(running);
+        }
+        assert_eq!(runner.bus.read_word(marker + 4), 1);
+        assert_eq!(runner.m68k.cpu.read_reg(Register::PC), entry + 2);
+        assert_eq!(runner.m68k.cpu.read_reg(Register::A7), stack + 4);
+        assert!(runner.active_interrupt_callback.is_none());
+        assert!(runner.dispatcher.guest_calls.is_empty());
+    }
+
     #[test]
     fn classic_calc_menu_size_executes_powerpc_mdef_and_resumes_once() {
         let ClassicPowerPcMdefFixture {
@@ -16134,6 +16196,15 @@ mod tests {
 
     #[test]
     fn classic_menu_select_retains_powerpc_mdef_until_mouse_release() {
+        run_classic_menu_select_with_powerpc_mdef(false);
+    }
+
+    #[test]
+    fn timer_after_classic_mdef_return_preserves_pending_tracking_results() {
+        run_classic_menu_select_with_powerpc_mdef(true);
+    }
+
+    fn run_classic_menu_select_with_powerpc_mdef(interrupt: bool) {
         use crate::memory::globals::addr;
         let ClassicPowerPcMdefFixture {
             mut runner,
@@ -16167,6 +16238,22 @@ mod tests {
         runner.bus.write_long(stack + 4, 0);
         runner.m68k.cpu.write_reg(Register::A7, stack);
         runner.push_canonical_mouse_down(10, 16);
+        if interrupt {
+            let mut parked = false;
+            for _ in 0..512 {
+                if runner.m68k.cpu.read_reg(Register::PC) == entry
+                    && runner.m68k.cpu.read_reg(Register::A7)
+                        == stack - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION
+                {
+                    parked = true;
+                    break;
+                }
+                assert!(runner.run_steps(1, None).1);
+            }
+            assert!(parked, "MDEF return must keep its result reservation live");
+            fire_menu_test_timer(&mut runner, menu, marker);
+        }
+
         for _ in 0..8 {
             assert!(runner.run_steps(128, None).1);
         }
@@ -16198,6 +16285,9 @@ mod tests {
         assert_eq!(runner.bus.read_long(stack + 4), (140 << 16) | 2);
         assert_eq!(runner.m68k.cpu.read_reg(Register::A7), stack + 4);
         assert_eq!(*runner.dispatcher.current_port, original_port);
+        if interrupt {
+            assert_eq!(runner.bus.read_word(marker + 4), 1);
+        }
     }
 
     #[test]

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -1299,9 +1299,6 @@ pub struct TrapDispatcher {
     /// Address of the lazily-allocated trampoline template used by the
     /// Control Manager to call a guest CDEF procedure.
     pub(crate) control_def_trampoline: u32,
-    /// Address of the lazily-allocated trampoline used by the Menu Manager to
-    /// call an application MDEF procedure.
-    pub(crate) menu_def_trampoline: u32,
     /// Reusable trampoline cells for multi-control CDEF callback chains.
     pub(crate) control_def_trampoline_chain: Vec<u32>,
     /// Address of the lazily-allocated trampoline used by DeferUserFn
@@ -3263,7 +3260,6 @@ impl TrapDispatcher {
             list_def_trampoline: 0,
             window_def_trampoline: 0,
             control_def_trampoline: 0,
-            menu_def_trampoline: 0,
             control_def_trampoline_chain: Vec::new(),
             defer_user_fn_trampoline: 0,
             qddone_seen_ports: HashSet::new(),

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -7335,6 +7335,7 @@ impl TrapDispatcher {
         cfm: Option<&crate::cfm::CfmState>,
         bindings: Option<&mut dyn crate::cfm::CfmSymbolBindings>,
     ) -> Result<()> {
+        crate::execution_m68k::complete_classic_manager_return(&self.guest_calls, cpu, bus);
         self.initialize_trap_tables(bus)?;
         // Low-memory Ticks is guest-owned writable state. Import it at the
         // ABI boundary before any manager, trace, or diagnostic path observes

--- a/src/trap/menu.rs
+++ b/src/trap/menu.rs
@@ -513,7 +513,7 @@ impl super::TrapDispatcher {
         };
         let scratch = entry + 60;
         let Some(frame) =
-            M68kMenuDefinitionFrame::new(invocation.call(scratch), proc_addr, return_pc, final_sp)
+            M68kMenuDefinitionFrame::new(invocation.call(scratch), proc_addr, final_sp, return_pc == cpu.read_reg(Register::PC))
         else {
             return false;
         };
@@ -525,7 +525,7 @@ impl super::TrapDispatcher {
         if return_pc != cpu.read_reg(Register::PC) {
             if !self.guest_calls.begin_m68k_with_operation(
                 GuestCallTarget { isa: GuestIsa::M68k, entry: proc_addr, rtoc: 0 },
-                return_pc, final_sp,
+                return_pc, final_sp, Some(frame.entry),
                 Some(crate::guest_call::ManagerContinuation::Menu(crate::menu_manager::MenuDefinitionOperation {
                     scratch, completion: completion.clone(),
                 })),
@@ -549,39 +549,22 @@ impl super::TrapDispatcher {
         {
             bus.write_byte(frame.entry + offset as u32, byte);
         }
-        cpu.write_reg(Register::A7, frame.entry);
+        bus.write_long(frame.entry - 4, return_pc);
+        cpu.write_reg(Register::A7, frame.entry - 4);
         cpu.write_reg(Register::PC, frame.entry);
         true
     }
 
-    fn retire_menu_definition<C: CpuOps>(&self, cpu: &C, bus: &MacMemoryBus) -> bool {
-        self.guest_calls.complete_m68k_with_operation(
-            cpu.read_reg(Register::PC),
-            cpu.read_reg(Register::A7),
-            |operation| {
-                let crate::guest_call::ManagerContinuation::Menu(operation) = operation else {
-                    panic!("classic menu return received a non-menu operation");
-                };
-                let result = if bus.is_guest_address_mapped(operation.scratch, 10) {
-                    <[u8; 10]>::try_from(bus.read_bytes(operation.scratch, 10))
-                        .map(SharedMenuDefinitionInvocation::decode_result)
-                        .map_err(|_| ())
-                } else {
-                    Err(())
-                };
-                operation.complete_result(result);
-            },
-        )
+    fn retire_menu_definition<C: CpuOps>(&self, cpu: &mut C, bus: &MacMemoryBus) -> bool {
+        crate::execution_m68k::complete_classic_manager_return(&self.guest_calls, cpu, bus)
     }
 
     fn complete_pending_menu_definition<C: CpuOps>(
         &mut self,
-        cpu: &C,
+        cpu: &mut C,
         bus: &MacMemoryBus,
     ) -> Option<crate::menu_manager::MenuDefinitionMessage> {
-        if !self.retire_menu_definition(cpu, bus) {
-            return None;
-        }
+        self.retire_menu_definition(cpu, bus);
         self.active_menu_definition_mut()?
             .complete_callback()
             .ok()
@@ -7279,9 +7262,9 @@ mod tests {
         let trampoline = cpu.read_reg(Register::PC);
         assert_ne!(trampoline, 0);
         assert_eq!(cpu.read_reg(Register::PC), trampoline);
-        assert_eq!(cpu.read_reg(Register::A7), trampoline);
-        assert_eq!(bus.read_long(trampoline + 50), TEST_SP + 4);
-        assert_eq!(bus.read_long(trampoline + 56), return_pc);
+        assert_eq!(cpu.read_reg(Register::A7), trampoline - 4);
+        assert_eq!(bus.read_word(trampoline + 50), 80);
+        assert_eq!(bus.read_long(trampoline - 4), return_pc);
         assert_eq!(bus.read_word(trampoline + 6), 2);
         assert_eq!(bus.read_long(trampoline + 10), handle);
         assert_eq!(bus.read_long(trampoline + 16), trampoline + 60);
@@ -7491,7 +7474,7 @@ mod tests {
 
         let trap_pc = 0x0012_3400;
         cpu.write_reg(Register::PC, trap_pc + 2);
-        cpu.write_reg(Register::A7, TEST_SP);
+        cpu.write_reg(Register::A7, if disp.guest_calls.is_empty() { TEST_SP } else { TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION });
         bus.write_word(TEST_SP, 10);
         bus.write_word(TEST_SP + 2, 12);
         bus.write_byte(crate::memory::globals::addr::MB_STATE, 0);
@@ -7504,13 +7487,13 @@ mod tests {
             .is_ok());
         let trampoline = cpu.read_reg(Register::PC);
         assert_eq!(bus.read_word(trampoline + 6), 0);
-        assert_eq!(bus.read_long(trampoline + 56), trap_pc);
+        assert_eq!(bus.read_long(trampoline - 4), trap_pc);
         assert!(disp.is_menu_definition_callback_pending());
         assert_eq!(disp.guest_calls.len(), 1);
         assert_eq!(*disp.current_port, disp.window_manager_cport);
 
         cpu.write_reg(Register::PC, trap_pc + 2);
-        cpu.write_reg(Register::A7, TEST_SP);
+        cpu.write_reg(Register::A7, if disp.guest_calls.is_empty() { TEST_SP } else { TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION });
         assert!(disp
             .dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
@@ -7527,7 +7510,7 @@ mod tests {
             .unwrap();
         bus.write_byte(crate::memory::globals::addr::MB_STATE, 0x80);
         cpu.write_reg(Register::PC, trap_pc + 2);
-        cpu.write_reg(Register::A7, TEST_SP);
+        cpu.write_reg(Register::A7, if disp.guest_calls.is_empty() { TEST_SP } else { TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION });
         assert!(disp
             .dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
@@ -7537,7 +7520,7 @@ mod tests {
         disp.menu_tracking.as_mut().unwrap().flash_delay = 0;
 
         cpu.write_reg(Register::PC, trap_pc + 2);
-        cpu.write_reg(Register::A7, TEST_SP);
+        cpu.write_reg(Register::A7, if disp.guest_calls.is_empty() { TEST_SP } else { TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION });
         disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
@@ -7554,7 +7537,7 @@ mod tests {
         tracking.flash_remaining = 1;
         tracking.flash_delay = 0;
         cpu.write_reg(Register::PC, trap_pc + 2);
-        cpu.write_reg(Register::A7, TEST_SP);
+        cpu.write_reg(Register::A7, if disp.guest_calls.is_empty() { TEST_SP } else { TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION });
         disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
@@ -7582,7 +7565,7 @@ mod tests {
 
         let trap_pc = 0x0012_3500;
         cpu.write_reg(Register::PC, trap_pc + 2);
-        cpu.write_reg(Register::A7, TEST_SP);
+        cpu.write_reg(Register::A7, if disp.guest_calls.is_empty() { TEST_SP } else { TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION });
         bus.write_word(TEST_SP, 4);
         bus.write_word(TEST_SP + 2, 30);
         bus.write_word(TEST_SP + 4, 40);
@@ -7603,7 +7586,7 @@ mod tests {
             bus.write_word(trampoline + 60 + offset, value as u16);
         }
         cpu.write_reg(Register::PC, trap_pc + 2);
-        cpu.write_reg(Register::A7, TEST_SP);
+        cpu.write_reg(Register::A7, if disp.guest_calls.is_empty() { TEST_SP } else { TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION });
         disp.dispatch_menu(true, 0x00B, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
@@ -7614,7 +7597,7 @@ mod tests {
         );
 
         cpu.write_reg(Register::PC, trap_pc + 2);
-        cpu.write_reg(Register::A7, TEST_SP);
+        cpu.write_reg(Register::A7, if disp.guest_calls.is_empty() { TEST_SP } else { TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION });
         disp.dispatch_menu(true, 0x00B, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
@@ -7624,7 +7607,7 @@ mod tests {
         bus.write_word(trampoline + 68, 2);
         bus.write_byte(crate::memory::globals::addr::MB_STATE, 0x80);
         cpu.write_reg(Register::PC, trap_pc + 2);
-        cpu.write_reg(Register::A7, TEST_SP);
+        cpu.write_reg(Register::A7, if disp.guest_calls.is_empty() { TEST_SP } else { TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION });
         disp.dispatch_menu(true, 0x00B, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
@@ -7633,7 +7616,7 @@ mod tests {
         disp.menu_tracking.as_mut().unwrap().flash_delay = 0;
 
         cpu.write_reg(Register::PC, trap_pc + 2);
-        cpu.write_reg(Register::A7, TEST_SP);
+        cpu.write_reg(Register::A7, if disp.guest_calls.is_empty() { TEST_SP } else { TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION });
         disp.dispatch_menu(true, 0x00B, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
@@ -7646,7 +7629,7 @@ mod tests {
         tracking.flash_remaining = 1;
         tracking.flash_delay = 0;
         cpu.write_reg(Register::PC, trap_pc + 2);
-        cpu.write_reg(Register::A7, TEST_SP);
+        cpu.write_reg(Register::A7, if disp.guest_calls.is_empty() { TEST_SP } else { TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION });
         disp.dispatch_menu(true, 0x00B, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
@@ -8902,7 +8885,7 @@ mod tests {
         });
         let trap_pc = 0x0012_3600;
         cpu.write_reg(Register::PC, trap_pc + 2);
-        cpu.write_reg(Register::A7, TEST_SP);
+        cpu.write_reg(Register::A7, if disp.guest_calls.is_empty() { TEST_SP } else { TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION });
         bus.write_word(TEST_SP, 900);
 
         disp.dispatch_menu(true, 0x1C0, &mut cpu, &mut bus)
@@ -8917,7 +8900,7 @@ mod tests {
         bus.write_word(bus.read_long(first_handle) + 4, 41);
 
         cpu.write_reg(Register::PC, trap_pc + 2);
-        cpu.write_reg(Register::A7, TEST_SP);
+        cpu.write_reg(Register::A7, if disp.guest_calls.is_empty() { TEST_SP } else { TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION });
         disp.dispatch_menu(true, 0x1C0, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
@@ -8928,7 +8911,7 @@ mod tests {
         bus.write_word(bus.read_long(second_handle) + 4, 42);
 
         cpu.write_reg(Register::PC, trap_pc + 2);
-        cpu.write_reg(Register::A7, TEST_SP);
+        cpu.write_reg(Register::A7, if disp.guest_calls.is_empty() { TEST_SP } else { TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION });
         disp.dispatch_menu(true, 0x1C0, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
@@ -16108,7 +16091,7 @@ mod tests {
         let title_mid_h = (title.0 + title.1) / 2;
         let trap_pc = 0x0012_3600;
         cpu.write_reg(Register::PC, trap_pc + 2);
-        cpu.write_reg(Register::A7, TEST_SP);
+        cpu.write_reg(Register::A7, if disp.guest_calls.is_empty() { TEST_SP } else { TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION });
         bus.write_word(TEST_SP, 10);
         bus.write_word(TEST_SP + 2, title_mid_h as u16);
         disp.input_state.mouse_pos = (10, title_mid_h);
@@ -16120,7 +16103,7 @@ mod tests {
         let root_rect = disp.menu_tracking.as_ref().unwrap().dropdown_rect();
         disp.input_state.mouse_pos = (root_rect.0 + 8, root_rect.1 + 16);
         cpu.write_reg(Register::PC, trap_pc + 2);
-        cpu.write_reg(Register::A7, TEST_SP);
+        cpu.write_reg(Register::A7, if disp.guest_calls.is_empty() { TEST_SP } else { TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION });
         disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
@@ -16141,14 +16124,14 @@ mod tests {
 
         disp.input_state.mouse_pos = (10, title_mid_h);
         cpu.write_reg(Register::PC, trap_pc + 2);
-        cpu.write_reg(Register::A7, TEST_SP);
+        cpu.write_reg(Register::A7, if disp.guest_calls.is_empty() { TEST_SP } else { TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION });
         disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
         assert_eq!(bus.read_word(trampoline + 6), 1);
         bus.write_word(trampoline + 68, 0);
         cpu.write_reg(Register::PC, trap_pc + 2);
-        cpu.write_reg(Register::A7, TEST_SP);
+        cpu.write_reg(Register::A7, if disp.guest_calls.is_empty() { TEST_SP } else { TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION });
         disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
@@ -16157,7 +16140,7 @@ mod tests {
 
         disp.input_state.mouse_pos = (root_rect.0 + 8, root_rect.1 + 16);
         cpu.write_reg(Register::PC, trap_pc + 2);
-        cpu.write_reg(Register::A7, TEST_SP);
+        cpu.write_reg(Register::A7, if disp.guest_calls.is_empty() { TEST_SP } else { TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION });
         disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
@@ -16165,7 +16148,7 @@ mod tests {
 
         disp.input_state.mouse_pos = (child_rect.0 + 8, child_rect.1 + 8);
         cpu.write_reg(Register::PC, trap_pc + 2);
-        cpu.write_reg(Register::A7, TEST_SP);
+        cpu.write_reg(Register::A7, if disp.guest_calls.is_empty() { TEST_SP } else { TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION });
         disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
@@ -16175,7 +16158,7 @@ mod tests {
         bus.write_word(trampoline + 68, 2);
         disp.input_state.mouse_button = false;
         cpu.write_reg(Register::PC, trap_pc + 2);
-        cpu.write_reg(Register::A7, TEST_SP);
+        cpu.write_reg(Register::A7, if disp.guest_calls.is_empty() { TEST_SP } else { TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION });
         disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
@@ -16188,7 +16171,7 @@ mod tests {
         tracking.flash_remaining = 1;
         tracking.flash_delay = 0;
         cpu.write_reg(Register::PC, trap_pc + 2);
-        cpu.write_reg(Register::A7, TEST_SP);
+        cpu.write_reg(Register::A7, if disp.guest_calls.is_empty() { TEST_SP } else { TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION });
         disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();

--- a/src/trap/menu.rs
+++ b/src/trap/menu.rs
@@ -162,7 +162,6 @@ const MENU_KEY_REDUCED_ICON: u8 = 0x1D;
 const MENU_KEY_SMALL_ICON: u8 = 0x1E;
 const MENU_ROW_HEIGHT: i16 = 16;
 
-const MDEF_TRAMPOLINE_SIZE: u32 = 60;
 
 /// Compute the size of a MENU resource in guest memory by scanning through it.
 /// MENU format: menuID(2), menuWidth(2), menuHeight(2), menuProc(4), enableFlags(4),
@@ -507,61 +506,72 @@ impl super::TrapDispatcher {
             return false;
         }
 
-        // MDEFs are Pascal procedures with five arguments. The definition
-        // procedure owns menuWidth/menuHeight for mSizeMsg, so the HLE only
-        // marshals the documented call and resumes the application afterward.
-        // Macintosh Toolbox Essentials (1992), pp. 3-148--3-151.
-        let trampoline = if self.menu_def_trampoline == 0 {
-            self.menu_def_trampoline = bus.alloc(MDEF_TRAMPOLINE_SIZE);
-            self.menu_def_trampoline
-        } else {
-            self.menu_def_trampoline
-        };
-        let call = invocation.call(trampoline + 50);
+        use crate::execution_m68k::M68kMenuDefinitionFrame;
         let final_sp = cpu.read_reg(Register::A7);
-        let return_slot = final_sp.wrapping_sub(4);
-
-        bus.write_word(trampoline, 0x48E7); // MOVEM.L D0-D3/A0-A3,-(SP)
-        bus.write_word(trampoline + 2, 0xF0F0);
-        bus.write_word(trampoline + 4, 0x3F3C); // MOVE.W #message,-(SP)
-        bus.write_word(trampoline + 6, call.message as i16 as u16);
-        for (offset, value) in [
-            (8, call.menu_handle),
-            (14, call.menu_rect),
-            (20, call.hit_point),
-            (26, call.which_item),
-        ] {
-            bus.write_word(trampoline + offset, 0x2F3C); // MOVE.L #value,-(SP)
-            bus.write_long(trampoline + offset + 2, value);
+        let Some(entry) = final_sp.checked_sub(M68kMenuDefinitionFrame::RESERVATION) else {
+            return false;
+        };
+        let scratch = entry + 60;
+        let Some(frame) =
+            M68kMenuDefinitionFrame::new(invocation.call(scratch), proc_addr, return_pc, final_sp)
+        else {
+            return false;
+        };
+        let floor = frame.entry - M68kMenuDefinitionFrame::STACK_PREFIX;
+        if !bus.is_guest_address_writable(floor, (final_sp - floor) as usize) {
+            return false;
         }
-        bus.write_word(trampoline + 32, 0x4EB9); // JSR abs.L
-        bus.write_long(trampoline + 34, proc_addr);
-        bus.write_word(trampoline + 38, 0x2E7C); // MOVEA.L #savedRegsSP,A7
-        bus.write_long(trampoline + 40, return_slot.wrapping_sub(32));
-        bus.write_word(trampoline + 44, 0x4CDF); // MOVEM.L (SP)+,D0-D3/A0-A3
-        bus.write_word(trampoline + 46, 0x0F0F);
-        bus.write_word(trampoline + 48, 0x4E75); // RTS
-        for (offset, byte) in invocation.scratch_bytes().into_iter().enumerate() {
-            bus.write_byte(trampoline + 50 + offset as u32, byte);
-        }
-
-        bus.write_long(return_slot, return_pc);
+        let completion = crate::menu_manager::MenuDefinitionCompletion::pending();
         if return_pc != cpu.read_reg(Register::PC) {
-            self.guest_calls.begin_m68k(
-                GuestCallTarget {
-                    // The Pascal wrapper runs on 68K; a descriptor then
-                    // submits its actual ISA transition through Mixed Mode.
-                    isa: GuestIsa::M68k,
-                    entry: proc_addr,
-                    rtoc: 0,
-                },
-                return_pc,
-                final_sp,
-            );
+            if !self.guest_calls.begin_m68k_with_operation(
+                GuestCallTarget { isa: GuestIsa::M68k, entry: proc_addr, rtoc: 0 },
+                return_pc, final_sp,
+                Some(crate::guest_call::ManagerContinuation::Menu(crate::menu_manager::MenuDefinitionOperation {
+                    scratch, completion: completion.clone(),
+                })),
+            ) { return false; }
+            if let Some(definition) = self.active_menu_definition_mut() {
+                definition.bind_completion(invocation, completion.clone());
+            }
+            if invocation.message == crate::menu_manager::MenuDefinitionMessage::Size {
+                if let Some(pending) = self.pending_menu_bar_build.as_mut() {
+                    pending
+                        .build
+                        .bind_completion(invocation.menu_handle, completion);
+                }
+            }
         }
-        cpu.write_reg(Register::A7, return_slot);
-        cpu.write_reg(Register::PC, trampoline);
+        for (offset, byte) in frame
+            .image
+            .into_iter()
+            .chain(invocation.scratch_bytes())
+            .enumerate()
+        {
+            bus.write_byte(frame.entry + offset as u32, byte);
+        }
+        cpu.write_reg(Register::A7, frame.entry);
+        cpu.write_reg(Register::PC, frame.entry);
         true
+    }
+
+    fn retire_menu_definition<C: CpuOps>(&self, cpu: &C, bus: &MacMemoryBus) -> bool {
+        self.guest_calls.complete_m68k_with_operation(
+            cpu.read_reg(Register::PC),
+            cpu.read_reg(Register::A7),
+            |operation| {
+                let crate::guest_call::ManagerContinuation::Menu(operation) = operation else {
+                    panic!("classic menu return received a non-menu operation");
+                };
+                let result = if bus.is_guest_address_mapped(operation.scratch, 10) {
+                    <[u8; 10]>::try_from(bus.read_bytes(operation.scratch, 10))
+                        .map(SharedMenuDefinitionInvocation::decode_result)
+                        .map_err(|_| ())
+                } else {
+                    Err(())
+                };
+                operation.complete_result(result);
+            },
+        )
     }
 
     fn complete_pending_menu_definition<C: CpuOps>(
@@ -569,27 +579,13 @@ impl super::TrapDispatcher {
         cpu: &C,
         bus: &MacMemoryBus,
     ) -> Option<crate::menu_manager::MenuDefinitionMessage> {
-        let trampoline = self.menu_def_trampoline;
-        if self
-            .active_menu_definition()
-            .and_then(SharedMenuDefinitionTracking::pending_invocation)
-            .is_none()
-            || trampoline == 0
-        {
+        if !self.retire_menu_definition(cpu, bus) {
             return None;
         }
-        if !self
-            .guest_calls
-            .complete_m68k(cpu.read_reg(Register::PC), cpu.read_reg(Register::A7))
-        {
-            return None;
-        }
-        let bytes = bus.read_bytes(trampoline + 50, 10);
-        let Ok(bytes) = <[u8; 10]>::try_from(bytes) else {
-            return None;
-        };
         self.active_menu_definition_mut()?
-            .complete_pending(SharedMenuDefinitionInvocation::decode_result(bytes))
+            .complete_callback()
+            .ok()
+            .flatten()
     }
 
     fn arm_pending_menu_definition<C: CpuOps>(
@@ -936,6 +932,7 @@ impl super::TrapDispatcher {
     }
 
     fn continue_menu_bar_build<C: CpuOps>(&mut self, cpu: &mut C, bus: &mut MacMemoryBus) {
+        self.retire_menu_definition(cpu, bus);
         loop {
             let Some(step) = self
                 .pending_menu_bar_build
@@ -7279,16 +7276,17 @@ mod tests {
             .unwrap()
             .is_ok());
 
-        let trampoline = disp.menu_def_trampoline;
+        let trampoline = cpu.read_reg(Register::PC);
         assert_ne!(trampoline, 0);
         assert_eq!(cpu.read_reg(Register::PC), trampoline);
-        assert_eq!(cpu.read_reg(Register::A7), TEST_SP);
-        assert_eq!(bus.read_long(TEST_SP), return_pc);
+        assert_eq!(cpu.read_reg(Register::A7), trampoline);
+        assert_eq!(bus.read_long(trampoline + 50), TEST_SP + 4);
+        assert_eq!(bus.read_long(trampoline + 56), return_pc);
         assert_eq!(bus.read_word(trampoline + 6), 2);
         assert_eq!(bus.read_long(trampoline + 10), handle);
-        assert_eq!(bus.read_long(trampoline + 16), trampoline + 50);
+        assert_eq!(bus.read_long(trampoline + 16), trampoline + 60);
         assert_eq!(bus.read_long(trampoline + 22), 0);
-        assert_eq!(bus.read_long(trampoline + 28), trampoline + 58);
+        assert_eq!(bus.read_long(trampoline + 28), trampoline + 68);
         assert_eq!(bus.read_long(trampoline + 34), mdef_ptr);
         assert!(disp.guest_calls.is_empty());
     }
@@ -7347,7 +7345,7 @@ mod tests {
             .unwrap()
             .is_ok());
 
-        let trampoline = disp.menu_def_trampoline;
+        let trampoline = cpu.read_reg(Register::PC);
         assert_ne!(trampoline, 0);
         assert_eq!(cpu.read_reg(Register::PC), trampoline);
         assert_eq!(bus.read_long(trampoline + 34), m68k_entry);
@@ -7397,8 +7395,41 @@ mod tests {
             .unwrap()
             .is_ok());
 
-        assert_eq!(disp.menu_def_trampoline, 0);
         assert_eq!(cpu.read_reg(Register::PC), return_pc);
+    }
+
+    #[test]
+    fn classic_mdef_refuses_invalid_stack_without_publishing_a_callback() {
+        for (sp, protected) in [(64, false), (TEST_SP - 1, false), (0xff00_0000, false), (TEST_SP, true)] {
+            let (mut disp, mut cpu, mut bus) = setup();
+            let handle =
+                new_menu_with_title(&mut disp, &mut cpu, &mut bus, 335, 0x306DD0, "Custom");
+            let menu_ptr = bus.read_long(handle);
+            let mdef_ptr = bus.alloc(2);
+            let mdef_handle = bus.alloc(4);
+            bus.write_word(mdef_ptr, 0x4e75);
+            bus.write_long(mdef_handle, mdef_ptr);
+            bus.write_long(menu_ptr + 6, mdef_handle);
+            disp.loaded_handles
+                .insert(mdef_handle, (mdef_ptr, *b"MDEF", 256));
+            let snapshot_start = TEST_SP - 160;
+            let before = bus.read_bytes(snapshot_start, 160);
+            if protected {
+                bus.protect_readonly_code(TEST_SP - 100, 1);
+            }
+            cpu.write_reg(Register::PC, 0x123456);
+            cpu.write_reg(Register::A7, sp);
+            assert!(!disp.arm_menu_definition_to(
+                &mut cpu,
+                &mut bus,
+                MenuDefinitionInvocation::size(handle),
+                0x123454
+            ));
+            assert_eq!(cpu.read_reg(Register::PC), 0x123456);
+            assert_eq!(cpu.read_reg(Register::A7), sp);
+            assert!(disp.guest_calls.is_empty());
+            assert_eq!(bus.read_bytes(snapshot_start, 160), before);
+        }
     }
 
     #[test]
@@ -7425,14 +7456,14 @@ mod tests {
         };
         assert!(disp.arm_menu_definition(&mut cpu, &mut bus, invocation));
 
-        let trampoline = disp.menu_def_trampoline;
+        let trampoline = cpu.read_reg(Register::PC);
         assert_eq!(bus.read_word(trampoline + 6), 1);
         assert_eq!(bus.read_long(trampoline + 10), handle);
-        assert_eq!(bus.read_long(trampoline + 16), trampoline + 50);
+        assert_eq!(bus.read_long(trampoline + 16), trampoline + 60);
         assert_eq!(bus.read_long(trampoline + 22), 0x0050_0060);
-        assert_eq!(bus.read_long(trampoline + 28), trampoline + 58);
+        assert_eq!(bus.read_long(trampoline + 28), trampoline + 68);
         assert_eq!(
-            bus.read_bytes(trampoline + 50, 10),
+            bus.read_bytes(trampoline + 60, 10),
             invocation.scratch_bytes()
         );
     }
@@ -7471,9 +7502,9 @@ mod tests {
             .dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .is_ok());
-        let trampoline = disp.menu_def_trampoline;
+        let trampoline = cpu.read_reg(Register::PC);
         assert_eq!(bus.read_word(trampoline + 6), 0);
-        assert_eq!(bus.read_long(TEST_SP - 4), trap_pc);
+        assert_eq!(bus.read_long(trampoline + 56), trap_pc);
         assert!(disp.is_menu_definition_callback_pending());
         assert_eq!(disp.guest_calls.len(), 1);
         assert_eq!(*disp.current_port, disp.window_manager_cport);
@@ -7486,9 +7517,9 @@ mod tests {
             .is_ok());
         assert_eq!(bus.read_word(trampoline + 6), 1);
         assert_eq!(bus.read_long(trampoline + 22), 0x001C_0014);
-        assert_eq!(bus.read_word(trampoline + 58), 0);
+        assert_eq!(bus.read_word(trampoline + 68), 0);
 
-        bus.write_word(trampoline + 58, 2);
+        bus.write_word(trampoline + 68, 2);
         cpu.write_reg(Register::A7, TEST_SP);
         bus.write_word(TEST_SP, 1);
         disp.dispatch_menu(true, 0x14A, &mut cpu, &mut bus)
@@ -7516,9 +7547,9 @@ mod tests {
             bus.read_long(trampoline + 22),
             (u32::from((top - 1) as u16) << 16) | u32::from(left as u16)
         );
-        assert_eq!(bus.read_word(trampoline + 58), 2);
+        assert_eq!(bus.read_word(trampoline + 68), 2);
 
-        bus.write_word(trampoline + 58, 0);
+        bus.write_word(trampoline + 68, 0);
         let tracking = disp.menu_tracking.as_mut().unwrap();
         tracking.flash_remaining = 1;
         tracking.flash_delay = 0;
@@ -7563,13 +7594,13 @@ mod tests {
         disp.dispatch_menu(true, 0x00B, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
-        let trampoline = disp.menu_def_trampoline;
+        let trampoline = cpu.read_reg(Register::PC);
         assert_eq!(bus.read_word(trampoline + 6), 3);
         assert_eq!(bus.read_long(trampoline + 22), 0x0028_001E);
-        assert_eq!(bus.read_word(trampoline + 58), 4);
+        assert_eq!(bus.read_word(trampoline + 68), 4);
 
         for (offset, value) in [(0, 40i16), (2, 30), (4, 72), (6, 110), (8, 0)] {
-            bus.write_word(trampoline + 50 + offset, value as u16);
+            bus.write_word(trampoline + 60 + offset, value as u16);
         }
         cpu.write_reg(Register::PC, trap_pc + 2);
         cpu.write_reg(Register::A7, TEST_SP);
@@ -7578,7 +7609,7 @@ mod tests {
             .unwrap();
         assert_eq!(bus.read_word(trampoline + 6), 0);
         assert_eq!(
-            bus.read_bytes(trampoline + 50, 8),
+            bus.read_bytes(trampoline + 60, 8),
             [0, 40, 0, 30, 0, 72, 0, 110]
         );
 
@@ -7590,7 +7621,7 @@ mod tests {
         assert_eq!(bus.read_word(trampoline + 6), 1);
         assert_eq!(bus.read_long(trampoline + 22), 0x0034_002D);
 
-        bus.write_word(trampoline + 58, 2);
+        bus.write_word(trampoline + 68, 2);
         bus.write_byte(crate::memory::globals::addr::MB_STATE, 0x80);
         cpu.write_reg(Register::PC, trap_pc + 2);
         cpu.write_reg(Register::A7, TEST_SP);
@@ -7608,9 +7639,9 @@ mod tests {
             .unwrap();
         assert_eq!(bus.read_word(trampoline + 6), 1);
         assert_eq!(bus.read_long(trampoline + 22), 0x0027_001E);
-        assert_eq!(bus.read_word(trampoline + 58), 2);
+        assert_eq!(bus.read_word(trampoline + 68), 2);
 
-        bus.write_word(trampoline + 58, 0);
+        bus.write_word(trampoline + 68, 0);
         let tracking = disp.menu_tracking.as_mut().unwrap();
         tracking.flash_remaining = 1;
         tracking.flash_delay = 0;
@@ -8523,7 +8554,7 @@ mod tests {
             mdef_ptr,
             "custom MDEF handle should dereference to the loaded resource"
         );
-        let trampoline = disp.menu_def_trampoline;
+        let trampoline = cpu.read_reg(Register::PC);
         assert_ne!(trampoline, 0);
         assert_eq!(
             bus.read_word(trampoline + 6),
@@ -8877,7 +8908,7 @@ mod tests {
         disp.dispatch_menu(true, 0x1C0, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
-        let trampoline = disp.menu_def_trampoline;
+        let trampoline = cpu.read_reg(Register::PC);
         assert_eq!(bus.read_word(trampoline + 6), 2);
         let first_handle = bus.read_long(trampoline + 10);
         assert_eq!(bus.read_word(bus.read_long(first_handle)), 601);
@@ -8906,6 +8937,10 @@ mod tests {
         assert_ne!(list_handle, 0);
         assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 2);
         assert_eq!(disp.pending_menu_bar_build, None);
+        assert!(
+            disp.guest_calls.is_empty(),
+            "completed GetNewMBar must retire every MDEF frame"
+        );
         assert_eq!(bus.read_word(bus.read_long(first_handle) + 2), 101);
         assert_eq!(bus.read_word(bus.read_long(second_handle) + 4), 42);
         assert_eq!(
@@ -16090,7 +16125,7 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        let trampoline = disp.menu_def_trampoline;
+        let trampoline = cpu.read_reg(Register::PC);
         let child_rect = disp.menu_tracking.as_ref().unwrap().submenus[0].dropdown_rect();
         assert_eq!(child_rect.3 - child_rect.1, 72);
         assert_eq!(child_rect.2 - child_rect.0, 32);
@@ -16111,7 +16146,7 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(bus.read_word(trampoline + 6), 1);
-        bus.write_word(trampoline + 58, 0);
+        bus.write_word(trampoline + 68, 0);
         cpu.write_reg(Register::PC, trap_pc + 2);
         cpu.write_reg(Register::A7, TEST_SP);
         disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
@@ -16137,7 +16172,7 @@ mod tests {
         assert_eq!(bus.read_word(trampoline + 6), 1);
         assert_eq!(bus.read_long(trampoline + 10), child);
 
-        bus.write_word(trampoline + 58, 2);
+        bus.write_word(trampoline + 68, 2);
         disp.input_state.mouse_button = false;
         cpu.write_reg(Register::PC, trap_pc + 2);
         cpu.write_reg(Register::A7, TEST_SP);


### PR DESCRIPTION
A classic MDEF that invokes another custom menu can overwrite its own callback wrapper and rectangle/item storage. An actual nested callback regression reads the inner `0x3344` instead of the outer `0x1122` on the previous implementation. GetNewMBar also advances custom sizing without retiring its classic callback frames, leaving live frames after returning the completed menu list.

Use one execution-layer Pascal frame builder for both classic and native-origin emulated MDEFs. Place each classic wrapper and its arguments in that callback's stack reservation, return atomically with RTD, and remove the reused dispatcher field and both duplicate assemblers. Keep tracked results above a parked stack pointer until execution captures them through the same exact-frame completion receipt used by native callbacks, then restore the caller ABI before trap/vector routing. The shared MenuBarBuild now waits for its own Size callback to return before advancing; nested receipts cannot replace its pending completion.

Validation: 5,109 headless library tests pass with JIT enabled (three existing ignored). Coverage includes the new actual nested classic callback, both cross-ISA directions, the GetNewMBar empty-frame assertion, nested receipt isolation, preparation refusal for short, odd, unmapped and protected stacks, and actual timer delivery immediately before and after the callback return. The identical nested callback test fails on the previous public source. Public CI is required before merging.

Progress toward #1512; this does not close it. Shared tracking policy, task-owned saved-port/build custody, nested manager requests, task/teardown handling and removal of remaining trap-refire policy are still outstanding.
