### PR TITLE
fix: share thread disposal and preserve automatic return retries

### DIFF
--- a/src/guest_call.rs
+++ b/src/guest_call.rs
@@ -546,10 +546,29 @@ struct YieldedTask {
     successor: TaskResumeContext,
 }
 
+struct RetiredTask {
+    storage: ThreadStorage,
+    successor: Option<(ExecutionTaskId, TaskResumeContext)>,
+    retired_live_native: bool,
+}
+
 #[derive(Debug, Eq, PartialEq)]
 pub(crate) enum ClassicYield {
     Stayed,
     Switched(Option<CooperativeThread>),
+}
+
+pub(crate) enum ClassicRetirement {
+    Removed(ThreadStorage),
+    Switched {
+        storage: ThreadStorage,
+        successor: Option<CooperativeThread>,
+    },
+}
+
+pub(crate) enum NativeRetirement {
+    Removed(ThreadStorage),
+    Switched(ThreadStorage),
 }
 
 impl TaskResumeContext {
@@ -1458,35 +1477,49 @@ impl ExecutionTaskCalls {
     fn retire_thread(
         &mut self,
         task: ExecutionTaskId,
-        successor: Option<ExecutionTaskId>,
         recycle: bool,
         commit: impl FnOnce(&ThreadStorage) -> bool,
-    ) -> Option<(ThreadStorage, Option<(ExecutionTaskId, TaskResumeContext)>)> {
+    ) -> Result<RetiredTask, i16> {
+        use crate::thread_manager::{THREAD_NOT_FOUND_ERR, THREAD_PROTOCOL_ERR};
+        if self.kernel.scheduling_state(task).is_none() {
+            return Err(THREAD_NOT_FOUND_ERR);
+        }
         // Thread Manager (1999), p. 60: DisposeThread may never retire
         // the application thread, even while a worker is running.
         if task == ExecutionTaskId::APPLICATION {
-            return None;
+            return Err(THREAD_PROTOCOL_ERR);
         }
         if self.handoff.is_some() {
-            return None;
+            return Err(THREAD_PROTOCOL_ERR);
         }
         if self.cooperative_contexts.get(task).is_none() && self.native_threads.get(task).is_none()
         {
-            return None;
+            return Err(THREAD_PROTOCOL_ERR);
         }
         let storage = self.thread_storage.get(task).copied().unwrap_or_default();
         let pooled_isa = if recycle && storage.stack_base != 0 {
-            Some(self.kernel.task_entry_isa(task)?)
+            Some(
+                self.kernel
+                    .task_entry_isa(task)
+                    .ok_or(THREAD_PROTOCOL_ERR)?,
+            )
         } else {
             None
         };
-        let next = match successor {
-            Some(next) => Some((next, self.saved_context(next)?)),
-            None => None,
+        let current = task == self.kernel.current_task();
+        let next = if current {
+            let next = self
+                .kernel
+                .next_ready_task(None)
+                .ok_or(THREAD_PROTOCOL_ERR)?;
+            Some((next, self.saved_context(next).ok_or(THREAD_PROTOCOL_ERR)?))
+        } else {
+            None
         };
+        let successor = next.as_ref().map(|(task, _)| *task);
         self.kernel
             .retire_task_with(task, successor, || commit(&storage))
-            .ok()?;
+            .map_err(|_| THREAD_PROTOCOL_ERR)?;
         self.cooperative_contexts.remove(task);
         self.native_threads.remove(task);
         self.thread_storage.remove(task);
@@ -1500,10 +1533,15 @@ impl ExecutionTaskCalls {
                 },
             ));
         }
-        if self.native_cpu_task == Some(task) {
+        let retired_live_native = self.native_cpu_task == Some(task);
+        if retired_live_native {
             self.native_cpu_task = None;
         }
-        Some((storage, next))
+        Ok(RetiredTask {
+            storage,
+            successor: next,
+            retired_live_native,
+        })
     }
 
     fn save_native_context(&mut self, task: ExecutionTaskId, context: PpcExecutionContext) {
@@ -1809,6 +1847,7 @@ impl SharedGuestCallStack {
         self.0.borrow().kernel.set_scheduling_state(task, state)
     }
 
+    #[cfg(test)]
     pub(crate) fn next_ready_task(
         &self,
         suggested: Option<ExecutionTaskId>,
@@ -1845,16 +1884,16 @@ impl SharedGuestCallStack {
 
     /// Commit result delivery and retirement while the execution owner keeps
     /// both task identities and their adapter snapshots stable.
-    pub(crate) fn retire_cooperative_context(
+    pub(crate) fn retire_classic_thread(
         &self,
         task: ExecutionTaskId,
-        successor: Option<ExecutionTaskId>,
         recycle: bool,
         commit: impl FnOnce(&ThreadStorage) -> bool,
-    ) -> Option<(ThreadStorage, Option<CooperativeThread>)> {
+    ) -> Result<ClassicRetirement, i16> {
         let mut tasks = self.0.borrow_mut();
-        let (finished, next) = tasks.retire_thread(task, successor, recycle, commit)?;
-        let classic = match next {
+        let retired = tasks.retire_thread(task, recycle, commit)?;
+        let switched = retired.successor.is_some();
+        let successor = match retired.successor {
             Some((_, TaskResumeContext::Classic(context))) => Some(context),
             Some((next, context)) => {
                 tasks.handoff = Some((next, context));
@@ -1862,7 +1901,14 @@ impl SharedGuestCallStack {
             }
             None => None,
         };
-        Some((finished, classic))
+        if switched {
+            Ok(ClassicRetirement::Switched {
+                storage: retired.storage,
+                successor,
+            })
+        } else {
+            Ok(ClassicRetirement::Removed(retired.storage))
+        }
     }
 
     pub(crate) fn thread_storage(&self, task: ExecutionTaskId) -> Option<ThreadStorage> {
@@ -2057,6 +2103,7 @@ impl SharedGuestCallStack {
             .extend(storage.into_iter().map(|storage| (isa, storage)));
     }
 
+    #[cfg(test)]
     pub(crate) fn switch_from_classic(
         &self,
         next: ExecutionTaskId,
@@ -2351,22 +2398,21 @@ impl SharedGuestCallStack {
         cpu: &mut PpcCpu,
         recycle: bool,
         commit: impl FnOnce(&ThreadStorage) -> bool,
-    ) -> Option<ThreadStorage> {
+    ) -> Result<NativeRetirement, i16> {
         let mut tasks = self.0.borrow_mut();
-        let successor = if task == tasks.kernel.current_task() {
-            Some(tasks.kernel.next_ready_task(None)?)
-        } else {
-            None
-        };
-        let retired_live_native = tasks.native_cpu_task == Some(task);
-        let (finished, successor) = tasks.retire_thread(task, successor, recycle, commit)?;
-        if retired_live_native {
+        let retired = tasks.retire_thread(task, recycle, commit)?;
+        let switched = retired.successor.is_some();
+        if retired.retired_live_native {
             cpu.invalidate_reservation();
         }
-        if let Some((next, context)) = successor {
+        if let Some((next, context)) = retired.successor {
             tasks.install_native_successor(next, context, cpu);
         }
-        Some(finished)
+        if switched {
+            Ok(NativeRetirement::Switched(retired.storage))
+        } else {
+            Ok(NativeRetirement::Removed(retired.storage))
+        }
     }
 
     pub(crate) fn cooperative_context(&self, task: ExecutionTaskId) -> Option<CooperativeThread> {
@@ -4398,35 +4444,126 @@ mod tests {
             )
             .unwrap();
         for recycle in [false, true] {
-            assert!(calls
-                .retire_cooperative_context(
-                    ExecutionTaskId::APPLICATION,
-                    Some(worker),
-                    recycle,
-                    |_| panic!("application disposal must not write its result")
-                )
-                .is_none());
-            assert!(calls
-                .retire_native_thread(
-                    ExecutionTaskId::APPLICATION,
-                    &mut PpcCpu::new(),
-                    recycle,
-                    |_| panic!("application disposal must not write its result")
-                )
-                .is_none());
+            assert_eq!(
+                calls
+                    .retire_classic_thread(ExecutionTaskId::APPLICATION, recycle, |_| panic!(
+                        "application disposal must not write its result"
+                    ))
+                    .err(),
+                Some(crate::thread_manager::THREAD_PROTOCOL_ERR)
+            );
+            assert_eq!(
+                calls
+                    .retire_native_thread(
+                        ExecutionTaskId::APPLICATION,
+                        &mut PpcCpu::new(),
+                        recycle,
+                        |_| panic!("application disposal must not write its result")
+                    )
+                    .err(),
+                Some(crate::thread_manager::THREAD_PROTOCOL_ERR)
+            );
             assert_eq!(calls.current_task(), ExecutionTaskId::APPLICATION);
             assert_eq!(calls.next_ready_task(None), Some(worker));
         }
         assert!(calls.switch_to_task(worker));
-        assert!(calls
-            .retire_cooperative_context(ExecutionTaskId::APPLICATION, None, false, |_| panic!(
-                "a worker must not dispose its application"
-            ))
-            .is_none());
+        assert_eq!(
+            calls
+                .retire_classic_thread(ExecutionTaskId::APPLICATION, false, |_| panic!(
+                    "a worker must not dispose its application"
+                ))
+                .err(),
+            Some(crate::thread_manager::THREAD_PROTOCOL_ERR)
+        );
         assert_eq!(calls.current_task(), worker);
         assert!(calls
             .cooperative_context(ExecutionTaskId::APPLICATION)
             .is_some());
+    }
+
+    #[test]
+    fn current_thread_retirement_refuses_critical_sections_before_publishing_both_abis() {
+        let classic_calls = SharedGuestCallStack::default();
+        assert!(classic_calls
+            .save_cooperative_context(ExecutionTaskId::APPLICATION, CooperativeThread::default(),));
+        let classic = classic_calls
+            .create_classic_thread(
+                CooperativeThread::default(),
+                ThreadStorage::default(),
+                false,
+                |_| true,
+            )
+            .unwrap();
+        assert!(classic_calls.switch_to_task(classic));
+        classic_calls.begin_critical();
+        let before_classic = classic_calls.clone();
+        let classic_published = std::cell::Cell::new(false);
+        assert_eq!(
+            classic_calls
+                .retire_classic_thread(classic, false, |_| {
+                    classic_published.set(true);
+                    true
+                })
+                .err(),
+            Some(crate::thread_manager::THREAD_PROTOCOL_ERR)
+        );
+        assert!(!classic_published.get());
+        assert_eq!(classic_calls, before_classic);
+        assert!(classic_calls.end_critical());
+        assert!(classic_calls
+            .retire_classic_thread(classic, false, |_| true)
+            .is_ok());
+
+        let native_calls = SharedGuestCallStack::default();
+        native_calls.start_native_engine();
+        assert!(native_calls.bind_task_entry_isa(ExecutionTaskId::APPLICATION, GuestIsa::PowerPc));
+        let native = native_calls
+            .create_native_thread(
+                NativeThreadContext {
+                    context: PpcExecutionContext::fresh(),
+                },
+                ThreadStorage::default(),
+                false,
+                |_| true,
+            )
+            .unwrap();
+        let mut cpu = PpcCpu::new();
+        assert!(native_calls
+            .yield_native_thread(&mut cpu, native.thread_id())
+            .unwrap());
+        establish_native_reservation(&mut cpu, 0x1000);
+        native_calls.begin_critical();
+        let before_native_calls = native_calls.clone();
+        let before_cpu = cpu.clone();
+        let native_published = std::cell::Cell::new(false);
+        assert_eq!(
+            native_calls
+                .retire_native_thread(native, &mut cpu, false, |_| {
+                    native_published.set(true);
+                    true
+                })
+                .err(),
+            Some(crate::thread_manager::THREAD_PROTOCOL_ERR)
+        );
+        assert!(!native_published.get());
+        assert_eq!(native_calls, before_native_calls);
+        assert_eq!(cpu.gpr, before_cpu.gpr);
+        assert_eq!(cpu.fpr, before_cpu.fpr);
+        assert_eq!(cpu.cr, before_cpu.cr);
+        assert_eq!(cpu.lr, before_cpu.lr);
+        assert_eq!(cpu.ctr, before_cpu.ctr);
+        assert_eq!(cpu.xer, before_cpu.xer);
+        assert_eq!(cpu.fpscr, before_cpu.fpscr);
+        assert_eq!(cpu.msr, before_cpu.msr);
+        assert_eq!(cpu.pc, before_cpu.pc);
+        assert_eq!(cpu.alignment_policy, before_cpu.alignment_policy);
+        assert_eq!(cpu.time_base(), before_cpu.time_base());
+        assert_eq!(cpu.reservation_address(), before_cpu.reservation_address());
+        assert!(native_calls.end_critical());
+        assert!(native_calls
+            .retire_native_thread(native, &mut cpu, false, |_| true)
+            .is_ok());
+        assert_eq!(cpu.reservation_address(), None);
     }
 
     #[test]
@@ -4459,23 +4596,23 @@ mod tests {
             )
             .unwrap();
         assert!(calls
-            .retire_cooperative_context(classic, None, true, |_| false)
-            .is_none());
+            .retire_classic_thread(classic, true, |_| false)
+            .is_err());
         assert_eq!(
             calls.request_thread_stack(GuestIsa::M68k, 1024, 2),
             Err(-617)
         );
         assert_eq!(calls.thread_storage(classic), Some(classic_storage));
         assert!(calls
-            .retire_cooperative_context(classic, None, true, |_| true)
-            .is_some());
+            .retire_classic_thread(classic, true, |_| true)
+            .is_ok());
         assert_eq!(
             calls.request_thread_stack(GuestIsa::PowerPc, 1024, 2),
             Err(-617)
         );
         assert!(calls
             .retire_native_thread(native, &mut PpcCpu::new(), true, |_| true)
-            .is_some());
+            .is_ok());
         assert_eq!(
             calls.request_thread_stack(GuestIsa::PowerPc, 1024, 2 | 16),
             Err(-617)
@@ -4533,7 +4670,7 @@ mod tests {
         establish_native_reservation(&mut cpu, 0x1000);
         assert!(calls
             .retire_native_thread(native, &mut cpu, false, |_| true)
-            .is_some());
+            .is_ok());
         assert_eq!(cpu.reservation_address(), None);
         assert_eq!(calls.current_task(), classic);
         assert!(calls.has_classic_task_handoff());
@@ -4597,7 +4734,7 @@ mod tests {
         establish_native_reservation(&mut cpu, 0x1000);
         assert!(calls
             .retire_native_thread(worker, &mut cpu, false, |_| true)
-            .is_none());
+            .is_err());
         assert_eq!(calls.current_task(), worker);
         assert!(calls.scheduling_state(worker).is_some());
         assert!(calls.0.borrow().powerpc_contexts.contains(worker, call));
@@ -4606,7 +4743,7 @@ mod tests {
         assert!(calls.complete_m68k_for_powerpc(0x4000, 0x3004, None, &mut cpu));
         assert!(calls
             .retire_native_thread(worker, &mut cpu, false, |_| true)
-            .is_some());
+            .is_ok());
         assert_eq!(calls.scheduling_state(worker), None);
         assert_eq!(cpu.reservation_address(), None);
     }
@@ -5192,10 +5329,10 @@ mod tests {
         assert!(calls.switch_to_task(ExecutionTaskId::APPLICATION));
         assert!(!calls.remove_task(worker));
         assert!(calls
-            .retire_cooperative_context(worker, None, false, |_| {
+            .retire_classic_thread(worker, false, |_| {
                 panic!("pending continuations must reject retirement before result delivery")
             })
-            .is_none());
+            .is_err());
         assert_eq!(calls.cooperative_context(worker), Some(context.clone()));
         let detached = calls.clone();
         let shared = calls.shared_handle();

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -30,7 +30,7 @@ use crate::event_queue::{
 use crate::guest_call::{
     format_ppc_import_action, install_powerpc_call_arguments, GuestCallContinuation,
     GuestCallEffect, GuestCallRequest, GuestCallTarget, MenuTrackingCall, MenuTrackingOrigin,
-    NativeThreadContext, SharedGuestCallStack, ThreadStorage,
+    NativeRetirement, NativeThreadContext, SharedGuestCallStack, ThreadStorage,
 };
 use crate::guest_procedure::{
     resolve_guest_procedure, resolve_same_isa_thread_entry, GuestIsa, GuestProcedure,
@@ -121,7 +121,7 @@ use crate::trap::manager::{
 };
 use crate::trap::types::{decode_mac_roman, encode_mac_roman_lossy, Rect};
 use crate::trap::{pict, TrapDispatcher};
-use crate::thread_manager::{NewThreadCreationEdge, ThreadManager};
+use crate::thread_manager::{NewThreadCreationEdge, RetiredThreadStorageEdge, ThreadManager};
 use crate::ui_theme::{render_scrollbar_bitmap, Rgb8, ThemeBitmap, UiThemeId};
 use ppc::{
     PpcAlignmentPolicy, PpcCpu, PpcException, PpcExecutionContext, PpcFetchHistogram,
@@ -7745,15 +7745,20 @@ impl PpcLoadedApp {
                     // Inside Macintosh: Thread Manager (1999), pp. 59–60.
                     let task = guest_calls.current_task();
                     let result = cpu.gpr[3];
-                    let _ = ppc_retire_native_thread(
-                        &guest_calls,
-                        cpu,
-                        memory,
-                        process_memory_manager,
-                        task,
-                        result,
-                        false,
-                    );
+                    if let Ok(retirement) =
+                        guest_calls.retire_native_thread(task, cpu, false, |context| {
+                            context.result_destination == 0
+                                || memory
+                                    .write_u32_be(context.result_destination, result)
+                                    .is_some()
+                        })
+                    {
+                        ppc_release_retired_thread_storage(
+                            process_memory_manager,
+                            retirement,
+                            false,
+                        );
+                    }
                     return PpcImportAction::Yield(1);
                 }
                 if index == PPC_GUEST_CALL_RETURN_IMPORT_INDEX {
@@ -24135,35 +24140,29 @@ fn dispatch_supported_import(
             let task = crate::guest_call::ExecutionTaskId::from_thread_id(
                 crate::thread_manager::ThreadManager::new(calls).resolve_thread(cpu.gpr[3]),
             );
-            if calls.scheduling_state(task).is_none() {
-                return Some(PpcImportAction::Return(ppc_i16_result(
-                    crate::thread_manager::THREAD_NOT_FOUND_ERR,
-                )));
-            }
-            let current = task == calls.current_task();
             let result = cpu.gpr[4];
             let recycle = cpu.gpr[5] as u8 != 0;
-            Some(
-                if ppc_retire_native_thread(
-                    calls,
-                    cpu,
-                    memory,
-                    process_memory_manager,
-                    task,
-                    result,
-                    recycle,
-                ) {
-                    if current {
+            Some(match calls.retire_native_thread(task, cpu, recycle, |context| {
+                context.result_destination == 0
+                    || memory
+                        .write_u32_be(context.result_destination, result)
+                        .is_some()
+            }) {
+                Ok(retirement) => {
+                    let switched = matches!(retirement, NativeRetirement::Switched(_));
+                    ppc_release_retired_thread_storage(
+                        process_memory_manager,
+                        retirement,
+                        recycle,
+                    );
+                    if switched {
                         PpcImportAction::Yield(1)
                     } else {
                         PpcImportAction::Return(0)
                     }
-                } else {
-                    PpcImportAction::Return(ppc_i16_result(
-                        crate::thread_manager::THREAD_PROTOCOL_ERR,
-                    ))
-                },
-            )
+                }
+                Err(error) => PpcImportAction::Return(ppc_i16_result(error)),
+            })
         }
         PpcImportDispatcherTarget::ThreadBeginCritical => {
             Some(PpcImportAction::Return(ppc_i16_result(
@@ -91026,31 +91025,34 @@ fn ppc_restore_native_exception(
     frame_is_valid.then_some(())
 }
 
-fn ppc_retire_native_thread(
-    calls: &crate::guest_call::SharedGuestCallStack,
-    cpu: &mut PpcCpu,
-    memory: &mut PpcSectionMem,
-    manager: &mut ProcessNativeMemoryManager,
-    task: crate::guest_call::ExecutionTaskId,
-    result: u32,
-    recycle: bool,
-) -> bool {
-    let Some(finished) = calls.retire_native_thread(task, cpu, recycle, |context| {
-        context.result_destination == 0
-            || memory
-                .write_u32_be(context.result_destination, result)
-                .is_some()
-    }) else {
-        return false;
-    };
-    if !recycle && finished.stack_base != 0 {
-        if finished.managed_pointer {
-            manager.dispose_native_ptr(finished.stack_base);
-        } else {
-            manager.dispose_classic_ptr_from_native_import(finished.stack_base);
-        }
+struct PpcRetiredThreadStorageEdge<'a> {
+    manager: &'a mut ProcessNativeMemoryManager,
+}
+
+impl RetiredThreadStorageEdge for PpcRetiredThreadStorageEdge<'_> {
+    fn release_classic(&mut self, stack_base: u32) {
+        self.manager
+            .dispose_classic_ptr_from_native_import(stack_base);
     }
-    true
+
+    fn release_native(&mut self, stack_base: u32) {
+        self.manager.dispose_native_ptr(stack_base);
+    }
+}
+
+fn ppc_release_retired_thread_storage(
+    manager: &mut ProcessNativeMemoryManager,
+    retirement: NativeRetirement,
+    recycle: bool,
+) {
+    let storage = match retirement {
+        NativeRetirement::Removed(storage) | NativeRetirement::Switched(storage) => storage,
+    };
+    ThreadManager::release_retired_storage(
+        storage,
+        recycle,
+        &mut PpcRetiredThreadStorageEdge { manager },
+    );
 }
 
 fn ppc_resolve_callback_target(

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -17499,6 +17499,201 @@ mod tests {
     }
 
     #[test]
+    fn dispose_thread_refuses_the_application_through_both_public_abis() {
+        const FRAME: u32 = 0x6000;
+
+        let mut app = halted_ppc_app_with_sound(PpcSoundState::default());
+        let loaded = app.ppc.as_mut().unwrap();
+        loaded.entry_pc = PPC_IMPORT_TRAP_BASE;
+        loaded.cpu.pc = PPC_IMPORT_TRAP_BASE;
+        loaded.memory.add_region(PPC_IMPORT_TRAP_BASE, vec![0; 4]);
+        let mut binding = test_ppc_import_binding(0, "InterfaceLib", "DisposeThread");
+        binding.dispatcher_target = PpcImportDispatcherTarget::DisposeThread;
+        binding.trap_pc = PPC_IMPORT_TRAP_BASE;
+        loaded.import_count = 1;
+        loaded.imports.push(binding);
+
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        runner.init_app(&app);
+        let calls = runner.dispatcher.guest_calls.shared_handle();
+        let before = calls.clone();
+        {
+            let cpu = &mut runner.native.application_mut().unwrap().cpu;
+            cpu.lr = PPC_CODE_BASE;
+            cpu.gpr[3] = ExecutionTaskId::APPLICATION.thread_id();
+            cpu.gpr[4] = 0xcafe_babe;
+            cpu.gpr[5] = 0;
+        }
+        assert!(runner.run_steps(32, None).1);
+        assert_eq!(
+            runner.native.application().unwrap().cpu.gpr[3] as i16,
+            crate::thread_manager::THREAD_PROTOCOL_ERR
+        );
+        assert_eq!(calls, before);
+
+        runner.m68k.cpu.write_reg(Register::A7, FRAME);
+        runner.bus.write_word(FRAME, 0);
+        runner.bus.write_long(FRAME + 2, 0xcafe_babe);
+        runner
+            .bus
+            .write_long(FRAME + 6, ExecutionTaskId::APPLICATION.thread_id());
+        runner.bus.write_word(FRAME + 10, 0xbeef);
+        runner.m68k.cpu.write_reg(Register::D0, 0x0504);
+        runner
+            .dispatcher
+            .dispatch_toolbox(true, 0x3f2, &mut runner.m68k.cpu, &mut runner.bus)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            runner.m68k.cpu.read_reg(Register::D0) as i16,
+            crate::thread_manager::THREAD_PROTOCOL_ERR
+        );
+        assert_eq!(runner.m68k.cpu.read_reg(Register::A7), FRAME + 10);
+        assert_eq!(
+            runner.bus.read_word(FRAME + 10) as i16,
+            crate::thread_manager::THREAD_PROTOCOL_ERR
+        );
+        assert_eq!(calls, before);
+    }
+
+    #[test]
+    fn classic_thread_return_trampoline_retries_refused_retirement_without_rts_fallthrough() {
+        const FRAME: u32 = 0x6000;
+        const YIELD_FRAME: u32 = 0x6100;
+        const MADE: u32 = 0x7000;
+        const RESULT: u32 = 0x7100;
+        const ENTRY: u32 = 0x8000;
+        const APP_PC: u32 = 0x9000;
+        const PARAM: u32 = 0xdead_beef;
+        const THREAD_RESULT: u32 = 0xcafe_babe;
+
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        runner.bus.write_word(ENTRY, 0x4e75); // RTS
+        runner.m68k.cpu.write_reg(Register::A7, FRAME);
+        for (offset, value) in [
+            (0, MADE),
+            (4, RESULT),
+            (8, 0),
+            (12, 1024),
+            (16, PARAM),
+            (20, ENTRY),
+            (24, 1),
+        ] {
+            runner.bus.write_long(FRAME + offset, value);
+        }
+        runner.m68k.cpu.write_reg(Register::D0, 0x0e03);
+        runner
+            .dispatcher
+            .dispatch_toolbox(true, 0x3f2, &mut runner.m68k.cpu, &mut runner.bus)
+            .unwrap()
+            .unwrap();
+        let worker = ExecutionTaskId::from_thread_id(runner.bus.read_long(MADE));
+        let worker_context = runner
+            .dispatcher
+            .guest_calls
+            .cooperative_context(worker)
+            .unwrap();
+        let worker_sp = worker_context.a_regs[7];
+        let trampoline = runner.bus.read_long(worker_sp);
+        assert_eq!(runner.bus.read_long(worker_sp + 4), PARAM);
+
+        runner.m68k.cpu.write_reg(Register::PC, APP_PC);
+        runner.m68k.cpu.write_reg(Register::A0, 0x1111_2222);
+        runner.m68k.cpu.write_reg(Register::A7, YIELD_FRAME);
+        runner.bus.write_long(YIELD_FRAME, worker.thread_id());
+        runner.bus.write_word(YIELD_FRAME + 4, 0xbeef);
+        runner.m68k.cpu.write_reg(Register::D0, 0x0205);
+        runner
+            .dispatcher
+            .dispatch_toolbox(true, 0x3f2, &mut runner.m68k.cpu, &mut runner.bus)
+            .unwrap()
+            .unwrap();
+        let application_context = runner
+            .dispatcher
+            .guest_calls
+            .cooperative_context(ExecutionTaskId::APPLICATION)
+            .unwrap();
+        assert_eq!(runner.dispatcher.guest_calls.current_task(), worker);
+        assert_eq!(runner.m68k.cpu.read_reg(Register::PC), ENTRY);
+        assert_eq!(runner.m68k.cpu.read_reg(Register::A7), worker_sp);
+
+        runner.m68k.cpu.write_reg(Register::A0, THREAD_RESULT);
+        runner.dispatcher.guest_calls.begin_critical();
+        assert!(matches!(
+            runner.m68k.cpu.step(&mut runner.bus),
+            crate::cpu::StepResult::Ok
+        ));
+        assert_eq!(runner.m68k.cpu.read_reg(Register::PC), trampoline);
+        assert_eq!(runner.m68k.cpu.read_reg(Register::A7), worker_sp + 4);
+        assert_eq!(runner.bus.read_long(worker_sp + 4), PARAM);
+
+        for _ in 0..2 {
+            assert!(matches!(
+                runner.m68k.cpu.step(&mut runner.bus),
+                crate::cpu::StepResult::Ok
+            ));
+            assert_eq!(runner.m68k.cpu.read_reg(Register::PC), trampoline + 4);
+            assert_eq!(runner.m68k.cpu.read_reg(Register::D0) & 0xffff, 0xfffe);
+            assert!(matches!(
+                runner.m68k.cpu.step(&mut runner.bus),
+                crate::cpu::StepResult::Aline(0xabf2)
+            ));
+            assert_eq!(runner.m68k.cpu.read_reg(Register::PC), trampoline + 6);
+            let before = runner.dispatcher.guest_calls.clone();
+            runner
+                .dispatch_classic_with_process_services(0xabf2)
+                .unwrap();
+            assert_eq!(runner.dispatcher.guest_calls, before);
+            assert_eq!(runner.m68k.cpu.read_reg(Register::PC), trampoline);
+            assert_eq!(runner.m68k.cpu.read_reg(Register::A7), worker_sp + 4);
+            assert_eq!(runner.m68k.cpu.read_reg(Register::A0), THREAD_RESULT);
+            assert_eq!(runner.m68k.cpu.read_reg(Register::D0) as i16, -619);
+            assert_eq!(runner.bus.read_long(worker_sp + 4), PARAM);
+            assert_eq!(runner.bus.read_long(RESULT), 0);
+        }
+
+        let before_bounded_retry = runner.dispatcher.guest_calls.clone();
+        let (steps, running) = runner.run_steps(8, None);
+        assert_eq!(steps, 8);
+        assert!(running);
+        assert_eq!(runner.dispatcher.guest_calls, before_bounded_retry);
+        assert_eq!(runner.m68k.cpu.read_reg(Register::PC), trampoline);
+        assert_eq!(runner.m68k.cpu.read_reg(Register::A7), worker_sp + 4);
+        assert_eq!(runner.m68k.cpu.read_reg(Register::A0), THREAD_RESULT);
+        assert_eq!(runner.bus.read_long(worker_sp + 4), PARAM);
+        assert_eq!(runner.bus.read_long(RESULT), 0);
+
+        assert!(runner.dispatcher.guest_calls.end_critical());
+        assert!(matches!(
+            runner.m68k.cpu.step(&mut runner.bus),
+            crate::cpu::StepResult::Ok
+        ));
+        assert_eq!(runner.m68k.cpu.read_reg(Register::PC), trampoline + 4);
+        assert!(matches!(
+            runner.m68k.cpu.step(&mut runner.bus),
+            crate::cpu::StepResult::Aline(0xabf2)
+        ));
+        runner
+            .dispatch_classic_with_process_services(0xabf2)
+            .unwrap();
+
+        assert_eq!(
+            runner.dispatcher.guest_calls.current_task(),
+            ExecutionTaskId::APPLICATION
+        );
+        assert_eq!(runner.bus.read_long(RESULT), THREAD_RESULT);
+        assert_eq!(
+            CooperativeThread::capture(&runner.m68k.cpu),
+            application_context
+        );
+        assert_eq!(runner.dispatcher.guest_calls.scheduling_state(worker), None);
+        assert_eq!(
+            runner.dispatcher.guest_calls.cooperative_context(worker),
+            None
+        );
+    }
+
+    #[test]
     fn stopped_last_thread_waits_for_a_task_reference_wakeup() {
         use crate::cpu::CpuOps;
         use crate::execution_kernel::ExecutionTaskState;
@@ -18852,7 +19047,7 @@ mod tests {
                 .unwrap());
             assert!(calls
                 .retire_native_thread(worker, cpu, false, |_| true)
-                .is_some());
+                .is_ok());
         }
         assert_eq!(calls.scheduling_state(worker), None);
         assert!(!calls.switch_to_task(worker));

--- a/src/thread_manager.rs
+++ b/src/thread_manager.rs
@@ -34,6 +34,12 @@ pub(crate) trait NewThreadCreationEdge {
     fn finish_publication_attempt(&mut self);
 }
 
+pub(crate) trait RetiredThreadStorageEdge {
+    fn release_classic(&mut self, stack_base: u32);
+
+    fn release_native(&mut self, stack_base: u32);
+}
+
 pub(crate) struct ThreadManager<'a> {
     execution: &'a SharedGuestCallStack,
 }
@@ -94,6 +100,21 @@ impl<'a> ThreadManager<'a> {
         }
         edge.finish_publication_attempt();
         result
+    }
+
+    pub(crate) fn release_retired_storage<E: RetiredThreadStorageEdge>(
+        storage: ThreadStorage,
+        recycle: bool,
+        edge: &mut E,
+    ) {
+        if recycle || storage.stack_base == 0 {
+            return;
+        }
+        if storage.managed_pointer {
+            edge.release_native(storage.stack_base);
+        } else {
+            edge.release_classic(storage.stack_base);
+        }
     }
 
     /// Prepare every allocation before publishing any pool entry. On failure,
@@ -507,5 +528,44 @@ mod tests {
                 .is_err());
             assert_eq!(execution.create_task().unwrap().thread_id(), 3);
         }
+    }
+
+    #[test]
+    fn retired_storage_release_uses_the_recorded_allocator_provenance_once() {
+        #[derive(Default)]
+        struct RecordingRetirementEdge {
+            classic: Vec<u32>,
+            native: Vec<u32>,
+        }
+
+        impl RetiredThreadStorageEdge for RecordingRetirementEdge {
+            fn release_classic(&mut self, stack_base: u32) {
+                self.classic.push(stack_base);
+            }
+
+            fn release_native(&mut self, stack_base: u32) {
+                self.native.push(stack_base);
+            }
+        }
+
+        let mut edge = RecordingRetirementEdge::default();
+        for (stack_base, managed_pointer, recycle) in [
+            (0x1000, false, false),
+            (0x2000, true, false),
+            (0x3000, false, true),
+            (0, true, false),
+        ] {
+            ThreadManager::release_retired_storage(
+                ThreadStorage {
+                    stack_base,
+                    managed_pointer,
+                    ..ThreadStorage::default()
+                },
+                recycle,
+                &mut edge,
+            );
+        }
+        assert_eq!(edge.classic, [0x1000]);
+        assert_eq!(edge.native, [0x2000]);
     }
 }

--- a/src/trap/toolbox.rs
+++ b/src/trap/toolbox.rs
@@ -1,13 +1,15 @@
 //! Toolbox Utility trap handlers (events, Random, Sound, misc).
 
 use crate::cpu::{CpuOps, Register};
-use crate::guest_call::{CooperativeThread, ExecutionTaskId, SharedGuestCallStack, ThreadStorage};
+use crate::guest_call::{
+    ClassicRetirement, CooperativeThread, ExecutionTaskId, SharedGuestCallStack, ThreadStorage,
+};
 use crate::guest_procedure::{resolve_same_isa_thread_entry, GuestIsa};
 use crate::memory::globals::addr;
 use crate::memory::{MacMemoryBus, MemoryBus};
 use crate::quickdraw::fonts::get_font_face_scaled;
 use crate::quickdraw::text::{get_font_metrics, get_glyph};
-use crate::thread_manager::{NewThreadCreationEdge, ThreadManager};
+use crate::thread_manager::{NewThreadCreationEdge, RetiredThreadStorageEdge, ThreadManager};
 use crate::{Error, Result};
 use std::collections::HashMap;
 use std::sync::OnceLock;
@@ -1212,6 +1214,24 @@ impl<C: CpuOps> NewThreadCreationEdge for ClassicNewThreadEdge<'_, C> {
     fn finish_publication_attempt(&mut self) {}
 }
 
+struct ClassicRetiredThreadStorageEdge<'a> {
+    bus: &'a mut MacMemoryBus,
+    manager: crate::process_context::SharedProcessMemoryManager,
+}
+
+impl RetiredThreadStorageEdge for ClassicRetiredThreadStorageEdge<'_> {
+    fn release_classic(&mut self, stack_base: u32) {
+        self.bus.free(stack_base);
+    }
+
+    fn release_native(&mut self, stack_base: u32) {
+        self.manager
+            .borrow_mut()
+            .native_mut()
+            .dispose_native_ptr(stack_base);
+    }
+}
+
 impl super::TrapDispatcher {
     /// Whether `SystemTask` currently has periodic Desk Manager work to do.
     ///
@@ -1316,96 +1336,25 @@ impl super::TrapDispatcher {
             .cooperative_context(ExecutionTaskId::from_thread_id(thread_id))
     }
 
-    /// Pick the next ready thread. `suggested_thread` wins when it names a
-    /// ready thread, matching `YieldToThread`; otherwise the ready queue
-    /// runs round-robin, as the stock 68K scheduler does.
-    fn next_ready_cooperative_thread(&mut self, suggested_thread: u32) -> Option<u32> {
-        self.guest_calls
-            .next_ready_task(
-                (suggested_thread > 1).then(|| ExecutionTaskId::from_thread_id(suggested_thread)),
-            )
-            .map(ExecutionTaskId::thread_id)
-    }
-
-    /// Retire a task and release its storage unless explicitly recycled.
-    fn retire_cooperative_thread(
-        &mut self,
-        thread_id: u32,
-        result: u32,
-        bus: &mut MacMemoryBus,
-        recycle: bool,
-    ) -> bool {
-        let task = ExecutionTaskId::from_thread_id(thread_id);
-        let Some((finished, _)) =
-            self.guest_calls
-                .retire_cooperative_context(task, None, recycle, |saved| {
-                    saved.result_destination == 0
-                        || bus.try_write_long(saved.result_destination, result)
-                })
-        else {
-            return false;
-        };
-        if !recycle && finished.stack_base != 0 {
-            if finished.managed_pointer {
-                self.process_memory_manager()
-                    .borrow_mut()
-                    .native_mut()
-                    .dispose_native_ptr(finished.stack_base);
-            } else {
-                bus.free(finished.stack_base);
-            }
-        }
-        true
-    }
-
-    /// ThreadEntryProc returns a pointer in A0 at the 68K ABI edge.
-    fn finish_cooperative_thread<C: CpuOps>(
+    fn apply_classic_retirement<C: CpuOps>(
         &mut self,
         cpu: &mut C,
         bus: &mut MacMemoryBus,
-    ) -> bool {
-        let result = cpu.read_reg(Register::A0);
-        self.finish_cooperative_thread_with_result(cpu, bus, result, false)
-    }
-
-    fn finish_cooperative_thread_with_result<C: CpuOps>(
-        &mut self,
-        cpu: &mut C,
-        bus: &mut MacMemoryBus,
-        result: u32,
         recycle: bool,
-    ) -> bool {
-        let finished = self.guest_calls.current_task();
-        let Some(next) = self.next_ready_cooperative_thread(0) else {
-            return false;
+        retirement: ClassicRetirement,
+    ) {
+        let (storage, successor) = match retirement {
+            ClassicRetirement::Removed(storage) => (storage, None),
+            ClassicRetirement::Switched { storage, successor } => (storage, successor),
         };
-        let Some((saved, successor)) = self.guest_calls.retire_cooperative_context(
-            finished,
-            Some(ExecutionTaskId::from_thread_id(next)),
-            recycle,
-            |saved| {
-                saved.result_destination == 0
-                    || bus.try_write_long(saved.result_destination, result)
-            },
-        ) else {
-            return false;
+        let mut edge = ClassicRetiredThreadStorageEdge {
+            bus,
+            manager: self.process_memory_manager(),
         };
-        // The execution owner validated both contexts and committed the result.
-        // Installing this owned snapshot cannot yield or fail.
+        ThreadManager::release_retired_storage(storage, recycle, &mut edge);
         if let Some(successor) = successor {
             successor.install(cpu);
         }
-        if !recycle && saved.stack_base != 0 {
-            if saved.managed_pointer {
-                self.process_memory_manager()
-                    .borrow_mut()
-                    .native_mut()
-                    .dispose_native_ptr(saved.stack_base);
-            } else {
-                bus.free(saved.stack_base);
-            }
-        }
-        true
     }
 
     fn apple_event_handler_for(
@@ -16428,15 +16377,28 @@ impl super::TrapDispatcher {
 
                 let result = match selector {
                     0xFFFE => {
-                        if self.finish_cooperative_thread(cpu, bus) {
+                        let task = self.guest_calls.current_task();
+                        let result = cpu.read_reg(Register::A0);
+                        let retirement = self.guest_calls.retire_classic_thread(
+                            task,
+                            false,
+                            |saved| {
+                                saved.result_destination == 0
+                                    || bus.try_write_long(saved.result_destination, result)
+                            },
+                        );
+                        if let Ok(retirement) = retirement {
+                            self.apply_classic_retirement(cpu, bus, false, retirement);
                             return Some(Ok(()));
                         }
                         // A thread cannot finish while one of its guest
                         // continuations is suspended. This is a guest-visible
                         // protocol failure, not an emulator invariant that
                         // justifies panicking.
-                        bus.write_word(sp, Self::THREAD_PROTOCOL_ERR as u16);
                         cpu.write_reg(Register::D0, Self::THREAD_PROTOCOL_ERR as u32);
+                        if self.thread_return_trampoline != 0 {
+                            cpu.write_reg(Register::PC, self.thread_return_trampoline);
+                        }
                         return Some(Ok(()));
                     }
                     0x0205 => {
@@ -16631,37 +16593,27 @@ impl super::TrapDispatcher {
                         let thread_result = bus.read_long(sp + 2);
                         let thread_to_dump =
                             self.resolve_cooperative_thread_id(bus.read_long(sp + 6));
-                        if !self
-                            .guest_calls
-                            .thread_storage(ExecutionTaskId::from_thread_id(thread_to_dump))
-                            .is_some()
-                            && thread_to_dump != Self::APPLICATION_THREAD_ID
-                        {
-                            Self::THREAD_NOT_FOUND_ERR
-                        } else if thread_to_dump == self.guest_calls.current_task().thread_id() {
-                            // Threads.h allows a thread to dispose of itself;
-                            // the call never returns to it.
-                            if self.finish_cooperative_thread_with_result(
-                                cpu,
-                                bus,
-                                thread_result,
-                                recycle,
-                            ) {
-                                return Some(Ok(()));
-                            } else {
-                                Self::THREAD_PROTOCOL_ERR
-                            }
-                        } else {
-                            if self.retire_cooperative_thread(
-                                thread_to_dump,
-                                thread_result,
-                                bus,
-                                recycle,
-                            ) {
+                        let retirement = self.guest_calls.retire_classic_thread(
+                            ExecutionTaskId::from_thread_id(thread_to_dump),
+                            recycle,
+                            |saved| {
+                                saved.result_destination == 0
+                                    || bus.try_write_long(saved.result_destination, thread_result)
+                            },
+                        );
+                        match retirement {
+                            Ok(retirement) => {
+                                let switched = matches!(
+                                    retirement,
+                                    ClassicRetirement::Switched { .. }
+                                );
+                                self.apply_classic_retirement(cpu, bus, recycle, retirement);
+                                if switched {
+                                    return Some(Ok(()));
+                                }
                                 0
-                            } else {
-                                Self::THREAD_PROTOCOL_ERR
                             }
+                            Err(error) => error,
                         }
                     }
                     // GetThreadState(threadToGet, threadState), and
@@ -27968,6 +27920,27 @@ mod tests {
         }
     }
 
+    fn retire_classic_for_test<C: CpuOps>(
+        disp: &mut TrapDispatcher,
+        cpu: &mut C,
+        bus: &mut MacMemoryBus,
+        task: ExecutionTaskId,
+        result: u32,
+        recycle: bool,
+    ) -> bool {
+        let retirement = disp
+            .guest_calls
+            .retire_classic_thread(task, recycle, |saved| {
+                saved.result_destination == 0
+                    || bus.try_write_long(saved.result_destination, result)
+            });
+        let Ok(retirement) = retirement else {
+            return false;
+        };
+        disp.apply_classic_retirement(cpu, bus, recycle, retirement);
+        true
+    }
+
     #[test]
     fn thread_retirement_rejects_partial_result_writes_and_can_retry() {
         for self_exit in [false, true] {
@@ -28003,11 +27976,8 @@ mod tests {
             cpu.write_reg(Register::A0, 0xcafe_babe);
             let current = disp.guest_calls.current_task();
             let ready = disp.guest_calls.next_ready_task(None);
-            let retired = if self_exit {
-                disp.finish_cooperative_thread(&mut cpu, &mut bus)
-            } else {
-                disp.retire_cooperative_thread(worker.thread_id(), 0xcafe_babe, &mut bus, false)
-            };
+            let retired =
+                retire_classic_for_test(&mut disp, &mut cpu, &mut bus, worker, 0xcafe_babe, false);
             assert!(!retired);
             assert_eq!(disp.guest_calls.current_task(), current);
             assert_eq!(disp.guest_calls.next_ready_task(None), ready);
@@ -28022,11 +27992,8 @@ mod tests {
 
             storage.result_destination = result_slot + 8;
             assert!(disp.guest_calls.set_thread_storage(worker, storage));
-            let retired = if self_exit {
-                disp.finish_cooperative_thread(&mut cpu, &mut bus)
-            } else {
-                disp.retire_cooperative_thread(worker.thread_id(), 0xcafe_babe, &mut bus, false)
-            };
+            let retired =
+                retire_classic_for_test(&mut disp, &mut cpu, &mut bus, worker, 0xcafe_babe, false);
             assert!(retired);
             assert_eq!(disp.guest_calls.current_task(), application);
             assert!(disp.guest_calls.cooperative_context(worker).is_none());
@@ -28066,7 +28033,14 @@ mod tests {
         assert!(disp.guest_calls.switch_to_task(worker));
         // The application is ready, but no adapter snapshot exists for it.
         cpu.write_reg(Register::A0, 0xcafe_babe);
-        assert!(!disp.finish_cooperative_thread(&mut cpu, &mut bus));
+        assert!(!retire_classic_for_test(
+            &mut disp,
+            &mut cpu,
+            &mut bus,
+            worker,
+            0xcafe_babe,
+            false,
+        ));
         assert_eq!(disp.guest_calls.current_task(), worker);
         assert_eq!(disp.guest_calls.cooperative_context(worker), Some(saved));
         assert_eq!(bus.read_long(result_slot), 0x1234_5678);


### PR DESCRIPTION
When a classic thread returned while retirement was refused, its private return trap left execution at the trailing RTS and overwrote the entry parameter with a Pascal error word. Retry now preserves the original result and stack parameter, reloads the private selector, and remains bounded by the runner execution budget.

Both classic and native DisposeThread and automatic-return routes now use one execution-owner retirement transaction. It validates the successor, saved context and result publication before removing task state. Stack release uses one shared allocator-provenance decision; recycled storage retains its original allocation type and receives a fresh task identity when reused. The displaced adapter retirement and successor-selection helpers are deleted.

Validation: reproduced the real pre-fix RTS/MOVE/trap failure; all 16 focused disposal/lifecycle checks passed. Independent default+test-support library suite against published PPC 0.6.0 passed 5,239 tests with 0 failures and 3 ignored. Source guard and bounded changed-item formatting passed. Tests cover both public ABI errors, output refusal/retry, outstanding mixed calls, critical sections, successor refusal, recycling, opposite-ABI allocation provenance, native automatic return and bounded classic retry. Full formatting, host/showcase and package checks are delegated to CI.

Closes #1570
