### PR TITLE
fix: retain menu bar builds by task and enclosing call

### DIFF
--- a/src/execution_m68k.rs
+++ b/src/execution_m68k.rs
@@ -17,6 +17,13 @@ pub(crate) struct M68kMenuDefinitionFrame {
 }
 
 impl M68kMenuDefinitionFrame {
+    /// Resume a retained Toolbox operation through a plain trap, without
+    /// repeating the original auto-pop entry's caller-return consumption.
+    pub(crate) fn trap_return(&mut self, opcode: u16) -> u32 {
+        self.image[52..54].copy_from_slice(&opcode.to_be_bytes());
+        self.entry + 52
+    }
+
     pub(crate) const RESERVATION: u32 = 80;
     pub(crate) const STACK_PREFIX: u32 = 58;
 

--- a/src/guest_call.rs
+++ b/src/guest_call.rs
@@ -560,12 +560,43 @@ impl TaskResumeContext {
     }
 }
 
+/// Identity of one retained Menu Manager build, independent of callback depth.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct MenuBarBuildId(u64);
+
+/// Caller return placement belongs to execution, not to menu sizing policy.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum MenuBarCallOrigin {
+    M68k { stack_pointer: u32, return_address: Option<u32> },
+    PowerPc { return_address: u32 },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum MenuBarBuildResume {
+    Size(u32),
+    Waiting,
+    Complete { result: u32, origin: MenuBarCallOrigin },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct MenuBarCall {
+    id: MenuBarBuildId,
+    task: ExecutionTaskId,
+    parent: Option<CallId>,
+    origin: MenuBarCallOrigin,
+    build: crate::menu_manager::MenuBarBuild<u32>,
+}
+
 #[derive(Debug)]
 struct ExecutionTaskCalls {
     /// Authoritative task/order/phase state. The frame map below is only the
     /// temporary CPU-adapter projection keyed by this store's CallId.
     kernel: ContinuationStore,
     frames: HashMap<CallId, GuestCallFrame>,
+    /// Manager roots outlive each individual guest callback and retain the
+    /// invoking task, enclosing call and original ABI return placement.
+    menu_bar_calls: Vec<MenuBarCall>,
+    next_menu_bar_call: u64,
     powerpc_contexts: ExecutionContextBank<Box<PpcCpu>>,
     m68k_contexts: Rc<RefCell<ExecutionContextBank<M68kCpu>>>,
     cooperative_contexts: ExecutionTaskContextBank<CooperativeThread>,
@@ -585,6 +616,8 @@ impl Clone for ExecutionTaskCalls {
         Self {
             kernel: self.kernel.clone(),
             frames: self.frames.clone(),
+            menu_bar_calls: self.menu_bar_calls.clone(),
+            next_menu_bar_call: self.next_menu_bar_call,
             powerpc_contexts: self.powerpc_contexts.clone(),
             m68k_contexts: Rc::new(RefCell::new(ExecutionContextBank::default())),
             cooperative_contexts: self.cooperative_contexts.clone(),
@@ -601,6 +634,8 @@ impl PartialEq for ExecutionTaskCalls {
     fn eq(&self, other: &Self) -> bool {
         self.kernel == other.kernel
             && self.frames == other.frames
+            && self.menu_bar_calls == other.menu_bar_calls
+            && self.next_menu_bar_call == other.next_menu_bar_call
             && self.powerpc_contexts.same_slots(&other.powerpc_contexts)
             && self
                 .m68k_contexts
@@ -629,6 +664,8 @@ impl Default for ExecutionTaskCalls {
         Self {
             kernel: ContinuationStore::default(),
             frames: HashMap::new(),
+            menu_bar_calls: Vec::new(),
+            next_menu_bar_call: 0,
             powerpc_contexts: ExecutionContextBank::default(),
             m68k_contexts: Rc::new(RefCell::new(ExecutionContextBank::default())),
             cooperative_contexts: ExecutionTaskContextBank::default(),
@@ -802,6 +839,7 @@ impl ExecutionTaskCalls {
         self.cooperative_contexts.remove(task);
         self.native_threads.remove(task);
         self.thread_storage.remove(task);
+        self.menu_bar_calls.retain(|call| call.task != task);
         if let Some(isa) = pooled_isa {
             self.thread_pool.push((
                 isa,
@@ -851,6 +889,8 @@ impl ExecutionTaskCalls {
 
     fn is_pristine(&self) -> bool {
         self.kernel.is_pristine()
+            && self.menu_bar_calls.is_empty()
+            && self.next_menu_bar_call == 0
             && self.m68k_contexts.borrow().is_empty()
             && self.cooperative_contexts.is_empty()
             && self.native_threads.is_empty()
@@ -910,7 +950,8 @@ impl SharedGuestCallStack {
     }
 
     pub(crate) fn is_empty(&self) -> bool {
-        self.0.borrow().kernel.is_empty()
+        let tasks = self.0.borrow();
+        tasks.kernel.is_empty() && tasks.menu_bar_calls.is_empty()
     }
 
     pub(crate) fn depth(&self) -> usize {
@@ -937,6 +978,113 @@ impl SharedGuestCallStack {
     #[cfg(test)]
     pub(crate) fn m68k_context_bank(&self) -> Rc<RefCell<ExecutionContextBank<M68kCpu>>> {
         self.classic_contexts()
+    }
+
+    /// The enclosing guest call distinguishes a nested Toolbox entry from
+    /// resumption after its own MDEF has retired. Another task cannot observe
+    /// or consume this operation, even when it uses the same import or trap.
+    pub(crate) fn menu_bar_build(&self) -> Option<MenuBarBuildId> {
+        let tasks = self.0.borrow();
+        let task = tasks.kernel.current_task();
+        let parent = tasks.kernel.peek(task).map(|call| call.call_id());
+        tasks
+            .menu_bar_calls
+            .iter()
+            .rev()
+            .find(|call| call.task == task && call.parent == parent)
+            .map(|call| call.id)
+    }
+
+    pub(crate) fn menu_bar_build_origin(&self) -> Option<MenuBarCallOrigin> {
+        let id = self.menu_bar_build()?;
+        self.0
+            .borrow()
+            .menu_bar_calls
+            .iter()
+            .find(|call| call.id == id)
+            .map(|call| call.origin)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn has_menu_bar_builds(&self) -> bool {
+        let tasks = self.0.borrow();
+        let task = tasks.kernel.current_task();
+        tasks.menu_bar_calls.iter().any(|call| call.task == task)
+    }
+
+    pub(crate) fn begin_menu_bar_build(
+        &self,
+        build: crate::menu_manager::MenuBarBuild<u32>,
+        origin: MenuBarCallOrigin,
+    ) -> Option<MenuBarBuildId> {
+        let mut tasks = self.0.borrow_mut();
+        let task = tasks.kernel.current_task();
+        let parent = tasks.kernel.peek(task).map(|call| call.call_id());
+        if tasks
+            .menu_bar_calls
+            .iter()
+            .any(|call| call.task == task && call.parent == parent)
+        {
+            return None;
+        }
+        let next = tasks.next_menu_bar_call.checked_add(1)?;
+        let id = MenuBarBuildId(tasks.next_menu_bar_call);
+        tasks.next_menu_bar_call = next;
+        tasks.menu_bar_calls.push(MenuBarCall {
+            id,
+            task,
+            parent,
+            origin,
+            build,
+        });
+        Some(id)
+    }
+
+    pub(crate) fn advance_menu_bar_build(&self, isa: GuestIsa) -> Option<MenuBarBuildResume> {
+        let mut tasks = self.0.borrow_mut();
+        let task = tasks.kernel.current_task();
+        let parent = tasks.kernel.peek(task).map(|call| call.call_id());
+        let index = tasks
+            .menu_bar_calls
+            .iter()
+            .rposition(|call| call.task == task && call.parent == parent)?;
+        let origin_isa = match tasks.menu_bar_calls[index].origin {
+            MenuBarCallOrigin::M68k { .. } => GuestIsa::M68k,
+            MenuBarCallOrigin::PowerPc { .. } => GuestIsa::PowerPc,
+        };
+        if origin_isa != isa {
+            return None;
+        }
+        match tasks.menu_bar_calls[index].build.next_step() {
+            Some(crate::menu_manager::MenuBarBuildStep::Size(handle)) => {
+                Some(MenuBarBuildResume::Size(handle))
+            }
+            Some(crate::menu_manager::MenuBarBuildStep::Complete(result)) => {
+                let call = tasks.menu_bar_calls.remove(index);
+                Some(MenuBarBuildResume::Complete {
+                    result,
+                    origin: call.origin,
+                })
+            }
+            None => Some(MenuBarBuildResume::Waiting),
+        }
+    }
+
+    pub(crate) fn bind_menu_bar_build_completion(
+        &self,
+        id: MenuBarBuildId,
+        handle: u32,
+        completion: crate::menu_manager::MenuDefinitionCompletion,
+    ) {
+        let mut tasks = self.0.borrow_mut();
+        let task = tasks.kernel.current_task();
+        if let Some(call) = tasks
+            .menu_bar_calls
+            .iter_mut()
+            .find(|call| call.id == id && call.task == task)
+        {
+            call.build.bind_completion(handle, completion);
+        }
     }
 
     pub(crate) fn current_task(&self) -> ExecutionTaskId {
@@ -1029,6 +1177,7 @@ impl SharedGuestCallStack {
         tasks.cooperative_contexts.remove(task);
         tasks.native_threads.remove(task);
         tasks.thread_storage.remove(task);
+        tasks.menu_bar_calls.retain(|call| call.task != task);
         true
     }
 
@@ -2601,6 +2750,111 @@ mod tests {
     use ppc::PpcRunResult;
 
     const RETURN_PC: u32 = 0x01f0_4000;
+
+    #[test]
+    fn menu_bar_operations_scope_nested_calls_and_preserve_each_return_abi() {
+        use crate::menu_manager::{
+            MenuBarBuild, MenuDefinitionCompletion, MenuDefinitionOperation, MenuDefinitionResult,
+        };
+        let calls = SharedGuestCallStack::default();
+        let outer_origin = MenuBarCallOrigin::M68k {
+            stack_pointer: 0x3000,
+            return_address: None,
+        };
+        let outer = calls
+            .begin_menu_bar_build(MenuBarBuild::new(111, vec![5]), outer_origin)
+            .unwrap();
+        assert_eq!(calls.advance_menu_bar_build(GuestIsa::PowerPc), None);
+        assert_eq!(calls.menu_bar_build(), Some(outer));
+        assert_eq!(
+            calls.advance_menu_bar_build(GuestIsa::M68k),
+            Some(MenuBarBuildResume::Size(5))
+        );
+        assert!(!calls.is_empty());
+        assert!(!calls.is_pristine());
+        assert!(calls.begin_m68k(
+            GuestCallTarget {
+                isa: GuestIsa::M68k,
+                entry: 0x1000,
+                rtoc: 0
+            },
+            0x2000,
+            0x3000
+        ));
+        assert_eq!(calls.menu_bar_build(), None);
+        let completion = MenuDefinitionCompletion::pending();
+        calls.bind_menu_bar_build_completion(outer, 5, completion.clone());
+        let inner_origin = MenuBarCallOrigin::PowerPc {
+            return_address: 0x4000,
+        };
+        let inner = calls
+            .begin_menu_bar_build(MenuBarBuild::new(222, vec![]), inner_origin)
+            .unwrap();
+        assert_ne!(inner, outer);
+        assert_eq!(
+            calls.advance_menu_bar_build(GuestIsa::PowerPc),
+            Some(MenuBarBuildResume::Complete {
+                result: 222,
+                origin: inner_origin
+            })
+        );
+        assert!(calls.complete_m68k(0x2002, 0x3000));
+        assert_eq!(calls.menu_bar_build(), Some(outer));
+        assert_eq!(
+            calls.advance_menu_bar_build(GuestIsa::M68k),
+            Some(MenuBarBuildResume::Waiting)
+        );
+        MenuDefinitionOperation {
+            scratch: 0,
+            completion,
+        }
+        .complete_result(Ok(MenuDefinitionResult {
+            menu_rect: (0, 0, 0, 0),
+            which_item: 0,
+        }));
+        assert_eq!(
+            calls.advance_menu_bar_build(GuestIsa::M68k),
+            Some(MenuBarBuildResume::Complete {
+                result: 111,
+                origin: outer_origin
+            })
+        );
+        assert_eq!(calls.advance_menu_bar_build(GuestIsa::M68k), None);
+        assert!(calls.is_empty());
+    }
+
+    #[test]
+    fn menu_bar_operations_follow_tasks_and_retirement() {
+        use crate::menu_manager::MenuBarBuild;
+        let calls = SharedGuestCallStack::default();
+        let origin = MenuBarCallOrigin::PowerPc {
+            return_address: 0x1000,
+        };
+        let main = calls
+            .begin_menu_bar_build(MenuBarBuild::new(111, vec![]), origin)
+            .unwrap();
+        let worker = ExecutionTaskId::from_thread_id(7);
+        assert!(calls.register_task(worker));
+        assert!(calls.set_scheduling_state(worker, ExecutionTaskState::Ready));
+        assert!(calls.switch_to_task(worker));
+        assert_eq!(calls.menu_bar_build(), None);
+        let owned = calls
+            .begin_menu_bar_build(MenuBarBuild::new(222, vec![]), origin)
+            .unwrap();
+        assert_ne!(main, owned);
+        assert!(calls.switch_to_task(ExecutionTaskId::APPLICATION));
+        assert_eq!(calls.menu_bar_build(), Some(main));
+        assert!(calls.remove_task(worker));
+        assert_eq!(calls.0.borrow().menu_bar_calls.len(), 1);
+        assert_eq!(
+            calls.advance_menu_bar_build(GuestIsa::PowerPc),
+            Some(MenuBarBuildResume::Complete {
+                result: 111,
+                origin
+            })
+        );
+        assert!(calls.is_empty());
+    }
 
     fn native_action(
         entry: u32,

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -5,6 +5,7 @@
 //! section bases, relocations, synthetic import TVectors, and an initial
 //! stack frame. It deliberately does not implement Toolbox imports yet.
 
+use crate::guest_call::{MenuBarBuildResume, MenuBarCallOrigin};
 #[cfg(test)]
 use super::pef::SECTION_KIND_UNPACKED_DATA;
 use super::pef::{
@@ -65,7 +66,7 @@ use crate::menu_manager::{
     standard_menu_icon_kind, standard_menu_icon_resource_id, standard_menu_item_layout,
     standard_menu_text_advance, standard_menu_title_advance, standard_menu_width,
     standard_popup_menu_layout, standard_pull_down_menu_layout, standard_submenu_layout,
-    ColorIconLayout, MenuBarBuild, MenuBarBuildStep, MenuBarResource, MenuBarTitleRegion,
+    ColorIconLayout, MenuBarBuild, MenuBarResource, MenuBarTitleRegion,
     MenuColorTable, MenuDefinitionInvocation, MenuDefinitionMessage, MenuDefinitionPane,
     MenuDefinitionTracking, MenuItem as PpcMenuItemDefinition, MenuItems, MenuKeyItem, MenuKeyMenu,
     MenuKeySelection, MenuList as PpcMenuListDefinition, MenuListInstallRequest, MenuRow, MenuRows,
@@ -2853,12 +2854,6 @@ struct PpcMenuSelectCall {
     return_address: u32,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct PpcPendingMenuBarBuild {
-    build: MenuBarBuild<u32>,
-    return_address: u32,
-}
-
 type PpcMenuTracking = ProcessMenuTrackingState;
 type PpcSubmenuTracking = ProcessTrackedMenuPane;
 
@@ -3037,7 +3032,6 @@ pub struct PpcToolboxStartupState {
     /// Custom popup MDEF state before its returned rectangle creates a pane.
     menu_definition_tracking: Option<MenuDefinitionTracking>,
     /// GetNewMBar result and remaining menus while custom mSizeMsg callbacks run.
-    pending_menu_bar_build: Option<PpcPendingMenuBarBuild>,
     /// Native call frame parked while a custom MDEF owns MenuSelect.
     menu_select_call: Option<PpcMenuSelectCall>,
     /// Caller QuickDraw port/device restored after a retained custom MDEF.
@@ -3118,7 +3112,6 @@ impl Default for PpcToolboxStartupState {
             pending_native_menu_selection: SharedNativeMenuSelection::default(),
             menu_tracking: SharedProcessMenuTracking::default(),
             menu_definition_tracking: None,
-            pending_menu_bar_build: None,
             menu_select_call: None,
             menu_definition_saved_gworld: None,
             popup_menu_call: None,
@@ -16882,7 +16875,7 @@ fn dispatch_supported_import(
             )))
         }
         PpcImportDispatcherTarget::GetNewMBar => {
-            if toolbox_startup.pending_menu_bar_build.is_some() {
+            if toolbox_startup.guest_calls.menu_bar_build().is_some() {
                 return Some(ppc_continue_menu_bar_build(
                     cpu,
                     process_memory_manager,
@@ -16912,10 +16905,12 @@ fn dispatch_supported_import(
             let menu_handles = ppc_menu_list_definition(memory, result_handle)
                 .map(|menu_list| menu_list.handles().collect())
                 .unwrap_or_default();
-            toolbox_startup.pending_menu_bar_build = Some(PpcPendingMenuBarBuild {
-                build: MenuBarBuild::new(result_handle, menu_handles),
-                return_address: cpu.lr,
-            });
+            if toolbox_startup.guest_calls.begin_menu_bar_build(
+                MenuBarBuild::new(result_handle, menu_handles),
+                MenuBarCallOrigin::PowerPc { return_address: cpu.lr },
+            ).is_none() {
+                return Some(PpcImportAction::Return(0));
+            }
             Some(ppc_continue_menu_bar_build(
                 cpu,
                 process_memory_manager,
@@ -76366,6 +76361,7 @@ fn ppc_dispatch_native_menu_definition_with_return(
     final_pc: u32,
     return_gpr3: PpcNativeReturnGpr3,
 ) -> Option<PpcImportAction> {
+    let menu_build = toolbox_startup.guest_calls.menu_bar_build();
     let target = ppc_menu_definition_target(cpu, memory, resources, invocation.menu_handle)?;
     let manager = process_memory_manager.as_deref_mut()?;
     // The emulated callback owns its wrapper and stack as well as its
@@ -76441,10 +76437,8 @@ fn ppc_dispatch_native_menu_definition_with_return(
         definition.bind_completion(invocation, completion.clone());
     }
     if invocation.message == MenuDefinitionMessage::Size {
-        if let Some(pending) = toolbox_startup.pending_menu_bar_build.as_mut() {
-            pending
-                .build
-                .bind_completion(invocation.menu_handle, completion);
+        if let Some(id) = menu_build {
+            toolbox_startup.guest_calls.bind_menu_bar_build_completion(id, invocation.menu_handle, completion);
         }
     }
     prepared
@@ -79594,23 +79588,20 @@ fn ppc_continue_menu_bar_build(
     current_resource_refnum: i16,
 ) -> PpcImportAction {
     loop {
-        let Some(step) = startup
-            .pending_menu_bar_build
-            .as_mut()
-            .and_then(|pending| pending.build.next_step())
-        else {
-            return PpcImportAction::Return(0);
-        };
-        let menu_handle = match step {
-            MenuBarBuildStep::Size(menu_handle) => menu_handle,
-            MenuBarBuildStep::Complete(result_handle) => {
-                let Some(pending) = startup.pending_menu_bar_build.take() else {
-                    return PpcImportAction::Return(0);
-                };
-                let return_address = pending.return_address;
+        let menu_handle = match startup
+            .guest_calls
+            .advance_menu_bar_build(GuestIsa::PowerPc)
+        {
+            Some(MenuBarBuildResume::Size(handle)) => handle,
+            Some(MenuBarBuildResume::Complete {
+                result,
+                origin: MenuBarCallOrigin::PowerPc { return_address },
+            }) => {
                 cpu.lr = return_address;
-                return PpcImportAction::Return(result_handle);
+                return PpcImportAction::Return(result);
             }
+            Some(MenuBarBuildResume::Waiting) => return PpcImportAction::Yield(u64::MAX),
+            _ => return PpcImportAction::Return(0),
         };
         if let Some(action) = ppc_dispatch_native_menu_definition(
             cpu,
@@ -102339,7 +102330,157 @@ pub(crate) mod tests {
             assert_eq!(loaded.memory.read_u16_be(menu + 2), Some(123));
             assert_eq!(loaded.memory.read_u16_be(menu + 4), Some(45));
         }
-        assert_eq!(loaded.toolbox_startup.pending_menu_bar_build, None);
+        assert!(!loaded.guest_calls.has_menu_bar_builds());
+    }
+
+    #[test]
+    fn nested_getnewmbar_keeps_each_build_and_its_return_separate() {
+        let pef = synthetic_pef_with_import(b"GetNewMBar");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let marker = PPC_DATA_BASE + 0x7800;
+        loaded.memory.add_region(marker, vec![0; 4]);
+        let descriptor = PPC_DATA_BASE + 0x7100;
+        let tvector = PPC_DATA_BASE + 0x7180;
+        install_test_powerpc_callback(
+            &mut loaded,
+            descriptor,
+            tvector,
+            PPC_CODE_BASE + 0x4000,
+            PPC_DATA_BASE + 0x7300,
+            test_stack_proc_info(
+                PPC_PROCINFO_SIZE_NONE,
+                &[
+                    PPC_PROCINFO_SIZE_TWO,
+                    PPC_PROCINFO_SIZE_FOUR,
+                    PPC_PROCINFO_SIZE_FOUR,
+                    PPC_PROCINFO_SIZE_FOUR,
+                    PPC_PROCINFO_SIZE_FOUR,
+                ],
+            ),
+            &[
+                0x9421_ffa0, // stwu r1,-96(r1)
+                0x7c08_02a6, // mflr r0
+                0x9001_0064, // stw r0,100(r1)
+                0x9081_0038, // retain the outer menu handle
+                0x3860_0385, // li r3,901: nested empty MBAR resource
+                0x3d80_0000 | (PPC_IMPORT_TRAP_BASE >> 16),
+                0x618c_0000 | (PPC_IMPORT_TRAP_BASE & 0xffff),
+                0x7d89_03a6, // mtctr r12
+                0x4e80_0421, // bctrl: nested GetNewMBar
+                0x3d40_0000 | (marker >> 16),
+                0x614a_0000 | (marker & 0xffff),
+                0x906a_0000, // retain the nested menu-list handle
+                0x8081_0038,
+                d_form_u(32, 6, 4, 0),
+                d_form_u(14, 7, 0, 123),
+                d_form_u(44, 7, 6, 2),
+                d_form_u(14, 7, 0, 45),
+                d_form_u(44, 7, 6, 4),
+                0x8001_0064,
+                0x7c08_03a6,
+                0x3821_0060,
+                BLR,
+            ],
+        );
+        let descriptor_bytes = ppc_memory_read_bytes(&mut loaded.memory, descriptor, 0x100).unwrap();
+        let ref_num = *loaded.process_file_system.current_resource_file;
+        loaded.process_file_system.vfs_resources.extend([
+            PpcVfsResourceRecord {
+                ref_num,
+                path: "Test App".to_string(),
+                res_type: u32::from_be_bytes(*b"MBAR"),
+                res_id: 901,
+                name: Vec::new(),
+                data: vec![0, 0],
+                raw_data: None,
+                raw_attrs: None,
+                attrs: 0,
+                handle: 0,
+            },
+            PpcVfsResourceRecord {
+                ref_num,
+                path: "Test App".to_string(),
+                res_type: u32::from_be_bytes(*b"MBAR"),
+                res_id: 900,
+                name: Vec::new(),
+                data: vec![0, 2, 2, 89, 2, 90],
+                raw_data: None,
+                raw_attrs: None,
+                attrs: 0,
+                handle: 0,
+            },
+            PpcVfsResourceRecord {
+                ref_num,
+                path: "Test App".to_string(),
+                res_type: u32::from_be_bytes(*b"MENU"),
+                res_id: 601,
+                name: Vec::new(),
+                data: test_menu_resource_with_mdef(601, 256, b"First"),
+                raw_data: None,
+                raw_attrs: None,
+                attrs: 0,
+                handle: 0,
+            },
+            PpcVfsResourceRecord {
+                ref_num,
+                path: "Test App".to_string(),
+                res_type: u32::from_be_bytes(*b"MENU"),
+                res_id: 602,
+                name: Vec::new(),
+                data: test_menu_resource_with_mdef(602, 256, b"Second"),
+                raw_data: None,
+                raw_attrs: None,
+                attrs: 0,
+                handle: 0,
+            },
+            PpcVfsResourceRecord {
+                ref_num,
+                path: "Test App".to_string(),
+                res_type: u32::from_be_bytes(*b"MDEF"),
+                res_id: 256,
+                name: Vec::new(),
+                data: descriptor_bytes,
+                raw_data: None,
+                raw_attrs: None,
+                attrs: 0,
+                handle: 0,
+            },
+        ]);
+        loaded.cpu.gpr[3] = 900;
+
+        loaded.cpu.pc = loaded.entry_pc;
+        loaded.cpu.lr = PPC_HALT_PC;
+        loaded.imports[0].dispatcher_target = PpcImportDispatcherTarget::GetNewMBar;
+        let probe = loaded.run_with_hle_imports(256);
+        assert_eq!(probe.handled_import_count, 5);
+        assert_eq!(probe.unsupported_import_index, None);
+
+        let inner = loaded.memory.read_u32_be(marker).unwrap();
+        assert_ne!(
+            inner, 0,
+            "nested GetNewMBar must produce its own menu-list handle"
+        );
+        assert_eq!(
+            ppc_menu_list_definition(&mut loaded.memory, inner)
+                .unwrap()
+                .handles()
+                .count(),
+            0
+        );
+        assert!(loaded.guest_calls.is_empty());
+        assert_eq!(loaded.cpu.pc, PPC_HALT_PC);
+        let list_handle = loaded.cpu.gpr[3];
+        let menu_handles = ppc_menu_list_definition(&mut loaded.memory, list_handle)
+            .unwrap()
+            .handles()
+            .collect::<Vec<_>>();
+        assert_eq!(menu_handles.len(), 2);
+        for menu_handle in menu_handles {
+            let menu = loaded.memory.read_u32_be(menu_handle).unwrap();
+            assert_eq!(loaded.memory.read_u16_be(menu + 2), Some(123));
+            assert_eq!(loaded.memory.read_u16_be(menu + 4), Some(45));
+        }
+        assert!(!loaded.guest_calls.has_menu_bar_builds());
     }
 
     #[test]

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -1644,7 +1644,6 @@ pub struct TrapDispatcher {
     /// Custom popup MDEF state before its returned rectangle creates a pane.
     pub(crate) menu_definition_tracking: Option<crate::menu_manager::MenuDefinitionTracking>,
     /// GetNewMBar result and remaining menus while custom mSizeMsg callbacks run.
-    pub(crate) pending_menu_bar_build: Option<super::menu::PendingMenuBarBuild>,
     /// Caller QuickDraw state restored after a retained custom MDEF finishes.
     pub(crate) menu_definition_port_state: Option<PortStateSnapshot>,
     /// 68k call frame parked while the shared Menu Manager state yields.
@@ -3361,7 +3360,6 @@ impl TrapDispatcher {
             menu_tracking: SharedProcessMenuTracking::default(),
             guest_calls: SharedGuestCallStack::default(),
             menu_definition_tracking: None,
-            pending_menu_bar_build: None,
             menu_definition_port_state: None,
             menu_tracking_stack_ptr: 0,
             pending_native_menu_selection: SharedNativeMenuSelection::default(),
@@ -3619,7 +3617,7 @@ impl TrapDispatcher {
         &self,
         menu_tracking: Option<&ProcessMenuTrackingState>,
     ) -> bool {
-        self.pending_menu_bar_build.is_some()
+        self.guest_calls.menu_bar_build().is_some()
             || self
                 .menu_tracking
                 .as_ref()
@@ -3645,7 +3643,6 @@ impl TrapDispatcher {
     ) -> bool {
         let trap_no_autopop = opcode & !0x0400;
         let is_menu_refire = trap_no_autopop == 0xA93D || trap_no_autopop == 0xA80B;
-        let is_menu_bar_build_refire = trap_no_autopop == 0xA9C0;
         let is_dialog_refire =
             matches!(trap_no_autopop, 0xA991 | 0xA985 | 0xA986 | 0xA987 | 0xA988);
         let is_standard_file_refire = trap_no_autopop == 0xA9EA;
@@ -3656,7 +3653,6 @@ impl TrapDispatcher {
         let is_grow_window_refire = trap_no_autopop == 0xA92B;
         let is_region_refire = matches!(trap_no_autopop, 0xA905 | 0xA926);
         (is_menu_refire && is_menu_tracking)
-            || (is_menu_bar_build_refire && self.pending_menu_bar_build.is_some())
             || (is_dialog_refire && self.is_dialog_tracking())
             || (is_standard_file_refire
                 && (self.is_standard_file_put_tracking() || self.is_standard_file_get_tracking()))

--- a/src/trap/menu.rs
+++ b/src/trap/menu.rs
@@ -1,5 +1,6 @@
 //! Menu Manager trap handlers.
 
+use crate::guest_call::{MenuBarBuildResume, MenuBarCallOrigin};
 use crate::cpu::{CpuOps, Register};
 use crate::guest_call::GuestCallTarget;
 use crate::guest_procedure::{resolve_guest_procedure, GuestIsa};
@@ -16,7 +17,7 @@ use crate::menu_manager::{
     standard_menu_width as shared_standard_menu_width, standard_popup_menu_layout,
     standard_pull_down_menu_layout, standard_submenu_layout,
     ColorIconLayout as SharedColorIconLayout, MenuBarBuild as SharedMenuBarBuild,
-    MenuBarBuildStep as SharedMenuBarBuildStep, MenuBarResource as SharedMenuBarResource,
+    MenuBarResource as SharedMenuBarResource,
     MenuBarTitleRegion as SharedMenuBarTitleRegion, MenuColorTable,
     MenuDefinitionInvocation as SharedMenuDefinitionInvocation,
     MenuDefinitionPane as SharedMenuDefinitionPane,
@@ -68,12 +69,6 @@ pub struct Menu {
 
 pub(crate) type MenuTrackingState = ProcessMenuTrackingState;
 pub(crate) type SubmenuTrackingState = ProcessTrackedMenuPane;
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) struct PendingMenuBarBuild {
-    pub(crate) stack_ptr: u32,
-    pub(crate) build: SharedMenuBarBuild<u32>,
-}
 
 pub(crate) fn tracked_menu_state(
     kind: MenuTrackingKind,
@@ -511,15 +506,23 @@ impl super::TrapDispatcher {
             return false;
         };
         let scratch = entry + 60;
-        let Some(frame) =
+        let Some(mut frame) =
             M68kMenuDefinitionFrame::new(invocation.call(scratch), proc_addr, final_sp, return_pc == cpu.read_reg(Register::PC))
         else {
             return false;
+        };
+        let auto_pop_build = matches!(self.guest_calls.menu_bar_build_origin(),
+            Some(MenuBarCallOrigin::M68k { return_address: Some(_), .. }));
+        let return_pc = if auto_pop_build {
+            frame.trap_return(0xa9c0)
+        } else {
+            return_pc
         };
         let floor = frame.entry - M68kMenuDefinitionFrame::STACK_PREFIX;
         if !bus.is_guest_address_writable(floor, (final_sp - floor) as usize) {
             return false;
         }
+        let menu_build = self.guest_calls.menu_bar_build();
         let completion = crate::menu_manager::MenuDefinitionCompletion::pending();
         if return_pc != cpu.read_reg(Register::PC) {
             if !self.guest_calls.begin_m68k_with_operation(
@@ -533,12 +536,13 @@ impl super::TrapDispatcher {
                 definition.bind_completion(invocation, completion.clone());
             }
             if invocation.message == crate::menu_manager::MenuDefinitionMessage::Size {
-                if let Some(pending) = self.pending_menu_bar_build.as_mut() {
-                    pending
-                        .build
-                        .bind_completion(invocation.menu_handle, completion);
+                if let Some(id) = menu_build {
+                    self.guest_calls.bind_menu_bar_build_completion(id, invocation.menu_handle, completion);
                 }
             }
+        }
+        if auto_pop_build && self.current_trap_caller.is_some() {
+            self.preserve_auto_pop_pc_once = true;
         }
         for (offset, byte) in frame
             .image
@@ -916,24 +920,25 @@ impl super::TrapDispatcher {
     fn continue_menu_bar_build<C: CpuOps>(&mut self, cpu: &mut C, bus: &mut MacMemoryBus) {
         self.retire_menu_definition(cpu, bus);
         loop {
-            let Some(step) = self
-                .pending_menu_bar_build
-                .as_mut()
-                .and_then(|pending| pending.build.next_step())
-            else {
-                return;
-            };
-            let menu_handle = match step {
-                SharedMenuBarBuildStep::Size(menu_handle) => menu_handle,
-                SharedMenuBarBuildStep::Complete(result_handle) => {
-                    let Some(pending) = self.pending_menu_bar_build.take() else {
-                        return;
-                    };
-                    let stack_ptr = pending.stack_ptr;
-                    bus.write_long(stack_ptr + 2, result_handle);
-                    cpu.write_reg(Register::A7, stack_ptr + 2);
+            let menu_handle = match self.guest_calls.advance_menu_bar_build(GuestIsa::M68k) {
+                Some(MenuBarBuildResume::Size(handle)) => handle,
+                Some(MenuBarBuildResume::Complete {
+                    result,
+                    origin:
+                        MenuBarCallOrigin::M68k {
+                            stack_pointer,
+                            return_address,
+                        },
+                }) => {
+                    bus.write_long(stack_pointer + 2, result);
+                    cpu.write_reg(Register::A7, stack_pointer + 2);
+                    if let Some(address) = return_address {
+                        cpu.write_reg(Register::PC, address);
+                        self.preserve_auto_pop_pc_once = self.current_trap_caller.is_some();
+                    }
                     return;
                 }
+                _ => return,
             };
             if self.arm_menu_definition_to(
                 cpu,
@@ -1975,7 +1980,8 @@ impl super::TrapDispatcher {
             // FUNCTION GetNewMBar(menuBarID: INTEGER): Handle;
             // Inside Macintosh Volume I, I-354
             (true, 0x1C0) => {
-                if self.pending_menu_bar_build.is_some() {
+                self.retire_menu_definition(cpu, bus);
+                if self.guest_calls.menu_bar_build().is_some() {
                     self.continue_menu_bar_build(cpu, bus);
                     return Some(Ok(()));
                 }
@@ -2005,16 +2011,20 @@ impl super::TrapDispatcher {
                     bus.write_bytes(list_block, &list_bytes);
                     let list_handle = bus.alloc(4);
                     bus.write_long(list_handle, list_block);
-                    self.pending_menu_bar_build = Some(PendingMenuBarBuild {
-                        stack_ptr: sp,
-                        build: SharedMenuBarBuild::new(list_handle, menu_handles),
-                    });
+                    if self.guest_calls.begin_menu_bar_build(
+                        SharedMenuBarBuild::new(list_handle, menu_handles),
+                        MenuBarCallOrigin::M68k { stack_pointer: sp, return_address: self.current_trap_caller },
+                    ).is_none() {
+                        bus.write_long(sp + 2, 0);
+                        cpu.write_reg(Register::A7, sp + 2);
+                        return Some(Ok(()));
+                    }
                     list_handle
                 } else {
                     0
                 };
 
-                if handle != 0 && self.pending_menu_bar_build.is_some() {
+                if handle != 0 && self.guest_calls.menu_bar_build().is_some() {
                     self.continue_menu_bar_build(cpu, bus);
                 } else {
                     bus.write_long(sp + 2, handle);
@@ -8814,6 +8824,133 @@ mod tests {
     }
 
     #[test]
+    fn nested_classic_getnewmbar_preserves_plain_and_auto_pop_returns() {
+        for opcode in [0xa9c0, 0xadc0] {
+            let (mut disp, _, mut bus) = setup();
+            let mut cpu = crate::cpu::M68kCpu::new();
+            let first_menu = seed_menu_resource(&mut bus, 601, "First");
+            let second_menu = seed_menu_resource(&mut bus, 602, "Second");
+            for menu in [first_menu, second_menu] {
+                bus.write_word(menu + 6, 256);
+                bus.write_word(menu + 8, 0);
+            }
+            let mdef = bus.alloc(96);
+            bus.write_word(mdef, 0x4E75);
+            let mbar = seed_mbar_resource(&mut bus, &[601, 602]);
+            disp.resources = Some(crate::trap::dispatch::LoadedResources {
+                files: std::collections::HashMap::from([(
+                    0,
+                    crate::trap::dispatch::ResourceFileMap {
+                        loaded: std::collections::HashMap::from([
+                            ((*b"MBAR", 900), mbar),
+                            ((*b"MENU", 601), first_menu),
+                            ((*b"MENU", 602), second_menu),
+                            ((*b"MDEF", 256), mdef),
+                        ]),
+                        named: std::collections::HashMap::new(),
+                        names_by_id: std::collections::HashMap::new(),
+                        attrs: std::collections::HashMap::new(),
+                        map_attrs: 0,
+                    },
+                )]),
+                names: std::collections::HashMap::new(),
+                search_order: vec![0],
+                current_file: 0,
+            });
+            let inner = seed_mbar_resource(&mut bus, &[]);
+            disp.resources
+                .as_mut()
+                .unwrap()
+                .files
+                .get_mut(&0)
+                .unwrap()
+                .loaded
+                .insert((*b"MBAR", 901), inner);
+            let marker = bus.alloc(4);
+            let code = [
+                0x206f,
+                16,     // menu handle from the Pascal MDEF frame
+                0x2050, // dereference the live menu record
+                0x2f08, // save the outer record
+                0x598f, // reserve nested Handle result
+                0x3f3c,
+                901,
+                0xa9c0, // nested GetNewMBar
+                0x201f, // consume nested result
+                0x23c0,
+                (marker >> 16) as u16,
+                marker as u16,
+                0x205f, // restore outer record
+                0x317c,
+                123,
+                2,
+                0x317c,
+                45,
+                4,
+                0x4e74,
+                18,
+            ];
+            for (index, word) in code.into_iter().enumerate() {
+                bus.write_word(mdef + index as u32 * 2, word);
+            }
+            let trap_pc = 0x0012_3600;
+            let return_pc = if opcode == 0xadc0 {
+                trap_pc + 0x100
+            } else {
+                trap_pc + 2
+            };
+            let parameters = if opcode == 0xadc0 {
+                TEST_SP + 4
+            } else {
+                TEST_SP
+            };
+            bus.write_word(trap_pc, opcode);
+            if opcode == 0xadc0 {
+                bus.write_long(TEST_SP, return_pc);
+            }
+            bus.write_word(parameters, 900);
+            cpu.write_reg(Register::PC, trap_pc);
+            cpu.write_reg(Register::A7, TEST_SP);
+            for _ in 0..256 {
+                match cpu.step(&mut bus) {
+                    crate::cpu::StepResult::Ok => {}
+                    crate::cpu::StepResult::Aline(trap) => {
+                        disp.dispatch(trap, &mut cpu, &mut bus).unwrap()
+                    }
+                    _ => panic!("unexpected instruction while building menus"),
+                }
+                if cpu.read_reg(Register::PC) == return_pc {
+                    break;
+                }
+            }
+            assert_eq!(cpu.read_reg(Register::PC), return_pc);
+            assert_eq!(cpu.read_reg(Register::A7), parameters + 2);
+            let inner_handle = bus.read_long(marker);
+            assert_ne!(inner_handle, 0);
+            assert_eq!(
+                menu_list_from_memory(&bus, inner_handle)
+                    .unwrap()
+                    .regular_handles()
+                    .count(),
+                0
+            );
+            let result = bus.read_long(parameters + 2);
+            let menus = menu_list_from_memory(&bus, result)
+                .unwrap()
+                .regular_handles()
+                .collect::<Vec<_>>();
+            assert_eq!(menus.len(), 2);
+            for handle in menus {
+                let record = bus.read_long(handle);
+                assert_eq!(bus.read_word(record + 2), 123);
+                assert_eq!(bus.read_word(record + 4), 45);
+            }
+            assert!(disp.guest_calls.is_empty());
+            assert!(!disp.preserve_auto_pop_pc_once);
+        }
+    }
+
+    #[test]
     fn getnewmbar_sizes_each_custom_menu_before_returning_the_list() {
         let (mut disp, mut cpu, mut bus) = setup();
         let first_menu = seed_menu_resource(&mut bus, 601, "First");
@@ -8857,7 +8994,7 @@ mod tests {
         assert_eq!(bus.read_word(trampoline + 6), 2);
         let first_handle = bus.read_long(trampoline + 10);
         assert_eq!(bus.read_word(bus.read_long(first_handle)), 601);
-        assert!(disp.is_tracking_refire(0xA9C0));
+        assert!(!disp.is_tracking_refire(0xA9C0));
         bus.write_word(bus.read_long(first_handle) + 2, 101);
         bus.write_word(bus.read_long(first_handle) + 4, 41);
 
@@ -8881,7 +9018,7 @@ mod tests {
         let list_handle = bus.read_long(TEST_SP + 2);
         assert_ne!(list_handle, 0);
         assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 2);
-        assert_eq!(disp.pending_menu_bar_build, None);
+        assert!(!disp.guest_calls.has_menu_bar_builds());
         assert!(
             disp.guest_calls.is_empty(),
             "completed GetNewMBar must retire every MDEF frame"


### PR DESCRIPTION
A custom MDEF that calls GetNewMBar while another menu bar is being sized currently receives a null result for a valid nested MBAR resource. Both gateways interpret any pending build as the current invocation. The new native regression reproduces this on master.

GetNewMBar now retains each shared MenuBarBuild and its caller return in an execution-owned operation identified by its task, enclosing guest call and a distinct operation ID. Callback receipts bind that ID before guest entry. Nested calls build and return their own menu list, and a different task or return ABI cannot consume the parent operation. Retiring a task removes its retained build records.

Both adapter-specific pending-build records are removed. Classic GetNewMBar also leaves the generic tracking-refire predicate. Auto-pop calls retain the original caller return and resume a plain trap in the existing callback frame, preventing a second return-address pop.

Validation: 5,121 headless library tests pass with JIT and test-support (three existing ignored), including ten GetNewMBar tests. Real native and 68K instruction tests check nested menu-list results, dimensions and caller state; the 68K test covers plain and auto-pop entries. Execution tests cover nested identities, callback waiting, task isolation, retirement and wrong-ABI refusal. CI on the exact merge tree passes 5,130 library tests (three existing ignored), 50 desktop tests, both architecture showcases, all-target builds, documentation, packaging and dependency licenses. The existing non-blocking formatter allocation failure and Clippy errors remain.

Part of #1512. MenuSelect/popup root operations, graphics-state ownership, nested presentation, MenuHook and comprehensive failed-return/guest-allocation teardown remain open.
