### PR TITLE
refactor: construct migrated process services coherently

### DIFF
--- a/src/copy_bits.rs
+++ b/src/copy_bits.rs
@@ -262,8 +262,10 @@ pub(crate) enum RowCopyOutcome {
 
 /// Adapter facts which are not retained in [`RowCopy`]. Callers must keep
 /// using their existing path unless the request had no mask, its source bounds
-/// are original guest bounds rather than sanitized substitutes, and its raw
-/// mode is exactly `srcCopy` without the separately defined dither flag.
+/// are original guest bounds rather than sanitized substitutes, its destination
+/// bounds are authoritative, its missing palette map means known index identity,
+/// and its raw mode is exactly `srcCopy` without the separately defined dither
+/// flag.
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct Indexed8HorizontalSelection(());
 
@@ -271,9 +273,16 @@ impl Indexed8HorizontalSelection {
     pub(crate) fn from_adapter_facts(
         mask_free: bool,
         source_bounds_are_original: bool,
+        destination_bounds_are_authoritative: bool,
+        indexed_palette_identity_known: bool,
         raw_mode: u16,
     ) -> Option<Self> {
-        (mask_free && source_bounds_are_original && raw_mode == 0).then_some(Self(()))
+        (mask_free
+            && source_bounds_are_original
+            && destination_bounds_are_authoritative
+            && indexed_palette_identity_known
+            && raw_mode == 0)
+            .then_some(Self(()))
     }
 }
 
@@ -930,7 +939,7 @@ mod tests {
     }
 
     fn indexed_selection() -> Indexed8HorizontalSelection {
-        Indexed8HorizontalSelection::from_adapter_facts(true, true, 0).unwrap()
+        Indexed8HorizontalSelection::from_adapter_facts(true, true, true, true, 0).unwrap()
     }
 
     #[derive(Default)]
@@ -980,12 +989,20 @@ mod tests {
 
     #[test]
     fn indexed_horizontal_selection_requires_all_adapter_provenance() {
-        assert!(Indexed8HorizontalSelection::from_adapter_facts(true, true, 0).is_some());
-        for facts in [(false, true, 0), (true, false, 0), (true, true, 0x40)] {
-            assert!(
-                Indexed8HorizontalSelection::from_adapter_facts(facts.0, facts.1, facts.2)
-                    .is_none()
-            );
+        assert!(
+            Indexed8HorizontalSelection::from_adapter_facts(true, true, true, true, 0).is_some()
+        );
+        for facts in [
+            (false, true, true, true, 0),
+            (true, false, true, true, 0),
+            (true, true, false, true, 0),
+            (true, true, true, false, 0),
+            (true, true, true, true, 0x40),
+        ] {
+            assert!(Indexed8HorizontalSelection::from_adapter_facts(
+                facts.0, facts.1, facts.2, facts.3, facts.4
+            )
+            .is_none());
         }
     }
 
@@ -1003,7 +1020,8 @@ mod tests {
             clip: [0, 0, 1, 3],
             palette: None,
         };
-        let selection = Indexed8HorizontalSelection::from_adapter_facts(true, true, 0x40);
+        let selection =
+            Indexed8HorizontalSelection::from_adapter_facts(true, true, true, true, 0x40);
         assert_eq!(
             copy.execute_with_indexed8_horizontal(&mut memory, selection),
             RowCopyOutcome::Completed

--- a/src/copy_bits.rs
+++ b/src/copy_bits.rs
@@ -3,7 +3,124 @@
 //! ABI decoding, port/mask resolution and picture recording stay at the callers
 //! until their corresponding operation families migrate.
 
+use std::ops::Range;
+
 use crate::memory::{GuestAddressSpace, MacMemoryBus, MemoryBus};
+
+const INDEXED_8_GUARD_BYTES: usize = 4;
+const INDEXED_8_MAP_ENTRIES: usize = 256;
+
+/// Pure horizontal plan for the indexed 8-bit identity-palette shrink path.
+/// Destination indices are relative to the complete, unclipped destination
+/// rectangle. `source_range` is relative to the submitted source pixel.
+///
+/// Imaging With QuickDraw defines rectangle scaling, but not the indexed
+/// reducer. The truncated fixed-point carry and rounded source/guard/map
+/// prefix are measured compatibility behavior; the finite-prefix saturation
+/// follows from unsigned-byte maximum and the complete identity map.
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) struct Indexed8HorizontalShrink {
+    groups: Vec<Range<usize>>,
+    source_range: Range<usize>,
+    staged_len: usize,
+}
+
+impl Indexed8HorizontalShrink {
+    pub(crate) fn new(
+        source_width: usize,
+        destination_width: usize,
+        visible: Range<usize>,
+    ) -> Option<Self> {
+        if !(1..=i16::MAX as usize).contains(&source_width)
+            || destination_width == 0
+            || destination_width >= source_width
+            || visible.start > visible.end
+            || visible.end > destination_width
+        {
+            return None;
+        }
+
+        let source = i64::try_from(source_width).ok()?;
+        let destination = i64::try_from(destination_width).ok()?;
+        let step = destination.checked_mul(1 << 16)?.checked_div(source)?;
+        if step <= 0 {
+            return None;
+        }
+        let phase = step / 2;
+        let boundary = |index: usize| {
+            let numerator = i64::try_from(index)
+                .ok()?
+                .checked_mul(1 << 16)?
+                .checked_sub(phase)?;
+            let quotient = numerator.div_euclid(step);
+            let rounded = quotient.checked_add(i64::from(numerator.rem_euclid(step) != 0))?;
+            usize::try_from(rounded).ok()
+        };
+
+        let mut endpoints = Vec::with_capacity(visible.end - visible.start + 1);
+        for index in visible.start..=visible.end {
+            endpoints.push(boundary(index)?);
+        }
+        let groups: Vec<_> = endpoints.windows(2).map(|pair| pair[0]..pair[1]).collect();
+        if groups.iter().any(|group| group.is_empty()) {
+            return None;
+        }
+
+        let staged_len = source_width.checked_add(3)? & !3;
+        let source_range = match (groups.first(), groups.last()) {
+            (Some(first), Some(last)) => first.start.min(staged_len)..last.end.min(staged_len),
+            (None, None) => 0..0,
+            _ => return None,
+        };
+        Some(Self {
+            groups,
+            source_range,
+            staged_len,
+        })
+    }
+
+    pub(crate) fn groups(&self) -> &[Range<usize>] {
+        &self.groups
+    }
+
+    pub(crate) fn source_range(&self) -> Range<usize> {
+        self.source_range.clone()
+    }
+
+    /// Reduces an exact snapshot of `source_range`. The remaining arena is the
+    /// operation-owned zero guard followed by big-endian identity-map entries.
+    pub(crate) fn reduce(&self, staged_source: &[u8]) -> Option<Vec<u8>> {
+        if staged_source.len() != self.source_range.len() {
+            return None;
+        }
+        let map_start = self.staged_len.checked_add(INDEXED_8_GUARD_BYTES)?;
+        let prefix_end = map_start.checked_add(INDEXED_8_MAP_ENTRIES.checked_mul(4)?)?;
+        let mut output = Vec::with_capacity(self.groups.len());
+
+        for group in &self.groups {
+            let mut maximum = None;
+            for index in group.start..group.end.min(prefix_end) {
+                let value = if index < self.staged_len {
+                    let source_index = index.checked_sub(self.source_range.start)?;
+                    *staged_source.get(source_index)?
+                } else if index < map_start {
+                    0
+                } else {
+                    let map_offset = index - map_start;
+                    let entry = u32::try_from(map_offset / 4).ok()?;
+                    entry.to_be_bytes()[map_offset % 4]
+                };
+                maximum = Some(maximum.map_or(value, |current: u8| current.max(value)));
+            }
+            let maximum = maximum?;
+            if group.end > prefix_end && maximum != u8::MAX {
+                return None;
+            }
+            output.push(maximum);
+        }
+        Some(output)
+    }
+}
 
 pub(crate) trait CopyBitsMemory {
     fn read_copy_row(&mut self, address: u32, bytes: &mut [u8]) -> Option<()>;
@@ -338,6 +455,187 @@ mod tests {
 
     const SOURCE: u32 = 0x0100_0000;
     const DESTINATION: u32 = 0x0200_0000;
+
+    #[test]
+    fn indexed_horizontal_groups_match_independent_oracle_boundaries() {
+        for (source, destination, expected) in [
+            (3, 2, &[0..2, 2..3][..]),
+            (5, 3, &[0..2, 2..3, 3..5][..]),
+            (
+                17,
+                7,
+                &[0..2, 2..5, 5..7, 7..10, 10..12, 12..15, 15..17][..],
+            ),
+            (
+                17,
+                16,
+                &[
+                    0..1,
+                    1..2,
+                    2..3,
+                    3..4,
+                    4..5,
+                    5..6,
+                    6..7,
+                    7..9,
+                    9..10,
+                    10..11,
+                    11..12,
+                    12..13,
+                    13..14,
+                    14..15,
+                    15..16,
+                    16..17,
+                ][..],
+            ),
+        ] {
+            let plan = Indexed8HorizontalShrink::new(source, destination, 0..destination)
+                .expect("oracle geometry is supported");
+            assert_eq!(plan.groups(), expected);
+        }
+    }
+
+    #[test]
+    fn indexed_horizontal_boundaries_match_independent_carry_loop() {
+        for source in 2usize..=32 {
+            for destination in 1usize..source {
+                let step = (destination * (1 << 16) / source) as u16;
+                let mut error = step / 2;
+                let mut source_index = 0;
+                let mut expected = Vec::with_capacity(destination);
+                for _ in 0..destination {
+                    let start = source_index;
+                    loop {
+                        source_index += 1;
+                        let (next, carry) = error.overflowing_add(step);
+                        error = next;
+                        if carry {
+                            break;
+                        }
+                    }
+                    expected.push(start..source_index);
+                }
+                let plan = Indexed8HorizontalShrink::new(source, destination, 0..destination)
+                    .expect("small positive shrink is supported");
+                assert_eq!(
+                    plan.groups(),
+                    expected,
+                    "source={source}, destination={destination}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn indexed_horizontal_plan_uses_signed_zero_boundary_and_visible_groups() {
+        let first = Indexed8HorizontalShrink::new(285, 2, 0..1).unwrap();
+        assert_eq!(first.groups(), &[0..143]);
+        assert_eq!(first.source_range(), 0..143);
+
+        let last = Indexed8HorizontalShrink::new(285, 2, 1..2).unwrap();
+        assert_eq!(last.groups(), &[143..286]);
+        assert_eq!(last.source_range(), 143..286);
+
+        let clipped_away = Indexed8HorizontalShrink::new(190, 1, 0..0).unwrap();
+        assert!(clipped_away.groups().is_empty());
+        assert_eq!(clipped_away.source_range(), 0..0);
+        assert_eq!(clipped_away.reduce(&[]), Some(vec![]));
+    }
+
+    #[test]
+    fn indexed_horizontal_origin_residues_use_only_submitted_pixels() {
+        for residue in 0..4 {
+            let mut row = vec![0x11; 256];
+            row[..residue].fill(250);
+            row[residue..residue + 190].fill(20);
+            row[residue + 189] = 30;
+            row[residue + 190..residue + 193].copy_from_slice(&[200, 150, 140]);
+            let plan = Indexed8HorizontalShrink::new(190, 1, 0..1).unwrap();
+            assert_eq!(plan.groups(), &[0..191]);
+            assert_eq!(plan.source_range(), 0..191);
+            let range = plan.source_range();
+            assert_eq!(
+                plan.reduce(&row[residue + range.start..residue + range.end]),
+                Some(vec![200])
+            );
+
+            row.fill(0x11);
+            row[..residue].fill(250);
+            row[residue..residue + 191].fill(20);
+            row[residue + 190] = 30;
+            row[residue + 191..residue + 194].copy_from_slice(&[240, 150, 140]);
+            let plan = Indexed8HorizontalShrink::new(191, 1, 0..1).unwrap();
+            assert_eq!(plan.groups(), &[0..191]);
+            assert_eq!(plan.source_range(), 0..191);
+            let range = plan.source_range();
+            assert_eq!(
+                plan.reduce(&row[residue + range.start..residue + range.end]),
+                Some(vec![30])
+            );
+        }
+    }
+
+    #[test]
+    fn indexed_horizontal_owned_map_matches_large_trace_pixels() {
+        for (source_width, endpoint, expected) in [
+            (4_097, 4_369, 65),
+            (5_000, 5_041, 8),
+            (5_001, 5_041, 7),
+            (10_924, 13_107, u8::MAX),
+        ] {
+            let plan = Indexed8HorizontalShrink::new(source_width, 1, 0..1).unwrap();
+            assert_eq!(plan.groups(), &[0..endpoint]);
+            let range = plan.source_range();
+            assert_eq!(range.start, 0);
+            assert_eq!(
+                plan.reduce(&vec![0; range.len()]),
+                Some(vec![expected]),
+                "source_width={source_width}"
+            );
+        }
+    }
+
+    #[test]
+    fn indexed_horizontal_final_column_stays_bounded_near_signed_limit() {
+        let guarded = Indexed8HorizontalShrink::new(32_761, 2, 1..2).unwrap();
+        assert_eq!(guarded.groups(), &[16_384..32_768]);
+        assert_eq!(guarded.source_range(), 16_384..32_764);
+        let mut guarded_source = vec![0; guarded.source_range().len()];
+        *guarded_source.last_mut().unwrap() = 77;
+        assert_eq!(guarded.reduce(&guarded_source), Some(vec![77]));
+
+        let unrounded = Indexed8HorizontalShrink::new(32_767, 2, 1..2).unwrap();
+        assert_eq!(unrounded.groups(), &[16_384..32_768]);
+        assert_eq!(unrounded.source_range(), 16_384..32_768);
+        let mut unrounded_source = vec![0; unrounded.source_range().len()];
+        *unrounded_source.last_mut().unwrap() = 88;
+        assert_eq!(unrounded.reduce(&unrounded_source), Some(vec![88]));
+
+        let saturated = Indexed8HorizontalShrink::new(31_736, 2, 1..2).unwrap();
+        assert_eq!(saturated.groups(), &[16_384..32_768]);
+        assert_eq!(saturated.source_range(), 16_384..31_736);
+        assert_eq!(
+            saturated.reduce(&vec![0; saturated.source_range().len()]),
+            Some(vec![u8::MAX])
+        );
+    }
+
+    #[test]
+    fn indexed_horizontal_plan_rejects_unproved_domains_and_wrong_snapshot() {
+        for (source, destination, visible) in [
+            (0, 1, 0..1),
+            (1, 1, 0..1),
+            (1, 2, 0..2),
+            (i16::MAX as usize + 1, 1, 0..1),
+            (5, 3, 2..1),
+            (5, 3, 0..4),
+        ] {
+            assert!(Indexed8HorizontalShrink::new(source, destination, visible).is_none());
+        }
+        let plan = Indexed8HorizontalShrink::new(190, 1, 0..1).unwrap();
+        assert_eq!(plan.reduce(&vec![0; 190]), None);
+        assert_eq!(plan.reduce(&vec![0; 192]), None);
+    }
 
     fn run(memory: &mut GuestAddressSpace, classic: bool, copy: RowCopy<'_>) -> RowCopyOutcome {
         if classic {

--- a/src/copy_bits.rs
+++ b/src/copy_bits.rs
@@ -908,7 +908,7 @@ mod tests {
             (1, 1, 0..1),
             (1, 2, 0..2),
             (i16::MAX as usize + 1, 1, 0..1),
-            (5, 3, 2..1),
+            (5, 3, std::ops::Range { start: 2, end: 1 }),
             (5, 3, 0..4),
         ] {
             assert!(Indexed8HorizontalShrink::new(source, destination, visible).is_none());

--- a/src/copy_bits.rs
+++ b/src/copy_bits.rs
@@ -57,11 +57,17 @@ impl Indexed8HorizontalShrink {
             usize::try_from(rounded).ok()
         };
 
-        let mut endpoints = Vec::with_capacity(visible.end - visible.start + 1);
+        let endpoint_count = visible.end.checked_sub(visible.start)?.checked_add(1)?;
+        let mut endpoints = Vec::new();
+        endpoints.try_reserve_exact(endpoint_count).ok()?;
         for index in visible.start..=visible.end {
             endpoints.push(boundary(index)?);
         }
-        let groups: Vec<_> = endpoints.windows(2).map(|pair| pair[0]..pair[1]).collect();
+        let mut groups = Vec::new();
+        groups
+            .try_reserve_exact(endpoint_count.saturating_sub(1))
+            .ok()?;
+        groups.extend(endpoints.windows(2).map(|pair| pair[0]..pair[1]));
         if groups.iter().any(|group| group.is_empty()) {
             return None;
         }
@@ -95,7 +101,8 @@ impl Indexed8HorizontalShrink {
         }
         let map_start = self.staged_len.checked_add(INDEXED_8_GUARD_BYTES)?;
         let prefix_end = map_start.checked_add(INDEXED_8_MAP_ENTRIES.checked_mul(4)?)?;
-        let mut output = Vec::with_capacity(self.groups.len());
+        let mut output = Vec::new();
+        output.try_reserve_exact(self.groups.len()).ok()?;
 
         for group in &self.groups {
             let mut maximum = None;
@@ -117,6 +124,22 @@ impl Indexed8HorizontalShrink {
                 return None;
             }
             output.push(maximum);
+        }
+        Some(output)
+    }
+
+    fn reduce_rows(&self, snapshots: &[u8], row_count: usize) -> Option<Vec<u8>> {
+        let row_len = self.source_range.len();
+        if snapshots.len() != row_count.checked_mul(row_len)? {
+            return None;
+        }
+        let output_len = row_count.checked_mul(self.groups.len())?;
+        let mut output = Vec::new();
+        output.try_reserve_exact(output_len).ok()?;
+        for row_index in 0..row_count {
+            let start = row_index.checked_mul(row_len)?;
+            let end = start.checked_add(row_len)?;
+            output.extend_from_slice(&self.reduce(snapshots.get(start..end)?)?);
         }
         Some(output)
     }
@@ -237,7 +260,256 @@ pub(crate) enum RowCopyOutcome {
     WriteFailure { rows_written: usize },
 }
 
+/// Adapter facts which are not retained in [`RowCopy`]. Callers must keep
+/// using their existing path unless the request had no mask, its source bounds
+/// are original guest bounds rather than sanitized substitutes, and its raw
+/// mode is exactly `srcCopy` without the separately defined dither flag.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct Indexed8HorizontalSelection(());
+
+impl Indexed8HorizontalSelection {
+    pub(crate) fn from_adapter_facts(
+        mask_free: bool,
+        source_bounds_are_original: bool,
+        raw_mode: u16,
+    ) -> Option<Self> {
+        (mask_free && source_bounds_are_original && raw_mode == 0).then_some(Self(()))
+    }
+}
+
 impl RowCopy<'_> {
+    /// Adds the indexed horizontal family ahead of the existing shared paths.
+    /// The adapters still receive one final outcome and therefore cannot
+    /// accidentally fall back after a selected family has touched memory.
+    pub(crate) fn execute_with_indexed8_horizontal(
+        self,
+        memory: &mut impl CopyBitsMemory,
+        selection: Option<Indexed8HorizontalSelection>,
+    ) -> RowCopyOutcome {
+        if let Some(selection) = selection {
+            let outcome = self.execute_indexed8_horizontal(memory, selection);
+            if outcome != RowCopyOutcome::Declined {
+                return outcome;
+            }
+        }
+        self.execute(memory)
+    }
+
+    /// Executes the measured indexed 8-bit horizontal shrink family.
+    ///
+    /// Only [`RowCopyOutcome::Declined`] permits the adapter to try its old
+    /// path. Once this method selects the family, address/read failures and
+    /// partial writes remain terminal. Source spans for every visible row are
+    /// snapshotted before the first destination write, including physical
+    /// bytes beyond the declared source bounds and row stride.
+    fn execute_indexed8_horizontal(
+        &self,
+        memory: &mut impl CopyBitsMemory,
+        _selection: Indexed8HorizontalSelection,
+    ) -> RowCopyOutcome {
+        if self.mode != 0
+            || self.source.depth != 8
+            || self.destination.depth != 8
+            || self.palette.is_some()
+        {
+            return RowCopyOutcome::Declined;
+        }
+
+        if self
+            .source_rect
+            .iter()
+            .chain(self.destination_rect.iter())
+            .chain(self.source.bounds.iter())
+            .chain(self.destination.bounds.iter())
+            .chain(self.clip.iter())
+            .any(|&coordinate| i16::try_from(coordinate).is_err())
+        {
+            return RowCopyOutcome::Declined;
+        }
+
+        let [st, sl, sb, sr] = self.source_rect;
+        let [dt, dl, db, dr] = self.destination_rect;
+        let Some(source_width) = sr.checked_sub(sl) else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        let Some(source_height) = sb.checked_sub(st) else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        let Some(destination_width) = dr.checked_sub(dl) else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        let Some(destination_height) = db.checked_sub(dt) else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        if source_width <= 0
+            || source_height <= 0
+            || destination_width <= 0
+            || destination_height <= 0
+        {
+            return RowCopyOutcome::NoOp;
+        }
+        if destination_width >= source_width || destination_height != source_height {
+            return RowCopyOutcome::Declined;
+        }
+        if source_width > i32::from(i16::MAX) || source_height > i32::from(i16::MAX) {
+            return RowCopyOutcome::Declined;
+        }
+
+        let [sbt, sbl, sbb, _] = self.source.bounds;
+        let Some(source_bounds_height) = sbb.checked_sub(sbt) else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        if source_bounds_height <= 0 {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        }
+        if st < sbt || sb > sbb {
+            return RowCopyOutcome::Declined;
+        }
+        let Some(source_x_delta) = sl.checked_sub(sbl) else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        if i16::try_from(source_x_delta).is_err() {
+            return RowCopyOutcome::Declined;
+        }
+        // Classic QuickDraw's signed source-bounds-height gate is observed at
+        // 32767/32768 for this otherwise-selected family.
+        if source_bounds_height > i32::from(i16::MAX) {
+            return RowCopyOutcome::NoOp;
+        }
+
+        let [dbt, dbl, dbb, dbr] = self.destination.bounds;
+        let [ct, cl, cb, cr] = self.clip;
+        let top = dt.max(dbt).max(ct);
+        let left = dl.max(dbl).max(cl);
+        let bottom = db.min(dbb).min(cb);
+        let right = dr.min(dbr).min(cr);
+        if top >= bottom || left >= right {
+            return RowCopyOutcome::NoOp;
+        }
+
+        let Some(visible_start) = left
+            .checked_sub(dl)
+            .and_then(|value| usize::try_from(value).ok())
+        else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        let Some(visible_end) = right
+            .checked_sub(dl)
+            .and_then(|value| usize::try_from(value).ok())
+        else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        let Some(plan) = Indexed8HorizontalShrink::new(
+            source_width as usize,
+            destination_width as usize,
+            visible_start..visible_end,
+        ) else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        let source_range = plan.source_range();
+        let Some(row_count) = bottom
+            .checked_sub(top)
+            .and_then(|value| usize::try_from(value).ok())
+        else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        let Some(output_len) = right
+            .checked_sub(left)
+            .and_then(|value| usize::try_from(value).ok())
+        else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+
+        let mut addresses = Vec::new();
+        if addresses.try_reserve_exact(row_count).is_err() {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        }
+        for destination_y in top..bottom {
+            let Some(source_y) = destination_y
+                .checked_sub(dt)
+                .and_then(|offset| st.checked_add(offset))
+            else {
+                return RowCopyOutcome::ReadOrGeometryFailure;
+            };
+            let source_address = if source_range.is_empty() {
+                None
+            } else {
+                let Some(row_delta) = source_y.checked_sub(sbt).map(i64::from) else {
+                    return RowCopyOutcome::ReadOrGeometryFailure;
+                };
+                let Some(submitted_origin) = row_delta
+                    .checked_mul(i64::from(self.source.row_bytes))
+                    .and_then(|offset| i64::from(self.source.base).checked_add(offset))
+                    .and_then(|address| address.checked_add(i64::from(source_x_delta)))
+                else {
+                    return RowCopyOutcome::ReadOrGeometryFailure;
+                };
+                let Some(source_start) = i64::try_from(source_range.start)
+                    .ok()
+                    .and_then(|offset| submitted_origin.checked_add(offset))
+                else {
+                    return RowCopyOutcome::ReadOrGeometryFailure;
+                };
+                let Some(source_end) = i64::try_from(source_range.end)
+                    .ok()
+                    .and_then(|offset| submitted_origin.checked_add(offset))
+                else {
+                    return RowCopyOutcome::ReadOrGeometryFailure;
+                };
+                if source_start < 0 || source_end < source_start || source_end > (1i64 << 32) {
+                    return RowCopyOutcome::ReadOrGeometryFailure;
+                }
+                Some(source_start as u32)
+            };
+            let Some(destination_address) =
+                self.destination
+                    .row_address(left, destination_y, output_len)
+            else {
+                return RowCopyOutcome::ReadOrGeometryFailure;
+            };
+            addresses.push((source_address, destination_address));
+        }
+
+        let Some(snapshot_len) = row_count.checked_mul(source_range.len()) else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        let mut snapshots = Vec::new();
+        if snapshots.try_reserve_exact(snapshot_len).is_err() {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        }
+        snapshots.resize(snapshot_len, 0);
+        for (row_index, (source, _)) in addresses.iter().enumerate() {
+            let Some(start) = row_index.checked_mul(source_range.len()) else {
+                return RowCopyOutcome::ReadOrGeometryFailure;
+            };
+            let Some(end) = start.checked_add(source_range.len()) else {
+                return RowCopyOutcome::ReadOrGeometryFailure;
+            };
+            if let Some(source) = source {
+                if memory
+                    .read_copy_row(*source, &mut snapshots[start..end])
+                    .is_none()
+                {
+                    return RowCopyOutcome::ReadOrGeometryFailure;
+                }
+            }
+        }
+
+        let Some(output) = plan.reduce_rows(&snapshots, row_count) else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        for (rows_written, ((_, destination), row)) in addresses
+            .iter()
+            .zip(output.chunks_exact(output_len))
+            .enumerate()
+        {
+            if memory.write_copy_row(*destination, row).is_none() {
+                return RowCopyOutcome::WriteFailure { rows_written };
+            }
+        }
+        RowCopyOutcome::Completed
+    }
+
     /// Snapshot all source rows before writing, including across different
     /// addresses that alias the same backing. Geometry/read failures write
     /// nothing. A destination failure preserves that row but may follow rows
@@ -655,6 +927,340 @@ mod tests {
             depth,
             bounds,
         }
+    }
+
+    fn indexed_selection() -> Indexed8HorizontalSelection {
+        Indexed8HorizontalSelection::from_adapter_facts(true, true, 0).unwrap()
+    }
+
+    #[derive(Default)]
+    struct SparseMemory {
+        bytes: std::collections::BTreeMap<u32, u8>,
+        fail_read: Option<u32>,
+        fail_write: Option<u32>,
+        writes: Vec<u32>,
+    }
+
+    impl SparseMemory {
+        fn insert(&mut self, address: u32, bytes: &[u8]) {
+            for (offset, byte) in bytes.iter().copied().enumerate() {
+                self.bytes.insert(address + offset as u32, byte);
+            }
+        }
+
+        fn bytes(&self, address: u32, len: usize) -> Vec<u8> {
+            (0..len)
+                .map(|offset| self.bytes[&(address + offset as u32)])
+                .collect()
+        }
+    }
+
+    impl CopyBitsMemory for SparseMemory {
+        fn read_copy_row(&mut self, address: u32, bytes: &mut [u8]) -> Option<()> {
+            if self.fail_read == Some(address) {
+                return None;
+            }
+            for (offset, byte) in bytes.iter_mut().enumerate() {
+                *byte = *self.bytes.get(&address.checked_add(offset as u32)?)?;
+            }
+            Some(())
+        }
+
+        fn write_copy_row(&mut self, address: u32, bytes: &[u8]) -> Option<()> {
+            if self.fail_write == Some(address) {
+                return None;
+            }
+            self.writes.push(address);
+            for (offset, byte) in bytes.iter().copied().enumerate() {
+                self.bytes.insert(address.checked_add(offset as u32)?, byte);
+            }
+            Some(())
+        }
+    }
+
+    #[test]
+    fn indexed_horizontal_selection_requires_all_adapter_provenance() {
+        assert!(Indexed8HorizontalSelection::from_adapter_facts(true, true, 0).is_some());
+        for facts in [(false, true, 0), (true, false, 0), (true, true, 0x40)] {
+            assert!(
+                Indexed8HorizontalSelection::from_adapter_facts(facts.0, facts.1, facts.2)
+                    .is_none()
+            );
+        }
+    }
+
+    #[test]
+    fn indexed_horizontal_raw_dither_flag_keeps_existing_unscaled_route() {
+        let mut memory = SparseMemory::default();
+        memory.insert(SOURCE, &[1, 2, 3, 0xaa]);
+        memory.insert(DESTINATION, &[0xaa; 4]);
+        let copy = RowCopy {
+            mode: 0,
+            source: pixmap(SOURCE, 4, 8, [0, 0, 1, 3]),
+            destination: pixmap(DESTINATION, 4, 8, [0, 0, 1, 3]),
+            source_rect: [0, 0, 1, 3],
+            destination_rect: [0, 0, 1, 3],
+            clip: [0, 0, 1, 3],
+            palette: None,
+        };
+        let selection = Indexed8HorizontalSelection::from_adapter_facts(true, true, 0x40);
+        assert_eq!(
+            copy.execute_with_indexed8_horizontal(&mut memory, selection),
+            RowCopyOutcome::Completed
+        );
+        assert_eq!(memory.bytes(DESTINATION, 4), [1, 2, 3, 0xaa]);
+    }
+
+    #[test]
+    fn indexed_horizontal_global_clip_reads_only_final_physical_ranges() {
+        let mut memory = SparseMemory::default();
+        // The submitted row origins are -1 and 7. Clipping away destination
+        // column zero makes the required physical starts 1 and 9, both valid.
+        memory.insert(1, &[22, 23, 24, 25, 26]);
+        memory.insert(9, &[32, 33, 34, 35, 36]);
+        memory.insert(DESTINATION, &[0xaa; 8]);
+        let copy = RowCopy {
+            mode: 0,
+            source: pixmap(1, 8, 8, [0, 8, 2, 13]),
+            destination: pixmap(DESTINATION, 4, 8, [0, 20, 2, 23]),
+            source_rect: [0, 6, 2, 13],
+            destination_rect: [0, 20, 2, 23],
+            clip: [0, 21, 2, 23],
+            palette: None,
+        };
+        assert_eq!(
+            copy.execute_with_indexed8_horizontal(&mut memory, Some(indexed_selection())),
+            RowCopyOutcome::Completed
+        );
+        assert_eq!(
+            memory.bytes(DESTINATION, 8),
+            [0xaa, 24, 26, 0xaa, 0xaa, 34, 36, 0xaa]
+        );
+    }
+
+    #[test]
+    fn indexed_horizontal_snapshots_all_aliasing_rows_before_writes() {
+        let mut memory = SparseMemory::default();
+        memory.insert(
+            SOURCE,
+            &[
+                1, 9, 2, 3, 4, 0xaa, 0xaa, 0xaa, 5, 1, 6, 0, 7, 0xaa, 0xaa, 0xaa,
+            ],
+        );
+        let copy = RowCopy {
+            mode: 0,
+            source: pixmap(SOURCE, 8, 8, [0, 0, 2, 5]),
+            destination: pixmap(SOURCE + 8, 3, 8, [0, 0, 2, 3]),
+            source_rect: [0, 0, 2, 5],
+            destination_rect: [0, 0, 2, 3],
+            clip: [0, 0, 2, 3],
+            palette: None,
+        };
+        assert_eq!(
+            copy.execute_with_indexed8_horizontal(&mut memory, Some(indexed_selection())),
+            RowCopyOutcome::Completed
+        );
+        assert_eq!(memory.bytes(SOURCE + 8, 6), [9, 2, 4, 5, 6, 7]);
+    }
+
+    #[test]
+    fn indexed_horizontal_snapshots_declared_same_row_overlap() {
+        let mut memory = SparseMemory::default();
+        memory.insert(SOURCE, &[1, 9, 2, 3, 4, 0xaa, 0xaa, 0xaa]);
+        let copy = RowCopy {
+            mode: 0,
+            source: pixmap(SOURCE, 8, 8, [0, 0, 1, 5]),
+            destination: pixmap(SOURCE + 1, 3, 8, [0, 0, 1, 3]),
+            source_rect: [0, 0, 1, 5],
+            destination_rect: [0, 0, 1, 3],
+            clip: [0, 0, 1, 3],
+            palette: None,
+        };
+        assert_eq!(
+            copy.execute_with_indexed8_horizontal(&mut memory, Some(indexed_selection())),
+            RowCopyOutcome::Completed
+        );
+        assert_eq!(memory.bytes(SOURCE, 5), [1, 9, 2, 4, 4]);
+    }
+
+    #[test]
+    fn indexed_horizontal_snapshots_rounded_tail_overlap() {
+        let mut memory = SparseMemory::default();
+        let mut backing = vec![10; 381];
+        backing[0] = 100;
+        backing[190..380].fill(20);
+        backing[190] = 80;
+        backing[380] = 90;
+        memory.insert(SOURCE, &backing);
+        let copy = RowCopy {
+            mode: 0,
+            source: pixmap(SOURCE, 190, 8, [0, 0, 2, 190]),
+            destination: pixmap(SOURCE + 190, 1, 8, [0, 0, 2, 1]),
+            source_rect: [0, 0, 2, 190],
+            destination_rect: [0, 0, 2, 1],
+            clip: [0, 0, 2, 1],
+            palette: None,
+        };
+        assert_eq!(
+            copy.execute_with_indexed8_horizontal(&mut memory, Some(indexed_selection())),
+            RowCopyOutcome::Completed
+        );
+        assert_eq!(memory.bytes(SOURCE + 190, 2), [100, 90]);
+    }
+
+    #[test]
+    fn indexed_horizontal_read_failure_is_prewrite_and_write_failure_is_partial() {
+        let request = || RowCopy {
+            mode: 0,
+            source: pixmap(SOURCE, 8, 8, [0, 0, 2, 5]),
+            destination: pixmap(DESTINATION, 3, 8, [0, 0, 2, 3]),
+            source_rect: [0, 0, 2, 5],
+            destination_rect: [0, 0, 2, 3],
+            clip: [0, 0, 2, 3],
+            palette: None,
+        };
+
+        let mut read_failure = SparseMemory::default();
+        read_failure.insert(SOURCE, &[1, 2, 3, 4, 5]);
+        read_failure.insert(SOURCE + 8, &[6, 7, 8, 9, 10]);
+        read_failure.insert(DESTINATION, &[0xaa; 6]);
+        read_failure.fail_read = Some(SOURCE + 8);
+        assert_eq!(
+            request()
+                .execute_with_indexed8_horizontal(&mut read_failure, Some(indexed_selection()),),
+            RowCopyOutcome::ReadOrGeometryFailure
+        );
+        assert!(read_failure.writes.is_empty());
+        assert_eq!(read_failure.bytes(DESTINATION, 6), [0xaa; 6]);
+
+        let mut write_failure = SparseMemory::default();
+        write_failure.insert(SOURCE, &[1, 2, 3, 4, 5]);
+        write_failure.insert(SOURCE + 8, &[6, 7, 8, 9, 10]);
+        write_failure.insert(DESTINATION, &[0xaa; 6]);
+        write_failure.fail_write = Some(DESTINATION + 3);
+        assert_eq!(
+            request()
+                .execute_with_indexed8_horizontal(&mut write_failure, Some(indexed_selection()),),
+            RowCopyOutcome::WriteFailure { rows_written: 1 }
+        );
+        assert_eq!(write_failure.writes, [DESTINATION]);
+        assert_eq!(
+            write_failure.bytes(DESTINATION, 6),
+            [2, 3, 5, 0xaa, 0xaa, 0xaa]
+        );
+
+        let mut first_write_failure = SparseMemory::default();
+        first_write_failure.insert(SOURCE, &[1, 2, 3, 4, 5]);
+        first_write_failure.insert(SOURCE + 8, &[6, 7, 8, 9, 10]);
+        first_write_failure.insert(DESTINATION, &[0xaa; 6]);
+        first_write_failure.fail_write = Some(DESTINATION);
+        assert_eq!(
+            request().execute_with_indexed8_horizontal(
+                &mut first_write_failure,
+                Some(indexed_selection()),
+            ),
+            RowCopyOutcome::WriteFailure { rows_written: 0 }
+        );
+        assert!(first_write_failure.writes.is_empty());
+        assert_eq!(first_write_failure.bytes(DESTINATION, 6), [0xaa; 6]);
+    }
+
+    #[test]
+    fn indexed_horizontal_signed_source_height_is_noop_without_memory_access() {
+        struct NoAccess;
+        impl CopyBitsMemory for NoAccess {
+            fn read_copy_row(&mut self, _: u32, _: &mut [u8]) -> Option<()> {
+                panic!("signed-height no-op reached source memory");
+            }
+
+            fn write_copy_row(&mut self, _: u32, _: &[u8]) -> Option<()> {
+                panic!("signed-height no-op reached destination memory");
+            }
+        }
+
+        let copy = RowCopy {
+            mode: 0,
+            source: pixmap(SOURCE, 8, 8, [-1, 0, 32_767, 7]),
+            destination: pixmap(DESTINATION, 3, 8, [0, 0, 1, 3]),
+            source_rect: [-1, 0, 0, 7],
+            destination_rect: [0, 0, 1, 3],
+            clip: [0, 0, 1, 3],
+            palette: None,
+        };
+        assert_eq!(
+            copy.execute_with_indexed8_horizontal(&mut NoAccess, Some(indexed_selection())),
+            RowCopyOutcome::NoOp
+        );
+    }
+
+    #[test]
+    fn indexed_horizontal_wide_relative_origin_declines_without_memory_access() {
+        struct NoAccess;
+        impl CopyBitsMemory for NoAccess {
+            fn read_copy_row(&mut self, _: u32, _: &mut [u8]) -> Option<()> {
+                panic!("declined wide origin reached source memory");
+            }
+
+            fn write_copy_row(&mut self, _: u32, _: &[u8]) -> Option<()> {
+                panic!("declined wide origin reached destination memory");
+            }
+        }
+
+        let copy = RowCopy {
+            mode: 0,
+            source: pixmap(SOURCE, 8, 8, [0, i16::MIN.into(), 1, -32_760]),
+            destination: pixmap(DESTINATION, 3, 8, [0, 0, 1, 3]),
+            source_rect: [0, 1, 1, 6],
+            destination_rect: [0, 0, 1, 3],
+            clip: [0, 0, 1, 3],
+            palette: None,
+        };
+        assert_eq!(
+            copy.execute_with_indexed8_horizontal(&mut NoAccess, Some(indexed_selection())),
+            RowCopyOutcome::Declined
+        );
+
+        let tall_copy = RowCopy {
+            mode: 0,
+            source: pixmap(SOURCE, 8, 8, [-1, i16::MIN.into(), 32_767, -32_760]),
+            destination: pixmap(DESTINATION, 3, 8, [0, 0, 1, 3]),
+            source_rect: [-1, 1, 0, 6],
+            destination_rect: [0, 0, 1, 3],
+            clip: [0, 0, 1, 3],
+            palette: None,
+        };
+        assert_eq!(
+            tall_copy.execute_with_indexed8_horizontal(&mut NoAccess, Some(indexed_selection())),
+            RowCopyOutcome::Declined
+        );
+    }
+
+    #[test]
+    fn indexed_horizontal_invalid_final_range_fails_before_memory_access() {
+        struct NoAccess;
+        impl CopyBitsMemory for NoAccess {
+            fn read_copy_row(&mut self, _: u32, _: &mut [u8]) -> Option<()> {
+                panic!("invalid final range reached source memory");
+            }
+
+            fn write_copy_row(&mut self, _: u32, _: &[u8]) -> Option<()> {
+                panic!("invalid final range reached destination memory");
+            }
+        }
+
+        let copy = RowCopy {
+            mode: 0,
+            source: pixmap(u32::MAX - 1, 8, 8, [0, 0, 1, 5]),
+            destination: pixmap(DESTINATION, 3, 8, [0, 0, 1, 3]),
+            source_rect: [0, 0, 1, 5],
+            destination_rect: [0, 0, 1, 3],
+            clip: [0, 0, 1, 3],
+            palette: None,
+        };
+        assert_eq!(
+            copy.execute_with_indexed8_horizontal(&mut NoAccess, Some(indexed_selection())),
+            RowCopyOutcome::ReadOrGeometryFailure
+        );
     }
 
     #[test]

--- a/src/execution_native.rs
+++ b/src/execution_native.rs
@@ -201,6 +201,12 @@ impl<T> NativeExecution<T> {
         Ok(())
     }
 
+    pub(crate) fn staged_companion(&self) -> Option<&T> {
+        matches!(self.companion, NativeSlot::Empty)
+            .then_some(self.staged.as_ref())
+            .flatten()
+    }
+
     #[cfg(test)]
     pub(crate) fn has_staged_companion(&self) -> bool {
         self.staged.is_some()

--- a/src/guest_call.rs
+++ b/src/guest_call.rs
@@ -884,6 +884,11 @@ impl std::ops::DerefMut for SharedMenuTracking {
     }
 }
 impl SharedMenuTracking {
+    pub(crate) fn is_view_of(&self, calls: &SharedGuestCallStack) -> bool {
+        let tasks = calls.0.borrow();
+        self.calls.ptr_eq(&tasks.menu_calls) && self.execution.ptr_eq(calls)
+    }
+
     #[cfg(test)]
     pub(crate) fn ptr_eq(&self, other: &Self) -> bool {
         self.calls.ptr_eq(&other.calls)
@@ -1614,6 +1619,10 @@ impl SharedGuestCallStack {
 
     pub(crate) fn shared_handle(&self) -> Self {
         Self(Rc::clone(&self.0))
+    }
+
+    pub(crate) fn ptr_eq(&self, other: &Self) -> bool {
+        Rc::ptr_eq(&self.0, &other.0)
     }
 
     pub(crate) fn attach_to(&mut self, process_calls: &Self) {
@@ -3629,6 +3638,83 @@ impl SharedGuestCallStack {
     }
 }
 
+/// One execution owner and its derived Menu Manager view.
+///
+/// Ordinary clones detach the execution snapshot exactly once, then derive the
+/// menu view from that clone. Shared installation uses `shared_from` explicitly.
+#[derive(Debug)]
+pub(crate) struct ExecutionMenuViews {
+    calls: SharedGuestCallStack,
+    menu: SharedMenuTracking,
+}
+
+impl Default for ExecutionMenuViews {
+    fn default() -> Self {
+        Self::detached()
+    }
+}
+
+impl Clone for ExecutionMenuViews {
+    fn clone(&self) -> Self {
+        debug_assert!(self.is_coherent());
+        let calls = self.calls.clone();
+        let menu = calls.menu_tracking_view();
+        Self { calls, menu }
+    }
+}
+
+impl PartialEq for ExecutionMenuViews {
+    fn eq(&self, other: &Self) -> bool {
+        debug_assert!(self.is_coherent());
+        debug_assert!(other.is_coherent());
+        self.calls == other.calls
+    }
+}
+
+impl Eq for ExecutionMenuViews {}
+
+impl ExecutionMenuViews {
+    pub(crate) fn detached() -> Self {
+        let calls = SharedGuestCallStack::default();
+        let menu = calls.menu_tracking_view();
+        Self { calls, menu }
+    }
+
+    pub(crate) fn shared_from(calls: &SharedGuestCallStack) -> Self {
+        let calls = calls.shared_handle();
+        let menu = calls.menu_tracking_view();
+        Self { calls, menu }
+    }
+
+    pub(crate) fn calls(&self) -> &SharedGuestCallStack {
+        &self.calls
+    }
+
+    pub(crate) fn menu(&self) -> &SharedMenuTracking {
+        &self.menu
+    }
+
+    pub(crate) fn menu_state_mut(
+        &mut self,
+    ) -> &mut Option<crate::menu_manager::ProcessMenuTrackingState> {
+        &mut self.menu
+    }
+
+    #[cfg(test)]
+    pub(crate) fn enter_test_menu(&mut self) -> MenuTrackingEntry {
+        self.menu.enter()
+    }
+
+    pub(crate) fn is_coherent(&self) -> bool {
+        self.menu.is_view_of(&self.calls)
+    }
+
+    pub(crate) fn install_process_calls(&mut self, process_calls: &SharedGuestCallStack) {
+        self.calls.attach_to(process_calls);
+        self.menu = self.calls.menu_tracking_view();
+    }
+}
+
 #[cfg(test)]
 pub(crate) fn test_native_import_action(
     entry: u32,
@@ -3685,6 +3771,73 @@ mod tests {
     use ppc::PpcRunResult;
 
     const RETURN_PC: u32 = 0x01f0_4000;
+
+    #[test]
+    fn execution_menu_views_clone_once_and_derive_each_menu_view() {
+        let mut original = ExecutionMenuViews::detached();
+        let root = original.enter_test_menu();
+        *original.menu_state_mut() = Some(crate::menu_manager::test_process_menu_tracking(0x1000));
+        assert!(original.is_coherent());
+
+        let mut snapshot = original.clone();
+        assert!(snapshot.is_coherent());
+        assert!(!snapshot.calls().ptr_eq(original.calls()));
+        assert!(!snapshot.menu().ptr_eq(original.menu()));
+        assert_eq!(snapshot, original);
+
+        snapshot.menu_state_mut().as_mut().unwrap().highlighted_item = 7;
+        assert_eq!(snapshot.menu().as_ref().unwrap().highlighted_item, 7);
+        assert_eq!(original.menu().as_ref().unwrap().highlighted_item, 1);
+
+        let shared = ExecutionMenuViews::shared_from(original.calls());
+        assert!(shared.is_coherent());
+        assert!(shared.calls().ptr_eq(original.calls()));
+        assert!(shared.menu().ptr_eq(original.menu()));
+        drop(root);
+    }
+
+    #[test]
+    fn execution_menu_views_adopt_parked_context_without_orphaning_its_bank() {
+        let mut adapter = ExecutionMenuViews::detached();
+        assert!(adapter.calls().begin_m68k(
+            GuestCallTarget {
+                isa: GuestIsa::M68k,
+                entry: 0x1000,
+                rtoc: 0,
+            },
+            0x2000,
+            0x3000,
+        ));
+        let (call, _) = adapter.calls().top_frame().unwrap();
+        let adapter_bank = adapter.calls().m68k_context_bank();
+        let mut cpu = M68kCpu::new();
+        cpu.core.set_d(7, 0x1234_5678);
+        assert!(adapter
+            .calls()
+            .park_context(
+                &mut adapter_bank.borrow_mut(),
+                ExecutionTaskId::APPLICATION,
+                call,
+                cpu,
+            )
+            .is_ok());
+
+        let process = SharedGuestCallStack::default();
+        adapter.install_process_calls(&process);
+
+        assert!(adapter.calls().ptr_eq(&process));
+        assert!(adapter.is_coherent());
+        assert!(Rc::ptr_eq(&adapter_bank, &process.m68k_context_bank()));
+        let restored = adapter_bank
+            .borrow_mut()
+            .take(
+                &process.0.borrow().kernel,
+                ExecutionTaskId::APPLICATION,
+                call,
+            )
+            .unwrap();
+        assert_eq!(restored.core.d(7), 0x1234_5678);
+    }
 
     fn establish_native_reservation(cpu: &mut PpcCpu, address: u32) {
         const LWARX_R12_R4_R5: u32 = (31 << 26) | (12 << 21) | (4 << 16) | (5 << 11) | (20 << 1);

--- a/src/guest_call.rs
+++ b/src/guest_call.rs
@@ -893,21 +893,6 @@ impl SharedMenuTracking {
     pub(crate) fn ptr_eq(&self, other: &Self) -> bool {
         self.calls.ptr_eq(&other.calls)
     }
-    pub(crate) fn bind_execution(&mut self, calls: &SharedGuestCallStack) {
-        let view = calls.menu_tracking_view();
-        if self.calls.ptr_eq(&view.calls) {
-            self.execution = calls.shared_handle();
-            return;
-        }
-        // Derived adapter clones hold detached but equal snapshots of their
-        // view and execution owner. Reconnect that view before execution;
-        // adopting conflicting populated owners remains forbidden.
-        if self.calls == view.calls {
-            *self = view;
-        } else {
-            self.attach_to(&view);
-        }
-    }
     #[cfg(test)]
     pub(crate) fn menu_hook_key(&self) -> Option<MenuHookKey> {
         let index = self.active_index()?;
@@ -1195,17 +1180,6 @@ impl SharedMenuTracking {
             call.id != id
                 || !matches!(&call.operation, MenuOperation::Tracking(operation) if operation.is_idle())
         });
-    }
-    pub(crate) fn attach_to(&mut self, other: &Self) {
-        assert!(
-            self.calls.ptr_eq(&other.calls)
-                || self.calls.calls.is_empty()
-                || other.calls.calls.is_empty(),
-            "cannot attach two active Menu Manager continuations"
-        );
-        self.calls
-            .attach_to(&other.calls, |calls| calls.calls.is_empty());
-        self.execution = other.execution.shared_handle();
     }
     #[cfg(test)]
     pub(crate) fn snapshot(&self) -> Option<crate::menu_manager::ProcessMenuTrackingState> {
@@ -2530,6 +2504,7 @@ impl SharedGuestCallStack {
         Some(call_id)
     }
 
+    #[cfg(test)]
     fn push_effect(&self, effect: GuestCallEffect) -> bool {
         self.submit_effect(effect).is_some()
     }
@@ -2970,6 +2945,7 @@ impl SharedGuestCallStack {
     /// Commit the ABI result and restore the exact caller under one validated
     /// retirement boundary. The adapter closure must leave state unchanged
     /// when it rejects a result and must not execute guest code.
+    #[cfg(test)]
     pub(crate) fn commit_m68k_resume(
         &self,
         apply: impl FnOnce(M68kResume, Option<&mut M68kCpu>) -> bool,
@@ -3680,6 +3656,7 @@ impl ExecutionMenuViews {
         Self { calls, menu }
     }
 
+    #[cfg(test)]
     pub(crate) fn shared_from(calls: &SharedGuestCallStack) -> Self {
         let calls = calls.shared_handle();
         let menu = calls.menu_tracking_view();
@@ -3700,9 +3677,60 @@ impl ExecutionMenuViews {
         &mut self.menu
     }
 
+    pub(crate) fn existing_menu_context_mut(&mut self) -> Option<&mut MenuTrackingContext> {
+        self.menu.existing_context_mut()
+    }
+
+    pub(crate) fn menu_context_mut(&mut self) -> &mut MenuTrackingContext {
+        self.menu.context_mut()
+    }
+
+    pub(crate) fn enter_menu_call(&mut self, call: MenuTrackingCall) -> MenuTrackingEntry {
+        self.menu.enter_new_call(call)
+    }
+
+    pub(crate) fn resume_menu_call(
+        &mut self,
+        isa: GuestIsa,
+    ) -> Option<(MenuTrackingCall, MenuTrackingEntry)> {
+        self.menu.resume_call(isa)
+    }
+
+    pub(crate) fn take_menu_state(
+        &mut self,
+    ) -> Option<crate::menu_manager::ProcessMenuTrackingState> {
+        self.menu.take()
+    }
+
+    pub(crate) fn request_menu_hook(&self, mouse_down: bool) -> Option<MenuHookKey> {
+        self.menu.request_menu_hook(mouse_down)
+    }
+
+    pub(crate) fn bind_menu_hook(
+        &mut self,
+        key: MenuHookKey,
+        completion: MenuHookCompletion,
+    ) -> bool {
+        self.menu.bind_menu_hook(key, completion)
+    }
+
+    pub(crate) fn bind_menu_definition_completion(
+        &mut self,
+        id: MenuOperationId,
+        invocation: crate::menu_manager::MenuDefinitionInvocation,
+        completion: crate::menu_manager::MenuDefinitionCompletion,
+    ) {
+        self.menu.bind_completion(id, invocation, completion);
+    }
+
     #[cfg(test)]
     pub(crate) fn enter_test_menu(&mut self) -> MenuTrackingEntry {
         self.menu.enter()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn finish_test_menu_if_idle(&mut self, id: MenuOperationId) {
+        self.menu.finish_if_idle(id);
     }
 
     pub(crate) fn is_coherent(&self) -> bool {
@@ -3788,6 +3816,11 @@ mod tests {
         snapshot.menu_state_mut().as_mut().unwrap().highlighted_item = 7;
         assert_eq!(snapshot.menu().as_ref().unwrap().highlighted_item, 7);
         assert_eq!(original.menu().as_ref().unwrap().highlighted_item, 1);
+
+        assert_eq!(snapshot.take_menu_state().unwrap().menu_handle, 0x1000);
+        snapshot.finish_test_menu_if_idle(root.id);
+        assert!(snapshot.calls().is_empty());
+        assert!(!original.calls().is_empty());
 
         let shared = ExecutionMenuViews::shared_from(original.calls());
         assert!(shared.is_coherent());
@@ -4412,37 +4445,6 @@ mod tests {
         assert!(view.take().is_none());
         assert!(view.existing_context_mut().is_none());
         assert!(calls.is_pristine());
-        let other = SharedGuestCallStack::default();
-        view.attach_to(&other.menu_tracking_view());
-        assert!(other.is_pristine());
-    }
-
-    #[test]
-    fn cloned_menu_view_reconnects_to_its_detached_execution_owner() {
-        let calls = SharedGuestCallStack::default();
-        let mut view = calls.menu_tracking_view();
-        let entry = view.enter();
-        *view = Some(crate::menu_manager::test_process_menu_tracking(111));
-        let cloned_calls = calls.clone();
-        let mut cloned_view = view.clone();
-        assert!(!view.ptr_eq(&cloned_view));
-        cloned_view.bind_execution(&cloned_calls);
-        cloned_view.as_mut().unwrap().highlighted_item = 3;
-        assert_eq!(
-            cloned_calls
-                .menu_tracking_view()
-                .as_ref()
-                .unwrap()
-                .highlighted_item,
-            3
-        );
-        assert_eq!(view.as_ref().unwrap().highlighted_item, 1);
-        *cloned_view = None;
-        cloned_view.finish_if_idle(entry.id);
-        assert!(cloned_calls.is_empty());
-        assert!(!calls.is_empty());
-        *view = None;
-        drop(entry);
     }
 
     #[test]

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -102640,7 +102640,8 @@ pub(crate) mod tests {
                 BLR,
             ],
         );
-        let descriptor_bytes = ppc_memory_read_bytes(&mut loaded.memory, descriptor, 0x100).unwrap();
+        let descriptor_bytes =
+            ppc_memory_read_bytes(&mut loaded.memory, descriptor, 0x100).unwrap();
         let ref_num = *loaded.process_file_system.current_resource_file;
         loaded.process_file_system.vfs_resources.extend([
             PpcVfsResourceRecord {
@@ -102843,8 +102844,7 @@ pub(crate) mod tests {
                 BLR,
             ],
         );
-        let descriptor_bytes =
-            ppc_memory_read_bytes(&mut loaded.memory, descriptor, 0x100).unwrap();
+        let descriptor_bytes = ppc_memory_read_bytes(&mut loaded.memory, descriptor, 0x100).unwrap();
         let ref_num = *loaded.process_file_system.current_resource_file;
         loaded.process_file_system.vfs_resources.extend([
             PpcVfsResourceRecord {

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -28,9 +28,9 @@ use crate::event_queue::{
     EventProbeResult, EventQueue, EventQueueProbeSnapshot, EventRecordSnapshot, QueuedEvent,
 };
 use crate::guest_call::{
-    format_ppc_import_action, install_powerpc_call_arguments, GuestCallContinuation,
-    GuestCallEffect, GuestCallRequest, GuestCallTarget, MenuTrackingCall, MenuTrackingOrigin,
-    NativeRetirement, NativeThreadContext, SharedGuestCallStack, ThreadStorage,
+    format_ppc_import_action, install_powerpc_call_arguments, ExecutionMenuViews,
+    GuestCallContinuation, GuestCallEffect, GuestCallRequest, GuestCallTarget, MenuTrackingCall,
+    MenuTrackingOrigin, NativeRetirement, NativeThreadContext, SharedGuestCallStack, ThreadStorage,
 };
 use crate::guest_procedure::{
     resolve_guest_procedure, resolve_same_isa_thread_entry, GuestIsa, GuestProcedure,
@@ -99,7 +99,7 @@ use crate::process_context::{
     SharedProcessCallbackScheduling, SharedProcessCursorState, SharedProcessDialogText,
     SharedProcessControlManager, SharedProcessEventQueue,
     SharedProcessFileSystem, SharedProcessInputState, SharedProcessMemoryManager,
-    DEFAULT_QUICKDRAW_HILITE_COLOR, SharedProcessMenuTracking,
+    DEFAULT_QUICKDRAW_HILITE_COLOR,
     SharedProcessMixedModeM68kState,
     SharedProcessQuickDrawHiliteColors, SharedProcessQuickDrawOpColors,
     SharedProcessQuickDrawPixelStates, SharedProcessTickState,
@@ -3078,11 +3078,10 @@ pub struct PpcToolboxStartupState {
     pub menu_bar_draw_count: u32,
     pub host_menu_bar_hidden: bool,
     pub(crate) pending_native_menu_selection: SharedNativeMenuSelection,
-    pub(crate) menu_tracking: SharedProcessMenuTracking,
+    pub(crate) execution: ExecutionMenuViews,
     /// Process-owned 68k switch marker/gateway and compatibility stack used
     /// whenever native PowerPC enters classic code through Mixed Mode.
     mixed_mode_m68k: SharedProcessMixedModeM68kState,
-    guest_calls: SharedGuestCallStack,
     go_away_tracking: Option<PpcGoAwayTrackingState>,
     drag_window_tracking: Option<PpcDragWindowTrackingState>,
     grow_window_tracking: Option<PpcGrowWindowTrackingState>,
@@ -3141,7 +3140,6 @@ pub struct PpcToolboxStartupState {
 
 impl Default for PpcToolboxStartupState {
     fn default() -> Self {
-        let guest_calls = SharedGuestCallStack::default();
         Self {
             init_graf_count: 0,
             init_graf_global_ptr: 0,
@@ -3151,9 +3149,8 @@ impl Default for PpcToolboxStartupState {
             menu_bar_draw_count: 0,
             host_menu_bar_hidden: false,
             pending_native_menu_selection: SharedNativeMenuSelection::default(),
-            menu_tracking: guest_calls.menu_tracking_view(),
+            execution: ExecutionMenuViews::detached(),
             mixed_mode_m68k: SharedProcessMixedModeM68kState::default(),
-            guest_calls,
             go_away_tracking: None,
             drag_window_tracking: None,
             grow_window_tracking: None,
@@ -3206,37 +3203,40 @@ impl Default for PpcToolboxStartupState {
 
 impl PpcToolboxStartupState {
     fn active_menu_definition(&self) -> Option<&MenuDefinitionTracking> {
-        self.menu_tracking
+        self.execution
+            .menu()
             .as_ref()
             .and_then(PpcMenuTracking::active_definition)
-            .or(self.menu_tracking.context().definition.as_ref())
+            .or(self.execution.menu().context().definition.as_ref())
     }
 
     fn active_menu_definition_mut(&mut self) -> Option<&mut MenuDefinitionTracking> {
         if self
-            .menu_tracking
+            .execution
+            .menu()
             .as_ref()
             .and_then(PpcMenuTracking::active_definition)
             .is_some()
         {
             return self
-                .menu_tracking
+                .execution
+                .menu_state_mut()
                 .as_mut()
                 .and_then(PpcMenuTracking::active_definition_mut);
         }
-        self.menu_tracking
-            .existing_context_mut()?
+        self.execution
+            .existing_menu_context_mut()?
             .definition
             .as_mut()
     }
 
     fn clear_active_menu_definition(&mut self) {
-        if let Some(tracking) = self.menu_tracking.as_mut() {
+        if let Some(tracking) = self.execution.menu_state_mut().as_mut() {
             if tracking.take_active_definition().is_some() {
                 return;
             }
         }
-        if let Some(context) = self.menu_tracking.existing_context_mut() {
+        if let Some(context) = self.execution.existing_menu_context_mut() {
             context.definition = None;
         }
     }
@@ -3247,8 +3247,9 @@ fn ppc_prepare_menu_definition_port(
     current_gworld: &mut u32,
     current_gdevice: &mut u32,
 ) {
-    if startup.menu_tracking.context().native_port.is_none() {
-        startup.menu_tracking.context_mut().native_port = Some((*current_gworld, *current_gdevice));
+    if startup.execution.menu().context().native_port.is_none() {
+        startup.execution.menu_context_mut().native_port =
+            Some((*current_gworld, *current_gdevice));
     }
     *current_gworld = PPC_MAIN_GWORLD;
     *current_gdevice = PPC_MAIN_GDEVICE;
@@ -3259,8 +3260,8 @@ fn ppc_preserve_menu_callback_port(
     current_gworld: u32,
     current_gdevice: u32,
 ) {
-    if startup.menu_tracking.context().native_port.is_none() {
-        startup.menu_tracking.context_mut().native_port = Some((current_gworld, current_gdevice));
+    if startup.execution.menu().context().native_port.is_none() {
+        startup.execution.menu_context_mut().native_port = Some((current_gworld, current_gdevice));
     }
 }
 
@@ -3270,8 +3271,8 @@ fn ppc_restore_menu_definition_port(
     current_gdevice: &mut u32,
 ) {
     if let Some((gworld, gdevice)) = startup
-        .menu_tracking
-        .existing_context_mut()
+        .execution
+        .existing_menu_context_mut()
         .and_then(|context| context.native_port.take())
     {
         *current_gworld = gworld;
@@ -3629,7 +3630,6 @@ pub struct PpcLoadedApp {
     pub(crate) process_input: SharedProcessInputState,
     pub(crate) event_queue: SharedProcessEventQueue,
     pub(crate) window_list: crate::process_context::SharedProcessWindowList,
-    pub(crate) guest_calls: SharedGuestCallStack,
     pub(crate) process_memory_manager: PpcProcessMemoryManager,
     pub draw_sprocket: PpcDrawSprocketState,
 }
@@ -3678,6 +3678,52 @@ fn ppc_set_current_resource_refnum(
 }
 
 impl PpcLoadedApp {
+    #[cfg(test)]
+    pub(crate) fn guest_calls(&self) -> &SharedGuestCallStack {
+        self.toolbox_startup.execution.calls()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_constructed_from_migrated_handles(
+        &self,
+        handles: &crate::process_context::MigratedProcessHandles,
+    ) -> bool {
+        self.tick_state.ptr_eq(&handles.ticks)
+            && self
+                .toolbox_startup
+                .execution
+                .calls()
+                .ptr_eq(&handles.execution)
+            && self.toolbox_startup.execution.is_coherent()
+    }
+
+    pub(crate) fn preflight_migrated_services(
+        &self,
+        context: &ProcessContext,
+        expected_process_tick_at_commit: u32,
+    ) -> Result<
+        crate::process_context::MigratedServiceAdoption,
+        crate::process_context::MigratedServiceConflict,
+    > {
+        context.preflight_migrated_adoption(
+            &self.tick_state,
+            &self.toolbox_startup.execution,
+            expected_process_tick_at_commit,
+        )
+    }
+
+    pub(crate) fn commit_migrated_services(
+        &mut self,
+        context: &ProcessContext,
+        plan: crate::process_context::MigratedServiceAdoption,
+    ) {
+        context.commit_migrated_adoption(
+            plan,
+            &mut self.tick_state,
+            &mut self.toolbox_startup.execution,
+        );
+    }
+
     pub(crate) fn cfm_symbol_bindings(
         &mut self,
     ) -> impl crate::cfm::CfmSymbolBindings + '_ {
@@ -4078,7 +4124,7 @@ impl PpcLoadedApp {
         Some(self.cursor_state.image.as_ref()?.mono_parts())
     }
 
-    pub(crate) fn attach_process_context(&mut self, context: &mut ProcessContext) {
+    pub(crate) fn attach_unconverted_process_services(&mut self, context: &mut ProcessContext) {
         let mut attached_memory_manager = None;
         context.attach_memory_manager(&mut attached_memory_manager);
         let attached_memory_manager =
@@ -4110,13 +4156,11 @@ impl PpcLoadedApp {
         if !self.process_memory_manager.ptr_eq(&attached_memory_manager) {
             let standalone_memory_manager = self.process_memory_manager.0.borrow();
             let memory_manager = attached_memory_manager.borrow();
-            memory_manager
-                .assert_can_adopt_process_memory_manager(&standalone_memory_manager);
+            memory_manager.assert_can_adopt_process_memory_manager(&standalone_memory_manager);
         }
         context.attach_file_system(&mut self.process_file_system);
         self.process_file_system.publish_native_vfs_catalogue();
         context.attach_sound_manager(&mut self.sound.manager);
-        context.attach_tick_state(&mut self.tick_state);
         context.attach_callback_tasks(
             &mut self.timer_tasks,
             &mut self.vbl_tasks,
@@ -4170,14 +4214,9 @@ impl PpcLoadedApp {
         );
         context
             .attach_native_menu_selection(&mut self.toolbox_startup.pending_native_menu_selection);
-        context.attach_guest_calls(&mut self.guest_calls);
-        context.attach_guest_calls(&mut self.toolbox_startup.guest_calls);
-        context.attach_menu_tracking(&mut self.toolbox_startup.menu_tracking);
         context.attach_mixed_mode_m68k_state(&mut self.toolbox_startup.mixed_mode_m68k);
         context.attach_apple_event_handlers(&mut self.apple_events.handlers);
-        context.attach_apple_event_launch_state(
-            &mut self.apple_events.apple_event_launch_state,
-        );
+        context.attach_apple_event_launch_state(&mut self.apple_events.apple_event_launch_state);
     }
 
     /// Run one native operation with every process manager continuously attached.
@@ -4207,7 +4246,7 @@ impl PpcLoadedApp {
         &mut self,
         caller: &mut crate::cpu::M68kCpu,
     ) -> Option<()> {
-        let pending = self.guest_calls.pending_powerpc_from_m68k()?;
+        let pending = self.toolbox_startup.execution.calls().pending_powerpc_from_m68k()?;
         let parameter_slots = pending
             .arguments
             .as_slice()
@@ -4220,7 +4259,7 @@ impl PpcLoadedApp {
         let callback_sp = caller_sp.checked_sub(frame_size)? & !15;
         // PowerPC System Software, 1-44–1-49: linkage and parameter areas
         // belong to the caller's grow-down stack, including worker stacks.
-        let (stack_base, stack_limit) = self.guest_calls.native_stack_bounds(
+        let (stack_base, stack_limit) = self.toolbox_startup.execution.calls().native_stack_bounds(
             self.stack_base,
             self.stack_base.checked_add(self.stack_size)?,
         )?;
@@ -4240,7 +4279,7 @@ impl PpcLoadedApp {
         self.memory
             .write_u32_be(callback_sp + PPC_LINKAGE_SAVED_RTOC_OFFSET, self.cpu.gpr[2])?;
 
-        let pending = self.guest_calls.activate_powerpc_with_classic_caller(
+        let pending = self.toolbox_startup.execution.calls().activate_powerpc_with_classic_caller(
             &mut self.cpu,
             caller,
             PPC_GUEST_CALL_RETURN_PC,
@@ -6955,7 +6994,7 @@ impl PpcLoadedApp {
             .checked_sub(PPC_INTERRUPT_RED_ZONE_SIZE)?
             .checked_sub(PPC_INITIAL_STACK_FRAME_SIZE)?
             & !15;
-        let (base, limit) = self.guest_calls.native_stack_bounds(
+        let (base, limit) = self.toolbox_startup.execution.calls().native_stack_bounds(
             self.stack_base,
             self.stack_base.checked_add(self.stack_size)?,
         )?;
@@ -7527,12 +7566,13 @@ impl PpcLoadedApp {
         mut process_cfm: Option<&mut PpcCfmState>,
     ) -> PpcHleRunProbe {
         self.assert_cfm_execution_owner(process_cfm.as_deref());
+        let guest_calls = self.toolbox_startup.execution.calls().shared_handle();
         // Wakeup selects and prepares a saved context before any native step.
-        self.guest_calls.resume_ready_task();
-        if !self.guest_calls.current_task_is_running()
-            || self.guest_calls.has_classic_task_handoff()
-            || (self.guest_calls.has_pending_task_handoff()
-                && !self.guest_calls.prepare_native_task(&mut self.cpu))
+        guest_calls.resume_ready_task();
+        if !guest_calls.current_task_is_running()
+            || guest_calls.has_classic_task_handoff()
+            || (guest_calls.has_pending_task_handoff()
+                && !guest_calls.prepare_native_task(&mut self.cpu))
         {
             return PpcHleRunProbe {
                 result: PpcRunResult::CycleLimit { cycles: 0 },
@@ -7668,10 +7708,6 @@ impl PpcLoadedApp {
         let mut input_sprocket_virtual_elements =
             std::mem::take(&mut self.input_sprocket_virtual_elements);
         let mut toolbox_startup = std::mem::take(&mut self.toolbox_startup);
-        toolbox_startup.guest_calls.attach_to(&self.guest_calls);
-        toolbox_startup
-            .menu_tracking
-            .bind_execution(&toolbox_startup.guest_calls);
         let mut quicktime = std::mem::take(&mut self.quicktime);
         let mut sound = std::mem::take(&mut self.sound);
         let mut timer_tasks = std::mem::take(&mut self.timer_tasks);
@@ -7716,7 +7752,6 @@ impl PpcLoadedApp {
         let mut scrap = std::mem::take(&mut self.scrap);
         let mut list_manager = std::mem::take(&mut self.list_manager);
         let mut draw_sprocket = self.draw_sprocket;
-        let guest_calls = self.guest_calls.shared_handle();
         let mut handled_import_count = 0u32;
         let mut last_import_index = None;
         let mut unsupported_import_index = None;
@@ -7770,7 +7805,7 @@ impl PpcLoadedApp {
                 }
                 if index == PPC_GUEST_CALL_RETURN_IMPORT_INDEX {
                     let mut resource_call = None;
-                    if toolbox_startup.menu_tracking.ready_call(GuestIsa::PowerPc).is_some()
+                    if toolbox_startup.execution.menu().ready_call(GuestIsa::PowerPc).is_some()
                         || guest_calls
                         .ready_menu_bar_build(GuestIsa::PowerPc)
                         .is_some()
@@ -7818,7 +7853,7 @@ impl PpcLoadedApp {
                                 *current_resource_refnum,
                             );
                         }
-                        if let Some((_call, _scope)) = toolbox_startup.menu_tracking.resume_call(GuestIsa::PowerPc) {
+                        if let Some((_call, _scope)) = toolbox_startup.execution.resume_menu_call(GuestIsa::PowerPc) {
                             let heap = process_memory_manager.native_heap_state()
                                 .expect("native allocator registered during execution");
                             let mut cursor = heap.heap_cursor;
@@ -13237,7 +13272,6 @@ fn load_pef_application_with_config_and_optional_system_reservation(
         process_input: SharedProcessInputState::default(),
         event_queue: SharedProcessEventQueue::default(),
         window_list: Default::default(),
-        guest_calls: SharedGuestCallStack::default(),
         process_memory_manager,
         draw_sprocket: PpcDrawSprocketState::default(),
     })
@@ -15559,9 +15593,6 @@ fn dispatch_supported_import(
     event_queue: &mut EventQueue,
     draw_sprocket: &mut PpcDrawSprocketState,
 ) -> Option<PpcImportAction> {
-    toolbox_startup
-        .menu_tracking
-        .bind_execution(&toolbox_startup.guest_calls);
     let _menu_root = (matches!(
         binding.dispatcher_target,
         PpcImportDispatcherTarget::MenuSelect | PpcImportDispatcherTarget::PopUpMenuSelect
@@ -15571,7 +15602,7 @@ fn dispatch_supported_import(
             PpcImportDispatcherTarget::PopUpMenuSelect => ppc_popup_menu_call(cpu),
             _ => ppc_menu_select_call(cpu, cpu.gpr[3]),
         };
-        toolbox_startup.menu_tracking.enter_new_call(call)
+        toolbox_startup.execution.enter_menu_call(call)
     });
     // The process registry is authoritative. Refresh the legacy vector
     // booleans at each native boundary so rendering/debugging code that still
@@ -16728,7 +16759,7 @@ fn dispatch_supported_import(
             let menu_handles = ppc_menu_list_definition(memory, result_handle)
                 .map(|menu_list| menu_list.handles().collect())
                 .unwrap_or_default();
-            if toolbox_startup.guest_calls.begin_menu_bar_build(
+            if toolbox_startup.execution.calls().begin_menu_bar_build(
                 MenuBarBuild::new(result_handle, menu_handles),
                 MenuBarCallOrigin::PowerPc { return_address: cpu.lr },
             ).is_none() {
@@ -20578,7 +20609,7 @@ fn dispatch_supported_import(
         ))),
         PpcImportDispatcherTarget::GetSharedLibrary => Some(ppc_get_shared_library(
             cpu,
-            &toolbox_startup.guest_calls,
+            &toolbox_startup.execution.calls(),
             process_memory_manager,
             memory,
             heap_cursor,
@@ -20631,7 +20662,7 @@ fn dispatch_supported_import(
         }
         PpcImportDispatcherTarget::GetMemFragment => Some(ppc_get_mem_fragment(
             cpu,
-            &toolbox_startup.guest_calls,
+            &toolbox_startup.execution.calls(),
             process_memory_manager,
             memory,
             heap_cursor,
@@ -22436,7 +22467,7 @@ fn dispatch_supported_import(
             Some(ppc_install_apple_event_handler(cpu, memory, apple_events))
         }
         PpcImportDispatcherTarget::AEProcessAppleEvent => {
-            let guest_call_depth = toolbox_startup.guest_calls.depth();
+            let guest_call_depth = toolbox_startup.execution.calls().depth();
             Some(ppc_process_apple_event(
                 cpu,
                 process_memory_manager,
@@ -23899,7 +23930,7 @@ fn dispatch_supported_import(
         PpcImportDispatcherTarget::GetCurrentThread => {
             // OSErr GetCurrentThread(ThreadID *currentThreadID);
             // Inside Macintosh: Thread Manager (1999), p. 62.
-            let id = crate::thread_manager::ThreadManager::new(&toolbox_startup.guest_calls)
+            let id = crate::thread_manager::ThreadManager::new(&toolbox_startup.execution.calls())
                 .current_thread();
             let result = if cpu.gpr[3] != 0 && memory.write_u32_be(cpu.gpr[3], id).is_some() {
                 PPC_NO_ERR
@@ -23914,7 +23945,7 @@ fn dispatch_supported_import(
             let result = if cpu.gpr[4] == 0 {
                 PPC_PARAM_ERR
             } else {
-                match crate::thread_manager::ThreadManager::new(&toolbox_startup.guest_calls)
+                match crate::thread_manager::ThreadManager::new(&toolbox_startup.execution.calls())
                     .state(cpu.gpr[3])
                 {
                     Ok(state) if memory.write_u16_be(cpu.gpr[4], state).is_some() => PPC_NO_ERR,
@@ -23927,7 +23958,7 @@ fn dispatch_supported_import(
         PpcImportDispatcherTarget::GetThreadCurrentTaskRef => {
             // OSErr GetThreadCurrentTaskRef(ThreadTaskRef *reference);
             // Inside Macintosh: Thread Manager (1999), p. 73.
-            let reference = crate::thread_manager::ThreadManager::new(&toolbox_startup.guest_calls)
+            let reference = crate::thread_manager::ThreadManager::new(&toolbox_startup.execution.calls())
                 .task_reference();
             let result = if cpu.gpr[3] != 0 && memory.write_u32_be(cpu.gpr[3], reference).is_some()
             {
@@ -23943,7 +23974,7 @@ fn dispatch_supported_import(
             let result = if cpu.gpr[5] == 0 {
                 PPC_PARAM_ERR
             } else {
-                match crate::thread_manager::ThreadManager::new(&toolbox_startup.guest_calls)
+                match crate::thread_manager::ThreadManager::new(&toolbox_startup.execution.calls())
                     .state_given_task(cpu.gpr[3], cpu.gpr[4])
                 {
                     Ok(state) if memory.write_u16_be(cpu.gpr[5], state).is_some() => 0,
@@ -23956,7 +23987,7 @@ fn dispatch_supported_import(
         PpcImportDispatcherTarget::SetThreadReadyGivenTaskRef => {
             // OSErr SetThreadReadyGivenTaskRef(ThreadTaskRef reference, ThreadID thread);
             // Inside Macintosh: Thread Manager (1999), pp. 75–76.
-            let result = crate::thread_manager::ThreadManager::new(&toolbox_startup.guest_calls)
+            let result = crate::thread_manager::ThreadManager::new(&toolbox_startup.execution.calls())
                 .ready_given_task(cpu.gpr[3], cpu.gpr[4]);
             Some(PpcImportAction::Return(ppc_i16_result(result)))
         }
@@ -23974,7 +24005,7 @@ fn dispatch_supported_import(
                 PpcImportDispatcherTarget::SetThreadStateEndCritical
             );
             Some(
-                match toolbox_startup.guest_calls.set_native_thread_state(
+                match toolbox_startup.execution.calls().set_native_thread_state(
                     cpu,
                     thread,
                     state,
@@ -23990,7 +24021,7 @@ fn dispatch_supported_import(
         PpcImportDispatcherTarget::CreateThreadPool => {
             // OSErr CreateThreadPool(ThreadStyle, short, Size);
             // Thread Manager (1999), pp. 50–51: all allocations or none.
-            let manager = crate::thread_manager::ThreadManager::new(&toolbox_startup.guest_calls);
+            let manager = crate::thread_manager::ThreadManager::new(&toolbox_startup.execution.calls());
             let result = manager.create_pool(
                 GuestIsa::PowerPc,
                 cpu.gpr[3],
@@ -24035,7 +24066,7 @@ fn dispatch_supported_import(
             let default_size =
                 binding.dispatcher_target == PpcImportDispatcherTarget::GetDefaultThreadStackSize;
             let output = if specific { cpu.gpr[5] } else { cpu.gpr[4] };
-            let manager = crate::thread_manager::ThreadManager::new(&toolbox_startup.guest_calls);
+            let manager = crate::thread_manager::ThreadManager::new(&toolbox_startup.execution.calls());
             let value = if default_size {
                 crate::thread_manager::ThreadManager::stack_size(GuestIsa::PowerPc, cpu.gpr[3], 0)
             } else {
@@ -24069,7 +24100,7 @@ fn dispatch_supported_import(
             // OSErr ThreadCurrentStackSpace(ThreadID, unsigned long *);
             // Thread Manager (1999), pp. 17–18 and 61.
             let output = cpu.gpr[4];
-            let manager = crate::thread_manager::ThreadManager::new(&toolbox_startup.guest_calls);
+            let manager = crate::thread_manager::ThreadManager::new(&toolbox_startup.execution.calls());
             let result = match manager.stack_space(
                 cpu.gpr[3],
                 GuestIsa::PowerPc,
@@ -24098,7 +24129,7 @@ fn dispatch_supported_import(
             let options = cpu.gpr[7];
             let result_destination = cpu.gpr[8];
             let made = cpu.gpr[9];
-            let execution = toolbox_startup.guest_calls.shared_handle();
+            let execution = toolbox_startup.execution.calls().shared_handle();
             let mut edge = PpcNewThreadEdge {
                 memory,
                 memory_manager: process_memory_manager,
@@ -24130,8 +24161,7 @@ fn dispatch_supported_import(
                 0
             };
             Some(
-                match toolbox_startup
-                    .guest_calls
+                match toolbox_startup.execution.calls()
                     .yield_native_thread(cpu, suggested)
                 {
                     Ok(true) => PpcImportAction::Yield(1),
@@ -24143,7 +24173,7 @@ fn dispatch_supported_import(
         PpcImportDispatcherTarget::DisposeThread => {
             // OSErr DisposeThread(ThreadID, void *, Boolean);
             // Inside Macintosh: Thread Manager (1999), pp. 59–60.
-            let calls = &toolbox_startup.guest_calls;
+            let calls = &toolbox_startup.execution.calls();
             let task = crate::guest_call::ExecutionTaskId::from_thread_id(
                 crate::thread_manager::ThreadManager::new(calls).resolve_thread(cpu.gpr[3]),
             );
@@ -24173,13 +24203,13 @@ fn dispatch_supported_import(
         }
         PpcImportDispatcherTarget::ThreadBeginCritical => {
             Some(PpcImportAction::Return(ppc_i16_result(
-                crate::thread_manager::ThreadManager::new(&toolbox_startup.guest_calls)
+                crate::thread_manager::ThreadManager::new(&toolbox_startup.execution.calls())
                     .begin_critical(),
             )))
         }
         PpcImportDispatcherTarget::ThreadEndCritical => {
             Some(PpcImportAction::Return(ppc_i16_result(
-                crate::thread_manager::ThreadManager::new(&toolbox_startup.guest_calls)
+                crate::thread_manager::ThreadManager::new(&toolbox_startup.execution.calls())
                     .end_critical(),
             )))
         }
@@ -26965,7 +26995,7 @@ fn dispatch_supported_import(
                     cpu,
                     memory,
                     process_memory_manager,
-                    &toolbox_startup.guest_calls,
+                    &toolbox_startup.execution.calls(),
                     heap_cursor,
                     heap_limit,
                     cfm_connections,
@@ -45052,7 +45082,7 @@ fn ppc_begin_m68k_universal_proc_inner(
         rtoc: target.rtoc,
     };
     let submitted = if let Some(operation) = operation {
-        startup.guest_calls.begin_powerpc_to_m68k_with_operation(
+        startup.execution.calls().begin_powerpc_to_m68k_with_operation(
             target,
             target.entry,
             initial_sp,
@@ -45066,7 +45096,7 @@ fn ppc_begin_m68k_universal_proc_inner(
             operation,
         )
     } else {
-        startup.guest_calls.begin_powerpc_to_m68k(
+        startup.execution.calls().begin_powerpc_to_m68k(
             target,
             target.entry,
             initial_sp,
@@ -59426,10 +59456,11 @@ fn ppc_set_depth(
     // PopUpMenuSelect overlay never owns TheMenu, so preserve that low-memory
     // value when cancelling popup tracking.
     let tracking_owned_menu_bar = toolbox_startup
-        .menu_tracking
+        .execution
+        .menu()
         .as_ref()
         .is_some_and(|state| state.kind == MenuTrackingKind::MenuBar);
-    if let Some(context) = toolbox_startup.menu_tracking.existing_context_mut() {
+    if let Some(context) = toolbox_startup.execution.existing_menu_context_mut() {
         context.tracking = None;
         context.clear_native_popup();
     }
@@ -71369,7 +71400,7 @@ fn ppc_dispatch_drag_window(
         return PpcImportAction::ReturnPreserve;
     }
 
-    if startup.menu_tracking.is_some()
+    if startup.execution.menu().is_some()
         || startup.go_away_tracking.is_some()
         || !input.mouse_button
         || call.window == 0
@@ -71546,7 +71577,7 @@ fn ppc_dispatch_grow_window(
         return PpcImportAction::Return(result);
     }
 
-    if startup.menu_tracking.is_some()
+    if startup.execution.menu().is_some()
         || startup.go_away_tracking.is_some()
         || startup.drag_window_tracking.is_some()
         || !input.mouse_button
@@ -71713,7 +71744,7 @@ fn ppc_dispatch_track_go_away(
         return PpcImportAction::Return(u32::from(inside));
     }
 
-    if startup.menu_tracking.is_some()
+    if startup.execution.menu().is_some()
         || !input.mouse_button
         || !ppc_go_away_window_is_trackable(memory, gworlds, call.window)
     {
@@ -76022,8 +76053,8 @@ fn ppc_dispatch_native_menu_definition_with_return(
     final_pc: u32,
     return_gpr3: PpcNativeReturnGpr3,
 ) -> Option<PpcImportAction> {
-    let menu_build = toolbox_startup.guest_calls.menu_bar_build();
-    let tracking_root = toolbox_startup.menu_tracking.entry_id();
+    let menu_build = toolbox_startup.execution.calls().menu_bar_build();
+    let tracking_root = toolbox_startup.execution.menu().entry_id();
     let final_pc = if menu_build.is_some() && invocation.message == MenuDefinitionMessage::Size {
         PPC_GUEST_CALL_RETURN_PC
     } else {
@@ -76056,7 +76087,7 @@ fn ppc_dispatch_native_menu_definition_with_return(
             GuestIsa::PowerPc => {
                 let effect = GuestCallEffect::call_guest(
                     GuestCallRequest::for_task(
-                        toolbox_startup.guest_calls.current_task(),
+                        toolbox_startup.execution.calls().current_task(),
                         GuestCallTarget {
                             isa: target.isa,
                             entry: target.entry,
@@ -76074,7 +76105,8 @@ fn ppc_dispatch_native_menu_definition_with_return(
                     ),
                 );
                 toolbox_startup
-                    .guest_calls
+                    .execution
+                    .calls()
                     .activate_powerpc_effect_with_operation(
                         cpu,
                         memory,
@@ -76103,17 +76135,18 @@ fn ppc_dispatch_native_menu_definition_with_return(
         return None;
     }
     if let Some(id) = tracking_root {
-        toolbox_startup
-            .menu_tracking
-            .bind_completion(id, invocation, completion.clone());
+        toolbox_startup.execution.bind_menu_definition_completion(
+            id,
+            invocation,
+            completion.clone(),
+        );
     }
     if invocation.message == MenuDefinitionMessage::Size {
         if let Some(id) = menu_build {
-            toolbox_startup.guest_calls.bind_menu_bar_build_completion(
-                id,
-                invocation.menu_handle,
-                completion,
-            );
+            toolbox_startup
+                .execution
+                .calls()
+                .bind_menu_bar_build_completion(id, invocation.menu_handle, completion);
         }
     }
     prepared
@@ -76150,7 +76183,7 @@ fn ppc_begin_m68k_menu_definition(
     registers.address[5] = PPC_DATA_BASE;
     let effect = GuestCallEffect::call_guest(
         GuestCallRequest::for_task(
-            startup.guest_calls.current_task(),
+            startup.execution.calls().current_task(),
             GuestCallTarget {
                 isa: target.isa,
                 entry: target.entry,
@@ -76166,7 +76199,7 @@ fn ppc_begin_m68k_menu_definition(
         }),
         GuestCallContinuation::to_powerpc(return_pc, final_pc, cpu.gpr[2], return_gpr3),
     );
-    if !startup.guest_calls.begin_m68k_operation(
+    if !startup.execution.calls().begin_m68k_operation(
         effect,
         operation.scratch,
         crate::guest_call::ManagerContinuation::Menu(
@@ -76306,7 +76339,7 @@ fn ppc_step_menu_tracking(
     )?;
     if matches!(action, PpcImportAction::Yield(_)) {
         let Some(key) = toolbox_startup
-            .menu_tracking
+            .execution
             .request_menu_hook(input.mouse_button)
         else {
             return Some(action);
@@ -76327,7 +76360,7 @@ fn ppc_step_menu_tracking(
                     GuestIsa::PowerPc => {
                         let effect = GuestCallEffect::call_guest(
                             GuestCallRequest::for_task(
-                                toolbox_startup.guest_calls.current_task(),
+                                toolbox_startup.execution.calls().current_task(),
                                 GuestCallTarget {
                                     isa: target.isa,
                                     entry: target.entry,
@@ -76344,8 +76377,7 @@ fn ppc_step_menu_tracking(
                                 return_value,
                             ),
                         );
-                        toolbox_startup
-                            .guest_calls
+                        toolbox_startup.execution.calls()
                             .activate_powerpc_effect_with_operation(
                                 cpu,
                                 memory,
@@ -76379,7 +76411,7 @@ fn ppc_step_menu_tracking(
                 };
                 if let Some(callback) = callback {
                     assert!(toolbox_startup
-                        .menu_tracking
+                        .execution
                         .bind_menu_hook(key, operation.completion.clone()));
                     ppc_preserve_menu_callback_port(
                         toolbox_startup,
@@ -76410,7 +76442,7 @@ fn ppc_step_menu_tracking_body(
     vfs_resources: &[PpcVfsResourceRecord],
     current_resource_refnum: i16,
 ) -> Option<PpcImportAction> {
-    let call = toolbox_startup.menu_tracking.context().call?;
+    let call = toolbox_startup.execution.menu().context().call?;
     let MenuTrackingOrigin::PowerPc {
         stack_pointer,
         return_address,
@@ -76436,13 +76468,14 @@ fn ppc_step_menu_tracking_body(
         MenuTrackingRequest::PopUp(_) => {
             let menu_color_bytes = ppc_menu_color_table_bytes(memory, &handles);
             let menu_colors = MenuColorTable::new(&menu_color_bytes);
-            if toolbox_startup.menu_tracking.context().caller_isa() == Some(GuestIsa::M68k) {
+            if toolbox_startup.execution.menu().context().caller_isa() == Some(GuestIsa::M68k) {
                 // A classic MenuSelect owns this process continuation. A
                 // nested native call must not consume its origin ABI frame.
                 Some(PpcImportAction::Return(0))
             } else if toolbox_startup.active_menu_definition().is_some() {
                 if toolbox_startup
-                    .menu_tracking
+                    .execution
+                    .menu()
                     .context()
                     .native_popup()
                     .is_some()
@@ -76465,7 +76498,7 @@ fn ppc_step_menu_tracking_body(
                 } else {
                     Some(PpcImportAction::Return(0))
                 }
-            } else if toolbox_startup.menu_tracking.is_none() {
+            } else if toolbox_startup.execution.menu().is_none() {
                 if let Some(action) = ppc_begin_custom_popup_menu_tracking(
                     cpu,
                     process_memory_manager,
@@ -76509,7 +76542,7 @@ fn ppc_step_menu_tracking_body(
         MenuTrackingRequest::MenuSelect { .. } => {
             let menu_color_bytes = ppc_menu_color_table_bytes(memory, &handles);
             let menu_colors = MenuColorTable::new(&menu_color_bytes);
-            if toolbox_startup.menu_tracking.context().caller_isa() == Some(GuestIsa::M68k) {
+            if toolbox_startup.execution.menu().context().caller_isa() == Some(GuestIsa::M68k) {
                 // A classic MenuSelect owns this process continuation. A
                 // nested native call must not consume its origin ABI frame.
                 Some(PpcImportAction::Return(0))
@@ -76531,18 +76564,19 @@ fn ppc_step_menu_tracking_body(
                     current_resource_refnum,
                 ))
             } else if toolbox_startup
-                .menu_tracking
+                .execution
+                .menu()
                 .as_ref()
                 .is_some_and(|state| state.kind == MenuTrackingKind::MenuBar && state.is_flashing())
             {
-                let mut state = toolbox_startup.menu_tracking.take().unwrap();
+                let mut state = toolbox_startup.execution.take_menu_state().unwrap();
                 let step = state.advance_flash();
                 if matches!(step, MenuFlashStep::Wait | MenuFlashStep::Inactive) {
-                    *toolbox_startup.menu_tracking = Some(state);
+                    *toolbox_startup.execution.menu_state_mut() = Some(state);
                     return Some(PpcImportAction::Yield(u64::MAX));
                 }
                 if let MenuFlashStep::Complete(result) = step {
-                    *toolbox_startup.menu_tracking = Some(state);
+                    *toolbox_startup.execution.menu_state_mut() = Some(state);
                     let result = ppc_complete_menu_bar_tracking_with_colors(
                         memory,
                         gworlds,
@@ -76570,10 +76604,11 @@ fn ppc_step_menu_tracking_body(
                         step == MenuFlashStep::Highlight(true),
                     );
                 }
-                *toolbox_startup.menu_tracking = Some(state);
+                *toolbox_startup.execution.menu_state_mut() = Some(state);
                 Some(PpcImportAction::Yield(u64::MAX))
             } else if toolbox_startup
-                .menu_tracking
+                .execution
+                .menu()
                 .as_ref()
                 .is_some_and(|state| state.kind != MenuTrackingKind::MenuBar)
             {
@@ -76608,7 +76643,7 @@ fn ppc_step_menu_tracking_body(
                 ppc_restore_menu_definition_port(toolbox_startup, current_gworld, current_gdevice);
                 Some(PpcImportAction::Return(result))
             } else if input.mouse_button {
-                if toolbox_startup.menu_tracking.is_none() {
+                if toolbox_startup.execution.menu().is_none() {
                     if let Some(action) = ppc_begin_custom_menu_bar_tracking(
                         cpu,
                         process_memory_manager,
@@ -76643,8 +76678,8 @@ fn ppc_step_menu_tracking_body(
                     .and_then(MenuDefinitionTracking::pending_invocation)
                 {
                     toolbox_startup
-                        .menu_tracking
-                        .context_mut()
+                        .execution
+                        .menu_context_mut()
                         .call
                         .get_or_insert(ppc_menu_select_call(cpu, cpu.gpr[3]));
                     ppc_prepare_menu_definition_port(
@@ -76665,13 +76700,13 @@ fn ppc_step_menu_tracking_body(
                     ) {
                         return Some(action);
                     }
-                    if let Some(state) = toolbox_startup.menu_tracking.take() {
+                    if let Some(state) = toolbox_startup.execution.take_menu_state() {
                         ppc_restore_menu_tracking(memory, state.front_buffer, &state);
                     }
                     toolbox_startup.clear_active_menu_definition();
                     toolbox_startup
-                        .menu_tracking
-                        .context_mut()
+                        .execution
+                        .menu_context_mut()
                         .clear_native_menu();
                     ppc_restore_menu_definition_port(
                         toolbox_startup,
@@ -76681,7 +76716,8 @@ fn ppc_step_menu_tracking_body(
                     return Some(PpcImportAction::Return(0));
                 }
                 if toolbox_startup
-                    .menu_tracking
+                    .execution
+                    .menu()
                     .as_ref()
                     .is_some_and(|state| state.kind == MenuTrackingKind::MenuBar)
                 {
@@ -76697,7 +76733,7 @@ fn ppc_step_menu_tracking_body(
                 // separate fixed-height shortcut. Macintosh Toolbox Essentials
                 // (1992), pp. 3-114--3-116.
                 let mut tracking_updated = false;
-                if toolbox_startup.menu_tracking.is_none() {
+                if toolbox_startup.execution.menu().is_none() {
                     if let Some(action) = ppc_begin_custom_menu_bar_tracking(
                         cpu,
                         process_memory_manager,
@@ -76729,7 +76765,7 @@ fn ppc_step_menu_tracking_body(
                     tracking_updated = true;
                 }
                 if !tracking_updated {
-                    if let Some(mut state) = toolbox_startup.menu_tracking.take() {
+                    if let Some(mut state) = toolbox_startup.execution.take_menu_state() {
                         ppc_update_menu_tracking(
                             memory,
                             gworlds,
@@ -76741,10 +76777,10 @@ fn ppc_step_menu_tracking_body(
                             vfs_resources,
                             current_resource_refnum,
                         );
-                        *toolbox_startup.menu_tracking = Some(state);
+                        *toolbox_startup.execution.menu_state_mut() = Some(state);
                     }
                 }
-                if let Some(state) = toolbox_startup.menu_tracking.as_ref() {
+                if let Some(state) = toolbox_startup.execution.menu().as_ref() {
                     if let Some((menu_handle, item)) = ppc_tracked_menu_selection(memory, state) {
                         let menu_id = memory
                             .read_u32_be(menu_handle)
@@ -76753,7 +76789,7 @@ fn ppc_step_menu_tracking_body(
                             .unwrap_or(0);
                         let result = (u32::from(menu_id) << 16) | u32::from(item as u16);
                         if result != 0 {
-                            let state = toolbox_startup.menu_tracking.as_mut().unwrap();
+                            let state = toolbox_startup.execution.menu_state_mut().as_mut().unwrap();
                             if state.begin_flash(
                                 memory
                                     .read_u16_be(crate::memory::globals::addr::MENU_FLASH)
@@ -76888,8 +76924,13 @@ fn ppc_begin_custom_popup_menu_tracking(
         return None;
     }
     ppc_menu_definition_target(cpu, memory, resources, menu_handle)?;
-    startup.menu_tracking.context_mut().definition = Some(call.popup_request().unwrap().begin_definition());
-    startup.menu_tracking.context_mut().call.get_or_insert(call);
+    startup.execution.menu_context_mut().definition =
+        Some(call.popup_request().unwrap().begin_definition());
+    startup
+        .execution
+        .menu_context_mut()
+        .call
+        .get_or_insert(call);
     ppc_prepare_menu_definition_port(startup, current_gworld, current_gdevice);
     let invocation = startup
         .active_menu_definition()
@@ -76907,7 +76948,7 @@ fn ppc_begin_custom_popup_menu_tracking(
     );
     if action.is_none() {
         startup.clear_active_menu_definition();
-        startup.menu_tracking.context_mut().clear_native_popup();
+        startup.execution.menu_context_mut().clear_native_popup();
         ppc_restore_menu_definition_port(startup, current_gworld, current_gdevice);
     }
     action
@@ -76929,7 +76970,7 @@ fn ppc_continue_custom_popup_menu_tracking(
     input: PpcInputSnapshot,
     resources: &[PpcVfsResourceRecord],
 ) -> PpcImportAction {
-    let Some(call) = startup.menu_tracking.context().native_popup() else {
+    let Some(call) = startup.execution.menu().context().native_popup() else {
         startup.clear_active_menu_definition();
         ppc_restore_menu_definition_port(startup, current_gworld, current_gdevice);
         return PpcImportAction::Return(0);
@@ -76941,7 +76982,7 @@ fn ppc_continue_custom_popup_menu_tracking(
     {
         Ok(completed) => completed.flatten(),
         Err(()) => {
-            if let Some(state) = startup.menu_tracking.take() {
+            if let Some(state) = startup.execution.take_menu_state() {
                 if ppc_live_front_buffer_for_gworld(memory, gworlds, PPC_MAIN_GWORLD)
                     .map(MenuTrackingSurface::from)
                     == state.front_buffer
@@ -76950,7 +76991,7 @@ fn ppc_continue_custom_popup_menu_tracking(
                 }
             }
             startup.clear_active_menu_definition();
-            startup.menu_tracking.context_mut().clear_native_popup();
+            startup.execution.menu_context_mut().clear_native_popup();
             ppc_restore_menu_definition_port(startup, current_gworld, current_gdevice);
             cpu.lr = call.origin.return_address();
             return PpcImportAction::Return(0);
@@ -76958,16 +76999,22 @@ fn ppc_continue_custom_popup_menu_tracking(
     };
 
     if startup
-        .menu_tracking
+        .execution
+        .menu()
         .as_ref()
         .is_some_and(|state| state.is_flashing())
     {
-        let step = startup.menu_tracking.as_mut().unwrap().advance_flash();
+        let step = startup
+            .execution
+            .menu_state_mut()
+            .as_mut()
+            .unwrap()
+            .advance_flash();
         if matches!(step, MenuFlashStep::Wait | MenuFlashStep::Inactive) {
             return PpcImportAction::Yield(u64::MAX);
         }
         if let MenuFlashStep::Complete(result) = step {
-            if let Some(state) = startup.menu_tracking.take() {
+            if let Some(state) = startup.execution.take_menu_state() {
                 if ppc_live_front_buffer_for_gworld(memory, gworlds, PPC_MAIN_GWORLD)
                     .map(MenuTrackingSurface::from)
                     == state.front_buffer
@@ -76976,7 +77023,7 @@ fn ppc_continue_custom_popup_menu_tracking(
                 }
             }
             startup.clear_active_menu_definition();
-            startup.menu_tracking.context_mut().clear_native_popup();
+            startup.execution.menu_context_mut().clear_native_popup();
             ppc_restore_menu_definition_port(startup, current_gworld, current_gdevice);
             cpu.lr = call.origin.return_address();
             return PpcImportAction::Return(result);
@@ -77003,7 +77050,7 @@ fn ppc_continue_custom_popup_menu_tracking(
     if completed == Some(MenuDefinitionMessage::PopUp) {
         let Some(front) = ppc_live_front_buffer_for_gworld(memory, gworlds, PPC_MAIN_GWORLD) else {
             startup.clear_active_menu_definition();
-            startup.menu_tracking.context_mut().clear_native_popup();
+            startup.execution.menu_context_mut().clear_native_popup();
             ppc_restore_menu_definition_port(startup, current_gworld, current_gdevice);
             cpu.lr = call.origin.return_address();
             return PpcImportAction::Return(0);
@@ -77024,7 +77071,7 @@ fn ppc_continue_custom_popup_menu_tracking(
             Vec::new(),
         ) else {
             startup.clear_active_menu_definition();
-            startup.menu_tracking.context_mut().clear_native_popup();
+            startup.execution.menu_context_mut().clear_native_popup();
             ppc_restore_menu_definition_port(startup, current_gworld, current_gdevice);
             cpu.lr = call.origin.return_address();
             return PpcImportAction::Return(0);
@@ -77041,13 +77088,13 @@ fn ppc_continue_custom_popup_menu_tracking(
         {
             ppc_restore_menu_tracking(memory, state.front_buffer, &state);
             startup.clear_active_menu_definition();
-            startup.menu_tracking.context_mut().clear_native_popup();
+            startup.execution.menu_context_mut().clear_native_popup();
             ppc_restore_menu_definition_port(startup, current_gworld, current_gdevice);
             cpu.lr = call.origin.return_address();
             return PpcImportAction::Return(0);
         }
-        state.definition = startup.menu_tracking.context_mut().definition.take();
-        *startup.menu_tracking = Some(state);
+        state.definition = startup.execution.menu_context_mut().definition.take();
+        *startup.execution.menu_state_mut() = Some(state);
         startup.active_menu_definition_mut().unwrap().draw();
         let invocation = startup
             .active_menu_definition()
@@ -77100,7 +77147,7 @@ fn ppc_continue_custom_popup_menu_tracking(
                 0
             };
             if result != 0 {
-                let state = startup.menu_tracking.as_mut().unwrap();
+                let state = startup.execution.menu_state_mut().as_mut().unwrap();
                 let flash_enabled = state.begin_flash(
                     memory
                         .read_u16_be(crate::memory::globals::addr::MENU_FLASH)
@@ -77108,7 +77155,7 @@ fn ppc_continue_custom_popup_menu_tracking(
                     result,
                 );
                 if !flash_enabled {
-                    if let Some(state) = startup.menu_tracking.take() {
+                    if let Some(state) = startup.execution.take_menu_state() {
                         if ppc_live_front_buffer_for_gworld(memory, gworlds, PPC_MAIN_GWORLD)
                             .map(MenuTrackingSurface::from)
                             == state.front_buffer
@@ -77117,14 +77164,14 @@ fn ppc_continue_custom_popup_menu_tracking(
                         }
                     }
                     startup.clear_active_menu_definition();
-                    startup.menu_tracking.context_mut().clear_native_popup();
+                    startup.execution.menu_context_mut().clear_native_popup();
                     ppc_restore_menu_definition_port(startup, current_gworld, current_gdevice);
                     cpu.lr = call.origin.return_address();
                     return PpcImportAction::Return(result);
                 }
                 return PpcImportAction::Yield(u64::MAX);
             }
-            if let Some(state) = startup.menu_tracking.take() {
+            if let Some(state) = startup.execution.take_menu_state() {
                 if ppc_live_front_buffer_for_gworld(memory, gworlds, PPC_MAIN_GWORLD)
                     .map(MenuTrackingSurface::from)
                     == state.front_buffer
@@ -77133,14 +77180,14 @@ fn ppc_continue_custom_popup_menu_tracking(
                 }
             }
             startup.clear_active_menu_definition();
-            startup.menu_tracking.context_mut().clear_native_popup();
+            startup.execution.menu_context_mut().clear_native_popup();
             ppc_restore_menu_definition_port(startup, current_gworld, current_gdevice);
             cpu.lr = call.origin.return_address();
             return PpcImportAction::Return(result);
         }
     }
 
-    if let Some(state) = startup.menu_tracking.take() {
+    if let Some(state) = startup.execution.take_menu_state() {
         if ppc_live_front_buffer_for_gworld(memory, gworlds, PPC_MAIN_GWORLD)
             .map(MenuTrackingSurface::from)
             == state.front_buffer
@@ -77149,7 +77196,7 @@ fn ppc_continue_custom_popup_menu_tracking(
         }
     }
     startup.clear_active_menu_definition();
-    startup.menu_tracking.context_mut().clear_native_popup();
+    startup.execution.menu_context_mut().clear_native_popup();
     ppc_restore_menu_definition_port(startup, current_gworld, current_gdevice);
     cpu.lr = call.origin.return_address();
     PpcImportAction::Return(0)
@@ -77171,14 +77218,14 @@ fn ppc_dispatch_pop_up_menu_select(
     let call = ppc_popup_menu_call(cpu);
     let current_menu_list = ppc_current_menu_list(memory);
 
-    if let Some(state) = startup.menu_tracking.as_ref() {
-        if startup.menu_tracking.context().caller_isa() == Some(GuestIsa::M68k) {
+    if let Some(state) = startup.execution.menu().as_ref() {
+        if startup.execution.menu().context().caller_isa() == Some(GuestIsa::M68k) {
             // A classic MenuSelect owns this process continuation. A nested
             // native call must not consume its save-under or origin ABI frame.
             return PpcImportAction::Return(0);
         }
         if state.kind != MenuTrackingKind::PopUp
-            || startup.menu_tracking.context().native_popup() != Some(call)
+            || startup.execution.menu().context().native_popup() != Some(call)
             || state.menu_handle != menu_handle
         {
             // A callback may enter a different modal menu routine while an
@@ -77191,30 +77238,30 @@ fn ppc_dispatch_pop_up_menu_select(
         if live_front.map(MenuTrackingSurface::from) != state.front_buffer {
             // A changed PixMap/depth makes the saved coordinates unsafe to
             // write. Abandon the overlay without touching either buffer.
-            *startup.menu_tracking = None;
-            startup.menu_tracking.context_mut().clear_native_popup();
+            *startup.execution.menu_state_mut() = None;
+            startup.execution.menu_context_mut().clear_native_popup();
             return PpcImportAction::Return(0);
         }
         if !ppc_popup_menu_is_inserted(memory, current_menu_list, menu_handle) {
-            let Some(state) = startup.menu_tracking.take() else {
+            let Some(state) = startup.execution.take_menu_state() else {
                 return PpcImportAction::Return(0);
             };
-            startup.menu_tracking.context_mut().clear_native_popup();
+            startup.execution.menu_context_mut().clear_native_popup();
             ppc_restore_menu_tracking(memory, state.front_buffer, &state);
             return PpcImportAction::Return(0);
         }
 
         if state.is_flashing() {
-            let Some(mut state) = startup.menu_tracking.take() else {
+            let Some(mut state) = startup.execution.take_menu_state() else {
                 return PpcImportAction::Return(0);
             };
             let step = state.advance_flash();
             if matches!(step, MenuFlashStep::Wait | MenuFlashStep::Inactive) {
-                *startup.menu_tracking = Some(state);
+                *startup.execution.menu_state_mut() = Some(state);
                 return PpcImportAction::Yield(u64::MAX);
             }
             if let MenuFlashStep::Complete(result) = step {
-                startup.menu_tracking.context_mut().clear_native_popup();
+                startup.execution.menu_context_mut().clear_native_popup();
                 ppc_restore_menu_tracking(memory, state.front_buffer, &state);
                 return PpcImportAction::Return(result);
             }
@@ -77231,11 +77278,11 @@ fn ppc_dispatch_pop_up_menu_select(
                 &state,
                 visible_item,
             );
-            *startup.menu_tracking = Some(state);
+            *startup.execution.menu_state_mut() = Some(state);
             return PpcImportAction::Yield(u64::MAX);
         }
 
-        let Some(mut state) = startup.menu_tracking.take() else {
+        let Some(mut state) = startup.execution.take_menu_state() else {
             return PpcImportAction::Return(0);
         };
         // Popup tracking uses the same retained MenuRows state as MenuSelect.
@@ -77256,7 +77303,7 @@ fn ppc_dispatch_pop_up_menu_select(
         let highlighted_item = state.highlighted_item;
         if !input.mouse_button {
             if highlighted_item == 0 {
-                startup.menu_tracking.context_mut().clear_native_popup();
+                startup.execution.menu_context_mut().clear_native_popup();
                 ppc_restore_menu_tracking(memory, state.front_buffer, &state);
                 return PpcImportAction::Return(0);
             }
@@ -77273,7 +77320,7 @@ fn ppc_dispatch_pop_up_menu_select(
                 result,
             );
             if !flash_enabled {
-                startup.menu_tracking.context_mut().clear_native_popup();
+                startup.execution.menu_context_mut().clear_native_popup();
                 ppc_restore_menu_tracking(memory, state.front_buffer, &state);
                 return PpcImportAction::Return(result);
             }
@@ -77285,7 +77332,7 @@ fn ppc_dispatch_pop_up_menu_select(
                 &state,
                 highlighted_item,
             );
-            *startup.menu_tracking = Some(state);
+            *startup.execution.menu_state_mut() = Some(state);
             return PpcImportAction::Yield(u64::MAX);
         }
 
@@ -77297,7 +77344,7 @@ fn ppc_dispatch_pop_up_menu_select(
             &state,
             highlighted_item,
         );
-        *startup.menu_tracking = Some(state);
+        *startup.execution.menu_state_mut() = Some(state);
         return PpcImportAction::Yield(u64::MAX);
     }
 
@@ -77351,8 +77398,8 @@ fn ppc_dispatch_pop_up_menu_select(
         &state,
         highlighted_item,
     );
-    *startup.menu_tracking = Some(state);
-    startup.menu_tracking.context_mut().call.get_or_insert(call);
+    *startup.execution.menu_state_mut() = Some(state);
+    startup.execution.menu_context_mut().call.get_or_insert(call);
     PpcImportAction::Yield(u64::MAX)
 }
 
@@ -78627,8 +78674,11 @@ fn ppc_begin_custom_menu_bar_tracking(
         StandardMenuPaneKind::PullDown,
         &state,
     )?;
-    *startup.menu_tracking = Some(state);
-    startup.menu_tracking.context_mut().call
+    *startup.execution.menu_state_mut() = Some(state);
+    startup
+        .execution
+        .menu_context_mut()
+        .call
         .get_or_insert(ppc_menu_select_call(cpu, initial_point));
     ppc_prepare_menu_definition_port(startup, current_gworld, current_gdevice);
     let invocation = startup
@@ -78646,11 +78696,11 @@ fn ppc_begin_custom_menu_bar_tracking(
         cpu.pc,
     );
     if action.is_none() {
-        if let Some(state) = startup.menu_tracking.take() {
+        if let Some(state) = startup.execution.take_menu_state() {
             ppc_restore_menu_tracking(memory, state.front_buffer, &state);
         }
         startup.clear_active_menu_definition();
-        startup.menu_tracking.context_mut().clear_native_menu();
+        startup.execution.menu_context_mut().clear_native_menu();
         ppc_restore_menu_definition_port(startup, current_gworld, current_gdevice);
         ppc_set_menu_command_highlight_with_colors(
             memory,
@@ -78683,21 +78733,21 @@ fn ppc_continue_custom_menu_bar_tracking(
     resources: &[PpcVfsResourceRecord],
     current_resource_refnum: i16,
 ) -> PpcImportAction {
-    let Some(call) = startup.menu_tracking.context().native_menu() else {
+    let Some(call) = startup.execution.menu().context().native_menu() else {
         startup.clear_active_menu_definition();
         ppc_restore_menu_definition_port(startup, current_gworld, current_gdevice);
         return PpcImportAction::Return(0);
     };
     let Some(definition) = startup.active_menu_definition_mut() else {
         cpu.lr = call.origin.return_address();
-        startup.menu_tracking.context_mut().clear_native_menu();
+        startup.execution.menu_context_mut().clear_native_menu();
         ppc_restore_menu_definition_port(startup, current_gworld, current_gdevice);
         return PpcImportAction::Return(0);
     };
     let completed = match definition.complete_callback() {
         Ok(completed) => completed,
         Err(()) => {
-            if let Some(state) = startup.menu_tracking.take() {
+            if let Some(state) = startup.execution.take_menu_state() {
                 if ppc_live_front_buffer_for_gworld(memory, gworlds, PPC_MAIN_GWORLD)
                     .map(MenuTrackingSurface::from)
                     == state.front_buffer
@@ -78706,7 +78756,7 @@ fn ppc_continue_custom_menu_bar_tracking(
                 }
             }
             startup.clear_active_menu_definition();
-            startup.menu_tracking.context_mut().clear_native_menu();
+            startup.execution.menu_context_mut().clear_native_menu();
             ppc_restore_menu_definition_port(startup, current_gworld, current_gdevice);
             cpu.lr = call.origin.return_address();
             return PpcImportAction::Return(0);
@@ -78714,17 +78764,15 @@ fn ppc_continue_custom_menu_bar_tracking(
     };
 
     if completed == Some(MenuDefinitionMessage::Choose) {
-        let active_submenu =
-            startup
-                .menu_tracking
-                .as_ref()
-                .and_then(|state| match state.active_definition_pane() {
-                    Some(MenuDefinitionPane::Submenu(depth)) => state
-                        .submenus
-                        .get(depth)
-                        .map(|submenu| submenu.dropdown_rect()),
-                    _ => None,
-                });
+        let active_submenu = startup.execution.menu().as_ref().and_then(|state| {
+            match state.active_definition_pane() {
+                Some(MenuDefinitionPane::Submenu(depth)) => state
+                    .submenus
+                    .get(depth)
+                    .map(|submenu| submenu.dropdown_rect()),
+                _ => None,
+            }
+        });
         if let Some((top, left, bottom, right)) = active_submenu {
             if input.mouse_v < top
                 || input.mouse_v >= bottom
@@ -78732,7 +78780,7 @@ fn ppc_continue_custom_menu_bar_tracking(
                 || input.mouse_h >= right
             {
                 let menu_list = ppc_current_menu_list(memory);
-                if let Some(mut state) = startup.menu_tracking.take() {
+                if let Some(mut state) = startup.execution.take_menu_state() {
                     ppc_update_menu_tracking(
                         memory,
                         gworlds,
@@ -78744,10 +78792,10 @@ fn ppc_continue_custom_menu_bar_tracking(
                         resources,
                         current_resource_refnum,
                     );
-                    *startup.menu_tracking = Some(state);
+                    *startup.execution.menu_state_mut() = Some(state);
                 }
                 if startup.active_menu_definition().is_none() {
-                    startup.menu_tracking.context_mut().clear_native_menu();
+                    startup.execution.menu_context_mut().clear_native_menu();
                     ppc_restore_menu_definition_port(startup, current_gworld, current_gdevice);
                     cpu.lr = call.origin.return_address();
                     return PpcImportAction::Yield(u64::MAX);
@@ -78775,16 +78823,22 @@ fn ppc_continue_custom_menu_bar_tracking(
     }
 
     if startup
-        .menu_tracking
+        .execution
+        .menu()
         .as_ref()
         .is_some_and(|state| state.is_flashing())
     {
-        let step = startup.menu_tracking.as_mut().unwrap().advance_flash();
+        let step = startup
+            .execution
+            .menu_state_mut()
+            .as_mut()
+            .unwrap()
+            .advance_flash();
         if matches!(step, MenuFlashStep::Wait | MenuFlashStep::Inactive) {
             return PpcImportAction::Yield(u64::MAX);
         }
         if let MenuFlashStep::Complete(result) = step {
-            if let Some(state) = startup.menu_tracking.take() {
+            if let Some(state) = startup.execution.take_menu_state() {
                 if ppc_live_front_buffer_for_gworld(memory, gworlds, PPC_MAIN_GWORLD)
                     .map(MenuTrackingSurface::from)
                     == state.front_buffer
@@ -78804,7 +78858,7 @@ fn ppc_continue_custom_menu_bar_tracking(
                 startup.host_menu_bar_hidden,
             );
             startup.clear_active_menu_definition();
-            startup.menu_tracking.context_mut().clear_native_menu();
+            startup.execution.menu_context_mut().clear_native_menu();
             ppc_restore_menu_definition_port(startup, current_gworld, current_gdevice);
             cpu.lr = call.origin.return_address();
             return PpcImportAction::Return(result);
@@ -78848,7 +78902,7 @@ fn ppc_continue_custom_menu_bar_tracking(
             return action;
         }
         let menu_list = ppc_current_menu_list(memory);
-        if let Some(state) = startup.menu_tracking.take() {
+        if let Some(state) = startup.execution.take_menu_state() {
             if ppc_live_front_buffer_for_gworld(memory, gworlds, PPC_MAIN_GWORLD)
                 .map(MenuTrackingSurface::from)
                 == state.front_buffer
@@ -78857,7 +78911,7 @@ fn ppc_continue_custom_menu_bar_tracking(
             }
         }
         startup.clear_active_menu_definition();
-        startup.menu_tracking.context_mut().clear_native_menu();
+        startup.execution.menu_context_mut().clear_native_menu();
         ppc_set_menu_command_highlight_with_colors(
             memory,
             gworlds,
@@ -78890,7 +78944,7 @@ fn ppc_continue_custom_menu_bar_tracking(
         0
     };
     if result != 0 {
-        let state = startup.menu_tracking.as_mut().unwrap();
+        let state = startup.execution.menu_state_mut().as_mut().unwrap();
         let flash_enabled = state.begin_flash(
             memory
                 .read_u16_be(crate::memory::globals::addr::MENU_FLASH)
@@ -78898,7 +78952,7 @@ fn ppc_continue_custom_menu_bar_tracking(
             result,
         );
         if !flash_enabled {
-            if let Some(state) = startup.menu_tracking.take() {
+            if let Some(state) = startup.execution.take_menu_state() {
                 if ppc_live_front_buffer_for_gworld(memory, gworlds, PPC_MAIN_GWORLD)
                     .map(MenuTrackingSurface::from)
                     == state.front_buffer
@@ -78918,14 +78972,14 @@ fn ppc_continue_custom_menu_bar_tracking(
                 startup.host_menu_bar_hidden,
             );
             startup.clear_active_menu_definition();
-            startup.menu_tracking.context_mut().clear_native_menu();
+            startup.execution.menu_context_mut().clear_native_menu();
             ppc_restore_menu_definition_port(startup, current_gworld, current_gdevice);
             cpu.lr = call.origin.return_address();
             return PpcImportAction::Return(result);
         }
         return PpcImportAction::Yield(u64::MAX);
     }
-    if let Some(state) = startup.menu_tracking.take() {
+    if let Some(state) = startup.execution.take_menu_state() {
         if ppc_live_front_buffer_for_gworld(memory, gworlds, PPC_MAIN_GWORLD)
             .map(MenuTrackingSurface::from)
             == state.front_buffer
@@ -78945,7 +78999,7 @@ fn ppc_continue_custom_menu_bar_tracking(
         startup.host_menu_bar_hidden,
     );
     startup.clear_active_menu_definition();
-    startup.menu_tracking.context_mut().clear_native_menu();
+    startup.execution.menu_context_mut().clear_native_menu();
     ppc_restore_menu_definition_port(startup, current_gworld, current_gdevice);
     cpu.lr = call.origin.return_address();
     PpcImportAction::Return(result)
@@ -78990,14 +79044,15 @@ fn ppc_track_menu_while_held_with_resources(
         return;
     };
     if startup
-        .menu_tracking
+        .execution
+        .menu()
         .as_ref()
         .is_some_and(|state| state.kind != MenuTrackingKind::MenuBar)
     {
         return;
     }
     if startup.host_menu_bar_hidden {
-        if let Some(previous) = startup.menu_tracking.take() {
+        if let Some(previous) = startup.execution.take_menu_state() {
             if previous.front_buffer == Some(front.into()) {
                 ppc_restore_menu_tracking(memory, Some(front.into()), &previous);
             }
@@ -79005,7 +79060,7 @@ fn ppc_track_menu_while_held_with_resources(
         let _ = memory.write_u16_be(PPC_THE_MENU_ADDR, 0);
         return;
     }
-    if let Some(previous) = startup.menu_tracking.take() {
+    if let Some(previous) = startup.execution.take_menu_state() {
         if previous.front_buffer != Some(front.into()) {
             ppc_restore_menu_tracking(memory, previous.front_buffer, &previous);
             let _ = memory.write_u16_be(PPC_THE_MENU_ADDR, 0);
@@ -79027,7 +79082,7 @@ fn ppc_track_menu_while_held_with_resources(
             .filter(|(menu_handle, _)| *menu_handle != previous.menu_handle);
         if let Some((menu_handle, title_left)) = switched {
             ppc_restore_menu_tracking(memory, Some(front.into()), &previous);
-            *startup.menu_tracking = ppc_begin_menu_bar_tracking_with_resources(
+            *startup.execution.menu_state_mut() = ppc_begin_menu_bar_tracking_with_resources(
                 memory,
                 front,
                 menu_handle,
@@ -79035,9 +79090,9 @@ fn ppc_track_menu_while_held_with_resources(
                 resources,
                 current_resource_refnum,
             );
-            startup.menu_tracking.context_mut().clear_native_popup();
+            startup.execution.menu_context_mut().clear_native_popup();
         } else {
-            *startup.menu_tracking = Some(previous);
+            *startup.execution.menu_state_mut() = Some(previous);
         }
     } else {
         let Some((menu_handle, title_left)) =
@@ -79055,10 +79110,10 @@ fn ppc_track_menu_while_held_with_resources(
         ) else {
             return;
         };
-        *startup.menu_tracking = Some(state);
-        startup.menu_tracking.context_mut().clear_native_popup();
+        *startup.execution.menu_state_mut() = Some(state);
+        startup.execution.menu_context_mut().clear_native_popup();
     }
-    let active_menu_id = startup.menu_tracking.as_ref().and_then(|state| {
+    let active_menu_id = startup.execution.menu().as_ref().and_then(|state| {
         memory
             .read_u32_be(state.menu_handle)
             .filter(|menu| *menu != 0)
@@ -79076,7 +79131,7 @@ fn ppc_track_menu_while_held_with_resources(
             startup.host_menu_bar_hidden,
         );
     }
-    if let Some(mut state) = startup.menu_tracking.take() {
+    if let Some(mut state) = startup.execution.take_menu_state() {
         // MenuSelect highlights the title and tracks the pointer until the
         // button is released, displaying the selected item inversely. A
         // hierarchical title opens its installed submenu while remaining
@@ -79093,7 +79148,7 @@ fn ppc_track_menu_while_held_with_resources(
             resources,
             current_resource_refnum,
         );
-        *startup.menu_tracking = Some(state);
+        *startup.execution.menu_state_mut() = Some(state);
     }
 }
 
@@ -79106,13 +79161,14 @@ fn ppc_finish_menu_bar_tracking_with_colors(
     _input: PpcInputSnapshot,
 ) -> Option<u32> {
     if startup
-        .menu_tracking
+        .execution
+        .menu()
         .as_ref()
         .is_some_and(|state| state.kind != MenuTrackingKind::MenuBar)
     {
         return None;
     }
-    let state = startup.menu_tracking.as_ref()?;
+    let state = startup.execution.menu().as_ref()?;
     let selection = (!startup.host_menu_bar_hidden)
         .then(|| ppc_tracked_menu_selection(memory, state))
         .flatten();
@@ -79144,7 +79200,7 @@ fn ppc_complete_menu_bar_tracking_with_colors(
     result: u32,
 ) -> Option<u32> {
     let current_menu_list = ppc_current_menu_list(memory);
-    let state = startup.menu_tracking.take()?;
+    let state = startup.execution.take_menu_state()?;
     if let Some(front) = ppc_live_front_buffer_for_gworld(memory, gworlds, PPC_MAIN_GWORLD) {
         if Some(MenuTrackingSurface::from(front)) == state.front_buffer {
             ppc_restore_menu_tracking(memory, Some(front.into()), &state);
@@ -79185,7 +79241,7 @@ fn ppc_finish_menu_bar_tracking(
     startup: &mut PpcToolboxStartupState,
     input: PpcInputSnapshot,
 ) -> Option<u32> {
-    if let Some(mut state) = startup.menu_tracking.take() {
+    if let Some(mut state) = startup.execution.take_menu_state() {
         let menu_list = ppc_current_menu_list(memory);
         ppc_update_menu_tracking(
             memory,
@@ -79198,7 +79254,7 @@ fn ppc_finish_menu_bar_tracking(
             &[],
             0,
         );
-        *startup.menu_tracking = Some(state);
+        *startup.execution.menu_state_mut() = Some(state);
     }
     ppc_finish_menu_bar_tracking_with_colors(
         memory,
@@ -79791,8 +79847,7 @@ fn ppc_continue_menu_bar_build(
     current_resource_refnum: i16,
 ) -> PpcImportAction {
     loop {
-        let menu_handle = match startup
-            .guest_calls
+        let menu_handle = match startup.execution.calls()
             .advance_menu_bar_build(GuestIsa::PowerPc)
         {
             Some(MenuBarBuildResume::Size(handle)) => handle,
@@ -91560,10 +91615,9 @@ pub(crate) mod tests {
     }
 
     fn drain_test_m68k_guest_calls(loaded: &mut PpcLoadedApp) {
-        while let Some(pending) = loaded
-            .guest_calls
+        while let Some(pending) = loaded.guest_calls()
             .active_m68k()
-            .or_else(|| loaded.guest_calls.activate_m68k())
+            .or_else(|| loaded.guest_calls().activate_m68k())
         {
             let mut cpu = m68k::CpuCore::new();
             cpu.set_cpu_type(REFERENCE_MACHINE_PROFILE.cpu_type());
@@ -91607,7 +91661,11 @@ pub(crate) mod tests {
                     panic!("special-case result selector {selector} requires the shared runner")
                 }
             };
-            assert!(loaded.guest_calls.complete_m68k_operation_for_powerpc(
+            assert!(loaded
+                .toolbox_startup
+                .execution
+                .calls()
+                .complete_m68k_operation_for_powerpc(
                 cpu.pc,
                 cpu.a(7),
                 result,
@@ -93625,7 +93683,7 @@ pub(crate) mod tests {
                 ..PpcInputSnapshot::default()
             },
         );
-        let tracking = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
+        let tracking = loaded.toolbox_startup.execution.menu().snapshot().unwrap();
         let command_text_advance = ppc_text_bytes_advance_for_font(
             b"Command",
             PPC_QD_TEXT_FONT_DEFAULT,
@@ -93907,7 +93965,7 @@ pub(crate) mod tests {
         let probe = loaded.run_with_hle_imports(64);
         assert!(matches!(probe.result, PpcRunResult::CycleLimit { .. }));
 
-        let tracking = loaded.toolbox_startup.menu_tracking.as_ref().unwrap();
+        let tracking = loaded.toolbox_startup.execution.menu().as_ref().unwrap();
         let front =
             ppc_live_front_buffer_for_gworld(&mut loaded.memory, &loaded.gworlds, PPC_MAIN_GWORLD)
                 .unwrap();
@@ -94206,7 +94264,7 @@ pub(crate) mod tests {
             .native_ptr_records()
             .iter()
             .all(|record| record.ptr != loaded.cpu.gpr[5]));
-        assert!(loaded.guest_calls.is_empty());
+        assert!(loaded.guest_calls().is_empty());
     }
 
     #[test]
@@ -94269,7 +94327,7 @@ pub(crate) mod tests {
         assert_eq!(probe.unsupported_import_index, None);
         assert_eq!(probe.handled_import_count, 2);
         assert_eq!(loaded.cpu.pc, PPC_HALT_PC);
-        assert!(loaded.guest_calls.is_empty());
+        assert!(loaded.guest_calls().is_empty());
         assert_eq!(
             loaded.memory.read_u32_be(marker),
             Some(0x1122),
@@ -94322,7 +94380,7 @@ pub(crate) mod tests {
             )
             .unwrap();
             assert!(matches!(action, PpcImportAction::Halt));
-            let pending = loaded.toolbox_startup.guest_calls.activate_m68k().unwrap();
+            let pending = loaded.toolbox_startup.execution.calls().activate_m68k().unwrap();
             loaded
                 .memory
                 .write_u32_be(pending.initial_sp - 100, 0x1122 + index)
@@ -94344,8 +94402,7 @@ pub(crate) mod tests {
         assert_eq!(manager.native_ptr_records().len(), initial_count + 2);
         for (index, pending) in intervals.into_iter().rev().enumerate() {
             assert!(loaded
-                .toolbox_startup
-                .guest_calls
+                .toolbox_startup.execution.calls()
                 .complete_m68k_operation_for_powerpc(
                     pending.return_pc,
                     pending.final_sp,
@@ -94359,7 +94416,7 @@ pub(crate) mod tests {
                 initial_count + 1 - index
             );
         }
-        assert!(loaded.toolbox_startup.guest_calls.is_empty());
+        assert!(loaded.toolbox_startup.execution.calls().is_empty());
         assert_eq!(loaded.toolbox_startup.mixed_mode_m68k.gateway, 0);
         assert_eq!(loaded.toolbox_startup.mixed_mode_m68k.stack_top, 0);
     }
@@ -94434,7 +94491,7 @@ pub(crate) mod tests {
         assert!(matches!(action, PpcImportAction::Continue));
         assert_eq!(loaded.cpu.pc, callback_entry);
         assert_eq!(loaded.cpu.gpr[2], callback_rtoc);
-        assert_eq!(loaded.toolbox_startup.guest_calls.len(), 1);
+        assert_eq!(loaded.toolbox_startup.execution.calls().len(), 1);
         let scratch = loaded.cpu.gpr[5];
         assert_eq!(
             ppc_memory_read_bytes(&mut loaded.memory, scratch, 10),
@@ -94446,8 +94503,7 @@ pub(crate) mod tests {
         );
         loaded.cpu.pc = PPC_GUEST_CALL_RETURN_PC;
         assert!(loaded
-            .toolbox_startup
-            .guest_calls
+            .toolbox_startup.execution.calls()
             .complete_powerpc_resuming_operation(
                 &mut loaded.cpu,
                 manager.native_mut(),
@@ -94482,13 +94538,13 @@ pub(crate) mod tests {
             )
             .unwrap();
             assert!(
-                loaded.toolbox_startup.guest_calls.is_pristine(),
+                loaded.toolbox_startup.execution.calls().is_pristine(),
                 "depth {screen_depth}"
             );
             let mut context = crate::process_context::ProcessContext::default();
-            loaded.attach_process_context(&mut context);
-            assert!(loaded.toolbox_startup.menu_tracking.is_none());
-            assert!(loaded.guest_calls.is_pristine());
+            loaded.attach_unconverted_process_services(&mut context);
+            assert!(loaded.toolbox_startup.execution.menu().is_none());
+            assert!(loaded.guest_calls().is_pristine());
             assert!(context.menu_tracking().is_none());
         }
     }
@@ -94606,8 +94662,8 @@ pub(crate) mod tests {
             );
             assert_eq!(loaded.cpu.pc, PPC_HALT_PC, "outer caller return");
             assert_eq!(loaded.cpu.gpr[3], (131u32 << 16) | 1, "outer selection");
-            assert!(loaded.guest_calls.is_empty());
-            assert!(loaded.toolbox_startup.menu_tracking.is_none());
+            assert!(loaded.guest_calls().is_empty());
+            assert!(loaded.toolbox_startup.execution.menu().is_none());
             assert_eq!(*loaded.current_gworld, 0x1234_0000);
             assert_eq!(*loaded.current_gdevice, 0x1234_1000);
             assert_eq!(
@@ -94692,7 +94748,7 @@ pub(crate) mod tests {
             ppc_memory_read_bytes(&mut loaded.memory, front.base_addr, framebuffer_len),
             Some(before.clone())
         );
-        let tracking = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
+        let tracking = loaded.toolbox_startup.execution.menu().snapshot().unwrap();
 
         loaded.set_input_snapshot(PpcInputSnapshot {
             mouse_button: false,
@@ -94706,7 +94762,7 @@ pub(crate) mod tests {
         assert_eq!(
             loaded
                 .toolbox_startup
-                .menu_tracking
+                .execution.menu()
                 .as_ref()
                 .unwrap()
                 .flash_remaining,
@@ -94718,7 +94774,7 @@ pub(crate) mod tests {
             assert_eq!(probe.handled_import_count, 0, "retained custom tracking bypasses public entry");
             let remaining = loaded
                 .toolbox_startup
-                .menu_tracking
+                .execution.menu()
                 .as_ref()
                 .map_or(0, |state| state.flash_remaining);
             if phases.last() != Some(&remaining) {
@@ -94732,13 +94788,13 @@ pub(crate) mod tests {
         assert_eq!(phases, [6, 5, 4, 3, 2, 1, 0]);
         assert_eq!(loaded.cpu.gpr[3], (131u32 << 16) | 2);
         assert_eq!(loaded.cpu.lr, return_address);
-        assert_eq!(loaded.toolbox_startup.menu_tracking, None);
+        assert!(loaded.toolbox_startup.execution.menu().is_none());
         assert_eq!(
-            loaded.toolbox_startup.menu_tracking.context().definition,
+            loaded.toolbox_startup.execution.menu().context().definition,
             None
         );
         assert_eq!(
-            loaded.toolbox_startup.menu_tracking.context().native_menu(),
+            loaded.toolbox_startup.execution.menu().context().native_menu(),
             None
         );
         assert_eq!(*loaded.current_gworld, 0x1234_0000);
@@ -94874,7 +94930,7 @@ pub(crate) mod tests {
         assert!(matches!(probe.result, PpcRunResult::CycleLimit { .. }));
         let root_rect = loaded
             .toolbox_startup
-            .menu_tracking
+            .execution.menu()
             .as_ref()
             .unwrap()
             .dropdown_rect();
@@ -94887,7 +94943,7 @@ pub(crate) mod tests {
         });
         let probe = loaded.run_with_hle_imports(512);
         assert!(matches!(probe.result, PpcRunResult::CycleLimit { .. }));
-        let tracking = loaded.toolbox_startup.menu_tracking.as_ref().unwrap();
+        let tracking = loaded.toolbox_startup.execution.menu().as_ref().unwrap();
         let child_rect = tracking.submenus[0].dropdown_rect();
         assert_eq!(child_rect.3 - child_rect.1, 72);
         assert_eq!(child_rect.2 - child_rect.0, 32);
@@ -94907,13 +94963,13 @@ pub(crate) mod tests {
         assert!(matches!(probe.result, PpcRunResult::CycleLimit { .. }));
         assert!(loaded
             .toolbox_startup
-            .menu_tracking
+            .execution.menu()
             .as_ref()
             .unwrap()
             .submenus
             .is_empty());
         assert_eq!(
-            loaded.toolbox_startup.menu_tracking.context().caller_isa(),
+            loaded.toolbox_startup.execution.menu().context().caller_isa(),
             Some(GuestIsa::PowerPc)
         );
         assert_eq!(*loaded.current_gworld, 0x1234_0000);
@@ -94930,7 +94986,7 @@ pub(crate) mod tests {
         assert_eq!(
             loaded
                 .toolbox_startup
-                .menu_tracking
+                .execution.menu()
                 .as_ref()
                 .unwrap()
                 .active_definition_pane(),
@@ -94963,7 +95019,7 @@ pub(crate) mod tests {
         let probe = loaded.run_with_hle_imports(256);
         assert!(matches!(probe.result, PpcRunResult::CycleLimit { .. }));
         {
-            let state = loaded.toolbox_startup.menu_tracking.as_mut().unwrap();
+            let state = loaded.toolbox_startup.execution.menu_state_mut().as_mut().unwrap();
             assert_eq!(state.flash_result, (141u32 << 16) | 2);
             state.flash_remaining = 1;
             state.flash_delay = 0;
@@ -94972,9 +95028,9 @@ pub(crate) mod tests {
         assert!(matches!(probe.result, PpcRunResult::Halted { .. }));
         assert_eq!(loaded.cpu.gpr[3], (141u32 << 16) | 2);
         assert_eq!(loaded.cpu.lr, return_address);
-        assert_eq!(loaded.toolbox_startup.menu_tracking, None);
+        assert!(loaded.toolbox_startup.execution.menu().is_none());
         assert_eq!(
-            loaded.toolbox_startup.menu_tracking.context().caller_isa(),
+            loaded.toolbox_startup.execution.menu().context().caller_isa(),
             None
         );
         assert_eq!(*loaded.current_gworld, 0x1234_0000);
@@ -95102,7 +95158,7 @@ pub(crate) mod tests {
             assert_eq!(
                 loaded
                     .toolbox_startup
-                    .menu_tracking
+                    .execution.menu()
                     .as_ref()
                     .unwrap()
                     .flash_remaining,
@@ -95114,7 +95170,7 @@ pub(crate) mod tests {
                 assert_eq!(probe.handled_import_count, 0, "retained custom tracking bypasses public entry");
                 let remaining = loaded
                     .toolbox_startup
-                    .menu_tracking
+                    .execution.menu()
                     .as_ref()
                     .map_or(0, |state| state.flash_remaining);
                 if phases.last() != Some(&remaining) {
@@ -95127,13 +95183,13 @@ pub(crate) mod tests {
             }
             assert_eq!(phases, [6, 5, 4, 3, 2, 1, 0]);
             assert_eq!(loaded.cpu.gpr[3], (132u32 << 16) | 2);
-            assert_eq!(loaded.toolbox_startup.menu_tracking, None);
+            assert!(loaded.toolbox_startup.execution.menu().is_none());
             assert_eq!(
-                loaded.toolbox_startup.menu_tracking.context().definition,
+                loaded.toolbox_startup.execution.menu().context().definition,
                 None
             );
             assert_eq!(
-                loaded.toolbox_startup.menu_tracking.context().native_popup(),
+                loaded.toolbox_startup.execution.menu().context().native_popup(),
                 None
             );
             assert_eq!(
@@ -95216,7 +95272,7 @@ pub(crate) mod tests {
                 &loaded.process_file_system.vfs_resources,
                 *loaded.process_file_system.current_resource_file,
             );
-            let tracking = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
+            let tracking = loaded.toolbox_startup.execution.menu().snapshot().unwrap();
             assert_eq!(
                 tracking
                     .item_appearances
@@ -95407,7 +95463,7 @@ pub(crate) mod tests {
             &loaded.process_file_system.vfs_resources,
             *loaded.process_file_system.current_resource_file,
         );
-        let root = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
+        let root = loaded.toolbox_startup.execution.menu().snapshot().unwrap();
         assert_eq!(root.item_appearances[0].height, 34);
         let parent_top = root.popup_top + root.item_appearances[0].height;
         ppc_track_menu_while_held_with_resources(
@@ -95426,7 +95482,7 @@ pub(crate) mod tests {
             &loaded.process_file_system.vfs_resources,
             *loaded.process_file_system.current_resource_file,
         );
-        let tracking = loaded.toolbox_startup.menu_tracking.as_ref().unwrap();
+        let tracking = loaded.toolbox_startup.execution.menu().as_ref().unwrap();
         let child = tracking.submenus.first().expect("submenu did not open");
         assert_eq!(tracking.highlighted_item, 2);
         assert_eq!(child.popup_top, parent_top);
@@ -95510,7 +95566,7 @@ pub(crate) mod tests {
                     ..PpcInputSnapshot::default()
                 },
             );
-            let tracking = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
+            let tracking = loaded.toolbox_startup.execution.menu().snapshot().unwrap();
             assert_eq!(tracking.front_buffer, Some(front.into()));
             assert_eq!(tracking.popup_left, STANDARD_MENU_BAR_FIRST_TITLE_LEFT);
             assert_eq!(tracking.saved_width, tracking.popup_width + 1);
@@ -95642,7 +95698,7 @@ pub(crate) mod tests {
                 ),
                 Some(0),
             );
-            assert_eq!(loaded.toolbox_startup.menu_tracking, None);
+            assert!(loaded.toolbox_startup.execution.menu().is_none());
             assert_eq!(loaded.memory.read_u16_be(PPC_THE_MENU_ADDR), Some(0));
             assert_eq!(
                 ppc_memory_read_bytes(
@@ -95757,7 +95813,7 @@ pub(crate) mod tests {
                     ..PpcInputSnapshot::default()
                 },
             );
-            let root = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
+            let root = loaded.toolbox_startup.execution.menu().snapshot().unwrap();
             let parent_hover = PpcInputSnapshot {
                 mouse_button: true,
                 mouse_v: root.popup_top + 8,
@@ -95772,7 +95828,7 @@ pub(crate) mod tests {
                 12,
                 parent_hover,
             );
-            let tracking = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
+            let tracking = loaded.toolbox_startup.execution.menu().snapshot().unwrap();
             let child = tracking.submenus.first().expect("submenu did not open");
             assert_eq!(tracking.highlighted_item, 1);
             assert_eq!(child.menu_handle, submenu);
@@ -95800,7 +95856,7 @@ pub(crate) mod tests {
             assert_eq!(
                 loaded
                     .toolbox_startup
-                    .menu_tracking
+                    .execution.menu()
                     .as_ref()
                     .and_then(|state| state.submenus.first())
                     .map(|child| child.highlighted_item),
@@ -95896,7 +95952,7 @@ pub(crate) mod tests {
             );
             assert!(loaded
                 .toolbox_startup
-                .menu_tracking
+                .execution.menu()
                 .as_ref()
                 .is_some_and(|state| !state.submenus.is_empty()));
             assert_eq!(
@@ -96073,9 +96129,9 @@ pub(crate) mod tests {
                 );
             };
             track(&mut loaded, (10, 12));
-            let root = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
+            let root = loaded.toolbox_startup.execution.menu().snapshot().unwrap();
             track(&mut loaded, (root.popup_top + 8, root.popup_left + 20));
-            let first = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
+            let first = loaded.toolbox_startup.execution.menu().snapshot().unwrap();
             assert_eq!(first.submenus.len(), 1);
             assert_eq!(first.submenus[0].menu_handle, options);
             let options_pane = first.submenus[0].clone();
@@ -96083,7 +96139,7 @@ pub(crate) mod tests {
                 &mut loaded,
                 (options_pane.popup_top + 8, options_pane.popup_left + 20),
             );
-            let nested = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
+            let nested = loaded.toolbox_startup.execution.menu().snapshot().unwrap();
             assert_eq!(nested.submenus.len(), 2);
             assert_eq!(nested.submenus[0].highlighted_item, 1);
             assert_eq!(nested.submenus[1].menu_handle, speed);
@@ -96095,14 +96151,14 @@ pub(crate) mod tests {
                     options_pane.popup_left + 20,
                 ),
             );
-            let switched = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
+            let switched = loaded.toolbox_startup.execution.menu().snapshot().unwrap();
             assert_eq!(switched.submenus.len(), 1);
             assert_eq!(switched.submenus[0].highlighted_item, 2);
             track(
                 &mut loaded,
                 (options_pane.popup_top + 8, options_pane.popup_left + 20),
             );
-            let reopened = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
+            let reopened = loaded.toolbox_startup.execution.menu().snapshot().unwrap();
             assert_eq!(reopened.submenus.len(), 2);
             let speed_pane = reopened.submenus[1].clone();
 
@@ -96110,7 +96166,7 @@ pub(crate) mod tests {
                 &mut loaded,
                 (speed_pane.popup_top + 8, speed_pane.popup_left + 20),
             );
-            let cycle = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
+            let cycle = loaded.toolbox_startup.execution.menu().snapshot().unwrap();
             assert_eq!(cycle.submenus.len(), 2, "circular submenu grew the chain");
             assert_eq!(cycle.submenus[1].highlighted_item, 1);
             assert_eq!(
@@ -96337,7 +96393,7 @@ pub(crate) mod tests {
                 ..PpcInputSnapshot::default()
             },
         );
-        let tracking = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
+        let tracking = loaded.toolbox_startup.execution.menu().snapshot().unwrap();
         assert_eq!(tracking.front_buffer, Some(live.into()));
         let selected = PpcInputSnapshot {
             mouse_button: true,
@@ -96550,7 +96606,7 @@ pub(crate) mod tests {
                 ..PpcInputSnapshot::default()
             },
         );
-        assert!(loaded.toolbox_startup.menu_tracking.is_some());
+        assert!(loaded.toolbox_startup.execution.menu().is_some());
         assert_ne!(loaded.memory.read_u8(popup_probe), Some(popup_before));
         assert_eq!(
             ppc_finish_menu_bar_tracking(
@@ -96667,7 +96723,7 @@ pub(crate) mod tests {
                     ..PpcInputSnapshot::default()
                 },
             );
-            let tracking = loaded.toolbox_startup.menu_tracking.as_ref().unwrap();
+            let tracking = loaded.toolbox_startup.execution.menu().as_ref().unwrap();
             let input = PpcInputSnapshot {
                 mouse_button: true,
                 mouse_v: tracking.popup_top + (item - 1) * 16 + 4,
@@ -96727,7 +96783,7 @@ pub(crate) mod tests {
                 ..PpcInputSnapshot::default()
             },
         );
-        let tracking = loaded.toolbox_startup.menu_tracking.as_ref().unwrap();
+        let tracking = loaded.toolbox_startup.execution.menu().as_ref().unwrap();
         let outside = PpcInputSnapshot {
             mouse_v: tracking.popup_top + 8,
             mouse_h: tracking.popup_left - 1,
@@ -96762,7 +96818,7 @@ pub(crate) mod tests {
                 ..PpcInputSnapshot::default()
             },
         );
-        let tracking = loaded.toolbox_startup.menu_tracking.as_ref().unwrap();
+        let tracking = loaded.toolbox_startup.execution.menu().as_ref().unwrap();
         let enabled = PpcInputSnapshot {
             mouse_v: tracking.popup_top + 6,
             mouse_h: tracking.popup_left + 4,
@@ -96925,12 +96981,21 @@ pub(crate) mod tests {
 
     #[test]
     fn process_owner_shares_one_retained_menu_continuation_between_adapters() {
-        let (mut classic, mut classic_cpu, mut classic_bus) = setup_with_port();
+        let (prepared, mut classic_cpu, mut classic_bus) = setup_with_port();
         let pef = synthetic_pef_with_import(b"MenuSelect");
         let mut native = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
-        classic.attach_process_context(&mut context);
-        native.attach_process_context(&mut context);
+        let mut classic = TrapDispatcher::new_with_migrated_handles(context.migrated_handles());
+        classic.scrap.clipboard_writable = prepared.scrap.clipboard_writable;
+        let (base, row_bytes, width, height, depth) = prepared.screen_mode;
+        classic.set_screen_mode_for_test(base, row_bytes, width, height, depth);
+        classic.read_tick_count(&classic_bus);
+        classic.attach_unconverted_process_services(&mut context);
+        let plan = native
+            .preflight_migrated_services(&context, classic_bus.read_long(0x016a))
+            .unwrap();
+        native.commit_migrated_services(&context, plan);
+        native.attach_unconverted_process_services(&mut context);
 
         let mut tracking = crate::menu_manager::test_process_menu_tracking(0x0012_3456);
         tracking.highlighted_item = 2;
@@ -96961,9 +97026,11 @@ pub(crate) mod tests {
 
         native.cpu.gpr[3] = 0;
         run_test_import(&mut native, PpcImportDispatcherTarget::MenuSelect);
+        assert!(native.is_constructed_from_migrated_handles(&context.migrated_handles()));
         native
             .toolbox_startup
-            .menu_tracking
+            .execution
+            .menu_state_mut()
             .as_mut()
             .unwrap()
             .highlighted_item = 4;
@@ -96975,7 +97042,7 @@ pub(crate) mod tests {
             Some(4)
         );
 
-        native.toolbox_startup.menu_tracking.context_mut().call =
+        native.toolbox_startup.execution.menu_context_mut().call =
             Some(ppc_menu_select_call(&native.cpu, 0));
         // Nor can an absent native surface turn its caller into a classic one.
         context.menu_tracking_mut().unwrap().front_buffer = None;
@@ -96995,7 +97062,8 @@ pub(crate) mod tests {
 
         context.take_menu_tracking();
         assert!(classic.menu_tracking.is_none());
-        assert!(native.toolbox_startup.menu_tracking.is_none());
+        assert!(native.toolbox_startup.execution.menu().is_none());
+        assert!(native.is_constructed_from_migrated_handles(&context.migrated_handles()));
     }
 
     #[test]
@@ -97005,8 +97073,8 @@ pub(crate) mod tests {
         let mut native = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
 
-        classic.attach_process_context(&mut context);
-        native.attach_process_context(&mut context);
+        classic.attach_unconverted_process_services(&mut context);
+        native.attach_unconverted_process_services(&mut context);
 
         assert!(!context.event_queue().menu_bar_is_invalid());
 
@@ -97047,8 +97115,8 @@ pub(crate) mod tests {
         let pef = synthetic_pef_with_import(b"GetNextEvent");
         let mut native = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
-        classic.attach_process_context(&mut context);
-        native.attach_process_context(&mut context);
+        classic.attach_unconverted_process_services(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         assert!(classic
             .apple_event_launch_state
             .ptr_eq(&native.apple_events.apple_event_launch_state));
@@ -97122,8 +97190,8 @@ pub(crate) mod tests {
         let pef = synthetic_pef_with_import(b"EventAvail");
         let mut native = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
-        classic.attach_process_context(&mut context);
-        native.attach_process_context(&mut context);
+        classic.attach_unconverted_process_services(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let low_memory = classic_bus
             .shared_ram_region(0, 0x0010_0000)
             .expect("classic adapter owns low memory");
@@ -97172,8 +97240,8 @@ pub(crate) mod tests {
         let pef = synthetic_pef_with_import(b"GetNextEvent");
         let mut native = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
-        classic.attach_process_context(&mut context);
-        native.attach_process_context(&mut context);
+        classic.attach_unconverted_process_services(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let low_memory = classic_bus
             .shared_ram_region(0, 0x0010_0000)
             .expect("classic adapter owns low memory");
@@ -97231,8 +97299,8 @@ pub(crate) mod tests {
         let mut native = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
 
-        classic.attach_process_context(&mut context);
-        native.attach_process_context(&mut context);
+        classic.attach_unconverted_process_services(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let detached = native.clone();
 
         classic.input_state.mouse_pos = (123, 456);
@@ -97275,8 +97343,8 @@ pub(crate) mod tests {
         let mut native = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
 
-        classic.attach_process_context(&mut context);
-        native.attach_process_context(&mut context);
+        classic.attach_unconverted_process_services(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let detached = native.clone();
 
         native.screen_clut[7] = [0x1111, 0x2222, 0x3333];
@@ -97322,8 +97390,8 @@ pub(crate) mod tests {
         let mut native = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
 
-        classic.attach_process_context(&mut context);
-        native.attach_process_context(&mut context);
+        classic.attach_unconverted_process_services(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let detached = native.clone();
 
         assert!(classic.current_port.ptr_eq(&native.current_gworld));
@@ -97360,8 +97428,8 @@ pub(crate) mod tests {
         let mut native =
             load_pef_application(&synthetic_pef_with_import(b"TestImport")).unwrap();
         let mut context = ProcessContext::default();
-        classic.attach_process_context(&mut context);
-        native.attach_process_context(&mut context);
+        classic.attach_unconverted_process_services(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let low_memory = classic_bus
             .shared_ram_region(0, 0x0010_0000)
             .expect("classic adapter owns low memory");
@@ -97460,8 +97528,8 @@ pub(crate) mod tests {
         let mut native =
             load_pef_application(&synthetic_pef_with_import(b"TestImport")).unwrap();
         let mut context = ProcessContext::default();
-        classic.attach_process_context(&mut context);
-        native.attach_process_context(&mut context);
+        classic.attach_unconverted_process_services(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let low_memory = classic_bus
             .shared_ram_region(0, 0x0010_0000)
             .expect("classic adapter owns low memory");
@@ -97533,8 +97601,8 @@ pub(crate) mod tests {
         let mut native =
             load_pef_application(&synthetic_pef_with_import(b"GetPixelsState")).unwrap();
         let mut context = ProcessContext::default();
-        classic.attach_process_context(&mut context);
-        native.attach_process_context(&mut context);
+        classic.attach_unconverted_process_services(&mut context);
+        native.attach_unconverted_process_services(&mut context);
 
         assert!(classic
             .gworld_pixel_states
@@ -97588,8 +97656,8 @@ pub(crate) mod tests {
         let mut native =
             load_pef_application(&synthetic_pef_with_import(b"TestImport")).unwrap();
         let mut context = ProcessContext::default();
-        classic.attach_process_context(&mut context);
-        native.attach_process_context(&mut context);
+        classic.attach_unconverted_process_services(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let mut detached = native.clone();
 
         assert!(classic
@@ -97632,7 +97700,7 @@ pub(crate) mod tests {
             where_h: 20,
             modifiers: 0,
         });
-        native.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
 
         let panic_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             native.event_queue.push_back(QueuedEvent {
@@ -97671,8 +97739,8 @@ pub(crate) mod tests {
         let mut second = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
 
-        first.attach_process_context(&mut context);
-        second.attach_process_context(&mut context);
+        first.attach_unconverted_process_services(&mut context);
+        second.attach_unconverted_process_services(&mut context);
         assert!(first
             .process_file_system
             .ptr_eq(&second.process_file_system));
@@ -97718,9 +97786,9 @@ pub(crate) mod tests {
         let pef = synthetic_pef_with_import(b"TestImport");
         let mut native = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let mut classic = TrapDispatcher::new();
-        classic.attach_process_context(&mut context);
+        classic.attach_unconverted_process_services(&mut context);
 
         native
             .files
@@ -97792,8 +97860,7 @@ pub(crate) mod tests {
         .into_ppc_import_action()
         .expect("native test request should adapt to the PPC ABI");
         assert!(matches!(
-            native
-                .guest_calls
+            native.toolbox_startup.execution.calls()
                 .externalize_powerpc_action(&mut native.cpu, action),
             PpcImportAction::Continue
         ));
@@ -97830,9 +97897,9 @@ pub(crate) mod tests {
         let pef = synthetic_pef_with_import(b"TestImport");
         let mut native = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let mut classic = TrapDispatcher::new();
-        classic.attach_process_context(&mut context);
+        classic.attach_unconverted_process_services(&mut context);
 
         native.resource_files.push(PpcResourceFileRecord {
             ref_num: PPC_FIRST_FILE_REF_NUM,
@@ -97891,9 +97958,9 @@ pub(crate) mod tests {
         let pef = synthetic_pef_with_import(b"LMGetCurApName");
         let mut native = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let mut classic = TrapDispatcher::new();
-        classic.attach_process_context(&mut context);
+        classic.attach_unconverted_process_services(&mut context);
 
         classic.set_launched_app_path("Apps/Classic App");
         assert_eq!(native.launched_app_path(), Some("Apps/Classic App"));
@@ -97922,9 +97989,9 @@ pub(crate) mod tests {
         let pef = synthetic_pef_with_import(b"TestImport");
         let mut native = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let mut classic = TrapDispatcher::new();
-        classic.attach_process_context(&mut context);
+        classic.attach_unconverted_process_services(&mut context);
 
         native.resource_files.push(PpcResourceFileRecord {
             ref_num: PPC_FIRST_FILE_REF_NUM,
@@ -97981,8 +98048,7 @@ pub(crate) mod tests {
         .into_ppc_import_action()
         .expect("native test request should adapt to the PPC ABI");
         assert!(matches!(
-            native
-                .guest_calls
+            native.toolbox_startup.execution.calls()
                 .externalize_powerpc_action(&mut native.cpu, action),
             PpcImportAction::Continue
         ));
@@ -98053,10 +98119,10 @@ pub(crate) mod tests {
         native.next_file_ref_num = PPC_FIRST_FILE_REF_NUM + 1;
 
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let detached = native.clone();
         let mut classic = TrapDispatcher::new();
-        classic.attach_process_context(&mut context);
+        classic.attach_unconverted_process_services(&mut context);
 
         assert!(classic.open_files.ptr_eq(&native.files));
         assert!(classic
@@ -98124,7 +98190,7 @@ pub(crate) mod tests {
         let pef = synthetic_pef_with_import(b"GetEOF");
         let mut native = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let executing_directories = native.vfs_directories.shared_handle();
         let executing_volumes = native.vfs_volumes.shared_handle();
         let executing_next_volume_ref_num =
@@ -98137,7 +98203,7 @@ pub(crate) mod tests {
             .shared_handle();
         let detached = native.clone();
         let mut classic = TrapDispatcher::new();
-        classic.attach_process_context(&mut context);
+        classic.attach_unconverted_process_services(&mut context);
         assert!(classic.vfs_directories.ptr_eq(&executing_directories));
         assert!(classic.next_vfs_dir_id.ptr_eq(&executing_next_dir_id));
 
@@ -98446,19 +98512,21 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn attached_ppc_menu_tracking_mutates_process_context_immediately() {
+    fn adopted_ppc_execution_pair_shares_and_snapshot_detaches_coherently() {
         let pef = synthetic_pef_with_import(b"MenuSelect");
         let mut native = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
         context.set_menu_tracking(Some(crate::menu_manager::test_process_menu_tracking(
             0x0012_3456,
         )));
-        native.attach_process_context(&mut context);
+        let plan = native.preflight_migrated_services(&context, 0).unwrap();
+        native.commit_migrated_services(&context, plan);
         let detached = native.clone();
 
         native
             .toolbox_startup
-            .menu_tracking
+            .execution
+            .menu_state_mut()
             .as_mut()
             .unwrap()
             .highlighted_item = 3;
@@ -98469,15 +98537,26 @@ pub(crate) mod tests {
                 .map(|tracking| tracking.highlighted_item),
             Some(3)
         );
-        assert_eq!(native.toolbox_startup.menu_tracking.as_ref().unwrap().highlighted_item, 3);
+        assert_eq!(
+            native
+                .toolbox_startup
+                .execution
+                .menu()
+                .as_ref()
+                .unwrap()
+                .highlighted_item,
+            3
+        );
         assert!(!native
             .toolbox_startup
-            .menu_tracking
-            .ptr_eq(&detached.toolbox_startup.menu_tracking));
+            .execution
+            .menu()
+            .ptr_eq(detached.toolbox_startup.execution.menu()));
         assert_eq!(
             detached
                 .toolbox_startup
-                .menu_tracking
+                .execution
+                .menu()
                 .as_ref()
                 .unwrap()
                 .highlighted_item,
@@ -98486,19 +98565,21 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn attached_ppc_menu_tracking_remains_shared_through_panic() {
+    fn adopted_ppc_execution_pair_remains_shared_through_panic() {
         let pef = synthetic_pef_with_import(b"MenuSelect");
         let mut native = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
         context.set_menu_tracking(Some(crate::menu_manager::test_process_menu_tracking(
             0x0012_3456,
         )));
-        native.attach_process_context(&mut context);
+        let plan = native.preflight_migrated_services(&context, 0).unwrap();
+        native.commit_migrated_services(&context, plan);
 
         let panic_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             native
                 .toolbox_startup
-                .menu_tracking
+                .execution
+                .menu_state_mut()
                 .as_mut()
                 .unwrap()
                 .highlighted_item = 5;
@@ -98512,7 +98593,16 @@ pub(crate) mod tests {
                 .map(|tracking| tracking.highlighted_item),
             Some(5)
         );
-        assert_eq!(native.toolbox_startup.menu_tracking.as_ref().unwrap().highlighted_item, 5);
+        assert_eq!(
+            native
+                .toolbox_startup
+                .execution
+                .menu()
+                .as_ref()
+                .unwrap()
+                .highlighted_item,
+            5
+        );
     }
 
     #[test]
@@ -98528,7 +98618,7 @@ pub(crate) mod tests {
         assert_ne!(handle, 0);
 
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let memory_manager = context.memory_manager_handle();
         let expected_cursor = native.heap_cursor() + 16;
         {
@@ -98622,7 +98712,7 @@ pub(crate) mod tests {
         let pef = synthetic_pef_with_import(b"NewPtr");
         let mut native = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let memory_manager = context.memory_manager_handle().clone();
 
         let panic_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -98753,7 +98843,7 @@ pub(crate) mod tests {
         let mut standalone = load_pef_application(&pef).unwrap();
         let mut attached = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
-        attached.attach_process_context(&mut context);
+        attached.attach_unconverted_process_services(&mut context);
         let memory_manager = context.memory_manager_handle().clone();
 
         standalone.cpu.gpr[3] = 24;
@@ -98873,8 +98963,8 @@ pub(crate) mod tests {
         let mut native = load_pef_application(&pef).unwrap();
         let mut classic = TrapDispatcher::new();
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
-        classic.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
+        classic.attach_unconverted_process_services(&mut context);
         let shared = native.memory.shared_view();
         let mut classic_bus = MacMemoryBus::new(8 * 1024 * 1024);
         classic_bus.attach_guest_address_space(shared);
@@ -98943,7 +99033,7 @@ pub(crate) mod tests {
         let pef = synthetic_pef_with_import(b"EmptyHandle");
         let mut native = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
 
         let mut classic_bus = MacMemoryBus::new(8 * 1024 * 1024);
         context.attach_classic_memory_bus(&mut classic_bus);
@@ -99015,7 +99105,7 @@ pub(crate) mod tests {
         let pef = synthetic_pef_with_import(b"DisposeHandle");
         let mut native = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
 
         let mut classic_bus = MacMemoryBus::new(8 * 1024 * 1024);
         context.attach_classic_memory_bus(&mut classic_bus);
@@ -99089,8 +99179,8 @@ pub(crate) mod tests {
         let mut native = load_pef_application(&pef).unwrap();
         let mut classic = TrapDispatcher::new();
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
-        classic.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
+        classic.attach_unconverted_process_services(&mut context);
 
         let mut classic_bus = MacMemoryBus::new(8 * 1024 * 1024);
         context.attach_classic_memory_bus(&mut classic_bus);
@@ -99244,7 +99334,7 @@ pub(crate) mod tests {
         let pef = synthetic_pef_with_import(b"GetPtrSize");
         let mut native = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let mut classic_bus = MacMemoryBus::new(8 * 1024 * 1024);
         context.attach_classic_memory_bus(&mut classic_bus);
         let ptr = context
@@ -99283,7 +99373,7 @@ pub(crate) mod tests {
         let pef = synthetic_pef_with_import(b"SetHandleSize");
         let mut native = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let mut classic_bus =
             attach_test_classic_heap(&mut native, &mut context, 8 * 1024 * 1024, 0x4000);
         let (handle, ptr) = context
@@ -99426,7 +99516,7 @@ pub(crate) mod tests {
         let pef = synthetic_pef_with_import(b"SetHandleSize");
         let mut native = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let mut classic_bus =
             attach_test_classic_heap(&mut native, &mut context, 8 * 1024 * 1024, 0x4000);
         let handle = context
@@ -99462,7 +99552,7 @@ pub(crate) mod tests {
         let pef = synthetic_pef_with_import(b"SetHandleSize");
         let mut native = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let mut classic_bus =
             attach_test_classic_heap(&mut native, &mut context, 3 * 1024 * 1024, 0x4000);
         let (handle, ptr) = context
@@ -99525,7 +99615,7 @@ pub(crate) mod tests {
         let pef = synthetic_pef_with_import(b"SetHandleSize");
         let mut native = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let mut classic_bus =
             attach_test_classic_heap(&mut native, &mut context, 8 * 1024 * 1024, 0x4000);
         let (handle, ptr) = context
@@ -99578,7 +99668,7 @@ pub(crate) mod tests {
         let pef = synthetic_pef_with_import(b"SetHandleSize");
         let mut native = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let mut classic_bus =
             attach_test_classic_heap(&mut native, &mut context, 8 * 1024 * 1024, 0x4000);
         let (handle, ptr) = context
@@ -99631,7 +99721,7 @@ pub(crate) mod tests {
         let pef = synthetic_pef_with_import(b"SetHandleSize");
         let mut native = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let mut classic_bus =
             attach_test_classic_heap(&mut native, &mut context, 8 * 1024 * 1024, 0x4000);
         let (handle, ptr) = context
@@ -99706,8 +99796,8 @@ pub(crate) mod tests {
         let mut native = load_pef_application(&pef).unwrap();
         let mut classic = TrapDispatcher::new();
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
-        classic.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
+        classic.attach_unconverted_process_services(&mut context);
         let mut classic_bus =
             attach_test_classic_heap(&mut native, &mut context, 8 * 1024 * 1024, 0x4000);
         let ptr = context
@@ -99765,7 +99855,7 @@ pub(crate) mod tests {
         );
         let mut native = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let mut classic_bus =
             attach_test_classic_heap(&mut native, &mut context, 8 * 1024 * 1024, 0x4000);
         classic_bus.attach_guest_address_space(native.memory.shared_view());
@@ -99853,7 +99943,7 @@ pub(crate) mod tests {
         let pef = synthetic_pef_with_import(b"SetPtrSize");
         let mut native = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
 
         let mut classic_bus = MacMemoryBus::new(8 * 1024 * 1024);
         context.attach_classic_memory_bus(&mut classic_bus);
@@ -100013,7 +100103,7 @@ pub(crate) mod tests {
             .ptr_eq(&native.process_memory_manager.0));
 
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let process_memory_manager = context.memory_manager_handle().clone();
         assert!(native
             .process_memory_manager
@@ -100140,13 +100230,13 @@ pub(crate) mod tests {
         );
         let ptr = owner.cpu.gpr[3];
         let mut context = ProcessContext::default();
-        owner.attach_process_context(&mut context);
+        owner.attach_unconverted_process_services(&mut context);
         let canonical = context.memory_manager_handle().clone();
         let canonical_allocator = canonical.borrow().native_allocator_snapshot();
 
         let mut observer = load_pef_application(&pef).unwrap();
         let standalone = observer.process_memory_manager.0.clone();
-        observer.attach_process_context(&mut context);
+        observer.attach_unconverted_process_services(&mut context);
 
         assert!(observer.process_memory_manager.ptr_eq(&canonical));
         assert_eq!(canonical.borrow().native_allocator_snapshot(), canonical_allocator);
@@ -100175,7 +100265,7 @@ pub(crate) mod tests {
             PpcImportDispatcherTarget::NewPtr { clear: true },
         );
         let mut context = ProcessContext::default();
-        owner.attach_process_context(&mut context);
+        owner.attach_unconverted_process_services(&mut context);
         let canonical = context.memory_manager_handle().clone();
 
         let mut rejected = load_pef_application(&pef).unwrap();
@@ -100191,7 +100281,7 @@ pub(crate) mod tests {
         let system_zone = rejected.memory.read_u32_be(PPC_SYSTEM_ZONE + 12);
 
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            rejected.attach_process_context(&mut context);
+            rejected.attach_unconverted_process_services(&mut context);
         }));
 
         assert!(result.is_err());
@@ -100214,7 +100304,7 @@ pub(crate) mod tests {
         let mut native = load_pef_application(&pef).unwrap();
         native.cpu.gpr[3] = 24;
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         native.with_process_memory_manager(
             |native, memory_manager| {
                 let prior_ptr = memory_manager.new_native_ptr(&mut native.memory, 24, false);
@@ -100296,9 +100386,9 @@ pub(crate) mod tests {
         let mut native = load_pef_application(&pef).unwrap();
         native.cpu.gpr[3] = 24;
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let mut classic_dispatcher = TrapDispatcher::new();
-        classic_dispatcher.attach_process_context(&mut context);
+        classic_dispatcher.attach_unconverted_process_services(&mut context);
         native.with_process_memory_manager(
             |native, memory_manager| {
                 native.run_with_process_memory_manager(64, false, false, memory_manager);
@@ -100510,9 +100600,9 @@ pub(crate) mod tests {
         native.cpu.gpr[3] = 16;
 
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let mut classic = TrapDispatcher::new();
-        classic.attach_process_context(&mut context);
+        classic.attach_unconverted_process_services(&mut context);
 
         native.with_process_memory_manager(|native, memory_manager| {
             native.run_with_process_memory_manager(64, false, false, memory_manager);
@@ -100595,7 +100685,7 @@ pub(crate) mod tests {
         let pef = synthetic_pef_with_import(b"RecoverHandle");
         let mut native = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let mut classic_bus = MacMemoryBus::new(8 * 1024 * 1024);
         context.attach_classic_memory_bus(&mut classic_bus);
         let classic_heap = classic_bus
@@ -100666,7 +100756,7 @@ pub(crate) mod tests {
         let pef = synthetic_pef_with_import(b"RecoverHandle");
         let mut native = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let mut classic_bus = MacMemoryBus::new(8 * 1024 * 1024);
         context.attach_classic_memory_bus(&mut classic_bus);
         let classic_heap = classic_bus
@@ -100707,7 +100797,7 @@ pub(crate) mod tests {
         let pef = synthetic_pef_with_import(b"RecoverHandle");
         let mut native = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let mut classic_bus = MacMemoryBus::new(8 * 1024 * 1024);
         context.attach_classic_memory_bus(&mut classic_bus);
         let classic_heap = classic_bus
@@ -100742,7 +100832,7 @@ pub(crate) mod tests {
         let pef = synthetic_pef_with_import(b"RecoverHandle");
         let mut native = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let (handle, ptr) = native.with_process_memory_manager(|native, memory_manager| {
             let handle = memory_manager.new_native_handle(&mut native.memory, 24, true);
             let ptr = PpcMemory::read_u32_be(&mut native.memory, handle).unwrap();
@@ -100777,7 +100867,7 @@ pub(crate) mod tests {
         let pef = synthetic_pef_with_import(b"NewHandle");
         let mut native = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
 
         native.with_process_memory_manager(|native, memory_manager| {
             native.cpu.gpr[3] = 24;
@@ -100815,9 +100905,9 @@ pub(crate) mod tests {
         let external_handle = PPC_DATA_BASE + 0x2140;
         native.memory.add_region(external_handle, vec![0; 4]);
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let mut classic_dispatcher = TrapDispatcher::new();
-        classic_dispatcher.attach_process_context(&mut context);
+        classic_dispatcher.attach_unconverted_process_services(&mut context);
         native.with_process_memory_manager(
             |native, memory_manager| {
                 let allocator = memory_manager.native_allocator_snapshot().unwrap();
@@ -100954,7 +101044,7 @@ pub(crate) mod tests {
         classic_bus.attach_guest_address_space(shared);
 
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         native.with_process_memory_manager(
             |native, memory_manager| {
                 native.cpu.gpr[3] = source;
@@ -101018,8 +101108,8 @@ pub(crate) mod tests {
         let mut native = load_pef_application(&pef).unwrap();
         let mut classic = TrapDispatcher::new();
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
-        classic.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
+        classic.attach_unconverted_process_services(&mut context);
         let mut classic_bus =
             attach_test_classic_heap(&mut native, &mut context, 8 * 1024 * 1024, 0x4000);
         classic_bus.attach_guest_address_space(native.memory.shared_view());
@@ -101107,7 +101197,7 @@ pub(crate) mod tests {
         let pef = synthetic_pef_with_import(b"HandToHand");
         let mut native = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let mut classic_bus =
             attach_test_classic_heap(&mut native, &mut context, 8 * 1024 * 1024, 0x4000);
 
@@ -101177,7 +101267,7 @@ pub(crate) mod tests {
         let pef = synthetic_pef_with_import(b"HandToHand");
         let mut native = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let mut classic_bus =
             attach_test_classic_heap(&mut native, &mut context, 8 * 1024 * 1024, 0x4000);
         let payload = b"disposed classic source";
@@ -101243,7 +101333,7 @@ pub(crate) mod tests {
         let pef = synthetic_pef_with_import(b"HandToHand");
         let mut native = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let memory_manager = context.memory_manager_handle().clone();
         let source_handle = memory_manager
             .borrow_mut()
@@ -101302,7 +101392,7 @@ pub(crate) mod tests {
             .write_u32_be(handle_variable, PPC_MAIN_CTABLE_HANDLE)
             .unwrap();
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let memory_manager = context.memory_manager_handle().clone();
 
         native.cpu.gpr[3] = handle_variable;
@@ -101339,7 +101429,7 @@ pub(crate) mod tests {
             .write_u32_be(handle_variable, PPC_MAIN_CTABLE_HANDLE)
             .unwrap();
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let memory_manager = context.memory_manager_handle().clone();
         let allocator_before = memory_manager
             .borrow()
@@ -101627,7 +101717,7 @@ pub(crate) mod tests {
             loaded.run_with_hle_imports(64).result,
             PpcRunResult::CycleLimit { .. }
         ));
-        let tracking = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
+        let tracking = loaded.toolbox_startup.execution.menu().snapshot().unwrap();
 
         loaded.set_input_snapshot(PpcInputSnapshot {
             mouse_button: false,
@@ -101638,7 +101728,7 @@ pub(crate) mod tests {
         let probe = loaded.run_with_hle_imports(64);
         assert!(matches!(probe.result, PpcRunResult::Halted { .. }));
         assert_eq!(loaded.cpu.gpr[3], 0);
-        assert_eq!(loaded.toolbox_startup.menu_tracking, None);
+        assert!(loaded.toolbox_startup.execution.menu().is_none());
 
         let expected = menu_choice_value(128, 1);
         assert_eq!(
@@ -102244,7 +102334,7 @@ pub(crate) mod tests {
         let menu = loaded.memory.read_u32_be(loaded.cpu.gpr[3]).unwrap();
         assert_eq!(loaded.memory.read_u16_be(menu + 2), Some(123));
         assert_eq!(loaded.memory.read_u16_be(menu + 4), Some(45));
-        assert!(loaded.guest_calls.is_empty());
+        assert!(loaded.guest_calls().is_empty());
         assert_eq!(loaded.toolbox_startup.mixed_mode_m68k.gateway, 0);
         assert_eq!(loaded.toolbox_startup.mixed_mode_m68k.stack_top, 0);
     }
@@ -102279,8 +102369,8 @@ pub(crate) mod tests {
         let mut first = load_pef_application(&pef).unwrap();
         let mut second = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
-        first.attach_process_context(&mut context);
-        second.attach_process_context(&mut context);
+        first.attach_unconverted_process_services(&mut context);
+        second.attach_unconverted_process_services(&mut context);
         assert!(first
             .toolbox_startup
             .mixed_mode_m68k
@@ -102713,7 +102803,7 @@ pub(crate) mod tests {
             assert_eq!(loaded.memory.read_u16_be(menu + 2), Some(123));
             assert_eq!(loaded.memory.read_u16_be(menu + 4), Some(45));
         }
-        assert!(!loaded.guest_calls.has_menu_bar_builds());
+        assert!(!loaded.guest_calls().has_menu_bar_builds());
     }
 
     #[test]
@@ -102779,7 +102869,7 @@ pub(crate) mod tests {
 
         run_test_import(&mut loaded, PpcImportDispatcherTarget::GetNewMBar);
         assert_eq!(loaded.cpu.pc, PPC_HALT_PC);
-        assert!(loaded.guest_calls.is_empty());
+        assert!(loaded.guest_calls().is_empty());
 
         let list_handle = loaded.cpu.gpr[3];
         let menu_handles = ppc_menu_list_definition(&mut loaded.memory, list_handle)
@@ -102792,7 +102882,7 @@ pub(crate) mod tests {
             assert_eq!(loaded.memory.read_u16_be(menu + 2), Some(123));
             assert_eq!(loaded.memory.read_u16_be(menu + 4), Some(45));
         }
-        assert!(!loaded.guest_calls.has_menu_bar_builds());
+        assert!(!loaded.guest_calls().has_menu_bar_builds());
     }
 
     #[test]
@@ -102929,7 +103019,7 @@ pub(crate) mod tests {
                 .count(),
             0
         );
-        assert!(loaded.guest_calls.is_empty());
+        assert!(loaded.guest_calls().is_empty());
         assert_eq!(loaded.cpu.pc, PPC_HALT_PC);
         let list_handle = loaded.cpu.gpr[3];
         let menu_handles = ppc_menu_list_definition(&mut loaded.memory, list_handle)
@@ -102942,7 +103032,7 @@ pub(crate) mod tests {
             assert_eq!(loaded.memory.read_u16_be(menu + 2), Some(123));
             assert_eq!(loaded.memory.read_u16_be(menu + 4), Some(45));
         }
-        assert!(!loaded.guest_calls.has_menu_bar_builds());
+        assert!(!loaded.guest_calls().has_menu_bar_builds());
     }
 
     #[test]
@@ -105170,11 +105260,11 @@ pub(crate) mod tests {
             let probe = loaded.run_with_hle_imports(64);
 
             if opens {
-                assert!(loaded.toolbox_startup.menu_tracking.is_some(), "{label}");
+                assert!(loaded.toolbox_startup.execution.menu().is_some(), "{label}");
                 assert!(
                     loaded
                         .toolbox_startup
-                        .menu_tracking
+                        .execution.menu()
                         .context()
                         .native_popup()
                         .is_some(),
@@ -105195,9 +105285,9 @@ pub(crate) mod tests {
                 },
                 "{label} TrackControl result",
             );
-            assert_eq!(loaded.toolbox_startup.menu_tracking, None, "{label}");
+            assert!(loaded.toolbox_startup.execution.menu().is_none(), "{label}");
             assert_eq!(
-                loaded.toolbox_startup.menu_tracking.context().native_popup(),
+                loaded.toolbox_startup.execution.menu().context().native_popup(),
                 None,
                 "{label}"
             );
@@ -109547,8 +109637,8 @@ pub(crate) mod tests {
         let mut native = load_pef_application(&pef).unwrap();
         let mut classic = TrapDispatcher::new();
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
-        classic.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
+        classic.attach_unconverted_process_services(&mut context);
         assert!(native
             .callback_scheduling
             .ptr_eq(&classic.callback_scheduling));
@@ -109667,8 +109757,8 @@ pub(crate) mod tests {
         let mut native = load_pef_application(&synthetic_pef()).unwrap();
         let mut classic = TrapDispatcher::new();
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
-        classic.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
+        classic.attach_unconverted_process_services(&mut context);
 
         assert!(native.timer_tasks.ptr_eq(&classic.timer_tasks));
         assert!(native.vbl_tasks.ptr_eq(&classic.vbl_tasks));
@@ -110017,7 +110107,7 @@ pub(crate) mod tests {
             loaded.memory.read_u32_be(callback_rtoc + 8),
             Some(callback_rtoc)
         );
-        assert!(loaded.guest_calls.is_empty());
+        assert!(loaded.guest_calls().is_empty());
     }
 
     #[test]
@@ -110036,24 +110126,21 @@ pub(crate) mod tests {
         loaded.run_with_hle_imports(64);
         assert_eq!(loaded.cpu.gpr[3], 0);
         let worker = ExecutionTaskId::from_thread_id(loaded.memory.read_u32_be(MADE).unwrap());
-        assert!(loaded
-            .guest_calls
+        assert!(loaded.toolbox_startup.execution.calls()
             .yield_native_thread(&mut loaded.cpu, worker.thread_id())
             .unwrap());
-        let storage = loaded.guest_calls.thread_storage(worker).unwrap();
+        let storage = loaded.guest_calls().thread_storage(worker).unwrap();
         let worker_sp = loaded.cpu.gpr[1];
         assert!(worker_sp < loaded.stack_base);
-        assert!(loaded
-            .guest_calls
+        assert!(loaded.guest_calls()
             .switch_to_task(ExecutionTaskId::APPLICATION));
         assert_eq!(
-            loaded
-                .guest_calls
+            loaded.guest_calls()
                 .native_stack_bounds(loaded.stack_base, PPC_STACK_TOP),
             Some((storage.stack_base, storage.stack_limit))
         );
-        assert!(loaded.guest_calls.switch_to_task(worker));
-        assert!(loaded.guest_calls.begin_m68k_to_powerpc(
+        assert!(loaded.guest_calls().switch_to_task(worker));
+        assert!(loaded.guest_calls().begin_m68k_to_powerpc(
             GuestCallTarget {
                 isa: GuestIsa::PowerPc,
                 entry: PPC_CODE_BASE + 0x1000,
@@ -110084,8 +110171,8 @@ pub(crate) mod tests {
             assert_eq!(loaded.cpu.fpr, before.fpr);
             assert_eq!(classic.read_reg(crate::cpu::Register::PC), 0x0010_0000);
             assert_eq!(loaded.memory.read_u32_be(sentinel), Some(0xface_cafe));
-            assert!(loaded.guest_calls.pending_powerpc_from_m68k().is_some());
-            assert!(!loaded.guest_calls.has_parked_m68k_contexts());
+            assert!(loaded.guest_calls().pending_powerpc_from_m68k().is_some());
+            assert!(!loaded.guest_calls().has_parked_m68k_contexts());
         }
         loaded.cpu.gpr[1] = worker_sp;
         loaded.activate_powerpc_from_m68k(&mut classic).unwrap();
@@ -110095,7 +110182,7 @@ pub(crate) mod tests {
         assert_eq!(loaded.memory.read_u32_be(callback_sp), Some(worker_sp));
         assert_eq!(loaded.cpu.gpr[3], 42);
         assert_eq!(loaded.cpu.pc, PPC_CODE_BASE + 0x1000);
-        assert!(loaded.guest_calls.has_parked_m68k_contexts());
+        assert!(loaded.guest_calls().has_parked_m68k_contexts());
     }
 
     #[test]
@@ -110107,7 +110194,7 @@ pub(crate) mod tests {
             .map(|value| 0x1000_0000 | value)
             .collect();
         let arguments = crate::guest_call::PowerPcArguments::from_slice(&values).unwrap();
-        assert!(loaded.guest_calls.begin_m68k_to_powerpc(
+        assert!(loaded.guest_calls().begin_m68k_to_powerpc(
             crate::guest_call::GuestCallTarget {
                 isa: GuestIsa::PowerPc,
                 entry: PPC_CODE_BASE + 0x1000,
@@ -110378,10 +110465,6 @@ pub(crate) mod tests {
         for (selector, arguments, data, address, stack, has_stack_result) in cases {
             let pef = synthetic_pef();
             let mut loaded = load_pef_application(&pef).unwrap();
-            loaded
-                .toolbox_startup
-                .guest_calls
-                .attach_to(&loaded.guest_calls);
             loaded.memory.add_region(RECT, vec![0; 0x20]);
             for (offset, byte) in (1u8..=8).enumerate() {
                 loaded
@@ -110421,7 +110504,7 @@ pub(crate) mod tests {
                 matches!(action, Some(PpcImportAction::Halt)),
                 "selector {selector}"
             );
-            let pending = loaded.guest_calls.activate_m68k().unwrap();
+            let pending = loaded.guest_calls().activate_m68k().unwrap();
             assert_eq!(pending.registers.data, data, "selector {selector}");
             assert_eq!(pending.registers.address, address, "selector {selector}");
             assert_eq!(
@@ -110483,7 +110566,7 @@ pub(crate) mod tests {
 
         assert_eq!(probe.handled_import_count, 1);
         assert_eq!(probe.unsupported_import_index, None);
-        let pending = loaded.guest_calls.activate_m68k().unwrap();
+        let pending = loaded.guest_calls().activate_m68k().unwrap();
         assert_eq!(
             loaded.memory.read_u32_be(pending.initial_sp + 4),
             Some(0x1234_5678)
@@ -110491,7 +110574,7 @@ pub(crate) mod tests {
         assert_eq!(pending.final_sp, pending.initial_sp + 8);
         drain_test_m68k_guest_calls(&mut loaded);
         assert_eq!(loaded.cpu.gpr[3], 0x1234_567f);
-        assert!(loaded.guest_calls.is_empty());
+        assert!(loaded.guest_calls().is_empty());
     }
 
     #[test]
@@ -110525,7 +110608,7 @@ pub(crate) mod tests {
         let probe = loaded.run_with_hle_imports(64);
 
         assert_eq!(probe.handled_import_count, 1);
-        let pending = loaded.guest_calls.activate_m68k().unwrap();
+        let pending = loaded.guest_calls().activate_m68k().unwrap();
         let frame = pending.initial_sp;
         assert_eq!(loaded.memory.read_u32_be(frame), Some(pending.return_pc));
         assert_eq!(loaded.memory.read_u32_be(frame + 4), Some(0xcafe_babe));
@@ -110571,7 +110654,7 @@ pub(crate) mod tests {
             let probe = loaded.run_with_hle_imports(64);
 
             assert_eq!(probe.handled_import_count, 1);
-            let pending = loaded.guest_calls.activate_m68k().unwrap();
+            let pending = loaded.guest_calls().activate_m68k().unwrap();
             let frame = pending.initial_sp;
             assert_eq!(loaded.memory.read_u8(frame + 4 + byte_offset), Some(0x78));
             assert_eq!(loaded.memory.read_u16_be(frame + 6), Some(0x4321));
@@ -110612,7 +110695,7 @@ pub(crate) mod tests {
         let probe = loaded.run_with_hle_imports(64);
 
         assert_eq!(probe.handled_import_count, 1);
-        let pending = loaded.guest_calls.activate_m68k().unwrap();
+        let pending = loaded.guest_calls().activate_m68k().unwrap();
         assert_eq!(pending.registers.data[1], 0x7654);
         assert_eq!(pending.registers.address[3], 0x1234_5678);
         assert_eq!(pending.registers.address[5], PPC_DATA_BASE);
@@ -110661,7 +110744,7 @@ pub(crate) mod tests {
             let probe = loaded.run_with_hle_imports(64);
 
             assert_eq!(probe.handled_import_count, 1);
-            let pending = loaded.guest_calls.activate_m68k().unwrap();
+            let pending = loaded.guest_calls().activate_m68k().unwrap();
             if let Some(register) = selector_register {
                 assert_eq!(pending.registers.data[register], 0x5678);
             } else {
@@ -110892,11 +110975,11 @@ pub(crate) mod tests {
             loaded.cpu.gpr[4] = proc_info;
             loaded.cpu.gpr[5] = 0x1234_5678;
             let registers = loaded.cpu.gpr[3..11].to_vec();
-            let calls = loaded.guest_calls.clone();
+            let calls = loaded.guest_calls().clone();
             let probe = loaded.run_with_hle_imports_with_trace(64, traced, false, None, None);
             assert_eq!(probe.unsupported_import_index, Some(0));
             assert_eq!(&loaded.cpu.gpr[3..11], registers.as_slice());
-            assert_eq!(loaded.guest_calls, calls);
+            assert_eq!(loaded.guest_calls(), &calls);
             for offset in 0..32 {
                 assert_eq!(loaded.memory.read_u8(sp + 24 + offset), Some(0xa5));
             }
@@ -110909,7 +110992,7 @@ pub(crate) mod tests {
             assert_eq!(probe.unsupported_import_index, None);
             assert_eq!(loaded.cpu.gpr[3], 0x1234_5678);
             assert_eq!(loaded.memory.read_u32_be(callback_rtoc), Some(0x1234_5678));
-            assert!(loaded.guest_calls.is_empty());
+            assert!(loaded.guest_calls().is_empty());
         }
     }
 
@@ -111908,7 +111991,7 @@ pub(crate) mod tests {
 
         assert_eq!(probe.handled_import_count, 1);
         assert_eq!(probe.unsupported_import_index, None);
-        let pending = loaded.guest_calls.activate_m68k().unwrap();
+        let pending = loaded.guest_calls().activate_m68k().unwrap();
         assert_eq!(pending.registers.data[1], 0xa11c);
         drain_test_m68k_guest_calls(&mut loaded);
         assert_eq!(loaded.cpu.gpr[3], 0xa121);
@@ -111946,7 +112029,7 @@ pub(crate) mod tests {
 
         assert_eq!(probe.handled_import_count, 1);
         assert_eq!(probe.unsupported_import_index, None);
-        let pending = loaded.guest_calls.activate_m68k().unwrap();
+        let pending = loaded.guest_calls().activate_m68k().unwrap();
         assert_eq!(pending.entry, callback_entry);
         assert_eq!(pending.registers.data[1], 0xa11e);
         assert_eq!(pending.registers.data[0], 0x20);
@@ -149294,7 +149377,7 @@ pub(crate) mod tests {
         let pef = synthetic_pef_with_import(b"NewGWorld");
         let mut native = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let detached = context.memory_manager_mut().detached_clone();
         let scratch = PPC_DATA_BASE + 0x1000;
         let bounds_ptr = scratch;
@@ -149448,7 +149531,7 @@ pub(crate) mod tests {
         let pef = synthetic_pef_with_import(b"NewGWorld");
         let mut native = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let scratch = PPC_DATA_BASE + 0x1000;
         let bounds_ptr = scratch;
         let gworld_out_ptr = scratch + 8;
@@ -162930,11 +163013,11 @@ pub(crate) mod tests {
             [loaded.cpu.gpr[4], loaded.cpu.gpr[5], loaded.cpu.gpr[6]],
             original_args
         );
-        let tracking = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
+        let tracking = loaded.toolbox_startup.execution.menu().snapshot().unwrap();
         let parked_lr = loaded.cpu.lr;
         assert_eq!(tracking.kind, MenuTrackingKind::PopUp);
         assert_eq!(
-            loaded.toolbox_startup.menu_tracking.context().native_popup(),
+            loaded.toolbox_startup.execution.menu().context().native_popup(),
             Some(MenuTrackingCall {
                 request: MenuTrackingRequest::PopUp(PopupMenuRequest {
                     menu_handle,
@@ -162989,7 +163072,7 @@ pub(crate) mod tests {
         assert_eq!(
             loaded
                 .toolbox_startup
-                .menu_tracking
+                .execution.menu()
                 .as_ref()
                 .unwrap()
                 .highlighted_item,
@@ -163009,7 +163092,7 @@ pub(crate) mod tests {
         loaded.set_input_snapshot(item_two_release);
         let probe = loaded.run_with_hle_imports(64);
         assert!(matches!(probe.result, PpcRunResult::CycleLimit { .. }));
-        let flash = loaded.toolbox_startup.menu_tracking.as_ref().unwrap();
+        let flash = loaded.toolbox_startup.execution.menu().as_ref().unwrap();
         assert_eq!(flash.flash_remaining, 2);
         assert_eq!(flash.highlighted_item, 2);
         assert_eq!(flash.flash_result, (300u32 << 16) | 2);
@@ -163023,7 +163106,7 @@ pub(crate) mod tests {
         let mut final_probe = None;
         for _ in 0..32 {
             let probe = loaded.run_with_hle_imports(64);
-            if loaded.toolbox_startup.menu_tracking.is_some() {
+            if loaded.toolbox_startup.execution.menu().is_some() {
                 flash_pixels.push(
                     ppc_quickdraw_read_pixel(&mut loaded.memory, front, flash_probe).unwrap(),
                 );
@@ -163087,7 +163170,7 @@ pub(crate) mod tests {
 
         assert!(matches!(probe.result, PpcRunResult::Halted { .. }));
         assert_eq!(loaded.cpu.gpr[3], 0);
-        assert_eq!(loaded.toolbox_startup.menu_tracking, None);
+        assert!(loaded.toolbox_startup.execution.menu().is_none());
         assert_eq!(
             ppc_memory_read_bytes(&mut loaded.memory, front.base_addr, framebuffer_len),
             Some(before)
@@ -163125,7 +163208,7 @@ pub(crate) mod tests {
                 "{label}"
             );
             assert_eq!(miss.cpu.gpr[3], 0, "{label}");
-            assert_eq!(miss.toolbox_startup.menu_tracking, None, "{label}");
+            assert!(miss.toolbox_startup.execution.menu().is_none(), "{label}");
             assert_eq!(
                 ppc_memory_read_bytes(&mut miss.memory, front.base_addr, framebuffer_len),
                 Some(before.clone()),
@@ -163166,7 +163249,7 @@ pub(crate) mod tests {
             });
             let probe = loaded.run_with_hle_imports(64);
             assert!(matches!(probe.result, PpcRunResult::CycleLimit { .. }));
-            let tracking = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
+            let tracking = loaded.toolbox_startup.execution.menu().snapshot().unwrap();
             loaded.set_input_snapshot(PpcInputSnapshot {
                 mouse_button: false,
                 mouse_v: tracking.popup_top + 16 + 4,
@@ -163181,7 +163264,7 @@ pub(crate) mod tests {
                 "{label}"
             );
             assert_eq!(loaded.cpu.gpr[3], 0, "{label}");
-            assert_eq!(loaded.toolbox_startup.menu_tracking, None, "{label}");
+            assert!(loaded.toolbox_startup.execution.menu().is_none(), "{label}");
             assert_eq!(
                 ppc_memory_read_bytes(&mut loaded.memory, front.base_addr, framebuffer_len),
                 Some(before),
@@ -163247,10 +163330,10 @@ pub(crate) mod tests {
             let probe = loaded.run_with_hle_imports(64);
 
             assert!(matches!(probe.result, PpcRunResult::CycleLimit { .. }));
-            let tracking = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
+            let tracking = loaded.toolbox_startup.execution.menu().snapshot().unwrap();
             assert_eq!(tracking.kind, MenuTrackingKind::PopUp);
             assert_eq!(
-                loaded.toolbox_startup.menu_tracking.context().native_popup(),
+                loaded.toolbox_startup.execution.menu().context().native_popup(),
                 Some(ppc_popup_menu_call(&loaded.cpu))
             );
             assert_eq!(
@@ -163279,7 +163362,7 @@ pub(crate) mod tests {
 
             assert!(matches!(probe.result, PpcRunResult::Halted { .. }));
             assert_eq!(loaded.cpu.gpr[3], 0);
-            assert_eq!(loaded.toolbox_startup.menu_tracking, None);
+            assert!(loaded.toolbox_startup.execution.menu().is_none());
             assert_eq!(
                 ppc_memory_read_bytes(&mut loaded.memory, front.base_addr, framebuffer_len),
                 Some(pattern),
@@ -163316,7 +163399,7 @@ pub(crate) mod tests {
         let probe = loaded.run_with_hle_imports(64);
 
         assert!(matches!(probe.result, PpcRunResult::CycleLimit { .. }));
-        let tracking = loaded.toolbox_startup.menu_tracking.as_ref().unwrap();
+        let tracking = loaded.toolbox_startup.execution.menu().as_ref().unwrap();
         assert_eq!(tracking.popup_top, 4);
         assert_eq!(tracking.popup_height, 576);
         assert_eq!(tracking.content_top, -204);
@@ -163387,7 +163470,7 @@ pub(crate) mod tests {
                 *loaded.process_file_system.current_resource_file,
             );
             assert!(matches!(action, PpcImportAction::Yield(_)));
-            let tracking = loaded.toolbox_startup.menu_tracking.as_ref().unwrap();
+            let tracking = loaded.toolbox_startup.execution.menu().as_ref().unwrap();
             assert_eq!(tracking.highlighted_item, expected_item);
             assert_eq!(tracking.content_top, expected_top);
             assert_eq!(
@@ -163486,9 +163569,9 @@ pub(crate) mod tests {
             let probe = loaded.run_with_hle_imports(128);
             assert!(matches!(probe.result, PpcRunResult::CycleLimit { .. }));
         }
-        assert!(loaded.toolbox_startup.menu_tracking.is_some());
+        assert!(loaded.toolbox_startup.execution.menu().is_some());
         assert_eq!(
-            loaded.toolbox_startup.menu_tracking.context().native_port,
+            loaded.toolbox_startup.execution.menu().context().native_port,
             Some(original_port),
         );
         assert_eq!(*loaded.current_gworld, PPC_DSP_BACK_GWORLD);
@@ -163520,8 +163603,8 @@ pub(crate) mod tests {
             (*loaded.current_gworld, *loaded.current_gdevice),
             original_port
         );
-        assert!(loaded.guest_calls.is_empty());
-        assert!(loaded.toolbox_startup.menu_tracking.is_none());
+        assert!(loaded.guest_calls().is_empty());
+        assert!(loaded.toolbox_startup.execution.menu().is_none());
     }
 
     #[test]
@@ -163540,10 +163623,10 @@ pub(crate) mod tests {
 
         let probe = loaded.run_with_hle_imports(128);
         assert!(matches!(probe.result, PpcRunResult::CycleLimit { .. }));
-        assert_eq!(loaded.guest_calls.depth(), 0);
-        assert_eq!(loaded.toolbox_startup.menu_tracking.menu_hook_key(), None);
+        assert_eq!(loaded.guest_calls().depth(), 0);
+        assert_eq!(loaded.toolbox_startup.execution.menu().menu_hook_key(), None);
         assert_eq!(
-            loaded.toolbox_startup.menu_tracking.context().native_port,
+            loaded.toolbox_startup.execution.menu().context().native_port,
             None
         );
         assert_eq!(loaded.memory.read_u32_be(marker), Some(0));
@@ -163555,10 +163638,10 @@ pub(crate) mod tests {
             .unwrap();
         let probe = loaded.run_with_hle_imports(128);
         assert!(matches!(probe.result, PpcRunResult::CycleLimit { .. }));
-        assert_eq!(loaded.guest_calls.depth(), 0);
-        assert_eq!(loaded.toolbox_startup.menu_tracking.menu_hook_key(), None);
+        assert_eq!(loaded.guest_calls().depth(), 0);
+        assert_eq!(loaded.toolbox_startup.execution.menu().menu_hook_key(), None);
         assert_eq!(
-            loaded.toolbox_startup.menu_tracking.context().native_port,
+            loaded.toolbox_startup.execution.menu().context().native_port,
             None
         );
         assert_eq!(loaded.memory.read_u32_be(marker), Some(0));
@@ -163574,7 +163657,7 @@ pub(crate) mod tests {
         assert!(loaded.memory.read_u32_be(marker).unwrap() > 0);
         assert!(loaded
             .toolbox_startup
-            .menu_tracking
+            .execution.menu()
             .context()
             .native_port
             .is_some());
@@ -163593,8 +163676,8 @@ pub(crate) mod tests {
                 break;
             }
         }
-        assert!(loaded.guest_calls.is_empty());
-        assert!(loaded.toolbox_startup.menu_tracking.is_none());
+        assert!(loaded.guest_calls().is_empty());
+        assert!(loaded.toolbox_startup.execution.menu().is_none());
     }
 
     #[test]
@@ -163632,8 +163715,8 @@ pub(crate) mod tests {
             (*loaded.current_gworld, *loaded.current_gdevice),
             original_port
         );
-        assert!(loaded.toolbox_startup.menu_tracking.is_none());
-        assert!(loaded.guest_calls.is_empty());
+        assert!(loaded.toolbox_startup.execution.menu().is_none());
+        assert!(loaded.guest_calls().is_empty());
     }
 
     #[test]
@@ -163677,8 +163760,8 @@ pub(crate) mod tests {
             (*loaded.current_gworld, *loaded.current_gdevice),
             original_port
         );
-        assert!(loaded.toolbox_startup.menu_tracking.is_none());
-        assert!(loaded.guest_calls.is_empty());
+        assert!(loaded.toolbox_startup.execution.menu().is_none());
+        assert!(loaded.guest_calls().is_empty());
     }
 
     #[test]
@@ -163721,8 +163804,8 @@ pub(crate) mod tests {
             });
             let first = loaded.run_with_hle_imports(64);
             assert_eq!(first.handled_import_count, 1);
-            assert!(loaded.toolbox_startup.menu_tracking.is_some(), "popup={popup}, result={:?}, r3={:08x}", first.result, loaded.cpu.gpr[3]);
-            let tracking = loaded.toolbox_startup.menu_tracking.as_ref().unwrap();
+            assert!(loaded.toolbox_startup.execution.menu().is_some(), "popup={popup}, result={:?}, r3={:08x}", first.result, loaded.cpu.gpr[3]);
+            let tracking = loaded.toolbox_startup.execution.menu().as_ref().unwrap();
             let pointer = (tracking.popup_top + 4, tracking.popup_left + 4);
             loaded.set_input_snapshot(PpcInputSnapshot {
                 mouse_button: true,
@@ -163746,8 +163829,8 @@ pub(crate) mod tests {
             assert_eq!(loaded.cpu.pc, PPC_HALT_PC);
             assert_eq!(loaded.cpu.gpr[1], original_sp);
             assert_eq!(loaded.cpu.gpr[3], (128 << 16) | 1);
-            assert!(loaded.toolbox_startup.menu_tracking.is_none());
-            assert!(loaded.guest_calls.is_empty());
+            assert!(loaded.toolbox_startup.execution.menu().is_none());
+            assert!(loaded.guest_calls().is_empty());
             // Returning to the public gateway is a new call and is counted again.
             loaded.cpu.pc = loaded.entry_pc;
             loaded.cpu.lr = PPC_HALT_PC;
@@ -163801,7 +163884,7 @@ pub(crate) mod tests {
         let probe = loaded.run_with_hle_imports(64);
         assert!(matches!(probe.result, PpcRunResult::Halted { .. }));
         assert_eq!(loaded.cpu.gpr[3], (128u32 << 16) | 1);
-        assert_eq!(loaded.toolbox_startup.menu_tracking, None);
+        assert!(loaded.toolbox_startup.execution.menu().is_none());
         assert_eq!(loaded.memory.read_u16_be(PPC_THE_MENU_ADDR), Some(128));
     }
 
@@ -163889,7 +163972,7 @@ pub(crate) mod tests {
             assert_eq!(
                 loaded
                     .toolbox_startup
-                    .menu_tracking
+                    .execution.menu()
                     .as_ref()
                     .map(|state| state.menu_handle),
                 Some(file_menu),
@@ -163908,7 +163991,7 @@ pub(crate) mod tests {
             assert_eq!(
                 loaded
                     .toolbox_startup
-                    .menu_tracking
+                    .execution.menu()
                     .as_ref()
                     .map(|state| state.menu_handle),
                 Some(edit_menu),
@@ -163930,7 +164013,7 @@ pub(crate) mod tests {
                 assert_eq!(
                     loaded
                         .toolbox_startup
-                        .menu_tracking
+                        .execution.menu()
                         .as_ref()
                         .map(|state| state.menu_handle),
                     Some(expected_menu),
@@ -163952,14 +164035,14 @@ pub(crate) mod tests {
             assert_eq!(
                 loaded
                     .toolbox_startup
-                    .menu_tracking
+                    .execution.menu()
                     .as_ref()
                     .map(|state| state.menu_handle),
                 Some(disabled_menu),
                 "{depth}bpp disabled title did not open",
             );
             assert_eq!(loaded.memory.read_u16_be(PPC_THE_MENU_ADDR), Some(130));
-            let disabled_tracking = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
+            let disabled_tracking = loaded.toolbox_startup.execution.menu().snapshot().unwrap();
             assert_eq!(
                 disabled_tracking.highlighted_item, 0,
                 "{depth}bpp disabled menu item became highlighted",
@@ -163975,7 +164058,7 @@ pub(crate) mod tests {
             assert!(matches!(probe.result, PpcRunResult::Halted { .. }));
             assert_eq!(loaded.cpu.gpr[3], 0);
             assert_eq!(loaded.cpu.gpr[1], original_sp);
-            assert_eq!(loaded.toolbox_startup.menu_tracking, None);
+            assert!(loaded.toolbox_startup.execution.menu().is_none());
             assert_eq!(loaded.memory.read_u16_be(PPC_THE_MENU_ADDR), Some(0));
             assert_eq!(
                 loaded
@@ -164022,7 +164105,7 @@ pub(crate) mod tests {
             loaded.run_with_hle_imports(64).result,
             PpcRunResult::CycleLimit { .. }
         ));
-        let switched = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
+        let switched = loaded.toolbox_startup.execution.menu().snapshot().unwrap();
         loaded
             .memory
             .write_u16_be(crate::memory::globals::addr::MENU_FLASH, 1)
@@ -164038,7 +164121,7 @@ pub(crate) mod tests {
         assert_eq!(
             loaded
                 .toolbox_startup
-                .menu_tracking
+                .execution.menu()
                 .as_ref()
                 .map(|state| state.flash_remaining),
             Some(2)
@@ -164051,7 +164134,8 @@ pub(crate) mod tests {
         });
         loaded
             .toolbox_startup
-            .menu_tracking
+            .execution
+            .menu_state_mut()
             .as_mut()
             .unwrap()
             .flash_delay = 0;
@@ -164061,14 +164145,15 @@ pub(crate) mod tests {
         ));
         loaded
             .toolbox_startup
-            .menu_tracking
+            .execution
+            .menu_state_mut()
             .as_mut()
             .unwrap()
             .flash_delay = 0;
         let probe = loaded.run_with_hle_imports(64);
         assert!(matches!(probe.result, PpcRunResult::Halted { .. }));
         assert_eq!(loaded.cpu.gpr[3], (129u32 << 16) | 1);
-        assert_eq!(loaded.toolbox_startup.menu_tracking, None);
+        assert!(loaded.toolbox_startup.execution.menu().is_none());
         assert_eq!(loaded.memory.read_u16_be(PPC_THE_MENU_ADDR), Some(129));
 
         loaded.cpu.pc = loaded.entry_pc;
@@ -164088,7 +164173,7 @@ pub(crate) mod tests {
             loaded.run_with_hle_imports(64).result,
             PpcRunResult::CycleLimit { .. }
         ));
-        let tracking = loaded.toolbox_startup.menu_tracking.snapshot().unwrap();
+        let tracking = loaded.toolbox_startup.execution.menu().snapshot().unwrap();
         loaded.set_input_snapshot(PpcInputSnapshot {
             mouse_button: false,
             mouse_v: tracking.popup_top + 6,
@@ -164098,7 +164183,7 @@ pub(crate) mod tests {
         let probe = loaded.run_with_hle_imports(64);
         assert!(matches!(probe.result, PpcRunResult::Halted { .. }));
         assert_eq!(loaded.cpu.gpr[3], (128u32 << 16) | 1);
-        assert_eq!(loaded.toolbox_startup.menu_tracking, None);
+        assert!(loaded.toolbox_startup.execution.menu().is_none());
     }
 
     #[test]
@@ -165388,8 +165473,8 @@ pub(crate) mod tests {
         let mut native = load_pef_application(&synthetic_pef_with_import(b"LNew")).unwrap();
         let (mut classic, _classic_cpu, _classic_bus) = setup_with_port();
         let mut context = ProcessContext::default();
-        classic.attach_process_context(&mut context);
-        native.attach_process_context(&mut context);
+        classic.attach_unconverted_process_services(&mut context);
+        native.attach_unconverted_process_services(&mut context);
 
         let scratch = PPC_DATA_BASE + 0x1800;
         let view_ptr = scratch;
@@ -166420,8 +166505,8 @@ pub(crate) mod tests {
         let mut native = load_pef_application(&pef).unwrap();
         let mut classic = TrapDispatcher::new();
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
-        classic.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
+        classic.attach_unconverted_process_services(&mut context);
 
         let mut classic_bus = MacMemoryBus::new(0x2000);
         classic_bus.attach_guest_address_space(native.memory.shared_view());
@@ -166465,8 +166550,8 @@ pub(crate) mod tests {
         let mut native = load_pef_application(&pef).unwrap();
         let mut classic = TrapDispatcher::new();
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
-        classic.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
+        classic.attach_unconverted_process_services(&mut context);
 
         let base = PPC_HEAP_BASE + 0x15_000;
         let port = base;
@@ -166615,8 +166700,8 @@ pub(crate) mod tests {
         let mut native = load_pef_application(&pef).unwrap();
         let mut classic = TrapDispatcher::new();
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
-        classic.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
+        classic.attach_unconverted_process_services(&mut context);
 
         let mut classic_bus = MacMemoryBus::new(0x2000);
         classic_bus.attach_guest_address_space(native.memory.shared_view());
@@ -166691,8 +166776,8 @@ pub(crate) mod tests {
         let mut native = load_pef_application(&pef).unwrap();
         let mut classic = TrapDispatcher::new();
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
-        classic.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
+        classic.attach_unconverted_process_services(&mut context);
 
         let base = PPC_HEAP_BASE + 0x12_000;
         let port = base;
@@ -166907,8 +166992,8 @@ pub(crate) mod tests {
             load_pef_application(&synthetic_pef_with_import(b"TestImport")).unwrap();
         let (mut classic, mut classic_cpu, mut classic_bus) = setup_with_port();
         let mut context = ProcessContext::default();
-        classic.attach_process_context(&mut context);
-        native.attach_process_context(&mut context);
+        classic.attach_unconverted_process_services(&mut context);
+        native.attach_unconverted_process_services(&mut context);
 
         classic_bus.write_word(TEST_SP, 0x00ff);
         classic_cpu.write_reg(Register::A7, TEST_SP);
@@ -166940,12 +167025,12 @@ pub(crate) mod tests {
             load_pef_application(&synthetic_pef_with_import(b"TestImport")).unwrap();
         let (mut classic, mut classic_cpu, mut classic_bus) = setup_with_port();
         let mut context = ProcessContext::default();
-        classic.attach_process_context(&mut context);
+        classic.attach_unconverted_process_services(&mut context);
         let low_memory = classic_bus
             .shared_ram_region(0, 0x0010_0000)
             .expect("classic adapter owns low memory");
         context.attach_memory(0, low_memory, &mut native.memory);
-        native.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
 
         let native_heap_ceiling = native.heap_limit();
         assert_eq!(
@@ -166992,8 +167077,8 @@ pub(crate) mod tests {
             load_pef_application(&synthetic_pef_with_import(b"TestImport")).unwrap();
         let (mut classic, mut classic_cpu, mut classic_bus) = setup_with_port();
         let mut context = ProcessContext::default();
-        classic.attach_process_context(&mut context);
-        native.attach_process_context(&mut context);
+        classic.attach_unconverted_process_services(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let low_memory = classic_bus
             .shared_ram_region(0, 0x0010_0000)
             .expect("classic adapter owns low memory");
@@ -167071,8 +167156,8 @@ pub(crate) mod tests {
         let mut native = load_pef_application(&pef).unwrap();
         let (mut classic, mut classic_cpu, mut classic_bus) = setup_with_port();
         let mut context = ProcessContext::default();
-        classic.attach_process_context(&mut context);
-        native.attach_process_context(&mut context);
+        classic.attach_unconverted_process_services(&mut context);
+        native.attach_unconverted_process_services(&mut context);
 
         let probe = native.run_with_hle_imports(64);
 
@@ -167094,8 +167179,8 @@ pub(crate) mod tests {
         let mut native = load_pef_application(&pef).unwrap();
         let (mut classic, mut classic_cpu, mut classic_bus) = setup_with_port();
         let mut context = ProcessContext::default();
-        classic.attach_process_context(&mut context);
-        native.attach_process_context(&mut context);
+        classic.attach_unconverted_process_services(&mut context);
+        native.attach_unconverted_process_services(&mut context);
 
         let native_cursor = PPC_DATA_BASE + 0x1000;
         let mut native_data = [0; 32];
@@ -167144,8 +167229,8 @@ pub(crate) mod tests {
         let mut native = load_pef_application(&pef).unwrap();
         let (mut classic, mut classic_cpu, mut classic_bus) = setup_with_port();
         let mut context = ProcessContext::default();
-        classic.attach_process_context(&mut context);
-        native.attach_process_context(&mut context);
+        classic.attach_unconverted_process_services(&mut context);
+        native.attach_unconverted_process_services(&mut context);
 
         run_test_import(&mut native, PpcImportDispatcherTarget::ZeroScrap);
         let native_source = PPC_DATA_BASE + 0x2600;
@@ -167204,8 +167289,8 @@ pub(crate) mod tests {
             load_pef_application(&synthetic_pef_with_import(b"TestImport")).unwrap();
         let (mut classic, mut classic_cpu, mut classic_bus) = setup_with_port();
         let mut context = ProcessContext::default();
-        classic.attach_process_context(&mut context);
-        native.attach_process_context(&mut context);
+        classic.attach_unconverted_process_services(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let te_handle = 0x0033_1000;
 
         classic_bus.write_long(TEST_SP, te_handle);
@@ -167238,8 +167323,8 @@ pub(crate) mod tests {
             load_pef_application(&synthetic_pef_with_import(b"TestImport")).unwrap();
         let (mut classic, _classic_cpu, mut classic_bus) = setup_with_port();
         let mut context = ProcessContext::default();
-        classic.attach_process_context(&mut context);
-        native.attach_process_context(&mut context);
+        classic.attach_unconverted_process_services(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let low_memory = classic_bus
             .shared_ram_region(0, 0x0010_0000)
             .expect("classic adapter owns low memory");
@@ -167349,8 +167434,8 @@ pub(crate) mod tests {
             load_pef_application(&synthetic_pef_with_import(b"TestImport")).unwrap();
         let (mut classic, _classic_cpu, mut classic_bus) = setup_with_port();
         let mut context = ProcessContext::default();
-        classic.attach_process_context(&mut context);
-        native.attach_process_context(&mut context);
+        classic.attach_unconverted_process_services(&mut context);
+        native.attach_unconverted_process_services(&mut context);
 
         let window = classic_bus.alloc(180);
         let (classic_handle, classic_pointer) = classic.create_control_record(
@@ -170318,7 +170403,7 @@ pub(crate) mod tests {
     fn apple_event_handler_bundle_is_process_owned_cross_isa_and_depth_disposed() {
         let mut native = load_pef_application(&synthetic_pef_with_import(b"TestImport")).unwrap();
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let detached = context.memory_manager_mut().detached_clone();
         let event_record = PPC_DATA_BASE + 0x2600;
         native.memory.add_region(event_record, vec![0; 16]);
@@ -170473,8 +170558,8 @@ pub(crate) mod tests {
         let (mut classic, mut classic_cpu, mut classic_bus) = setup_with_port();
         let mut native = load_pef_application(&synthetic_pef_with_import(b"TestImport")).unwrap();
         let mut context = ProcessContext::default();
-        classic.attach_process_context(&mut context);
-        native.attach_process_context(&mut context);
+        classic.attach_unconverted_process_services(&mut context);
+        native.attach_unconverted_process_services(&mut context);
 
         let ram_end = classic_bus.ram_size();
         let low_memory_end = 0x0010_0000.min(ram_end);
@@ -170616,7 +170701,7 @@ pub(crate) mod tests {
         let mut native = load_pef_application(&synthetic_pef_with_import(b"TestImport")).unwrap();
         native.set_heap_cursor(native.heap_limit().saturating_sub(8));
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let event_record = PPC_DATA_BASE + 0x2700;
         native.memory.add_region(event_record, vec![0; 16]);
         native
@@ -170718,7 +170803,7 @@ pub(crate) mod tests {
     fn native_apple_event_dispatch_enters_registered_classic_handler() {
         let mut native = load_pef_application(&synthetic_pef_with_import(b"TestImport")).unwrap();
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let event_record = PPC_DATA_BASE + 0x2800;
         native.memory.add_region(event_record, vec![0; 16]);
         native
@@ -170770,8 +170855,8 @@ pub(crate) mod tests {
         };
 
         assert_eq!(action, PpcImportAction::Halt);
-        assert!(native.guest_calls.has_m68k_execution());
-        let pending = native.guest_calls.activate_m68k().unwrap();
+        assert!(native.guest_calls().has_m68k_execution());
+        let pending = native.guest_calls().activate_m68k().unwrap();
         assert_eq!(pending.entry, classic_handler);
         assert_eq!(native.apple_events.pending_dispatches.len(), 1);
     }
@@ -171761,12 +171846,11 @@ pub(crate) mod tests {
             .unwrap();
         loaded.memory.add_region(OUTPUT, vec![0; 4]);
         assert!(loaded.application_heap_limit() > 0x9000);
-        assert!(loaded
-            .guest_calls
+        assert!(loaded.guest_calls()
             .bind_task_entry_isa(ExecutionTaskId::APPLICATION, GuestIsa::M68k));
         let mut classic = crate::cpu::M68kCpu::new();
         classic.core.set_a(7, 0x9000);
-        assert!(loaded.guest_calls.begin_m68k_to_powerpc(
+        assert!(loaded.guest_calls().begin_m68k_to_powerpc(
             GuestCallTarget {
                 isa: GuestIsa::PowerPc,
                 entry: loaded.entry_pc,
@@ -171837,8 +171921,7 @@ pub(crate) mod tests {
         assert_eq!(loaded.memory.read_u32_be(OUTPUT), Some(4096 - 64));
         let mut classic = CooperativeThread::default();
         classic.a_regs[7] = 0x9300;
-        let classic = loaded
-            .guest_calls
+        let classic = loaded.guest_calls()
             .create_classic_thread(
                 classic,
                 ThreadStorage {
@@ -171852,12 +171935,11 @@ pub(crate) mod tests {
             .unwrap();
         assert_eq!(query(&mut loaded, classic.thread_id(), OUTPUT), 0);
         assert_eq!(loaded.memory.read_u32_be(OUTPUT), Some(0x300));
-        assert!(loaded
-            .guest_calls
+        assert!(loaded.toolbox_startup.execution.calls()
             .yield_native_thread(&mut loaded.cpu, worker.thread_id())
             .unwrap());
         let worker_sp = loaded.cpu.gpr[1];
-        let storage = loaded.guest_calls.thread_storage(worker).unwrap();
+        let storage = loaded.guest_calls().thread_storage(worker).unwrap();
         assert_eq!(query(&mut loaded, 1, OUTPUT), 0);
         assert_eq!(
             loaded.memory.read_u32_be(OUTPUT),
@@ -171866,7 +171948,7 @@ pub(crate) mod tests {
         assert_eq!(query(&mut loaded, 2, OUTPUT), 0);
         assert_eq!(loaded.memory.read_u32_be(OUTPUT), Some(main_sp - limit));
         assert_eq!(
-            crate::thread_manager::ThreadManager::new(&loaded.guest_calls).stack_space(
+            crate::thread_manager::ThreadManager::new(loaded.guest_calls()).stack_space(
                 2,
                 GuestIsa::M68k,
                 0x1234,
@@ -171891,7 +171973,7 @@ pub(crate) mod tests {
             Some(vec![0x5a; 3])
         );
         assert_eq!(query(&mut loaded, 1, 0), -50);
-        assert_eq!(loaded.guest_calls.current_task(), worker);
+        assert_eq!(loaded.guest_calls().current_task(), worker);
     }
 
     #[test]
@@ -171954,7 +172036,7 @@ pub(crate) mod tests {
         assert_eq!(loaded.memory.read_u32_be(output), Some(3));
         assert_eq!(invoke(&mut loaded, "GetFreeThreadCount", [1, output, 0]), 0);
         assert_eq!(loaded.memory.read_u16_be(output), Some(3));
-        assert_eq!(loaded.guest_calls.thread_pool_count(GuestIsa::M68k, 0), 0);
+        assert_eq!(loaded.guest_calls().thread_pool_count(GuestIsa::M68k, 0), 0);
     }
 
     #[test]
@@ -171969,7 +172051,7 @@ pub(crate) mod tests {
         assert_eq!(loaded.run_with_hle_imports(64).handled_import_count, 1);
         assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_PARAM_ERR));
         assert_eq!(loaded.memory.read_u32_be(made), Some(0));
-        assert!(!loaded.guest_calls.has_live_workers());
+        assert!(!loaded.guest_calls().has_live_workers());
         loaded.cpu.pc = loaded.entry_pc;
         loaded.cpu.lr = PPC_HALT_PC;
         loaded.cpu.gpr[3] = 1;
@@ -171977,7 +172059,7 @@ pub(crate) mod tests {
         assert_eq!(loaded.run_with_hle_imports(64).handled_import_count, 1);
         assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(-617));
         assert_eq!(loaded.memory.read_u32_be(made), Some(0));
-        assert!(!loaded.guest_calls.has_live_workers());
+        assert!(!loaded.guest_calls().has_live_workers());
         loaded.cpu.pc = loaded.entry_pc;
         loaded.cpu.lr = PPC_HALT_PC;
         loaded.cpu.gpr[3] = 1;
@@ -172058,7 +172140,7 @@ pub(crate) mod tests {
             assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_PARAM_ERR));
             assert_eq!(loaded.memory.read_u32_be(made), Some(0));
             assert_eq!(loaded.heap_cursor(), heap_before);
-            assert!(!loaded.guest_calls.has_live_workers());
+            assert!(!loaded.guest_calls().has_live_workers());
         }
 
         loaded.memory.write_u32_be(descriptor, target).unwrap();
@@ -172067,8 +172149,7 @@ pub(crate) mod tests {
         assert_eq!(loaded.cpu.gpr[3], 0);
         let worker = ExecutionTaskId::from_thread_id(loaded.memory.read_u32_be(made).unwrap());
         assert_eq!(worker.thread_id(), 3);
-        assert!(loaded
-            .guest_calls
+        assert!(loaded.toolbox_startup.execution.calls()
             .yield_native_thread(&mut loaded.cpu, worker.thread_id())
             .unwrap());
         assert_eq!(loaded.cpu.pc, target);
@@ -172113,7 +172194,7 @@ pub(crate) mod tests {
         assert_eq!(protected.heap_cursor(), protected_cursor);
         assert_eq!(protected.ptrs(), protected_ptrs);
         assert_eq!(protected.last_mem_error(), protected_mem_error);
-        assert!(!protected.guest_calls.has_live_workers());
+        assert!(!protected.guest_calls().has_live_workers());
         invoke(&mut protected, valid_made, 4096);
         assert_eq!(protected.cpu.gpr[3], 0);
         assert_eq!(protected.memory.read_u32_be(valid_made), Some(3));
@@ -172150,7 +172231,7 @@ pub(crate) mod tests {
                 .0
             )
         );
-        assert!(!exhausted.guest_calls.has_live_workers());
+        assert!(!exhausted.guest_calls().has_live_workers());
 
         invoke(&mut exhausted, made, 4096);
         assert_eq!(exhausted.cpu.gpr[3], 0);
@@ -172203,21 +172284,21 @@ pub(crate) mod tests {
         loaded.cpu.lr = PPC_HALT_PC;
         let creator = loaded.cpu.clone();
         loaded.run_with_hle_imports(64);
-        assert_eq!(loaded.guest_calls.current_task(), worker);
+        assert_eq!(loaded.guest_calls().current_task(), worker);
         assert_eq!(loaded.cpu.pc, ENTRY);
         assert_eq!(loaded.cpu.gpr[2], creator.gpr[2]);
         assert_eq!(loaded.cpu.gpr[3], 17);
         loaded.run_with_hle_imports(64);
-        assert_eq!(loaded.guest_calls.current_task(), worker);
+        assert_eq!(loaded.guest_calls().current_task(), worker);
         assert_eq!(loaded.cpu.pc, PPC_THREAD_RETURN_PC);
         assert_eq!(loaded.cpu.gpr[3], 42);
         loaded.memory.add_region(RESULT, vec![0; 4]);
         loaded.run_with_hle_imports(64);
         assert_eq!(
-            loaded.guest_calls.current_task(),
+            loaded.guest_calls().current_task(),
             ExecutionTaskId::APPLICATION
         );
-        assert_eq!(loaded.guest_calls.scheduling_state(worker), None);
+        assert_eq!(loaded.guest_calls().scheduling_state(worker), None);
         assert_eq!(loaded.memory.read_u32_be(RESULT), Some(42));
         assert_eq!(loaded.cpu.pc, PPC_HALT_PC);
         assert_eq!(loaded.cpu.gpr[20], creator.gpr[20]);
@@ -172237,8 +172318,7 @@ pub(crate) mod tests {
             let mut worker_cpu = loaded.cpu.clone();
             worker_cpu.pc = PPC_CODE_BASE + 0x2000;
             worker_cpu.gpr[1] = PPC_DATA_BASE + 0x4000;
-            let worker = loaded
-                .guest_calls
+            let worker = loaded.guest_calls()
                 .create_native_thread(
                     NativeThreadContext {
                         context: worker_cpu.capture_execution_context(),
@@ -172248,7 +172328,7 @@ pub(crate) mod tests {
                     |_| true,
                 )
                 .unwrap();
-            loaded.guest_calls.begin_critical();
+            loaded.guest_calls().begin_critical();
             loaded.cpu.pc = loaded.entry_pc;
             loaded.cpu.lr = PPC_HALT_PC;
             loaded.cpu.gpr[3] = worker.thread_id();
@@ -172256,7 +172336,7 @@ pub(crate) mod tests {
             loaded.cpu.fpr[20] = 0x4009_21fb_5444_2d18;
             loaded.cpu.cr = 0x1357_2468;
             establish_loaded_reservation(&mut loaded, PPC_DATA_BASE);
-            let before_calls = loaded.guest_calls.clone();
+            let before_calls = loaded.guest_calls().clone();
 
             let probe = loaded.run_with_hle_imports(64);
 
@@ -172267,12 +172347,12 @@ pub(crate) mod tests {
             assert_eq!(loaded.cpu.fpr[20], 0x4009_21fb_5444_2d18);
             assert_eq!(loaded.cpu.cr, 0x1357_2468);
             assert_eq!(loaded.cpu.reservation_address(), Some(PPC_DATA_BASE));
-            assert_eq!(loaded.guest_calls, before_calls);
+            assert_eq!(loaded.guest_calls(), &before_calls);
             assert_eq!(
-                loaded.guest_calls.current_task(),
+                loaded.guest_calls().current_task(),
                 ExecutionTaskId::APPLICATION
             );
-            assert_eq!(loaded.guest_calls.critical_depth(), 1);
+            assert_eq!(loaded.guest_calls().critical_depth(), 1);
         }
 
         let mut loaded = load_pef_application(&synthetic_pef_with_import(b"YieldToAnyThread")).unwrap();
@@ -172280,7 +172360,7 @@ pub(crate) mod tests {
         loaded.cpu.fpr[20] = 0x3ff0_0000_0000_0000;
         loaded.cpu.cr = 0x2468_1357;
         establish_loaded_reservation(&mut loaded, PPC_DATA_BASE);
-        let before_calls = loaded.guest_calls.clone();
+        let before_calls = loaded.guest_calls().clone();
 
         let probe = loaded.run_with_hle_imports(64);
 
@@ -172291,9 +172371,9 @@ pub(crate) mod tests {
         assert_eq!(loaded.cpu.fpr[20], 0x3ff0_0000_0000_0000);
         assert_eq!(loaded.cpu.cr, 0x2468_1357);
         assert_eq!(loaded.cpu.reservation_address(), Some(PPC_DATA_BASE));
-        assert_eq!(loaded.guest_calls, before_calls);
+        assert_eq!(loaded.guest_calls(), &before_calls);
         assert_eq!(
-            loaded.guest_calls.current_task(),
+            loaded.guest_calls().current_task(),
             ExecutionTaskId::APPLICATION
         );
     }
@@ -172302,12 +172382,12 @@ pub(crate) mod tests {
     fn standalone_native_thread_stays_stopped_until_ready() {
         let mut loaded =
             load_pef_application(&synthetic_pef_with_import(b"SetThreadStateEndCritical")).unwrap();
-        loaded.guest_calls.begin_critical();
+        loaded.guest_calls().begin_critical();
         loaded.cpu.gpr[3] = 1;
         loaded.cpu.gpr[4] = 1;
         loaded.cpu.gpr[5] = 0;
         assert_eq!(loaded.run_with_hle_imports(64).handled_import_count, 1);
-        assert!(!loaded.guest_calls.current_task_is_running());
+        assert!(!loaded.guest_calls().current_task_is_running());
         let pc = loaded.cpu.pc;
         let time = loaded.cpu.time_base();
         for _ in 0..3 {
@@ -172317,7 +172397,7 @@ pub(crate) mod tests {
             assert_eq!(loaded.cpu.pc, pc);
             assert_eq!(loaded.cpu.time_base(), time);
         }
-        let manager = crate::thread_manager::ThreadManager::new(&loaded.guest_calls);
+        let manager = crate::thread_manager::ThreadManager::new(loaded.guest_calls());
         assert_eq!(manager.ready_given_task(manager.task_reference(), 2), 0);
         loaded.run_with_hle_imports(64);
         assert_eq!(loaded.cpu.pc, PPC_HALT_PC);
@@ -172331,7 +172411,7 @@ pub(crate) mod tests {
             load_pef_application(&synthetic_pef_with_import(b"SetThreadReadyGivenTaskRef"))
                 .unwrap();
         let worker = ExecutionTaskId::from_thread_id(3);
-        assert!(loaded.guest_calls.register_task(worker));
+        assert!(loaded.guest_calls().register_task(worker));
         for (reference, thread, result) in [
             (99, 3, -619),
             (2, 99, -618),
@@ -172346,14 +172426,15 @@ pub(crate) mod tests {
             assert_eq!(loaded.run_with_hle_imports(64).handled_import_count, 1);
             assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(result));
             assert_eq!(
-                loaded.guest_calls.current_task(),
+                loaded.guest_calls().current_task(),
                 ExecutionTaskId::APPLICATION
             );
         }
         let mut query =
             load_pef_application(&synthetic_pef_with_import(b"GetThreadStateGivenTaskRef"))
                 .unwrap();
-        query.guest_calls = loaded.guest_calls.shared_handle();
+        query.toolbox_startup.execution =
+            ExecutionMenuViews::shared_from(loaded.guest_calls());
         let out = PPC_DATA_BASE + 0x1000;
         query.memory.add_region(out, vec![0xaa; 4]);
         for (reference, thread, result, state) in
@@ -172401,8 +172482,7 @@ pub(crate) mod tests {
             worker_cpu.pc = code;
             worker_cpu.lr = PPC_HALT_PC;
             worker_cpu.gpr[20] = 0;
-            let worker = loaded
-                .guest_calls
+            let worker = loaded.guest_calls()
                 .create_native_thread(
                     NativeThreadContext {
                         context: worker_cpu.capture_execution_context(),
@@ -172423,17 +172503,16 @@ pub(crate) mod tests {
             loaded.cpu.gpr[5] = worker.thread_id();
             loaded.cpu.lr = PPC_HALT_PC;
             if end_critical {
-                loaded.guest_calls.begin_critical();
+                loaded.guest_calls().begin_critical();
             }
             assert_eq!(loaded.run_with_hle_imports(64).handled_import_count, 1);
-            assert_eq!(loaded.guest_calls.current_task(), worker);
+            assert_eq!(loaded.guest_calls().current_task(), worker);
             assert_eq!(
-                loaded
-                    .guest_calls
+                loaded.guest_calls()
                     .scheduling_state(ExecutionTaskId::APPLICATION),
                 Some(ExecutionTaskState::Stopped)
             );
-            assert_eq!(loaded.guest_calls.critical_depth(), 0);
+            assert_eq!(loaded.guest_calls().critical_depth(), 0);
             loaded.run_with_hle_imports(64);
             assert_eq!(loaded.cpu.gpr[20], 0x55);
             // Wake the creator without switching away from the worker.
@@ -172443,13 +172522,12 @@ pub(crate) mod tests {
             loaded.cpu.gpr[4] = 0;
             loaded.cpu.gpr[5] = 0;
             if end_critical {
-                loaded.guest_calls.begin_critical();
+                loaded.guest_calls().begin_critical();
             }
             assert_eq!(loaded.run_with_hle_imports(64).handled_import_count, 1);
-            assert_eq!(loaded.guest_calls.current_task(), worker);
+            assert_eq!(loaded.guest_calls().current_task(), worker);
             assert_eq!(
-                loaded
-                    .guest_calls
+                loaded.guest_calls()
                     .scheduling_state(ExecutionTaskId::APPLICATION),
                 Some(ExecutionTaskState::Ready)
             );
@@ -172460,11 +172538,11 @@ pub(crate) mod tests {
             loaded.cpu.gpr[4] = 1;
             loaded.cpu.gpr[5] = ExecutionTaskId::APPLICATION.thread_id();
             if end_critical {
-                loaded.guest_calls.begin_critical();
+                loaded.guest_calls().begin_critical();
             }
             assert_eq!(loaded.run_with_hle_imports(64).handled_import_count, 1);
             assert_eq!(
-                loaded.guest_calls.current_task(),
+                loaded.guest_calls().current_task(),
                 ExecutionTaskId::APPLICATION
             );
             assert_eq!(loaded.cpu.gpr[3], 0);
@@ -172473,7 +172551,7 @@ pub(crate) mod tests {
             loaded.run_with_hle_imports(64);
             assert_eq!(loaded.cpu.pc, PPC_HALT_PC);
             assert_eq!(
-                loaded.guest_calls.scheduling_state(worker),
+                loaded.guest_calls().scheduling_state(worker),
                 Some(ExecutionTaskState::Stopped)
             );
         }
@@ -172486,11 +172564,10 @@ pub(crate) mod tests {
         let mut loaded =
             load_pef_application(&synthetic_pef_with_import(b"SetThreadStateEndCritical")).unwrap();
         let worker = ExecutionTaskId::from_thread_id(3);
-        assert!(loaded.guest_calls.register_task(worker));
-        assert!(loaded
-            .guest_calls
+        assert!(loaded.guest_calls().register_task(worker));
+        assert!(loaded.guest_calls()
             .set_scheduling_state(worker, ExecutionTaskState::Ready));
-        loaded.guest_calls.begin_critical();
+        loaded.guest_calls().begin_critical();
         loaded.cpu.gpr[20] = 0x1234_5678;
         loaded.cpu.fpr[20] = 0x4009_21fb_5444_2d18;
         loaded.cpu.cr = 0x1357_2468;
@@ -172508,11 +172585,11 @@ pub(crate) mod tests {
             loaded.cpu.gpr[3] = thread;
             loaded.cpu.gpr[4] = state;
             loaded.cpu.gpr[5] = 3;
-            let before = loaded.guest_calls.clone();
+            let before = loaded.guest_calls().clone();
             assert_eq!(loaded.run_with_hle_imports(64).handled_import_count, 1);
             assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(error));
-            assert_eq!(loaded.guest_calls, before);
-            assert_eq!(loaded.guest_calls.critical_depth(), 1);
+            assert_eq!(loaded.guest_calls(), &before);
+            assert_eq!(loaded.guest_calls().critical_depth(), 1);
             assert_eq!(loaded.cpu.gpr[20], 0x1234_5678);
             assert_eq!(loaded.cpu.fpr[20], 0x4009_21fb_5444_2d18);
             assert_eq!(loaded.cpu.cr, 0x1357_2468);
@@ -172544,7 +172621,8 @@ pub(crate) mod tests {
         assert_eq!(cpu.read_reg(Register::D0), 0);
         let mut loaded =
             load_pef_application(&synthetic_pef_with_import(b"GetThreadState")).unwrap();
-        loaded.guest_calls = classic.guest_calls.shared_handle();
+        loaded.toolbox_startup.execution =
+            ExecutionMenuViews::shared_from(&classic.guest_calls);
         let out = PPC_DATA_BASE + 0x1000;
         loaded.memory.add_region(out, vec![0xaa; 4]);
         for (thread, expected_result, expected_state) in [(3, 0, 0), (1, 0, 2), (99, -618, 0xaaaa)]
@@ -172622,7 +172700,7 @@ pub(crate) mod tests {
         assert_eq!(classic.guest_calls.critical_depth(), 1);
         let mut end =
             load_pef_application(&synthetic_pef_with_import(b"ThreadEndCritical")).unwrap();
-        end.guest_calls = classic.guest_calls.shared_handle();
+        end.toolbox_startup.execution = ExecutionMenuViews::shared_from(&classic.guest_calls);
         assert_eq!(end.run_with_hle_imports(64).handled_import_count, 1);
         assert_eq!(end.cpu.gpr[3], 0);
         assert_eq!(classic.guest_calls.critical_depth(), 0);
@@ -172634,7 +172712,7 @@ pub(crate) mod tests {
 
         let mut begin =
             load_pef_application(&synthetic_pef_with_import(b"ThreadBeginCritical")).unwrap();
-        begin.guest_calls = classic.guest_calls.shared_handle();
+        begin.toolbox_startup.execution = ExecutionMenuViews::shared_from(&classic.guest_calls);
         assert_eq!(begin.run_with_hle_imports(64).handled_import_count, 1);
         assert_eq!(begin.cpu.gpr[3], 0);
         assert_eq!(classic.guest_calls.critical_depth(), 1);
@@ -173930,7 +174008,7 @@ pub(crate) mod tests {
             item_appearances: Vec::new(),
             submenus: Vec::new(),
         };
-        *loaded.toolbox_startup.menu_tracking = Some(tracking.clone());
+        *loaded.toolbox_startup.execution.menu_state_mut() = Some(tracking.clone());
         loaded.memory.write_u16_be(PPC_THE_MENU_ADDR, 128).unwrap();
 
         loaded.cpu.gpr[3] = PPC_MAIN_GDEVICE;
@@ -173940,7 +174018,7 @@ pub(crate) mod tests {
         run_test_import(&mut loaded, PpcImportDispatcherTarget::SetDepth);
 
         assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_PARAM_ERR));
-        assert_eq!(loaded.toolbox_startup.menu_tracking, Some(tracking.clone()));
+        assert_eq!(loaded.toolbox_startup.execution.menu().as_ref(), Some(&tracking));
         assert_eq!(loaded.memory.read_u16_be(PPC_THE_MENU_ADDR), Some(128));
 
         loaded.cpu.gpr[3] = PPC_MAIN_GDEVICE;
@@ -173950,15 +174028,15 @@ pub(crate) mod tests {
         run_test_import(&mut loaded, PpcImportDispatcherTarget::SetDepth);
 
         assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_NO_ERR));
-        assert_eq!(loaded.toolbox_startup.menu_tracking, None);
+        assert!(loaded.toolbox_startup.execution.menu().is_none());
         assert_eq!(loaded.memory.read_u16_be(PPC_THE_MENU_ADDR), Some(0));
 
         let mut popup_tracking = tracking;
         popup_tracking.kind = MenuTrackingKind::PopUp;
         loaded
             .toolbox_startup
-            .menu_tracking
-            .context_mut()
+            .execution
+            .menu_context_mut()
             .call = Some(MenuTrackingCall {
             request: MenuTrackingRequest::PopUp(PopupMenuRequest {
                 menu_handle: popup_tracking.menu_handle,
@@ -173967,7 +174045,7 @@ pub(crate) mod tests {
             }),
             origin: MenuTrackingOrigin::PowerPc { stack_pointer: loaded.cpu.gpr[1], return_address: loaded.cpu.lr },
         });
-        *loaded.toolbox_startup.menu_tracking = Some(popup_tracking);
+        *loaded.toolbox_startup.execution.menu_state_mut() = Some(popup_tracking);
         loaded
             .memory
             .write_u16_be(PPC_THE_MENU_ADDR, 0x2468)
@@ -173979,7 +174057,7 @@ pub(crate) mod tests {
         run_test_import(&mut loaded, PpcImportDispatcherTarget::SetDepth);
 
         assert_eq!(loaded.cpu.gpr[3], ppc_i16_result(PPC_NO_ERR));
-        assert_eq!(loaded.toolbox_startup.menu_tracking, None);
+        assert!(loaded.toolbox_startup.execution.menu().is_none());
         assert_eq!(
             loaded.memory.read_u16_be(PPC_THE_MENU_ADDR),
             Some(0x2468),
@@ -175056,7 +175134,7 @@ pub(crate) mod tests {
                         ..PpcInputSnapshot::default()
                     },
                 );
-                let tracking = loaded.toolbox_startup.menu_tracking.as_ref().unwrap();
+                let tracking = loaded.toolbox_startup.execution.menu().as_ref().unwrap();
                 assert_eq!((tracking.popup_left, tracking.popup_top), (11, 20));
                 assert_eq!(
                     ppc_quickdraw_read_pixel(
@@ -179445,11 +179523,10 @@ pub(crate) mod tests {
             loaded.run_with_hle_imports(64);
             assert_eq!(loaded.cpu.gpr[3], 0);
             let worker = ExecutionTaskId::from_thread_id(loaded.memory.read_u32_be(MADE).unwrap());
-            assert!(loaded
-                .guest_calls
+            assert!(loaded.toolbox_startup.execution.calls()
                 .yield_native_thread(&mut loaded.cpu, worker.thread_id())
                 .unwrap());
-            let storage = loaded.guest_calls.thread_storage(worker).unwrap();
+            let storage = loaded.guest_calls().thread_storage(worker).unwrap();
             let worker_sp = loaded.cpu.gpr[1];
             assert!(worker_sp < loaded.stack_base);
             loaded.memory.add_region(OUTPUT, vec![0; 4]);
@@ -179504,7 +179581,7 @@ pub(crate) mod tests {
                 assert_eq!(loaded.cpu.cr, saved.cr);
                 assert_eq!(loaded.cpu.time_base(), saved.time_base());
                 assert_eq!(loaded.cpu.reservation_address(), saved.reservation_address());
-                assert_eq!(loaded.guest_calls.current_task(), worker);
+                assert_eq!(loaded.guest_calls().current_task(), worker);
             }
             loaded.cpu.gpr[1] = worker_sp;
             // A valid SP is insufficient when only part of the frame is
@@ -179550,7 +179627,7 @@ pub(crate) mod tests {
             assert_eq!(loaded.cpu.gpr, saved.gpr);
             assert_eq!(loaded.cpu.pc, saved.pc);
             assert_eq!(loaded.cpu.reservation_address(), None);
-            assert_eq!(loaded.guest_calls.current_task(), worker);
+            assert_eq!(loaded.guest_calls().current_task(), worker);
         }
     }
 
@@ -180029,8 +180106,8 @@ pub(crate) mod tests {
             load_pef_application(&synthetic_pef_with_import(b"ParamText")).unwrap();
         let (mut classic, mut classic_cpu, mut classic_bus) = setup_with_port();
         let mut context = ProcessContext::default();
-        classic.attach_process_context(&mut context);
-        native.attach_process_context(&mut context);
+        classic.attach_unconverted_process_services(&mut context);
+        native.attach_unconverted_process_services(&mut context);
 
         let native_text = PPC_DATA_BASE + 0x2900;
         native.memory.add_region(native_text, vec![0; 32]);
@@ -180835,13 +180912,13 @@ pub(crate) mod tests {
             prepare_call(&mut loaded);
             if initialization.is_some() {
                 for _ in 0..16 {
-                    if loaded.guest_calls.is_resource_preparation_pending(record) {
+                    if loaded.guest_calls().is_resource_preparation_pending(record) {
                         break;
                     }
                     let slice = loaded.run_with_hle_imports(1);
                     assert_eq!(slice.unsupported_import_index, None);
                 }
-                assert!(loaded.guest_calls.is_resource_preparation_pending(record));
+                assert!(loaded.guest_calls().is_resource_preparation_pending(record));
                 assert_eq!(loaded.memory.read_u16_be(record + 6), Some(3));
                 let request = match crate::guest_procedure::inspect_guest_procedure(
                     &mut loaded.memory,
@@ -180864,6 +180941,7 @@ pub(crate) mod tests {
                     loaded.import_count,
                     ppc_import_layout(),
                 );
+                let guest_calls = loaded.guest_calls().shared_handle();
                 let mut manager = loaded.process_memory_manager.0.borrow_mut();
                 let limit = manager.native_heap_state().unwrap().heap_limit;
                 let cfm = loaded.cfm.as_mut().unwrap();
@@ -180872,7 +180950,7 @@ pub(crate) mod tests {
                         &mut recursive_cpu,
                         &mut loaded.memory,
                         &mut manager,
-                        &loaded.guest_calls,
+                        &guest_calls,
                         &mut cursor,
                         limit,
                         &mut cfm.connections,
@@ -180886,7 +180964,7 @@ pub(crate) mod tests {
                 (loaded.imports, loaded.import_count) = import_run_state.into_parts();
                 assert_eq!(recursive_cpu.gpr, before_cpu.gpr);
                 assert_eq!(recursive_cpu.pc, before_cpu.pc);
-                assert!(loaded.guest_calls.is_resource_preparation_pending(record));
+                assert!(loaded.guest_calls().is_resource_preparation_pending(record));
             }
             let result = loaded.run_with_hle_imports(128);
             assert_eq!(result.unsupported_import_index, None);
@@ -180899,7 +180977,7 @@ pub(crate) mod tests {
             ));
             assert_eq!(loaded.cpu.gpr[2], caller_rtoc);
             assert_eq!(loaded.cpu.gpr[1], sp);
-            assert!(loaded.guest_calls.is_empty());
+            assert!(loaded.guest_calls().is_empty());
             if initialization == Some(1) {
                 assert_eq!(
                     loaded.cpu.gpr[3],
@@ -180962,7 +181040,7 @@ pub(crate) mod tests {
         let pef = synthetic_pef_with_library_import(b"StdCLib", b"malloc");
         let mut native = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let detached = context.memory_manager_mut().detached_clone();
         native.set_last_mem_error(PPC_PARAM_ERR);
 
@@ -181051,7 +181129,7 @@ pub(crate) mod tests {
         let pef = synthetic_pef_with_library_import(b"StdCLib", b"fopen");
         let mut native = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let detached = context.memory_manager_mut().detached_clone();
         let heap_before = context
             .memory_manager_mut()
@@ -182783,7 +182861,7 @@ pub(crate) mod tests {
         let pef = synthetic_pef_with_library_import(b"InterfaceLib", b"AECreateDesc");
         let mut native = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let detached = context.memory_manager_mut().detached_clone();
         let scratch = PPC_DATA_BASE + 0x2000;
         let source = scratch;
@@ -182852,7 +182930,7 @@ pub(crate) mod tests {
         let mut native = load_pef_application(&pef).unwrap();
         native.set_heap_cursor(native.heap_limit().saturating_sub(8));
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let scratch = PPC_DATA_BASE + 0x2200;
         let descriptor = scratch + 0x20;
         native.memory.add_region(scratch, vec![0xaa; 0x40]);
@@ -182904,7 +182982,7 @@ pub(crate) mod tests {
         let pef = synthetic_pef_with_library_import(b"ObjectSupportLib", b"CreateObjSpecifier");
         let mut native = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let detached = context.memory_manager_mut().detached_clone();
         let descriptor = PPC_DATA_BASE + 0x2400;
         native.memory.add_region(descriptor, vec![0; 8]);
@@ -182951,7 +183029,7 @@ pub(crate) mod tests {
         let pef = synthetic_pef_with_library_import(b"InterfaceLib", b"AECreateAppleEvent");
         let mut native = load_pef_application(&pef).unwrap();
         let mut context = ProcessContext::default();
-        native.attach_process_context(&mut context);
+        native.attach_unconverted_process_services(&mut context);
         let descriptor = PPC_DATA_BASE + 0x2500;
         native.memory.add_region(descriptor, vec![0; 8]);
         native.cpu.gpr[8] = descriptor;

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -153024,6 +153024,172 @@ pub(crate) mod tests {
         );
     }
 
+    fn run_ppc_indexed_horizontal_oracle_case(
+        source_width: u16,
+        destination_width: u16,
+        source_left: u16,
+        source_row: &[u8],
+    ) -> Vec<u8> {
+        let pef = synthetic_pef_with_import(b"CopyBits");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let scratch = PPC_HEAP_BASE + 0x16800;
+        let source_stride = (source_row.len() + 1) & !1;
+        let destination_stride = (usize::from(destination_width) + 5) & !1;
+        let dst_pixels = scratch + u32::try_from((source_stride + 0x3f) & !0x3f).unwrap();
+        let records = dst_pixels + u32::try_from(destination_stride).unwrap() + 0x20;
+        let src_pixmap = records;
+        let dst_pixmap = records + 0x40;
+        let rects = records + 0x80;
+        let allocation_size = usize::try_from(rects + 0x10 - scratch).unwrap();
+        loaded.memory.add_region(scratch, vec![0; allocation_size]);
+        ppc_write_pixmap(
+            &mut loaded.memory,
+            src_pixmap,
+            scratch,
+            source_stride as u32,
+            0,
+            0,
+            1,
+            (source_left + source_width) as i16,
+            8,
+        )
+        .unwrap();
+        ppc_write_pixmap(
+            &mut loaded.memory,
+            dst_pixmap,
+            dst_pixels,
+            destination_stride as u32,
+            0,
+            0,
+            1,
+            destination_width as i16,
+            8,
+        )
+        .unwrap();
+        loaded.memory.write_bytes(scratch, source_row).unwrap();
+        loaded
+            .memory
+            .write_bytes(dst_pixels, &vec![0xa5; destination_stride])
+            .unwrap();
+        ppc_write_rect(
+            &mut loaded.memory,
+            rects,
+            0,
+            source_left as i16,
+            1,
+            (source_left + source_width) as i16,
+        )
+        .unwrap();
+        ppc_write_rect(
+            &mut loaded.memory,
+            rects + 8,
+            0,
+            0,
+            1,
+            destination_width as i16,
+        )
+        .unwrap();
+        loaded.cpu.gpr[3] = src_pixmap;
+        loaded.cpu.gpr[4] = dst_pixmap;
+        loaded.cpu.gpr[5] = rects;
+        loaded.cpu.gpr[6] = rects + 8;
+        loaded.cpu.gpr[7] = 0;
+        loaded.cpu.gpr[8] = 0;
+
+        let probe = loaded.run_with_hle_imports(64);
+
+        assert_eq!(probe.handled_import_count, 1);
+        assert_eq!(probe.unsupported_import_index, None);
+        let mut copied = vec![0; destination_stride];
+        loaded
+            .memory
+            .read_bytes_into(dst_pixels, &mut copied)
+            .unwrap();
+        copied
+    }
+
+    fn ppc_indexed_horizontal_tail_low(source_width: usize) -> Vec<u8> {
+        let mut row = vec![200; (source_width + 3) & !3];
+        row[source_width - 1] = 0;
+        row[source_width] = 254;
+        row
+    }
+
+    fn ppc_indexed_horizontal_nonmonotonic(source_width: usize, case_index: usize) -> Vec<u8> {
+        let mut row = vec![0; (source_width + 3) & !3];
+        for (position, value) in row[..source_width].iter_mut().enumerate() {
+            *value = ((position * 73 + case_index * 19) % 251 + 1) as u8;
+        }
+        row[source_width] = 254;
+        row
+    }
+
+    #[test]
+    fn hle_import_runner_copybits_matches_large_indexed_horizontal_oracles() {
+        // Literal results from controlled Mac OS 8.1 CopyBits and StdBits
+        // captures. The tail-low rows isolate the staged physical tail; the
+        // nonmonotonic rows use the captured position encoding verbatim.
+        for source_left in 0..4u16 {
+            let mut row = vec![0x11; usize::from(source_left) + 194];
+            row[..usize::from(source_left)].fill(250);
+            row[usize::from(source_left)..usize::from(source_left) + 190].fill(20);
+            row[usize::from(source_left) + 189] = 30;
+            row[usize::from(source_left) + 190..usize::from(source_left) + 193]
+                .copy_from_slice(&[200, 150, 140]);
+            let actual = run_ppc_indexed_horizontal_oracle_case(190, 1, source_left, &row);
+            assert_eq!(actual[0], 200, "190->1, source_left={source_left}");
+            assert!(actual[1..].iter().all(|&byte| byte == 0xa5));
+
+            row.fill(0x11);
+            row[..usize::from(source_left)].fill(250);
+            row[usize::from(source_left)..usize::from(source_left) + 191].fill(20);
+            row[usize::from(source_left) + 190] = 30;
+            row[usize::from(source_left) + 191..usize::from(source_left) + 194]
+                .copy_from_slice(&[240, 150, 140]);
+            let actual = run_ppc_indexed_horizontal_oracle_case(191, 1, source_left, &row);
+            assert_eq!(actual[0], 30, "191->1, source_left={source_left}");
+            assert!(actual[1..].iter().all(|&byte| byte == 0xa5));
+        }
+
+        for (source_width, destination_width, source, expected) in [
+            (
+                285,
+                2,
+                ppc_indexed_horizontal_tail_low(285),
+                &[200, 254][..],
+            ),
+            (
+                285,
+                2,
+                ppc_indexed_horizontal_nonmonotonic(285, 1),
+                &[251, 254][..],
+            ),
+            (
+                511,
+                3,
+                ppc_indexed_horizontal_tail_low(511),
+                &[200, 200, 254][..],
+            ),
+            (
+                511,
+                3,
+                ppc_indexed_horizontal_nonmonotonic(511, 7),
+                &[251, 249, 254][..],
+            ),
+        ] {
+            let actual =
+                run_ppc_indexed_horizontal_oracle_case(source_width, destination_width, 0, &source);
+            assert_eq!(&actual[..expected.len()], expected);
+            assert!(actual[expected.len()..].iter().all(|&byte| byte == 0xa5));
+        }
+
+        for (source_width, expected) in [(4_097, 65), (5_000, 8), (5_001, 7), (10_924, u8::MAX)] {
+            let source = vec![0; (source_width + 3) & !3];
+            let actual = run_ppc_indexed_horizontal_oracle_case(source_width as u16, 1, 0, &source);
+            assert_eq!(actual[0], expected, "{source_width}->1");
+            assert!(actual[1..].iter().all(|&byte| byte == 0xa5));
+        }
+    }
     #[test]
     fn hle_import_runner_copybits_does_not_select_unresolved_equal_fallback_cluts() {
         let pef = synthetic_pef_with_import(b"CopyBits");

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -3353,6 +3353,13 @@ struct PpcPixMapBits {
     depth: u32,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PpcResolvedPixMapBits {
+    bits: PpcPixMapBits,
+    guest_bounds: bool,
+    authoritative_bounds: bool,
+}
+
 #[derive(Debug, Default)]
 pub(crate) struct PpcProcessMemoryManager(SharedProcessMemoryManager);
 
@@ -57024,6 +57031,14 @@ fn ppc_resolve_pixmap_bits(
     gworlds: &[PpcGWorldRecord],
     bits_ptr: u32,
 ) -> Option<PpcPixMapBits> {
+    ppc_resolve_pixmap_bits_with_provenance(memory, gworlds, bits_ptr).map(|resolved| resolved.bits)
+}
+
+fn ppc_resolve_pixmap_bits_with_provenance(
+    memory: &mut PpcSectionMem,
+    gworlds: &[PpcGWorldRecord],
+    bits_ptr: u32,
+) -> Option<PpcResolvedPixMapBits> {
     if bits_ptr == 0 {
         return None;
     }
@@ -57040,7 +57055,7 @@ fn ppc_resolve_pixmap_bits(
         if record.port == bits_ptr || record.port.checked_add(2) == Some(bits_ptr) {
             let surface = ppc_live_quickdraw_surface(memory, gworlds, record.port)?;
             let front = surface.front_buffer;
-            return Some(PpcPixMapBits {
+            let bits = PpcPixMapBits {
                 base_addr: front.base_addr,
                 row_bytes: front.row_bytes,
                 top: surface.top,
@@ -57054,6 +57069,14 @@ fn ppc_resolve_pixmap_bits(
                 width: front.width,
                 height: front.height,
                 depth: front.depth,
+            };
+            let exact_bottom = i64::from(surface.top) + i64::from(front.height);
+            let exact_right = i64::from(surface.left) + i64::from(front.width);
+            return Some(PpcResolvedPixMapBits {
+                bits,
+                guest_bounds: false,
+                authoritative_bounds: i16::try_from(exact_bottom).is_ok()
+                    && i16::try_from(exact_right).is_ok(),
             });
         }
         let bits = if record.pixmap_handle == bits_ptr {
@@ -57061,14 +57084,36 @@ fn ppc_resolve_pixmap_bits(
         } else {
             ppc_read_pixmap_bits(memory, record.pixmap)
         };
-        return bits.or_else(|| ppc_pixmap_bits_from_record(record));
+        return bits
+            .map(|bits| PpcResolvedPixMapBits {
+                bits,
+                guest_bounds: true,
+                authoritative_bounds: true,
+            })
+            .or_else(|| {
+                ppc_pixmap_bits_from_record(record).map(|bits| PpcResolvedPixMapBits {
+                    bits,
+                    guest_bounds: false,
+                    authoritative_bounds: i16::try_from(record.height).is_ok()
+                        && i16::try_from(record.width).is_ok(),
+                })
+            });
     }
     if let Some(bits) = ppc_read_pixmap_bits(memory, bits_ptr) {
-        return Some(bits);
+        return Some(PpcResolvedPixMapBits {
+            bits,
+            guest_bounds: true,
+            authoritative_bounds: true,
+        });
     }
     let pixmap_or_handle = memory.read_u32_be(bits_ptr)?;
     ppc_read_pixmap_bits(memory, pixmap_or_handle)
         .or_else(|| ppc_read_pixmap_handle_bits(memory, pixmap_or_handle))
+        .map(|bits| PpcResolvedPixMapBits {
+            bits,
+            guest_bounds: true,
+            authoritative_bounds: true,
+        })
 }
 
 fn ppc_read_pixmap_raw_pixel(
@@ -57299,6 +57344,20 @@ fn ppc_resolve_pixmap_ctable_handle(
     gworlds: &[PpcGWorldRecord],
     bits_ptr: u32,
 ) -> Option<u32> {
+    ppc_resolve_pixmap_ctable_handle_with_provenance(memory, gworlds, bits_ptr).handle
+}
+
+#[derive(Clone, Copy)]
+struct PpcOptionalHandleResolution {
+    handle: Option<u32>,
+    known: bool,
+}
+
+fn ppc_resolve_pixmap_ctable_handle_with_provenance(
+    memory: &mut PpcSectionMem,
+    gworlds: &[PpcGWorldRecord],
+    bits_ptr: u32,
+) -> PpcOptionalHandleResolution {
     let tracked_pixmap = gworlds.iter().find_map(|record| {
         if record.pixmap == bits_ptr {
             return Some(record.pixmap);
@@ -57328,11 +57387,26 @@ fn ppc_resolve_pixmap_ctable_handle(
             .and_then(|row_bytes| memory.read_u16_be(row_bytes))
             .filter(|row_bytes| row_bytes & 0x8000 != 0)
             .map(|_| indirect)
-    })?;
-    pixmap
+    });
+    let Some(pixmap) = pixmap else {
+        return PpcOptionalHandleResolution {
+            handle: None,
+            known: false,
+        };
+    };
+    let raw_handle = pixmap
         .checked_add(42)
-        .and_then(|pm_table| memory.read_u32_be(pm_table))
-        .filter(|ctable_handle| *ctable_handle != 0)
+        .and_then(|pm_table| memory.read_u32_be(pm_table));
+    let Some(raw_handle) = raw_handle else {
+        return PpcOptionalHandleResolution {
+            handle: None,
+            known: false,
+        };
+    };
+    PpcOptionalHandleResolution {
+        handle: (raw_handle != 0).then_some(raw_handle),
+        known: true,
+    }
 }
 
 fn ppc_color_tables_share_index_space(
@@ -57378,14 +57452,25 @@ fn ppc_copy_bits_clut(
     ctable_handle: u32,
     color_manager_clut: &[[u16; 3]; 256],
 ) -> [[u16; 3]; 256] {
+    ppc_copy_bits_clut_with_provenance(memory, ctable_handle, color_manager_clut).0
+}
+
+fn ppc_copy_bits_clut_with_provenance(
+    memory: &mut PpcSectionMem,
+    ctable_handle: u32,
+    color_manager_clut: &[[u16; 3]; 256],
+) -> ([[u16; 3]; 256], bool) {
     if ctable_handle == 0 {
-        return *color_manager_clut;
+        return (*color_manager_clut, true);
     }
     // Inside Macintosh Volume V (1986), p. V-143: SetEntries updates the
     // current GDevice's ColorTable as well as its hardware lookup table.
     // Read even the main device table from guest memory so CopyBits sees
     // palette animation instead of the immutable startup palette.
-    ppc_read_ctable_clut(memory, ctable_handle, color_manager_clut).unwrap_or(*color_manager_clut)
+    match ppc_read_ctable_clut(memory, ctable_handle, color_manager_clut) {
+        Some(clut) => (clut, true),
+        None => (*color_manager_clut, false),
+    }
 }
 
 fn ppc_copy_bits_palette_index_map(
@@ -57641,14 +57726,20 @@ fn ppc_copy_bits(
             reason = "unsupported-mode";
             return None;
         }
-        let Some(src_bits) = ppc_resolve_pixmap_bits(memory, gworlds, src_bits_ptr) else {
+        let Some(src_resolved) =
+            ppc_resolve_pixmap_bits_with_provenance(memory, gworlds, src_bits_ptr)
+        else {
             reason = "src-bits";
             return None;
         };
-        let Some(dst_bits) = ppc_resolve_pixmap_bits(memory, gworlds, dst_bits_ptr) else {
+        let Some(dst_resolved) =
+            ppc_resolve_pixmap_bits_with_provenance(memory, gworlds, dst_bits_ptr)
+        else {
             reason = "dst-bits";
             return None;
         };
+        let src_bits = src_resolved.bits;
+        let dst_bits = dst_resolved.bits;
         let transparent = mode == 36;
         let supported_source = matches!(src_bits.depth, 1 | 2 | 4 | 8 | 16);
         let supported_destination = matches!(dst_bits.depth, 1 | 2 | 4 | 8 | 16);
@@ -57665,19 +57756,35 @@ fn ppc_copy_bits(
             reason = "depth";
             return None;
         }
-        let src_ctable = ppc_resolve_pixmap_ctable_handle(memory, gworlds, src_bits_ptr);
-        let dst_ctable = ppc_resolve_pixmap_ctable_handle(memory, gworlds, dst_bits_ptr);
+        let src_ctable_resolution =
+            ppc_resolve_pixmap_ctable_handle_with_provenance(memory, gworlds, src_bits_ptr);
+        let dst_ctable_resolution =
+            ppc_resolve_pixmap_ctable_handle_with_provenance(memory, gworlds, dst_bits_ptr);
+        // Keep the legacy Option values below: unreadable lookup metadata has
+        // always fallen back to the Color Manager table. The additional
+        // provenance only prevents that fallback from selecting the new raw
+        // indexed reducer as if a readable nil pmTable had been observed.
+        let src_ctable = src_ctable_resolution.handle;
+        let dst_ctable = dst_ctable_resolution.handle;
+        let mut src_clut_resolution_known = false;
         let src_clut = ppc_indexed_depth_entry_count(src_bits.depth).map(|_| {
             let src_ctable = src_ctable.unwrap_or(0);
-            ppc_copy_bits_linked_palette_clut(
+            if let Some(clut) = ppc_copy_bits_linked_palette_clut(
                 memory,
                 src_ctable,
                 current_gworld,
                 current_gdevice,
                 toolbox_startup,
                 color_manager_clut,
-            )
-            .unwrap_or_else(|| ppc_copy_bits_clut(memory, src_ctable, color_manager_clut))
+            ) {
+                src_clut_resolution_known = src_ctable_resolution.known;
+                clut
+            } else {
+                let (clut, known) =
+                    ppc_copy_bits_clut_with_provenance(memory, src_ctable, color_manager_clut);
+                src_clut_resolution_known = src_ctable_resolution.known && known;
+                clut
+            }
         });
         // Inside Macintosh Volume V (1986), p. V-69: CopyBits assumes that
         // an indexed destination uses the current GDevice's color table,
@@ -57688,10 +57795,19 @@ fn ppc_copy_bits(
         // colors into the current GDevice. The destination PixMap's table is
         // not the inverse-mapping target, even when it differs from that
         // device table.
+        let dst_device_ctable_resolution =
+            ppc_gdevice_ctable_handle_with_provenance(memory, current_gdevice);
+        let mut dst_clut_resolution_known = false;
         let dst_clut = ppc_indexed_depth_entry_count(dst_bits.depth).map(|_| {
-            ppc_gdevice_ctable_handle(memory, current_gdevice)
-                .map(|handle| ppc_copy_bits_clut(memory, handle, color_manager_clut))
-                .unwrap_or(*color_manager_clut)
+            if let Some(handle) = dst_device_ctable_resolution.handle {
+                let (clut, known) =
+                    ppc_copy_bits_clut_with_provenance(memory, handle, color_manager_clut);
+                dst_clut_resolution_known = dst_device_ctable_resolution.known && known;
+                clut
+            } else {
+                dst_clut_resolution_known = dst_device_ctable_resolution.known;
+                *color_manager_clut
+            }
         });
         // A shared nonzero ctSeed identifies a particular ColorTable instance.
         // When two same-depth ordinary image tables also describe the same
@@ -57700,7 +57816,10 @@ fn ppc_copy_bits(
         // Imaging With QuickDraw (1994), pp. 4-56--4-57 and 4-97.
         let same_indexed_ctable_identity = src_bits.depth == dst_bits.depth
             && ppc_indexed_depth_entry_count(src_bits.depth).is_some()
+            && src_ctable_resolution.known
+            && dst_ctable_resolution.known
             && ppc_color_tables_share_index_space(memory, src_ctable, dst_ctable);
+        let mut indexed_palette_identity_known = false;
         let palette_map = if src_bits.depth == 8 && dst_bits.depth == 8 {
             let src_ctable = src_ctable.unwrap_or(0);
             let src_clut = src_clut.as_ref().unwrap();
@@ -57720,18 +57839,24 @@ fn ppc_copy_bits(
             if let Some(linked_palette_map) = linked_palette_map {
                 Some(linked_palette_map)
             } else if same_indexed_ctable_identity {
+                indexed_palette_identity_known =
+                    src_clut_resolution_known && dst_clut_resolution_known;
                 None
             } else {
                 // Inside Macintosh Volume V (1986), p. V-135: the high
                 // ctFlags bit distinguishes a GDevice table from a PixMap
                 // image table. Its pixels are already device indexes, so an
                 // indexed CopyBits preserves them.
-                (!source_uses_device_indices && src_clut != dst_clut).then(|| {
-                    std::array::from_fn::<u8, 256, _>(|index| {
+                if source_uses_device_indices || src_clut == dst_clut {
+                    indexed_palette_identity_known =
+                        src_clut_resolution_known && dst_clut_resolution_known;
+                    None
+                } else {
+                    Some(std::array::from_fn::<u8, 256, _>(|index| {
                         let [red, green, blue] = src_clut[index];
                         pict::closest_clut_index(red, green, blue, dst_clut)
-                    })
-                })
+                    }))
+                }
             }
         } else if src_bits.depth == dst_bits.depth && matches!(src_bits.depth, 1 | 2 | 4) {
             let src_ctable = src_ctable.unwrap_or(0);
@@ -57823,7 +57948,17 @@ fn ppc_copy_bits(
         // resolves records and masks; the shared operation owns pure
         // byte-aligned or packed srcCopy format, mode, and geometry eligibility.
         if mask_storage.is_none() {
-            use crate::copy_bits::{BytePixmap, RowCopy, RowCopyOutcome};
+            use crate::copy_bits::{
+                BytePixmap, Indexed8HorizontalSelection, RowCopy, RowCopyOutcome,
+            };
+
+            let indexed8_horizontal = Indexed8HorizontalSelection::from_adapter_facts(
+                mask_rgn == 0,
+                src_resolved.guest_bounds,
+                dst_resolved.authoritative_bounds,
+                indexed_palette_identity_known,
+                transfer_mode,
+            );
 
             let outcome = RowCopy {
                 mode,
@@ -57846,7 +57981,7 @@ fn ppc_copy_bits(
                 clip: [copy_top, copy_left, copy_bottom, copy_right],
                 palette: palette_map.as_ref(),
             }
-            .execute(memory);
+            .execute_with_indexed8_horizontal(memory, indexed8_horizontal);
             match outcome {
                 RowCopyOutcome::Completed => return Some(()),
                 RowCopyOutcome::NoOp => {
@@ -66337,16 +66472,62 @@ fn ppc_current_gdevice_record(memory: &mut PpcSectionMem, current_gdevice: u32) 
 }
 
 fn ppc_gdevice_ctable_handle(memory: &mut PpcSectionMem, current_gdevice: u32) -> Option<u32> {
-    let gdevice = ppc_current_gdevice_record(memory, current_gdevice)?;
-    let pixmap_handle = memory
-        .read_u32_be(gdevice.checked_add(22)?)
-        .filter(|handle| *handle != 0)?;
-    let pixmap = memory
+    ppc_gdevice_ctable_handle_with_provenance(memory, current_gdevice).handle
+}
+
+fn ppc_gdevice_ctable_handle_with_provenance(
+    memory: &mut PpcSectionMem,
+    current_gdevice: u32,
+) -> PpcOptionalHandleResolution {
+    let Some(gdevice) = memory.read_u32_be(current_gdevice) else {
+        return PpcOptionalHandleResolution {
+            handle: None,
+            known: false,
+        };
+    };
+    if gdevice == 0 {
+        return PpcOptionalHandleResolution {
+            handle: None,
+            known: false,
+        };
+    }
+    let Some(pixmap_handle) = gdevice
+        .checked_add(22)
+        .and_then(|field| memory.read_u32_be(field))
+    else {
+        return PpcOptionalHandleResolution {
+            handle: None,
+            known: false,
+        };
+    };
+    if pixmap_handle == 0 {
+        return PpcOptionalHandleResolution {
+            handle: None,
+            known: false,
+        };
+    }
+    let Some(pixmap) = memory
         .read_u32_be(pixmap_handle)
-        .filter(|pixmap| *pixmap != 0)?;
-    memory
-        .read_u32_be(pixmap.checked_add(42)?)
-        .filter(|handle| *handle != 0)
+        .filter(|pixmap| *pixmap != 0)
+    else {
+        return PpcOptionalHandleResolution {
+            handle: None,
+            known: false,
+        };
+    };
+    let Some(raw_handle) = pixmap
+        .checked_add(42)
+        .and_then(|field| memory.read_u32_be(field))
+    else {
+        return PpcOptionalHandleResolution {
+            handle: None,
+            known: false,
+        };
+    };
+    PpcOptionalHandleResolution {
+        handle: (raw_handle != 0).then_some(raw_handle),
+        known: true,
+    }
 }
 
 fn ppc_index_to_color(
@@ -102459,8 +102640,7 @@ pub(crate) mod tests {
                 BLR,
             ],
         );
-        let descriptor_bytes =
-            ppc_memory_read_bytes(&mut loaded.memory, descriptor, 0x100).unwrap();
+        let descriptor_bytes = ppc_memory_read_bytes(&mut loaded.memory, descriptor, 0x100).unwrap();
         let ref_num = *loaded.process_file_system.current_resource_file;
         loaded.process_file_system.vfs_resources.extend([
             PpcVfsResourceRecord {
@@ -102663,7 +102843,8 @@ pub(crate) mod tests {
                 BLR,
             ],
         );
-        let descriptor_bytes = ppc_memory_read_bytes(&mut loaded.memory, descriptor, 0x100).unwrap();
+        let descriptor_bytes =
+            ppc_memory_read_bytes(&mut loaded.memory, descriptor, 0x100).unwrap();
         let ref_num = *loaded.process_file_system.current_resource_file;
         loaded.process_file_system.vfs_resources.extend([
             PpcVfsResourceRecord {
@@ -152571,6 +152752,721 @@ pub(crate) mod tests {
             copied,
             [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 42, 42, 42, 42]
         );
+    }
+
+    #[test]
+    fn hle_import_runner_copybits_reduces_physical_source_bound_crossing() {
+        let pef = synthetic_pef_with_import(b"CopyBits");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let scratch = PPC_HEAP_BASE + 0x12c00;
+        let source_allocation = scratch;
+        let src_pixels = source_allocation + 2;
+        let dst_pixels = scratch + 0x20;
+        let src_pixmap = scratch + 0x40;
+        let dst_pixmap = scratch + 0x80;
+        let rects = scratch + 0xc0;
+        let ctable_handle = scratch + 0xd0;
+        let ctable = scratch + 0xe0;
+        loaded.memory.add_region(scratch, vec![0; 0x100]);
+        ppc_write_pixmap(&mut loaded.memory, src_pixmap, src_pixels, 8, 0, 0, 1, 8, 8).unwrap();
+        loaded.memory.write_u16_be(src_pixmap + 8, 2).unwrap();
+        loaded.memory.write_u16_be(src_pixmap + 12, 7).unwrap();
+        ppc_write_pixmap(&mut loaded.memory, dst_pixmap, dst_pixels, 3, 0, 0, 1, 3, 8).unwrap();
+        loaded
+            .memory
+            .write_u32_be(src_pixmap + 42, ctable_handle)
+            .unwrap();
+        loaded
+            .memory
+            .write_u32_be(dst_pixmap + 42, ctable_handle)
+            .unwrap();
+        loaded.memory.write_u32_be(ctable_handle, ctable).unwrap();
+        loaded.memory.write_u32_be(ctable, 0x1234_5678).unwrap();
+        loaded.memory.write_u16_be(ctable + 4, 0).unwrap();
+        loaded.memory.write_u16_be(ctable + 6, 0).unwrap();
+        loaded.memory.write_u16_be(ctable + 8, 0).unwrap();
+        let [red, green, blue] = loaded.color_manager_clut[0];
+        loaded.memory.write_u16_be(ctable + 10, red).unwrap();
+        loaded.memory.write_u16_be(ctable + 12, green).unwrap();
+        loaded.memory.write_u16_be(ctable + 14, blue).unwrap();
+        loaded
+            .memory
+            .write_bytes(source_allocation, &[240, 241, 10, 20, 30, 40, 50, 0, 0, 0])
+            .unwrap();
+        loaded.memory.write_bytes(dst_pixels, &[0xa5; 4]).unwrap();
+        ppc_write_rect(&mut loaded.memory, rects, 0, 0, 1, 7).unwrap();
+        ppc_write_rect(&mut loaded.memory, rects + 8, 0, 0, 1, 3).unwrap();
+        loaded.cpu.gpr[3] = src_pixmap;
+        loaded.cpu.gpr[4] = dst_pixmap;
+        loaded.cpu.gpr[5] = rects;
+        loaded.cpu.gpr[6] = rects + 8;
+        loaded.cpu.gpr[7] = 0;
+        loaded.cpu.gpr[8] = 0;
+
+        let probe = loaded.run_with_hle_imports(64);
+
+        assert_eq!(probe.handled_import_count, 1);
+        assert_eq!(probe.unsupported_import_index, None);
+        let mut copied = [0; 4];
+        loaded
+            .memory
+            .read_bytes_into(dst_pixels, &mut copied)
+            .unwrap();
+        assert_eq!(copied, [241, 30, 50, 0xa5]);
+    }
+
+    #[test]
+    fn pixmap_ctable_resolution_uses_fallback_after_failed_tracked_port_lookup() {
+        let mut loaded = load_pef_application(&synthetic_pef_with_import(b"CopyBits")).unwrap();
+        let pixmap = PPC_HEAP_BASE + 0x16400;
+        let ctable_handle = pixmap + 0x40;
+        loaded.memory.add_region(pixmap, vec![0; 0x50]);
+        ppc_write_pixmap(&mut loaded.memory, pixmap, pixmap + 0x48, 8, 0, 0, 1, 8, 8).unwrap();
+        loaded
+            .memory
+            .write_u32_be(pixmap + 42, ctable_handle)
+            .unwrap();
+        let tracked_port = PpcGWorldRecord {
+            ui_theme: crate::ui_theme::UiThemeId::ClassicSystem7,
+            port: pixmap,
+            pixmap_handle: 0,
+            pixmap: pixmap + 0x1000,
+            base_addr: pixmap + 0x48,
+            gdevice: PPC_MAIN_GDEVICE,
+            width: 8,
+            height: 1,
+            depth: 8,
+            row_bytes: 8,
+            pixels_locked: false,
+            pixels_no_purge: false,
+        };
+
+        let resolved = ppc_resolve_pixmap_ctable_handle_with_provenance(
+            &mut loaded.memory,
+            &[tracked_port],
+            pixmap,
+        );
+
+        assert_eq!(resolved.handle, Some(ctable_handle));
+        assert!(resolved.known);
+    }
+
+    #[test]
+    fn pixmap_ctable_resolution_tries_indirect_when_direct_rowbytes_are_unreadable() {
+        const INDIRECT: u32 = 0x0952_0000;
+        let mut loaded = load_pef_application(&synthetic_pef_with_import(b"CopyBits")).unwrap();
+        let pixmap = PPC_HEAP_BASE + 0x16500;
+        let ctable_handle = pixmap + 0x40;
+        loaded
+            .memory
+            .add_region(INDIRECT, pixmap.to_be_bytes().to_vec());
+        loaded.memory.add_region(pixmap, vec![0; 0x50]);
+        ppc_write_pixmap(&mut loaded.memory, pixmap, pixmap + 0x48, 8, 0, 0, 1, 8, 8).unwrap();
+        loaded
+            .memory
+            .write_u32_be(pixmap + 42, ctable_handle)
+            .unwrap();
+
+        let resolved =
+            ppc_resolve_pixmap_ctable_handle_with_provenance(&mut loaded.memory, &[], INDIRECT);
+
+        assert_eq!(resolved.handle, Some(ctable_handle));
+        assert!(resolved.known);
+    }
+
+    #[test]
+    fn gdevice_ctable_resolution_preserves_mapped_low_memory_zero_handle_chain() {
+        let mut loaded = load_pef_application(&synthetic_pef_with_import(b"CopyBits")).unwrap();
+        let records = PPC_HEAP_BASE + 0x16580;
+        let gdevice = records;
+        let pixmap_handle = records + 0x40;
+        let pixmap = records + 0x50;
+        let ctable_handle = records + 0x90;
+        loaded.memory.add_region(0, gdevice.to_be_bytes().to_vec());
+        loaded.memory.add_region(records, vec![0; 0xa0]);
+        loaded
+            .memory
+            .write_u32_be(gdevice + 22, pixmap_handle)
+            .unwrap();
+        loaded.memory.write_u32_be(pixmap_handle, pixmap).unwrap();
+        loaded
+            .memory
+            .write_u32_be(pixmap + 42, ctable_handle)
+            .unwrap();
+
+        let resolved = ppc_gdevice_ctable_handle_with_provenance(&mut loaded.memory, 0);
+
+        assert_eq!(resolved.handle, Some(ctable_handle));
+        assert!(resolved.known);
+        assert_eq!(
+            ppc_gdevice_ctable_handle(&mut loaded.memory, 0),
+            Some(ctable_handle)
+        );
+    }
+
+    fn run_ppc_indexed_horizontal_adapter_case(
+        raw_mode: u16,
+        clip_left_column: bool,
+        synthesized_source: bool,
+        nonidentity_palette: bool,
+    ) -> [u8; 4] {
+        let pef = synthetic_pef_with_import(b"CopyBits");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let scratch = PPC_HEAP_BASE + 0x16440;
+        let source_allocation = scratch;
+        let src_pixels = source_allocation + 2;
+        let dst_pixels = scratch + 0x20;
+        let src_pixmap = scratch + 0x40;
+        let dst_pixmap = scratch + 0x80;
+        let rects = scratch + 0xc0;
+        let ctable_handle = scratch + 0xd0;
+        let ctable = scratch + 0xe0;
+        loaded.memory.add_region(scratch, vec![0; 0x160]);
+        ppc_write_pixmap(&mut loaded.memory, src_pixmap, src_pixels, 8, 0, 2, 1, 7, 8).unwrap();
+        ppc_write_pixmap(&mut loaded.memory, dst_pixmap, dst_pixels, 3, 0, 0, 1, 3, 8).unwrap();
+        let source_bits_ptr = if synthesized_source {
+            const SYNTHESIZED_PIXMAP: u32 = 0x0951_0000;
+            loaded.gworlds.push(PpcGWorldRecord {
+                ui_theme: crate::ui_theme::UiThemeId::ClassicSystem7,
+                port: SYNTHESIZED_PIXMAP + 0x1000,
+                pixmap_handle: 0,
+                pixmap: SYNTHESIZED_PIXMAP,
+                base_addr: src_pixels,
+                gdevice: PPC_MAIN_GDEVICE,
+                width: 5,
+                height: 1,
+                depth: 8,
+                row_bytes: 8,
+                pixels_locked: false,
+                pixels_no_purge: false,
+            });
+            SYNTHESIZED_PIXMAP
+        } else {
+            src_pixmap
+        };
+        if nonidentity_palette {
+            loaded
+                .memory
+                .write_u32_be(src_pixmap + 42, ctable_handle)
+                .unwrap();
+            loaded.memory.write_u32_be(ctable_handle, ctable).unwrap();
+            loaded.memory.write_u32_be(ctable, 0x1234_5678).unwrap();
+            loaded.memory.write_u16_be(ctable + 4, 0).unwrap();
+            loaded.memory.write_u16_be(ctable + 6, 10).unwrap();
+            for index in 0..=10u32 {
+                let color_index = if index == 10 { 200 } else { index as usize };
+                let [red, green, blue] = loaded.color_manager_clut[color_index];
+                let entry = ctable + 8 + index * 8;
+                loaded.memory.write_u16_be(entry, index as u16).unwrap();
+                loaded.memory.write_u16_be(entry + 2, red).unwrap();
+                loaded.memory.write_u16_be(entry + 4, green).unwrap();
+                loaded.memory.write_u16_be(entry + 6, blue).unwrap();
+            }
+        }
+        loaded
+            .memory
+            .write_bytes(source_allocation, &[240, 241, 10, 20, 30, 40, 50, 0, 0, 0])
+            .unwrap();
+        loaded.memory.write_bytes(dst_pixels, &[0xa5; 4]).unwrap();
+        ppc_write_rect(&mut loaded.memory, rects, 0, 0, 1, 7).unwrap();
+        ppc_write_rect(&mut loaded.memory, rects + 8, 0, 0, 1, 3).unwrap();
+        if clip_left_column {
+            loaded.memory.write_u16_be(dst_pixmap + 8, 1).unwrap();
+        }
+        loaded.cpu.gpr[3] = source_bits_ptr;
+        loaded.cpu.gpr[4] = dst_pixmap;
+        loaded.cpu.gpr[5] = rects;
+        loaded.cpu.gpr[6] = rects + 8;
+        loaded.cpu.gpr[7] = u32::from(raw_mode);
+        loaded.cpu.gpr[8] = 0;
+
+        let probe = loaded.run_with_hle_imports(64);
+
+        assert_eq!(probe.handled_import_count, 1);
+        assert_eq!(probe.unsupported_import_index, None);
+        let mut copied = [0; 4];
+        loaded
+            .memory
+            .read_bytes_into(dst_pixels, &mut copied)
+            .unwrap();
+        copied
+    }
+
+    #[test]
+    fn hle_import_runner_copybits_keeps_dithered_horizontal_shrink_on_legacy_scaler() {
+        assert_eq!(
+            run_ppc_indexed_horizontal_adapter_case(0x40, false, false, false),
+            [0xa5, 10, 30, 0xa5]
+        );
+    }
+
+    #[test]
+    fn hle_import_runner_copybits_keeps_global_groups_after_destination_clip() {
+        assert_eq!(
+            run_ppc_indexed_horizontal_adapter_case(0, true, false, false),
+            [30, 50, 0xa5, 0xa5]
+        );
+    }
+
+    #[test]
+    fn hle_import_runner_copybits_keeps_valid_nonidentity_palette_on_legacy_scaler() {
+        assert_eq!(
+            run_ppc_indexed_horizontal_adapter_case(0, false, false, true),
+            [0xa5, 200, 30, 0xa5]
+        );
+    }
+
+    #[test]
+    fn hle_import_runner_copybits_does_not_select_synthesized_source_bounds() {
+        assert_eq!(
+            run_ppc_indexed_horizontal_adapter_case(0, false, true, false),
+            [10, 30, 50, 0xa5]
+        );
+    }
+
+    #[test]
+    fn hle_import_runner_copybits_does_not_select_unresolved_equal_fallback_cluts() {
+        let pef = synthetic_pef_with_import(b"CopyBits");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let scratch = PPC_HEAP_BASE + 0x12d00;
+        let source_allocation = scratch;
+        let src_pixels = source_allocation + 2;
+        let dst_pixels = scratch + 0x20;
+        let src_pixmap = scratch + 0x40;
+        let dst_pixmap = scratch + 0x80;
+        let rects = scratch + 0xc0;
+        loaded.memory.add_region(scratch, vec![0; 0xe0]);
+        ppc_write_pixmap(&mut loaded.memory, src_pixmap, src_pixels, 8, 0, 0, 1, 8, 8).unwrap();
+        loaded.memory.write_u16_be(src_pixmap + 8, 2).unwrap();
+        loaded.memory.write_u16_be(src_pixmap + 12, 7).unwrap();
+        ppc_write_pixmap(&mut loaded.memory, dst_pixmap, dst_pixels, 3, 0, 0, 1, 3, 8).unwrap();
+        loaded
+            .memory
+            .write_u32_be(src_pixmap + 42, 0x0bad_0000)
+            .unwrap();
+        loaded
+            .memory
+            .write_u32_be(dst_pixmap + 42, 0x0bad_1000)
+            .unwrap();
+        loaded
+            .memory
+            .write_bytes(source_allocation, &[240, 241, 10, 20, 30, 40, 50, 0, 0, 0])
+            .unwrap();
+        loaded.memory.write_bytes(dst_pixels, &[0xa5; 4]).unwrap();
+        ppc_write_rect(&mut loaded.memory, rects, 0, 0, 1, 7).unwrap();
+        ppc_write_rect(&mut loaded.memory, rects + 8, 0, 0, 1, 3).unwrap();
+        loaded.cpu.gpr[3] = src_pixmap;
+        loaded.cpu.gpr[4] = dst_pixmap;
+        loaded.cpu.gpr[5] = rects;
+        loaded.cpu.gpr[6] = rects + 8;
+        loaded.cpu.gpr[7] = 0;
+        loaded.cpu.gpr[8] = 0;
+
+        let probe = loaded.run_with_hle_imports(64);
+
+        assert_eq!(probe.handled_import_count, 1);
+        assert_eq!(probe.unsupported_import_index, None);
+        let mut copied = [0; 4];
+        loaded
+            .memory
+            .read_bytes_into(dst_pixels, &mut copied)
+            .unwrap();
+        assert_eq!(copied, [0xa5, 10, 30, 0xa5]);
+    }
+
+    #[test]
+    fn hle_import_runner_copybits_does_not_select_when_source_table_field_is_unreadable() {
+        const TRUNCATED_PIXMAP: u32 = 0x0950_0000;
+        let pef = synthetic_pef_with_import(b"CopyBits");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let scratch = PPC_HEAP_BASE + 0x16000;
+        let source_allocation = scratch;
+        let src_pixels = source_allocation + 2;
+        let dst_pixels = scratch + 0x20;
+        let dst_pixmap = scratch + 0x40;
+        let rects = scratch + 0x80;
+        loaded.memory.add_region(scratch, vec![0; 0xa0]);
+        loaded.memory.add_region(TRUNCATED_PIXMAP, vec![0; 34]);
+        // The resolver can read pixelSize at +32 but cannot read pmTable at
+        // +42. The legacy path still receives its existing fallback CLUT;
+        // only the new raw-index reducer must reject this unresolved lookup.
+        assert_eq!(
+            ppc_write_pixmap(
+                &mut loaded.memory,
+                TRUNCATED_PIXMAP,
+                src_pixels,
+                8,
+                0,
+                0,
+                1,
+                8,
+                8,
+            ),
+            None
+        );
+        loaded.memory.write_u16_be(TRUNCATED_PIXMAP + 8, 2).unwrap();
+        loaded
+            .memory
+            .write_u16_be(TRUNCATED_PIXMAP + 12, 7)
+            .unwrap();
+        ppc_write_pixmap(&mut loaded.memory, dst_pixmap, dst_pixels, 3, 0, 0, 1, 3, 8).unwrap();
+        loaded
+            .memory
+            .write_bytes(source_allocation, &[240, 241, 10, 20, 30, 40, 50, 0, 0, 0])
+            .unwrap();
+        loaded.memory.write_bytes(dst_pixels, &[0xa5; 4]).unwrap();
+        ppc_write_rect(&mut loaded.memory, rects, 0, 0, 1, 7).unwrap();
+        ppc_write_rect(&mut loaded.memory, rects + 8, 0, 0, 1, 3).unwrap();
+        loaded.cpu.gpr[3] = TRUNCATED_PIXMAP;
+        loaded.cpu.gpr[4] = dst_pixmap;
+        loaded.cpu.gpr[5] = rects;
+        loaded.cpu.gpr[6] = rects + 8;
+        loaded.cpu.gpr[7] = 0;
+        loaded.cpu.gpr[8] = 0;
+
+        let probe = loaded.run_with_hle_imports(64);
+
+        assert_eq!(probe.handled_import_count, 1);
+        assert_eq!(probe.unsupported_import_index, None);
+        let mut copied = [0; 4];
+        loaded
+            .memory
+            .read_bytes_into(dst_pixels, &mut copied)
+            .unwrap();
+        assert_eq!(copied, [0xa5, 10, 30, 0xa5]);
+    }
+
+    #[test]
+    fn hle_import_runner_copybits_does_not_select_through_broken_current_device_chain() {
+        let pef = synthetic_pef_with_import(b"CopyBits");
+        let mut loaded = load_pef_application(&pef).unwrap();
+        let scratch = PPC_HEAP_BASE + 0x16300;
+        let source_allocation = scratch;
+        let src_pixels = source_allocation + 2;
+        let dst_pixels = scratch + 0x20;
+        let src_pixmap = scratch + 0x40;
+        let dst_pixmap = scratch + 0x80;
+        let rects = scratch + 0xc0;
+        let gdevice_handle = scratch + 0xd0;
+        let gdevice = scratch + 0xe0;
+        loaded.memory.add_region(scratch, vec![0; 0x110]);
+        ppc_write_pixmap(&mut loaded.memory, src_pixmap, src_pixels, 8, 0, 0, 1, 8, 8).unwrap();
+        loaded.memory.write_u16_be(src_pixmap + 8, 2).unwrap();
+        loaded.memory.write_u16_be(src_pixmap + 12, 7).unwrap();
+        ppc_write_pixmap(&mut loaded.memory, dst_pixmap, dst_pixels, 3, 0, 0, 1, 3, 8).unwrap();
+        loaded.memory.write_u32_be(gdevice_handle, gdevice).unwrap();
+        loaded
+            .memory
+            .write_u32_be(gdevice + 22, 0x0bad_2000)
+            .unwrap();
+        *loaded.current_gdevice = gdevice_handle;
+        loaded
+            .memory
+            .write_bytes(source_allocation, &[240, 241, 10, 20, 30, 40, 50, 0, 0, 0])
+            .unwrap();
+        loaded.memory.write_bytes(dst_pixels, &[0xa5; 4]).unwrap();
+        ppc_write_rect(&mut loaded.memory, rects, 0, 0, 1, 7).unwrap();
+        ppc_write_rect(&mut loaded.memory, rects + 8, 0, 0, 1, 3).unwrap();
+        loaded.cpu.gpr[3] = src_pixmap;
+        loaded.cpu.gpr[4] = dst_pixmap;
+        loaded.cpu.gpr[5] = rects;
+        loaded.cpu.gpr[6] = rects + 8;
+        loaded.cpu.gpr[7] = 0;
+        loaded.cpu.gpr[8] = 0;
+
+        let probe = loaded.run_with_hle_imports(64);
+
+        assert_eq!(probe.handled_import_count, 1);
+        assert_eq!(probe.unsupported_import_index, None);
+        let mut copied = [0; 4];
+        loaded
+            .memory
+            .read_bytes_into(dst_pixels, &mut copied)
+            .unwrap();
+        assert_eq!(copied, [0xa5, 10, 30, 0xa5]);
+    }
+
+    #[test]
+    fn hle_import_runner_copybits_uses_signed_source_height_gate() {
+        for (bounds_bottom, expected) in [(32_766i16, [20, 50, 70, 0xa5]), (32_767i16, [0xa5; 4])] {
+            let pef = synthetic_pef_with_import(b"CopyBits");
+            let mut loaded = load_pef_application(&pef).unwrap();
+            let scratch = PPC_HEAP_BASE + 0x12e00;
+            let src_pixels = scratch;
+            let dst_pixels = scratch + 0x20;
+            let src_pixmap = scratch + 0x40;
+            let dst_pixmap = scratch + 0x80;
+            let rects = scratch + 0xc0;
+            loaded.memory.add_region(scratch, vec![0; 0xe0]);
+            ppc_write_pixmap(
+                &mut loaded.memory,
+                src_pixmap,
+                src_pixels,
+                8,
+                -1,
+                0,
+                1,
+                8,
+                8,
+            )
+            .unwrap();
+            loaded
+                .memory
+                .write_u16_be(src_pixmap + 10, bounds_bottom as u16)
+                .unwrap();
+            ppc_write_pixmap(&mut loaded.memory, dst_pixmap, dst_pixels, 3, 0, 0, 1, 3, 8).unwrap();
+            loaded
+                .memory
+                .write_bytes(src_pixels, &[10, 20, 30, 40, 50, 60, 70, 0])
+                .unwrap();
+            loaded.memory.write_bytes(dst_pixels, &[0xa5; 4]).unwrap();
+            ppc_write_rect(&mut loaded.memory, rects, -1, 0, 0, 7).unwrap();
+            ppc_write_rect(&mut loaded.memory, rects + 8, 0, 0, 1, 3).unwrap();
+            loaded.cpu.gpr[3] = src_pixmap;
+            loaded.cpu.gpr[4] = dst_pixmap;
+            loaded.cpu.gpr[5] = rects;
+            loaded.cpu.gpr[6] = rects + 8;
+            loaded.cpu.gpr[7] = 0;
+            loaded.cpu.gpr[8] = 0;
+
+            let probe = loaded.run_with_hle_imports(64);
+
+            assert_eq!(probe.handled_import_count, 1);
+            assert_eq!(probe.unsupported_import_index, None);
+            let mut copied = [0; 4];
+            loaded
+                .memory
+                .read_bytes_into(dst_pixels, &mut copied)
+                .unwrap();
+            assert_eq!(copied, expected, "bounds_bottom={bounds_bottom}");
+        }
+    }
+
+    #[test]
+    fn hle_import_runner_copybits_selects_only_exact_record_destination_bounds() {
+        for (record_width, expected) in [
+            (3u32, [241, 30, 50, 0xa5]),
+            (40_000u32, [0xa5, 10, 30, 0xa5]),
+        ] {
+            let pef = synthetic_pef_with_import(b"CopyBits");
+            let mut loaded = load_pef_application(&pef).unwrap();
+            let scratch = PPC_HEAP_BASE + 0x12f00;
+            let source_allocation = scratch;
+            let src_pixels = source_allocation + 2;
+            let dst_pixels = scratch + 0x20;
+            let src_pixmap = scratch + 0x40;
+            let destination_record = scratch + 0x80;
+            let rects = scratch + 0xc0;
+            loaded.memory.add_region(scratch, vec![0; 0xe0]);
+            ppc_write_pixmap(&mut loaded.memory, src_pixmap, src_pixels, 8, 0, 0, 1, 8, 8).unwrap();
+            loaded.memory.write_u16_be(src_pixmap + 8, 2).unwrap();
+            loaded.memory.write_u16_be(src_pixmap + 12, 7).unwrap();
+            loaded.gworlds.push(PpcGWorldRecord {
+                ui_theme: crate::ui_theme::UiThemeId::ClassicSystem7,
+                port: destination_record + 0x1000,
+                pixmap_handle: 0,
+                pixmap: destination_record,
+                base_addr: dst_pixels,
+                gdevice: PPC_MAIN_GDEVICE,
+                width: record_width,
+                height: 1,
+                depth: 8,
+                row_bytes: 3,
+                pixels_locked: false,
+                pixels_no_purge: false,
+            });
+            loaded
+                .memory
+                .write_bytes(source_allocation, &[240, 241, 10, 20, 30, 40, 50, 0, 0, 0])
+                .unwrap();
+            loaded.memory.write_bytes(dst_pixels, &[0xa5; 4]).unwrap();
+            ppc_write_rect(&mut loaded.memory, rects, 0, 0, 1, 7).unwrap();
+            ppc_write_rect(&mut loaded.memory, rects + 8, 0, 0, 1, 3).unwrap();
+            loaded.cpu.gpr[3] = src_pixmap;
+            loaded.cpu.gpr[4] = destination_record;
+            loaded.cpu.gpr[5] = rects;
+            loaded.cpu.gpr[6] = rects + 8;
+            loaded.cpu.gpr[7] = 0;
+            loaded.cpu.gpr[8] = 0;
+
+            let probe = loaded.run_with_hle_imports(64);
+
+            assert_eq!(probe.handled_import_count, 1);
+            assert_eq!(probe.unsupported_import_index, None);
+            let mut copied = [0; 4];
+            loaded
+                .memory
+                .read_bytes_into(dst_pixels, &mut copied)
+                .unwrap();
+            assert_eq!(copied, expected, "record_width={record_width}");
+        }
+    }
+
+    #[test]
+    fn hle_import_runner_copybits_snapshots_indexed_horizontal_aliases() {
+        const SOURCE: u32 = 0x0920_0000;
+        const DESTINATION: u32 = 0x0a20_0000;
+        let mut loaded = load_pef_application(&synthetic_pef_with_import(b"CopyBits")).unwrap();
+        let backing = crate::memory::bus::SharedRamRegion::from_owned_bytes(vec![
+            10, 20, 30, 40, 50, 60, 70, 0, 80, 90, 100, 110, 120, 130, 140, 0,
+        ]);
+        // SAFETY: the import accesses both aliases serially through one
+        // operation, and no borrowed byte slice survives a memory call.
+        unsafe {
+            loaded.memory.add_shared_region(SOURCE, backing.clone());
+            loaded.memory.add_shared_region(DESTINATION, backing);
+        }
+        let records = PPC_HEAP_BASE + 0x16120;
+        let src_pixmap = records;
+        let dst_pixmap = records + 0x40;
+        let rects = records + 0x80;
+        loaded.memory.add_region(records, vec![0; 0x90]);
+        ppc_write_pixmap(&mut loaded.memory, src_pixmap, SOURCE, 8, 0, 0, 2, 8, 8).unwrap();
+        ppc_write_pixmap(
+            &mut loaded.memory,
+            dst_pixmap,
+            DESTINATION + 8,
+            3,
+            0,
+            0,
+            2,
+            3,
+            8,
+        )
+        .unwrap();
+        ppc_write_rect(&mut loaded.memory, rects, 0, 0, 2, 7).unwrap();
+        ppc_write_rect(&mut loaded.memory, rects + 8, 0, 0, 2, 3).unwrap();
+        loaded.cpu.gpr[3] = src_pixmap;
+        loaded.cpu.gpr[4] = dst_pixmap;
+        loaded.cpu.gpr[5] = rects;
+        loaded.cpu.gpr[6] = rects + 8;
+        loaded.cpu.gpr[7] = 0;
+        loaded.cpu.gpr[8] = 0;
+
+        let probe = loaded.run_with_hle_imports(64);
+
+        assert_eq!(probe.handled_import_count, 1);
+        assert_eq!(probe.unsupported_import_index, None);
+        let mut actual = [0; 16];
+        loaded.memory.read_bytes_into(SOURCE, &mut actual).unwrap();
+        assert_eq!(
+            actual,
+            [10, 20, 30, 40, 50, 60, 70, 0, 20, 50, 70, 90, 120, 140, 140, 0]
+        );
+    }
+
+    #[test]
+    fn hle_import_runner_copybits_selected_failures_do_not_fallback() {
+        const SOURCE: u32 = 0x0930_0000;
+        const DESTINATION: u32 = 0x0a30_0000;
+        for source_failure in [true, false] {
+            let mut loaded = load_pef_application(&synthetic_pef_with_import(b"CopyBits")).unwrap();
+            loaded.memory.add_region(
+                SOURCE,
+                if source_failure {
+                    vec![10, 20, 30, 40, 50, 60]
+                } else {
+                    vec![10, 20, 30, 40, 50, 60, 70, 0]
+                },
+            );
+            loaded.memory.add_region(DESTINATION, vec![0xa5; 4]);
+            if !source_failure {
+                loaded
+                    .memory
+                    .add_readonly_region(DESTINATION, vec![0xa5; 3]);
+            }
+            let records = PPC_HEAP_BASE + 0x161b0;
+            let src_pixmap = records;
+            let dst_pixmap = records + 0x40;
+            let rects = records + 0x80;
+            loaded.memory.add_region(records, vec![0; 0x90]);
+            ppc_write_pixmap(&mut loaded.memory, src_pixmap, SOURCE, 8, 0, 0, 1, 8, 8).unwrap();
+            ppc_write_pixmap(
+                &mut loaded.memory,
+                dst_pixmap,
+                DESTINATION,
+                3,
+                0,
+                0,
+                1,
+                3,
+                8,
+            )
+            .unwrap();
+            ppc_write_rect(&mut loaded.memory, rects, 0, 0, 1, 7).unwrap();
+            ppc_write_rect(&mut loaded.memory, rects + 8, 0, 0, 1, 3).unwrap();
+            loaded.cpu.gpr[3] = src_pixmap;
+            loaded.cpu.gpr[4] = dst_pixmap;
+            loaded.cpu.gpr[5] = rects;
+            loaded.cpu.gpr[6] = rects + 8;
+            loaded.cpu.gpr[7] = 0;
+            loaded.cpu.gpr[8] = 0;
+
+            let probe = loaded.run_with_hle_imports(64);
+
+            assert_eq!(probe.handled_import_count, 1);
+            assert_eq!(probe.unsupported_import_index, None);
+            let mut actual = [0; 4];
+            loaded
+                .memory
+                .read_bytes_into(DESTINATION, &mut actual)
+                .unwrap();
+            assert_eq!(actual, [0xa5; 4], "source_failure={source_failure}");
+        }
+    }
+
+    #[test]
+    fn hle_import_runner_copybits_selected_refusal_preserves_later_rows() {
+        const SOURCE: u32 = 0x0940_0000;
+        const DESTINATION: u32 = 0x0a40_0000;
+        let mut loaded = load_pef_application(&synthetic_pef_with_import(b"CopyBits")).unwrap();
+        loaded.memory.add_region(
+            SOURCE,
+            vec![
+                10, 20, 30, 40, 50, 60, 70, 0, 80, 90, 100, 110, 120, 130, 140, 0,
+            ],
+        );
+        loaded.memory.add_region(DESTINATION, vec![0xa5; 6]);
+        loaded
+            .memory
+            .add_readonly_region(DESTINATION + 3, vec![0xa5; 3]);
+        let records = PPC_HEAP_BASE + 0x16240;
+        let src_pixmap = records;
+        let dst_pixmap = records + 0x40;
+        let rects = records + 0x80;
+        loaded.memory.add_region(records, vec![0; 0x90]);
+        ppc_write_pixmap(&mut loaded.memory, src_pixmap, SOURCE, 8, 0, 0, 2, 8, 8).unwrap();
+        ppc_write_pixmap(
+            &mut loaded.memory,
+            dst_pixmap,
+            DESTINATION,
+            3,
+            0,
+            0,
+            2,
+            3,
+            8,
+        )
+        .unwrap();
+        ppc_write_rect(&mut loaded.memory, rects, 0, 0, 2, 7).unwrap();
+        ppc_write_rect(&mut loaded.memory, rects + 8, 0, 0, 2, 3).unwrap();
+        loaded.cpu.gpr[3] = src_pixmap;
+        loaded.cpu.gpr[4] = dst_pixmap;
+        loaded.cpu.gpr[5] = rects;
+        loaded.cpu.gpr[6] = rects + 8;
+        loaded.cpu.gpr[7] = 0;
+        loaded.cpu.gpr[8] = 0;
+
+        let probe = loaded.run_with_hle_imports(64);
+
+        assert_eq!(probe.handled_import_count, 1);
+        assert_eq!(probe.unsupported_import_index, None);
+        let mut actual = [0; 6];
+        loaded
+            .memory
+            .read_bytes_into(DESTINATION, &mut actual)
+            .unwrap();
+        assert_eq!(actual, [20, 50, 70, 0xa5, 0xa5, 0xa5]);
     }
 
     #[test]

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -7,7 +7,7 @@ use crate::display::{
     DisplayGamma,
 };
 use crate::event_queue::EventQueue;
-use crate::guest_call::SharedGuestCallStack;
+use crate::guest_call::{ExecutionMenuViews, SharedGuestCallStack};
 use crate::guest_procedure::GuestProcedure;
 use crate::list_manager::ProcessListManagerState;
 use crate::memory::bus::SharedRamRegion;
@@ -6174,6 +6174,137 @@ pub(crate) struct ProcessContext {
     device_gamma_explicit: SharedProcessValue<bool>,
 }
 
+/// Scoped shared handles for services constructed directly from a process.
+///
+/// This bundle carries capabilities to the existing owners. It does not clone
+/// their values or retain a separate menu view.
+#[derive(Debug)]
+pub(crate) struct MigratedProcessHandles {
+    pub(crate) ticks: SharedProcessTickState,
+    pub(crate) execution: SharedGuestCallStack,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum MigratedServiceConflict {
+    Ticks,
+    Execution,
+}
+
+#[derive(Debug)]
+enum TickAdoption {
+    AlreadyShared {
+        process: SharedProcessTickState,
+        expected_process_tick: u32,
+    },
+    DetachedSeed {
+        process: SharedProcessTickState,
+        adapter: SharedProcessTickState,
+        adapter_seed: u32,
+        expected_process_tick: u32,
+    },
+}
+
+#[derive(Debug)]
+enum ExecutionAdoption {
+    AlreadyShared {
+        process: SharedGuestCallStack,
+    },
+    Detached {
+        process: SharedGuestCallStack,
+        adapter: SharedGuestCallStack,
+        process_pristine: bool,
+        adapter_pristine: bool,
+    },
+}
+
+/// Single-use proof that both selected services can be adopted together.
+#[derive(Debug)]
+pub(crate) struct MigratedServiceAdoption {
+    ticks: TickAdoption,
+    execution: ExecutionAdoption,
+}
+
+impl TickAdoption {
+    fn validate(
+        &self,
+        process_tick: &SharedProcessTickState,
+        adapter_tick: &SharedProcessTickState,
+    ) {
+        match self {
+            Self::AlreadyShared {
+                process,
+                expected_process_tick,
+            } => {
+                assert!(process.ptr_eq(process_tick));
+                assert!(process.ptr_eq(adapter_tick));
+                assert_eq!(process.current_tick(), *expected_process_tick);
+            }
+            Self::DetachedSeed {
+                process,
+                adapter,
+                adapter_seed,
+                expected_process_tick,
+            } => {
+                assert!(process.ptr_eq(process_tick));
+                assert!(adapter.ptr_eq(adapter_tick));
+                assert!(!process.ptr_eq(adapter));
+                assert_eq!(process.current_tick(), *expected_process_tick);
+                assert_eq!(adapter.current_tick(), *adapter_seed);
+            }
+        }
+    }
+
+    fn commit(
+        self,
+        process_tick: &SharedProcessTickState,
+        adapter_tick: &mut SharedProcessTickState,
+    ) {
+        match self {
+            Self::AlreadyShared { .. } => {}
+            Self::DetachedSeed {
+                adapter_seed,
+                expected_process_tick,
+                ..
+            } => {
+                if expected_process_tick == 0 && adapter_seed != 0 {
+                    process_tick.set_tick(adapter_seed);
+                }
+                *adapter_tick = process_tick.shared_handle();
+            }
+        }
+    }
+}
+
+impl ExecutionAdoption {
+    fn validate(&self, process_calls: &SharedGuestCallStack, adapter: &ExecutionMenuViews) {
+        assert!(adapter.is_coherent());
+        match self {
+            Self::AlreadyShared { process } => {
+                assert!(process.ptr_eq(process_calls));
+                assert!(process.ptr_eq(adapter.calls()));
+            }
+            Self::Detached {
+                process,
+                adapter: expected_adapter,
+                process_pristine,
+                adapter_pristine,
+            } => {
+                assert!(process.ptr_eq(process_calls));
+                assert!(expected_adapter.ptr_eq(adapter.calls()));
+                assert!(!process.ptr_eq(expected_adapter));
+                assert_eq!(process.is_pristine(), *process_pristine);
+                assert_eq!(expected_adapter.is_pristine(), *adapter_pristine);
+            }
+        }
+    }
+
+    fn commit(self, adapter: &mut ExecutionMenuViews) {
+        if let Self::Detached { process, .. } = self {
+            adapter.install_process_calls(&process);
+        }
+    }
+}
+
 impl Default for ProcessContext {
     fn default() -> Self {
         let guest_calls = SharedGuestCallStack::default();
@@ -6217,6 +6348,81 @@ impl Default for ProcessContext {
 }
 
 impl ProcessContext {
+    pub(crate) fn migrated_handles(&self) -> MigratedProcessHandles {
+        assert!(self.menu_tracking.is_view_of(&self.guest_calls));
+        MigratedProcessHandles {
+            ticks: self.tick_state.shared_handle(),
+            execution: self.guest_calls.shared_handle(),
+        }
+    }
+
+    pub(crate) fn preflight_migrated_adoption(
+        &self,
+        adapter_tick: &SharedProcessTickState,
+        adapter_execution: &ExecutionMenuViews,
+        expected_process_tick_at_commit: u32,
+    ) -> Result<MigratedServiceAdoption, MigratedServiceConflict> {
+        assert!(self.menu_tracking.is_view_of(&self.guest_calls));
+        assert!(adapter_execution.is_coherent());
+
+        let ticks = if adapter_tick.ptr_eq(&self.tick_state) {
+            TickAdoption::AlreadyShared {
+                process: self.tick_state.shared_handle(),
+                expected_process_tick: expected_process_tick_at_commit,
+            }
+        } else {
+            let adapter_seed = adapter_tick.current_tick();
+            if adapter_seed != 0
+                && expected_process_tick_at_commit != 0
+                && adapter_seed != expected_process_tick_at_commit
+            {
+                return Err(MigratedServiceConflict::Ticks);
+            }
+            TickAdoption::DetachedSeed {
+                process: self.tick_state.shared_handle(),
+                adapter: adapter_tick.shared_handle(),
+                adapter_seed,
+                expected_process_tick: expected_process_tick_at_commit,
+            }
+        };
+
+        let execution = if adapter_execution.calls().ptr_eq(&self.guest_calls) {
+            ExecutionAdoption::AlreadyShared {
+                process: self.guest_calls.shared_handle(),
+            }
+        } else {
+            let process_pristine = self.guest_calls.is_pristine();
+            let adapter_pristine = adapter_execution.calls().is_pristine();
+            if !process_pristine && !adapter_pristine {
+                return Err(MigratedServiceConflict::Execution);
+            }
+            ExecutionAdoption::Detached {
+                process: self.guest_calls.shared_handle(),
+                adapter: adapter_execution.calls().shared_handle(),
+                process_pristine,
+                adapter_pristine,
+            }
+        };
+
+        Ok(MigratedServiceAdoption { ticks, execution })
+    }
+
+    pub(crate) fn commit_migrated_adoption(
+        &self,
+        plan: MigratedServiceAdoption,
+        adapter_tick: &mut SharedProcessTickState,
+        adapter_execution: &mut ExecutionMenuViews,
+    ) {
+        assert!(self.menu_tracking.is_view_of(&self.guest_calls));
+        plan.ticks.validate(&self.tick_state, adapter_tick);
+        plan.execution
+            .validate(&self.guest_calls, adapter_execution);
+
+        plan.ticks.commit(&self.tick_state, adapter_tick);
+        plan.execution.commit(adapter_execution);
+        assert!(adapter_execution.is_coherent());
+    }
+
     pub(crate) fn cfm(&self) -> &crate::cfm::CfmState {
         &self.cfm
     }
@@ -6680,6 +6886,184 @@ mod tests {
     use crate::guest_procedure::GuestIsa;
     use crate::memory::{MacMemoryBus, MemoryBus};
     use ppc::PpcMemory;
+
+    fn begin_test_call(calls: &SharedGuestCallStack, entry: u32) {
+        assert!(calls.begin_m68k(
+            GuestCallTarget {
+                isa: GuestIsa::M68k,
+                entry,
+                rtoc: 0,
+            },
+            entry.wrapping_add(2),
+            0x3000,
+        ));
+    }
+
+    #[test]
+    fn migrated_handles_are_scoped_views_of_the_process_owners() {
+        let context = ProcessContext::default();
+        let first = context.migrated_handles();
+        let second = context.migrated_handles();
+
+        assert!(first.ticks.ptr_eq(&second.ticks));
+        assert!(first.execution.ptr_eq(&second.execution));
+        assert!(context.menu_tracking.is_view_of(&first.execution));
+        first.ticks.set_tick(17);
+        begin_test_call(&first.execution, 0x1000);
+        assert_eq!(second.ticks.current_tick(), 17);
+        assert_eq!(second.execution.len(), 1);
+    }
+
+    #[test]
+    fn migrated_adoption_accepts_populated_shared_execution_and_tick_sync() {
+        let context = ProcessContext::default();
+        let handles = context.migrated_handles();
+        handles.ticks.set_tick(7);
+        begin_test_call(&handles.execution, 0x1000);
+        let mut adapter_tick = handles.ticks.shared_handle();
+        let mut adapter_execution = ExecutionMenuViews::shared_from(&handles.execution);
+
+        let plan = context
+            .preflight_migrated_adoption(&adapter_tick, &adapter_execution, 42)
+            .unwrap();
+        handles.ticks.set_tick(42);
+        context.commit_migrated_adoption(plan, &mut adapter_tick, &mut adapter_execution);
+
+        assert!(adapter_tick.ptr_eq(&handles.ticks));
+        assert_eq!(adapter_tick.current_tick(), 42);
+        assert!(adapter_execution.calls().ptr_eq(&handles.execution));
+        assert!(adapter_execution.is_coherent());
+        assert_eq!(adapter_execution.calls().len(), 1);
+    }
+
+    #[test]
+    fn migrated_adoption_moves_one_detached_execution_menu_and_tick_seed() {
+        let context = ProcessContext::default();
+        let handles = context.migrated_handles();
+        let mut adapter_tick = SharedProcessTickState::from_value(41);
+        let mut adapter_execution = ExecutionMenuViews::detached();
+        {
+            let entry = adapter_execution.enter_test_menu();
+            *adapter_execution.menu_state_mut() =
+                Some(crate::menu_manager::test_process_menu_tracking(0x1234));
+            drop(entry);
+        }
+
+        let plan = context
+            .preflight_migrated_adoption(&adapter_tick, &adapter_execution, 0)
+            .unwrap();
+        context.commit_migrated_adoption(plan, &mut adapter_tick, &mut adapter_execution);
+
+        assert!(adapter_tick.ptr_eq(&handles.ticks));
+        assert_eq!(handles.ticks.current_tick(), 41);
+        assert!(adapter_execution.calls().ptr_eq(&handles.execution));
+        assert!(adapter_execution.is_coherent());
+        assert_eq!(
+            adapter_execution
+                .menu()
+                .as_ref()
+                .map(|state| state.menu_handle),
+            Some(0x1234)
+        );
+        assert_eq!(
+            handles
+                .execution
+                .menu_tracking_view()
+                .as_ref()
+                .map(|state| state.menu_handle),
+            Some(0x1234)
+        );
+    }
+
+    #[test]
+    fn migrated_adoption_binds_a_pristine_detached_pair_to_populated_process_state() {
+        let context = ProcessContext::default();
+        let handles = context.migrated_handles();
+        handles.ticks.set_tick(23);
+        begin_test_call(&handles.execution, 0x1000);
+        let mut adapter_tick = SharedProcessTickState::from_value(23);
+        let mut adapter_execution = ExecutionMenuViews::detached();
+
+        let plan = context
+            .preflight_migrated_adoption(&adapter_tick, &adapter_execution, 23)
+            .unwrap();
+        context.commit_migrated_adoption(plan, &mut adapter_tick, &mut adapter_execution);
+
+        assert!(adapter_tick.ptr_eq(&handles.ticks));
+        assert!(adapter_execution.calls().ptr_eq(&handles.execution));
+        assert!(adapter_execution.is_coherent());
+        assert_eq!(adapter_execution.calls().len(), 1);
+    }
+
+    #[test]
+    fn migrated_adoption_conflicts_preserve_both_selected_services() {
+        let context = ProcessContext::default();
+        let handles = context.migrated_handles();
+        handles.ticks.set_tick(41);
+        begin_test_call(&handles.execution, 0x1000);
+        let adapter_tick = SharedProcessTickState::from_value(42);
+        let adapter_execution = ExecutionMenuViews::detached();
+        begin_test_call(adapter_execution.calls(), 0x2000);
+
+        assert!(matches!(
+            context.preflight_migrated_adoption(&adapter_tick, &adapter_execution, 41),
+            Err(MigratedServiceConflict::Ticks)
+        ));
+        assert_eq!(handles.ticks.current_tick(), 41);
+        assert_eq!(adapter_tick.current_tick(), 42);
+        assert!(!adapter_tick.ptr_eq(&handles.ticks));
+        assert_eq!(handles.execution.len(), 1);
+        assert_eq!(adapter_execution.calls().len(), 1);
+        assert!(!adapter_execution.calls().ptr_eq(&handles.execution));
+
+        let adapter_tick = SharedProcessTickState::from_value(41);
+        assert!(matches!(
+            context.preflight_migrated_adoption(&adapter_tick, &adapter_execution, 41),
+            Err(MigratedServiceConflict::Execution)
+        ));
+        assert!(!adapter_tick.ptr_eq(&handles.ticks));
+        assert!(!adapter_execution.calls().ptr_eq(&handles.execution));
+    }
+
+    #[test]
+    fn migrated_adoption_revalidates_all_facts_before_either_service_mutates() {
+        use std::panic::{catch_unwind, AssertUnwindSafe};
+
+        let context = ProcessContext::default();
+        let handles = context.migrated_handles();
+        let mut adapter_tick = SharedProcessTickState::from_value(41);
+        let mut adapter_execution = ExecutionMenuViews::detached();
+        begin_test_call(adapter_execution.calls(), 0x1000);
+        let plan = context
+            .preflight_migrated_adoption(&adapter_tick, &adapter_execution, 0)
+            .unwrap();
+        adapter_tick.set_tick(42);
+        assert!(catch_unwind(AssertUnwindSafe(|| {
+            context.commit_migrated_adoption(plan, &mut adapter_tick, &mut adapter_execution);
+        }))
+        .is_err());
+        assert_eq!(handles.ticks.current_tick(), 0);
+        assert!(handles.execution.is_pristine());
+        assert!(!adapter_tick.ptr_eq(&handles.ticks));
+        assert!(!adapter_execution.calls().ptr_eq(&handles.execution));
+
+        let context = ProcessContext::default();
+        let handles = context.migrated_handles();
+        let mut adapter_tick = SharedProcessTickState::from_value(41);
+        let mut adapter_execution = ExecutionMenuViews::detached();
+        let plan = context
+            .preflight_migrated_adoption(&adapter_tick, &adapter_execution, 0)
+            .unwrap();
+        begin_test_call(adapter_execution.calls(), 0x2000);
+        assert!(catch_unwind(AssertUnwindSafe(|| {
+            context.commit_migrated_adoption(plan, &mut adapter_tick, &mut adapter_execution);
+        }))
+        .is_err());
+        assert_eq!(handles.ticks.current_tick(), 0);
+        assert!(handles.execution.is_pristine());
+        assert!(!adapter_tick.ptr_eq(&handles.ticks));
+        assert!(!adapter_execution.calls().ptr_eq(&handles.execution));
+    }
 
     #[test]
     fn cfm_seed_installation_moves_one_owner_and_refuses_conflicts() {

--- a/src/process_context.rs
+++ b/src/process_context.rs
@@ -6532,27 +6532,6 @@ impl ProcessContext {
         adapter.attach_to(&self.sound_manager, SoundManager::is_pristine);
     }
 
-    /// Attach an ISA adapter to the process-wide wrapping Macintosh tick
-    /// counter. A nonzero detached adapter may seed a pristine process value;
-    /// two conflicting populated values are rejected before attachment.
-    /// Inside Macintosh Volume I (1985), p. I-260; Volume II (1985),
-    /// pp. II-349--II-350.
-    pub(crate) fn attach_tick_state(&self, adapter: &mut SharedProcessTickState) {
-        if adapter.ptr_eq(&self.tick_state) {
-            return;
-        }
-        let adapter_value = adapter.current_tick();
-        let process_value = self.tick_state.current_tick();
-        assert!(
-            adapter_value == 0 || process_value == 0 || adapter_value == process_value,
-            "cannot attach two populated process manager values"
-        );
-        if process_value == 0 && adapter_value != 0 {
-            self.tick_state.set_tick(adapter_value);
-        }
-        *adapter = self.tick_state.shared_handle();
-    }
-
     pub(crate) fn attach_callback_tasks(
         &self,
         timer_tasks: &mut SharedProcessTimerTasks,
@@ -6709,10 +6688,6 @@ impl ProcessContext {
         adapter.attach_to(&self.input_state, ProcessInputState::is_pristine);
     }
 
-    pub(crate) fn attach_menu_tracking(&self, adapter: &mut SharedProcessMenuTracking) {
-        adapter.attach_to(&self.guest_calls.menu_tracking_view());
-    }
-
     pub(crate) fn attach_classic_file_system(
         &self,
         data_forks: &mut SharedProcessValue<ProcessForkMap>,
@@ -6846,10 +6821,6 @@ impl ProcessContext {
 
     pub(crate) fn attach_native_menu_selection(&self, adapter: &mut SharedNativeMenuSelection) {
         adapter.attach_to(&self.pending_native_menu_selection);
-    }
-
-    pub(crate) fn attach_guest_calls(&self, adapter: &mut SharedGuestCallStack) {
-        adapter.attach_to(&self.guest_calls);
     }
 
     pub(crate) fn attach_apple_event_handlers(
@@ -7666,8 +7637,8 @@ mod tests {
         assert_eq!(native_selection.take(), Some((128, 2)));
         assert!(classic_selection.is_none());
 
-        let mut classic_calls = SharedGuestCallStack::default();
-        classic_calls.begin_m68k(
+        let mut classic_execution = ExecutionMenuViews::detached();
+        classic_execution.calls().begin_m68k(
             GuestCallTarget {
                 isa: GuestIsa::M68k,
                 entry: 0x1000,
@@ -7676,12 +7647,20 @@ mod tests {
             0x2000,
             0x3000,
         );
-        let mut native_calls = SharedGuestCallStack::default();
-        context.attach_guest_calls(&mut classic_calls);
-        context.attach_guest_calls(&mut native_calls);
-        assert_eq!(native_calls.len(), 1);
-        assert!(native_calls.complete_m68k(0x2002, 0x3000));
-        assert!(classic_calls.is_empty());
+        let mut classic_tick = SharedProcessTickState::default();
+        let plan = context
+            .preflight_migrated_adoption(&classic_tick, &classic_execution, 0)
+            .unwrap();
+        context.commit_migrated_adoption(plan, &mut classic_tick, &mut classic_execution);
+        let mut native_tick = SharedProcessTickState::default();
+        let mut native_execution = ExecutionMenuViews::detached();
+        let plan = context
+            .preflight_migrated_adoption(&native_tick, &native_execution, 0)
+            .unwrap();
+        context.commit_migrated_adoption(plan, &mut native_tick, &mut native_execution);
+        assert_eq!(native_execution.calls().len(), 1);
+        assert!(native_execution.calls().complete_m68k(0x2002, 0x3000));
+        assert!(classic_execution.calls().is_empty());
     }
 
     #[test]
@@ -7708,15 +7687,25 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "cannot attach two active Menu Manager continuations")]
     fn adopting_two_active_menu_continuations_is_always_rejected() {
         let mut context = ProcessContext::default();
         context.set_menu_tracking(Some(crate::menu_manager::test_process_menu_tracking(
             0x1000,
         )));
-        let mut second = SharedProcessMenuTracking::default();
-        *second = Some(crate::menu_manager::test_process_menu_tracking(0x2000));
-        context.attach_menu_tracking(&mut second);
+        let adapter_tick = SharedProcessTickState::default();
+        let mut adapter_execution = ExecutionMenuViews::detached();
+        let _entry = adapter_execution.enter_test_menu();
+        *adapter_execution.menu_state_mut() =
+            Some(crate::menu_manager::test_process_menu_tracking(0x2000));
+        assert!(matches!(
+            context.preflight_migrated_adoption(&adapter_tick, &adapter_execution, 0),
+            Err(MigratedServiceConflict::Execution)
+        ));
+        assert_eq!(context.menu_tracking().unwrap().menu_handle, 0x1000);
+        assert_eq!(
+            adapter_execution.menu().as_ref().unwrap().menu_handle,
+            0x2000
+        );
     }
 
     #[test]
@@ -7732,7 +7721,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "cannot attach two initialized execution owners")]
     fn attaching_two_active_guest_call_stacks_is_always_rejected() {
         fn begin_call(calls: &SharedGuestCallStack, entry: u32) {
             calls.begin_m68k(
@@ -7747,12 +7735,17 @@ mod tests {
         }
 
         let context = ProcessContext::default();
-        let mut first = SharedGuestCallStack::default();
-        let mut second = SharedGuestCallStack::default();
-        begin_call(&first, 0x1000);
-        begin_call(&second, 0x2000);
-        context.attach_guest_calls(&mut first);
-        context.attach_guest_calls(&mut second);
+        let handles = context.migrated_handles();
+        begin_call(&handles.execution, 0x1000);
+        let adapter_tick = SharedProcessTickState::default();
+        let adapter_execution = ExecutionMenuViews::detached();
+        begin_call(adapter_execution.calls(), 0x2000);
+        assert!(matches!(
+            context.preflight_migrated_adoption(&adapter_tick, &adapter_execution, 0),
+            Err(MigratedServiceConflict::Execution)
+        ));
+        assert_eq!(handles.execution.len(), 1);
+        assert_eq!(adapter_execution.calls().len(), 1);
     }
 
     #[test]
@@ -9613,10 +9606,18 @@ mod tests {
     fn attached_tick_states_share_wrapping_clock_while_snapshot_detaches() {
         let context = ProcessContext::default();
         let mut classic = SharedProcessTickState::from_value(41);
+        let mut classic_execution = ExecutionMenuViews::detached();
         let mut native = SharedProcessTickState::default();
+        let mut native_execution = ExecutionMenuViews::detached();
 
-        context.attach_tick_state(&mut classic);
-        context.attach_tick_state(&mut native);
+        let plan = context
+            .preflight_migrated_adoption(&classic, &classic_execution, 0)
+            .unwrap();
+        context.commit_migrated_adoption(plan, &mut classic, &mut classic_execution);
+        let plan = context
+            .preflight_migrated_adoption(&native, &native_execution, 41)
+            .unwrap();
+        context.commit_migrated_adoption(plan, &mut native, &mut native_execution);
         let detached = native.detached_snapshot();
 
         assert!(classic.ptr_eq(&native));
@@ -9638,18 +9639,20 @@ mod tests {
 
     #[test]
     fn conflicting_tick_attachment_preserves_both_detached_values() {
-        use std::panic::{catch_unwind, AssertUnwindSafe};
-
         let context = ProcessContext::default();
         let mut classic = SharedProcessTickState::from_value(41);
-        context.attach_tick_state(&mut classic);
-        let mut native = SharedProcessTickState::from_value(42);
+        let mut classic_execution = ExecutionMenuViews::detached();
+        let plan = context
+            .preflight_migrated_adoption(&classic, &classic_execution, 0)
+            .unwrap();
+        context.commit_migrated_adoption(plan, &mut classic, &mut classic_execution);
+        let native = SharedProcessTickState::from_value(42);
+        let native_execution = ExecutionMenuViews::detached();
 
-        let result = catch_unwind(AssertUnwindSafe(|| {
-            context.attach_tick_state(&mut native);
-        }));
-
-        assert!(result.is_err());
+        assert!(matches!(
+            context.preflight_migrated_adoption(&native, &native_execution, 41),
+            Err(MigratedServiceConflict::Ticks)
+        ));
         assert_eq!(classic.current_tick(), 41);
         assert_eq!(native.current_tick(), 42);
         assert!(!classic.ptr_eq(&native));
@@ -9728,22 +9731,31 @@ mod tests {
     #[test]
     fn attached_menu_tracking_is_immediate_while_clones_detach() {
         let context = ProcessContext::default();
-        let mut classic = SharedProcessMenuTracking::default();
-        *classic = Some(crate::menu_manager::test_process_menu_tracking(0x1234));
-        let mut native = SharedProcessMenuTracking::default();
+        let mut classic_tick = SharedProcessTickState::default();
+        let mut classic = ExecutionMenuViews::detached();
+        let _entry = classic.enter_test_menu();
+        *classic.menu_state_mut() = Some(crate::menu_manager::test_process_menu_tracking(0x1234));
+        let plan = context
+            .preflight_migrated_adoption(&classic_tick, &classic, 0)
+            .unwrap();
+        context.commit_migrated_adoption(plan, &mut classic_tick, &mut classic);
 
-        context.attach_menu_tracking(&mut classic);
-        context.attach_menu_tracking(&mut native);
+        let mut native_tick = SharedProcessTickState::default();
+        let mut native = ExecutionMenuViews::detached();
+        let plan = context
+            .preflight_migrated_adoption(&native_tick, &native, 0)
+            .unwrap();
+        context.commit_migrated_adoption(plan, &mut native_tick, &mut native);
         let detached = native.clone();
 
-        classic.as_mut().unwrap().highlighted_item = 4;
+        classic.menu_state_mut().as_mut().unwrap().highlighted_item = 4;
 
-        assert!(classic.ptr_eq(&native));
-        assert_eq!(native.as_ref().unwrap().highlighted_item, 4);
-        assert_eq!(detached.as_ref().unwrap().highlighted_item, 1);
-        assert_eq!(native.take().unwrap().menu_handle, 0x1234);
-        assert!(classic.is_none());
-        assert_eq!(detached.as_ref().unwrap().menu_handle, 0x1234);
+        assert!(classic.calls().ptr_eq(native.calls()));
+        assert_eq!(native.menu().as_ref().unwrap().highlighted_item, 4);
+        assert_eq!(detached.menu().as_ref().unwrap().highlighted_item, 1);
+        assert_eq!(native.take_menu_state().unwrap().menu_handle, 0x1234);
+        assert!(classic.menu().is_none());
+        assert_eq!(detached.menu().as_ref().unwrap().menu_handle, 0x1234);
     }
 
     #[test]

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -1842,7 +1842,8 @@ impl FixtureRunner {
             "screen_depth must be 1, 2, 4, or 8"
         );
         let mut process_context = ProcessContext::with_file_system(file_system);
-        let mut dispatcher = TrapDispatcher::new();
+        let mut dispatcher =
+            TrapDispatcher::new_with_migrated_handles(process_context.migrated_handles());
         dispatcher.attach_process_context(&mut process_context);
         dispatcher.set_menu_bar_policy(config.menu_bar_policy);
         dispatcher.mmu_mode = u8::from(config.addressing_32_bit);
@@ -11478,6 +11479,125 @@ mod tests {
     use std::cell::RefCell;
     use std::collections::{HashMap, VecDeque};
     use std::rc::Rc;
+
+    fn start_real_classic_menu_definition(runner: &mut FixtureRunner) -> u32 {
+        use crate::memory::globals::addr;
+
+        let menu = runner.bus.alloc(4);
+        let record = runner.bus.alloc(64);
+        let definition = runner.bus.alloc(2);
+        let definition_handle = runner.bus.alloc(4);
+        let entry = runner.bus.alloc(4);
+        let stack = runner.bus.alloc(8);
+
+        runner.bus.write_long(menu, record);
+        runner.bus.write_word(record, 140);
+        runner.bus.write_word(record + 2, 80);
+        runner.bus.write_word(record + 4, 32);
+        runner.bus.write_long(record + 6, definition_handle);
+        runner.bus.write_long(record + 10, u32::MAX);
+        runner.bus.write_bytes(
+            record + 14,
+            b"\x06Shared\x01A\x00\x00\x00\x00\x01B\x00\x00\x00\x00\x00",
+        );
+        runner.bus.write_word(definition, 0x60FE); // real guest MDEF parks while owned
+        runner.bus.write_long(definition_handle, definition);
+        runner.bus.write_word(stack, 0);
+        runner.bus.write_long(stack + 2, menu);
+        runner.m68k.cpu.write_reg(Register::A7, stack);
+        runner
+            .dispatcher
+            .dispatch_menu(true, 0x135, &mut runner.m68k.cpu, &mut runner.bus)
+            .unwrap()
+            .unwrap();
+        runner.dispatcher.menu_bar_hidden = false;
+        runner.bus.write_word(addr::MBAR_HEIGHT, 20);
+        runner.bus.write_word(addr::MENU_FLASH, 0);
+        runner.dispatcher.draw_menu_bar_to_fb(&mut runner.bus);
+
+        runner.bus.write_word(entry, 0xA93D); // MenuSelect
+        runner.bus.write_word(entry + 2, 0x60FE); // park after the call
+        runner.bus.write_word(stack, 10);
+        runner.bus.write_word(stack + 2, 16);
+        runner.bus.write_long(stack + 4, 0);
+        runner.m68k.cpu.write_reg(Register::PC, entry);
+        runner.m68k.cpu.write_reg(Register::A7, stack);
+        runner.push_canonical_mouse_down(10, 16);
+
+        for _ in 0..64 {
+            assert!(runner.run_steps(1, None).1);
+            if runner.process_context.menu_tracking().is_some()
+                && runner.dispatcher.guest_calls.depth() != 0
+            {
+                return menu;
+            }
+        }
+        panic!("classic MenuSelect did not enter its real guest MDEF continuation");
+    }
+
+    #[test]
+    fn classic_runner_constructs_migrated_services_from_one_owner() {
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        let process_handles = runner.process_context.migrated_handles();
+        assert!(runner
+            .dispatcher
+            .is_constructed_from_migrated_handles(&process_handles));
+
+        let tick_result = runner.bus.alloc(4);
+        runner
+            .bus
+            .write_long(crate::memory::globals::addr::TICKS, 0x1234_5678);
+        runner.m68k.cpu.write_reg(Register::A7, tick_result);
+        runner
+            .dispatcher
+            .dispatch(0xA975, &mut runner.m68k.cpu, &mut runner.bus)
+            .unwrap();
+        assert_eq!(runner.bus.read_long(tick_result), 0x1234_5678);
+        assert_eq!(process_handles.ticks.current_tick(), 0x1234_5678);
+
+        let menu = start_real_classic_menu_definition(&mut runner);
+        assert_eq!(
+            runner
+                .process_context
+                .menu_tracking()
+                .expect("real classic menu root remains active")
+                .menu_handle,
+            menu,
+        );
+        assert!(runner.dispatcher.guest_calls.depth() > 0);
+        assert!(runner
+            .dispatcher
+            .is_constructed_from_migrated_handles(&process_handles));
+    }
+
+    #[test]
+    fn independent_runners_keep_migrated_services_isolated() {
+        let mut first = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        let second = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        let first_handles = first.process_context.migrated_handles();
+        let second_handles = second.process_context.migrated_handles();
+
+        assert!(!first_handles.ticks.ptr_eq(&second_handles.ticks));
+        assert!(!first_handles.execution.ptr_eq(&second_handles.execution));
+
+        let tick_result = first.bus.alloc(4);
+        first
+            .bus
+            .write_long(crate::memory::globals::addr::TICKS, 0x1020_3040);
+        first.m68k.cpu.write_reg(Register::A7, tick_result);
+        first
+            .dispatcher
+            .dispatch(0xA975, &mut first.m68k.cpu, &mut first.bus)
+            .unwrap();
+        assert_eq!(first_handles.ticks.current_tick(), 0x1020_3040);
+        assert_ne!(second_handles.ticks.current_tick(), 0x1020_3040);
+
+        start_real_classic_menu_definition(&mut first);
+        assert!(first.process_context.menu_tracking().is_some());
+        assert!(first.dispatcher.guest_calls.depth() > 0);
+        assert!(second.process_context.menu_tracking().is_none());
+        assert!(second.dispatcher.guest_calls.is_empty());
+    }
 
     fn cfm_test_connection(id: u32) -> crate::cfm::CfmConnection {
         crate::cfm::CfmConnection {

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -1844,7 +1844,7 @@ impl FixtureRunner {
         let mut process_context = ProcessContext::with_file_system(file_system);
         let mut dispatcher =
             TrapDispatcher::new_with_migrated_handles(process_context.migrated_handles());
-        dispatcher.attach_process_context(&mut process_context);
+        dispatcher.attach_unconverted_process_services(&mut process_context);
         dispatcher.set_menu_bar_policy(config.menu_bar_policy);
         dispatcher.mmu_mode = u8::from(config.addressing_32_bit);
         dispatcher.set_ui_theme_id(config.ui_theme);
@@ -3698,10 +3698,17 @@ impl FixtureRunner {
             app.ppc.as_ref().is_none_or(|native| native.cfm.is_some()),
             "native relaunch requires an uninstalled CFM seed"
         );
+        let native_launch = app.ppc.clone().map(|native| {
+            let launch_ticks = self.launch_ticks_override.unwrap_or(0);
+            let migrated_services = native
+                .preflight_migrated_services(&self.process_context, launch_ticks)
+                .expect("native application services conflict with the process registry");
+            (native, migrated_services)
+        });
         assert!(self.native.reset_for_launch(app.ppc.is_some()));
         self.process_context.reset_cfm_for_launch();
-        if let Some(ppc_app) = app.ppc.clone() {
-            self.init_ppc_app(ppc_app);
+        if let Some((ppc_app, migrated_services)) = native_launch {
+            self.init_ppc_app_with_services(ppc_app, migrated_services);
             return;
         }
 
@@ -4113,14 +4120,28 @@ impl FixtureRunner {
         self.native.companion().is_some() || self.native.has_staged_companion()
     }
 
-    fn init_ppc_companion(&mut self, mut ppc_companion: PpcLoadedApp) {
+    #[cfg(test)]
+    fn init_ppc_companion(&mut self, ppc_companion: PpcLoadedApp) {
         assert!(
             self.process_context
                 .can_install_cfm_seed(&ppc_companion.cfm),
             "CFM seed conflicts with the process registry"
         );
+        let current_tick = self.process_context.migrated_handles().ticks.current_tick();
+        let migrated_services = ppc_companion
+            .preflight_migrated_services(&self.process_context, current_tick)
+            .expect("native companion services conflict with the process registry");
+        self.init_ppc_companion_with_services(ppc_companion, migrated_services);
+    }
+
+    fn init_ppc_companion_with_services(
+        &mut self,
+        mut ppc_companion: PpcLoadedApp,
+        migrated_services: crate::process_context::MigratedServiceAdoption,
+    ) {
+        ppc_companion.commit_migrated_services(&self.process_context, migrated_services);
         self.share_ppc_process_memory(&mut ppc_companion);
-        ppc_companion.attach_process_context(&mut self.process_context);
+        ppc_companion.attach_unconverted_process_services(&mut self.process_context);
         assert!(self
             .process_context
             .install_cfm_seed(&mut ppc_companion.cfm));
@@ -4131,13 +4152,26 @@ impl FixtureRunner {
             .unwrap_or_else(|_| panic!("native engine slot is occupied"));
     }
 
-    fn init_ppc_app(&mut self, mut ppc_app: PpcLoadedApp) {
+    #[cfg(test)]
+    fn init_ppc_app(&mut self, ppc_app: PpcLoadedApp) {
+        let launch_ticks = self.launch_ticks_override.unwrap_or(0);
+        let migrated_services = ppc_app
+            .preflight_migrated_services(&self.process_context, launch_ticks)
+            .expect("native application services conflict with the process registry");
+        self.init_ppc_app_with_services(ppc_app, migrated_services);
+    }
+
+    fn init_ppc_app_with_services(
+        &mut self,
+        mut ppc_app: PpcLoadedApp,
+        migrated_services: crate::process_context::MigratedServiceAdoption,
+    ) {
         assert!(
             self.process_context.can_install_cfm_seed(&ppc_app.cfm),
             "CFM seed conflicts with the process registry"
         );
         use crate::memory::globals::addr;
-
+        let launch_ticks = self.launch_ticks_override.unwrap_or(0);
         // A native application carries its parsed SIZE capability before it
         // attaches to the runner-owned process state. Start this launch with
         // that capability and a fresh process-wide OAPP claim so a prior
@@ -4175,9 +4209,9 @@ impl FixtureRunner {
         self.bus.write_word(0x09dc, 1); // PaintWhite
         let ram_size = self.bus.ram_size();
         self.bus.write_long(addr::MEM_TOP, ram_size);
-        let launch_ticks = self.launch_ticks_override.unwrap_or(0);
         self.bus.write_long(addr::TICKS, launch_ticks);
         self.dispatcher.read_tick_count(&self.bus);
+        ppc_app.commit_migrated_services(&self.process_context, migrated_services);
         let time = self
             .app_start_time
             .unwrap_or_else(current_mac_epoch_seconds);
@@ -4192,7 +4226,7 @@ impl FixtureRunner {
         self.process_context
             .event_queue_mut()
             .merge(detached_events);
-        ppc_app.attach_process_context(&mut self.process_context);
+        ppc_app.attach_unconverted_process_services(&mut self.process_context);
         assert!(self.process_context.install_cfm_seed(&mut ppc_app.cfm));
         if let Some(time_base) = self.launch_ppc_time_base_override {
             ppc_app.cpu.set_time_base(time_base);
@@ -4243,7 +4277,11 @@ impl FixtureRunner {
             crate::guest_procedure::GuestIsa::PowerPc
         ));
         ppc_app.set_ui_theme(self.config.ui_theme);
-        ppc_app.guest_calls.start_native_engine();
+        ppc_app
+            .toolbox_startup
+            .execution
+            .calls()
+            .start_native_engine();
         self.native
             .install(NativeEngineRole::Application, ppc_app)
             .unwrap_or_else(|_| panic!("native engine slot is occupied"));
@@ -5618,11 +5656,25 @@ impl FixtureRunner {
         }
 
         if route == ExecutionRoute::PrepareCompanion {
+            let current_tick = self.process_context.migrated_handles().ticks.current_tick();
+            let migrated_services = {
+                let companion = self
+                    .native
+                    .staged_companion()
+                    .expect("selected staged native companion");
+                assert!(
+                    self.process_context.can_install_cfm_seed(&companion.cfm),
+                    "CFM seed conflicts with the process registry"
+                );
+                companion
+                    .preflight_migrated_services(&self.process_context, current_tick)
+                    .expect("native companion services conflict with the process registry")
+            };
             let companion = self
                 .native
                 .take_staged_companion()
                 .expect("selected staged native companion");
-            self.init_ppc_companion(companion);
+            self.init_ppc_companion_with_services(companion, migrated_services);
         }
         if matches!(
             route,
@@ -6513,7 +6565,7 @@ impl FixtureRunner {
         let mut ppc_app = native_context.adapter_mut();
 
         ppc_app.set_ui_theme(self.config.ui_theme);
-        if !ppc_app.guest_calls.prepare_native_task(&mut ppc_app.cpu) {
+        if !ppc_app.toolbox_startup.execution.calls().prepare_native_task(&mut ppc_app.cpu) {
             return (0, !self.halted);
         }
         ppc_app.toolbox_startup.host_menu_bar_hidden = self.dispatcher.menu_bar_hidden;
@@ -6525,7 +6577,7 @@ impl FixtureRunner {
             cycles_per_tick,
             cycles_per_tick.saturating_sub(remaining_cycles),
         );
-        if ppc_app.guest_calls.pending_powerpc_from_m68k().is_some()
+        if ppc_app.toolbox_startup.execution.calls().pending_powerpc_from_m68k().is_some()
             && ppc_app
                 .activate_powerpc_from_m68k(&mut self.m68k.cpu)
                 .is_none()
@@ -6539,8 +6591,8 @@ impl FixtureRunner {
                 .unwrap_or_else(|_| panic!("native context lost its owner"));
             return (0, false);
         }
-        if ppc_app.guest_calls.has_m68k_execution() {
-            let ppc_task = ppc_app.guest_calls.current_task();
+        if ppc_app.toolbox_startup.execution.calls().has_m68k_execution() {
+            let ppc_task = ppc_app.toolbox_startup.execution.calls().current_task();
             let ppc_start_time = self.bus.read_long(crate::memory::globals::addr::TIME);
             let (mixed_steps, running) = self
                 .run_pending_m68k_guest_call(&mut ppc_app, ppc_max_steps)
@@ -6553,8 +6605,8 @@ impl FixtureRunner {
             // the native caller is parked. Do not deliver the native
             // application's VBL/Time Manager work against that successor's
             // task; the callback phase is retried once its owner is selected.
-            let native_callbacks_allowed = ppc_app.guest_calls.current_task_is_running()
-                && ppc_app.guest_calls.current_task() == ppc_task
+            let native_callbacks_allowed = ppc_app.toolbox_startup.execution.calls().current_task_is_running()
+                && ppc_app.toolbox_startup.execution.calls().current_task() == ppc_task
                 && ExecutionTaskId::from_thread_id(
                     self.dispatcher.guest_calls.current_task().thread_id(),
                 ) == ppc_task;
@@ -6612,7 +6664,7 @@ impl FixtureRunner {
                 running,
             );
         }
-        let ppc_task = ppc_app.guest_calls.current_task();
+        let ppc_task = ppc_app.toolbox_startup.execution.calls().current_task();
         let ppc_start_time = self.bus.read_long(crate::memory::globals::addr::TIME);
         let profile_ppc = ppc_profile_enabled();
         let profile_total_start = profile_ppc.then(Instant::now);
@@ -6669,8 +6721,8 @@ impl FixtureRunner {
             (Vec::new(), Vec::new())
         } else {
             let tick_advance = self.advance_ticks_for_ppc_cycles(cycles, tick_cap);
-            let native_callbacks_allowed = ppc_app.guest_calls.current_task_is_running()
-                && ppc_app.guest_calls.current_task() == ppc_task
+            let native_callbacks_allowed = ppc_app.toolbox_startup.execution.calls().current_task_is_running()
+                && ppc_app.toolbox_startup.execution.calls().current_task() == ppc_task
                 && ExecutionTaskId::from_thread_id(
                     self.dispatcher.guest_calls.current_task().thread_id(),
                 ) == ppc_task;
@@ -6909,13 +6961,13 @@ impl FixtureRunner {
         max_steps: usize,
     ) -> Option<(usize, bool)> {
         self.m68k.apply_task_handoff();
-        if !ppc_app.guest_calls.has_m68k_execution() {
+        if !ppc_app.toolbox_startup.execution.calls().has_m68k_execution() {
             return None;
         }
-        if !ppc_app.guest_calls.prepare_native_task(&mut ppc_app.cpu) {
+        if !ppc_app.toolbox_startup.execution.calls().prepare_native_task(&mut ppc_app.cpu) {
             return Some((0, true));
         }
-        let task = ppc_app.guest_calls.current_task();
+        let task = ppc_app.toolbox_startup.execution.calls().current_task();
         let pending = self.m68k.activate_pending(&mut ppc_app.cpu)?;
 
         // Thread Manager calls are allowed to yield while guest callback code
@@ -6923,8 +6975,8 @@ impl FixtureRunner {
         // task and the continuation captured above must remain suspended until
         // its owner is scheduled again. Continuing here would execute the old
         // callback against the new task's registers and stack.
-        if ppc_app.guest_calls.current_task() != task
-            || !ppc_app.guest_calls.current_task_is_running()
+        if ppc_app.toolbox_startup.execution.calls().current_task() != task
+            || !ppc_app.toolbox_startup.execution.calls().current_task_is_running()
         {
             return Some((0, true));
         }
@@ -7016,15 +7068,15 @@ impl FixtureRunner {
                         running = false;
                         break;
                     }
-                    if ppc_app.guest_calls.current_task() != task
-                        || !ppc_app.guest_calls.current_task_is_running()
+                    if ppc_app.toolbox_startup.execution.calls().current_task() != task
+                        || !ppc_app.toolbox_startup.execution.calls().current_task_is_running()
                     {
                         // The trap switched cooperative tasks. Preserve the active
                         // frame and let the outer scheduler run the newly selected
                         // task; only this task may resume the captured continuation.
                         return Some((executed, true));
                     }
-                    if ppc_app.guest_calls.has_powerpc_from_m68k() {
+                    if ppc_app.toolbox_startup.execution.calls().has_powerpc_from_m68k() {
                         break;
                     }
                 }
@@ -11599,6 +11651,258 @@ mod tests {
         assert!(second.dispatcher.guest_calls.is_empty());
     }
 
+    fn halted_ppc_adapter() -> PpcLoadedApp {
+        halted_ppc_app_with_sound(PpcSoundState::default())
+            .ppc
+            .expect("halted native fixture")
+    }
+
+    #[test]
+    fn native_application_adopts_detached_populated_services_before_publication() {
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        let handles = runner.process_context.migrated_handles();
+        let mut native = load_pef_application(&crate::loader::ppc::tests::synthetic_pef_with_import(
+            b"TickCount",
+        ))
+        .unwrap();
+        native.tick_state = SharedProcessTickState::from_value(41);
+        native.cpu.gpr[3] = 0xfeed_face;
+        let _menu = native.toolbox_startup.execution.enter_test_menu();
+        *native.toolbox_startup.execution.menu_state_mut() =
+            Some(crate::menu_manager::test_process_menu_tracking(0x1234));
+        let app = LoadedApp::from_ppc(native);
+
+        runner.init_app(&app);
+
+        assert_eq!(handles.ticks.current_tick(), 41);
+        let (steps, _) = runner.run_steps(64, None);
+        assert!(steps > 0);
+        let installed = runner
+            .native
+            .adapter_mut(NativeEngineRole::Application)
+            .expect("native application installed");
+        assert!(installed.is_constructed_from_migrated_handles(&handles));
+        assert_eq!(installed.cpu.gpr[3], 0);
+        assert_eq!(handles.ticks.current_tick(), 0);
+        assert_eq!(
+            installed
+                .memory
+                .read_u32_be(crate::memory::globals::addr::TICKS),
+            Some(0)
+        );
+        assert_eq!(
+            runner
+                .process_context
+                .menu_tracking()
+                .map(|state| state.menu_handle),
+            Some(0x1234)
+        );
+    }
+
+    #[test]
+    fn native_application_accepts_shared_tick_identity_across_launch_sync() {
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        runner.set_launch_state(42, 1, 0);
+        let handles = runner.process_context.migrated_handles();
+        handles.ticks.set_tick(7);
+        let mut native = load_pef_application(&crate::loader::ppc::tests::synthetic_pef_with_import(
+            b"TickCount",
+        ))
+        .unwrap();
+        native.tick_state = handles.ticks.shared_handle();
+        native.toolbox_startup.execution =
+            crate::guest_call::ExecutionMenuViews::shared_from(&handles.execution);
+
+        runner.init_ppc_app(native);
+
+        let installed = runner
+            .native
+            .adapter_mut(NativeEngineRole::Application)
+            .expect("native application installed");
+        assert!(installed.is_constructed_from_migrated_handles(&handles));
+        assert_eq!(handles.ticks.current_tick(), 42);
+        assert_eq!(
+            installed
+                .memory
+                .read_u32_be(crate::memory::globals::addr::TICKS),
+            Some(42)
+        );
+        let (steps, _) = runner.run_steps(64, None);
+        assert!(steps > 0);
+        let installed = runner
+            .native
+            .adapter_mut(NativeEngineRole::Application)
+            .expect("native application retained");
+        assert!(installed.is_constructed_from_migrated_handles(&handles));
+        assert_eq!(installed.cpu.gpr[3], 42);
+    }
+
+    #[test]
+    fn native_companion_joins_live_classic_execution_for_both_tick_identities() {
+        for already_shared in [false, true] {
+            run_classic_menu_select_with_powerpc_mdef_identity(false, already_shared);
+        }
+    }
+
+    #[test]
+    fn staged_native_companion_conflict_preserves_owner_and_retries_same_adapter() {
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        let handles = runner.process_context.migrated_handles();
+        handles.ticks.set_tick(41);
+        let mut conflict = halted_ppc_adapter();
+        conflict.tick_state = SharedProcessTickState::from_value(42);
+        assert!(handles.execution.begin_m68k_to_powerpc(
+            crate::guest_call::GuestCallTarget {
+                isa: crate::guest_procedure::GuestIsa::PowerPc,
+                entry: conflict.entry_pc,
+                rtoc: conflict.rtoc,
+            },
+            crate::guest_call::PowerPcArguments::from_slice(&[]).unwrap(),
+            0x1000,
+            0x2000,
+            None,
+        ));
+        let before_calls = handles.execution.clone();
+        runner.stage_ppc_companion(conflict);
+
+        let refused = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            runner.run_steps(1, None);
+        }));
+        assert!(refused.is_err());
+        assert!(runner.native.has_staged_companion());
+        assert!(runner.native.companion().is_none());
+        assert_eq!(handles.ticks.current_tick(), 41);
+        assert_eq!(handles.execution, before_calls);
+
+        handles.ticks.set_tick(42);
+        let (steps, _) = runner.run_steps(1, None);
+        assert!(steps > 0);
+        assert!(!runner.native.has_staged_companion());
+        assert!(runner
+            .native
+            .adapter_mut(NativeEngineRole::Companion)
+            .expect("retained staged adapter installs on retry")
+            .is_constructed_from_migrated_handles(&handles));
+    }
+
+    #[test]
+    fn native_application_relaunch_refuses_two_live_execution_owners_before_publication() {
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        let menu = start_real_classic_menu_definition(&mut runner);
+        let handles = runner.process_context.migrated_handles();
+        let before_calls = handles.execution.clone();
+        runner.process_context.cfm_mut().next_connection_id = 77;
+        let before_cfm = runner.process_context.cfm_mut().clone();
+        runner
+            .dispatcher
+            .apple_event_launch_state
+            .reset_for_launch(true);
+        let before_apple_events = runner.dispatcher.apple_event_launch_state.clone();
+        runner
+            .bus
+            .write_long(crate::memory::globals::addr::TICKS, 0x1122_3344);
+        let mut installed = halted_ppc_adapter();
+        installed.cpu.gpr[31] = 0xfeed_beef;
+        assert!(runner
+            .native
+            .install(NativeEngineRole::Application, installed)
+            .is_ok());
+        let mut app = halted_ppc_app_with_sound(PpcSoundState::default());
+        let conflict = app.ppc.as_mut().unwrap();
+        let _menu = conflict.toolbox_startup.execution.enter_test_menu();
+        *conflict.toolbox_startup.execution.menu_state_mut() =
+            Some(crate::menu_manager::test_process_menu_tracking(0x5678));
+
+        let refused = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            runner.init_app(&app);
+        }));
+
+        assert!(refused.is_err());
+        assert_eq!(
+            runner.native.application().unwrap().cpu.gpr[31],
+            0xfeed_beef
+        );
+        assert_eq!(handles.execution, before_calls);
+        assert_eq!(*runner.process_context.cfm_mut(), before_cfm);
+        assert_eq!(
+            runner.dispatcher.apple_event_launch_state,
+            before_apple_events
+        );
+        assert_eq!(
+            runner.bus.read_long(crate::memory::globals::addr::TICKS),
+            0x1122_3344
+        );
+        assert_eq!(
+            runner
+                .process_context
+                .menu_tracking()
+                .map(|state| state.menu_handle),
+            Some(menu)
+        );
+    }
+
+    #[test]
+    fn native_application_relaunch_preflight_preserves_nonlive_process_state() {
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        let handles = runner.process_context.migrated_handles();
+        assert!(handles.execution.begin_m68k(
+            crate::guest_call::GuestCallTarget {
+                isa: crate::guest_procedure::GuestIsa::M68k,
+                entry: 0x1000,
+                rtoc: 0,
+            },
+            0x2000,
+            0x3000,
+        ));
+        assert!(handles.execution.complete_m68k(0x2002, 0x3000));
+        assert!(handles.execution.is_empty());
+        assert!(!handles.execution.is_pristine());
+        assert!(runner.m68k.can_relaunch());
+        assert!(runner.native.can_relaunch());
+        let before_calls = handles.execution.clone();
+        runner.process_context.cfm_mut().next_connection_id = 77;
+        let before_cfm = runner.process_context.cfm_mut().clone();
+        runner
+            .dispatcher
+            .apple_event_launch_state
+            .reset_for_launch(true);
+        let before_apple_events = runner.dispatcher.apple_event_launch_state.clone();
+        runner
+            .bus
+            .write_long(crate::memory::globals::addr::TICKS, 0x1122_3344);
+        let mut installed = halted_ppc_adapter();
+        installed.cpu.gpr[31] = 0xfeed_beef;
+        assert!(runner
+            .native
+            .install(NativeEngineRole::Application, installed)
+            .is_ok());
+
+        let mut app = halted_ppc_app_with_sound(PpcSoundState::default());
+        let conflict = app.ppc.as_mut().unwrap();
+        let _menu = conflict.toolbox_startup.execution.enter_test_menu();
+        *conflict.toolbox_startup.execution.menu_state_mut() =
+            Some(crate::menu_manager::test_process_menu_tracking(0x5678));
+        let refused = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            runner.init_app(&app);
+        }));
+
+        assert!(refused.is_err());
+        assert_eq!(
+            runner.native.application().unwrap().cpu.gpr[31],
+            0xfeed_beef
+        );
+        assert_eq!(handles.execution, before_calls);
+        assert_eq!(*runner.process_context.cfm_mut(), before_cfm);
+        assert_eq!(
+            runner.dispatcher.apple_event_launch_state,
+            before_apple_events
+        );
+        assert_eq!(
+            runner.bus.read_long(crate::memory::globals::addr::TICKS),
+            0x1122_3344
+        );
+    }
+
     fn cfm_test_connection(id: u32) -> crate::cfm::CfmConnection {
         crate::cfm::CfmConnection {
             id,
@@ -11945,7 +12249,7 @@ mod tests {
                 .unwrap();
         }
         native.memory.write_u32_be(STACK, RETURN).unwrap();
-        assert!(native.guest_calls.begin_powerpc_to_m68k(
+        assert!(native.guest_calls().begin_powerpc_to_m68k(
             GuestCallTarget {
                 isa: GuestIsa::M68k,
                 entry: CALLBACK,
@@ -15639,7 +15943,6 @@ mod tests {
             process_input: Default::default(),
             event_queue: Default::default(),
             window_list: Default::default(),
-            guest_calls: Default::default(),
             process_memory_manager: PpcProcessMemoryManager::with_heap(
                 PPC_HEAP_BASE,
                 PPC_STACK_BASE,
@@ -15688,8 +15991,8 @@ mod tests {
             0x3000,
         );
         let ppc_app = runner.native.application_mut().expect("PPC app");
-        assert_eq!(ppc_app.guest_calls.len(), 1);
-        assert!(ppc_app.guest_calls.complete_m68k(0x2002, 0x3000));
+        assert_eq!(ppc_app.toolbox_startup.execution.calls().len(), 1);
+        assert!(ppc_app.toolbox_startup.execution.calls().complete_m68k(0x2002, 0x3000));
         assert!(runner.dispatcher.guest_calls.is_empty());
     }
 
@@ -16318,7 +16621,7 @@ mod tests {
         ppc_app.memory.add_region(RESULT, vec![0; 4]);
         ppc_app.memory.add_region(STACK_BASE, vec![0; 0x100]);
         ppc_app.memory.write_u32_be(INITIAL_SP, RETURN_PC).unwrap();
-        assert!(ppc_app.guest_calls.begin_powerpc_to_m68k(
+        assert!(ppc_app.toolbox_startup.execution.calls().begin_powerpc_to_m68k(
             crate::guest_call::GuestCallTarget {
                 isa: crate::guest_procedure::GuestIsa::M68k,
                 entry: M68K_ENTRY,
@@ -16385,7 +16688,7 @@ mod tests {
         );
         ppc_app.memory.add_region(STACK_BASE, vec![0; 0x100]);
         ppc_app.memory.write_u32_be(INITIAL_SP, RETURN_PC).unwrap();
-        assert!(ppc_app.guest_calls.begin_powerpc_to_m68k(
+        assert!(ppc_app.toolbox_startup.execution.calls().begin_powerpc_to_m68k(
             crate::guest_call::GuestCallTarget {
                 isa: crate::guest_procedure::GuestIsa::M68k,
                 entry: M68K_ENTRY,
@@ -16446,7 +16749,7 @@ mod tests {
         let arguments =
             PowerPcArguments::from_slice(&[0, 0, 0, 0, 0, 0, OUTPUTS, OUTPUTS + 2, OUTPUTS + 4])
                 .unwrap();
-        assert!(ppc_app.guest_calls.begin_powerpc_to_m68k(
+        assert!(ppc_app.toolbox_startup.execution.calls().begin_powerpc_to_m68k(
             crate::guest_call::GuestCallTarget {
                 isa: crate::guest_procedure::GuestIsa::M68k,
                 entry: M68K_ENTRY,
@@ -16561,7 +16864,7 @@ mod tests {
             .memory
             .write_u32_be(INITIAL_SP + 4, ARGUMENT)
             .unwrap();
-        assert!(ppc_app.guest_calls.begin_powerpc_to_m68k(
+        assert!(ppc_app.toolbox_startup.execution.calls().begin_powerpc_to_m68k(
             crate::guest_call::GuestCallTarget {
                 isa: crate::guest_procedure::GuestIsa::M68k,
                 entry: DESCRIPTOR,
@@ -16626,6 +16929,12 @@ mod tests {
     }
 
     fn classic_powerpc_mdef_fixture() -> ClassicPowerPcMdefFixture {
+        classic_powerpc_mdef_fixture_with_tick_identity(false)
+    }
+
+    fn classic_powerpc_mdef_fixture_with_tick_identity(
+        already_shared_tick: bool,
+    ) -> ClassicPowerPcMdefFixture {
         use crate::guest_procedure::{
             ROUTINE_DESCRIPTOR_HEADER_SIZE, ROUTINE_DESCRIPTOR_MIXED_MODE_TRAP,
             ROUTINE_DESCRIPTOR_VERSION, ROUTINE_FLAG_USE_NATIVE_ISA, ROUTINE_RECORD_FLAGS_OFFSET,
@@ -16685,6 +16994,13 @@ mod tests {
             size_resource: None,
         };
         let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        if already_shared_tick {
+            native.tick_state = runner
+                .process_context
+                .migrated_handles()
+                .ticks
+                .shared_handle();
+        }
         runner.stage_ppc_companion(native);
         runner.init_app(&classic);
         runner.bus.write_long(MENU, RECORD);
@@ -16868,6 +17184,10 @@ mod tests {
     }
 
     fn run_classic_menu_select_with_powerpc_mdef(interrupt: bool) {
+        run_classic_menu_select_with_powerpc_mdef_identity(interrupt, false);
+    }
+
+    fn run_classic_menu_select_with_powerpc_mdef_identity(interrupt: bool, already_shared_tick: bool) {
         use crate::memory::globals::addr;
         let ClassicPowerPcMdefFixture {
             mut runner,
@@ -16876,7 +17196,8 @@ mod tests {
             marker,
             entry,
             stack,
-        } = classic_powerpc_mdef_fixture();
+        } = classic_powerpc_mdef_fixture_with_tick_identity(already_shared_tick);
+        let migrated_handles = runner.process_context.migrated_handles();
         runner.dispatcher.menu_bar_hidden = false;
         runner.bus.write_word(addr::MBAR_HEIGHT, 20);
         runner.bus.write_word(addr::MENU_FLASH, 0);
@@ -16904,7 +17225,8 @@ mod tests {
         if interrupt {
             let mut parked = false;
             for _ in 0..512 {
-                if runner.m68k.cpu.read_reg(Register::PC) == stack - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION + 52
+                if runner.m68k.cpu.read_reg(Register::PC)
+                    == stack - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION + 52
                     && runner.m68k.cpu.read_reg(Register::A7)
                         == stack - crate::execution_m68k::M68kMenuDefinitionFrame::RESERVATION
                 {
@@ -16945,12 +17267,29 @@ mod tests {
         }
         assert!(runner.process_context.menu_tracking().is_none());
         assert!(runner.dispatcher.guest_calls.is_empty());
+        assert!(runner
+            .native
+            .adapter_mut(NativeEngineRole::Companion)
+            .expect("mixed callback companion retained")
+            .is_constructed_from_migrated_handles(&migrated_handles));
         assert_eq!(runner.bus.read_long(stack + 4), (140 << 16) | 2);
         assert_eq!(runner.m68k.cpu.read_reg(Register::A7), stack + 4);
         assert_eq!(*runner.dispatcher.current_port, original_port);
         if interrupt {
             assert_eq!(runner.bus.read_word(marker + 4), 1);
         }
+
+        let completed_result = runner.bus.read_long(stack + 4);
+        let completed_sp = runner.m68k.cpu.read_reg(Register::A7);
+        let completed_pc = runner.m68k.cpu.read_reg(Register::PC);
+        let completed_marker = runner.bus.read_long(marker);
+        assert!(runner.run_steps(16, None).1);
+        assert_eq!(runner.bus.read_long(stack + 4), completed_result);
+        assert_eq!(runner.m68k.cpu.read_reg(Register::A7), completed_sp);
+        assert_eq!(runner.m68k.cpu.read_reg(Register::PC), completed_pc);
+        assert_eq!(runner.bus.read_long(marker), completed_marker);
+        assert!(runner.process_context.menu_tracking().is_none());
+        assert!(runner.dispatcher.guest_calls.is_empty());
     }
 
     #[test]
@@ -17683,7 +18022,7 @@ mod tests {
         let mut registers = M68kRegisterState::default();
         registers.data[0] = BYTE_COUNT;
         registers.data[1] = 0xdead_beef;
-        assert!(ppc_app.guest_calls.begin_powerpc_to_m68k(
+        assert!(ppc_app.toolbox_startup.execution.calls().begin_powerpc_to_m68k(
             GuestCallTarget {
                 isa: GuestIsa::M68k,
                 entry: M68K_ENTRY,
@@ -18555,7 +18894,7 @@ mod tests {
                 ppc_app.import_count = 2;
             }
 
-            assert!(ppc_app.guest_calls.begin_powerpc_to_m68k(
+            assert!(ppc_app.toolbox_startup.execution.calls().begin_powerpc_to_m68k(
                 crate::guest_call::GuestCallTarget {
                     isa: crate::guest_procedure::GuestIsa::M68k,
                     entry: OUTER_ENTRY,
@@ -18843,7 +19182,7 @@ mod tests {
         ppc_app.imports = vec![call_universal_proc];
         let mut outer_registers = crate::guest_call::M68kRegisterState::default();
         outer_registers.data[6] = OUTER_D6;
-        assert!(ppc_app.guest_calls.begin_powerpc_to_m68k(
+        assert!(ppc_app.toolbox_startup.execution.calls().begin_powerpc_to_m68k(
             crate::guest_call::GuestCallTarget {
                 isa: crate::guest_procedure::GuestIsa::M68k,
                 entry: DESCRIPTOR,
@@ -18922,7 +19261,7 @@ mod tests {
                         .len(),
                     1
                 );
-                assert_eq!(ppc_app.guest_calls.len(), frame_count);
+                assert_eq!(ppc_app.toolbox_startup.execution.calls().len(), frame_count);
                 runner
                     .native
                     .restore(native_context)
@@ -18977,14 +19316,12 @@ mod tests {
             .expect("PPC app");
         let mut ppc_app = native_context.adapter_mut();
         let return_pc = 0x01f0_4000;
-        ppc_app
-            .guest_calls
+        ppc_app.toolbox_startup.execution.calls()
             .activate_powerpc_from_m68k(&mut ppc_app.cpu, return_pc)
             .unwrap();
         ppc_app.cpu.pc = return_pc;
         ppc_app.cpu.gpr[3] = 1;
-        assert!(ppc_app
-            .guest_calls
+        assert!(ppc_app.toolbox_startup.execution.calls()
             .complete_powerpc_for_m68k(&mut ppc_app.cpu));
 
         assert!(runner.resume_m68k_after_powerpc(&mut ppc_app));
@@ -18992,7 +19329,7 @@ mod tests {
         assert_eq!(runner.m68k.cpu.core.get_ccr(), 0x14);
         assert_eq!(runner.m68k.cpu.read_reg(Register::PC), 0x0010_0000);
         assert_eq!(runner.m68k.cpu.read_reg(Register::A7), 0x0010_1000);
-        assert!(ppc_app.guest_calls.is_empty());
+        assert!(ppc_app.toolbox_startup.execution.calls().is_empty());
         runner
             .native
             .restore(native_context)
@@ -19372,7 +19709,7 @@ mod tests {
         let ppc_app = native_context.adapter_mut();
         ppc_app.cpu.gpr[3] = NATIVE_R3;
         let arguments = PowerPcArguments::from_slice(&[0, 0]).unwrap();
-        assert!(ppc_app.guest_calls.begin_powerpc_to_m68k(
+        assert!(ppc_app.toolbox_startup.execution.calls().begin_powerpc_to_m68k(
             crate::guest_call::GuestCallTarget {
                 isa: crate::guest_procedure::GuestIsa::M68k,
                 entry: M68K_ENTRY,
@@ -19392,7 +19729,7 @@ mod tests {
             0,
             PpcNativeReturnGpr3::Preserve,
         ));
-        let pending = ppc_app.guest_calls.activate_m68k().unwrap();
+        let pending = ppc_app.toolbox_startup.execution.calls().activate_m68k().unwrap();
         runner.m68k.cpu.write_reg(Register::PC, pending.return_pc);
         runner.m68k.cpu.write_reg(Register::A7, pending.final_sp);
 
@@ -19405,7 +19742,7 @@ mod tests {
                 manager
             )));
         assert_eq!(ppc_app.cpu.gpr[3], NATIVE_R3);
-        assert!(ppc_app.guest_calls.is_empty());
+        assert!(ppc_app.toolbox_startup.execution.calls().is_empty());
     }
 
     #[test]
@@ -19556,7 +19893,7 @@ mod tests {
             runner.init_app(&app);
             let mut native_context = runner.native.take(NativeEngineRole::Application).unwrap();
             let mut ppc_app = native_context.adapter_mut();
-            assert!(ppc_app.guest_calls.begin_m68k_to_powerpc(
+            assert!(ppc_app.toolbox_startup.execution.calls().begin_m68k_to_powerpc(
                 crate::guest_call::GuestCallTarget {
                     isa: crate::guest_procedure::GuestIsa::PowerPc,
                     entry: PPC_CODE_BASE,
@@ -19567,21 +19904,18 @@ mod tests {
                 FINAL_SP,
                 Some(target),
             ));
-            ppc_app
-                .guest_calls
+            ppc_app.toolbox_startup.execution.calls()
                 .activate_powerpc_from_m68k(&mut ppc_app.cpu, RETURN_PC)
                 .unwrap();
             ppc_app.cpu.pc = RETURN_PC;
             ppc_app.cpu.gpr[3] = 0x1234_5678;
-            assert!(ppc_app
-                .guest_calls
+            assert!(ppc_app.toolbox_startup.execution.calls()
                 .complete_powerpc_for_m68k(&mut ppc_app.cpu));
-            let (task, call_id) = ppc_app.guest_calls.pending_m68k_resume_owner().unwrap();
+            let (task, call_id) = ppc_app.toolbox_startup.execution.calls().pending_m68k_resume_owner().unwrap();
             runner.m68k.cpu.core.set_d(1, 0xabcd_0000);
             runner.m68k.cpu.core.set_d(7, 0xcafe_babe);
             runner.m68k.cpu.core.set_ccr(0x11);
-            assert!(ppc_app
-                .guest_calls
+            assert!(ppc_app.guest_calls()
                 .park_context(
                     &mut runner
                         .dispatcher
@@ -19608,7 +19942,7 @@ mod tests {
             assert_eq!(runner.m68k.cpu.core.d(7), 0xcafe_babe);
             assert_eq!(runner.m68k.cpu.read_reg(Register::PC), RETURN_PC);
             assert_eq!(runner.m68k.cpu.read_reg(Register::A7), FINAL_SP);
-            assert!(ppc_app.guest_calls.is_empty());
+            assert!(ppc_app.toolbox_startup.execution.calls().is_empty());
             assert!(runner
                 .dispatcher
                 .guest_calls
@@ -19636,7 +19970,7 @@ mod tests {
             .take(NativeEngineRole::Application)
             .expect("PPC app");
         let mut ppc_app = native_context.adapter_mut();
-        assert!(ppc_app.guest_calls.begin_m68k_to_powerpc(
+        assert!(ppc_app.toolbox_startup.execution.calls().begin_m68k_to_powerpc(
             crate::guest_call::GuestCallTarget {
                 isa: crate::guest_procedure::GuestIsa::PowerPc,
                 entry: PPC_CODE_BASE,
@@ -19650,25 +19984,21 @@ mod tests {
                 size: 4,
             }),
         ));
-        ppc_app
-            .guest_calls
+        ppc_app.toolbox_startup.execution.calls()
             .activate_powerpc_from_m68k(&mut ppc_app.cpu, RETURN_PC)
             .unwrap();
         ppc_app.cpu.pc = RETURN_PC;
         ppc_app.cpu.gpr[3] = RESULT_VALUE;
-        assert!(ppc_app
-            .guest_calls
+        assert!(ppc_app.toolbox_startup.execution.calls()
             .complete_powerpc_for_m68k(&mut ppc_app.cpu));
 
         // Model the caller parked by a nested native-to-68K transition. The
         // failed write must not consume either this context or its completion.
-        let (task, call_id) = ppc_app
-            .guest_calls
+        let (task, call_id) = ppc_app.guest_calls()
             .pending_m68k_resume_owner()
             .expect("completed continuation owner");
         runner.m68k.cpu.core.set_d(0, PARKED_D0);
-        assert!(ppc_app
-            .guest_calls
+        assert!(ppc_app.guest_calls()
             .park_context(
                 &mut runner
                     .dispatcher
@@ -19689,7 +20019,7 @@ mod tests {
                 .task_len(task),
             1
         );
-        assert!(ppc_app.guest_calls.peek_m68k_resume().is_some());
+        assert!(ppc_app.toolbox_startup.execution.calls().peek_m68k_resume().is_some());
 
         assert!(!runner.resume_m68k_after_powerpc(&mut ppc_app));
         assert_eq!(
@@ -19701,7 +20031,7 @@ mod tests {
                 .task_len(task),
             1
         );
-        assert!(ppc_app.guest_calls.peek_m68k_resume().is_some());
+        assert!(ppc_app.toolbox_startup.execution.calls().peek_m68k_resume().is_some());
 
         ppc_app.memory.add_readonly_region(RESULT, vec![0xaa; 4]);
         assert!(!runner.resume_m68k_after_powerpc(&mut ppc_app));
@@ -19715,7 +20045,7 @@ mod tests {
                 .task_len(task),
             1
         );
-        assert!(ppc_app.guest_calls.peek_m68k_resume().is_some());
+        assert!(ppc_app.toolbox_startup.execution.calls().peek_m68k_resume().is_some());
 
         ppc_app.memory.add_region(RESULT, vec![0; 4]);
         assert!(runner.resume_m68k_after_powerpc(&mut ppc_app));
@@ -19728,7 +20058,7 @@ mod tests {
                 .task_len(task),
             0
         );
-        assert!(ppc_app.guest_calls.peek_m68k_resume().is_none());
+        assert!(ppc_app.toolbox_startup.execution.calls().peek_m68k_resume().is_none());
         assert_eq!(ppc_app.memory.read_u32_be(RESULT), Some(RESULT_VALUE));
         assert_eq!(runner.m68k.cpu.core.d(0), PARKED_D0);
     }
@@ -20436,7 +20766,6 @@ mod tests {
             process_input: Default::default(),
             event_queue: Default::default(),
             window_list: Default::default(),
-            guest_calls: Default::default(),
             process_memory_manager: PpcProcessMemoryManager::with_heap(
                 PPC_HEAP_BASE,
                 PPC_STACK_BASE,
@@ -21251,7 +21580,6 @@ mod tests {
             process_input: Default::default(),
             event_queue: Default::default(),
             window_list: Default::default(),
-            guest_calls: Default::default(),
             process_memory_manager: PpcProcessMemoryManager::with_heap(
                 PPC_HEAP_BASE,
                 PPC_STACK_BASE,
@@ -21404,7 +21732,6 @@ mod tests {
             process_input: Default::default(),
             event_queue: Default::default(),
             window_list: Default::default(),
-            guest_calls: Default::default(),
             process_memory_manager: PpcProcessMemoryManager::with_heap(
                 PPC_HEAP_BASE,
                 PPC_STACK_BASE,
@@ -21804,7 +22131,6 @@ mod tests {
             process_input: Default::default(),
             event_queue: Default::default(),
             window_list: Default::default(),
-            guest_calls: Default::default(),
             process_memory_manager: PpcProcessMemoryManager::with_heap(
                 PPC_HEAP_BASE + 8,
                 PPC_STACK_BASE,
@@ -22121,7 +22447,6 @@ mod tests {
             process_input: Default::default(),
             event_queue: Default::default(),
             window_list: Default::default(),
-            guest_calls: Default::default(),
             process_memory_manager: PpcProcessMemoryManager::with_heap(
                 PPC_HEAP_BASE + 8 * 16,
                 PPC_STACK_BASE,
@@ -22401,7 +22726,7 @@ mod tests {
                 .expect("packed indexed mode");
             let mut runner = FixtureRunner::new(8 * 1024 * 1024, config);
             let mut ppc_app = app.ppc.take().expect("PPC app");
-            ppc_app.attach_process_context(&mut runner.process_context);
+            ppc_app.attach_unconverted_process_services(&mut runner.process_context);
             let (mut device_clut, _) =
                 TrapDispatcher::standard_mac_indexed_clut(depth).expect("standard indexed depth");
             device_clut[0][0] = 0xfffe;

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -2220,8 +2220,8 @@ impl TrapDispatcher {
         &mut self.sound_manager
     }
 
-    /// Attach shared process resources to this dispatcher.
-    pub(crate) fn attach_process_context(&mut self, context: &mut ProcessContext) {
+    /// Attach process services outside the construction-owned migration pair.
+    pub(crate) fn attach_unconverted_process_services(&mut self, context: &mut ProcessContext) {
         let mut memory_manager = None;
         context.attach_memory_manager(&mut memory_manager);
         let memory_manager = memory_manager.expect("process context supplies a Memory Manager");
@@ -2256,7 +2256,6 @@ impl TrapDispatcher {
             .shared_handle();
         self.file_positions = self.process_file_system.files.positions();
         context.attach_sound_manager(&mut self.sound_manager);
-        context.attach_tick_state(&mut self.tick_state);
         context.attach_callback_tasks(
             &mut self.timer_tasks,
             &mut self.vbl_tasks,
@@ -2296,8 +2295,6 @@ impl TrapDispatcher {
         );
         self.attach_memory_manager_handle(memory_manager);
         context.attach_native_menu_selection(&mut self.pending_native_menu_selection);
-        context.attach_guest_calls(&mut self.guest_calls);
-        context.attach_menu_tracking(&mut self.menu_tracking);
         context.attach_apple_event_handlers(&mut self.ae_handlers);
         context.attach_apple_event_launch_state(&mut self.apple_event_launch_state);
     }
@@ -10969,7 +10966,7 @@ mod tests {
     fn attached_event_queue_remains_shared_through_panic() {
         let mut dispatcher = TrapDispatcher::new();
         let mut context = ProcessContext::default();
-        dispatcher.attach_process_context(&mut context);
+        dispatcher.attach_unconverted_process_services(&mut context);
         context.event_queue_mut().push_back(QueuedEvent {
             what: 1,
             message: 0x1111,
@@ -11014,7 +11011,7 @@ mod tests {
         assert!(dispatcher.guest_calls.ptr_eq(&expected_execution));
         assert!(dispatcher.menu_tracking.is_view_of(&dispatcher.guest_calls));
 
-        dispatcher.attach_process_context(&mut context);
+        dispatcher.attach_unconverted_process_services(&mut context);
         assert!(dispatcher.tick_state.ptr_eq(&expected_ticks));
         assert!(dispatcher.guest_calls.ptr_eq(&expected_execution));
         assert!(dispatcher.menu_tracking.is_view_of(&dispatcher.guest_calls));
@@ -11058,8 +11055,8 @@ mod tests {
         let mut first = TrapDispatcher::new();
         let mut second = TrapDispatcher::new();
 
-        first.attach_process_context(&mut context);
-        second.attach_process_context(&mut context);
+        first.attach_unconverted_process_services(&mut context);
+        second.attach_unconverted_process_services(&mut context);
 
         assert!(first
             .process_file_system
@@ -11125,8 +11122,8 @@ mod tests {
         let mut first = TrapDispatcher::new();
         let mut second = TrapDispatcher::new();
 
-        first.attach_process_context(&mut context);
-        second.attach_process_context(&mut context);
+        first.attach_unconverted_process_services(&mut context);
+        second.attach_unconverted_process_services(&mut context);
         assert!(first
             .pending_file_completions
             .ptr_eq(&second.pending_file_completions));
@@ -11141,12 +11138,12 @@ mod tests {
 
     #[test]
     fn attached_menu_tracking_mutates_process_context_immediately() {
-        let mut dispatcher = TrapDispatcher::new();
         let mut context = ProcessContext::default();
         context.set_menu_tracking(Some(crate::menu_manager::test_process_menu_tracking(
             0x1234,
         )));
-        dispatcher.attach_process_context(&mut context);
+        let mut dispatcher = TrapDispatcher::new_with_migrated_handles(context.migrated_handles());
+        dispatcher.attach_unconverted_process_services(&mut context);
 
         assert_eq!(
             dispatcher.menu_tracking.as_ref().map(|t| t.menu_handle),
@@ -11168,12 +11165,12 @@ mod tests {
 
     #[test]
     fn attached_menu_tracking_remains_shared_through_panic() {
-        let mut dispatcher = TrapDispatcher::new();
         let mut context = ProcessContext::default();
         context.set_menu_tracking(Some(crate::menu_manager::test_process_menu_tracking(
             0x5678,
         )));
-        dispatcher.attach_process_context(&mut context);
+        let mut dispatcher = TrapDispatcher::new_with_migrated_handles(context.migrated_handles());
+        dispatcher.attach_unconverted_process_services(&mut context);
 
         let panic_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             dispatcher.menu_tracking.as_mut().unwrap().highlighted_item = 9;
@@ -11195,12 +11192,12 @@ mod tests {
 
     #[test]
     fn attached_process_state_remains_canonical_through_panic() {
-        let mut dispatcher = TrapDispatcher::new();
         let mut context = ProcessContext::default();
         context.set_menu_tracking(Some(crate::menu_manager::test_process_menu_tracking(
             0x9abc,
         )));
-        dispatcher.attach_process_context(&mut context);
+        let mut dispatcher = TrapDispatcher::new_with_migrated_handles(context.migrated_handles());
+        dispatcher.attach_unconverted_process_services(&mut context);
         let memory_manager = context.memory_manager_handle().clone();
 
         let panic_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -11254,8 +11251,8 @@ mod tests {
         let mut second = TrapDispatcher::new();
         let mut first_context = ProcessContext::default();
         let mut second_context = ProcessContext::default();
-        first.attach_process_context(&mut first_context);
-        second.attach_process_context(&mut second_context);
+        first.attach_unconverted_process_services(&mut first_context);
+        second.attach_unconverted_process_services(&mut second_context);
 
         first.track_handle_ptr(0x2200, 0x1100);
         first.set_handle_state_bits(0x1100, 0x80);
@@ -11277,7 +11274,7 @@ mod tests {
         dispatcher.set_handle_state_bits(0x1100, 0x80);
 
         let mut context = ProcessContext::default();
-        dispatcher.attach_process_context(&mut context);
+        dispatcher.attach_unconverted_process_services(&mut context);
         let attached = dispatcher.process_memory_manager();
 
         assert!(!attached.ptr_eq(&standalone));
@@ -11310,7 +11307,7 @@ mod tests {
         );
 
         let mut context = ProcessContext::default();
-        dispatcher.attach_process_context(&mut context);
+        dispatcher.attach_unconverted_process_services(&mut context);
         let attached = dispatcher.process_memory_manager();
 
         assert!(!attached.ptr_eq(&standalone));
@@ -11332,7 +11329,7 @@ mod tests {
         assert_ne!(ptr, 0);
 
         let mut context = ProcessContext::default();
-        dispatcher.attach_process_context(&mut context);
+        dispatcher.attach_unconverted_process_services(&mut context);
         context.attach_classic_memory_bus(&mut bus);
 
         assert_eq!(
@@ -11385,7 +11382,7 @@ mod tests {
         let shared = native.shared_view();
         bus.attach_guest_address_space(shared);
         let mut dispatcher = TrapDispatcher::new();
-        dispatcher.attach_process_context(&mut context);
+        dispatcher.attach_unconverted_process_services(&mut context);
         let replacement = vec![0x5a; 48];
 
         assert!(dispatcher.replace_process_native_handle_bytes(

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -26,7 +26,8 @@ use crate::managers::resource::ResourceFork;
 use crate::memory::{MacMemoryBus, MemoryBus};
 use crate::menu_manager::{ProcessMenuTrackingState, SharedNativeMenuSelection};
 use crate::process_context::{
-    PendingFileCompletion, ProcessContext, ProcessForkMap, ProcessKeyRepeatState,
+    MigratedProcessHandles, PendingFileCompletion, ProcessContext, ProcessForkMap,
+    ProcessKeyRepeatState,
     ProcessLoadedResources, ProcessResourceFileMap, ProcessResourceManagerState,
     ProcessVfsDirectory, ProcessVfsMetadata, ProcessVfsVolumeRecord, ProcessWorkingDirectory,
     SharedProcessAppleEventHandlers, SharedProcessAppleEventLaunchState,
@@ -3188,7 +3189,32 @@ impl TrapDispatcher {
     }
 
     pub fn new() -> Self {
-        let guest_calls = SharedGuestCallStack::default();
+        Self::new_inner(MigratedProcessHandles {
+            ticks: SharedProcessTickState::default(),
+            execution: SharedGuestCallStack::default(),
+        })
+    }
+
+    pub(crate) fn new_with_migrated_handles(handles: MigratedProcessHandles) -> Self {
+        Self::new_inner(handles)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_constructed_from_migrated_handles(
+        &self,
+        handles: &MigratedProcessHandles,
+    ) -> bool {
+        self.tick_state.ptr_eq(&handles.ticks)
+            && self.guest_calls.ptr_eq(&handles.execution)
+            && self.menu_tracking.is_view_of(&self.guest_calls)
+    }
+
+    fn new_inner(handles: MigratedProcessHandles) -> Self {
+        let MigratedProcessHandles {
+            ticks: tick_state,
+            execution: guest_calls,
+        } = handles;
+        let menu_tracking = guest_calls.menu_tracking_view();
         let mut process_file_system = SharedProcessFileSystem::default();
         *process_file_system.vfs_directories = vec![ProcessVfsDirectory {
             dir_id: 2,
@@ -3321,7 +3347,7 @@ impl TrapDispatcher {
             tx_size: 12,
             outline_preferred: false,
             preserve_glyph: false,
-            tick_state: SharedProcessTickState::default(),
+            tick_state,
             power_idle_last_update_tick: 0,
             power_idle_disable_count: 0,
             serial_port_a_powered: false,
@@ -3351,7 +3377,7 @@ impl TrapDispatcher {
             menu_bar_hidden: false,
             sound_manager: SharedProcessSoundManager::default(),
             menus: Vec::new(),
-            menu_tracking: guest_calls.menu_tracking_view(),
+            menu_tracking,
             guest_calls,
             pending_native_menu_selection: SharedNativeMenuSelection::default(),
             pending_native_menu_event: None,
@@ -10973,6 +10999,36 @@ mod tests {
         assert!(context.event_queue().menu_bar_is_invalid());
         assert_eq!(dispatcher.event_queue.len(), 2);
         assert!(dispatcher.event_queue.menu_bar_is_invalid());
+    }
+
+    #[test]
+    fn migrated_constructor_uses_exact_process_tick_and_execution_owners() {
+        let mut context = ProcessContext::default();
+        let handles = context.migrated_handles();
+        let expected_ticks = handles.ticks.shared_handle();
+        let expected_execution = handles.execution.shared_handle();
+
+        let mut dispatcher = TrapDispatcher::new_with_migrated_handles(handles);
+
+        assert!(dispatcher.tick_state.ptr_eq(&expected_ticks));
+        assert!(dispatcher.guest_calls.ptr_eq(&expected_execution));
+        assert!(dispatcher.menu_tracking.is_view_of(&dispatcher.guest_calls));
+
+        dispatcher.attach_process_context(&mut context);
+        assert!(dispatcher.tick_state.ptr_eq(&expected_ticks));
+        assert!(dispatcher.guest_calls.ptr_eq(&expected_execution));
+        assert!(dispatcher.menu_tracking.is_view_of(&dispatcher.guest_calls));
+    }
+
+    #[test]
+    fn standalone_constructors_create_independent_coherent_service_owners() {
+        let first = TrapDispatcher::new();
+        let second = TrapDispatcher::new();
+
+        assert!(!first.tick_state.ptr_eq(&second.tick_state));
+        assert!(!first.guest_calls.ptr_eq(&second.guest_calls));
+        assert!(first.menu_tracking.is_view_of(&first.guest_calls));
+        assert!(second.menu_tracking.is_view_of(&second.guest_calls));
     }
 
     #[test]

--- a/src/trap/memory.rs
+++ b/src/trap/memory.rs
@@ -4592,7 +4592,7 @@ mod tests {
         let (mut dispatcher, mut cpu, mut bus) = setup();
         let mut context = ProcessContext::default();
         context.attach_classic_memory_bus(&mut bus);
-        dispatcher.attach_process_context(&mut context);
+        dispatcher.attach_unconverted_process_services(&mut context);
 
         cpu.write_reg(Register::D0, 24);
         let memory_manager = context.memory_manager_handle();
@@ -4727,7 +4727,7 @@ mod tests {
                 0,
             )]);
         }
-        dispatcher.attach_process_context(&mut context);
+        dispatcher.attach_unconverted_process_services(&mut context);
 
         cpu.write_reg(Register::A0, handle);
         cpu.write_reg(Register::D0, 48);
@@ -4800,7 +4800,7 @@ mod tests {
                 0xE0,
             )]);
         }
-        dispatcher.attach_process_context(&mut context);
+        dispatcher.attach_unconverted_process_services(&mut context);
 
         cpu.write_reg(Register::A0, handle);
         cpu.write_reg(Register::D0, 17);
@@ -4875,7 +4875,7 @@ mod tests {
                 0x60,
             )]);
         }
-        dispatcher.attach_process_context(&mut context);
+        dispatcher.attach_unconverted_process_services(&mut context);
 
         cpu.write_reg(Register::A0, handle);
         dispatcher.current_trap_word = 0xA02B;
@@ -4951,7 +4951,7 @@ mod tests {
             );
             manager.register_native_handle_records([(record, 0xE0)]);
         }
-        dispatcher.attach_process_context(&mut context);
+        dispatcher.attach_unconverted_process_services(&mut context);
 
         cpu.write_reg(Register::A0, handle);
         dispatcher.current_trap_word = 0xA023;
@@ -5020,7 +5020,7 @@ mod tests {
             manager.register_native_handle_records([(source_record, 0xE0)]);
         }
         let detached = memory_manager.detached_clone();
-        dispatcher.attach_process_context(&mut context);
+        dispatcher.attach_unconverted_process_services(&mut context);
 
         cpu.write_reg(Register::A0, SOURCE_HANDLE);
         dispatcher
@@ -5089,7 +5089,7 @@ mod tests {
         let (mut dispatcher, mut cpu, mut bus) = setup();
         let mut context = ProcessContext::default();
         context.attach_classic_memory_bus(&mut bus);
-        dispatcher.attach_process_context(&mut context);
+        dispatcher.attach_unconverted_process_services(&mut context);
 
         cpu.write_reg(Register::D0, 12);
         dispatcher.current_trap_word = 0xA022;
@@ -5145,7 +5145,7 @@ mod tests {
                 0,
             )]);
         }
-        dispatcher.attach_process_context(&mut context);
+        dispatcher.attach_unconverted_process_services(&mut context);
         assert_eq!(bus.get_alloc_size(HANDLE_PTR), None);
         assert_eq!(bus.get_alloc_size(PTR), None);
 
@@ -7086,8 +7086,8 @@ mod tests {
         let (mut classic, mut cpu, mut bus) = setup();
         let mut attached_view = super::super::TrapDispatcher::new();
         let mut context = ProcessContext::default();
-        classic.attach_process_context(&mut context);
-        attached_view.attach_process_context(&mut context);
+        classic.attach_unconverted_process_services(&mut context);
+        attached_view.attach_unconverted_process_services(&mut context);
 
         let timer = bus.alloc(22);
         bus.write_long(timer + 6, 0x1234_5678);

--- a/src/trap/menu.rs
+++ b/src/trap/menu.rs
@@ -1746,7 +1746,6 @@ impl super::TrapDispatcher {
         cpu: &mut C,
         bus: &mut MacMemoryBus,
     ) -> Option<Result<()>> {
-        self.menu_tracking.bind_execution(&self.guest_calls);
         self.retire_menu_definition(cpu, bus);
         let _menu_root = (is_tool && matches!(trap_num, 0x13d | 0x00b)).then(|| {
             let sp = cpu.read_reg(Register::A7);

--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -3157,6 +3157,11 @@ impl super::TrapDispatcher {
                 let dst_bottom = bus.read_word(dst_rect_ptr + 4) as i16;
                 let dst_right = bus.read_word(dst_rect_ptr + 6) as i16;
                 let mode_base = (mode & 0x3F) as u16;
+                let source_bounds_are_original = src_info.bounds_bottom > src_info.bounds_top
+                    && src_info.bounds_right > src_info.bounds_left;
+                let destination_bounds_are_authoritative = dst_info.bounds_bottom
+                    > dst_info.bounds_top
+                    && dst_info.bounds_right > dst_info.bounds_left;
                 Self::sanitize_copy_bitmap_bounds(
                     &mut src_info,
                     src_top,
@@ -3433,14 +3438,16 @@ impl super::TrapDispatcher {
                 };
 
                 let dst_ctab_handle = self.copy_bits_destination_ctab_handle(bus, port, &dst_info);
-                let src_clut = matches!(src_info.pixel_size, 2 | 4 | 8)
-                    .then(|| self.read_port_clut(bus, src_info.ctab_handle));
-                let dst_clut = self.read_indexed_destination_clut(
+                let src_clut_resolution = matches!(src_info.pixel_size, 2 | 4 | 8)
+                    .then(|| self.read_port_clut_with_provenance(bus, src_info.ctab_handle));
+                let src_clut = src_clut_resolution.as_ref().map(|(clut, _)| *clut);
+                let dst_clut_resolution = self.read_indexed_destination_clut_with_provenance(
                     bus,
                     dst_ctab_handle,
                     dst_info.pixel_size,
                     screen_copybits_rect.is_some(),
                 );
+                let dst_clut = dst_clut_resolution.as_ref().map(|(clut, _)| *clut);
                 let src_ctab_seed = Self::ctab_seed(bus, src_info.ctab_handle);
                 // Executor's translation gate compares the source PixMap's
                 // CTab seed against `CTAB_SEED(PIXMAP_TABLE(GD_PMAP(the_gd)))` —
@@ -3595,6 +3602,16 @@ impl super::TrapDispatcher {
                     (Some(src_clut), Some(dst_clut)) => src_clut != dst_clut,
                     _ => src_ctab_seed != dst_ctab_seed,
                 };
+                let indexed_palette_identity_known = src_info.pixel_size == 8
+                    && dst_info.pixel_size == 8
+                    && (src_info.ctab_handle == dst_info.ctab_handle
+                        || matches!(
+                            (src_clut_resolution.as_ref(), dst_clut_resolution.as_ref()),
+                            (Some((src_clut, true)), Some((dst_clut, true)))
+                                if src_clut == dst_clut
+                        )
+                        || skip_device_translation_to_screen
+                        || skip_explicit_palette_translation);
                 let palette_translation = if matches!(src_info.pixel_size, 2 | 4 | 8)
                     && matches!(dst_info.pixel_size, 2 | 4 | 8)
                     && src_info.ctab_handle != dst_info.ctab_handle
@@ -3654,7 +3671,15 @@ impl super::TrapDispatcher {
                     && !trace_menu_redraw_enabled()
                     && trace_probes.is_empty();
                 if row_copy_edge_eligible {
-                    use crate::copy_bits::RowCopyOutcome;
+                    use crate::copy_bits::{Indexed8HorizontalSelection, RowCopyOutcome};
+
+                    let indexed8_horizontal = Indexed8HorizontalSelection::from_adapter_facts(
+                        mask_rgn == 0,
+                        source_bounds_are_original,
+                        destination_bounds_are_authoritative,
+                        indexed_palette_identity_known,
+                        mode as u16,
+                    );
 
                     let outcome = resolved_row_copy(
                         mode_base,
@@ -3665,7 +3690,7 @@ impl super::TrapDispatcher {
                         [clip_t, clip_l, clip_b, clip_r].map(i32::from),
                         palette_translation,
                     )
-                    .execute(bus);
+                    .execute_with_indexed8_horizontal(bus, indexed8_horizontal);
                     let wrote_rows = match outcome {
                         RowCopyOutcome::Completed => true,
                         RowCopyOutcome::WriteFailure { rows_written } => rows_written != 0,
@@ -17569,9 +17594,13 @@ impl super::TrapDispatcher {
     /// Read a 256-entry CLUT from a CTabHandle in guest memory.
     /// Falls back to the device CLUT if the handle is NULL.
     /// Imaging With QuickDraw 1994, p. 4-82
-    pub(crate) fn read_port_clut(&self, bus: &MacMemoryBus, ctab_handle: u32) -> [[u16; 3]; 256] {
+    fn read_port_clut_with_provenance(
+        &self,
+        bus: &MacMemoryBus,
+        ctab_handle: u32,
+    ) -> ([[u16; 3]; 256], bool) {
         if ctab_handle == 0 {
-            return *self.color_manager_clut;
+            return (*self.color_manager_clut, true);
         }
         let screen_ctab_handle = if self.main_gdevice_handle != 0 {
             Self::gdevice_ctab_handle(bus, self.main_gdevice_handle)
@@ -17579,13 +17608,25 @@ impl super::TrapDispatcher {
             0
         };
         if ctab_handle == screen_ctab_handle {
-            return *self.color_manager_clut;
+            return (*self.color_manager_clut, true);
         }
+        let handle_is_mapped = bus.is_guest_address_mapped(ctab_handle, 4);
         let ctab_ptr = bus.read_long(ctab_handle);
         if ctab_ptr == 0 {
-            return *self.color_manager_clut;
+            return (*self.color_manager_clut, false);
         }
-        self.read_color_table_ptr_clut(bus, ctab_ptr)
+        // Preserve the legacy total-read result even for a malformed or
+        // partially mapped table. Provenance qualifies only whether that
+        // result may establish raw index identity for the new reducer.
+        let clut = self.read_color_table_ptr_clut(bus, ctab_ptr);
+        let entry_count = u32::from(bus.read_word(ctab_ptr.wrapping_add(6)).min(255)) + 1;
+        let table_len = 8usize + entry_count as usize * 8;
+        let known = handle_is_mapped && bus.is_guest_address_mapped(ctab_ptr, table_len);
+        (clut, known)
+    }
+
+    pub(crate) fn read_port_clut(&self, bus: &MacMemoryBus, ctab_handle: u32) -> [[u16; 3]; 256] {
+        self.read_port_clut_with_provenance(bus, ctab_handle).0
     }
 
     fn read_indexed_destination_clut(
@@ -17595,13 +17636,29 @@ impl super::TrapDispatcher {
         pixel_size: u32,
         screen_destination: bool,
     ) -> Option<[[u16; 3]; 256]> {
+        self.read_indexed_destination_clut_with_provenance(
+            bus,
+            ctab_handle,
+            pixel_size,
+            screen_destination,
+        )
+        .map(|(clut, _)| clut)
+    }
+
+    fn read_indexed_destination_clut_with_provenance(
+        &self,
+        bus: &MacMemoryBus,
+        ctab_handle: u32,
+        pixel_size: u32,
+        screen_destination: bool,
+    ) -> Option<([[u16; 3]; 256], bool)> {
         if !matches!(pixel_size, 1 | 2 | 4 | 8) {
             return None;
         }
-        let mut clut = if pixel_size == 1 {
-            let mut clut = [[0u16; 3]; 256];
-            clut[0] = [0xFFFF, 0xFFFF, 0xFFFF];
-            clut
+        let (mut clut, known) = if pixel_size == 1 {
+            let mut monochrome = [[0u16; 3]; 256];
+            monochrome[0] = [0xFFFF, 0xFFFF, 0xFFFF];
+            (monochrome, true)
         } else if screen_destination {
             // CopyBits uses the current GDevice's ColorTable for an indexed
             // destination because the Color Manager needs that table's
@@ -17610,16 +17667,16 @@ impl super::TrapDispatcher {
             // logical GDevice table; `device_clut` is the transient physical
             // hardware view used while fades are in progress. Imaging With
             // QuickDraw (1994), p. 3-117.
-            *self.color_manager_clut
+            (*self.color_manager_clut, true)
         } else {
-            self.read_port_clut(bus, ctab_handle)
+            self.read_port_clut_with_provenance(bus, ctab_handle)
         };
         if pixel_size < 8 {
             let entry_count = 1usize << pixel_size;
             let terminal = clut[entry_count - 1];
             clut[entry_count..].fill(terminal);
         }
-        Some(clut)
+        Some((clut, known))
     }
 
     pub(super) fn read_ctab_handle_clut(
@@ -20327,6 +20384,10 @@ impl super::TrapDispatcher {
         let dst_bottom = bus.read_word(dst_rect_ptr + 4) as i16;
         let dst_right = bus.read_word(dst_rect_ptr + 6) as i16;
         let mode_base = (mode & 0x3F) as u16;
+        let source_bounds_are_original = src_info.bounds_bottom > src_info.bounds_top
+            && src_info.bounds_right > src_info.bounds_left;
+        let destination_bounds_are_authoritative = dst_info.bounds_bottom > dst_info.bounds_top
+            && dst_info.bounds_right > dst_info.bounds_left;
         Self::sanitize_copy_bitmap_bounds(&mut src_info, src_top, src_left, src_bottom, src_right);
         Self::sanitize_copy_bitmap_bounds(&mut dst_info, dst_top, dst_left, dst_bottom, dst_right);
 
@@ -20499,23 +20560,32 @@ impl super::TrapDispatcher {
         };
 
         let dst_ctab_handle = self.copy_bits_destination_ctab_handle(bus, port, &dst_info);
-        let src_clut = matches!(src_info.pixel_size, 2 | 4 | 8)
-            .then(|| self.read_port_clut(bus, src_info.ctab_handle));
+        let src_clut_resolution = matches!(src_info.pixel_size, 2 | 4 | 8)
+            .then(|| self.read_port_clut_with_provenance(bus, src_info.ctab_handle));
+        let src_clut = src_clut_resolution.as_ref().map(|(clut, _)| *clut);
         let screen_destination = dst_info.base == self.screen_mode.0
             && dst_info.row_bytes == self.screen_mode.1
             && dst_info.pixel_size == u32::from(self.screen_mode.4);
-        let dst_clut = self.read_indexed_destination_clut(
+        let dst_clut_resolution = self.read_indexed_destination_clut_with_provenance(
             bus,
             dst_ctab_handle,
             dst_info.pixel_size,
             screen_destination,
         );
+        let dst_clut = dst_clut_resolution.as_ref().map(|(clut, _)| *clut);
         let src_ctab_seed = Self::ctab_seed(bus, src_info.ctab_handle);
         let dst_ctab_seed = Self::ctab_seed(bus, dst_ctab_handle);
         let indexed_tables_differ = match (src_clut.as_ref(), dst_clut.as_ref()) {
             (Some(src_clut), Some(dst_clut)) => src_clut != dst_clut,
             _ => src_ctab_seed != dst_ctab_seed,
         };
+        let indexed_palette_identity_known = src_info.pixel_size == 8
+            && dst_info.pixel_size == 8
+            && (src_info.ctab_handle == dst_info.ctab_handle
+                || matches!(
+                    (src_clut_resolution.as_ref(), dst_clut_resolution.as_ref()),
+                    (Some((src_clut, true)), Some((dst_clut, true))) if src_clut == dst_clut
+                ));
         let palette_translation = if matches!(src_info.pixel_size, 2 | 4 | 8)
             && matches!(dst_info.pixel_size, 2 | 4 | 8)
             && src_info.ctab_handle != dst_info.ctab_handle
@@ -20632,7 +20702,15 @@ impl super::TrapDispatcher {
             && !Self::region_is_complex(bus, mask_rgn)
             && trace_probes.is_empty();
         let shared_rows_written = if row_copy_edge_eligible {
-            use crate::copy_bits::RowCopyOutcome;
+            use crate::copy_bits::{Indexed8HorizontalSelection, RowCopyOutcome};
+
+            let indexed8_horizontal = Indexed8HorizontalSelection::from_adapter_facts(
+                mask_rgn == 0,
+                source_bounds_are_original,
+                destination_bounds_are_authoritative,
+                indexed_palette_identity_known,
+                mode as u16,
+            );
 
             match resolved_row_copy(
                 mode_base,
@@ -20643,7 +20721,7 @@ impl super::TrapDispatcher {
                 [clip_t, clip_l, clip_b, clip_r].map(i32::from),
                 palette_translation,
             )
-            .execute(bus)
+            .execute_with_indexed8_horizontal(bus, indexed8_horizontal)
             {
                 RowCopyOutcome::Completed => true,
                 RowCopyOutcome::WriteFailure { rows_written } if rows_written != 0 => true,
@@ -27256,6 +27334,69 @@ mod tests {
         bus.write_word(entry + 6, 0xCCCC);
         let updated_clut = d.read_port_clut(&bus, ctab_handle);
         assert_eq!(updated_clut[5], [0xAAAA, 0xBBBB, 0xCCCC]);
+    }
+
+    #[test]
+    fn read_port_clut_provenance_preserves_partial_table_legacy_bytes() {
+        const TABLE: u32 = 0x00d5_0000;
+        let (d, _cpu, mut bus) = setup();
+        let mut memory = GuestAddressSpace::new();
+        let mut partial = vec![0; 16];
+        partial[6..8].copy_from_slice(&1u16.to_be_bytes());
+        partial[8..10].copy_from_slice(&5u16.to_be_bytes());
+        partial[10..12].copy_from_slice(&0x1111u16.to_be_bytes());
+        partial[12..14].copy_from_slice(&0x2222u16.to_be_bytes());
+        partial[14..16].copy_from_slice(&0x3333u16.to_be_bytes());
+        memory.add_region(TABLE, partial);
+        bus.attach_guest_address_space(memory.shared_view());
+        let handle = bus.alloc(4);
+        bus.write_long(handle, TABLE);
+
+        let legacy = d.read_port_clut(&bus, handle);
+        let (qualified, known) = d.read_port_clut_with_provenance(&bus, handle);
+
+        assert_eq!(qualified, legacy);
+        assert!(!known);
+        // The missing second ColorSpec retains the old total-read behavior:
+        // its zero value overwrites index zero, while the mapped first entry
+        // remains visible at index five.
+        assert_eq!(qualified[0], [0, 0, 0]);
+        assert_eq!(qualified[5], [0x1111, 0x2222, 0x3333]);
+    }
+
+    #[test]
+    fn read_port_clut_provenance_accepts_complete_sparse_table() {
+        const TABLE: u32 = 0x00d6_0000;
+        let (d, _cpu, mut bus) = setup();
+        let mut memory = GuestAddressSpace::new();
+        let mut table = vec![0; 16];
+        table[6..8].copy_from_slice(&0u16.to_be_bytes());
+        table[8..10].copy_from_slice(&7u16.to_be_bytes());
+        table[10..12].copy_from_slice(&0x4444u16.to_be_bytes());
+        table[12..14].copy_from_slice(&0x5555u16.to_be_bytes());
+        table[14..16].copy_from_slice(&0x6666u16.to_be_bytes());
+        memory.add_region(TABLE, table);
+        bus.attach_guest_address_space(memory.shared_view());
+        let handle = bus.alloc(4);
+        bus.write_long(handle, TABLE);
+
+        let (clut, known) = d.read_port_clut_with_provenance(&bus, handle);
+
+        assert!(known);
+        assert_eq!(clut[7], [0x4444, 0x5555, 0x6666]);
+    }
+
+    #[test]
+    fn read_port_clut_provenance_preserves_wrapping_legacy_read_without_qualifying_it() {
+        let (d, _cpu, mut bus) = setup();
+        let handle = bus.alloc(4);
+        bus.write_long(handle, u32::MAX - 3);
+
+        let legacy = d.read_port_clut(&bus, handle);
+        let (qualified, known) = d.read_port_clut_with_provenance(&bus, handle);
+
+        assert_eq!(qualified, legacy);
+        assert!(!known);
     }
 
     #[test]
@@ -35369,6 +35510,320 @@ mod tests {
     fn std_bits_packed_identity_preserves_edges_and_padding() {
         for depth in [2, 4] {
             run_packed_identity_route(depth, true);
+        }
+    }
+
+    fn run_indexed_horizontal_shrink_route(
+        std_bits: bool,
+        raw_mode: u16,
+        clip_left_column: bool,
+        palette_case: u8,
+    ) -> Vec<u8> {
+        let (mut d, mut cpu, mut bus) = setup_with_port();
+        let source_pixmap = bus.alloc(50);
+        let destination_pixmap = bus.alloc(50);
+        let destination_handle = bus.alloc(4);
+        let source_allocation = bus.alloc(16);
+        let source_base = source_allocation + 2;
+        // Four-byte allocations are movable-memory handles in the PixMap
+        // resolver, so use an ordinary direct pixel allocation here.
+        let destination_base = bus.alloc(8);
+        let source_rect = bus.alloc(8);
+        let destination_rect = bus.alloc(8);
+
+        write_pixmap_8(&mut bus, source_pixmap, source_base, 8, 1, 0);
+        // The submitted seven-pixel source starts two pixels before the declared
+        // image. The normal QuickDraw oracle consumes the initialized physical
+        // pixels while retaining the original three reduction groups.
+        bus.write_word(source_pixmap + 8, 2);
+        bus.write_word(source_pixmap + 12, 7);
+        write_pixmap_8(&mut bus, destination_pixmap, destination_base, 3, 1, 0);
+        if palette_case == 1 {
+            let source_ctable_handle = bus.alloc(4);
+            let destination_ctable_handle = bus.alloc(4);
+            bus.write_long(source_pixmap + 42, source_ctable_handle);
+            bus.write_long(destination_pixmap + 42, destination_ctable_handle);
+        } else if palette_case == 2 {
+            let source_ctable_handle = bus.alloc(4);
+            let source_ctable = bus.alloc(8 + 11 * 8);
+            bus.write_long(source_pixmap + 42, source_ctable_handle);
+            bus.write_long(source_ctable_handle, source_ctable);
+            bus.write_long(source_ctable, 0x1234_5678);
+            bus.write_word(source_ctable + 4, 0);
+            bus.write_word(source_ctable + 6, 10);
+            for index in 0..=10u32 {
+                let color_index = if index == 10 { 200 } else { index as usize };
+                let [red, green, blue] = d.color_manager_clut[color_index];
+                let entry = source_ctable + 8 + index * 8;
+                bus.write_word(entry, index as u16);
+                bus.write_word(entry + 2, red);
+                bus.write_word(entry + 4, green);
+                bus.write_word(entry + 6, blue);
+            }
+        }
+        if clip_left_column {
+            bus.write_word(destination_pixmap + 8, 1);
+        }
+        bus.write_bytes(source_allocation, &[240, 241, 10, 20, 30, 40, 50, 0, 0, 0]);
+        bus.write_bytes(destination_base, &[0xa5; 4]);
+        write_rect(&mut bus, source_rect, 0, 0, 1, 7);
+        write_rect(&mut bus, destination_rect, 0, 0, 1, 3);
+
+        cpu.write_reg(Register::A7, TEST_SP);
+        bus.write_long(TEST_SP, 0);
+        bus.write_word(TEST_SP + 4, raw_mode);
+        bus.write_long(TEST_SP + 6, destination_rect);
+        bus.write_long(TEST_SP + 10, source_rect);
+        if std_bits {
+            const PORT: u32 = 0x181000;
+            bus.write_long(destination_handle, destination_pixmap);
+            bus.write_long(PORT + 2, destination_handle);
+            bus.write_word(PORT + 6, 0xc000);
+            *d.current_port = PORT;
+            bus.write_long(TEST_SP + 14, source_pixmap);
+        } else {
+            bus.write_long(TEST_SP + 14, destination_pixmap);
+            bus.write_long(TEST_SP + 18, source_pixmap);
+        }
+
+        assert!(d
+            .dispatch_quickdraw(
+                true,
+                if std_bits { 0x0eb } else { 0x0ec },
+                &mut cpu,
+                &mut bus,
+            )
+            .unwrap()
+            .is_ok());
+        bus.read_bytes(destination_base, 4)
+    }
+
+    #[test]
+    fn copy_bits_and_std_bits_share_indexed_horizontal_source_crossing() {
+        for std_bits in [false, true] {
+            assert_eq!(
+                run_indexed_horizontal_shrink_route(std_bits, 0, false, 0),
+                vec![241, 30, 50, 0xa5],
+                "std_bits={std_bits}"
+            );
+        }
+    }
+
+    #[test]
+    fn copy_bits_and_std_bits_keep_global_groups_after_destination_clip() {
+        for std_bits in [false, true] {
+            assert_eq!(
+                run_indexed_horizontal_shrink_route(std_bits, 0, true, 0),
+                vec![30, 50, 0xa5, 0xa5],
+                "std_bits={std_bits}"
+            );
+        }
+    }
+
+    #[test]
+    fn copy_bits_and_std_bits_keep_dither_flag_on_legacy_scaler() {
+        for std_bits in [false, true] {
+            assert_eq!(
+                run_indexed_horizontal_shrink_route(std_bits, 0x40, false, 0),
+                vec![0xa5, 10, 30, 0xa5],
+                "std_bits={std_bits}"
+            );
+        }
+    }
+
+    #[test]
+    fn copy_bits_and_std_bits_do_not_select_equal_fallback_from_distinct_unreadable_tables() {
+        for std_bits in [false, true] {
+            assert_eq!(
+                run_indexed_horizontal_shrink_route(std_bits, 0, false, 1),
+                vec![0xa5, 10, 30, 0xa5],
+                "std_bits={std_bits}"
+            );
+        }
+    }
+
+    #[test]
+    fn copy_bits_and_std_bits_keep_valid_nonidentity_palette_on_legacy_scaler() {
+        for std_bits in [false, true] {
+            assert_eq!(
+                run_indexed_horizontal_shrink_route(std_bits, 0, false, 2),
+                vec![0xa5, 200, 30, 0xa5],
+                "std_bits={std_bits}"
+            );
+        }
+    }
+
+    fn run_indexed_horizontal_height_gate(std_bits: bool, bounds_bottom: i16) -> Vec<u8> {
+        let (mut d, mut cpu, mut bus) = setup_with_port();
+        let source_pixmap = bus.alloc(50);
+        let destination_pixmap = bus.alloc(50);
+        let destination_handle = bus.alloc(4);
+        let source_base = bus.alloc(8);
+        let destination_base = bus.alloc(8);
+        let source_rect = bus.alloc(8);
+        let destination_rect = bus.alloc(8);
+        write_pixmap_8(&mut bus, source_pixmap, source_base, 8, 1, 0);
+        bus.write_word(source_pixmap + 6, (-1i16) as u16);
+        bus.write_word(source_pixmap + 10, bounds_bottom as u16);
+        write_pixmap_8(&mut bus, destination_pixmap, destination_base, 3, 1, 0);
+        bus.write_bytes(source_base, &[10, 20, 30, 40, 50, 60, 70, 0]);
+        bus.write_bytes(destination_base, &[0xa5; 4]);
+        write_rect(&mut bus, source_rect, -1, 0, 0, 7);
+        write_rect(&mut bus, destination_rect, 0, 0, 1, 3);
+        cpu.write_reg(Register::A7, TEST_SP);
+        bus.write_long(TEST_SP, 0);
+        bus.write_word(TEST_SP + 4, 0);
+        bus.write_long(TEST_SP + 6, destination_rect);
+        bus.write_long(TEST_SP + 10, source_rect);
+        if std_bits {
+            const PORT: u32 = 0x181000;
+            bus.write_long(destination_handle, destination_pixmap);
+            bus.write_long(PORT + 2, destination_handle);
+            bus.write_word(PORT + 6, 0xc000);
+            *d.current_port = PORT;
+            bus.write_long(TEST_SP + 14, source_pixmap);
+        } else {
+            bus.write_long(TEST_SP + 14, destination_pixmap);
+            bus.write_long(TEST_SP + 18, source_pixmap);
+        }
+        assert!(d
+            .dispatch_quickdraw(
+                true,
+                if std_bits { 0x0eb } else { 0x0ec },
+                &mut cpu,
+                &mut bus,
+            )
+            .unwrap()
+            .is_ok());
+        bus.read_bytes(destination_base, 4)
+    }
+
+    #[test]
+    fn copy_bits_and_std_bits_share_signed_source_height_gate() {
+        for std_bits in [false, true] {
+            assert_eq!(
+                run_indexed_horizontal_height_gate(std_bits, 32_766),
+                vec![20, 50, 70, 0xa5],
+                "32767, std_bits={std_bits}"
+            );
+            assert_eq!(
+                run_indexed_horizontal_height_gate(std_bits, 32_767),
+                vec![0xa5; 4],
+                "32768, std_bits={std_bits}"
+            );
+        }
+    }
+
+    #[test]
+    fn copy_bits_and_std_bits_do_not_fallback_after_selected_failure() {
+        const SOURCE: u32 = 0x00d2_0000;
+        const DESTINATION: u32 = 0x00e2_0000;
+        for trap in [0x0ec, 0x0eb] {
+            for source_failure in [true, false] {
+                let (mut d, mut cpu, mut bus) = setup_with_port();
+                let mut memory = GuestAddressSpace::new();
+                memory.add_region(
+                    SOURCE,
+                    if source_failure {
+                        vec![10, 20, 30, 40, 50, 60]
+                    } else {
+                        vec![10, 20, 30, 40, 50, 60, 70, 0]
+                    },
+                );
+                memory.add_region(DESTINATION, vec![0xa5; 4]);
+                if !source_failure {
+                    memory.add_readonly_region(DESTINATION, vec![0xa5; 3]);
+                }
+                bus.attach_guest_address_space(memory.shared_view());
+                let source_pixmap = bus.alloc(50);
+                let destination_pixmap = bus.alloc(50);
+                let destination_handle = bus.alloc(4);
+                let source_rect = bus.alloc(8);
+                let destination_rect = bus.alloc(8);
+                write_pixmap_8(&mut bus, source_pixmap, SOURCE, 8, 1, 0);
+                write_pixmap_8(&mut bus, destination_pixmap, DESTINATION, 3, 1, 0);
+                write_rect(&mut bus, source_rect, 0, 0, 1, 7);
+                write_rect(&mut bus, destination_rect, 0, 0, 1, 3);
+                cpu.write_reg(Register::A7, TEST_SP);
+                bus.write_long(TEST_SP, 0);
+                bus.write_word(TEST_SP + 4, 0);
+                bus.write_long(TEST_SP + 6, destination_rect);
+                bus.write_long(TEST_SP + 10, source_rect);
+                if trap == 0x0eb {
+                    const PORT: u32 = 0x181000;
+                    bus.write_long(destination_handle, destination_pixmap);
+                    bus.write_long(PORT + 2, destination_handle);
+                    bus.write_word(PORT + 6, 0xc000);
+                    *d.current_port = PORT;
+                    bus.write_long(TEST_SP + 14, source_pixmap);
+                } else {
+                    bus.write_long(TEST_SP + 14, destination_pixmap);
+                    bus.write_long(TEST_SP + 18, source_pixmap);
+                }
+
+                assert!(d
+                    .dispatch_quickdraw(true, trap, &mut cpu, &mut bus)
+                    .unwrap()
+                    .is_ok());
+                let mut actual = [0; 4];
+                memory.read_bytes_into(DESTINATION, &mut actual).unwrap();
+                assert_eq!(
+                    actual, [0xa5; 4],
+                    "trap={trap:03x}, source_failure={source_failure}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn copy_bits_and_std_bits_publish_only_complete_rows_before_selected_refusal() {
+        const SOURCE: u32 = 0x00d3_0000;
+        const DESTINATION: u32 = 0x00e3_0000;
+        for trap in [0x0ec, 0x0eb] {
+            let (mut d, mut cpu, mut bus) = setup_with_port();
+            let mut memory = GuestAddressSpace::new();
+            memory.add_region(
+                SOURCE,
+                vec![
+                    10, 20, 30, 40, 50, 60, 70, 0, 80, 90, 100, 110, 120, 130, 140, 0,
+                ],
+            );
+            memory.add_region(DESTINATION, vec![0xa5; 6]);
+            memory.add_readonly_region(DESTINATION + 3, vec![0xa5; 3]);
+            bus.attach_guest_address_space(memory.shared_view());
+            let source_pixmap = bus.alloc(50);
+            let destination_pixmap = bus.alloc(50);
+            let destination_handle = bus.alloc(4);
+            let source_rect = bus.alloc(8);
+            let destination_rect = bus.alloc(8);
+            write_pixmap_8(&mut bus, source_pixmap, SOURCE, 8, 2, 0);
+            write_pixmap_8(&mut bus, destination_pixmap, DESTINATION, 3, 2, 0);
+            write_rect(&mut bus, source_rect, 0, 0, 2, 7);
+            write_rect(&mut bus, destination_rect, 0, 0, 2, 3);
+            cpu.write_reg(Register::A7, TEST_SP);
+            bus.write_long(TEST_SP, 0);
+            bus.write_word(TEST_SP + 4, 0);
+            bus.write_long(TEST_SP + 6, destination_rect);
+            bus.write_long(TEST_SP + 10, source_rect);
+            if trap == 0x0eb {
+                const PORT: u32 = 0x181000;
+                bus.write_long(destination_handle, destination_pixmap);
+                bus.write_long(PORT + 2, destination_handle);
+                bus.write_word(PORT + 6, 0xc000);
+                *d.current_port = PORT;
+                bus.write_long(TEST_SP + 14, source_pixmap);
+            } else {
+                bus.write_long(TEST_SP + 14, destination_pixmap);
+                bus.write_long(TEST_SP + 18, source_pixmap);
+            }
+
+            assert!(d
+                .dispatch_quickdraw(true, trap, &mut cpu, &mut bus)
+                .unwrap()
+                .is_ok());
+            let mut actual = [0; 6];
+            memory.read_bytes_into(DESTINATION, &mut actual).unwrap();
+            assert_eq!(actual, [20, 50, 70, 0xa5, 0xa5, 0xa5], "trap={trap:03x}");
         }
     }
 

--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -35714,6 +35714,182 @@ mod tests {
         }
     }
 
+    fn run_indexed_horizontal_oracle_route(
+        std_bits: bool,
+        source_width: u16,
+        destination_width: u16,
+        source_left: u16,
+        source_row: &[u8],
+    ) -> Vec<u8> {
+        let (mut d, mut cpu, mut bus) = setup_with_port();
+        let source_stride = u16::try_from((source_row.len() + 1) & !1).unwrap();
+        let destination_stride = (destination_width + 4 + 1) & !1;
+        let source_pixmap = bus.alloc(50);
+        let destination_pixmap = bus.alloc(50);
+        let destination_handle = bus.alloc(4);
+        let source_base = bus.alloc(u32::from(source_stride));
+        let destination_base = bus.alloc(u32::from(destination_stride));
+        let source_rect = bus.alloc(8);
+        let destination_rect = bus.alloc(8);
+
+        write_pixmap_8(&mut bus, source_pixmap, source_base, source_stride, 1, 0);
+        bus.write_word(source_pixmap + 12, source_left + source_width);
+        write_pixmap_8(
+            &mut bus,
+            destination_pixmap,
+            destination_base,
+            destination_stride,
+            1,
+            0,
+        );
+        bus.write_word(destination_pixmap + 12, destination_width);
+        bus.write_bytes(source_base, source_row);
+        bus.write_bytes(
+            destination_base,
+            &vec![0xa5; usize::from(destination_stride)],
+        );
+        write_rect(
+            &mut bus,
+            source_rect,
+            0,
+            source_left as i16,
+            1,
+            (source_left + source_width) as i16,
+        );
+        write_rect(
+            &mut bus,
+            destination_rect,
+            0,
+            0,
+            1,
+            destination_width as i16,
+        );
+
+        cpu.write_reg(Register::A7, TEST_SP);
+        bus.write_long(TEST_SP, 0);
+        bus.write_word(TEST_SP + 4, 0);
+        bus.write_long(TEST_SP + 6, destination_rect);
+        bus.write_long(TEST_SP + 10, source_rect);
+        if std_bits {
+            const PORT: u32 = 0x181000;
+            bus.write_long(destination_handle, destination_pixmap);
+            bus.write_long(PORT + 2, destination_handle);
+            bus.write_word(PORT + 6, 0xc000);
+            *d.current_port = PORT;
+            bus.write_long(TEST_SP + 14, source_pixmap);
+        } else {
+            bus.write_long(TEST_SP + 14, destination_pixmap);
+            bus.write_long(TEST_SP + 18, source_pixmap);
+        }
+
+        assert!(d
+            .dispatch_quickdraw(
+                true,
+                if std_bits { 0x0eb } else { 0x0ec },
+                &mut cpu,
+                &mut bus,
+            )
+            .unwrap()
+            .is_ok());
+        bus.read_bytes(destination_base, usize::from(destination_stride))
+    }
+
+    fn indexed_horizontal_tail_low(source_width: usize) -> Vec<u8> {
+        let mut row = vec![200; (source_width + 3) & !3];
+        row[source_width - 1] = 0;
+        row[source_width] = 254;
+        row
+    }
+
+    fn indexed_horizontal_nonmonotonic(source_width: usize, case_index: usize) -> Vec<u8> {
+        let mut row = vec![0; (source_width + 3) & !3];
+        for (position, value) in row[..source_width].iter_mut().enumerate() {
+            *value = ((position * 73 + case_index * 19) % 251 + 1) as u8;
+        }
+        row[source_width] = 254;
+        row
+    }
+
+    #[test]
+    fn copy_bits_and_std_bits_match_large_indexed_horizontal_oracles() {
+        // Literal results from controlled Mac OS 8.1 CopyBits and StdBits
+        // captures. The tail-low rows isolate the staged physical tail; the
+        // nonmonotonic rows use the captured position encoding verbatim.
+        for std_bits in [false, true] {
+            for source_left in 0..4u16 {
+                let mut row = vec![0x11; usize::from(source_left) + 194];
+                row[..usize::from(source_left)].fill(250);
+                row[usize::from(source_left)..usize::from(source_left) + 190].fill(20);
+                row[usize::from(source_left) + 189] = 30;
+                row[usize::from(source_left) + 190..usize::from(source_left) + 193]
+                    .copy_from_slice(&[200, 150, 140]);
+                let actual =
+                    run_indexed_horizontal_oracle_route(std_bits, 190, 1, source_left, &row);
+                assert_eq!(actual[0], 200);
+                assert!(actual[1..].iter().all(|&byte| byte == 0xa5));
+
+                row.fill(0x11);
+                row[..usize::from(source_left)].fill(250);
+                row[usize::from(source_left)..usize::from(source_left) + 191].fill(20);
+                row[usize::from(source_left) + 190] = 30;
+                row[usize::from(source_left) + 191..usize::from(source_left) + 194]
+                    .copy_from_slice(&[240, 150, 140]);
+                let actual =
+                    run_indexed_horizontal_oracle_route(std_bits, 191, 1, source_left, &row);
+                assert_eq!(actual[0], 30);
+                assert!(actual[1..].iter().all(|&byte| byte == 0xa5));
+            }
+
+            for (source_width, destination_width, source, expected) in [
+                (285, 2, indexed_horizontal_tail_low(285), &[200, 254][..]),
+                (
+                    285,
+                    2,
+                    indexed_horizontal_nonmonotonic(285, 1),
+                    &[251, 254][..],
+                ),
+                (
+                    511,
+                    3,
+                    indexed_horizontal_tail_low(511),
+                    &[200, 200, 254][..],
+                ),
+                (
+                    511,
+                    3,
+                    indexed_horizontal_nonmonotonic(511, 7),
+                    &[251, 249, 254][..],
+                ),
+            ] {
+                let actual = run_indexed_horizontal_oracle_route(
+                    std_bits,
+                    source_width,
+                    destination_width,
+                    0,
+                    &source,
+                );
+                assert_eq!(&actual[..expected.len()], expected);
+                assert!(actual[expected.len()..].iter().all(|&byte| byte == 0xa5));
+            }
+
+            for (source_width, expected) in [(4_097, 65), (5_000, 8), (5_001, 7), (10_924, u8::MAX)]
+            {
+                let source = vec![0; (source_width + 3) & !3];
+                let actual = run_indexed_horizontal_oracle_route(
+                    std_bits,
+                    source_width as u16,
+                    1,
+                    0,
+                    &source,
+                );
+                assert_eq!(
+                    actual[0], expected,
+                    "{source_width}->1, std_bits={std_bits}"
+                );
+                assert!(actual[1..].iter().all(|&byte| byte == 0xa5));
+            }
+        }
+    }
     #[test]
     fn copy_bits_and_std_bits_do_not_fallback_after_selected_failure() {
         const SOURCE: u32 = 0x00d2_0000;

--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -9605,7 +9605,7 @@ mod tests {
         context.attach_memory(0, shared, &mut native);
         let foreign = native.shared_view();
         bus.attach_guest_address_space(foreign);
-        disp.attach_process_context(&mut context);
+        disp.attach_unconverted_process_services(&mut context);
 
         let memory_manager = disp.process_memory_manager();
         let handle = {


### PR DESCRIPTION
Classic and native adapters now construct the migrated tick and execution/menu services from one process owner. A native snapshot clones its execution state once and derives its menu view, removing the runtime repair that previously reconnected independently cloned handles.

Native launch and staged companion activation preflight both services before publishing launch state or taking the staged adapter. Conflicting adoption preserves the prior process state and permits retry. Launch still preserves the existing distinction between shared tick identity and a detached seed; real TickCount reads continue to observe canonical guest memory. Unconverted managers retain explicitly named compatibility attachment paths.

Validation:

- 21 focused construction, clone, mixed-callback, TickCount, refusal/retry, and process-isolation tests passed.
- Headless library: 5,302 passed, 0 failed, 3 ignored.
- Default-feature library: 5,311 passed, 0 failed, 3 ignored.
- Optimized toolbox showcase passed in both 68k and PPC configurations.

The optional full formatting/Clippy checks remain non-clean. Their reported formatting differences, formatter allocation failure, and `mut_from_ref`/`erasing_op` errors are also present in the base revision's CI. Changed items were formatted in bounded passes.

Closes #1576.
