### PR TITLE
fix: resume classic menu tracking without repeating public traps

### DIFF
--- a/src/guest_call.rs
+++ b/src/guest_call.rs
@@ -826,13 +826,54 @@ impl SharedMenuTracking {
             _ => unreachable!(),
         }
     }
-    pub(crate) fn enter_call(&mut self, call: MenuTrackingCall) -> MenuTrackingEntry {
-        let entry = self.enter();
-        self.context_mut().call.get_or_insert(call);
-        entry
+    pub(crate) fn enter_new_call(&mut self, call: MenuTrackingCall) -> MenuTrackingEntry {
+        let task = self.execution.current_task();
+        let parent = self
+            .execution
+            .0
+            .borrow()
+            .kernel
+            .peek(task)
+            .map(|call| call.call_id());
+        let id = self.push_tracking(task, parent);
+        self.context_mut().call = Some(call);
+        self.scope(id)
     }
-    pub(crate) fn enter(&mut self) -> MenuTrackingEntry {
-        let id = self.begin();
+
+    pub(crate) fn ready_call(&self, isa: GuestIsa) -> Option<MenuTrackingCall> {
+        if !self.execution.current_task_is_running() {
+            return None;
+        }
+        let task = self.execution.current_task();
+        let parent = self
+            .execution
+            .0
+            .borrow()
+            .kernel
+            .peek(task)
+            .map(|call| call.call_id());
+        let root = &self.calls.calls[self.active_index()?];
+        if root.parent != parent {
+            return None;
+        }
+        let MenuOperation::Tracking(context) = &root.operation else {
+            return None;
+        };
+        context
+            .call
+            .filter(|call| call.origin.isa() == isa && !context.is_idle())
+    }
+
+    pub(crate) fn resume_call(
+        &mut self,
+        isa: GuestIsa,
+    ) -> Option<(MenuTrackingCall, MenuTrackingEntry)> {
+        let call = self.ready_call(isa)?;
+        let id = self.calls.calls[self.active_index()?].id;
+        Some((call, self.scope(id)))
+    }
+
+    fn scope(&self, id: MenuOperationId) -> MenuTrackingEntry {
         MenuTrackingEntry {
             id,
             tracking: Self {
@@ -842,6 +883,17 @@ impl SharedMenuTracking {
             },
         }
     }
+
+    pub(crate) fn enter_call(&mut self, call: MenuTrackingCall) -> MenuTrackingEntry {
+        let entry = self.enter();
+        self.context_mut().call.get_or_insert(call);
+        entry
+    }
+    pub(crate) fn enter(&mut self) -> MenuTrackingEntry {
+        let id = self.begin();
+        self.scope(id)
+    }
+
     pub(crate) fn entry_id(&self) -> Option<MenuOperationId> {
         let task = self.execution.current_task();
         let parent = self
@@ -903,6 +955,9 @@ impl SharedMenuTracking {
         }) {
             return call.id;
         }
+        self.push_tracking(task, parent)
+    }
+    fn push_tracking(&mut self, task: ExecutionTaskId, parent: Option<CallId>) -> MenuOperationId {
         let id = MenuOperationId(self.calls.next_id);
         self.calls.next_id = self
             .calls
@@ -3191,6 +3246,55 @@ mod tests {
         );
         assert_eq!(calls.advance_menu_bar_build(GuestIsa::M68k), None);
         assert_eq!(calls.ready_menu_bar_build(GuestIsa::M68k), None);
+        assert!(calls.is_empty());
+    }
+
+    #[test]
+    fn fresh_menu_entries_and_resumption_use_exact_call_ownership() {
+        use crate::menu_manager::{test_process_menu_tracking, MenuTrackingRequest};
+        let calls = SharedGuestCallStack::default();
+        let mut tracking = calls.menu_tracking_view();
+        let original = MenuTrackingCall {
+            request: MenuTrackingRequest::MenuSelect { initial_point: 12 },
+            origin: MenuTrackingOrigin::M68k {
+                stack_pointer: 0x4000,
+                return_address: 0x5000,
+            },
+        };
+        let outer = tracking.enter_new_call(original);
+        *tracking = Some(test_process_menu_tracking(111));
+        assert_eq!(tracking.ready_call(GuestIsa::M68k), Some(original));
+        assert_eq!(tracking.ready_call(GuestIsa::PowerPc), None);
+        assert!(calls.begin_m68k(
+            GuestCallTarget {
+                isa: GuestIsa::M68k,
+                entry: 0x1000,
+                rtoc: 0
+            },
+            0x2000,
+            0x3000
+        ));
+        assert_eq!(
+            tracking.ready_call(GuestIsa::M68k),
+            None,
+            "a live callback still owns execution"
+        );
+        assert!(calls.complete_m68k(0x2002, 0x3000));
+        assert_eq!(tracking.ready_call(GuestIsa::M68k), Some(original));
+        let inner = tracking.enter_new_call(original);
+        assert_ne!(
+            inner.id, outer.id,
+            "a fresh public entry cannot resume the prior operation"
+        );
+        *tracking = Some(test_process_menu_tracking(222));
+        *tracking = None;
+        drop(inner);
+        assert_eq!(tracking.as_ref().unwrap().menu_handle, 111);
+        let (_, resumed) = tracking.resume_call(GuestIsa::M68k).unwrap();
+        assert_eq!(resumed.id, outer.id);
+        *tracking = None;
+        drop(resumed);
+        drop(outer);
         assert!(calls.is_empty());
     }
 

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -5995,6 +5995,44 @@ impl FixtureRunner {
                 break;
             }
 
+            if !sound_work_only
+                && self.active_interrupt_callback.is_none()
+                && self.dispatcher.has_ready_menu_tracking()
+            {
+                // Preserve the guest-time charge of a menu wait step after removing trap reentry.
+                let wait_cost = 1 + hle_trap_extra_tick_cost(0xa93d);
+                if self.frozen_ticks.is_none() && self.charge_tick_budget(wait_cost, tick_cap) {
+                    break;
+                }
+                if self.active_interrupt_callback.is_some() {
+                    continue;
+                }
+                self.dispatcher.yield_for_ui = yield_for_ui;
+                if let Some(opcode) = self
+                    .dispatcher
+                    .resume_menu_tracking(&mut self.m68k.cpu, &mut self.bus)
+                {
+                    count += 1;
+                    self.total_instructions = self.total_instructions.wrapping_add(1);
+                    if self.dispatcher.has_ready_menu_tracking() {
+                        if yield_for_ui && self.frozen_ticks.is_none() {
+                            self.frozen_ticks = Some(self.guest_tick());
+                        }
+                        let fired_hook = self.fire_menu_hook_proc(opcode);
+                        if yield_for_ui && !fired_hook {
+                            if finish_frame {
+                                self.finish_host_frame(audio_samples, sound_interrupt_dispatched);
+                            }
+                            return (count, true);
+                        }
+                    } else if self.process_context.menu_tracking().is_none() && self.frozen_ticks.is_some()
+                    {
+                        self.unfreeze_ticks_to(real_tick_cap);
+                    }
+                    continue;
+                }
+            }
+
             if pc == 0 {
                 // App's RTS chain reached PC=0 — treat as clean exit.
                 // Some apps (e.g. Centaurian 1.2.1) zero out our
@@ -6229,9 +6267,8 @@ impl FixtureRunner {
                 }
                 BatchExit::AlineTrap { opcode } => {
                     if self.m68k.complete_manager_return(&self.bus)
-                        && self
-                            .dispatcher
-                            .resume_completed_menu_bar_build(&mut self.m68k.cpu, &mut self.bus)
+                        && (self.dispatcher.resume_completed_menu_bar_build(&mut self.m68k.cpu, &mut self.bus)
+                            || self.dispatcher.resume_menu_tracking(&mut self.m68k.cpu, &mut self.bus).is_some())
                     {
                         continue;
                     }
@@ -6310,7 +6347,7 @@ impl FixtureRunner {
                             // The m68k CPU already advanced PC past the A-line
                             // instruction during fetch (read_imm_16 does pc += 2).
                             //
-                            // When menu or dialog tracking is active, REWIND PC
+                            // For remaining tracking traps, rewind PC
                             // back to the A-line instruction so it re-fires on
                             // the next frame.
                             //
@@ -6318,13 +6355,10 @@ impl FixtureRunner {
                             // push-back logic — both call
                             // `TrapDispatcher::is_tracking_refire` so
                             // they can never diverge. Strips auto-pop
-                            // bit so `$AD3D` / `$AC0B` / `$AD91`
+                            // bit so `$AD91`
                             // match too.
                             let is_tracking_refire =
-                                self.dispatcher.is_tracking_refire_with_menu_tracking(
-                                    opcode,
-                                    self.process_context.menu_tracking().is_some(),
-                                );
+                                self.dispatcher.is_tracking_refire(opcode);
                             if is_tracking_refire {
                                 // An asynchronous callback may have been
                                 // injected while this tracking trap was
@@ -6372,26 +6406,19 @@ impl FixtureRunner {
                                 }
                                 self.m68k.cpu.write_reg(Register::PC, pc);
 
-                                // Fire MenuSelect's documented MenuHook while
-                                // the dropdown is still live on screen. The
-                                // hook is guest code, so inject it before the
-                                // next A93D re-fire instead of approximating it
-                                // inside the HLE trap body.
-                                let fired_menu_hook = self.fire_menu_hook_proc(opcode);
-
                                 // Fire pending dialog userItem draw procs.
                                 // The trampoline redirects PC to execute the
                                 // 68K draw proc; when it RTS's, PC returns to
                                 // the ModalDialog A-line for the next re-fire.
                                 let uses_dialog_callbacks =
                                     tracking_refire_uses_dialog_callbacks(opcode);
-                                let fired_draw_proc = if fired_menu_hook || !uses_dialog_callbacks {
+                                let fired_draw_proc = if !uses_dialog_callbacks {
                                     false
                                 } else {
                                     self.fire_dialog_draw_procs()
                                 };
                                 let mut fired_filter_proc = false;
-                                if uses_dialog_callbacks && !fired_menu_hook && !fired_draw_proc {
+                                if uses_dialog_callbacks && !fired_draw_proc {
                                     // Fire the filter proc for any dialog that has one,
                                     // once draw procs are complete. On a real Mac,
                                     // ModalDialog calls the filter for every event
@@ -6409,7 +6436,6 @@ impl FixtureRunner {
                                 // presenting here shows half-painted screens.
                                 // Headless mode keeps executing as before.
                                 if yield_for_ui
-                                    && !fired_menu_hook
                                     && !fired_draw_proc
                                     && !fired_filter_proc
                                 {
@@ -7007,7 +7033,8 @@ impl FixtureRunner {
             return Some((0, true));
         }
 
-        if self.m68k.cpu.read_reg(Register::PC) == pending.return_pc
+        if !self.dispatcher.has_ready_menu_tracking()
+            && self.m68k.cpu.read_reg(Register::PC) == pending.return_pc
             && self.m68k.cpu.read_reg(Register::A7) == pending.final_sp
         {
             let completed = self.process_context.with_memory_and_cfm(|manager, _| {
@@ -7024,6 +7051,10 @@ impl FixtureRunner {
         let mut running = true;
         let mut watch_buf = Vec::with_capacity(4);
         while executed < max_steps {
+            if self.dispatcher.resume_menu_tracking(&mut self.m68k.cpu, &mut self.bus).is_some() {
+                executed += 1;
+                continue;
+            }
             if self.m68k.cpu.read_reg(Register::PC) == pending.return_pc {
                 running = self.process_context.with_memory_and_cfm(|manager, _| {
                     self.m68k.complete_pending(
@@ -7064,9 +7095,8 @@ impl FixtureRunner {
                 }
                 BatchExit::AlineTrap { opcode } => {
                     if self.m68k.complete_manager_return(&self.bus)
-                        && self
-                            .dispatcher
-                            .resume_completed_menu_bar_build(&mut self.m68k.cpu, &mut self.bus)
+                        && (self.dispatcher.resume_completed_menu_bar_build(&mut self.m68k.cpu, &mut self.bus)
+                            || self.dispatcher.resume_menu_tracking(&mut self.m68k.cpu, &mut self.bus).is_some())
                     {
                         continue;
                     }
@@ -16253,7 +16283,7 @@ mod tests {
         if interrupt {
             let mut parked = false;
             for _ in 0..512 {
-                if runner.m68k.cpu.read_reg(Register::PC) == entry
+                if runner.m68k.cpu.read_reg(Register::PC) == stack - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION + 52
                     && runner.m68k.cpu.read_reg(Register::A7)
                         == stack - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION
                 {
@@ -16300,6 +16330,144 @@ mod tests {
         if interrupt {
             assert_eq!(runner.bus.read_word(marker + 4), 1);
         }
+    }
+
+    #[test]
+    fn classic_menu_wait_resumes_without_refiring_new_trap_patch() {
+        for auto_pop in [false, true] {
+            for custom in [false, true] {
+                run_menu_patch_during_tracking(auto_pop, custom);
+            }
+        }
+    }
+
+    fn run_menu_patch_during_tracking(auto_pop: bool, custom: bool) {
+        use crate::memory::globals::addr;
+        let ClassicPowerPcMdefFixture {
+            mut runner,
+            menu,
+            record,
+            marker,
+            entry,
+            stack,
+        } = classic_powerpc_mdef_fixture();
+        runner.dispatcher.menu_bar_hidden = false;
+        runner.bus.write_word(addr::MBAR_HEIGHT, 20);
+        runner.bus.write_word(addr::MENU_FLASH, 0);
+        if !custom {
+            let code = runner
+                .bus
+                .alloc(crate::menu_manager::STANDARD_MENU_DEFINITION_SHIM.len() as u32);
+            runner
+                .bus
+                .write_bytes(code, &crate::menu_manager::STANDARD_MENU_DEFINITION_SHIM);
+            let handle = runner.bus.alloc(4);
+            runner.bus.write_long(handle, code);
+            runner.bus.write_long(record + 6, handle);
+        }
+        runner.bus.write_word(record + 2, 80);
+        runner.bus.write_word(record + 4, 32);
+        runner.bus.write_bytes(
+            record + 14,
+            b"\x06Custom\x01A\x00\x00\x00\x00\x01B\x00\x00\x00\x00\x00",
+        );
+        runner.bus.write_word(stack, 0);
+        runner.bus.write_long(stack + 2, menu);
+        runner
+            .dispatcher
+            .dispatch_menu(true, 0x135, &mut runner.m68k.cpu, &mut runner.bus)
+            .unwrap()
+            .unwrap();
+        runner.dispatcher.draw_menu_bar_to_fb(&mut runner.bus);
+        let original_port = *runner.dispatcher.current_port;
+        let parameters = stack + if auto_pop { 4 } else { 0 };
+        let return_pc = entry + if auto_pop { 0x100 } else { 2 };
+        runner.bus.write_word(return_pc, 0x60fe);
+        runner
+            .bus
+            .write_word(entry, if auto_pop { 0xAD3D } else { 0xA93D });
+        if auto_pop {
+            runner.bus.write_long(stack, return_pc);
+        }
+        runner.bus.write_word(parameters, 10);
+        runner.bus.write_word(parameters + 2, 16);
+        runner.bus.write_long(parameters + 4, 0);
+        runner.m68k.cpu.write_reg(Register::A7, stack);
+        runner.push_canonical_mouse_down(10, 16);
+
+        for _ in 0..8 {
+            assert!(runner.run_steps(128, None).1);
+        }
+        let rect = runner
+            .process_context
+            .menu_tracking()
+            .expect("classic tracking remains active")
+            .dropdown_rect();
+        if custom {
+            assert!(
+                runner.bus.read_long(marker) > 0,
+                "PowerPC draw callback ran"
+            );
+        }
+        let (v, h) = (rect.0 + 24, rect.1 + 16);
+        runner.dispatcher.set_mouse_position(v, h);
+        for _ in 0..8 {
+            assert!(runner.run_steps(128, None).1);
+        }
+        runner.push_canonical_mouse_up(v, h);
+        let patch_marker = runner.bus.alloc(4);
+        let patch = runner.bus.alloc(12);
+        for (index, word) in [
+            0x23fc,
+            0,
+            1,
+            (patch_marker >> 16) as u16,
+            patch_marker as u16,
+            0x4e75,
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            runner.bus.write_word(patch + index as u32 * 2, word);
+        }
+        runner
+            .dispatcher
+            .install_trap_address(&mut runner.bus, 0xa93d, patch)
+            .unwrap();
+        for _ in 0..16 {
+            assert!(runner.run_steps(128, None).1);
+            assert_eq!(
+                runner.bus.read_long(patch_marker),
+                0,
+                "a new MenuSelect patch intercepted the already-active interaction"
+            );
+            if runner.process_context.menu_tracking().is_none()
+                && runner.dispatcher.guest_calls.is_empty()
+            {
+                break;
+            }
+        }
+        assert!(runner.process_context.menu_tracking().is_none(),
+            "tracking stayed live: pc={:08x}, sp={:08x}, patch={:08x}, marker={}, depth={}, pending={:?}",
+            runner.m68k.cpu.read_reg(Register::PC), runner.m68k.cpu.read_reg(Register::A7), patch,
+            runner.bus.read_long(patch_marker), runner.dispatcher.guest_calls.depth(),
+            runner.dispatcher.menu_tracking.as_ref().and_then(|tracking| tracking.definition.as_ref()).and_then(|definition| definition.pending_invocation()));
+        assert!(runner.dispatcher.guest_calls.is_empty());
+        assert_eq!(runner.bus.read_long(parameters + 4), (140 << 16) | 2);
+        assert_eq!(runner.m68k.cpu.read_reg(Register::A7), parameters + 4);
+        assert_eq!(*runner.dispatcher.current_port, original_port);
+        assert_eq!(runner.m68k.cpu.read_reg(Register::PC), return_pc);
+        if auto_pop {
+            runner.bus.write_long(stack, return_pc);
+        }
+        runner.m68k.cpu.write_reg(Register::PC, entry);
+        runner.m68k.cpu.write_reg(Register::A7, stack);
+        assert!(runner.run_steps(128, None).1);
+        assert_eq!(
+            runner.bus.read_long(patch_marker),
+            1,
+            "fresh entries must still honor the new patch"
+        );
     }
 
     #[test]

--- a/src/scripted_traces.rs
+++ b/src/scripted_traces.rs
@@ -1342,6 +1342,9 @@ fn scripted_call_menu_trap(
     trap_num: u16,
     label: &str,
 ) -> Result<(), String> {
+    if matches!(trap_num, 0x13d | 0x00b) && dispatcher.resume_menu_tracking(cpu, bus).is_some() {
+        return Ok(());
+    }
     dispatcher
         .dispatch_menu(true, trap_num, cpu, bus)
         .ok_or_else(|| format!("{label} was not handled"))?

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -3624,16 +3624,8 @@ impl TrapDispatcher {
     /// tracking loops is active and the trap is the matching routine. Strips
     /// the auto-pop bit (0x0400) so auto-pop variants match too.
     pub fn is_tracking_refire(&self, opcode: u16) -> bool {
-        self.is_tracking_refire_with_menu_tracking(opcode, self.is_menu_tracking())
-    }
 
-    pub(crate) fn is_tracking_refire_with_menu_tracking(
-        &self,
-        opcode: u16,
-        is_menu_tracking: bool,
-    ) -> bool {
         let trap_no_autopop = opcode & !0x0400;
-        let is_menu_refire = trap_no_autopop == 0xA93D || trap_no_autopop == 0xA80B;
         let is_dialog_refire =
             matches!(trap_no_autopop, 0xA991 | 0xA985 | 0xA986 | 0xA987 | 0xA988);
         let is_standard_file_refire = trap_no_autopop == 0xA9EA;
@@ -3643,8 +3635,7 @@ impl TrapDispatcher {
         let is_track_box_refire = trap_no_autopop == 0xA83B;
         let is_grow_window_refire = trap_no_autopop == 0xA92B;
         let is_region_refire = matches!(trap_no_autopop, 0xA905 | 0xA926);
-        (is_menu_refire && is_menu_tracking)
-            || (is_dialog_refire && self.is_dialog_tracking())
+        (is_dialog_refire && self.is_dialog_tracking())
             || (is_standard_file_refire
                 && (self.is_standard_file_put_tracking() || self.is_standard_file_get_tracking()))
             || (is_control_refire
@@ -7323,7 +7314,8 @@ impl TrapDispatcher {
         bindings: Option<&mut dyn crate::cfm::CfmSymbolBindings>,
     ) -> Result<()> {
         if crate::execution_m68k::complete_classic_manager_return(&self.guest_calls, cpu, bus)
-            && self.resume_completed_menu_bar_build(cpu, bus)
+            && (self.resume_completed_menu_bar_build(cpu, bus)
+                || self.resume_menu_tracking(cpu, bus).is_some())
         {
             return Ok(());
         }
@@ -7527,7 +7519,7 @@ impl TrapDispatcher {
         let route = raw_trap_route(effective_trap);
         let is_tool = route.is_toolbox;
         // Count game traps: from game code (PC < 0x800000), NOT during
-        // menu/dialog tracking loops (synthetic HLE re-dispatches), and
+        // remaining tracking loops (synthetic HLE re-dispatches), and
         // NOT idle-loop traps (GetNextEvent, WaitNextEvent, EventAvail)
         // which fire at wildly different rates depending on CPU speed.
         let trap_number = route.table_slot;
@@ -7818,7 +7810,7 @@ impl TrapDispatcher {
         }
         // Handle auto-pop return.
         // Only push ret_addr back when the CURRENT trap is one of the
-        // menu/dialog refire traps (matches the runner's is_tracking_refire
+        // remaining refire traps (matches the runner's is_tracking_refire
         // logic). is_tracking_refire is shared so dispatch.rs and runner.rs
         // can never diverge on the match logic.
         if let Some(ret_addr) = saved_return_addr {
@@ -10666,14 +10658,14 @@ mod tests {
     }
 
     #[test]
-    fn is_tracking_refire_true_for_menu_traps_when_menu_tracking() {
+    fn menu_tracking_uses_operation_resumption_instead_of_refiring() {
         let mut disp = TrapDispatcher::new();
         install_menu_tracking(&mut disp);
-        assert!(disp.is_tracking_refire(0xA93D));
-        assert!(disp.is_tracking_refire(0xA80B));
+        assert!(!disp.is_tracking_refire(0xA93D));
+        assert!(!disp.is_tracking_refire(0xA80B));
         // Auto-pop variants share the same predicate.
-        assert!(disp.is_tracking_refire(0xAD3D));
-        assert!(disp.is_tracking_refire(0xAC0B));
+        assert!(!disp.is_tracking_refire(0xAD3D));
+        assert!(!disp.is_tracking_refire(0xAC0B));
     }
 
     #[test]

--- a/src/trap/menu.rs
+++ b/src/trap/menu.rs
@@ -519,6 +519,12 @@ impl super::TrapDispatcher {
         let tracking_root = self.menu_tracking.entry_id();
         let return_pc = if menu_build.is_some() {
             frame.trap_return(0xa9c0)
+        } else if let Some(call) = tracking_root.and(self.menu_tracking.context().call) {
+            frame.trap_return(if call.popup_request().is_some() {
+                0xa80b
+            } else {
+                0xa93d
+            })
         } else {
             return_pc
         };
@@ -1740,17 +1746,97 @@ impl super::TrapDispatcher {
                     requested_item: bus.read_word(sp) as i16,
                 })
             } else {
-                MenuTrackingRequest::MenuSelect { initial_point: bus.read_long(sp) }
+                MenuTrackingRequest::MenuSelect {
+                    initial_point: bus.read_long(sp),
+                }
             };
-            self.menu_tracking.enter_call(MenuTrackingCall {
+            self.menu_tracking.enter_new_call(MenuTrackingCall {
                 request,
                 origin: MenuTrackingOrigin::M68k {
                     stack_pointer: sp,
-                    return_address: self.current_trap_caller
+                    return_address: self
+                        .current_trap_caller
                         .unwrap_or_else(|| cpu.read_reg(Register::PC)),
                 },
             })
         });
+        let result = self.dispatch_menu_body(is_tool, trap_num, cpu, bus);
+        if _menu_root.is_some()
+            && self.current_trap_caller.is_some()
+            && self.menu_tracking.context().call.is_some()
+            && (self.menu_tracking.is_some() || self.active_menu_definition().is_some())
+        {
+            self.preserve_auto_pop_pc_once = true;
+        }
+        result
+    }
+
+    #[cfg(test)]
+    fn step_menu_fixture<C: CpuOps>(
+        &mut self,
+        is_tool: bool,
+        trap_num: u16,
+        cpu: &mut C,
+        bus: &mut MacMemoryBus,
+    ) -> Option<Result<()>> {
+        let tracking_call = self.menu_tracking.context().call.filter(|call| {
+            call.origin.isa() == GuestIsa::M68k
+                && is_tool
+                && match call.request {
+                    MenuTrackingRequest::MenuSelect { .. } => trap_num == 0x13d,
+                    MenuTrackingRequest::PopUp(_) => trap_num == 0x00b,
+                }
+        });
+        if let Some(call) = tracking_call {
+            // These adapter fixtures write the MDEF result directly instead
+            // of executing its instruction stream. Retire that exact installed
+            // frame before stepping the retained operation.
+            let MenuTrackingOrigin::M68k { stack_pointer, .. } = call.origin else {
+                unreachable!()
+            };
+            let frame_sp =
+                stack_pointer - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION;
+            if self.guest_calls.depth() > 0 && cpu.read_reg(Register::A7) == frame_sp {
+                cpu.write_reg(Register::PC, frame_sp + 54);
+                self.retire_menu_definition(cpu, bus);
+            }
+            if self.resume_menu_tracking(cpu, bus).is_some() {
+                return Some(Ok(()));
+            }
+        }
+        self.dispatch_menu(is_tool, trap_num, cpu, bus)
+    }
+
+    pub(crate) fn has_ready_menu_tracking(&self) -> bool {
+        self.menu_tracking.ready_call(GuestIsa::M68k).is_some()
+    }
+
+    pub(crate) fn resume_menu_tracking<C: CpuOps>(
+        &mut self,
+        cpu: &mut C,
+        bus: &mut MacMemoryBus,
+    ) -> Option<u16> {
+        let (call, _scope) = self.menu_tracking.resume_call(GuestIsa::M68k)?;
+        let MenuTrackingOrigin::M68k {
+            stack_pointer,
+            return_address,
+        } = call.origin
+        else {
+            unreachable!()
+        };
+        let trap_num = match call.request {
+            MenuTrackingRequest::MenuSelect { .. } => 0x13d,
+            MenuTrackingRequest::PopUp(_) => 0x00b,
+        };
+        cpu.write_reg(Register::A7, stack_pointer);
+        cpu.write_reg(Register::PC, return_address);
+        self.dispatch_menu_body(true, trap_num, cpu, bus)?.ok()?;
+        Some(0xa800 | trap_num)
+    }
+
+    fn dispatch_menu_body<C: CpuOps>(
+        &mut self, is_tool: bool, trap_num: u16, cpu: &mut C, bus: &mut MacMemoryBus,
+    ) -> Option<Result<()>> {
         self.read_tick_count(bus);
         Some(match (is_tool, trap_num) {
             // InitMenus ($A930)
@@ -7514,8 +7600,7 @@ mod tests {
             bus.write_word(addr::MOUSE_LOC2, (state.popup_top + 8) as u16);
             bus.write_word(addr::MOUSE_LOC2 + 2, (state.popup_left + 8) as u16);
             bus.write_byte(addr::MB_STATE, 0x80);
-            cpu.write_reg(Register::PC, trap_pc + 2);
-            disp.dispatch(opcode, &mut cpu, &mut bus).unwrap();
+            assert!(disp.resume_menu_tracking(&mut cpu, &mut bus).is_some());
             let result_slot = parameters + if popup { 10 } else { 4 };
             assert_eq!(
                 bus.read_long(result_slot),
@@ -7657,12 +7742,12 @@ mod tests {
         bus.write_word(crate::memory::globals::addr::MOUSE_LOC2 + 2, 20);
 
         assert!(disp
-            .dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+            .step_menu_fixture(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .is_ok());
         let trampoline = cpu.read_reg(Register::PC);
         assert_eq!(bus.read_word(trampoline + 6), 0);
-        assert_eq!(bus.read_long(trampoline - 4), trap_pc);
+        assert_eq!(bus.read_long(trampoline - 4), trampoline + 52);
         assert!(disp.is_menu_definition_callback_pending());
         assert_eq!(disp.guest_calls.len(), 1);
         assert_eq!(*disp.current_port, disp.window_manager_cport);
@@ -7670,7 +7755,7 @@ mod tests {
         cpu.write_reg(Register::PC, trap_pc + 2);
         cpu.write_reg(Register::A7, if disp.guest_calls.depth() == 0 { TEST_SP } else { TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION });
         assert!(disp
-            .dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+            .step_menu_fixture(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .is_ok());
         assert_eq!(bus.read_word(trampoline + 6), 1);
@@ -7687,7 +7772,7 @@ mod tests {
         cpu.write_reg(Register::PC, trap_pc + 2);
         cpu.write_reg(Register::A7, if disp.guest_calls.depth() == 0 { TEST_SP } else { TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION });
         assert!(disp
-            .dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+            .step_menu_fixture(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .is_ok());
         assert_eq!(disp.menu_tracking.as_ref().unwrap().flash_remaining, 2);
@@ -7696,7 +7781,7 @@ mod tests {
 
         cpu.write_reg(Register::PC, trap_pc + 2);
         cpu.write_reg(Register::A7, if disp.guest_calls.depth() == 0 { TEST_SP } else { TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION });
-        disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+        disp.step_menu_fixture(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
         assert_eq!(bus.read_word(trampoline + 6), 1);
@@ -7713,7 +7798,7 @@ mod tests {
         tracking.flash_delay = 0;
         cpu.write_reg(Register::PC, trap_pc + 2);
         cpu.write_reg(Register::A7, if disp.guest_calls.depth() == 0 { TEST_SP } else { TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION });
-        disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+        disp.step_menu_fixture(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
         assert_eq!(bus.read_long(TEST_SP + 4), (337u32 << 16) | 2);
@@ -7761,7 +7846,7 @@ mod tests {
             bus.write_word(crate::memory::globals::addr::MOUSE_LOC2, 52);
             bus.write_word(crate::memory::globals::addr::MOUSE_LOC2 + 2, 45);
 
-            disp.dispatch_menu(true, 0x00B, &mut cpu, &mut bus)
+            disp.step_menu_fixture(true, 0x00B, &mut cpu, &mut bus)
                 .unwrap()
                 .unwrap();
             let trampoline = cpu.read_reg(Register::PC);
@@ -7784,7 +7869,7 @@ mod tests {
                     TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION
                 },
             );
-            disp.dispatch_menu(true, 0x00B, &mut cpu, &mut bus)
+            disp.step_menu_fixture(true, 0x00B, &mut cpu, &mut bus)
                 .unwrap()
                 .unwrap();
             assert_eq!(bus.read_word(trampoline + 6), 0);
@@ -7802,7 +7887,7 @@ mod tests {
                     TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION
                 },
             );
-            disp.dispatch_menu(true, 0x00B, &mut cpu, &mut bus)
+            disp.step_menu_fixture(true, 0x00B, &mut cpu, &mut bus)
                 .unwrap()
                 .unwrap();
             assert_eq!(bus.read_word(trampoline + 6), 1);
@@ -7819,7 +7904,7 @@ mod tests {
                     TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION
                 },
             );
-            disp.dispatch_menu(true, 0x00B, &mut cpu, &mut bus)
+            disp.step_menu_fixture(true, 0x00B, &mut cpu, &mut bus)
                 .unwrap()
                 .unwrap();
             assert_eq!(disp.menu_tracking.as_ref().unwrap().flash_remaining, 6);
@@ -7835,7 +7920,7 @@ mod tests {
                     TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION
                 },
             );
-            disp.dispatch_menu(true, 0x00B, &mut cpu, &mut bus)
+            disp.step_menu_fixture(true, 0x00B, &mut cpu, &mut bus)
                 .unwrap()
                 .unwrap();
             assert_eq!(bus.read_word(trampoline + 6), 1);
@@ -7855,7 +7940,7 @@ mod tests {
                     TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION
                 },
             );
-            disp.dispatch_menu(true, 0x00B, &mut cpu, &mut bus)
+            disp.step_menu_fixture(true, 0x00B, &mut cpu, &mut bus)
                 .unwrap()
                 .unwrap();
             assert_eq!(bus.read_long(TEST_SP + 10), (338u32 << 16) | 2);
@@ -9990,7 +10075,7 @@ mod tests {
             bus.write_word(TEST_SP, 1);
             bus.write_long(TEST_SP + 2, handle);
             assert!(disp
-                .dispatch_menu(true, trap, &mut cpu, &mut bus)
+                .step_menu_fixture(true, trap, &mut cpu, &mut bus)
                 .unwrap()
                 .is_ok());
         }
@@ -14128,7 +14213,7 @@ mod tests {
         bus.write_long(sp + 6, menu);
         bus.write_long(sp + 10, 0xDEAD_BEEF); // result placeholder
 
-        let result = disp.dispatch_menu(true, 0x00B, &mut cpu, &mut bus);
+        let result = disp.step_menu_fixture(true, 0x00B, &mut cpu, &mut bus);
         assert!(result.is_some(), "PopUpMenuSelect should be handled");
         assert!(result.unwrap().is_ok(), "PopUpMenuSelect should return");
         assert_eq!(
@@ -14178,7 +14263,7 @@ mod tests {
         bus.write_long(sp + 6, menu);
         bus.write_long(sp + 10, 0xDEAD_BEEF); // result placeholder
 
-        let result = disp.dispatch_menu(true, 0x00B, &mut cpu, &mut bus);
+        let result = disp.step_menu_fixture(true, 0x00B, &mut cpu, &mut bus);
         assert!(result.is_some(), "PopUpMenuSelect should be handled");
         assert!(result.unwrap().is_ok(), "PopUpMenuSelect should return");
         assert_eq!(
@@ -15322,7 +15407,7 @@ mod tests {
         bus.write_word(TEST_SP + 2, 120);
         bus.write_long(TEST_SP + 4, 0xDEAD_BEEF);
 
-        let result = disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus);
+        let result = disp.step_menu_fixture(true, 0x13D, &mut cpu, &mut bus);
         assert!(result.is_some(), "MenuSelect should be handled");
         assert!(result.unwrap().is_ok(), "MenuSelect should succeed");
         assert_eq!(
@@ -15378,7 +15463,7 @@ mod tests {
         bus.write_word(TEST_SP + 2, title_mid_h as u16);
         bus.write_long(TEST_SP + 4, 0xA5A5_A5A5);
 
-        let result = disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus);
+        let result = disp.step_menu_fixture(true, 0x13D, &mut cpu, &mut bus);
         assert!(result.is_some(), "MenuSelect should be handled");
         assert!(result.unwrap().is_ok(), "MenuSelect should succeed");
         assert_eq!(
@@ -15439,7 +15524,7 @@ mod tests {
         bus.write_word(TEST_SP, 10);
         bus.write_word(TEST_SP + 2, title_mid_h as u16);
         bus.write_long(TEST_SP + 4, 0xA5A5_A5A5);
-        disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+        disp.step_menu_fixture(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
         assert!(disp.menu_tracking.is_some());
@@ -15447,7 +15532,7 @@ mod tests {
         let (dropdown_top, dropdown_left, _, _) =
             disp.menu_tracking.as_ref().unwrap().dropdown_rect();
         disp.input_state.mouse_pos = (dropdown_top + 17, dropdown_left + 8);
-        disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+        disp.step_menu_fixture(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
         assert_eq!(
@@ -15458,7 +15543,7 @@ mod tests {
         );
 
         disp.input_state.mouse_button = false;
-        disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+        disp.step_menu_fixture(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
         assert_eq!(
@@ -15472,7 +15557,7 @@ mod tests {
             if disp.menu_tracking.is_none() {
                 break;
             }
-            disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+            disp.step_menu_fixture(true, 0x13D, &mut cpu, &mut bus)
                 .unwrap()
                 .unwrap();
         }
@@ -15536,14 +15621,14 @@ mod tests {
         bus.write_word(TEST_SP, 10);
         bus.write_word(TEST_SP + 2, title_mid_h as u16);
         bus.write_long(TEST_SP + 4, 0xA5A5_A5A5);
-        disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+        disp.step_menu_fixture(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
 
         let (dropdown_top, dropdown_left, _, _) =
             disp.menu_tracking.as_ref().unwrap().dropdown_rect();
         disp.input_state.mouse_pos = (dropdown_top + 17, dropdown_left + 8);
-        disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+        disp.step_menu_fixture(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
         let expected = menu_choice_value(520, 2);
@@ -15560,7 +15645,7 @@ mod tests {
         );
 
         disp.input_state.mouse_button = false;
-        disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+        disp.step_menu_fixture(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
         assert_eq!(bus.read_long(TEST_SP + 4), 0);
@@ -15600,7 +15685,7 @@ mod tests {
         bus.write_word(TEST_SP, 10);
         bus.write_word(TEST_SP + 2, title_mid_h as u16);
         bus.write_long(TEST_SP + 4, 0xA5A5_A5A5);
-        disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+        disp.step_menu_fixture(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
 
@@ -15611,7 +15696,7 @@ mod tests {
 
         let (top, left, _, _) = disp.menu_tracking.as_ref().unwrap().dropdown_rect();
         disp.input_state.mouse_pos = (top + 8, left + 8);
-        disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+        disp.step_menu_fixture(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
         assert_eq!(
@@ -15627,7 +15712,7 @@ mod tests {
         );
 
         disp.input_state.mouse_button = false;
-        disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+        disp.step_menu_fixture(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
         assert_eq!(bus.read_long(TEST_SP + 4), 0);
@@ -15671,7 +15756,7 @@ mod tests {
         bus.write_word(TEST_SP, 10);
         bus.write_word(TEST_SP + 2, title_mid_h as u16);
         bus.write_long(TEST_SP + 4, 0xA5A5_A5A5);
-        disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+        disp.step_menu_fixture(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
         let (top, left, _, _) = disp
@@ -15681,7 +15766,7 @@ mod tests {
             .dropdown_rect();
 
         disp.input_state.mouse_pos = (top + 8, left + 8);
-        disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+        disp.step_menu_fixture(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
         let expected = menu_choice_value(522, 1);
@@ -15697,7 +15782,7 @@ mod tests {
         );
 
         disp.input_state.mouse_button = false;
-        disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+        disp.step_menu_fixture(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
         assert_eq!(bus.read_long(TEST_SP + 4), 0);
@@ -15749,7 +15834,7 @@ mod tests {
         bus.write_word(TEST_SP, 10);
         bus.write_word(TEST_SP + 2, title_mid_h as u16);
         bus.write_long(TEST_SP + 4, 0xA5A5_A5A5);
-        disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+        disp.step_menu_fixture(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
 
@@ -15762,7 +15847,7 @@ mod tests {
             .unwrap();
         disp.input_state.mouse_button = false;
         cpu.write_reg(Register::A7, TEST_SP);
-        disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+        disp.step_menu_fixture(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
 
@@ -16030,7 +16115,7 @@ mod tests {
         bus.write_long(TEST_SP + 6, menu_handle);
         bus.write_long(TEST_SP + 10, 0xDEAD_BEEF);
         assert!(
-            disp.dispatch_menu(true, 0x00B, cpu, bus).unwrap().is_ok(),
+            disp.step_menu_fixture(true, 0x00B, cpu, bus).unwrap().is_ok(),
             "PopUpMenuSelect should succeed"
         );
     }
@@ -16166,7 +16251,7 @@ mod tests {
             if disp.menu_tracking.is_none() {
                 break;
             }
-            disp.dispatch_menu(true, 0x00B, cpu, bus).unwrap().unwrap();
+            disp.step_menu_fixture(true, 0x00B, cpu, bus).unwrap().unwrap();
         }
         (
             bus.read_long(TEST_SP + 10),
@@ -16387,26 +16472,26 @@ mod tests {
         bus.write_word(TEST_SP, 10);
         bus.write_word(TEST_SP + 2, 15);
         bus.write_long(TEST_SP + 4, 0xA5A5_A5A5);
-        disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+        disp.step_menu_fixture(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
 
         let dropdown_rect = disp.menu_tracking.as_ref().unwrap().dropdown_rect();
         let (dropdown_top, dropdown_left, _, _) = dropdown_rect;
         disp.input_state.mouse_pos = (dropdown_top + 17, dropdown_left + 8);
-        disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+        disp.step_menu_fixture(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
 
         disp.input_state.mouse_button = false;
-        disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+        disp.step_menu_fixture(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
         for _ in 0..40 {
             if disp.menu_tracking.is_none() {
                 break;
             }
-            disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+            disp.step_menu_fixture(true, 0x13D, &mut cpu, &mut bus)
                 .unwrap()
                 .unwrap();
         }
@@ -16485,7 +16570,7 @@ mod tests {
         bus.write_long(TEST_SP + 4, 0xFFFF_FFFF);
 
         assert!(
-            disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+            disp.step_menu_fixture(true, 0x13D, &mut cpu, &mut bus)
                 .unwrap()
                 .is_ok(),
             "MenuSelect should enter tracking on the File title"
@@ -16500,7 +16585,7 @@ mod tests {
 
         disp.input_state.mouse_pos = (parent_item_y, parent_rect.1 + 24);
         assert!(
-            disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+            disp.step_menu_fixture(true, 0x13D, &mut cpu, &mut bus)
                 .unwrap()
                 .is_ok(),
             "MenuSelect should track the hierarchical parent item"
@@ -16508,7 +16593,7 @@ mod tests {
 
         disp.input_state.mouse_pos = (parent_item_y, parent_rect.3 + 20);
         assert!(
-            disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+            disp.step_menu_fixture(true, 0x13D, &mut cpu, &mut bus)
                 .unwrap()
                 .is_ok(),
             "MenuSelect should track into the submenu"
@@ -16517,7 +16602,7 @@ mod tests {
         disp.input_state.mouse_button = false;
         for _ in 0..40 {
             assert!(
-                disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+                disp.step_menu_fixture(true, 0x13D, &mut cpu, &mut bus)
                     .unwrap()
                     .is_ok(),
                 "MenuSelect should finish submenu selection"
@@ -16598,7 +16683,7 @@ mod tests {
         bus.write_word(TEST_SP + 2, title_mid_h as u16);
         disp.input_state.mouse_pos = (10, title_mid_h);
         disp.input_state.mouse_button = true;
-        disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+        disp.step_menu_fixture(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
 
@@ -16606,7 +16691,7 @@ mod tests {
         disp.input_state.mouse_pos = (root_rect.0 + 8, root_rect.1 + 16);
         cpu.write_reg(Register::PC, trap_pc + 2);
         cpu.write_reg(Register::A7, if disp.guest_calls.depth() == 0 { TEST_SP } else { TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION });
-        disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+        disp.step_menu_fixture(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
 
@@ -16627,14 +16712,14 @@ mod tests {
         disp.input_state.mouse_pos = (10, title_mid_h);
         cpu.write_reg(Register::PC, trap_pc + 2);
         cpu.write_reg(Register::A7, if disp.guest_calls.depth() == 0 { TEST_SP } else { TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION });
-        disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+        disp.step_menu_fixture(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
         assert_eq!(bus.read_word(trampoline + 6), 1);
         bus.write_word(trampoline + 68, 0);
         cpu.write_reg(Register::PC, trap_pc + 2);
         cpu.write_reg(Register::A7, if disp.guest_calls.depth() == 0 { TEST_SP } else { TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION });
-        disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+        disp.step_menu_fixture(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
         assert!(disp.menu_tracking.as_ref().unwrap().submenus.is_empty());
@@ -16643,7 +16728,7 @@ mod tests {
         disp.input_state.mouse_pos = (root_rect.0 + 8, root_rect.1 + 16);
         cpu.write_reg(Register::PC, trap_pc + 2);
         cpu.write_reg(Register::A7, if disp.guest_calls.depth() == 0 { TEST_SP } else { TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION });
-        disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+        disp.step_menu_fixture(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
         assert_eq!(bus.read_word(trampoline + 6), 0);
@@ -16651,7 +16736,7 @@ mod tests {
         disp.input_state.mouse_pos = (child_rect.0 + 8, child_rect.1 + 8);
         cpu.write_reg(Register::PC, trap_pc + 2);
         cpu.write_reg(Register::A7, if disp.guest_calls.depth() == 0 { TEST_SP } else { TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION });
-        disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+        disp.step_menu_fixture(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
         assert_eq!(bus.read_word(trampoline + 6), 1);
@@ -16661,7 +16746,7 @@ mod tests {
         disp.input_state.mouse_button = false;
         cpu.write_reg(Register::PC, trap_pc + 2);
         cpu.write_reg(Register::A7, if disp.guest_calls.depth() == 0 { TEST_SP } else { TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION });
-        disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+        disp.step_menu_fixture(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
         assert_eq!(
@@ -16674,7 +16759,7 @@ mod tests {
         tracking.flash_delay = 0;
         cpu.write_reg(Register::PC, trap_pc + 2);
         cpu.write_reg(Register::A7, if disp.guest_calls.depth() == 0 { TEST_SP } else { TEST_SP - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION });
-        disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+        disp.step_menu_fixture(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
         assert_eq!(bus.read_long(TEST_SP + 4), (141u32 << 16) | 2);
@@ -16726,23 +16811,23 @@ mod tests {
         bus.write_word(TEST_SP, 10);
         bus.write_word(TEST_SP + 2, game_mid_h as u16);
         bus.write_long(TEST_SP + 4, 0xFFFF_FFFF);
-        disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+        disp.step_menu_fixture(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
 
         let root_rect = disp.menu_tracking.as_ref().unwrap().dropdown_rect();
         disp.input_state.mouse_pos = (root_rect.0 + 9, root_rect.1 + 24);
-        disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+        disp.step_menu_fixture(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
         let options_rect = disp.menu_tracking.as_ref().unwrap().submenus[0].dropdown_rect();
         disp.input_state.mouse_pos = (options_rect.0 + 9, options_rect.1 + 24);
-        disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+        disp.step_menu_fixture(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
         let speed_rect = disp.menu_tracking.as_ref().unwrap().submenus[1].dropdown_rect();
         disp.input_state.mouse_pos = (speed_rect.0 + 9, speed_rect.1 + 24);
-        disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+        disp.step_menu_fixture(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
         assert_eq!(
@@ -16751,13 +16836,13 @@ mod tests {
             "a circular submenu must not grow the retained hierarchy"
         );
         disp.input_state.mouse_pos = (speed_rect.0 + 1 + 16 + 8, speed_rect.1 + 24);
-        disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+        disp.step_menu_fixture(true, 0x13D, &mut cpu, &mut bus)
             .unwrap()
             .unwrap();
 
         disp.input_state.mouse_button = false;
         for _ in 0..40 {
-            disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+            disp.step_menu_fixture(true, 0x13D, &mut cpu, &mut bus)
                 .unwrap()
                 .unwrap();
             if disp.menu_tracking.is_none() {
@@ -16820,7 +16905,7 @@ mod tests {
         bus.write_long(TEST_SP + 4, 0xA5A5_A5A5);
 
         assert!(
-            disp.dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+            disp.step_menu_fixture(true, 0x13D, &mut cpu, &mut bus)
                 .unwrap()
                 .is_ok(),
             "MenuSelect should enter tracking on the Edit title"
@@ -17091,7 +17176,7 @@ mod tests {
         cpu.write_reg(Register::A7, TEST_SP);
         bus.write_long(TEST_SP + 4, 0xDEAD_BEEF);
         let result = disp
-            .dispatch_menu(true, 0x13D, &mut cpu, &mut bus)
+            .step_menu_fixture(true, 0x13D, &mut cpu, &mut bus)
             .expect("MenuSelect handled");
         assert!(result.is_ok());
         assert_eq!(bus.read_long(TEST_SP + 4), 0xFF88_0001);


### PR DESCRIPTION
Classic MenuSelect could repeatedly grow the return stack when a new trap patch was installed while tracking was suspended. The runner rewound the public trap after dispatch had redirected execution to the patch, leaving the menu active indefinitely.

Classic MenuSelect and PopUpMenuSelect now resume their retained operation directly after MDEF callbacks and input waits. Each fresh public entry receives a new operation ID; resumption requires the original task, enclosing call and caller ISA. Ordinary and auto-pop callers retain their original stack and return address. Remaining dialog/control refiring is preserved.

Validation: 5,134 headless JIT/test-support library tests pass (three ignored), developer-tools compilation is warning-free, and all 57 architecture guard fixtures pass on the final source. Actual-instruction regression coverage includes standard and PowerPC MDEF menus, both classic entry forms, a patch installed during tracking, and fresh calls that must still honor that patch. Public CI must pass, including both architecture showcases, before merging.

Partial progress on #1512; native import resumption, shared tracking policy, MenuHook execution ownership and comprehensive teardown remain open.
