### PR TITLE
refactor: separate host execution budgets from guest capabilities

### DIFF
--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -51,7 +51,9 @@ use crate::guest_procedure::{
     ROUTINE_FLAG_PROC_DESCRIPTOR_RELATIVE as PPC_ROUTINE_FLAG_PROC_DESCRIPTOR_RELATIVE,
     ROUTINE_RECORD_SELECTOR_OFFSET as PPC_ROUTINE_RECORD_SELECTOR_OFFSET,
 };
-use crate::machine_profile::REFERENCE_MACHINE_PROFILE;
+use crate::machine_profile::{
+    REFERENCE_MACHINE_PROFILE, REFERENCE_POWERPC_EXECUTION_CAPABILITIES,
+};
 use crate::managers::resource::{
     serialize_resource_fork_with_attrs, ResourceFork, ResourceForkEntry,
 };
@@ -445,8 +447,6 @@ const PPC_GUEST_SND_CHANNEL_SIZE: u32 = 1088;
 const PPC_SQUARE_WAVE_SYNTH_ID: i16 = 1;
 const PPC_WAVE_TABLE_SYNTH_ID: i16 = 3;
 const PPC_SAMPLED_SYNTH_ID: i16 = 5;
-const PPC_GESTALT_CPU_604: u32 = 0x0104;
-const PPC_GESTALT_PROCESSOR_POWERPC: u32 = 2;
 const PPC_QUICKTIME_VERSION: u32 = 0x0300_0000;
 const PPC_QD3D_VERSION: u32 = 0x0150_8000;
 const PPC_MAIN_GDEVICE_RECORD: u32 = 0x02f0_0200;
