### PR TITLE
refactor: share packed identity CopyBits row transfers

### DIFF
--- a/src/copy_bits.rs
+++ b/src/copy_bits.rs
@@ -1,4 +1,4 @@
-//! Shared byte-aligned, unscaled srcCopy transfers.
+//! Shared byte-aligned and packed, unscaled srcCopy transfers.
 //! Imaging With QuickDraw (1994), pp. 3-112–3-117 and 4-27–4-28.
 //! ABI decoding, port/mask resolution and picture recording stay at the callers
 //! until their corresponding operation families migrate.
@@ -71,6 +71,32 @@ impl BytePixmap {
         }
         Some(address)
     }
+
+    fn packed_row_span(self, x: i32, y: i32, width: i32) -> Option<(u32, usize, u32)> {
+        let [top, left, bottom, right] = self.bounds;
+        let end = x.checked_add(width)?;
+        if x < left || end > right || width <= 0 || y < top || y >= bottom {
+            return None;
+        }
+        let first_pixel = u32::try_from(x.checked_sub(left)?).ok()?;
+        let end_pixel = u32::try_from(end.checked_sub(left)?).ok()?;
+        let first_bit = first_pixel.checked_mul(self.depth)?;
+        let end_bit = end_pixel.checked_mul(self.depth)?;
+        let first_byte = first_bit / 8;
+        let end_byte = end_bit.checked_add(7)? / 8;
+        if end_byte > self.row_bytes {
+            return None;
+        }
+        let len = usize::try_from(end_byte.checked_sub(first_byte)?).ok()?;
+        let y_bytes = u32::try_from(y.checked_sub(top)?)
+            .ok()?
+            .checked_mul(self.row_bytes)?;
+        let address = self.base.checked_add(y_bytes)?.checked_add(first_byte)?;
+        if u64::from(address) + len as u64 > 1u64 << 32 {
+            return None;
+        }
+        Some((address, len, first_bit % 8))
+    }
 }
 
 /// One synchronous transfer, consumed before any guest callback can run.
