### PR TITLE
fix: resume menu bar builds without repeating guest dispatch

### DIFF
--- a/src/execution_m68k.rs
+++ b/src/execution_m68k.rs
@@ -17,8 +17,9 @@ pub(crate) struct M68kMenuDefinitionFrame {
 }
 
 impl M68kMenuDefinitionFrame {
-    /// Resume a retained Toolbox operation through a plain trap, without
-    /// repeating the original auto-pop entry's caller-return consumption.
+    /// Emit an internal A-line return boundary inside the live callback frame.
+    /// Execution matches its PC/SP before guest trap routing; the retained
+    /// operation supplies the caller return instead of repeating guest entry.
     pub(crate) fn trap_return(&mut self, opcode: u16) -> u32 {
         self.image[52..54].copy_from_slice(&opcode.to_be_bytes());
         self.entry + 52

--- a/src/guest_call.rs
+++ b/src/guest_call.rs
@@ -567,7 +567,7 @@ pub(crate) struct MenuBarBuildId(u64);
 /// Caller return placement belongs to execution, not to menu sizing policy.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum MenuBarCallOrigin {
-    M68k { stack_pointer: u32, return_address: Option<u32> },
+    M68k { stack_pointer: u32, return_address: u32 },
     PowerPc { return_address: u32 },
 }
 
@@ -995,14 +995,25 @@ impl SharedGuestCallStack {
             .map(|call| call.id)
     }
 
-    pub(crate) fn menu_bar_build_origin(&self) -> Option<MenuBarCallOrigin> {
-        let id = self.menu_bar_build()?;
-        self.0
-            .borrow()
+    pub(crate) fn ready_menu_bar_build(&self, isa: GuestIsa) -> Option<MenuBarBuildId> {
+        let tasks = self.0.borrow();
+        let task = tasks.kernel.current_task();
+        let parent = tasks.kernel.peek(task).map(|call| call.call_id());
+        tasks
             .menu_bar_calls
             .iter()
-            .find(|call| call.id == id)
-            .map(|call| call.origin)
+            .rev()
+            .find(|call| {
+                let origin_isa = match call.origin {
+                    MenuBarCallOrigin::M68k { .. } => GuestIsa::M68k,
+                    MenuBarCallOrigin::PowerPc { .. } => GuestIsa::PowerPc,
+                };
+                call.task == task
+                    && call.parent == parent
+                    && origin_isa == isa
+                    && call.build.callback_ready()
+            })
+            .map(|call| call.id)
     }
 
     #[cfg(test)]
@@ -2759,7 +2770,7 @@ mod tests {
         let calls = SharedGuestCallStack::default();
         let outer_origin = MenuBarCallOrigin::M68k {
             stack_pointer: 0x3000,
-            return_address: None,
+            return_address: 0x2002,
         };
         let outer = calls
             .begin_menu_bar_build(MenuBarBuild::new(111, vec![5]), outer_origin)
@@ -2782,6 +2793,7 @@ mod tests {
             0x3000
         ));
         assert_eq!(calls.menu_bar_build(), None);
+        assert_eq!(calls.ready_menu_bar_build(GuestIsa::M68k), None);
         let completion = MenuDefinitionCompletion::pending();
         calls.bind_menu_bar_build_completion(outer, 5, completion.clone());
         let inner_origin = MenuBarCallOrigin::PowerPc {
@@ -2812,6 +2824,8 @@ mod tests {
             menu_rect: (0, 0, 0, 0),
             which_item: 0,
         }));
+        assert_eq!(calls.ready_menu_bar_build(GuestIsa::PowerPc), None);
+        assert_eq!(calls.ready_menu_bar_build(GuestIsa::M68k), Some(outer));
         assert_eq!(
             calls.advance_menu_bar_build(GuestIsa::M68k),
             Some(MenuBarBuildResume::Complete {
@@ -2820,6 +2834,7 @@ mod tests {
             })
         );
         assert_eq!(calls.advance_menu_bar_build(GuestIsa::M68k), None);
+        assert_eq!(calls.ready_menu_bar_build(GuestIsa::M68k), None);
         assert!(calls.is_empty());
     }
 

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -7692,7 +7692,10 @@ impl PpcLoadedApp {
                 }
                 if index == PPC_GUEST_CALL_RETURN_IMPORT_INDEX {
                     let mut resource_call = None;
-                    if guest_calls.complete_powerpc_resuming_operation(
+                    if guest_calls
+                        .ready_menu_bar_build(GuestIsa::PowerPc)
+                        .is_some()
+                        || guest_calls.complete_powerpc_resuming_operation(
                         cpu,
                         process_memory_manager,
                         |operation, result| match operation {
@@ -7714,6 +7717,23 @@ impl PpcLoadedApp {
                             },
                         },
                     ) {
+                        if guest_calls.ready_menu_bar_build(GuestIsa::PowerPc).is_some() {
+                            let heap = process_memory_manager.native_heap_state()
+                                .expect("native allocator registered during execution");
+                            let mut cursor = heap.heap_cursor;
+                            let limit =
+                                process_memory_manager.native_allocation_limit(heap.heap_limit);
+                            return ppc_continue_menu_bar_build(
+                                cpu,
+                                process_memory_manager,
+                                memory,
+                                &mut cursor,
+                                limit,
+                                &mut toolbox_startup,
+                                &process_file_system.resource_manager.vfs_resources,
+                                *current_resource_refnum,
+                            );
+                        }
                         if let Some(call) = resource_call {
                             if let Err(error) = ppc_invoke_prepared_resource(
                                 cpu,
@@ -16875,18 +16895,6 @@ fn dispatch_supported_import(
             )))
         }
         PpcImportDispatcherTarget::GetNewMBar => {
-            if toolbox_startup.guest_calls.menu_bar_build().is_some() {
-                return Some(ppc_continue_menu_bar_build(
-                    cpu,
-                    process_memory_manager,
-                    memory,
-                    heap_cursor,
-                    heap_limit,
-                    toolbox_startup,
-                    vfs_resources,
-                    *current_resource_refnum,
-                ));
-            }
             let result_handle = ppc_get_new_mbar(
                 cpu.gpr[3] as u16 as i16,
                 process_memory_manager,
@@ -76362,6 +76370,11 @@ fn ppc_dispatch_native_menu_definition_with_return(
     return_gpr3: PpcNativeReturnGpr3,
 ) -> Option<PpcImportAction> {
     let menu_build = toolbox_startup.guest_calls.menu_bar_build();
+    let final_pc = if menu_build.is_some() && invocation.message == MenuDefinitionMessage::Size {
+        PPC_GUEST_CALL_RETURN_PC
+    } else {
+        final_pc
+    };
     let target = ppc_menu_definition_target(cpu, memory, resources, invocation.menu_handle)?;
     let manager = process_memory_manager.as_deref_mut()?;
     // The emulated callback owns its wrapper and stack as well as its
@@ -91445,11 +91458,12 @@ pub(crate) mod tests {
                 loaded.process_memory_manager.0.borrow_mut().native_mut(),
             ));
 
-            if loaded.cpu.pc >= loaded.import_trap_base
-                && loaded.cpu.pc
-                    < loaded
-                        .import_trap_base
-                        .saturating_add(loaded.import_count.saturating_mul(4))
+            if loaded.cpu.pc == PPC_GUEST_CALL_RETURN_PC
+                || (loaded.cpu.pc >= loaded.import_trap_base
+                    && loaded.cpu.pc
+                        < loaded
+                            .import_trap_base
+                            .saturating_add(loaded.import_count.saturating_mul(4)))
             {
                 let probe = loaded.run_with_hle_imports(64);
                 assert_eq!(probe.unsupported_import_index, None);
@@ -102316,8 +102330,87 @@ pub(crate) mod tests {
         loaded.cpu.lr = PPC_HALT_PC;
         loaded.imports[0].dispatcher_target = PpcImportDispatcherTarget::GetNewMBar;
         let probe = loaded.run_with_hle_imports(64);
-        assert_eq!(probe.handled_import_count, 3);
+        assert_eq!(probe.handled_import_count, 1);
         assert_eq!(probe.unsupported_import_index, None);
+
+        let list_handle = loaded.cpu.gpr[3];
+        let menu_handles = ppc_menu_list_definition(&mut loaded.memory, list_handle)
+            .unwrap()
+            .handles()
+            .collect::<Vec<_>>();
+        assert_eq!(menu_handles.len(), 2);
+        for menu_handle in menu_handles {
+            let menu = loaded.memory.read_u32_be(menu_handle).unwrap();
+            assert_eq!(loaded.memory.read_u16_be(menu + 2), Some(123));
+            assert_eq!(loaded.memory.read_u16_be(menu + 4), Some(45));
+        }
+        assert!(!loaded.guest_calls.has_menu_bar_builds());
+    }
+
+    #[test]
+    fn native_getnewmbar_resumes_internally_after_classic_mdefs() {
+        let pef = synthetic_pef_with_import(b"GetNewMBar");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let descriptor_bytes = vec![
+            0x20, 0x6f, 0x00, 0x10, 0x20, 0x50, 0x31, 0x7c, 0x00, 0x7b, 0x00, 0x02, 0x31, 0x7c,
+            0x00, 0x2d, 0x00, 0x04, 0x4e, 0x74, 0x00, 0x12,
+        ];
+        let ref_num = *loaded.process_file_system.current_resource_file;
+        loaded.process_file_system.vfs_resources.extend([
+            PpcVfsResourceRecord {
+                ref_num,
+                path: "Test App".to_string(),
+                res_type: u32::from_be_bytes(*b"MBAR"),
+                res_id: 900,
+                name: Vec::new(),
+                data: vec![0, 2, 2, 89, 2, 90],
+                raw_data: None,
+                raw_attrs: None,
+                attrs: 0,
+                handle: 0,
+            },
+            PpcVfsResourceRecord {
+                ref_num,
+                path: "Test App".to_string(),
+                res_type: u32::from_be_bytes(*b"MENU"),
+                res_id: 601,
+                name: Vec::new(),
+                data: test_menu_resource_with_mdef(601, 256, b"First"),
+                raw_data: None,
+                raw_attrs: None,
+                attrs: 0,
+                handle: 0,
+            },
+            PpcVfsResourceRecord {
+                ref_num,
+                path: "Test App".to_string(),
+                res_type: u32::from_be_bytes(*b"MENU"),
+                res_id: 602,
+                name: Vec::new(),
+                data: test_menu_resource_with_mdef(602, 256, b"Second"),
+                raw_data: None,
+                raw_attrs: None,
+                attrs: 0,
+                handle: 0,
+            },
+            PpcVfsResourceRecord {
+                ref_num,
+                path: "Test App".to_string(),
+                res_type: u32::from_be_bytes(*b"MDEF"),
+                res_id: 256,
+                name: Vec::new(),
+                data: descriptor_bytes,
+                raw_data: None,
+                raw_attrs: None,
+                attrs: 0,
+                handle: 0,
+            },
+        ]);
+        loaded.cpu.gpr[3] = 900;
+
+        run_test_import(&mut loaded, PpcImportDispatcherTarget::GetNewMBar);
+        assert_eq!(loaded.cpu.pc, PPC_HALT_PC);
+        assert!(loaded.guest_calls.is_empty());
 
         let list_handle = loaded.cpu.gpr[3];
         let menu_handles = ppc_menu_list_definition(&mut loaded.memory, list_handle)
@@ -102452,7 +102545,7 @@ pub(crate) mod tests {
         loaded.cpu.lr = PPC_HALT_PC;
         loaded.imports[0].dispatcher_target = PpcImportDispatcherTarget::GetNewMBar;
         let probe = loaded.run_with_hle_imports(256);
-        assert_eq!(probe.handled_import_count, 5);
+        assert_eq!(probe.handled_import_count, 3);
         assert_eq!(probe.unsupported_import_index, None);
 
         let inner = loaded.memory.read_u32_be(marker).unwrap();

--- a/src/menu_manager.rs
+++ b/src/menu_manager.rs
@@ -193,6 +193,16 @@ impl<Handle: Copy + PartialEq> MenuBarBuild<Handle> {
         }
     }
 
+    /// Only this build's published, unconsumed callback receipt can resume it.
+    pub(crate) fn callback_ready(&self) -> bool {
+        self.completion.as_ref().is_some_and(|completion| {
+            matches!(
+                *completion.0.borrow(),
+                MenuDefinitionCompletionState::Ready(_)
+            )
+        })
+    }
+
     pub(crate) fn next_step(&mut self) -> Option<MenuBarBuildStep<Handle>> {
         if let Some(completion) = self.completion.as_ref() {
             // mSizeMsg publishes dimensions in the live menu record, not its

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -6228,7 +6228,13 @@ impl FixtureRunner {
                     return (count, false);
                 }
                 BatchExit::AlineTrap { opcode } => {
-                    self.m68k.complete_manager_return(&self.bus);
+                    if self.m68k.complete_manager_return(&self.bus)
+                        && self
+                            .dispatcher
+                            .resume_completed_menu_bar_build(&mut self.m68k.cpu, &mut self.bus)
+                    {
+                        continue;
+                    }
                     // Accounting (count/ticks) happened via `executed`
                     // above. The batch may have retired instructions before
                     // the trap, so the loop-top `pc` is stale; the trap
@@ -7057,7 +7063,13 @@ impl FixtureRunner {
                     break;
                 }
                 BatchExit::AlineTrap { opcode } => {
-                    self.m68k.complete_manager_return(&self.bus);
+                    if self.m68k.complete_manager_return(&self.bus)
+                        && self
+                            .dispatcher
+                            .resume_completed_menu_bar_build(&mut self.m68k.cpu, &mut self.bus)
+                    {
+                        continue;
+                    }
                     if !self.dispatcher.aline_vector_is_default(&self.bus) {
                         self.m68k.cpu.core.take_aline_exception(&mut self.bus);
                         continue;

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -7331,7 +7331,11 @@ impl TrapDispatcher {
         cfm: Option<&crate::cfm::CfmState>,
         bindings: Option<&mut dyn crate::cfm::CfmSymbolBindings>,
     ) -> Result<()> {
-        crate::execution_m68k::complete_classic_manager_return(&self.guest_calls, cpu, bus);
+        if crate::execution_m68k::complete_classic_manager_return(&self.guest_calls, cpu, bus)
+            && self.resume_completed_menu_bar_build(cpu, bus)
+        {
+            return Ok(());
+        }
         self.initialize_trap_tables(bus)?;
         // Low-memory Ticks is guest-owned writable state. Import it at the
         // ABI boundary before any manager, trace, or diagnostic path observes

--- a/src/trap/menu.rs
+++ b/src/trap/menu.rs
@@ -511,18 +511,16 @@ impl super::TrapDispatcher {
         else {
             return false;
         };
-        let auto_pop_build = matches!(self.guest_calls.menu_bar_build_origin(),
-            Some(MenuBarCallOrigin::M68k { return_address: Some(_), .. }));
-        let return_pc = if auto_pop_build {
-            frame.trap_return(0xa9c0)
-        } else {
-            return_pc
-        };
         let floor = frame.entry - M68kMenuDefinitionFrame::STACK_PREFIX;
         if !bus.is_guest_address_writable(floor, (final_sp - floor) as usize) {
             return false;
         }
         let menu_build = self.guest_calls.menu_bar_build();
+        let return_pc = if menu_build.is_some() {
+            frame.trap_return(0xa9c0)
+        } else {
+            return_pc
+        };
         let completion = crate::menu_manager::MenuDefinitionCompletion::pending();
         if return_pc != cpu.read_reg(Register::PC) {
             if !self.guest_calls.begin_m68k_with_operation(
@@ -540,9 +538,6 @@ impl super::TrapDispatcher {
                     self.guest_calls.bind_menu_bar_build_completion(id, invocation.menu_handle, completion);
                 }
             }
-        }
-        if auto_pop_build && self.current_trap_caller.is_some() {
-            self.preserve_auto_pop_pc_once = true;
         }
         for (offset, byte) in frame
             .image
@@ -917,8 +912,28 @@ impl super::TrapDispatcher {
         bus.write_word(menu_ptr + 4, menu_height as u16);
     }
 
-    fn continue_menu_bar_build<C: CpuOps>(&mut self, cpu: &mut C, bus: &mut MacMemoryBus) {
-        self.retire_menu_definition(cpu, bus);
+    pub(crate) fn resume_completed_menu_bar_build<C: CpuOps>(
+        &mut self,
+        cpu: &mut C,
+        bus: &mut MacMemoryBus,
+    ) -> bool {
+        if self
+            .guest_calls
+            .ready_menu_bar_build(GuestIsa::M68k)
+            .is_none()
+        {
+            return false;
+        }
+        self.continue_menu_bar_build(cpu, bus, false);
+        true
+    }
+
+    fn continue_menu_bar_build<C: CpuOps>(
+        &mut self,
+        cpu: &mut C,
+        bus: &mut MacMemoryBus,
+        preserve_auto_pop: bool,
+    ) {
         loop {
             let menu_handle = match self.guest_calls.advance_menu_bar_build(GuestIsa::M68k) {
                 Some(MenuBarBuildResume::Size(handle)) => handle,
@@ -932,9 +947,9 @@ impl super::TrapDispatcher {
                 }) => {
                     bus.write_long(stack_pointer + 2, result);
                     cpu.write_reg(Register::A7, stack_pointer + 2);
-                    if let Some(address) = return_address {
-                        cpu.write_reg(Register::PC, address);
-                        self.preserve_auto_pop_pc_once = self.current_trap_caller.is_some();
+                    cpu.write_reg(Register::PC, return_address);
+                    if preserve_auto_pop {
+                        self.preserve_auto_pop_pc_once = true;
                     }
                     return;
                 }
@@ -946,6 +961,9 @@ impl super::TrapDispatcher {
                 SharedMenuDefinitionInvocation::size(menu_handle),
                 cpu.read_reg(Register::PC).wrapping_sub(2),
             ) {
+                if preserve_auto_pop {
+                    self.preserve_auto_pop_pc_once = true;
+                }
                 return;
             }
             self.calculate_standard_menu_size(bus, menu_handle);
@@ -1980,11 +1998,6 @@ impl super::TrapDispatcher {
             // FUNCTION GetNewMBar(menuBarID: INTEGER): Handle;
             // Inside Macintosh Volume I, I-354
             (true, 0x1C0) => {
-                self.retire_menu_definition(cpu, bus);
-                if self.guest_calls.menu_bar_build().is_some() {
-                    self.continue_menu_bar_build(cpu, bus);
-                    return Some(Ok(()));
-                }
                 let sp = cpu.read_reg(Register::A7);
                 let mbar_id = bus.read_word(sp) as i16;
                 let handle = if let Some((_, mbar_ptr)) =
@@ -2013,7 +2026,7 @@ impl super::TrapDispatcher {
                     bus.write_long(list_handle, list_block);
                     if self.guest_calls.begin_menu_bar_build(
                         SharedMenuBarBuild::new(list_handle, menu_handles),
-                        MenuBarCallOrigin::M68k { stack_pointer: sp, return_address: self.current_trap_caller },
+                        MenuBarCallOrigin::M68k { stack_pointer: sp, return_address: self.current_trap_caller.unwrap_or_else(|| cpu.read_reg(Register::PC)) },
                     ).is_none() {
                         bus.write_long(sp + 2, 0);
                         cpu.write_reg(Register::A7, sp + 2);
@@ -2024,8 +2037,8 @@ impl super::TrapDispatcher {
                     0
                 };
 
-                if handle != 0 && self.guest_calls.menu_bar_build().is_some() {
-                    self.continue_menu_bar_build(cpu, bus);
+                if handle != 0 {
+                    self.continue_menu_bar_build(cpu, bus, self.current_trap_caller.is_some());
                 } else {
                     bus.write_long(sp + 2, handle);
                     cpu.write_reg(Register::A7, sp + 2);
@@ -8951,6 +8964,159 @@ mod tests {
     }
 
     #[test]
+    fn menu_build_completion_does_not_reenter_a_newly_installed_trap_patch() {
+        for opcode in [0xa9c0, 0xadc0] {
+            let (mut disp, _, mut bus) = setup();
+            let mut cpu = crate::cpu::M68kCpu::new();
+            let first_menu = seed_menu_resource(&mut bus, 601, "First");
+            let second_menu = seed_menu_resource(&mut bus, 602, "Second");
+            for menu in [first_menu, second_menu] {
+                bus.write_word(menu + 6, 256);
+                bus.write_word(menu + 8, 0);
+            }
+            let mdef = bus.alloc(96);
+            bus.write_word(mdef, 0x4E75);
+            let mbar = seed_mbar_resource(&mut bus, &[601]);
+            disp.resources = Some(crate::trap::dispatch::LoadedResources {
+                files: std::collections::HashMap::from([(
+                    0,
+                    crate::trap::dispatch::ResourceFileMap {
+                        loaded: std::collections::HashMap::from([
+                            ((*b"MBAR", 900), mbar),
+                            ((*b"MENU", 601), first_menu),
+                            ((*b"MENU", 602), second_menu),
+                            ((*b"MDEF", 256), mdef),
+                        ]),
+                        named: std::collections::HashMap::new(),
+                        names_by_id: std::collections::HashMap::new(),
+                        attrs: std::collections::HashMap::new(),
+                        map_attrs: 0,
+                    },
+                )]),
+                names: std::collections::HashMap::new(),
+                search_order: vec![0],
+                current_file: 0,
+            });
+            let inner = seed_mbar_resource(&mut bus, &[]);
+            disp.resources
+                .as_mut()
+                .unwrap()
+                .files
+                .get_mut(&0)
+                .unwrap()
+                .loaded
+                .insert((*b"MBAR", 901), inner);
+            let marker = bus.alloc(4);
+            let code = [
+                0x206f,
+                16,     // menu handle from the Pascal MDEF frame
+                0x2050, // dereference the live menu record
+                0x2f08, // save the outer record
+                0x598f, // reserve nested Handle result
+                0x3f3c,
+                901,
+                0xa9c0, // nested GetNewMBar
+                0x201f, // consume nested result
+                0x23c0,
+                (marker >> 16) as u16,
+                marker as u16,
+                0x205f, // restore outer record
+                0x317c,
+                123,
+                2,
+                0x317c,
+                45,
+                4,
+                0x4e74,
+                18,
+            ];
+            for (index, word) in code.into_iter().enumerate() {
+                bus.write_word(mdef + index as u32 * 2, word);
+            }
+            let trap_pc = 0x0012_3600;
+            let return_pc = if opcode == 0xadc0 {
+                trap_pc + 0x100
+            } else {
+                trap_pc + 2
+            };
+            let parameters = if opcode == 0xadc0 {
+                TEST_SP + 4
+            } else {
+                TEST_SP
+            };
+            bus.write_word(trap_pc, opcode);
+            if opcode == 0xadc0 {
+                bus.write_long(TEST_SP, return_pc);
+            }
+            bus.write_word(parameters, 900);
+            cpu.write_reg(Register::PC, trap_pc);
+            cpu.write_reg(Register::A7, TEST_SP);
+            let patch = bus.alloc(4);
+            bus.write_word(patch, 0x4e72);
+            bus.write_word(patch + 2, 0x2700);
+            let mut wrapper = None;
+            let mut patched = false;
+            for _ in 0..256 {
+                match cpu.step(&mut bus) {
+                    crate::cpu::StepResult::Ok => {}
+                    crate::cpu::StepResult::Aline(trap) => {
+                        disp.dispatch(trap, &mut cpu, &mut bus).unwrap()
+                    }
+                    crate::cpu::StepResult::Stopped => break,
+                    _ => panic!("unexpected instruction while building menus"),
+                }
+                if wrapper.is_none() {
+                    wrapper = Some(cpu.read_reg(Register::PC));
+                }
+                if !patched && cpu.read_reg(Register::PC) == wrapper.unwrap() + 48 {
+                    assert!(disp.install_trap_address(&mut bus, 0xa9c0, patch).is_ok());
+                    patched = true;
+                }
+                if cpu.read_reg(Register::PC) == return_pc {
+                    break;
+                }
+            }
+            assert!(patched);
+            assert_eq!(
+                cpu.read_reg(Register::PC),
+                return_pc,
+                "completion must not re-enter the patched GetNewMBar"
+            );
+            assert_eq!(cpu.read_reg(Register::A7), parameters + 2);
+            let inner_handle = bus.read_long(marker);
+            assert_ne!(inner_handle, 0);
+            assert_eq!(
+                menu_list_from_memory(&bus, inner_handle)
+                    .unwrap()
+                    .regular_handles()
+                    .count(),
+                0
+            );
+            let result = bus.read_long(parameters + 2);
+            let menus = menu_list_from_memory(&bus, result)
+                .unwrap()
+                .regular_handles()
+                .collect::<Vec<_>>();
+            assert_eq!(menus.len(), 1);
+            for handle in menus {
+                let record = bus.read_long(handle);
+                assert_eq!(bus.read_word(record + 2), 123);
+                assert_eq!(bus.read_word(record + 4), 45);
+            }
+            assert!(disp.guest_calls.is_empty());
+            assert!(!disp.preserve_auto_pop_pc_once);
+            cpu.write_reg(Register::PC, trap_pc + 2);
+            cpu.write_reg(Register::A7, TEST_SP);
+            disp.dispatch(0xa9c0, &mut cpu, &mut bus).unwrap();
+            assert_eq!(
+                cpu.read_reg(Register::PC),
+                patch,
+                "a fresh guest entry must still honor the patch"
+            );
+        }
+    }
+
+    #[test]
     fn getnewmbar_sizes_each_custom_menu_before_returning_the_list() {
         let (mut disp, mut cpu, mut bus) = setup();
         let first_menu = seed_menu_resource(&mut bus, 601, "First");
@@ -8998,22 +9164,18 @@ mod tests {
         bus.write_word(bus.read_long(first_handle) + 2, 101);
         bus.write_word(bus.read_long(first_handle) + 4, 41);
 
-        cpu.write_reg(Register::PC, trap_pc + 2);
+        cpu.write_reg(Register::PC, trampoline + 54);
         cpu.write_reg(Register::A7, if disp.guest_calls.is_empty() { TEST_SP } else { TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION });
-        disp.dispatch_menu(true, 0x1C0, &mut cpu, &mut bus)
-            .unwrap()
-            .unwrap();
+        disp.dispatch(0xa9c0, &mut cpu, &mut bus).unwrap();
         assert_eq!(bus.read_word(trampoline + 6), 2);
         let second_handle = bus.read_long(trampoline + 10);
         assert_eq!(bus.read_word(bus.read_long(second_handle)), 602);
         bus.write_word(bus.read_long(second_handle) + 2, 102);
         bus.write_word(bus.read_long(second_handle) + 4, 42);
 
-        cpu.write_reg(Register::PC, trap_pc + 2);
+        cpu.write_reg(Register::PC, trampoline + 54);
         cpu.write_reg(Register::A7, if disp.guest_calls.is_empty() { TEST_SP } else { TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION });
-        disp.dispatch_menu(true, 0x1C0, &mut cpu, &mut bus)
-            .unwrap()
-            .unwrap();
+        disp.dispatch(0xa9c0, &mut cpu, &mut bus).unwrap();
 
         let list_handle = bus.read_long(TEST_SP + 2);
         assert_ne!(list_handle, 0);


### PR DESCRIPTION
When an MDEF installs a GetNewMBar trap patch while a menu bar is being built, the pending build currently returns through ordinary trap dispatch and can enter that new patch instead of completing. Retain the original caller return for both classic entry forms and resume the task-owned build directly from the checked callback boundary. Native builds likewise resume at the internal guest-call return boundary, including after an emulated 68K MDEF, instead of repeating the public import.

Build readiness requires the current task, enclosing call, caller ISA and the build's own completed receipt. Fresh guest GetNewMBar calls still take the normal patch route.

Validation includes a regression that fails on the previous implementation for plain and auto-pop classic entry, real native-to-classic sizing callbacks, existing nested/mixed-ISA menu tests and the full headless library suite. The patch regression also verifies that a fresh call enters the installed patch.

Partial progress toward #1512; full tracking ownership, graphics restoration and teardown remain open, so this PR leaves that issue open.
