### PR TITLE
fix: share atomic cooperative thread yielding across ABIs

### DIFF
--- a/src/guest_call.rs
+++ b/src/guest_call.rs
@@ -540,6 +540,18 @@ enum TaskResumeContext {
     Native(PpcExecutionContext),
 }
 
+struct YieldedTask {
+    current: ExecutionTaskId,
+    next: ExecutionTaskId,
+    successor: TaskResumeContext,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) enum ClassicYield {
+    Stayed,
+    Switched(Option<CooperativeThread>),
+}
+
 impl TaskResumeContext {
     fn stack_pointer(&self) -> u32 {
         match self {
@@ -1265,6 +1277,44 @@ impl Default for ExecutionTaskCalls {
 }
 
 impl ExecutionTaskCalls {
+    fn yield_task(
+        &mut self,
+        suggested: u32,
+        outgoing: TaskResumeContext,
+    ) -> Result<Option<YieldedTask>, i16> {
+        use crate::thread_manager::{THREAD_NOT_FOUND_ERR, THREAD_PROTOCOL_ERR};
+        if self.kernel.critical_depth() != 0 || self.handoff.is_some() {
+            return Err(THREAD_PROTOCOL_ERR);
+        }
+        let current = self.kernel.current_task();
+        let explicit = (suggested > 1).then(|| ExecutionTaskId::from_thread_id(suggested));
+        let unavailable = explicit.is_some_and(|task| {
+            task != current && self.kernel.scheduling_state(task) != Some(ExecutionTaskState::Ready)
+        });
+        let Some(next) = self.kernel.next_ready_task(explicit) else {
+            return if unavailable {
+                Err(THREAD_NOT_FOUND_ERR)
+            } else {
+                Ok(None)
+            };
+        };
+        let successor = self.saved_context(next).ok_or(THREAD_PROTOCOL_ERR)?;
+        self.kernel
+            .switch_to_task(next)
+            .map_err(|_| THREAD_PROTOCOL_ERR)?;
+        match outgoing {
+            TaskResumeContext::Classic(context) => {
+                self.cooperative_contexts.insert(current, context);
+            }
+            TaskResumeContext::Native(context) => self.save_native_context(current, context),
+        }
+        Ok(Some(YieldedTask {
+            current,
+            next,
+            successor,
+        }))
+    }
+
     fn pending_powerpc_from_m68k(&self, task: ExecutionTaskId) -> Option<PendingPowerPcExecution> {
         let semantic = self.kernel.peek(task)?;
         let frame = self.frames.get(&semantic.call_id())?;
@@ -2261,31 +2311,38 @@ impl SharedGuestCallStack {
         cpu: &mut PpcCpu,
         suggested: u32,
     ) -> Result<bool, i16> {
-        use crate::thread_manager::THREAD_PROTOCOL_ERR;
         let mut tasks = self.0.borrow_mut();
-        if tasks.kernel.critical_depth() != 0 || tasks.handoff.is_some() {
-            return Err(THREAD_PROTOCOL_ERR);
-        }
-        let current = tasks.kernel.current_task();
-        let Some(next) = tasks
-            .kernel
-            .next_ready_task((suggested > 1).then(|| ExecutionTaskId::from_thread_id(suggested)))
-        else {
-            return Ok(false);
-        };
-        let next_context = tasks.saved_context(next).ok_or(THREAD_PROTOCOL_ERR)?;
         let mut outgoing = cpu.capture_execution_context();
         outgoing.architectural_mut().pc = outgoing.architectural().lr;
         outgoing.architectural_mut().gpr[3] = 0;
-        tasks
-            .kernel
-            .switch_to_task(next)
-            .map_err(|_| THREAD_PROTOCOL_ERR)?;
-        tasks.save_native_context(current, outgoing.clone());
+        let Some(yielded) =
+            tasks.yield_task(suggested, TaskResumeContext::Native(outgoing.clone()))?
+        else {
+            return Ok(false);
+        };
         cpu.install_execution_context(outgoing);
-        tasks.native_cpu_task = Some(current);
-        tasks.install_native_successor(next, next_context, cpu);
+        tasks.native_cpu_task = Some(yielded.current);
+        tasks.install_native_successor(yielded.next, yielded.successor, cpu);
         Ok(true)
+    }
+
+    pub(crate) fn yield_classic_thread(
+        &self,
+        outgoing: CooperativeThread,
+        suggested: u32,
+    ) -> Result<ClassicYield, i16> {
+        let mut tasks = self.0.borrow_mut();
+        let Some(yielded) = tasks.yield_task(suggested, TaskResumeContext::Classic(outgoing))?
+        else {
+            return Ok(ClassicYield::Stayed);
+        };
+        match yielded.successor {
+            TaskResumeContext::Classic(context) => Ok(ClassicYield::Switched(Some(context))),
+            context => {
+                tasks.handoff = Some((yielded.next, context));
+                Ok(ClassicYield::Switched(None))
+            }
+        }
     }
 
     pub(crate) fn retire_native_thread(
@@ -4751,6 +4808,185 @@ mod tests {
         assert_eq!(cpu.fpscr, 0x5555_6666);
         assert_eq!(cpu.msr, 0x7777_8888);
         assert_eq!(cpu.time_base(), 1);
+    }
+
+    #[test]
+    fn yield_suggestion_fallback_and_no_successor_preserve_compatibility() {
+        let classic = |pc| CooperativeThread {
+            pc,
+            a_regs: [0, 0, 0, 0, 0, 0, 0, 0x8000 + pc],
+            ..Default::default()
+        };
+        for suggested in [0, 1, ExecutionTaskId::APPLICATION.thread_id()] {
+            let calls = SharedGuestCallStack::default();
+            assert_eq!(
+                calls.yield_classic_thread(classic(1), suggested),
+                Ok(ClassicYield::Stayed)
+            );
+            assert_eq!(
+                calls.cooperative_context(ExecutionTaskId::APPLICATION),
+                None
+            );
+        }
+        let calls = SharedGuestCallStack::default();
+        let fallback = calls.create_task().unwrap();
+        let fallback_context = classic(5);
+        assert!(calls.save_cooperative_context(fallback, fallback_context.clone()));
+        assert!(calls.set_scheduling_state(fallback, ExecutionTaskState::Ready));
+        assert_eq!(
+            calls.yield_classic_thread(classic(6), ExecutionTaskId::APPLICATION.thread_id()),
+            Ok(ClassicYield::Switched(Some(fallback_context)))
+        );
+        assert_eq!(calls.current_task(), fallback);
+        assert_eq!(
+            calls.cooperative_context(ExecutionTaskId::APPLICATION),
+            Some(classic(6))
+        );
+        for stopped in [false, true] {
+            let calls = SharedGuestCallStack::default();
+            let unavailable = if stopped {
+                calls.create_task().unwrap()
+            } else {
+                ExecutionTaskId::from_thread_id(99)
+            };
+            assert_eq!(
+                calls.yield_classic_thread(classic(2), unavailable.thread_id()),
+                Err(crate::thread_manager::THREAD_NOT_FOUND_ERR)
+            );
+            assert_eq!(calls.current_task(), ExecutionTaskId::APPLICATION);
+            assert_eq!(
+                calls.cooperative_context(ExecutionTaskId::APPLICATION),
+                None
+            );
+        }
+        for stopped in [false, true] {
+            let calls = SharedGuestCallStack::default();
+            let unavailable = if stopped {
+                calls.create_task().unwrap()
+            } else {
+                ExecutionTaskId::from_thread_id(99)
+            };
+            let fallback = calls.create_task().unwrap();
+            let fallback_context = classic(3);
+            assert!(calls.save_cooperative_context(fallback, fallback_context.clone()));
+            assert!(calls.set_scheduling_state(fallback, ExecutionTaskState::Ready));
+            assert_eq!(
+                calls.yield_classic_thread(classic(4), unavailable.thread_id()),
+                Ok(ClassicYield::Switched(Some(fallback_context)))
+            );
+            assert_eq!(calls.current_task(), fallback);
+            assert_eq!(
+                calls.cooperative_context(ExecutionTaskId::APPLICATION),
+                Some(classic(4))
+            );
+            assert_eq!(
+                calls.scheduling_state(unavailable),
+                if stopped {
+                    Some(ExecutionTaskState::Stopped)
+                } else {
+                    None
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn yield_to_any_without_successor_publishes_no_native_snapshot() {
+        let calls = SharedGuestCallStack::default();
+        let mut cpu = PpcCpu::new();
+        cpu.pc = 0x1234;
+        cpu.lr = 0x5678;
+        cpu.gpr[3] = 99;
+        let before = cpu.clone();
+        assert!(!calls.yield_native_thread(&mut cpu, 0).unwrap());
+        assert_eq!(cpu.pc, before.pc);
+        assert_eq!(cpu.lr, before.lr);
+        assert_eq!(cpu.gpr, before.gpr);
+        assert!(calls.0.borrow().native_threads.is_empty());
+        assert_eq!(calls.current_task(), ExecutionTaskId::APPLICATION);
+    }
+
+    #[test]
+    fn pending_cross_isa_handoff_refuses_both_yield_wrappers_atomically() {
+        const NATIVE_RETURN: u32 = 0x2400;
+        const NATIVE_FINAL: u32 = 0x3400;
+        let calls = SharedGuestCallStack::default();
+        let native = calls
+            .create_native_thread(
+                NativeThreadContext {
+                    context: PpcExecutionContext::fresh(),
+                },
+                ThreadStorage::default(),
+                false,
+                |_| true,
+            )
+            .unwrap();
+        let classic_outgoing = CooperativeThread {
+            pc: 0x1400,
+            a_regs: [0, 0, 0, 0, 0, 0, 0, 0x8400],
+            ..Default::default()
+        };
+        assert_eq!(
+            calls.yield_classic_thread(classic_outgoing, native.thread_id()),
+            Ok(ClassicYield::Switched(None))
+        );
+        assert_eq!(calls.current_task(), native);
+        assert!(calls.has_pending_task_handoff());
+
+        let mut native_cpu = PpcCpu::new();
+        native_cpu.install_execution_context(pending_native_import_context(
+            0x1000,
+            NATIVE_RETURN,
+            NATIVE_FINAL,
+            0xaaaa_0002,
+            0xaaaa_0003,
+        ));
+        native_cpu.gpr[20] = 0x1234_5678;
+        native_cpu.fpr[20] = 0x4009_21fb_5444_2d18;
+        native_cpu.cr = 0x1357_2468;
+        establish_native_reservation(&mut native_cpu, 0x1000);
+        native_cpu.set_time_base(44);
+        let before_owner = calls.clone();
+        let before_native = native_cpu.capture_execution_context();
+        let before_time = native_cpu.time_base();
+        let before_reservation = native_cpu.reservation_address();
+
+        assert_eq!(calls.yield_native_thread(&mut native_cpu, 0), Err(-619));
+        assert_eq!(calls, before_owner);
+        assert_eq!(
+            native_cpu.capture_execution_context().architectural(),
+            before_native.architectural()
+        );
+        assert_eq!(native_cpu.time_base(), before_time);
+        assert_eq!(native_cpu.reservation_address(), before_reservation);
+
+        let mut classic_cpu = crate::cpu::M68kCpu::new();
+        classic_cpu.write_reg(crate::cpu::Register::PC, 0x1500);
+        classic_cpu.write_reg(crate::cpu::Register::D3, 0x89ab_cdef);
+        classic_cpu.write_reg(crate::cpu::Register::A7, 0x8500);
+        let before_classic = CooperativeThread::capture(&classic_cpu);
+        let before_extended = classic_cpu.capture_extended_context();
+        let before_owner = calls.clone();
+        assert_eq!(
+            calls.yield_classic_thread(before_classic.clone(), 0),
+            Err(-619)
+        );
+        assert_eq!(calls, before_owner);
+        assert_eq!(CooperativeThread::capture(&classic_cpu), before_classic);
+        assert_eq!(classic_cpu.capture_extended_context(), before_extended);
+
+        let mut memory = GuestAddressSpace::new();
+        assert_eq!(
+            native_cpu.run_with_imports(&mut memory, 2, NATIVE_FINAL, 0, 0, |_, _, _| unreachable!(),),
+            PpcRunResult::Halted {
+                pc: NATIVE_FINAL,
+                cycles: 1,
+            }
+        );
+        assert_eq!(
+            (native_cpu.gpr[2], native_cpu.gpr[3]),
+            (0xaaaa_0002, 0xaaaa_0003)
+        );
     }
 
     #[test]

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -171165,6 +171165,76 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn native_yield_imports_preserve_state_when_refused_or_quiescent() {
+        use crate::guest_call::{ExecutionTaskId, NativeThreadContext, ThreadStorage};
+
+        for symbol in [b"YieldToAnyThread".as_slice(), b"YieldToThread".as_slice()] {
+            let mut loaded = load_pef_application(&synthetic_pef_with_import(symbol)).unwrap();
+            let mut worker_cpu = loaded.cpu.clone();
+            worker_cpu.pc = PPC_CODE_BASE + 0x2000;
+            worker_cpu.gpr[1] = PPC_DATA_BASE + 0x4000;
+            let worker = loaded
+                .guest_calls
+                .create_native_thread(
+                    NativeThreadContext {
+                        context: worker_cpu.capture_execution_context(),
+                    },
+                    ThreadStorage::default(),
+                    false,
+                    |_| true,
+                )
+                .unwrap();
+            loaded.guest_calls.begin_critical();
+            loaded.cpu.pc = loaded.entry_pc;
+            loaded.cpu.lr = PPC_HALT_PC;
+            loaded.cpu.gpr[3] = worker.thread_id();
+            loaded.cpu.gpr[20] = 0x1234_5678;
+            loaded.cpu.fpr[20] = 0x4009_21fb_5444_2d18;
+            loaded.cpu.cr = 0x1357_2468;
+            establish_loaded_reservation(&mut loaded, PPC_DATA_BASE);
+            let before_calls = loaded.guest_calls.clone();
+
+            let probe = loaded.run_with_hle_imports(64);
+
+            assert_eq!(probe.handled_import_count, 1);
+            assert_eq!(probe.unsupported_import_index, None);
+            assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(-619));
+            assert_eq!(loaded.cpu.gpr[20], 0x1234_5678);
+            assert_eq!(loaded.cpu.fpr[20], 0x4009_21fb_5444_2d18);
+            assert_eq!(loaded.cpu.cr, 0x1357_2468);
+            assert_eq!(loaded.cpu.reservation_address(), Some(PPC_DATA_BASE));
+            assert_eq!(loaded.guest_calls, before_calls);
+            assert_eq!(
+                loaded.guest_calls.current_task(),
+                ExecutionTaskId::APPLICATION
+            );
+            assert_eq!(loaded.guest_calls.critical_depth(), 1);
+        }
+
+        let mut loaded = load_pef_application(&synthetic_pef_with_import(b"YieldToAnyThread")).unwrap();
+        loaded.cpu.gpr[20] = 0x8765_4321;
+        loaded.cpu.fpr[20] = 0x3ff0_0000_0000_0000;
+        loaded.cpu.cr = 0x2468_1357;
+        establish_loaded_reservation(&mut loaded, PPC_DATA_BASE);
+        let before_calls = loaded.guest_calls.clone();
+
+        let probe = loaded.run_with_hle_imports(64);
+
+        assert_eq!(probe.handled_import_count, 1);
+        assert_eq!(probe.unsupported_import_index, None);
+        assert_eq!(loaded.cpu.gpr[3], 0);
+        assert_eq!(loaded.cpu.gpr[20], 0x8765_4321);
+        assert_eq!(loaded.cpu.fpr[20], 0x3ff0_0000_0000_0000);
+        assert_eq!(loaded.cpu.cr, 0x2468_1357);
+        assert_eq!(loaded.cpu.reservation_address(), Some(PPC_DATA_BASE));
+        assert_eq!(loaded.guest_calls, before_calls);
+        assert_eq!(
+            loaded.guest_calls.current_task(),
+            ExecutionTaskId::APPLICATION
+        );
+    }
+
+    #[test]
     fn standalone_native_thread_stays_stopped_until_ready() {
         let mut loaded =
             load_pef_application(&synthetic_pef_with_import(b"SetThreadStateEndCritical")).unwrap();

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -1316,18 +1316,6 @@ impl super::TrapDispatcher {
             .cooperative_context(ExecutionTaskId::from_thread_id(thread_id))
     }
 
-    /// Save the running thread's registers into its record without
-    /// changing its scheduling state.
-    fn save_current_cooperative_thread<C: CpuOps>(&mut self, cpu: &C) {
-        let current_id = self.guest_calls.current_task().thread_id();
-        let mut thread = self
-            .cooperative_thread_snapshot(cpu, current_id)
-            .unwrap_or_default();
-        thread.save_registers(cpu);
-        self.guest_calls
-            .save_cooperative_context(ExecutionTaskId::from_thread_id(current_id), thread);
-    }
-
     /// Pick the next ready thread. `suggested_thread` wins when it names a
     /// ready thread, matching `YieldToThread`; otherwise the ready queue
     /// runs round-robin, as the stock 68K scheduler does.
@@ -1337,28 +1325,6 @@ impl super::TrapDispatcher {
                 (suggested_thread > 1).then(|| ExecutionTaskId::from_thread_id(suggested_thread)),
             )
             .map(ExecutionTaskId::thread_id)
-    }
-
-    /// Validate the saved adapter context before committing the task switch.
-    fn switch_to_cooperative_thread<C: CpuOps>(&mut self, cpu: &mut C, next_id: u32) -> bool {
-        let task = ExecutionTaskId::from_thread_id(next_id);
-        let Some(next) = self.guest_calls.switch_from_classic(task) else {
-            return false;
-        };
-        if let Some(next) = next {
-            next.install(cpu);
-        }
-        true
-    }
-
-    /// Scheduling policy lives with the task cursor; this adapter only saves
-    /// and installs registers. Inside Macintosh: Thread Manager (1999), pp. 65–70.
-    fn yield_cooperative_thread<C: CpuOps>(&mut self, cpu: &mut C, suggested_thread: u32) {
-        let Some(next_id) = self.next_ready_cooperative_thread(suggested_thread) else {
-            return;
-        };
-        self.save_current_cooperative_thread(cpu);
-        self.switch_to_cooperative_thread(cpu, next_id);
     }
 
     /// Retire a task and release its storage unless explicitly recycled.
@@ -16475,10 +16441,26 @@ impl super::TrapDispatcher {
                     }
                     0x0205 => {
                         let suggested_thread = bus.read_long(sp);
-                        bus.write_word(sp + 4, 0);
-                        cpu.write_reg(Register::A7, sp + 4);
-                        cpu.write_reg(Register::D0, 0);
-                        self.yield_cooperative_thread(cpu, suggested_thread);
+                        let result_sp = sp.wrapping_add(4);
+                        let current = self.guest_calls.current_task();
+                        let mut outgoing = self
+                            .guest_calls
+                            .cooperative_context(current)
+                            .unwrap_or_else(|| CooperativeThread::capture(cpu));
+                        outgoing.save_registers(cpu);
+                        outgoing.d_regs[0] = 0;
+                        outgoing.a_regs[7] = result_sp;
+                        let result = self
+                            .guest_calls
+                            .yield_classic_thread(outgoing, suggested_thread);
+                        let error = result.as_ref().err().copied().unwrap_or(0);
+                        bus.write_word(result_sp, error as u16);
+                        cpu.write_reg(Register::D0, error as u32);
+                        cpu.write_reg(Register::A7, result_sp);
+                        if let Ok(crate::guest_call::ClassicYield::Switched(Some(context))) = result
+                        {
+                            context.install(cpu);
+                        }
                         return Some(Ok(()));
                     }
                     // GetCurrentThread(currentThreadID)
@@ -28524,6 +28506,169 @@ mod tests {
         assert_eq!(saved.switch_in, (0x1000, 1));
         assert_eq!(saved.switch_out, (0x2000, 2));
         assert_eq!(saved.terminator, (0x3000, 3));
+    }
+
+    #[test]
+    fn classic_yield_refuses_missing_successor_context_without_publishing_source() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let application = ExecutionTaskId::APPLICATION;
+        let worker = ExecutionTaskId::from_thread_id(3);
+        assert!(disp.guest_calls.register_task(worker));
+        assert!(disp
+            .guest_calls
+            .set_scheduling_state(worker, ExecutionTaskState::Ready));
+        let saved = crate::guest_call::CooperativeThread {
+            d_regs: [0x1111_0000; 8],
+            a_regs: [0x2222_0000; 8],
+            pc: 0x3333_0000,
+            ccr: 0x14,
+            extended: None,
+            switch_in: (0x4444_0000, 1),
+            switch_out: (0x5555_0000, 2),
+            terminator: (0x6666_0000, 3),
+        };
+        assert!(disp
+            .guest_calls
+            .save_cooperative_context(application, saved.clone()));
+        cpu.write_reg(Register::PC, 0x1234_5678);
+        cpu.write_reg(Register::D3, 0x89ab_cdef);
+        cpu.write_reg(Register::A5, 0x7654_3210);
+        let sp = TEST_SP;
+        cpu.write_reg(Register::A7, sp);
+        bus.write_long(sp, worker.thread_id());
+        bus.write_word(sp + 4, 0xbeef);
+        cpu.write_reg(Register::D0, 0x0205);
+        let mut expected_live = crate::guest_call::CooperativeThread::capture(&cpu);
+        expected_live.d_regs[0] = (-619i16) as u32;
+        expected_live.a_regs[7] = sp.wrapping_add(4);
+        let before_extended = cpu.capture_extended_context();
+        let before_calls = disp.guest_calls.clone();
+
+        disp.dispatch_toolbox(true, 0x3f2, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(cpu.read_reg(Register::D0), (-619i16) as u32);
+        assert_eq!(cpu.read_reg(Register::A7), sp.wrapping_add(4));
+        assert_eq!(bus.read_word(sp + 4), (-619i16) as u16);
+        assert_eq!(
+            crate::guest_call::CooperativeThread::capture(&cpu),
+            expected_live
+        );
+        assert_eq!(cpu.capture_extended_context(), before_extended);
+        assert_eq!(disp.guest_calls, before_calls);
+        assert_eq!(disp.guest_calls.current_task(), application);
+        assert_eq!(
+            disp.guest_calls.scheduling_state(worker),
+            Some(ExecutionTaskState::Ready)
+        );
+        assert_eq!(
+            disp.guest_calls.cooperative_context(application),
+            Some(saved)
+        );
+        assert_eq!(disp.guest_calls.cooperative_context(worker), None);
+        assert!(!disp.guest_calls.has_pending_task_handoff());
+    }
+
+    #[test]
+    fn classic_yield_refuses_during_critical_sections_without_mutating_contexts() {
+        for suggested in [0, 3] {
+            let (mut disp, mut cpu, mut bus) = setup();
+            let application = ExecutionTaskId::APPLICATION;
+            let worker = ExecutionTaskId::from_thread_id(3);
+            let worker_context = crate::guest_call::CooperativeThread {
+                pc: 0x3000,
+                a_regs: [0, 0, 0, 0, 0, 0, 0, 0x9000],
+                ..Default::default()
+            };
+            assert!(disp.guest_calls.register_task(worker));
+            assert!(disp
+                .guest_calls
+                .save_cooperative_context(worker, worker_context.clone()));
+            assert!(disp
+                .guest_calls
+                .set_scheduling_state(worker, ExecutionTaskState::Ready));
+            disp.guest_calls.begin_critical();
+            cpu.write_reg(Register::PC, 0x1234_5678);
+            cpu.write_reg(Register::D3, 0x89ab_cdef);
+            let sp = TEST_SP;
+            cpu.write_reg(Register::A7, sp);
+            bus.write_long(sp, suggested);
+            bus.write_word(sp + 4, 0xbeef);
+            cpu.write_reg(Register::D0, 0x0205);
+            let mut expected_live = crate::guest_call::CooperativeThread::capture(&cpu);
+            expected_live.d_regs[0] = (-619i16) as u32;
+            expected_live.a_regs[7] = sp.wrapping_add(4);
+            let before_extended = cpu.capture_extended_context();
+            let before_application = disp.guest_calls.cooperative_context(application);
+            let before_calls = disp.guest_calls.clone();
+
+            disp.dispatch_toolbox(true, 0x3f2, &mut cpu, &mut bus)
+                .unwrap()
+                .unwrap();
+
+            assert_eq!(cpu.read_reg(Register::D0), (-619i16) as u32);
+            assert_eq!(cpu.read_reg(Register::A7), sp.wrapping_add(4));
+            assert_eq!(bus.read_word(sp + 4), (-619i16) as u16);
+            assert_eq!(
+                crate::guest_call::CooperativeThread::capture(&cpu),
+                expected_live
+            );
+            assert_eq!(cpu.capture_extended_context(), before_extended);
+            assert_eq!(disp.guest_calls, before_calls);
+            assert_eq!(disp.guest_calls.current_task(), application);
+            assert_eq!(disp.guest_calls.critical_depth(), 1);
+            assert_eq!(
+                disp.guest_calls.cooperative_context(application),
+                before_application
+            );
+            assert_eq!(
+                disp.guest_calls.cooperative_context(worker),
+                Some(worker_context)
+            );
+            assert!(!disp.guest_calls.has_pending_task_handoff());
+        }
+    }
+
+    #[test]
+    fn classic_yield_to_any_without_successor_returns_without_publishing_snapshot() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        let sp = u32::MAX - 3;
+        cpu.write_reg(Register::PC, 0x1234_5678);
+        cpu.write_reg(Register::D3, 0x89ab_cdef);
+        cpu.write_reg(Register::A7, sp);
+        cpu.write_reg(Register::D0, 0x0205);
+        let mut expected_live = crate::guest_call::CooperativeThread::capture(&cpu);
+        expected_live.d_regs[0] = 0;
+        expected_live.a_regs[7] = 0;
+        let before_extended = cpu.capture_extended_context();
+        let before_application = disp
+            .guest_calls
+            .cooperative_context(ExecutionTaskId::APPLICATION);
+        let before_calls = disp.guest_calls.clone();
+
+        disp.dispatch_toolbox(true, 0x3f2, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(cpu.read_reg(Register::D0), 0);
+        assert_eq!(cpu.read_reg(Register::A7), 0);
+        assert_eq!(
+            crate::guest_call::CooperativeThread::capture(&cpu),
+            expected_live
+        );
+        assert_eq!(cpu.capture_extended_context(), before_extended);
+        assert_eq!(disp.guest_calls, before_calls);
+        assert_eq!(
+            disp.guest_calls.current_task(),
+            ExecutionTaskId::APPLICATION
+        );
+        assert_eq!(
+            disp.guest_calls
+                .cooperative_context(ExecutionTaskId::APPLICATION),
+            before_application
+        );
+        assert!(!disp.guest_calls.has_pending_task_handoff());
     }
 
     #[test]


### PR DESCRIPTION
Classic yielding could report success and overwrite the outgoing task snapshot when a ready successor had no saved context. Both behaviors were reproduced through ThreadDispatch on the previous implementation. Yielding now uses one execution-owner transaction for both ABIs: classify the suggestion, preflight the selected context, commit the scheduler switch, and only then publish the outgoing context.

Classic critical-section yields now report threadProtocolErr. Both routes preserve the reviewed fallback behavior: aliases and current-task suggestions may stay successfully when no successor exists; missing or stopped explicit suggestions use a ready fallback, or return threadNotFoundErr when none exists. Native capture and installation retain opaque engine state and deferred import continuations. The classic adapter preserves best-effort Pascal result writes and wrapping stack arithmetic.

The change deletes the classic save/select/switch helper sequence and native duplicate selection policy. Tests cover actual classic and native entry routes, mixed execution, full CPU and owner preservation on refusal, no-successor behavior, and an already-pending cross-ISA handoff. The latter also proves the private native import continuation still completes after refusal.

Validation: the independent full default/test-support suite passed 5,234 tests with three ignored. One final added refusal regression then passed independently on the committed package. The source guard and focused yield/continuation matrix passed. The rebased public export exactly matches all tested package files. Required CI and package checks must pass before merge.

Closes #1564