@@ -50598,8 +50598,14 @@ fn ppc_gestalt_response(selector: u32) -> Option<(u32, i16)> {
         b"ostt" => Some((crate::trap::dispatch::OS_TRAP_TABLE_BASE, PPC_NO_ERR)),
         b"tbtt" => Some((crate::trap::dispatch::TOOLBOX_TRAP_TABLE_BASE, PPC_NO_ERR)),
         b"evnt" => Some((0x0001, PPC_NO_ERR)),
-        b"cput" => Some((PPC_GESTALT_CPU_604, PPC_NO_ERR)),
-        b"proc" => Some((PPC_GESTALT_PROCESSOR_POWERPC, PPC_NO_ERR)),
+        b"cput" => Some((
+            REFERENCE_POWERPC_EXECUTION_CAPABILITIES.native_cpu_type,
+            PPC_NO_ERR,
+        )),
+        b"proc" => Some((
+            REFERENCE_POWERPC_EXECUTION_CAPABILITIES.processor_type,
+            PPC_NO_ERR,
+        )),
         b"mach" => Some((
             u32::from(REFERENCE_MACHINE_PROFILE.gestalt_machine_type),
             PPC_NO_ERR,
@@ -50610,8 +50616,14 @@ fn ppc_gestalt_response(selector: u32) -> Option<(u32, i16)> {
         b"qd  " => Some((0x0230, PPC_NO_ERR)),
         b"qdrw" => Some((0x000F, PPC_NO_ERR)),
         b"ram " => Some((REFERENCE_MACHINE_PROFILE.ram_size_bytes, PPC_NO_ERR)),
-        b"fpu " => Some((REFERENCE_MACHINE_PROFILE.gestalt_fpu_type, PPC_NO_ERR)),
-        b"mmu " => Some((REFERENCE_MACHINE_PROFILE.gestalt_mmu_type, PPC_NO_ERR)),
+        b"fpu " => Some((
+            REFERENCE_POWERPC_EXECUTION_CAPABILITIES.fpu_type,
+            PPC_NO_ERR,
+        )),
+        b"mmu " => Some((
+            REFERENCE_POWERPC_EXECUTION_CAPABILITIES.mmu_type,
+            PPC_NO_ERR,
+        )),
         b"snd " => Some((0x1CFB, PPC_NO_ERR)),
         b"tmgr" => Some((2, PPC_NO_ERR)),
         b"dplv" => Some((0x0002_0006, PPC_NO_ERR)),
@@ -113324,24 +113336,29 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn hle_import_runner_handles_gestalt_powerpc_cpu_type() {
+    fn hle_import_runner_handles_gestalt_powerpc_capabilities_and_rejects_sysa() {
         let pef = synthetic_pef_with_import(b"Gestalt");
         let mut loaded = load_pef_application(&pef).unwrap();
         let response_ptr = PPC_HEAP_BASE;
         loaded.memory.add_region(response_ptr, vec![0; 16]);
-        loaded.cpu.gpr[3] = u32::from_be_bytes(*b"cput");
-        loaded.cpu.gpr[4] = response_ptr;
 
-        let probe = loaded.run_with_hle_imports(64);
+        for (selector, expected_error, expected_response) in [
+            (*b"cput", PPC_NO_ERR, 0x0104),
+            (*b"proc", PPC_NO_ERR, 2),
+            (*b"fpu ", PPC_NO_ERR, 3),
+            (*b"mmu ", PPC_NO_ERR, 4),
+            (*b"sysa", PPC_GESTALT_UNDEF_SELECTOR_ERR, 0),
+        ] {
+            loaded.cpu.gpr[3] = u32::from_be_bytes(selector);
+            loaded.cpu.gpr[4] = response_ptr;
+            run_test_import(&mut loaded, PpcImportDispatcherTarget::Gestalt);
 
-        assert_eq!(probe.handled_import_count, 1);
-        assert_eq!(probe.unsupported_import_index, None);
-        assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_NO_ERR));
-        assert_eq!(
-            loaded.memory.read_u32_be(response_ptr),
-            Some(PPC_GESTALT_CPU_604)
-        );
-        assert_ne!(loaded.memory.read_u32_be(response_ptr), Some(0x0101));
+            assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(expected_error));
+            assert_eq!(
+                loaded.memory.read_u32_be(response_ptr),
+                Some(expected_response)
+            );
+        }
     }
 
     #[test]

--- a/src/machine_profile.rs
+++ b/src/machine_profile.rs
@@ -14,7 +14,7 @@ use m68k::CpuType;
 
 /// Bag of constants describing one canonical guest machine: Gestalt
 /// selector responses, screen geometry, RAM size, VBL rate, realtime
-/// CPU MHz target.
+/// guest-advertised CPU MHz.
 ///
 /// Field accessors are field-name-direct (`profile.screen_width`)
 /// since downstream callers compare specific values rather than
@@ -51,14 +51,71 @@ pub struct MachineProfile {
     pub screen_depth: u16,
     /// VBL interrupt rate in Hz. 60.15 matches Compact Mac timing.
     pub vbl_hz: f64,
-    /// Target instruction throughput for realtime frontends, in
-    /// MHz × 1,000,000 instructions/sec equivalent. Used by
-    /// `systemless`'s wall-clock pacing — non-realtime callers
-    /// (scripted harnesses, tests) ignore this.
+    /// Guest-visible effective CPU speed in MHz, returned by
+    /// `GetCPUSpeed`.
     pub realtime_cpu_mhz: f64,
 }
 
+/// Guest-visible processor capabilities for one execution architecture.
+///
+/// This is crate-private so the trap adapters can share one value record
+/// without expanding the public [`MachineProfile`] shape.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct GuestExecutionCapabilities {
+    /// `gestaltSysArchitecture` response, or `None` when the adapter does not
+    /// support that selector.
+    pub(crate) system_architecture: Option<u32>,
+    pub(crate) native_cpu_type: u32,
+    pub(crate) processor_type: u32,
+    pub(crate) fpu_type: u32,
+    pub(crate) mmu_type: u32,
+}
+
+/// Host-only execution rates. These values control work performed between
+/// guest ticks; they do not describe values returned through guest APIs.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct HostExecutionPolicy {
+    pub(crate) scripted_instructions_per_tick: u32,
+    pub(crate) realtime_m68k_cpu_mhz: f64,
+    pub(crate) realtime_powerpc_cpu_mhz: f64,
+}
+
+pub(crate) const DEFAULT_HOST_EXECUTION_POLICY: HostExecutionPolicy = HostExecutionPolicy {
+    scripted_instructions_per_tick: 12_000,
+    realtime_m68k_cpu_mhz: 25.0,
+    realtime_powerpc_cpu_mhz: 120.0,
+};
+
 impl MachineProfile {
+    /// 68K guest capabilities derived from this profile's existing fields.
+    pub(crate) const fn m68k_execution_capabilities(self) -> GuestExecutionCapabilities {
+        GuestExecutionCapabilities {
+            // Inside Macintosh: Operating System Utilities (1994), p. 1-24:
+            // gestalt68k = 1.
+            system_architecture: Some(1),
+            native_cpu_type: self.gestalt_native_cpu_type,
+            processor_type: self.gestalt_processor_type,
+            fpu_type: self.gestalt_fpu_type,
+            mmu_type: self.gestalt_mmu_type,
+        }
+    }
+
+    /// Native PowerPC capabilities, preserving the adapter's 604 identity.
+    /// FPU and MMU values intentionally retain the existing shared-profile
+    /// compatibility behavior; this does not claim a corrected native
+    /// hardware profile.
+    pub(crate) const fn powerpc_execution_capabilities(self) -> GuestExecutionCapabilities {
+        GuestExecutionCapabilities {
+            // The native adapter does not currently support the 'sysa'
+            // selector, so keep that absence explicit.
+            system_architecture: None,
+            native_cpu_type: 0x0104,
+            processor_type: 2,
+            fpu_type: self.gestalt_fpu_type,
+            mmu_type: self.gestalt_mmu_type,
+        }
+    }
+
     /// Concrete `m68k::CpuType` corresponding to this profile.
     /// Hardcoded to `M68040` for now — the only shipped profile is
     /// the Basilisk-II play machine, which is a Quadra 900 (68040).
@@ -117,6 +174,11 @@ pub const BASILISK_II_PLAY_PROFILE: MachineProfile = MachineProfile {
 
 pub const REFERENCE_MACHINE_PROFILE: MachineProfile = BASILISK_II_PLAY_PROFILE;
 
+pub(crate) const REFERENCE_M68K_EXECUTION_CAPABILITIES: GuestExecutionCapabilities =
+    REFERENCE_MACHINE_PROFILE.m68k_execution_capabilities();
+pub(crate) const REFERENCE_POWERPC_EXECUTION_CAPABILITIES: GuestExecutionCapabilities =
+    REFERENCE_MACHINE_PROFILE.powerpc_execution_capabilities();
+
 /// Returns the reference machine profile, optionally overridden by
 /// `SYSTEMLESS_SCREEN_WIDTH` and `SYSTEMLESS_SCREEN_HEIGHT` environment variables.
 pub fn reference_machine_profile() -> MachineProfile {
@@ -132,4 +194,73 @@ pub fn reference_machine_profile() -> MachineProfile {
         }
     }
     p
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn m68k_capabilities_derive_from_machine_profile_fields() {
+        let profile = MachineProfile {
+            gestalt_native_cpu_type: 0x11,
+            gestalt_processor_type: 0x22,
+            gestalt_fpu_type: 0x33,
+            gestalt_mmu_type: 0x44,
+            ..REFERENCE_MACHINE_PROFILE
+        };
+
+        assert_eq!(
+            profile.m68k_execution_capabilities(),
+            GuestExecutionCapabilities {
+                system_architecture: Some(1),
+                native_cpu_type: 0x11,
+                processor_type: 0x22,
+                fpu_type: 0x33,
+                mmu_type: 0x44,
+            }
+        );
+    }
+
+    #[test]
+    fn host_execution_policy_is_independent_of_guest_cpu_speed() {
+        let guest_profile = MachineProfile {
+            realtime_cpu_mhz: 1.0,
+            ..REFERENCE_MACHINE_PROFILE
+        };
+
+        assert_eq!(DEFAULT_HOST_EXECUTION_POLICY.realtime_m68k_cpu_mhz, 25.0);
+        assert_ne!(
+            DEFAULT_HOST_EXECUTION_POLICY.realtime_m68k_cpu_mhz,
+            guest_profile.realtime_cpu_mhz
+        );
+    }
+
+    #[test]
+    fn m68k_capability_record_preserves_shipped_values() {
+        assert_eq!(
+            REFERENCE_M68K_EXECUTION_CAPABILITIES,
+            GuestExecutionCapabilities {
+                system_architecture: Some(1),
+                native_cpu_type: 4,
+                processor_type: 5,
+                fpu_type: 3,
+                mmu_type: 4,
+            }
+        );
+    }
+
+    #[test]
+    fn powerpc_capability_record_preserves_shipped_values_and_unsupported_sysa() {
+        assert_eq!(
+            REFERENCE_POWERPC_EXECUTION_CAPABILITIES,
+            GuestExecutionCapabilities {
+                system_architecture: None,
+                native_cpu_type: 0x0104,
+                processor_type: 2,
+                fpu_type: 3,
+                mmu_type: 4,
+            }
+        );
+    }
 }

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -1494,16 +1494,17 @@ const DIALOG_FILTER_EVENT_OFFSET: u32 = 0x80;
 const DIALOG_FILTER_RESULT_OFFSET: u32 = 0x96;
 const DIALOG_CALLBACK_SCRATCH_SIZE: u32 = 0xC0;
 /// Compact Mac video hardware refreshes at approximately 60.15 Hz.
-pub const DEFAULT_VBL_HZ: f64 = 60.15;
+pub const DEFAULT_VBL_HZ: f64 = crate::machine_profile::REFERENCE_MACHINE_PROFILE.vbl_hz;
 
-/// Default emulated CPU speed from the canonical machine profile.
+/// Default host execution rate for 68K realtime frontends.
 pub const DEFAULT_REALTIME_CPU_MHZ: f64 =
-    crate::machine_profile::REFERENCE_MACHINE_PROFILE.realtime_cpu_mhz;
-/// PowerPC clock exposed by the native 604 machine profile. The Power
-/// Macintosh 9500/120 paired a 120 MHz clock with the same 604 processor
+    crate::machine_profile::DEFAULT_HOST_EXECUTION_POLICY.realtime_m68k_cpu_mhz;
+/// Default host execution rate for native PowerPC realtime frontends. The
+/// Power Macintosh 9500/120 paired a 120 MHz clock with the 604 processor
 /// reported by the PPC Gestalt implementation.
 /// <https://support.apple.com/en-hk/112050>
-pub const DEFAULT_REALTIME_PPC_CPU_MHZ: f64 = 120.0;
+pub const DEFAULT_REALTIME_PPC_CPU_MHZ: f64 =
+    crate::machine_profile::DEFAULT_HOST_EXECUTION_POLICY.realtime_powerpc_cpu_mhz;
 /// Default direct-color display depth for native PowerPC applications.
 /// Imaging With QuickDraw (1994), p. 6-16, defines 16 bits per pixel as a
 /// supported Color QuickDraw screen and offscreen graphics-world depth.
@@ -1521,11 +1522,6 @@ pub fn default_realtime_instructions_per_tick(powerpc: bool) -> u32 {
     };
     (mhz * 1_000_000.0 / DEFAULT_VBL_HZ).round() as u32
 }
