### PR TITLE
fix: share indexed horizontal reduction across graphics adapters

### DIFF
--- a/src/copy_bits.rs
+++ b/src/copy_bits.rs
@@ -262,8 +262,10 @@ pub(crate) enum RowCopyOutcome {
 
 /// Adapter facts which are not retained in [`RowCopy`]. Callers must keep
 /// using their existing path unless the request had no mask, its source bounds
-/// are original guest bounds rather than sanitized substitutes, and its raw
-/// mode is exactly `srcCopy` without the separately defined dither flag.
+/// are original guest bounds rather than sanitized substitutes, its destination
+/// bounds are authoritative, its missing palette map means known index identity,
+/// and its raw mode is exactly `srcCopy` without the separately defined dither
+/// flag.
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct Indexed8HorizontalSelection(());
 
@@ -271,9 +273,16 @@ impl Indexed8HorizontalSelection {
     pub(crate) fn from_adapter_facts(
         mask_free: bool,
         source_bounds_are_original: bool,
+        destination_bounds_are_authoritative: bool,
+        indexed_palette_identity_known: bool,
         raw_mode: u16,
     ) -> Option<Self> {
-        (mask_free && source_bounds_are_original && raw_mode == 0).then_some(Self(()))
+        (mask_free
+            && source_bounds_are_original
+            && destination_bounds_are_authoritative
+            && indexed_palette_identity_known
+            && raw_mode == 0)
+            .then_some(Self(()))
     }
 }
 
@@ -930,7 +939,7 @@ mod tests {
     }
 
     fn indexed_selection() -> Indexed8HorizontalSelection {
-        Indexed8HorizontalSelection::from_adapter_facts(true, true, 0).unwrap()
+        Indexed8HorizontalSelection::from_adapter_facts(true, true, true, true, 0).unwrap()
     }
 
     #[derive(Default)]
@@ -980,12 +989,20 @@ mod tests {
 
     #[test]
     fn indexed_horizontal_selection_requires_all_adapter_provenance() {
-        assert!(Indexed8HorizontalSelection::from_adapter_facts(true, true, 0).is_some());
-        for facts in [(false, true, 0), (true, false, 0), (true, true, 0x40)] {
-            assert!(
-                Indexed8HorizontalSelection::from_adapter_facts(facts.0, facts.1, facts.2)
-                    .is_none()
-            );
+        assert!(
+            Indexed8HorizontalSelection::from_adapter_facts(true, true, true, true, 0).is_some()
+        );
+        for facts in [
+            (false, true, true, true, 0),
+            (true, false, true, true, 0),
+            (true, true, false, true, 0),
+            (true, true, true, false, 0),
+            (true, true, true, true, 0x40),
+        ] {
+            assert!(Indexed8HorizontalSelection::from_adapter_facts(
+                facts.0, facts.1, facts.2, facts.3, facts.4
+            )
+            .is_none());
         }
     }
 
@@ -1003,7 +1020,8 @@ mod tests {
             clip: [0, 0, 1, 3],
             palette: None,
         };
-        let selection = Indexed8HorizontalSelection::from_adapter_facts(true, true, 0x40);
+        let selection =
+            Indexed8HorizontalSelection::from_adapter_facts(true, true, true, true, 0x40);
         assert_eq!(
             copy.execute_with_indexed8_horizontal(&mut memory, selection),
             RowCopyOutcome::Completed

--- a/src/copy_bits.rs
+++ b/src/copy_bits.rs
@@ -3,7 +3,124 @@
 //! ABI decoding, port/mask resolution and picture recording stay at the callers
 //! until their corresponding operation families migrate.
 
+use std::ops::Range;
+
 use crate::memory::{GuestAddressSpace, MacMemoryBus, MemoryBus};
+
+const INDEXED_8_GUARD_BYTES: usize = 4;
+const INDEXED_8_MAP_ENTRIES: usize = 256;
+
+/// Pure horizontal plan for the indexed 8-bit identity-palette shrink path.
+/// Destination indices are relative to the complete, unclipped destination
+/// rectangle. `source_range` is relative to the submitted source pixel.
+///
+/// Imaging With QuickDraw defines rectangle scaling, but not the indexed
+/// reducer. The truncated fixed-point carry and rounded source/guard/map
+/// prefix are measured compatibility behavior; the finite-prefix saturation
+/// follows from unsigned-byte maximum and the complete identity map.
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) struct Indexed8HorizontalShrink {
+    groups: Vec<Range<usize>>,
+    source_range: Range<usize>,
+    staged_len: usize,
+}
+
+impl Indexed8HorizontalShrink {
+    pub(crate) fn new(
+        source_width: usize,
+        destination_width: usize,
+        visible: Range<usize>,
+    ) -> Option<Self> {
+        if !(1..=i16::MAX as usize).contains(&source_width)
+            || destination_width == 0
+            || destination_width >= source_width
+            || visible.start > visible.end
+            || visible.end > destination_width
+        {
+            return None;
+        }
+
+        let source = i64::try_from(source_width).ok()?;
+        let destination = i64::try_from(destination_width).ok()?;
+        let step = destination.checked_mul(1 << 16)?.checked_div(source)?;
+        if step <= 0 {
+            return None;
+        }
+        let phase = step / 2;
+        let boundary = |index: usize| {
+            let numerator = i64::try_from(index)
+                .ok()?
+                .checked_mul(1 << 16)?
+                .checked_sub(phase)?;
+            let quotient = numerator.div_euclid(step);
+            let rounded = quotient.checked_add(i64::from(numerator.rem_euclid(step) != 0))?;
+            usize::try_from(rounded).ok()
+        };
+
+        let mut endpoints = Vec::with_capacity(visible.end - visible.start + 1);
+        for index in visible.start..=visible.end {
+            endpoints.push(boundary(index)?);
+        }
+        let groups: Vec<_> = endpoints.windows(2).map(|pair| pair[0]..pair[1]).collect();
+        if groups.iter().any(|group| group.is_empty()) {
+            return None;
+        }
+
+        let staged_len = source_width.checked_add(3)? & !3;
+        let source_range = match (groups.first(), groups.last()) {
+            (Some(first), Some(last)) => first.start.min(staged_len)..last.end.min(staged_len),
+            (None, None) => 0..0,
+            _ => return None,
+        };
+        Some(Self {
+            groups,
+            source_range,
+            staged_len,
+        })
+    }
+
+    pub(crate) fn groups(&self) -> &[Range<usize>] {
+        &self.groups
+    }
+
+    pub(crate) fn source_range(&self) -> Range<usize> {
+        self.source_range.clone()
+    }
+
+    /// Reduces an exact snapshot of `source_range`. The remaining arena is the
+    /// operation-owned zero guard followed by big-endian identity-map entries.
+    pub(crate) fn reduce(&self, staged_source: &[u8]) -> Option<Vec<u8>> {
+        if staged_source.len() != self.source_range.len() {
+            return None;
+        }
+        let map_start = self.staged_len.checked_add(INDEXED_8_GUARD_BYTES)?;
+        let prefix_end = map_start.checked_add(INDEXED_8_MAP_ENTRIES.checked_mul(4)?)?;
+        let mut output = Vec::with_capacity(self.groups.len());
+
+        for group in &self.groups {
+            let mut maximum = None;
+            for index in group.start..group.end.min(prefix_end) {
+                let value = if index < self.staged_len {
+                    let source_index = index.checked_sub(self.source_range.start)?;
+                    *staged_source.get(source_index)?
+                } else if index < map_start {
+                    0
+                } else {
+                    let map_offset = index - map_start;
+                    let entry = u32::try_from(map_offset / 4).ok()?;
+                    entry.to_be_bytes()[map_offset % 4]
+                };
+                maximum = Some(maximum.map_or(value, |current: u8| current.max(value)));
+            }
+            let maximum = maximum?;
+            if group.end > prefix_end && maximum != u8::MAX {
+                return None;
+            }
+            output.push(maximum);
+        }
+        Some(output)
+    }
+}
 
 pub(crate) trait CopyBitsMemory {
     fn read_copy_row(&mut self, address: u32, bytes: &mut [u8]) -> Option<()>;
@@ -338,6 +455,187 @@ mod tests {
 
     const SOURCE: u32 = 0x0100_0000;
     const DESTINATION: u32 = 0x0200_0000;
+
+    #[test]
+    fn indexed_horizontal_groups_match_independent_oracle_boundaries() {
+        for (source, destination, expected) in [
+            (3, 2, &[0..2, 2..3][..]),
+            (5, 3, &[0..2, 2..3, 3..5][..]),
+            (
+                17,
+                7,
+                &[0..2, 2..5, 5..7, 7..10, 10..12, 12..15, 15..17][..],
+            ),
+            (
+                17,
+                16,
+                &[
+                    0..1,
+                    1..2,
+                    2..3,
+                    3..4,
+                    4..5,
+                    5..6,
+                    6..7,
+                    7..9,
+                    9..10,
+                    10..11,
+                    11..12,
+                    12..13,
+                    13..14,
+                    14..15,
+                    15..16,
+                    16..17,
+                ][..],
+            ),
+        ] {
+            let plan = Indexed8HorizontalShrink::new(source, destination, 0..destination)
+                .expect("oracle geometry is supported");
+            assert_eq!(plan.groups(), expected);
+        }
+    }
+
+    #[test]
+    fn indexed_horizontal_boundaries_match_independent_carry_loop() {
+        for source in 2usize..=32 {
+            for destination in 1usize..source {
+                let step = (destination * (1 << 16) / source) as u16;
+                let mut error = step / 2;
+                let mut source_index = 0;
+                let mut expected = Vec::with_capacity(destination);
+                for _ in 0..destination {
+                    let start = source_index;
+                    loop {
+                        source_index += 1;
+                        let (next, carry) = error.overflowing_add(step);
+                        error = next;
+                        if carry {
+                            break;
+                        }
+                    }
+                    expected.push(start..source_index);
+                }
+                let plan = Indexed8HorizontalShrink::new(source, destination, 0..destination)
+                    .expect("small positive shrink is supported");
+                assert_eq!(
+                    plan.groups(),
+                    expected,
+                    "source={source}, destination={destination}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn indexed_horizontal_plan_uses_signed_zero_boundary_and_visible_groups() {
+        let first = Indexed8HorizontalShrink::new(285, 2, 0..1).unwrap();
+        assert_eq!(first.groups(), &[0..143]);
+        assert_eq!(first.source_range(), 0..143);
+
+        let last = Indexed8HorizontalShrink::new(285, 2, 1..2).unwrap();
+        assert_eq!(last.groups(), &[143..286]);
+        assert_eq!(last.source_range(), 143..286);
+
+        let clipped_away = Indexed8HorizontalShrink::new(190, 1, 0..0).unwrap();
+        assert!(clipped_away.groups().is_empty());
+        assert_eq!(clipped_away.source_range(), 0..0);
+        assert_eq!(clipped_away.reduce(&[]), Some(vec![]));
+    }
+
+    #[test]
+    fn indexed_horizontal_origin_residues_use_only_submitted_pixels() {
+        for residue in 0..4 {
+            let mut row = vec![0x11; 256];
+            row[..residue].fill(250);
+            row[residue..residue + 190].fill(20);
+            row[residue + 189] = 30;
+            row[residue + 190..residue + 193].copy_from_slice(&[200, 150, 140]);
+            let plan = Indexed8HorizontalShrink::new(190, 1, 0..1).unwrap();
+            assert_eq!(plan.groups(), &[0..191]);
+            assert_eq!(plan.source_range(), 0..191);
+            let range = plan.source_range();
+            assert_eq!(
+                plan.reduce(&row[residue + range.start..residue + range.end]),
+                Some(vec![200])
+            );
+
+            row.fill(0x11);
+            row[..residue].fill(250);
+            row[residue..residue + 191].fill(20);
+            row[residue + 190] = 30;
+            row[residue + 191..residue + 194].copy_from_slice(&[240, 150, 140]);
+            let plan = Indexed8HorizontalShrink::new(191, 1, 0..1).unwrap();
+            assert_eq!(plan.groups(), &[0..191]);
+            assert_eq!(plan.source_range(), 0..191);
+            let range = plan.source_range();
+            assert_eq!(
+                plan.reduce(&row[residue + range.start..residue + range.end]),
+                Some(vec![30])
+            );
+        }
+    }
+
+    #[test]
+    fn indexed_horizontal_owned_map_matches_large_trace_pixels() {
+        for (source_width, endpoint, expected) in [
+            (4_097, 4_369, 65),
+            (5_000, 5_041, 8),
+            (5_001, 5_041, 7),
+            (10_924, 13_107, u8::MAX),
+        ] {
+            let plan = Indexed8HorizontalShrink::new(source_width, 1, 0..1).unwrap();
+            assert_eq!(plan.groups(), &[0..endpoint]);
+            let range = plan.source_range();
+            assert_eq!(range.start, 0);
+            assert_eq!(
+                plan.reduce(&vec![0; range.len()]),
+                Some(vec![expected]),
+                "source_width={source_width}"
+            );
+        }
+    }
+
+    #[test]
+    fn indexed_horizontal_final_column_stays_bounded_near_signed_limit() {
+        let guarded = Indexed8HorizontalShrink::new(32_761, 2, 1..2).unwrap();
+        assert_eq!(guarded.groups(), &[16_384..32_768]);
+        assert_eq!(guarded.source_range(), 16_384..32_764);
+        let mut guarded_source = vec![0; guarded.source_range().len()];
+        *guarded_source.last_mut().unwrap() = 77;
+        assert_eq!(guarded.reduce(&guarded_source), Some(vec![77]));
+
+        let unrounded = Indexed8HorizontalShrink::new(32_767, 2, 1..2).unwrap();
+        assert_eq!(unrounded.groups(), &[16_384..32_768]);
+        assert_eq!(unrounded.source_range(), 16_384..32_768);
+        let mut unrounded_source = vec![0; unrounded.source_range().len()];
+        *unrounded_source.last_mut().unwrap() = 88;
+        assert_eq!(unrounded.reduce(&unrounded_source), Some(vec![88]));
+
+        let saturated = Indexed8HorizontalShrink::new(31_736, 2, 1..2).unwrap();
+        assert_eq!(saturated.groups(), &[16_384..32_768]);
+        assert_eq!(saturated.source_range(), 16_384..31_736);
+        assert_eq!(
+            saturated.reduce(&vec![0; saturated.source_range().len()]),
+            Some(vec![u8::MAX])
+        );
+    }
+
+    #[test]
+    fn indexed_horizontal_plan_rejects_unproved_domains_and_wrong_snapshot() {
+        for (source, destination, visible) in [
+            (0, 1, 0..1),
+            (1, 1, 0..1),
+            (1, 2, 0..2),
+            (i16::MAX as usize + 1, 1, 0..1),
+            (5, 3, 2..1),
+            (5, 3, 0..4),
+        ] {
+            assert!(Indexed8HorizontalShrink::new(source, destination, visible).is_none());
+        }
+        let plan = Indexed8HorizontalShrink::new(190, 1, 0..1).unwrap();
+        assert_eq!(plan.reduce(&vec![0; 190]), None);
+        assert_eq!(plan.reduce(&vec![0; 192]), None);
+    }
 
     fn run(memory: &mut GuestAddressSpace, classic: bool, copy: RowCopy<'_>) -> RowCopyOutcome {
         if classic {

--- a/src/copy_bits.rs
+++ b/src/copy_bits.rs
@@ -908,7 +908,7 @@ mod tests {
             (1, 1, 0..1),
             (1, 2, 0..2),
             (i16::MAX as usize + 1, 1, 0..1),
-            (5, 3, 2..1),
+            (5, 3, std::ops::Range { start: 2, end: 1 }),
             (5, 3, 0..4),
         ] {
             assert!(Indexed8HorizontalShrink::new(source, destination, visible).is_none());

--- a/src/copy_bits.rs
+++ b/src/copy_bits.rs
@@ -57,11 +57,17 @@ impl Indexed8HorizontalShrink {
             usize::try_from(rounded).ok()
         };
 
-        let mut endpoints = Vec::with_capacity(visible.end - visible.start + 1);
+        let endpoint_count = visible.end.checked_sub(visible.start)?.checked_add(1)?;
+        let mut endpoints = Vec::new();
+        endpoints.try_reserve_exact(endpoint_count).ok()?;
         for index in visible.start..=visible.end {
             endpoints.push(boundary(index)?);
         }
-        let groups: Vec<_> = endpoints.windows(2).map(|pair| pair[0]..pair[1]).collect();
+        let mut groups = Vec::new();
+        groups
+            .try_reserve_exact(endpoint_count.saturating_sub(1))
+            .ok()?;
+        groups.extend(endpoints.windows(2).map(|pair| pair[0]..pair[1]));
         if groups.iter().any(|group| group.is_empty()) {
             return None;
         }
@@ -95,7 +101,8 @@ impl Indexed8HorizontalShrink {
         }
         let map_start = self.staged_len.checked_add(INDEXED_8_GUARD_BYTES)?;
         let prefix_end = map_start.checked_add(INDEXED_8_MAP_ENTRIES.checked_mul(4)?)?;
-        let mut output = Vec::with_capacity(self.groups.len());
+        let mut output = Vec::new();
+        output.try_reserve_exact(self.groups.len()).ok()?;
 
         for group in &self.groups {
             let mut maximum = None;
@@ -117,6 +124,22 @@ impl Indexed8HorizontalShrink {
                 return None;
             }
             output.push(maximum);
+        }
+        Some(output)
+    }
+
+    fn reduce_rows(&self, snapshots: &[u8], row_count: usize) -> Option<Vec<u8>> {
+        let row_len = self.source_range.len();
+        if snapshots.len() != row_count.checked_mul(row_len)? {
+            return None;
+        }
+        let output_len = row_count.checked_mul(self.groups.len())?;
+        let mut output = Vec::new();
+        output.try_reserve_exact(output_len).ok()?;
+        for row_index in 0..row_count {
+            let start = row_index.checked_mul(row_len)?;
+            let end = start.checked_add(row_len)?;
+            output.extend_from_slice(&self.reduce(snapshots.get(start..end)?)?);
         }
         Some(output)
     }
@@ -237,7 +260,256 @@ pub(crate) enum RowCopyOutcome {
     WriteFailure { rows_written: usize },
 }
 
+/// Adapter facts which are not retained in [`RowCopy`]. Callers must keep
+/// using their existing path unless the request had no mask, its source bounds
+/// are original guest bounds rather than sanitized substitutes, and its raw
+/// mode is exactly `srcCopy` without the separately defined dither flag.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct Indexed8HorizontalSelection(());
+
+impl Indexed8HorizontalSelection {
+    pub(crate) fn from_adapter_facts(
+        mask_free: bool,
+        source_bounds_are_original: bool,
+        raw_mode: u16,
+    ) -> Option<Self> {
+        (mask_free && source_bounds_are_original && raw_mode == 0).then_some(Self(()))
+    }
+}
+
 impl RowCopy<'_> {
+    /// Adds the indexed horizontal family ahead of the existing shared paths.
+    /// The adapters still receive one final outcome and therefore cannot
+    /// accidentally fall back after a selected family has touched memory.
+    pub(crate) fn execute_with_indexed8_horizontal(
+        self,
+        memory: &mut impl CopyBitsMemory,
+        selection: Option<Indexed8HorizontalSelection>,
+    ) -> RowCopyOutcome {
+        if let Some(selection) = selection {
+            let outcome = self.execute_indexed8_horizontal(memory, selection);
+            if outcome != RowCopyOutcome::Declined {
+                return outcome;
+            }
+        }
+        self.execute(memory)
+    }
+
+    /// Executes the measured indexed 8-bit horizontal shrink family.
+    ///
+    /// Only [`RowCopyOutcome::Declined`] permits the adapter to try its old
+    /// path. Once this method selects the family, address/read failures and
+    /// partial writes remain terminal. Source spans for every visible row are
+    /// snapshotted before the first destination write, including physical
+    /// bytes beyond the declared source bounds and row stride.
+    fn execute_indexed8_horizontal(
+        &self,
+        memory: &mut impl CopyBitsMemory,
+        _selection: Indexed8HorizontalSelection,
+    ) -> RowCopyOutcome {
+        if self.mode != 0
+            || self.source.depth != 8
+            || self.destination.depth != 8
+            || self.palette.is_some()
+        {
+            return RowCopyOutcome::Declined;
+        }
+
+        if self
+            .source_rect
+            .iter()
+            .chain(self.destination_rect.iter())
+            .chain(self.source.bounds.iter())
+            .chain(self.destination.bounds.iter())
+            .chain(self.clip.iter())
+            .any(|&coordinate| i16::try_from(coordinate).is_err())
+        {
+            return RowCopyOutcome::Declined;
+        }
+
+        let [st, sl, sb, sr] = self.source_rect;
+        let [dt, dl, db, dr] = self.destination_rect;
+        let Some(source_width) = sr.checked_sub(sl) else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        let Some(source_height) = sb.checked_sub(st) else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        let Some(destination_width) = dr.checked_sub(dl) else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        let Some(destination_height) = db.checked_sub(dt) else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        if source_width <= 0
+            || source_height <= 0
+            || destination_width <= 0
+            || destination_height <= 0
+        {
+            return RowCopyOutcome::NoOp;
+        }
+        if destination_width >= source_width || destination_height != source_height {
+            return RowCopyOutcome::Declined;
+        }
+        if source_width > i32::from(i16::MAX) || source_height > i32::from(i16::MAX) {
+            return RowCopyOutcome::Declined;
+        }
+
+        let [sbt, sbl, sbb, _] = self.source.bounds;
+        let Some(source_bounds_height) = sbb.checked_sub(sbt) else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        if source_bounds_height <= 0 {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        }
+        if st < sbt || sb > sbb {
+            return RowCopyOutcome::Declined;
+        }
+        let Some(source_x_delta) = sl.checked_sub(sbl) else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        if i16::try_from(source_x_delta).is_err() {
+            return RowCopyOutcome::Declined;
+        }
+        // Classic QuickDraw's signed source-bounds-height gate is observed at
+        // 32767/32768 for this otherwise-selected family.
+        if source_bounds_height > i32::from(i16::MAX) {
+            return RowCopyOutcome::NoOp;
+        }
+
+        let [dbt, dbl, dbb, dbr] = self.destination.bounds;
+        let [ct, cl, cb, cr] = self.clip;
+        let top = dt.max(dbt).max(ct);
+        let left = dl.max(dbl).max(cl);
+        let bottom = db.min(dbb).min(cb);
+        let right = dr.min(dbr).min(cr);
+        if top >= bottom || left >= right {
+            return RowCopyOutcome::NoOp;
+        }
+
+        let Some(visible_start) = left
+            .checked_sub(dl)
+            .and_then(|value| usize::try_from(value).ok())
+        else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        let Some(visible_end) = right
+            .checked_sub(dl)
+            .and_then(|value| usize::try_from(value).ok())
+        else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        let Some(plan) = Indexed8HorizontalShrink::new(
+            source_width as usize,
+            destination_width as usize,
+            visible_start..visible_end,
+        ) else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        let source_range = plan.source_range();
+        let Some(row_count) = bottom
+            .checked_sub(top)
+            .and_then(|value| usize::try_from(value).ok())
+        else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        let Some(output_len) = right
+            .checked_sub(left)
+            .and_then(|value| usize::try_from(value).ok())
+        else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+
+        let mut addresses = Vec::new();
+        if addresses.try_reserve_exact(row_count).is_err() {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        }
+        for destination_y in top..bottom {
+            let Some(source_y) = destination_y
+                .checked_sub(dt)
+                .and_then(|offset| st.checked_add(offset))
+            else {
+                return RowCopyOutcome::ReadOrGeometryFailure;
+            };
+            let source_address = if source_range.is_empty() {
+                None
+            } else {
+                let Some(row_delta) = source_y.checked_sub(sbt).map(i64::from) else {
+                    return RowCopyOutcome::ReadOrGeometryFailure;
+                };
+                let Some(submitted_origin) = row_delta
+                    .checked_mul(i64::from(self.source.row_bytes))
+                    .and_then(|offset| i64::from(self.source.base).checked_add(offset))
+                    .and_then(|address| address.checked_add(i64::from(source_x_delta)))
+                else {
+                    return RowCopyOutcome::ReadOrGeometryFailure;
+                };
+                let Some(source_start) = i64::try_from(source_range.start)
+                    .ok()
+                    .and_then(|offset| submitted_origin.checked_add(offset))
+                else {
+                    return RowCopyOutcome::ReadOrGeometryFailure;
+                };
+                let Some(source_end) = i64::try_from(source_range.end)
+                    .ok()
+                    .and_then(|offset| submitted_origin.checked_add(offset))
+                else {
+                    return RowCopyOutcome::ReadOrGeometryFailure;
+                };
+                if source_start < 0 || source_end < source_start || source_end > (1i64 << 32) {
+                    return RowCopyOutcome::ReadOrGeometryFailure;
+                }
+                Some(source_start as u32)
+            };
+            let Some(destination_address) =
+                self.destination
+                    .row_address(left, destination_y, output_len)
+            else {
+                return RowCopyOutcome::ReadOrGeometryFailure;
+            };
+            addresses.push((source_address, destination_address));
+        }
+
+        let Some(snapshot_len) = row_count.checked_mul(source_range.len()) else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        let mut snapshots = Vec::new();
+        if snapshots.try_reserve_exact(snapshot_len).is_err() {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        }
+        snapshots.resize(snapshot_len, 0);
+        for (row_index, (source, _)) in addresses.iter().enumerate() {
+            let Some(start) = row_index.checked_mul(source_range.len()) else {
+                return RowCopyOutcome::ReadOrGeometryFailure;
+            };
+            let Some(end) = start.checked_add(source_range.len()) else {
+                return RowCopyOutcome::ReadOrGeometryFailure;
+            };
+            if let Some(source) = source {
+                if memory
+                    .read_copy_row(*source, &mut snapshots[start..end])
+                    .is_none()
+                {
+                    return RowCopyOutcome::ReadOrGeometryFailure;
+                }
+            }
+        }
+
+        let Some(output) = plan.reduce_rows(&snapshots, row_count) else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        for (rows_written, ((_, destination), row)) in addresses
+            .iter()
+            .zip(output.chunks_exact(output_len))
+            .enumerate()
+        {
+            if memory.write_copy_row(*destination, row).is_none() {
+                return RowCopyOutcome::WriteFailure { rows_written };
+            }
+        }
+        RowCopyOutcome::Completed
+    }
+
     /// Snapshot all source rows before writing, including across different
     /// addresses that alias the same backing. Geometry/read failures write
     /// nothing. A destination failure preserves that row but may follow rows
@@ -655,6 +927,340 @@ mod tests {
             depth,
             bounds,
         }
+    }
+
+    fn indexed_selection() -> Indexed8HorizontalSelection {
+        Indexed8HorizontalSelection::from_adapter_facts(true, true, 0).unwrap()
+    }
+
+    #[derive(Default)]
+    struct SparseMemory {
+        bytes: std::collections::BTreeMap<u32, u8>,
+        fail_read: Option<u32>,
+        fail_write: Option<u32>,
+        writes: Vec<u32>,
+    }
+
+    impl SparseMemory {
+        fn insert(&mut self, address: u32, bytes: &[u8]) {
+            for (offset, byte) in bytes.iter().copied().enumerate() {
+                self.bytes.insert(address + offset as u32, byte);
+            }
+        }
+
+        fn bytes(&self, address: u32, len: usize) -> Vec<u8> {
+            (0..len)
+                .map(|offset| self.bytes[&(address + offset as u32)])
+                .collect()
+        }
+    }
+
+    impl CopyBitsMemory for SparseMemory {
+        fn read_copy_row(&mut self, address: u32, bytes: &mut [u8]) -> Option<()> {
+            if self.fail_read == Some(address) {
+                return None;
+            }
+            for (offset, byte) in bytes.iter_mut().enumerate() {
+                *byte = *self.bytes.get(&address.checked_add(offset as u32)?)?;
+            }
+            Some(())
+        }
+
+        fn write_copy_row(&mut self, address: u32, bytes: &[u8]) -> Option<()> {
+            if self.fail_write == Some(address) {
+                return None;
+            }
+            self.writes.push(address);
+            for (offset, byte) in bytes.iter().copied().enumerate() {
+                self.bytes.insert(address.checked_add(offset as u32)?, byte);
+            }
+            Some(())
+        }
+    }
+
+    #[test]
+    fn indexed_horizontal_selection_requires_all_adapter_provenance() {
+        assert!(Indexed8HorizontalSelection::from_adapter_facts(true, true, 0).is_some());
+        for facts in [(false, true, 0), (true, false, 0), (true, true, 0x40)] {
+            assert!(
+                Indexed8HorizontalSelection::from_adapter_facts(facts.0, facts.1, facts.2)
+                    .is_none()
+            );
+        }
+    }
+
+    #[test]
+    fn indexed_horizontal_raw_dither_flag_keeps_existing_unscaled_route() {
+        let mut memory = SparseMemory::default();
+        memory.insert(SOURCE, &[1, 2, 3, 0xaa]);
+        memory.insert(DESTINATION, &[0xaa; 4]);
+        let copy = RowCopy {
+            mode: 0,
+            source: pixmap(SOURCE, 4, 8, [0, 0, 1, 3]),
+            destination: pixmap(DESTINATION, 4, 8, [0, 0, 1, 3]),
+            source_rect: [0, 0, 1, 3],
+            destination_rect: [0, 0, 1, 3],
+            clip: [0, 0, 1, 3],
+            palette: None,
+        };
+        let selection = Indexed8HorizontalSelection::from_adapter_facts(true, true, 0x40);
+        assert_eq!(
+            copy.execute_with_indexed8_horizontal(&mut memory, selection),
+            RowCopyOutcome::Completed
+        );
+        assert_eq!(memory.bytes(DESTINATION, 4), [1, 2, 3, 0xaa]);
+    }
+
+    #[test]
+    fn indexed_horizontal_global_clip_reads_only_final_physical_ranges() {
+        let mut memory = SparseMemory::default();
+        // The submitted row origins are -1 and 7. Clipping away destination
+        // column zero makes the required physical starts 1 and 9, both valid.
+        memory.insert(1, &[22, 23, 24, 25, 26]);
+        memory.insert(9, &[32, 33, 34, 35, 36]);
+        memory.insert(DESTINATION, &[0xaa; 8]);
+        let copy = RowCopy {
+            mode: 0,
+            source: pixmap(1, 8, 8, [0, 8, 2, 13]),
+            destination: pixmap(DESTINATION, 4, 8, [0, 20, 2, 23]),
+            source_rect: [0, 6, 2, 13],
+            destination_rect: [0, 20, 2, 23],
+            clip: [0, 21, 2, 23],
+            palette: None,
+        };
+        assert_eq!(
+            copy.execute_with_indexed8_horizontal(&mut memory, Some(indexed_selection())),
+            RowCopyOutcome::Completed
+        );
+        assert_eq!(
+            memory.bytes(DESTINATION, 8),
+            [0xaa, 24, 26, 0xaa, 0xaa, 34, 36, 0xaa]
+        );
+    }
+
+    #[test]
+    fn indexed_horizontal_snapshots_all_aliasing_rows_before_writes() {
+        let mut memory = SparseMemory::default();
+        memory.insert(
+            SOURCE,
+            &[
+                1, 9, 2, 3, 4, 0xaa, 0xaa, 0xaa, 5, 1, 6, 0, 7, 0xaa, 0xaa, 0xaa,
+            ],
+        );
+        let copy = RowCopy {
+            mode: 0,
+            source: pixmap(SOURCE, 8, 8, [0, 0, 2, 5]),
+            destination: pixmap(SOURCE + 8, 3, 8, [0, 0, 2, 3]),
+            source_rect: [0, 0, 2, 5],
+            destination_rect: [0, 0, 2, 3],
+            clip: [0, 0, 2, 3],
+            palette: None,
+        };
+        assert_eq!(
+            copy.execute_with_indexed8_horizontal(&mut memory, Some(indexed_selection())),
+            RowCopyOutcome::Completed
+        );
+        assert_eq!(memory.bytes(SOURCE + 8, 6), [9, 2, 4, 5, 6, 7]);
+    }
+
+    #[test]
+    fn indexed_horizontal_snapshots_declared_same_row_overlap() {
+        let mut memory = SparseMemory::default();
+        memory.insert(SOURCE, &[1, 9, 2, 3, 4, 0xaa, 0xaa, 0xaa]);
+        let copy = RowCopy {
+            mode: 0,
+            source: pixmap(SOURCE, 8, 8, [0, 0, 1, 5]),
+            destination: pixmap(SOURCE + 1, 3, 8, [0, 0, 1, 3]),
+            source_rect: [0, 0, 1, 5],
+            destination_rect: [0, 0, 1, 3],
+            clip: [0, 0, 1, 3],
+            palette: None,
+        };
+        assert_eq!(
+            copy.execute_with_indexed8_horizontal(&mut memory, Some(indexed_selection())),
+            RowCopyOutcome::Completed
+        );
+        assert_eq!(memory.bytes(SOURCE, 5), [1, 9, 2, 4, 4]);
+    }
+
+    #[test]
+    fn indexed_horizontal_snapshots_rounded_tail_overlap() {
+        let mut memory = SparseMemory::default();
+        let mut backing = vec![10; 381];
+        backing[0] = 100;
+        backing[190..380].fill(20);
+        backing[190] = 80;
+        backing[380] = 90;
+        memory.insert(SOURCE, &backing);
+        let copy = RowCopy {
+            mode: 0,
+            source: pixmap(SOURCE, 190, 8, [0, 0, 2, 190]),
+            destination: pixmap(SOURCE + 190, 1, 8, [0, 0, 2, 1]),
+            source_rect: [0, 0, 2, 190],
+            destination_rect: [0, 0, 2, 1],
+            clip: [0, 0, 2, 1],
+            palette: None,
+        };
+        assert_eq!(
+            copy.execute_with_indexed8_horizontal(&mut memory, Some(indexed_selection())),
+            RowCopyOutcome::Completed
+        );
+        assert_eq!(memory.bytes(SOURCE + 190, 2), [100, 90]);
+    }
+
+    #[test]
+    fn indexed_horizontal_read_failure_is_prewrite_and_write_failure_is_partial() {
+        let request = || RowCopy {
+            mode: 0,
+            source: pixmap(SOURCE, 8, 8, [0, 0, 2, 5]),
+            destination: pixmap(DESTINATION, 3, 8, [0, 0, 2, 3]),
+            source_rect: [0, 0, 2, 5],
+            destination_rect: [0, 0, 2, 3],
+            clip: [0, 0, 2, 3],
+            palette: None,
+        };
+
+        let mut read_failure = SparseMemory::default();
+        read_failure.insert(SOURCE, &[1, 2, 3, 4, 5]);
+        read_failure.insert(SOURCE + 8, &[6, 7, 8, 9, 10]);
+        read_failure.insert(DESTINATION, &[0xaa; 6]);
+        read_failure.fail_read = Some(SOURCE + 8);
+        assert_eq!(
+            request()
+                .execute_with_indexed8_horizontal(&mut read_failure, Some(indexed_selection()),),
+            RowCopyOutcome::ReadOrGeometryFailure
+        );
+        assert!(read_failure.writes.is_empty());
+        assert_eq!(read_failure.bytes(DESTINATION, 6), [0xaa; 6]);
+
+        let mut write_failure = SparseMemory::default();
+        write_failure.insert(SOURCE, &[1, 2, 3, 4, 5]);
+        write_failure.insert(SOURCE + 8, &[6, 7, 8, 9, 10]);
+        write_failure.insert(DESTINATION, &[0xaa; 6]);
+        write_failure.fail_write = Some(DESTINATION + 3);
+        assert_eq!(
+            request()
+                .execute_with_indexed8_horizontal(&mut write_failure, Some(indexed_selection()),),
+            RowCopyOutcome::WriteFailure { rows_written: 1 }
+        );
+        assert_eq!(write_failure.writes, [DESTINATION]);
+        assert_eq!(
+            write_failure.bytes(DESTINATION, 6),
+            [2, 3, 5, 0xaa, 0xaa, 0xaa]
+        );
+
+        let mut first_write_failure = SparseMemory::default();
+        first_write_failure.insert(SOURCE, &[1, 2, 3, 4, 5]);
+        first_write_failure.insert(SOURCE + 8, &[6, 7, 8, 9, 10]);
+        first_write_failure.insert(DESTINATION, &[0xaa; 6]);
+        first_write_failure.fail_write = Some(DESTINATION);
+        assert_eq!(
+            request().execute_with_indexed8_horizontal(
+                &mut first_write_failure,
+                Some(indexed_selection()),
+            ),
+            RowCopyOutcome::WriteFailure { rows_written: 0 }
+        );
+        assert!(first_write_failure.writes.is_empty());
+        assert_eq!(first_write_failure.bytes(DESTINATION, 6), [0xaa; 6]);
+    }
+
+    #[test]
+    fn indexed_horizontal_signed_source_height_is_noop_without_memory_access() {
+        struct NoAccess;
+        impl CopyBitsMemory for NoAccess {
+            fn read_copy_row(&mut self, _: u32, _: &mut [u8]) -> Option<()> {
+                panic!("signed-height no-op reached source memory");
+            }
+
+            fn write_copy_row(&mut self, _: u32, _: &[u8]) -> Option<()> {
+                panic!("signed-height no-op reached destination memory");
+            }
+        }
+
+        let copy = RowCopy {
+            mode: 0,
+            source: pixmap(SOURCE, 8, 8, [-1, 0, 32_767, 7]),
+            destination: pixmap(DESTINATION, 3, 8, [0, 0, 1, 3]),
+            source_rect: [-1, 0, 0, 7],
+            destination_rect: [0, 0, 1, 3],
+            clip: [0, 0, 1, 3],
+            palette: None,
+        };
+        assert_eq!(
+            copy.execute_with_indexed8_horizontal(&mut NoAccess, Some(indexed_selection())),
+            RowCopyOutcome::NoOp
+        );
+    }
+
+    #[test]
+    fn indexed_horizontal_wide_relative_origin_declines_without_memory_access() {
+        struct NoAccess;
+        impl CopyBitsMemory for NoAccess {
+            fn read_copy_row(&mut self, _: u32, _: &mut [u8]) -> Option<()> {
+                panic!("declined wide origin reached source memory");
+            }
+
+            fn write_copy_row(&mut self, _: u32, _: &[u8]) -> Option<()> {
+                panic!("declined wide origin reached destination memory");
+            }
+        }
+
+        let copy = RowCopy {
+            mode: 0,
+            source: pixmap(SOURCE, 8, 8, [0, i16::MIN.into(), 1, -32_760]),
+            destination: pixmap(DESTINATION, 3, 8, [0, 0, 1, 3]),
+            source_rect: [0, 1, 1, 6],
+            destination_rect: [0, 0, 1, 3],
+            clip: [0, 0, 1, 3],
+            palette: None,
+        };
+        assert_eq!(
+            copy.execute_with_indexed8_horizontal(&mut NoAccess, Some(indexed_selection())),
+            RowCopyOutcome::Declined
+        );
+
+        let tall_copy = RowCopy {
+            mode: 0,
+            source: pixmap(SOURCE, 8, 8, [-1, i16::MIN.into(), 32_767, -32_760]),
+            destination: pixmap(DESTINATION, 3, 8, [0, 0, 1, 3]),
+            source_rect: [-1, 1, 0, 6],
+            destination_rect: [0, 0, 1, 3],
+            clip: [0, 0, 1, 3],
+            palette: None,
+        };
+        assert_eq!(
+            tall_copy.execute_with_indexed8_horizontal(&mut NoAccess, Some(indexed_selection())),
+            RowCopyOutcome::Declined
+        );
+    }
+
+    #[test]
+    fn indexed_horizontal_invalid_final_range_fails_before_memory_access() {
+        struct NoAccess;
+        impl CopyBitsMemory for NoAccess {
+            fn read_copy_row(&mut self, _: u32, _: &mut [u8]) -> Option<()> {
+                panic!("invalid final range reached source memory");
+            }
+
+            fn write_copy_row(&mut self, _: u32, _: &[u8]) -> Option<()> {
+                panic!("invalid final range reached destination memory");
+            }
+        }
+
+        let copy = RowCopy {
+            mode: 0,
+            source: pixmap(u32::MAX - 1, 8, 8, [0, 0, 1, 5]),
+            destination: pixmap(DESTINATION, 3, 8, [0, 0, 1, 3]),
+            source_rect: [0, 0, 1, 5],
+            destination_rect: [0, 0, 1, 3],
+            clip: [0, 0, 1, 3],
+            palette: None,
+        };
+        assert_eq!(
+            copy.execute_with_indexed8_horizontal(&mut NoAccess, Some(indexed_selection())),
+            RowCopyOutcome::ReadOrGeometryFailure
+        );
     }
 
     #[test]

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -102640,7 +102640,8 @@ pub(crate) mod tests {
                 BLR,
             ],
         );
-        let descriptor_bytes = ppc_memory_read_bytes(&mut loaded.memory, descriptor, 0x100).unwrap();
+        let descriptor_bytes =
+            ppc_memory_read_bytes(&mut loaded.memory, descriptor, 0x100).unwrap();
         let ref_num = *loaded.process_file_system.current_resource_file;
         loaded.process_file_system.vfs_resources.extend([
             PpcVfsResourceRecord {
@@ -102843,8 +102844,7 @@ pub(crate) mod tests {
                 BLR,
             ],
         );
-        let descriptor_bytes =
-            ppc_memory_read_bytes(&mut loaded.memory, descriptor, 0x100).unwrap();
+        let descriptor_bytes = ppc_memory_read_bytes(&mut loaded.memory, descriptor, 0x100).unwrap();
         let ref_num = *loaded.process_file_system.current_resource_file;
         loaded.process_file_system.vfs_resources.extend([
             PpcVfsResourceRecord {

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -153024,6 +153024,172 @@ pub(crate) mod tests {
         );
     }
 
+    fn run_ppc_indexed_horizontal_oracle_case(
+        source_width: u16,
+        destination_width: u16,
+        source_left: u16,
+        source_row: &[u8],
+    ) -> Vec<u8> {
+        let pef = synthetic_pef_with_import(b"CopyBits");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let scratch = PPC_HEAP_BASE + 0x16800;
+        let source_stride = (source_row.len() + 1) & !1;
+        let destination_stride = (usize::from(destination_width) + 5) & !1;
+        let dst_pixels = scratch + u32::try_from((source_stride + 0x3f) & !0x3f).unwrap();
+        let records = dst_pixels + u32::try_from(destination_stride).unwrap() + 0x20;
+        let src_pixmap = records;
+        let dst_pixmap = records + 0x40;
+        let rects = records + 0x80;
+        let allocation_size = usize::try_from(rects + 0x10 - scratch).unwrap();
+        loaded.memory.add_region(scratch, vec![0; allocation_size]);
+        ppc_write_pixmap(
+            &mut loaded.memory,
+            src_pixmap,
+            scratch,
+            source_stride as u32,
+            0,
+            0,
+            1,
+            (source_left + source_width) as i16,
+            8,
+        )
+        .unwrap();
+        ppc_write_pixmap(
+            &mut loaded.memory,
+            dst_pixmap,
+            dst_pixels,
+            destination_stride as u32,
+            0,
+            0,
+            1,
+            destination_width as i16,
+            8,
+        )
+        .unwrap();
+        loaded.memory.write_bytes(scratch, source_row).unwrap();
+        loaded
+            .memory
+            .write_bytes(dst_pixels, &vec![0xa5; destination_stride])
+            .unwrap();
+        ppc_write_rect(
+            &mut loaded.memory,
+            rects,
+            0,
+            source_left as i16,
+            1,
+            (source_left + source_width) as i16,
+        )
+        .unwrap();
+        ppc_write_rect(
+            &mut loaded.memory,
+            rects + 8,
+            0,
+            0,
+            1,
+            destination_width as i16,
+        )
+        .unwrap();
+        loaded.cpu.gpr[3] = src_pixmap;
+        loaded.cpu.gpr[4] = dst_pixmap;
+        loaded.cpu.gpr[5] = rects;
+        loaded.cpu.gpr[6] = rects + 8;
+        loaded.cpu.gpr[7] = 0;
+        loaded.cpu.gpr[8] = 0;
+
+        let probe = loaded.run_with_hle_imports(64);
+
+        assert_eq!(probe.handled_import_count, 1);
+        assert_eq!(probe.unsupported_import_index, None);
+        let mut copied = vec![0; destination_stride];
+        loaded
+            .memory
+            .read_bytes_into(dst_pixels, &mut copied)
+            .unwrap();
+        copied
+    }
+
+    fn ppc_indexed_horizontal_tail_low(source_width: usize) -> Vec<u8> {
+        let mut row = vec![200; (source_width + 3) & !3];
+        row[source_width - 1] = 0;
+        row[source_width] = 254;
+        row
+    }
+
+    fn ppc_indexed_horizontal_nonmonotonic(source_width: usize, case_index: usize) -> Vec<u8> {
+        let mut row = vec![0; (source_width + 3) & !3];
+        for (position, value) in row[..source_width].iter_mut().enumerate() {
+            *value = ((position * 73 + case_index * 19) % 251 + 1) as u8;
+        }
+        row[source_width] = 254;
+        row
+    }
+
+    #[test]
+    fn hle_import_runner_copybits_matches_large_indexed_horizontal_oracles() {
+        // Literal results from controlled Mac OS 8.1 CopyBits and StdBits
+        // captures. The tail-low rows isolate the staged physical tail; the
+        // nonmonotonic rows use the captured position encoding verbatim.
+        for source_left in 0..4u16 {
+            let mut row = vec![0x11; usize::from(source_left) + 194];
+            row[..usize::from(source_left)].fill(250);
+            row[usize::from(source_left)..usize::from(source_left) + 190].fill(20);
+            row[usize::from(source_left) + 189] = 30;
+            row[usize::from(source_left) + 190..usize::from(source_left) + 193]
+                .copy_from_slice(&[200, 150, 140]);
+            let actual = run_ppc_indexed_horizontal_oracle_case(190, 1, source_left, &row);
+            assert_eq!(actual[0], 200, "190->1, source_left={source_left}");
+            assert!(actual[1..].iter().all(|&byte| byte == 0xa5));
+
+            row.fill(0x11);
+            row[..usize::from(source_left)].fill(250);
+            row[usize::from(source_left)..usize::from(source_left) + 191].fill(20);
+            row[usize::from(source_left) + 190] = 30;
+            row[usize::from(source_left) + 191..usize::from(source_left) + 194]
+                .copy_from_slice(&[240, 150, 140]);
+            let actual = run_ppc_indexed_horizontal_oracle_case(191, 1, source_left, &row);
+            assert_eq!(actual[0], 30, "191->1, source_left={source_left}");
+            assert!(actual[1..].iter().all(|&byte| byte == 0xa5));
+        }
+
+        for (source_width, destination_width, source, expected) in [
+            (
+                285,
+                2,
+                ppc_indexed_horizontal_tail_low(285),
+                &[200, 254][..],
+            ),
+            (
+                285,
+                2,
+                ppc_indexed_horizontal_nonmonotonic(285, 1),
+                &[251, 254][..],
+            ),
+            (
+                511,
+                3,
+                ppc_indexed_horizontal_tail_low(511),
+                &[200, 200, 254][..],
+            ),
+            (
+                511,
+                3,
+                ppc_indexed_horizontal_nonmonotonic(511, 7),
+                &[251, 249, 254][..],
+            ),
+        ] {
+            let actual =
+                run_ppc_indexed_horizontal_oracle_case(source_width, destination_width, 0, &source);
+            assert_eq!(&actual[..expected.len()], expected);
+            assert!(actual[expected.len()..].iter().all(|&byte| byte == 0xa5));
+        }
+
+        for (source_width, expected) in [(4_097, 65), (5_000, 8), (5_001, 7), (10_924, u8::MAX)] {
+            let source = vec![0; (source_width + 3) & !3];
+            let actual = run_ppc_indexed_horizontal_oracle_case(source_width as u16, 1, 0, &source);
+            assert_eq!(actual[0], expected, "{source_width}->1");
+            assert!(actual[1..].iter().all(|&byte| byte == 0xa5));
+        }
+    }
     #[test]
     fn hle_import_runner_copybits_does_not_select_unresolved_equal_fallback_cluts() {
         let pef = synthetic_pef_with_import(b"CopyBits");

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -3353,6 +3353,13 @@ struct PpcPixMapBits {
     depth: u32,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PpcResolvedPixMapBits {
+    bits: PpcPixMapBits,
+    guest_bounds: bool,
+    authoritative_bounds: bool,
+}
+
 #[derive(Debug, Default)]
 pub(crate) struct PpcProcessMemoryManager(SharedProcessMemoryManager);
 
@@ -57024,6 +57031,14 @@ fn ppc_resolve_pixmap_bits(
     gworlds: &[PpcGWorldRecord],
     bits_ptr: u32,
 ) -> Option<PpcPixMapBits> {
+    ppc_resolve_pixmap_bits_with_provenance(memory, gworlds, bits_ptr).map(|resolved| resolved.bits)
+}
+
+fn ppc_resolve_pixmap_bits_with_provenance(
+    memory: &mut PpcSectionMem,
+    gworlds: &[PpcGWorldRecord],
+    bits_ptr: u32,
+) -> Option<PpcResolvedPixMapBits> {
     if bits_ptr == 0 {
         return None;
     }
@@ -57040,7 +57055,7 @@ fn ppc_resolve_pixmap_bits(
         if record.port == bits_ptr || record.port.checked_add(2) == Some(bits_ptr) {
             let surface = ppc_live_quickdraw_surface(memory, gworlds, record.port)?;
             let front = surface.front_buffer;
-            return Some(PpcPixMapBits {
+            let bits = PpcPixMapBits {
                 base_addr: front.base_addr,
                 row_bytes: front.row_bytes,
                 top: surface.top,
@@ -57054,6 +57069,14 @@ fn ppc_resolve_pixmap_bits(
                 width: front.width,
                 height: front.height,
                 depth: front.depth,
+            };
+            let exact_bottom = i64::from(surface.top) + i64::from(front.height);
+            let exact_right = i64::from(surface.left) + i64::from(front.width);
+            return Some(PpcResolvedPixMapBits {
+                bits,
+                guest_bounds: false,
+                authoritative_bounds: i16::try_from(exact_bottom).is_ok()
+                    && i16::try_from(exact_right).is_ok(),
             });
         }
         let bits = if record.pixmap_handle == bits_ptr {
@@ -57061,14 +57084,36 @@ fn ppc_resolve_pixmap_bits(
         } else {
             ppc_read_pixmap_bits(memory, record.pixmap)
         };
-        return bits.or_else(|| ppc_pixmap_bits_from_record(record));
+        return bits
+            .map(|bits| PpcResolvedPixMapBits {
+                bits,
+                guest_bounds: true,
+                authoritative_bounds: true,
+            })
+            .or_else(|| {
+                ppc_pixmap_bits_from_record(record).map(|bits| PpcResolvedPixMapBits {
+                    bits,
+                    guest_bounds: false,
+                    authoritative_bounds: i16::try_from(record.height).is_ok()
+                        && i16::try_from(record.width).is_ok(),
+                })
+            });
     }
     if let Some(bits) = ppc_read_pixmap_bits(memory, bits_ptr) {
-        return Some(bits);
+        return Some(PpcResolvedPixMapBits {
+            bits,
+            guest_bounds: true,
+            authoritative_bounds: true,
+        });
     }
     let pixmap_or_handle = memory.read_u32_be(bits_ptr)?;
     ppc_read_pixmap_bits(memory, pixmap_or_handle)
         .or_else(|| ppc_read_pixmap_handle_bits(memory, pixmap_or_handle))
+        .map(|bits| PpcResolvedPixMapBits {
+            bits,
+            guest_bounds: true,
+            authoritative_bounds: true,
+        })
 }
 
 fn ppc_read_pixmap_raw_pixel(
@@ -57299,6 +57344,20 @@ fn ppc_resolve_pixmap_ctable_handle(
     gworlds: &[PpcGWorldRecord],
     bits_ptr: u32,
 ) -> Option<u32> {
+    ppc_resolve_pixmap_ctable_handle_with_provenance(memory, gworlds, bits_ptr).handle
+}
+
+#[derive(Clone, Copy)]
+struct PpcOptionalHandleResolution {
+    handle: Option<u32>,
+    known: bool,
+}
+
+fn ppc_resolve_pixmap_ctable_handle_with_provenance(
+    memory: &mut PpcSectionMem,
+    gworlds: &[PpcGWorldRecord],
+    bits_ptr: u32,
+) -> PpcOptionalHandleResolution {
     let tracked_pixmap = gworlds.iter().find_map(|record| {
         if record.pixmap == bits_ptr {
             return Some(record.pixmap);
@@ -57328,11 +57387,26 @@ fn ppc_resolve_pixmap_ctable_handle(
             .and_then(|row_bytes| memory.read_u16_be(row_bytes))
             .filter(|row_bytes| row_bytes & 0x8000 != 0)
             .map(|_| indirect)
-    })?;
-    pixmap
+    });
+    let Some(pixmap) = pixmap else {
+        return PpcOptionalHandleResolution {
+            handle: None,
+            known: false,
+        };
+    };
+    let raw_handle = pixmap
         .checked_add(42)
-        .and_then(|pm_table| memory.read_u32_be(pm_table))
-        .filter(|ctable_handle| *ctable_handle != 0)
+        .and_then(|pm_table| memory.read_u32_be(pm_table));
+    let Some(raw_handle) = raw_handle else {
+        return PpcOptionalHandleResolution {
+            handle: None,
+            known: false,
+        };
+    };
+    PpcOptionalHandleResolution {
+        handle: (raw_handle != 0).then_some(raw_handle),
+        known: true,
+    }
 }
 
 fn ppc_color_tables_share_index_space(
@@ -57378,14 +57452,25 @@ fn ppc_copy_bits_clut(
     ctable_handle: u32,
     color_manager_clut: &[[u16; 3]; 256],
 ) -> [[u16; 3]; 256] {
+    ppc_copy_bits_clut_with_provenance(memory, ctable_handle, color_manager_clut).0
+}
+
+fn ppc_copy_bits_clut_with_provenance(
+    memory: &mut PpcSectionMem,
+    ctable_handle: u32,
+    color_manager_clut: &[[u16; 3]; 256],
+) -> ([[u16; 3]; 256], bool) {
     if ctable_handle == 0 {
-        return *color_manager_clut;
+        return (*color_manager_clut, true);
     }
     // Inside Macintosh Volume V (1986), p. V-143: SetEntries updates the
     // current GDevice's ColorTable as well as its hardware lookup table.
     // Read even the main device table from guest memory so CopyBits sees
     // palette animation instead of the immutable startup palette.
-    ppc_read_ctable_clut(memory, ctable_handle, color_manager_clut).unwrap_or(*color_manager_clut)
+    match ppc_read_ctable_clut(memory, ctable_handle, color_manager_clut) {
+        Some(clut) => (clut, true),
+        None => (*color_manager_clut, false),
+    }
 }
 
 fn ppc_copy_bits_palette_index_map(
@@ -57641,14 +57726,20 @@ fn ppc_copy_bits(
             reason = "unsupported-mode";
             return None;
         }
-        let Some(src_bits) = ppc_resolve_pixmap_bits(memory, gworlds, src_bits_ptr) else {
+        let Some(src_resolved) =
+            ppc_resolve_pixmap_bits_with_provenance(memory, gworlds, src_bits_ptr)
+        else {
             reason = "src-bits";
             return None;
         };
-        let Some(dst_bits) = ppc_resolve_pixmap_bits(memory, gworlds, dst_bits_ptr) else {
+        let Some(dst_resolved) =
+            ppc_resolve_pixmap_bits_with_provenance(memory, gworlds, dst_bits_ptr)
+        else {
             reason = "dst-bits";
             return None;
         };
+        let src_bits = src_resolved.bits;
+        let dst_bits = dst_resolved.bits;
         let transparent = mode == 36;
         let supported_source = matches!(src_bits.depth, 1 | 2 | 4 | 8 | 16);
         let supported_destination = matches!(dst_bits.depth, 1 | 2 | 4 | 8 | 16);
@@ -57665,19 +57756,35 @@ fn ppc_copy_bits(
             reason = "depth";
             return None;
         }
-        let src_ctable = ppc_resolve_pixmap_ctable_handle(memory, gworlds, src_bits_ptr);
-        let dst_ctable = ppc_resolve_pixmap_ctable_handle(memory, gworlds, dst_bits_ptr);
+        let src_ctable_resolution =
+            ppc_resolve_pixmap_ctable_handle_with_provenance(memory, gworlds, src_bits_ptr);
+        let dst_ctable_resolution =
+            ppc_resolve_pixmap_ctable_handle_with_provenance(memory, gworlds, dst_bits_ptr);
+        // Keep the legacy Option values below: unreadable lookup metadata has
+        // always fallen back to the Color Manager table. The additional
+        // provenance only prevents that fallback from selecting the new raw
+        // indexed reducer as if a readable nil pmTable had been observed.
+        let src_ctable = src_ctable_resolution.handle;
+        let dst_ctable = dst_ctable_resolution.handle;
+        let mut src_clut_resolution_known = false;
         let src_clut = ppc_indexed_depth_entry_count(src_bits.depth).map(|_| {
             let src_ctable = src_ctable.unwrap_or(0);
-            ppc_copy_bits_linked_palette_clut(
+            if let Some(clut) = ppc_copy_bits_linked_palette_clut(
                 memory,
                 src_ctable,
                 current_gworld,
                 current_gdevice,
                 toolbox_startup,
                 color_manager_clut,
-            )
-            .unwrap_or_else(|| ppc_copy_bits_clut(memory, src_ctable, color_manager_clut))
+            ) {
+                src_clut_resolution_known = src_ctable_resolution.known;
+                clut
+            } else {
+                let (clut, known) =
+                    ppc_copy_bits_clut_with_provenance(memory, src_ctable, color_manager_clut);
+                src_clut_resolution_known = src_ctable_resolution.known && known;
+                clut
+            }
         });
         // Inside Macintosh Volume V (1986), p. V-69: CopyBits assumes that
         // an indexed destination uses the current GDevice's color table,
@@ -57688,10 +57795,19 @@ fn ppc_copy_bits(
         // colors into the current GDevice. The destination PixMap's table is
         // not the inverse-mapping target, even when it differs from that
         // device table.
+        let dst_device_ctable_resolution =
+            ppc_gdevice_ctable_handle_with_provenance(memory, current_gdevice);
+        let mut dst_clut_resolution_known = false;
         let dst_clut = ppc_indexed_depth_entry_count(dst_bits.depth).map(|_| {
-            ppc_gdevice_ctable_handle(memory, current_gdevice)
-                .map(|handle| ppc_copy_bits_clut(memory, handle, color_manager_clut))
-                .unwrap_or(*color_manager_clut)
+            if let Some(handle) = dst_device_ctable_resolution.handle {
+                let (clut, known) =
+                    ppc_copy_bits_clut_with_provenance(memory, handle, color_manager_clut);
+                dst_clut_resolution_known = dst_device_ctable_resolution.known && known;
+                clut
+            } else {
+                dst_clut_resolution_known = dst_device_ctable_resolution.known;
+                *color_manager_clut
+            }
         });
         // A shared nonzero ctSeed identifies a particular ColorTable instance.
         // When two same-depth ordinary image tables also describe the same
@@ -57700,7 +57816,10 @@ fn ppc_copy_bits(
         // Imaging With QuickDraw (1994), pp. 4-56--4-57 and 4-97.
         let same_indexed_ctable_identity = src_bits.depth == dst_bits.depth
             && ppc_indexed_depth_entry_count(src_bits.depth).is_some()
+            && src_ctable_resolution.known
+            && dst_ctable_resolution.known
             && ppc_color_tables_share_index_space(memory, src_ctable, dst_ctable);
+        let mut indexed_palette_identity_known = false;
         let palette_map = if src_bits.depth == 8 && dst_bits.depth == 8 {
             let src_ctable = src_ctable.unwrap_or(0);
             let src_clut = src_clut.as_ref().unwrap();
@@ -57720,18 +57839,24 @@ fn ppc_copy_bits(
             if let Some(linked_palette_map) = linked_palette_map {
                 Some(linked_palette_map)
             } else if same_indexed_ctable_identity {
+                indexed_palette_identity_known =
+                    src_clut_resolution_known && dst_clut_resolution_known;
                 None
             } else {
                 // Inside Macintosh Volume V (1986), p. V-135: the high
                 // ctFlags bit distinguishes a GDevice table from a PixMap
                 // image table. Its pixels are already device indexes, so an
                 // indexed CopyBits preserves them.
-                (!source_uses_device_indices && src_clut != dst_clut).then(|| {
-                    std::array::from_fn::<u8, 256, _>(|index| {
+                if source_uses_device_indices || src_clut == dst_clut {
+                    indexed_palette_identity_known =
+                        src_clut_resolution_known && dst_clut_resolution_known;
+                    None
+                } else {
+                    Some(std::array::from_fn::<u8, 256, _>(|index| {
                         let [red, green, blue] = src_clut[index];
                         pict::closest_clut_index(red, green, blue, dst_clut)
-                    })
-                })
+                    }))
+                }
             }
         } else if src_bits.depth == dst_bits.depth && matches!(src_bits.depth, 1 | 2 | 4) {
             let src_ctable = src_ctable.unwrap_or(0);
@@ -57823,7 +57948,17 @@ fn ppc_copy_bits(
         // resolves records and masks; the shared operation owns pure
         // byte-aligned or packed srcCopy format, mode, and geometry eligibility.
         if mask_storage.is_none() {
-            use crate::copy_bits::{BytePixmap, RowCopy, RowCopyOutcome};
+            use crate::copy_bits::{
+                BytePixmap, Indexed8HorizontalSelection, RowCopy, RowCopyOutcome,
+            };
+
+            let indexed8_horizontal = Indexed8HorizontalSelection::from_adapter_facts(
+                mask_rgn == 0,
+                src_resolved.guest_bounds,
+                dst_resolved.authoritative_bounds,
+                indexed_palette_identity_known,
+                transfer_mode,
+            );
 
             let outcome = RowCopy {
                 mode,
@@ -57846,7 +57981,7 @@ fn ppc_copy_bits(
                 clip: [copy_top, copy_left, copy_bottom, copy_right],
                 palette: palette_map.as_ref(),
             }
-            .execute(memory);
+            .execute_with_indexed8_horizontal(memory, indexed8_horizontal);
             match outcome {
                 RowCopyOutcome::Completed => return Some(()),
                 RowCopyOutcome::NoOp => {
@@ -66337,16 +66472,62 @@ fn ppc_current_gdevice_record(memory: &mut PpcSectionMem, current_gdevice: u32) 
 }
 
 fn ppc_gdevice_ctable_handle(memory: &mut PpcSectionMem, current_gdevice: u32) -> Option<u32> {
-    let gdevice = ppc_current_gdevice_record(memory, current_gdevice)?;
-    let pixmap_handle = memory
-        .read_u32_be(gdevice.checked_add(22)?)
-        .filter(|handle| *handle != 0)?;
-    let pixmap = memory
+    ppc_gdevice_ctable_handle_with_provenance(memory, current_gdevice).handle
+}
+
+fn ppc_gdevice_ctable_handle_with_provenance(
+    memory: &mut PpcSectionMem,
+    current_gdevice: u32,
+) -> PpcOptionalHandleResolution {
+    let Some(gdevice) = memory.read_u32_be(current_gdevice) else {
+        return PpcOptionalHandleResolution {
+            handle: None,
+            known: false,
+        };
+    };
+    if gdevice == 0 {
+        return PpcOptionalHandleResolution {
+            handle: None,
+            known: false,
+        };
+    }
+    let Some(pixmap_handle) = gdevice
+        .checked_add(22)
+        .and_then(|field| memory.read_u32_be(field))
+    else {
+        return PpcOptionalHandleResolution {
+            handle: None,
+            known: false,
+        };
+    };
+    if pixmap_handle == 0 {
+        return PpcOptionalHandleResolution {
+            handle: None,
+            known: false,
+        };
+    }
+    let Some(pixmap) = memory
         .read_u32_be(pixmap_handle)
-        .filter(|pixmap| *pixmap != 0)?;
-    memory
-        .read_u32_be(pixmap.checked_add(42)?)
-        .filter(|handle| *handle != 0)
+        .filter(|pixmap| *pixmap != 0)
+    else {
+        return PpcOptionalHandleResolution {
+            handle: None,
+            known: false,
+        };
+    };
+    let Some(raw_handle) = pixmap
+        .checked_add(42)
+        .and_then(|field| memory.read_u32_be(field))
+    else {
+        return PpcOptionalHandleResolution {
+            handle: None,
+            known: false,
+        };
+    };
+    PpcOptionalHandleResolution {
+        handle: (raw_handle != 0).then_some(raw_handle),
+        known: true,
+    }
 }
 
 fn ppc_index_to_color(
@@ -102459,8 +102640,7 @@ pub(crate) mod tests {
                 BLR,
             ],
         );
-        let descriptor_bytes =
-            ppc_memory_read_bytes(&mut loaded.memory, descriptor, 0x100).unwrap();
+        let descriptor_bytes = ppc_memory_read_bytes(&mut loaded.memory, descriptor, 0x100).unwrap();
         let ref_num = *loaded.process_file_system.current_resource_file;
         loaded.process_file_system.vfs_resources.extend([
             PpcVfsResourceRecord {
@@ -102663,7 +102843,8 @@ pub(crate) mod tests {
                 BLR,
             ],
         );
-        let descriptor_bytes = ppc_memory_read_bytes(&mut loaded.memory, descriptor, 0x100).unwrap();
+        let descriptor_bytes =
+            ppc_memory_read_bytes(&mut loaded.memory, descriptor, 0x100).unwrap();
         let ref_num = *loaded.process_file_system.current_resource_file;
         loaded.process_file_system.vfs_resources.extend([
             PpcVfsResourceRecord {
@@ -152571,6 +152752,721 @@ pub(crate) mod tests {
             copied,
             [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 42, 42, 42, 42]
         );
+    }
+
+    #[test]
+    fn hle_import_runner_copybits_reduces_physical_source_bound_crossing() {
+        let pef = synthetic_pef_with_import(b"CopyBits");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let scratch = PPC_HEAP_BASE + 0x12c00;
+        let source_allocation = scratch;
+        let src_pixels = source_allocation + 2;
+        let dst_pixels = scratch + 0x20;
+        let src_pixmap = scratch + 0x40;
+        let dst_pixmap = scratch + 0x80;
+        let rects = scratch + 0xc0;
+        let ctable_handle = scratch + 0xd0;
+        let ctable = scratch + 0xe0;
+        loaded.memory.add_region(scratch, vec![0; 0x100]);
+        ppc_write_pixmap(&mut loaded.memory, src_pixmap, src_pixels, 8, 0, 0, 1, 8, 8).unwrap();
+        loaded.memory.write_u16_be(src_pixmap + 8, 2).unwrap();
+        loaded.memory.write_u16_be(src_pixmap + 12, 7).unwrap();
+        ppc_write_pixmap(&mut loaded.memory, dst_pixmap, dst_pixels, 3, 0, 0, 1, 3, 8).unwrap();
+        loaded
+            .memory
+            .write_u32_be(src_pixmap + 42, ctable_handle)
+            .unwrap();
+        loaded
+            .memory
+            .write_u32_be(dst_pixmap + 42, ctable_handle)
+            .unwrap();
+        loaded.memory.write_u32_be(ctable_handle, ctable).unwrap();
+        loaded.memory.write_u32_be(ctable, 0x1234_5678).unwrap();
+        loaded.memory.write_u16_be(ctable + 4, 0).unwrap();
+        loaded.memory.write_u16_be(ctable + 6, 0).unwrap();
+        loaded.memory.write_u16_be(ctable + 8, 0).unwrap();
+        let [red, green, blue] = loaded.color_manager_clut[0];
+        loaded.memory.write_u16_be(ctable + 10, red).unwrap();
+        loaded.memory.write_u16_be(ctable + 12, green).unwrap();
+        loaded.memory.write_u16_be(ctable + 14, blue).unwrap();
+        loaded
+            .memory
+            .write_bytes(source_allocation, &[240, 241, 10, 20, 30, 40, 50, 0, 0, 0])
+            .unwrap();
+        loaded.memory.write_bytes(dst_pixels, &[0xa5; 4]).unwrap();
+        ppc_write_rect(&mut loaded.memory, rects, 0, 0, 1, 7).unwrap();
+        ppc_write_rect(&mut loaded.memory, rects + 8, 0, 0, 1, 3).unwrap();
+        loaded.cpu.gpr[3] = src_pixmap;
+        loaded.cpu.gpr[4] = dst_pixmap;
+        loaded.cpu.gpr[5] = rects;
+        loaded.cpu.gpr[6] = rects + 8;
+        loaded.cpu.gpr[7] = 0;
+        loaded.cpu.gpr[8] = 0;
+
+        let probe = loaded.run_with_hle_imports(64);
+
+        assert_eq!(probe.handled_import_count, 1);
+        assert_eq!(probe.unsupported_import_index, None);
+        let mut copied = [0; 4];
+        loaded
+            .memory
+            .read_bytes_into(dst_pixels, &mut copied)
+            .unwrap();
+        assert_eq!(copied, [241, 30, 50, 0xa5]);
+    }
+
+    #[test]
+    fn pixmap_ctable_resolution_uses_fallback_after_failed_tracked_port_lookup() {
+        let mut loaded = load_pef_application(&synthetic_pef_with_import(b"CopyBits")).unwrap();
+        let pixmap = PPC_HEAP_BASE + 0x16400;
+        let ctable_handle = pixmap + 0x40;
+        loaded.memory.add_region(pixmap, vec![0; 0x50]);
+        ppc_write_pixmap(&mut loaded.memory, pixmap, pixmap + 0x48, 8, 0, 0, 1, 8, 8).unwrap();
+        loaded
+            .memory
+            .write_u32_be(pixmap + 42, ctable_handle)
+            .unwrap();
+        let tracked_port = PpcGWorldRecord {
+            ui_theme: crate::ui_theme::UiThemeId::ClassicSystem7,
+            port: pixmap,
+            pixmap_handle: 0,
+            pixmap: pixmap + 0x1000,
+            base_addr: pixmap + 0x48,
+            gdevice: PPC_MAIN_GDEVICE,
+            width: 8,
+            height: 1,
+            depth: 8,
+            row_bytes: 8,
+            pixels_locked: false,
+            pixels_no_purge: false,
+        };
+
+        let resolved = ppc_resolve_pixmap_ctable_handle_with_provenance(
+            &mut loaded.memory,
+            &[tracked_port],
+            pixmap,
+        );
+
+        assert_eq!(resolved.handle, Some(ctable_handle));
+        assert!(resolved.known);
+    }
+
+    #[test]
+    fn pixmap_ctable_resolution_tries_indirect_when_direct_rowbytes_are_unreadable() {
+        const INDIRECT: u32 = 0x0952_0000;
+        let mut loaded = load_pef_application(&synthetic_pef_with_import(b"CopyBits")).unwrap();
+        let pixmap = PPC_HEAP_BASE + 0x16500;
+        let ctable_handle = pixmap + 0x40;
+        loaded
+            .memory
+            .add_region(INDIRECT, pixmap.to_be_bytes().to_vec());
+        loaded.memory.add_region(pixmap, vec![0; 0x50]);
+        ppc_write_pixmap(&mut loaded.memory, pixmap, pixmap + 0x48, 8, 0, 0, 1, 8, 8).unwrap();
+        loaded
+            .memory
+            .write_u32_be(pixmap + 42, ctable_handle)
+            .unwrap();
+
+        let resolved =
+            ppc_resolve_pixmap_ctable_handle_with_provenance(&mut loaded.memory, &[], INDIRECT);
+
+        assert_eq!(resolved.handle, Some(ctable_handle));
+        assert!(resolved.known);
+    }
+
+    #[test]
+    fn gdevice_ctable_resolution_preserves_mapped_low_memory_zero_handle_chain() {
+        let mut loaded = load_pef_application(&synthetic_pef_with_import(b"CopyBits")).unwrap();
+        let records = PPC_HEAP_BASE + 0x16580;
+        let gdevice = records;
+        let pixmap_handle = records + 0x40;
+        let pixmap = records + 0x50;
+        let ctable_handle = records + 0x90;
+        loaded.memory.add_region(0, gdevice.to_be_bytes().to_vec());
+        loaded.memory.add_region(records, vec![0; 0xa0]);
+        loaded
+            .memory
+            .write_u32_be(gdevice + 22, pixmap_handle)
+            .unwrap();
+        loaded.memory.write_u32_be(pixmap_handle, pixmap).unwrap();
+        loaded
+            .memory
+            .write_u32_be(pixmap + 42, ctable_handle)
+            .unwrap();
+
+        let resolved = ppc_gdevice_ctable_handle_with_provenance(&mut loaded.memory, 0);
+
+        assert_eq!(resolved.handle, Some(ctable_handle));
+        assert!(resolved.known);
+        assert_eq!(
+            ppc_gdevice_ctable_handle(&mut loaded.memory, 0),
+            Some(ctable_handle)
+        );
+    }
+
+    fn run_ppc_indexed_horizontal_adapter_case(
+        raw_mode: u16,
+        clip_left_column: bool,
+        synthesized_source: bool,
+        nonidentity_palette: bool,
+    ) -> [u8; 4] {
+        let pef = synthetic_pef_with_import(b"CopyBits");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let scratch = PPC_HEAP_BASE + 0x16440;
+        let source_allocation = scratch;
+        let src_pixels = source_allocation + 2;
+        let dst_pixels = scratch + 0x20;
+        let src_pixmap = scratch + 0x40;
+        let dst_pixmap = scratch + 0x80;
+        let rects = scratch + 0xc0;
+        let ctable_handle = scratch + 0xd0;
+        let ctable = scratch + 0xe0;
+        loaded.memory.add_region(scratch, vec![0; 0x160]);
+        ppc_write_pixmap(&mut loaded.memory, src_pixmap, src_pixels, 8, 0, 2, 1, 7, 8).unwrap();
+        ppc_write_pixmap(&mut loaded.memory, dst_pixmap, dst_pixels, 3, 0, 0, 1, 3, 8).unwrap();
+        let source_bits_ptr = if synthesized_source {
+            const SYNTHESIZED_PIXMAP: u32 = 0x0951_0000;
+            loaded.gworlds.push(PpcGWorldRecord {
+                ui_theme: crate::ui_theme::UiThemeId::ClassicSystem7,
+                port: SYNTHESIZED_PIXMAP + 0x1000,
+                pixmap_handle: 0,
+                pixmap: SYNTHESIZED_PIXMAP,
+                base_addr: src_pixels,
+                gdevice: PPC_MAIN_GDEVICE,
+                width: 5,
+                height: 1,
+                depth: 8,
+                row_bytes: 8,
+                pixels_locked: false,
+                pixels_no_purge: false,
+            });
+            SYNTHESIZED_PIXMAP
+        } else {
+            src_pixmap
+        };
+        if nonidentity_palette {
+            loaded
+                .memory
+                .write_u32_be(src_pixmap + 42, ctable_handle)
+                .unwrap();
+            loaded.memory.write_u32_be(ctable_handle, ctable).unwrap();
+            loaded.memory.write_u32_be(ctable, 0x1234_5678).unwrap();
+            loaded.memory.write_u16_be(ctable + 4, 0).unwrap();
+            loaded.memory.write_u16_be(ctable + 6, 10).unwrap();
+            for index in 0..=10u32 {
+                let color_index = if index == 10 { 200 } else { index as usize };
+                let [red, green, blue] = loaded.color_manager_clut[color_index];
+                let entry = ctable + 8 + index * 8;
+                loaded.memory.write_u16_be(entry, index as u16).unwrap();
+                loaded.memory.write_u16_be(entry + 2, red).unwrap();
+                loaded.memory.write_u16_be(entry + 4, green).unwrap();
+                loaded.memory.write_u16_be(entry + 6, blue).unwrap();
+            }
+        }
+        loaded
+            .memory
+            .write_bytes(source_allocation, &[240, 241, 10, 20, 30, 40, 50, 0, 0, 0])
+            .unwrap();
+        loaded.memory.write_bytes(dst_pixels, &[0xa5; 4]).unwrap();
+        ppc_write_rect(&mut loaded.memory, rects, 0, 0, 1, 7).unwrap();
+        ppc_write_rect(&mut loaded.memory, rects + 8, 0, 0, 1, 3).unwrap();
+        if clip_left_column {
+            loaded.memory.write_u16_be(dst_pixmap + 8, 1).unwrap();
+        }
+        loaded.cpu.gpr[3] = source_bits_ptr;
+        loaded.cpu.gpr[4] = dst_pixmap;
+        loaded.cpu.gpr[5] = rects;
+        loaded.cpu.gpr[6] = rects + 8;
+        loaded.cpu.gpr[7] = u32::from(raw_mode);
+        loaded.cpu.gpr[8] = 0;
+
+        let probe = loaded.run_with_hle_imports(64);
+
+        assert_eq!(probe.handled_import_count, 1);
+        assert_eq!(probe.unsupported_import_index, None);
+        let mut copied = [0; 4];
+        loaded
+            .memory
+            .read_bytes_into(dst_pixels, &mut copied)
+            .unwrap();
+        copied
+    }
+
+    #[test]
+    fn hle_import_runner_copybits_keeps_dithered_horizontal_shrink_on_legacy_scaler() {
+        assert_eq!(
+            run_ppc_indexed_horizontal_adapter_case(0x40, false, false, false),
+            [0xa5, 10, 30, 0xa5]
+        );
+    }
+
+    #[test]
+    fn hle_import_runner_copybits_keeps_global_groups_after_destination_clip() {
+        assert_eq!(
+            run_ppc_indexed_horizontal_adapter_case(0, true, false, false),
+            [30, 50, 0xa5, 0xa5]
+        );
+    }
+
+    #[test]
+    fn hle_import_runner_copybits_keeps_valid_nonidentity_palette_on_legacy_scaler() {
+        assert_eq!(
+            run_ppc_indexed_horizontal_adapter_case(0, false, false, true),
+            [0xa5, 200, 30, 0xa5]
+        );
+    }
+
+    #[test]
+    fn hle_import_runner_copybits_does_not_select_synthesized_source_bounds() {
+        assert_eq!(
+            run_ppc_indexed_horizontal_adapter_case(0, false, true, false),
+            [10, 30, 50, 0xa5]
+        );
+    }
+
+    #[test]
+    fn hle_import_runner_copybits_does_not_select_unresolved_equal_fallback_cluts() {
+        let pef = synthetic_pef_with_import(b"CopyBits");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let scratch = PPC_HEAP_BASE + 0x12d00;
+        let source_allocation = scratch;
+        let src_pixels = source_allocation + 2;
+        let dst_pixels = scratch + 0x20;
+        let src_pixmap = scratch + 0x40;
+        let dst_pixmap = scratch + 0x80;
+        let rects = scratch + 0xc0;
+        loaded.memory.add_region(scratch, vec![0; 0xe0]);
+        ppc_write_pixmap(&mut loaded.memory, src_pixmap, src_pixels, 8, 0, 0, 1, 8, 8).unwrap();
+        loaded.memory.write_u16_be(src_pixmap + 8, 2).unwrap();
+        loaded.memory.write_u16_be(src_pixmap + 12, 7).unwrap();
+        ppc_write_pixmap(&mut loaded.memory, dst_pixmap, dst_pixels, 3, 0, 0, 1, 3, 8).unwrap();
+        loaded
+            .memory
+            .write_u32_be(src_pixmap + 42, 0x0bad_0000)
+            .unwrap();
+        loaded
+            .memory
+            .write_u32_be(dst_pixmap + 42, 0x0bad_1000)
+            .unwrap();
+        loaded
+            .memory
+            .write_bytes(source_allocation, &[240, 241, 10, 20, 30, 40, 50, 0, 0, 0])
+            .unwrap();
+        loaded.memory.write_bytes(dst_pixels, &[0xa5; 4]).unwrap();
+        ppc_write_rect(&mut loaded.memory, rects, 0, 0, 1, 7).unwrap();
+        ppc_write_rect(&mut loaded.memory, rects + 8, 0, 0, 1, 3).unwrap();
+        loaded.cpu.gpr[3] = src_pixmap;
+        loaded.cpu.gpr[4] = dst_pixmap;
+        loaded.cpu.gpr[5] = rects;
+        loaded.cpu.gpr[6] = rects + 8;
+        loaded.cpu.gpr[7] = 0;
+        loaded.cpu.gpr[8] = 0;
+
+        let probe = loaded.run_with_hle_imports(64);
+
+        assert_eq!(probe.handled_import_count, 1);
+        assert_eq!(probe.unsupported_import_index, None);
+        let mut copied = [0; 4];
+        loaded
+            .memory
+            .read_bytes_into(dst_pixels, &mut copied)
+            .unwrap();
+        assert_eq!(copied, [0xa5, 10, 30, 0xa5]);
+    }
+
+    #[test]
+    fn hle_import_runner_copybits_does_not_select_when_source_table_field_is_unreadable() {
+        const TRUNCATED_PIXMAP: u32 = 0x0950_0000;
+        let pef = synthetic_pef_with_import(b"CopyBits");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let scratch = PPC_HEAP_BASE + 0x16000;
+        let source_allocation = scratch;
+        let src_pixels = source_allocation + 2;
+        let dst_pixels = scratch + 0x20;
+        let dst_pixmap = scratch + 0x40;
+        let rects = scratch + 0x80;
+        loaded.memory.add_region(scratch, vec![0; 0xa0]);
+        loaded.memory.add_region(TRUNCATED_PIXMAP, vec![0; 34]);
+        // The resolver can read pixelSize at +32 but cannot read pmTable at
+        // +42. The legacy path still receives its existing fallback CLUT;
+        // only the new raw-index reducer must reject this unresolved lookup.
+        assert_eq!(
+            ppc_write_pixmap(
+                &mut loaded.memory,
+                TRUNCATED_PIXMAP,
+                src_pixels,
+                8,
+                0,
+                0,
+                1,
+                8,
+                8,
+            ),
+            None
+        );
+        loaded.memory.write_u16_be(TRUNCATED_PIXMAP + 8, 2).unwrap();
+        loaded
+            .memory
+            .write_u16_be(TRUNCATED_PIXMAP + 12, 7)
+            .unwrap();
+        ppc_write_pixmap(&mut loaded.memory, dst_pixmap, dst_pixels, 3, 0, 0, 1, 3, 8).unwrap();
+        loaded
+            .memory
+            .write_bytes(source_allocation, &[240, 241, 10, 20, 30, 40, 50, 0, 0, 0])
+            .unwrap();
+        loaded.memory.write_bytes(dst_pixels, &[0xa5; 4]).unwrap();
+        ppc_write_rect(&mut loaded.memory, rects, 0, 0, 1, 7).unwrap();
+        ppc_write_rect(&mut loaded.memory, rects + 8, 0, 0, 1, 3).unwrap();
+        loaded.cpu.gpr[3] = TRUNCATED_PIXMAP;
+        loaded.cpu.gpr[4] = dst_pixmap;
+        loaded.cpu.gpr[5] = rects;
+        loaded.cpu.gpr[6] = rects + 8;
+        loaded.cpu.gpr[7] = 0;
+        loaded.cpu.gpr[8] = 0;
+
+        let probe = loaded.run_with_hle_imports(64);
+
+        assert_eq!(probe.handled_import_count, 1);
+        assert_eq!(probe.unsupported_import_index, None);
+        let mut copied = [0; 4];
+        loaded
+            .memory
+            .read_bytes_into(dst_pixels, &mut copied)
+            .unwrap();
+        assert_eq!(copied, [0xa5, 10, 30, 0xa5]);
+    }
+
+    #[test]
+    fn hle_import_runner_copybits_does_not_select_through_broken_current_device_chain() {
+        let pef = synthetic_pef_with_import(b"CopyBits");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let scratch = PPC_HEAP_BASE + 0x16300;
+        let source_allocation = scratch;
+        let src_pixels = source_allocation + 2;
+        let dst_pixels = scratch + 0x20;
+        let src_pixmap = scratch + 0x40;
+        let dst_pixmap = scratch + 0x80;
+        let rects = scratch + 0xc0;
+        let gdevice_handle = scratch + 0xd0;
+        let gdevice = scratch + 0xe0;
+        loaded.memory.add_region(scratch, vec![0; 0x110]);
+        ppc_write_pixmap(&mut loaded.memory, src_pixmap, src_pixels, 8, 0, 0, 1, 8, 8).unwrap();
+        loaded.memory.write_u16_be(src_pixmap + 8, 2).unwrap();
+        loaded.memory.write_u16_be(src_pixmap + 12, 7).unwrap();
+        ppc_write_pixmap(&mut loaded.memory, dst_pixmap, dst_pixels, 3, 0, 0, 1, 3, 8).unwrap();
+        loaded.memory.write_u32_be(gdevice_handle, gdevice).unwrap();
+        loaded
+            .memory
+            .write_u32_be(gdevice + 22, 0x0bad_2000)
+            .unwrap();
+        *loaded.current_gdevice = gdevice_handle;
+        loaded
+            .memory
+            .write_bytes(source_allocation, &[240, 241, 10, 20, 30, 40, 50, 0, 0, 0])
+            .unwrap();
+        loaded.memory.write_bytes(dst_pixels, &[0xa5; 4]).unwrap();
+        ppc_write_rect(&mut loaded.memory, rects, 0, 0, 1, 7).unwrap();
+        ppc_write_rect(&mut loaded.memory, rects + 8, 0, 0, 1, 3).unwrap();
+        loaded.cpu.gpr[3] = src_pixmap;
+        loaded.cpu.gpr[4] = dst_pixmap;
+        loaded.cpu.gpr[5] = rects;
+        loaded.cpu.gpr[6] = rects + 8;
+        loaded.cpu.gpr[7] = 0;
+        loaded.cpu.gpr[8] = 0;
+
+        let probe = loaded.run_with_hle_imports(64);
+
+        assert_eq!(probe.handled_import_count, 1);
+        assert_eq!(probe.unsupported_import_index, None);
+        let mut copied = [0; 4];
+        loaded
+            .memory
+            .read_bytes_into(dst_pixels, &mut copied)
+            .unwrap();
+        assert_eq!(copied, [0xa5, 10, 30, 0xa5]);
+    }
+
+    #[test]
+    fn hle_import_runner_copybits_uses_signed_source_height_gate() {
+        for (bounds_bottom, expected) in [(32_766i16, [20, 50, 70, 0xa5]), (32_767i16, [0xa5; 4])] {
+            let pef = synthetic_pef_with_import(b"CopyBits");
+            let mut loaded = load_pef_application(&pef).unwrap();
+            let scratch = PPC_HEAP_BASE + 0x12e00;
+            let src_pixels = scratch;
+            let dst_pixels = scratch + 0x20;
+            let src_pixmap = scratch + 0x40;
+            let dst_pixmap = scratch + 0x80;
+            let rects = scratch + 0xc0;
+            loaded.memory.add_region(scratch, vec![0; 0xe0]);
+            ppc_write_pixmap(
+                &mut loaded.memory,
+                src_pixmap,
+                src_pixels,
+                8,
+                -1,
+                0,
+                1,
+                8,
+                8,
+            )
+            .unwrap();
+            loaded
+                .memory
+                .write_u16_be(src_pixmap + 10, bounds_bottom as u16)
+                .unwrap();
+            ppc_write_pixmap(&mut loaded.memory, dst_pixmap, dst_pixels, 3, 0, 0, 1, 3, 8).unwrap();
+            loaded
+                .memory
+                .write_bytes(src_pixels, &[10, 20, 30, 40, 50, 60, 70, 0])
+                .unwrap();
+            loaded.memory.write_bytes(dst_pixels, &[0xa5; 4]).unwrap();
+            ppc_write_rect(&mut loaded.memory, rects, -1, 0, 0, 7).unwrap();
+            ppc_write_rect(&mut loaded.memory, rects + 8, 0, 0, 1, 3).unwrap();
+            loaded.cpu.gpr[3] = src_pixmap;
+            loaded.cpu.gpr[4] = dst_pixmap;
+            loaded.cpu.gpr[5] = rects;
+            loaded.cpu.gpr[6] = rects + 8;
+            loaded.cpu.gpr[7] = 0;
+            loaded.cpu.gpr[8] = 0;
+
+            let probe = loaded.run_with_hle_imports(64);
+
+            assert_eq!(probe.handled_import_count, 1);
+            assert_eq!(probe.unsupported_import_index, None);
+            let mut copied = [0; 4];
+            loaded
+                .memory
+                .read_bytes_into(dst_pixels, &mut copied)
+                .unwrap();
+            assert_eq!(copied, expected, "bounds_bottom={bounds_bottom}");
+        }
+    }
+
+    #[test]
+    fn hle_import_runner_copybits_selects_only_exact_record_destination_bounds() {
+        for (record_width, expected) in [
+            (3u32, [241, 30, 50, 0xa5]),
+            (40_000u32, [0xa5, 10, 30, 0xa5]),
+        ] {
+            let pef = synthetic_pef_with_import(b"CopyBits");
+            let mut loaded = load_pef_application(&pef).unwrap();
+            let scratch = PPC_HEAP_BASE + 0x12f00;
+            let source_allocation = scratch;
+            let src_pixels = source_allocation + 2;
+            let dst_pixels = scratch + 0x20;
+            let src_pixmap = scratch + 0x40;
+            let destination_record = scratch + 0x80;
+            let rects = scratch + 0xc0;
+            loaded.memory.add_region(scratch, vec![0; 0xe0]);
+            ppc_write_pixmap(&mut loaded.memory, src_pixmap, src_pixels, 8, 0, 0, 1, 8, 8).unwrap();
+            loaded.memory.write_u16_be(src_pixmap + 8, 2).unwrap();
+            loaded.memory.write_u16_be(src_pixmap + 12, 7).unwrap();
+            loaded.gworlds.push(PpcGWorldRecord {
+                ui_theme: crate::ui_theme::UiThemeId::ClassicSystem7,
+                port: destination_record + 0x1000,
+                pixmap_handle: 0,
+                pixmap: destination_record,
+                base_addr: dst_pixels,
+                gdevice: PPC_MAIN_GDEVICE,
+                width: record_width,
+                height: 1,
+                depth: 8,
+                row_bytes: 3,
+                pixels_locked: false,
+                pixels_no_purge: false,
+            });
+            loaded
+                .memory
+                .write_bytes(source_allocation, &[240, 241, 10, 20, 30, 40, 50, 0, 0, 0])
+                .unwrap();
+            loaded.memory.write_bytes(dst_pixels, &[0xa5; 4]).unwrap();
+            ppc_write_rect(&mut loaded.memory, rects, 0, 0, 1, 7).unwrap();
+            ppc_write_rect(&mut loaded.memory, rects + 8, 0, 0, 1, 3).unwrap();
+            loaded.cpu.gpr[3] = src_pixmap;
+            loaded.cpu.gpr[4] = destination_record;
+            loaded.cpu.gpr[5] = rects;
+            loaded.cpu.gpr[6] = rects + 8;
+            loaded.cpu.gpr[7] = 0;
+            loaded.cpu.gpr[8] = 0;
+
+            let probe = loaded.run_with_hle_imports(64);
+
+            assert_eq!(probe.handled_import_count, 1);
+            assert_eq!(probe.unsupported_import_index, None);
+            let mut copied = [0; 4];
+            loaded
+                .memory
+                .read_bytes_into(dst_pixels, &mut copied)
+                .unwrap();
+            assert_eq!(copied, expected, "record_width={record_width}");
+        }
+    }
+
+    #[test]
+    fn hle_import_runner_copybits_snapshots_indexed_horizontal_aliases() {
+        const SOURCE: u32 = 0x0920_0000;
+        const DESTINATION: u32 = 0x0a20_0000;
+        let mut loaded = load_pef_application(&synthetic_pef_with_import(b"CopyBits")).unwrap();
+        let backing = crate::memory::bus::SharedRamRegion::from_owned_bytes(vec![
+            10, 20, 30, 40, 50, 60, 70, 0, 80, 90, 100, 110, 120, 130, 140, 0,
+        ]);
+        // SAFETY: the import accesses both aliases serially through one
+        // operation, and no borrowed byte slice survives a memory call.
+        unsafe {
+            loaded.memory.add_shared_region(SOURCE, backing.clone());
+            loaded.memory.add_shared_region(DESTINATION, backing);
+        }
+        let records = PPC_HEAP_BASE + 0x16120;
+        let src_pixmap = records;
+        let dst_pixmap = records + 0x40;
+        let rects = records + 0x80;
+        loaded.memory.add_region(records, vec![0; 0x90]);
+        ppc_write_pixmap(&mut loaded.memory, src_pixmap, SOURCE, 8, 0, 0, 2, 8, 8).unwrap();
+        ppc_write_pixmap(
+            &mut loaded.memory,
+            dst_pixmap,
+            DESTINATION + 8,
+            3,
+            0,
+            0,
+            2,
+            3,
+            8,
+        )
+        .unwrap();
+        ppc_write_rect(&mut loaded.memory, rects, 0, 0, 2, 7).unwrap();
+        ppc_write_rect(&mut loaded.memory, rects + 8, 0, 0, 2, 3).unwrap();
+        loaded.cpu.gpr[3] = src_pixmap;
+        loaded.cpu.gpr[4] = dst_pixmap;
+        loaded.cpu.gpr[5] = rects;
+        loaded.cpu.gpr[6] = rects + 8;
+        loaded.cpu.gpr[7] = 0;
+        loaded.cpu.gpr[8] = 0;
+
+        let probe = loaded.run_with_hle_imports(64);
+
+        assert_eq!(probe.handled_import_count, 1);
+        assert_eq!(probe.unsupported_import_index, None);
+        let mut actual = [0; 16];
+        loaded.memory.read_bytes_into(SOURCE, &mut actual).unwrap();
+        assert_eq!(
+            actual,
+            [10, 20, 30, 40, 50, 60, 70, 0, 20, 50, 70, 90, 120, 140, 140, 0]
+        );
+    }
+
+    #[test]
+    fn hle_import_runner_copybits_selected_failures_do_not_fallback() {
+        const SOURCE: u32 = 0x0930_0000;
+        const DESTINATION: u32 = 0x0a30_0000;
+        for source_failure in [true, false] {
+            let mut loaded = load_pef_application(&synthetic_pef_with_import(b"CopyBits")).unwrap();
+            loaded.memory.add_region(
+                SOURCE,
+                if source_failure {
+                    vec![10, 20, 30, 40, 50, 60]
+                } else {
+                    vec![10, 20, 30, 40, 50, 60, 70, 0]
+                },
+            );
+            loaded.memory.add_region(DESTINATION, vec![0xa5; 4]);
+            if !source_failure {
+                loaded
+                    .memory
+                    .add_readonly_region(DESTINATION, vec![0xa5; 3]);
+            }
+            let records = PPC_HEAP_BASE + 0x161b0;
+            let src_pixmap = records;
+            let dst_pixmap = records + 0x40;
+            let rects = records + 0x80;
+            loaded.memory.add_region(records, vec![0; 0x90]);
+            ppc_write_pixmap(&mut loaded.memory, src_pixmap, SOURCE, 8, 0, 0, 1, 8, 8).unwrap();
+            ppc_write_pixmap(
+                &mut loaded.memory,
+                dst_pixmap,
+                DESTINATION,
+                3,
+                0,
+                0,
+                1,
+                3,
+                8,
+            )
+            .unwrap();
+            ppc_write_rect(&mut loaded.memory, rects, 0, 0, 1, 7).unwrap();
+            ppc_write_rect(&mut loaded.memory, rects + 8, 0, 0, 1, 3).unwrap();
+            loaded.cpu.gpr[3] = src_pixmap;
+            loaded.cpu.gpr[4] = dst_pixmap;
+            loaded.cpu.gpr[5] = rects;
+            loaded.cpu.gpr[6] = rects + 8;
+            loaded.cpu.gpr[7] = 0;
+            loaded.cpu.gpr[8] = 0;
+
+            let probe = loaded.run_with_hle_imports(64);
+
+            assert_eq!(probe.handled_import_count, 1);
+            assert_eq!(probe.unsupported_import_index, None);
+            let mut actual = [0; 4];
+            loaded
+                .memory
+                .read_bytes_into(DESTINATION, &mut actual)
+                .unwrap();
+            assert_eq!(actual, [0xa5; 4], "source_failure={source_failure}");
+        }
+    }
+
+    #[test]
+    fn hle_import_runner_copybits_selected_refusal_preserves_later_rows() {
+        const SOURCE: u32 = 0x0940_0000;
+        const DESTINATION: u32 = 0x0a40_0000;
+        let mut loaded = load_pef_application(&synthetic_pef_with_import(b"CopyBits")).unwrap();
+        loaded.memory.add_region(
+            SOURCE,
+            vec![
+                10, 20, 30, 40, 50, 60, 70, 0, 80, 90, 100, 110, 120, 130, 140, 0,
+            ],
+        );
+        loaded.memory.add_region(DESTINATION, vec![0xa5; 6]);
+        loaded
+            .memory
+            .add_readonly_region(DESTINATION + 3, vec![0xa5; 3]);
+        let records = PPC_HEAP_BASE + 0x16240;
+        let src_pixmap = records;
+        let dst_pixmap = records + 0x40;
+        let rects = records + 0x80;
+        loaded.memory.add_region(records, vec![0; 0x90]);
+        ppc_write_pixmap(&mut loaded.memory, src_pixmap, SOURCE, 8, 0, 0, 2, 8, 8).unwrap();
+        ppc_write_pixmap(
+            &mut loaded.memory,
+            dst_pixmap,
+            DESTINATION,
+            3,
+            0,
+            0,
+            2,
+            3,
+            8,
+        )
+        .unwrap();
+        ppc_write_rect(&mut loaded.memory, rects, 0, 0, 2, 7).unwrap();
+        ppc_write_rect(&mut loaded.memory, rects + 8, 0, 0, 2, 3).unwrap();
+        loaded.cpu.gpr[3] = src_pixmap;
+        loaded.cpu.gpr[4] = dst_pixmap;
+        loaded.cpu.gpr[5] = rects;
+        loaded.cpu.gpr[6] = rects + 8;
+        loaded.cpu.gpr[7] = 0;
+        loaded.cpu.gpr[8] = 0;
+
+        let probe = loaded.run_with_hle_imports(64);
+
+        assert_eq!(probe.handled_import_count, 1);
+        assert_eq!(probe.unsupported_import_index, None);
+        let mut actual = [0; 6];
+        loaded
+            .memory
+            .read_bytes_into(DESTINATION, &mut actual)
+            .unwrap();
+        assert_eq!(actual, [20, 50, 70, 0xa5, 0xa5, 0xa5]);
     }
 
     #[test]

--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -3157,6 +3157,11 @@ impl super::TrapDispatcher {
                 let dst_bottom = bus.read_word(dst_rect_ptr + 4) as i16;
                 let dst_right = bus.read_word(dst_rect_ptr + 6) as i16;
                 let mode_base = (mode & 0x3F) as u16;
+                let source_bounds_are_original = src_info.bounds_bottom > src_info.bounds_top
+                    && src_info.bounds_right > src_info.bounds_left;
+                let destination_bounds_are_authoritative = dst_info.bounds_bottom
+                    > dst_info.bounds_top
+                    && dst_info.bounds_right > dst_info.bounds_left;
                 Self::sanitize_copy_bitmap_bounds(
                     &mut src_info,
                     src_top,
@@ -3433,14 +3438,16 @@ impl super::TrapDispatcher {
                 };
 
                 let dst_ctab_handle = self.copy_bits_destination_ctab_handle(bus, port, &dst_info);
-                let src_clut = matches!(src_info.pixel_size, 2 | 4 | 8)
-                    .then(|| self.read_port_clut(bus, src_info.ctab_handle));
-                let dst_clut = self.read_indexed_destination_clut(
+                let src_clut_resolution = matches!(src_info.pixel_size, 2 | 4 | 8)
+                    .then(|| self.read_port_clut_with_provenance(bus, src_info.ctab_handle));
+                let src_clut = src_clut_resolution.as_ref().map(|(clut, _)| *clut);
+                let dst_clut_resolution = self.read_indexed_destination_clut_with_provenance(
                     bus,
                     dst_ctab_handle,
                     dst_info.pixel_size,
                     screen_copybits_rect.is_some(),
                 );
+                let dst_clut = dst_clut_resolution.as_ref().map(|(clut, _)| *clut);
                 let src_ctab_seed = Self::ctab_seed(bus, src_info.ctab_handle);
                 // Executor's translation gate compares the source PixMap's
                 // CTab seed against `CTAB_SEED(PIXMAP_TABLE(GD_PMAP(the_gd)))` —
@@ -3595,6 +3602,16 @@ impl super::TrapDispatcher {
                     (Some(src_clut), Some(dst_clut)) => src_clut != dst_clut,
                     _ => src_ctab_seed != dst_ctab_seed,
                 };
+                let indexed_palette_identity_known = src_info.pixel_size == 8
+                    && dst_info.pixel_size == 8
+                    && (src_info.ctab_handle == dst_info.ctab_handle
+                        || matches!(
+                            (src_clut_resolution.as_ref(), dst_clut_resolution.as_ref()),
+                            (Some((src_clut, true)), Some((dst_clut, true)))
+                                if src_clut == dst_clut
+                        )
+                        || skip_device_translation_to_screen
+                        || skip_explicit_palette_translation);
                 let palette_translation = if matches!(src_info.pixel_size, 2 | 4 | 8)
                     && matches!(dst_info.pixel_size, 2 | 4 | 8)
                     && src_info.ctab_handle != dst_info.ctab_handle
@@ -3654,7 +3671,15 @@ impl super::TrapDispatcher {
                     && !trace_menu_redraw_enabled()
                     && trace_probes.is_empty();
                 if row_copy_edge_eligible {
-                    use crate::copy_bits::RowCopyOutcome;
+                    use crate::copy_bits::{Indexed8HorizontalSelection, RowCopyOutcome};
+
+                    let indexed8_horizontal = Indexed8HorizontalSelection::from_adapter_facts(
+                        mask_rgn == 0,
+                        source_bounds_are_original,
+                        destination_bounds_are_authoritative,
+                        indexed_palette_identity_known,
+                        mode as u16,
+                    );
 
                     let outcome = resolved_row_copy(
                         mode_base,
@@ -3665,7 +3690,7 @@ impl super::TrapDispatcher {
                         [clip_t, clip_l, clip_b, clip_r].map(i32::from),
                         palette_translation,
                     )
-                    .execute(bus);
+                    .execute_with_indexed8_horizontal(bus, indexed8_horizontal);
                     let wrote_rows = match outcome {
                         RowCopyOutcome::Completed => true,
                         RowCopyOutcome::WriteFailure { rows_written } => rows_written != 0,
@@ -17569,9 +17594,13 @@ impl super::TrapDispatcher {
     /// Read a 256-entry CLUT from a CTabHandle in guest memory.
     /// Falls back to the device CLUT if the handle is NULL.
     /// Imaging With QuickDraw 1994, p. 4-82
-    pub(crate) fn read_port_clut(&self, bus: &MacMemoryBus, ctab_handle: u32) -> [[u16; 3]; 256] {
+    fn read_port_clut_with_provenance(
+        &self,
+        bus: &MacMemoryBus,
+        ctab_handle: u32,
+    ) -> ([[u16; 3]; 256], bool) {
         if ctab_handle == 0 {
-            return *self.color_manager_clut;
+            return (*self.color_manager_clut, true);
         }
         let screen_ctab_handle = if self.main_gdevice_handle != 0 {
             Self::gdevice_ctab_handle(bus, self.main_gdevice_handle)
@@ -17579,13 +17608,25 @@ impl super::TrapDispatcher {
             0
         };
         if ctab_handle == screen_ctab_handle {
-            return *self.color_manager_clut;
+            return (*self.color_manager_clut, true);
         }
+        let handle_is_mapped = bus.is_guest_address_mapped(ctab_handle, 4);
         let ctab_ptr = bus.read_long(ctab_handle);
         if ctab_ptr == 0 {
-            return *self.color_manager_clut;
+            return (*self.color_manager_clut, false);
         }
-        self.read_color_table_ptr_clut(bus, ctab_ptr)
+        // Preserve the legacy total-read result even for a malformed or
+        // partially mapped table. Provenance qualifies only whether that
+        // result may establish raw index identity for the new reducer.
+        let clut = self.read_color_table_ptr_clut(bus, ctab_ptr);
+        let entry_count = u32::from(bus.read_word(ctab_ptr.wrapping_add(6)).min(255)) + 1;
+        let table_len = 8usize + entry_count as usize * 8;
+        let known = handle_is_mapped && bus.is_guest_address_mapped(ctab_ptr, table_len);
+        (clut, known)
+    }
+
+    pub(crate) fn read_port_clut(&self, bus: &MacMemoryBus, ctab_handle: u32) -> [[u16; 3]; 256] {
+        self.read_port_clut_with_provenance(bus, ctab_handle).0
     }
 
     fn read_indexed_destination_clut(
@@ -17595,13 +17636,29 @@ impl super::TrapDispatcher {
         pixel_size: u32,
         screen_destination: bool,
     ) -> Option<[[u16; 3]; 256]> {
+        self.read_indexed_destination_clut_with_provenance(
+            bus,
+            ctab_handle,
+            pixel_size,
+            screen_destination,
+        )
+        .map(|(clut, _)| clut)
+    }
+
+    fn read_indexed_destination_clut_with_provenance(
+        &self,
+        bus: &MacMemoryBus,
+        ctab_handle: u32,
+        pixel_size: u32,
+        screen_destination: bool,
+    ) -> Option<([[u16; 3]; 256], bool)> {
         if !matches!(pixel_size, 1 | 2 | 4 | 8) {
             return None;
         }
-        let mut clut = if pixel_size == 1 {
-            let mut clut = [[0u16; 3]; 256];
-            clut[0] = [0xFFFF, 0xFFFF, 0xFFFF];
-            clut
+        let (mut clut, known) = if pixel_size == 1 {
+            let mut monochrome = [[0u16; 3]; 256];
+            monochrome[0] = [0xFFFF, 0xFFFF, 0xFFFF];
+            (monochrome, true)
         } else if screen_destination {
             // CopyBits uses the current GDevice's ColorTable for an indexed
             // destination because the Color Manager needs that table's
@@ -17610,16 +17667,16 @@ impl super::TrapDispatcher {
             // logical GDevice table; `device_clut` is the transient physical
             // hardware view used while fades are in progress. Imaging With
             // QuickDraw (1994), p. 3-117.
-            *self.color_manager_clut
+            (*self.color_manager_clut, true)
         } else {
-            self.read_port_clut(bus, ctab_handle)
+            self.read_port_clut_with_provenance(bus, ctab_handle)
         };
         if pixel_size < 8 {
             let entry_count = 1usize << pixel_size;
             let terminal = clut[entry_count - 1];
             clut[entry_count..].fill(terminal);
         }
-        Some(clut)
+        Some((clut, known))
     }
 
     pub(super) fn read_ctab_handle_clut(
@@ -20327,6 +20384,10 @@ impl super::TrapDispatcher {
         let dst_bottom = bus.read_word(dst_rect_ptr + 4) as i16;
         let dst_right = bus.read_word(dst_rect_ptr + 6) as i16;
         let mode_base = (mode & 0x3F) as u16;
+        let source_bounds_are_original = src_info.bounds_bottom > src_info.bounds_top
+            && src_info.bounds_right > src_info.bounds_left;
+        let destination_bounds_are_authoritative = dst_info.bounds_bottom > dst_info.bounds_top
+            && dst_info.bounds_right > dst_info.bounds_left;
         Self::sanitize_copy_bitmap_bounds(&mut src_info, src_top, src_left, src_bottom, src_right);
         Self::sanitize_copy_bitmap_bounds(&mut dst_info, dst_top, dst_left, dst_bottom, dst_right);
 
@@ -20499,23 +20560,32 @@ impl super::TrapDispatcher {
         };
 
         let dst_ctab_handle = self.copy_bits_destination_ctab_handle(bus, port, &dst_info);
-        let src_clut = matches!(src_info.pixel_size, 2 | 4 | 8)
-            .then(|| self.read_port_clut(bus, src_info.ctab_handle));
+        let src_clut_resolution = matches!(src_info.pixel_size, 2 | 4 | 8)
+            .then(|| self.read_port_clut_with_provenance(bus, src_info.ctab_handle));
+        let src_clut = src_clut_resolution.as_ref().map(|(clut, _)| *clut);
         let screen_destination = dst_info.base == self.screen_mode.0
             && dst_info.row_bytes == self.screen_mode.1
             && dst_info.pixel_size == u32::from(self.screen_mode.4);
-        let dst_clut = self.read_indexed_destination_clut(
+        let dst_clut_resolution = self.read_indexed_destination_clut_with_provenance(
             bus,
             dst_ctab_handle,
             dst_info.pixel_size,
             screen_destination,
         );
+        let dst_clut = dst_clut_resolution.as_ref().map(|(clut, _)| *clut);
         let src_ctab_seed = Self::ctab_seed(bus, src_info.ctab_handle);
         let dst_ctab_seed = Self::ctab_seed(bus, dst_ctab_handle);
         let indexed_tables_differ = match (src_clut.as_ref(), dst_clut.as_ref()) {
             (Some(src_clut), Some(dst_clut)) => src_clut != dst_clut,
             _ => src_ctab_seed != dst_ctab_seed,
         };
+        let indexed_palette_identity_known = src_info.pixel_size == 8
+            && dst_info.pixel_size == 8
+            && (src_info.ctab_handle == dst_info.ctab_handle
+                || matches!(
+                    (src_clut_resolution.as_ref(), dst_clut_resolution.as_ref()),
+                    (Some((src_clut, true)), Some((dst_clut, true))) if src_clut == dst_clut
+                ));
         let palette_translation = if matches!(src_info.pixel_size, 2 | 4 | 8)
             && matches!(dst_info.pixel_size, 2 | 4 | 8)
             && src_info.ctab_handle != dst_info.ctab_handle
@@ -20632,7 +20702,15 @@ impl super::TrapDispatcher {
             && !Self::region_is_complex(bus, mask_rgn)
             && trace_probes.is_empty();
         let shared_rows_written = if row_copy_edge_eligible {
-            use crate::copy_bits::RowCopyOutcome;
+            use crate::copy_bits::{Indexed8HorizontalSelection, RowCopyOutcome};
+
+            let indexed8_horizontal = Indexed8HorizontalSelection::from_adapter_facts(
+                mask_rgn == 0,
+                source_bounds_are_original,
+                destination_bounds_are_authoritative,
+                indexed_palette_identity_known,
+                mode as u16,
+            );
 
             match resolved_row_copy(
                 mode_base,
@@ -20643,7 +20721,7 @@ impl super::TrapDispatcher {
                 [clip_t, clip_l, clip_b, clip_r].map(i32::from),
                 palette_translation,
             )
-            .execute(bus)
+            .execute_with_indexed8_horizontal(bus, indexed8_horizontal)
             {
                 RowCopyOutcome::Completed => true,
                 RowCopyOutcome::WriteFailure { rows_written } if rows_written != 0 => true,
@@ -27256,6 +27334,69 @@ mod tests {
         bus.write_word(entry + 6, 0xCCCC);
         let updated_clut = d.read_port_clut(&bus, ctab_handle);
         assert_eq!(updated_clut[5], [0xAAAA, 0xBBBB, 0xCCCC]);
+    }
+
+    #[test]
+    fn read_port_clut_provenance_preserves_partial_table_legacy_bytes() {
+        const TABLE: u32 = 0x00d5_0000;
+        let (d, _cpu, mut bus) = setup();
+        let mut memory = GuestAddressSpace::new();
+        let mut partial = vec![0; 16];
+        partial[6..8].copy_from_slice(&1u16.to_be_bytes());
+        partial[8..10].copy_from_slice(&5u16.to_be_bytes());
+        partial[10..12].copy_from_slice(&0x1111u16.to_be_bytes());
+        partial[12..14].copy_from_slice(&0x2222u16.to_be_bytes());
+        partial[14..16].copy_from_slice(&0x3333u16.to_be_bytes());
+        memory.add_region(TABLE, partial);
+        bus.attach_guest_address_space(memory.shared_view());
+        let handle = bus.alloc(4);
+        bus.write_long(handle, TABLE);
+
+        let legacy = d.read_port_clut(&bus, handle);
+        let (qualified, known) = d.read_port_clut_with_provenance(&bus, handle);
+
+        assert_eq!(qualified, legacy);
+        assert!(!known);
+        // The missing second ColorSpec retains the old total-read behavior:
+        // its zero value overwrites index zero, while the mapped first entry
+        // remains visible at index five.
+        assert_eq!(qualified[0], [0, 0, 0]);
+        assert_eq!(qualified[5], [0x1111, 0x2222, 0x3333]);
+    }
+
+    #[test]
+    fn read_port_clut_provenance_accepts_complete_sparse_table() {
+        const TABLE: u32 = 0x00d6_0000;
+        let (d, _cpu, mut bus) = setup();
+        let mut memory = GuestAddressSpace::new();
+        let mut table = vec![0; 16];
+        table[6..8].copy_from_slice(&0u16.to_be_bytes());
+        table[8..10].copy_from_slice(&7u16.to_be_bytes());
+        table[10..12].copy_from_slice(&0x4444u16.to_be_bytes());
+        table[12..14].copy_from_slice(&0x5555u16.to_be_bytes());
+        table[14..16].copy_from_slice(&0x6666u16.to_be_bytes());
+        memory.add_region(TABLE, table);
+        bus.attach_guest_address_space(memory.shared_view());
+        let handle = bus.alloc(4);
+        bus.write_long(handle, TABLE);
+
+        let (clut, known) = d.read_port_clut_with_provenance(&bus, handle);
+
+        assert!(known);
+        assert_eq!(clut[7], [0x4444, 0x5555, 0x6666]);
+    }
+
+    #[test]
+    fn read_port_clut_provenance_preserves_wrapping_legacy_read_without_qualifying_it() {
+        let (d, _cpu, mut bus) = setup();
+        let handle = bus.alloc(4);
+        bus.write_long(handle, u32::MAX - 3);
+
+        let legacy = d.read_port_clut(&bus, handle);
+        let (qualified, known) = d.read_port_clut_with_provenance(&bus, handle);
+
+        assert_eq!(qualified, legacy);
+        assert!(!known);
     }
 
     #[test]
@@ -35369,6 +35510,320 @@ mod tests {
     fn std_bits_packed_identity_preserves_edges_and_padding() {
         for depth in [2, 4] {
             run_packed_identity_route(depth, true);
+        }
+    }
+
+    fn run_indexed_horizontal_shrink_route(
+        std_bits: bool,
+        raw_mode: u16,
+        clip_left_column: bool,
+        palette_case: u8,
+    ) -> Vec<u8> {
+        let (mut d, mut cpu, mut bus) = setup_with_port();
+        let source_pixmap = bus.alloc(50);
+        let destination_pixmap = bus.alloc(50);
+        let destination_handle = bus.alloc(4);
+        let source_allocation = bus.alloc(16);
+        let source_base = source_allocation + 2;
+        // Four-byte allocations are movable-memory handles in the PixMap
+        // resolver, so use an ordinary direct pixel allocation here.
+        let destination_base = bus.alloc(8);
+        let source_rect = bus.alloc(8);
+        let destination_rect = bus.alloc(8);
+
+        write_pixmap_8(&mut bus, source_pixmap, source_base, 8, 1, 0);
+        // The submitted seven-pixel source starts two pixels before the declared
+        // image. The normal QuickDraw oracle consumes the initialized physical
+        // pixels while retaining the original three reduction groups.
+        bus.write_word(source_pixmap + 8, 2);
+        bus.write_word(source_pixmap + 12, 7);
+        write_pixmap_8(&mut bus, destination_pixmap, destination_base, 3, 1, 0);
+        if palette_case == 1 {
+            let source_ctable_handle = bus.alloc(4);
+            let destination_ctable_handle = bus.alloc(4);
+            bus.write_long(source_pixmap + 42, source_ctable_handle);
+            bus.write_long(destination_pixmap + 42, destination_ctable_handle);
+        } else if palette_case == 2 {
+            let source_ctable_handle = bus.alloc(4);
+            let source_ctable = bus.alloc(8 + 11 * 8);
+            bus.write_long(source_pixmap + 42, source_ctable_handle);
+            bus.write_long(source_ctable_handle, source_ctable);
+            bus.write_long(source_ctable, 0x1234_5678);
+            bus.write_word(source_ctable + 4, 0);
+            bus.write_word(source_ctable + 6, 10);
+            for index in 0..=10u32 {
+                let color_index = if index == 10 { 200 } else { index as usize };
+                let [red, green, blue] = d.color_manager_clut[color_index];
+                let entry = source_ctable + 8 + index * 8;
+                bus.write_word(entry, index as u16);
+                bus.write_word(entry + 2, red);
+                bus.write_word(entry + 4, green);
+                bus.write_word(entry + 6, blue);
+            }
+        }
+        if clip_left_column {
+            bus.write_word(destination_pixmap + 8, 1);
+        }
+        bus.write_bytes(source_allocation, &[240, 241, 10, 20, 30, 40, 50, 0, 0, 0]);
+        bus.write_bytes(destination_base, &[0xa5; 4]);
+        write_rect(&mut bus, source_rect, 0, 0, 1, 7);
+        write_rect(&mut bus, destination_rect, 0, 0, 1, 3);
+
+        cpu.write_reg(Register::A7, TEST_SP);
+        bus.write_long(TEST_SP, 0);
+        bus.write_word(TEST_SP + 4, raw_mode);
+        bus.write_long(TEST_SP + 6, destination_rect);
+        bus.write_long(TEST_SP + 10, source_rect);
+        if std_bits {
+            const PORT: u32 = 0x181000;
+            bus.write_long(destination_handle, destination_pixmap);
+            bus.write_long(PORT + 2, destination_handle);
+            bus.write_word(PORT + 6, 0xc000);
+            *d.current_port = PORT;
+            bus.write_long(TEST_SP + 14, source_pixmap);
+        } else {
+            bus.write_long(TEST_SP + 14, destination_pixmap);
+            bus.write_long(TEST_SP + 18, source_pixmap);
+        }
+
+        assert!(d
+            .dispatch_quickdraw(
+                true,
+                if std_bits { 0x0eb } else { 0x0ec },
+                &mut cpu,
+                &mut bus,
+            )
+            .unwrap()
+            .is_ok());
+        bus.read_bytes(destination_base, 4)
+    }
+
+    #[test]
+    fn copy_bits_and_std_bits_share_indexed_horizontal_source_crossing() {
+        for std_bits in [false, true] {
+            assert_eq!(
+                run_indexed_horizontal_shrink_route(std_bits, 0, false, 0),
+                vec![241, 30, 50, 0xa5],
+                "std_bits={std_bits}"
+            );
+        }
+    }
+
+    #[test]
+    fn copy_bits_and_std_bits_keep_global_groups_after_destination_clip() {
+        for std_bits in [false, true] {
+            assert_eq!(
+                run_indexed_horizontal_shrink_route(std_bits, 0, true, 0),
+                vec![30, 50, 0xa5, 0xa5],
+                "std_bits={std_bits}"
+            );
+        }
+    }
+
+    #[test]
+    fn copy_bits_and_std_bits_keep_dither_flag_on_legacy_scaler() {
+        for std_bits in [false, true] {
+            assert_eq!(
+                run_indexed_horizontal_shrink_route(std_bits, 0x40, false, 0),
+                vec![0xa5, 10, 30, 0xa5],
+                "std_bits={std_bits}"
+            );
+        }
+    }
+
+    #[test]
+    fn copy_bits_and_std_bits_do_not_select_equal_fallback_from_distinct_unreadable_tables() {
+        for std_bits in [false, true] {
+            assert_eq!(
+                run_indexed_horizontal_shrink_route(std_bits, 0, false, 1),
+                vec![0xa5, 10, 30, 0xa5],
+                "std_bits={std_bits}"
+            );
+        }
+    }
+
+    #[test]
+    fn copy_bits_and_std_bits_keep_valid_nonidentity_palette_on_legacy_scaler() {
+        for std_bits in [false, true] {
+            assert_eq!(
+                run_indexed_horizontal_shrink_route(std_bits, 0, false, 2),
+                vec![0xa5, 200, 30, 0xa5],
+                "std_bits={std_bits}"
+            );
+        }
+    }
+
+    fn run_indexed_horizontal_height_gate(std_bits: bool, bounds_bottom: i16) -> Vec<u8> {
+        let (mut d, mut cpu, mut bus) = setup_with_port();
+        let source_pixmap = bus.alloc(50);
+        let destination_pixmap = bus.alloc(50);
+        let destination_handle = bus.alloc(4);
+        let source_base = bus.alloc(8);
+        let destination_base = bus.alloc(8);
+        let source_rect = bus.alloc(8);
+        let destination_rect = bus.alloc(8);
+        write_pixmap_8(&mut bus, source_pixmap, source_base, 8, 1, 0);
+        bus.write_word(source_pixmap + 6, (-1i16) as u16);
+        bus.write_word(source_pixmap + 10, bounds_bottom as u16);
+        write_pixmap_8(&mut bus, destination_pixmap, destination_base, 3, 1, 0);
+        bus.write_bytes(source_base, &[10, 20, 30, 40, 50, 60, 70, 0]);
+        bus.write_bytes(destination_base, &[0xa5; 4]);
+        write_rect(&mut bus, source_rect, -1, 0, 0, 7);
+        write_rect(&mut bus, destination_rect, 0, 0, 1, 3);
+        cpu.write_reg(Register::A7, TEST_SP);
+        bus.write_long(TEST_SP, 0);
+        bus.write_word(TEST_SP + 4, 0);
+        bus.write_long(TEST_SP + 6, destination_rect);
+        bus.write_long(TEST_SP + 10, source_rect);
+        if std_bits {
+            const PORT: u32 = 0x181000;
+            bus.write_long(destination_handle, destination_pixmap);
+            bus.write_long(PORT + 2, destination_handle);
+            bus.write_word(PORT + 6, 0xc000);
+            *d.current_port = PORT;
+            bus.write_long(TEST_SP + 14, source_pixmap);
+        } else {
+            bus.write_long(TEST_SP + 14, destination_pixmap);
+            bus.write_long(TEST_SP + 18, source_pixmap);
+        }
+        assert!(d
+            .dispatch_quickdraw(
+                true,
+                if std_bits { 0x0eb } else { 0x0ec },
+                &mut cpu,
+                &mut bus,
+            )
+            .unwrap()
+            .is_ok());
+        bus.read_bytes(destination_base, 4)
+    }
+
+    #[test]
+    fn copy_bits_and_std_bits_share_signed_source_height_gate() {
+        for std_bits in [false, true] {
+            assert_eq!(
+                run_indexed_horizontal_height_gate(std_bits, 32_766),
+                vec![20, 50, 70, 0xa5],
+                "32767, std_bits={std_bits}"
+            );
+            assert_eq!(
+                run_indexed_horizontal_height_gate(std_bits, 32_767),
+                vec![0xa5; 4],
+                "32768, std_bits={std_bits}"
+            );
+        }
+    }
+
+    #[test]
+    fn copy_bits_and_std_bits_do_not_fallback_after_selected_failure() {
+        const SOURCE: u32 = 0x00d2_0000;
+        const DESTINATION: u32 = 0x00e2_0000;
+        for trap in [0x0ec, 0x0eb] {
+            for source_failure in [true, false] {
+                let (mut d, mut cpu, mut bus) = setup_with_port();
+                let mut memory = GuestAddressSpace::new();
+                memory.add_region(
+                    SOURCE,
+                    if source_failure {
+                        vec![10, 20, 30, 40, 50, 60]
+                    } else {
+                        vec![10, 20, 30, 40, 50, 60, 70, 0]
+                    },
+                );
+                memory.add_region(DESTINATION, vec![0xa5; 4]);
+                if !source_failure {
+                    memory.add_readonly_region(DESTINATION, vec![0xa5; 3]);
+                }
+                bus.attach_guest_address_space(memory.shared_view());
+                let source_pixmap = bus.alloc(50);
+                let destination_pixmap = bus.alloc(50);
+                let destination_handle = bus.alloc(4);
+                let source_rect = bus.alloc(8);
+                let destination_rect = bus.alloc(8);
+                write_pixmap_8(&mut bus, source_pixmap, SOURCE, 8, 1, 0);
+                write_pixmap_8(&mut bus, destination_pixmap, DESTINATION, 3, 1, 0);
+                write_rect(&mut bus, source_rect, 0, 0, 1, 7);
+                write_rect(&mut bus, destination_rect, 0, 0, 1, 3);
+                cpu.write_reg(Register::A7, TEST_SP);
+                bus.write_long(TEST_SP, 0);
+                bus.write_word(TEST_SP + 4, 0);
+                bus.write_long(TEST_SP + 6, destination_rect);
+                bus.write_long(TEST_SP + 10, source_rect);
+                if trap == 0x0eb {
+                    const PORT: u32 = 0x181000;
+                    bus.write_long(destination_handle, destination_pixmap);
+                    bus.write_long(PORT + 2, destination_handle);
+                    bus.write_word(PORT + 6, 0xc000);
+                    *d.current_port = PORT;
+                    bus.write_long(TEST_SP + 14, source_pixmap);
+                } else {
+                    bus.write_long(TEST_SP + 14, destination_pixmap);
+                    bus.write_long(TEST_SP + 18, source_pixmap);
+                }
+
+                assert!(d
+                    .dispatch_quickdraw(true, trap, &mut cpu, &mut bus)
+                    .unwrap()
+                    .is_ok());
+                let mut actual = [0; 4];
+                memory.read_bytes_into(DESTINATION, &mut actual).unwrap();
+                assert_eq!(
+                    actual, [0xa5; 4],
+                    "trap={trap:03x}, source_failure={source_failure}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn copy_bits_and_std_bits_publish_only_complete_rows_before_selected_refusal() {
+        const SOURCE: u32 = 0x00d3_0000;
+        const DESTINATION: u32 = 0x00e3_0000;
+        for trap in [0x0ec, 0x0eb] {
+            let (mut d, mut cpu, mut bus) = setup_with_port();
+            let mut memory = GuestAddressSpace::new();
+            memory.add_region(
+                SOURCE,
+                vec![
+                    10, 20, 30, 40, 50, 60, 70, 0, 80, 90, 100, 110, 120, 130, 140, 0,
+                ],
+            );
+            memory.add_region(DESTINATION, vec![0xa5; 6]);
+            memory.add_readonly_region(DESTINATION + 3, vec![0xa5; 3]);
+            bus.attach_guest_address_space(memory.shared_view());
+            let source_pixmap = bus.alloc(50);
+            let destination_pixmap = bus.alloc(50);
+            let destination_handle = bus.alloc(4);
+            let source_rect = bus.alloc(8);
+            let destination_rect = bus.alloc(8);
+            write_pixmap_8(&mut bus, source_pixmap, SOURCE, 8, 2, 0);
+            write_pixmap_8(&mut bus, destination_pixmap, DESTINATION, 3, 2, 0);
+            write_rect(&mut bus, source_rect, 0, 0, 2, 7);
+            write_rect(&mut bus, destination_rect, 0, 0, 2, 3);
+            cpu.write_reg(Register::A7, TEST_SP);
+            bus.write_long(TEST_SP, 0);
+            bus.write_word(TEST_SP + 4, 0);
+            bus.write_long(TEST_SP + 6, destination_rect);
+            bus.write_long(TEST_SP + 10, source_rect);
+            if trap == 0x0eb {
+                const PORT: u32 = 0x181000;
+                bus.write_long(destination_handle, destination_pixmap);
+                bus.write_long(PORT + 2, destination_handle);
+                bus.write_word(PORT + 6, 0xc000);
+                *d.current_port = PORT;
+                bus.write_long(TEST_SP + 14, source_pixmap);
+            } else {
+                bus.write_long(TEST_SP + 14, destination_pixmap);
+                bus.write_long(TEST_SP + 18, source_pixmap);
+            }
+
+            assert!(d
+                .dispatch_quickdraw(true, trap, &mut cpu, &mut bus)
+                .unwrap()
+                .is_ok());
+            let mut actual = [0; 6];
+            memory.read_bytes_into(DESTINATION, &mut actual).unwrap();
+            assert_eq!(actual, [20, 50, 70, 0xa5, 0xa5, 0xa5], "trap={trap:03x}");
         }
     }
 

--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -35714,6 +35714,182 @@ mod tests {
         }
     }
 
+    fn run_indexed_horizontal_oracle_route(
+        std_bits: bool,
+        source_width: u16,
+        destination_width: u16,
+        source_left: u16,
+        source_row: &[u8],
+    ) -> Vec<u8> {
+        let (mut d, mut cpu, mut bus) = setup_with_port();
+        let source_stride = u16::try_from((source_row.len() + 1) & !1).unwrap();
+        let destination_stride = (destination_width + 4 + 1) & !1;
+        let source_pixmap = bus.alloc(50);
+        let destination_pixmap = bus.alloc(50);
+        let destination_handle = bus.alloc(4);
+        let source_base = bus.alloc(u32::from(source_stride));
+        let destination_base = bus.alloc(u32::from(destination_stride));
+        let source_rect = bus.alloc(8);
+        let destination_rect = bus.alloc(8);
+
+        write_pixmap_8(&mut bus, source_pixmap, source_base, source_stride, 1, 0);
+        bus.write_word(source_pixmap + 12, source_left + source_width);
+        write_pixmap_8(
+            &mut bus,
+            destination_pixmap,
+            destination_base,
+            destination_stride,
+            1,
+            0,
+        );
+        bus.write_word(destination_pixmap + 12, destination_width);
+        bus.write_bytes(source_base, source_row);
+        bus.write_bytes(
+            destination_base,
+            &vec![0xa5; usize::from(destination_stride)],
+        );
+        write_rect(
+            &mut bus,
+            source_rect,
+            0,
+            source_left as i16,
+            1,
+            (source_left + source_width) as i16,
+        );
+        write_rect(
+            &mut bus,
+            destination_rect,
+            0,
+            0,
+            1,
+            destination_width as i16,
+        );
+
+        cpu.write_reg(Register::A7, TEST_SP);
+        bus.write_long(TEST_SP, 0);
+        bus.write_word(TEST_SP + 4, 0);
+        bus.write_long(TEST_SP + 6, destination_rect);
+        bus.write_long(TEST_SP + 10, source_rect);
+        if std_bits {
+            const PORT: u32 = 0x181000;
+            bus.write_long(destination_handle, destination_pixmap);
+            bus.write_long(PORT + 2, destination_handle);
+            bus.write_word(PORT + 6, 0xc000);
+            *d.current_port = PORT;
+            bus.write_long(TEST_SP + 14, source_pixmap);
+        } else {
+            bus.write_long(TEST_SP + 14, destination_pixmap);
+            bus.write_long(TEST_SP + 18, source_pixmap);
+        }
+
+        assert!(d
+            .dispatch_quickdraw(
+                true,
+                if std_bits { 0x0eb } else { 0x0ec },
+                &mut cpu,
+                &mut bus,
+            )
+            .unwrap()
+            .is_ok());
+        bus.read_bytes(destination_base, usize::from(destination_stride))
+    }
+
+    fn indexed_horizontal_tail_low(source_width: usize) -> Vec<u8> {
+        let mut row = vec![200; (source_width + 3) & !3];
+        row[source_width - 1] = 0;
+        row[source_width] = 254;
+        row
+    }
+
+    fn indexed_horizontal_nonmonotonic(source_width: usize, case_index: usize) -> Vec<u8> {
+        let mut row = vec![0; (source_width + 3) & !3];
+        for (position, value) in row[..source_width].iter_mut().enumerate() {
+            *value = ((position * 73 + case_index * 19) % 251 + 1) as u8;
+        }
+        row[source_width] = 254;
+        row
+    }
+
+    #[test]
+    fn copy_bits_and_std_bits_match_large_indexed_horizontal_oracles() {
+        // Literal results from controlled Mac OS 8.1 CopyBits and StdBits
+        // captures. The tail-low rows isolate the staged physical tail; the
+        // nonmonotonic rows use the captured position encoding verbatim.
+        for std_bits in [false, true] {
+            for source_left in 0..4u16 {
+                let mut row = vec![0x11; usize::from(source_left) + 194];
+                row[..usize::from(source_left)].fill(250);
+                row[usize::from(source_left)..usize::from(source_left) + 190].fill(20);
+                row[usize::from(source_left) + 189] = 30;
+                row[usize::from(source_left) + 190..usize::from(source_left) + 193]
+                    .copy_from_slice(&[200, 150, 140]);
+                let actual =
+                    run_indexed_horizontal_oracle_route(std_bits, 190, 1, source_left, &row);
+                assert_eq!(actual[0], 200);
+                assert!(actual[1..].iter().all(|&byte| byte == 0xa5));
+
+                row.fill(0x11);
+                row[..usize::from(source_left)].fill(250);
+                row[usize::from(source_left)..usize::from(source_left) + 191].fill(20);
+                row[usize::from(source_left) + 190] = 30;
+                row[usize::from(source_left) + 191..usize::from(source_left) + 194]
+                    .copy_from_slice(&[240, 150, 140]);
+                let actual =
+                    run_indexed_horizontal_oracle_route(std_bits, 191, 1, source_left, &row);
+                assert_eq!(actual[0], 30);
+                assert!(actual[1..].iter().all(|&byte| byte == 0xa5));
+            }
+
+            for (source_width, destination_width, source, expected) in [
+                (285, 2, indexed_horizontal_tail_low(285), &[200, 254][..]),
+                (
+                    285,
+                    2,
+                    indexed_horizontal_nonmonotonic(285, 1),
+                    &[251, 254][..],
+                ),
+                (
+                    511,
+                    3,
+                    indexed_horizontal_tail_low(511),
+                    &[200, 200, 254][..],
+                ),
+                (
+                    511,
+                    3,
+                    indexed_horizontal_nonmonotonic(511, 7),
+                    &[251, 249, 254][..],
+                ),
+            ] {
+                let actual = run_indexed_horizontal_oracle_route(
+                    std_bits,
+                    source_width,
+                    destination_width,
+                    0,
+                    &source,
+                );
+                assert_eq!(&actual[..expected.len()], expected);
+                assert!(actual[expected.len()..].iter().all(|&byte| byte == 0xa5));
+            }
+
+            for (source_width, expected) in [(4_097, 65), (5_000, 8), (5_001, 7), (10_924, u8::MAX)]
+            {
+                let source = vec![0; (source_width + 3) & !3];
+                let actual = run_indexed_horizontal_oracle_route(
+                    std_bits,
+                    source_width as u16,
+                    1,
+                    0,
+                    &source,
+                );
+                assert_eq!(
+                    actual[0], expected,
+                    "{source_width}->1, std_bits={std_bits}"
+                );
+                assert!(actual[1..].iter().all(|&byte| byte == 0xa5));
+            }
+        }
+    }
     #[test]
     fn copy_bits_and_std_bits_do_not_fallback_after_selected_failure() {
         const SOURCE: u32 = 0x00d2_0000;


### PR DESCRIPTION
Indexed 8-bit horizontal shrinking now uses one shared reducer through CopyBits, StdBits, and the native CopyBits import. For example, the captured 285-to-2 tail pattern produces `[200, 254]`, including the required physical source tail. The previous adapter sampling paths did not reproduce that result consistently.

The shared operation preserves the original clipping phase, snapshots contributing source bytes before writing, constructs bounded scratch storage, and treats selected read or write failures as terminal. Palette and geometry provenance keep unqualified requests on their existing paths while preserving legacy palette lookup results. Raw ditherCopy, vertical scaling, packed scaling, nonidentity palette translation, masks, and custom procedures remain outside this horizontal family.

Validation:

- Controlled Mac OS 8.1 CopyBits/StdBits captures supply independent expected values. Real adapter tests cover 190/191 source-origin residues, 285/511 tail and nonmonotonic patterns, and 4097/5000/5001/10924 reductions: 48 route cases across two tests.
- Focused clipping, overlap, source-read failure, partial-row publication, geometry, and palette-provenance regressions passed.
- The integrated headless library suite passed 5,283 tests with three existing ignores before the final test-only acceptance addition.
- Final default-feature library suite: 5,294 passed, three existing ignores. Both optimized classic and PPC Toolbox showcases passed. A subsequent cleanup restores only two unrelated test line wraps; required CI validated the exact PR head.
- CI identified a new lint in the intentionally reversed-range rejection test. It now constructs that invalid input explicitly; the focused rejection test passed after the correction.

The optional formatting/Clippy job is not clean: its formatting differences are in unchanged files, and its existing `mut_from_ref` and `erasing_op` errors predate this change. Those were verified against the base rather than inferred from the nonblocking job status. The exact-head recheck confirms the introduced reversed-range lint is gone; required build, library and desktop tests, both optimized architecture showcases, headless build, documentation, packaging, artifact verification, and dependency-license checks passed on head b96a49dad6731a4fe02b207890805388a94a94b4 (CI run 34080956846).

Closes #1565. Contributes to #1363; the remaining graphics families retain their separate acceptance gates.
