### PR TITLE
fix: execute MenuHook through task-owned guest calls

### DIFF
--- a/src/execution_m68k.rs
+++ b/src/execution_m68k.rs
@@ -74,6 +74,45 @@ impl M68kMenuDefinitionFrame {
     }
 }
 
+/// Stack-local no-argument callback frame. Saved registers and code remain
+/// below the caller SP until execution retires the exact internal return.
+/// MenuHook's Pascal no-argument contract: Macintosh Toolbox Essentials
+/// (1992), p. 3-116.
+pub(crate) struct M68kMenuHookFrame {
+    pub(crate) entry: u32,
+    pub(crate) image: [u8; 32],
+}
+
+impl M68kMenuHookFrame {
+    pub(crate) fn new(target: u32, caller_sp: u32) -> Option<Self> {
+        let entry = caller_sp.checked_sub(48)?;
+        let saved_sp = entry.checked_sub(66)?;
+        if entry & 1 != 0 {
+            return None;
+        }
+        let mut image = [0; 32];
+        for (offset, word) in [
+            (0, 0x40e7u16), // MOVE SR,-(SP)
+            (2, 0x48e7),
+            (4, 0xfffe),  // MOVEM all D/A except SP
+            (6, 0x4eb9),  // JSR target
+            (12, 0x2e7c), // MOVEA.L #saved-register SP,A7
+            (18, 0x4cdf),
+            (20, 0x7fff), // restore all D/A except SP
+            (22, 0x46df), // MOVE (SP)+,SR
+            (24, 0x4e74),
+            (26, 0), // RTD into the internal boundary
+            (28, 0xa93d),
+            (30, 0x4e71),
+        ] {
+            image[offset..offset + 2].copy_from_slice(&word.to_be_bytes());
+        }
+        image[8..12].copy_from_slice(&target.to_be_bytes());
+        image[14..18].copy_from_slice(&saved_sp.to_be_bytes());
+        Some(Self { entry, image })
+    }
+}
+
 /// Consume a manager result while its stack reservation is still live, then
 /// restore the caller ABI before trap/vector lookup can invoke more guest code.
 pub(crate) fn complete_classic_manager_return<C: crate::cpu::CpuOps>(

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -76312,6 +76312,104 @@ fn ppc_step_menu_tracking(
     vfs_resources: &[PpcVfsResourceRecord],
     current_resource_refnum: i16,
 ) -> Option<PpcImportAction> {
+    let action = ppc_step_menu_tracking_body(
+        cpu,
+        process_memory_manager,
+        memory,
+        heap_cursor,
+        heap_limit,
+        gworlds,
+        screen_clut,
+        toolbox_startup,
+        current_gworld,
+        current_gdevice,
+        input,
+        vfs_resources,
+        current_resource_refnum,
+    )?;
+    if matches!(action, PpcImportAction::Yield(_))
+        && toolbox_startup
+            .menu_tracking
+            .as_ref()
+            .is_some_and(|tracking| tracking.should_invoke_menu_hook(input.mouse_button))
+    {
+        let pointer = memory.read_u32_be(0x0a30).unwrap_or(0);
+        if let Some(target) = resolve_guest_procedure(
+            memory,
+            pointer,
+            cpu.gpr[2],
+            None,
+            GuestIsa::PowerPc,
+            GuestIsa::M68k,
+        ) {
+            if target.proc_info == 0 {
+                let return_value = PpcNativeReturnGpr3::Set(cpu.gpr[3]);
+                let callback = match target.isa {
+                    GuestIsa::PowerPc => {
+                        let effect = GuestCallEffect::call_guest(
+                            GuestCallRequest::for_task(
+                                toolbox_startup.guest_calls.current_task(),
+                                GuestCallTarget {
+                                    isa: target.isa,
+                                    entry: target.entry,
+                                    rtoc: target.rtoc,
+                                },
+                            )
+                            .with_powerpc_arguments(
+                                crate::guest_call::PowerPcArguments::from_slice(&[])?,
+                            ),
+                            GuestCallContinuation::to_powerpc(
+                                PPC_GUEST_CALL_RETURN_PC,
+                                PPC_GUEST_CALL_RETURN_PC,
+                                cpu.gpr[2],
+                                return_value,
+                            ),
+                        );
+                        toolbox_startup
+                            .guest_calls
+                            .activate_powerpc_effect_with_operation(cpu, memory, effect, None, None)
+                            .then_some(PpcImportAction::Continue)
+                    }
+                    GuestIsa::M68k => ppc_begin_m68k_universal_proc(
+                        cpu,
+                        Some(process_memory_manager),
+                        memory,
+                        heap_cursor,
+                        heap_limit,
+                        toolbox_startup,
+                        target,
+                        0,
+                        None,
+                        Vec::new(),
+                        PPC_GUEST_CALL_RETURN_PC,
+                        return_value,
+                    ),
+                };
+                if let Some(callback) = callback {
+                    return Some(callback);
+                }
+            }
+        }
+    }
+    Some(action)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn ppc_step_menu_tracking_body(
+    cpu: &mut PpcCpu,
+    process_memory_manager: &mut ProcessNativeMemoryManager,
+    memory: &mut PpcSectionMem,
+    heap_cursor: &mut u32,
+    heap_limit: u32,
+    gworlds: &[PpcGWorldRecord],
+    screen_clut: &[[u16; 3]; 256],
+    toolbox_startup: &mut PpcToolboxStartupState,
+    current_gworld: &mut u32,
+    current_gdevice: &mut u32,
+    input: PpcInputSnapshot,
+    vfs_resources: &[PpcVfsResourceRecord],
+    current_resource_refnum: i16,
+) -> Option<PpcImportAction> {
     let call = toolbox_startup.menu_tracking.context().call?;
     let MenuTrackingOrigin::PowerPc {
         stack_pointer,
@@ -161823,6 +161921,85 @@ pub(crate) mod tests {
                 Some(expected_bottom),
             );
         }
+    }
+
+    pub(crate) fn native_menu_hook_fixture() -> (PpcLoadedApp, u32) {
+        let pef = synthetic_pef_with_import(b"MenuSelect");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        install_test_menu(
+            &mut loaded,
+            PPC_DATA_BASE + 0x1000,
+            128,
+            b"File",
+            b"Open;Close",
+        );
+        let descriptor = PPC_DATA_BASE + 0x7100;
+        let tvector = PPC_DATA_BASE + 0x7180;
+        let marker = PPC_DATA_BASE + 0x7400;
+        loaded.memory.add_region(marker, vec![0; 4]);
+        install_test_powerpc_callback(
+            &mut loaded,
+            descriptor,
+            tvector,
+            PPC_CODE_BASE + 0x4000,
+            PPC_DATA_BASE + 0x7300,
+            test_stack_proc_info(PPC_PROCINFO_SIZE_NONE, &[]),
+            &[
+                d_form_u(15, 8, 0, (marker >> 16) as u16),
+                d_form_u(24, 8, 8, marker as u16),
+                d_form_u(32, 9, 8, 0),
+                d_form_u(14, 9, 9, 1),
+                d_form_u(36, 9, 8, 0),
+                BLR,
+            ],
+        );
+        loaded.memory.write_u32_be(0x0a30, descriptor).unwrap();
+        (loaded, marker)
+    }
+
+    #[test]
+    fn native_menu_tracking_invokes_menu_hook_while_held() {
+        let (mut loaded, marker) = native_menu_hook_fixture();
+        let original_sp = loaded.cpu.gpr[1];
+        let original_return = loaded.cpu.lr;
+        loaded
+            .memory
+            .write_u16_be(crate::memory::globals::addr::MENU_FLASH, 0)
+            .unwrap();
+        loaded.cpu.gpr[3] =
+            (10u32 << 16) | u32::from((STANDARD_MENU_BAR_FIRST_TITLE_LEFT + 2) as u16);
+        loaded.set_input_snapshot(PpcInputSnapshot {
+            mouse_button: true,
+            mouse_v: 28,
+            mouse_h: 20,
+            ..PpcInputSnapshot::default()
+        });
+        for _ in 0..4 {
+            let probe = loaded.run_with_hle_imports(128);
+            assert!(matches!(probe.result, PpcRunResult::CycleLimit { .. }));
+        }
+        assert!(loaded.toolbox_startup.menu_tracking.is_some());
+        assert!(
+            loaded.memory.read_u32_be(marker).unwrap() > 0,
+            "MenuSelect must invoke MenuHook while held"
+        );
+        loaded.set_input_snapshot(PpcInputSnapshot {
+            mouse_button: false,
+            mouse_v: 28,
+            mouse_h: 20,
+            ..PpcInputSnapshot::default()
+        });
+        for _ in 0..8 {
+            let probe = loaded.run_with_hle_imports(128);
+            if matches!(probe.result, PpcRunResult::Halted { .. }) {
+                break;
+            }
+        }
+        assert_eq!(loaded.cpu.pc, original_return);
+        assert_eq!(loaded.cpu.gpr[1], original_sp);
+        assert_eq!(loaded.cpu.gpr[3], (128 << 16) | 1);
+        assert!(loaded.guest_calls.is_empty());
+        assert!(loaded.toolbox_startup.menu_tracking.is_none());
     }
 
     #[test]

--- a/src/menu_manager.rs
+++ b/src/menu_manager.rs
@@ -1109,6 +1109,18 @@ impl<MenuRef: Copy, Surface, Pixel, Appearance>
             })
     }
 
