### PR TITLE
fix: project window snapshots consistently across execution engines

### DIFF
--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -83,102 +83,6 @@ pub struct ResourceManagerSnapshot {
     pub data_entries: Vec<ResourceManagerEntrySnapshot>,
 }
 
-const PPC_WINDOW_STRUCTURE_RGN_OFFSET: u32 = 114;
-const PPC_WINDOW_UPDATE_RGN_OFFSET: u32 = 122;
-const PPC_WINDOW_TITLE_HANDLE_OFFSET: u32 = 134;
-const PPC_WINDOW_HILITED_OFFSET: u32 = 111;
-const PPC_WINDOW_VISIBLE_OFFSET: u32 = 110;
-
-fn ppc_read_rect(memory: &mut PpcSectionMem, address: u32) -> Option<(i16, i16, i16, i16)> {
-    Some((
-        memory.read_u16_be(address)? as i16,
-        memory.read_u16_be(address + 2)? as i16,
-        memory.read_u16_be(address + 4)? as i16,
-        memory.read_u16_be(address + 6)? as i16,
-    ))
-}
-
-fn ppc_region_bbox(memory: &mut PpcSectionMem, handle: u32) -> Option<(i16, i16, i16, i16)> {
-    let region = memory.read_u32_be(handle).filter(|ptr| *ptr != 0)?;
-    let rect = (memory.read_u16_be(region)? >= 10).then(|| ppc_read_rect(memory, region + 2))??;
-    (rect.2 > rect.0 && rect.3 > rect.1).then_some(rect)
-}
-
-fn ppc_read_title(memory: &mut PpcSectionMem, handle: u32) -> String {
-    let Some(pointer) = memory.read_u32_be(handle).filter(|ptr| *ptr != 0) else {
-        return String::new();
-    };
-    let length = usize::from(memory.read_u8(pointer).unwrap_or(0));
-    let bytes = (0..length)
-        .filter_map(|index| memory.read_u8(pointer + 1 + index as u32))
-        .collect::<Vec<_>>();
-    crate::mac_roman::decode_mac_roman(&bytes)
-}
-
-fn ppc_window_snapshot(app: &mut PpcLoadedApp) -> Vec<WindowSnapshot> {
-    let order = (*app.window_list).clone();
-    let front = order
-        .iter()
-        .copied()
-        .find(|&window| app.memory.read_u8(window + PPC_WINDOW_VISIBLE_OFFSET) == Some(1));
-
-    order
-        .into_iter()
-        .filter(|&window| window != 0)
-        .map(|window| {
-            let visible = app.memory.read_u8(window + PPC_WINDOW_VISIBLE_OFFSET) == Some(1);
-            let port = ppc_read_rect(&mut app.memory, window + 16).unwrap_or((0, 0, 0, 0));
-            let pixmap = app
-                .memory
-                .read_u32_be(window + 2)
-                .and_then(|handle| app.memory.read_u32_be(handle));
-            let surface = pixmap
-                .and_then(|pixmap| ppc_read_rect(&mut app.memory, pixmap + 6))
-                .unwrap_or((0, 0, 0, 0));
-            let bounds = (
-                port.0.saturating_sub(surface.0),
-                port.1.saturating_sub(surface.1),
-                port.2.saturating_sub(surface.0),
-                port.3.saturating_sub(surface.1),
-            );
-            let structure_handle = app
-                .memory
-                .read_u32_be(window + PPC_WINDOW_STRUCTURE_RGN_OFFSET)
-                .unwrap_or(0);
-            let structure_bounds = ppc_region_bbox(&mut app.memory, structure_handle);
-            let visible_handle = app.memory.read_u32_be(window + 24).unwrap_or(0);
-            let visible_region = ppc_region_bbox(&mut app.memory, visible_handle).map(|rect| {
-                (
-                    rect.0.saturating_add(bounds.0),
-                    rect.1.saturating_add(bounds.1),
-                    rect.2.saturating_add(bounds.0),
-                    rect.3.saturating_add(bounds.1),
-                )
-            });
-            let update_handle = app
-                .memory
-                .read_u32_be(window + PPC_WINDOW_UPDATE_RGN_OFFSET)
-                .unwrap_or(0);
-            let update_region = ppc_region_bbox(&mut app.memory, update_handle);
-            let title_handle = app
-                .memory
-                .read_u32_be(window + PPC_WINDOW_TITLE_HANDLE_OFFSET)
-                .unwrap_or(0);
-            let title = ppc_read_title(&mut app.memory, title_handle);
-            WindowSnapshot {
-                title,
-                bounds,
-                structure_bounds,
-                visible_region,
-                update_region,
-                visible,
-                active: front == Some(window)
-                    || app.memory.read_u8(window + PPC_WINDOW_HILITED_OFFSET) == Some(1),
-            }
-        })
-        .collect()
-}
-
 fn resource_manager_snapshot_classic(
     dispatcher: &TrapDispatcher,
     bus: &MacMemoryBus,
@@ -2280,11 +2184,9 @@ impl FixtureRunner {
     /// regions, and pending repaint regions without relying on screenshots.
     #[doc(hidden)]
     pub fn window_stack_snapshot(&mut self) -> Vec<WindowSnapshot> {
-        if let Some(ppc_app) = self.native.application_mut() {
-            ppc_window_snapshot(ppc_app)
-        } else {
-            self.dispatcher.window_stack_snapshot(&self.bus)
-        }
+        crate::window_manager::snapshot_window_stack(&self.dispatcher.window_list, |address| {
+            self.bus.read_byte(address)
+        })
     }
 
     /// Returns the selected UI theme provider. `classic-system7` is the
@@ -11571,6 +11473,7 @@ mod tests {
         DialogItem, DialogTrackingState, LoadedResources, PendingWaitNextEventReturn, QueuedEvent,
         ResourceFileMap, TimerTask, VblTask,
     };
+    use crate::window_manager::WindowRect;
     use ppc::{PpcCpu, PpcNativeReturnGpr3};
     use std::cell::RefCell;
     use std::collections::{HashMap, VecDeque};
@@ -13252,6 +13155,399 @@ mod tests {
         assert_eq!(&*detached, &[0x1000, 0x2000]);
     }
 
+    fn write_snapshot_rect(bus: &mut MacMemoryBus, address: u32, rect: WindowRect) {
+        for (index, value) in [rect.0, rect.1, rect.2, rect.3].into_iter().enumerate() {
+            bus.write_word(address.wrapping_add(index as u32 * 2), value as u16);
+        }
+    }
+
+    fn write_snapshot_region_bounds(bus: &mut MacMemoryBus, handle: u32, bounds: WindowRect) {
+        let region = bus.read_long(handle);
+        assert_ne!(region, 0, "window operation must allocate region data");
+        bus.write_word(region, 10);
+        write_snapshot_rect(bus, region.wrapping_add(2), bounds);
+    }
+
+    fn configure_snapshot_window(runner: &mut FixtureRunner, window: u32, color: bool) {
+        runner.bus.write_byte(window.wrapping_add(110), 0xFF);
+        runner.bus.write_byte(window.wrapping_add(111), 0xFF);
+        write_snapshot_rect(&mut runner.bus, window.wrapping_add(16), (10, 20, 30, 40));
+        if color {
+            let pixmap_handle = runner.bus.read_long(window.wrapping_add(2));
+            let pixmap = runner.bus.read_long(pixmap_handle);
+            assert_ne!(pixmap, 0, "NewCWindow must install a PixMap");
+            runner
+                .bus
+                .write_word(pixmap.wrapping_add(6), (-100i16) as u16);
+            runner
+                .bus
+                .write_word(pixmap.wrapping_add(8), (-200i16) as u16);
+        } else {
+            runner
+                .bus
+                .write_word(window.wrapping_add(8), (-100i16) as u16);
+            runner
+                .bus
+                .write_word(window.wrapping_add(10), (-200i16) as u16);
+        }
+        for (offset, bounds) in [
+            (114, (100, 200, 140, 250)),
+            (24, (5, 7, 15, 17)),
+            (122, (101, 202, 111, 212)),
+        ] {
+            let handle = runner.bus.read_long(window.wrapping_add(offset));
+            assert_ne!(handle, 0, "window operation must install region handle");
+            write_snapshot_region_bounds(&mut runner.bus, handle, bounds);
+        }
+        *runner.dispatcher.window_list = vec![window];
+        runner
+            .bus
+            .write_long(crate::memory::globals::addr::GHOST_WINDOW, 0);
+    }
+
+    fn create_classic_snapshot_window(title: &[u8]) -> (FixtureRunner, u32) {
+        const BOUNDS: u32 = 0x0030_0000;
+        const TITLE: u32 = 0x0030_0100;
+        const STACK: u32 = 0x0030_1000;
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        write_snapshot_rect(&mut runner.bus, BOUNDS, (20, 10, 260, 330));
+        runner.bus.write_pstring(TITLE, title);
+        for offset in 0..30 {
+            runner.bus.write_byte(STACK + offset, 0);
+        }
+        runner.bus.write_byte(STACK + 4, 1);
+        runner.bus.write_long(STACK + 6, u32::MAX);
+        runner.bus.write_byte(STACK + 12, 1);
+        runner.bus.write_long(STACK + 14, TITLE);
+        runner.bus.write_long(STACK + 18, BOUNDS);
+        runner.m68k.cpu.write_reg(Register::A7, STACK);
+        runner
+            .dispatcher
+            .dispatch(0xA913, &mut runner.m68k.cpu, &mut runner.bus)
+            .expect("classic NewWindow must return");
+        let window = runner.bus.read_long(STACK + 26);
+        assert_ne!(window, 0);
+        (runner, window)
+    }
+
+    fn create_native_snapshot_window(title: &[u8]) -> (FixtureRunner, u32) {
+        use crate::loader::ppc::tests::synthetic_pef_with_import;
+        const SCRATCH: u32 = PPC_DATA_BASE + 0x1000;
+        let mut native = load_pef_application(&synthetic_pef_with_import(b"NewCWindow")).unwrap();
+        native.memory.add_region(SCRATCH, vec![0; 512]);
+        for (index, value) in [20i16, 10, 260, 330].into_iter().enumerate() {
+            native
+                .memory
+                .write_u16_be(SCRATCH + index as u32 * 2, value as u16)
+                .unwrap();
+        }
+        native
+            .memory
+            .write_u8(SCRATCH + 16, title.len() as u8)
+            .unwrap();
+        native.memory.write_bytes(SCRATCH + 17, title).unwrap();
+        native.cpu.gpr[3] = 0;
+        native.cpu.gpr[4] = SCRATCH;
+        native.cpu.gpr[5] = SCRATCH + 16;
+        native.cpu.gpr[6] = 1;
+        native.cpu.gpr[7] = 0;
+        native.cpu.gpr[8] = u32::MAX;
+        native.cpu.gpr[9] = 1;
+        native.cpu.gpr[10] = 0;
+        let probe = native.run_with_hle_imports(64);
+        assert_eq!(probe.handled_import_count, 1);
+        assert_eq!(probe.unsupported_import_index, None);
+        let window = native.cpu.gpr[3];
+        assert_ne!(window, 0);
+
+        let app = LoadedApp::from_ppc(native);
+        let mut runner = FixtureRunner::new(64 * 1024 * 1024, FixtureRunnerConfig::default());
+        runner.init_app(&app);
+        (runner, window)
+    }
+
+    // Retain the two divergent expressions from the deleted native projector so
+    // the integration test proves the common projection changes their result.
+    // This is source-model evidence; it is not presented as a captured old run.
+    fn deleted_native_visibility_and_visible_region_model(
+        app: &mut PpcLoadedApp,
+        window: u32,
+    ) -> (bool, Option<WindowRect>) {
+        let visible = app.memory.read_u8(window.wrapping_add(110)) == Some(1);
+        let port = (
+            app.memory.read_u16_be(window.wrapping_add(16)).unwrap_or(0) as i16,
+            app.memory.read_u16_be(window.wrapping_add(18)).unwrap_or(0) as i16,
+            app.memory.read_u16_be(window.wrapping_add(20)).unwrap_or(0) as i16,
+            app.memory.read_u16_be(window.wrapping_add(22)).unwrap_or(0) as i16,
+        );
+        let pixmap = app
+            .memory
+            .read_u32_be(window.wrapping_add(2))
+            .and_then(|handle| app.memory.read_u32_be(handle));
+        let origin = pixmap.map(|pixmap| {
+            (
+                app.memory.read_u16_be(pixmap.wrapping_add(6)).unwrap_or(0) as i16,
+                app.memory.read_u16_be(pixmap.wrapping_add(8)).unwrap_or(0) as i16,
+            )
+        });
+        let global_port = origin.map(|origin| {
+            (
+                port.0.saturating_sub(origin.0),
+                port.1.saturating_sub(origin.1),
+                port.2.saturating_sub(origin.0),
+                port.3.saturating_sub(origin.1),
+            )
+        });
+        let visible_region = app
+            .memory
+            .read_u32_be(window.wrapping_add(24))
+            .and_then(|handle| app.memory.read_u32_be(handle))
+            .map(|region| {
+                (
+                    app.memory.read_u16_be(region.wrapping_add(2)).unwrap_or(0) as i16,
+                    app.memory.read_u16_be(region.wrapping_add(4)).unwrap_or(0) as i16,
+                    app.memory.read_u16_be(region.wrapping_add(6)).unwrap_or(0) as i16,
+                    app.memory.read_u16_be(region.wrapping_add(8)).unwrap_or(0) as i16,
+                )
+            })
+            .zip(global_port)
+            .map(|(rect, port)| {
+                (
+                    rect.0.saturating_add(port.0),
+                    rect.1.saturating_add(port.1),
+                    rect.2.saturating_add(port.0),
+                    rect.3.saturating_add(port.1),
+                )
+            });
+        (visible, visible_region)
+    }
+
+    #[test]
+    fn runner_window_snapshot_matches_classic_and_native_window_operations() {
+        let title = b"Caf\x8e";
+        let (mut classic, classic_window) = create_classic_snapshot_window(title);
+        let initial_classic = classic.window_stack_snapshot();
+
+        let (mut native, native_window) = create_native_snapshot_window(title);
+        let initial_native = native.window_stack_snapshot();
+        assert_eq!(initial_classic.len(), 1);
+        assert_eq!(initial_native.len(), 1);
+        let classic_created = &initial_classic[0];
+        let native_created = &initial_native[0];
+        assert_eq!(classic_created.title, native_created.title);
+        assert_eq!(classic_created.bounds, native_created.bounds);
+        assert_eq!(
+            classic_created.structure_bounds,
+            native_created.structure_bounds
+        );
+        assert_eq!(
+            classic_created.visible_region,
+            native_created.visible_region
+        );
+        assert_eq!(classic_created.visible, native_created.visible);
+        assert_eq!(classic_created.active, native_created.active);
+        // Preserve the routes' existing initial-update policy: the classic
+        // NewWindow route invalidates its content immediately, while the native
+        // NewCWindow import currently does not. Snapshot unification must expose
+        // that difference without taking ownership of window-creation behavior.
+        assert_eq!(classic_created.update_region, Some((20, 10, 260, 330)));
+        assert_eq!(native_created.update_region, None);
+
+        configure_snapshot_window(&mut classic, classic_window, false);
+        let classic_snapshot = classic.window_stack_snapshot();
+
+        configure_snapshot_window(&mut native, native_window, true);
+        let deleted_native_model = deleted_native_visibility_and_visible_region_model(
+            native.native.application_mut().expect("native app"),
+            native_window,
+        );
+        assert_eq!(deleted_native_model, (false, Some((115, 227, 125, 237))));
+        let native_snapshot = native.window_stack_snapshot();
+
+        assert_eq!(classic_snapshot, native_snapshot);
+        assert_eq!(native_snapshot[0].bounds, (110, 220, 130, 240));
+        assert_eq!(
+            native_snapshot[0].visible_region,
+            Some((105, 207, 115, 217))
+        );
+        assert!(native_snapshot[0].visible);
+        assert!(native_snapshot[0].active);
+        assert_eq!(
+            native_snapshot[0].title,
+            crate::mac_roman::decode_mac_roman(title)
+        );
+    }
+
+    fn write_minimal_snapshot_window(
+        bus: &mut MacMemoryBus,
+        window: u32,
+        title_handle: u32,
+        title: u32,
+        bytes: &[u8],
+    ) {
+        bus.write_word(window.wrapping_add(6), 0);
+        write_snapshot_rect(bus, window.wrapping_add(16), (1, 2, 11, 22));
+        bus.write_byte(window.wrapping_add(110), 0xFF);
+        bus.write_long(window.wrapping_add(134), title_handle);
+        bus.write_long(title_handle, title);
+        bus.write_pstring(title, bytes);
+    }
+
+    #[test]
+    fn runner_snapshot_routes_flat_and_native_sparse_records_through_one_bus() {
+        const FLAT: u32 = 0x0002_0000;
+        const SPARSE: u32 = 0x0188_0000;
+        let mut app = halted_ppc_app_with_sound(PpcSoundState::default());
+        app.ppc
+            .as_mut()
+            .expect("native app")
+            .memory
+            .add_region(SPARSE, vec![0; 0x1000]);
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        runner.init_app(&app);
+        write_minimal_snapshot_window(&mut runner.bus, FLAT, FLAT + 0x200, FLAT + 0x300, b"Flat");
+        write_minimal_snapshot_window(
+            &mut runner.bus,
+            SPARSE,
+            SPARSE + 0x200,
+            SPARSE + 0x300,
+            b"Sparse",
+        );
+        *runner.dispatcher.window_list = vec![FLAT, SPARSE];
+
+        assert_eq!(
+            runner
+                .native
+                .application_mut()
+                .unwrap()
+                .memory
+                .read_u8(SPARSE + 110),
+            Some(0xFF)
+        );
+        let result = runner.window_stack_snapshot();
+        assert_eq!(
+            result
+                .iter()
+                .map(|window| window.title.as_str())
+                .collect::<Vec<_>>(),
+            ["Flat", "Sparse"]
+        );
+        assert!(result.iter().all(|window| window.visible));
+    }
+
+    #[test]
+    fn mixed_isa_window_snapshot_uses_shared_process_state() {
+        use crate::guest_call::{ExecutionTaskId, NativeThreadContext, ThreadStorage};
+        use crate::guest_procedure::GuestIsa;
+        use crate::loader::ppc::tests::synthetic_pef_with_import;
+        const CLASSIC_CODE: u32 = 0x0031_0000;
+        const CLASSIC_STACK: u32 = 0x0031_1000;
+        let (mut runner, window) = create_classic_snapshot_window(b"Mixed");
+        let mut companion =
+            load_pef_application(&synthetic_pef_with_import(b"YieldToThread")).unwrap();
+        companion.cpu.gpr[3] = ExecutionTaskId::APPLICATION.thread_id();
+        let worker_context = companion.cpu.capture_execution_context();
+        runner.init_ppc_companion(companion);
+        let calls = runner.dispatcher.guest_calls.shared_handle();
+        assert!(calls.bind_task_entry_isa(ExecutionTaskId::APPLICATION, GuestIsa::M68k));
+        let worker = calls
+            .create_native_thread(
+                NativeThreadContext {
+                    context: worker_context,
+                },
+                ThreadStorage::default(),
+                false,
+                |_| true,
+            )
+            .unwrap();
+
+        let mut context = runner.native.take(NativeEngineRole::Companion).unwrap();
+        context
+            .adapter_mut()
+            .memory
+            .write_u8(window + 110, 0x7F)
+            .unwrap();
+        *context.adapter_mut().window_list = vec![window];
+        assert!(runner.native.restore(context).is_ok());
+        assert_eq!(runner.bus.read_byte(window + 110), 0x7F);
+        assert_eq!(&*runner.dispatcher.window_list, &[window]);
+
+        for (index, word) in [
+            0x303c, 0x0205, // MOVE.W #YieldToThread,D0
+            0xabf2, // ThreadDispatch to the native worker
+            0x60fe, // BRA.S -2 after the native import yields back
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            runner.bus.write_word(CLASSIC_CODE + index as u32 * 2, word);
+        }
+        runner.bus.write_long(CLASSIC_STACK, worker.thread_id());
+        runner.bus.write_word(CLASSIC_STACK + 4, 0xBEEF);
+        runner.m68k.cpu.write_reg(Register::PC, CLASSIC_CODE);
+        runner.m68k.cpu.write_reg(Register::A7, CLASSIC_STACK);
+
+        let (steps, running) = runner.run_steps(64, None);
+        assert!(steps > 0 && running);
+        assert_eq!(calls.current_task(), worker);
+        assert!(calls.has_pending_task_handoff());
+        let (steps, running) = runner.run_steps(64, None);
+        assert!(steps > 0 && running);
+        assert_eq!(calls.current_task(), ExecutionTaskId::APPLICATION);
+        assert_eq!(runner.bus.read_word(CLASSIC_STACK + 4), 0);
+        assert!(!calls.has_pending_task_handoff());
+        assert_eq!(runner.m68k.cpu.read_reg(Register::PC), CLASSIC_CODE + 6);
+        assert_eq!(runner.m68k.cpu.read_reg(Register::A7), CLASSIC_STACK + 4);
+        let companion = runner.native.companion().unwrap();
+        assert_eq!(companion.cpu.gpr[3], 0);
+        // synthetic_code calls the import trap with bctrl at +12, so the
+        // native yield saves its successful return at the encoded LR (+16).
+        assert_eq!(companion.cpu.pc, PPC_CODE_BASE + 16);
+
+        let result = runner.window_stack_snapshot();
+        assert_eq!(runner.bus.read_byte(window + 110), 0x7F);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].title, "Mixed");
+        assert!(result[0].visible);
+        assert_eq!(calls.current_task(), ExecutionTaskId::APPLICATION);
+    }
+
+    #[test]
+    fn window_snapshot_poll_is_read_only() {
+        let (mut runner, window) = create_native_snapshot_window(b"Read only");
+        configure_snapshot_window(&mut runner, window, true);
+        let list = (*runner.dispatcher.window_list).clone();
+        let events = runner.event_manager_snapshot();
+        let m68k = CpuArchitecturalSnapshot::capture(&runner.m68k.cpu.core);
+        let calls = runner.dispatcher.guest_calls.shared_handle();
+        let calls_before = calls.clone();
+        let native = &runner.native.application().unwrap().cpu;
+        let native_context = native.capture_execution_context();
+        let native_alignment = native.alignment_policy;
+        let native_time = native.time_base();
+        let native_reservation = native.reservation_address();
+
+        runner.bus.begin_uncapped_write_probe();
+        let first = runner.window_stack_snapshot();
+        let second = runner.window_stack_snapshot();
+        assert!(runner.bus.finish_write_probe_unchanged());
+        assert_eq!(first, second);
+        assert_eq!(&*runner.dispatcher.window_list, list.as_slice());
+        assert_eq!(runner.event_manager_snapshot(), events);
+        assert_eq!(
+            CpuArchitecturalSnapshot::capture(&runner.m68k.cpu.core),
+            m68k
+        );
+        assert_eq!(calls, calls_before);
+        let after = &runner.native.application().unwrap().cpu;
+        assert_eq!(
+            after.capture_execution_context().architectural(),
+            native_context.architectural()
+        );
+        assert_eq!(after.alignment_policy, native_alignment);
+        assert_eq!(after.time_base(), native_time);
+        assert_eq!(after.reservation_address(), native_reservation);
+    }
     #[test]
     fn ppc_slice_keeps_ticks_coherent_across_runner_and_guest_memory() {
         use crate::memory::globals::addr;

--- a/src/trap/window.rs
+++ b/src/trap/window.rs
@@ -6,7 +6,6 @@ use crate::memory::{MacMemoryBus, MemoryBus};
 use crate::trap::dispatch::{DrawOldState, PortDrawState, QueuedEvent};
 use crate::trap::quickdraw::RegionBooleanOp;
 use crate::trap::types::{Rect, ShapeOp};
-use crate::window_manager::WindowSnapshot;
 use crate::Result;
 use std::sync::OnceLock;
 
@@ -2616,55 +2615,6 @@ impl super::TrapDispatcher {
 
     pub(crate) fn window_visible(&self, bus: &MacMemoryBus, window_ptr: u32) -> bool {
         window_ptr != 0 && bus.read_byte(window_ptr + Self::WINDOW_VISIBLE_OFFSET) != 0
-    }
-
-    /// Return the process Window Manager list in front-to-back order with
-    /// enough guest-visible state for architecture-neutral fixture checks.
-    ///
-    /// Macintosh Toolbox Essentials (1992), pp. 4-63--4-65 and 4-89--4-93:
-    /// WindowList is front-to-back, `hilited` identifies the active window,
-    /// `visRgn` excludes structure regions above the window, and `updateRgn`
-    /// carries pending repaint work.  Keep the WindowPtr itself private so
-    /// deterministic callers compare titles and geometry rather than guest
-    /// allocation addresses.
-    pub(crate) fn window_stack_snapshot(&self, bus: &MacMemoryBus) -> Vec<WindowSnapshot> {
-        self.window_list
-            .iter()
-            .copied()
-            .filter(|&window_ptr| window_ptr != 0)
-            .map(|window_ptr| {
-                let title_handle = bus.read_long(window_ptr + Self::WINDOW_TITLE_HANDLE_OFFSET);
-                let title_ptr = if title_handle != 0 {
-                    bus.read_long(title_handle)
-                } else {
-                    0
-                };
-                let title = if title_ptr != 0 {
-                    decode_mac_roman(&bus.read_pstring(title_ptr))
-                } else {
-                    String::new()
-                };
-                let visible = self.window_visible(bus, window_ptr);
-                let bounds = self.window_global_port_rect(bus, window_ptr);
-                let structure_bounds = Self::region_handle_rect(
-                    bus,
-                    bus.read_long(window_ptr + Self::WINDOW_STRUC_RGN_OFFSET),
-                );
-                let visible_region = Self::region_handle_rect(bus, bus.read_long(window_ptr + 24))
-                    .map(|rect| self.window_local_rect_to_global(bus, window_ptr, rect));
-                let update_region = self.window_update_rect(bus, window_ptr);
-                WindowSnapshot {
-                    title,
-                    bounds,
-                    structure_bounds,
-                    visible_region,
-                    update_region,
-                    visible,
-                    active: window_ptr == self.front_window
-                        || bus.read_byte(window_ptr + Self::WINDOW_HILITED_OFFSET) != 0,
-                }
-            })
-            .collect()
     }
 
     fn frontmost_visible_window_in_list(&self, bus: &MacMemoryBus) -> u32 {

--- a/src/window_manager.rs
+++ b/src/window_manager.rs
@@ -53,6 +53,171 @@ pub struct WindowSnapshot {
     pub active: bool,
 }
 
+const WINDOW_VISIBLE_OFFSET: u32 = 110;
+const WINDOW_HILITED_OFFSET: u32 = 111;
+const WINDOW_STRUCTURE_RGN_OFFSET: u32 = 114;
+const WINDOW_UPDATE_RGN_OFFSET: u32 = 122;
+const WINDOW_TITLE_HANDLE_OFFSET: u32 = 134;
+
+fn snapshot_read_word(read_byte: &mut impl FnMut(u32) -> u8, address: u32) -> u16 {
+    u16::from_be_bytes([read_byte(address), read_byte(address.wrapping_add(1))])
+}
+
+fn snapshot_read_long(read_byte: &mut impl FnMut(u32) -> u8, address: u32) -> u32 {
+    u32::from_be_bytes([
+        read_byte(address),
+        read_byte(address.wrapping_add(1)),
+        read_byte(address.wrapping_add(2)),
+        read_byte(address.wrapping_add(3)),
+    ])
+}
+
+fn snapshot_read_rect(read_byte: &mut impl FnMut(u32) -> u8, address: u32) -> WindowRect {
+    (
+        snapshot_read_word(read_byte, address) as i16,
+        snapshot_read_word(read_byte, address.wrapping_add(2)) as i16,
+        snapshot_read_word(read_byte, address.wrapping_add(4)) as i16,
+        snapshot_read_word(read_byte, address.wrapping_add(6)) as i16,
+    )
+}
+
+fn snapshot_region_bounds(
+    read_byte: &mut impl FnMut(u32) -> u8,
+    handle: u32,
+) -> Option<WindowRect> {
+    if handle == 0 {
+        return None;
+    }
+    let region = snapshot_read_long(read_byte, handle);
+    if region == 0 {
+        return None;
+    }
+    let bounds = snapshot_read_rect(read_byte, region.wrapping_add(2));
+    (bounds.2 > bounds.0 && bounds.3 > bounds.1).then_some(bounds)
+}
+
+fn snapshot_port_bounds_origin(read_byte: &mut impl FnMut(u32) -> u8, window: u32) -> (i16, i16) {
+    let port_version = snapshot_read_word(read_byte, window.wrapping_add(6));
+    if port_version & 0xC000 == 0 {
+        return (
+            snapshot_read_word(read_byte, window.wrapping_add(8)) as i16,
+            snapshot_read_word(read_byte, window.wrapping_add(10)) as i16,
+        );
+    }
+
+    let pixmap_handle = snapshot_read_long(read_byte, window.wrapping_add(2));
+    if pixmap_handle == 0 {
+        return (0, 0);
+    }
+    let pixmap = snapshot_read_long(read_byte, pixmap_handle);
+    if pixmap == 0 {
+        return (0, 0);
+    }
+    (
+        snapshot_read_word(read_byte, pixmap.wrapping_add(6)) as i16,
+        snapshot_read_word(read_byte, pixmap.wrapping_add(8)) as i16,
+    )
+}
+
+fn snapshot_local_rect_to_global(rect: WindowRect, origin: (i16, i16)) -> WindowRect {
+    (
+        rect.0.wrapping_sub(origin.0),
+        rect.1.wrapping_sub(origin.1),
+        rect.2.wrapping_sub(origin.0),
+        rect.3.wrapping_sub(origin.1),
+    )
+}
+
+fn snapshot_title(read_byte: &mut impl FnMut(u32) -> u8, handle: u32) -> String {
+    if handle == 0 {
+        return String::new();
+    }
+    let title = snapshot_read_long(read_byte, handle);
+    if title == 0 {
+        return String::new();
+    }
+    let length = usize::from(read_byte(title));
+    let bytes = (0..length)
+        .map(|index| read_byte(title.wrapping_add(1).wrapping_add(index as u32)))
+        .collect::<Vec<_>>();
+    crate::mac_roman::decode_mac_roman(&bytes)
+}
+
+/// Project the process Window Manager list into an owned diagnostic snapshot.
+///
+/// The byte reader is total: missing bytes contribute zero, and guest-address
+/// field arithmetic wraps at 32 bits. Window Manager Boolean fields are true
+/// when nonzero. `GhostWindow` is excluded only from the list-derived front
+/// candidate; a live nonzero `hilited` field remains independently visible.
+/// Inside Macintosh Volume I (1985), pp. I-276--I-287; Macintosh Toolbox
+/// Essentials (1992), pp. 4-63--4-65.
+pub(crate) fn snapshot_window_stack(
+    order: &[u32],
+    mut read_byte: impl FnMut(u32) -> u8,
+) -> Vec<WindowSnapshot> {
+    struct DecodedWindow {
+        pointer: u32,
+        hilited: bool,
+        snapshot: WindowSnapshot,
+    }
+
+    let ghost_window =
+        snapshot_read_long(&mut read_byte, crate::memory::globals::addr::GHOST_WINDOW);
+    let mut windows = order
+        .iter()
+        .copied()
+        .filter(|window| *window != 0)
+        .map(|window| {
+            let visible = read_byte(window.wrapping_add(WINDOW_VISIBLE_OFFSET)) != 0;
+            let hilited = read_byte(window.wrapping_add(WINDOW_HILITED_OFFSET)) != 0;
+            let origin = snapshot_port_bounds_origin(&mut read_byte, window);
+            let bounds = snapshot_local_rect_to_global(
+                snapshot_read_rect(&mut read_byte, window.wrapping_add(16)),
+                origin,
+            );
+            let structure_handle = snapshot_read_long(
+                &mut read_byte,
+                window.wrapping_add(WINDOW_STRUCTURE_RGN_OFFSET),
+            );
+            let structure_bounds = snapshot_region_bounds(&mut read_byte, structure_handle);
+            let visible_handle = snapshot_read_long(&mut read_byte, window.wrapping_add(24));
+            let visible_region = snapshot_region_bounds(&mut read_byte, visible_handle)
+                .map(|rect| snapshot_local_rect_to_global(rect, origin));
+            let update_handle = snapshot_read_long(
+                &mut read_byte,
+                window.wrapping_add(WINDOW_UPDATE_RGN_OFFSET),
+            );
+            let update_region = snapshot_region_bounds(&mut read_byte, update_handle);
+            let title_handle = snapshot_read_long(
+                &mut read_byte,
+                window.wrapping_add(WINDOW_TITLE_HANDLE_OFFSET),
+            );
+            let title = snapshot_title(&mut read_byte, title_handle);
+            DecodedWindow {
+                pointer: window,
+                hilited,
+                snapshot: WindowSnapshot {
+                    title,
+                    bounds,
+                    structure_bounds,
+                    visible_region,
+                    update_region,
+                    visible,
+                    active: false,
+                },
+            }
+        })
+        .collect::<Vec<_>>();
+    let front = windows
+        .iter()
+        .find(|window| window.pointer != ghost_window && window.snapshot.visible)
+        .map(|window| window.pointer);
+    for window in &mut windows {
+        window.snapshot.active = front == Some(window.pointer) || window.hilited;
+    }
+    windows.into_iter().map(|window| window.snapshot).collect()
+}
+
 pub(crate) fn standard_window_structure_bounds(content: WindowRect) -> WindowRect {
     (
         content.0.saturating_sub(19),
@@ -371,7 +536,214 @@ mod tests {
         );
     }
     use super::*;
+    use std::collections::BTreeMap;
 
+    #[derive(Clone, Debug, Default, Eq, PartialEq)]
+    struct SnapshotMemory {
+        bytes: BTreeMap<u32, u8>,
+    }
+
+    impl SnapshotMemory {
+        fn read_byte(&self, address: u32) -> u8 {
+            self.bytes.get(&address).copied().unwrap_or(0)
+        }
+
+        fn write_byte(&mut self, address: u32, value: u8) {
+            self.bytes.insert(address, value);
+        }
+
+        fn write_word(&mut self, address: u32, value: u16) {
+            for (index, byte) in value.to_be_bytes().into_iter().enumerate() {
+                self.write_byte(address.wrapping_add(index as u32), byte);
+            }
+        }
+
+        fn write_long(&mut self, address: u32, value: u32) {
+            for (index, byte) in value.to_be_bytes().into_iter().enumerate() {
+                self.write_byte(address.wrapping_add(index as u32), byte);
+            }
+        }
+
+        fn write_rect(&mut self, address: u32, rect: WindowRect) {
+            for (index, value) in [rect.0, rect.1, rect.2, rect.3].into_iter().enumerate() {
+                self.write_word(address.wrapping_add(index as u32 * 2), value as u16);
+            }
+        }
+
+        fn write_region(&mut self, handle: u32, region: u32, size: u16, bounds: WindowRect) {
+            self.write_long(handle, region);
+            self.write_word(region, size);
+            self.write_rect(region.wrapping_add(2), bounds);
+        }
+
+        fn write_title(&mut self, handle: u32, title: u32, bytes: &[u8]) {
+            self.write_long(handle, title);
+            self.write_byte(title, bytes.len() as u8);
+            for (index, byte) in bytes.iter().copied().enumerate() {
+                self.write_byte(title.wrapping_add(1).wrapping_add(index as u32), byte);
+            }
+        }
+
+        fn write_window_flags(&mut self, window: u32, visible: u8, hilited: u8) {
+            self.write_byte(window.wrapping_add(WINDOW_VISIBLE_OFFSET), visible);
+            self.write_byte(window.wrapping_add(WINDOW_HILITED_OFFSET), hilited);
+        }
+
+        fn write_window_title(&mut self, window: u32, handle: u32, title: u32, bytes: &[u8]) {
+            self.write_long(window.wrapping_add(WINDOW_TITLE_HANDLE_OFFSET), handle);
+            self.write_title(handle, title, bytes);
+        }
+    }
+
+    fn snapshots(memory: &SnapshotMemory, order: &[u32]) -> Vec<WindowSnapshot> {
+        snapshot_window_stack(order, |address| memory.read_byte(address))
+    }
+
+    #[test]
+    fn window_snapshot_applies_ghost_window_to_the_list_derived_active_candidate() {
+        const UTILITY: u32 = 0x1000;
+        const DOCUMENT: u32 = 0x1200;
+        let mut memory = SnapshotMemory::default();
+        memory.write_window_flags(UTILITY, 0xFF, 0);
+        memory.write_window_flags(DOCUMENT, 0xFF, 0xFF);
+        memory.write_window_title(UTILITY, 0x2000, 0x2100, b"Utility");
+        memory.write_window_title(DOCUMENT, 0x2200, 0x2300, b"Document");
+        memory.write_long(crate::memory::globals::addr::GHOST_WINDOW, UTILITY);
+
+        let ghosted = snapshots(&memory, &[UTILITY, 0, DOCUMENT]);
+        assert_eq!(
+            ghosted
+                .iter()
+                .map(|window| window.title.as_str())
+                .collect::<Vec<_>>(),
+            ["Utility", "Document"]
+        );
+        assert!(!ghosted[0].active);
+        assert!(ghosted[1].active);
+
+        memory.write_long(crate::memory::globals::addr::GHOST_WINDOW, 0);
+        let ordinary = snapshots(&memory, &[UTILITY, DOCUMENT]);
+        assert!(ordinary[0].active);
+        assert!(ordinary[1].active, "direct hilite remains visible");
+    }
+
+    #[test]
+    fn window_snapshot_accepts_documented_ff_booleans() {
+        let mut memory = SnapshotMemory::default();
+        for (window, visible, hilited) in [(0x1000, 0xFF, 0), (0x1200, 1, 0), (0x1400, 2, 2)] {
+            memory.write_window_flags(window, visible, hilited);
+        }
+
+        let result = snapshots(&memory, &[0x1000, 0x1200, 0x1400]);
+        assert!(result.iter().all(|window| window.visible));
+        assert!(result[0].active, "first visible list entry is front");
+        assert!(!result[1].active);
+        assert!(result[2].active, "every nonzero hilite value is true");
+    }
+
+    fn write_complete_window(memory: &mut SnapshotMemory, window: u32, color: bool) {
+        const PIXMAP_HANDLE: u32 = 0x3000;
+        const PIXMAP: u32 = 0x3100;
+        const STRUCTURE_HANDLE: u32 = 0x3200;
+        const STRUCTURE: u32 = 0x3300;
+        const VISIBLE_HANDLE: u32 = 0x3400;
+        const VISIBLE: u32 = 0x3500;
+        const UPDATE_HANDLE: u32 = 0x3600;
+        const UPDATE: u32 = 0x3700;
+        const TITLE_HANDLE: u32 = 0x3800;
+        const TITLE: u32 = 0x3900;
+
+        memory.write_window_flags(window, 0xFF, 0xFF);
+        memory.write_rect(window.wrapping_add(16), (10, 20, 30, 40));
+        if color {
+            memory.write_word(window.wrapping_add(6), 0xC000);
+            memory.write_long(window.wrapping_add(2), PIXMAP_HANDLE);
+            memory.write_long(PIXMAP_HANDLE, PIXMAP);
+            memory.write_word(PIXMAP.wrapping_add(6), (-100i16) as u16);
+            memory.write_word(PIXMAP.wrapping_add(8), (-200i16) as u16);
+        } else {
+            memory.write_word(window.wrapping_add(6), 0);
+            memory.write_word(window.wrapping_add(8), (-100i16) as u16);
+            memory.write_word(window.wrapping_add(10), (-200i16) as u16);
+        }
+        memory.write_long(
+            window.wrapping_add(WINDOW_STRUCTURE_RGN_OFFSET),
+            STRUCTURE_HANDLE,
+        );
+        memory.write_region(STRUCTURE_HANDLE, STRUCTURE, 10, (100, 200, 140, 250));
+        memory.write_long(window.wrapping_add(24), VISIBLE_HANDLE);
+        memory.write_region(VISIBLE_HANDLE, VISIBLE, 10, (5, 7, 15, 17));
+        memory.write_long(window.wrapping_add(WINDOW_UPDATE_RGN_OFFSET), UPDATE_HANDLE);
+        memory.write_region(UPDATE_HANDLE, UPDATE, 10, (101, 202, 111, 212));
+        memory.write_window_title(window, TITLE_HANDLE, TITLE, b"Window");
+    }
+
+    #[test]
+    fn window_snapshot_decodes_grafport_and_cgrafport_equivalently() {
+        let mut graf = SnapshotMemory::default();
+        let mut color = SnapshotMemory::default();
+        write_complete_window(&mut graf, 0x1000, false);
+        write_complete_window(&mut color, 0x1000, true);
+
+        let graf = snapshots(&graf, &[0x1000]);
+        let color = snapshots(&color, &[0x1000]);
+        assert_eq!(graf, color);
+        assert_eq!(graf[0].bounds, (110, 220, 130, 240));
+        assert_eq!(graf[0].visible_region, Some((105, 207, 115, 217)));
+        assert_eq!(graf[0].structure_bounds, Some((100, 200, 140, 250)));
+        assert_eq!(graf[0].update_region, Some((101, 202, 111, 212)));
+    }
+
+    #[test]
+    fn window_snapshot_has_one_explicit_malformed_projection() {
+        const WINDOW: u32 = u32::MAX - 32;
+        const BROKEN_PIXMAP_HANDLE: u32 = 0x900;
+        const STRUCTURE_HANDLE: u32 = 0xA00;
+        const STRUCTURE: u32 = 0xA20;
+        const TITLE_HANDLE: u32 = 0xB00;
+        const TITLE: u32 = 0xB20;
+        let mut memory = SnapshotMemory::default();
+        memory.write_word(WINDOW.wrapping_add(6), 0xC000);
+        memory.write_long(WINDOW.wrapping_add(2), BROKEN_PIXMAP_HANDLE);
+        memory.write_rect(WINDOW.wrapping_add(16), (10, 20, 30, 40));
+        memory.write_long(
+            WINDOW.wrapping_add(WINDOW_STRUCTURE_RGN_OFFSET),
+            STRUCTURE_HANDLE,
+        );
+        memory.write_region(STRUCTURE_HANDLE, STRUCTURE, 2, (1, 2, 5, 7));
+        memory.write_long(
+            WINDOW.wrapping_add(WINDOW_TITLE_HANDLE_OFFSET),
+            TITLE_HANDLE,
+        );
+        memory.write_long(TITLE_HANDLE, TITLE);
+        memory.write_byte(TITLE, 3);
+        memory.write_byte(TITLE.wrapping_add(1), b'A');
+        memory.write_byte(TITLE.wrapping_add(3), b'C');
+
+        let result = snapshots(&memory, &[WINDOW]);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].bounds, (10, 20, 30, 40));
+        assert_eq!(result[0].structure_bounds, Some((1, 2, 5, 7)));
+        assert_eq!(result[0].visible_region, None);
+        assert_eq!(result[0].update_region, None);
+        assert_eq!(result[0].title.as_bytes(), b"A\0C");
+        assert!(!result[0].visible);
+        assert!(!result[0].active);
+    }
+
+    #[test]
+    fn window_snapshot_returns_owned_data_without_mutating_input() {
+        let mut memory = SnapshotMemory::default();
+        memory.write_window_flags(0x1000, 0xFF, 0xFF);
+        memory.write_window_title(0x1000, 0x2000, 0x2100, b"Before");
+        let before = memory.clone();
+        let result = snapshots(&memory, &[0x1000]);
+        assert_eq!(memory, before);
+
+        memory.write_window_title(0x1000, 0x2000, 0x2100, b"After");
+        assert_eq!(result[0].title, "Before");
+        assert_eq!(snapshots(&memory, &[0x1000])[0].title, "After");
+    }
     #[test]
     fn occluders_are_only_eligible_windows_in_front_of_the_target() {
         assert_eq!(


### PR DESCRIPTION
Window snapshots previously selected separate classic and native implementations. The native path interpreted Boolean values differently and translated visible regions incorrectly when a port had a nonzero local origin. Host output now comes from one Window Manager projection over canonical window order and guest memory, with explicit GrafPort/CGrafPort decoding, GhostWindow handling, and consistent malformed-record behavior.

Deletes the runner's ISA branch and native snapshot helpers, plus the classic dispatcher projector. The public snapshot shape is unchanged. Real trap/import tests cover equivalent guest records, shared flat and sparse memory, actual mixed-ISA yield/return, and polling without memory, event, execution, or CPU mutation. The old native expressions are retained only as clearly labeled source-model regression evidence.

The real creation comparison also exposed different initial update regions. That separate Window Manager defect remains tracked in #1577; this change records the difference explicitly and does not claim identical creation or painting policy.

Validation: independent library suite with test-support passed 5,248 tests (three existing ignored). Matching structural guard passed. The same optimized showcase executable passed in both 68k and PowerPC configurations. Changed items were formatted sequentially on the memory-constrained local host. CI’s non-blocking formatting/lint job reports inherited formatting differences and two Clippy errors (`mut_from_ref` in `memory/address_space.rs`, `erasing_op` in an existing PPC test). Every file named by these failures is byte-identical to the PR base; no new failure from the snapshot patch was found. These checks are not being reported as passing.

Closes #1573.
