### PR TITLE
fix: preserve MenuHook completion ownership across task switches

### DIFF
--- a/src/execution_m68k.rs
+++ b/src/execution_m68k.rs
@@ -121,25 +121,34 @@ pub(crate) fn complete_classic_manager_return<C: crate::cpu::CpuOps>(
     bus: &crate::memory::MacMemoryBus,
 ) -> bool {
     use crate::memory::MemoryBus;
+    let mut hook = None;
     let restored_sp = calls.complete_m68k_with_operation(
         cpu.read_reg(Register::PC),
         cpu.read_reg(Register::A7),
-        |operation| {
-            let crate::guest_call::ManagerContinuation::Menu(operation) = operation else {
-                panic!("classic manager return has no completion consumer");
-            };
-            let result = if bus.is_guest_address_mapped(operation.scratch, 10) {
-                <[u8; 10]>::try_from(bus.read_bytes(operation.scratch, 10))
-                    .map(crate::menu_manager::MenuDefinitionInvocation::decode_result)
-                    .map_err(|_| ())
-            } else {
-                Err(())
-            };
-            operation.complete_result(result);
+        |operation| match operation {
+            crate::guest_call::ManagerContinuation::Menu(
+                crate::guest_call::MenuManagerContinuation::Definition(operation),
+            ) => {
+                let result = if bus.is_guest_address_mapped(operation.scratch, 10) {
+                    <[u8; 10]>::try_from(bus.read_bytes(operation.scratch, 10))
+                        .map(crate::menu_manager::MenuDefinitionInvocation::decode_result)
+                        .map_err(|_| ())
+                } else {
+                    Err(())
+                };
+                operation.complete_result(result);
+            }
+            crate::guest_call::ManagerContinuation::Menu(
+                crate::guest_call::MenuManagerContinuation::Hook(operation),
+            ) => hook = Some(operation),
+            _ => panic!("classic manager return has no completion consumer"),
         },
     );
     if let Some(sp) = restored_sp {
         cpu.write_reg(Register::A7, sp);
+        if let Some(hook) = hook {
+            assert!(hook.complete(), "MenuHook completion must be single-use");
+        }
         true
     } else {
         false
@@ -200,19 +209,34 @@ impl M68kExecution {
 
     /// Apply a completed native result to its actual caller, then restore it.
     pub(crate) fn resume_after_powerpc(&mut self, memory: &mut PpcSectionMem) -> bool {
-        let Some(parked) = self.calls.commit_m68k_resume(|resume, parked| {
-            let cpu = parked.unwrap_or(&mut self.cpu);
-            if !Self::apply_m68k_resume_result(cpu, memory, resume) {
-                return false;
-            }
-            cpu.write_reg(Register::PC, resume.return_pc);
-            cpu.write_reg(Register::A7, resume.final_sp);
-            true
-        }) else {
+        let Some((parked, operation)) =
+            self.calls
+                .commit_m68k_resume_with_operation(|resume, parked| {
+                    let cpu = parked.unwrap_or(&mut self.cpu);
+                    if !Self::apply_m68k_resume_result(cpu, memory, resume) {
+                        return false;
+                    }
+                    cpu.write_reg(Register::PC, resume.return_pc);
+                    cpu.write_reg(Register::A7, resume.final_sp);
+                    true
+                })
+        else {
             return false;
         };
         if let Some(parked) = parked {
             self.cpu = parked;
+        }
+        match operation {
+            Some(crate::guest_call::ManagerContinuation::Menu(
+                crate::guest_call::MenuManagerContinuation::Hook(operation),
+            )) => {
+                assert!(
+                    operation.complete(),
+                    "MenuHook completion must be single-use"
+                );
+            }
+            Some(_) => panic!("reverse manager return has no completion consumer"),
+            None => {}
         }
         true
     }
@@ -542,7 +566,10 @@ impl M68kExecution {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::guest_call::{GuestCallTarget, M68kRegisterState};
+    use crate::guest_call::{
+        GuestCallTarget, M68kRegisterState, ManagerContinuation, MenuHookOperation,
+        MenuManagerContinuation, MenuTrackingCall, MenuTrackingContext, MenuTrackingOrigin,
+    };
     use crate::guest_procedure::GuestIsa;
 
     #[test]
@@ -582,6 +609,127 @@ mod tests {
         assert_eq!(native.reservation_address(), Some(ADDRESS));
         assert!(engine.activate_pending(&mut native).is_some());
         assert_eq!(native.reservation_address(), Some(ADDRESS));
+    }
+
+    #[test]
+    fn classic_menu_hook_completion_waits_for_its_task_and_restores_the_caller_first() {
+        use crate::execution_kernel::ExecutionTaskState;
+        use crate::guest_call::ExecutionTaskId;
+        use crate::menu_manager::{test_process_menu_tracking, MenuTrackingRequest};
+
+        let calls = SharedGuestCallStack::default();
+        let mut tracking = calls.menu_tracking_view();
+        let call = MenuTrackingCall {
+            request: MenuTrackingRequest::MenuSelect { initial_point: 12 },
+            origin: MenuTrackingOrigin::M68k {
+                stack_pointer: 0x3000,
+                return_address: 0x4000,
+            },
+        };
+        let entry = tracking.enter_new_call(call);
+        *tracking = Some(test_process_menu_tracking(111));
+        let key = tracking.request_menu_hook(true).unwrap();
+        let operation = MenuHookOperation::pending(key);
+        assert!(calls.begin_m68k_with_operation(
+            GuestCallTarget {
+                isa: GuestIsa::M68k,
+                entry: 0x1000,
+                rtoc: 0,
+            },
+            0x2000,
+            0x3000,
+            None,
+            Some(ManagerContinuation::Menu(MenuManagerContinuation::Hook(
+                operation.clone(),
+            ))),
+        ));
+        assert!(tracking.bind_menu_hook(key, operation.completion.clone()));
+
+        let mut execution = M68kExecution::new(&calls);
+        execution.cpu.write_reg(Register::PC, 0x2002);
+        execution.cpu.write_reg(Register::A7, 0x3000);
+        let worker = ExecutionTaskId::from_thread_id(7);
+        assert!(calls.register_task(worker));
+        assert!(calls.set_scheduling_state(worker, ExecutionTaskState::Ready));
+        assert!(calls.switch_to_task(worker));
+        assert!(!execution.complete_manager_return(&crate::memory::MacMemoryBus::new(0x1000)));
+        assert!(calls.switch_to_task(ExecutionTaskId::APPLICATION));
+        assert_eq!(tracking.menu_hook_key(), Some(key));
+
+        assert!(execution.complete_manager_return(&crate::memory::MacMemoryBus::new(0x1000)));
+        assert_eq!(execution.cpu.read_reg(Register::A7), 0x3000);
+        assert_eq!(tracking.ready_call(GuestIsa::M68k), Some(call));
+        let (_, resumed) = tracking.resume_call(GuestIsa::M68k).unwrap();
+        assert_eq!(tracking.menu_hook_key(), None);
+        *tracking.context_mut() = MenuTrackingContext::default();
+        drop(resumed);
+        drop(entry);
+        assert!(calls.remove_task(worker));
+        assert!(calls.is_empty());
+    }
+
+    #[test]
+    fn native_menu_hook_restores_classic_context_before_releasing_its_receipt() {
+        use crate::guest_call::ExecutionTaskId;
+        use crate::menu_manager::{test_process_menu_tracking, MenuTrackingRequest};
+
+        let calls = SharedGuestCallStack::default();
+        let mut tracking = calls.menu_tracking_view();
+        let call = MenuTrackingCall {
+            request: MenuTrackingRequest::MenuSelect { initial_point: 12 },
+            origin: MenuTrackingOrigin::M68k {
+                stack_pointer: 0x3000,
+                return_address: 0x4000,
+            },
+        };
+        let entry = tracking.enter_new_call(call);
+        *tracking = Some(test_process_menu_tracking(111));
+        let key = tracking.request_menu_hook(true).unwrap();
+        let operation = MenuHookOperation::pending(key);
+        assert!(calls.begin_m68k_to_powerpc_with_operation(
+            GuestCallTarget {
+                isa: GuestIsa::PowerPc,
+                entry: 0x1000,
+                rtoc: 0x2000,
+            },
+            crate::guest_call::PowerPcArguments::from_slice(&[]).unwrap(),
+            0x3000,
+            0x4000,
+            None,
+            ManagerContinuation::Menu(MenuManagerContinuation::Hook(operation.clone())),
+        ));
+        assert!(tracking.bind_menu_hook(key, operation.completion.clone()));
+
+        let mut execution = M68kExecution::new(&calls);
+        execution.cpu.write_reg(Register::PC, 0xaaaa);
+        execution.cpu.write_reg(Register::A7, 0xbbbb);
+        let mut native = ppc::PpcCpu::new();
+        assert!(calls
+            .activate_powerpc_with_classic_caller(&mut native, &mut execution.cpu, 0x5000,)
+            .is_some());
+        native.pc = 0x5004;
+        assert!(!calls.complete_powerpc_for_m68k(&mut native));
+        assert_eq!(tracking.menu_hook_key(), Some(key));
+        native.pc = 0x5000;
+        assert!(calls.complete_powerpc_for_m68k(&mut native));
+        assert_eq!(tracking.ready_call(GuestIsa::M68k), None);
+
+        let mut memory = crate::memory::GuestAddressSpace::new();
+        assert!(execution.resume_after_powerpc(&mut memory));
+        assert_eq!(
+            (
+                execution.cpu.read_reg(Register::PC),
+                execution.cpu.read_reg(Register::A7),
+            ),
+            (0x3000, 0x4000),
+        );
+        assert_eq!(tracking.ready_call(GuestIsa::M68k), Some(call));
+        let (_, resumed) = tracking.resume_call(GuestIsa::M68k).unwrap();
+        *tracking.context_mut() = MenuTrackingContext::default();
+        drop(resumed);
+        drop(entry);
+        assert_eq!(calls.current_task(), ExecutionTaskId::APPLICATION);
+        assert!(calls.is_empty());
     }
 
     #[test]

--- a/src/guest_call.rs
+++ b/src/guest_call.rs
@@ -227,7 +227,13 @@ enum GuestCallOrigin {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum ManagerContinuation {
     Cfm(CfmOperation),
-    Menu(crate::menu_manager::MenuDefinitionOperation),
+    Menu(MenuManagerContinuation),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum MenuManagerContinuation {
+    Definition(crate::menu_manager::MenuDefinitionOperation),
+    Hook(MenuHookOperation),
 }
 
 #[derive(Clone, Debug)]
@@ -865,6 +871,29 @@ impl SharedMenuTracking {
         } else {
             self.attach_to(&view);
         }
+    }
+    #[cfg(test)]
+    pub(crate) fn menu_hook_key(&self) -> Option<MenuHookKey> {
+        let index = self.active_index()?;
+        match &self.calls.calls[index].operation {
+            MenuOperation::Tracking(operation) => operation.hook.as_ref().map(|hook| hook.key),
+            _ => None,
+        }
+    }
+    #[cfg(test)]
+    pub(crate) fn menu_hook_is_pending(&self, key: MenuHookKey) -> bool {
+        self.calls.calls.iter().any(|root| {
+            root.task == key.task
+                && root.id == key.menu
+                && root.parent == key.parent
+                && matches!(
+                    &root.operation,
+                    MenuOperation::Tracking(operation)
+                        if operation.hook.as_ref().is_some_and(|hook| {
+                            hook.key == key && !hook.completion.is_returned()
+                        })
+                )
+        })
     }
     fn active_index(&self) -> Option<usize> {
         let task = self.execution.current_task();
@@ -2438,15 +2467,55 @@ impl SharedGuestCallStack {
         final_sp: u32,
         result: Option<M68kResultTarget>,
     ) -> bool {
+        self.begin_m68k_to_powerpc_inner(target, arguments, return_pc, final_sp, result, None)
+    }
+
+    pub(crate) fn begin_m68k_to_powerpc_with_operation(
+        &self,
+        target: GuestCallTarget,
+        arguments: PowerPcArguments,
+        return_pc: u32,
+        final_sp: u32,
+        result: Option<M68kResultTarget>,
+        operation: ManagerContinuation,
+    ) -> bool {
+        self.begin_m68k_to_powerpc_inner(
+            target,
+            arguments,
+            return_pc,
+            final_sp,
+            result,
+            Some(operation),
+        )
+    }
+
+    fn begin_m68k_to_powerpc_inner(
+        &self,
+        target: GuestCallTarget,
+        arguments: PowerPcArguments,
+        return_pc: u32,
+        final_sp: u32,
+        result: Option<M68kResultTarget>,
+        operation: Option<ManagerContinuation>,
+    ) -> bool {
         if self.has_powerpc_from_m68k() {
             return false;
         }
         debug_assert_eq!(target.isa, GuestIsa::PowerPc);
-        self.push_effect(GuestCallEffect::call_guest(
+        let Some(id) = self.submit_effect(GuestCallEffect::call_guest(
             GuestCallRequest::for_task(self.current_task(), target)
                 .with_powerpc_arguments(arguments),
             GuestCallContinuation::to_m68k(return_pc, final_sp, result),
-        ))
+        )) else {
+            return false;
+        };
+        self.0
+            .borrow_mut()
+            .frames
+            .get_mut(&id)
+            .expect("submitted native call")
+            .operation = operation;
+        true
     }
 
     /// Prepare the emulated 68K interval for a native caller. Activation
@@ -2466,8 +2535,68 @@ impl SharedGuestCallStack {
         restore_rtoc: u32,
         return_gpr3: impl Into<GuestCallReturnPolicy>,
     ) -> bool {
+        self.begin_powerpc_to_m68k_inner(
+            target,
+            entry,
+            initial_sp,
+            return_pc,
+            final_sp,
+            registers,
+            result,
+            final_pc,
+            restore_rtoc,
+            return_gpr3.into(),
+            None,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn begin_powerpc_to_m68k_with_operation(
+        &self,
+        target: GuestCallTarget,
+        entry: u32,
+        initial_sp: u32,
+        return_pc: u32,
+        final_sp: u32,
+        registers: M68kRegisterState,
+        result: Option<M68kResultSource>,
+        final_pc: u32,
+        restore_rtoc: u32,
+        return_gpr3: impl Into<GuestCallReturnPolicy>,
+        operation: ManagerContinuation,
+    ) -> bool {
+        self.begin_powerpc_to_m68k_inner(
+            target,
+            entry,
+            initial_sp,
+            return_pc,
+            final_sp,
+            registers,
+            result,
+            final_pc,
+            restore_rtoc,
+            return_gpr3.into(),
+            Some(operation),
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn begin_powerpc_to_m68k_inner(
+        &self,
+        target: GuestCallTarget,
+        entry: u32,
+        initial_sp: u32,
+        return_pc: u32,
+        final_sp: u32,
+        registers: M68kRegisterState,
+        result: Option<M68kResultSource>,
+        final_pc: u32,
+        restore_rtoc: u32,
+        return_gpr3: GuestCallReturnPolicy,
+        operation: Option<ManagerContinuation>,
+    ) -> bool {
         debug_assert_eq!(target.isa, GuestIsa::M68k);
-        self.push_effect(GuestCallEffect::call_guest(
+        let Some(id) = self.submit_effect(GuestCallEffect::call_guest(
             GuestCallRequest::for_task(self.current_task(), target).with_m68k_request(
                 M68kCallRequest {
                     entry,
@@ -2478,7 +2607,16 @@ impl SharedGuestCallStack {
                 },
             ),
             GuestCallContinuation::to_powerpc(return_pc, final_pc, restore_rtoc, return_gpr3),
-        ))
+        )) else {
+            return false;
+        };
+        self.0
+            .borrow_mut()
+            .frames
+            .get_mut(&id)
+            .expect("submitted classic call")
+            .operation = operation;
+        true
     }
 
     /// Adopt prepared emulated ABI storage into one exact task-owned call.
@@ -2724,21 +2862,42 @@ impl SharedGuestCallStack {
         &self,
         apply: impl FnOnce(M68kResume, Option<&mut M68kCpu>) -> bool,
     ) -> Option<Option<M68kCpu>> {
+        let (context, operation) = self.commit_m68k_resume_inner(false, apply)?;
+        debug_assert!(operation.is_none());
+        Some(context)
+    }
+
+    pub(crate) fn commit_m68k_resume_with_operation(
+        &self,
+        apply: impl FnOnce(M68kResume, Option<&mut M68kCpu>) -> bool,
+    ) -> Option<(Option<M68kCpu>, Option<ManagerContinuation>)> {
+        self.commit_m68k_resume_inner(true, apply)
+    }
+
+    fn commit_m68k_resume_inner(
+        &self,
+        accept_operation: bool,
+        apply: impl FnOnce(M68kResume, Option<&mut M68kCpu>) -> bool,
+    ) -> Option<(Option<M68kCpu>, Option<ManagerContinuation>)> {
         let bank = self.classic_contexts();
         let mut bank = bank.borrow_mut();
         let resume = self.peek_m68k_resume()?;
         let (task, call_id) = self.pending_m68k_resume_owner()?;
         let mut tasks = self.0.borrow_mut();
+        if !accept_operation && tasks.frames.get(&call_id)?.operation.is_some() {
+            return None;
+        }
         let context = bank
             .retire_with_context(&tasks.kernel, task, call_id, |context| {
                 apply(resume, context)
             })
             .ok()?;
-        tasks
+        let operation = tasks
             .frames
             .remove(&call_id)
-            .expect("validated resume frame");
-        Some(context)
+            .expect("validated resume frame")
+            .operation;
+        Some((context, operation))
     }
 
     /// Take and retire a completed 68K-origin continuation.
@@ -3095,9 +3254,18 @@ impl SharedGuestCallStack {
         // service resumes. The enclosing frame stays live, and no execution
         // store borrow may span the semantic consumer.
         drop(tasks);
+        let mut hook = None;
         if let Some(operation) = operation {
-            cpu.gpr[3] =
-                resume.expect("manager return requires its semantic consumer")(operation, cpu.gpr[3]);
+            match operation {
+                ManagerContinuation::Menu(MenuManagerContinuation::Hook(operation)) => {
+                    hook = Some(operation);
+                }
+                operation => {
+                    cpu.gpr[3] = resume.expect("manager return requires its semantic consumer")(
+                        operation, cpu.gpr[3],
+                    );
+                }
+            }
         }
         if let Some(scratch) = scratch {
             memory_manager
@@ -3105,6 +3273,9 @@ impl SharedGuestCallStack {
                 .release_native_scratch(scratch);
         }
         Self::apply_powerpc_return(cpu, origin);
+        if let Some(hook) = hook {
+            assert!(hook.complete(), "MenuHook completion must be single-use");
+        }
         true
     }
 
@@ -3241,9 +3412,19 @@ impl SharedGuestCallStack {
             .remove(&call_id)
             .expect("semantic continuation must have an adapter frame");
         drop(tasks);
+        let mut hook = None;
         if let Some((memory, manager)) = services {
-            if let Some(ManagerContinuation::Menu(operation)) = operation {
-                operation.complete(memory);
+            match operation {
+                Some(ManagerContinuation::Menu(MenuManagerContinuation::Definition(operation))) => {
+                    operation.complete(memory)
+                }
+                Some(ManagerContinuation::Menu(MenuManagerContinuation::Hook(operation))) => {
+                    hook = Some(operation);
+                }
+                Some(ManagerContinuation::Cfm(_)) => {
+                    unreachable!("CFM operation rejected before classic completion")
+                }
+                None => {}
             }
             if let Some(scratch) = scratch {
                 manager.release_native_scratch(scratch);
@@ -3256,6 +3437,9 @@ impl SharedGuestCallStack {
             cpu.gpr[3] = result;
         }
         Self::apply_powerpc_return(cpu, origin);
+        if let Some(hook) = hook {
+            assert!(hook.complete(), "MenuHook completion must be single-use");
+        }
         true
     }
 
@@ -5248,6 +5432,129 @@ mod tests {
             assert!(bank.borrow().is_empty());
             assert!(calls.is_empty());
         }
+    }
+
+    #[test]
+    fn reverse_operation_commit_is_transactional_and_returns_its_exact_carrier() {
+        let calls = SharedGuestCallStack::default();
+        let hook = MenuHookOperation::pending(MenuHookKey {
+            task: ExecutionTaskId::APPLICATION,
+            menu: MenuOperationId(17),
+            parent: None,
+        });
+        assert!(calls.begin_m68k_to_powerpc_with_operation(
+            GuestCallTarget {
+                isa: GuestIsa::PowerPc,
+                entry: 0x1000,
+                rtoc: 0x2000,
+            },
+            PowerPcArguments::from_slice(&[]).unwrap(),
+            0x3000,
+            0x4000,
+            None,
+            ManagerContinuation::Menu(MenuManagerContinuation::Hook(hook.clone()),),
+        ));
+        let mut classic = M68kCpu::new();
+        classic.core.set_a(7, 0x9876);
+        let mut native = PpcCpu::new();
+        assert!(calls
+            .activate_powerpc_with_classic_caller(&mut native, &mut classic, RETURN_PC)
+            .is_some());
+        native.pc = RETURN_PC;
+        assert!(calls.complete_powerpc_for_m68k(&mut native));
+
+        assert!(calls.commit_m68k_resume(|_, _| true).is_none());
+        assert!(calls
+            .commit_m68k_resume_with_operation(|resume, parked| {
+                assert_eq!((resume.return_pc, resume.final_sp), (0x3000, 0x4000));
+                assert_eq!(parked.unwrap().core.a(7), 0x9876);
+                false
+            })
+            .is_none());
+        assert!(!hook.completion.is_returned());
+        assert!(calls.peek_m68k_resume().is_some());
+
+        let (parked, operation) = calls
+            .commit_m68k_resume_with_operation(|_, parked| {
+                assert_eq!(parked.as_ref().unwrap().core.a(7), 0x9876);
+                true
+            })
+            .unwrap();
+        assert_eq!(parked.unwrap().core.a(7), 0x9876);
+        let Some(ManagerContinuation::Menu(MenuManagerContinuation::Hook(returned))) = operation
+        else {
+            panic!("exact MenuHook carrier must return with the classic context");
+        };
+        assert_eq!(returned, hook);
+        assert!(returned.complete());
+        assert!(hook.completion.is_returned());
+        assert!(calls.is_empty());
+    }
+
+    #[test]
+    fn native_menu_hook_restores_r3_before_releasing_its_receipt() {
+        let calls = SharedGuestCallStack::default();
+        let mut tracking = calls.menu_tracking_view();
+        let call = MenuTrackingCall {
+            request: crate::menu_manager::MenuTrackingRequest::MenuSelect { initial_point: 12 },
+            origin: MenuTrackingOrigin::PowerPc {
+                stack_pointer: 0x1000,
+                return_address: 0x6000,
+            },
+        };
+        let entry = tracking.enter_new_call(call);
+        *tracking = Some(crate::menu_manager::test_process_menu_tracking(111));
+        let key = tracking.request_menu_hook(true).unwrap();
+        let operation = MenuHookOperation::pending(key);
+        let effect = GuestCallEffect::call_guest(
+            GuestCallRequest::for_task(
+                ExecutionTaskId::APPLICATION,
+                GuestCallTarget {
+                    isa: GuestIsa::PowerPc,
+                    entry: 0x2000,
+                    rtoc: 0x3000,
+                },
+            )
+            .with_powerpc_arguments(PowerPcArguments::from_slice(&[]).unwrap()),
+            GuestCallContinuation::to_powerpc(
+                0x5000,
+                0x6000,
+                0x7000,
+                PpcNativeReturnGpr3::Set(0x1234_5678),
+            ),
+        );
+        let mut cpu = PpcCpu::new();
+        cpu.gpr[1] = 0x1000;
+        let mut memory = GuestAddressSpace::new();
+        memory.add_region(0x1000, vec![0; 128]);
+        assert!(calls.activate_powerpc_effect_with_operation(
+            &mut cpu,
+            &mut memory,
+            effect,
+            None,
+            Some(ManagerContinuation::Menu(MenuManagerContinuation::Hook(
+                operation.clone(),
+            ))),
+        ));
+        assert!(tracking.bind_menu_hook(key, operation.completion.clone()));
+        cpu.pc = 0x5000;
+        cpu.gpr[3] = 77;
+        let mut manager = ProcessNativeMemoryManager::default();
+        assert!(
+            calls.complete_powerpc_resuming_operation(&mut cpu, &mut manager, |_, _| panic!(
+                "MenuHook must complete at the execution boundary"
+            ),)
+        );
+        assert_eq!(
+            (cpu.pc, cpu.gpr[2], cpu.gpr[3]),
+            (0x6000, 0x7000, 0x1234_5678)
+        );
+        assert_eq!(tracking.ready_call(GuestIsa::PowerPc), Some(call));
+        let (_, resumed) = tracking.resume_call(GuestIsa::PowerPc).unwrap();
+        *tracking.context_mut() = MenuTrackingContext::default();
+        drop(resumed);
+        drop(entry);
+        assert!(calls.is_empty());
     }
 
     #[test]

--- a/src/guest_call.rs
+++ b/src/guest_call.rs
@@ -591,7 +591,97 @@ enum MenuOperation {
         origin: MenuBarCallOrigin,
         build: crate::menu_manager::MenuBarBuild<u32>,
     },
-    Tracking(Box<MenuTrackingContext>),
+    Tracking(MenuTrackingOperation),
+}
+
+/// Exact owner of one no-argument MenuHook invocation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct MenuHookKey {
+    pub(crate) task: ExecutionTaskId,
+    pub(crate) menu: MenuOperationId,
+    pub(crate) parent: Option<CallId>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum MenuHookCompletionState {
+    Pending,
+    Returned,
+    Consumed,
+}
+
+/// Single-use notification that the exact MenuHook callback has returned.
+#[derive(Clone, Debug)]
+pub(crate) struct MenuHookCompletion(Rc<RefCell<MenuHookCompletionState>>);
+
+impl PartialEq for MenuHookCompletion {
+    fn eq(&self, other: &Self) -> bool {
+        Rc::ptr_eq(&self.0, &other.0)
+    }
+}
+impl Eq for MenuHookCompletion {}
+
+impl MenuHookCompletion {
+    pub(crate) fn pending() -> Self {
+        Self(Rc::new(RefCell::new(MenuHookCompletionState::Pending)))
+    }
+
+    pub(crate) fn complete(self) -> bool {
+        let mut state = self.0.borrow_mut();
+        if *state != MenuHookCompletionState::Pending {
+            return false;
+        }
+        *state = MenuHookCompletionState::Returned;
+        true
+    }
+
+    fn is_returned(&self) -> bool {
+        *self.0.borrow() == MenuHookCompletionState::Returned
+    }
+
+    fn take(&self) -> bool {
+        let mut state = self.0.borrow_mut();
+        match std::mem::replace(&mut *state, MenuHookCompletionState::Consumed) {
+            MenuHookCompletionState::Returned => true,
+            MenuHookCompletionState::Pending => {
+                *state = MenuHookCompletionState::Pending;
+                false
+            }
+            MenuHookCompletionState::Consumed => false,
+        }
+    }
+}
+
+/// Execution carries this operation while the matching menu root retains a
+/// clone of its completion receipt.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct MenuHookOperation {
+    pub(crate) key: MenuHookKey,
+    pub(crate) completion: MenuHookCompletion,
+}
+
+impl MenuHookOperation {
+    pub(crate) fn pending(key: MenuHookKey) -> Self {
+        Self {
+            key,
+            completion: MenuHookCompletion::pending(),
+        }
+    }
+
+    pub(crate) fn complete(self) -> bool {
+        self.completion.complete()
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+struct MenuTrackingOperation {
+    context: Box<MenuTrackingContext>,
+    hook: Option<MenuHookOperation>,
+}
+
+impl MenuTrackingOperation {
+    fn is_idle(&self) -> bool {
+        self.context.is_idle() && self.hook.is_none()
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -785,7 +875,7 @@ impl SharedMenuTracking {
     pub(crate) fn context(&self) -> &MenuTrackingContext {
         self.active_index()
             .and_then(|index| match &self.calls.calls[index].operation {
-                MenuOperation::Tracking(context) => Some(&**context),
+                MenuOperation::Tracking(operation) => Some(operation.context.as_ref()),
                 _ => None,
             })
             .unwrap_or(&self.empty)
@@ -793,7 +883,7 @@ impl SharedMenuTracking {
     pub(crate) fn existing_context_mut(&mut self) -> Option<&mut MenuTrackingContext> {
         let index = self.active_index()?;
         match &mut self.calls.calls[index].operation {
-            MenuOperation::Tracking(context) => Some(context),
+            MenuOperation::Tracking(operation) => Some(operation.context.as_mut()),
             _ => None,
         }
     }
@@ -812,7 +902,7 @@ impl SharedMenuTracking {
             }
         };
         match &mut self.calls.calls[index].operation {
-            MenuOperation::Tracking(context) => context,
+            MenuOperation::Tracking(operation) => operation.context.as_mut(),
             _ => unreachable!(),
         }
     }
@@ -846,12 +936,20 @@ impl SharedMenuTracking {
         if root.parent != parent {
             return None;
         }
-        let MenuOperation::Tracking(context) = &root.operation else {
+        let MenuOperation::Tracking(operation) = &root.operation else {
             return None;
         };
-        context
+        if operation
+            .hook
+            .as_ref()
+            .is_some_and(|hook| !hook.completion.is_returned())
+        {
+            return None;
+        }
+        operation
+            .context
             .call
-            .filter(|call| call.origin.isa() == isa && !context.is_idle())
+            .filter(|call| call.origin.isa() == isa && !operation.is_idle())
     }
 
     pub(crate) fn resume_call(
@@ -859,8 +957,76 @@ impl SharedMenuTracking {
         isa: GuestIsa,
     ) -> Option<(MenuTrackingCall, MenuTrackingEntry)> {
         let call = self.ready_call(isa)?;
-        let id = self.calls.calls[self.active_index()?].id;
+        let index = self.active_index()?;
+        let id = self.calls.calls[index].id;
+        let MenuOperation::Tracking(operation) = &mut self.calls.calls[index].operation else {
+            return None;
+        };
+        if let Some(hook) = operation.hook.as_ref() {
+            if !hook.completion.take() {
+                return None;
+            }
+            operation.hook = None;
+        }
         Some((call, self.scope(id)))
+    }
+
+    /// Request one hook for the exact current menu root without changing it.
+    pub(crate) fn request_menu_hook(&self, mouse_down: bool) -> Option<MenuHookKey> {
+        if !self.execution.current_task_is_running() {
+            return None;
+        }
+        let task = self.execution.current_task();
+        let parent = self
+            .execution
+            .0
+            .borrow()
+            .kernel
+            .peek(task)
+            .map(|call| call.call_id());
+        let root = &self.calls.calls[self.active_index()?];
+        let MenuOperation::Tracking(operation) = &root.operation else {
+            return None;
+        };
+        if root.parent != parent
+            || operation.hook.is_some()
+            || !operation
+                .context
+                .tracking
+                .as_ref()
+                .is_some_and(|tracking| tracking.should_invoke_menu_hook(mouse_down))
+        {
+            return None;
+        }
+        Some(MenuHookKey {
+            task,
+            menu: root.id,
+            parent,
+        })
+    }
+
+    /// Attach a receipt after synchronous callback submission changed the top
+    /// execution frame. Lookup uses the copied owner key, not current parent.
+    pub(crate) fn bind_menu_hook(
+        &mut self,
+        key: MenuHookKey,
+        completion: MenuHookCompletion,
+    ) -> bool {
+        let Some(root) =
+            self.calls.calls.iter_mut().find(|root| {
+                root.task == key.task && root.id == key.menu && root.parent == key.parent
+            })
+        else {
+            return false;
+        };
+        let MenuOperation::Tracking(operation) = &mut root.operation else {
+            return false;
+        };
+        if operation.hook.is_some() {
+            return false;
+        }
+        operation.hook = Some(MenuHookOperation { key, completion });
+        true
     }
 
     fn scope(&self, id: MenuOperationId) -> MenuTrackingEntry {
@@ -907,14 +1073,15 @@ impl SharedMenuTracking {
         else {
             return;
         };
-        let MenuOperation::Tracking(context) = &mut call.operation else {
+        let MenuOperation::Tracking(operation) = &mut call.operation else {
             return;
         };
-        let definition = context
+        let definition = operation
+            .context
             .tracking
             .as_mut()
             .and_then(|tracking| tracking.active_definition_mut())
-            .or(context.definition.as_mut());
+            .or(operation.context.definition.as_mut());
         if let Some(definition) = definition {
             definition.bind_completion(invocation, completion);
         }
@@ -932,7 +1099,7 @@ impl SharedMenuTracking {
         // A subsequent entry starts a fresh operation and cannot inherit its caller.
         self.calls.calls.retain(|call| {
             call.task != task || call.parent != parent
-                || !matches!(&call.operation, MenuOperation::Tracking(context) if context.is_idle())
+                || !matches!(&call.operation, MenuOperation::Tracking(operation) if operation.is_idle())
         });
         if let Some(call) = self.calls.calls.iter().rev().find(|call| {
             call.task == task
@@ -954,14 +1121,14 @@ impl SharedMenuTracking {
             id,
             task,
             parent,
-            operation: MenuOperation::Tracking(Box::default()),
+            operation: MenuOperation::Tracking(MenuTrackingOperation::default()),
         });
         id
     }
     pub(crate) fn finish_if_idle(&mut self, id: MenuOperationId) {
         self.calls.calls.retain(|call| {
             call.id != id
-                || !matches!(&call.operation, MenuOperation::Tracking(context) if context.is_idle())
+                || !matches!(&call.operation, MenuOperation::Tracking(operation) if operation.is_idle())
         });
     }
     pub(crate) fn attach_to(&mut self, other: &Self) {
@@ -1352,7 +1519,7 @@ impl SharedGuestCallStack {
 
     pub(crate) fn is_empty(&self) -> bool {
         let tasks = self.0.borrow();
-        tasks.kernel.is_empty() && tasks.menu_calls.calls.iter().all(|call| matches!(&call.operation, MenuOperation::Tracking(context) if context.is_idle()))
+        tasks.kernel.is_empty() && tasks.menu_calls.calls.iter().all(|call| matches!(&call.operation, MenuOperation::Tracking(operation) if operation.is_idle()))
     }
 
     pub(crate) fn depth(&self) -> usize {
@@ -3392,6 +3559,246 @@ mod tests {
         *tracking = None;
         drop(resumed);
         drop(outer);
+        assert!(calls.is_empty());
+    }
+
+    #[test]
+    fn menu_hook_receipt_resumes_only_its_task_operation_and_parent() {
+        use crate::menu_manager::{test_process_menu_tracking, MenuTrackingRequest};
+
+        let calls = SharedGuestCallStack::default();
+        let mut tracking = calls.menu_tracking_view();
+        let outer_call = MenuTrackingCall {
+            request: MenuTrackingRequest::MenuSelect { initial_point: 12 },
+            origin: MenuTrackingOrigin::M68k {
+                stack_pointer: 0x4000,
+                return_address: 0x5000,
+            },
+        };
+        let outer = tracking.enter_new_call(outer_call);
+        *tracking = Some(test_process_menu_tracking(111));
+        let outer_key = tracking.request_menu_hook(true).unwrap();
+        assert_eq!(outer_key.task, ExecutionTaskId::APPLICATION);
+        assert_eq!(outer_key.menu, outer.id);
+        assert_eq!(outer_key.parent, None);
+
+        assert!(calls.begin_m68k(
+            GuestCallTarget {
+                isa: GuestIsa::M68k,
+                entry: 0x1000,
+                rtoc: 0,
+            },
+            0x2000,
+            0x3000,
+        ));
+        let inner_call = MenuTrackingCall {
+            request: MenuTrackingRequest::MenuSelect { initial_point: 34 },
+            origin: MenuTrackingOrigin::M68k {
+                stack_pointer: 0x6000,
+                return_address: 0x7000,
+            },
+        };
+        let inner = tracking.enter_new_call(inner_call);
+        *tracking = Some(test_process_menu_tracking(222));
+        let inner_key = tracking.request_menu_hook(true).unwrap();
+        assert_ne!(inner_key.menu, outer_key.menu);
+        assert_ne!(inner_key.parent, outer_key.parent);
+        let outer_operation = MenuHookOperation::pending(outer_key);
+        assert!(!tracking.bind_menu_hook(
+            MenuHookKey {
+                parent: inner_key.parent,
+                ..outer_key
+            },
+            outer_operation.completion.clone(),
+        ));
+        assert!(tracking.bind_menu_hook(outer_key, outer_operation.completion.clone()));
+        let inner_operation = MenuHookOperation::pending(inner_key);
+        assert!(tracking.bind_menu_hook(inner_key, inner_operation.completion.clone()));
+        assert!(inner_operation.complete());
+        assert_eq!(tracking.ready_call(GuestIsa::M68k), Some(inner_call));
+        let (resumed_inner, inner_resume) = tracking.resume_call(GuestIsa::M68k).unwrap();
+        assert_eq!(resumed_inner, inner_call);
+        assert_eq!(inner_resume.id, inner.id);
+        *tracking.context_mut() = MenuTrackingContext::default();
+        drop(inner_resume);
+        drop(inner);
+
+        assert_eq!(tracking.context().call, Some(outer_call));
+        assert_eq!(tracking.ready_call(GuestIsa::M68k), None);
+        assert!(outer_operation.complete());
+        assert_eq!(
+            tracking.ready_call(GuestIsa::M68k),
+            None,
+            "the returned outer receipt still waits for its saved parent"
+        );
+        assert!(calls.complete_m68k(0x2002, 0x3000));
+        let (resumed_outer, outer_resume) = tracking.resume_call(GuestIsa::M68k).unwrap();
+        assert_eq!(resumed_outer, outer_call);
+        assert_eq!(outer_resume.id, outer.id);
+        *tracking.context_mut() = MenuTrackingContext::default();
+        drop(outer_resume);
+        drop(outer);
+        assert!(calls.is_empty());
+    }
+
+    #[test]
+    fn menu_hook_pending_receipt_blocks_readiness_and_idle_drop_until_consumed() {
+        use crate::menu_manager::{test_process_menu_tracking, MenuTrackingRequest};
+
+        let calls = SharedGuestCallStack::default();
+        let mut tracking = calls.menu_tracking_view();
+        let call = MenuTrackingCall {
+            request: MenuTrackingRequest::MenuSelect { initial_point: 12 },
+            origin: MenuTrackingOrigin::PowerPc {
+                stack_pointer: 0x4000,
+                return_address: 0x5000,
+            },
+        };
+        let entry = tracking.enter_new_call(call);
+        *tracking = Some(test_process_menu_tracking(111));
+        assert_eq!(tracking.request_menu_hook(false), None);
+        let key = tracking.request_menu_hook(true).unwrap();
+        let operation = MenuHookOperation::pending(key);
+
+        let wrong_task = MenuHookKey {
+            task: ExecutionTaskId::from_thread_id(99),
+            ..key
+        };
+        assert!(!tracking.bind_menu_hook(wrong_task, operation.completion.clone()));
+        let wrong_menu = MenuHookKey {
+            menu: MenuOperationId(key.menu.0 + 1),
+            ..key
+        };
+        assert!(!tracking.bind_menu_hook(wrong_menu, operation.completion.clone()));
+        assert!(tracking.bind_menu_hook(key, operation.completion.clone()));
+        assert!(!tracking.bind_menu_hook(key, operation.completion.clone()));
+        assert_eq!(tracking.request_menu_hook(true), None);
+        assert_eq!(tracking.ready_call(GuestIsa::PowerPc), None);
+
+        *tracking = None;
+        drop(entry);
+        assert!(
+            !calls.is_empty(),
+            "the pending receipt keeps its root alive"
+        );
+        assert!(operation.clone().complete());
+        assert!(!operation.complete(), "callback completion is single-use");
+        assert_eq!(tracking.ready_call(GuestIsa::PowerPc), Some(call));
+        let (_, resumed) = tracking.resume_call(GuestIsa::PowerPc).unwrap();
+        drop(resumed);
+        assert!(calls.is_empty(), "receipt consumption permits idle cleanup");
+        assert!(tracking.resume_call(GuestIsa::PowerPc).is_none());
+    }
+
+    #[test]
+    fn menu_hook_receipts_resume_only_their_owning_task() {
+        use crate::menu_manager::{test_process_menu_tracking, MenuTrackingRequest};
+
+        let calls = SharedGuestCallStack::default();
+        let mut tracking = calls.menu_tracking_view();
+        let application_call = MenuTrackingCall {
+            request: MenuTrackingRequest::MenuSelect { initial_point: 12 },
+            origin: MenuTrackingOrigin::M68k {
+                stack_pointer: 0x4000,
+                return_address: 0x5000,
+            },
+        };
+        let application_entry = tracking.enter_new_call(application_call);
+        *tracking = Some(test_process_menu_tracking(111));
+        let application_operation =
+            MenuHookOperation::pending(tracking.request_menu_hook(true).unwrap());
+        assert!(tracking.bind_menu_hook(
+            application_operation.key,
+            application_operation.completion.clone(),
+        ));
+
+        let worker = ExecutionTaskId::from_thread_id(7);
+        assert!(calls.register_task(worker));
+        assert!(calls.set_scheduling_state(worker, ExecutionTaskState::Ready));
+        assert!(calls.switch_to_task(worker));
+        let worker_call = MenuTrackingCall {
+            request: MenuTrackingRequest::MenuSelect { initial_point: 34 },
+            origin: MenuTrackingOrigin::M68k {
+                stack_pointer: 0x6000,
+                return_address: 0x7000,
+            },
+        };
+        let worker_entry = tracking.enter_new_call(worker_call);
+        *tracking = Some(test_process_menu_tracking(222));
+        let worker_operation =
+            MenuHookOperation::pending(tracking.request_menu_hook(true).unwrap());
+        assert_ne!(worker_operation.key.task, application_operation.key.task);
+        assert_ne!(worker_operation.key.menu, application_operation.key.menu);
+        assert!(tracking.bind_menu_hook(worker_operation.key, worker_operation.completion.clone(),));
+
+        assert!(application_operation.complete());
+        assert_eq!(tracking.ready_call(GuestIsa::M68k), None);
+        assert!(worker_operation.complete());
+        assert_eq!(tracking.ready_call(GuestIsa::M68k), Some(worker_call));
+        let (_, worker_resume) = tracking.resume_call(GuestIsa::M68k).unwrap();
+        *tracking.context_mut() = MenuTrackingContext::default();
+        drop(worker_resume);
+        drop(worker_entry);
+
+        assert!(calls.switch_to_task(ExecutionTaskId::APPLICATION));
+        assert_eq!(tracking.ready_call(GuestIsa::M68k), Some(application_call));
+        let (_, application_resume) = tracking.resume_call(GuestIsa::M68k).unwrap();
+        *tracking.context_mut() = MenuTrackingContext::default();
+        drop(application_resume);
+        drop(application_entry);
+        assert!(calls.remove_task(worker));
+        assert!(calls.is_empty());
+    }
+
+    #[test]
+    fn pending_menu_hook_frame_blocks_task_retirement_until_callback_completion() {
+        use crate::menu_manager::{test_process_menu_tracking, MenuTrackingRequest};
+
+        let calls = SharedGuestCallStack::default();
+        let mut tracking = calls.menu_tracking_view();
+        let worker = ExecutionTaskId::from_thread_id(7);
+        assert!(calls.register_task(worker));
+        assert!(calls.set_scheduling_state(worker, ExecutionTaskState::Ready));
+        assert!(calls.switch_to_task(worker));
+        let owned = tracking.enter_new_call(MenuTrackingCall {
+            request: MenuTrackingRequest::MenuSelect { initial_point: 12 },
+            origin: MenuTrackingOrigin::M68k {
+                stack_pointer: 0x4000,
+                return_address: 0x5000,
+            },
+        });
+        *tracking = Some(test_process_menu_tracking(222));
+        let key = tracking.request_menu_hook(true).unwrap();
+        assert_eq!(key.task, worker);
+        let operation = MenuHookOperation::pending(key);
+        assert!(calls.begin_m68k(
+            GuestCallTarget {
+                isa: GuestIsa::M68k,
+                entry: 0x1000,
+                rtoc: 0,
+            },
+            0x2000,
+            0x3000,
+        ));
+        assert!(tracking.bind_menu_hook(key, operation.completion.clone()));
+
+        assert!(calls.switch_to_task(ExecutionTaskId::APPLICATION));
+        assert_eq!(tracking.ready_call(GuestIsa::M68k), None);
+        assert!(!calls.remove_task(worker));
+        assert_eq!(calls.task_depth(worker), 1);
+        assert_eq!(calls.0.borrow().menu_calls.calls.len(), 1);
+
+        assert!(calls.switch_to_task(worker));
+        assert!(calls.complete_m68k(0x2002, 0x3000));
+        assert!(operation.complete());
+        assert_eq!(
+            tracking.ready_call(GuestIsa::M68k).unwrap().request,
+            MenuTrackingRequest::MenuSelect { initial_point: 12 }
+        );
+        assert!(calls.switch_to_task(ExecutionTaskId::APPLICATION));
+        assert!(calls.remove_task(worker));
+        drop(owned);
+        assert!(calls.0.borrow().menu_calls.calls.is_empty());
         assert!(calls.is_empty());
     }
 

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -3254,6 +3254,16 @@ fn ppc_prepare_menu_definition_port(
     *current_gdevice = PPC_MAIN_GDEVICE;
 }
 
+fn ppc_preserve_menu_callback_port(
+    startup: &mut PpcToolboxStartupState,
+    current_gworld: u32,
+    current_gdevice: u32,
+) {
+    if startup.menu_tracking.context().native_port.is_none() {
+        startup.menu_tracking.context_mut().native_port = Some((current_gworld, current_gdevice));
+    }
+}
+
 fn ppc_restore_menu_definition_port(
     startup: &mut PpcToolboxStartupState,
     current_gworld: &mut u32,
@@ -7756,10 +7766,15 @@ impl PpcLoadedApp {
                         cpu,
                         process_memory_manager,
                         |operation, result| match operation {
-                            crate::guest_call::ManagerContinuation::Menu(operation) => {
+                            crate::guest_call::ManagerContinuation::Menu(
+                                crate::guest_call::MenuManagerContinuation::Definition(operation),
+                            ) => {
                                 operation.complete(memory);
                                 result
                             }
+                            crate::guest_call::ManagerContinuation::Menu(
+                                crate::guest_call::MenuManagerContinuation::Hook(_),
+                            ) => unreachable!("MenuHook completes after native caller restore"),
                             crate::guest_call::ManagerContinuation::Cfm(CfmOperation::Load(
                                 load,
                             )) => ppc_complete_cfm_load(load, result, memory, &mut cfm_connections),
@@ -44671,6 +44686,72 @@ fn ppc_begin_m68k_universal_proc(
     final_pc: u32,
     return_gpr3: PpcNativeReturnGpr3,
 ) -> Option<PpcImportAction> {
+    ppc_begin_m68k_universal_proc_inner(
+        cpu,
+        process_memory_manager,
+        memory,
+        heap_cursor,
+        heap_limit,
+        startup,
+        target,
+        proc_info,
+        selector,
+        arguments,
+        final_pc,
+        return_gpr3,
+        None,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn ppc_begin_m68k_universal_proc_with_operation(
+    cpu: &PpcCpu,
+    process_memory_manager: Option<&mut ProcessNativeMemoryManager>,
+    memory: &mut PpcSectionMem,
+    heap_cursor: &mut u32,
+    heap_limit: u32,
+    startup: &mut PpcToolboxStartupState,
+    target: GuestProcedure,
+    proc_info: u32,
+    selector: Option<u32>,
+    arguments: Vec<u32>,
+    final_pc: u32,
+    return_gpr3: PpcNativeReturnGpr3,
+    operation: crate::guest_call::ManagerContinuation,
+) -> Option<PpcImportAction> {
+    ppc_begin_m68k_universal_proc_inner(
+        cpu,
+        process_memory_manager,
+        memory,
+        heap_cursor,
+        heap_limit,
+        startup,
+        target,
+        proc_info,
+        selector,
+        arguments,
+        final_pc,
+        return_gpr3,
+        Some(operation),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn ppc_begin_m68k_universal_proc_inner(
+    cpu: &PpcCpu,
+    process_memory_manager: Option<&mut ProcessNativeMemoryManager>,
+    memory: &mut PpcSectionMem,
+    heap_cursor: &mut u32,
+    heap_limit: u32,
+    startup: &mut PpcToolboxStartupState,
+    target: GuestProcedure,
+    proc_info: u32,
+    selector: Option<u32>,
+    arguments: Vec<u32>,
+    final_pc: u32,
+    return_gpr3: PpcNativeReturnGpr3,
+    operation: Option<crate::guest_call::ManagerContinuation>,
+) -> Option<PpcImportAction> {
     use crate::guest_call::{M68kRegisterState, M68kResultSource};
 
     // The 68k side follows the stack/register layouts in Inside Macintosh:
@@ -44959,22 +45040,40 @@ fn ppc_begin_m68k_universal_proc(
         };
     }
 
-    if !startup.guest_calls.begin_powerpc_to_m68k(
-        crate::guest_call::GuestCallTarget {
-            isa: target.isa,
-            entry: target.entry,
-            rtoc: target.rtoc,
-        },
-        target.entry,
-        initial_sp,
-        return_pc,
-        final_sp,
-        registers,
-        result,
-        final_pc,
-        cpu.gpr[2],
-        return_gpr3,
-    ) {
+    let target = crate::guest_call::GuestCallTarget {
+        isa: target.isa,
+        entry: target.entry,
+        rtoc: target.rtoc,
+    };
+    let submitted = if let Some(operation) = operation {
+        startup.guest_calls.begin_powerpc_to_m68k_with_operation(
+            target,
+            target.entry,
+            initial_sp,
+            return_pc,
+            final_sp,
+            registers,
+            result,
+            final_pc,
+            cpu.gpr[2],
+            return_gpr3,
+            operation,
+        )
+    } else {
+        startup.guest_calls.begin_powerpc_to_m68k(
+            target,
+            target.entry,
+            initial_sp,
+            return_pc,
+            final_sp,
+            registers,
+            result,
+            final_pc,
+            cpu.gpr[2],
+            return_gpr3,
+        )
+    };
+    if !submitted {
         return None;
     }
     Some(PpcImportAction::Halt)
@@ -75801,7 +75900,9 @@ fn ppc_dispatch_native_menu_definition_with_return(
                         memory,
                         effect,
                         Some(scratch),
-                        Some(crate::guest_call::ManagerContinuation::Menu(operation)),
+                        Some(crate::guest_call::ManagerContinuation::Menu(
+                            crate::guest_call::MenuManagerContinuation::Definition(operation),
+                        )),
                     )
                     .then_some(PpcImportAction::Continue)
             }
@@ -75828,7 +75929,11 @@ fn ppc_dispatch_native_menu_definition_with_return(
     }
     if invocation.message == MenuDefinitionMessage::Size {
         if let Some(id) = menu_build {
-            toolbox_startup.guest_calls.bind_menu_bar_build_completion(id, invocation.menu_handle, completion);
+            toolbox_startup.guest_calls.bind_menu_bar_build_completion(
+                id,
+                invocation.menu_handle,
+                completion,
+            );
         }
     }
     prepared
@@ -75884,7 +75989,9 @@ fn ppc_begin_m68k_menu_definition(
     if !startup.guest_calls.begin_m68k_operation(
         effect,
         operation.scratch,
-        crate::guest_call::ManagerContinuation::Menu(operation),
+        crate::guest_call::ManagerContinuation::Menu(
+            crate::guest_call::MenuManagerContinuation::Definition(operation),
+        ),
     ) {
         return None;
     }
@@ -76017,12 +76124,13 @@ fn ppc_step_menu_tracking(
         vfs_resources,
         current_resource_refnum,
     )?;
-    if matches!(action, PpcImportAction::Yield(_))
-        && toolbox_startup
+    if matches!(action, PpcImportAction::Yield(_)) {
+        let Some(key) = toolbox_startup
             .menu_tracking
-            .as_ref()
-            .is_some_and(|tracking| tracking.should_invoke_menu_hook(input.mouse_button))
-    {
+            .request_menu_hook(input.mouse_button)
+        else {
+            return Some(action);
+        };
         let pointer = memory.read_u32_be(0x0a30).unwrap_or(0);
         if let Some(target) = resolve_guest_procedure(
             memory,
@@ -76034,6 +76142,7 @@ fn ppc_step_menu_tracking(
         ) {
             if target.proc_info == 0 {
                 let return_value = PpcNativeReturnGpr3::Set(cpu.gpr[3]);
+                let operation = crate::guest_call::MenuHookOperation::pending(key);
                 let callback = match target.isa {
                     GuestIsa::PowerPc => {
                         let effect = GuestCallEffect::call_guest(
@@ -76057,10 +76166,20 @@ fn ppc_step_menu_tracking(
                         );
                         toolbox_startup
                             .guest_calls
-                            .activate_powerpc_effect_with_operation(cpu, memory, effect, None, None)
+                            .activate_powerpc_effect_with_operation(
+                                cpu,
+                                memory,
+                                effect,
+                                None,
+                                Some(crate::guest_call::ManagerContinuation::Menu(
+                                    crate::guest_call::MenuManagerContinuation::Hook(
+                                        operation.clone(),
+                                    ),
+                                )),
+                            )
                             .then_some(PpcImportAction::Continue)
                     }
-                    GuestIsa::M68k => ppc_begin_m68k_universal_proc(
+                    GuestIsa::M68k => ppc_begin_m68k_universal_proc_with_operation(
                         cpu,
                         Some(process_memory_manager),
                         memory,
@@ -76073,9 +76192,20 @@ fn ppc_step_menu_tracking(
                         Vec::new(),
                         PPC_GUEST_CALL_RETURN_PC,
                         return_value,
+                        crate::guest_call::ManagerContinuation::Menu(
+                            crate::guest_call::MenuManagerContinuation::Hook(operation.clone()),
+                        ),
                     ),
                 };
                 if let Some(callback) = callback {
+                    assert!(toolbox_startup
+                        .menu_tracking
+                        .bind_menu_hook(key, operation.completion.clone()));
+                    ppc_preserve_menu_callback_port(
+                        toolbox_startup,
+                        *current_gworld,
+                        *current_gdevice,
+                    );
                     return Some(callback);
                 }
             }
@@ -76242,6 +76372,11 @@ fn ppc_step_menu_tracking_body(
                         result,
                     )
                     .unwrap_or(result);
+                    ppc_restore_menu_definition_port(
+                        toolbox_startup,
+                        current_gworld,
+                        current_gdevice,
+                    );
                     return Some(PpcImportAction::Return(result));
                 }
                 if let Some(selected) = ppc_deepest_highlighted_menu_item(&state) {
@@ -76269,16 +76404,28 @@ fn ppc_step_menu_tracking_body(
                 let result =
                     ppc_menu_selection_result(memory, current_menu_list, menu_id, item_number)
                         .unwrap_or(0);
-                ppc_set_menu_command_highlight_with_colors(
+                let result = ppc_complete_menu_bar_tracking_with_colors(
                     memory,
                     gworlds,
-                    current_menu_list,
-                    result,
-                    None,
                     screen_clut,
                     menu_colors,
-                    toolbox_startup.host_menu_bar_hidden,
-                );
+                    toolbox_startup,
+                    result,
+                )
+                .unwrap_or_else(|| {
+                    ppc_set_menu_command_highlight_with_colors(
+                        memory,
+                        gworlds,
+                        current_menu_list,
+                        result,
+                        None,
+                        screen_clut,
+                        menu_colors,
+                        toolbox_startup.host_menu_bar_hidden,
+                    );
+                    result
+                });
+                ppc_restore_menu_definition_port(toolbox_startup, current_gworld, current_gdevice);
                 Some(PpcImportAction::Return(result))
             } else if input.mouse_button {
                 if toolbox_startup.menu_tracking.is_none() {
@@ -76459,6 +76606,7 @@ fn ppc_step_menu_tracking_body(
                     );
                     0
                 });
+                ppc_restore_menu_definition_port(toolbox_startup, current_gworld, current_gdevice);
                 Some(PpcImportAction::Return(result))
             }
         }
@@ -94121,7 +94269,10 @@ pub(crate) mod tests {
                 &mut loaded.cpu,
                 manager.native_mut(),
                 |operation, result| {
-                    let crate::guest_call::ManagerContinuation::Menu(operation) = operation else {
+                    let crate::guest_call::ManagerContinuation::Menu(
+                        crate::guest_call::MenuManagerContinuation::Definition(operation),
+                    ) = operation
+                    else {
                         panic!("MDEF continuation");
                     };
                     operation.complete(&mut loaded.memory);
@@ -162185,51 +162336,82 @@ pub(crate) mod tests {
         }
     }
 
-    pub(crate) fn native_menu_hook_fixture() -> (PpcLoadedApp, u32) {
+    pub(crate) fn native_menu_hook_fixture() -> (PpcLoadedApp, u32, u32) {
         let pef = synthetic_pef_with_import(b"MenuSelect");
         let mut loaded = load_pef_application(&pef).unwrap();
-        install_test_menu(
+        let menu = install_test_menu(
             &mut loaded,
             PPC_DATA_BASE + 0x1000,
             128,
             b"File",
             b"Open;Close",
         );
+        let menu_record = loaded.memory.read_u32_be(menu).unwrap();
         let descriptor = PPC_DATA_BASE + 0x7100;
         let tvector = PPC_DATA_BASE + 0x7180;
         let marker = PPC_DATA_BASE + 0x7400;
         loaded.memory.add_region(marker, vec![0; 4]);
+        let mut set_port = compatibility_binding(
+            "InterfaceLib",
+            "SetPort",
+            PpcImportDispatcherTarget::SetPort,
+        );
+        set_port.symbol_index = 1;
+        set_port.trap_pc = PPC_IMPORT_TRAP_BASE + 4;
+        loaded
+            .memory
+            .add_region(PPC_IMPORT_TRAP_BASE + 4, vec![0; 4]);
+        loaded.imports.push(set_port);
+        loaded.import_count = 2;
+        let callback_entry = PPC_CODE_BASE + 0x4000;
         install_test_powerpc_callback(
             &mut loaded,
             descriptor,
             tvector,
-            PPC_CODE_BASE + 0x4000,
+            callback_entry,
             PPC_DATA_BASE + 0x7300,
             test_stack_proc_info(PPC_PROCINFO_SIZE_NONE, &[]),
             &[
+                0x7fe8_02a6,
+                d_form_u(15, 3, 0, (PPC_DSP_BACK_GWORLD >> 16) as u16),
+                d_form_u(24, 3, 3, PPC_DSP_BACK_GWORLD as u16),
+                0x4800_0000
+                    | ((PPC_IMPORT_TRAP_BASE + 4).wrapping_sub(callback_entry + 3 * 4)
+                        & 0x03ff_fffc)
+                    | 1,
+                0x7fe8_03a6,
+                d_form_u(15, 7, 0, (menu_record >> 16) as u16),
+                d_form_u(24, 7, 7, menu_record as u16),
+                d_form_u(40, 10, 7, 2),
+                d_form_u(14, 10, 10, 1),
+                d_form_u(44, 10, 7, 2),
                 d_form_u(15, 8, 0, (marker >> 16) as u16),
                 d_form_u(24, 8, 8, marker as u16),
                 d_form_u(32, 9, 8, 0),
                 d_form_u(14, 9, 9, 1),
                 d_form_u(36, 9, 8, 0),
+                d_form_u(14, 3, 0, 77),
                 BLR,
             ],
         );
         loaded.memory.write_u32_be(0x0a30, descriptor).unwrap();
-        (loaded, marker)
+        (loaded, marker, menu_record)
     }
 
     #[test]
     fn native_menu_tracking_invokes_menu_hook_while_held() {
-        let (mut loaded, marker) = native_menu_hook_fixture();
+        let (mut loaded, marker, menu_record) = native_menu_hook_fixture();
+        let original_menu_width = loaded.memory.read_u16_be(menu_record + 2).unwrap();
         let original_sp = loaded.cpu.gpr[1];
         let original_return = loaded.cpu.lr;
+        let original_port = (*loaded.current_gworld, *loaded.current_gdevice);
         loaded
             .memory
             .write_u16_be(crate::memory::globals::addr::MENU_FLASH, 0)
             .unwrap();
-        loaded.cpu.gpr[3] =
+        let initial_point =
             (10u32 << 16) | u32::from((STANDARD_MENU_BAR_FIRST_TITLE_LEFT + 2) as u16);
+        loaded.cpu.gpr[3] = initial_point;
         loaded.set_input_snapshot(PpcInputSnapshot {
             mouse_button: true,
             mouse_v: 28,
@@ -162241,10 +162423,20 @@ pub(crate) mod tests {
             assert!(matches!(probe.result, PpcRunResult::CycleLimit { .. }));
         }
         assert!(loaded.toolbox_startup.menu_tracking.is_some());
+        assert_eq!(
+            loaded.toolbox_startup.menu_tracking.context().native_port,
+            Some(original_port),
+        );
+        assert_eq!(*loaded.current_gworld, PPC_DSP_BACK_GWORLD);
+        assert_ne!(
+            (*loaded.current_gworld, *loaded.current_gdevice),
+            original_port
+        );
         assert!(
             loaded.memory.read_u32_be(marker).unwrap() > 0,
             "MenuSelect must invoke MenuHook while held"
         );
+        assert!(loaded.memory.read_u16_be(menu_record + 2).unwrap() > original_menu_width);
         loaded.set_input_snapshot(PpcInputSnapshot {
             mouse_button: false,
             mouse_v: 28,
@@ -162260,8 +162452,169 @@ pub(crate) mod tests {
         assert_eq!(loaded.cpu.pc, original_return);
         assert_eq!(loaded.cpu.gpr[1], original_sp);
         assert_eq!(loaded.cpu.gpr[3], (128 << 16) | 1);
+        assert_eq!(
+            (*loaded.current_gworld, *loaded.current_gdevice),
+            original_port
+        );
         assert!(loaded.guest_calls.is_empty());
         assert!(loaded.toolbox_startup.menu_tracking.is_none());
+    }
+
+    #[test]
+    fn refused_native_menu_hook_leaves_no_receipt_or_port_and_retries() {
+        let (mut loaded, marker, _) = native_menu_hook_fixture();
+        let descriptor = loaded.memory.read_u32_be(0x0a30).unwrap();
+        loaded.memory.write_u32_be(0x0a30, 0).unwrap();
+        loaded.cpu.gpr[3] =
+            (10u32 << 16) | u32::from((STANDARD_MENU_BAR_FIRST_TITLE_LEFT + 2) as u16);
+        loaded.set_input_snapshot(PpcInputSnapshot {
+            mouse_button: true,
+            mouse_v: 28,
+            mouse_h: 20,
+            ..PpcInputSnapshot::default()
+        });
+
+        let probe = loaded.run_with_hle_imports(128);
+        assert!(matches!(probe.result, PpcRunResult::CycleLimit { .. }));
+        assert_eq!(loaded.guest_calls.depth(), 0);
+        assert_eq!(loaded.toolbox_startup.menu_tracking.menu_hook_key(), None);
+        assert_eq!(
+            loaded.toolbox_startup.menu_tracking.context().native_port,
+            None
+        );
+        assert_eq!(loaded.memory.read_u32_be(marker), Some(0));
+
+        loaded.memory.write_u32_be(0x0a30, descriptor).unwrap();
+        loaded
+            .memory
+            .write_u32_be(descriptor + PPC_ROUTINE_DESCRIPTOR_HEADER_SIZE, 1)
+            .unwrap();
+        let probe = loaded.run_with_hle_imports(128);
+        assert!(matches!(probe.result, PpcRunResult::CycleLimit { .. }));
+        assert_eq!(loaded.guest_calls.depth(), 0);
+        assert_eq!(loaded.toolbox_startup.menu_tracking.menu_hook_key(), None);
+        assert_eq!(
+            loaded.toolbox_startup.menu_tracking.context().native_port,
+            None
+        );
+        assert_eq!(loaded.memory.read_u32_be(marker), Some(0));
+
+        loaded
+            .memory
+            .write_u32_be(descriptor + PPC_ROUTINE_DESCRIPTOR_HEADER_SIZE, 0)
+            .unwrap();
+        for _ in 0..4 {
+            let probe = loaded.run_with_hle_imports(128);
+            assert!(matches!(probe.result, PpcRunResult::CycleLimit { .. }));
+        }
+        assert!(loaded.memory.read_u32_be(marker).unwrap() > 0);
+        assert!(loaded
+            .toolbox_startup
+            .menu_tracking
+            .context()
+            .native_port
+            .is_some());
+
+        loaded.set_input_snapshot(PpcInputSnapshot {
+            mouse_button: false,
+            mouse_v: 500,
+            mouse_h: 500,
+            ..PpcInputSnapshot::default()
+        });
+        for _ in 0..8 {
+            if matches!(
+                loaded.run_with_hle_imports(128).result,
+                PpcRunResult::Halted { .. }
+            ) {
+                break;
+            }
+        }
+        assert!(loaded.guest_calls.is_empty());
+        assert!(loaded.toolbox_startup.menu_tracking.is_none());
+    }
+
+    #[test]
+    fn native_menu_hook_host_selection_restores_port_and_retires_its_root() {
+        let (mut loaded, marker, _) = native_menu_hook_fixture();
+        let original_port = (*loaded.current_gworld, *loaded.current_gdevice);
+        loaded.cpu.gpr[3] =
+            (10u32 << 16) | u32::from((STANDARD_MENU_BAR_FIRST_TITLE_LEFT + 2) as u16);
+        loaded.set_input_snapshot(PpcInputSnapshot {
+            mouse_button: true,
+            mouse_v: 28,
+            mouse_h: 20,
+            ..PpcInputSnapshot::default()
+        });
+        for _ in 0..4 {
+            let probe = loaded.run_with_hle_imports(128);
+            assert!(matches!(probe.result, PpcRunResult::CycleLimit { .. }));
+        }
+        assert!(loaded.memory.read_u32_be(marker).unwrap() > 0);
+        assert!(loaded
+            .toolbox_startup
+            .pending_native_menu_selection
+            .stage((128, 1)));
+
+        for _ in 0..8 {
+            if matches!(
+                loaded.run_with_hle_imports(128).result,
+                PpcRunResult::Halted { .. }
+            ) {
+                break;
+            }
+        }
+        assert_eq!(loaded.cpu.gpr[3], (128 << 16) | 1);
+        assert_eq!(
+            (*loaded.current_gworld, *loaded.current_gdevice),
+            original_port
+        );
+        assert!(loaded.toolbox_startup.menu_tracking.is_none());
+        assert!(loaded.guest_calls.is_empty());
+    }
+
+    #[test]
+    fn native_menu_hook_flash_completion_restores_port_and_retires_its_root() {
+        let (mut loaded, marker, _) = native_menu_hook_fixture();
+        let original_port = (*loaded.current_gworld, *loaded.current_gdevice);
+        loaded
+            .memory
+            .write_u16_be(crate::memory::globals::addr::MENU_FLASH, 1)
+            .unwrap();
+        loaded.cpu.gpr[3] =
+            (10u32 << 16) | u32::from((STANDARD_MENU_BAR_FIRST_TITLE_LEFT + 2) as u16);
+        loaded.set_input_snapshot(PpcInputSnapshot {
+            mouse_button: true,
+            mouse_v: 28,
+            mouse_h: 20,
+            ..PpcInputSnapshot::default()
+        });
+        for _ in 0..4 {
+            let probe = loaded.run_with_hle_imports(128);
+            assert!(matches!(probe.result, PpcRunResult::CycleLimit { .. }));
+        }
+        assert!(loaded.memory.read_u32_be(marker).unwrap() > 0);
+        loaded.set_input_snapshot(PpcInputSnapshot {
+            mouse_button: false,
+            mouse_v: 28,
+            mouse_h: 20,
+            ..PpcInputSnapshot::default()
+        });
+
+        for _ in 0..16 {
+            if matches!(
+                loaded.run_with_hle_imports(128).result,
+                PpcRunResult::Halted { .. }
+            ) {
+                break;
+            }
+        }
+        assert_eq!(loaded.cpu.gpr[3], (128 << 16) | 1);
+        assert_eq!(
+            (*loaded.current_gworld, *loaded.current_gdevice),
+            original_port
+        );
+        assert!(loaded.toolbox_startup.menu_tracking.is_none());
+        assert!(loaded.guest_calls.is_empty());
     }
 
     #[test]

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -10359,16 +10359,13 @@ impl FixtureRunner {
         if self.active_interrupt_callback.is_some() || (opcode & !0x0400) != 0xa93d {
             return false;
         }
-        if !self
-            .process_context
-            .menu_tracking()
-            .as_ref()
-            .is_some_and(|tracking| {
-                tracking.should_invoke_menu_hook(self.bus.read_byte(0x0172) == 0)
-            })
-        {
+        let Some(key) = self
+            .dispatcher
+            .menu_tracking
+            .request_menu_hook(self.bus.read_byte(0x0172) == 0)
+        else {
             return false;
-        }
+        };
         let pointer = self.bus.read_long(0x0a30);
         let Some(procedure) = crate::guest_procedure::resolve_guest_procedure(
             &mut self.bus,
@@ -10388,21 +10385,36 @@ impl FixtureRunner {
             entry: procedure.entry,
             rtoc: procedure.rtoc,
         };
-        self.dispatcher.preserve_menu_callback_port(&self.bus);
         let sp = self.m68k.cpu.read_reg(Register::A7);
+        let operation = crate::guest_call::MenuHookOperation::pending(key);
         if procedure.isa == GuestIsa::PowerPc {
-            return self.dispatcher.guest_calls.begin_m68k_to_powerpc(
-                target,
-                crate::guest_call::PowerPcArguments::from_slice(&[]).unwrap(),
-                self.m68k.cpu.read_reg(Register::PC),
-                sp,
-                None,
-            );
+            if !self
+                .dispatcher
+                .guest_calls
+                .begin_m68k_to_powerpc_with_operation(
+                    target,
+                    crate::guest_call::PowerPcArguments::from_slice(&[]).unwrap(),
+                    self.m68k.cpu.read_reg(Register::PC),
+                    sp,
+                    None,
+                    crate::guest_call::ManagerContinuation::Menu(
+                        crate::guest_call::MenuManagerContinuation::Hook(operation.clone()),
+                    ),
+                )
+            {
+                return false;
+            }
+            assert!(self
+                .dispatcher
+                .menu_tracking
+                .bind_menu_hook(key, operation.completion.clone()));
+            self.dispatcher.preserve_menu_callback_port(&self.bus);
+            return true;
         }
         let Some(frame) = crate::execution_m68k::M68kMenuHookFrame::new(procedure.entry, sp) else {
             return false;
         };
-        if !self.bus.is_guest_address_mapped(frame.entry - 66, 114) {
+        if !self.bus.is_guest_address_writable(frame.entry - 66, 114) {
             return false;
         }
         let return_pc = frame.entry + 28;
@@ -10411,10 +10423,17 @@ impl FixtureRunner {
             return_pc,
             sp,
             Some(frame.entry),
-            None,
+            Some(crate::guest_call::ManagerContinuation::Menu(
+                crate::guest_call::MenuManagerContinuation::Hook(operation.clone()),
+            )),
         ) {
             return false;
         }
+        assert!(self
+            .dispatcher
+            .menu_tracking
+            .bind_menu_hook(key, operation.completion.clone()));
+        self.dispatcher.preserve_menu_callback_port(&self.bus);
         self.bus.write_bytes(frame.entry, &frame.image);
         self.bus.write_long(frame.entry - 4, return_pc);
         self.m68k.cpu.write_reg(Register::A7, frame.entry - 4);
@@ -16532,7 +16551,7 @@ mod tests {
         use crate::loader::ppc::tests::native_menu_hook_fixture;
         use crate::memory::globals::addr;
         for cancel in [false, true] {
-            let (mut native, _) = native_menu_hook_fixture();
+            let (mut native, _, _) = native_menu_hook_fixture();
             native.cpu.gpr[3] = (10 << 16) | 12;
             native.memory.write_u16_be(addr::MENU_FLASH, 0).unwrap();
             let original_sp = native.cpu.gpr[1];
@@ -16646,6 +16665,9 @@ mod tests {
             .unwrap();
         runner.dispatcher.draw_menu_bar_to_fb(&mut runner.bus);
         let original_port = *runner.dispatcher.current_port;
+        let hook_port = runner.bus.alloc(170);
+        let original_port_image = runner.bus.read_bytes(original_port, 170).to_vec();
+        runner.bus.write_bytes(hook_port, &original_port_image);
         let parameters = stack + if auto_pop { 4 } else { 0 };
         let return_pc = entry + if auto_pop { 0x100 } else { 2 };
         runner.bus.write_word(return_pc, 0x60fe);
@@ -16660,14 +16682,61 @@ mod tests {
         runner.bus.write_long(parameters + 4, 0);
         runner.m68k.cpu.write_reg(Register::A7, stack);
         let hook_marker = runner.bus.alloc(4);
+        let hook_after_yield_marker = runner.bus.alloc(4);
+        let cooperative_switch = hook && !native_hook && !auto_pop;
+        let mut hook_yield_resume_pc = None;
+        let mut worker_yield_result = None;
         if hook {
-            let code = runner.bus.alloc(24);
-            runner.bus.write_word(code, 0x7e63); // MOVEQ #99,D7
-            runner.bus.write_word(code + 2, 0x2c7c); // MOVEA.L #value,A6
-            runner.bus.write_long(code + 4, 0x12345678);
-            runner.bus.write_word(code + 8, 0x52b9); // ADDQ.L #1,marker
-            runner.bus.write_long(code + 10, hook_marker);
-            runner.bus.write_word(code + 14, 0x4e75);
+            let mut hook_words = vec![
+                0x7e63, // MOVEQ #99,D7
+                0x2c7c, // MOVEA.L #value,A6
+                0x1234,
+                0x5678,
+            ];
+            if !native_hook {
+                hook_words.extend([
+                    0x2f3c,
+                    (hook_port >> 16) as u16,
+                    hook_port as u16,
+                    0xa873, // SetPort(hook_port)
+                ]);
+            }
+            hook_words.extend([
+                0x52b9, // ADDQ.L #1,marker
+                (hook_marker >> 16) as u16,
+                hook_marker as u16,
+            ]);
+            if cooperative_switch {
+                hook_words.extend([
+                    0x558f, // SUBQ.L #2,SP: Pascal result word
+                    0x42a7, // CLR.L -(SP): synthetic suggested ThreadID
+                    0x303c, 0x0205, // MOVE.W #YieldToAnyThread,D0
+                    0xabf2, // ThreadDispatch
+                    0x548f, // ADDQ.L #2,SP: pop Pascal result
+                ]);
+                hook_words.extend([
+                    0x52b9, // ADDQ.L #1,after-yield marker
+                    (hook_after_yield_marker >> 16) as u16,
+                    hook_after_yield_marker as u16,
+                ]);
+            }
+            hook_words.extend([
+                0x5279, // ADDQ.W #1,menuWidth
+                ((record + 2) >> 16) as u16,
+                (record + 2) as u16,
+                0x4e75,
+            ]);
+            let code = runner.bus.alloc((hook_words.len() * 2) as u32);
+            if cooperative_switch {
+                let trap_index = hook_words
+                    .iter()
+                    .position(|word| *word == 0xabf2)
+                    .unwrap();
+                hook_yield_resume_pc = Some(code + (trap_index as u32 + 1) * 2);
+            }
+            for (index, word) in hook_words.into_iter().enumerate() {
+                runner.bus.write_word(code + index as u32 * 2, word);
+            }
             runner.bus.write_long(0x0a30, code);
             if native_hook {
                 use crate::guest_procedure::{
@@ -16676,8 +16745,13 @@ mod tests {
                     ROUTINE_RECORD_FLAGS_OFFSET, ROUTINE_RECORD_ISA_OFFSET,
                     ROUTINE_RECORD_POWERPC_ISA, ROUTINE_RECORD_PROC_DESCRIPTOR_OFFSET,
                 };
-                let native_code = runner.bus.alloc(28);
+                let native_code = runner.bus.alloc(48);
                 for (index, word) in [
+                    0x3ce0_0000 | (record >> 16),
+                    0x60e7_0000 | (record & 0xffff),
+                    0xa147_0002,
+                    0x394a_0001,
+                    0xb147_0002,
                     0x3d00_0000 | (hook_marker >> 16),
                     0x6108_0000 | (hook_marker & 0xffff),
                     0x8128_0000,
@@ -16718,10 +16792,185 @@ mod tests {
             runner.m68k.cpu.write_reg(Register::D7, 0x77777777);
             runner.m68k.cpu.write_reg(Register::A6, 0x66666666);
         }
-        runner.push_canonical_mouse_down(10, 16);
+        if hook && !native_hook {
+            let hook_pointer = runner.bus.read_long(0x0a30);
+            runner.bus.write_long(0x0a30, 0);
+            runner.push_canonical_mouse_down(10, 16);
+            for _ in 0..8 {
+                assert!(runner.run_steps(128, None).1);
+                if runner
+                    .dispatcher
+                    .menu_tracking
+                    .request_menu_hook(true)
+                    .is_some()
+                {
+                    break;
+                }
+            }
+            let key = runner
+                .dispatcher
+                .menu_tracking
+                .request_menu_hook(true)
+                .expect("held menu requests its classic hook");
+            let call_depth = runner.dispatcher.guest_calls.depth();
+            runner.bus.write_long(0x0a30, hook_pointer);
+            let procedure = crate::guest_procedure::resolve_guest_procedure(
+                &mut runner.bus,
+                hook_pointer,
+                0,
+                None,
+                GuestIsa::M68k,
+                GuestIsa::M68k,
+            )
+            .expect("classic hook remains resolvable");
+            assert_eq!(procedure.isa, GuestIsa::M68k);
+            assert_eq!(procedure.entry, hook_pointer);
+            let valid_sp = runner.m68k.cpu.read_reg(Register::A7);
+            let frame_start = runner.bus.alloc(114);
+            let frame_len = 114;
+            runner
+                .bus
+                .protect_readonly_code(frame_start, frame_len as u32);
+            assert!(runner.bus.is_guest_address_mapped(frame_start, frame_len));
+            assert!(!runner.bus.is_guest_address_writable(frame_start, frame_len));
+            let frame_snapshot = runner.bus.read_bytes(frame_start, frame_len).to_vec();
+            runner
+                .m68k
+                .cpu
+                .write_reg(Register::A7, frame_start + frame_len as u32);
+            assert!(!runner.fire_menu_hook_proc(0xa93d));
+            assert_eq!(runner.bus.read_bytes(frame_start, frame_len), frame_snapshot);
+            assert_eq!(
+                runner.dispatcher.menu_tracking.request_menu_hook(true),
+                Some(key)
+            );
+            assert_eq!(runner.dispatcher.menu_tracking.context().classic_port, None);
+            assert_eq!(runner.dispatcher.guest_calls.depth(), call_depth);
+            runner.m68k.cpu.write_reg(Register::A7, valid_sp);
+            if cooperative_switch {
+                let worker = ExecutionTaskId::from_thread_id(3);
+                let worker_entry = runner.bus.alloc(8);
+                let worker_stack = runner.bus.alloc(64);
+                let worker_sp = worker_stack + 58;
+                for (index, word) in [
+                    0x303c, 0x0205, // MOVE.W #YieldToAnyThread,D0
+                    0xabf2, // ThreadDispatch back to the application
+                    0x60fe, // BRA.S -2 if no successor is runnable
+                ]
+                .into_iter()
+                .enumerate()
+                {
+                    runner.bus.write_word(worker_entry + index as u32 * 2, word);
+                }
+                runner.bus.write_long(worker_sp, 0);
+                runner.bus.write_word(worker_sp + 4, 0xbeef);
+                worker_yield_result = Some(worker_sp + 4);
+                assert!(runner.dispatcher.guest_calls.register_task(worker));
+                assert!(runner.dispatcher.guest_calls.set_thread_storage(
+                    worker,
+                    crate::guest_call::ThreadStorage {
+                        stack_base: worker_stack,
+                        stack_limit: worker_stack + 64,
+                        ..Default::default()
+                    }
+                ));
+                assert!(runner.dispatcher.guest_calls.save_cooperative_context(
+                    worker,
+                    CooperativeThread {
+                        a_regs: [0, 0, 0, 0, 0, 0, 0, worker_sp],
+                        pc: worker_entry,
+                        ..Default::default()
+                    }
+                ));
+                assert!(runner.dispatcher.guest_calls.set_scheduling_state(
+                    worker,
+                    crate::execution_kernel::ExecutionTaskState::Ready
+                ));
+            }
+            assert!(runner.fire_menu_hook_proc(0xa93d));
+            assert_eq!(runner.dispatcher.menu_tracking.menu_hook_key(), Some(key));
+            assert!(runner
+                .dispatcher
+                .menu_tracking
+                .context()
+                .classic_port
+                .is_some());
+            if cooperative_switch {
+                runner.bus.write_long(0x0a30, 0);
+                let worker = ExecutionTaskId::from_thread_id(3);
+                for _ in 0..32 {
+                    runner.run_steps(1, None);
+                    if runner.dispatcher.guest_calls.current_task() == worker {
+                        break;
+                    }
+                }
+                assert_eq!(runner.dispatcher.guest_calls.current_task(), worker);
+                assert_eq!(runner.bus.read_long(hook_marker), 1);
+                assert_eq!(runner.bus.read_long(hook_after_yield_marker), 0);
+                assert_eq!(runner.bus.read_byte(0x0172), 0);
+                assert_eq!(*runner.dispatcher.current_port, hook_port);
+                assert_eq!(runner.dispatcher.menu_tracking.menu_hook_key(), None);
+                assert!(runner.dispatcher.menu_tracking.menu_hook_is_pending(key));
+                assert!(runner
+                    .dispatcher
+                    .menu_tracking
+                    .ready_call(GuestIsa::M68k)
+                    .is_none());
+                let parked = runner
+                    .dispatcher
+                    .guest_calls
+                    .cooperative_context(ExecutionTaskId::APPLICATION)
+                    .expect("suspended hook context");
+                assert_eq!(parked.pc, hook_yield_resume_pc.unwrap());
+                for _ in 0..32 {
+                    runner.run_steps(1, None);
+                    if runner.dispatcher.guest_calls.current_task()
+                        == ExecutionTaskId::APPLICATION
+                    {
+                        break;
+                    }
+                }
+                assert_eq!(
+                    runner.dispatcher.guest_calls.current_task(),
+                    ExecutionTaskId::APPLICATION
+                );
+                assert_eq!(runner.bus.read_word(worker_yield_result.unwrap()), 0);
+                assert_eq!(runner.m68k.cpu.read_reg(Register::PC), parked.pc);
+                assert_eq!(runner.m68k.cpu.read_reg(Register::A7), parked.a_regs[7]);
+                assert_eq!(runner.dispatcher.menu_tracking.menu_hook_key(), Some(key));
+                for _ in 0..32 {
+                    runner.run_steps(1, None);
+                    assert!(
+                        runner.process_context.menu_tracking().is_some(),
+                        "held root vanished before hook receipt consumption: task={:?} pc={:08x} button={:02x}",
+                        runner.dispatcher.guest_calls.current_task(),
+                        runner.m68k.cpu.read_reg(Register::PC),
+                        runner.bus.read_byte(0x0172),
+                    );
+                    if runner.bus.read_long(hook_after_yield_marker) == 1
+                        && runner.dispatcher.menu_tracking.menu_hook_key().is_none()
+                    {
+                        break;
+                    }
+                }
+                assert_eq!(runner.bus.read_long(hook_after_yield_marker), 1);
+                assert_eq!(runner.dispatcher.menu_tracking.menu_hook_key(), None);
+                assert!(runner.process_context.menu_tracking().is_some());
+            }
+        } else {
+            runner.push_canonical_mouse_down(10, 16);
+        }
 
-        for _ in 0..8 {
-            assert!(runner.run_steps(128, None).1);
+        if !cooperative_switch {
+            for _ in 0..8 {
+                assert!(runner.run_steps(128, None).1);
+            }
+        }
+        if hook && !native_hook {
+            assert_eq!(*runner.dispatcher.current_port, hook_port);
+            if cooperative_switch {
+                assert_eq!(runner.bus.read_long(hook_after_yield_marker), 1);
+            }
         }
         let rect = runner
             .process_context
@@ -16784,6 +17033,7 @@ mod tests {
         assert_eq!(runner.m68k.cpu.read_reg(Register::PC), return_pc);
         if hook {
             assert!(runner.bus.read_long(hook_marker) > 0, "the guest hook ran");
+            assert!(runner.bus.read_word(record + 2) > 80);
             assert_eq!(runner.m68k.cpu.read_reg(Register::D7), 0x77777777);
             assert_eq!(runner.m68k.cpu.read_reg(Register::A6), 0x66666666);
             assert!(runner.dispatcher.guest_calls.is_empty());

--- a/src/trap/menu.rs
+++ b/src/trap/menu.rs
@@ -533,9 +533,13 @@ impl super::TrapDispatcher {
             if !self.guest_calls.begin_m68k_with_operation(
                 GuestCallTarget { isa: GuestIsa::M68k, entry: proc_addr, rtoc: 0 },
                 return_pc, final_sp, Some(frame.entry),
-                Some(crate::guest_call::ManagerContinuation::Menu(crate::menu_manager::MenuDefinitionOperation {
-                    scratch, completion: completion.clone(),
-                })),
+                Some(crate::guest_call::ManagerContinuation::Menu(
+                    crate::guest_call::MenuManagerContinuation::Definition(
+                        crate::menu_manager::MenuDefinitionOperation {
+                            scratch, completion: completion.clone(),
+                        },
+                    ),
+                )),
             ) { return false; }
             if let Some(id) = tracking_root {
                 self.menu_tracking


### PR DESCRIPTION
MenuHook submissions now carry a single-use completion receipt owned by the exact task, menu operation, and enclosing call. Shared menu tracking chooses hook eligibility, and the ABI adapters prepare and submit the callback. A pending receipt keeps its owning operation alive across nested calls and cooperative task switches; completion becomes available only after the caller context and return state have been restored.

All four classic/native caller and hook combinations use that operation-bearing path. Reverse-ISA restoration retains the carrier through refusal and consumes it after successful context retirement. Origin-port restoration covers normal selection, cancellation, flash completion, and pending host selection. The change removes adapter-owned hook eligibility policy and retains one existing menu-operation store.

Validation: 13 focused MenuHook tests plus the reverse-carrier regression passed. Real guest code changes the graphics port through classic and native SetPort, and a classic hook yields to another real cooperative task and resumes at its exact parked PC/SP while its receipt remains pending. Tests also cover nested MenuSelect and writable-frame refusal followed by retry on the same eligible operation. The final package passed 5,228 default/test-support library tests with three ignored against published PPC 0.6.0, and the source guard passed. The exported public package is byte-identical to the independently tested package. Required public CI and package checks must pass before merge.

Closes #1544