+    /// MenuSelect calls its no-argument hook repeatedly while held. A pending
+    /// definition must return before another callback can take execution.
+    /// Macintosh Toolbox Essentials (1992), p. 3-116.
+    pub(crate) fn should_invoke_menu_hook(&self, mouse_down: bool) -> bool {
+        self.kind == MenuTrackingKind::MenuBar
+            && mouse_down
+            && self
+                .active_definition()
+                .and_then(MenuDefinitionTracking::pending_invocation)
+                .is_none()
+    }
+
     pub(crate) fn active_definition(&self) -> Option<&MenuDefinitionTracking> {
         match self.active_definition_pane()? {
             MenuDefinitionPane::Root => self.definition.as_ref(),

--- a/src/runner/interrupt.rs
+++ b/src/runner/interrupt.rs
@@ -12,7 +12,6 @@ pub(crate) enum ActiveInterruptCallbackSource {
     FileCompletion,
     DialogDrawProc,
     DialogFilterProc,
-    MenuHook,
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -1492,7 +1492,6 @@ const DIALOG_FILTER_TRAMPOLINE_OFFSET: u32 = 0x40;
 const DIALOG_FILTER_EVENT_OFFSET: u32 = 0x80;
 // 2-byte scratch where the filter trampoline writes its Boolean return value.
 const DIALOG_FILTER_RESULT_OFFSET: u32 = 0x96;
-const MENU_HOOK_TRAMPOLINE_OFFSET: u32 = 0xA0;
 const DIALOG_CALLBACK_SCRATCH_SIZE: u32 = 0xC0;
 /// Compact Mac video hardware refreshes at approximately 60.15 Hz.
 pub const DEFAULT_VBL_HZ: f64 = 60.15;
@@ -1833,7 +1832,7 @@ pub struct FixtureRunner {
     /// Guest-memory trampoline used to invoke File Manager asynchronous
     /// completion procedures.
     file_completion_trampoline: u32,
-    /// Systemless-owned storage for dialog and MenuHook callback trampolines.
+    /// Systemless-owned storage for dialog callback trampolines.
     /// This must not overlap the architectural low-memory trap tables.
     dialog_callback_scratch_base: u32,
     /// Guest-memory address of the dialog userItem draw proc trampoline (26 bytes).
@@ -1842,9 +1841,6 @@ pub struct FixtureRunner {
     /// Guest-memory address of the ModalDialog filter proc trampoline.
     /// Allocated once on first use and reused for all callback invocations.
     dialog_filter_trampoline: u32,
-    /// Guest-memory address of the MenuSelect MenuHook trampoline.
-    /// Allocated once on first use and reused for all callback invocations.
-    menu_hook_trampoline: u32,
     /// Guest-memory address of a scratch EventRecord passed to ModalDialog filters.
     dialog_filter_event: u32,
     /// Last dialog/tick pair that received a synthetic ModalDialog null event.
@@ -2037,7 +2033,6 @@ impl FixtureRunner {
             dialog_callback_scratch_base,
             dialog_draw_trampoline: 0,
             dialog_filter_trampoline: 0,
-            menu_hook_trampoline: 0,
             dialog_filter_event: 0,
             dialog_filter_last_null_event_tick: None,
             dialog_filter_last_update_event_tick: None,
@@ -10363,86 +10358,69 @@ impl FixtureRunner {
     }
 
     fn fire_menu_hook_proc(&mut self, opcode: u16) -> bool {
-        if self.active_interrupt_callback.is_some() || (opcode & !0x0400) != 0xA93D {
+        if self.active_interrupt_callback.is_some() || (opcode & !0x0400) != 0xa93d {
             return false;
         }
-        if self.process_context.menu_tracking().is_none() || self.bus.read_byte(0x0172) != 0x00 {
+        if !self
+            .process_context
+            .menu_tracking()
+            .as_ref()
+            .is_some_and(|tracking| {
+                tracking.should_invoke_menu_hook(self.bus.read_byte(0x0172) == 0)
+            })
+        {
             return false;
         }
-
-        // MenuHook ($0A30)
-        // Address of a no-argument routine that MenuSelect calls repeatedly
-        // while the mouse button is down.
-        // PROCEDURE MyMenuHook;
-        // Inside Macintosh Volume I, I-356; Inside Macintosh Volume III, III-446
-        let hook_addr = self.bus.read_long(0x0A30);
-        let Some(call_addr) = self.resolve_dialog_draw_proc_addr(hook_addr) else {
+        let pointer = self.bus.read_long(0x0a30);
+        let Some(procedure) = crate::guest_procedure::resolve_guest_procedure(
+            &mut self.bus,
+            pointer,
+            0,
+            None,
+            GuestIsa::M68k,
+            GuestIsa::M68k,
+        ) else {
             return false;
         };
-
-        // Trampoline (22 bytes):
-        //   +0:  MOVEM.L D0-D3/A0-A3,-(SP)   ; 48E7 F0F0
-        //   +4:  JSR     hook_addr            ; 4EB9 xxxx xxxx
-        //   +10: MOVEA.L #savedRegsSP,A7      ; 4FF9 xxxx xxxx
-        //   +16: MOVEM.L (SP)+,D0-D3/A0-A3   ; 4CDF 0F0F
-        //   +20: RTS                          ; 4E75
-        if self.menu_hook_trampoline == 0 {
-            let tramp = self.dialog_callback_scratch_base() + MENU_HOOK_TRAMPOLINE_OFFSET;
-            self.bus.write_word(tramp, 0x48E7); // MOVEM.L regs,-(SP)
-            self.bus.write_word(tramp + 2, 0xF0F0); // D0-D3/A0-A3
-            self.bus.write_word(tramp + 4, 0x4EB9); // JSR abs.L
-                                                    // +6..+9: hook_addr
-            self.bus.write_word(tramp + 10, 0x4FF9); // MOVEA.L #imm,A7
-                                                     // +12..+15: savedRegsSP
-            self.bus.write_word(tramp + 16, 0x4CDF); // MOVEM.L (SP)+,regs
-            self.bus.write_word(tramp + 18, 0x0F0F); // D0-D3/A0-A3
-            self.bus.write_word(tramp + 20, 0x4E75); // RTS
-            self.menu_hook_trampoline = tramp;
+        if procedure.proc_info != 0 {
+            return false;
         }
-
-        let tramp = self.menu_hook_trampoline;
-        self.bus.write_long(tramp + 6, call_addr);
-
-        let current_pc = self.m68k.cpu.read_reg(Register::PC);
+        let target = crate::guest_call::GuestCallTarget {
+            isa: procedure.isa,
+            entry: procedure.entry,
+            rtoc: procedure.rtoc,
+        };
+        self.dispatcher.preserve_menu_callback_port(&self.bus);
         let sp = self.m68k.cpu.read_reg(Register::A7);
-        let d_regs = [
-            self.m68k.cpu.read_reg(Register::D0),
-            self.m68k.cpu.read_reg(Register::D1),
-            self.m68k.cpu.read_reg(Register::D2),
-            self.m68k.cpu.read_reg(Register::D3),
-            self.m68k.cpu.read_reg(Register::D4),
-            self.m68k.cpu.read_reg(Register::D5),
-            self.m68k.cpu.read_reg(Register::D6),
-            self.m68k.cpu.read_reg(Register::D7),
-        ];
-        let a_regs = [
-            self.m68k.cpu.read_reg(Register::A0),
-            self.m68k.cpu.read_reg(Register::A1),
-            self.m68k.cpu.read_reg(Register::A2),
-            self.m68k.cpu.read_reg(Register::A3),
-            self.m68k.cpu.read_reg(Register::A4),
-            self.m68k.cpu.read_reg(Register::A5),
-            self.m68k.cpu.read_reg(Register::A6),
+        if procedure.isa == GuestIsa::PowerPc {
+            return self.dispatcher.guest_calls.begin_m68k_to_powerpc(
+                target,
+                crate::guest_call::PowerPcArguments::from_slice(&[]).unwrap(),
+                self.m68k.cpu.read_reg(Register::PC),
+                sp,
+                None,
+            );
+        }
+        let Some(frame) = crate::execution_m68k::M68kMenuHookFrame::new(procedure.entry, sp) else {
+            return false;
+        };
+        if !self.bus.is_guest_address_mapped(frame.entry - 66, 114) {
+            return false;
+        }
+        let return_pc = frame.entry + 28;
+        if !self.dispatcher.guest_calls.begin_m68k_with_operation(
+            target,
+            return_pc,
             sp,
-        ];
-        let ccr = self.m68k.cpu.core.get_ccr();
-        let sr = self.m68k.cpu.core.get_sr();
-        let new_sp = sp.wrapping_sub(4);
-        let saved_regs_sp = new_sp.wrapping_sub(32);
-        self.bus.write_long(tramp + 12, saved_regs_sp);
-        self.bus.write_long(new_sp, current_pc);
-        self.m68k.cpu.write_reg(Register::A7, new_sp);
-        self.active_interrupt_callback = Some(ActiveInterruptCallback {
-            source: ActiveInterruptCallbackSource::MenuHook,
-            resume_pc: current_pc,
-            resume_sp: sp,
-            d_regs,
-            a_regs,
-            sr,
-            ccr,
-            restore_port: None,
-        });
-        self.m68k.cpu.write_reg(Register::PC, tramp);
+            Some(frame.entry),
+            None,
+        ) {
+            return false;
+        }
+        self.bus.write_bytes(frame.entry, &frame.image);
+        self.bus.write_long(frame.entry - 4, return_pc);
+        self.m68k.cpu.write_reg(Register::A7, frame.entry - 4);
+        self.m68k.cpu.write_reg(Register::PC, frame.entry);
         true
     }
 
@@ -16336,12 +16314,92 @@ mod tests {
     fn classic_menu_wait_resumes_without_refiring_new_trap_patch() {
         for auto_pop in [false, true] {
             for custom in [false, true] {
-                run_menu_patch_during_tracking(auto_pop, custom);
+                run_menu_patch_during_tracking(auto_pop, custom, false, false);
             }
         }
     }
 
-    fn run_menu_patch_during_tracking(auto_pop: bool, custom: bool) {
+    #[test]
+    fn native_menu_hook_runs_classic_guest_code_and_releases_ownership() {
+        use crate::loader::ppc::tests::native_menu_hook_fixture;
+        use crate::memory::globals::addr;
+        for cancel in [false, true] {
+            let (mut native, _) = native_menu_hook_fixture();
+            native.cpu.gpr[3] = (10 << 16) | 12;
+            native.memory.write_u16_be(addr::MENU_FLASH, 0).unwrap();
+            let original_sp = native.cpu.gpr[1];
+            let original_return = native.cpu.lr;
+            let app = LoadedApp::from_ppc(native);
+            let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+            runner.set_ui_theme(UiThemeId::ClassicSystem7);
+            runner.init_app(&app);
+            let code = 0x0030_8000;
+            let marker = code + 0x100;
+            for (index, word) in [
+                0x42a7, // CLR.L -(SP): inner result
+                0x2f3c,
+                0x01f4,
+                0x01f4, // inner MenuSelect outside the menu bar
+                0xa93d,
+                0x23df,
+                ((marker + 4) >> 16) as u16,
+                (marker + 4) as u16,
+                0x52b9,
+                (marker >> 16) as u16,
+                marker as u16,
+                0x4e75,
+            ]
+            .into_iter()
+            .enumerate()
+            {
+                runner.bus.write_word(code + index as u32 * 2, word);
+            }
+            runner.bus.write_long(marker + 4, u32::MAX);
+            runner.bus.write_long(0x0a30, code);
+            runner.push_canonical_mouse_down(10, 12);
+            for _ in 0..8 {
+                assert!(runner.run_steps(128, None).1);
+            }
+            assert!(
+                runner.bus.read_long(marker) > 0,
+                "native MenuSelect invoked the classic hook"
+            );
+            assert!(runner.process_context.menu_tracking().is_some());
+            assert_eq!(
+                runner.bus.read_long(marker + 4),
+                0,
+                "nested no-hit MenuSelect returned independently"
+            );
+            if cancel {
+                runner.push_canonical_mouse_up(500, 500);
+            } else {
+                runner.push_canonical_mouse_up(28, 20);
+            }
+            for _ in 0..32 {
+                if !runner.run_steps(128, None).1 {
+                    break;
+                }
+            }
+            assert!(runner.is_halted());
+            assert!(runner.process_context.menu_tracking().is_none());
+            assert!(runner.dispatcher.guest_calls.is_empty());
+            let native = runner.native.application_mut().unwrap();
+            assert_eq!(native.cpu.pc, original_return);
+            assert_eq!(native.cpu.gpr[1], original_sp);
+            assert_eq!(native.cpu.gpr[3], if cancel { 0 } else { (128 << 16) | 1 });
+        }
+    }
+
+    #[test]
+    fn classic_menu_hook_uses_owned_stack_frame_and_restores_registers() {
+        for auto_pop in [false, true] {
+            for native_hook in [false, true] {
+                run_menu_patch_during_tracking(auto_pop, false, true, native_hook);
+            }
+        }
+    }
+
+    fn run_menu_patch_during_tracking(auto_pop: bool, custom: bool, hook: bool, native_hook: bool) {
         use crate::memory::globals::addr;
         let ClassicPowerPcMdefFixture {
             mut runner,
@@ -16393,6 +16451,65 @@ mod tests {
         runner.bus.write_word(parameters + 2, 16);
         runner.bus.write_long(parameters + 4, 0);
         runner.m68k.cpu.write_reg(Register::A7, stack);
+        let hook_marker = runner.bus.alloc(4);
+        if hook {
+            let code = runner.bus.alloc(24);
+            runner.bus.write_word(code, 0x7e63); // MOVEQ #99,D7
+            runner.bus.write_word(code + 2, 0x2c7c); // MOVEA.L #value,A6
+            runner.bus.write_long(code + 4, 0x12345678);
+            runner.bus.write_word(code + 8, 0x52b9); // ADDQ.L #1,marker
+            runner.bus.write_long(code + 10, hook_marker);
+            runner.bus.write_word(code + 14, 0x4e75);
+            runner.bus.write_long(0x0a30, code);
+            if native_hook {
+                use crate::guest_procedure::{
+                    ROUTINE_DESCRIPTOR_HEADER_SIZE, ROUTINE_DESCRIPTOR_MIXED_MODE_TRAP,
+                    ROUTINE_DESCRIPTOR_VERSION, ROUTINE_FLAG_USE_NATIVE_ISA,
+                    ROUTINE_RECORD_FLAGS_OFFSET, ROUTINE_RECORD_ISA_OFFSET,
+                    ROUTINE_RECORD_POWERPC_ISA, ROUTINE_RECORD_PROC_DESCRIPTOR_OFFSET,
+                };
+                let native_code = runner.bus.alloc(28);
+                for (index, word) in [
+                    0x3d00_0000 | (hook_marker >> 16),
+                    0x6108_0000 | (hook_marker & 0xffff),
+                    0x8128_0000,
+                    0x3929_0001,
+                    0x9128_0000,
+                    0x4e80_0020,
+                ]
+                .into_iter()
+                .enumerate()
+                {
+                    runner.bus.write_long(native_code + index as u32 * 4, word);
+                }
+                let descriptor = runner.bus.alloc(64);
+                let tvector = descriptor + 48;
+                let record = descriptor + ROUTINE_DESCRIPTOR_HEADER_SIZE;
+                runner
+                    .bus
+                    .write_word(descriptor, ROUTINE_DESCRIPTOR_MIXED_MODE_TRAP);
+                runner
+                    .bus
+                    .write_byte(descriptor + 2, ROUTINE_DESCRIPTOR_VERSION);
+                runner.bus.write_byte(
+                    record + ROUTINE_RECORD_ISA_OFFSET,
+                    ROUTINE_RECORD_POWERPC_ISA,
+                );
+                runner.bus.write_word(
+                    record + ROUTINE_RECORD_FLAGS_OFFSET,
+                    ROUTINE_FLAG_USE_NATIVE_ISA,
+                );
+                runner
+                    .bus
+                    .write_long(record + ROUTINE_RECORD_PROC_DESCRIPTOR_OFFSET, tvector);
+                runner.bus.write_long(tvector, native_code);
+                runner.bus.write_long(tvector + 4, 0);
+                runner.bus.write_long(0x0a30, descriptor);
+            }
+
+            runner.m68k.cpu.write_reg(Register::D7, 0x77777777);
+            runner.m68k.cpu.write_reg(Register::A6, 0x66666666);
+        }
         runner.push_canonical_mouse_down(10, 16);
 
         for _ in 0..8 {
@@ -16457,6 +16574,14 @@ mod tests {
         assert_eq!(runner.m68k.cpu.read_reg(Register::A7), parameters + 4);
         assert_eq!(*runner.dispatcher.current_port, original_port);
         assert_eq!(runner.m68k.cpu.read_reg(Register::PC), return_pc);
+        if hook {
+            assert!(runner.bus.read_long(hook_marker) > 0, "the guest hook ran");
+            assert_eq!(runner.m68k.cpu.read_reg(Register::D7), 0x77777777);
+            assert_eq!(runner.m68k.cpu.read_reg(Register::A6), 0x66666666);
+            assert!(runner.dispatcher.guest_calls.is_empty());
+            assert!(runner.active_interrupt_callback.is_none());
+        }
+
         if auto_pop {
             runner.bus.write_long(stack, return_pc);
         }

--- a/src/trap/menu.rs
+++ b/src/trap/menu.rs
@@ -626,6 +626,13 @@ impl super::TrapDispatcher {
         }
     }
 
+    pub(crate) fn preserve_menu_callback_port(&mut self, bus: &MacMemoryBus) {
+        if self.menu_tracking.context().classic_port.is_none() {
+            self.menu_tracking.context_mut().classic_port =
+                Some(self.capture_current_port_state(bus));
+        }
+    }
+
     fn prepare_menu_definition_port<C: CpuOps>(&mut self, cpu: &mut C, bus: &mut MacMemoryBus) {
         if self.menu_tracking.context().classic_port.is_none() {
             self.menu_tracking.context_mut().classic_port =
@@ -1831,6 +1838,9 @@ impl super::TrapDispatcher {
         cpu.write_reg(Register::A7, stack_pointer);
         cpu.write_reg(Register::PC, return_address);
         self.dispatch_menu_body(true, trap_num, cpu, bus)?.ok()?;
+        if self.menu_tracking.is_none() && self.active_menu_definition().is_none() {
+            self.restore_menu_definition_port(cpu, bus);
+        }
         Some(0xa800 | trap_num)
     }
 


### PR DESCRIPTION
Native MenuSelect never invoked the application’s MenuHook. Classic MenuSelect used a shared mutable trampoline and interrupt record, leaving the hook outside task-owned guest execution.

Both callers now use the Menu Manager’s shared hook eligibility and submit task-owned guest calls. Classic callbacks use a stack-local frame that restores registers before the exact internal return; the shared trampoline and interrupt-source variant are removed. The retained menu preserves the caller’s port across native companion activation and restores it on completion.

Actual guest-instruction tests cover all caller/target ISA combinations, normal and auto-pop classic entry, native release, a hook that makes a nested no-hit MenuSelect, selection and cancellation, register/stack/result/port restoration and drained ownership. The native invocation regression fails before this change.

Local validation: 5,138 headless JIT/test-support library tests pass (three ignored), all 61 architecture guard fixtures pass, and developer-tools compilation is warning-free. Required public CI includes both architecture showcases. Known non-blocking formatter allocation and Clippy failures are unchanged.

Partial progress on #1512. Task retirement, invalid return placement, comprehensive failure cleanup, common tracking policy and graphics normalization remain open.