@@ -101,11 +127,10 @@ impl RowCopy<'_> {
     /// already committed; this does not promise rectangle-wide atomicity.
     pub(crate) fn execute(self, memory: &mut impl CopyBitsMemory) -> RowCopyOutcome {
         let depth = self.source.depth;
-        if self.mode != 0
-            || depth != self.destination.depth
-            || !matches!(depth, 8 | 16 | 24 | 32)
-            || (self.palette.is_some() && depth != 8)
-        {
+        let packed = matches!(depth, 2 | 4) && self.palette.is_none();
+        let byte_aligned =
+            matches!(depth, 8 | 16 | 24 | 32) && (self.palette.is_none() || depth == 8);
+        if self.mode != 0 || depth != self.destination.depth || (!packed && !byte_aligned) {
             return RowCopyOutcome::Declined;
         }
         let [st, sl, sb, sr] = self.source_rect;
@@ -171,6 +196,14 @@ impl RowCopy<'_> {
         else {
             return RowCopyOutcome::ReadOrGeometryFailure;
         };
+        if packed {
+            return self.execute_packed(
+                memory,
+                [top, left, bottom, right],
+                [y_delta, x_delta],
+                count,
+            );
+        }
         let mut addresses = Vec::with_capacity(count);
         // Check every row's arithmetic before allocating or reading pixels.
         for y in top..bottom {
@@ -208,6 +241,90 @@ impl RowCopy<'_> {
             .enumerate()
         {
             if memory.write_copy_row(*destination, row).is_none() {
+                return RowCopyOutcome::WriteFailure { rows_written };
+            }
+        }
+        RowCopyOutcome::Completed
+    }
+
+    fn execute_packed(
+        self,
+        memory: &mut impl CopyBitsMemory,
+        rectangle: [i32; 4],
+        delta: [i32; 2],
+        count: usize,
+    ) -> RowCopyOutcome {
+        let [top, left, bottom, right] = rectangle;
+        let [y_delta, x_delta] = delta;
+        let depth = self.source.depth;
+        let Some(width) = right
+            .checked_sub(left)
+            .and_then(|width| usize::try_from(width).ok())
+        else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        let Some(pixel_count) = count.checked_mul(width) else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        let mut spans = Vec::with_capacity(count);
+        for y in top..bottom {
+            let Some(source_x) = left.checked_add(x_delta) else {
+                return RowCopyOutcome::ReadOrGeometryFailure;
+            };
+            let Some(source_y) = y.checked_add(y_delta) else {
+                return RowCopyOutcome::ReadOrGeometryFailure;
+            };
+            let Some(source) = self
+                .source
+                .packed_row_span(source_x, source_y, right - left)
+            else {
+                return RowCopyOutcome::ReadOrGeometryFailure;
+            };
+            let Some(destination) = self.destination.packed_row_span(left, y, right - left) else {
+                return RowCopyOutcome::ReadOrGeometryFailure;
+            };
+            spans.push((source, destination));
+        }
+
+        let mut pixels = vec![0; pixel_count];
+        for (((source_address, source_len, source_bit), _), row) in
+            spans.iter().zip(pixels.chunks_exact_mut(width))
+        {
+            let mut source = vec![0; *source_len];
+            if memory.read_copy_row(*source_address, &mut source).is_none() {
+                return RowCopyOutcome::ReadOrGeometryFailure;
+            }
+            for (x, pixel) in row.iter_mut().enumerate() {
+                let bit = *source_bit as usize + x * depth as usize;
+                let shift = 8 - depth as usize - bit % 8;
+                *pixel = (source[bit / 8] >> shift) & ((1 << depth) - 1) as u8;
+            }
+        }
+
+        let mut destinations = Vec::with_capacity(count);
+        for (_, (address, len, _)) in &spans {
+            let mut row = vec![0; *len];
+            if memory.read_copy_row(*address, &mut row).is_none() {
+                return RowCopyOutcome::ReadOrGeometryFailure;
+            }
+            destinations.push(row);
+        }
+        for (((_, (_, _, destination_bit)), pixels), destination) in spans
+            .iter()
+            .zip(pixels.chunks_exact(width))
+            .zip(destinations.iter_mut())
+        {
+            for (x, pixel) in pixels.iter().copied().enumerate() {
+                let bit = *destination_bit as usize + x * depth as usize;
+                let shift = 8 - depth as usize - bit % 8;
+                let mask = (((1 << depth) - 1) as u8) << shift;
+                destination[bit / 8] = (destination[bit / 8] & !mask) | (pixel << shift);
+            }
+        }
+        for (rows_written, ((_, (address, _, _)), row)) in
+            spans.iter().zip(destinations.iter()).enumerate()
+        {
+            if memory.write_copy_row(*address, row).is_none() {
                 return RowCopyOutcome::WriteFailure { rows_written };
             }
         }
@@ -312,6 +429,286 @@ mod tests {
                 memory.read_bytes_into(DESTINATION, &mut actual).unwrap();
                 assert_eq!(actual, expected, "classic={classic}, depth={depth}");
             }
+        }
+    }
+
+    #[test]
+    fn packed_rows_are_msb_first_and_preserve_edge_fields_and_padding() {
+        for classic in [false, true] {
+            for (depth, source_row, destination_row, expected_row, width) in [
+                (
+                    2,
+                    &[0x1b, 0xe4, 0x91][..],
+                    &[0x80, 0x01, 0x5a][..],
+                    &[0x9b, 0xe5, 0x5a][..],
+                    8,
+                ),
+                (
+                    4,
+                    &[0x01, 0x23, 0x45, 0x92][..],
+                    &[0xa0, 0x00, 0x0b, 0x5a][..],
+                    &[0xa1, 0x23, 0x4b, 0x5a][..],
+                    6,
+                ),
+            ] {
+                let stride = source_row.len() as u32;
+                let mut memory = GuestAddressSpace::new();
+                let mut source = source_row.repeat(2);
+                *source.last_mut().unwrap() ^= 1;
+                let mut destination = destination_row.repeat(2);
+                *destination.last_mut().unwrap() ^= 1;
+                memory.add_region(SOURCE, source);
+                memory.add_region(DESTINATION, destination);
+                assert_eq!(
+                    run(
+                        &mut memory,
+                        classic,
+                        RowCopy {
+                            mode: 0,
+                            source: pixmap(SOURCE, stride, depth, [-2, 10, 0, 10 + width]),
+                            destination: pixmap(
+                                DESTINATION,
+                                stride,
+                                depth,
+                                [20, 30, 22, 30 + width],
+                            ),
+                            source_rect: [-2, 11, 0, 10 + width - 1],
+                            destination_rect: [20, 31, 22, 30 + width - 1],
+                            clip: [20, 31, 22, 30 + width - 1],
+                            palette: None,
+                        },
+                    ),
+                    RowCopyOutcome::Completed
+                );
+                let mut actual = vec![0; destination_row.len() * 2];
+                memory.read_bytes_into(DESTINATION, &mut actual).unwrap();
+                let mut expected = expected_row.repeat(2);
+                *expected.last_mut().unwrap() ^= 1;
+                assert_eq!(actual, expected, "classic={classic}, depth={depth}");
+            }
+        }
+    }
+
+    #[test]
+    fn packed_rows_translate_unequal_source_and_destination_field_offsets() {
+        for classic in [false, true] {
+            for (depth, source, destination, expected, source_rect, destination_rect) in [
+                (
+                    2,
+                    &[0x1b, 0xe4][..],
+                    &[0x80, 0x01][..],
+                    &[0x6f, 0x91][..],
+                    [0, 1, 1, 7],
+                    [0, 0, 1, 6],
+                ),
+                (
+                    4,
+                    &[0x01, 0x23, 0x45][..],
+                    &[0xa0, 0x00, 0x0b][..],
+                    &[0x12, 0x34, 0x0b][..],
+                    [0, 1, 1, 5],
+                    [0, 0, 1, 4],
+                ),
+            ] {
+                let mut memory = GuestAddressSpace::new();
+                memory.add_region(SOURCE, source.to_vec());
+                memory.add_region(DESTINATION, destination.to_vec());
+                assert_eq!(
+                    run(
+                        &mut memory,
+                        classic,
+                        RowCopy {
+                            mode: 0,
+                            source: pixmap(SOURCE, source.len() as u32, depth, [0, 0, 1, 8]),
+                            destination: pixmap(
+                                DESTINATION,
+                                destination.len() as u32,
+                                depth,
+                                [0, 0, 1, 8],
+                            ),
+                            source_rect,
+                            destination_rect,
+                            clip: destination_rect,
+                            palette: None,
+                        },
+                    ),
+                    RowCopyOutcome::Completed
+                );
+                let mut actual = vec![0; destination.len()];
+                memory.read_bytes_into(DESTINATION, &mut actual).unwrap();
+                assert_eq!(actual, expected, "classic={classic}, depth={depth}");
+            }
+        }
+    }
+
+    #[test]
+    fn packed_distinct_aliases_snapshot_later_source_rows() {
+        for classic in [false, true] {
+            let mut memory = GuestAddressSpace::new();
+            let backing = crate::memory::bus::SharedRamRegion::from_owned_bytes(vec![
+                0x1b, 0xe4, 0xaa, 0xe4, 0x1b, 0xbb, 0, 0, 0xcc,
+            ]);
+            // SAFETY: both aliases are accessed serially through one copy.
+            unsafe {
+                memory.add_shared_region(SOURCE, backing.clone());
+                memory.add_shared_region(DESTINATION, backing);
+            }
+            assert_eq!(
+                run(
+                    &mut memory,
+                    classic,
+                    RowCopy {
+                        mode: 0,
+                        source: pixmap(SOURCE, 3, 2, [0, 0, 2, 8]),
+                        destination: pixmap(DESTINATION + 3, 3, 2, [0, 0, 2, 8]),
+                        source_rect: [0, 0, 2, 8],
+                        destination_rect: [0, 0, 2, 8],
+                        clip: [0, 0, 2, 8],
+                        palette: None,
+                    },
+                ),
+                RowCopyOutcome::Completed
+            );
+            let mut actual = [0; 9];
+            memory.read_bytes_into(SOURCE, &mut actual).unwrap();
+            assert_eq!(
+                actual,
+                [0x1b, 0xe4, 0xaa, 0x1b, 0xe4, 0xbb, 0xe4, 0x1b, 0xcc]
+            );
+        }
+    }
+
+    #[test]
+    fn packed_source_failure_is_prewrite_and_later_refusal_is_row_atomic() {
+        for classic in [false, true] {
+            let request = || RowCopy {
+                mode: 0,
+                source: pixmap(SOURCE, 3, 2, [0, 0, 2, 8]),
+                destination: pixmap(DESTINATION, 3, 2, [0, 0, 2, 8]),
+                source_rect: [0, 1, 2, 7],
+                destination_rect: [0, 1, 2, 7],
+                clip: [0, 1, 2, 7],
+                palette: None,
+            };
+
+            let mut missing_source = GuestAddressSpace::new();
+            missing_source.add_region(SOURCE, vec![0x1b, 0xe4, 0xaa]);
+            missing_source.add_region(DESTINATION, vec![0x80, 0x01, 0x5a, 0x81, 0x02, 0x5b]);
+            assert_eq!(
+                run(&mut missing_source, classic, request()),
+                RowCopyOutcome::ReadOrGeometryFailure
+            );
+            let mut unchanged = [0; 6];
+            missing_source
+                .read_bytes_into(DESTINATION, &mut unchanged)
+                .unwrap();
+            assert_eq!(unchanged, [0x80, 0x01, 0x5a, 0x81, 0x02, 0x5b]);
+
+            let mut protected_destination = GuestAddressSpace::new();
+            protected_destination.add_region(SOURCE, vec![0x1b, 0xe4, 0xaa, 0xe4, 0x1b, 0xbb]);
+            protected_destination.add_region(DESTINATION, vec![0x80, 0x01, 0x5a, 0x81, 0x02, 0x5b]);
+            protected_destination.add_readonly_region(DESTINATION + 3, vec![0x81, 0x02]);
+            assert_eq!(
+                run(&mut protected_destination, classic, request()),
+                RowCopyOutcome::WriteFailure { rows_written: 1 }
+            );
+            let mut actual = [0; 6];
+            protected_destination
+                .read_bytes_into(DESTINATION, &mut actual)
+                .unwrap();
+            assert_eq!(actual, [0x9b, 0xe5, 0x5a, 0x81, 0x02, 0x5b]);
+        }
+    }
+
+    #[test]
+    fn packed_destination_read_failure_precedes_all_publication() {
+        for classic in [false, true] {
+            let mut memory = GuestAddressSpace::new();
+            memory.add_region(SOURCE, vec![0x1b, 0xe4, 0xaa, 0xe4, 0x1b, 0xbb]);
+            memory.add_region(DESTINATION, vec![0x80, 0x01, 0x5a]);
+            assert_eq!(
+                run(
+                    &mut memory,
+                    classic,
+                    RowCopy {
+                        mode: 0,
+                        source: pixmap(SOURCE, 3, 2, [0, 0, 2, 8]),
+                        destination: pixmap(DESTINATION, 3, 2, [0, 0, 2, 8]),
+                        source_rect: [0, 1, 2, 7],
+                        destination_rect: [0, 1, 2, 7],
+                        clip: [0, 1, 2, 7],
+                        palette: None,
+                    },
+                ),
+                RowCopyOutcome::ReadOrGeometryFailure
+            );
+            let mut actual = [0; 3];
+            memory.read_bytes_into(DESTINATION, &mut actual).unwrap();
+            assert_eq!(actual, [0x80, 0x01, 0x5a]);
+        }
+    }
+
+    #[test]
+    fn packed_stride_and_address_overflow_fail_before_memory_access() {
+        struct NoAccess;
+        impl CopyBitsMemory for NoAccess {
+            fn read_copy_row(&mut self, _: u32, _: &mut [u8]) -> Option<()> {
+                panic!("invalid packed geometry reached memory");
+            }
+            fn write_copy_row(&mut self, _: u32, _: &[u8]) -> Option<()> {
+                panic!("invalid packed geometry reached memory");
+            }
+        }
+        for source in [
+            pixmap(SOURCE, 2, 4, [0, 0, 1, 6]),
+            pixmap(u32::MAX, 3, 2, [0, 0, 1, 8]),
+        ] {
+            assert_eq!(
+                RowCopy {
+                    mode: 0,
+                    source,
+                    destination: pixmap(DESTINATION, 3, source.depth, source.bounds),
+                    source_rect: source.bounds,
+                    destination_rect: source.bounds,
+                    clip: source.bounds,
+                    palette: None,
+                }
+                .execute(&mut NoAccess),
+                RowCopyOutcome::ReadOrGeometryFailure
+            );
+        }
+    }
+
+    #[test]
+    fn packed_unmigrated_families_decline_before_memory_access() {
+        struct NoAccess;
+        impl CopyBitsMemory for NoAccess {
+            fn read_copy_row(&mut self, _: u32, _: &mut [u8]) -> Option<()> {
+                panic!("declined request reached memory");
+            }
+            fn write_copy_row(&mut self, _: u32, _: &[u8]) -> Option<()> {
+                panic!("declined request reached memory");
+            }
+        }
+        let palette = [0; 256];
+        for (depth, destination_rect, palette) in [
+            (1, [0, 0, 1, 8], None),
+            (2, [0, 0, 1, 8], Some(&palette)),
+            (4, [0, 0, 1, 4], None),
+        ] {
+            assert_eq!(
+                RowCopy {
+                    mode: 0,
+                    source: pixmap(SOURCE, 2, depth, [0, 0, 1, 8]),
+                    destination: pixmap(DESTINATION, 2, depth, [0, 0, 1, 8]),
+                    source_rect: [0, 0, 1, 8],
+                    destination_rect,
+                    clip: [0, 0, 1, 8],
+                    palette,
+                }
+                .execute(&mut NoAccess),
+                RowCopyOutcome::Declined
+            );
         }
     }
 

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -58045,7 +58045,7 @@ fn ppc_copy_bits(
         // and 4-27: CopyBits copies bitmap or PixMap pixels between graphics
         // ports and GWorlds, including indexed-color PixMaps. The import
         // resolves records and masks; the shared operation owns pure
-        // byte-aligned srcCopy format, mode, and geometry eligibility.
+        // byte-aligned or packed srcCopy format, mode, and geometry eligibility.
         if mask_storage.is_none() {
             use crate::copy_bits::{BytePixmap, RowCopy, RowCopyOutcome};
 
@@ -151857,6 +151857,273 @@ pub(crate) mod tests {
                 .read_bytes_into(dst_pixels, &mut copied)
                 .unwrap();
             assert_eq!(copied, [packed[0], packed[1], 0x77]);
+        }
+    }
+
+    #[test]
+    fn hle_import_runner_copybits_packed_identity_preserves_edges_and_padding() {
+        let pef = synthetic_pef_with_import(b"CopyBits");
+        for (depth, width, copy_right, source_row, destination_row, expected_row) in [
+            (
+                2,
+                8,
+                17,
+                &[0x1b, 0xe4, 0x91][..],
+                &[0x80, 0x01, 0x5a][..],
+                &[0x9b, 0xe5, 0x5a][..],
+            ),
+            (
+                4,
+                6,
+                15,
+                &[0x01, 0x23, 0x45, 0x92][..],
+                &[0xa0, 0x00, 0x0b, 0x5a][..],
+                &[0xa1, 0x23, 0x4b, 0x5a][..],
+            ),
+        ] {
+            let mut loaded = load_pef_application(&pef).unwrap();
+            let scratch = PPC_HEAP_BASE + 0x127c0;
+            let source_pixels = scratch;
+            let destination_pixels = scratch + 0x10;
+            let source_pixmap = scratch + 0x20;
+            let destination_pixmap = scratch + 0x60;
+            let rects = scratch + 0xa0;
+            loaded.memory.add_region(scratch, vec![0; 0xc0]);
+            ppc_write_pixmap(
+                &mut loaded.memory,
+                source_pixmap,
+                source_pixels,
+                source_row.len() as u32,
+                -2,
+                10,
+                0,
+                10 + width,
+                depth,
+            )
+            .unwrap();
+            ppc_write_pixmap(
+                &mut loaded.memory,
+                destination_pixmap,
+                destination_pixels,
+                destination_row.len() as u32,
+                20,
+                30,
+                22,
+                30 + width,
+                depth,
+            )
+            .unwrap();
+            for pixmap in [source_pixmap, destination_pixmap] {
+                loaded
+                    .memory
+                    .write_u32_be(pixmap + 42, PPC_MAIN_CTABLE_HANDLE)
+                    .unwrap();
+            }
+            let mut source = source_row.repeat(2);
+            *source.last_mut().unwrap() ^= 1;
+            let mut destination = destination_row.repeat(2);
+            *destination.last_mut().unwrap() ^= 1;
+            loaded.memory.write_bytes(source_pixels, &source).unwrap();
+            loaded
+                .memory
+                .write_bytes(destination_pixels, &destination)
+                .unwrap();
+            ppc_write_rect(&mut loaded.memory, rects, -2, 11, 0, copy_right).unwrap();
+            ppc_write_rect(
+                &mut loaded.memory,
+                rects + 8,
+                20,
+                31,
+                22,
+                31 + (copy_right - 11),
+            )
+            .unwrap();
+            loaded.cpu.gpr[3] = source_pixmap;
+            loaded.cpu.gpr[4] = destination_pixmap;
+            loaded.cpu.gpr[5] = rects;
+            loaded.cpu.gpr[6] = rects + 8;
+            loaded.cpu.gpr[7] = 0;
+            loaded.cpu.gpr[8] = 0;
+
+            let probe = loaded.run_with_hle_imports(64);
+
+            assert_eq!(probe.handled_import_count, 1);
+            assert_eq!(probe.unsupported_import_index, None);
+            let mut actual = vec![0; destination.len()];
+            loaded
+                .memory
+                .read_bytes_into(destination_pixels, &mut actual)
+                .unwrap();
+            let mut expected = expected_row.repeat(2);
+            *expected.last_mut().unwrap() ^= 1;
+            assert_eq!(actual, expected, "depth={depth}");
+
+            loaded.cpu.pc = loaded.entry_pc;
+            loaded.cpu.lr = PPC_HALT_PC;
+            loaded
+                .memory
+                .write_bytes(destination_pixels, &destination)
+                .unwrap();
+            let (unequal_source_right, unequal_destination_right, unequal_expected) = if depth == 2
+            {
+                (17, 36, &[0x6f, 0x91, 0x5a][..])
+            } else {
+                (15, 34, &[0x12, 0x34, 0x0b, 0x5a][..])
+            };
+            ppc_write_rect(&mut loaded.memory, rects, -2, 11, -1, unequal_source_right).unwrap();
+            ppc_write_rect(
+                &mut loaded.memory,
+                rects + 8,
+                20,
+                30,
+                21,
+                unequal_destination_right,
+            )
+            .unwrap();
+
+            let probe = loaded.run_with_hle_imports(64);
+
+            assert_eq!(probe.handled_import_count, 1);
+            assert_eq!(probe.unsupported_import_index, None);
+            let mut actual = vec![0; destination_row.len()];
+            loaded
+                .memory
+                .read_bytes_into(destination_pixels, &mut actual)
+                .unwrap();
+            assert_eq!(
+                actual, unequal_expected,
+                "unequal field offsets: depth={depth}"
+            );
+        }
+    }
+
+    #[test]
+    fn hle_import_runner_copybits_packed_distinct_aliases_snapshot_source() {
+        const SOURCE: u32 = 0x0900_0000;
+        const DESTINATION: u32 = 0x0A00_0000;
+        let mut loaded = load_pef_application(&synthetic_pef_with_import(b"CopyBits")).unwrap();
+        let backing = crate::memory::bus::SharedRamRegion::from_owned_bytes(vec![
+            0x1b, 0xe4, 0xaa, 0xe4, 0x1b, 0xbb, 0, 0, 0xcc,
+        ]);
+        // SAFETY: the import accesses both aliases serially through one
+        // operation, and no byte slice survives a memory call.
+        unsafe {
+            loaded.memory.add_shared_region(SOURCE, backing.clone());
+            loaded.memory.add_shared_region(DESTINATION, backing);
+        }
+        let records = PPC_HEAP_BASE + 0x16090;
+        let source_pixmap = records;
+        let destination_pixmap = records + 0x40;
+        let rect = records + 0x80;
+        loaded.memory.add_region(records, vec![0; 0x90]);
+        ppc_write_pixmap(&mut loaded.memory, source_pixmap, SOURCE, 3, 0, 0, 2, 8, 2).unwrap();
+        ppc_write_pixmap(
+            &mut loaded.memory,
+            destination_pixmap,
+            DESTINATION + 3,
+            3,
+            0,
+            0,
+            2,
+            8,
+            2,
+        )
+        .unwrap();
+        for pixmap in [source_pixmap, destination_pixmap] {
+            loaded
+                .memory
+                .write_u32_be(pixmap + 42, PPC_MAIN_CTABLE_HANDLE)
+                .unwrap();
+        }
+        ppc_write_rect(&mut loaded.memory, rect, 0, 0, 2, 8).unwrap();
+        loaded.cpu.gpr[3] = source_pixmap;
+        loaded.cpu.gpr[4] = destination_pixmap;
+        loaded.cpu.gpr[5] = rect;
+        loaded.cpu.gpr[6] = rect;
+        loaded.cpu.gpr[7] = 0;
+        loaded.cpu.gpr[8] = 0;
+
+        let probe = loaded.run_with_hle_imports(64);
+
+        assert_eq!(probe.handled_import_count, 1);
+        assert_eq!(probe.unsupported_import_index, None);
+        let mut actual = [0; 9];
+        loaded.memory.read_bytes_into(SOURCE, &mut actual).unwrap();
+        assert_eq!(
+            actual,
+            [0x1b, 0xe4, 0xaa, 0x1b, 0xe4, 0xbb, 0xe4, 0x1b, 0xcc]
+        );
+    }
+
+    #[test]
+    fn hle_import_runner_copybits_packed_failures_do_not_fallback() {
+        const SOURCE: u32 = 0x0900_0000;
+        const DESTINATION: u32 = 0x0A00_0000;
+        for source_failure in [true, false] {
+            let mut loaded = load_pef_application(&synthetic_pef_with_import(b"CopyBits")).unwrap();
+            loaded.memory.add_region(
+                SOURCE,
+                if source_failure {
+                    vec![0x1b, 0xe4, 0xaa]
+                } else {
+                    vec![0x1b, 0xe4, 0xaa, 0xe4, 0x1b, 0xbb]
+                },
+            );
+            loaded
+                .memory
+                .add_region(DESTINATION, vec![0x80, 0x01, 0x5a, 0x81, 0x02, 0x5b]);
+            if !source_failure {
+                loaded
+                    .memory
+                    .add_readonly_region(DESTINATION + 3, vec![0x81, 0x02]);
+            }
+            let records = PPC_HEAP_BASE + 0x16090;
+            let source_pixmap = records;
+            let destination_pixmap = records + 0x40;
+            let rect = records + 0x80;
+            loaded.memory.add_region(records, vec![0; 0x90]);
+            ppc_write_pixmap(&mut loaded.memory, source_pixmap, SOURCE, 3, 0, 0, 2, 8, 2).unwrap();
+            ppc_write_pixmap(
+                &mut loaded.memory,
+                destination_pixmap,
+                DESTINATION,
+                3,
+                0,
+                0,
+                2,
+                8,
+                2,
+            )
+            .unwrap();
+            for pixmap in [source_pixmap, destination_pixmap] {
+                loaded
+                    .memory
+                    .write_u32_be(pixmap + 42, PPC_MAIN_CTABLE_HANDLE)
+                    .unwrap();
+            }
+            ppc_write_rect(&mut loaded.memory, rect, 0, 1, 2, 7).unwrap();
+            loaded.cpu.gpr[3] = source_pixmap;
+            loaded.cpu.gpr[4] = destination_pixmap;
+            loaded.cpu.gpr[5] = rect;
+            loaded.cpu.gpr[6] = rect;
+            loaded.cpu.gpr[7] = 0;
+            loaded.cpu.gpr[8] = 0;
+
+            let probe = loaded.run_with_hle_imports(64);
+
+            assert_eq!(probe.handled_import_count, 1);
+            assert_eq!(probe.unsupported_import_index, None);
+            let mut actual = [0; 6];
+            loaded
+                .memory
+                .read_bytes_into(DESTINATION, &mut actual)
+                .unwrap();
+            let expected = if source_failure {
+                [0x80, 0x01, 0x5a, 0x81, 0x02, 0x5b]
+            } else {
+                [0x9b, 0xe5, 0x5a, 0x81, 0x02, 0x5b]
+            };
+            assert_eq!(actual, expected, "source_failure={source_failure}");
         }
     }
 

--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -3644,7 +3644,7 @@ impl super::TrapDispatcher {
                 // Port/region resolution, diagnostics, and picture/screen
                 // effects remain at this edge. The shared operation decides
                 // whether the resolved format, mode, and geometry belong to
-                // its rectangular byte-aligned srcCopy family.
+                // its rectangular byte-aligned or packed srcCopy family.
                 let row_copy_edge_eligible = !Self::region_is_complex(bus, vis_rgn_handle)
                     && !Self::region_is_complex(bus, clip_rgn_handle)
                     && !Self::region_is_complex(bus, mask_rgn)
@@ -35225,6 +35225,153 @@ mod tests {
 
     // ==================== CopyBits ====================
 
+    fn run_packed_identity_route(depth: u16, std_bits: bool) {
+        let (mut d, mut cpu, mut bus) = setup_with_port();
+        let source_pixmap = bus.alloc(50);
+        let destination_pixmap = bus.alloc(50);
+        let destination_handle = bus.alloc(4);
+        let source_base = bus.alloc(8);
+        let destination_base = bus.alloc(8);
+        let source_rect = bus.alloc(8);
+        let destination_rect = bus.alloc(8);
+        let (width, source_row, destination_row, expected_row) = match depth {
+            2 => (
+                8,
+                [0x1b, 0xe4, 0x91, 0],
+                [0x80, 0x01, 0x5a, 0],
+                [0x9b, 0xe5, 0x5a, 0],
+            ),
+            4 => (
+                6,
+                [0x01, 0x23, 0x45, 0x92],
+                [0xa0, 0x00, 0x0b, 0x5a],
+                [0xa1, 0x23, 0x4b, 0x5a],
+            ),
+            _ => unreachable!(),
+        };
+        let row_bytes = if depth == 2 { 3 } else { 4 };
+        write_pixmap_indexed(
+            &mut bus,
+            source_pixmap,
+            source_base,
+            row_bytes,
+            width,
+            2,
+            depth,
+            0,
+        );
+        write_pixmap_indexed(
+            &mut bus,
+            destination_pixmap,
+            destination_base,
+            row_bytes,
+            width,
+            2,
+            depth,
+            0,
+        );
+        for (pixmap, bounds) in [
+            (source_pixmap, [-2, 10, 0, 10 + width as i16]),
+            (destination_pixmap, [20, 30, 22, 30 + width as i16]),
+        ] {
+            for (offset, value) in [6, 8, 10, 12].into_iter().zip(bounds) {
+                bus.write_word(pixmap + offset, value as u16);
+            }
+        }
+        let mut source = source_row[..row_bytes as usize].repeat(2);
+        *source.last_mut().unwrap() ^= 1;
+        let mut destination = destination_row[..row_bytes as usize].repeat(2);
+        *destination.last_mut().unwrap() ^= 1;
+        bus.write_bytes(source_base, &source);
+        bus.write_bytes(destination_base, &destination);
+        let copy_right = if depth == 2 { 17 } else { 15 };
+        write_rect(&mut bus, source_rect, -2, 11, 0, copy_right);
+        write_rect(
+            &mut bus,
+            destination_rect,
+            20,
+            31,
+            22,
+            31 + (copy_right - 11),
+        );
+
+        bus.write_long(TEST_SP, 0);
+        bus.write_word(TEST_SP + 4, 0);
+        bus.write_long(TEST_SP + 6, destination_rect);
+        bus.write_long(TEST_SP + 10, source_rect);
+        if std_bits {
+            const PORT: u32 = 0x181000;
+            bus.write_long(destination_handle, destination_pixmap);
+            bus.write_long(PORT + 2, destination_handle);
+            bus.write_word(PORT + 6, 0xc000);
+            *d.current_port = PORT;
+            bus.write_long(TEST_SP + 14, source_pixmap);
+            assert!(d
+                .dispatch_quickdraw(true, 0x0eb, &mut cpu, &mut bus)
+                .unwrap()
+                .is_ok());
+        } else {
+            bus.write_long(TEST_SP + 14, destination_pixmap);
+            bus.write_long(TEST_SP + 18, source_pixmap);
+            assert!(d
+                .dispatch_quickdraw(true, 0x0ec, &mut cpu, &mut bus)
+                .unwrap()
+                .is_ok());
+        }
+        let mut expected = expected_row[..row_bytes as usize].repeat(2);
+        *expected.last_mut().unwrap() ^= 1;
+        assert_eq!(
+            bus.read_bytes(destination_base, row_bytes as usize * 2),
+            expected,
+            "depth={depth}, std_bits={std_bits}"
+        );
+
+        cpu.write_reg(Register::A7, TEST_SP);
+        bus.write_bytes(destination_base, &destination);
+        let (unequal_source_right, unequal_destination_right, unequal_expected) = if depth == 2 {
+            (17, 36, &[0x6f, 0x91, 0x5a][..])
+        } else {
+            (15, 34, &[0x12, 0x34, 0x0b, 0x5a][..])
+        };
+        write_rect(&mut bus, source_rect, -2, 11, -1, unequal_source_right);
+        write_rect(
+            &mut bus,
+            destination_rect,
+            20,
+            30,
+            21,
+            unequal_destination_right,
+        );
+        assert!(d
+            .dispatch_quickdraw(
+                true,
+                if std_bits { 0x0eb } else { 0x0ec },
+                &mut cpu,
+                &mut bus,
+            )
+            .unwrap()
+            .is_ok());
+        assert_eq!(
+            bus.read_bytes(destination_base, row_bytes as usize),
+            unequal_expected,
+            "unequal field offsets: depth={depth}, std_bits={std_bits}"
+        );
+    }
+
+    #[test]
+    fn copy_bits_packed_identity_preserves_edges_and_padding() {
+        for depth in [2, 4] {
+            run_packed_identity_route(depth, false);
+        }
+    }
+
+    #[test]
+    fn std_bits_packed_identity_preserves_edges_and_padding() {
+        for depth in [2, 4] {
+            run_packed_identity_route(depth, true);
+        }
+    }
+
     #[test]
     fn test_copy_bits() {
         let (mut d, mut cpu, mut bus) = setup_with_port();
@@ -36045,6 +36192,143 @@ mod tests {
                 [0, 1, 2, 3, 0, 1, 2, 7, 4, 5, 6, 11, 8, 9, 10, 15],
                 "trap=${trap:03X}"
             );
+        }
+    }
+
+    #[test]
+    fn copybits_and_stdbits_snapshot_packed_distinct_guest_aliases() {
+        const SOURCE: u32 = 0x00D0_0000;
+        const DESTINATION: u32 = 0x00E0_0000;
+        for trap in [0x0EC, 0x0EB] {
+            let (mut d, mut cpu, mut bus) = setup_with_port();
+            let mut memory = GuestAddressSpace::new();
+            let backing = SharedRamRegion::from_owned_bytes(vec![
+                0x1b, 0xe4, 0xaa, 0xe4, 0x1b, 0xbb, 0, 0, 0xcc,
+            ]);
+            // SAFETY: the trap accesses both aliases serially through one
+            // attached bus, and no byte slice survives a memory call.
+            unsafe {
+                memory.add_shared_region(SOURCE, backing.clone());
+                memory.add_shared_region(DESTINATION, backing);
+            }
+            bus.attach_guest_address_space(memory.shared_view());
+
+            let port = 0x181000;
+            let source_pixmap = bus.alloc(50);
+            let destination_pixmap = bus.alloc(50);
+            let destination_handle = bus.alloc(4);
+            let rect = bus.alloc(8);
+            write_pixmap_indexed(&mut bus, source_pixmap, SOURCE, 3, 8, 2, 2, 0);
+            write_pixmap_indexed(&mut bus, destination_pixmap, DESTINATION + 3, 3, 8, 2, 2, 0);
+            bus.write_long(destination_handle, destination_pixmap);
+            bus.write_long(port + 2, destination_handle);
+            bus.write_word(port + 6, 0xC000);
+            bus.write_long(port + 24, 0);
+            bus.write_long(port + 28, 0);
+            *d.current_port = port;
+            write_rect(&mut bus, rect, 0, 0, 2, 8);
+
+            cpu.write_reg(Register::A7, TEST_SP);
+            bus.write_long(TEST_SP, 0);
+            bus.write_word(TEST_SP + 4, 0);
+            bus.write_long(TEST_SP + 6, rect);
+            bus.write_long(TEST_SP + 10, rect);
+            bus.write_long(
+                TEST_SP + 14,
+                if trap == 0x0EC {
+                    destination_pixmap
+                } else {
+                    source_pixmap
+                },
+            );
+            if trap == 0x0EC {
+                bus.write_long(TEST_SP + 18, source_pixmap);
+            }
+            assert!(d
+                .dispatch_quickdraw(true, trap, &mut cpu, &mut bus)
+                .unwrap()
+                .is_ok());
+
+            let mut actual = [0; 9];
+            memory.read_bytes_into(SOURCE, &mut actual).unwrap();
+            assert_eq!(
+                actual,
+                [0x1b, 0xe4, 0xaa, 0x1b, 0xe4, 0xbb, 0xe4, 0x1b, 0xcc],
+                "trap=${trap:03X}"
+            );
+        }
+    }
+
+    #[test]
+    fn copybits_and_stdbits_packed_failures_do_not_fallback() {
+        const SOURCE: u32 = 0x00D0_0000;
+        const DESTINATION: u32 = 0x00E0_0000;
+        for trap in [0x0EC, 0x0EB] {
+            for source_failure in [true, false] {
+                let (mut d, mut cpu, mut bus) = setup_with_port();
+                let mut memory = GuestAddressSpace::new();
+                memory.add_region(
+                    SOURCE,
+                    if source_failure {
+                        vec![0x1b, 0xe4, 0xaa]
+                    } else {
+                        vec![0x1b, 0xe4, 0xaa, 0xe4, 0x1b, 0xbb]
+                    },
+                );
+                memory.add_region(DESTINATION, vec![0x80, 0x01, 0x5a, 0x81, 0x02, 0x5b]);
+                if !source_failure {
+                    memory.add_readonly_region(DESTINATION + 3, vec![0x81, 0x02]);
+                }
+                bus.attach_guest_address_space(memory.shared_view());
+
+                let port = 0x181000;
+                let source_pixmap = bus.alloc(50);
+                let destination_pixmap = bus.alloc(50);
+                let destination_handle = bus.alloc(4);
+                let rect = bus.alloc(8);
+                write_pixmap_indexed(&mut bus, source_pixmap, SOURCE, 3, 8, 2, 2, 0);
+                write_pixmap_indexed(&mut bus, destination_pixmap, DESTINATION, 3, 8, 2, 2, 0);
+                bus.write_long(destination_handle, destination_pixmap);
+                bus.write_long(port + 2, destination_handle);
+                bus.write_word(port + 6, 0xC000);
+                bus.write_long(port + 24, 0);
+                bus.write_long(port + 28, 0);
+                *d.current_port = port;
+                write_rect(&mut bus, rect, 0, 1, 2, 7);
+
+                cpu.write_reg(Register::A7, TEST_SP);
+                bus.write_long(TEST_SP, 0);
+                bus.write_word(TEST_SP + 4, 0);
+                bus.write_long(TEST_SP + 6, rect);
+                bus.write_long(TEST_SP + 10, rect);
+                bus.write_long(
+                    TEST_SP + 14,
+                    if trap == 0x0EC {
+                        destination_pixmap
+                    } else {
+                        source_pixmap
+                    },
+                );
+                if trap == 0x0EC {
+                    bus.write_long(TEST_SP + 18, source_pixmap);
+                }
+                assert!(d
+                    .dispatch_quickdraw(true, trap, &mut cpu, &mut bus)
+                    .unwrap()
+                    .is_ok());
+
+                let mut actual = [0; 6];
+                memory.read_bytes_into(DESTINATION, &mut actual).unwrap();
+                let expected = if source_failure {
+                    [0x80, 0x01, 0x5a, 0x81, 0x02, 0x5b]
+                } else {
+                    [0x9b, 0xe5, 0x5a, 0x81, 0x02, 0x5b]
+                };
+                assert_eq!(
+                    actual, expected,
+                    "trap=${trap:03X}, source_failure={source_failure}"
+                );
+            }
         }
     }
 


### PR DESCRIPTION
Route equal-depth, unscaled 2-bit and 4-bit identity `srcCopy` through the shared row transfer used by classic CopyBits, StdBits, and native CopyBits. The operation now validates packed spans, snapshots source pixels across distinct guest aliases, preserves edge fields and padding, and publishes one affected destination span per row.

Geometry and source/destination read failures occur before publication. A later write refusal leaves that row unchanged and preserves earlier committed rows; only an explicit decline permits the legacy path. Existing generic pixel loops remain for palette translation, 1-bit coloration, scaling, cross-depth transfers, complex regions, other modes, and diagnostic routes. This change does not complete those migrations.

Independent byte expectations cover both packed depths and all three entry paths, including unequal source/destination bit offsets. Tests also cover aliased source rows, read failure, later-row write refusal without fallback, destination preread failure, invalid rowBytes, and address overflow. The unequal-offset tests exposed a bit-offset binding error during review, which was fixed before the final test runs.

Validation: full default-feature library suite passed 5,173 tests; independent combined headless validation passed 5,165 (three ignored in each). Focused tests, the no-default production check, source guardrails, and all 54 guardrail fixtures passed. Changed hunks were format-checked without unrelated formatting churn. Local strict clippy was blocked by the existing unrelated `needless_arbitrary_self_type` warning in `src/loader/cfrg.rs`; required public CI remains the merge gate.

Closes #1548. Contributes to #1363.
