### PR TITLE
refactor: retain explicit menu tracking callers

### DIFF
--- a/src/guest_call.rs
+++ b/src/guest_call.rs
@@ -618,36 +618,95 @@ struct MenuCalls {
     next_id: u64,
 }
 
+/// The original caller's return boundary, independent of menu presentation.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) struct NativeMenuSelectOrigin {
-    pub(crate) initial_point: u32,
-    pub(crate) return_address: u32,
+pub(crate) enum MenuTrackingOrigin {
+    M68k {
+        stack_pointer: u32,
+        return_address: u32,
+    },
+    PowerPc {
+        stack_pointer: u32,
+        return_address: u32,
+    },
+}
+
+impl MenuTrackingOrigin {
+    pub(crate) fn isa(self) -> GuestIsa {
+        match self {
+            Self::M68k { .. } => GuestIsa::M68k,
+            Self::PowerPc { .. } => GuestIsa::PowerPc,
+        }
+    }
+    pub(crate) fn return_address(self) -> u32 {
+        match self {
+            Self::M68k { return_address, .. } | Self::PowerPc { return_address, .. } => {
+                return_address
+            }
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) struct NativePopupMenuOrigin {
-    pub(crate) request: crate::menu_manager::PopupMenuRequest,
-    pub(crate) stack_pointer: u32,
-    pub(crate) return_address: u32,
+pub(crate) struct MenuTrackingCall {
+    pub(crate) request: crate::menu_manager::MenuTrackingRequest,
+    pub(crate) origin: MenuTrackingOrigin,
+}
+
+impl MenuTrackingCall {
+    pub(crate) fn popup_request(self) -> Option<crate::menu_manager::PopupMenuRequest> {
+        match self.request {
+            crate::menu_manager::MenuTrackingRequest::PopUp(request) => Some(request),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub(crate) struct MenuTrackingContext {
     pub(crate) tracking: Option<crate::menu_manager::ProcessMenuTrackingState>,
     pub(crate) definition: Option<crate::menu_manager::MenuDefinitionTracking>,
-    pub(crate) native_menu: Option<NativeMenuSelectOrigin>,
-    pub(crate) native_popup: Option<NativePopupMenuOrigin>,
+    pub(crate) call: Option<MenuTrackingCall>,
     pub(crate) native_port: Option<(u32, u32)>,
     pub(crate) classic_port: Option<crate::trap::dispatch::PortStateSnapshot>,
-    pub(crate) classic_stack: u32,
 }
 
 impl MenuTrackingContext {
+    pub(crate) fn caller_isa(&self) -> Option<GuestIsa> {
+        self.call.map(|call| call.origin.isa())
+    }
+    pub(crate) fn native_menu(&self) -> Option<MenuTrackingCall> {
+        self.call.filter(|call| {
+            call.origin.isa() == GuestIsa::PowerPc
+                && matches!(
+                    call.request,
+                    crate::menu_manager::MenuTrackingRequest::MenuSelect { .. }
+                )
+        })
+    }
+    pub(crate) fn native_popup(&self) -> Option<MenuTrackingCall> {
+        self.call
+            .filter(|call| call.origin.isa() == GuestIsa::PowerPc && call.popup_request().is_some())
+    }
+    pub(crate) fn clear_native_menu(&mut self) {
+        if self.native_menu().is_some() {
+            self.call = None;
+        }
+    }
+    pub(crate) fn clear_native_popup(&mut self) {
+        if self.native_popup().is_some() {
+            self.call = None;
+        }
+    }
+    pub(crate) fn classic_stack(&self) -> u32 {
+        match self.call.map(|call| call.origin) {
+            Some(MenuTrackingOrigin::M68k { stack_pointer, .. }) => stack_pointer,
+            _ => panic!("classic menu call must be prepared before tracking"),
+        }
+    }
     fn is_idle(&self) -> bool {
         self.tracking.is_none()
             && self.definition.is_none()
-            && self.native_menu.is_none()
-            && self.native_popup.is_none()
             && self.native_port.is_none()
             && self.classic_port.is_none()
     }
@@ -767,6 +826,11 @@ impl SharedMenuTracking {
             _ => unreachable!(),
         }
     }
+    pub(crate) fn enter_call(&mut self, call: MenuTrackingCall) -> MenuTrackingEntry {
+        let entry = self.enter();
+        self.context_mut().call.get_or_insert(call);
+        entry
+    }
     pub(crate) fn enter(&mut self) -> MenuTrackingEntry {
         let id = self.begin();
         MenuTrackingEntry {
@@ -826,6 +890,12 @@ impl SharedMenuTracking {
             .kernel
             .peek(task)
             .map(|call| call.call_id());
+        // Cancellation can empty a root outside its original ABI entry.
+        // A subsequent entry starts a fresh operation and cannot inherit its caller.
+        self.calls.calls.retain(|call| {
+            call.task != task || call.parent != parent
+                || !matches!(&call.operation, MenuOperation::Tracking(context) if context.is_idle())
+        });
         if let Some(call) = self.calls.calls.iter().rev().find(|call| {
             call.task == task
                 && call.parent == parent
@@ -3125,6 +3195,70 @@ mod tests {
     }
 
     #[test]
+    fn tracking_reentry_preserves_the_original_request_and_return_boundary() {
+        use crate::menu_manager::{test_process_menu_tracking, MenuTrackingRequest};
+        for origin in [
+            MenuTrackingOrigin::M68k {
+                stack_pointer: 0x1000,
+                return_address: 0x2000,
+            },
+            MenuTrackingOrigin::PowerPc {
+                stack_pointer: 0x3000,
+                return_address: 0x4000,
+            },
+        ] {
+            let calls = SharedGuestCallStack::default();
+            let mut tracking = calls.menu_tracking_view();
+            let original = MenuTrackingCall {
+                request: MenuTrackingRequest::MenuSelect {
+                    initial_point: 0x1234_5678,
+                },
+                origin,
+            };
+            let entry = tracking.enter_call(original);
+            *tracking = Some(test_process_menu_tracking(111));
+            let reentry = tracking.enter_call(MenuTrackingCall {
+                request: MenuTrackingRequest::MenuSelect { initial_point: 0 },
+                origin: MenuTrackingOrigin::PowerPc {
+                    stack_pointer: 0x5000,
+                    return_address: 0x6000,
+                },
+            });
+            assert_eq!(entry.id, reentry.id);
+            assert_eq!(tracking.context().call, Some(original));
+            assert_eq!(tracking.context().caller_isa(), Some(origin.isa()));
+            drop(reentry);
+            assert_eq!(tracking.context().call, Some(original));
+            *tracking = None;
+            drop(entry);
+            assert!(calls.is_empty());
+            assert_eq!(tracking.context().call, None);
+            let cancelled = tracking.enter_call(original);
+            *tracking = Some(test_process_menu_tracking(222));
+            *tracking = None;
+            let replacement = MenuTrackingCall {
+                request: MenuTrackingRequest::MenuSelect { initial_point: 9 },
+                origin: MenuTrackingOrigin::PowerPc {
+                    stack_pointer: 0x7000,
+                    return_address: 0x8000,
+                },
+            };
+            let fresh = tracking.enter_call(replacement);
+            assert_ne!(cancelled.id, fresh.id);
+            drop(cancelled);
+            assert_eq!(tracking.context().call, Some(replacement));
+            drop(fresh);
+            let idle = tracking.enter_call(original);
+            drop(idle);
+            assert!(
+                calls.is_empty(),
+                "an immediate return cannot retain an idle call record"
+            );
+            assert_eq!(tracking.context().call, None);
+        }
+    }
+
+    #[test]
     fn menu_tracking_roots_preserve_parent_state_and_exact_receipts() {
         use crate::menu_manager::{
             test_process_menu_tracking, MenuDefinitionCompletion, MenuDefinitionMessage,
@@ -3135,13 +3269,15 @@ mod tests {
         let outer = tracking.enter();
         let outer_id = outer.id;
         *tracking = Some(test_process_menu_tracking(111));
-        tracking.context_mut().native_menu = Some(NativeMenuSelectOrigin {
-            initial_point: 12,
-            return_address: 0x1234,
+        tracking.context_mut().call = Some(MenuTrackingCall {
+            request: crate::menu_manager::MenuTrackingRequest::MenuSelect { initial_point: 12 },
+            origin: MenuTrackingOrigin::PowerPc {
+                stack_pointer: 0x1000,
+                return_address: 0x1234,
+            },
         });
         tracking.context_mut().native_port = Some((0x2000, 0x3000));
-        tracking.context_mut().definition =
-            Some(MenuDefinitionTracking::begin_draw(111, (1, 2, 3, 4)));
+        tracking.context_mut().definition = Some(MenuDefinitionTracking::begin_draw(111, (1, 2, 3, 4)));
         let invocation = tracking
             .context()
             .definition
@@ -3172,8 +3308,7 @@ mod tests {
         assert!(tracking.is_none());
         assert_eq!(tracking.context().native_port, None);
         *tracking = Some(test_process_menu_tracking(222));
-        tracking.context_mut().definition =
-            Some(MenuDefinitionTracking::begin_draw(111, (1, 2, 3, 4)));
+        tracking.context_mut().definition = Some(MenuDefinitionTracking::begin_draw(111, (1, 2, 3, 4)));
         MenuDefinitionOperation {
             scratch: 0,
             completion,
@@ -3197,7 +3332,12 @@ mod tests {
         assert_eq!(tracking.as_ref().unwrap().menu_handle, 111);
         assert_eq!(tracking.context().native_port, Some((0x2000, 0x3000)));
         assert_eq!(
-            tracking.context().native_menu.unwrap().return_address,
+            tracking
+                .context()
+                .native_menu()
+                .unwrap()
+                .origin
+                .return_address(),
             0x1234
         );
         assert!(calls.complete_m68k(0x4002, 0x5000));
@@ -3276,19 +3416,23 @@ mod tests {
         let owned = tracking.enter();
         assert_ne!(main.id, owned.id);
         *tracking = Some(crate::menu_manager::test_process_menu_tracking(222));
-        tracking.context_mut().native_popup = Some(NativePopupMenuOrigin {
-            request: crate::menu_manager::PopupMenuRequest {
-                menu_handle: 222,
-                anchor: (20, 30),
-                requested_item: 2,
+        tracking.context_mut().call = Some(MenuTrackingCall {
+            request: crate::menu_manager::MenuTrackingRequest::PopUp(
+                crate::menu_manager::PopupMenuRequest {
+                    menu_handle: 222,
+                    anchor: (20, 30),
+                    requested_item: 2,
+                },
+            ),
+            origin: MenuTrackingOrigin::PowerPc {
+                stack_pointer: 0x4000,
+                return_address: 0x5000,
             },
-            stack_pointer: 0x4000,
-            return_address: 0x5000,
         });
         tracking.context_mut().native_port = Some((0x6000, 0x7000));
         assert!(calls.switch_to_task(ExecutionTaskId::APPLICATION));
         assert_eq!(tracking.as_ref().unwrap().menu_handle, 111);
-        assert_eq!(tracking.context().native_popup, None);
+        assert_eq!(tracking.context().native_popup(), None);
         assert!(calls.remove_task(worker));
         drop(owned);
         assert_eq!(calls.0.borrow().menu_calls.calls.len(), 1);

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -29,8 +29,8 @@ use crate::event_queue::{
 };
 use crate::guest_call::{
     format_ppc_import_action, install_powerpc_call_arguments, GuestCallContinuation,
-    GuestCallEffect, GuestCallRequest, GuestCallTarget, NativeMenuSelectOrigin,
-    NativePopupMenuOrigin, SharedGuestCallStack,
+    GuestCallEffect, GuestCallRequest, GuestCallTarget, MenuTrackingCall,
+    MenuTrackingOrigin, SharedGuestCallStack,
 };
 use crate::guest_procedure::{
     resolve_guest_procedure, GuestIsa, GuestProcedure,
@@ -71,7 +71,7 @@ use crate::menu_manager::{
     MenuColorTable, MenuDefinitionInvocation, MenuDefinitionMessage, MenuDefinitionPane,
     MenuDefinitionTracking, MenuItem as PpcMenuItemDefinition, MenuItems, MenuKeyItem, MenuKeyMenu,
     MenuKeySelection, MenuList as PpcMenuListDefinition, MenuListInstallRequest, MenuRow, MenuRows,
-    MenuSnapshotRecord, MenuFlashStep, MenuTrackingKind, MenuTrackingPane, MenuTrackingSurface,
+    MenuSnapshotRecord, MenuFlashStep, MenuTrackingKind, MenuTrackingPane, MenuTrackingRequest, MenuTrackingSurface,
     MonochromeMenuIconLayout, PopupMenuRequest, ProcessMenuTrackingState, ProcessTrackedMenuPane,
     SharedNativeMenuSelection, StandardMenuChrome, StandardMenuIconKind, StandardMenuItemWidth,
     StandardMenuPaneKind, SubmenuReconciliation, SubmenuRequest,
@@ -15680,7 +15680,13 @@ fn dispatch_supported_import(
         binding.dispatcher_target,
         PpcImportDispatcherTarget::MenuSelect | PpcImportDispatcherTarget::PopUpMenuSelect
     ))
-    .then(|| toolbox_startup.menu_tracking.enter());
+    .then(|| {
+        let call = match binding.dispatcher_target {
+            PpcImportDispatcherTarget::PopUpMenuSelect => ppc_popup_menu_call(cpu),
+            _ => ppc_menu_select_call(cpu, cpu.gpr[3]),
+        };
+        toolbox_startup.menu_tracking.enter_call(call)
+    });
     // The process registry is authoritative. Refresh the legacy vector
     // booleans at each native boundary so rendering/debugging code that still
     // reads them sees any classic-side transition before this import runs.
@@ -16668,10 +16674,7 @@ fn dispatch_supported_import(
         PpcImportDispatcherTarget::PopUpMenuSelect => {
             let menu_color_bytes = ppc_menu_color_table_bytes(memory, handles);
             let menu_colors = MenuColorTable::new(&menu_color_bytes);
-            if toolbox_startup
-                .menu_tracking
-                .as_ref()
-                .is_some_and(|state| state.front_buffer.is_none())
+            if toolbox_startup.menu_tracking.context().caller_isa() == Some(GuestIsa::M68k)
             {
                 // A classic MenuSelect owns this process continuation. A
                 // nested native call must not consume its origin ABI frame.
@@ -16680,7 +16683,7 @@ fn dispatch_supported_import(
                 if toolbox_startup
                     .menu_tracking
                     .context()
-                    .native_popup
+                    .native_popup()
                     .is_some()
                 {
                     Some(ppc_continue_custom_popup_menu_tracking(
@@ -17204,10 +17207,7 @@ fn dispatch_supported_import(
         PpcImportDispatcherTarget::MenuSelect => {
             let menu_color_bytes = ppc_menu_color_table_bytes(memory, handles);
             let menu_colors = MenuColorTable::new(&menu_color_bytes);
-            if toolbox_startup
-                .menu_tracking
-                .as_ref()
-                .is_some_and(|state| state.front_buffer.is_none())
+            if toolbox_startup.menu_tracking.context().caller_isa() == Some(GuestIsa::M68k)
             {
                 // A classic MenuSelect owns this process continuation. A
                 // nested native call must not consume its origin ABI frame.
@@ -17322,11 +17322,8 @@ fn dispatch_supported_import(
                     .active_menu_definition()
                     .and_then(MenuDefinitionTracking::pending_invocation)
                 {
-                    toolbox_startup.menu_tracking.context_mut().native_menu =
-                        Some(NativeMenuSelectOrigin {
-                            initial_point: cpu.gpr[3],
-                            return_address: cpu.lr,
-                        });
+                    toolbox_startup.menu_tracking.context_mut().call
+                        .get_or_insert(ppc_menu_select_call(cpu, cpu.gpr[3]));
                     ppc_prepare_menu_definition_port(
                         toolbox_startup,
                         current_gworld,
@@ -17349,7 +17346,7 @@ fn dispatch_supported_import(
                         ppc_restore_menu_tracking(memory, state.front_buffer, &state);
                     }
                     toolbox_startup.clear_active_menu_definition();
-                    toolbox_startup.menu_tracking.context_mut().native_menu = None;
+                    toolbox_startup.menu_tracking.context_mut().clear_native_menu();
                     ppc_restore_menu_definition_port(
                         toolbox_startup,
                         current_gworld,
@@ -59824,7 +59821,7 @@ fn ppc_set_depth(
         .is_some_and(|state| state.kind == MenuTrackingKind::MenuBar);
     if let Some(context) = toolbox_startup.menu_tracking.existing_context_mut() {
         context.tracking = None;
-        context.native_popup = None;
+        context.clear_native_popup();
     }
     toolbox_startup.go_away_tracking = None;
     toolbox_startup.drag_window_tracking = None;
@@ -76612,15 +76609,27 @@ fn ppc_menu_selection_result(
     ppc_guest_menu_snapshot(memory, menu_list_handle).selectable_result(menu_id, item_number)
 }
 
-fn ppc_popup_menu_call(cpu: &PpcCpu) -> NativePopupMenuOrigin {
-    NativePopupMenuOrigin {
-        request: PopupMenuRequest {
+fn ppc_menu_select_call(cpu: &PpcCpu, initial_point: u32) -> MenuTrackingCall {
+    MenuTrackingCall {
+        request: MenuTrackingRequest::MenuSelect { initial_point },
+        origin: MenuTrackingOrigin::PowerPc {
+            stack_pointer: cpu.gpr[1],
+            return_address: cpu.lr,
+        },
+    }
+}
+
+fn ppc_popup_menu_call(cpu: &PpcCpu) -> MenuTrackingCall {
+    MenuTrackingCall {
+        request: MenuTrackingRequest::PopUp(PopupMenuRequest {
             menu_handle: cpu.gpr[3],
             anchor: (cpu.gpr[4] as u16 as i16, cpu.gpr[5] as u16 as i16),
             requested_item: cpu.gpr[6] as u16 as i16,
+        }),
+        origin: MenuTrackingOrigin::PowerPc {
+            stack_pointer: cpu.gpr[1],
+            return_address: cpu.lr,
         },
-        stack_pointer: cpu.gpr[1],
-        return_address: cpu.lr,
     }
 }
 
@@ -76695,8 +76704,8 @@ fn ppc_begin_custom_popup_menu_tracking(
         return None;
     }
     ppc_menu_definition_target(cpu, memory, resources, menu_handle)?;
-    startup.menu_tracking.context_mut().definition = Some(call.request.begin_definition());
-    startup.menu_tracking.context_mut().native_popup = Some(call);
+    startup.menu_tracking.context_mut().definition = Some(call.popup_request().unwrap().begin_definition());
+    startup.menu_tracking.context_mut().call.get_or_insert(call);
     ppc_prepare_menu_definition_port(startup, current_gworld, current_gdevice);
     let invocation = startup
         .active_menu_definition()
@@ -76714,7 +76723,7 @@ fn ppc_begin_custom_popup_menu_tracking(
     );
     if action.is_none() {
         startup.clear_active_menu_definition();
-        startup.menu_tracking.context_mut().native_popup = None;
+        startup.menu_tracking.context_mut().clear_native_popup();
         ppc_restore_menu_definition_port(startup, current_gworld, current_gdevice);
     }
     action
@@ -76736,7 +76745,7 @@ fn ppc_continue_custom_popup_menu_tracking(
     input: PpcInputSnapshot,
     resources: &[PpcVfsResourceRecord],
 ) -> PpcImportAction {
-    let Some(call) = startup.menu_tracking.context().native_popup else {
+    let Some(call) = startup.menu_tracking.context().native_popup() else {
         startup.clear_active_menu_definition();
         ppc_restore_menu_definition_port(startup, current_gworld, current_gdevice);
         return PpcImportAction::Return(0);
@@ -76757,9 +76766,9 @@ fn ppc_continue_custom_popup_menu_tracking(
                 }
             }
             startup.clear_active_menu_definition();
-            startup.menu_tracking.context_mut().native_popup = None;
+            startup.menu_tracking.context_mut().clear_native_popup();
             ppc_restore_menu_definition_port(startup, current_gworld, current_gdevice);
-            cpu.lr = call.return_address;
+            cpu.lr = call.origin.return_address();
             return PpcImportAction::Return(0);
         }
     };
@@ -76783,9 +76792,9 @@ fn ppc_continue_custom_popup_menu_tracking(
                 }
             }
             startup.clear_active_menu_definition();
-            startup.menu_tracking.context_mut().native_popup = None;
+            startup.menu_tracking.context_mut().clear_native_popup();
             ppc_restore_menu_definition_port(startup, current_gworld, current_gdevice);
-            cpu.lr = call.return_address;
+            cpu.lr = call.origin.return_address();
             return PpcImportAction::Return(result);
         }
         let invocation = startup
@@ -76810,9 +76819,9 @@ fn ppc_continue_custom_popup_menu_tracking(
     if completed == Some(MenuDefinitionMessage::PopUp) {
         let Some(front) = ppc_live_front_buffer_for_gworld(memory, gworlds, PPC_MAIN_GWORLD) else {
             startup.clear_active_menu_definition();
-            startup.menu_tracking.context_mut().native_popup = None;
+            startup.menu_tracking.context_mut().clear_native_popup();
             ppc_restore_menu_definition_port(startup, current_gworld, current_gdevice);
-            cpu.lr = call.return_address;
+            cpu.lr = call.origin.return_address();
             return PpcImportAction::Return(0);
         };
         let definition = startup.active_menu_definition().unwrap().clone();
@@ -76831,9 +76840,9 @@ fn ppc_continue_custom_popup_menu_tracking(
             Vec::new(),
         ) else {
             startup.clear_active_menu_definition();
-            startup.menu_tracking.context_mut().native_popup = None;
+            startup.menu_tracking.context_mut().clear_native_popup();
             ppc_restore_menu_definition_port(startup, current_gworld, current_gdevice);
-            cpu.lr = call.return_address;
+            cpu.lr = call.origin.return_address();
             return PpcImportAction::Return(0);
         };
         if ppc_draw_tracked_menu_chrome(
@@ -76848,9 +76857,9 @@ fn ppc_continue_custom_popup_menu_tracking(
         {
             ppc_restore_menu_tracking(memory, state.front_buffer, &state);
             startup.clear_active_menu_definition();
-            startup.menu_tracking.context_mut().native_popup = None;
+            startup.menu_tracking.context_mut().clear_native_popup();
             ppc_restore_menu_definition_port(startup, current_gworld, current_gdevice);
-            cpu.lr = call.return_address;
+            cpu.lr = call.origin.return_address();
             return PpcImportAction::Return(0);
         }
         state.definition = startup.menu_tracking.context_mut().definition.take();
@@ -76924,9 +76933,9 @@ fn ppc_continue_custom_popup_menu_tracking(
                         }
                     }
                     startup.clear_active_menu_definition();
-                    startup.menu_tracking.context_mut().native_popup = None;
+                    startup.menu_tracking.context_mut().clear_native_popup();
                     ppc_restore_menu_definition_port(startup, current_gworld, current_gdevice);
-                    cpu.lr = call.return_address;
+                    cpu.lr = call.origin.return_address();
                     return PpcImportAction::Return(result);
                 }
                 return PpcImportAction::Yield(u64::MAX);
@@ -76940,9 +76949,9 @@ fn ppc_continue_custom_popup_menu_tracking(
                 }
             }
             startup.clear_active_menu_definition();
-            startup.menu_tracking.context_mut().native_popup = None;
+            startup.menu_tracking.context_mut().clear_native_popup();
             ppc_restore_menu_definition_port(startup, current_gworld, current_gdevice);
-            cpu.lr = call.return_address;
+            cpu.lr = call.origin.return_address();
             return PpcImportAction::Return(result);
         }
     }
@@ -76956,9 +76965,9 @@ fn ppc_continue_custom_popup_menu_tracking(
         }
     }
     startup.clear_active_menu_definition();
-    startup.menu_tracking.context_mut().native_popup = None;
+    startup.menu_tracking.context_mut().clear_native_popup();
     ppc_restore_menu_definition_port(startup, current_gworld, current_gdevice);
-    cpu.lr = call.return_address;
+    cpu.lr = call.origin.return_address();
     PpcImportAction::Return(0)
 }
 
@@ -76979,13 +76988,13 @@ fn ppc_dispatch_pop_up_menu_select(
     let current_menu_list = ppc_current_menu_list(memory);
 
     if let Some(state) = startup.menu_tracking.as_ref() {
-        if state.front_buffer.is_none() {
+        if startup.menu_tracking.context().caller_isa() == Some(GuestIsa::M68k) {
             // A classic MenuSelect owns this process continuation. A nested
             // native call must not consume its save-under or origin ABI frame.
             return PpcImportAction::Return(0);
         }
         if state.kind != MenuTrackingKind::PopUp
-            || startup.menu_tracking.context().native_popup != Some(call)
+            || startup.menu_tracking.context().native_popup() != Some(call)
             || state.menu_handle != menu_handle
         {
             // A callback may enter a different modal menu routine while an
@@ -76999,14 +77008,14 @@ fn ppc_dispatch_pop_up_menu_select(
             // A changed PixMap/depth makes the saved coordinates unsafe to
             // write. Abandon the overlay without touching either buffer.
             *startup.menu_tracking = None;
-            startup.menu_tracking.context_mut().native_popup = None;
+            startup.menu_tracking.context_mut().clear_native_popup();
             return PpcImportAction::Return(0);
         }
         if !ppc_popup_menu_is_inserted(memory, current_menu_list, menu_handle) {
             let Some(state) = startup.menu_tracking.take() else {
                 return PpcImportAction::Return(0);
             };
-            startup.menu_tracking.context_mut().native_popup = None;
+            startup.menu_tracking.context_mut().clear_native_popup();
             ppc_restore_menu_tracking(memory, state.front_buffer, &state);
             return PpcImportAction::Return(0);
         }
@@ -77021,7 +77030,7 @@ fn ppc_dispatch_pop_up_menu_select(
                 return PpcImportAction::Yield(u64::MAX);
             }
             if let MenuFlashStep::Complete(result) = step {
-                startup.menu_tracking.context_mut().native_popup = None;
+                startup.menu_tracking.context_mut().clear_native_popup();
                 ppc_restore_menu_tracking(memory, state.front_buffer, &state);
                 return PpcImportAction::Return(result);
             }
@@ -77063,7 +77072,7 @@ fn ppc_dispatch_pop_up_menu_select(
         let highlighted_item = state.highlighted_item;
         if !input.mouse_button {
             if highlighted_item == 0 {
-                startup.menu_tracking.context_mut().native_popup = None;
+                startup.menu_tracking.context_mut().clear_native_popup();
                 ppc_restore_menu_tracking(memory, state.front_buffer, &state);
                 return PpcImportAction::Return(0);
             }
@@ -77080,7 +77089,7 @@ fn ppc_dispatch_pop_up_menu_select(
                 result,
             );
             if !flash_enabled {
-                startup.menu_tracking.context_mut().native_popup = None;
+                startup.menu_tracking.context_mut().clear_native_popup();
                 ppc_restore_menu_tracking(memory, state.front_buffer, &state);
                 return PpcImportAction::Return(result);
             }
@@ -77117,7 +77126,7 @@ fn ppc_dispatch_pop_up_menu_select(
     let Some((popup_left, popup_top, popup_width, popup_height, requested_item, content_top)) =
         ppc_popup_menu_layout_with_resources(
             memory,
-            call.request,
+            call.popup_request().unwrap(),
             front,
             resources,
             current_resource_refnum,
@@ -77159,7 +77168,7 @@ fn ppc_dispatch_pop_up_menu_select(
         highlighted_item,
     );
     *startup.menu_tracking = Some(state);
-    startup.menu_tracking.context_mut().native_popup = Some(call);
+    startup.menu_tracking.context_mut().call.get_or_insert(call);
     PpcImportAction::Yield(u64::MAX)
 }
 
@@ -78435,10 +78444,8 @@ fn ppc_begin_custom_menu_bar_tracking(
         &state,
     )?;
     *startup.menu_tracking = Some(state);
-    startup.menu_tracking.context_mut().native_menu = Some(NativeMenuSelectOrigin {
-        initial_point,
-        return_address: cpu.lr,
-    });
+    startup.menu_tracking.context_mut().call
+        .get_or_insert(ppc_menu_select_call(cpu, initial_point));
     ppc_prepare_menu_definition_port(startup, current_gworld, current_gdevice);
     let invocation = startup
         .active_menu_definition()
@@ -78459,7 +78466,7 @@ fn ppc_begin_custom_menu_bar_tracking(
             ppc_restore_menu_tracking(memory, state.front_buffer, &state);
         }
         startup.clear_active_menu_definition();
-        startup.menu_tracking.context_mut().native_menu = None;
+        startup.menu_tracking.context_mut().clear_native_menu();
         ppc_restore_menu_definition_port(startup, current_gworld, current_gdevice);
         ppc_set_menu_command_highlight_with_colors(
             memory,
@@ -78492,14 +78499,14 @@ fn ppc_continue_custom_menu_bar_tracking(
     resources: &[PpcVfsResourceRecord],
     current_resource_refnum: i16,
 ) -> PpcImportAction {
-    let Some(call) = startup.menu_tracking.context().native_menu else {
+    let Some(call) = startup.menu_tracking.context().native_menu() else {
         startup.clear_active_menu_definition();
         ppc_restore_menu_definition_port(startup, current_gworld, current_gdevice);
         return PpcImportAction::Return(0);
     };
     let Some(definition) = startup.active_menu_definition_mut() else {
-        cpu.lr = call.return_address;
-        startup.menu_tracking.context_mut().native_menu = None;
+        cpu.lr = call.origin.return_address();
+        startup.menu_tracking.context_mut().clear_native_menu();
         ppc_restore_menu_definition_port(startup, current_gworld, current_gdevice);
         return PpcImportAction::Return(0);
     };
@@ -78515,9 +78522,9 @@ fn ppc_continue_custom_menu_bar_tracking(
                 }
             }
             startup.clear_active_menu_definition();
-            startup.menu_tracking.context_mut().native_menu = None;
+            startup.menu_tracking.context_mut().clear_native_menu();
             ppc_restore_menu_definition_port(startup, current_gworld, current_gdevice);
-            cpu.lr = call.return_address;
+            cpu.lr = call.origin.return_address();
             return PpcImportAction::Return(0);
         }
     };
@@ -78556,9 +78563,9 @@ fn ppc_continue_custom_menu_bar_tracking(
                     *startup.menu_tracking = Some(state);
                 }
                 if startup.active_menu_definition().is_none() {
-                    startup.menu_tracking.context_mut().native_menu = None;
+                    startup.menu_tracking.context_mut().clear_native_menu();
                     ppc_restore_menu_definition_port(startup, current_gworld, current_gdevice);
-                    cpu.lr = call.return_address;
+                    cpu.lr = call.origin.return_address();
                     return PpcImportAction::Yield(u64::MAX);
                 }
                 if let Some(invocation) = startup
@@ -78613,9 +78620,9 @@ fn ppc_continue_custom_menu_bar_tracking(
                 startup.host_menu_bar_hidden,
             );
             startup.clear_active_menu_definition();
-            startup.menu_tracking.context_mut().native_menu = None;
+            startup.menu_tracking.context_mut().clear_native_menu();
             ppc_restore_menu_definition_port(startup, current_gworld, current_gdevice);
-            cpu.lr = call.return_address;
+            cpu.lr = call.origin.return_address();
             return PpcImportAction::Return(result);
         }
         let invocation = startup
@@ -78666,7 +78673,7 @@ fn ppc_continue_custom_menu_bar_tracking(
             }
         }
         startup.clear_active_menu_definition();
-        startup.menu_tracking.context_mut().native_menu = None;
+        startup.menu_tracking.context_mut().clear_native_menu();
         ppc_set_menu_command_highlight_with_colors(
             memory,
             gworlds,
@@ -78678,7 +78685,7 @@ fn ppc_continue_custom_menu_bar_tracking(
             startup.host_menu_bar_hidden,
         );
         ppc_restore_menu_definition_port(startup, current_gworld, current_gdevice);
-        cpu.lr = call.return_address;
+        cpu.lr = call.origin.return_address();
         return PpcImportAction::Return(0);
     }
     if input.mouse_button {
@@ -78727,9 +78734,9 @@ fn ppc_continue_custom_menu_bar_tracking(
                 startup.host_menu_bar_hidden,
             );
             startup.clear_active_menu_definition();
-            startup.menu_tracking.context_mut().native_menu = None;
+            startup.menu_tracking.context_mut().clear_native_menu();
             ppc_restore_menu_definition_port(startup, current_gworld, current_gdevice);
-            cpu.lr = call.return_address;
+            cpu.lr = call.origin.return_address();
             return PpcImportAction::Return(result);
         }
         return PpcImportAction::Yield(u64::MAX);
@@ -78754,9 +78761,9 @@ fn ppc_continue_custom_menu_bar_tracking(
         startup.host_menu_bar_hidden,
     );
     startup.clear_active_menu_definition();
-    startup.menu_tracking.context_mut().native_menu = None;
+    startup.menu_tracking.context_mut().clear_native_menu();
     ppc_restore_menu_definition_port(startup, current_gworld, current_gdevice);
-    cpu.lr = call.return_address;
+    cpu.lr = call.origin.return_address();
     PpcImportAction::Return(result)
 }
 
@@ -78844,7 +78851,7 @@ fn ppc_track_menu_while_held_with_resources(
                 resources,
                 current_resource_refnum,
             );
-            startup.menu_tracking.context_mut().native_popup = None;
+            startup.menu_tracking.context_mut().clear_native_popup();
         } else {
             *startup.menu_tracking = Some(previous);
         }
@@ -78865,7 +78872,7 @@ fn ppc_track_menu_while_held_with_resources(
             return;
         };
         *startup.menu_tracking = Some(state);
-        startup.menu_tracking.context_mut().native_popup = None;
+        startup.menu_tracking.context_mut().clear_native_popup();
     }
     let active_menu_id = startup.menu_tracking.as_ref().and_then(|state| {
         memory
@@ -94574,7 +94581,7 @@ pub(crate) mod tests {
             None
         );
         assert_eq!(
-            loaded.toolbox_startup.menu_tracking.context().native_menu,
+            loaded.toolbox_startup.menu_tracking.context().native_menu(),
             None
         );
         assert_eq!(*loaded.current_gworld, 0x1234_0000);
@@ -94749,7 +94756,7 @@ pub(crate) mod tests {
             .submenus
             .is_empty());
         assert_eq!(
-            loaded.toolbox_startup.menu_tracking.context().native_menu,
+            loaded.toolbox_startup.menu_tracking.context().native_menu(),
             None
         );
         assert_eq!(*loaded.current_gworld, 0x1234_0000);
@@ -94810,7 +94817,7 @@ pub(crate) mod tests {
         assert_eq!(loaded.cpu.lr, return_address);
         assert_eq!(loaded.toolbox_startup.menu_tracking, None);
         assert_eq!(
-            loaded.toolbox_startup.menu_tracking.context().native_menu,
+            loaded.toolbox_startup.menu_tracking.context().native_menu(),
             None
         );
         assert_eq!(*loaded.current_gworld, 0x1234_0000);
@@ -94966,7 +94973,7 @@ pub(crate) mod tests {
                 None
             );
             assert_eq!(
-                loaded.toolbox_startup.menu_tracking.context().native_popup,
+                loaded.toolbox_startup.menu_tracking.context().native_popup(),
                 None
             );
             assert_eq!(
@@ -96768,6 +96775,16 @@ pub(crate) mod tests {
         let mut tracking = crate::menu_manager::test_process_menu_tracking(0x0012_3456);
         tracking.highlighted_item = 2;
         context.set_menu_tracking(Some(tracking));
+        classic.menu_tracking.context_mut().call = Some(MenuTrackingCall {
+            request: MenuTrackingRequest::MenuSelect { initial_point: 0 },
+            origin: MenuTrackingOrigin::M68k {
+                stack_pointer: TEST_SP,
+                return_address: 0x1234,
+            },
+        });
+        // A drawing surface cannot turn a classic operation into a native one.
+        let native_front = native.current_front_buffer().unwrap();
+        context.menu_tracking_mut().unwrap().front_buffer = Some(native_front.into());
         assert_eq!(
             classic
                 .menu_tracking
@@ -96798,8 +96815,10 @@ pub(crate) mod tests {
             Some(4)
         );
 
-        let native_front = native.current_front_buffer().unwrap();
-        context.menu_tracking_mut().unwrap().front_buffer = Some(native_front.into());
+        native.toolbox_startup.menu_tracking.context_mut().call =
+            Some(ppc_menu_select_call(&native.cpu, 0));
+        // Nor can an absent native surface turn its caller into a classic one.
+        context.menu_tracking_mut().unwrap().front_buffer = None;
         classic_cpu.write_reg(Register::A7, TEST_SP);
         classic_bus.write_long(TEST_SP, 0);
         classic_bus.write_long(TEST_SP + 4, u32::MAX);
@@ -104997,7 +105016,7 @@ pub(crate) mod tests {
                         .toolbox_startup
                         .menu_tracking
                         .context()
-                        .native_popup
+                        .native_popup()
                         .is_some(),
                     "{label}"
                 );
@@ -105018,7 +105037,7 @@ pub(crate) mod tests {
             );
             assert_eq!(loaded.toolbox_startup.menu_tracking, None, "{label}");
             assert_eq!(
-                loaded.toolbox_startup.menu_tracking.context().native_popup,
+                loaded.toolbox_startup.menu_tracking.context().native_popup(),
                 None,
                 "{label}"
             );
@@ -161267,15 +161286,14 @@ pub(crate) mod tests {
         let parked_lr = loaded.cpu.lr;
         assert_eq!(tracking.kind, MenuTrackingKind::PopUp);
         assert_eq!(
-            loaded.toolbox_startup.menu_tracking.context().native_popup,
-            Some(NativePopupMenuOrigin {
-                request: PopupMenuRequest {
+            loaded.toolbox_startup.menu_tracking.context().native_popup(),
+            Some(MenuTrackingCall {
+                request: MenuTrackingRequest::PopUp(PopupMenuRequest {
                     menu_handle,
                     anchor: (100, 50),
                     requested_item: 2,
-                },
-                stack_pointer: original_sp,
-                return_address: parked_lr,
+                }),
+                origin: MenuTrackingOrigin::PowerPc { stack_pointer: original_sp, return_address: parked_lr },
             })
         );
         assert_eq!(tracking.popup_left, 50);
@@ -161584,7 +161602,7 @@ pub(crate) mod tests {
             let tracking = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
             assert_eq!(tracking.kind, MenuTrackingKind::PopUp);
             assert_eq!(
-                loaded.toolbox_startup.menu_tracking.context().native_popup,
+                loaded.toolbox_startup.menu_tracking.context().native_popup(),
                 Some(ppc_popup_menu_call(&loaded.cpu))
             );
             assert_eq!(
@@ -171670,14 +171688,13 @@ pub(crate) mod tests {
             .toolbox_startup
             .menu_tracking
             .context_mut()
-            .native_popup = Some(NativePopupMenuOrigin {
-            request: PopupMenuRequest {
+            .call = Some(MenuTrackingCall {
+            request: MenuTrackingRequest::PopUp(PopupMenuRequest {
                 menu_handle: popup_tracking.menu_handle,
                 anchor: (100, 50),
                 requested_item: 1,
-            },
-            stack_pointer: loaded.cpu.gpr[1],
-            return_address: loaded.cpu.lr,
+            }),
+            origin: MenuTrackingOrigin::PowerPc { stack_pointer: loaded.cpu.gpr[1], return_address: loaded.cpu.lr },
         });
         *loaded.toolbox_startup.menu_tracking = Some(popup_tracking);
         loaded

--- a/src/menu_manager.rs
+++ b/src/menu_manager.rs
@@ -2387,6 +2387,13 @@ const STANDARD_POPUP_SCREEN_MARGIN: i16 = 4;
 const STANDARD_POPUP_BOTTOM_RESERVE: i16 = 20;
 const STANDARD_POPUP_SCROLL_STEP: i16 = 16;
 
+/// Logical entry to a retained Menu Manager interaction.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum MenuTrackingRequest {
+    MenuSelect { initial_point: u32 },
+    PopUp(PopupMenuRequest),
+}
+
 /// Logical PopUpMenuSelect arguments, independent of the caller's return ABI.
 /// Macintosh Toolbox Essentials (1992), pp. 3-119--3-120.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/src/trap/menu.rs
+++ b/src/trap/menu.rs
@@ -1,6 +1,6 @@
 //! Menu Manager trap handlers.
 
-use crate::guest_call::{MenuBarBuildResume, MenuBarCallOrigin};
+use crate::guest_call::{MenuBarBuildResume, MenuBarCallOrigin, MenuTrackingCall, MenuTrackingOrigin};
 use crate::cpu::{CpuOps, Register};
 use crate::guest_call::GuestCallTarget;
 use crate::guest_procedure::{resolve_guest_procedure, GuestIsa};
@@ -26,7 +26,7 @@ use crate::menu_manager::{
     MenuListInstallRequest, MenuRow as SharedMenuRow, MenuRows as SharedMenuRows,
     MenuSnapshotRecord as SharedMenuSnapshotRecord, MenuFlashStep, MenuTrackingKind, MenuTrackingPane,
     MonochromeMenuIconLayout as SharedMonochromeMenuIconLayout, ProcessMenuTrackingState,
-    PopupMenuRequest, ProcessTrackedMenuPane, StandardMenuChrome, StandardMenuIconKind, StandardMenuItemWidth,
+    MenuTrackingRequest, PopupMenuRequest, ProcessTrackedMenuPane, StandardMenuChrome, StandardMenuIconKind, StandardMenuItemWidth,
     StandardMenuPaneKind, SubmenuReconciliation, SubmenuRequest, TrackedMenuPaneView,
     MAX_MENU_LIST_ENTRIES, MENU_COLOR_ENTRY_SIZE, STANDARD_MENU_BAR_FIRST_TITLE_LEFT,
     STANDARD_MENU_BAR_TITLE_SPACING, STANDARD_MENU_DEFINITION_SHIM, STANDARD_MENU_SEPARATOR_HEIGHT,
@@ -657,7 +657,7 @@ impl super::TrapDispatcher {
             self.restore_visible_dialog_snapshots(bus);
         }
         self.restore_menu_definition_port(cpu, bus);
-        self.finish_menu_no_hit(bus, cpu, self.menu_tracking.context().classic_stack, result_offset);
+        self.finish_menu_no_hit(bus, cpu, self.menu_tracking.context().classic_stack(), result_offset);
     }
 
     fn finish_custom_menu_tracking<C: CpuOps>(
@@ -679,7 +679,7 @@ impl super::TrapDispatcher {
             self.restore_visible_dialog_snapshots(bus);
         }
         self.restore_menu_definition_port(cpu, bus);
-        let sp = self.menu_tracking.context().classic_stack;
+        let sp = self.menu_tracking.context().classic_stack();
         bus.write_long(sp + result_offset, result);
         cpu.write_reg(Register::A7, sp + result_offset);
     }
@@ -1731,8 +1731,26 @@ impl super::TrapDispatcher {
     ) -> Option<Result<()>> {
         self.menu_tracking.bind_execution(&self.guest_calls);
         self.retire_menu_definition(cpu, bus);
-        let _menu_root =
-            (is_tool && matches!(trap_num, 0x13d | 0x00b)).then(|| self.menu_tracking.enter());
+        let _menu_root = (is_tool && matches!(trap_num, 0x13d | 0x00b)).then(|| {
+            let sp = cpu.read_reg(Register::A7);
+            let request = if trap_num == 0x00b {
+                MenuTrackingRequest::PopUp(PopupMenuRequest {
+                    menu_handle: bus.read_long(sp + 6),
+                    anchor: (bus.read_word(sp + 4) as i16, bus.read_word(sp + 2) as i16),
+                    requested_item: bus.read_word(sp) as i16,
+                })
+            } else {
+                MenuTrackingRequest::MenuSelect { initial_point: bus.read_long(sp) }
+            };
+            self.menu_tracking.enter_call(MenuTrackingCall {
+                request,
+                origin: MenuTrackingOrigin::M68k {
+                    stack_pointer: sp,
+                    return_address: self.current_trap_caller
+                        .unwrap_or_else(|| cpu.read_reg(Register::PC)),
+                },
+            })
+        });
         self.read_tick_count(bus);
         Some(match (is_tool, trap_num) {
             // InitMenus ($A930)
@@ -2134,10 +2152,7 @@ impl super::TrapDispatcher {
             // Inside Macintosh Volume I, I-355
             // MenuSelect ($A93D): Full mouse tracking with dropdown, highlighting, flashing
             (true, 0x13D) => {
-                if self
-                    .menu_tracking
-                    .as_ref()
-                    .is_some_and(|tracking| tracking.front_buffer.is_some())
+                if self.menu_tracking.context().caller_isa() == Some(GuestIsa::PowerPc)
                 {
                     // A native MenuSelect owns this process continuation. A
                     // nested 68k call must not consume its presentation state
@@ -2238,10 +2253,9 @@ impl super::TrapDispatcher {
                                     && mv < mbar_h
                                 {
                                     let old_saved = self.menu_tracking.take().unwrap();
-                                    let sp = self.menu_tracking.context().classic_stack;
                                     self.clear_active_menu_definition();
                                     self.restore_menu_tracking_pixels(bus, old_saved);
-                                    if self.open_menu_dropdown(bus, new_idx, sp) {
+                                    if self.open_menu_dropdown(bus, new_idx) {
                                         self.prepare_menu_definition_port(cpu, bus);
                                         if !self.arm_pending_menu_definition(
                                             cpu,
@@ -2305,7 +2319,7 @@ impl super::TrapDispatcher {
                             self.menu_tracking.as_mut().unwrap().advance_flash()
                         {
                             // Flash complete — finish up
-                            let sp = self.menu_tracking.context().classic_stack;
+                            let sp = self.menu_tracking.context().classic_stack();
                             let saved = self.menu_tracking.take().unwrap();
                             let active_menu = saved
                                 .submenus
@@ -2404,7 +2418,7 @@ impl super::TrapDispatcher {
                                 .menu_tracking
                                 .as_ref()
                                 .map(|tracking| {
-                                    (self.menu_tracking.context().classic_stack, tracking.menu_handle)
+                                    (self.menu_tracking.context().classic_stack(), tracking.menu_handle)
                                 })
                                 .unwrap();
                             let saved = self.menu_tracking.take().unwrap();
@@ -2436,9 +2450,8 @@ impl super::TrapDispatcher {
                             {
                                 // Switch to different menu
                                 let old_saved = self.menu_tracking.take().unwrap();
-                                let sp = self.menu_tracking.context().classic_stack;
                                 self.restore_menu_tracking_pixels(bus, old_saved);
-                                if self.open_menu_dropdown(bus, new_idx, sp) {
+                                if self.open_menu_dropdown(bus, new_idx) {
                                     self.prepare_menu_definition_port(cpu, bus);
                                     if !self.arm_pending_menu_definition(
                                         cpu,
@@ -2533,7 +2546,7 @@ impl super::TrapDispatcher {
                         // Pop the Point parameter (4 bytes) but keep result space
                         // Stack on entry: SP+0: pt(4), SP+4: result(4)
                         // We store SP so we can write result later
-                        if self.open_menu_dropdown(bus, menu_idx, sp) {
+                        if self.open_menu_dropdown(bus, menu_idx) {
                             self.prepare_menu_definition_port(cpu, bus);
                             if !self.arm_pending_menu_definition(
                                 cpu,
@@ -2574,10 +2587,7 @@ impl super::TrapDispatcher {
             // Macintosh Toolbox Essentials 1992, 3-120
             // PopUpMenuSelect ($A80B): Full re-fire tracking with dropdown display, item highlighting, flash animation; uses MenuTrackingState
             (true, 0x00B) => {
-                if self
-                    .menu_tracking
-                    .as_ref()
-                    .is_some_and(|tracking| tracking.front_buffer.is_some())
+                if self.menu_tracking.context().caller_isa() == Some(GuestIsa::PowerPc)
                 {
                     // Preserve an outer native retained call and return from
                     // this nested Pascal call through its own result slot.
@@ -2690,7 +2700,7 @@ impl super::TrapDispatcher {
                         if let MenuFlashStep::Complete(result) =
                             self.menu_tracking.as_mut().unwrap().advance_flash()
                         {
-                            let sp = self.menu_tracking.context().classic_stack;
+                            let sp = self.menu_tracking.context().classic_stack();
                             let saved = self.menu_tracking.take().unwrap();
                             self.restore_menu_tracking_pixels(bus, saved);
                             self.restore_visible_dialog_snapshots(bus);
@@ -2715,7 +2725,7 @@ impl super::TrapDispatcher {
                                 self.finish_custom_menu_tracking(cpu, bus, 10, result);
                             }
                         } else {
-                            let sp = self.menu_tracking.context().classic_stack;
+                            let sp = self.menu_tracking.context().classic_stack();
                             let saved = self.menu_tracking.take().unwrap();
                             self.restore_menu_tracking_pixels(bus, saved);
                             self.restore_visible_dialog_snapshots(bus);
@@ -2763,7 +2773,6 @@ impl super::TrapDispatcher {
                                 (0, 0, 0, 0),
                                 Vec::new(),
                             ));
-                            self.menu_tracking.context_mut().classic_stack = sp;
                             self.menu_tracking.context_mut().definition =
                                 Some(request.begin_definition());
                             self.prepare_menu_definition_port(cpu, bus);
@@ -2801,7 +2810,6 @@ impl super::TrapDispatcher {
                         ));
                         let rows = self.menu_rows(bus, &self.menus[menu_idx].items);
                         Self::write_menu_scrolling_globals(bus, &rows, content_top);
-                        self.menu_tracking.context_mut().classic_stack = sp;
                         self.draw_menu_dropdown(bus, menu_idx, dd_rect);
                         if highlighted_item > 0 {
                             self.set_menu_tracking_highlight(bus, highlighted_item);
@@ -4390,7 +4398,6 @@ impl super::TrapDispatcher {
         &mut self,
         bus: &mut MacMemoryBus,
         menu_idx: usize,
-        stack_ptr: u32,
     ) -> bool {
         // Fault in this menu's icon resources while `self` is still
         // mutable; the draw path below reads them through `&self` only.
@@ -4459,7 +4466,6 @@ impl super::TrapDispatcher {
             let rows = self.menu_rows(bus, &self.menus[menu_idx].items);
             Self::write_menu_scrolling_globals(bus, &rows, dropdown_rect.0);
         }
-        self.menu_tracking.context_mut().classic_stack = stack_ptr;
         custom_definition
     }
 
@@ -7446,6 +7452,82 @@ mod tests {
             bus.read_bytes(trampoline + 60, 10),
             invocation.scratch_bytes()
         );
+    }
+
+    #[test]
+    fn classic_tracking_retains_original_return_for_both_menu_entry_forms() {
+        use crate::guest_call::{MenuTrackingCall, MenuTrackingOrigin};
+        use crate::memory::globals::addr;
+        use crate::menu_manager::{MenuTrackingRequest, PopupMenuRequest};
+        for opcode in [0xa93d, 0xad3d, 0xa80b, 0xac0b] {
+            let (mut disp, mut cpu, mut bus) = setup_with_port();
+            setup_8bpp_menu_screen(&mut disp, &mut bus, 160, 96);
+            disp.menu_bar_hidden = false;
+            bus.write_word(addr::MBAR_HEIGHT, 20);
+            bus.write_word(addr::MENU_FLASH, 0);
+            let handle = new_menu_with_title(&mut disp, &mut cpu, &mut bus, 337, 0x306E40, "File");
+            append_menu_data(&mut disp, &mut cpu, &mut bus, handle, 0x306E80, "One;Two");
+            insert_menu(&mut disp, &mut cpu, &mut bus, handle);
+            disp.draw_menu_bar_to_fb(&mut bus);
+            let auto_pop = opcode & 0x0400 != 0;
+            let popup = opcode & !0x0400 == 0xa80b;
+            let trap_pc = 0x0012_3600;
+            let parameters = TEST_SP + if auto_pop { 4 } else { 0 };
+            let return_pc = trap_pc + if auto_pop { 0x100 } else { 2 };
+            if auto_pop {
+                bus.write_long(TEST_SP, return_pc);
+            }
+            let request = if popup {
+                bus.write_word(parameters, 1);
+                bus.write_word(parameters + 2, 30);
+                bus.write_word(parameters + 4, 30);
+                bus.write_long(parameters + 6, handle);
+                MenuTrackingRequest::PopUp(PopupMenuRequest {
+                    menu_handle: handle,
+                    anchor: (30, 30),
+                    requested_item: 1,
+                })
+            } else {
+                let initial_point = (10u32 << 16) | 12;
+                bus.write_long(parameters, initial_point);
+                MenuTrackingRequest::MenuSelect { initial_point }
+            };
+            bus.write_byte(addr::MB_STATE, 0);
+            cpu.write_reg(Register::PC, trap_pc + 2);
+            cpu.write_reg(Register::A7, TEST_SP);
+            disp.dispatch(opcode, &mut cpu, &mut bus).unwrap();
+            assert_eq!(
+                disp.menu_tracking.context().call,
+                Some(MenuTrackingCall {
+                    request,
+                    origin: MenuTrackingOrigin::M68k {
+                        stack_pointer: parameters,
+                        return_address: return_pc
+                    },
+                }),
+                "opcode {opcode:04x}"
+            );
+            let state = disp
+                .menu_tracking
+                .as_ref()
+                .expect("standard menu remains live until release");
+            bus.write_word(addr::MOUSE_LOC2, (state.popup_top + 8) as u16);
+            bus.write_word(addr::MOUSE_LOC2 + 2, (state.popup_left + 8) as u16);
+            bus.write_byte(addr::MB_STATE, 0x80);
+            cpu.write_reg(Register::PC, trap_pc + 2);
+            disp.dispatch(opcode, &mut cpu, &mut bus).unwrap();
+            let result_slot = parameters + if popup { 10 } else { 4 };
+            assert_eq!(
+                bus.read_long(result_slot),
+                (337u32 << 16) | 1,
+                "opcode {opcode:04x}"
+            );
+            assert_eq!(cpu.read_reg(Register::A7), result_slot);
+            assert_eq!(cpu.read_reg(Register::PC), return_pc);
+            assert!(disp.menu_tracking.is_none());
+            assert_eq!(disp.menu_tracking.context().call, None);
+            assert!(disp.guest_calls.is_empty());
+        }
     }
 
     #[test]
@@ -13579,7 +13661,7 @@ mod tests {
             super::super::TrapDispatcher::fb_pixel_index_for_rgb(&bus, [0xFFFF; 3]).unwrap();
         let black = super::super::TrapDispatcher::fb_pixel_index_for_rgb(&bus, [0; 3]).unwrap();
 
-        disp.open_menu_dropdown(&mut bus, 0, TEST_SP);
+        disp.open_menu_dropdown(&mut bus, 0);
 
         assert_eq!(
             disp.menu_tracking.as_ref().unwrap().dropdown_rect(),
@@ -13634,7 +13716,7 @@ mod tests {
         let wide_item_width =
             super::super::TrapDispatcher::fb_measure_string("Wide Underline", 0, 12) + 32;
 
-        disp.open_menu_dropdown(&mut bus, 0, TEST_SP);
+        disp.open_menu_dropdown(&mut bus, 0);
 
         assert_eq!(
             expected_width, wide_item_width,
@@ -13704,7 +13786,7 @@ mod tests {
             .standard_menu_width(&bus, &disp.menus[0].items)
             .max(regions[0].1 - regions[0].0 + 20);
 
-        disp.open_menu_dropdown(&mut bus, 0, TEST_SP);
+        disp.open_menu_dropdown(&mut bus, 0);
         let rect = disp.menu_tracking.as_ref().unwrap().dropdown_rect();
 
         assert_eq!(
@@ -13804,7 +13886,7 @@ mod tests {
         disp.install_test_resource(&mut bus, *b"SICN", 263, &sicn);
         insert_menu(&mut disp, &mut cpu, &mut bus, menu);
 
-        disp.open_menu_dropdown(&mut bus, 0, TEST_SP);
+        disp.open_menu_dropdown(&mut bus, 0);
         let rect = disp.menu_tracking.as_ref().unwrap().dropdown_rect();
 
         assert_eq!(
@@ -13850,7 +13932,7 @@ mod tests {
         disp.install_test_resource(&mut bus, *b"SICN", 263, &sicn);
         insert_menu(&mut disp, &mut cpu, &mut bus, menu);
 
-        disp.open_menu_dropdown(&mut bus, 0, TEST_SP);
+        disp.open_menu_dropdown(&mut bus, 0);
         let rect = disp.menu_tracking.as_ref().unwrap().dropdown_rect();
 
         assert_eq!(
@@ -13946,7 +14028,7 @@ mod tests {
         disp.install_test_resource(&mut bus, *b"ICON", 263, &icon);
         insert_menu(&mut disp, &mut cpu, &mut bus, menu);
 
-        disp.open_menu_dropdown(&mut bus, 0, TEST_SP);
+        disp.open_menu_dropdown(&mut bus, 0);
         let rect = disp.menu_tracking.as_ref().unwrap().dropdown_rect();
 
         assert_eq!(
@@ -14319,7 +14401,7 @@ mod tests {
             "Open/O;Close/W",
         );
         insert_menu(&mut disp, &mut cpu, &mut bus, handle);
-        disp.open_menu_dropdown(&mut bus, 0, TEST_SP);
+        disp.open_menu_dropdown(&mut bus, 0);
         assert!(
             disp.menu_tracking.is_some(),
             "precondition: dropdown tracking should be active"


### PR DESCRIPTION
Retained menu tracking infers caller architecture from whether it has a native drawing surface, and its caller arguments are split between native records and a classic stack slot. This lets presentation state stand in for execution ownership and leaves standard tracking without a complete original return boundary.

Prepare one MenuTrackingCall at either public entry, combining the logical MenuSelect/popup request with its explicit caller ISA, original argument stack and return address. Both adapters check that caller instead of the drawing surface. Reentry preserves the original call, while an idle cancelled operation is retired before a new entry so its ID and caller cannot be inherited. The two native record types and separate classic stack field are removed.

Validation covers contradictory surface/caller combinations in both directions, retained request/return identity, idle cancellation and scope cleanup, and MenuSelect/popup dispatch through both ordinary and auto-pop classic forms with exact results and returns. Existing actual nested and mixed-ISA MDEF tests remain in the full suite. All 5,132 local headless library tests pass (three ignored), and the development-tools check is warning-free.

Partial progress toward #1512. Callback/input refiring, shared tracking decisions, MenuHook, normalized graphics state and complete guest cleanup on cancellation or failed return remain open.
