### PR TITLE
fix: preserve PPC engine state across context restoration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1777,9 +1777,9 @@ dependencies = [
 
 [[package]]
 name = "ppc"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cc5839a690e28cb2552c77d1d57ce04cd462c312ad1ad0757b30133b02303c8"
+checksum = "e3c3398a600341cf4832aa283433bc481194ebbefe68d42baf8b140601d5a19b"
 dependencies = [
  "ieee-apsqrt",
  "rustc_apfloat",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ include = [
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
 m68k = { version = "0.11.6" }
-ppc = "0.5.0"
+ppc = "0.6.0"
 thiserror = "2"
 tracing = "0.1"
 serde = { version = "1", features = ["derive"] }

--- a/src/execution_m68k.rs
+++ b/src/execution_m68k.rs
@@ -181,7 +181,7 @@ impl M68kExecution {
     /// Validate and park the outgoing context before installing the callback.
     pub(crate) fn activate_pending(
         &mut self,
-        native: &ppc::PpcCpu,
+        native: &mut ppc::PpcCpu,
     ) -> Option<PendingM68kExecution> {
         if let Some(active) = self.calls.active_m68k() {
             return Some(active);
@@ -542,8 +542,47 @@ impl M68kExecution {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::guest_call::GuestCallTarget;
+    use crate::guest_call::{GuestCallTarget, M68kRegisterState};
     use crate::guest_procedure::GuestIsa;
+
+    #[test]
+    fn already_active_callback_preserves_the_live_native_reservation() {
+        const ADDRESS: u32 = 0x1000;
+        const LWARX_R12_R4_R5: u32 = (31 << 26) | (12 << 21) | (4 << 16) | (5 << 11) | (20 << 1);
+        let calls = SharedGuestCallStack::default();
+        assert!(calls.begin_powerpc_to_m68k(
+            GuestCallTarget {
+                isa: GuestIsa::M68k,
+                entry: 0x2000,
+                rtoc: 0,
+            },
+            0x2000,
+            0x3000,
+            0x4000,
+            0x3004,
+            M68kRegisterState::default(),
+            None,
+            0x5000,
+            0x6000,
+            ppc::PpcNativeReturnGpr3::Preserve,
+        ));
+        let mut engine = M68kExecution::new(&calls);
+        let mut native = ppc::PpcCpu::new();
+        native.gpr[1] = 0x7000;
+        assert!(engine.activate_pending(&mut native).is_some());
+        assert_eq!(native.reservation_address(), None);
+
+        let mut memory = crate::memory::GuestAddressSpace::new();
+        memory.add_region(ADDRESS, 0x1122_3344u32.to_be_bytes().to_vec());
+        native.gpr[4] = ADDRESS;
+        assert_eq!(
+            native.step(&mut memory, LWARX_R12_R4_R5),
+            ppc::PpcStepResult::Stepped
+        );
+        assert_eq!(native.reservation_address(), Some(ADDRESS));
+        assert!(engine.activate_pending(&mut native).is_some());
+        assert_eq!(native.reservation_address(), Some(ADDRESS));
+    }
 
     #[test]
     fn native_task_handoff_restores_classic_status_fpu_and_frame_state() {

--- a/src/guest_call.rs
+++ b/src/guest_call.rs
@@ -25,19 +25,10 @@ use crate::execution_kernel::{
 use crate::guest_procedure::GuestIsa;
 use crate::memory::GuestAddressSpace;
 use crate::process_context::{ProcessNativeMemoryManager, SharedProcessValue};
-use ppc::{PpcCpu, PpcImportAction, PpcMemory, PpcNativeReturnGpr3};
+use ppc::{PpcCpu, PpcExecutionContext, PpcImportAction, PpcMemory, PpcNativeReturnGpr3};
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
-
-/// Install a saved register context while retaining the furthest native
-/// execution time. Task switches, mixed-mode returns and interrupt returns
-/// share this policy; restoring registers must not rewind the time base.
-pub(crate) fn restore_powerpc_context(cpu: &mut PpcCpu, context: PpcCpu) {
-    let time_base = cpu.time_base().max(context.time_base());
-    *cpu = context;
-    cpu.set_time_base(time_base);
-}
 
 /// Exclusive, synchronous preparation of the PowerPC word-argument ABI.
 /// No guest execution or mapping change may intervene before installation.
@@ -520,11 +511,10 @@ impl PartialEq for GuestCallFrame {
 
 impl Eq for GuestCallFrame {}
 
-/// Full native engine state is retained, including the CPU's private import
-/// continuations. The active CPU remains with its engine between task switches.
+/// Suspendable native state owned by one cooperative task.
 #[derive(Clone, Debug)]
 pub(crate) struct NativeThreadContext {
-    pub(crate) cpu: Box<PpcCpu>,
+    pub(crate) context: PpcExecutionContext,
 }
 
 /// Process-owned storage provenance is independent of a task's current ISA.
@@ -541,14 +531,14 @@ pub(crate) struct ThreadStorage {
 #[derive(Clone, Debug)]
 enum TaskResumeContext {
     Classic(CooperativeThread),
-    Native(Box<PpcCpu>),
+    Native(PpcExecutionContext),
 }
 
 impl TaskResumeContext {
     fn stack_pointer(&self) -> u32 {
         match self {
             Self::Classic(context) => context.a_regs[7],
-            Self::Native(cpu) => cpu.gpr[1],
+            Self::Native(context) => context.architectural().gpr[1],
         }
     }
 
@@ -1000,7 +990,7 @@ struct ExecutionTaskCalls {
     /// Manager roots outlive each individual guest callback and retain the
     /// invoking task, enclosing call and original ABI return placement.
     menu_calls: SharedProcessValue<MenuCalls>,
-    powerpc_contexts: ExecutionContextBank<Box<PpcCpu>>,
+    powerpc_contexts: ExecutionContextBank<PpcExecutionContext>,
     m68k_contexts: Rc<RefCell<ExecutionContextBank<M68kCpu>>>,
     cooperative_contexts: ExecutionTaskContextBank<CooperativeThread>,
     native_threads: ExecutionTaskContextBank<NativeThreadContext>,
@@ -1130,7 +1120,7 @@ impl ExecutionTaskCalls {
             GuestIsa::PowerPc => self
                 .native_threads
                 .get(task)
-                .map(|saved| TaskResumeContext::Native(saved.cpu.clone())),
+                .map(|saved| TaskResumeContext::Native(saved.context.clone())),
         }
     }
 
@@ -1205,9 +1195,9 @@ impl ExecutionTaskCalls {
             TaskResumeContext::Classic(context) => {
                 self.cooperative_contexts.insert(task, context);
             }
-            TaskResumeContext::Native(cpu) => {
+            TaskResumeContext::Native(context) => {
                 self.native_threads
-                    .insert(task, NativeThreadContext { cpu });
+                    .insert(task, NativeThreadContext { context });
             }
         }
         self.thread_storage.insert(task, storage);
@@ -1270,19 +1260,12 @@ impl ExecutionTaskCalls {
         Some((storage, next))
     }
 
-    fn save_native_cpu(&mut self, task: ExecutionTaskId, cpu: &PpcCpu) {
+    fn save_native_context(&mut self, task: ExecutionTaskId, context: PpcExecutionContext) {
         if self.kernel.scheduling_state(task).is_none() {
             return;
         }
-        let mut context = self
-            .native_threads
-            .get(task)
-            .cloned()
-            .unwrap_or(NativeThreadContext {
-                cpu: Box::new(cpu.clone()),
-            });
-        context.cpu = Box::new(cpu.clone());
-        self.native_threads.insert(task, context);
+        self.native_threads
+            .insert(task, NativeThreadContext { context });
     }
 
     fn install_native_successor(
@@ -1296,7 +1279,7 @@ impl ExecutionTaskCalls {
                 self.handoff = Some((task, TaskResumeContext::Classic(context)));
             }
             TaskResumeContext::Native(next) => {
-                restore_powerpc_context(cpu, *next);
+                cpu.install_execution_context(next);
                 self.native_cpu_task = Some(task);
             }
         }
@@ -1715,8 +1698,8 @@ impl SharedGuestCallStack {
                     tasks.frames.get(&call.call_id())?.origin,
                     GuestCallOrigin::PowerPc(_)
                 ) {
-                    if let Some(cpu) = tasks.powerpc_contexts.get(task, call.call_id()) {
-                        return Some((entry, cpu.gpr[1]));
+                    if let Some(context) = tasks.powerpc_contexts.get(task, call.call_id()) {
+                        return Some((entry, context.architectural().gpr[1]));
                     }
                 }
             }
@@ -1934,17 +1917,18 @@ impl SharedGuestCallStack {
             tasks
                 .native_threads
                 .get(current)
-                .map(|context| context.cpu.clone())
+                .map(|context| context.context.clone())
         } else {
             None
         };
         if replacing_owner {
             if let Some(previous) = tasks.native_cpu_task {
-                tasks.save_native_cpu(previous, cpu);
+                tasks.save_native_context(previous, cpu.capture_execution_context());
+                cpu.invalidate_reservation();
             }
         }
         if let Some(next) = next {
-            restore_powerpc_context(cpu, *next);
+            cpu.install_execution_context(next);
         }
         tasks.native_cpu_task = Some(current);
         true
@@ -1981,7 +1965,7 @@ impl SharedGuestCallStack {
         commit: impl FnOnce(ExecutionTaskId) -> bool,
     ) -> Option<ExecutionTaskId> {
         self.0.borrow_mut().create_thread(
-            TaskResumeContext::Native(context.cpu),
+            TaskResumeContext::Native(context.context),
             storage,
             suspended,
             commit,
@@ -2037,11 +2021,11 @@ impl SharedGuestCallStack {
         {
             return Ok(false);
         }
-        let mut outgoing = cpu.clone();
-        outgoing.pc = outgoing.lr;
-        outgoing.gpr[3] = 0;
-        tasks.save_native_cpu(current, &outgoing);
-        *cpu = outgoing;
+        let mut outgoing = cpu.capture_execution_context();
+        outgoing.architectural_mut().pc = outgoing.architectural().lr;
+        outgoing.architectural_mut().gpr[3] = 0;
+        tasks.save_native_context(current, outgoing.clone());
+        cpu.install_execution_context(outgoing);
         tasks.native_cpu_task = Some(current);
         if let Some((next, context)) = successor {
             tasks.install_native_successor(next, context, cpu);
@@ -2092,15 +2076,15 @@ impl SharedGuestCallStack {
             return Ok(false);
         };
         let next_context = tasks.saved_context(next).ok_or(THREAD_PROTOCOL_ERR)?;
-        let mut outgoing = cpu.clone();
-        outgoing.pc = outgoing.lr;
-        outgoing.gpr[3] = 0;
+        let mut outgoing = cpu.capture_execution_context();
+        outgoing.architectural_mut().pc = outgoing.architectural().lr;
+        outgoing.architectural_mut().gpr[3] = 0;
         tasks
             .kernel
             .switch_to_task(next)
             .map_err(|_| THREAD_PROTOCOL_ERR)?;
-        tasks.save_native_cpu(current, &outgoing);
-        *cpu = outgoing;
+        tasks.save_native_context(current, outgoing.clone());
+        cpu.install_execution_context(outgoing);
         tasks.native_cpu_task = Some(current);
         tasks.install_native_successor(next, next_context, cpu);
         Ok(true)
@@ -2119,7 +2103,11 @@ impl SharedGuestCallStack {
         } else {
             None
         };
+        let retired_live_native = tasks.native_cpu_task == Some(task);
         let (finished, successor) = tasks.retire_thread(task, successor, recycle, commit)?;
+        if retired_live_native {
+            cpu.invalidate_reservation();
+        }
         if let Some((next, context)) = successor {
             tasks.install_native_successor(next, context, cpu);
         }
@@ -2400,16 +2388,17 @@ impl SharedGuestCallStack {
                     &kernel,
                     task,
                     call_id,
-                    Box::new(cpu.clone()),
+                    cpu.capture_execution_context(),
                     caller,
                 )
                 .ok()?;
         } else {
             tasks
                 .powerpc_contexts
-                .park_while_activating(&kernel, task, call_id, Box::new(cpu.clone()))
+                .park_while_activating(&kernel, task, call_id, cpu.capture_execution_context())
                 .ok()?;
         }
+        cpu.invalidate_reservation();
         let frame = tasks
             .frames
             .get_mut(&call_id)
@@ -2499,7 +2488,7 @@ impl SharedGuestCallStack {
             .as_mut()
             .expect("validated PowerPC transition must have an execution payload");
         execution.completed = Some(result);
-        restore_powerpc_context(cpu, *parked_cpu);
+        cpu.install_execution_context(parked_cpu);
         true
     }
 
@@ -2607,7 +2596,7 @@ impl SharedGuestCallStack {
     pub(crate) fn activate_m68k_parking(
         &self,
         installed: &mut M68kCpu,
-        native: &PpcCpu,
+        native: &mut PpcCpu,
     ) -> Option<PendingM68kExecution> {
         let caller = self.suspended_m68k_context_owner().map(|(_, call)| call);
         let bank = self.classic_contexts();
@@ -2621,7 +2610,7 @@ impl SharedGuestCallStack {
         bank: &mut ExecutionContextBank<T>,
         installed: &mut T,
         caller: Option<CallId>,
-        native: Option<&PpcCpu>,
+        native: Option<&mut PpcCpu>,
     ) -> Option<PendingM68kExecution> {
         let (task, call_id, pending, started) = {
             let tasks = self.0.borrow();
@@ -2645,15 +2634,17 @@ impl SharedGuestCallStack {
         let mut tasks = self.0.borrow_mut();
         if let Some(native) = native {
             let kernel = tasks.kernel.shared_handle();
+            let context = native.capture_execution_context();
             bank.activate_parking_caller_with_context(
                 &kernel,
                 task,
                 call_id,
                 caller,
                 installed,
-                Some((&mut tasks.powerpc_contexts, Box::new(native.clone()))),
+                Some((&mut tasks.powerpc_contexts, context)),
             )
             .ok()?;
+            native.invalidate_reservation();
         } else {
             bank.activate_parking_caller(&tasks.kernel, task, call_id, caller, installed)
                 .ok()?;
@@ -3090,7 +3081,7 @@ impl SharedGuestCallStack {
             }
         }
         if let Some(native) = native {
-            restore_powerpc_context(cpu, *native);
+            cpu.install_execution_context(native);
         }
         if let Some(result) = result {
             cpu.gpr[3] = result;
@@ -3122,7 +3113,10 @@ impl SharedGuestCallStack {
     /// exact caller PC and stack pointer. A native frame remains untouched.
     #[cfg(test)]
     pub(crate) fn complete_m68k(&self, post_trap_pc: u32, final_sp: u32) -> bool {
-        self.complete_m68k_with_operation(post_trap_pc, final_sp, |_| panic!("unhandled manager completion")).is_some()
+        self.complete_m68k_with_operation(post_trap_pc, final_sp, |_| {
+            panic!("unhandled manager completion")
+        })
+        .is_some()
     }
 
     pub(crate) fn complete_m68k_with_operation(
@@ -3180,12 +3174,99 @@ impl SharedGuestCallStack {
 }
 
 #[cfg(test)]
+pub(crate) fn test_native_import_action(
+    entry: u32,
+    entry_rtoc: u32,
+    return_pc: u32,
+    final_pc: u32,
+    restore_rtoc: u32,
+    return_gpr3: PpcNativeReturnGpr3,
+) -> PpcImportAction {
+    GuestCallEffect::call_guest(
+        GuestCallRequest::new(GuestCallTarget {
+            isa: GuestIsa::PowerPc,
+            entry,
+            rtoc: entry_rtoc,
+        }),
+        GuestCallContinuation::to_powerpc(return_pc, final_pc, restore_rtoc, return_gpr3),
+    )
+    .into_ppc_import_action()
+    .expect("native PowerPC request should adapt to CallNative")
+}
+
+#[cfg(test)]
+pub(crate) fn seed_pending_native_import_context(
+    cpu: &mut PpcCpu,
+    memory: &mut impl PpcMemory,
+    trap_pc: u32,
+    entry: u32,
+    entry_rtoc: u32,
+    return_pc: u32,
+    final_pc: u32,
+    restore_rtoc: u32,
+    return_gpr3: PpcNativeReturnGpr3,
+) {
+    cpu.pc = trap_pc;
+    assert_eq!(
+        cpu.run_with_imports(memory, 1, 0, trap_pc, 1, |_, _, _| {
+            test_native_import_action(
+                entry,
+                entry_rtoc,
+                return_pc,
+                final_pc,
+                restore_rtoc,
+                return_gpr3,
+            )
+        }),
+        ppc::PpcRunResult::CycleLimit { cycles: 1 }
+    );
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::memory::GuestAddressSpace;
     use ppc::PpcRunResult;
 
     const RETURN_PC: u32 = 0x01f0_4000;
+
+    fn establish_native_reservation(cpu: &mut PpcCpu, address: u32) {
+        const LWARX_R12_R4_R5: u32 = (31 << 26) | (12 << 21) | (4 << 16) | (5 << 11) | (20 << 1);
+        let preserved = (cpu.pc, cpu.gpr[4], cpu.gpr[5], cpu.gpr[12]);
+        let mut memory = GuestAddressSpace::new();
+        memory.add_region(address, 0x1122_3344u32.to_be_bytes().to_vec());
+        cpu.gpr[4] = address;
+        cpu.gpr[5] = 0;
+        assert_eq!(
+            cpu.step(&mut memory, LWARX_R12_R4_R5),
+            ppc::PpcStepResult::Stepped
+        );
+        assert_eq!(cpu.reservation_address(), Some(address));
+        (cpu.pc, cpu.gpr[4], cpu.gpr[5], cpu.gpr[12]) = preserved;
+    }
+
+    fn pending_native_import_context(
+        trap_pc: u32,
+        return_pc: u32,
+        final_pc: u32,
+        restored_rtoc: u32,
+        result: u32,
+    ) -> PpcExecutionContext {
+        let mut cpu = PpcCpu::new();
+        let mut memory = GuestAddressSpace::new();
+        seed_pending_native_import_context(
+            &mut cpu,
+            &mut memory,
+            trap_pc,
+            return_pc,
+            restored_rtoc ^ 0xffff_0000,
+            return_pc,
+            final_pc,
+            restored_rtoc,
+            PpcNativeReturnGpr3::Set(result),
+        );
+        cpu.capture_execution_context()
+    }
 
     #[test]
     fn menu_bar_operations_scope_nested_calls_and_preserve_each_return_abi() {
@@ -3598,16 +3679,14 @@ mod tests {
         final_pc: u32,
         return_gpr3: PpcNativeReturnGpr3,
     ) -> PpcImportAction {
-        GuestCallEffect::call_guest(
-            GuestCallRequest::new(GuestCallTarget {
-                isa: GuestIsa::PowerPc,
-                entry,
-                rtoc: entry + 0x100,
-            }),
-            GuestCallContinuation::to_powerpc(RETURN_PC, final_pc, final_pc + 0x100, return_gpr3),
+        test_native_import_action(
+            entry,
+            entry + 0x100,
+            RETURN_PC,
+            final_pc,
+            final_pc + 0x100,
+            return_gpr3,
         )
-        .into_ppc_import_action()
-        .expect("native PowerPC request should adapt to CallNative")
     }
 
     #[test]
@@ -3717,7 +3796,7 @@ mod tests {
         let native = calls
             .create_native_thread(
                 NativeThreadContext {
-                    cpu: Box::new(PpcCpu::new()),
+                    context: PpcExecutionContext::fresh(),
                 },
                 ThreadStorage {
                     stack_base: 0x2000,
@@ -3787,7 +3866,7 @@ mod tests {
         let native = calls
             .create_native_thread(
                 NativeThreadContext {
-                    cpu: Box::new(PpcCpu::new()),
+                    context: PpcExecutionContext::fresh(),
                 },
                 crate::guest_call::ThreadStorage {
                     result_destination: 0,
@@ -3801,9 +3880,11 @@ mod tests {
             .unwrap();
         assert!(calls.switch_to_task(native));
         assert!(calls.prepare_native_task(&mut cpu));
+        establish_native_reservation(&mut cpu, 0x1000);
         assert!(calls
             .retire_native_thread(native, &mut cpu, false, |_| true)
             .is_some());
+        assert_eq!(cpu.reservation_address(), None);
         assert_eq!(calls.current_task(), classic);
         assert!(calls.has_classic_task_handoff());
         let blocked_pc = cpu.pc;
@@ -3824,6 +3905,63 @@ mod tests {
     }
 
     #[test]
+    fn native_retirement_refuses_a_parked_mixed_mode_context_then_removes_it() {
+        let calls = SharedGuestCallStack::default();
+        let mut cpu = PpcCpu::new();
+        calls.start_native_engine();
+        assert!(calls.bind_task_entry_isa(ExecutionTaskId::APPLICATION, GuestIsa::PowerPc));
+        let worker = calls
+            .create_native_thread(
+                NativeThreadContext {
+                    context: PpcExecutionContext::fresh(),
+                },
+                ThreadStorage::default(),
+                false,
+                |_| true,
+            )
+            .unwrap();
+        assert!(calls
+            .yield_native_thread(&mut cpu, worker.thread_id())
+            .unwrap());
+        assert!(calls.begin_powerpc_to_m68k(
+            GuestCallTarget {
+                isa: GuestIsa::M68k,
+                entry: 0x2000,
+                rtoc: 0,
+            },
+            0x2000,
+            0x3000,
+            0x4000,
+            0x3004,
+            M68kRegisterState::default(),
+            None,
+            0x5000,
+            0x6000,
+            PpcNativeReturnGpr3::Preserve,
+        ));
+        let (call, _) = calls.top_frame().unwrap();
+        let mut classic = M68kCpu::new();
+        assert!(calls
+            .activate_m68k_parking(&mut classic, &mut cpu)
+            .is_some());
+        establish_native_reservation(&mut cpu, 0x1000);
+        assert!(calls
+            .retire_native_thread(worker, &mut cpu, false, |_| true)
+            .is_none());
+        assert_eq!(calls.current_task(), worker);
+        assert!(calls.scheduling_state(worker).is_some());
+        assert!(calls.0.borrow().powerpc_contexts.contains(worker, call));
+        assert!(calls.thread_storage(worker).is_some());
+        assert_eq!(cpu.reservation_address(), Some(0x1000));
+        assert!(calls.complete_m68k_for_powerpc(0x4000, 0x3004, None, &mut cpu));
+        assert!(calls
+            .retire_native_thread(worker, &mut cpu, false, |_| true)
+            .is_some());
+        assert_eq!(calls.scheduling_state(worker), None);
+        assert_eq!(cpu.reservation_address(), None);
+    }
+
+    #[test]
     fn native_installation_refuses_missing_snapshot_before_saving_or_relabeling() {
         let calls = SharedGuestCallStack::default();
         assert!(calls.bind_task_entry_isa(ExecutionTaskId::APPLICATION, GuestIsa::PowerPc));
@@ -3839,6 +3977,7 @@ mod tests {
         cpu.pc = 0x789a_bcde;
         cpu.alignment_policy = ppc::PpcAlignmentPolicy::EmulateData;
         cpu.set_time_base(0x1234_5678_9abc_def0);
+        establish_native_reservation(&mut cpu, 0x1000);
 
         let initial = cpu.clone();
         assert!(calls.prepare_native_task(&mut cpu));
@@ -3895,10 +4034,32 @@ mod tests {
         cpu.pc = 0x1234;
         cpu.lr = 0x4560;
         cpu.gpr[3] = 99;
+        cpu.fpr[20] = 0x4009_21fb_5444_2d18;
+        cpu.cr = 0x1357_2468;
+        cpu.ctr = 0x2468_1357;
+        cpu.xer = 0x89ab_cdef;
+        cpu.fpscr = 0x1020_3040;
+        cpu.msr = 0x5060_7080;
+        establish_native_reservation(&mut cpu, 0x1000);
+        cpu.set_time_base(u64::MAX);
+        let mut worker_context = PpcExecutionContext::fresh();
+        {
+            let state = worker_context.architectural_mut();
+            state.gpr[1] = 0x8000;
+            state.gpr[20] = 0xaabb_ccdd;
+            state.fpr[20] = 0x3ff0_0000_0000_0000;
+            state.cr = 0xaaaa_5555;
+            state.lr = 0x9000;
+            state.ctr = 0x1111_2222;
+            state.xer = 0x3333_4444;
+            state.fpscr = 0x5555_6666;
+            state.msr = 0x7777_8888;
+            state.pc = 0x7000;
+        }
         let worker = calls
             .create_native_thread(
                 NativeThreadContext {
-                    cpu: Box::new(PpcCpu::new()),
+                    context: worker_context,
                 },
                 crate::guest_call::ThreadStorage {
                     result_destination: 0,
@@ -3910,6 +4071,18 @@ mod tests {
                 |_| true,
             )
             .unwrap();
+        assert_eq!(
+            calls
+                .0
+                .borrow()
+                .native_threads
+                .get(worker)
+                .unwrap()
+                .context
+                .architectural()
+                .gpr[20],
+            0xaabb_ccdd
+        );
         calls.begin_critical();
         assert_eq!(
             calls.yield_native_thread(&mut cpu, worker.thread_id()),
@@ -3917,6 +4090,7 @@ mod tests {
         );
         assert_eq!(cpu.pc, 0x1234);
         assert_eq!(cpu.gpr[3], 99);
+        assert_eq!(cpu.reservation_address(), Some(0x1000));
         assert_eq!(calls.current_task(), ExecutionTaskId::APPLICATION);
         assert!(calls.end_critical());
         let classic = calls.create_task().unwrap();
@@ -3927,17 +4101,140 @@ mod tests {
         );
         assert_eq!(cpu.pc, 0x1234);
         assert_eq!(cpu.gpr[3], 99);
+        assert_eq!(cpu.reservation_address(), Some(0x1000));
         assert_eq!(calls.current_task(), ExecutionTaskId::APPLICATION);
         assert!(calls
             .yield_native_thread(&mut cpu, worker.thread_id())
             .unwrap());
         assert_eq!(calls.current_task(), worker);
+        assert_eq!(cpu.gpr[20], 0xaabb_ccdd);
+        assert_eq!(cpu.fpr[20], 0x3ff0_0000_0000_0000);
+        assert_eq!(cpu.cr, 0xaaaa_5555);
+        assert_eq!(cpu.pc, 0x7000);
+        assert_eq!(cpu.lr, 0x9000);
+        assert_eq!(cpu.ctr, 0x1111_2222);
+        assert_eq!(cpu.xer, 0x3333_4444);
+        assert_eq!(cpu.fpscr, 0x5555_6666);
+        assert_eq!(cpu.msr, 0x7777_8888);
+        assert_eq!(cpu.reservation_address(), None);
+        assert_eq!(cpu.time_base(), u64::MAX);
+        establish_native_reservation(&mut cpu, 0x1000);
         cpu.lr = 0x9000;
         assert!(calls
             .yield_native_thread(&mut cpu, ExecutionTaskId::APPLICATION.thread_id())
             .unwrap());
         assert_eq!(cpu.pc, 0x4560);
         assert_eq!(cpu.gpr[3], 0);
+        assert_eq!(cpu.fpr[20], 0x4009_21fb_5444_2d18);
+        assert_eq!(cpu.cr, 0x1357_2468);
+        assert_eq!(cpu.pc, 0x4560);
+        assert_eq!(cpu.lr, 0x4560);
+        assert_eq!(cpu.ctr, 0x2468_1357);
+        assert_eq!(cpu.xer, 0x89ab_cdef);
+        assert_eq!(cpu.fpscr, 0x1020_3040);
+        assert_eq!(cpu.msr, 0x5060_7080);
+        assert_eq!(cpu.reservation_address(), None);
+        assert_eq!(cpu.time_base(), 0);
+        let mut memory = GuestAddressSpace::new();
+        assert_eq!(
+            cpu.step(
+                &mut memory,
+                (31 << 26) | (11 << 21) | (12 << 16) | (8 << 11) | (371 << 1)
+            ),
+            ppc::PpcStepResult::Stepped
+        );
+        assert_eq!(cpu.gpr[11], 0);
+        assert_eq!(cpu.time_base(), 1);
+        assert!(calls
+            .yield_native_thread(&mut cpu, worker.thread_id())
+            .unwrap());
+        assert_eq!(cpu.gpr[20], 0xaabb_ccdd);
+        assert_eq!(cpu.fpr[20], 0x3ff0_0000_0000_0000);
+        assert_eq!(cpu.cr, 0xaaaa_5555);
+        assert_eq!(cpu.pc, 0x9000);
+        assert_eq!(cpu.lr, 0x9000);
+        assert_eq!(cpu.ctr, 0x1111_2222);
+        assert_eq!(cpu.xer, 0x3333_4444);
+        assert_eq!(cpu.fpscr, 0x5555_6666);
+        assert_eq!(cpu.msr, 0x7777_8888);
+        assert_eq!(cpu.time_base(), 1);
+    }
+
+    #[test]
+    fn native_task_switch_restores_each_private_import_continuation_once() {
+        const A_RETURN: u32 = 0x2000;
+        const A_FINAL: u32 = 0x3000;
+        const B_RETURN: u32 = 0x2100;
+        const B_FINAL: u32 = 0x3100;
+        let calls = SharedGuestCallStack::default();
+        calls.start_native_engine();
+        assert!(calls.bind_task_entry_isa(ExecutionTaskId::APPLICATION, GuestIsa::PowerPc));
+        let mut cpu = PpcCpu::new();
+        cpu.install_execution_context(pending_native_import_context(
+            0x1000,
+            A_RETURN,
+            A_FINAL,
+            0xaaaa_0001,
+            0xaaaa_0003,
+        ));
+        let worker = calls
+            .create_native_thread(
+                NativeThreadContext {
+                    context: pending_native_import_context(
+                        0x1100,
+                        B_RETURN,
+                        B_FINAL,
+                        0xbbbb_0002,
+                        0xbbbb_0003,
+                    ),
+                },
+                ThreadStorage::default(),
+                false,
+                |_| true,
+            )
+            .unwrap();
+        let mut memory = GuestAddressSpace::new();
+
+        assert!(calls
+            .yield_native_thread(&mut cpu, worker.thread_id())
+            .unwrap());
+        assert_eq!(
+            cpu.run_with_imports(&mut memory, 2, B_FINAL, 0, 0, |_, _, _| unreachable!()),
+            PpcRunResult::Halted {
+                pc: B_FINAL,
+                cycles: 1
+            }
+        );
+        assert_eq!((cpu.gpr[2], cpu.gpr[3]), (0xbbbb_0002, 0xbbbb_0003));
+        assert!(calls
+            .yield_native_thread(&mut cpu, ExecutionTaskId::APPLICATION.thread_id())
+            .unwrap());
+        assert_eq!(
+            cpu.run_with_imports(&mut memory, 2, A_FINAL, 0, 0, |_, _, _| unreachable!()),
+            PpcRunResult::Halted {
+                pc: A_FINAL,
+                cycles: 1
+            }
+        );
+        assert_eq!((cpu.gpr[2], cpu.gpr[3]), (0xaaaa_0001, 0xaaaa_0003));
+        assert_eq!(
+            cpu.run_with_imports(&mut memory, 2, A_FINAL, 0, 0, |_, _, _| unreachable!()),
+            PpcRunResult::Halted {
+                pc: A_FINAL,
+                cycles: 0
+            }
+        );
+        assert!(calls
+            .yield_native_thread(&mut cpu, worker.thread_id())
+            .unwrap());
+        assert_eq!(
+            cpu.run_with_imports(&mut memory, 2, B_FINAL, 0, 0, |_, _, _| unreachable!()),
+            PpcRunResult::Halted {
+                pc: B_FINAL,
+                cycles: 0
+            }
+        );
+        assert_eq!((cpu.gpr[2], cpu.gpr[3]), (0xbbbb_0002, 0));
     }
 
     #[test]
@@ -4631,7 +4928,7 @@ mod tests {
                         .unwrap();
                 };
             let enter_classic =
-                |calls: &SharedGuestCallStack, classic: &mut M68kCpu, native: &PpcCpu| {
+                |calls: &SharedGuestCallStack, classic: &mut M68kCpu, native: &mut PpcCpu| {
                     assert!(calls.begin_powerpc_to_m68k(
                         GuestCallTarget {
                             isa: GuestIsa::M68k,
@@ -4654,7 +4951,7 @@ mod tests {
             if entry == GuestIsa::M68k {
                 enter_native(&calls, &mut classic, &mut native);
             }
-            enter_classic(&calls, &mut classic, &native);
+            enter_classic(&calls, &mut classic, &mut native);
             let manager = ThreadManager::new(&calls);
             assert_eq!(
                 manager.stack_space(1, GuestIsa::M68k, 0x6000, |_| 0x8000),
@@ -4671,7 +4968,7 @@ mod tests {
                 manager.stack_space(1, GuestIsa::PowerPc, native.gpr[1], |_| 0x8000),
                 Ok(expected)
             );
-            enter_classic(&calls, &mut classic, &native);
+            enter_classic(&calls, &mut classic, &mut native);
             let depth = calls.len();
             assert_eq!(
                 manager.stack_space(1, GuestIsa::M68k, 0x6000, |_| 0x8000),
@@ -4860,6 +5157,7 @@ mod tests {
             native.fpr[20] = 0x400921fb54442d18;
             native.cr = 0x12345678;
             native.set_time_base(7);
+            establish_native_reservation(&mut native, 0x1000);
             if occupied {
                 let kernel = calls.0.borrow().kernel.shared_handle();
                 assert!(calls
@@ -4870,20 +5168,22 @@ mod tests {
                         &kernel,
                         ExecutionTaskId::APPLICATION,
                         call,
-                        Box::new(native.clone())
+                        native.capture_execution_context()
                     )
                     .is_ok());
             }
             let mut classic = M68kCpu::new();
             classic.core.set_d(6, 0x7777);
-            let activated = calls.activate_m68k_parking(&mut classic, &native);
+            let activated = calls.activate_m68k_parking(&mut classic, &mut native);
             if occupied {
                 assert!(activated.is_none());
                 assert_eq!(classic.core.d(6), 0x7777);
                 assert!(calls.active_m68k().is_none());
+                assert_eq!(native.reservation_address(), Some(0x1000));
                 continue;
             }
             assert!(activated.is_some());
+            assert_eq!(native.reservation_address(), None);
             assert!(calls
                 .0
                 .borrow()
@@ -4913,6 +5213,67 @@ mod tests {
             assert!(calls.0.borrow().powerpc_contexts.is_empty());
             assert!(calls.is_empty());
         }
+    }
+
+    #[test]
+    fn mixed_callback_restores_private_import_state_across_live_time_wrap() {
+        const NATIVE_RETURN: u32 = 0x5000;
+        const NATIVE_FINAL: u32 = 0x7000;
+        let calls = SharedGuestCallStack::default();
+        let mut native = PpcCpu::new();
+        native.install_execution_context(pending_native_import_context(
+            0x1000,
+            NATIVE_RETURN,
+            NATIVE_FINAL,
+            0x6000,
+            0x1234_5678,
+        ));
+        native.gpr[1] = 0x9000;
+        native.set_time_base(u64::MAX);
+        assert!(calls.begin_powerpc_to_m68k(
+            GuestCallTarget {
+                isa: GuestIsa::M68k,
+                entry: 0x2000,
+                rtoc: 0,
+            },
+            0x2000,
+            0x3000,
+            0x4000,
+            0x3004,
+            M68kRegisterState::default(),
+            None,
+            NATIVE_RETURN,
+            0x6000,
+            PpcNativeReturnGpr3::Preserve,
+        ));
+        let mut classic = M68kCpu::new();
+        assert!(calls
+            .activate_m68k_parking(&mut classic, &mut native)
+            .is_some());
+        assert_eq!(
+            native.step_instruction(0x6000_0000),
+            ppc::PpcStepResult::Stepped
+        );
+        assert_eq!(native.time_base(), 0);
+        assert!(calls.complete_m68k_for_powerpc(0x4000, 0x3004, None, &mut native));
+        assert_eq!(native.time_base(), 0);
+        assert_eq!(native.pc, NATIVE_RETURN);
+        assert_eq!(
+            native.step_instruction((31 << 26) | (11 << 21) | (12 << 16) | (8 << 11) | (371 << 1)),
+            ppc::PpcStepResult::Stepped
+        );
+        assert_eq!(native.gpr[11], 0);
+        assert_eq!(native.time_base(), 1);
+        native.pc = NATIVE_RETURN;
+        let mut memory = GuestAddressSpace::new();
+        assert_eq!(
+            native.run_with_imports(&mut memory, 2, NATIVE_FINAL, 0, 0, |_, _, _| unreachable!()),
+            PpcRunResult::Halted {
+                pc: NATIVE_FINAL,
+                cycles: 1
+            }
+        );
+        assert_eq!((native.gpr[2], native.gpr[3]), (0x6000, 0x1234_5678));
     }
 
     #[test]

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -123,8 +123,9 @@ use crate::trap::types::{decode_mac_roman, encode_mac_roman_lossy, Rect};
 use crate::trap::{pict, TrapDispatcher};
 use crate::ui_theme::{render_scrollbar_bitmap, Rgb8, ThemeBitmap, UiThemeId};
 use ppc::{
-    PpcAlignmentPolicy, PpcCpu, PpcException, PpcFetchHistogram, PpcFetchObserver, PpcImportAction,
-    PpcMemory, PpcMemoryWriteObserver, PpcNativeReturnGpr3, PpcRunResult, PpcSectionMemSpan,
+    PpcAlignmentPolicy, PpcCpu, PpcException, PpcExecutionContext, PpcFetchHistogram,
+    PpcFetchObserver, PpcImportAction, PpcMemory, PpcMemoryWriteObserver, PpcNativeReturnGpr3,
+    PpcRunResult, PpcSectionMemSpan,
 };
 use std::cell::Cell;
 use std::collections::{HashMap, HashSet, VecDeque};
@@ -6988,9 +6989,9 @@ impl PpcLoadedApp {
         mut process_cfm: Option<&mut PpcCfmState>,
     ) -> PpcSoundCompletionCallProbe {
         self.assert_cfm_execution_owner(process_cfm.as_deref());
-        let saved_cpu = self.cpu.clone();
-        let default_rtoc = if saved_cpu.gpr[2] != 0 {
-            saved_cpu.gpr[2]
+        let saved_context = self.cpu.capture_execution_context();
+        let default_rtoc = if saved_context.architectural().gpr[2] != 0 {
+            saved_context.architectural().gpr[2]
         } else {
             self.rtoc
         };
@@ -7006,7 +7007,10 @@ impl PpcLoadedApp {
             proc_info: 0,
             routine_flags: 0,
         });
+        let mut entered = false;
         let probe = if let Some(callback_sp) = self.prepare_interrupt_callback_frame(default_rtoc) {
+            self.cpu.invalidate_reservation();
+            entered = true;
             self.cpu.pc = target.entry;
             self.cpu.lr = self.halt_pc;
             self.cpu.gpr[1] = callback_sp;
@@ -7046,7 +7050,9 @@ impl PpcLoadedApp {
         let end_sp = self.cpu.gpr[1];
         let end_r3 = self.cpu.gpr[3];
         let cycles = ppc_run_result_cycles(probe.result);
-        crate::guest_call::restore_powerpc_context(&mut self.cpu, saved_cpu);
+        if entered {
+            self.cpu.install_execution_context(saved_context);
+        }
 
         PpcSoundCompletionCallProbe {
             invocation: PpcSoundCompletionInvocationRecord {
@@ -7168,10 +7174,10 @@ impl PpcLoadedApp {
         mut process_cfm: Option<&mut PpcCfmState>,
     ) -> PpcTimerCallbackProbe {
         self.assert_cfm_execution_owner(process_cfm.as_deref());
-        let saved_cpu = self.cpu.clone();
+        let saved_context = self.cpu.capture_execution_context();
         let saved_current_resource_refnum = self.current_resource_refnum();
-        let default_rtoc = if saved_cpu.gpr[2] != 0 {
-            saved_cpu.gpr[2]
+        let default_rtoc = if saved_context.architectural().gpr[2] != 0 {
+            saved_context.architectural().gpr[2]
         } else {
             self.rtoc
         };
@@ -7182,7 +7188,10 @@ impl PpcLoadedApp {
                 proc_info: 0,
                 routine_flags: 0,
             });
+        let mut entered = false;
         let probe = if let Some(callback_sp) = self.prepare_interrupt_callback_frame(default_rtoc) {
+            self.cpu.invalidate_reservation();
+            entered = true;
             self.cpu.pc = target.entry;
             self.cpu.lr = self.halt_pc;
             self.cpu.gpr[1] = callback_sp;
@@ -7205,7 +7214,9 @@ impl PpcLoadedApp {
         let end_sp = self.cpu.gpr[1];
         let end_r3 = self.cpu.gpr[3];
         let cycles = ppc_run_result_cycles(probe.result);
-        crate::guest_call::restore_powerpc_context(&mut self.cpu, saved_cpu);
+        if entered {
+            self.cpu.install_execution_context(saved_context);
+        }
         self.set_current_resource_refnum(saved_current_resource_refnum);
 
         PpcTimerCallbackProbe {
@@ -7327,10 +7338,10 @@ impl PpcLoadedApp {
         mut process_cfm: Option<&mut PpcCfmState>,
     ) -> PpcVblCallbackProbe {
         self.assert_cfm_execution_owner(process_cfm.as_deref());
-        let saved_cpu = self.cpu.clone();
+        let saved_context = self.cpu.capture_execution_context();
         let saved_current_resource_refnum = self.current_resource_refnum();
-        let default_rtoc = if saved_cpu.gpr[2] != 0 {
-            saved_cpu.gpr[2]
+        let default_rtoc = if saved_context.architectural().gpr[2] != 0 {
+            saved_context.architectural().gpr[2]
         } else {
             self.rtoc
         };
@@ -7341,7 +7352,10 @@ impl PpcLoadedApp {
                 proc_info: 0,
                 routine_flags: 0,
             });
+        let mut entered = false;
         let probe = if let Some(callback_sp) = self.prepare_interrupt_callback_frame(default_rtoc) {
+            self.cpu.invalidate_reservation();
+            entered = true;
             self.cpu.pc = target.entry;
             self.cpu.lr = self.halt_pc;
             self.cpu.gpr[1] = callback_sp;
@@ -7366,7 +7380,9 @@ impl PpcLoadedApp {
         let end_sp = self.cpu.gpr[1];
         let end_r3 = self.cpu.gpr[3];
         let cycles = ppc_run_result_cycles(probe.result);
-        crate::guest_call::restore_powerpc_context(&mut self.cpu, saved_cpu);
+        if entered {
+            self.cpu.install_execution_context(saved_context);
+        }
         self.set_current_resource_refnum(saved_current_resource_refnum);
 
         PpcVblCallbackProbe {
@@ -7415,9 +7431,9 @@ impl PpcLoadedApp {
         mut process_cfm: Option<&mut PpcCfmState>,
     ) -> PpcSoundCompletionCallProbe {
         self.assert_cfm_execution_owner(process_cfm.as_deref());
-        let saved_cpu = self.cpu.clone();
-        let default_rtoc = if saved_cpu.gpr[2] != 0 {
-            saved_cpu.gpr[2]
+        let saved_context = self.cpu.capture_execution_context();
+        let default_rtoc = if saved_context.architectural().gpr[2] != 0 {
+            saved_context.architectural().gpr[2]
         } else {
             self.rtoc
         };
@@ -7429,7 +7445,10 @@ impl PpcLoadedApp {
                     proc_info: 0,
                     routine_flags: 0,
                 });
+        let mut entered = false;
         let probe = if let Some(callback_sp) = self.prepare_interrupt_callback_frame(default_rtoc) {
+            self.cpu.invalidate_reservation();
+            entered = true;
             self.cpu.pc = target.entry;
             self.cpu.lr = self.halt_pc;
             self.cpu.gpr[1] = callback_sp;
@@ -7454,7 +7473,9 @@ impl PpcLoadedApp {
         let end_sp = self.cpu.gpr[1];
         let end_r3 = self.cpu.gpr[3];
         let cycles = ppc_run_result_cycles(probe.result);
-        crate::guest_call::restore_powerpc_context(&mut self.cpu, saved_cpu);
+        if entered {
+            self.cpu.install_execution_context(saved_context);
+        }
 
         PpcSoundCompletionCallProbe {
             invocation: PpcSoundCompletionInvocationRecord {
@@ -23988,17 +24009,17 @@ fn dispatch_supported_import(
                 let _ = memory.write_u32_be(made, 0);
                 return Some(PpcImportAction::Return(ppc_i16_result(PPC_MEM_FULL_ERR)));
             };
-            let mut thread_cpu = PpcCpu::new();
-            thread_cpu.alignment_policy = cpu.alignment_policy;
-            thread_cpu.msr = cpu.msr;
-            thread_cpu.pc = target.entry;
-            thread_cpu.lr = PPC_THREAD_RETURN_PC;
-            thread_cpu.gpr[1] = (top & !15) - PPC_INITIAL_STACK_FRAME_SIZE;
-            thread_cpu.gpr[2] = target.rtoc;
-            thread_cpu.gpr[3] = param;
+            let mut thread_context = PpcExecutionContext::fresh();
+            let thread_state = thread_context.architectural_mut();
+            thread_state.msr = cpu.msr;
+            thread_state.pc = target.entry;
+            thread_state.lr = PPC_THREAD_RETURN_PC;
+            thread_state.gpr[1] = (top & !15) - PPC_INITIAL_STACK_FRAME_SIZE;
+            thread_state.gpr[2] = target.rtoc;
+            thread_state.gpr[3] = param;
             let created = toolbox_startup.guest_calls.create_native_thread(
                 crate::guest_call::NativeThreadContext {
-                    cpu: Box::new(thread_cpu),
+                    context: thread_context,
                 },
                 crate::guest_call::ThreadStorage {
                     result_destination,
@@ -170683,7 +170704,7 @@ pub(crate) mod tests {
                 .guest_calls
                 .create_native_thread(
                     NativeThreadContext {
-                        cpu: Box::new(worker_cpu),
+                        context: worker_cpu.capture_execution_context(),
                     },
                     crate::guest_call::ThreadStorage {
                         result_destination: 0,
@@ -170769,6 +170790,15 @@ pub(crate) mod tests {
             .guest_calls
             .set_scheduling_state(worker, ExecutionTaskState::Ready));
         loaded.guest_calls.begin_critical();
+        loaded.cpu.gpr[20] = 0x1234_5678;
+        loaded.cpu.fpr[20] = 0x4009_21fb_5444_2d18;
+        loaded.cpu.cr = 0x1357_2468;
+        loaded.cpu.ctr = 0x2468_1357;
+        loaded.cpu.xer = 0x89ab_cdef;
+        loaded.cpu.fpscr = 0x1020_3040;
+        loaded.cpu.msr = 0x5060_7080;
+        loaded.cpu.alignment_policy = PpcAlignmentPolicy::EmulateData;
+        establish_loaded_reservation(&mut loaded, PPC_DATA_BASE);
         // The ready identity has no saved execution context. Do not partially
         // end critical or stop the caller when successor preparation refuses.
         for (thread, state, error) in [(1, 1, -619), (99, 0, -618), (1, 99, -619), (3, 2, -619)] {
@@ -170782,6 +170812,14 @@ pub(crate) mod tests {
             assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(error));
             assert_eq!(loaded.guest_calls, before);
             assert_eq!(loaded.guest_calls.critical_depth(), 1);
+            assert_eq!(loaded.cpu.gpr[20], 0x1234_5678);
+            assert_eq!(loaded.cpu.fpr[20], 0x4009_21fb_5444_2d18);
+            assert_eq!(loaded.cpu.cr, 0x1357_2468);
+            assert_eq!(loaded.cpu.xer, 0x89ab_cdef);
+            assert_eq!(loaded.cpu.fpscr, 0x1020_3040);
+            assert_eq!(loaded.cpu.msr, 0x5060_7080);
+            assert_eq!(loaded.cpu.alignment_policy, PpcAlignmentPolicy::EmulateData);
+            assert_eq!(loaded.cpu.reservation_address(), Some(PPC_DATA_BASE));
         }
     }
 
@@ -177483,6 +177521,30 @@ pub(crate) mod tests {
         }
     }
 
+    fn establish_loaded_reservation(loaded: &mut PpcLoadedApp, address: u32) {
+        const LWARX_R12_R4_R5: u32 =
+            (31 << 26) | (12 << 21) | (4 << 16) | (5 << 11) | (20 << 1);
+        let preserved = (
+            loaded.cpu.pc,
+            loaded.cpu.gpr[4],
+            loaded.cpu.gpr[5],
+            loaded.cpu.gpr[12],
+        );
+        loaded.cpu.gpr[4] = address;
+        loaded.cpu.gpr[5] = 0;
+        assert_eq!(
+            loaded.cpu.step(&mut loaded.memory, LWARX_R12_R4_R5),
+            ppc::PpcStepResult::Stepped
+        );
+        assert_eq!(loaded.cpu.reservation_address(), Some(address));
+        (
+            loaded.cpu.pc,
+            loaded.cpu.gpr[4],
+            loaded.cpu.gpr[5],
+            loaded.cpu.gpr[12],
+        ) = preserved;
+    }
+
     #[test]
     fn interrupt_callbacks_preserve_time_base_on_return_fault_and_cycle_limit() {
         const OUTPUT: u32 = PPC_DATA_BASE + 0x3000;
@@ -177519,7 +177581,11 @@ pub(crate) mod tests {
                 loaded.cpu.gpr[20] = 0xdead_0000;
                 loaded.cpu.fpr[20] = 0x4009_21fb_5444_2d18;
                 loaded.cpu.cr = 0x1357_2468;
+                loaded.cpu.fpscr = 0x1020_3040;
+                loaded.cpu.msr = 0x5060_7080;
+                loaded.cpu.alignment_policy = PpcAlignmentPolicy::EmulateData;
                 loaded.cpu.set_time_base(START);
+                establish_loaded_reservation(&mut loaded, OUTPUT);
                 let saved = loaded.cpu.clone();
                 let result = invoke_worker_interrupt_for_test(&mut loaded, kind);
                 match outcome {
@@ -177549,6 +177615,10 @@ pub(crate) mod tests {
                 assert_eq!(loaded.cpu.lr, saved.lr);
                 assert_eq!(loaded.cpu.ctr, saved.ctr);
                 assert_eq!(loaded.cpu.xer, saved.xer);
+                assert_eq!(loaded.cpu.fpscr, saved.fpscr);
+                assert_eq!(loaded.cpu.msr, saved.msr);
+                assert_eq!(loaded.cpu.alignment_policy, saved.alignment_policy);
+                assert_eq!(loaded.cpu.reservation_address(), None);
                 // The resumed caller observes that same elapsed time through
                 // guest instructions, rather than only a host-side accessor.
                 loaded.cpu.step_instruction(xfx_form(31, 11, 268, 371));
@@ -177556,6 +177626,100 @@ pub(crate) mod tests {
                 loaded.cpu.step_instruction(xfx_form(31, 12, 269, 371));
                 assert_eq!(loaded.cpu.gpr[12], ((elapsed + 1) >> 32) as u32);
             }
+        }
+    }
+
+    #[test]
+    fn interrupt_callbacks_retain_wrapped_live_engine_time() {
+        const VECTOR: u32 = PPC_DATA_BASE + 0x4000;
+        const ENTRY: u32 = PPC_CODE_BASE + 0x2000;
+        for kind in 0..4 {
+            let mut loaded = load_pef_application(&synthetic_pef()).unwrap();
+            loaded.memory.add_region(VECTOR, vec![0; 8]);
+            loaded.memory.write_u32_be(VECTOR, ENTRY).unwrap();
+            loaded
+                .memory
+                .write_u32_be(VECTOR + 4, PPC_DATA_BASE)
+                .unwrap();
+            loaded.memory.add_region(ENTRY, BLR.to_be_bytes().to_vec());
+            loaded.cpu.set_time_base(u64::MAX);
+
+            let result = invoke_worker_interrupt_for_test(&mut loaded, kind);
+            assert!(matches!(result, PpcRunResult::Halted { cycles: 1, .. }), "{kind}");
+            assert_eq!(loaded.cpu.time_base(), 0, "callback family {kind}");
+            assert_eq!(
+                loaded
+                    .cpu
+                    .step(&mut loaded.memory, xfx_form(31, 11, 268, 371)),
+                ppc::PpcStepResult::Stepped
+            );
+            assert_eq!(loaded.cpu.gpr[11], 0, "callback family {kind}");
+            assert_eq!(loaded.cpu.time_base(), 1, "callback family {kind}");
+        }
+    }
+
+    #[test]
+    fn interrupt_callbacks_restore_the_interrupted_private_import_continuation() {
+        const VECTOR: u32 = PPC_DATA_BASE + 0x4000;
+        const ENTRY: u32 = PPC_CODE_BASE + 0x2000;
+        const TRAP: u32 = PPC_CODE_BASE + 0x3000;
+        const RETURN: u32 = PPC_CODE_BASE + 0x3100;
+        const FINAL: u32 = PPC_CODE_BASE + 0x3200;
+        for kind in 0..4 {
+            let mut loaded = load_pef_application(&synthetic_pef()).unwrap();
+            loaded.memory.add_region(VECTOR, vec![0; 8]);
+            loaded.memory.write_u32_be(VECTOR, ENTRY).unwrap();
+            loaded
+                .memory
+                .write_u32_be(VECTOR + 4, PPC_DATA_BASE)
+                .unwrap();
+            loaded.memory.add_region(ENTRY, BLR.to_be_bytes().to_vec());
+            crate::guest_call::seed_pending_native_import_context(
+                &mut loaded.cpu,
+                &mut loaded.memory,
+                TRAP,
+                RETURN,
+                0xaaaa_0002,
+                RETURN,
+                FINAL,
+                0xbbbb_0002,
+                PpcNativeReturnGpr3::Set(0xcccc_0003),
+            );
+            let result = invoke_worker_interrupt_for_test(&mut loaded, kind);
+            assert!(matches!(result, PpcRunResult::Halted { cycles: 1, .. }));
+            assert_eq!(loaded.cpu.pc, RETURN);
+            assert_eq!(
+                loaded.cpu.run_with_imports(
+                    &mut loaded.memory,
+                    2,
+                    FINAL,
+                    0,
+                    0,
+                    |_, _, _| unreachable!()
+                ),
+                PpcRunResult::Halted {
+                    pc: FINAL,
+                    cycles: 1
+                }
+            );
+            assert_eq!(
+                (loaded.cpu.gpr[2], loaded.cpu.gpr[3]),
+                (0xbbbb_0002, 0xcccc_0003)
+            );
+            assert_eq!(
+                loaded.cpu.run_with_imports(
+                    &mut loaded.memory,
+                    2,
+                    FINAL,
+                    0,
+                    0,
+                    |_, _, _| unreachable!()
+                ),
+                PpcRunResult::Halted {
+                    pc: FINAL,
+                    cycles: 0
+                }
+            );
         }
     }
 
@@ -177615,6 +177779,7 @@ pub(crate) mod tests {
                 .add_region(storage.stack_limit, vec![0x5a; 128]);
             for invalid_sp in [storage.stack_base + 128, storage.stack_limit + 16, 16] {
                 loaded.cpu.gpr[1] = invalid_sp;
+                establish_loaded_reservation(&mut loaded, OUTPUT);
                 let saved = loaded.cpu.clone();
                 let frame = ppc_interrupt_callback_stack_pointer(invalid_sp);
                 let before = ppc_memory_read_bytes(&mut loaded.memory, frame, 64);
@@ -177637,12 +177802,14 @@ pub(crate) mod tests {
                 assert_eq!(loaded.cpu.lr, saved.lr);
                 assert_eq!(loaded.cpu.cr, saved.cr);
                 assert_eq!(loaded.cpu.time_base(), saved.time_base());
+                assert_eq!(loaded.cpu.reservation_address(), saved.reservation_address());
                 assert_eq!(loaded.guest_calls.current_task(), worker);
             }
             loaded.cpu.gpr[1] = worker_sp;
             // A valid SP is insufficient when only part of the frame is
             // writable. Refusal must not clear even the accessible prefix.
             let frame = ppc_interrupt_callback_stack_pointer(worker_sp);
+            establish_loaded_reservation(&mut loaded, OUTPUT);
             let memory = std::mem::replace(&mut loaded.memory, PpcSectionMem::new());
             loaded.memory.add_region(frame, vec![0x5a; 32]);
             let saved = loaded.cpu.clone();
@@ -177657,6 +177824,7 @@ pub(crate) mod tests {
             );
             assert_eq!(loaded.cpu.gpr, saved.gpr);
             assert_eq!(loaded.cpu.pc, saved.pc);
+            assert_eq!(loaded.cpu.reservation_address(), saved.reservation_address());
             loaded.memory = memory;
             let protected_base = worker_sp - PPC_INTERRUPT_RED_ZONE_SIZE;
             let protected = vec![0xa5; (PPC_INTERRUPT_RED_ZONE_SIZE + 64) as usize];
@@ -177664,6 +177832,7 @@ pub(crate) mod tests {
                 .memory
                 .write_bytes(protected_base, &protected)
                 .unwrap();
+            establish_loaded_reservation(&mut loaded, OUTPUT);
             let saved = loaded.cpu.clone();
             let result = invoke_worker_interrupt_for_test(&mut loaded, kind);
             assert!(
@@ -177679,6 +177848,7 @@ pub(crate) mod tests {
             );
             assert_eq!(loaded.cpu.gpr, saved.gpr);
             assert_eq!(loaded.cpu.pc, saved.pc);
+            assert_eq!(loaded.cpu.reservation_address(), None);
             assert_eq!(loaded.guest_calls.current_task(), worker);
         }
     }

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -7013,7 +7013,7 @@ impl FixtureRunner {
             return Some((0, true));
         }
         let task = ppc_app.guest_calls.current_task();
-        let pending = self.m68k.activate_pending(&ppc_app.cpu)?;
+        let pending = self.m68k.activate_pending(&mut ppc_app.cpu)?;
 
         // Thread Manager calls are allowed to yield while guest callback code
         // is running. Once that happens, `self.m68k.cpu` belongs to the successor
@@ -11663,6 +11663,216 @@ mod tests {
     }
 
     #[test]
+    fn companion_engine_installs_native_worker_context_and_hands_back_to_classic() {
+        use crate::guest_call::{
+            seed_pending_native_import_context, CooperativeThread, ExecutionTaskId,
+            NativeThreadContext, ThreadStorage,
+        };
+        use crate::guest_procedure::GuestIsa;
+        const ADDRESS: u32 = PPC_DATA_BASE + 0x5000;
+        const A_RETURN: u32 = 0x5678;
+        const A_FINAL: u32 = 0x6678;
+        const B_RETURN: u32 = 0x7678;
+        const B_FINAL: u32 = 0x8678;
+        const LWARX_R12_R4_R5: u32 = (31 << 26) | (12 << 21) | (4 << 16) | (5 << 11) | (20 << 1);
+        let native = halted_ppc_app_with_sound(PpcSoundState::default())
+            .ppc
+            .take()
+            .unwrap();
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        runner.init_ppc_companion(native);
+        let calls = runner.dispatcher.guest_calls.shared_handle();
+        assert!(calls.bind_task_entry_isa(ExecutionTaskId::APPLICATION, GuestIsa::M68k));
+        let mut classic = CooperativeThread::default();
+        classic.pc = 0x1234;
+        assert!(calls.save_cooperative_context(ExecutionTaskId::APPLICATION, classic));
+        let pending_context = |trap_pc, return_pc, final_pc, rtoc, result| {
+            let mut cpu = PpcCpu::new();
+            let mut memory = PpcSectionMem::new();
+            seed_pending_native_import_context(
+                &mut cpu,
+                &mut memory,
+                trap_pc,
+                return_pc,
+                rtoc ^ 0xffff_0000,
+                return_pc,
+                final_pc,
+                rtoc,
+                PpcNativeReturnGpr3::Set(result),
+            );
+            cpu.capture_execution_context()
+        };
+        let worker_a = calls
+            .create_native_thread(
+                NativeThreadContext {
+                    context: pending_context(0x5000, A_RETURN, A_FINAL, 0xaaaa_0002, 0xaaaa_0003),
+                },
+                ThreadStorage::default(),
+                false,
+                |_| true,
+            )
+            .unwrap();
+        let worker_b = calls
+            .create_native_thread(
+                NativeThreadContext {
+                    context: pending_context(0x7000, B_RETURN, B_FINAL, 0xbbbb_0002, 0xbbbb_0003),
+                },
+                ThreadStorage::default(),
+                false,
+                |_| true,
+            )
+            .unwrap();
+        assert_eq!(calls.switch_from_classic(worker_a), Some(None));
+        let mut context = runner.native.take(NativeEngineRole::Companion).unwrap();
+        {
+            let companion = context.adapter_mut();
+            assert!(calls.prepare_native_task(&mut companion.cpu));
+            assert_eq!(companion.cpu.pc, A_RETURN);
+            assert!(calls
+                .yield_native_thread(&mut companion.cpu, worker_b.thread_id())
+                .unwrap());
+            assert_eq!(companion.cpu.pc, B_RETURN);
+            assert_eq!(
+                companion.cpu.run_with_imports(
+                    &mut companion.memory,
+                    2,
+                    B_FINAL,
+                    0,
+                    0,
+                    |_, _, _| unreachable!()
+                ),
+                PpcRunResult::Halted {
+                    pc: B_FINAL,
+                    cycles: 1
+                }
+            );
+            assert_eq!(
+                (companion.cpu.gpr[2], companion.cpu.gpr[3]),
+                (0xbbbb_0002, 0xbbbb_0003)
+            );
+            assert!(calls
+                .yield_native_thread(&mut companion.cpu, worker_a.thread_id())
+                .unwrap());
+            assert_eq!(
+                companion.cpu.run_with_imports(
+                    &mut companion.memory,
+                    2,
+                    A_FINAL,
+                    0,
+                    0,
+                    |_, _, _| unreachable!()
+                ),
+                PpcRunResult::Halted {
+                    pc: A_FINAL,
+                    cycles: 1
+                }
+            );
+            assert_eq!(
+                (companion.cpu.gpr[2], companion.cpu.gpr[3]),
+                (0xaaaa_0002, 0xaaaa_0003)
+            );
+            companion
+                .memory
+                .add_region(ADDRESS, 0x5566_7788u32.to_be_bytes().to_vec());
+            companion.cpu.gpr[4] = ADDRESS;
+            assert_eq!(
+                companion.cpu.step(&mut companion.memory, LWARX_R12_R4_R5),
+                ppc::PpcStepResult::Stepped
+            );
+            assert_eq!(companion.cpu.reservation_address(), Some(ADDRESS));
+            assert!(calls
+                .yield_native_thread(&mut companion.cpu, worker_b.thread_id())
+                .unwrap());
+            assert_eq!(
+                companion.cpu.run_with_imports(
+                    &mut companion.memory,
+                    2,
+                    B_FINAL,
+                    0,
+                    0,
+                    |_, _, _| unreachable!()
+                ),
+                PpcRunResult::Halted {
+                    pc: B_FINAL,
+                    cycles: 0
+                }
+            );
+            assert_eq!(companion.cpu.reservation_address(), None);
+            assert!(calls
+                .yield_native_thread(&mut companion.cpu, ExecutionTaskId::APPLICATION.thread_id())
+                .unwrap());
+            assert!(calls.has_classic_task_handoff());
+            assert_eq!(companion.cpu.reservation_address(), None);
+        }
+        assert!(runner.native.restore(context).is_ok());
+        assert!(runner.native.application().is_none());
+        assert!(runner.native.companion().is_some());
+    }
+
+    #[test]
+    fn companion_new_thread_import_installs_a_fresh_worker_on_the_live_engine() {
+        use crate::guest_call::{CooperativeThread, ExecutionTaskId};
+        use crate::guest_procedure::GuestIsa;
+        use crate::loader::ppc::tests::synthetic_pef_with_import;
+        const MADE: u32 = PPC_DATA_BASE + 0x5000;
+        const THREAD_RETURN: u32 = PPC_IMPORT_TRAP_BASE + (4096 + 1) * 4;
+        let native = load_pef_application(&synthetic_pef_with_import(b"NewThread")).unwrap();
+        let entry = native.entry_pc;
+        let expected_rtoc = native.cpu.gpr[2];
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        runner.init_ppc_companion(native);
+        let calls = runner.dispatcher.guest_calls.shared_handle();
+        assert!(calls.bind_task_entry_isa(ExecutionTaskId::APPLICATION, GuestIsa::M68k));
+        let worker;
+        let live_time;
+        {
+            let mut context = runner.native.take(NativeEngineRole::Companion).unwrap();
+            let companion = context.adapter_mut();
+            companion.memory.add_region(MADE, vec![0; 4]);
+            companion.cpu.msr = 0x5060_7080;
+            companion.cpu.alignment_policy = ppc::PpcAlignmentPolicy::EmulateData;
+            companion.cpu.set_time_base(0xffff_ffff_0000_0000);
+            companion.cpu.gpr[3] = 1;
+            companion.cpu.gpr[4] = entry;
+            companion.cpu.gpr[5] = 0x1234_5678;
+            companion.cpu.gpr[6] = 4096;
+            companion.cpu.gpr[7] = 0;
+            companion.cpu.gpr[8] = 0;
+            companion.cpu.gpr[9] = MADE;
+            let probe = runner.process_context.with_memory_and_cfm(|mm, cfm| {
+                companion.run_with_process_services(64, false, false, mm, cfm)
+            });
+            assert_eq!(probe.handled_import_count, 1);
+            assert_eq!(companion.cpu.gpr[3], 0);
+            worker = ExecutionTaskId::from_thread_id(companion.memory.read_u32_be(MADE).unwrap());
+            live_time = companion.cpu.time_base();
+            assert!(runner.native.restore(context).is_ok());
+        }
+        let mut classic = CooperativeThread::default();
+        classic.pc = 0x1234;
+        assert!(calls.save_cooperative_context(ExecutionTaskId::APPLICATION, classic));
+        assert_eq!(calls.switch_from_classic(worker), Some(None));
+        let mut context = runner.native.take(NativeEngineRole::Companion).unwrap();
+        {
+            let companion = context.adapter_mut();
+            assert!(calls.prepare_native_task(&mut companion.cpu));
+            assert_eq!(companion.cpu.pc, entry);
+            assert_eq!(companion.cpu.lr, THREAD_RETURN);
+            assert_eq!(companion.cpu.gpr[1] & 15, 0);
+            assert_eq!(companion.cpu.gpr[2], expected_rtoc);
+            assert_eq!(companion.cpu.gpr[3], 0x1234_5678);
+            assert_eq!(companion.cpu.msr, 0x5060_7080);
+            assert_eq!(
+                companion.cpu.alignment_policy,
+                ppc::PpcAlignmentPolicy::EmulateData
+            );
+            assert_eq!(companion.cpu.time_base(), live_time);
+            assert_eq!(companion.cpu.reservation_address(), None);
+        }
+        assert!(runner.native.restore(context).is_ok());
+    }
+
+    #[test]
     fn find_symbol_during_native_to_classic_callback_borrows_the_checked_out_adapter() {
         use crate::guest_call::{GuestCallTarget, M68kRegisterState, M68kResultSource};
         use crate::guest_procedure::GuestIsa;
@@ -12752,7 +12962,7 @@ mod tests {
         use crate::memory::globals::addr;
 
         let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
-        runner.set_launch_state(4321, 0x7654_3210, 0x8877_6655_4433_2211);
+        runner.set_launch_state(4321, 0x7654_3210, u64::MAX);
         let mut app = halted_ppc_app_with_sound(PpcSoundState::default());
         app.ppc
             .as_mut()
@@ -12798,7 +13008,7 @@ mod tests {
             .write_u32_be(toolbox_entry, 0x0021_0000)
             .expect("write shared Toolbox trap entry");
         assert_eq!(runner.bus.read_long(toolbox_entry), 0x0021_0000);
-        assert_eq!(ppc_app.cpu.time_base(), 0x8877_6655_4433_2211);
+        assert_eq!(ppc_app.cpu.time_base(), u64::MAX);
     }
 
     #[test]
@@ -17513,7 +17723,9 @@ mod tests {
                     .dispatcher
                     .guest_calls
                     .create_native_thread(
-                        crate::guest_call::NativeThreadContext { cpu: Box::new(cpu) },
+                        crate::guest_call::NativeThreadContext {
+                            context: cpu.capture_execution_context(),
+                        },
                         crate::guest_call::ThreadStorage {
                             result_destination: 0,
                             stack_base: 0,
@@ -18337,6 +18549,7 @@ mod tests {
 
     #[test]
     fn relaunch_with_pending_execution_preserves_the_existing_engine() {
+        use crate::execution_kernel::ExecutionTaskState;
         let app = halted_ppc_app_with_sound(PpcSoundState::default());
         let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
         runner.init_app(&app);
@@ -18362,7 +18575,7 @@ mod tests {
         let worker = calls
             .create_native_thread(
                 crate::guest_call::NativeThreadContext {
-                    cpu: Box::new(PpcCpu::new()),
+                    context: PpcCpu::new().capture_execution_context(),
                 },
                 crate::guest_call::ThreadStorage {
                     result_destination: 0,
@@ -18380,6 +18593,52 @@ mod tests {
         assert!(rejected.is_err());
         assert_eq!(runner.native.application().unwrap().cpu.pc, native_pc);
         assert!(calls.scheduling_state(worker).is_some());
+        assert!(calls.set_scheduling_state(worker, ExecutionTaskState::Ready));
+        {
+            let cpu = &mut runner.native.application_mut().unwrap().cpu;
+            assert!(calls.yield_native_thread(cpu, worker.thread_id()).unwrap());
+            assert!(calls
+                .yield_native_thread(cpu, ExecutionTaskId::APPLICATION.thread_id())
+                .unwrap());
+            assert!(calls
+                .retire_native_thread(worker, cpu, false, |_| true)
+                .is_some());
+        }
+        assert_eq!(calls.scheduling_state(worker), None);
+        assert!(!calls.switch_to_task(worker));
+        runner.set_launch_state(41, 1, u64::MAX);
+        runner.init_app(&app);
+        assert_eq!(
+            runner.native.application().unwrap().cpu.time_base(),
+            u64::MAX
+        );
+        {
+            let cpu = &mut runner.native.application_mut().unwrap().cpu;
+            assert_eq!(
+                cpu.step_instruction((31 << 26) | (11 << 21) | (12 << 16) | (8 << 11) | (371 << 1)),
+                ppc::PpcStepResult::Stepped
+            );
+            assert_eq!(cpu.gpr[11], u32::MAX);
+            assert_eq!(cpu.time_base(), 0);
+        }
+        let mut replacement = ppc::PpcExecutionContext::fresh();
+        replacement.architectural_mut().gpr[20] = 0xaabb_ccdd;
+        let replacement = calls
+            .create_native_thread(
+                crate::guest_call::NativeThreadContext {
+                    context: replacement,
+                },
+                crate::guest_call::ThreadStorage::default(),
+                false,
+                |_| true,
+            )
+            .unwrap();
+        let cpu = &mut runner.native.application_mut().unwrap().cpu;
+        assert!(calls
+            .yield_native_thread(cpu, replacement.thread_id())
+            .unwrap());
+        assert_eq!(cpu.gpr[20], 0xaabb_ccdd);
+        assert_eq!(cpu.time_base(), 0);
     }
 
     #[test]

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -27785,7 +27785,7 @@ mod tests {
             crate::guest_call::GuestCallReturnPolicy::Preserve
         ));
         disp.guest_calls
-            .activate_m68k_parking(&mut classic, &native)
+            .activate_m68k_parking(&mut classic, &mut native)
             .unwrap();
         cpu.write_reg(Register::A7, TEST_SP);
         cpu.write_reg(Register::D0, 0x0414);
@@ -27832,7 +27832,7 @@ mod tests {
             .guest_calls
             .create_native_thread(
                 crate::guest_call::NativeThreadContext {
-                    cpu: Box::new(native),
+                    context: native.capture_execution_context(),
                 },
                 crate::guest_call::ThreadStorage {
                     stack_base: 0x8000,


### PR DESCRIPTION
Suspending a native task or callback currently saves a whole PPC engine. Restoring it can replace engine caches and private engine state, and the numeric maximum used for time restoration is incorrect when the live counter wraps.

Use PPC 0.6.0's opaque execution contexts for native tasks, mixed-mode callers and all four interrupt callback families. Keep the live engine, its caches, alignment policy and wrapping counter in place. Restore task-owned registers and import continuations, and invalidate reservations only after a committed suspension or owner change. Fresh native threads prepare contexts rather than additional engines.

Regression coverage includes task round trips, nested mixed-mode calls, application and companion execution, callback return/fault/cycle-limit outcomes, preparation refusal, counter rollover and relaunch ownership. For example, after a live counter wraps from `u64::MAX` to zero, restoring a caller retains zero rather than reinstating the saved maximum.

Validation against the published registry dependency:

- Default library suite: 5,201 passed, 3 ignored; six additional feature-gated scripted-trace tests passed separately.
- Browser-target check and all-target/all-feature check passed without warnings.
- Runtime source guard passed; package file listing checked.
- The exported package tree is identical to the tested tree.

Closes #1552.