-// Default instructions per VBL tick for non-realtime execution (scripted harnesses, tests).
-// Realtime frontends override this via set_instructions_per_tick() to match the
-// architecture-specific machine profile defined above.
-// This lower value lets scripted harnesses run quickly without being wall-clock-paced.
-const INSTRUCTIONS_PER_TICK: u32 = 12_000;
 const DEFAULT_LAUNCH_TICKS: u32 = 600;
 /// Default double-click interval: 20 VBL ticks, approximately one third of a
 /// second. This is the conventional classic Mac OS setting exposed through
@@ -2008,9 +2004,11 @@ impl FixtureRunner {
             halted_sp: None,
             halted_d0: None,
             total_instructions: 0,
-            instructions_per_tick: INSTRUCTIONS_PER_TICK,
+            instructions_per_tick: crate::machine_profile::DEFAULT_HOST_EXECUTION_POLICY
+                .scripted_instructions_per_tick,
             wait_sleep_cap_in_headless: None,
-            tick_budget: INSTRUCTIONS_PER_TICK as i32,
+            tick_budget: crate::machine_profile::DEFAULT_HOST_EXECUTION_POLICY
+                .scripted_instructions_per_tick as i32,
             idle_cycle_last_seen: None,
             idle_cycle_probe: None,
             idle_cycle_sites: [IdleCycleSiteRecord::default(); IDLE_CYCLE_SITE_SLOTS],
@@ -19811,9 +19809,11 @@ mod tests {
             assert!(ppc_app.sound.completion_invocations.is_empty());
         }
 
-        let (steps, running) = runner.run_steps_with_audio(INSTRUCTIONS_PER_TICK as usize, None, 0);
+        let default_budget =
+            crate::machine_profile::DEFAULT_HOST_EXECUTION_POLICY.scripted_instructions_per_tick;
+        let (steps, running) = runner.run_steps_with_audio(default_budget as usize, None, 0);
 
-        assert_eq!(steps, INSTRUCTIONS_PER_TICK as usize);
+        assert_eq!(steps, default_budget as usize);
         assert!(running);
         assert!(runner.drain_audio().is_empty());
         assert_eq!(runner.guest_tick(), 1);
@@ -23937,6 +23937,213 @@ mod tests {
         assert!(runner.active_interrupt_callback.is_none());
         assert_eq!(runner.m68k.cpu.core.get_sr(), 0x2004);
         assert_eq!(runner.m68k.cpu.read_reg(Register::A7), interrupted_sp);
+    }
+
+    #[test]
+    fn shipped_host_execution_policy_preserves_public_defaults() {
+        let runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+
+        assert_eq!(runner.instructions_per_tick(), 12_000);
+        assert_eq!(DEFAULT_VBL_HZ, 60.15);
+        assert_eq!(DEFAULT_REALTIME_CPU_MHZ, 25.0);
+        assert_eq!(DEFAULT_REALTIME_PPC_CPU_MHZ, 120.0);
+        assert_eq!(DEFAULT_REALTIME_INSTRUCTIONS_PER_SECOND, 25_000_000.0);
+        assert_eq!(default_realtime_instructions_per_tick(false), 415_628);
+        assert_eq!(default_realtime_instructions_per_tick(true), 1_995_012);
+    }
+
+    #[test]
+    fn host_pacing_override_preserves_m68k_guest_profile_and_canonical_ticks() {
+        const SYS_ENV: u32 = 0x0030_0000;
+        const PROGRAM: u32 = 0x0001_0000;
+
+        fn guest_profile(runner: &mut FixtureRunner) -> ([u32; 5], [u16; 3], u8, u32) {
+            let mut gestalt = [0; 5];
+            for (index, selector) in [*b"sysa", *b"cput", *b"proc", *b"fpu ", *b"mmu "]
+                .into_iter()
+                .enumerate()
+            {
+                runner
+                    .m68k
+                    .cpu
+                    .write_reg(Register::D0, u32::from_be_bytes(selector));
+                runner
+                    .dispatcher
+                    .dispatch(0xA1AD, &mut runner.m68k.cpu, &mut runner.bus)
+                    .unwrap();
+                gestalt[index] = runner.m68k.cpu.read_reg(Register::A0);
+            }
+
+            runner.m68k.cpu.write_reg(Register::A0, SYS_ENV);
+            runner.m68k.cpu.write_reg(Register::D0, 2);
+            runner
+                .dispatcher
+                .dispatch(0xA090, &mut runner.m68k.cpu, &mut runner.bus)
+                .unwrap();
+            let sys_environs = [
+                runner.bus.read_word(SYS_ENV + 2),
+                runner.bus.read_word(SYS_ENV + 4),
+                runner.bus.read_word(SYS_ENV + 6),
+            ];
+            let has_fpu = runner.bus.read_byte(SYS_ENV + 8);
+
+            runner.m68k.cpu.write_reg(Register::D0, u32::MAX);
+            runner
+                .dispatcher
+                .dispatch(0xA485, &mut runner.m68k.cpu, &mut runner.bus)
+                .unwrap();
+            let cpu_speed = runner.m68k.cpu.read_reg(Register::D0);
+            (gestalt, sys_environs, has_fpu, cpu_speed)
+        }
+
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        let default_guest_profile = guest_profile(&mut runner);
+        assert_eq!(
+            default_guest_profile,
+            ([1, 4, 5, 3, 4], [20, 0x0810, 5], 1, 25)
+        );
+
+        runner.set_instructions_per_tick(3);
+        assert_eq!(guest_profile(&mut runner), default_guest_profile);
+
+        for offset in (0..14).step_by(2) {
+            runner.bus.write_word(PROGRAM + offset, 0x4E71);
+        }
+        runner.m68k.cpu.write_reg(Register::PC, PROGRAM);
+        runner.m68k.cpu.write_reg(Register::A7, 0x007F_FFC0);
+        runner.set_guest_tick_for_test(0);
+        runner
+            .bus
+            .write_long(crate::memory::globals::addr::TICKS, 500);
+        let tick_result = runner.m68k.cpu.read_reg(Register::A7);
+        runner.bus.write_long(tick_result, 0);
+        runner
+            .dispatcher
+            .dispatch(0xA975, &mut runner.m68k.cpu, &mut runner.bus)
+            .unwrap();
+        assert_eq!(runner.bus.read_long(tick_result), 500);
+
+        let (steps, running) = runner.run_steps(7, None);
+
+        assert!(running);
+        assert_eq!(steps, 7);
+        assert_eq!(
+            runner.bus.read_long(crate::memory::globals::addr::TICKS),
+            502
+        );
+        runner.bus.write_long(tick_result, 0);
+        runner
+            .dispatcher
+            .dispatch(0xA975, &mut runner.m68k.cpu, &mut runner.bus)
+            .unwrap();
+        assert_eq!(runner.bus.read_long(tick_result), 502);
+    }
+
+    #[test]
+    fn host_pacing_override_preserves_powerpc_guest_profile_and_tick_visibility() {
+        use crate::loader::ppc::tests::synthetic_pef_with_import;
+
+        const RESPONSE: u32 = PPC_HEAP_BASE + 0x1000;
+        const SYS_ENV: u32 = RESPONSE + 0x100;
+
+        fn guest_state(runner: &mut FixtureRunner) -> ([(u32, u32); 5], [u16; 4], [u8; 2], u32) {
+            let mut context = runner
+                .native
+                .take(NativeEngineRole::Companion)
+                .expect("PPC companion installed");
+            let native = context.adapter_mut();
+            let mut capabilities = [(0, 0); 5];
+
+            native.cpu.pc = native.imports[0].trap_pc;
+            native.cpu.lr = PPC_HALT_PC;
+            native.imports[0].dispatcher_target = PpcImportDispatcherTarget::TickCount;
+            let probe = runner
+                .process_context
+                .with_memory_and_cfm(|memory_manager, cfm| {
+                    native.run_with_process_services(64, false, false, memory_manager, cfm)
+                });
+            assert_eq!(probe.handled_import_count, 1);
+            assert_eq!(probe.unsupported_import_index, None);
+            let tick_count = native.cpu.gpr[3];
+
+            for (index, selector) in [*b"cput", *b"proc", *b"fpu ", *b"mmu ", *b"sysa"]
+                .into_iter()
+                .enumerate()
+            {
+                native.cpu.pc = native.imports[0].trap_pc;
+                native.cpu.lr = PPC_HALT_PC;
+                native.imports[0].dispatcher_target = PpcImportDispatcherTarget::Gestalt;
+                native.cpu.gpr[3] = u32::from_be_bytes(selector);
+                native.cpu.gpr[4] = RESPONSE;
+                let probe = runner
+                    .process_context
+                    .with_memory_and_cfm(|memory_manager, cfm| {
+                        native.run_with_process_services(64, false, false, memory_manager, cfm)
+                    });
+                assert_eq!(probe.handled_import_count, 1);
+                assert_eq!(probe.unsupported_import_index, None);
+                capabilities[index] = (
+                    native.cpu.gpr[3],
+                    native.memory.read_u32_be(RESPONSE).unwrap(),
+                );
+            }
+
+            native.cpu.pc = native.imports[0].trap_pc;
+            native.cpu.lr = PPC_HALT_PC;
+            native.imports[0].dispatcher_target = PpcImportDispatcherTarget::SysEnvirons;
+            native.cpu.gpr[3] = 2;
+            native.cpu.gpr[4] = SYS_ENV;
+            let probe = runner
+                .process_context
+                .with_memory_and_cfm(|memory_manager, cfm| {
+                    native.run_with_process_services(64, false, false, memory_manager, cfm)
+                });
+            assert_eq!(probe.handled_import_count, 1);
+            assert_eq!(probe.unsupported_import_index, None);
+            assert_eq!(native.cpu.gpr[3], 0);
+            let sys_environs = [
+                native.memory.read_u16_be(SYS_ENV).unwrap(),
+                native.memory.read_u16_be(SYS_ENV + 2).unwrap(),
+                native.memory.read_u16_be(SYS_ENV + 4).unwrap(),
+                native.memory.read_u16_be(SYS_ENV + 6).unwrap(),
+            ];
+            let sys_environs_flags = [
+                native.memory.read_u8(SYS_ENV + 8).unwrap(),
+                native.memory.read_u8(SYS_ENV + 9).unwrap(),
+            ];
+
+            assert!(runner.native.restore(context).is_ok());
+            (capabilities, sys_environs, sys_environs_flags, tick_count)
+        }
+
+        let mut native = load_pef_application(&synthetic_pef_with_import(b"Gestalt")).unwrap();
+        native.memory.add_region(RESPONSE, vec![0; 0x110]);
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        runner.init_ppc_companion(native);
+        runner
+            .bus
+            .write_long(crate::memory::globals::addr::TICKS, 700);
+
+        let default_guest_state = guest_state(&mut runner);
+        assert_eq!(
+            default_guest_state,
+            (
+                [(0, 0x0104), (0, 2), (0, 3), (0, 4), ((-5551i32) as u32, 0)],
+                [2, 20, 0x0810, 5],
+                [1, 1],
+                700,
+            )
+        );
+
+        runner.set_instructions_per_tick(7);
+        runner
+            .bus
+            .write_long(crate::memory::globals::addr::TICKS, 900);
+        let paced_guest_state = guest_state(&mut runner);
+        assert_eq!(paced_guest_state.0, default_guest_state.0);
+        assert_eq!(paced_guest_state.1, default_guest_state.1);
+        assert_eq!(paced_guest_state.2, default_guest_state.2);
+        assert_eq!(paced_guest_state.3, 900);
     }
 
     #[test]

--- a/src/trap/memory.rs
+++ b/src/trap/memory.rs
@@ -6,7 +6,7 @@ use super::dispatch::{
 use super::manager::{TrapManager, TrapManagerSetError, TrapTableKind};
 use crate::callback_manager::CallbackTaskArchitecture;
 use crate::cpu::{CpuOps, Register};
-use crate::machine_profile::REFERENCE_MACHINE_PROFILE;
+use crate::machine_profile::{REFERENCE_M68K_EXECUTION_CAPABILITIES, REFERENCE_MACHINE_PROFILE};
 use crate::memory::{globals::addr, MacMemoryBus, MemoryBus};
 use crate::process_context::{
     ProcessHandleHeap, ProcessNewHandleBackend, ProcessNewHandleRequest, ProcessNewHandleResult,
@@ -1443,9 +1443,12 @@ impl super::TrapDispatcher {
                 bus.write_word(rec_ptr + 4, REFERENCE_MACHINE_PROFILE.system_version_bcd);
                 bus.write_word(
                     rec_ptr + 6,
-                    REFERENCE_MACHINE_PROFILE.gestalt_processor_type as u16,
+                    REFERENCE_M68K_EXECUTION_CAPABILITIES.processor_type as u16,
                 );
-                bus.write_byte(rec_ptr + 8, u8::from(REFERENCE_MACHINE_PROFILE.has_fpu()));
+                bus.write_byte(
+                    rec_ptr + 8,
+                    u8::from(REFERENCE_M68K_EXECUTION_CAPABILITIES.fpu_type != 0),
+                );
                 bus.write_byte(rec_ptr + 9, 1); // hasColorQD
                 bus.write_word(rec_ptr + 10, 0);
                 bus.write_word(rec_ptr + 12, 0);

--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -2,7 +2,7 @@
 
 use crate::cpu::{CpuOps, Register};
 use crate::loader::CodeSegmentHeader;
-use crate::machine_profile::REFERENCE_MACHINE_PROFILE;
+use crate::machine_profile::{REFERENCE_M68K_EXECUTION_CAPABILITIES, REFERENCE_MACHINE_PROFILE};
 use crate::managers::resource::ResourceFork;
 use crate::memory::globals::addr;
 use crate::memory::{MacMemoryBus, MemoryBus};
@@ -3561,7 +3561,12 @@ impl super::TrapDispatcher {
                     // Inside Macintosh: Operating System Utilities 1994,
                     // p. 1-24: gestalt68k = 1, gestaltPowerPC = 2.
                     b"sysa" => {
-                        cpu.write_reg(Register::A0, 1);
+                        cpu.write_reg(
+                            Register::A0,
+                            REFERENCE_M68K_EXECUTION_CAPABILITIES
+                                .system_architecture
+                                .expect("68K Gestalt supports gestaltSysArchitecture"),
+                        );
                         cpu.write_reg(Register::D0, 0);
                     }
                     // gestaltOSTable / gestaltToolboxTable return the bases
@@ -3610,7 +3615,7 @@ impl super::TrapDispatcher {
                     b"cput" => {
                         cpu.write_reg(
                             Register::A0,
-                            REFERENCE_MACHINE_PROFILE.gestalt_native_cpu_type,
+                            REFERENCE_M68K_EXECUTION_CAPABILITIES.native_cpu_type,
                         );
                         cpu.write_reg(Register::D0, 0);
                     }
@@ -3618,7 +3623,7 @@ impl super::TrapDispatcher {
                     b"proc" => {
                         cpu.write_reg(
                             Register::A0,
-                            REFERENCE_MACHINE_PROFILE.gestalt_processor_type,
+                            REFERENCE_M68K_EXECUTION_CAPABILITIES.processor_type,
                         );
                         cpu.write_reg(Register::D0, 0);
                     }
@@ -3684,12 +3689,12 @@ impl super::TrapDispatcher {
                     }
                     // gestaltFPUType ('fpu ') -> 68040 FPU
                     b"fpu " => {
-                        cpu.write_reg(Register::A0, REFERENCE_MACHINE_PROFILE.gestalt_fpu_type);
+                        cpu.write_reg(Register::A0, REFERENCE_M68K_EXECUTION_CAPABILITIES.fpu_type);
                         cpu.write_reg(Register::D0, 0);
                     }
                     // gestaltMMUType ('mmu ') -> 68040 MMU
                     b"mmu " => {
-                        cpu.write_reg(Register::A0, REFERENCE_MACHINE_PROFILE.gestalt_mmu_type);
+                        cpu.write_reg(Register::A0, REFERENCE_M68K_EXECUTION_CAPABILITIES.mmu_type);
                         cpu.write_reg(Register::D0, 0);
                     }
                     // gestaltSoundAttr ('snd ') -> advertise a full late-68k


### PR DESCRIPTION
Host instruction budgets previously reused the guest CPU-speed field, so changing pacing could also change the hardware information reported to applications. This separates the private host execution policy from guest capabilities while preserving the public profile shape, scripted and realtime defaults, and canonical low-memory Ticks.

Both ABI adapters use explicit capability records; the 68K record derives from the existing profile fields. The duplicated PPC CPU constants are removed. Existing PPC selector support and compatibility values are preserved. Tests exercise Gestalt, SysEnvirons, guest GetCPUSpeed, changed runner budgets, and direct low-memory tick writes through both execution routes.

Validation: worker library suite with default features and without test-support **5,175 passed, 3 ignored**; independent default-feature library suite **5,181 passed, 3 ignored**; runtime source checks and all 54 checker fixtures passed. Changed-function formatting was checked in bounded pieces; a full local format pass was deferred because the loader exceeds available memory. Public CI supplies the package, desktop, and both showcase checks before merge.

The non-blocking Clippy step reports existing `mut_from_ref` in the address-space accessor and `erasing_op` in an unrelated window test. Both expressions are unchanged from the base revision; this patch does not suppress them.

Closes #1550
