### PR TITLE
refactor: share indexed vertical scaling across toolbox adapters

### DIFF
--- a/src/copy_bits.rs
+++ b/src/copy_bits.rs
@@ -145,6 +145,114 @@ impl Indexed8HorizontalShrink {
     }
 }
 
+/// Pure vertical plan for indexed 8-bit identity-palette scaling. Destination
+/// indices are relative to the complete, unclipped destination rectangle, so
+/// slicing `visible` preserves the original vertical phase.
+///
+/// Imaging With QuickDraw defines rectangle scaling. The source-row carry,
+/// exact-integral reduction branch, and maximum-index reduction are measured
+/// Mac OS 8.1 compatibility behavior.
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) struct Indexed8VerticalScale {
+    groups: Vec<Range<usize>>,
+    source_range: Range<usize>,
+}
+
+impl Indexed8VerticalScale {
+    pub(crate) fn new(
+        source_height: usize,
+        destination_height: usize,
+        visible: Range<usize>,
+    ) -> Option<Self> {
+        if !(1..=i16::MAX as usize).contains(&source_height)
+            || !(1..=i16::MAX as usize).contains(&destination_height)
+            || visible.start > visible.end
+            || visible.end > destination_height
+        {
+            return None;
+        }
+
+        let mut all_groups = Vec::new();
+        all_groups.try_reserve_exact(destination_height).ok()?;
+        if source_height == destination_height {
+            for index in 0..destination_height {
+                all_groups.push(index..index.checked_add(1)?);
+            }
+        } else if source_height > destination_height && source_height % destination_height == 0 {
+            let group_height = source_height / destination_height;
+            for destination in 0..destination_height {
+                let start = destination.checked_mul(group_height)?;
+                all_groups.push(start..start.checked_add(group_height)?);
+            }
+        } else {
+            let source_height = i64::try_from(source_height).ok()?;
+            let destination_height = i64::try_from(destination_height).ok()?;
+            let mut error = -(source_height / 2);
+            let mut source = -1i64;
+            let mut endpoints = Vec::new();
+            endpoints
+                .try_reserve_exact(usize::try_from(destination_height).ok()?)
+                .ok()?;
+            while endpoints.len() < usize::try_from(destination_height).ok()? {
+                source = source.checked_add(1)?;
+                error = error.checked_add(destination_height)?;
+                while error <= 0 && source.checked_add(1)? < source_height {
+                    source = source.checked_add(1)?;
+                    error = error.checked_add(destination_height)?;
+                }
+                loop {
+                    endpoints.push(usize::try_from(source).ok()?);
+                    error = error.checked_sub(source_height)?;
+                    if error < 0 || endpoints.len() == usize::try_from(destination_height).ok()? {
+                        break;
+                    }
+                }
+            }
+
+            if source_height > destination_height {
+                let mut start = 0usize;
+                for endpoint in endpoints {
+                    let end = endpoint.checked_add(1)?;
+                    all_groups.push(start..end);
+                    start = end;
+                }
+            } else {
+                for source in endpoints {
+                    all_groups.push(source..source.checked_add(1)?);
+                }
+            }
+        }
+        if all_groups
+            .iter()
+            .any(|group| group.is_empty() || group.end > source_height)
+        {
+            return None;
+        }
+
+        let visible_groups = all_groups.get(visible.clone())?;
+        let mut groups = Vec::new();
+        groups.try_reserve_exact(visible_groups.len()).ok()?;
+        groups.extend(visible_groups.iter().cloned());
+        let source_range = match (groups.first(), groups.last()) {
+            (Some(first), Some(last)) => first.start..last.end,
+            (None, None) => 0..0,
+            _ => return None,
+        };
+        Some(Self {
+            groups,
+            source_range,
+        })
+    }
+
+    pub(crate) fn groups(&self) -> &[Range<usize>] {
+        &self.groups
+    }
+
+    pub(crate) fn source_range(&self) -> Range<usize> {
+        self.source_range.clone()
+    }
+}
+
 pub(crate) trait CopyBitsMemory {
     fn read_copy_row(&mut self, address: u32, bytes: &mut [u8]) -> Option<()>;
     fn write_copy_row(&mut self, address: u32, bytes: &[u8]) -> Option<()>;
@@ -287,6 +395,27 @@ impl Indexed8HorizontalSelection {
 }
 
 impl RowCopy<'_> {
+    /// Adds the shared indexed scaling families ahead of the existing paths.
+    /// Adapters receive one final outcome, so only a decline before memory is
+    /// touched reaches the legacy implementation.
+    pub(crate) fn execute_with_indexed8_scaling(
+        self,
+        memory: &mut impl CopyBitsMemory,
+        selection: Option<Indexed8HorizontalSelection>,
+    ) -> RowCopyOutcome {
+        if let Some(selection) = selection {
+            let horizontal = self.execute_indexed8_horizontal(memory, selection);
+            if horizontal != RowCopyOutcome::Declined {
+                return horizontal;
+            }
+            let vertical = self.execute_indexed8_vertical(memory, selection);
+            if vertical != RowCopyOutcome::Declined {
+                return vertical;
+            }
+        }
+        self.execute(memory)
+    }
+
     /// Adds the indexed horizontal family ahead of the existing shared paths.
     /// The adapters still receive one final outcome and therefore cannot
     /// accidentally fall back after a selected family has touched memory.
@@ -513,6 +642,238 @@ impl RowCopy<'_> {
             .enumerate()
         {
             if memory.write_copy_row(*destination, row).is_none() {
+                return RowCopyOutcome::WriteFailure { rows_written };
+            }
+        }
+        RowCopyOutcome::Completed
+    }
+
+    /// Executes the measured indexed 8-bit vertical scale family. Required
+    /// source rows are snapshotted before the first write. Rows belonging only
+    /// to clipped-away destination groups are never addressed.
+    fn execute_indexed8_vertical(
+        &self,
+        memory: &mut impl CopyBitsMemory,
+        _selection: Indexed8HorizontalSelection,
+    ) -> RowCopyOutcome {
+        if self.mode != 0
+            || self.source.depth != 8
+            || self.destination.depth != 8
+            || self.palette.is_some()
+        {
+            return RowCopyOutcome::Declined;
+        }
+
+        if self
+            .source_rect
+            .iter()
+            .chain(self.destination_rect.iter())
+            .chain(self.source.bounds.iter())
+            .chain(self.destination.bounds.iter())
+            .chain(self.clip.iter())
+            .any(|&coordinate| i16::try_from(coordinate).is_err())
+        {
+            return RowCopyOutcome::Declined;
+        }
+
+        let [st, sl, sb, sr] = self.source_rect;
+        let [dt, dl, db, dr] = self.destination_rect;
+        let Some(source_width) = sr.checked_sub(sl) else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        let Some(source_height) = sb.checked_sub(st) else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        let Some(destination_width) = dr.checked_sub(dl) else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        let Some(destination_height) = db.checked_sub(dt) else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        if source_width <= 0
+            || source_height <= 0
+            || destination_width <= 0
+            || destination_height <= 0
+        {
+            return RowCopyOutcome::NoOp;
+        }
+        if destination_width != source_width || destination_height == source_height {
+            return RowCopyOutcome::Declined;
+        }
+        if source_width > i32::from(i16::MAX)
+            || source_height > i32::from(i16::MAX)
+            || destination_height > i32::from(i16::MAX)
+        {
+            return RowCopyOutcome::Declined;
+        }
+
+        let [sbt, sbl, sbb, sbr] = self.source.bounds;
+        let Some(source_bounds_height) = sbb.checked_sub(sbt) else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        if source_bounds_height <= 0 {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        }
+        if st < sbt || sl < sbl || sb > sbb || sr > sbr {
+            return RowCopyOutcome::Declined;
+        }
+        let Some(source_y_delta) = st.checked_sub(sbt) else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        let Some(source_x_delta) = sl.checked_sub(sbl) else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        if i16::try_from(source_y_delta).is_err() || i16::try_from(source_x_delta).is_err() {
+            return RowCopyOutcome::Declined;
+        }
+        // Classic QuickDraw's signed source-bounds-height gate is observed at
+        // 32767/32768 for otherwise-identical contained vertical transfers.
+        if source_bounds_height > i32::from(i16::MAX) {
+            return RowCopyOutcome::NoOp;
+        }
+
+        let [dbt, dbl, dbb, dbr] = self.destination.bounds;
+        let [ct, cl, cb, cr] = self.clip;
+        let top = dt.max(dbt).max(ct);
+        let left = dl.max(dbl).max(cl);
+        let bottom = db.min(dbb).min(cb);
+        let right = dr.min(dbr).min(cr);
+        if top >= bottom || left >= right {
+            return RowCopyOutcome::NoOp;
+        }
+
+        let Some(visible_start) = top
+            .checked_sub(dt)
+            .and_then(|value| usize::try_from(value).ok())
+        else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        let Some(visible_end) = bottom
+            .checked_sub(dt)
+            .and_then(|value| usize::try_from(value).ok())
+        else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        let Some(plan) = Indexed8VerticalScale::new(
+            source_height as usize,
+            destination_height as usize,
+            visible_start..visible_end,
+        ) else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        let source_range = plan.source_range();
+        let Some(output_width) = right
+            .checked_sub(left)
+            .and_then(|value| usize::try_from(value).ok())
+        else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+
+        let Some(source_x) = left
+            .checked_sub(dl)
+            .and_then(|offset| sl.checked_add(offset))
+        else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        let mut source_addresses = Vec::new();
+        if source_addresses
+            .try_reserve_exact(source_range.len())
+            .is_err()
+        {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        }
+        for source_index in source_range.clone() {
+            let Some(source_y) = i32::try_from(source_index)
+                .ok()
+                .and_then(|offset| st.checked_add(offset))
+            else {
+                return RowCopyOutcome::ReadOrGeometryFailure;
+            };
+            let Some(address) = self.source.row_address(source_x, source_y, output_width) else {
+                return RowCopyOutcome::ReadOrGeometryFailure;
+            };
+            source_addresses.push(address);
+        }
+
+        let mut destination_addresses = Vec::new();
+        if destination_addresses
+            .try_reserve_exact(plan.groups().len())
+            .is_err()
+        {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        }
+        for destination_y in top..bottom {
+            let Some(address) = self
+                .destination
+                .row_address(left, destination_y, output_width)
+            else {
+                return RowCopyOutcome::ReadOrGeometryFailure;
+            };
+            destination_addresses.push(address);
+        }
+
+        let Some(snapshot_len) = source_range.len().checked_mul(output_width) else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        let mut snapshots = Vec::new();
+        if snapshots.try_reserve_exact(snapshot_len).is_err() {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        }
+        snapshots.resize(snapshot_len, 0);
+        for (row, address) in source_addresses.iter().copied().enumerate() {
+            let Some(start) = row.checked_mul(output_width) else {
+                return RowCopyOutcome::ReadOrGeometryFailure;
+            };
+            let Some(end) = start.checked_add(output_width) else {
+                return RowCopyOutcome::ReadOrGeometryFailure;
+            };
+            if memory
+                .read_copy_row(address, &mut snapshots[start..end])
+                .is_none()
+            {
+                return RowCopyOutcome::ReadOrGeometryFailure;
+            }
+        }
+
+        let Some(output_len) = plan.groups().len().checked_mul(output_width) else {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        };
+        let mut output = Vec::new();
+        if output.try_reserve_exact(output_len).is_err() {
+            return RowCopyOutcome::ReadOrGeometryFailure;
+        }
+        for group in plan.groups() {
+            for x in 0..output_width {
+                let mut maximum = None;
+                for source_index in group.clone() {
+                    let Some(row) = source_index.checked_sub(source_range.start) else {
+                        return RowCopyOutcome::ReadOrGeometryFailure;
+                    };
+                    let Some(index) = row
+                        .checked_mul(output_width)
+                        .and_then(|start| start.checked_add(x))
+                    else {
+                        return RowCopyOutcome::ReadOrGeometryFailure;
+                    };
+                    let Some(value) = snapshots.get(index).copied() else {
+                        return RowCopyOutcome::ReadOrGeometryFailure;
+                    };
+                    maximum = Some(maximum.map_or(value, |current: u8| current.max(value)));
+                }
+                let Some(maximum) = maximum else {
+                    return RowCopyOutcome::ReadOrGeometryFailure;
+                };
+                output.push(maximum);
+            }
+        }
+
+        for (rows_written, (address, row)) in destination_addresses
+            .iter()
+            .copied()
+            .zip(output.chunks_exact(output_width))
+            .enumerate()
+        {
+            if memory.write_copy_row(address, row).is_none() {
                 return RowCopyOutcome::WriteFailure { rows_written };
             }
         }
@@ -918,6 +1279,312 @@ mod tests {
         assert_eq!(plan.reduce(&vec![0; 192]), None);
     }
 
+    // Monotonic source-row indices captured through CopyBits on Mac OS 8.1
+    // for every source/destination height pair in 1..=16.
+    const VERTICAL_GRID_SOURCE_ROWS: &[u8] = &[
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 1,
+        1, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 1, 1, 1,
+        1, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 1, 1,
+        1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1,
+        1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1,
+        1, 1, 2, 0, 2, 0, 1, 2, 0, 0, 1, 2, 0, 0, 1, 1, 2, 0, 0, 1, 1, 2, 2, 0, 0, 0, 1, 1, 2, 2,
+        0, 0, 0, 1, 1, 1, 2, 2, 0, 0, 0, 1, 1, 1, 2, 2, 2, 0, 0, 0, 0, 1, 1, 1, 2, 2, 2, 0, 0, 0,
+        0, 1, 1, 1, 1, 2, 2, 2, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2,
+        2, 2, 2, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2,
+        2, 2, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 1, 3, 0, 2, 3, 0, 1, 2, 3, 0, 1,
+        1, 2, 3, 0, 0, 1, 2, 2, 3, 0, 0, 1, 1, 2, 3, 3, 0, 0, 1, 1, 2, 2, 3, 3, 0, 0, 1, 1, 1, 2,
+        2, 3, 3, 0, 0, 0, 1, 1, 2, 2, 2, 3, 3, 0, 0, 0, 1, 1, 1, 2, 2, 3, 3, 3, 0, 0, 0, 1, 1, 1,
+        2, 2, 2, 3, 3, 3, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 0, 0, 0, 0, 1, 1, 1, 2, 2, 2, 2,
+        3, 3, 3, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 3, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2,
+        3, 3, 3, 3, 4, 1, 3, 0, 2, 4, 0, 1, 3, 4, 0, 1, 2, 3, 4, 0, 1, 1, 2, 3, 4, 0, 0, 1, 2, 3,
+        3, 4, 0, 0, 1, 2, 2, 3, 3, 4, 0, 0, 1, 1, 2, 2, 3, 4, 4, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 0,
+        0, 1, 1, 1, 2, 2, 3, 3, 4, 4, 0, 0, 0, 1, 1, 2, 2, 3, 3, 3, 4, 4, 0, 0, 0, 1, 1, 2, 2, 2,
+        3, 3, 3, 4, 4, 0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 4, 4, 4, 0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3,
+        3, 4, 4, 4, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 2, 5, 1, 3, 5, 0, 2, 3, 5,
+        0, 1, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 2, 3, 4, 5, 0, 1, 1, 2, 3, 4, 4, 5, 0, 0, 1, 2,
+        2, 3, 4, 4, 5, 0, 0, 1, 2, 2, 3, 3, 4, 5, 5, 0, 0, 1, 1, 2, 2, 3, 4, 4, 5, 5, 0, 0, 1, 1,
+        2, 2, 3, 3, 4, 4, 5, 5, 0, 0, 1, 1, 2, 2, 2, 3, 3, 4, 4, 5, 5, 0, 0, 1, 1, 1, 2, 2, 3, 3,
+        4, 4, 4, 5, 5, 0, 0, 0, 1, 1, 2, 2, 2, 3, 3, 4, 4, 4, 5, 5, 0, 0, 0, 1, 1, 2, 2, 2, 3, 3,
+        3, 4, 4, 5, 5, 5, 6, 1, 5, 1, 3, 5, 0, 2, 4, 6, 0, 2, 3, 4, 6, 0, 1, 2, 4, 5, 6, 0, 1, 2,
+        3, 4, 5, 6, 0, 1, 2, 2, 3, 4, 5, 6, 0, 1, 1, 2, 3, 4, 4, 5, 6, 0, 0, 1, 2, 3, 3, 4, 5, 5,
+        6, 0, 0, 1, 2, 2, 3, 4, 4, 5, 5, 6, 0, 0, 1, 1, 2, 3, 3, 4, 4, 5, 6, 6, 0, 0, 1, 1, 2, 2,
+        3, 3, 4, 5, 5, 6, 6, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 0, 0, 1, 1, 2, 2, 2, 3, 3,
+        4, 4, 5, 5, 6, 6, 0, 0, 1, 1, 1, 2, 2, 3, 3, 4, 4, 4, 5, 5, 6, 6, 7, 3, 7, 1, 4, 6, 1, 3,
+        5, 7, 0, 2, 4, 5, 7, 0, 2, 3, 4, 6, 7, 0, 1, 2, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1,
+        2, 3, 3, 4, 5, 6, 7, 0, 1, 1, 2, 3, 4, 5, 5, 6, 7, 0, 1, 1, 2, 3, 3, 4, 5, 6, 6, 7, 0, 0,
+        1, 2, 2, 3, 4, 4, 5, 6, 6, 7, 0, 0, 1, 2, 2, 3, 3, 4, 5, 5, 6, 7, 7, 0, 0, 1, 1, 2, 3, 3,
+        4, 4, 5, 5, 6, 7, 7, 0, 0, 1, 1, 2, 2, 3, 3, 4, 5, 5, 6, 6, 7, 7, 0, 0, 1, 1, 2, 2, 3, 3,
+        4, 4, 5, 5, 6, 6, 7, 7, 8, 2, 6, 2, 5, 8, 1, 3, 5, 7, 0, 2, 4, 6, 8, 0, 2, 3, 5, 6, 8, 0,
+        1, 3, 4, 5, 7, 8, 0, 1, 2, 3, 5, 6, 7, 8, 0, 1, 2, 3, 4, 5, 6, 7, 8, 0, 1, 2, 3, 3, 4, 5,
+        6, 7, 8, 0, 1, 1, 2, 3, 4, 5, 6, 6, 7, 8, 0, 1, 1, 2, 3, 4, 4, 5, 6, 7, 7, 8, 0, 0, 1, 2,
+        3, 3, 4, 5, 5, 6, 7, 7, 8, 0, 0, 1, 2, 2, 3, 4, 4, 5, 6, 6, 7, 7, 8, 0, 0, 1, 2, 2, 3, 3,
+        4, 5, 5, 6, 6, 7, 8, 8, 0, 0, 1, 1, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 8, 8, 9, 4, 9, 1, 5, 8,
+        1, 3, 6, 8, 1, 3, 5, 7, 9, 0, 2, 4, 5, 7, 9, 0, 2, 3, 5, 6, 7, 9, 0, 1, 3, 4, 5, 6, 8, 9,
+        0, 1, 2, 3, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 4, 5, 6, 7, 8, 9,
+        0, 1, 2, 2, 3, 4, 5, 6, 7, 7, 8, 9, 0, 1, 1, 2, 3, 4, 4, 5, 6, 7, 8, 8, 9, 0, 1, 1, 2, 3,
+        3, 4, 5, 6, 6, 7, 8, 8, 9, 0, 0, 1, 2, 2, 3, 4, 4, 5, 6, 6, 7, 8, 8, 9, 0, 0, 1, 2, 2, 3,
+        4, 4, 5, 5, 6, 7, 7, 8, 9, 9, 10, 2, 8, 1, 5, 9, 1, 4, 6, 9, 1, 3, 5, 7, 9, 0, 2, 4, 6, 8,
+        10, 0, 2, 3, 5, 7, 8, 10, 0, 2, 3, 4, 6, 7, 8, 10, 0, 1, 3, 4, 5, 6, 7, 9, 10, 0, 1, 2, 3,
+        4, 6, 7, 8, 9, 10, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 0, 1, 2, 3, 4, 4, 5, 6, 7, 8, 9, 10,
+        0, 1, 2, 2, 3, 4, 5, 6, 7, 7, 8, 9, 10, 0, 1, 1, 2, 3, 4, 5, 5, 6, 7, 8, 8, 9, 10, 0, 1, 1,
+        2, 3, 3, 4, 5, 6, 6, 7, 8, 9, 9, 10, 0, 0, 1, 2, 3, 3, 4, 5, 5, 6, 7, 7, 8, 9, 9, 10, 11,
+        5, 11, 3, 7, 11, 2, 5, 8, 11, 1, 3, 6, 8, 10, 1, 3, 5, 7, 9, 11, 0, 2, 4, 6, 7, 9, 11, 0,
+        2, 3, 5, 6, 8, 9, 11, 0, 2, 3, 4, 6, 7, 8, 10, 11, 0, 1, 3, 4, 5, 6, 7, 9, 10, 11, 0, 1, 2,
+        3, 4, 6, 7, 8, 9, 10, 11, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 0, 1, 2, 3, 4, 5, 5, 6, 7,
+        8, 9, 10, 11, 0, 1, 2, 2, 3, 4, 5, 6, 7, 8, 8, 9, 10, 11, 0, 1, 1, 2, 3, 4, 5, 5, 6, 7, 8,
+        9, 9, 10, 11, 0, 1, 1, 2, 3, 4, 4, 5, 6, 7, 7, 8, 9, 10, 10, 11, 12, 3, 9, 2, 6, 10, 1, 4,
+        8, 11, 1, 3, 6, 9, 11, 1, 3, 5, 7, 9, 11, 0, 2, 4, 6, 8, 10, 12, 0, 2, 4, 5, 7, 8, 10, 12,
+        0, 2, 3, 5, 6, 7, 9, 10, 12, 0, 1, 3, 4, 5, 7, 8, 9, 11, 12, 0, 1, 2, 4, 5, 6, 7, 8, 10,
+        11, 12, 0, 1, 2, 3, 4, 5, 7, 8, 9, 10, 11, 12, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 0,
+        1, 2, 3, 4, 5, 5, 6, 7, 8, 9, 10, 11, 12, 0, 1, 2, 2, 3, 4, 5, 6, 7, 8, 9, 9, 10, 11, 12,
+        0, 1, 1, 2, 3, 4, 5, 6, 6, 7, 8, 9, 10, 10, 11, 12, 13, 6, 13, 2, 7, 11, 1, 5, 8, 12, 1, 4,
+        7, 9, 12, 1, 3, 5, 8, 10, 12, 1, 3, 5, 7, 9, 11, 13, 0, 2, 4, 6, 7, 9, 11, 13, 0, 2, 3, 5,
+        7, 8, 10, 11, 13, 0, 2, 3, 4, 6, 7, 9, 10, 11, 13, 0, 1, 3, 4, 5, 7, 8, 9, 10, 12, 13, 0,
+        1, 2, 4, 5, 6, 7, 8, 9, 11, 12, 13, 0, 1, 2, 3, 4, 5, 7, 8, 9, 10, 11, 12, 13, 0, 1, 2, 3,
+        4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 0, 1, 2, 3, 4, 5, 6, 6, 7, 8, 9, 10, 11, 12, 13, 0, 1, 2,
+        3, 3, 4, 5, 6, 7, 8, 9, 10, 10, 11, 12, 13, 14, 3, 11, 4, 9, 14, 1, 5, 9, 13, 2, 5, 8, 11,
+        14, 1, 3, 6, 8, 11, 13, 1, 3, 5, 7, 9, 11, 13, 0, 2, 4, 6, 8, 10, 12, 14, 0, 2, 4, 5, 7, 9,
+        10, 12, 14, 0, 2, 3, 5, 6, 8, 9, 11, 12, 14, 0, 2, 3, 4, 6, 7, 8, 10, 11, 12, 14, 0, 1, 3,
+        4, 5, 6, 8, 9, 10, 11, 13, 14, 0, 1, 2, 4, 5, 6, 7, 8, 9, 10, 12, 13, 14, 0, 1, 2, 3, 4, 5,
+        6, 8, 9, 10, 11, 12, 13, 14, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 0, 1, 2, 3,
+        4, 5, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 7, 15, 2, 8, 13, 3, 7, 11, 15, 1, 4, 8, 11,
+        14, 1, 4, 6, 9, 12, 14, 1, 3, 5, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15, 0, 2, 4, 6, 8,
+        9, 11, 13, 15, 0, 2, 4, 5, 7, 8, 10, 12, 13, 15, 0, 2, 3, 5, 6, 8, 9, 10, 12, 13, 15, 0, 2,
+        3, 4, 6, 7, 8, 10, 11, 12, 14, 15, 0, 1, 3, 4, 5, 6, 8, 9, 10, 11, 12, 14, 15, 0, 1, 2, 4,
+        5, 6, 7, 8, 9, 10, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1,
+        2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+    ];
+
+    #[test]
+    fn indexed_vertical_groups_match_independent_oracle_boundaries() {
+        for (source, destination, expected) in [
+            (3, 2, &[0..1, 1..3][..]),
+            (5, 3, &[0..1, 1..3, 3..5][..]),
+            (17, 7, &[0..2, 2..4, 4..7, 7..9, 9..11, 11..14, 14..16][..]),
+            (
+                17,
+                16,
+                &[
+                    0..1,
+                    1..2,
+                    2..3,
+                    3..4,
+                    4..5,
+                    5..6,
+                    6..7,
+                    7..8,
+                    8..10,
+                    10..11,
+                    11..12,
+                    12..13,
+                    13..14,
+                    14..15,
+                    15..16,
+                    16..17,
+                ][..],
+            ),
+            (
+                17,
+                18,
+                &[
+                    0..1,
+                    1..2,
+                    2..3,
+                    3..4,
+                    4..5,
+                    5..6,
+                    6..7,
+                    7..8,
+                    7..8,
+                    8..9,
+                    9..10,
+                    10..11,
+                    11..12,
+                    12..13,
+                    13..14,
+                    14..15,
+                    15..16,
+                    16..17,
+                ][..],
+            ),
+        ] {
+            let plan = Indexed8VerticalScale::new(source, destination, 0..destination)
+                .expect("captured vertical geometry is supported");
+            assert_eq!(plan.groups(), expected);
+        }
+
+        for (source, destination, expected) in [
+            (4, 1, &[0..4][..]),
+            (8, 2, &[0..4, 4..8][..]),
+            (6, 2, &[0..3, 3..6][..]),
+        ] {
+            let plan = Indexed8VerticalScale::new(source, destination, 0..destination).unwrap();
+            assert_eq!(plan.groups(), expected);
+        }
+        for (source, factor) in [(34, 2), (51, 3)] {
+            let expected: Vec<_> = (0..17)
+                .map(|index| index * factor..index * factor + factor)
+                .collect();
+            let plan = Indexed8VerticalScale::new(source, 17, 0..17).unwrap();
+            assert_eq!(plan.groups(), expected);
+        }
+    }
+
+    #[test]
+    fn indexed_vertical_groups_match_complete_captured_small_grid() {
+        let mut cursor = 0;
+        for source in 1..=16 {
+            for destination in 1..=16 {
+                let expected = &VERTICAL_GRID_SOURCE_ROWS[cursor..cursor + destination];
+                cursor += destination;
+                let plan = Indexed8VerticalScale::new(source, destination, 0..destination).unwrap();
+                let selected: Vec<u8> = plan
+                    .groups()
+                    .iter()
+                    .map(|group| u8::try_from(group.end - 1).unwrap())
+                    .collect();
+                assert_eq!(
+                    selected, expected,
+                    "source={source}, destination={destination}"
+                );
+            }
+        }
+        assert_eq!(cursor, VERTICAL_GRID_SOURCE_ROWS.len());
+    }
+
+    #[test]
+    fn indexed_vertical_phase_holdouts_and_visible_slice_match_captures() {
+        let shrink = Indexed8VerticalScale::new(257, 256, 0..256).unwrap();
+        let shrink_rows: Vec<_> = shrink.groups().iter().map(|group| group.end - 1).collect();
+        let expected_shrink: Vec<_> = (0..128).chain(129..257).collect();
+        assert_eq!(shrink_rows, expected_shrink);
+        let enlarge = Indexed8VerticalScale::new(256, 257, 0..257).unwrap();
+        let enlarge_rows: Vec<_> = enlarge.groups().iter().map(|group| group.start).collect();
+        let expected_enlarge: Vec<_> = (0..128).chain(127..256).collect();
+        assert_eq!(enlarge_rows, expected_enlarge);
+
+        let full = Indexed8VerticalScale::new(17, 7, 0..7).unwrap();
+        let clipped = Indexed8VerticalScale::new(17, 7, 2..6).unwrap();
+        assert_eq!(clipped.groups(), &full.groups()[2..6]);
+        assert_eq!(clipped.source_range(), 4..14);
+        for visible in [0..1, 3..4, 6..7] {
+            let sliced = Indexed8VerticalScale::new(17, 7, visible.clone()).unwrap();
+            assert_eq!(sliced.groups(), &full.groups()[visible]);
+        }
+        assert!(Indexed8VerticalScale::new(17, 7, 3..3)
+            .unwrap()
+            .source_range()
+            .is_empty());
+    }
+
+    #[test]
+    fn indexed_vertical_plan_has_checked_nonempty_groups_over_broad_domain() {
+        for source in 1..=128 {
+            for destination in 1..=128 {
+                let plan = Indexed8VerticalScale::new(source, destination, 0..destination).unwrap();
+                assert_eq!(plan.groups().len(), destination);
+                assert!(plan.groups().iter().all(|group| !group.is_empty()));
+                assert!(plan
+                    .groups()
+                    .windows(2)
+                    .all(|pair| pair[0].start <= pair[1].start));
+                assert!(plan.groups().iter().all(|group| group.end <= source));
+            }
+        }
+        for (source, destination) in [
+            (190, 1),
+            (191, 1),
+            (256, 257),
+            (257, 256),
+            (285, 2),
+            (511, 3),
+            (4097, 1),
+            (5000, 3),
+            (10_924, 1),
+            (32_767, 2),
+            (2, 32_767),
+        ] {
+            let plan = Indexed8VerticalScale::new(source, destination, 0..destination).unwrap();
+            assert_eq!(plan.groups().len(), destination);
+            assert!(plan
+                .groups()
+                .iter()
+                .all(|group| !group.is_empty() && group.end <= source));
+            assert!(plan.source_range().end <= source);
+        }
+        for (source, destination, visible) in [
+            (0, 1, 0..1),
+            (1, 0, 0..0),
+            (i16::MAX as usize + 1, 1, 0..1),
+            (1, i16::MAX as usize + 1, 0..1),
+            (5, 3, std::ops::Range { start: 2, end: 1 }),
+            (5, 3, 0..4),
+        ] {
+            assert!(Indexed8VerticalScale::new(source, destination, visible).is_none());
+        }
+    }
+
+    #[test]
+    fn indexed_vertical_groups_match_independent_source_row_walk() {
+        for source in 1usize..=64 {
+            for destination in 1usize..=64 {
+                if source == destination {
+                    continue;
+                }
+                let expected = if source > destination && source % destination == 0 {
+                    let height = source / destination;
+                    (0..destination)
+                        .map(|index| index * height..(index + 1) * height)
+                        .collect::<Vec<_>>()
+                } else {
+                    // This reference walks each source row once and emits all
+                    // destination rows reached there, rather than advancing
+                    // source rows on demand for each destination endpoint.
+                    let mut error = -(i64::try_from(source).unwrap() / 2);
+                    let mut endpoints = Vec::new();
+                    for source_row in 0..source {
+                        error += i64::try_from(destination).unwrap();
+                        if error > 0 {
+                            loop {
+                                endpoints.push(source_row);
+                                error -= i64::try_from(source).unwrap();
+                                if error < 0 || endpoints.len() == destination {
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    if source > destination {
+                        let mut start = 0;
+                        endpoints
+                            .into_iter()
+                            .map(|endpoint| {
+                                let group = start..endpoint + 1;
+                                start = endpoint + 1;
+                                group
+                            })
+                            .collect()
+                    } else {
+                        endpoints
+                            .into_iter()
+                            .map(|source_row| source_row..source_row + 1)
+                            .collect()
+                    }
+                };
+                let plan = Indexed8VerticalScale::new(source, destination, 0..destination).unwrap();
+                assert_eq!(
+                    plan.groups(),
+                    expected,
+                    "source={source}, destination={destination}"
+                );
+            }
+        }
+    }
+
     fn run(memory: &mut GuestAddressSpace, classic: bool, copy: RowCopy<'_>) -> RowCopyOutcome {
         if classic {
             let mut bus = MacMemoryBus::new(0x10000);
@@ -985,6 +1652,344 @@ mod tests {
             }
             Some(())
         }
+    }
+
+    #[test]
+    fn indexed_vertical_executor_preserves_phase_and_avoids_discarded_rows_and_columns() {
+        let mut memory = SparseMemory::default();
+        // Only the source rows and columns needed by logical destination rows
+        // 2..6 and columns 1..3 are mapped.
+        for source_index in 4u32..14 {
+            memory.insert(
+                SOURCE + (source_index + 5) * 4 + 1,
+                &[20 + source_index as u8, 40 + source_index as u8],
+            );
+        }
+        memory.insert(DESTINATION, &[0xa5; 28]);
+        let copy = RowCopy {
+            mode: 0,
+            source: pixmap(SOURCE, 4, 8, [0, 0, 30, 3]),
+            destination: pixmap(DESTINATION, 4, 8, [0, 10, 7, 13]),
+            source_rect: [5, 0, 22, 3],
+            destination_rect: [0, 10, 7, 13],
+            clip: [2, 11, 6, 13],
+            palette: None,
+        };
+        assert_eq!(
+            copy.execute_with_indexed8_scaling(&mut memory, Some(indexed_selection())),
+            RowCopyOutcome::Completed
+        );
+        assert_eq!(
+            memory.bytes(DESTINATION, 28),
+            [
+                0xa5, 0xa5, 0xa5, 0xa5, 0xa5, 0xa5, 0xa5, 0xa5, 0xa5, 26, 46, 0xa5, 0xa5, 28, 48,
+                0xa5, 0xa5, 30, 50, 0xa5, 0xa5, 33, 53, 0xa5, 0xa5, 0xa5, 0xa5, 0xa5,
+            ]
+        );
+    }
+
+    #[test]
+    fn indexed_vertical_executor_enlarges_by_repeating_captured_rows() {
+        let mut memory = SparseMemory::default();
+        memory.insert(SOURCE, &[10, 20, 30, 40, 50]);
+        memory.insert(DESTINATION, &[0xa5; 14]);
+        let copy = RowCopy {
+            mode: 0,
+            source: pixmap(SOURCE, 1, 8, [0, 0, 5, 1]),
+            destination: pixmap(DESTINATION, 2, 8, [0, 0, 7, 1]),
+            source_rect: [0, 0, 5, 1],
+            destination_rect: [0, 0, 7, 1],
+            clip: [0, 0, 7, 1],
+            palette: None,
+        };
+        assert_eq!(
+            copy.execute_with_indexed8_scaling(&mut memory, Some(indexed_selection())),
+            RowCopyOutcome::Completed
+        );
+        assert_eq!(
+            memory.bytes(DESTINATION, 14),
+            [10, 0xa5, 10, 0xa5, 20, 0xa5, 30, 0xa5, 40, 0xa5, 40, 0xa5, 50, 0xa5]
+        );
+    }
+
+    #[test]
+    fn indexed_vertical_executor_snapshots_aliasing_rows_before_writes() {
+        let mut memory = SparseMemory::default();
+        memory.insert(SOURCE, &[1, 11, 4, 14, 3, 13, 8, 18, 2, 12]);
+        let copy = RowCopy {
+            mode: 0,
+            source: pixmap(SOURCE, 2, 8, [0, 0, 5, 2]),
+            destination: pixmap(SOURCE + 2, 2, 8, [0, 0, 3, 2]),
+            source_rect: [0, 0, 5, 2],
+            destination_rect: [0, 0, 3, 2],
+            clip: [0, 0, 3, 2],
+            palette: None,
+        };
+        assert_eq!(
+            copy.execute_with_indexed8_scaling(&mut memory, Some(indexed_selection())),
+            RowCopyOutcome::Completed
+        );
+        assert_eq!(memory.bytes(SOURCE + 2, 6), [1, 11, 4, 14, 8, 18]);
+
+        let mut reverse = SparseMemory::default();
+        reverse.insert(SOURCE, &[0xa5, 0xa5, 1, 11, 4, 14, 3, 13, 8, 18, 2, 12]);
+        let copy = RowCopy {
+            mode: 0,
+            source: pixmap(SOURCE + 2, 2, 8, [0, 0, 5, 2]),
+            destination: pixmap(SOURCE, 2, 8, [0, 0, 3, 2]),
+            source_rect: [0, 0, 5, 2],
+            destination_rect: [0, 0, 3, 2],
+            clip: [0, 0, 3, 2],
+            palette: None,
+        };
+        assert_eq!(
+            copy.execute_with_indexed8_scaling(&mut reverse, Some(indexed_selection())),
+            RowCopyOutcome::Completed
+        );
+        assert_eq!(reverse.bytes(SOURCE, 6), [1, 11, 4, 14, 8, 18]);
+
+        let mut same_base = SparseMemory::default();
+        same_base.insert(SOURCE, &[1, 11, 4, 14, 3, 13, 8, 18, 2, 12]);
+        let reduction = RowCopy {
+            mode: 0,
+            source: pixmap(SOURCE, 2, 8, [0, 0, 5, 2]),
+            destination: pixmap(SOURCE, 2, 8, [0, 0, 3, 2]),
+            source_rect: [0, 0, 5, 2],
+            destination_rect: [0, 0, 3, 2],
+            clip: [0, 0, 3, 2],
+            palette: None,
+        };
+        assert_eq!(
+            reduction.execute_with_indexed8_scaling(&mut same_base, Some(indexed_selection())),
+            RowCopyOutcome::Completed
+        );
+        assert_eq!(same_base.bytes(SOURCE, 6), [1, 11, 4, 14, 8, 18]);
+
+        let mut same_base_enlarge = SparseMemory::default();
+        same_base_enlarge.insert(
+            SOURCE,
+            &[
+                10, 0xa5, 20, 0xa5, 30, 0xa5, 40, 0xa5, 50, 0xa5, 0xa5, 0xa5, 0xa5, 0xa5,
+            ],
+        );
+        let enlargement = RowCopy {
+            mode: 0,
+            source: pixmap(SOURCE, 2, 8, [0, 0, 5, 1]),
+            destination: pixmap(SOURCE, 2, 8, [0, 0, 7, 1]),
+            source_rect: [0, 0, 5, 1],
+            destination_rect: [0, 0, 7, 1],
+            clip: [0, 0, 7, 1],
+            palette: None,
+        };
+        assert_eq!(
+            enlargement
+                .execute_with_indexed8_scaling(&mut same_base_enlarge, Some(indexed_selection()),),
+            RowCopyOutcome::Completed
+        );
+        assert_eq!(
+            same_base_enlarge.bytes(SOURCE, 14),
+            [10, 0xa5, 10, 0xa5, 20, 0xa5, 30, 0xa5, 40, 0xa5, 40, 0xa5, 50, 0xa5]
+        );
+    }
+
+    #[test]
+    fn indexed_vertical_failures_preserve_prewrite_and_partial_row_contracts() {
+        let request = || RowCopy {
+            mode: 0,
+            source: pixmap(SOURCE, 2, 8, [0, 0, 5, 2]),
+            destination: pixmap(DESTINATION, 2, 8, [0, 0, 3, 2]),
+            source_rect: [0, 0, 5, 2],
+            destination_rect: [0, 0, 3, 2],
+            clip: [0, 0, 3, 2],
+            palette: None,
+        };
+
+        let mut read_failure = SparseMemory::default();
+        read_failure.insert(SOURCE, &[1, 11, 4, 14, 3, 13, 8, 18, 2, 12]);
+        read_failure.insert(DESTINATION, &[0xa5; 6]);
+        read_failure.fail_read = Some(SOURCE + 4);
+        assert_eq!(
+            request().execute_with_indexed8_scaling(&mut read_failure, Some(indexed_selection()),),
+            RowCopyOutcome::ReadOrGeometryFailure
+        );
+        assert!(read_failure.writes.is_empty());
+        assert_eq!(read_failure.bytes(DESTINATION, 6), [0xa5; 6]);
+
+        let mut write_failure = SparseMemory::default();
+        write_failure.insert(SOURCE, &[1, 11, 4, 14, 3, 13, 8, 18, 2, 12]);
+        write_failure.insert(DESTINATION, &[0xa5; 6]);
+        write_failure.fail_write = Some(DESTINATION + 2);
+        assert_eq!(
+            request().execute_with_indexed8_scaling(&mut write_failure, Some(indexed_selection()),),
+            RowCopyOutcome::WriteFailure { rows_written: 1 }
+        );
+        assert_eq!(write_failure.writes, [DESTINATION]);
+        assert_eq!(
+            write_failure.bytes(DESTINATION, 6),
+            [1, 11, 0xa5, 0xa5, 0xa5, 0xa5]
+        );
+
+        let mut first_write_failure = SparseMemory::default();
+        first_write_failure.insert(SOURCE, &[1, 11, 4, 14, 3, 13, 8, 18, 2, 12]);
+        first_write_failure.insert(DESTINATION, &[0xa5; 6]);
+        first_write_failure.fail_write = Some(DESTINATION);
+        assert_eq!(
+            request().execute_with_indexed8_scaling(
+                &mut first_write_failure,
+                Some(indexed_selection()),
+            ),
+            RowCopyOutcome::WriteFailure { rows_written: 0 }
+        );
+        assert!(first_write_failure.writes.is_empty());
+        assert_eq!(first_write_failure.bytes(DESTINATION, 6), [0xa5; 6]);
+    }
+
+    #[test]
+    fn indexed_vertical_signed_source_height_noop_and_exclusions_do_not_access_memory() {
+        struct NoAccess;
+        impl CopyBitsMemory for NoAccess {
+            fn read_copy_row(&mut self, _: u32, _: &mut [u8]) -> Option<()> {
+                panic!("excluded vertical transfer reached source memory");
+            }
+
+            fn write_copy_row(&mut self, _: u32, _: &[u8]) -> Option<()> {
+                panic!("excluded vertical transfer reached destination memory");
+            }
+        }
+
+        let request = |source_bounds, source_rect, destination_rect, palette| RowCopy {
+            mode: 0,
+            source: pixmap(SOURCE, 8, 8, source_bounds),
+            destination: pixmap(DESTINATION, 8, 8, [0, 0, 8, 8]),
+            source_rect,
+            destination_rect,
+            clip: [0, 0, 8, 8],
+            palette,
+        };
+        assert_eq!(
+            request([-1, 0, 32_767, 7], [-1, 0, 0, 7], [0, 0, 3, 7], None,)
+                .execute_indexed8_vertical(&mut NoAccess, indexed_selection()),
+            RowCopyOutcome::NoOp
+        );
+        assert_eq!(
+            request([0, 0, 5, 7], [0, 0, 5, 7], [0, 0, 3, 6], None)
+                .execute_indexed8_vertical(&mut NoAccess, indexed_selection()),
+            RowCopyOutcome::Declined
+        );
+        assert_eq!(
+            request([0, 0, 5, 7], [0, 0, 5, 7], [0, 0, 3, 7], Some(&[0; 256]))
+                .execute_indexed8_vertical(&mut NoAccess, indexed_selection()),
+            RowCopyOutcome::Declined
+        );
+        assert_eq!(
+            request(
+                [i16::MIN.into(), 0, i16::MAX.into(), 7],
+                [0, 0, 5, 7],
+                [0, 0, 3, 7],
+                None,
+            )
+            .execute_indexed8_vertical(&mut NoAccess, indexed_selection()),
+            RowCopyOutcome::Declined
+        );
+        assert_eq!(
+            request(
+                [i16::MIN.into(), 0, i16::MAX.into(), 7],
+                [i16::MIN.into(), 0, 1, 7],
+                [0, 0, 3, 7],
+                None,
+            )
+            .execute_indexed8_vertical(&mut NoAccess, indexed_selection()),
+            RowCopyOutcome::Declined
+        );
+    }
+
+    #[test]
+    fn indexed_vertical_signed_source_bounds_threshold_matches_capture() {
+        let mut source = Vec::new();
+        for row in 1..=17u8 {
+            source.extend_from_slice(&[row * 10; 7]);
+            source.push(0xa5);
+        }
+        let mut memory = SparseMemory::default();
+        memory.insert(SOURCE, &source);
+        memory.insert(DESTINATION, &[0xa5; 56]);
+        let selected = RowCopy {
+            mode: 0,
+            source: pixmap(SOURCE, 8, 8, [-1, 0, 32_766, 7]),
+            destination: pixmap(DESTINATION, 8, 8, [0, 0, 7, 7]),
+            source_rect: [-1, 0, 16, 7],
+            destination_rect: [0, 0, 7, 7],
+            clip: [0, 0, 7, 7],
+            palette: None,
+        };
+        assert_eq!(
+            selected.execute_indexed8_vertical(&mut memory, indexed_selection()),
+            RowCopyOutcome::Completed
+        );
+        let mut expected = Vec::new();
+        for value in [20, 40, 70, 90, 110, 140, 160] {
+            expected.extend_from_slice(&[value; 7]);
+            expected.push(0xa5);
+        }
+        assert_eq!(memory.bytes(DESTINATION, 56), expected);
+
+        struct NoAccess;
+        impl CopyBitsMemory for NoAccess {
+            fn read_copy_row(&mut self, _: u32, _: &mut [u8]) -> Option<()> {
+                panic!("height-32768 no-op reached source memory");
+            }
+
+            fn write_copy_row(&mut self, _: u32, _: &[u8]) -> Option<()> {
+                panic!("height-32768 no-op reached destination memory");
+            }
+        }
+        let excluded = RowCopy {
+            mode: 0,
+            source: pixmap(SOURCE, 8, 8, [-1, 0, 32_767, 7]),
+            destination: pixmap(DESTINATION, 8, 8, [0, 0, 7, 7]),
+            source_rect: [-1, 0, 16, 7],
+            destination_rect: [0, 0, 7, 7],
+            clip: [0, 0, 7, 7],
+            palette: None,
+        };
+        assert_eq!(
+            excluded.execute_indexed8_vertical(&mut NoAccess, indexed_selection()),
+            RowCopyOutcome::NoOp
+        );
+    }
+
+    #[test]
+    fn indexed_vertical_invalid_final_addresses_fail_before_memory_access() {
+        struct NoAccess;
+        impl CopyBitsMemory for NoAccess {
+            fn read_copy_row(&mut self, _: u32, _: &mut [u8]) -> Option<()> {
+                panic!("invalid vertical geometry reached source memory");
+            }
+
+            fn write_copy_row(&mut self, _: u32, _: &[u8]) -> Option<()> {
+                panic!("invalid vertical geometry reached destination memory");
+            }
+        }
+
+        let request = |source, destination| RowCopy {
+            mode: 0,
+            source: pixmap(source, 4, 8, [0, 0, 5, 4]),
+            destination: pixmap(destination, 4, 8, [0, 0, 3, 4]),
+            source_rect: [0, 0, 5, 4],
+            destination_rect: [0, 0, 3, 4],
+            clip: [0, 0, 3, 4],
+            palette: None,
+        };
+        assert_eq!(
+            request(u32::MAX - 3, DESTINATION)
+                .execute_indexed8_vertical(&mut NoAccess, indexed_selection()),
+            RowCopyOutcome::ReadOrGeometryFailure
+        );
+        assert_eq!(
+            request(SOURCE, u32::MAX - 3)
+                .execute_indexed8_vertical(&mut NoAccess, indexed_selection()),
+            RowCopyOutcome::ReadOrGeometryFailure
+        );
     }
 
     #[test]

--- a/src/copy_bits.rs
+++ b/src/copy_bits.rs
@@ -1977,9 +1977,7 @@ mod tests {
 
     #[test]
     fn indexed_scaling_selection_requires_all_adapter_provenance() {
-        assert!(
-            Indexed8ScalingSelection::from_adapter_facts(true, true, true, true, 0).is_some()
-        );
+        assert!(Indexed8ScalingSelection::from_adapter_facts(true, true, true, true, 0).is_some());
         for facts in [
             (false, true, true, true, 0),
             (true, false, true, true, 0),
@@ -2008,8 +2006,7 @@ mod tests {
             clip: [0, 0, 1, 3],
             palette: None,
         };
-        let selection =
-            Indexed8ScalingSelection::from_adapter_facts(true, true, true, true, 0x40);
+        let selection = Indexed8ScalingSelection::from_adapter_facts(true, true, true, true, 0x40);
         assert_eq!(
             copy.execute_with_indexed8_scaling(&mut memory, selection),
             RowCopyOutcome::Completed
@@ -2132,8 +2129,7 @@ mod tests {
         read_failure.insert(DESTINATION, &[0xaa; 6]);
         read_failure.fail_read = Some(SOURCE + 8);
         assert_eq!(
-            request()
-                .execute_with_indexed8_scaling(&mut read_failure, Some(indexed_selection()),),
+            request().execute_with_indexed8_scaling(&mut read_failure, Some(indexed_selection()),),
             RowCopyOutcome::ReadOrGeometryFailure
         );
         assert!(read_failure.writes.is_empty());
@@ -2145,8 +2141,7 @@ mod tests {
         write_failure.insert(DESTINATION, &[0xaa; 6]);
         write_failure.fail_write = Some(DESTINATION + 3);
         assert_eq!(
-            request()
-                .execute_with_indexed8_scaling(&mut write_failure, Some(indexed_selection()),),
+            request().execute_with_indexed8_scaling(&mut write_failure, Some(indexed_selection()),),
             RowCopyOutcome::WriteFailure { rows_written: 1 }
         );
         assert_eq!(write_failure.writes, [DESTINATION]);

--- a/src/copy_bits.rs
+++ b/src/copy_bits.rs
@@ -1,4 +1,4 @@
-//! Shared byte-aligned and packed, unscaled srcCopy transfers.
+//! Shared byte-aligned and packed srcCopy transfers.
 //! Imaging With QuickDraw (1994), pp. 3-112–3-117 and 4-27–4-28.
 //! ABI decoding, port/mask resolution and picture recording stay at the callers
 //! until their corresponding operation families migrate.
@@ -375,9 +375,9 @@ pub(crate) enum RowCopyOutcome {
 /// and its raw mode is exactly `srcCopy` without the separately defined dither
 /// flag.
 #[derive(Clone, Copy, Debug)]
-pub(crate) struct Indexed8HorizontalSelection(());
+pub(crate) struct Indexed8ScalingSelection(());
 
-impl Indexed8HorizontalSelection {
+impl Indexed8ScalingSelection {
     pub(crate) fn from_adapter_facts(
         mask_free: bool,
         source_bounds_are_original: bool,
@@ -401,7 +401,7 @@ impl RowCopy<'_> {
     pub(crate) fn execute_with_indexed8_scaling(
         self,
         memory: &mut impl CopyBitsMemory,
-        selection: Option<Indexed8HorizontalSelection>,
+        selection: Option<Indexed8ScalingSelection>,
     ) -> RowCopyOutcome {
         if let Some(selection) = selection {
             let horizontal = self.execute_indexed8_horizontal(memory, selection);
@@ -411,23 +411,6 @@ impl RowCopy<'_> {
             let vertical = self.execute_indexed8_vertical(memory, selection);
             if vertical != RowCopyOutcome::Declined {
                 return vertical;
-            }
-        }
-        self.execute(memory)
-    }
-
-    /// Adds the indexed horizontal family ahead of the existing shared paths.
-    /// The adapters still receive one final outcome and therefore cannot
-    /// accidentally fall back after a selected family has touched memory.
-    pub(crate) fn execute_with_indexed8_horizontal(
-        self,
-        memory: &mut impl CopyBitsMemory,
-        selection: Option<Indexed8HorizontalSelection>,
-    ) -> RowCopyOutcome {
-        if let Some(selection) = selection {
-            let outcome = self.execute_indexed8_horizontal(memory, selection);
-            if outcome != RowCopyOutcome::Declined {
-                return outcome;
             }
         }
         self.execute(memory)
@@ -443,7 +426,7 @@ impl RowCopy<'_> {
     fn execute_indexed8_horizontal(
         &self,
         memory: &mut impl CopyBitsMemory,
-        _selection: Indexed8HorizontalSelection,
+        _selection: Indexed8ScalingSelection,
     ) -> RowCopyOutcome {
         if self.mode != 0
             || self.source.depth != 8
@@ -654,7 +637,7 @@ impl RowCopy<'_> {
     fn execute_indexed8_vertical(
         &self,
         memory: &mut impl CopyBitsMemory,
-        _selection: Indexed8HorizontalSelection,
+        _selection: Indexed8ScalingSelection,
     ) -> RowCopyOutcome {
         if self.mode != 0
             || self.source.depth != 8
@@ -1605,8 +1588,8 @@ mod tests {
         }
     }
 
-    fn indexed_selection() -> Indexed8HorizontalSelection {
-        Indexed8HorizontalSelection::from_adapter_facts(true, true, true, true, 0).unwrap()
+    fn indexed_selection() -> Indexed8ScalingSelection {
+        Indexed8ScalingSelection::from_adapter_facts(true, true, true, true, 0).unwrap()
     }
 
     #[derive(Default)]
@@ -1993,9 +1976,9 @@ mod tests {
     }
 
     #[test]
-    fn indexed_horizontal_selection_requires_all_adapter_provenance() {
+    fn indexed_scaling_selection_requires_all_adapter_provenance() {
         assert!(
-            Indexed8HorizontalSelection::from_adapter_facts(true, true, true, true, 0).is_some()
+            Indexed8ScalingSelection::from_adapter_facts(true, true, true, true, 0).is_some()
         );
         for facts in [
             (false, true, true, true, 0),
@@ -2004,7 +1987,7 @@ mod tests {
             (true, true, true, false, 0),
             (true, true, true, true, 0x40),
         ] {
-            assert!(Indexed8HorizontalSelection::from_adapter_facts(
+            assert!(Indexed8ScalingSelection::from_adapter_facts(
                 facts.0, facts.1, facts.2, facts.3, facts.4
             )
             .is_none());
@@ -2026,9 +2009,9 @@ mod tests {
             palette: None,
         };
         let selection =
-            Indexed8HorizontalSelection::from_adapter_facts(true, true, true, true, 0x40);
+            Indexed8ScalingSelection::from_adapter_facts(true, true, true, true, 0x40);
         assert_eq!(
-            copy.execute_with_indexed8_horizontal(&mut memory, selection),
+            copy.execute_with_indexed8_scaling(&mut memory, selection),
             RowCopyOutcome::Completed
         );
         assert_eq!(memory.bytes(DESTINATION, 4), [1, 2, 3, 0xaa]);
@@ -2052,7 +2035,7 @@ mod tests {
             palette: None,
         };
         assert_eq!(
-            copy.execute_with_indexed8_horizontal(&mut memory, Some(indexed_selection())),
+            copy.execute_with_indexed8_scaling(&mut memory, Some(indexed_selection())),
             RowCopyOutcome::Completed
         );
         assert_eq!(
@@ -2080,7 +2063,7 @@ mod tests {
             palette: None,
         };
         assert_eq!(
-            copy.execute_with_indexed8_horizontal(&mut memory, Some(indexed_selection())),
+            copy.execute_with_indexed8_scaling(&mut memory, Some(indexed_selection())),
             RowCopyOutcome::Completed
         );
         assert_eq!(memory.bytes(SOURCE + 8, 6), [9, 2, 4, 5, 6, 7]);
@@ -2100,7 +2083,7 @@ mod tests {
             palette: None,
         };
         assert_eq!(
-            copy.execute_with_indexed8_horizontal(&mut memory, Some(indexed_selection())),
+            copy.execute_with_indexed8_scaling(&mut memory, Some(indexed_selection())),
             RowCopyOutcome::Completed
         );
         assert_eq!(memory.bytes(SOURCE, 5), [1, 9, 2, 4, 4]);
@@ -2125,7 +2108,7 @@ mod tests {
             palette: None,
         };
         assert_eq!(
-            copy.execute_with_indexed8_horizontal(&mut memory, Some(indexed_selection())),
+            copy.execute_with_indexed8_scaling(&mut memory, Some(indexed_selection())),
             RowCopyOutcome::Completed
         );
         assert_eq!(memory.bytes(SOURCE + 190, 2), [100, 90]);
@@ -2150,7 +2133,7 @@ mod tests {
         read_failure.fail_read = Some(SOURCE + 8);
         assert_eq!(
             request()
-                .execute_with_indexed8_horizontal(&mut read_failure, Some(indexed_selection()),),
+                .execute_with_indexed8_scaling(&mut read_failure, Some(indexed_selection()),),
             RowCopyOutcome::ReadOrGeometryFailure
         );
         assert!(read_failure.writes.is_empty());
@@ -2163,7 +2146,7 @@ mod tests {
         write_failure.fail_write = Some(DESTINATION + 3);
         assert_eq!(
             request()
-                .execute_with_indexed8_horizontal(&mut write_failure, Some(indexed_selection()),),
+                .execute_with_indexed8_scaling(&mut write_failure, Some(indexed_selection()),),
             RowCopyOutcome::WriteFailure { rows_written: 1 }
         );
         assert_eq!(write_failure.writes, [DESTINATION]);
@@ -2178,7 +2161,7 @@ mod tests {
         first_write_failure.insert(DESTINATION, &[0xaa; 6]);
         first_write_failure.fail_write = Some(DESTINATION);
         assert_eq!(
-            request().execute_with_indexed8_horizontal(
+            request().execute_with_indexed8_scaling(
                 &mut first_write_failure,
                 Some(indexed_selection()),
             ),
@@ -2211,7 +2194,7 @@ mod tests {
             palette: None,
         };
         assert_eq!(
-            copy.execute_with_indexed8_horizontal(&mut NoAccess, Some(indexed_selection())),
+            copy.execute_with_indexed8_scaling(&mut NoAccess, Some(indexed_selection())),
             RowCopyOutcome::NoOp
         );
     }
@@ -2239,7 +2222,7 @@ mod tests {
             palette: None,
         };
         assert_eq!(
-            copy.execute_with_indexed8_horizontal(&mut NoAccess, Some(indexed_selection())),
+            copy.execute_with_indexed8_scaling(&mut NoAccess, Some(indexed_selection())),
             RowCopyOutcome::Declined
         );
 
@@ -2253,7 +2236,7 @@ mod tests {
             palette: None,
         };
         assert_eq!(
-            tall_copy.execute_with_indexed8_horizontal(&mut NoAccess, Some(indexed_selection())),
+            tall_copy.execute_with_indexed8_scaling(&mut NoAccess, Some(indexed_selection())),
             RowCopyOutcome::Declined
         );
     }
@@ -2281,7 +2264,7 @@ mod tests {
             palette: None,
         };
         assert_eq!(
-            copy.execute_with_indexed8_horizontal(&mut NoAccess, Some(indexed_selection())),
+            copy.execute_with_indexed8_scaling(&mut NoAccess, Some(indexed_selection())),
             RowCopyOutcome::ReadOrGeometryFailure
         );
     }

--- a/src/loader/ppc/mod.rs
+++ b/src/loader/ppc/mod.rs
@@ -57979,10 +57979,10 @@ fn ppc_copy_bits(
         // byte-aligned or packed srcCopy format, mode, and geometry eligibility.
         if mask_storage.is_none() {
             use crate::copy_bits::{
-                BytePixmap, Indexed8HorizontalSelection, RowCopy, RowCopyOutcome,
+                BytePixmap, Indexed8ScalingSelection, RowCopy, RowCopyOutcome,
             };
 
-            let indexed8_horizontal = Indexed8HorizontalSelection::from_adapter_facts(
+            let indexed8_scaling = Indexed8ScalingSelection::from_adapter_facts(
                 mask_rgn == 0,
                 src_resolved.guest_bounds,
                 dst_resolved.authoritative_bounds,
@@ -58011,7 +58011,7 @@ fn ppc_copy_bits(
                 clip: [copy_top, copy_left, copy_bottom, copy_right],
                 palette: palette_map.as_ref(),
             }
-            .execute_with_indexed8_horizontal(memory, indexed8_horizontal);
+            .execute_with_indexed8_scaling(memory, indexed8_scaling);
             match outcome {
                 RowCopyOutcome::Completed => return Some(()),
                 RowCopyOutcome::NoOp => {
@@ -152987,6 +152987,288 @@ pub(crate) mod tests {
         );
     }
 
+    fn ppc_indexed_vertical_oracle_groups(
+        destination_height: usize,
+    ) -> &'static [std::ops::Range<usize>] {
+        match destination_height {
+            7 => &[0..2, 2..4, 4..7, 7..9, 9..11, 11..14, 14..16],
+            18 => &[
+                0..1,
+                1..2,
+                2..3,
+                3..4,
+                4..5,
+                5..6,
+                6..7,
+                7..8,
+                7..8,
+                8..9,
+                9..10,
+                10..11,
+                11..12,
+                12..13,
+                13..14,
+                14..15,
+                15..16,
+                16..17,
+            ],
+            _ => unreachable!(),
+        }
+    }
+
+    fn run_ppc_indexed_vertical_route(
+        destination_height: usize,
+        source_top: usize,
+        visible_rows: std::ops::Range<usize>,
+        visible_columns: std::ops::Range<usize>,
+        impulse: usize,
+    ) -> Vec<u8> {
+        let mut loaded = load_pef_application(&synthetic_pef_with_import(b"CopyBits")).unwrap();
+        let scratch = PPC_HEAP_BASE + 0x17400;
+        let source_pixels = scratch;
+        let destination_allocation = scratch + 0x80;
+        let destination_pixels =
+            destination_allocation + visible_rows.start as u32 * 4 + visible_columns.start as u32;
+        let source_pixmap = scratch + 0x100;
+        let destination_pixmap = scratch + 0x140;
+        let rects = scratch + 0x180;
+        loaded.memory.add_region(scratch, vec![0; 0x1a0]);
+        ppc_write_pixmap(
+            &mut loaded.memory,
+            source_pixmap,
+            source_pixels,
+            4,
+            0,
+            0,
+            (source_top + 17) as i16,
+            4,
+            8,
+        )
+        .unwrap();
+        ppc_write_pixmap(
+            &mut loaded.memory,
+            destination_pixmap,
+            destination_pixels,
+            4,
+            visible_rows.start as i16,
+            visible_columns.start as i16,
+            visible_rows.end as i16,
+            visible_columns.end as i16,
+            8,
+        )
+        .unwrap();
+        let mut source = vec![0xcc; (source_top + 17) * 4];
+        for row in 0..17 {
+            for column in 0..3 {
+                source[(source_top + row) * 4 + column] = u8::from(row == impulse) * 255;
+            }
+        }
+        loaded.memory.write_bytes(source_pixels, &source).unwrap();
+        loaded
+            .memory
+            .write_bytes(destination_allocation, &vec![0xa5; destination_height * 4])
+            .unwrap();
+        ppc_write_rect(
+            &mut loaded.memory,
+            rects,
+            source_top as i16,
+            0,
+            (source_top + 17) as i16,
+            3,
+        )
+        .unwrap();
+        assert_eq!(loaded.memory.read_u16_be(source_pixmap + 6), Some(0));
+        assert_eq!(loaded.memory.read_u16_be(rects), Some(source_top as u16));
+        ppc_write_rect(
+            &mut loaded.memory,
+            rects + 8,
+            0,
+            0,
+            destination_height as i16,
+            3,
+        )
+        .unwrap();
+        loaded.cpu.gpr[3] = source_pixmap;
+        loaded.cpu.gpr[4] = destination_pixmap;
+        loaded.cpu.gpr[5] = rects;
+        loaded.cpu.gpr[6] = rects + 8;
+        loaded.cpu.gpr[7] = 0;
+        loaded.cpu.gpr[8] = 0;
+        let probe = loaded.run_with_hle_imports(64);
+        assert_eq!(probe.handled_import_count, 1);
+        assert_eq!(probe.unsupported_import_index, None);
+        let mut actual = vec![0; destination_height * 4];
+        loaded
+            .memory
+            .read_bytes_into(destination_allocation, &mut actual)
+            .unwrap();
+        actual
+    }
+
+    #[test]
+    fn hle_import_runner_copybits_matches_indexed_vertical_phase_oracles() {
+        // Literal one-hot source-row memberships captured through classic
+        // CopyBits/StdBits on Mac OS 8.1 and reused to validate the PPC ABI.
+        // Repeated columns and horizontal clipping extend only the orthogonal
+        // coverage; they do not claim an additional PPC oracle capture.
+        let cases = [
+            (7, 0, 0..7, 0..3),
+            (7, 1, 0..7, 0..3),
+            (7, 0, 2..7, 0..3),
+            (7, 1, 0..5, 0..3),
+            (18, 0, 0..18, 0..3),
+            (18, 1, 0..18, 0..3),
+            (18, 1, 2..18, 0..3),
+            (18, 1, 0..16, 0..3),
+            (7, 1, 2..7, 1..3),
+        ];
+        for (destination_height, source_top, visible_rows, visible_columns) in cases {
+            for impulse in 0..17 {
+                let actual = run_ppc_indexed_vertical_route(
+                    destination_height,
+                    source_top,
+                    visible_rows.clone(),
+                    visible_columns.clone(),
+                    impulse,
+                );
+                let groups = ppc_indexed_vertical_oracle_groups(destination_height);
+                let mut expected = vec![0xa5; destination_height * 4];
+                for row in visible_rows.clone() {
+                    for column in visible_columns.clone() {
+                        expected[row * 4 + column] = u8::from(groups[row].contains(&impulse)) * 255;
+                    }
+                }
+                assert_eq!(
+                    actual, expected,
+                    "destination_height={destination_height}, source_top={source_top}, visible_rows={visible_rows:?}, visible_columns={visible_columns:?}, impulse={impulse}"
+                );
+            }
+        }
+    }
+
+    fn run_ppc_indexed_vertical_legacy_case(
+        raw_mode: u16,
+        nonidentity_palette: bool,
+        two_axis: bool,
+        source_outside_bounds: bool,
+    ) -> [u8; 6] {
+        let mut loaded = load_pef_application(&synthetic_pef_with_import(b"CopyBits")).unwrap();
+        let source_width = if two_axis { 3 } else { 2 };
+        let scratch = PPC_HEAP_BASE + 0x17c00;
+        let source_pixels = scratch;
+        let destination_pixels = scratch + 0x40;
+        let source_pixmap = scratch + 0x80;
+        let destination_pixmap = scratch + 0xc0;
+        let rects = scratch + 0x100;
+        let table_handle = scratch + 0x110;
+        let table = scratch + 0x120;
+        loaded.memory.add_region(scratch, vec![0; 0x240]);
+        ppc_write_pixmap(
+            &mut loaded.memory,
+            source_pixmap,
+            source_pixels,
+            source_width,
+            if source_outside_bounds { 1 } else { 0 },
+            0,
+            5,
+            source_width as i16,
+            8,
+        )
+        .unwrap();
+        ppc_write_pixmap(
+            &mut loaded.memory,
+            destination_pixmap,
+            destination_pixels,
+            2,
+            0,
+            0,
+            3,
+            2,
+            8,
+        )
+        .unwrap();
+        if nonidentity_palette {
+            loaded
+                .memory
+                .write_u32_be(source_pixmap + 42, table_handle)
+                .unwrap();
+            loaded.memory.write_u32_be(table_handle, table).unwrap();
+            loaded.memory.write_u32_be(table, 0x1234_5678).unwrap();
+            loaded.memory.write_u16_be(table + 4, 0).unwrap();
+            loaded.memory.write_u16_be(table + 6, 30).unwrap();
+            for index in 0..=30u32 {
+                let color_index = if index == 10 { 200 } else { index as usize };
+                let [red, green, blue] = loaded.color_manager_clut[color_index];
+                let entry = table + 8 + index * 8;
+                loaded.memory.write_u16_be(entry, index as u16).unwrap();
+                loaded.memory.write_u16_be(entry + 2, red).unwrap();
+                loaded.memory.write_u16_be(entry + 4, green).unwrap();
+                loaded.memory.write_u16_be(entry + 6, blue).unwrap();
+            }
+        }
+        let rows: [[u8; 3]; 5] = if nonidentity_palette {
+            [[10, 10, 0], [1, 1, 0], [20, 20, 0], [2, 2, 0], [30, 30, 0]]
+        } else {
+            [
+                [10, 11, 12],
+                [20, 21, 22],
+                [30, 31, 32],
+                [40, 41, 42],
+                [50, 51, 52],
+            ]
+        };
+        for row in 0..5usize {
+            loaded
+                .memory
+                .write_bytes(
+                    source_pixels + (row * source_width as usize) as u32,
+                    &rows[row][..source_width as usize],
+                )
+                .unwrap();
+        }
+        loaded
+            .memory
+            .write_bytes(destination_pixels, &[0xa5; 6])
+            .unwrap();
+        ppc_write_rect(&mut loaded.memory, rects, 0, 0, 5, source_width as i16).unwrap();
+        ppc_write_rect(&mut loaded.memory, rects + 8, 0, 0, 3, 2).unwrap();
+        loaded.cpu.gpr[3] = source_pixmap;
+        loaded.cpu.gpr[4] = destination_pixmap;
+        loaded.cpu.gpr[5] = rects;
+        loaded.cpu.gpr[6] = rects + 8;
+        loaded.cpu.gpr[7] = raw_mode as u32;
+        loaded.cpu.gpr[8] = 0;
+        let probe = loaded.run_with_hle_imports(64);
+        assert_eq!(probe.handled_import_count, 1);
+        assert_eq!(probe.unsupported_import_index, None);
+        let mut actual = [0; 6];
+        loaded
+            .memory
+            .read_bytes_into(destination_pixels, &mut actual)
+            .unwrap();
+        actual
+    }
+
+    #[test]
+    fn hle_import_runner_copybits_keeps_vertical_exclusions_on_legacy_scaler() {
+        assert_eq!(
+            run_ppc_indexed_vertical_legacy_case(0x40, false, false, false),
+            [10, 11, 20, 21, 40, 41]
+        );
+        assert_eq!(
+            run_ppc_indexed_vertical_legacy_case(0, true, false, false),
+            [200, 200, 1, 1, 2, 2]
+        );
+        assert_eq!(
+            run_ppc_indexed_vertical_legacy_case(0, false, true, false),
+            [10, 11, 20, 21, 40, 41]
+        );
+        assert_eq!(
+            run_ppc_indexed_vertical_legacy_case(0, false, false, true),
+            [0xa5, 0xa5, 10, 11, 30, 31]
+        );
+    }
+
     fn run_ppc_indexed_horizontal_adapter_case(
         raw_mode: u16,
         clip_left_column: bool,
@@ -153492,6 +153774,81 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn hle_import_runner_copybits_matches_vertical_signed_source_height_capture() {
+        for (bounds_bottom, expected_pixels) in [
+            (32_766i16, vec![20, 40, 70, 90, 110, 140, 160]),
+            (32_767i16, vec![0xa5; 7]),
+        ] {
+            let mut loaded = load_pef_application(&synthetic_pef_with_import(b"CopyBits")).unwrap();
+            let scratch = PPC_HEAP_BASE + 0x17600;
+            let source_pixels = scratch;
+            let destination_pixels = scratch + 0x80;
+            let source_pixmap = scratch + 0x100;
+            let destination_pixmap = scratch + 0x140;
+            let rects = scratch + 0x180;
+            loaded.memory.add_region(scratch, vec![0; 0x1a0]);
+            ppc_write_pixmap(
+                &mut loaded.memory,
+                source_pixmap,
+                source_pixels,
+                2,
+                -1,
+                0,
+                16,
+                1,
+                8,
+            )
+            .unwrap();
+            loaded
+                .memory
+                .write_u16_be(source_pixmap + 10, bounds_bottom as u16)
+                .unwrap();
+            ppc_write_pixmap(
+                &mut loaded.memory,
+                destination_pixmap,
+                destination_pixels,
+                2,
+                0,
+                0,
+                7,
+                1,
+                8,
+            )
+            .unwrap();
+            let mut source = Vec::new();
+            for value in (10..=170).step_by(10) {
+                source.extend_from_slice(&[value, 0xcc]);
+            }
+            loaded.memory.write_bytes(source_pixels, &source).unwrap();
+            loaded
+                .memory
+                .write_bytes(destination_pixels, &[0xa5; 14])
+                .unwrap();
+            ppc_write_rect(&mut loaded.memory, rects, -1, 0, 16, 1).unwrap();
+            ppc_write_rect(&mut loaded.memory, rects + 8, 0, 0, 7, 1).unwrap();
+            loaded.cpu.gpr[3] = source_pixmap;
+            loaded.cpu.gpr[4] = destination_pixmap;
+            loaded.cpu.gpr[5] = rects;
+            loaded.cpu.gpr[6] = rects + 8;
+            loaded.cpu.gpr[7] = 0;
+            loaded.cpu.gpr[8] = 0;
+            let probe = loaded.run_with_hle_imports(64);
+            assert_eq!(probe.handled_import_count, 1);
+            assert_eq!(probe.unsupported_import_index, None);
+            let mut actual = [0; 14];
+            loaded
+                .memory
+                .read_bytes_into(destination_pixels, &mut actual)
+                .unwrap();
+            let mut expected = [0xa5; 14];
+            for (row, value) in expected_pixels.into_iter().enumerate() {
+                expected[row * 2] = value;
+            }
+            assert_eq!(actual, expected, "bounds_bottom={bounds_bottom}");
+        }
+    }
+
+    #[test]
     fn hle_import_runner_copybits_selects_only_exact_record_destination_bounds() {
         for (record_width, expected) in [
             (3u32, [241, 30, 50, 0xa5]),
@@ -153716,6 +154073,133 @@ pub(crate) mod tests {
             .read_bytes_into(DESTINATION, &mut actual)
             .unwrap();
         assert_eq!(actual, [20, 50, 70, 0xa5, 0xa5, 0xa5]);
+    }
+
+    #[test]
+    fn hle_import_runner_copybits_vertical_failures_are_terminal_and_row_atomic() {
+        const SOURCE: u32 = 0x0960_0000;
+        const DESTINATION: u32 = 0x0a60_0000;
+        for failure in [0, 1, 2] {
+            let mut loaded = load_pef_application(&synthetic_pef_with_import(b"CopyBits")).unwrap();
+            loaded.memory.add_region(
+                SOURCE,
+                if failure == 0 {
+                    vec![1, 11, 4, 14, 3, 13, 8, 18]
+                } else {
+                    vec![1, 11, 4, 14, 3, 13, 8, 18, 2, 12]
+                },
+            );
+            loaded.memory.add_region(DESTINATION, vec![0xa5; 6]);
+            match failure {
+                0 => {}
+                1 => loaded
+                    .memory
+                    .add_readonly_region(DESTINATION, vec![0xa5; 6]),
+                2 => loaded
+                    .memory
+                    .add_readonly_region(DESTINATION + 2, vec![0xa5; 4]),
+                _ => unreachable!(),
+            }
+            let records = PPC_HEAP_BASE + 0x17800;
+            let source_pixmap = records;
+            let destination_pixmap = records + 0x40;
+            let rects = records + 0x80;
+            loaded.memory.add_region(records, vec![0; 0x90]);
+            ppc_write_pixmap(&mut loaded.memory, source_pixmap, SOURCE, 2, 0, 0, 5, 2, 8).unwrap();
+            ppc_write_pixmap(
+                &mut loaded.memory,
+                destination_pixmap,
+                DESTINATION,
+                2,
+                0,
+                0,
+                3,
+                2,
+                8,
+            )
+            .unwrap();
+            ppc_write_rect(&mut loaded.memory, rects, 0, 0, 5, 2).unwrap();
+            ppc_write_rect(&mut loaded.memory, rects + 8, 0, 0, 3, 2).unwrap();
+            loaded.cpu.gpr[3] = source_pixmap;
+            loaded.cpu.gpr[4] = destination_pixmap;
+            loaded.cpu.gpr[5] = rects;
+            loaded.cpu.gpr[6] = rects + 8;
+            loaded.cpu.gpr[7] = 0;
+            loaded.cpu.gpr[8] = 0;
+            let probe = loaded.run_with_hle_imports(64);
+            assert_eq!(probe.handled_import_count, 1);
+            assert_eq!(probe.unsupported_import_index, None);
+            let mut actual = [0; 6];
+            loaded
+                .memory
+                .read_bytes_into(DESTINATION, &mut actual)
+                .unwrap();
+            let expected = if failure == 2 {
+                [1, 11, 0xa5, 0xa5, 0xa5, 0xa5]
+            } else {
+                [0xa5; 6]
+            };
+            assert_eq!(actual, expected, "failure={failure}");
+        }
+    }
+
+    #[test]
+    fn hle_import_runner_copybits_snapshots_indexed_vertical_aliases() {
+        const SOURCE: u32 = 0x0970_0000;
+        const DESTINATION: u32 = 0x0a70_0000;
+        for offset in [0, 2] {
+            let mut loaded = load_pef_application(&synthetic_pef_with_import(b"CopyBits")).unwrap();
+            let backing = crate::memory::bus::SharedRamRegion::from_owned_bytes(vec![
+                1, 11, 4, 14, 3, 13, 8, 18, 2, 12,
+            ]);
+            // SAFETY: CopyBits accesses the aliases serially and retains no
+            // borrowed slice across a memory operation.
+            unsafe {
+                loaded.memory.add_shared_region(SOURCE, backing.clone());
+                loaded.memory.add_shared_region(DESTINATION, backing);
+            }
+            let records = PPC_HEAP_BASE + 0x17a00;
+            let source_pixmap = records;
+            let destination_pixmap = records + 0x40;
+            let rects = records + 0x80;
+            loaded.memory.add_region(records, vec![0; 0x90]);
+            ppc_write_pixmap(&mut loaded.memory, source_pixmap, SOURCE, 2, 0, 0, 5, 2, 8).unwrap();
+            ppc_write_pixmap(
+                &mut loaded.memory,
+                destination_pixmap,
+                if offset == 0 {
+                    SOURCE
+                } else {
+                    DESTINATION + offset
+                },
+                2,
+                0,
+                0,
+                3,
+                2,
+                8,
+            )
+            .unwrap();
+            ppc_write_rect(&mut loaded.memory, rects, 0, 0, 5, 2).unwrap();
+            ppc_write_rect(&mut loaded.memory, rects + 8, 0, 0, 3, 2).unwrap();
+            loaded.cpu.gpr[3] = source_pixmap;
+            loaded.cpu.gpr[4] = destination_pixmap;
+            loaded.cpu.gpr[5] = rects;
+            loaded.cpu.gpr[6] = rects + 8;
+            loaded.cpu.gpr[7] = 0;
+            loaded.cpu.gpr[8] = 0;
+            let probe = loaded.run_with_hle_imports(64);
+            assert_eq!(probe.handled_import_count, 1);
+            assert_eq!(probe.unsupported_import_index, None);
+            let mut actual = [0; 10];
+            loaded.memory.read_bytes_into(SOURCE, &mut actual).unwrap();
+            let expected = if offset == 0 {
+                [1, 11, 4, 14, 8, 18, 8, 18, 2, 12]
+            } else {
+                [1, 11, 1, 11, 4, 14, 8, 18, 2, 12]
+            };
+            assert_eq!(actual, expected, "offset={offset}");
+        }
     }
 
     #[test]

--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -3671,9 +3671,9 @@ impl super::TrapDispatcher {
                     && !trace_menu_redraw_enabled()
                     && trace_probes.is_empty();
                 if row_copy_edge_eligible {
-                    use crate::copy_bits::{Indexed8HorizontalSelection, RowCopyOutcome};
+                    use crate::copy_bits::{Indexed8ScalingSelection, RowCopyOutcome};
 
-                    let indexed8_horizontal = Indexed8HorizontalSelection::from_adapter_facts(
+                    let indexed8_scaling = Indexed8ScalingSelection::from_adapter_facts(
                         mask_rgn == 0,
                         source_bounds_are_original,
                         destination_bounds_are_authoritative,
@@ -3690,7 +3690,7 @@ impl super::TrapDispatcher {
                         [clip_t, clip_l, clip_b, clip_r].map(i32::from),
                         palette_translation,
                     )
-                    .execute_with_indexed8_horizontal(bus, indexed8_horizontal);
+                    .execute_with_indexed8_scaling(bus, indexed8_scaling);
                     let wrote_rows = match outcome {
                         RowCopyOutcome::Completed => true,
                         RowCopyOutcome::WriteFailure { rows_written } => rows_written != 0,
@@ -20702,9 +20702,9 @@ impl super::TrapDispatcher {
             && !Self::region_is_complex(bus, mask_rgn)
             && trace_probes.is_empty();
         let shared_rows_written = if row_copy_edge_eligible {
-            use crate::copy_bits::{Indexed8HorizontalSelection, RowCopyOutcome};
+            use crate::copy_bits::{Indexed8ScalingSelection, RowCopyOutcome};
 
-            let indexed8_horizontal = Indexed8HorizontalSelection::from_adapter_facts(
+            let indexed8_scaling = Indexed8ScalingSelection::from_adapter_facts(
                 mask_rgn == 0,
                 source_bounds_are_original,
                 destination_bounds_are_authoritative,
@@ -20721,7 +20721,7 @@ impl super::TrapDispatcher {
                 [clip_t, clip_l, clip_b, clip_r].map(i32::from),
                 palette_translation,
             )
-            .execute_with_indexed8_horizontal(bus, indexed8_horizontal)
+            .execute_with_indexed8_scaling(bus, indexed8_scaling)
             {
                 RowCopyOutcome::Completed => true,
                 RowCopyOutcome::WriteFailure { rows_written } if rows_written != 0 => true,
@@ -35440,12 +35440,12 @@ mod tests {
         bus.write_word(TEST_SP + 4, 0);
         bus.write_long(TEST_SP + 6, destination_rect);
         bus.write_long(TEST_SP + 10, source_rect);
+        const PORT: u32 = 0x181000;
+        bus.write_long(destination_handle, destination_pixmap);
+        bus.write_long(PORT + 2, destination_handle);
+        bus.write_word(PORT + 6, 0xc000);
+        *d.current_port = PORT;
         if std_bits {
-            const PORT: u32 = 0x181000;
-            bus.write_long(destination_handle, destination_pixmap);
-            bus.write_long(PORT + 2, destination_handle);
-            bus.write_word(PORT + 6, 0xc000);
-            *d.current_port = PORT;
             bus.write_long(TEST_SP + 14, source_pixmap);
             assert!(d
                 .dispatch_quickdraw(true, 0x0eb, &mut cpu, &mut bus)
@@ -35510,6 +35510,343 @@ mod tests {
     fn std_bits_packed_identity_preserves_edges_and_padding() {
         for depth in [2, 4] {
             run_packed_identity_route(depth, true);
+        }
+    }
+
+    fn indexed_vertical_oracle_groups(destination_height: usize) -> &'static [std::ops::Range<usize>] {
+        match destination_height {
+            7 => &[0..2, 2..4, 4..7, 7..9, 9..11, 11..14, 14..16],
+            18 => &[
+                0..1,
+                1..2,
+                2..3,
+                3..4,
+                4..5,
+                5..6,
+                6..7,
+                7..8,
+                7..8,
+                8..9,
+                9..10,
+                10..11,
+                11..12,
+                12..13,
+                13..14,
+                14..15,
+                15..16,
+                16..17,
+            ],
+            _ => unreachable!(),
+        }
+    }
+
+    fn run_indexed_vertical_route(
+        std_bits: bool,
+        destination_height: usize,
+        source_top: usize,
+        visible_rows: std::ops::Range<usize>,
+        visible_columns: std::ops::Range<usize>,
+        clip_with_destination_bounds: bool,
+        impulse: usize,
+    ) -> Vec<u8> {
+        let (mut d, mut cpu, mut bus) = setup_with_port();
+        let source_pixmap = bus.alloc(50);
+        let destination_pixmap = bus.alloc(50);
+        let destination_handle = bus.alloc(4);
+        let source_stride = 4u32;
+        let destination_stride = 4u32;
+        let source_base = bus.alloc(source_stride * (source_top as u32 + 17));
+        let destination_allocation = bus.alloc(destination_stride * destination_height as u32);
+        let destination_base = if clip_with_destination_bounds {
+            destination_allocation
+                + destination_stride * visible_rows.start as u32
+                + visible_columns.start as u32
+        } else {
+            destination_allocation
+        };
+        let source_rect = bus.alloc(8);
+        let destination_rect = bus.alloc(8);
+
+        write_pixmap_8(
+            &mut bus,
+            source_pixmap,
+            source_base,
+            source_stride as u16,
+            (source_top + 17) as u16,
+            0,
+        );
+        write_pixmap_8(
+            &mut bus,
+            destination_pixmap,
+            destination_base,
+            destination_stride as u16,
+            if clip_with_destination_bounds {
+                visible_rows.end as u16
+            } else {
+                destination_height as u16
+            },
+            0,
+        );
+        if clip_with_destination_bounds {
+            bus.write_word(destination_pixmap + 6, visible_rows.start as u16);
+            bus.write_word(destination_pixmap + 8, visible_columns.start as u16);
+            bus.write_word(destination_pixmap + 10, visible_rows.end as u16);
+            bus.write_word(destination_pixmap + 12, visible_columns.end as u16);
+        } else {
+            bus.write_word(destination_pixmap + 12, 3);
+        }
+
+        let mut source = vec![0xcc; source_stride as usize * (source_top + 17)];
+        for row in 0..17 {
+            for column in 0..3 {
+                source[(source_top + row) * source_stride as usize + column] =
+                    u8::from(row == impulse) * 255;
+            }
+        }
+        bus.write_bytes(source_base, &source);
+        bus.write_bytes(
+            destination_allocation,
+            &vec![0xa5; destination_stride as usize * destination_height],
+        );
+        write_rect(
+            &mut bus,
+            source_rect,
+            source_top as i16,
+            0,
+            (source_top + 17) as i16,
+            3,
+        );
+        assert_eq!(bus.read_word(source_pixmap + 6) as i16, 0);
+        assert_eq!(bus.read_word(source_rect) as i16, source_top as i16);
+        write_rect(
+            &mut bus,
+            destination_rect,
+            0,
+            0,
+            destination_height as i16,
+            3,
+        );
+
+        cpu.write_reg(Register::A7, TEST_SP);
+        bus.write_long(TEST_SP, 0);
+        bus.write_word(TEST_SP + 4, 0);
+        bus.write_long(TEST_SP + 6, destination_rect);
+        bus.write_long(TEST_SP + 10, source_rect);
+        const PORT: u32 = 0x181000;
+        bus.write_long(destination_handle, destination_pixmap);
+        bus.write_long(PORT + 2, destination_handle);
+        bus.write_word(PORT + 6, 0xc000);
+        *d.current_port = PORT;
+        if std_bits {
+            bus.write_long(TEST_SP + 14, source_pixmap);
+        } else {
+            bus.write_long(TEST_SP + 14, destination_pixmap);
+            bus.write_long(TEST_SP + 18, source_pixmap);
+        }
+        if !clip_with_destination_bounds
+            && (visible_rows != (0..destination_height) || visible_columns != (0..3))
+        {
+            let region = bus.alloc(10);
+            let region_handle = bus.alloc(4);
+            make_rgn(
+                &mut bus,
+                region,
+                region_handle,
+                visible_rows.start as i16,
+                visible_columns.start as i16,
+                visible_rows.end as i16,
+                visible_columns.end as i16,
+            );
+            bus.write_long(PORT + 28, region_handle);
+        }
+        assert!(d
+            .dispatch_quickdraw(
+                true,
+                if std_bits { 0x0eb } else { 0x0ec },
+                &mut cpu,
+                &mut bus,
+            )
+            .unwrap()
+            .is_ok());
+        bus.read_bytes(
+            destination_allocation,
+            destination_stride as usize * destination_height,
+        )
+    }
+
+    #[test]
+    fn copy_bits_and_std_bits_match_indexed_vertical_phase_oracles() {
+        // One-hot source-row membership captured through CopyBits and StdBits
+        // on Mac OS 8.1. Expected groups are literal and independent of the
+        // shared planner.
+        let cases = [
+            (7, 0, 0..7, 0..3, false),
+            (7, 1, 0..7, 0..3, false),
+            (7, 0, 2..7, 0..3, false),
+            (7, 1, 0..5, 0..3, true),
+            (18, 0, 0..18, 0..3, false),
+            (18, 1, 0..18, 0..3, false),
+            (18, 1, 2..18, 0..3, false),
+            (18, 1, 0..16, 0..3, false),
+            (7, 1, 2..7, 1..3, false),
+        ];
+        for std_bits in [false, true] {
+            for (
+                destination_height,
+                source_top,
+                visible_rows,
+                visible_columns,
+                clip_with_destination_bounds,
+            ) in cases.clone()
+            {
+                for impulse in 0..17 {
+                    let actual = run_indexed_vertical_route(
+                        std_bits,
+                        destination_height,
+                        source_top,
+                        visible_rows.clone(),
+                        visible_columns.clone(),
+                        clip_with_destination_bounds,
+                        impulse,
+                    );
+                    let groups = indexed_vertical_oracle_groups(destination_height);
+                    let mut expected = vec![0xa5; destination_height * 4];
+                    for row in visible_rows.clone() {
+                        for column in visible_columns.clone() {
+                            expected[row * 4 + column] = u8::from(groups[row].contains(&impulse)) * 255;
+                        }
+                    }
+                    assert_eq!(
+                        actual, expected,
+                        "std_bits={std_bits}, destination_height={destination_height}, source_top={source_top}, visible_rows={visible_rows:?}, visible_columns={visible_columns:?}, bounds_clip={clip_with_destination_bounds}, impulse={impulse}"
+                    );
+                }
+            }
+        }
+    }
+
+    fn run_indexed_vertical_legacy_route(
+        std_bits: bool,
+        raw_mode: u16,
+        nonidentity_palette: bool,
+        two_axis: bool,
+        source_outside_bounds: bool,
+    ) -> Vec<u8> {
+        let (mut d, mut cpu, mut bus) = setup_with_port();
+        let source_width = if two_axis { 3 } else { 2 };
+        let destination_width = 2;
+        let source_pixmap = bus.alloc(50);
+        let destination_pixmap = bus.alloc(50);
+        let destination_handle = bus.alloc(4);
+        let source_base = bus.alloc((source_width * 5) as u32);
+        let destination_base = bus.alloc(6);
+        let source_rect = bus.alloc(8);
+        let destination_rect = bus.alloc(8);
+        write_pixmap_8(&mut bus, source_pixmap, source_base, source_width, 5, 0);
+        write_pixmap_8(
+            &mut bus,
+            destination_pixmap,
+            destination_base,
+            destination_width,
+            3,
+            0,
+        );
+        if source_outside_bounds {
+            bus.write_word(source_pixmap + 6, 1);
+        }
+        if nonidentity_palette {
+            let handle = bus.alloc(4);
+            let table = bus.alloc(8 + 31 * 8);
+            bus.write_long(source_pixmap + 42, handle);
+            bus.write_long(handle, table);
+            bus.write_long(table, 0x1234_5678);
+            bus.write_word(table + 4, 0);
+            bus.write_word(table + 6, 30);
+            for index in 0..=30u32 {
+                let color_index = if index == 10 { 200 } else { index as usize };
+                let [red, green, blue] = d.color_manager_clut[color_index];
+                let entry = table + 8 + index * 8;
+                bus.write_word(entry, index as u16);
+                bus.write_word(entry + 2, red);
+                bus.write_word(entry + 4, green);
+                bus.write_word(entry + 6, blue);
+            }
+        }
+        let rows: [[u8; 3]; 5] = if nonidentity_palette {
+            [[10, 10, 0], [1, 1, 0], [20, 20, 0], [2, 2, 0], [30, 30, 0]]
+        } else {
+            [
+                [10, 11, 12],
+                [20, 21, 22],
+                [30, 31, 32],
+                [40, 41, 42],
+                [50, 51, 52],
+            ]
+        };
+        for row in 0..5usize {
+            let start = row * source_width as usize;
+            bus.write_bytes(
+                source_base + start as u32,
+                &rows[row][..source_width as usize],
+            );
+        }
+        bus.write_bytes(destination_base, &[0xa5; 6]);
+        write_rect(&mut bus, source_rect, 0, 0, 5, source_width as i16);
+        write_rect(
+            &mut bus,
+            destination_rect,
+            0,
+            0,
+            3,
+            destination_width as i16,
+        );
+        cpu.write_reg(Register::A7, TEST_SP);
+        bus.write_long(TEST_SP, 0);
+        bus.write_word(TEST_SP + 4, raw_mode);
+        bus.write_long(TEST_SP + 6, destination_rect);
+        bus.write_long(TEST_SP + 10, source_rect);
+        if std_bits {
+            const PORT: u32 = 0x181000;
+            bus.write_long(destination_handle, destination_pixmap);
+            bus.write_long(PORT + 2, destination_handle);
+            bus.write_word(PORT + 6, 0xc000);
+            *d.current_port = PORT;
+            bus.write_long(TEST_SP + 14, source_pixmap);
+        } else {
+            bus.write_long(TEST_SP + 14, destination_pixmap);
+            bus.write_long(TEST_SP + 18, source_pixmap);
+        }
+        assert!(d
+            .dispatch_quickdraw(
+                true,
+                if std_bits { 0x0eb } else { 0x0ec },
+                &mut cpu,
+                &mut bus,
+            )
+            .unwrap()
+            .is_ok());
+        bus.read_bytes(destination_base, 6)
+    }
+
+    #[test]
+    fn copy_bits_and_std_bits_keep_vertical_exclusions_on_legacy_scaler() {
+        for std_bits in [false, true] {
+            assert_eq!(
+                run_indexed_vertical_legacy_route(std_bits, 0x40, false, false, false),
+                vec![10, 11, 20, 21, 40, 41]
+            );
+            assert_eq!(
+                run_indexed_vertical_legacy_route(std_bits, 0, true, false, false),
+                vec![200, 200, 1, 1, 2, 2]
+            );
+            assert_eq!(
+                run_indexed_vertical_legacy_route(std_bits, 0, false, true, false),
+                vec![10, 11, 20, 21, 40, 41]
+            );
+            assert_eq!(
+                run_indexed_vertical_legacy_route(std_bits, 0, false, false, true),
+                vec![0xa5, 0xa5, 10, 11, 30, 31]
+            );
         }
     }
 
@@ -35709,6 +36046,77 @@ mod tests {
             assert_eq!(
                 run_indexed_horizontal_height_gate(std_bits, 32_767),
                 vec![0xa5; 4],
+                "32768, std_bits={std_bits}"
+            );
+        }
+    }
+
+    fn run_indexed_vertical_height_gate(std_bits: bool, bounds_bottom: i16) -> Vec<u8> {
+        let (mut d, mut cpu, mut bus) = setup_with_port();
+        let source_pixmap = bus.alloc(50);
+        let destination_pixmap = bus.alloc(50);
+        let destination_handle = bus.alloc(4);
+        let source_base = bus.alloc(34);
+        let destination_base = bus.alloc(14);
+        let source_rect = bus.alloc(8);
+        let destination_rect = bus.alloc(8);
+        write_pixmap_8(&mut bus, source_pixmap, source_base, 2, 17, 0);
+        bus.write_word(source_pixmap + 6, (-1i16) as u16);
+        bus.write_word(source_pixmap + 10, bounds_bottom as u16);
+        bus.write_word(source_pixmap + 12, 1);
+        write_pixmap_8(&mut bus, destination_pixmap, destination_base, 2, 7, 0);
+        bus.write_word(destination_pixmap + 12, 1);
+        let mut source = Vec::new();
+        for value in (10..=170).step_by(10) {
+            source.extend_from_slice(&[value, 0xcc]);
+        }
+        bus.write_bytes(source_base, &source);
+        bus.write_bytes(destination_base, &[0xa5; 14]);
+        write_rect(&mut bus, source_rect, -1, 0, 16, 1);
+        write_rect(&mut bus, destination_rect, 0, 0, 7, 1);
+        cpu.write_reg(Register::A7, TEST_SP);
+        bus.write_long(TEST_SP, 0);
+        bus.write_word(TEST_SP + 4, 0);
+        bus.write_long(TEST_SP + 6, destination_rect);
+        bus.write_long(TEST_SP + 10, source_rect);
+        if std_bits {
+            const PORT: u32 = 0x181000;
+            bus.write_long(destination_handle, destination_pixmap);
+            bus.write_long(PORT + 2, destination_handle);
+            bus.write_word(PORT + 6, 0xc000);
+            *d.current_port = PORT;
+            bus.write_long(TEST_SP + 14, source_pixmap);
+        } else {
+            bus.write_long(TEST_SP + 14, destination_pixmap);
+            bus.write_long(TEST_SP + 18, source_pixmap);
+        }
+        assert!(d
+            .dispatch_quickdraw(
+                true,
+                if std_bits { 0x0eb } else { 0x0ec },
+                &mut cpu,
+                &mut bus,
+            )
+            .unwrap()
+            .is_ok());
+        bus.read_bytes(destination_base, 14)
+    }
+
+    #[test]
+    fn copy_bits_and_std_bits_match_vertical_signed_source_height_capture() {
+        let mut selected = Vec::new();
+        for value in [20, 40, 70, 90, 110, 140, 160] {
+            selected.extend_from_slice(&[value, 0xa5]);
+        }
+        for std_bits in [false, true] {
+            assert_eq!(
+                run_indexed_vertical_height_gate(std_bits, 32_766),
+                selected,
+                "32767, std_bits={std_bits}"
+            );
+            assert_eq!(
+                run_indexed_vertical_height_gate(std_bits, 32_767),
+                vec![0xa5; 14],
                 "32768, std_bits={std_bits}"
             );
         }
@@ -36004,6 +36412,135 @@ mod tests {
     }
 
     #[test]
+    fn copy_bits_and_std_bits_vertical_failures_are_terminal_and_row_atomic() {
+        const SOURCE: u32 = 0x00d4_0000;
+        const DESTINATION: u32 = 0x00e4_0000;
+        for trap in [0x0ec, 0x0eb] {
+            for failure in [0, 1, 2] {
+                let (mut d, mut cpu, mut bus) = setup_with_port();
+                let mut memory = GuestAddressSpace::new();
+                memory.add_region(
+                    SOURCE,
+                    if failure == 0 {
+                        vec![1, 11, 4, 14, 3, 13, 8, 18]
+                    } else {
+                        vec![1, 11, 4, 14, 3, 13, 8, 18, 2, 12]
+                    },
+                );
+                memory.add_region(DESTINATION, vec![0xa5; 6]);
+                match failure {
+                    0 => {}
+                    1 => memory.add_readonly_region(DESTINATION, vec![0xa5; 6]),
+                    2 => memory.add_readonly_region(DESTINATION + 2, vec![0xa5; 4]),
+                    _ => unreachable!(),
+                }
+                bus.attach_guest_address_space(memory.shared_view());
+                let source_pixmap = bus.alloc(50);
+                let destination_pixmap = bus.alloc(50);
+                let destination_handle = bus.alloc(4);
+                let source_rect = bus.alloc(8);
+                let destination_rect = bus.alloc(8);
+                write_pixmap_8(&mut bus, source_pixmap, SOURCE, 2, 5, 0);
+                write_pixmap_8(&mut bus, destination_pixmap, DESTINATION, 2, 3, 0);
+                write_rect(&mut bus, source_rect, 0, 0, 5, 2);
+                write_rect(&mut bus, destination_rect, 0, 0, 3, 2);
+                cpu.write_reg(Register::A7, TEST_SP);
+                bus.write_long(TEST_SP, 0);
+                bus.write_word(TEST_SP + 4, 0);
+                bus.write_long(TEST_SP + 6, destination_rect);
+                bus.write_long(TEST_SP + 10, source_rect);
+                if trap == 0x0eb {
+                    const PORT: u32 = 0x181000;
+                    bus.write_long(destination_handle, destination_pixmap);
+                    bus.write_long(PORT + 2, destination_handle);
+                    bus.write_word(PORT + 6, 0xc000);
+                    *d.current_port = PORT;
+                    bus.write_long(TEST_SP + 14, source_pixmap);
+                } else {
+                    bus.write_long(TEST_SP + 14, destination_pixmap);
+                    bus.write_long(TEST_SP + 18, source_pixmap);
+                }
+                assert!(d
+                    .dispatch_quickdraw(true, trap, &mut cpu, &mut bus)
+                    .unwrap()
+                    .is_ok());
+                let mut actual = [0; 6];
+                memory.read_bytes_into(DESTINATION, &mut actual).unwrap();
+                let expected = if failure == 2 {
+                    [1, 11, 0xa5, 0xa5, 0xa5, 0xa5]
+                } else {
+                    [0xa5; 6]
+                };
+                assert_eq!(actual, expected, "trap={trap:03x}, failure={failure}");
+            }
+        }
+    }
+
+    #[test]
+    fn copy_bits_and_std_bits_snapshot_indexed_vertical_aliases() {
+        const SOURCE: u32 = 0x00d5_0000;
+        const DESTINATION: u32 = 0x00e5_0000;
+        for trap in [0x0ec, 0x0eb] {
+            for offset in [0, 2] {
+                let (mut d, mut cpu, mut bus) = setup_with_port();
+                let mut memory = GuestAddressSpace::new();
+                let backing = crate::memory::bus::SharedRamRegion::from_owned_bytes(vec![
+                    1, 11, 4, 14, 3, 13, 8, 18, 2, 12,
+                ]);
+                // SAFETY: CopyBits accesses the aliases serially and retains no
+                // borrowed slice across a memory operation.
+                unsafe {
+                    memory.add_shared_region(SOURCE, backing.clone());
+                    memory.add_shared_region(DESTINATION, backing);
+                }
+                bus.attach_guest_address_space(memory.shared_view());
+                let source_pixmap = bus.alloc(50);
+                let destination_pixmap = bus.alloc(50);
+                let destination_handle = bus.alloc(4);
+                let source_rect = bus.alloc(8);
+                let destination_rect = bus.alloc(8);
+                write_pixmap_8(&mut bus, source_pixmap, SOURCE, 2, 5, 0);
+                let destination_base = if offset == 0 {
+                    SOURCE
+                } else {
+                    DESTINATION + offset
+                };
+                write_pixmap_8(&mut bus, destination_pixmap, destination_base, 2, 3, 0);
+                write_rect(&mut bus, source_rect, 0, 0, 5, 2);
+                write_rect(&mut bus, destination_rect, 0, 0, 3, 2);
+                cpu.write_reg(Register::A7, TEST_SP);
+                bus.write_long(TEST_SP, 0);
+                bus.write_word(TEST_SP + 4, 0);
+                bus.write_long(TEST_SP + 6, destination_rect);
+                bus.write_long(TEST_SP + 10, source_rect);
+                if trap == 0x0eb {
+                    const PORT: u32 = 0x181000;
+                    bus.write_long(destination_handle, destination_pixmap);
+                    bus.write_long(PORT + 2, destination_handle);
+                    bus.write_word(PORT + 6, 0xc000);
+                    *d.current_port = PORT;
+                    bus.write_long(TEST_SP + 14, source_pixmap);
+                } else {
+                    bus.write_long(TEST_SP + 14, destination_pixmap);
+                    bus.write_long(TEST_SP + 18, source_pixmap);
+                }
+                assert!(d
+                    .dispatch_quickdraw(true, trap, &mut cpu, &mut bus)
+                    .unwrap()
+                    .is_ok());
+                let mut actual = [0; 10];
+                memory.read_bytes_into(SOURCE, &mut actual).unwrap();
+                let expected = if offset == 0 {
+                    [1, 11, 4, 14, 8, 18, 8, 18, 2, 12]
+                } else {
+                    [1, 11, 1, 11, 4, 14, 8, 18, 2, 12]
+                };
+                assert_eq!(actual, expected, "trap={trap:03x}, offset={offset}");
+            }
+        }
+    }
+
+    #[test]
     fn test_copy_bits() {
         let (mut d, mut cpu, mut bus) = setup_with_port();
         let port_ptr = 0x181000u32;
@@ -36097,6 +36634,117 @@ mod tests {
             0x7A,
             "identity CopyBits screen writes into a visible dialog must update the retained snapshot"
         );
+    }
+
+    #[test]
+    fn indexed_vertical_screen_effects_follow_completed_row_outcomes() {
+        const SCREEN: u32 = 0x00e6_0000;
+        const SOURCE: u32 = 0x00d6_0000;
+        for trap in [0x0ec, 0x0eb] {
+            for failure in [0, 1, 2] {
+                let (mut d, mut cpu, mut bus) = setup_with_port();
+                let dialog = 0x181000u32;
+                let mut memory = GuestAddressSpace::new();
+                memory.add_region(
+                    SOURCE,
+                    if failure == 1 {
+                        vec![1, 11, 4, 14, 3, 13, 8, 18]
+                    } else {
+                        vec![1, 11, 4, 14, 3, 13, 8, 18, 2, 12]
+                    },
+                );
+                memory.add_region(SCREEN, vec![0xa5; 16 * 16]);
+                if failure == 2 {
+                    memory.add_readonly_region(SCREEN + 3 * 16 + 2, vec![0xa5; 2]);
+                }
+                bus.attach_guest_address_space(memory.shared_view());
+                let source_pixmap = bus.alloc(50);
+                let destination_pixmap = bus.alloc(50);
+                let destination_handle = bus.alloc(4);
+                let source_rect = bus.alloc(8);
+                let destination_rect = bus.alloc(8);
+                write_pixmap_8(&mut bus, source_pixmap, SOURCE, 2, 5, 0);
+                write_pixmap_8(&mut bus, destination_pixmap, SCREEN, 16, 16, 0);
+                bus.write_long(destination_handle, destination_pixmap);
+                bus.write_long(dialog + 2, destination_handle);
+                bus.write_word(dialog + 6, 0xc000);
+                write_rect(&mut bus, dialog + 16, 0, 0, 16, 16);
+                bus.write_byte(dialog + 110, 0xff);
+                let vis_region = bus.alloc(10);
+                let vis_handle = bus.alloc(4);
+                make_rgn(&mut bus, vis_region, vis_handle, 0, 0, 16, 16);
+                bus.write_long(dialog + 24, vis_handle);
+                let clip_region = bus.alloc(10);
+                let clip_handle = bus.alloc(4);
+                make_rgn(&mut bus, clip_region, clip_handle, 0, 0, 16, 16);
+                bus.write_long(dialog + 28, clip_handle);
+                let global_ptr = bus.read_long(cpu.read_reg(Register::A5));
+                bus.write_long(global_ptr, dialog);
+                *d.current_port = dialog;
+                d.front_window = dialog;
+                d.dialog_items.insert(
+                    dialog,
+                    vec![DialogItem {
+                        item_type: 0x80,
+                        rect: (2, 2, 5, 4),
+                        text: String::new(),
+                        resource_id: 0,
+                        proc_ptr: 0,
+                        sel_start: 0,
+                        sel_end: 0,
+                    }],
+                );
+                d.screen_mode = (SCREEN, 16, 16, 16, 8);
+                bus.write_long(0x0824, SCREEN);
+                write_rect(&mut bus, source_rect, 0, 0, 5, 2);
+                write_rect(&mut bus, destination_rect, 2, 2, 5, 4);
+                cpu.write_reg(Register::A7, TEST_SP);
+                bus.write_long(TEST_SP, 0);
+                bus.write_word(TEST_SP + 4, 0);
+                bus.write_long(TEST_SP + 6, destination_rect);
+                bus.write_long(TEST_SP + 10, source_rect);
+                if trap == 0x0eb {
+                    bus.write_long(TEST_SP + 14, source_pixmap);
+                } else {
+                    bus.write_long(TEST_SP + 14, destination_pixmap);
+                    bus.write_long(TEST_SP + 18, source_pixmap);
+                }
+                assert!(d
+                    .dispatch_quickdraw(true, trap, &mut cpu, &mut bus)
+                    .unwrap()
+                    .is_ok());
+                let mut actual_screen = vec![0; 16 * 16];
+                memory.read_bytes_into(SCREEN, &mut actual_screen).unwrap();
+                let mut expected_screen = vec![0xa5; 16 * 16];
+                if failure != 1 {
+                    expected_screen[2 * 16 + 2..2 * 16 + 4].copy_from_slice(&[1, 11]);
+                }
+                if failure == 0 {
+                    expected_screen[3 * 16 + 2..3 * 16 + 4].copy_from_slice(&[4, 14]);
+                    expected_screen[4 * 16 + 2..4 * 16 + 4].copy_from_slice(&[8, 18]);
+                }
+                assert_eq!(
+                    actual_screen, expected_screen,
+                    "trap={trap:03x}, failure={failure}"
+                );
+                if failure == 1 {
+                    assert!(!d.dialog_visible_snapshots.contains_key(&dialog));
+                    continue;
+                }
+                assert!(d.dialog_visible_snapshots.contains_key(&dialog));
+                bus.write_bytes(SCREEN + 2 * 16 + 2, &[0, 0]);
+                d.restore_visible_dialog_snapshots(&mut bus);
+                assert_eq!(bus.read_bytes(SCREEN + 2 * 16 + 2, 2), vec![1, 11]);
+                assert_eq!(
+                    bus.read_bytes(SCREEN + 3 * 16 + 2, 2),
+                    if failure == 2 {
+                        vec![0xa5; 2]
+                    } else {
+                        vec![4, 14]
+                    }
+                );
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
CopyBits and StdBits now use one shared executor for the supported indexed 8-bit vertical scaling family through both classic traps and PPC imports. The shared entry selects horizontal or vertical scaling and owns sampling, clipping phase, overlap snapshots, and terminal failures; ABI adapters retain argument decoding and existing effects.

Literal classic Mac OS 8.1 oracle memberships cover 17→7 and 17→18 scaling, source origins, clipping, padding, and the signed source-bounds-height threshold. Route tests cover source/write failure, partial rows, aliases, screen snapshots, and exclusions. Selected failures cannot fall back to scalar copies. Other depths, dither flags, two-axis scaling, palette translation/uncertainty, and unsupported geometry retain existing paths. PPC's existing destination-bounds-only clipping remains unchanged; this does not claim complete CopyBits parity.

Validation on the reviewed source:

- Focused vertical tests: 26 passed.
- Headless library suite with test-support: 5,325 passed, 3 ignored.
- Default-feature library suite with test-support: 5,334 passed, 3 ignored.
- Optimized toolbox showcase: passed separately for 68k and PPC.
- Sequential formatting of changed items; full formatting was deferred on the 8 GiB development host because these large modules exceed its formatting memory budget.

The first CI run passed its required jobs. Its optional lint log reported four new test-call wrapping differences, now corrected, alongside the inherited whole-module formatting allocation failure and existing Clippy errors in memory access and an unrelated PPC test. Final CI passed on the formatting-only follow-up, including build/tests, both ISA showcases, dependency licenses, and package verification. The optional lint log now contains only the inherited failures described above; the runtime and test logic are unchanged.

Closes #1580.
