### PR TITLE
refactor: share cooperative NewThread creation policy

### DIFF
--- a/src/guest_call.rs
+++ b/src/guest_call.rs
@@ -1722,6 +1722,7 @@ impl SharedGuestCallStack {
         self.request_classic_thread_stack(size, 2).ok().flatten()
     }
 
+    #[cfg(test)]
     pub(crate) fn request_classic_thread_stack(
         &self,
         size: u32,
@@ -1774,6 +1775,7 @@ impl SharedGuestCallStack {
         ));
     }
 
+    #[cfg(test)]
     pub(crate) fn recycle_classic_thread_stack(&self, stack: (u32, u32)) {
         self.recycle_thread_stack(
             GuestIsa::M68k,

--- a/src/guest_procedure.rs
+++ b/src/guest_procedure.rs
@@ -192,6 +192,28 @@ pub(crate) fn resolve_guest_procedure(
     }
 }
 
+/// Resolve a direct NewThread entry for its declared ISA. Thread Manager
+/// (1999), pp. 56–58 requires every thread to use the application's instruction
+/// set and prohibits RoutineDescriptor entry points. Rejecting a recognized
+/// descriptor header is the runtime's explicit `paramErr` compatibility policy;
+/// the ABI adapter encodes that error.
+pub(crate) fn resolve_same_isa_thread_entry(
+    memory: &mut impl GuestProcedureMemory,
+    pointer: u32,
+    default_powerpc_rtoc: u32,
+    isa: GuestIsa,
+) -> Option<GuestProcedure> {
+    if pointer == 0
+        || memory.procedure_read_u16(pointer) == Some(ROUTINE_DESCRIPTOR_MIXED_MODE_TRAP)
+    {
+        return None;
+    }
+    Some(match isa {
+        GuestIsa::M68k => GuestProcedure::raw_m68k(pointer),
+        GuestIsa::PowerPc => resolve_powerpc_pointer(memory, pointer, default_powerpc_rtoc, false),
+    })
+}
+
 /// Inspect a procedure without executing or preparing its code. Callers that
 /// can run CFM retain the preparation request and resume resolution afterwards.
 /// Callable-only consumers must not execute an unprepared fragment container.
@@ -440,6 +462,65 @@ mod tests {
             resolve_guest_procedure(memory, pointer, 0x1234, selector, isa, isa),
             resolve_guest_procedure(&mut classic, pointer, 0x1234, selector, isa, isa),
         ]
+    }
+
+    fn resolve_direct_both_views(
+        memory: &mut GuestAddressSpace,
+        pointer: u32,
+        isa: GuestIsa,
+    ) -> [Option<GuestProcedure>; 2] {
+        let mut classic = MacMemoryBus::new(0x10000);
+        classic.set_addressing_32_bit(true);
+        classic.attach_guest_address_space(memory.shared_view());
+        [
+            resolve_same_isa_thread_entry(memory, pointer, 0x1234, isa),
+            resolve_same_isa_thread_entry(&mut classic, pointer, 0x1234, isa),
+        ]
+    }
+
+    #[test]
+    fn same_isa_thread_entries_reject_null_and_descriptor_headers_in_either_view() {
+        let mut memory = descriptor_memory();
+        write_descriptor_header(&mut memory, 0);
+        for isa in [GuestIsa::M68k, GuestIsa::PowerPc] {
+            assert_eq!(resolve_direct_both_views(&mut memory, 0, isa), [None; 2]);
+            assert_eq!(resolve_direct_both_views(&mut memory, BASE, isa), [None; 2]);
+        }
+    }
+
+    #[test]
+    fn same_isa_thread_entries_preserve_raw_and_powerpc_vector_rules_in_either_view() {
+        let pointer = BASE + 0x100;
+        let entry = BASE + 0x180;
+        let mut memory = descriptor_memory();
+
+        let classic = resolve_direct_both_views(&mut memory, pointer, GuestIsa::M68k);
+        assert_eq!(classic[0], classic[1]);
+        assert_eq!(classic[0], Some(GuestProcedure::raw_m68k(pointer)));
+
+        memory.write_u32_be(pointer, entry).unwrap();
+        memory.write_u32_be(pointer + 4, 0x5678).unwrap();
+        memory.write_u32_be(entry, 0x4e80_0020).unwrap();
+        let native = resolve_direct_both_views(&mut memory, pointer, GuestIsa::PowerPc);
+        assert_eq!(native[0], native[1]);
+        assert_eq!(native[0].unwrap().entry, entry);
+        assert_eq!(native[0].unwrap().rtoc, 0x5678);
+        assert_eq!(
+            native[0].unwrap().representation,
+            GuestProcedureRepresentation::PowerPcTransitionVector { address: pointer }
+        );
+
+        let unmapped = BASE + 0x300;
+        memory.write_u32_be(unmapped, 0x0020_0000).unwrap();
+        memory.write_u32_be(unmapped + 4, 0x9abc).unwrap();
+        let raw = resolve_direct_both_views(&mut memory, unmapped, GuestIsa::PowerPc);
+        assert_eq!(raw[0], raw[1]);
+        assert_eq!(raw[0].unwrap().entry, unmapped);
+        assert_eq!(raw[0].unwrap().rtoc, 0x1234);
+        assert_eq!(
+            raw[0].unwrap().representation,
+            GuestProcedureRepresentation::RawCode
+        );
     }
 
     #[test]

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -29,11 +29,11 @@ use crate::event_queue::{
 };
 use crate::guest_call::{
     format_ppc_import_action, install_powerpc_call_arguments, GuestCallContinuation,
-    GuestCallEffect, GuestCallRequest, GuestCallTarget, MenuTrackingCall,
-    MenuTrackingOrigin, SharedGuestCallStack,
+    GuestCallEffect, GuestCallRequest, GuestCallTarget, MenuTrackingCall, MenuTrackingOrigin,
+    NativeThreadContext, SharedGuestCallStack, ThreadStorage,
 };
 use crate::guest_procedure::{
-    resolve_guest_procedure, GuestIsa, GuestProcedure,
+    resolve_guest_procedure, resolve_same_isa_thread_entry, GuestIsa, GuestProcedure,
     ROUTINE_DESCRIPTOR_HEADER_SIZE as PPC_ROUTINE_DESCRIPTOR_HEADER_SIZE,
     ROUTINE_DESCRIPTOR_MIXED_MODE_TRAP as PPC_MIXED_MODE_TRAP,
     ROUTINE_DESCRIPTOR_VERSION as PPC_ROUTINE_DESCRIPTOR_VERSION,
@@ -121,6 +121,7 @@ use crate::trap::manager::{
 };
 use crate::trap::types::{decode_mac_roman, encode_mac_roman_lossy, Rect};
 use crate::trap::{pict, TrapDispatcher};
+use crate::thread_manager::{NewThreadCreationEdge, ThreadManager};
 use crate::ui_theme::{render_scrollbar_bitmap, Rgb8, ThemeBitmap, UiThemeId};
 use ppc::{
     PpcAlignmentPolicy, PpcCpu, PpcException, PpcExecutionContext, PpcFetchHistogram,
@@ -15253,6 +15254,118 @@ fn ppc_apply_process_native_allocator(
     ppc_update_zone_free_bytes(memory, *heap_cursor, allocation_limit);
 }
 
+struct PpcNewThreadEdge<'a> {
+    memory: &'a mut PpcSectionMem,
+    memory_manager: &'a mut ProcessNativeMemoryManager,
+    heap_cursor: &'a mut u32,
+    last_mem_error: &'a mut i16,
+    msr: u32,
+    entry_pointer: u32,
+    default_rtoc: u32,
+    parameter: u32,
+    result_destination: u32,
+    thread_made: u32,
+    target: Option<GuestProcedure>,
+}
+
+impl NewThreadCreationEdge for PpcNewThreadEdge<'_> {
+    fn preflight(&mut self, _size: u32) -> std::result::Result<(), i16> {
+        if self.thread_made == 0 || !ppc_memory_can_write_bytes(self.memory, self.thread_made, 4) {
+            return Err(PPC_PARAM_ERR);
+        }
+        self.target = resolve_same_isa_thread_entry(
+            self.memory,
+            self.entry_pointer,
+            self.default_rtoc,
+            GuestIsa::PowerPc,
+        );
+        if self.target.is_some() {
+            Ok(())
+        } else {
+            Err(PPC_PARAM_ERR)
+        }
+    }
+
+    fn allocate_fresh(&mut self, size: u32) -> std::result::Result<ThreadStorage, i16> {
+        let stack = self.memory_manager.new_native_ptr(self.memory, size, true);
+        ppc_apply_process_native_allocator(
+            self.memory_manager,
+            self.memory,
+            self.heap_cursor,
+            self.last_mem_error,
+        );
+        if stack == 0 {
+            return Err(PPC_MEM_FULL_ERR);
+        }
+        let Some(stack_limit) = stack.checked_add(size) else {
+            self.memory_manager.dispose_native_ptr(stack);
+            ppc_apply_process_native_allocator(
+                self.memory_manager,
+                self.memory,
+                self.heap_cursor,
+                self.last_mem_error,
+            );
+            return Err(PPC_MEM_FULL_ERR);
+        };
+        Ok(ThreadStorage {
+            result_destination: self.result_destination,
+            stack_base: stack,
+            stack_limit,
+            managed_pointer: true,
+        })
+    }
+
+    fn prepare_and_publish(
+        &mut self,
+        execution: &SharedGuestCallStack,
+        mut storage: ThreadStorage,
+        suspended: bool,
+    ) -> std::result::Result<Option<crate::guest_call::ExecutionTaskId>, i16> {
+        let target = self.target.expect("successful preflight resolves a target");
+        storage.result_destination = self.result_destination;
+        storage.managed_pointer = true;
+        let Some(stack_pointer) =
+            (storage.stack_limit & !15).checked_sub(PPC_INITIAL_STACK_FRAME_SIZE)
+        else {
+            return Err(PPC_MEM_FULL_ERR);
+        };
+        if stack_pointer < storage.stack_base {
+            return Err(PPC_MEM_FULL_ERR);
+        }
+        let mut context = PpcExecutionContext::fresh();
+        let state = context.architectural_mut();
+        state.msr = self.msr;
+        state.pc = target.entry;
+        state.lr = PPC_THREAD_RETURN_PC;
+        state.gpr[1] = stack_pointer;
+        state.gpr[2] = target.rtoc;
+        state.gpr[3] = self.parameter;
+        Ok(execution.create_native_thread(
+            NativeThreadContext { context },
+            storage,
+            suspended,
+            |task| {
+                self.memory
+                    .write_u32_be(self.thread_made, task.thread_id())
+                    .is_some()
+            },
+        ))
+    }
+
+    fn release_fresh(&mut self, storage: ThreadStorage) {
+        self.memory_manager.dispose_native_ptr(storage.stack_base);
+    }
+
+    fn finish_publication_attempt(&mut self) {
+        ppc_apply_process_native_allocator(
+            self.memory_manager,
+            self.memory,
+            self.heap_cursor,
+            self.last_mem_error,
+        );
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn ppc_dispose_process_native_handle(
     memory_manager: &mut ProcessNativeMemoryManager,
@@ -23954,105 +24067,31 @@ fn dispatch_supported_import(
             let style = cpu.gpr[3];
             let entry = cpu.gpr[4];
             let param = cpu.gpr[5];
-            let size = if cpu.gpr[6] == 0 {
-                crate::thread_manager::DEFAULT_COOPERATIVE_THREAD_STACK_SIZE
-            } else {
-                cpu.gpr[6]
-            };
+            let size = cpu.gpr[6];
             let options = cpu.gpr[7];
             let result_destination = cpu.gpr[8];
             let made = cpu.gpr[9];
-            let target = ppc_resolve_callback_target(memory, entry, cpu.gpr[2], None);
-            if style != 1
-                || size < 256
-                || size > i32::MAX as u32
-                || made == 0
-                || !ppc_memory_can_write_bytes(memory, made, 4)
-                || target.is_none()
-            {
-                if made != 0 {
-                    let _ = memory.write_u32_be(made, 0);
-                }
-                return Some(PpcImportAction::Return(ppc_i16_result(PPC_PARAM_ERR)));
-            }
-            let target = target.unwrap();
-            let pooled = match toolbox_startup.guest_calls.request_thread_stack(
-                GuestIsa::PowerPc,
-                size,
-                options,
-            ) {
-                Ok(pooled) => pooled,
-                Err(error) => {
-                    let _ = memory.write_u32_be(made, 0);
-                    return Some(PpcImportAction::Return(ppc_i16_result(error)));
-                }
-            };
-            let stack = pooled.map_or_else(
-                || process_memory_manager.new_native_ptr(memory, size, true),
-                |storage| storage.stack_base,
-            );
-            ppc_apply_process_native_allocator(
-                process_memory_manager,
+            let execution = toolbox_startup.guest_calls.shared_handle();
+            let mut edge = PpcNewThreadEdge {
                 memory,
+                memory_manager: process_memory_manager,
                 heap_cursor,
                 last_mem_error,
-            );
-            if stack == 0 {
-                let _ = memory.write_u32_be(made, 0);
-                return Some(PpcImportAction::Return(ppc_i16_result(PPC_MEM_FULL_ERR)));
-            }
-            let Some(top) = pooled
-                .map(|storage| storage.stack_limit)
-                .or_else(|| stack.checked_add(size))
-            else {
-                process_memory_manager.dispose_native_ptr(stack);
-                let _ = memory.write_u32_be(made, 0);
-                return Some(PpcImportAction::Return(ppc_i16_result(PPC_MEM_FULL_ERR)));
+                msr: cpu.msr,
+                entry_pointer: entry,
+                default_rtoc: cpu.gpr[2],
+                parameter: param,
+                result_destination,
+                thread_made: made,
+                target: None,
             };
-            let mut thread_context = PpcExecutionContext::fresh();
-            let thread_state = thread_context.architectural_mut();
-            thread_state.msr = cpu.msr;
-            thread_state.pc = target.entry;
-            thread_state.lr = PPC_THREAD_RETURN_PC;
-            thread_state.gpr[1] = (top & !15) - PPC_INITIAL_STACK_FRAME_SIZE;
-            thread_state.gpr[2] = target.rtoc;
-            thread_state.gpr[3] = param;
-            let created = toolbox_startup.guest_calls.create_native_thread(
-                crate::guest_call::NativeThreadContext {
-                    context: thread_context,
-                },
-                crate::guest_call::ThreadStorage {
-                    result_destination,
-                    stack_base: stack,
-                    stack_limit: top,
-                    managed_pointer: true,
-                },
-                options & 1 != 0,
-                |task| memory.write_u32_be(made, task.thread_id()).is_some(),
-            );
-            if created.is_none() {
-                if let Some(storage) = pooled {
-                    toolbox_startup
-                        .guest_calls
-                        .recycle_thread_stack(GuestIsa::PowerPc, storage);
-                } else {
-                    process_memory_manager.dispose_native_ptr(stack);
-                }
-                let _ = memory.write_u32_be(made, 0);
+            let result = ThreadManager::new(&execution)
+                .create_thread(GuestIsa::PowerPc, style, size, options, &mut edge)
+                .map_or_else(|error| error, |_| PPC_NO_ERR);
+            if result != PPC_NO_ERR && made != 0 {
+                let _ = edge.memory.write_u32_be(made, 0);
             }
-            ppc_apply_process_native_allocator(
-                process_memory_manager,
-                memory,
-                heap_cursor,
-                last_mem_error,
-            );
-            Some(PpcImportAction::Return(ppc_i16_result(
-                if created.is_some() {
-                    PPC_NO_ERR
-                } else {
-                    PPC_MEM_FULL_ERR
-                },
-            )))
+            Some(PpcImportAction::Return(ppc_i16_result(result)))
         }
         PpcImportDispatcherTarget::YieldToThread | PpcImportDispatcherTarget::YieldToAnyThread => {
             // OSErr YieldToThread(ThreadID); OSErr YieldToAnyThread(void);
@@ -170532,6 +170571,180 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn native_thread_creation_rejects_descriptors_before_allocation_and_preserves_vector_state() {
+        use crate::guest_call::ExecutionTaskId;
+        let mut loaded = load_pef_application(&synthetic_pef_with_import(b"NewThread")).unwrap();
+        let made = PPC_DATA_BASE + 0x1000;
+        let descriptor = PPC_DATA_BASE + 0x2000;
+        let target = loaded.entry_pc;
+        let rtoc = PPC_DATA_BASE + 0x3000;
+        loaded.memory.add_region(made, vec![0xaa; 4]);
+        loaded.memory.add_region(descriptor, vec![0; 0x100]);
+        loaded
+            .memory
+            .write_u16_be(descriptor, PPC_MIXED_MODE_TRAP)
+            .unwrap();
+        loaded
+            .memory
+            .write_u8(descriptor + 2, PPC_ROUTINE_DESCRIPTOR_VERSION)
+            .unwrap();
+        loaded.memory.write_u16_be(descriptor + 10, 0).unwrap();
+        let heap_before = loaded.heap_cursor();
+
+        let invoke = |loaded: &mut PpcLoadedApp| {
+            loaded.cpu.pc = loaded.entry_pc;
+            loaded.cpu.lr = PPC_HALT_PC;
+            loaded.cpu.gpr[3] = 1;
+            loaded.cpu.gpr[4] = descriptor;
+            loaded.cpu.gpr[5] = 0x1234;
+            loaded.cpu.gpr[6] = 4096;
+            loaded.cpu.gpr[7] = 0;
+            loaded.cpu.gpr[8] = 0;
+            loaded.cpu.gpr[9] = made;
+            assert_eq!(loaded.run_with_hle_imports(64).handled_import_count, 1);
+        };
+
+        let record = descriptor + PPC_ROUTINE_DESCRIPTOR_HEADER_SIZE;
+        let tvector = descriptor + 0x40;
+        loaded.memory.write_u32_be(tvector, target).unwrap();
+        loaded.memory.write_u32_be(tvector + 4, rtoc).unwrap();
+        for (isa, procedure) in [
+            (PPC_ROUTINE_RECORD_POWERPC_ISA, tvector),
+            (PPC_ROUTINE_RECORD_M68K_ISA, PPC_CODE_BASE),
+        ] {
+            assert!(ppc_write_routine_record(
+                &mut loaded.memory,
+                record,
+                0,
+                isa,
+                0,
+                procedure,
+            ));
+            let callable = resolve_guest_procedure(
+                &mut loaded.memory,
+                descriptor,
+                loaded.cpu.gpr[2],
+                None,
+                GuestIsa::PowerPc,
+                GuestIsa::PowerPc,
+            )
+            .expect("the test descriptor must be callable through the generic resolver");
+            let (expected_isa, expected_entry) = if isa == PPC_ROUTINE_RECORD_POWERPC_ISA {
+                (GuestIsa::PowerPc, target)
+            } else {
+                (GuestIsa::M68k, PPC_CODE_BASE)
+            };
+            assert_eq!(callable.isa, expected_isa);
+            assert_eq!(callable.entry, expected_entry);
+            loaded.memory.write_u32_be(made, 0xaaaa_aaaa).unwrap();
+            invoke(&mut loaded);
+            assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_PARAM_ERR));
+            assert_eq!(loaded.memory.read_u32_be(made), Some(0));
+            assert_eq!(loaded.heap_cursor(), heap_before);
+            assert!(!loaded.guest_calls.has_live_workers());
+        }
+
+        loaded.memory.write_u32_be(descriptor, target).unwrap();
+        loaded.memory.write_u32_be(descriptor + 4, rtoc).unwrap();
+        invoke(&mut loaded);
+        assert_eq!(loaded.cpu.gpr[3], 0);
+        let worker = ExecutionTaskId::from_thread_id(loaded.memory.read_u32_be(made).unwrap());
+        assert_eq!(worker.thread_id(), 3);
+        assert!(loaded
+            .guest_calls
+            .yield_native_thread(&mut loaded.cpu, worker.thread_id())
+            .unwrap());
+        assert_eq!(loaded.cpu.pc, target);
+        assert_eq!(loaded.cpu.gpr[2], rtoc);
+        assert_eq!(loaded.cpu.gpr[3], 0x1234);
+    }
+
+    #[test]
+    fn native_thread_creation_preflights_output_and_projects_real_allocation_failure() {
+        use crate::guest_call::ExecutionTaskId;
+
+        let invoke = |loaded: &mut PpcLoadedApp, made: u32, size: u32| {
+            loaded.cpu.pc = loaded.entry_pc;
+            loaded.cpu.lr = PPC_HALT_PC;
+            loaded.cpu.gpr[3] = 1;
+            loaded.cpu.gpr[4] = PPC_CODE_BASE;
+            loaded.cpu.gpr[5] = 0x1234;
+            loaded.cpu.gpr[6] = size;
+            loaded.cpu.gpr[7] = 0;
+            loaded.cpu.gpr[8] = 0;
+            loaded.cpu.gpr[9] = made;
+            assert_eq!(loaded.run_with_hle_imports(64).handled_import_count, 1);
+        };
+
+        let mut protected = load_pef_application(&synthetic_pef_with_import(b"NewThread")).unwrap();
+        let partial_made = PPC_DATA_BASE + 0x1000;
+        let valid_made = partial_made + 0x100;
+        protected.memory.add_region(partial_made, vec![0xaa; 4]);
+        protected
+            .memory
+            .add_readonly_region(partial_made + 3, vec![0xaa]);
+        protected.memory.add_region(valid_made, vec![0; 4]);
+        let protected_cursor = protected.heap_cursor();
+        let protected_ptrs = protected.ptrs();
+        let protected_mem_error = protected.last_mem_error();
+        invoke(&mut protected, partial_made, 4096);
+        assert_eq!(protected.cpu.gpr[3], ppc_i16_result(PPC_PARAM_ERR));
+        assert_eq!(
+            ppc_memory_read_bytes(&mut protected.memory, partial_made, 4),
+            Some(vec![0xaa; 4])
+        );
+        assert_eq!(protected.heap_cursor(), protected_cursor);
+        assert_eq!(protected.ptrs(), protected_ptrs);
+        assert_eq!(protected.last_mem_error(), protected_mem_error);
+        assert!(!protected.guest_calls.has_live_workers());
+        invoke(&mut protected, valid_made, 4096);
+        assert_eq!(protected.cpu.gpr[3], 0);
+        assert_eq!(protected.memory.read_u32_be(valid_made), Some(3));
+
+        let mut exhausted = load_pef_application(&synthetic_pef_with_import(b"NewThread")).unwrap();
+        let made = PPC_DATA_BASE + 0x1000;
+        exhausted.memory.add_region(made, vec![0xaa; 4]);
+        let cursor = exhausted.heap_cursor();
+        let ptrs = exhausted.ptrs();
+        let free_ptrs = exhausted.free_ptr_blocks();
+        let free_bytes = exhausted
+            .memory
+            .read_u32_be(PPC_APPLICATION_ZONE + 12)
+            .unwrap();
+        invoke(&mut exhausted, made, i32::MAX as u32);
+        assert_eq!(exhausted.cpu.gpr[3], ppc_i16_result(PPC_MEM_FULL_ERR));
+        assert_eq!(exhausted.memory.read_u32_be(made), Some(0));
+        assert_eq!(exhausted.heap_cursor(), cursor);
+        assert_eq!(exhausted.ptrs(), ptrs);
+        assert_eq!(exhausted.free_ptr_blocks(), free_ptrs);
+        assert_eq!(exhausted.last_mem_error(), PPC_MEM_FULL_ERR);
+        assert_eq!(
+            exhausted.memory.read_u32_be(PPC_APPLICATION_ZONE + 12),
+            Some(free_bytes)
+        );
+        assert_eq!(
+            exhausted.memory.read_u32_be(PPC_APPLICATION_ZONE + 12),
+            Some(
+                ppc_heap_free_capacity(
+                    &exhausted.memory,
+                    exhausted.heap_cursor(),
+                    test_heap_limit!(exhausted),
+                )
+                .0
+            )
+        );
+        assert!(!exhausted.guest_calls.has_live_workers());
+
+        invoke(&mut exhausted, made, 4096);
+        assert_eq!(exhausted.cpu.gpr[3], 0);
+        assert_eq!(
+            exhausted.memory.read_u32_be(made),
+            Some(ExecutionTaskId::from_thread_id(3).thread_id())
+        );
+        assert_eq!(exhausted.last_mem_error(), PPC_NO_ERR);
+    }
+
+    #[test]
     fn native_thread_entry_returns_to_its_creator_and_retries_result_delivery() {
         use crate::guest_call::ExecutionTaskId;
         const ENTRY: u32 = PPC_CODE_BASE + 0x2000;
@@ -170575,6 +170788,7 @@ pub(crate) mod tests {
         loaded.run_with_hle_imports(64);
         assert_eq!(loaded.guest_calls.current_task(), worker);
         assert_eq!(loaded.cpu.pc, ENTRY);
+        assert_eq!(loaded.cpu.gpr[2], creator.gpr[2]);
         assert_eq!(loaded.cpu.gpr[3], 17);
         loaded.run_with_hle_imports(64);
         assert_eq!(loaded.guest_calls.current_task(), worker);

--- a/src/thread_manager.rs
+++ b/src/thread_manager.rs
@@ -13,6 +13,27 @@ pub(crate) const DEFAULT_COOPERATIVE_THREAD_STACK_SIZE: u32 = 32 * 1024;
 pub(crate) const THREAD_NOT_FOUND_ERR: i16 = -618;
 pub(crate) const THREAD_PROTOCOL_ERR: i16 = -619;
 
+pub(crate) trait NewThreadCreationEdge {
+    /// Validate and prepare ABI-local state before storage selection. Edge
+    /// operations are sequential, and no borrow may survive guest execution.
+    fn preflight(&mut self, size: u32) -> Result<(), i16>;
+
+    fn allocate_fresh(&mut self, size: u32) -> Result<ThreadStorage, i16>;
+
+    /// Publish ABI state and the execution task together. `None` means the
+    /// execution owner refused publication without consuming a task identity.
+    fn prepare_and_publish(
+        &mut self,
+        execution: &SharedGuestCallStack,
+        storage: ThreadStorage,
+        suspended: bool,
+    ) -> Result<Option<ExecutionTaskId>, i16>;
+
+    fn release_fresh(&mut self, storage: ThreadStorage);
+
+    fn finish_publication_attempt(&mut self);
+}
+
 pub(crate) struct ThreadManager<'a> {
     execution: &'a SharedGuestCallStack,
 }
@@ -39,6 +60,40 @@ impl<'a> ThreadManager<'a> {
         } else {
             Ok(size)
         }
+    }
+
+    /// Apply the common NewThread policy while leaving ABI frame construction,
+    /// allocation, and output publication at the calling edge.
+    pub(crate) fn create_thread<E: NewThreadCreationEdge>(
+        &self,
+        isa: GuestIsa,
+        style: u32,
+        requested_size: u32,
+        options: u32,
+        edge: &mut E,
+    ) -> Result<ExecutionTaskId, i16> {
+        let size = Self::stack_size(isa, style, requested_size)?;
+        edge.preflight(size)?;
+
+        let pooled = self.execution.request_thread_stack(isa, size, options)?;
+        let (storage, came_from_pool) = match pooled {
+            Some(storage) => (storage, true),
+            None => (edge.allocate_fresh(size)?, false),
+        };
+        let result = match edge.prepare_and_publish(self.execution, storage, options & 1 != 0) {
+            Ok(Some(task)) => Ok(task),
+            Ok(None) => Err(-108),
+            Err(error) => Err(error),
+        };
+        if result.is_err() {
+            if came_from_pool {
+                self.execution.recycle_thread_stack(isa, storage);
+            } else {
+                edge.release_fresh(storage);
+            }
+        }
+        edge.finish_publication_attempt();
+        result
     }
 
     /// Prepare every allocation before publishing any pool entry. On failure,
@@ -200,6 +255,215 @@ impl<'a> ThreadManager<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::guest_call::CooperativeThread;
+
+    #[derive(Clone, Copy)]
+    enum PublicationResult {
+        Accept,
+        Refuse,
+        Error(i16),
+    }
+
+    struct RecordingNewThreadEdge {
+        preflight_error: Option<i16>,
+        allocation: Result<ThreadStorage, i16>,
+        publication: PublicationResult,
+        preflight_sizes: Vec<u32>,
+        allocated_sizes: Vec<u32>,
+        published_storage: Vec<ThreadStorage>,
+        suspended: Vec<bool>,
+        released: Vec<ThreadStorage>,
+        finish_count: usize,
+    }
+
+    impl RecordingNewThreadEdge {
+        fn accepting(storage: ThreadStorage) -> Self {
+            Self {
+                preflight_error: None,
+                allocation: Ok(storage),
+                publication: PublicationResult::Accept,
+                preflight_sizes: Vec::new(),
+                allocated_sizes: Vec::new(),
+                published_storage: Vec::new(),
+                suspended: Vec::new(),
+                released: Vec::new(),
+                finish_count: 0,
+            }
+        }
+    }
+
+    impl NewThreadCreationEdge for RecordingNewThreadEdge {
+        fn preflight(&mut self, size: u32) -> Result<(), i16> {
+            self.preflight_sizes.push(size);
+            self.preflight_error.map_or(Ok(()), Err)
+        }
+
+        fn allocate_fresh(&mut self, size: u32) -> Result<ThreadStorage, i16> {
+            self.allocated_sizes.push(size);
+            self.allocation
+        }
+
+        fn prepare_and_publish(
+            &mut self,
+            execution: &SharedGuestCallStack,
+            storage: ThreadStorage,
+            suspended: bool,
+        ) -> Result<Option<ExecutionTaskId>, i16> {
+            self.published_storage.push(storage);
+            self.suspended.push(suspended);
+            match self.publication {
+                PublicationResult::Accept => Ok(execution.create_classic_thread(
+                    CooperativeThread::default(),
+                    storage,
+                    suspended,
+                    |_| true,
+                )),
+                PublicationResult::Refuse => Ok(execution.create_classic_thread(
+                    CooperativeThread::default(),
+                    storage,
+                    suspended,
+                    |_| false,
+                )),
+                PublicationResult::Error(error) => Err(error),
+            }
+        }
+
+        fn release_fresh(&mut self, storage: ThreadStorage) {
+            self.released.push(storage);
+        }
+
+        fn finish_publication_attempt(&mut self) {
+            self.finish_count += 1;
+        }
+    }
+
+    fn storage(base: u32, size: u32) -> ThreadStorage {
+        ThreadStorage {
+            stack_base: base,
+            stack_limit: base + size,
+            result_destination: base + 4,
+            managed_pointer: false,
+        }
+    }
+
+    #[test]
+    fn new_thread_creation_validates_before_selecting_or_allocating_storage() {
+        let execution = SharedGuestCallStack::default();
+        let manager = ThreadManager::new(&execution);
+        let mut edge = RecordingNewThreadEdge::accepting(storage(0x1000, 1024));
+
+        assert_eq!(
+            manager.create_thread(GuestIsa::M68k, 0, 1024, 4, &mut edge),
+            Err(-50)
+        );
+        assert!(edge.preflight_sizes.is_empty());
+        assert!(edge.allocated_sizes.is_empty());
+
+        edge.preflight_error = Some(-37);
+        assert_eq!(
+            manager.create_thread(GuestIsa::M68k, 1, 1024, 4, &mut edge),
+            Err(-37)
+        );
+        assert_eq!(edge.preflight_sizes, [1024]);
+        assert!(edge.allocated_sizes.is_empty());
+        assert_eq!(edge.finish_count, 0);
+
+        edge.preflight_error = None;
+        assert_eq!(
+            manager.create_thread(GuestIsa::M68k, 1, 1024, 2, &mut edge),
+            Err(-617)
+        );
+        assert!(edge.allocated_sizes.is_empty());
+        assert_eq!(edge.finish_count, 0);
+
+        edge.allocation = Err(-108);
+        assert_eq!(
+            manager.create_thread(GuestIsa::M68k, 1, 1024, 4, &mut edge),
+            Err(-108)
+        );
+        assert_eq!(edge.allocated_sizes, [1024]);
+        assert!(edge.published_storage.is_empty());
+        assert!(edge.released.is_empty());
+        assert_eq!(edge.finish_count, 0);
+
+        edge.allocation = Ok(storage(0x1000, 1024));
+        let task = manager
+            .create_thread(GuestIsa::M68k, 1, 1024, 4, &mut edge)
+            .unwrap();
+        assert_eq!(task.thread_id(), 3);
+    }
+
+    #[test]
+    fn new_thread_creation_uses_and_recycles_pool_without_fresh_allocation() {
+        let execution = SharedGuestCallStack::default();
+        let manager = ThreadManager::new(&execution);
+        let pooled = storage(0x2000, 1024);
+        execution.publish_thread_pool(GuestIsa::M68k, vec![pooled]);
+        let mut edge = RecordingNewThreadEdge::accepting(storage(0x8000, 1024));
+        edge.publication = PublicationResult::Refuse;
+
+        assert_eq!(
+            manager.create_thread(GuestIsa::M68k, 1, 1024, 3, &mut edge),
+            Err(-108)
+        );
+        assert!(edge.allocated_sizes.is_empty());
+        assert!(edge.released.is_empty());
+        assert_eq!(edge.finish_count, 1);
+        assert_eq!(manager.free_count(GuestIsa::M68k, 1, 1024), Ok(1));
+
+        edge.publication = PublicationResult::Accept;
+        let task = manager
+            .create_thread(GuestIsa::M68k, 1, 1024, 3, &mut edge)
+            .unwrap();
+        assert_eq!(task.thread_id(), 3);
+        assert_eq!(edge.published_storage[0], pooled);
+        assert_eq!(
+            edge.published_storage[1],
+            ThreadStorage {
+                result_destination: 0,
+                ..pooled
+            }
+        );
+        assert!(edge.allocated_sizes.is_empty());
+        assert_eq!(
+            execution.scheduling_state(task),
+            Some(ExecutionTaskState::Stopped)
+        );
+    }
+
+    #[test]
+    fn new_thread_creation_releases_fresh_storage_on_every_publication_failure() {
+        for publication in [PublicationResult::Error(-50), PublicationResult::Refuse] {
+            let execution = SharedGuestCallStack::default();
+            let manager = ThreadManager::new(&execution);
+            let fresh = storage(0x3000, 1024);
+            let mut edge = RecordingNewThreadEdge::accepting(fresh);
+            edge.publication = publication;
+
+            let expected = match publication {
+                PublicationResult::Error(error) => error,
+                PublicationResult::Refuse => -108,
+                PublicationResult::Accept => unreachable!(),
+            };
+            assert_eq!(
+                manager.create_thread(GuestIsa::M68k, 1, 1024, 4, &mut edge),
+                Err(expected)
+            );
+            assert_eq!(edge.allocated_sizes, [1024]);
+            assert_eq!(edge.released, [fresh]);
+            assert_eq!(edge.finish_count, 1);
+
+            edge.publication = PublicationResult::Accept;
+            let task = manager
+                .create_thread(GuestIsa::M68k, 1, 1024, 4, &mut edge)
+                .unwrap();
+            assert_eq!(task.thread_id(), 3);
+            assert_eq!(
+                execution.scheduling_state(task),
+                Some(ExecutionTaskState::Ready)
+            );
+        }
+    }
 
     #[test]
     fn thread_pool_preparation_preserves_existing_entries_and_returns_every_reserved_stack() {

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -1,13 +1,13 @@
 //! Toolbox Utility trap handlers (events, Random, Sound, misc).
 
 use crate::cpu::{CpuOps, Register};
-use crate::guest_call::CooperativeThread;
-use crate::guest_call::ExecutionTaskId;
+use crate::guest_call::{CooperativeThread, ExecutionTaskId, SharedGuestCallStack, ThreadStorage};
+use crate::guest_procedure::{resolve_same_isa_thread_entry, GuestIsa};
 use crate::memory::globals::addr;
 use crate::memory::{MacMemoryBus, MemoryBus};
 use crate::quickdraw::fonts::get_font_face_scaled;
 use crate::quickdraw::text::{get_font_metrics, get_glyph};
-use crate::thread_manager::ThreadManager;
+use crate::thread_manager::{NewThreadCreationEdge, ThreadManager};
 use crate::{Error, Result};
 use std::collections::HashMap;
 use std::sync::OnceLock;
@@ -1113,6 +1113,103 @@ fn dispatch_cfm_symbols<C: CpuOps>(
     cpu.write_reg(Register::A7, result_slot);
     cpu.write_reg(Register::D0, error as i32 as u32);
     Ok(())
+}
+
+struct ClassicNewThreadEdge<'a, C> {
+    dispatcher: &'a mut super::TrapDispatcher,
+    cpu: &'a C,
+    bus: &'a mut MacMemoryBus,
+    thread_entry: u32,
+    thread_param: u32,
+    result_destination: u32,
+    thread_made: u32,
+    result_slot: u32,
+    trampoline: u32,
+}
+
+impl<C: CpuOps> NewThreadCreationEdge for ClassicNewThreadEdge<'_, C> {
+    fn preflight(&mut self, _size: u32) -> std::result::Result<(), i16> {
+        if self.thread_made == 0
+            || self.thread_entry & 1 != 0
+            || !self.bus.is_guest_address_mapped(self.thread_entry, 2)
+            || !self.bus.is_guest_address_writable(self.thread_made, 4)
+            || !self.bus.is_guest_address_writable(self.result_slot, 2)
+            || resolve_same_isa_thread_entry(self.bus, self.thread_entry, 0, GuestIsa::M68k)
+                .is_none()
+        {
+            return Err(-50);
+        }
+        self.trampoline = self.dispatcher.thread_return_trampoline(self.bus);
+        if self.trampoline == 0 {
+            Err(-108)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn allocate_fresh(&mut self, size: u32) -> std::result::Result<ThreadStorage, i16> {
+        let base = self.bus.alloc(size);
+        let Some(limit) = base.checked_add(size) else {
+            self.bus.free(base);
+            return Err(-108);
+        };
+        if base == 0 {
+            return Err(-108);
+        }
+        Ok(ThreadStorage {
+            result_destination: self.result_destination,
+            stack_base: base,
+            stack_limit: limit,
+            managed_pointer: false,
+        })
+    }
+
+    fn prepare_and_publish(
+        &mut self,
+        execution: &SharedGuestCallStack,
+        mut storage: ThreadStorage,
+        suspended: bool,
+    ) -> std::result::Result<Option<ExecutionTaskId>, i16> {
+        storage.result_destination = self.result_destination;
+        let Some(entry_sp) = storage.stack_limit.checked_sub(8).map(|sp| sp & !1) else {
+            return Err(-108);
+        };
+        let overlap = |address: u32, length: u32, other: u32, other_length: u32| {
+            u64::from(address) < u64::from(other) + u64::from(other_length)
+                && u64::from(other) < u64::from(address) + u64::from(length)
+        };
+        if storage.stack_base == 0
+            || storage.stack_limit < storage.stack_base
+            || entry_sp < storage.stack_base
+            || !self.bus.is_guest_address_writable(entry_sp, 8)
+            || overlap(self.thread_made, 4, entry_sp, 8)
+            || overlap(self.result_slot, 2, entry_sp, 8)
+            || overlap(self.thread_made, 4, self.result_slot, 2)
+        {
+            return Err(-50);
+        }
+        let mut thread = CooperativeThread::capture(self.cpu);
+        thread.pc = self.thread_entry;
+        thread.a_regs[7] = entry_sp;
+        let mut frame = [0u8; 8];
+        frame[..4].copy_from_slice(&self.trampoline.to_be_bytes());
+        frame[4..].copy_from_slice(&self.thread_param.to_be_bytes());
+        Ok(
+            execution.create_classic_thread(thread, storage, suspended, |task| {
+                self.bus.try_write_ranges_atomic(&[
+                    (entry_sp, &frame),
+                    (self.thread_made, &task.thread_id().to_be_bytes()),
+                    (self.result_slot, &0u16.to_be_bytes()),
+                ])
+            }),
+        )
+    }
+
+    fn release_fresh(&mut self, storage: ThreadStorage) {
+        self.bus.free(storage.stack_base);
+    }
+
+    fn finish_publication_attempt(&mut self) {}
 }
 
 impl super::TrapDispatcher {
@@ -16362,8 +16459,6 @@ impl super::TrapDispatcher {
             (true, 0x3F2) => {
                 let selector = cpu.read_reg(Register::D0) & 0xFFFF;
                 let sp = cpu.read_reg(Register::A7);
-                // Threads.h option and style bits.
-                const K_NEW_SUSPEND: u32 = 1 << 0;
 
                 let result = match selector {
                     0xFFFE => {
@@ -16410,100 +16505,25 @@ impl super::TrapDispatcher {
                         // NewThread publishes no identity until its ABI frame and
                         // output destinations are committed. Thread Manager (1999),
                         // pp. 56–58: threadMade is kNoThreadID on failure.
-                        let result = (|| -> std::result::Result<(), i16> {
-                            let result_slot = sp.checked_add(28).ok_or(-50_i16)?;
-                            let size = ThreadManager::stack_size(
-                                crate::guest_procedure::GuestIsa::M68k,
-                                thread_style,
-                                stack_size,
-                            )?;
-                            if thread_made == 0
-                                || thread_entry == 0
-                                || thread_entry & 1 != 0
-                                || thread_style != 1
-                                || size < 8
-                                || size > i32::MAX as u32
-                                || !bus.is_guest_address_mapped(thread_entry, 2)
-                                || !bus.is_guest_address_writable(thread_made, 4)
-                                || !bus.is_guest_address_writable(result_slot, 2)
-                            {
-                                return Err(-50);
-                            }
-                            let trampoline = self.thread_return_trampoline(bus);
-                            if trampoline == 0 {
-                                return Err(-108);
-                            }
-                            let pooled = self
-                                .guest_calls
-                                .request_classic_thread_stack(size, options)?;
-                            let (base, limit) = pooled.unwrap_or_else(|| {
-                                let base = bus.alloc(size);
-                                (base, base.saturating_add(size))
-                            });
-                            let fail_stack = base == 0 || limit < base || limit - base < 8;
-                            if fail_stack {
-                                if base != 0 {
-                                    if pooled.is_some() {
-                                        self.guest_calls
-                                            .recycle_classic_thread_stack((base, limit));
-                                    } else {
-                                        bus.free(base);
-                                    }
-                                }
-                                return Err(-108);
-                            }
-                            let entry_sp = (limit - 8) & !1;
-                            let overlap =
-                                |address: u32, length: u32, other: u32, other_length: u32| {
-                                    u64::from(address) < u64::from(other) + u64::from(other_length)
-                                        && u64::from(other) < u64::from(address) + u64::from(length)
-                                };
-                            if entry_sp < base
-                                || !bus.is_guest_address_writable(entry_sp, 8)
-                                || overlap(thread_made, 4, entry_sp, 8)
-                                || overlap(result_slot, 2, entry_sp, 8)
-                                || overlap(thread_made, 4, result_slot, 2)
-                            {
-                                if pooled.is_some() {
-                                    self.guest_calls.recycle_classic_thread_stack((base, limit));
-                                } else {
-                                    bus.free(base);
-                                }
-                                return Err(-50);
-                            }
-                            let mut thread = CooperativeThread::capture(cpu);
-                            thread.pc = thread_entry;
-                            thread.a_regs[7] = entry_sp;
-                            let mut frame = [0u8; 8];
-                            frame[..4].copy_from_slice(&trampoline.to_be_bytes());
-                            frame[4..].copy_from_slice(&thread_param.to_be_bytes());
-                            let made = self.guest_calls.create_classic_thread(
-                                thread,
-                                crate::guest_call::ThreadStorage {
-                                    result_destination,
-                                    stack_base: base,
-                                    stack_limit: limit,
-                                    managed_pointer: false,
-                                },
-                                options & K_NEW_SUSPEND != 0,
-                                |task| {
-                                    bus.try_write_ranges_atomic(&[
-                                        (entry_sp, &frame),
-                                        (thread_made, &task.thread_id().to_be_bytes()),
-                                        (result_slot, &0u16.to_be_bytes()),
-                                    ])
-                                },
-                            );
-                            if made.is_none() {
-                                if pooled.is_some() {
-                                    self.guest_calls.recycle_classic_thread_stack((base, limit));
-                                } else {
-                                    bus.free(base);
-                                }
-                                return Err(-108);
-                            }
-                            Ok(())
-                        })();
+                        let result = sp.checked_add(28).ok_or(-50_i16).and_then(|result_slot| {
+                            // The manager uses a detached shared handle so the edge can
+                            // borrow this dispatcher for trampoline preparation.
+                            let execution = self.guest_calls.shared_handle();
+                            let mut edge = ClassicNewThreadEdge {
+                                dispatcher: self,
+                                cpu,
+                                bus,
+                                thread_entry,
+                                thread_param,
+                                result_destination,
+                                thread_made,
+                                result_slot,
+                                trampoline: 0,
+                            };
+                            ThreadManager::new(&execution)
+                                .create_thread(GuestIsa::M68k, thread_style, stack_size, options, &mut edge)
+                                .map(|_| ())
+                        });
                         match result {
                             Ok(()) => 0,
                             Err(error) => {
@@ -27509,6 +27529,47 @@ mod tests {
         assert_eq!(cpu.read_reg(Register::A7), sp + 28);
         assert_eq!(bus.read_long(thread_made), 0, "no ThreadID on failure");
         assert!(disp.guest_calls.is_pristine());
+    }
+
+    #[test]
+    fn threaddispatch_newthread_rejects_descriptor_before_allocating_and_preserves_task_id() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let sp = TEST_SP;
+        let thread_made = TEST_SP + 0x400;
+        let entry = 0x0004_2000;
+        let heap_before = bus.heap_bump_ptr();
+        bus.write_word(
+            entry,
+            crate::guest_procedure::ROUTINE_DESCRIPTOR_MIXED_MODE_TRAP,
+        );
+
+        let invoke =
+            |disp: &mut crate::trap::TrapDispatcher, cpu: &mut MockCpu, bus: &mut MacMemoryBus| {
+                cpu.write_reg(Register::A7, sp);
+                bus.write_long(sp, thread_made);
+                bus.write_long(sp + 4, 0);
+                bus.write_long(sp + 8, 0);
+                bus.write_long(sp + 12, 4096);
+                bus.write_long(sp + 16, 0x1234);
+                bus.write_long(sp + 20, entry);
+                bus.write_long(sp + 24, 1);
+                cpu.write_reg(Register::D0, 0x0000_0E03);
+                disp.dispatch_toolbox(true, 0x3F2, cpu, bus)
+                    .expect("ThreadDispatch should handle NewThread")
+                    .expect("NewThread should return");
+            };
+
+        invoke(&mut disp, &mut cpu, &mut bus);
+        assert_eq!(cpu.read_reg(Register::D0) as i16, -50);
+        assert_eq!(bus.read_long(thread_made), 0);
+        assert_eq!(bus.heap_bump_ptr(), heap_before);
+        assert_eq!(disp.thread_return_trampoline, 0);
+        assert!(disp.guest_calls.is_pristine());
+
+        bus.write_word(entry, 0x4E75);
+        invoke(&mut disp, &mut cpu, &mut bus);
+        assert_eq!(cpu.read_reg(Register::D0), 0);
+        assert_eq!(bus.read_long(thread_made), 3);
     }
 
     /// `kApplicationThreadID` exists implicitly from launch, so


### PR DESCRIPTION
NewThread now uses one creation operation for both classic ThreadDispatch and native InterfaceLib calls. ThreadManager applies size/style validation, selects pooled or fresh stack storage, publishes through the existing execution owner, and rolls storage back once when preparation or publication fails. The ABI adapters retain frame construction, guest output encoding, and allocator synchronization.

The native route prepares an opaque PPC execution context. Both routes use the direct same-ISA entry resolver and reject recognized RoutineDescriptor inputs before allocating or publishing an identity. That paramErr response is an explicit compatibility choice for prohibited caller input.

The change removes duplicated stack-selection and rollback branches plus native size/style policy. Tests cover pooled storage without fresh allocation, allocation/publication refusal, retry without consuming task IDs, descriptor refusal, output handling, and both ABI entry routes. Validation: all 52 thread-focused tests passed against published PPC 0.6.0, including creation service tests, classic trap and native import tests, and lifecycle regressions. The exported package exactly matches the tested source. The same runtime source previously passed the complete headless suite (5,208 tests; three ignored), default suite (5,216 tests; three ignored), source guard, wasm, and all-target/all-feature checks using the reviewed CPU implementation subsequently published as PPC 0.6.0. Required public CI and package checks must pass before merge.

Closes #1563
