### PR TITLE
refactor: share logical popup menu requests

### DIFF
--- a/src/guest_call.rs
+++ b/src/guest_call.rs
@@ -626,9 +626,7 @@ pub(crate) struct NativeMenuSelectOrigin {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct NativePopupMenuOrigin {
-    pub(crate) top: i16,
-    pub(crate) left: i16,
-    pub(crate) pop_up_item: i16,
+    pub(crate) request: crate::menu_manager::PopupMenuRequest,
     pub(crate) stack_pointer: u32,
     pub(crate) return_address: u32,
 }
@@ -3279,9 +3277,11 @@ mod tests {
         assert_ne!(main.id, owned.id);
         *tracking = Some(crate::menu_manager::test_process_menu_tracking(222));
         tracking.context_mut().native_popup = Some(NativePopupMenuOrigin {
-            top: 20,
-            left: 30,
-            pop_up_item: 2,
+            request: crate::menu_manager::PopupMenuRequest {
+                menu_handle: 222,
+                anchor: (20, 30),
+                requested_item: 2,
+            },
             stack_pointer: 0x4000,
             return_address: 0x5000,
         });

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -72,7 +72,7 @@ use crate::menu_manager::{
     MenuDefinitionTracking, MenuItem as PpcMenuItemDefinition, MenuItems, MenuKeyItem, MenuKeyMenu,
     MenuKeySelection, MenuList as PpcMenuListDefinition, MenuListInstallRequest, MenuRow, MenuRows,
     MenuSnapshotRecord, MenuFlashStep, MenuTrackingKind, MenuTrackingPane, MenuTrackingSurface,
-    MonochromeMenuIconLayout, ProcessMenuTrackingState, ProcessTrackedMenuPane,
+    MonochromeMenuIconLayout, PopupMenuRequest, ProcessMenuTrackingState, ProcessTrackedMenuPane,
     SharedNativeMenuSelection, StandardMenuChrome, StandardMenuIconKind, StandardMenuItemWidth,
     StandardMenuPaneKind, SubmenuReconciliation, SubmenuRequest,
     TrackedMenuIcon as PpcTrackedMenuIcon,
@@ -76614,9 +76614,11 @@ fn ppc_menu_selection_result(
 
 fn ppc_popup_menu_call(cpu: &PpcCpu) -> NativePopupMenuOrigin {
     NativePopupMenuOrigin {
-        top: cpu.gpr[4] as u16 as i16,
-        left: cpu.gpr[5] as u16 as i16,
-        pop_up_item: cpu.gpr[6] as u16 as i16,
+        request: PopupMenuRequest {
+            menu_handle: cpu.gpr[3],
+            anchor: (cpu.gpr[4] as u16 as i16, cpu.gpr[5] as u16 as i16),
+            requested_item: cpu.gpr[6] as u16 as i16,
+        },
         stack_pointer: cpu.gpr[1],
         return_address: cpu.lr,
     }
@@ -76636,12 +76638,12 @@ fn ppc_popup_menu_is_inserted(
 
 fn ppc_popup_menu_layout_with_resources(
     memory: &mut PpcSectionMem,
-    menu_handle: u32,
+    request: PopupMenuRequest,
     front: PpcFrontBuffer,
-    call: NativePopupMenuOrigin,
     resources: &[PpcVfsResourceRecord],
     current_resource_refnum: i16,
 ) -> Option<(i16, i16, i16, i16, i16, i16)> {
+    let menu_handle = request.menu_handle;
     let menu = memory.read_u32_be(menu_handle).filter(|ptr| *ptr != 0)?;
     let count = i16::try_from(ppc_count_menu_items(memory, menu_handle)).ok()?;
     if count <= 0 || front.width <= 1 || front.height <= 1 {
@@ -76659,8 +76661,8 @@ fn ppc_popup_menu_layout_with_resources(
             ppc_u32_to_i16_saturating(front.width),
             ppc_u32_to_i16_saturating(front.height),
         ),
-        (call.top, call.left),
-        call.pop_up_item,
+        request.anchor,
+        request.requested_item,
     )?;
 
     Some((
@@ -76693,12 +76695,7 @@ fn ppc_begin_custom_popup_menu_tracking(
         return None;
     }
     ppc_menu_definition_target(cpu, memory, resources, menu_handle)?;
-    let hit_point = (u32::from(call.top as u16) << 16) | u32::from(call.left as u16);
-    startup.menu_tracking.context_mut().definition = Some(MenuDefinitionTracking::begin_popup(
-        menu_handle,
-        hit_point,
-        call.pop_up_item,
-    ));
+    startup.menu_tracking.context_mut().definition = Some(call.request.begin_definition());
     startup.menu_tracking.context_mut().native_popup = Some(call);
     ppc_prepare_menu_definition_port(startup, current_gworld, current_gdevice);
     let invocation = startup
@@ -77120,9 +77117,8 @@ fn ppc_dispatch_pop_up_menu_select(
     let Some((popup_left, popup_top, popup_width, popup_height, requested_item, content_top)) =
         ppc_popup_menu_layout_with_resources(
             memory,
-            menu_handle,
+            call.request,
             front,
-            call,
             resources,
             current_resource_refnum,
         )
@@ -94823,137 +94819,161 @@ pub(crate) mod tests {
 
     #[test]
     fn native_popup_menu_select_runs_custom_popup_draw_and_choose_sequence() {
-        let pef = synthetic_pef_with_import(b"PopUpMenuSelect");
-        let mut loaded = load_pef_application(&pef).unwrap();
-        let menu = install_test_popup_menu(
-            &mut loaded,
-            PPC_DATA_BASE + 0x1000,
-            132,
-            b"Custom",
-            b"Opaque definition data",
-        );
-        let menu_ptr = loaded.memory.read_u32_be(menu).unwrap();
-        let mdef_handle = PPC_DATA_BASE + 0x7000;
-        let descriptor = PPC_DATA_BASE + 0x7100;
-        let tvector = PPC_DATA_BASE + 0x7180;
-        loaded.memory.add_region(mdef_handle, vec![0; 4]);
-        install_test_powerpc_callback(
-            &mut loaded,
-            descriptor,
-            tvector,
-            PPC_CODE_BASE + 0x4000,
-            PPC_DATA_BASE + 0x7300,
-            test_stack_proc_info(
-                PPC_PROCINFO_SIZE_NONE,
+        for (top, left, requested_item) in [
+            (40i16, 30i16, 4i16),
+            (-40, -30, -1),
+            (i16::MIN, i16::MAX, 0),
+        ] {
+            let pef = synthetic_pef_with_import(b"PopUpMenuSelect");
+            let mut loaded = load_pef_application(&pef).unwrap();
+            let menu = install_test_popup_menu(
+                &mut loaded,
+                PPC_DATA_BASE + 0x1000,
+                132,
+                b"Custom",
+                b"Opaque definition data",
+            );
+            let menu_ptr = loaded.memory.read_u32_be(menu).unwrap();
+            let mdef_handle = PPC_DATA_BASE + 0x7000;
+            let descriptor = PPC_DATA_BASE + 0x7100;
+            let tvector = PPC_DATA_BASE + 0x7180;
+            loaded.memory.add_region(mdef_handle, vec![0; 4]);
+            install_test_powerpc_callback(
+                &mut loaded,
+                descriptor,
+                tvector,
+                PPC_CODE_BASE + 0x4000,
+                PPC_DATA_BASE + 0x7300,
+                test_stack_proc_info(
+                    PPC_PROCINFO_SIZE_NONE,
+                    &[
+                        PPC_PROCINFO_SIZE_TWO,
+                        PPC_PROCINFO_SIZE_FOUR,
+                        PPC_PROCINFO_SIZE_FOUR,
+                        PPC_PROCINFO_SIZE_FOUR,
+                        PPC_PROCINFO_SIZE_FOUR,
+                    ],
+                ),
                 &[
-                    PPC_PROCINFO_SIZE_TWO,
-                    PPC_PROCINFO_SIZE_FOUR,
-                    PPC_PROCINFO_SIZE_FOUR,
-                    PPC_PROCINFO_SIZE_FOUR,
-                    PPC_PROCINFO_SIZE_FOUR,
+                    d_form_u(14, 8, 0, 40),
+                    d_form_u(44, 8, 5, 0),
+                    d_form_u(14, 8, 0, 30),
+                    d_form_u(44, 8, 5, 2),
+                    d_form_u(14, 8, 0, 72),
+                    d_form_u(44, 8, 5, 4),
+                    d_form_u(14, 8, 0, 110),
+                    d_form_u(44, 8, 5, 6),
+                    d_form_u(14, 8, 0, 2),
+                    d_form_u(44, 8, 7, 0),
+                    BLR,
                 ],
-            ),
-            &[
-                d_form_u(14, 8, 0, 40),
-                d_form_u(44, 8, 5, 0),
-                d_form_u(14, 8, 0, 30),
-                d_form_u(44, 8, 5, 2),
-                d_form_u(14, 8, 0, 72),
-                d_form_u(44, 8, 5, 4),
-                d_form_u(14, 8, 0, 110),
-                d_form_u(44, 8, 5, 6),
-                d_form_u(14, 8, 0, 2),
-                d_form_u(44, 8, 7, 0),
-                BLR,
-            ],
-        );
-        loaded.memory.write_u32_be(mdef_handle, descriptor).unwrap();
-        loaded
-            .memory
-            .write_u32_be(menu_ptr + 6, mdef_handle)
-            .unwrap();
-        let front = ppc_front_buffer_for_gworld(&loaded.gworlds, PPC_MAIN_GWORLD).unwrap();
-        let framebuffer_len = front.row_bytes * front.height;
-        let before =
-            ppc_memory_read_bytes(&mut loaded.memory, front.base_addr, framebuffer_len).unwrap();
+            );
+            loaded.memory.write_u32_be(mdef_handle, descriptor).unwrap();
+            loaded
+                .memory
+                .write_u32_be(menu_ptr + 6, mdef_handle)
+                .unwrap();
+            let front = ppc_front_buffer_for_gworld(&loaded.gworlds, PPC_MAIN_GWORLD).unwrap();
+            let framebuffer_len = front.row_bytes * front.height;
+            let before =
+                ppc_memory_read_bytes(&mut loaded.memory, front.base_addr, framebuffer_len).unwrap();
 
-        loaded.cpu.gpr[3] = menu;
-        loaded.cpu.gpr[4] = 40;
-        loaded.cpu.gpr[5] = 30;
-        loaded.cpu.gpr[6] = 4;
-        loaded.set_input_snapshot(PpcInputSnapshot {
-            mouse_button: true,
-            mouse_v: 52,
-            mouse_h: 45,
-            ..PpcInputSnapshot::default()
-        });
-        let probe = loaded.run_with_hle_imports(512);
-        assert!(matches!(probe.result, PpcRunResult::CycleLimit { .. }));
-        assert_eq!(
-            loaded
-                .toolbox_startup
-                .active_menu_definition()
-                .unwrap()
-                .which_item(),
-            2
-        );
-        assert_eq!(
-            loaded
-                .toolbox_startup
-                .active_menu_definition()
-                .unwrap()
-                .menu_rect(),
-            (40, 30, 72, 110)
-        );
-
-        loaded.set_input_snapshot(PpcInputSnapshot {
-            mouse_button: false,
-            mouse_v: 52,
-            mouse_h: 45,
-            ..PpcInputSnapshot::default()
-        });
-        let probe = loaded.run_with_hle_imports(512);
-        assert!(matches!(probe.result, PpcRunResult::CycleLimit { .. }));
-        assert_eq!(
-            loaded
-                .toolbox_startup
-                .menu_tracking
-                .as_ref()
-                .unwrap()
-                .flash_remaining,
-            6
-        );
-        let mut phases = vec![6];
-        for _ in 0..64 {
+            loaded.cpu.gpr[3] = menu;
+            loaded.cpu.gpr[4] = 0x1234_0000 | u32::from(top as u16);
+            loaded.cpu.gpr[5] = 0x5678_0000 | u32::from(left as u16);
+            loaded.cpu.gpr[6] = 0x9ABC_0000 | u32::from(requested_item as u16);
+            loaded.set_input_snapshot(PpcInputSnapshot {
+                mouse_button: true,
+                mouse_v: 52,
+                mouse_h: 45,
+                ..PpcInputSnapshot::default()
+            });
+            for _ in 0..32 {
+                if loaded.cpu.pc == PPC_CODE_BASE + 0x4000 {
+                    break;
+                }
+                let probe = loaded.run_with_hle_imports(1);
+                assert_eq!(probe.unsupported_import_index, None);
+            }
+            assert_eq!(loaded.cpu.pc, PPC_CODE_BASE + 0x4000);
+            assert_eq!(loaded.cpu.gpr[3], 3);
+            assert_eq!(loaded.cpu.gpr[4], menu);
+            assert_eq!(
+                loaded.cpu.gpr[6],
+                (u32::from(top as u16) << 16) | u32::from(left as u16)
+            );
+            assert_eq!(
+                loaded.memory.read_u16_be(loaded.cpu.gpr[7]),
+                Some(requested_item as u16)
+            );
             let probe = loaded.run_with_hle_imports(512);
-            let remaining = loaded
-                .toolbox_startup
-                .menu_tracking
-                .as_ref()
-                .map_or(0, |state| state.flash_remaining);
-            if phases.last() != Some(&remaining) {
-                phases.push(remaining);
-            }
-            if matches!(probe.result, PpcRunResult::Halted { .. }) {
-                break;
-            }
             assert!(matches!(probe.result, PpcRunResult::CycleLimit { .. }));
+            assert_eq!(
+                loaded
+                    .toolbox_startup
+                    .active_menu_definition()
+                    .unwrap()
+                    .which_item(),
+                2
+            );
+            assert_eq!(
+                loaded
+                    .toolbox_startup
+                    .active_menu_definition()
+                    .unwrap()
+                    .menu_rect(),
+                (40, 30, 72, 110)
+            );
+
+            loaded.set_input_snapshot(PpcInputSnapshot {
+                mouse_button: false,
+                mouse_v: 52,
+                mouse_h: 45,
+                ..PpcInputSnapshot::default()
+            });
+            let probe = loaded.run_with_hle_imports(512);
+            assert!(matches!(probe.result, PpcRunResult::CycleLimit { .. }));
+            assert_eq!(
+                loaded
+                    .toolbox_startup
+                    .menu_tracking
+                    .as_ref()
+                    .unwrap()
+                    .flash_remaining,
+                6
+            );
+            let mut phases = vec![6];
+            for _ in 0..64 {
+                let probe = loaded.run_with_hle_imports(512);
+                let remaining = loaded
+                    .toolbox_startup
+                    .menu_tracking
+                    .as_ref()
+                    .map_or(0, |state| state.flash_remaining);
+                if phases.last() != Some(&remaining) {
+                    phases.push(remaining);
+                }
+                if matches!(probe.result, PpcRunResult::Halted { .. }) {
+                    break;
+                }
+                assert!(matches!(probe.result, PpcRunResult::CycleLimit { .. }));
+            }
+            assert_eq!(phases, [6, 5, 4, 3, 2, 1, 0]);
+            assert_eq!(loaded.cpu.gpr[3], (132u32 << 16) | 2);
+            assert_eq!(loaded.toolbox_startup.menu_tracking, None);
+            assert_eq!(
+                loaded.toolbox_startup.menu_tracking.context().definition,
+                None
+            );
+            assert_eq!(
+                loaded.toolbox_startup.menu_tracking.context().native_popup,
+                None
+            );
+            assert_eq!(
+                ppc_memory_read_bytes(&mut loaded.memory, front.base_addr, framebuffer_len),
+                Some(before)
+            );
         }
-        assert_eq!(phases, [6, 5, 4, 3, 2, 1, 0]);
-        assert_eq!(loaded.cpu.gpr[3], (132u32 << 16) | 2);
-        assert_eq!(loaded.toolbox_startup.menu_tracking, None);
-        assert_eq!(
-            loaded.toolbox_startup.menu_tracking.context().definition,
-            None
-        );
-        assert_eq!(
-            loaded.toolbox_startup.menu_tracking.context().native_popup,
-            None
-        );
-        assert_eq!(
-            ppc_memory_read_bytes(&mut loaded.memory, front.base_addr, framebuffer_len),
-            Some(before)
-        );
     }
 
     #[test]
@@ -161249,9 +161269,11 @@ pub(crate) mod tests {
         assert_eq!(
             loaded.toolbox_startup.menu_tracking.context().native_popup,
             Some(NativePopupMenuOrigin {
-                top: 100,
-                left: 50,
-                pop_up_item: 2,
+                request: PopupMenuRequest {
+                    menu_handle,
+                    anchor: (100, 50),
+                    requested_item: 2,
+                },
                 stack_pointer: original_sp,
                 return_address: parked_lr,
             })
@@ -171649,9 +171671,11 @@ pub(crate) mod tests {
             .menu_tracking
             .context_mut()
             .native_popup = Some(NativePopupMenuOrigin {
-            top: 100,
-            left: 50,
-            pop_up_item: 1,
+            request: PopupMenuRequest {
+                menu_handle: popup_tracking.menu_handle,
+                anchor: (100, 50),
+                requested_item: 1,
+            },
             stack_pointer: loaded.cpu.gpr[1],
             return_address: loaded.cpu.lr,
         });

--- a/src/menu_manager.rs
+++ b/src/menu_manager.rs
@@ -2387,6 +2387,22 @@ const STANDARD_POPUP_SCREEN_MARGIN: i16 = 4;
 const STANDARD_POPUP_BOTTOM_RESERVE: i16 = 20;
 const STANDARD_POPUP_SCROLL_STEP: i16 = 16;
 
+/// Logical PopUpMenuSelect arguments, independent of the caller's return ABI.
+/// Macintosh Toolbox Essentials (1992), pp. 3-119--3-120.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct PopupMenuRequest {
+    pub(crate) menu_handle: u32,
+    pub(crate) anchor: (i16, i16),
+    pub(crate) requested_item: i16,
+}
+
+impl PopupMenuRequest {
+    pub(crate) fn begin_definition(self) -> MenuDefinitionTracking {
+        let hit_point = (u32::from(self.anchor.0 as u16) << 16) | u32::from(self.anchor.1 as u16);
+        MenuDefinitionTracking::begin_popup(self.menu_handle, hit_point, self.requested_item)
+    }
+}
+
 /// Position the standard Mac OS 8.1 pop-up menu and its uncropped content.
 ///
 /// The standard MDEF's `mPopUpMsg` aligns the requested item's top-left with

--- a/src/trap/menu.rs
+++ b/src/trap/menu.rs
@@ -26,7 +26,7 @@ use crate::menu_manager::{
     MenuListInstallRequest, MenuRow as SharedMenuRow, MenuRows as SharedMenuRows,
     MenuSnapshotRecord as SharedMenuSnapshotRecord, MenuFlashStep, MenuTrackingKind, MenuTrackingPane,
     MonochromeMenuIconLayout as SharedMonochromeMenuIconLayout, ProcessMenuTrackingState,
-    ProcessTrackedMenuPane, StandardMenuChrome, StandardMenuIconKind, StandardMenuItemWidth,
+    PopupMenuRequest, ProcessTrackedMenuPane, StandardMenuChrome, StandardMenuIconKind, StandardMenuItemWidth,
     StandardMenuPaneKind, SubmenuReconciliation, SubmenuRequest, TrackedMenuPaneView,
     MAX_MENU_LIST_ENTRIES, MENU_COLOR_ENTRY_SIZE, STANDARD_MENU_BAR_FIRST_TITLE_LEFT,
     STANDARD_MENU_BAR_TITLE_SPACING, STANDARD_MENU_DEFINITION_SHIM, STANDARD_MENU_SEPARATOR_HEIGHT,
@@ -2735,10 +2735,12 @@ impl super::TrapDispatcher {
                         self.finish_menu_no_hit(bus, cpu, sp, 10);
                         return Some(Ok(()));
                     }
-                    let popup_item = bus.read_word(sp) as i16;
-                    let left = bus.read_word(sp + 2) as i16;
-                    let top = bus.read_word(sp + 4) as i16;
-                    let menu_handle = bus.read_long(sp + 6);
+                    let request = PopupMenuRequest {
+                        menu_handle: bus.read_long(sp + 6),
+                        anchor: (bus.read_word(sp + 4) as i16, bus.read_word(sp + 2) as i16),
+                        requested_item: bus.read_word(sp) as i16,
+                    };
+                    let menu_handle = request.menu_handle;
                     // Stack: popUpItem(2) + left(2) + top(2) + menu(4) + result(4)
                     // Don't pop yet — store SP for result write later
 
@@ -2762,13 +2764,8 @@ impl super::TrapDispatcher {
                                 Vec::new(),
                             ));
                             self.menu_tracking.context_mut().classic_stack = sp;
-                            let hit_point = (u32::from(top as u16) << 16) | u32::from(left as u16);
                             self.menu_tracking.context_mut().definition =
-                                Some(SharedMenuDefinitionTracking::begin_popup(
-                                    menu_handle,
-                                    hit_point,
-                                    popup_item,
-                                ));
+                                Some(request.begin_definition());
                             self.prepare_menu_definition_port(cpu, bus);
                             if !self.arm_pending_menu_definition(
                                 cpu,
@@ -2787,7 +2784,7 @@ impl super::TrapDispatcher {
                         // taking precedence over the monochrome families.
                         self.preload_menu_item_icon_resources(bus, menu_idx);
                         let Some((dd_rect, highlighted_item, content_top)) =
-                            self.popup_menu_dropdown_rect(bus, menu_idx, top, left, popup_item)
+                            self.popup_menu_dropdown_rect(bus, menu_idx, request)
                         else {
                             self.finish_menu_no_hit(bus, cpu, sp, 10);
                             return Some(Ok(()));
@@ -4363,9 +4360,7 @@ impl super::TrapDispatcher {
         &self,
         bus: &MacMemoryBus,
         menu_idx: usize,
-        top: i16,
-        left: i16,
-        popup_item: i16,
+        request: PopupMenuRequest,
     ) -> Option<((i16, i16, i16, i16), i16, i16)> {
         let (_screen_base, _row_bytes, screen_width, screen_height, _pixel_size) =
             self.get_screen_params();
@@ -4377,8 +4372,8 @@ impl super::TrapDispatcher {
             &rows,
             width,
             (screen_width, screen_height),
-            (top, left),
-            popup_item,
+            request.anchor,
+            request.requested_item,
         )?;
         Some((layout.rect(), layout.highlighted_item, layout.content_top))
     }
@@ -7649,92 +7644,143 @@ mod tests {
 
     #[test]
     fn popup_menu_select_runs_custom_popup_draw_and_choose_sequence() {
-        let (mut disp, mut cpu, mut bus) = setup_with_port();
-        setup_8bpp_menu_screen(&mut disp, &mut bus, 160, 96);
-        let handle = new_menu_with_title(&mut disp, &mut cpu, &mut bus, 338, 0x306E80, "Custom");
-        let menu_ptr = bus.read_long(handle);
-        let mdef_ptr = bus.alloc(2);
-        let mdef_handle = bus.alloc(4);
-        bus.write_word(mdef_ptr, 0x4E75);
-        bus.write_long(mdef_handle, mdef_ptr);
-        bus.write_long(menu_ptr + 6, mdef_handle);
-        disp.loaded_handles
-            .insert(mdef_handle, (mdef_ptr, *b"MDEF", 256));
+        for (top, left, requested_item) in [
+            (40i16, 30i16, 4i16),
+            (-40, -30, -1),
+            (i16::MIN, i16::MAX, 0),
+        ] {
+            let (mut disp, mut cpu, mut bus) = setup_with_port();
+            setup_8bpp_menu_screen(&mut disp, &mut bus, 160, 96);
+            let handle = new_menu_with_title(&mut disp, &mut cpu, &mut bus, 338, 0x306E80, "Custom");
+            let menu_ptr = bus.read_long(handle);
+            let mdef_ptr = bus.alloc(2);
+            let mdef_handle = bus.alloc(4);
+            bus.write_word(mdef_ptr, 0x4E75);
+            bus.write_long(mdef_handle, mdef_ptr);
+            bus.write_long(menu_ptr + 6, mdef_handle);
+            disp.loaded_handles
+                .insert(mdef_handle, (mdef_ptr, *b"MDEF", 256));
 
-        let trap_pc = 0x0012_3500;
-        cpu.write_reg(Register::PC, trap_pc + 2);
-        cpu.write_reg(Register::A7, if disp.guest_calls.depth() == 0 { TEST_SP } else { TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION });
-        bus.write_word(TEST_SP, 4);
-        bus.write_word(TEST_SP + 2, 30);
-        bus.write_word(TEST_SP + 4, 40);
-        bus.write_long(TEST_SP + 6, handle);
-        bus.write_byte(crate::memory::globals::addr::MB_STATE, 0);
-        bus.write_word(crate::memory::globals::addr::MOUSE_LOC2, 52);
-        bus.write_word(crate::memory::globals::addr::MOUSE_LOC2 + 2, 45);
+            let trap_pc = 0x0012_3500;
+            cpu.write_reg(Register::PC, trap_pc + 2);
+            cpu.write_reg(
+                Register::A7,
+                if disp.guest_calls.depth() == 0 {
+                    TEST_SP
+                } else {
+                    TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION
+                },
+            );
+            bus.write_word(TEST_SP, requested_item as u16);
+            bus.write_word(TEST_SP + 2, left as u16);
+            bus.write_word(TEST_SP + 4, top as u16);
+            bus.write_long(TEST_SP + 6, handle);
+            bus.write_byte(crate::memory::globals::addr::MB_STATE, 0);
+            bus.write_word(crate::memory::globals::addr::MOUSE_LOC2, 52);
+            bus.write_word(crate::memory::globals::addr::MOUSE_LOC2 + 2, 45);
 
-        disp.dispatch_menu(true, 0x00B, &mut cpu, &mut bus)
-            .unwrap()
-            .unwrap();
-        let trampoline = cpu.read_reg(Register::PC);
-        assert_eq!(bus.read_word(trampoline + 6), 3);
-        assert_eq!(bus.read_long(trampoline + 22), 0x0028_001E);
-        assert_eq!(bus.read_word(trampoline + 68), 4);
+            disp.dispatch_menu(true, 0x00B, &mut cpu, &mut bus)
+                .unwrap()
+                .unwrap();
+            let trampoline = cpu.read_reg(Register::PC);
+            assert_eq!(bus.read_word(trampoline + 6), 3);
+            assert_eq!(
+                bus.read_long(trampoline + 22),
+                (u32::from(top as u16) << 16) | u32::from(left as u16)
+            );
+            assert_eq!(bus.read_word(trampoline + 68), requested_item as u16);
 
-        for (offset, value) in [(0, 40i16), (2, 30), (4, 72), (6, 110), (8, 0)] {
-            bus.write_word(trampoline + 60 + offset, value as u16);
+            for (offset, value) in [(0, 40i16), (2, 30), (4, 72), (6, 110), (8, 0)] {
+                bus.write_word(trampoline + 60 + offset, value as u16);
+            }
+            cpu.write_reg(Register::PC, trap_pc + 2);
+            cpu.write_reg(
+                Register::A7,
+                if disp.guest_calls.depth() == 0 {
+                    TEST_SP
+                } else {
+                    TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION
+                },
+            );
+            disp.dispatch_menu(true, 0x00B, &mut cpu, &mut bus)
+                .unwrap()
+                .unwrap();
+            assert_eq!(bus.read_word(trampoline + 6), 0);
+            assert_eq!(
+                bus.read_bytes(trampoline + 60, 8),
+                [0, 40, 0, 30, 0, 72, 0, 110]
+            );
+
+            cpu.write_reg(Register::PC, trap_pc + 2);
+            cpu.write_reg(
+                Register::A7,
+                if disp.guest_calls.depth() == 0 {
+                    TEST_SP
+                } else {
+                    TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION
+                },
+            );
+            disp.dispatch_menu(true, 0x00B, &mut cpu, &mut bus)
+                .unwrap()
+                .unwrap();
+            assert_eq!(bus.read_word(trampoline + 6), 1);
+            assert_eq!(bus.read_long(trampoline + 22), 0x0034_002D);
+
+            bus.write_word(trampoline + 68, 2);
+            bus.write_byte(crate::memory::globals::addr::MB_STATE, 0x80);
+            cpu.write_reg(Register::PC, trap_pc + 2);
+            cpu.write_reg(
+                Register::A7,
+                if disp.guest_calls.depth() == 0 {
+                    TEST_SP
+                } else {
+                    TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION
+                },
+            );
+            disp.dispatch_menu(true, 0x00B, &mut cpu, &mut bus)
+                .unwrap()
+                .unwrap();
+            assert_eq!(disp.menu_tracking.as_ref().unwrap().flash_remaining, 6);
+            assert_eq!(cpu.read_reg(Register::A7), TEST_SP);
+            disp.menu_tracking.as_mut().unwrap().flash_delay = 0;
+
+            cpu.write_reg(Register::PC, trap_pc + 2);
+            cpu.write_reg(
+                Register::A7,
+                if disp.guest_calls.depth() == 0 {
+                    TEST_SP
+                } else {
+                    TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION
+                },
+            );
+            disp.dispatch_menu(true, 0x00B, &mut cpu, &mut bus)
+                .unwrap()
+                .unwrap();
+            assert_eq!(bus.read_word(trampoline + 6), 1);
+            assert_eq!(bus.read_long(trampoline + 22), 0x0027_001E);
+            assert_eq!(bus.read_word(trampoline + 68), 2);
+
+            bus.write_word(trampoline + 68, 0);
+            let tracking = disp.menu_tracking.as_mut().unwrap();
+            tracking.flash_remaining = 1;
+            tracking.flash_delay = 0;
+            cpu.write_reg(Register::PC, trap_pc + 2);
+            cpu.write_reg(
+                Register::A7,
+                if disp.guest_calls.depth() == 0 {
+                    TEST_SP
+                } else {
+                    TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION
+                },
+            );
+            disp.dispatch_menu(true, 0x00B, &mut cpu, &mut bus)
+                .unwrap()
+                .unwrap();
+            assert_eq!(bus.read_long(TEST_SP + 10), (338u32 << 16) | 2);
+            assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 10);
+            assert_eq!(disp.menu_tracking, None);
+            assert_eq!(disp.menu_tracking.context().definition, None);
         }
-        cpu.write_reg(Register::PC, trap_pc + 2);
-        cpu.write_reg(Register::A7, if disp.guest_calls.depth() == 0 { TEST_SP } else { TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION });
-        disp.dispatch_menu(true, 0x00B, &mut cpu, &mut bus)
-            .unwrap()
-            .unwrap();
-        assert_eq!(bus.read_word(trampoline + 6), 0);
-        assert_eq!(
-            bus.read_bytes(trampoline + 60, 8),
-            [0, 40, 0, 30, 0, 72, 0, 110]
-        );
-
-        cpu.write_reg(Register::PC, trap_pc + 2);
-        cpu.write_reg(Register::A7, if disp.guest_calls.depth() == 0 { TEST_SP } else { TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION });
-        disp.dispatch_menu(true, 0x00B, &mut cpu, &mut bus)
-            .unwrap()
-            .unwrap();
-        assert_eq!(bus.read_word(trampoline + 6), 1);
-        assert_eq!(bus.read_long(trampoline + 22), 0x0034_002D);
-
-        bus.write_word(trampoline + 68, 2);
-        bus.write_byte(crate::memory::globals::addr::MB_STATE, 0x80);
-        cpu.write_reg(Register::PC, trap_pc + 2);
-        cpu.write_reg(Register::A7, if disp.guest_calls.depth() == 0 { TEST_SP } else { TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION });
-        disp.dispatch_menu(true, 0x00B, &mut cpu, &mut bus)
-            .unwrap()
-            .unwrap();
-        assert_eq!(disp.menu_tracking.as_ref().unwrap().flash_remaining, 6);
-        assert_eq!(cpu.read_reg(Register::A7), TEST_SP);
-        disp.menu_tracking.as_mut().unwrap().flash_delay = 0;
-
-        cpu.write_reg(Register::PC, trap_pc + 2);
-        cpu.write_reg(Register::A7, if disp.guest_calls.depth() == 0 { TEST_SP } else { TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION });
-        disp.dispatch_menu(true, 0x00B, &mut cpu, &mut bus)
-            .unwrap()
-            .unwrap();
-        assert_eq!(bus.read_word(trampoline + 6), 1);
-        assert_eq!(bus.read_long(trampoline + 22), 0x0027_001E);
-        assert_eq!(bus.read_word(trampoline + 68), 2);
-
-        bus.write_word(trampoline + 68, 0);
-        let tracking = disp.menu_tracking.as_mut().unwrap();
-        tracking.flash_remaining = 1;
-        tracking.flash_delay = 0;
-        cpu.write_reg(Register::PC, trap_pc + 2);
-        cpu.write_reg(Register::A7, if disp.guest_calls.depth() == 0 { TEST_SP } else { TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION });
-        disp.dispatch_menu(true, 0x00B, &mut cpu, &mut bus)
-            .unwrap()
-            .unwrap();
-        assert_eq!(bus.read_long(TEST_SP + 10), (338u32 << 16) | 2);
-        assert_eq!(cpu.read_reg(Register::A7), TEST_SP + 10);
-        assert_eq!(disp.menu_tracking, None);
-        assert_eq!(disp.menu_tracking.context().definition, None);
     }
 
     #[test]


### PR DESCRIPTION
Popup preparation mixes logical inputs with caller return state: native layout accepts a record containing the stack pointer and return address, while both adapters separately construct the custom definition request.

Introduce PopupMenuRequest with the menu handle, signed anchor and requested item. Both PopUpMenuSelect entry paths decode that request and use its shared custom-definition preparation. Layout accepts only logical inputs. The native execution record retains the request alongside its return ABI, preserving exact request identity across the existing wait path.

Validation extends both custom-popup sequences through negative and extreme coordinates and signed item values. The native test reaches the actual MDEF entry, verifies the delivered arguments, and proves irrelevant upper register bits are discarded; both sequences still select, flash and release retained tracking. Existing popup layout, pixel restoration, supported-depth and return-ABI tests remain in the full suite.

Partial progress toward #1512. MenuSelect normalization, common tracking transition policy, direct resumption, normalized saved graphics state and complete cancellation/failed-return cleanup remain open.
