### PR TITLE
refactor: share rectangular CopyBits transfer outcomes

### DIFF
--- a/src/copy_bits.rs
+++ b/src/copy_bits.rs
@@ -75,6 +75,7 @@ impl BytePixmap {
 
 /// One synchronous transfer, consumed before any guest callback can run.
 pub(crate) struct RowCopy<'a> {
+    pub(crate) mode: u16,
     pub(crate) source: BytePixmap,
     pub(crate) destination: BytePixmap,
     pub(crate) source_rect: [i32; 4],
@@ -83,71 +84,134 @@ pub(crate) struct RowCopy<'a> {
     pub(crate) palette: Option<&'a [u8; 256]>,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[must_use = "only Declined permits a caller to try another raster path"]
+pub(crate) enum RowCopyOutcome {
+    Completed,
+    NoOp,
+    Declined,
+    ReadOrGeometryFailure,
+    WriteFailure { rows_written: usize },
+}
+
 impl RowCopy<'_> {
     /// Snapshot all source rows before writing, including across different
     /// addresses that alias the same backing. Geometry/read failures write
     /// nothing. A destination failure preserves that row but may follow rows
     /// already committed; this does not promise rectangle-wide atomicity.
-    pub(crate) fn execute(self, memory: &mut impl CopyBitsMemory) -> Option<()> {
+    pub(crate) fn execute(self, memory: &mut impl CopyBitsMemory) -> RowCopyOutcome {
         let depth = self.source.depth;
-        if depth != self.destination.depth
+        if self.mode != 0
+            || depth != self.destination.depth
             || !matches!(depth, 8 | 16 | 24 | 32)
             || (self.palette.is_some() && depth != 8)
         {
-            return None;
+            return RowCopyOutcome::Declined;
         }
         let [st, sl, sb, sr] = self.source_rect;
         let [dt, dl, db, dr] = self.destination_rect;
-        let width = sr.checked_sub(sl)?;
-        let height = sb.checked_sub(st)?;
-        if width <= 0
-            || height <= 0
-            || dr.checked_sub(dl)? != width
-            || db.checked_sub(dt)? != height
-        {
-            return None;
+        let Some(width) = sr.checked_sub(sl) else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        let Some(height) = sb.checked_sub(st) else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        let Some(destination_width) = dr.checked_sub(dl) else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        let Some(destination_height) = db.checked_sub(dt) else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        if width <= 0 || height <= 0 || destination_width <= 0 || destination_height <= 0 {
+            return RowCopyOutcome::NoOp;
         }
-        let x_delta = sl.checked_sub(dl)?;
-        let y_delta = st.checked_sub(dt)?;
+        if destination_width != width || destination_height != height {
+            return RowCopyOutcome::Declined;
+        }
+        let Some(x_delta) = sl.checked_sub(dl) else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        let Some(y_delta) = st.checked_sub(dt) else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
         let [sbt, sbl, sbb, sbr] = self.source.bounds;
         let [dbt, dbl, dbb, dbr] = self.destination.bounds;
         let [ct, cl, cb, cr] = self.clip;
-        let top = dt.max(dbt).max(ct).max(sbt.checked_sub(y_delta)?);
-        let left = dl.max(dbl).max(cl).max(sbl.checked_sub(x_delta)?);
-        let bottom = db.min(dbb).min(cb).min(sbb.checked_sub(y_delta)?);
-        let right = dr.min(dbr).min(cr).min(sbr.checked_sub(x_delta)?);
+        let Some(source_top) = sbt.checked_sub(y_delta) else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        let Some(source_left) = sbl.checked_sub(x_delta) else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        let Some(source_bottom) = sbb.checked_sub(y_delta) else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        let Some(source_right) = sbr.checked_sub(x_delta) else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        let top = dt.max(dbt).max(ct).max(source_top);
+        let left = dl.max(dbl).max(cl).max(source_left);
+        let bottom = db.min(dbb).min(cb).min(source_bottom);
+        let right = dr.min(dbr).min(cr).min(source_right);
         if top >= bottom || left >= right {
-            return None;
+            return RowCopyOutcome::NoOp;
         }
-        let row_len = usize::try_from(right.checked_sub(left)?)
-            .ok()?
-            .checked_mul((depth / 8) as usize)?;
-        let count = usize::try_from(bottom.checked_sub(top)?).ok()?;
+        let Some(pixel_width) = right.checked_sub(left) else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        let Some(row_len) = usize::try_from(pixel_width)
+            .ok()
+            .and_then(|width| width.checked_mul((depth / 8) as usize))
+        else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        let Some(count) = bottom
+            .checked_sub(top)
+            .and_then(|count| usize::try_from(count).ok())
+        else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
         let mut addresses = Vec::with_capacity(count);
         // Check every row's arithmetic before allocating or reading pixels.
         for y in top..bottom {
-            addresses.push((
-                self.source.row_address(
-                    left.checked_add(x_delta)?,
-                    y.checked_add(y_delta)?,
-                    row_len,
-                )?,
-                self.destination.row_address(left, y, row_len)?,
-            ));
+            let Some(source_x) = left.checked_add(x_delta) else {
+                return RowCopyOutcome::ReadOrGeometryFailure;
+            };
+            let Some(source_y) = y.checked_add(y_delta) else {
+                return RowCopyOutcome::ReadOrGeometryFailure;
+            };
+            let Some(source_address) = self.source.row_address(source_x, source_y, row_len) else {
+                return RowCopyOutcome::ReadOrGeometryFailure;
+            };
+            let Some(destination_address) = self.destination.row_address(left, y, row_len) else {
+                return RowCopyOutcome::ReadOrGeometryFailure;
+            };
+            addresses.push((source_address, destination_address));
         }
-        let mut pixels = vec![0; count.checked_mul(row_len)?];
+        let Some(pixel_count) = count.checked_mul(row_len) else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        let mut pixels = vec![0; pixel_count];
         for ((source, _), row) in addresses.iter().zip(pixels.chunks_exact_mut(row_len)) {
-            memory.read_copy_row(*source, row)?;
+            if memory.read_copy_row(*source, row).is_none() {
+                return RowCopyOutcome::ReadOrGeometryFailure;
+            }
             if let Some(palette) = self.palette {
                 for pixel in row {
                     *pixel = palette[usize::from(*pixel)];
                 }
             }
         }
-        for ((_, destination), row) in addresses.iter().zip(pixels.chunks_exact(row_len)) {
-            memory.write_copy_row(*destination, row)?;
+        for (rows_written, ((_, destination), row)) in addresses
+            .iter()
+            .zip(pixels.chunks_exact(row_len))
+            .enumerate()
+        {
+            if memory.write_copy_row(*destination, row).is_none() {
+                return RowCopyOutcome::WriteFailure { rows_written };
+            }
         }
-        Some(())
+        RowCopyOutcome::Completed
     }
 }
 
@@ -158,7 +222,7 @@ mod tests {
     const SOURCE: u32 = 0x0100_0000;
     const DESTINATION: u32 = 0x0200_0000;
 
-    fn run(memory: &mut GuestAddressSpace, classic: bool, copy: RowCopy<'_>) -> Option<()> {
+    fn run(memory: &mut GuestAddressSpace, classic: bool, copy: RowCopy<'_>) -> RowCopyOutcome {
         if classic {
             let mut bus = MacMemoryBus::new(0x10000);
             bus.set_addressing_32_bit(true);
@@ -179,6 +243,46 @@ mod tests {
     }
 
     #[test]
+    fn no_op_and_decline_are_distinct_prewrite_outcomes() {
+        struct NoAccess;
+        impl CopyBitsMemory for NoAccess {
+            fn read_copy_row(&mut self, _: u32, _: &mut [u8]) -> Option<()> {
+                panic!("prewrite outcome reached source memory");
+            }
+
+            fn write_copy_row(&mut self, _: u32, _: &[u8]) -> Option<()> {
+                panic!("prewrite outcome reached destination memory");
+            }
+        }
+
+        let request = |mode, source_rect, destination_rect, clip| RowCopy {
+            mode,
+            source: pixmap(SOURCE, 4, 8, [0, 0, 2, 4]),
+            destination: pixmap(DESTINATION, 4, 8, [0, 0, 2, 4]),
+            source_rect,
+            destination_rect,
+            clip,
+            palette: None,
+        };
+        assert_eq!(
+            request(0, [0, 0, 0, 4], [0, 0, 0, 4], [0, 0, 2, 4]).execute(&mut NoAccess),
+            RowCopyOutcome::NoOp
+        );
+        assert_eq!(
+            request(0, [0, 0, 2, 4], [0, 0, 2, 4], [3, 0, 4, 4]).execute(&mut NoAccess),
+            RowCopyOutcome::NoOp
+        );
+        assert_eq!(
+            request(1, [0, 0, 2, 4], [0, 0, 2, 4], [0, 0, 2, 4]).execute(&mut NoAccess),
+            RowCopyOutcome::Declined
+        );
+        assert_eq!(
+            request(0, [0, 0, 2, 4], [0, 0, 1, 4], [0, 0, 2, 4]).execute(&mut NoAccess),
+            RowCopyOutcome::Declined
+        );
+    }
+
+    #[test]
     fn clipped_offset_rows_preserve_padding_in_both_memory_views() {
         for classic in [false, true] {
             for depth in [8, 16, 24, 32] {
@@ -189,6 +293,7 @@ mod tests {
                 memory.add_region(SOURCE, source.clone());
                 memory.add_region(DESTINATION, vec![0xAA; (stride * 3) as usize]);
                 let copy = RowCopy {
+                    mode: 0,
                     source: pixmap(SOURCE, stride, depth, [-2, -3, 1, 1]),
                     destination: pixmap(DESTINATION, stride, depth, [10, 20, 13, 24]),
                     source_rect: [-3, -4, 1, 1],
@@ -196,7 +301,7 @@ mod tests {
                     clip: [11, 21, 13, 23],
                     palette: None,
                 };
-                assert_eq!(run(&mut memory, classic, copy), Some(()));
+                assert_eq!(run(&mut memory, classic, copy), RowCopyOutcome::Completed);
                 let mut expected = vec![0xAA; (stride * 3) as usize];
                 for row in 1..3 {
                     let start = (row * stride + bytes) as usize;
@@ -227,6 +332,7 @@ mod tests {
                         &mut memory,
                         classic,
                         RowCopy {
+                            mode: 0,
                             source: pixmap(source, 4, 8, [0, 0, 3, 3]),
                             destination: pixmap(destination, 4, 8, [0, 0, 3, 3]),
                             source_rect: [0, 0, 3, 3],
@@ -235,7 +341,7 @@ mod tests {
                             palette: Some(&palette),
                         }
                     ),
-                    Some(())
+                    RowCopyOutcome::Completed
                 );
                 let mut expected: Vec<u8> = (0..16).collect();
                 for row in 0..3 {
@@ -267,6 +373,7 @@ mod tests {
                     &mut memory,
                     classic,
                     RowCopy {
+                        mode: 0,
                         source: pixmap(SOURCE, 4, 8, [0, 0, 3, 3]),
                         destination: pixmap(DESTINATION + 4, 4, 8, [0, 0, 3, 3]),
                         source_rect: [0, 0, 3, 3],
@@ -275,7 +382,7 @@ mod tests {
                         palette: None,
                     }
                 ),
-                Some(())
+                RowCopyOutcome::Completed
             );
             let mut actual = [0; 16];
             memory.read_bytes_into(SOURCE, &mut actual).unwrap();
@@ -306,6 +413,7 @@ mod tests {
         ] {
             assert_eq!(
                 RowCopy {
+                    mode: 0,
                     source: pixmap(base, stride, 8, bounds),
                     destination: pixmap(DESTINATION, stride, 8, bounds),
                     source_rect: rect,
@@ -314,7 +422,7 @@ mod tests {
                     palette: None,
                 }
                 .execute(&mut NoAccess),
-                None
+                RowCopyOutcome::ReadOrGeometryFailure
             );
         }
     }
@@ -331,6 +439,7 @@ mod tests {
                         &mut memory,
                         classic,
                         RowCopy {
+                            mode: 0,
                             source: pixmap(SOURCE, if bad_stride { 3 } else { 4 }, 8, [0, 0, 2, 4]),
                             destination: pixmap(DESTINATION, 4, 8, [0, 0, 2, 4]),
                             source_rect: [0, 0, 2, 4],
@@ -339,7 +448,7 @@ mod tests {
                             palette: None,
                         }
                     ),
-                    None
+                    RowCopyOutcome::ReadOrGeometryFailure
                 );
                 let mut actual = [0; 8];
                 memory.read_bytes_into(DESTINATION, &mut actual).unwrap();
@@ -360,6 +469,7 @@ mod tests {
                     &mut memory,
                     classic,
                     RowCopy {
+                        mode: 0,
                         source: pixmap(SOURCE, 4, 8, [0, 0, 2, 4]),
                         destination: pixmap(DESTINATION, 4, 8, [0, 0, 2, 4]),
                         source_rect: [0, 0, 2, 4],
@@ -368,7 +478,7 @@ mod tests {
                         palette: None,
                     }
                 ),
-                None
+                RowCopyOutcome::WriteFailure { rows_written: 1 }
             );
             let mut actual = [0; 8];
             memory.read_bytes_into(DESTINATION, &mut actual).unwrap();

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -58043,18 +58043,14 @@ fn ppc_copy_bits(
 
         // Inside Macintosh: Imaging With QuickDraw (1994), pp. 3-112–3-116
         // and 4-27: CopyBits copies bitmap or PixMap pixels between graphics
-        // ports and GWorlds, including indexed-color PixMaps. Keep the common
-        // unscaled copy row-based so an 8-bit full-screen blit remains native
-        // host memory bandwidth rather than 307,200 scalar HLE writes.
-        if mode == 0
-            && src_bits.depth == dst_bits.depth
-            && matches!(src_bits.depth, 8 | 16)
-            && mask_storage.is_none()
-            && src_width == dst_width
-            && src_height == dst_height
-        {
-            use crate::copy_bits::{BytePixmap, RowCopy};
-            return RowCopy {
+        // ports and GWorlds, including indexed-color PixMaps. The import
+        // resolves records and masks; the shared operation owns pure
+        // byte-aligned srcCopy format, mode, and geometry eligibility.
+        if mask_storage.is_none() {
+            use crate::copy_bits::{BytePixmap, RowCopy, RowCopyOutcome};
+
+            let outcome = RowCopy {
+                mode,
                 source: BytePixmap {
                     base: src_bits.base_addr,
                     row_bytes: src_bits.row_bytes,
@@ -58075,6 +58071,22 @@ fn ppc_copy_bits(
                 palette: palette_map.as_ref(),
             }
             .execute(memory);
+            match outcome {
+                RowCopyOutcome::Completed => return Some(()),
+                RowCopyOutcome::NoOp => {
+                    reason = "row-copy-no-op";
+                    return Some(());
+                }
+                RowCopyOutcome::Declined => {}
+                RowCopyOutcome::ReadOrGeometryFailure => {
+                    reason = "row-copy-read-or-geometry";
+                    return None;
+                }
+                RowCopyOutcome::WriteFailure { .. } => {
+                    reason = "row-copy-write";
+                    return None;
+                }
+            }
         }
 
         let transparent_back_pixel = match src_bits.depth {
@@ -150959,6 +150971,155 @@ pub(crate) mod tests {
         let mut actual = [0; 16];
         loaded.memory.read_bytes_into(pixels, &mut actual).unwrap();
         assert_eq!(actual, [1, 2, 3, 90, 1, 2, 3, 91, 4, 5, 6, 92, 7, 8, 9, 93]);
+    }
+
+    #[test]
+    fn hle_import_runner_copybits_snapshots_distinct_guest_aliases() {
+        const SOURCE: u32 = 0x0900_0000;
+        const DESTINATION: u32 = 0x0A00_0000;
+        let mut loaded = load_pef_application(&synthetic_pef_with_import(b"CopyBits")).unwrap();
+        let backing = crate::memory::bus::SharedRamRegion::from_owned_bytes((0..16).collect());
+        // SAFETY: the import accesses both aliases serially through one
+        // operation, and no borrowed byte slice survives a memory call.
+        unsafe {
+            loaded.memory.add_shared_region(SOURCE, backing.clone());
+            loaded.memory.add_shared_region(DESTINATION, backing);
+        }
+        let records = PPC_HEAP_BASE + 0x16000;
+        let src_pixmap = records;
+        let dst_pixmap = records + 0x40;
+        let rect = records + 0x80;
+        loaded.memory.add_region(records, vec![0; 0x90]);
+        ppc_write_pixmap(&mut loaded.memory, src_pixmap, SOURCE, 4, 0, 0, 3, 4, 8).unwrap();
+        ppc_write_pixmap(
+            &mut loaded.memory,
+            dst_pixmap,
+            DESTINATION + 4,
+            4,
+            0,
+            0,
+            3,
+            4,
+            8,
+        )
+        .unwrap();
+        ppc_write_rect(&mut loaded.memory, rect, 0, 0, 3, 3).unwrap();
+        loaded.cpu.gpr[3] = src_pixmap;
+        loaded.cpu.gpr[4] = dst_pixmap;
+        loaded.cpu.gpr[5] = rect;
+        loaded.cpu.gpr[6] = rect;
+        loaded.cpu.gpr[7] = 0x40; // ditherCopy flag, srcCopy base mode
+        loaded.cpu.gpr[8] = 0;
+
+        let probe = loaded.run_with_hle_imports(64);
+
+        assert_eq!(probe.handled_import_count, 1);
+        assert_eq!(probe.unsupported_import_index, None);
+        let mut actual = [0; 16];
+        loaded.memory.read_bytes_into(SOURCE, &mut actual).unwrap();
+        assert_eq!(actual, [0, 1, 2, 3, 0, 1, 2, 7, 4, 5, 6, 11, 8, 9, 10, 15]);
+    }
+
+    #[test]
+    fn hle_import_runner_copybits_does_not_fallback_after_later_row_write_failure() {
+        const SOURCE: u32 = 0x0900_0000;
+        const DESTINATION: u32 = 0x0A00_0000;
+        let mut loaded = load_pef_application(&synthetic_pef_with_import(b"CopyBits")).unwrap();
+        loaded
+            .memory
+            .add_region(SOURCE, vec![1, 2, 3, 4, 5, 6, 7, 8]);
+        loaded.memory.add_region(DESTINATION, vec![0xAA; 8]);
+        loaded
+            .memory
+            .add_readonly_region(DESTINATION + 6, vec![0xAA]);
+        let records = PPC_HEAP_BASE + 0x16000;
+        let src_pixmap = records;
+        let dst_pixmap = records + 0x40;
+        let rect = records + 0x80;
+        loaded.memory.add_region(records, vec![0; 0x90]);
+        ppc_write_pixmap(&mut loaded.memory, src_pixmap, SOURCE, 4, 0, 0, 2, 4, 8).unwrap();
+        ppc_write_pixmap(
+            &mut loaded.memory,
+            dst_pixmap,
+            DESTINATION,
+            4,
+            0,
+            0,
+            2,
+            4,
+            8,
+        )
+        .unwrap();
+        ppc_write_rect(&mut loaded.memory, rect, 0, 0, 2, 4).unwrap();
+        loaded.cpu.gpr[3] = src_pixmap;
+        loaded.cpu.gpr[4] = dst_pixmap;
+        loaded.cpu.gpr[5] = rect;
+        loaded.cpu.gpr[6] = rect;
+        loaded.cpu.gpr[7] = 0;
+        loaded.cpu.gpr[8] = 0;
+
+        let probe = loaded.run_with_hle_imports(64);
+
+        assert_eq!(probe.handled_import_count, 1);
+        assert_eq!(probe.unsupported_import_index, None);
+        let mut actual = [0; 8];
+        loaded
+            .memory
+            .read_bytes_into(DESTINATION, &mut actual)
+            .unwrap();
+        assert_eq!(
+            actual,
+            [1, 2, 3, 4, 0xAA, 0xAA, 0xAA, 0xAA],
+            "a fallback would partially overwrite the refused row"
+        );
+    }
+
+    #[test]
+    fn hle_import_runner_copybits_does_not_fallback_after_source_read_failure() {
+        const SOURCE: u32 = 0x0900_0000;
+        const DESTINATION: u32 = 0x0A00_0000;
+        let mut loaded = load_pef_application(&synthetic_pef_with_import(b"CopyBits")).unwrap();
+        loaded.memory.add_region(SOURCE, vec![1, 2, 3, 4]);
+        loaded.memory.add_region(DESTINATION, vec![0xAA; 8]);
+        let records = PPC_HEAP_BASE + 0x16000;
+        let src_pixmap = records;
+        let dst_pixmap = records + 0x40;
+        let rect = records + 0x80;
+        loaded.memory.add_region(records, vec![0; 0x90]);
+        ppc_write_pixmap(&mut loaded.memory, src_pixmap, SOURCE, 4, 0, 0, 2, 4, 8).unwrap();
+        ppc_write_pixmap(
+            &mut loaded.memory,
+            dst_pixmap,
+            DESTINATION,
+            4,
+            0,
+            0,
+            2,
+            4,
+            8,
+        )
+        .unwrap();
+        ppc_write_rect(&mut loaded.memory, rect, 0, 0, 2, 4).unwrap();
+        loaded.cpu.gpr[3] = src_pixmap;
+        loaded.cpu.gpr[4] = dst_pixmap;
+        loaded.cpu.gpr[5] = rect;
+        loaded.cpu.gpr[6] = rect;
+        loaded.cpu.gpr[7] = 0;
+        loaded.cpu.gpr[8] = 0;
+
+        let probe = loaded.run_with_hle_imports(64);
+
+        assert_eq!(probe.handled_import_count, 1);
+        assert_eq!(probe.unsupported_import_index, None);
+        let mut actual = [0; 8];
+        loaded
+            .memory
+            .read_bytes_into(DESTINATION, &mut actual)
+            .unwrap();
+        assert_eq!(
+            actual, [0xAA; 8],
+            "a fallback would write after the failed source snapshot"
+        );
     }
 
     #[test]

--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -29,6 +29,50 @@ pub(super) struct CopyBitmapInfo {
     pub(super) ctab_handle: u32,
 }
 
+fn resolved_row_copy<'a>(
+    mode: u16,
+    source: CopyBitmapInfo,
+    destination: CopyBitmapInfo,
+    source_rect: [i32; 4],
+    destination_rect: [i32; 4],
+    clip: [i32; 4],
+    palette: Option<&'a [u8; 256]>,
+) -> crate::copy_bits::RowCopy<'a> {
+    use crate::copy_bits::{BytePixmap, RowCopy};
+
+    RowCopy {
+        mode,
+        source: BytePixmap {
+            base: source.base,
+            row_bytes: source.row_bytes,
+            depth: source.pixel_size,
+            bounds: [
+                source.bounds_top,
+                source.bounds_left,
+                source.bounds_bottom,
+                source.bounds_right,
+            ]
+            .map(i32::from),
+        },
+        destination: BytePixmap {
+            base: destination.base,
+            row_bytes: destination.row_bytes,
+            depth: destination.pixel_size,
+            bounds: [
+                destination.bounds_top,
+                destination.bounds_left,
+                destination.bounds_bottom,
+                destination.bounds_right,
+            ]
+            .map(i32::from),
+        },
+        source_rect,
+        destination_rect,
+        clip,
+        palette,
+    }
+}
+
 /// Resolved location of an individual pixel in a CGrafPort/GrafPort
 /// pixmap. Produced by `resolve_pixel_target` and consumed by
 /// `read_cpixel` / `write_cpixel` for SetCPixel and GetCPixel.
@@ -3597,16 +3641,11 @@ impl super::TrapDispatcher {
                 ));
                 let (copy_fg_rgb, copy_bg_rgb) = self.copy_bits_port_draw_colors(bus, port);
 
-                // Rectangular, byte-aligned srcCopy uses the common transfer
-                // operation. It snapshots the source before any destination
-                // write, including overlapping or differently mapped aliases.
-                // Port/region resolution and picture/screen effects remain here.
-                let pixel_size_ok = src_info.pixel_size == dst_info.pixel_size
-                    && matches!(src_info.pixel_size, 8 | 16 | 24 | 32);
-                let identity_blit = mode_base == 0
-                    && no_scaling
-                    && pixel_size_ok
-                    && !Self::region_is_complex(bus, vis_rgn_handle)
+                // Port/region resolution, diagnostics, and picture/screen
+                // effects remain at this edge. The shared operation decides
+                // whether the resolved format, mode, and geometry belong to
+                // its rectangular byte-aligned srcCopy family.
+                let row_copy_edge_eligible = !Self::region_is_complex(bus, vis_rgn_handle)
                     && !Self::region_is_complex(bus, clip_rgn_handle)
                     && !Self::region_is_complex(bus, mask_rgn)
                     && trace_copybits_hud_probe().is_none()
@@ -3614,58 +3653,50 @@ impl super::TrapDispatcher {
                     && !trace_copybits_all_enabled()
                     && !trace_menu_redraw_enabled()
                     && trace_probes.is_empty();
-                if identity_blit {
-                    use crate::copy_bits::{BytePixmap, RowCopy};
-                    let _ = RowCopy {
-                        source: BytePixmap {
-                            base: src_info.base,
-                            row_bytes: src_info.row_bytes,
-                            depth: src_info.pixel_size,
-                            bounds: [
-                                src_info.bounds_top,
-                                src_info.bounds_left,
-                                src_info.bounds_bottom,
-                                src_info.bounds_right,
-                            ]
-                            .map(i32::from),
-                        },
-                        destination: BytePixmap {
-                            base: dst_info.base,
-                            row_bytes: dst_info.row_bytes,
-                            depth: dst_info.pixel_size,
-                            bounds: [
-                                dst_info.bounds_top,
-                                dst_info.bounds_left,
-                                dst_info.bounds_bottom,
-                                dst_info.bounds_right,
-                            ]
-                            .map(i32::from),
-                        },
-                        source_rect: [src_top, src_left, src_bottom, src_right].map(i32::from),
-                        destination_rect: [dst_top, dst_left, dst_bottom, dst_right].map(i32::from),
-                        clip: [clip_t, clip_l, clip_b, clip_r].map(i32::from),
-                        palette: palette_translation,
-                    }
+                if row_copy_edge_eligible {
+                    use crate::copy_bits::RowCopyOutcome;
+
+                    let outcome = resolved_row_copy(
+                        mode_base,
+                        src_info,
+                        dst_info,
+                        [src_top, src_left, src_bottom, src_right].map(i32::from),
+                        [dst_top, dst_left, dst_bottom, dst_right].map(i32::from),
+                        [clip_t, clip_l, clip_b, clip_r].map(i32::from),
+                        palette_translation,
+                    )
                     .execute(bus);
-                    if let Some(rect) = screen_copybits_rect {
-                        self.fill_kiosk_letterbox_for_copybits(bus, rect);
-                        self.refresh_dialog_saved_pixels_after_screen_draw(
-                            bus,
-                            *self.current_port,
-                            (
-                                clip_t.saturating_sub(dst_info.bounds_top),
-                                clip_l.saturating_sub(dst_info.bounds_left),
-                                clip_b.saturating_sub(dst_info.bounds_top),
-                                clip_r.saturating_sub(dst_info.bounds_left),
-                            ),
-                        );
-                        self.refresh_visible_dialog_snapshot_after_bulk_port_draw(
-                            bus,
-                            *self.current_port,
-                            (rect.dst_top, rect.dst_left, rect.dst_bottom, rect.dst_right),
-                        );
+                    let wrote_rows = match outcome {
+                        RowCopyOutcome::Completed => true,
+                        RowCopyOutcome::WriteFailure { rows_written } => rows_written != 0,
+                        RowCopyOutcome::NoOp | RowCopyOutcome::ReadOrGeometryFailure => {
+                            return Some(Ok(()));
+                        }
+                        RowCopyOutcome::Declined => false,
+                    };
+                    if outcome != RowCopyOutcome::Declined {
+                        if wrote_rows {
+                            if let Some(rect) = screen_copybits_rect {
+                                self.fill_kiosk_letterbox_for_copybits(bus, rect);
+                                self.refresh_dialog_saved_pixels_after_screen_draw(
+                                    bus,
+                                    *self.current_port,
+                                    (
+                                        clip_t.saturating_sub(dst_info.bounds_top),
+                                        clip_l.saturating_sub(dst_info.bounds_left),
+                                        clip_b.saturating_sub(dst_info.bounds_top),
+                                        clip_r.saturating_sub(dst_info.bounds_left),
+                                    ),
+                                );
+                                self.refresh_visible_dialog_snapshot_after_bulk_port_draw(
+                                    bus,
+                                    *self.current_port,
+                                    (rect.dst_top, rect.dst_left, rect.dst_bottom, rect.dst_right),
+                                );
+                            }
+                        }
+                        return Some(Ok(()));
                     }
-                    return Some(Ok(()));
                 }
 
                 // SYSTEMLESS_TRACE_COPYBITS logs "interesting" CopyBits (mask,
@@ -20593,7 +20624,39 @@ impl super::TrapDispatcher {
             transformed_blit,
         ));
 
-        let source_snapshot = if src_info.base == dst_info.base {
+        // StdBits resolves the current-port destination at this edge, then
+        // submits the same pure rectangular request as CopyBits. Complex
+        // region spans and diagnostic probes remain on the legacy path.
+        let row_copy_edge_eligible = !Self::region_is_complex(bus, vis_rgn_handle)
+            && !Self::region_is_complex(bus, clip_rgn_handle)
+            && !Self::region_is_complex(bus, mask_rgn)
+            && trace_probes.is_empty();
+        let shared_rows_written = if row_copy_edge_eligible {
+            use crate::copy_bits::RowCopyOutcome;
+
+            match resolved_row_copy(
+                mode_base,
+                src_info,
+                dst_info,
+                [src_top, src_left, src_bottom, src_right].map(i32::from),
+                [dst_top, dst_left, dst_bottom, dst_right].map(i32::from),
+                [clip_t, clip_l, clip_b, clip_r].map(i32::from),
+                palette_translation,
+            )
+            .execute(bus)
+            {
+                RowCopyOutcome::Completed => true,
+                RowCopyOutcome::WriteFailure { rows_written } if rows_written != 0 => true,
+                RowCopyOutcome::WriteFailure { .. }
+                | RowCopyOutcome::NoOp
+                | RowCopyOutcome::ReadOrGeometryFailure => return Ok(()),
+                RowCopyOutcome::Declined => false,
+            }
+        } else {
+            false
+        };
+
+        let source_snapshot = if !shared_rows_written && src_info.base == dst_info.base {
             let mut row_start = u32::MAX;
             let mut row_end = 0u32;
             for dy in clip_t..clip_b {
@@ -20659,41 +20722,43 @@ impl super::TrapDispatcher {
         // preconditions for that shape; the table comes from the function the
         // (8, 8) arm below calls per pixel, with the arguments it passes. The
         // area floor keeps blits smaller than the table from paying for it.
-        let rows_copied = mode_base == 0
-            && no_scaling
-            && src_info.pixel_size == 8
-            && dst_info.pixel_size == 8
-            && source_snapshot.is_none()
-            && trace_probes.is_empty()
-            && (i32::from(clip_b) - i32::from(clip_t)) * (i32::from(clip_r) - i32::from(clip_l))
-                >= COPY_BITS_ROW_PATH_MIN_PIXELS
-            && self
-                .copy_bits_src_copy_table(
-                    bus,
-                    dst_ctab_handle,
-                    src_clut,
-                    dst_clut,
-                    palette_translation,
-                    None,
-                    copy_fg_rgb,
-                    copy_bg_rgb,
-                )
-                .is_some_and(|table| {
-                    Self::copy_bits_src_copy_rows_8bpp(
+        let rows_copied = shared_rows_written
+            || (mode_base == 0
+                && no_scaling
+                && src_info.pixel_size == 8
+                && dst_info.pixel_size == 8
+                && source_snapshot.is_none()
+                && trace_probes.is_empty()
+                && (i32::from(clip_b) - i32::from(clip_t))
+                    * (i32::from(clip_r) - i32::from(clip_l))
+                    >= COPY_BITS_ROW_PATH_MIN_PIXELS
+                && self
+                    .copy_bits_src_copy_table(
                         bus,
-                        &src_info,
-                        &dst_info,
-                        (src_top, src_left),
-                        (dst_top, dst_left, dst_w, dst_h),
-                        (clip_t, clip_l, clip_b, clip_r),
-                        [
-                            (vis_test, vis_membership.as_ref()),
-                            (clip_test, clip_membership.as_ref()),
-                            (mask_test, mask_membership.as_ref()),
-                        ],
-                        &table,
+                        dst_ctab_handle,
+                        src_clut,
+                        dst_clut,
+                        palette_translation,
+                        None,
+                        copy_fg_rgb,
+                        copy_bg_rgb,
                     )
-                });
+                    .is_some_and(|table| {
+                        Self::copy_bits_src_copy_rows_8bpp(
+                            bus,
+                            &src_info,
+                            &dst_info,
+                            (src_top, src_left),
+                            (dst_top, dst_left, dst_w, dst_h),
+                            (clip_t, clip_l, clip_b, clip_r),
+                            [
+                                (vis_test, vis_membership.as_ref()),
+                                (clip_test, clip_membership.as_ref()),
+                                (mask_test, mask_membership.as_ref()),
+                            ],
+                            &table,
+                        )
+                    }));
         // With the rows already written the loop has nothing left to do; the
         // screen bookkeeping after it still runs.
         let pixel_rows = if rows_copied {
@@ -25183,7 +25248,8 @@ mod tests {
     use super::super::test_helpers::{setup, setup_with_port, TEST_SP};
     use crate::cpu::{CpuOps, Register};
     use crate::display::CursorImage;
-    use crate::memory::{MacMemoryBus, MemoryBus};
+    use crate::memory::bus::SharedRamRegion;
+    use crate::memory::{GuestAddressSpace, MacMemoryBus, MemoryBus};
     use crate::trap::dispatch::{
         DialogItem, LoadedResources, RecentColorTableFetch, ResourceFileMap, ScreenCopyBitsRect,
     };
@@ -35918,6 +35984,182 @@ mod tests {
             bus.read_bytes(pixels, 16),
             vec![1, 2, 3, 90, 1, 2, 3, 91, 4, 5, 6, 92, 7, 8, 9, 93]
         );
+    }
+
+    #[test]
+    fn copybits_and_stdbits_snapshot_distinct_guest_aliases() {
+        const SOURCE: u32 = 0x00D0_0000;
+        const DESTINATION: u32 = 0x00E0_0000;
+        for trap in [0x0EC, 0x0EB] {
+            let (mut d, mut cpu, mut bus) = setup_with_port();
+            let mut memory = GuestAddressSpace::new();
+            let backing = SharedRamRegion::from_owned_bytes((0..16).collect());
+            // SAFETY: the trap accesses both aliases serially through one
+            // attached bus, and no byte slice survives a memory call.
+            unsafe {
+                memory.add_shared_region(SOURCE, backing.clone());
+                memory.add_shared_region(DESTINATION, backing);
+            }
+            bus.attach_guest_address_space(memory.shared_view());
+
+            let port = 0x181000;
+            let src_pixmap = bus.alloc(50);
+            let dst_pixmap = bus.alloc(50);
+            let dst_handle = bus.alloc(4);
+            let rect = bus.alloc(8);
+            write_pixmap_8(&mut bus, src_pixmap, SOURCE, 4, 3, 0);
+            write_pixmap_8(&mut bus, dst_pixmap, DESTINATION + 4, 4, 3, 0);
+            bus.write_long(dst_handle, dst_pixmap);
+            bus.write_long(port + 2, dst_handle);
+            bus.write_word(port + 6, 0xC000);
+            bus.write_long(port + 24, 0);
+            bus.write_long(port + 28, 0);
+            let global_ptr = bus.read_long(cpu.read_reg(Register::A5));
+            bus.write_long(global_ptr, port);
+            *d.current_port = port;
+            write_rect(&mut bus, rect, 0, 0, 3, 3);
+
+            cpu.write_reg(Register::A7, TEST_SP);
+            bus.write_long(TEST_SP, 0);
+            bus.write_word(TEST_SP + 4, 0x40); // ditherCopy flag, srcCopy base mode
+            bus.write_long(TEST_SP + 6, rect);
+            bus.write_long(TEST_SP + 10, rect);
+            bus.write_long(
+                TEST_SP + 14,
+                if trap == 0x0EC {
+                    dst_pixmap
+                } else {
+                    src_pixmap
+                },
+            );
+            if trap == 0x0EC {
+                bus.write_long(TEST_SP + 18, src_pixmap);
+            }
+            let result = d.dispatch_quickdraw(true, trap, &mut cpu, &mut bus);
+            assert!(result.unwrap().is_ok());
+
+            let mut actual = [0; 16];
+            memory.read_bytes_into(SOURCE, &mut actual).unwrap();
+            assert_eq!(
+                actual,
+                [0, 1, 2, 3, 0, 1, 2, 7, 4, 5, 6, 11, 8, 9, 10, 15],
+                "trap=${trap:03X}"
+            );
+        }
+    }
+
+    #[test]
+    fn copybits_and_stdbits_do_not_fallback_after_later_row_write_failure() {
+        const SOURCE: u32 = 0x00D0_0000;
+        const DESTINATION: u32 = 0x00E0_0000;
+        for trap in [0x0EC, 0x0EB] {
+            let (mut d, mut cpu, mut bus) = setup_with_port();
+            let mut memory = GuestAddressSpace::new();
+            memory.add_region(SOURCE, vec![1, 2, 3, 4, 5, 6, 7, 8]);
+            memory.add_region(DESTINATION, vec![0xAA; 8]);
+            memory.add_readonly_region(DESTINATION + 6, vec![0xAA]);
+            bus.attach_guest_address_space(memory.shared_view());
+
+            let port = 0x181000;
+            let src_pixmap = bus.alloc(50);
+            let dst_pixmap = bus.alloc(50);
+            let dst_handle = bus.alloc(4);
+            let rect = bus.alloc(8);
+            write_pixmap_8(&mut bus, src_pixmap, SOURCE, 4, 2, 0);
+            write_pixmap_8(&mut bus, dst_pixmap, DESTINATION, 4, 2, 0);
+            bus.write_long(dst_handle, dst_pixmap);
+            bus.write_long(port + 2, dst_handle);
+            bus.write_word(port + 6, 0xC000);
+            bus.write_long(port + 24, 0);
+            bus.write_long(port + 28, 0);
+            let global_ptr = bus.read_long(cpu.read_reg(Register::A5));
+            bus.write_long(global_ptr, port);
+            *d.current_port = port;
+            write_rect(&mut bus, rect, 0, 0, 2, 4);
+
+            cpu.write_reg(Register::A7, TEST_SP);
+            bus.write_long(TEST_SP, 0);
+            bus.write_word(TEST_SP + 4, 0);
+            bus.write_long(TEST_SP + 6, rect);
+            bus.write_long(TEST_SP + 10, rect);
+            bus.write_long(
+                TEST_SP + 14,
+                if trap == 0x0EC {
+                    dst_pixmap
+                } else {
+                    src_pixmap
+                },
+            );
+            if trap == 0x0EC {
+                bus.write_long(TEST_SP + 18, src_pixmap);
+            }
+            let result = d.dispatch_quickdraw(true, trap, &mut cpu, &mut bus);
+            assert!(result.unwrap().is_ok());
+
+            let mut actual = [0; 8];
+            memory.read_bytes_into(DESTINATION, &mut actual).unwrap();
+            assert_eq!(
+                actual,
+                [1, 2, 3, 4, 0xAA, 0xAA, 0xAA, 0xAA],
+                "a fallback would partially overwrite the refused row for trap=${trap:03X}"
+            );
+        }
+    }
+
+    #[test]
+    fn copybits_and_stdbits_do_not_fallback_after_source_read_failure() {
+        const SOURCE: u32 = 0x00D0_0000;
+        const DESTINATION: u32 = 0x00E0_0000;
+        for trap in [0x0EC, 0x0EB] {
+            let (mut d, mut cpu, mut bus) = setup_with_port();
+            let mut memory = GuestAddressSpace::new();
+            memory.add_region(SOURCE, vec![1, 2, 3, 4]);
+            memory.add_region(DESTINATION, vec![0xAA; 8]);
+            bus.attach_guest_address_space(memory.shared_view());
+
+            let port = 0x181000;
+            let src_pixmap = bus.alloc(50);
+            let dst_pixmap = bus.alloc(50);
+            let dst_handle = bus.alloc(4);
+            let rect = bus.alloc(8);
+            write_pixmap_8(&mut bus, src_pixmap, SOURCE, 4, 2, 0);
+            write_pixmap_8(&mut bus, dst_pixmap, DESTINATION, 4, 2, 0);
+            bus.write_long(dst_handle, dst_pixmap);
+            bus.write_long(port + 2, dst_handle);
+            bus.write_word(port + 6, 0xC000);
+            bus.write_long(port + 24, 0);
+            bus.write_long(port + 28, 0);
+            let global_ptr = bus.read_long(cpu.read_reg(Register::A5));
+            bus.write_long(global_ptr, port);
+            *d.current_port = port;
+            write_rect(&mut bus, rect, 0, 0, 2, 4);
+
+            cpu.write_reg(Register::A7, TEST_SP);
+            bus.write_long(TEST_SP, 0);
+            bus.write_word(TEST_SP + 4, 0);
+            bus.write_long(TEST_SP + 6, rect);
+            bus.write_long(TEST_SP + 10, rect);
+            bus.write_long(
+                TEST_SP + 14,
+                if trap == 0x0EC {
+                    dst_pixmap
+                } else {
+                    src_pixmap
+                },
+            );
+            if trap == 0x0EC {
+                bus.write_long(TEST_SP + 18, src_pixmap);
+            }
+            let result = d.dispatch_quickdraw(true, trap, &mut cpu, &mut bus);
+            assert!(result.unwrap().is_ok());
+
+            let mut actual = [0; 8];
+            memory.read_bytes_into(DESTINATION, &mut actual).unwrap();
+            assert_eq!(
+                actual, [0xAA; 8],
+                "a fallback would write after the failed snapshot for trap=${trap:03X}"
+            );
+        }
     }
 
     fn write_pixmap_8(


### PR DESCRIPTION
Use the shared rectangular srcCopy operation from classic CopyBits, classic StdBits, and native CopyBits. The operation now owns format/mode/geometry eligibility and returns explicit completion, no-op, decline, read/geometry failure, or partial-write outcomes. Only a decline permits another raster path, preventing retries after partial writes or failed source snapshots.

Source rows are snapshotted before destination writes, including distinct guest addresses that alias the same backing. Preserve row-level write failure semantics, the existing 8/16/24/32-bit family, precomputed palette mapping, and base-mode flag decoding. Complex regions, packed/scaled transfers, callbacks, and recording remain separate migration work.

Reviewed regressions cover aliasing/padding, source-read failure, and later-row write refusal through all three entry paths, plus retained palette and 24/32-bit behavior. The independent headless suite passed 5,149 tests; the integrated default-feature suite with the tick-service change passed 5,159 tests (three ignored in each). Source guardrails and all 54 guardrail fixtures passed. Formatting was limited to the changed files, preserving unrelated existing formatting.

Closes #1540.
