### PR TITLE
refactor: share menu release blink transitions

### DIFF
--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -69,14 +69,14 @@ use crate::menu_manager::{
     MenuColorTable, MenuDefinitionInvocation, MenuDefinitionMessage, MenuDefinitionPane,
     MenuDefinitionTracking, MenuItem as PpcMenuItemDefinition, MenuItems, MenuKeyItem, MenuKeyMenu,
     MenuKeySelection, MenuList as PpcMenuListDefinition, MenuListInstallRequest, MenuRow, MenuRows,
-    MenuSnapshotRecord, MenuTrackingKind, MenuTrackingPane, MenuTrackingSurface,
+    MenuSnapshotRecord, MenuFlashStep, MenuTrackingKind, MenuTrackingPane, MenuTrackingSurface,
     MonochromeMenuIconLayout, ProcessMenuTrackingState, ProcessTrackedMenuPane,
     SharedNativeMenuSelection, StandardMenuChrome, StandardMenuIconKind, StandardMenuItemWidth,
     StandardMenuPaneKind, SubmenuReconciliation, SubmenuRequest,
     TrackedMenuIcon as PpcTrackedMenuIcon,
     TrackedMenuItemAppearance as PpcTrackedMenuItemAppearance, TrackedMenuPaneView,
     MAX_MENU_LIST_ENTRIES, STANDARD_MENU_BAR_FIRST_TITLE_LEFT, STANDARD_MENU_BAR_TITLE_SPACING,
-    STANDARD_MENU_DEFINITION_SHIM, STANDARD_MENU_FLASH_PHASE_DELAY, STANDARD_MENU_SEPARATOR_HEIGHT,
+    STANDARD_MENU_DEFINITION_SHIM, STANDARD_MENU_SEPARATOR_HEIGHT,
 };
 #[cfg(test)]
 use crate::menu_manager::{
@@ -17230,18 +17230,15 @@ fn dispatch_supported_import(
                     *current_resource_refnum,
                 ))
             } else if toolbox_startup.menu_tracking.as_ref().is_some_and(|state| {
-                state.kind == MenuTrackingKind::MenuBar && state.flash_remaining > 0
+                state.kind == MenuTrackingKind::MenuBar && state.is_flashing()
             }) {
                 let mut state = toolbox_startup.menu_tracking.take().unwrap();
-                if state.flash_delay > 0 {
-                    state.flash_delay -= 1;
+                let step = state.advance_flash();
+                if matches!(step, MenuFlashStep::Wait | MenuFlashStep::Inactive) {
                     *toolbox_startup.menu_tracking = Some(state);
                     return Some(PpcImportAction::Yield(u64::MAX));
                 }
-                state.flash_remaining -= 1;
-                state.flash_delay = STANDARD_MENU_FLASH_PHASE_DELAY;
-                let result = state.flash_result;
-                if state.flash_remaining == 0 {
+                if let MenuFlashStep::Complete(result) = step {
                     *toolbox_startup.menu_tracking = Some(state);
                     let result = ppc_complete_menu_bar_tracking_with_colors(
                         memory,
@@ -17262,7 +17259,7 @@ fn dispatch_supported_import(
                         menu_colors,
                         &state,
                         selected,
-                        state.flash_remaining & 1 == 0,
+                        step == MenuFlashStep::Highlight(true),
                     );
                 }
                 *toolbox_startup.menu_tracking = Some(state);
@@ -76763,18 +76760,13 @@ fn ppc_continue_custom_popup_menu_tracking(
     if startup
         .menu_tracking
         .as_ref()
-        .is_some_and(|state| state.flash_remaining > 0)
+        .is_some_and(|state| state.is_flashing())
     {
-        let state = startup.menu_tracking.as_mut().unwrap();
-        if state.flash_delay > 0 {
-            state.flash_delay -= 1;
+        let step = startup.menu_tracking.as_mut().unwrap().advance_flash();
+        if matches!(step, MenuFlashStep::Wait | MenuFlashStep::Inactive) {
             return PpcImportAction::Yield(u64::MAX);
         }
-        state.flash_remaining -= 1;
-        state.flash_delay = STANDARD_MENU_FLASH_PHASE_DELAY;
-        let remaining = state.flash_remaining;
-        let result = state.flash_result;
-        if remaining == 0 {
+        if let MenuFlashStep::Complete(result) = step {
             if let Some(state) = startup.menu_tracking.take() {
                 if ppc_live_front_buffer_for_gworld(memory, gworlds, PPC_MAIN_GWORLD)
                     .map(MenuTrackingSurface::from)
@@ -76789,10 +76781,6 @@ fn ppc_continue_custom_popup_menu_tracking(
             cpu.lr = call.return_address;
             return PpcImportAction::Return(result);
         }
-        startup
-            .active_menu_definition_mut()
-            .unwrap()
-            .flash(remaining & 1 == 0);
         let invocation = startup
             .active_menu_definition()
             .and_then(MenuDefinitionTracking::pending_invocation)
@@ -77016,24 +77004,21 @@ fn ppc_dispatch_pop_up_menu_select(
             return PpcImportAction::Return(0);
         }
 
-        if state.flash_remaining > 0 {
+        if state.is_flashing() {
             let Some(mut state) = startup.menu_tracking.take() else {
                 return PpcImportAction::Return(0);
             };
-            if state.flash_delay > 0 {
-                state.flash_delay -= 1;
+            let step = state.advance_flash();
+            if matches!(step, MenuFlashStep::Wait | MenuFlashStep::Inactive) {
                 *startup.menu_tracking = Some(state);
                 return PpcImportAction::Yield(u64::MAX);
             }
-            state.flash_remaining -= 1;
-            if state.flash_remaining == 0 {
-                let result = state.flash_result;
+            if let MenuFlashStep::Complete(result) = step {
                 startup.popup_menu_call = None;
                 ppc_restore_menu_tracking(memory, state.front_buffer, &state);
                 return PpcImportAction::Return(result);
             }
-            state.flash_delay = STANDARD_MENU_FLASH_PHASE_DELAY;
-            let visible_item = if state.flash_remaining & 1 == 0 {
+            let visible_item = if step == MenuFlashStep::Highlight(true) {
                 state.highlighted_item
             } else {
                 0
@@ -78595,18 +78580,13 @@ fn ppc_continue_custom_menu_bar_tracking(
     if startup
         .menu_tracking
         .as_ref()
-        .is_some_and(|state| state.flash_remaining > 0)
+        .is_some_and(|state| state.is_flashing())
     {
-        let state = startup.menu_tracking.as_mut().unwrap();
-        if state.flash_delay > 0 {
-            state.flash_delay -= 1;
+        let step = startup.menu_tracking.as_mut().unwrap().advance_flash();
+        if matches!(step, MenuFlashStep::Wait | MenuFlashStep::Inactive) {
             return PpcImportAction::Yield(u64::MAX);
         }
-        state.flash_remaining -= 1;
-        state.flash_delay = STANDARD_MENU_FLASH_PHASE_DELAY;
-        let remaining = state.flash_remaining;
-        let result = state.flash_result;
-        if remaining == 0 {
+        if let MenuFlashStep::Complete(result) = step {
             if let Some(state) = startup.menu_tracking.take() {
                 if ppc_live_front_buffer_for_gworld(memory, gworlds, PPC_MAIN_GWORLD)
                     .map(MenuTrackingSurface::from)
@@ -78632,10 +78612,6 @@ fn ppc_continue_custom_menu_bar_tracking(
             cpu.lr = call.return_address;
             return PpcImportAction::Return(result);
         }
-        startup
-            .active_menu_definition_mut()
-            .unwrap()
-            .flash(remaining & 1 == 0);
         let invocation = startup
             .active_menu_definition()
             .and_then(MenuDefinitionTracking::pending_invocation)
@@ -94420,30 +94396,23 @@ pub(crate) mod tests {
                 .flash_remaining,
             6
         );
-        {
-            let state = loaded.toolbox_startup.menu_tracking.as_mut().unwrap();
-            state.flash_remaining = 2;
-            state.flash_delay = 0;
-        }
-        let probe = loaded.run_with_hle_imports(256);
-        assert!(matches!(probe.result, PpcRunResult::CycleLimit { .. }));
-        assert_eq!(
-            loaded
+        let mut phases = vec![6];
+        for _ in 0..64 {
+            let probe = loaded.run_with_hle_imports(256);
+            let remaining = loaded
                 .toolbox_startup
                 .menu_tracking
                 .as_ref()
-                .unwrap()
-                .flash_remaining,
-            1
-        );
-        loaded
-            .toolbox_startup
-            .menu_tracking
-            .as_mut()
-            .unwrap()
-            .flash_delay = 0;
-        let probe = loaded.run_with_hle_imports(256);
-        assert!(matches!(probe.result, PpcRunResult::Halted { .. }));
+                .map_or(0, |state| state.flash_remaining);
+            if phases.last() != Some(&remaining) {
+                phases.push(remaining);
+            }
+            if matches!(probe.result, PpcRunResult::Halted { .. }) {
+                break;
+            }
+            assert!(matches!(probe.result, PpcRunResult::CycleLimit { .. }));
+        }
+        assert_eq!(phases, [6, 5, 4, 3, 2, 1, 0]);
         assert_eq!(loaded.cpu.gpr[3], (131u32 << 16) | 2);
         assert_eq!(loaded.cpu.lr, return_address);
         assert_eq!(loaded.toolbox_startup.menu_tracking, None);
@@ -94785,30 +94754,23 @@ pub(crate) mod tests {
                 .flash_remaining,
             6
         );
-        {
-            let state = loaded.toolbox_startup.menu_tracking.as_mut().unwrap();
-            state.flash_remaining = 2;
-            state.flash_delay = 0;
-        }
-        let probe = loaded.run_with_hle_imports(512);
-        assert!(matches!(probe.result, PpcRunResult::CycleLimit { .. }));
-        assert_eq!(
-            loaded
+        let mut phases = vec![6];
+        for _ in 0..64 {
+            let probe = loaded.run_with_hle_imports(512);
+            let remaining = loaded
                 .toolbox_startup
                 .menu_tracking
                 .as_ref()
-                .unwrap()
-                .flash_remaining,
-            1
-        );
-        loaded
-            .toolbox_startup
-            .menu_tracking
-            .as_mut()
-            .unwrap()
-            .flash_delay = 0;
-        let probe = loaded.run_with_hle_imports(512);
-        assert!(matches!(probe.result, PpcRunResult::Halted { .. }));
+                .map_or(0, |state| state.flash_remaining);
+            if phases.last() != Some(&remaining) {
+                phases.push(remaining);
+            }
+            if matches!(probe.result, PpcRunResult::Halted { .. }) {
+                break;
+            }
+            assert!(matches!(probe.result, PpcRunResult::CycleLimit { .. }));
+        }
+        assert_eq!(phases, [6, 5, 4, 3, 2, 1, 0]);
         assert_eq!(loaded.cpu.gpr[3], (132u32 << 16) | 2);
         assert_eq!(loaded.toolbox_startup.menu_tracking, None);
         assert_eq!(loaded.toolbox_startup.menu_definition_tracking, None);

--- a/src/menu_manager.rs
+++ b/src/menu_manager.rs
@@ -439,7 +439,7 @@ impl MenuDefinitionTracking {
     /// contract unhighlights on an outside point and highlights on the saved
     /// selection point; repeated `mChooseMsg` calls produce the blink.
     /// Inside Macintosh Volume I (1985), p. I-366.
-    pub(crate) fn flash(&mut self, visible: bool) -> Option<MenuDefinitionInvocation> {
+    fn flash(&mut self, visible: bool) -> Option<MenuDefinitionInvocation> {
         if self.pending_invocation.is_some() {
             return None;
         }
@@ -796,6 +796,15 @@ pub(crate) struct TrackedMenuPane<MenuRef, Surface, Pixel, Appearance> {
     pub(crate) item_appearances: Vec<Appearance>,
 }
 
+/// The next presentation or completion step of the shared release blink.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum MenuFlashStep {
+    Inactive,
+    Wait,
+    Highlight(bool),
+    Complete(u32),
+}
+
 /// One retained Menu Manager tracking continuation.
 ///
 /// `Surface` and `Appearance` are presentation snapshots supplied by an
@@ -1036,6 +1045,40 @@ impl<MenuRef: Copy, Surface, Pixel, Appearance>
         };
         self.flash_result = result;
         self.flash_remaining != 0
+    }
+
+    pub(crate) fn is_flashing(&self) -> bool {
+        self.flash_remaining != 0
+    }
+
+    /// Advance one presentation pulse, retaining the release result throughout
+    /// the blink. Custom panes receive the same phases through their MDEF.
+    /// A pending guest call must complete before another phase can be issued.
+    /// Macintosh Toolbox Essentials (1992), SetMenuFlash; Inside Macintosh
+    /// Volume I (1985), p. I-366, menu definition blinking protocol.
+    pub(crate) fn advance_flash(&mut self) -> MenuFlashStep {
+        if !self.is_flashing() {
+            return MenuFlashStep::Inactive;
+        }
+        if self.active_definition().is_some_and(|definition| {
+            definition.pending_invocation().is_some()
+        }) {
+            return MenuFlashStep::Wait;
+        }
+        if self.flash_delay > 0 {
+            self.flash_delay -= 1;
+            return MenuFlashStep::Wait;
+        }
+        self.flash_remaining -= 1;
+        if self.flash_remaining == 0 {
+            return MenuFlashStep::Complete(self.flash_result);
+        }
+        self.flash_delay = STANDARD_MENU_FLASH_PHASE_DELAY;
+        let visible = self.flash_remaining & 1 == 0;
+        if let Some(definition) = self.active_definition_mut() {
+            definition.flash(visible);
+        }
+        MenuFlashStep::Highlight(visible)
     }
 
     pub(crate) fn active_definition_pane(&self) -> Option<MenuDefinitionPane> {
@@ -3765,6 +3808,107 @@ mod tests {
         assert_eq!(tracking.flash_remaining, 0);
         assert_eq!(tracking.flash_delay, 0);
         assert_eq!(tracking.flash_result, 0x0080_0003);
+    }
+
+    #[test]
+    fn menu_flash_completes_each_blink_before_returning_the_release_result_once() {
+        for kind in [MenuTrackingKind::MenuBar, MenuTrackingKind::PopUp] {
+            for count in [0, 1, 3] {
+                let mut tracking = test_process_menu_tracking(128);
+                tracking.kind = kind;
+                let result = 0x0080_0002;
+                assert_eq!(tracking.advance_flash(), MenuFlashStep::Inactive);
+                assert_eq!(tracking.begin_flash(count, result), count != 0);
+                for phase in 0..u32::from(count) * 2 {
+                    for _ in 0..STANDARD_MENU_FLASH_PHASE_DELAY {
+                        assert_eq!(tracking.advance_flash(), MenuFlashStep::Wait);
+                    }
+                    let expected = if phase + 1 == u32::from(count) * 2 {
+                        MenuFlashStep::Complete(result)
+                    } else {
+                        MenuFlashStep::Highlight(phase & 1 != 0)
+                    };
+                    assert_eq!(tracking.advance_flash(), expected);
+                }
+                assert!(!tracking.is_flashing());
+                assert_eq!(tracking.advance_flash(), MenuFlashStep::Inactive);
+            }
+        }
+    }
+
+    #[test]
+    fn menu_flash_waits_for_the_active_definition_and_keeps_its_release_point() {
+        for child in [false, true] {
+            let mut tracking = tracking_with_child(128u32, 129);
+            let rect = (20, 30, 60, 90);
+            let point = (40 << 16) | 50;
+            let selected = MenuDefinitionResult {
+                menu_rect: rect,
+                which_item: 2,
+            };
+            let mut definition = MenuDefinitionTracking::begin_draw(129, rect);
+            definition.complete_pending(selected);
+            definition.choose(point).unwrap();
+            definition.complete_pending(selected);
+            if child {
+                tracking.submenus[0].definition = Some(definition);
+            } else {
+                tracking.definition = Some(definition);
+            }
+            assert!(tracking.begin_flash(2, 0x0081_0002));
+            for visible in [false, true, false] {
+                for _ in 0..STANDARD_MENU_FLASH_PHASE_DELAY {
+                    assert_eq!(tracking.advance_flash(), MenuFlashStep::Wait);
+                }
+                assert_eq!(tracking.advance_flash(), MenuFlashStep::Highlight(visible));
+                let invocation = tracking
+                    .active_definition()
+                    .unwrap()
+                    .pending_invocation()
+                    .unwrap();
+                assert_eq!(invocation.message, MenuDefinitionMessage::Choose);
+                assert_eq!(
+                    invocation.hit_point,
+                    if visible { point } else { (19 << 16) | 30 }
+                );
+                let completion = MenuDefinitionCompletion::pending();
+                tracking
+                    .active_definition_mut()
+                    .unwrap()
+                    .bind_completion(invocation, completion.clone());
+                let before = (tracking.flash_remaining, tracking.flash_delay);
+                for _ in 0..10 {
+                    assert_eq!(tracking.advance_flash(), MenuFlashStep::Wait);
+                }
+                assert_eq!((tracking.flash_remaining, tracking.flash_delay), before);
+                MenuDefinitionOperation {
+                    scratch: 0,
+                    completion,
+                }
+                .complete_result(Ok(MenuDefinitionResult {
+                    which_item: if visible { 2 } else { 0 },
+                    ..selected
+                }));
+                // Publication alone must not permit a phase to replace the
+                // invocation whose result has not yet been consumed.
+                assert_eq!(tracking.advance_flash(), MenuFlashStep::Wait);
+                assert_eq!(
+                    tracking
+                        .active_definition_mut()
+                        .unwrap()
+                        .complete_callback(),
+                    Ok(Some(MenuDefinitionMessage::Choose))
+                );
+            }
+            for _ in 0..STANDARD_MENU_FLASH_PHASE_DELAY {
+                assert_eq!(tracking.advance_flash(), MenuFlashStep::Wait);
+            }
+            assert_eq!(
+                tracking.advance_flash(),
+                MenuFlashStep::Complete(0x0081_0002)
+            );
+            assert_eq!(tracking.advance_flash(), MenuFlashStep::Inactive);
+        }
     }
 
     #[test]

--- a/src/trap/menu.rs
+++ b/src/trap/menu.rs
@@ -23,13 +23,12 @@ use crate::menu_manager::{
     MenuDefinitionTracking as SharedMenuDefinitionTracking, MenuItems as SharedMenuItems,
     MenuKeyItem as SharedMenuKeyItem, MenuKeyMenu as SharedMenuKeyMenu, MenuList as SharedMenuList,
     MenuListInstallRequest, MenuRow as SharedMenuRow, MenuRows as SharedMenuRows,
-    MenuSnapshotRecord as SharedMenuSnapshotRecord, MenuTrackingKind, MenuTrackingPane,
+    MenuSnapshotRecord as SharedMenuSnapshotRecord, MenuFlashStep, MenuTrackingKind, MenuTrackingPane,
     MonochromeMenuIconLayout as SharedMonochromeMenuIconLayout, ProcessMenuTrackingState,
     ProcessTrackedMenuPane, StandardMenuChrome, StandardMenuIconKind, StandardMenuItemWidth,
     StandardMenuPaneKind, SubmenuReconciliation, SubmenuRequest, TrackedMenuPaneView,
     MAX_MENU_LIST_ENTRIES, MENU_COLOR_ENTRY_SIZE, STANDARD_MENU_BAR_FIRST_TITLE_LEFT,
-    STANDARD_MENU_BAR_TITLE_SPACING, STANDARD_MENU_DEFINITION_SHIM,
-    STANDARD_MENU_FLASH_PHASE_DELAY, STANDARD_MENU_SEPARATOR_HEIGHT,
+    STANDARD_MENU_BAR_TITLE_SPACING, STANDARD_MENU_DEFINITION_SHIM, STANDARD_MENU_SEPARATOR_HEIGHT,
 };
 #[cfg(test)]
 use crate::menu_manager::{parse_menu_item_specs, standard_menu_row_height};
@@ -2171,24 +2170,16 @@ impl super::TrapDispatcher {
                         if self
                             .menu_tracking
                             .as_ref()
-                            .is_some_and(|tracking| tracking.flash_remaining > 0)
+                            .is_some_and(|tracking| tracking.is_flashing())
                         {
-                            let tracking = self.menu_tracking.as_mut().unwrap();
-                            if tracking.flash_delay > 0 {
-                                tracking.flash_delay -= 1;
-                                return Some(Ok(()));
+                            match self.menu_tracking.as_mut().unwrap().advance_flash() {
+                                MenuFlashStep::Wait | MenuFlashStep::Inactive => return Some(Ok(())),
+                                MenuFlashStep::Complete(result) => {
+                                    self.finish_custom_menu_tracking(cpu, bus, 4, result);
+                                    return Some(Ok(()));
+                                }
+                                MenuFlashStep::Highlight(_) => {}
                             }
-                            tracking.flash_remaining -= 1;
-                            tracking.flash_delay = STANDARD_MENU_FLASH_PHASE_DELAY;
-                            let remaining = tracking.flash_remaining;
-                            let result = tracking.flash_result;
-                            if remaining == 0 {
-                                self.finish_custom_menu_tracking(cpu, bus, 4, result);
-                                return Some(Ok(()));
-                            }
-                            self.active_menu_definition_mut()
-                                .unwrap()
-                                .flash(remaining & 1 == 0);
                             if !self.arm_pending_menu_definition(
                                 cpu,
                                 bus,
@@ -2270,23 +2261,10 @@ impl super::TrapDispatcher {
                         return Some(Ok(()));
                     }
                     // Re-fire: we're in tracking mode
-                    if self.menu_tracking.as_ref().unwrap().flash_remaining > 0 {
-                        // Flashing phase: hold each toggle for 3 frames (~50ms),
-                        // matching the real Mac's ~3-tick delay per phase.
-                        // redraw_chrome handles the visual state based on
-                        // whether flash_remaining is even or odd.
-                        let result = self.menu_tracking.as_ref().unwrap().flash_result;
-                        let t = self.menu_tracking.as_mut().unwrap();
-                        if t.flash_delay > 0 {
-                            t.flash_delay -= 1;
-                            return Some(Ok(()));
-                        }
-                        // Advance to next toggle
-                        t.flash_remaining -= 1;
-                        t.flash_delay = STANDARD_MENU_FLASH_PHASE_DELAY;
-                        let new_remaining = t.flash_remaining;
-
-                        if new_remaining == 0 {
+                    if self.menu_tracking.as_ref().unwrap().is_flashing() {
+                        if let MenuFlashStep::Complete(result) =
+                            self.menu_tracking.as_mut().unwrap().advance_flash()
+                        {
                             // Flash complete — finish up
                             let sp = self.menu_tracking_stack_ptr;
                             let saved = self.menu_tracking.take().unwrap();
@@ -2607,24 +2585,16 @@ impl super::TrapDispatcher {
                         if self
                             .menu_tracking
                             .as_ref()
-                            .is_some_and(|tracking| tracking.flash_remaining > 0)
+                            .is_some_and(|tracking| tracking.is_flashing())
                         {
-                            let tracking = self.menu_tracking.as_mut().unwrap();
-                            if tracking.flash_delay > 0 {
-                                tracking.flash_delay -= 1;
-                                return Some(Ok(()));
+                            match self.menu_tracking.as_mut().unwrap().advance_flash() {
+                                MenuFlashStep::Wait | MenuFlashStep::Inactive => return Some(Ok(())),
+                                MenuFlashStep::Complete(result) => {
+                                    self.finish_custom_menu_tracking(cpu, bus, 10, result);
+                                    return Some(Ok(()));
+                                }
+                                MenuFlashStep::Highlight(_) => {}
                             }
-                            tracking.flash_remaining -= 1;
-                            tracking.flash_delay = STANDARD_MENU_FLASH_PHASE_DELAY;
-                            let remaining = tracking.flash_remaining;
-                            let result = tracking.flash_result;
-                            if remaining == 0 {
-                                self.finish_custom_menu_tracking(cpu, bus, 10, result);
-                                return Some(Ok(()));
-                            }
-                            self.active_menu_definition_mut()
-                                .unwrap()
-                                .flash(remaining & 1 == 0);
                             if !self.arm_pending_menu_definition(
                                 cpu,
                                 bus,
@@ -2676,18 +2646,10 @@ impl super::TrapDispatcher {
                         return Some(Ok(()));
                     }
                     // Re-fire: popup tracking is active
-                    if self.menu_tracking.as_ref().unwrap().flash_remaining > 0 {
-                        let result = self.menu_tracking.as_ref().unwrap().flash_result;
-                        let t = self.menu_tracking.as_mut().unwrap();
-                        if t.flash_delay > 0 {
-                            t.flash_delay -= 1;
-                            return Some(Ok(()));
-                        }
-                        t.flash_remaining -= 1;
-                        t.flash_delay = STANDARD_MENU_FLASH_PHASE_DELAY;
-                        let new_remaining = t.flash_remaining;
-
-                        if new_remaining == 0 {
+                    if self.menu_tracking.as_ref().unwrap().is_flashing() {
+                        if let MenuFlashStep::Complete(result) =
+                            self.menu_tracking.as_mut().unwrap().advance_flash()
+                        {
                             let sp = self.menu_tracking_stack_ptr;
                             let saved = self.menu_tracking.take().unwrap();
                             self.restore_menu_tracking_pixels(bus, saved);


### PR DESCRIPTION
Menu-bar and popup selection used eight separate release-blink loops across the classic/native gateways and standard/custom definitions. They now use one Menu Manager transition for phase timing, highlight requests and final result delivery. Pending MDEF invocations hold the phase until their completion is consumed, so another tracking pulse cannot replace an outstanding callback.

The shared operation also queues MDEF highlight changes; that helper is now private to the manager. Presentation, guest-call execution and ABI result placement stay at their existing boundaries. No retained fields are added. This retains the existing presentation-pulse timing.

Validation: all 366 menu tests pass. New tests cover zero/one/three blinks, single-use completion and root/child callback waiting. Native menu-bar and popup regressions now execute all three blinks through actual guest callbacks instead of skipping phases by rewriting test counters. The full headless library suite with JIT and test-support passes 5,117 tests (three existing ignored). CI on the exact merge tree passes 5,126 library tests (three existing ignored), 50 desktop tests, both architecture showcases, all-target builds, documentation, packaging and dependency licenses. The existing non-blocking formatter allocation failure and Clippy errors remain.

Part of #1512. Task-owned root operations, the remaining tracking policy, saved graphics state, build custody and adapter return/refire removal remain open.
