### PR TITLE
fix(headless): replay simulated time with GUI wait scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,33 @@ The terminal reports CPU, compositing, outline rendering and Metal drawable-wait
 phases that take at least 50 ms. During normal gameplay, drawable waits on the
 presentation worker do not block the guest CPU or input handling.
 
+### Headless replays
+
+`systemless --headless --max-ticks 600 game.sit` runs 600 simulated frontend
+ticks (about ten seconds) without opening a window or sleeping in host time.
+It uses the GUI runner's retained-wait/callback scheduling, advances audio,
+uses the same architecture-specific instruction rate as the GUI, and
+composites once per frontend tick. This is also the default headless
+mode when neither legacy instruction option is supplied.
+
+Use `--tick-input-script inputs.txt` with `--max-ticks` to replay inputs;
+each line is `<elapsed-tick> <action> [args]`, e.g. `120 mousedown 317 491`
+and `122 mouseup 317 491` (coordinates are vertical, horizontal). The
+frontend clock continues while menu tracking freezes guest TickCount.
+Reports include both clocks and actual instruction work. Startup Mac time
+is fixed for repeatability; `--headless-start-time SECONDS` overrides it.
+Inputs at or beyond the endpoint are rejected. The summary also reports
+same-tick frames and frames that exhausted the instruction safety budget;
+those counters help detect stalled or unmatched workloads. Use a fresh copy
+of the same save files for each comparison (saves live beside the archive).
+
+`--max-instructions` and `--input-script` retain the old instruction-clock
+diagnostic mode. Retained modal waits can re-fire repeatedly in that mode,
+so its CPU totals are **not a proxy for GUI or gameplay CPU usage**. Tick
+scripts and instruction scripts cannot be combined. Time-based headless
+results still exclude the host window, compositor, and physical audio device;
+compare equal game progress and outputs, and verify windowed CPU separately.
+
 ## Try it in your browser
 
 | [Marathon](https://systemless.org/marathon) | [Escape Velocity](https://systemless.org/escape-velocity) |

--- a/src/bin/desktop/headless_time.rs
+++ b/src/bin/desktop/headless_time.rs
@@ -1,0 +1,429 @@
+//! Simulated frontend time, without a window or wall-clock sleeps.
+//!
+//! An instruction-bounded run is useful for interpreter diagnostics, but a
+//! retained Toolbox wait is not useful guest computation. Drive the existing
+//! GUI scheduling path with one-tick deadlines instead of re-firing that wait
+//! until millions of synthetic A-line instructions have retired.
+
+use super::{
+    configure_realtime_execution_rate, foreground_cpu_batch_instructions, game, save_screenshot,
+    service_pending_sound_work_budgeted, DesktopSaveStore, FixtureRunner, HostMouseReleaseLatch,
+    InputAction, ScriptedInput, UiThemeId, AUDIO_CALLBACK_CHUNK_SAMPLES,
+};
+
+fn deliver(runner: &mut FixtureRunner, mouse: &mut HostMouseReleaseLatch, action: InputAction) {
+    match action {
+        InputAction::MouseMove { v, h } => runner.set_mouse_position(v, h),
+        InputAction::MouseDown { v, h } => {
+            mouse.press();
+            runner.push_mouse_down(v, h);
+        }
+        InputAction::MouseUp { v, h } => {
+            if let Some((v, h)) = mouse.release((v, h)) {
+                runner.push_mouse_up(v, h);
+            }
+        }
+        InputAction::KeyDown { key, ch } => runner.push_key_down(key, ch),
+        InputAction::KeyUp { key, ch } => runner.push_key_up(key, ch),
+    }
+}
+
+#[derive(Debug, Default)]
+pub(super) struct FrameWork {
+    instructions: usize,
+    foreground: usize,
+    budget_exhausted: bool,
+}
+
+fn service_sound(runner: &mut FixtureRunner, total: &mut usize, reserve_used: &mut usize) {
+    if let Some(steps) = service_pending_sound_work_budgeted(
+        runner,
+        game::MAX_INSTRUCTIONS_PER_FRAME,
+        *total,
+        reserve_used,
+    ) {
+        *total = total.saturating_add(steps);
+    }
+}
+
+/// One virtual frontend tick. The frontend clock keeps moving while a menu
+/// freezes guest TickCount, just as the real host clock and audio do. A short
+/// retained-tracking slice is a yield boundary, not an invitation to re-fire
+/// the same wait. Other short slices can be ordinary engine/task handoffs.
+pub(super) fn frame(runner: &mut FixtureRunner, audio_samples: usize) -> FrameWork {
+    runner.advance_menu_presentation_clock(super::FRAME_DURATION);
+    let target = runner.guest_tick().saturating_add(1);
+    let batch =
+        foreground_cpu_batch_instructions(runner.is_powerpc_app(), runner.instructions_per_tick());
+    let mut work = FrameWork::default();
+    let mut audio_mixed = 0;
+    let mut reserve_used = 0;
+    while work.instructions < game::MAX_INSTRUCTIONS_PER_FRAME && !runner.is_halted() {
+        let remaining = game::MAX_INSTRUCTIONS_PER_FRAME - work.instructions;
+        let requested = batch.min(remaining);
+        let batches_left = remaining.div_ceil(batch).max(1);
+        let batch_audio = (audio_samples - audio_mixed).div_ceil(batches_left);
+        // Match the desktop's deferred presentation: CPU batches do not
+        // repaint chrome. Audio still runs between batches, including its
+        // guest callbacks; the frame's presentation pass follows below.
+        let (steps, running) = runner.run_gui_cpu_slice(requested, target);
+        work.foreground += steps;
+        work.instructions += steps;
+        audio_mixed += batch_audio;
+        if batch_audio > 0 {
+            runner.mix_gui_audio_slice(batch_audio);
+            service_sound(runner, &mut work.instructions, &mut reserve_used);
+        }
+        if !running
+            || runner.guest_tick() >= target
+            || steps == 0
+            || (steps < requested && runner.is_ui_tracking_active())
+        {
+            break;
+        }
+    }
+    work.budget_exhausted =
+        work.instructions >= game::MAX_INSTRUCTIONS_PER_FRAME && runner.guest_tick() < target;
+
+    // Audio is driven by frontend time even when guest ticks are frozen.
+    // Mix in the same bounded chunks used by the GUI, giving double-buffer
+    // callbacks an opportunity to refill between chunks. No host device is
+    // attached, but guest-visible playback and callback work still executes.
+    let mut remaining_audio = audio_samples - audio_mixed;
+    if remaining_audio > 0 {
+        service_sound(runner, &mut work.instructions, &mut reserve_used);
+    }
+    while remaining_audio > 0 && !runner.is_halted() {
+        let chunk = remaining_audio.min(AUDIO_CALLBACK_CHUNK_SAMPLES);
+        runner.mix_gui_audio_slice(chunk);
+        remaining_audio -= chunk;
+        service_sound(runner, &mut work.instructions, &mut reserve_used);
+    }
+    service_sound(runner, &mut work.instructions, &mut reserve_used);
+    runner.prepare_text_presentation();
+    runner.composite_frame();
+    work
+}
+
+fn validate_script(script: &[ScriptedInput], ticks: u32) -> Result<(), String> {
+    if let Some(event) = script.iter().find(|event| event.at >= ticks as usize) {
+        return Err(format!(
+            "input at tick {} would not execute: --max-ticks {ticks} runs ticks 0 through {}",
+            event.at,
+            ticks - 1
+        ));
+    }
+    Ok(())
+}
+
+pub(super) fn run(
+    path: &std::path::Path,
+    ticks: u32,
+    start_time: u32,
+    addressing_24_bit: bool,
+    screen_depth: Option<u16>,
+    script: &[ScriptedInput],
+    theme: UiThemeId,
+) {
+    if let Err(error) = validate_script(script, ticks) {
+        eprintln!("[HEADLESS-TIME] {error}");
+        std::process::exit(1);
+    }
+    let mut runner = match screen_depth {
+        Some(depth) => game::new_runner_with_configuration(!addressing_24_bit, depth),
+        None => game::new_runner_with_addressing(!addressing_24_bit),
+    };
+    runner.set_ui_theme(theme);
+    runner.set_app_start_time(start_time);
+    let app = game::load_game_from_path(&mut runner, path).expect("Failed to load game");
+    let mut saves = DesktopSaveStore::for_loaded_archive(path, &mut runner);
+    for file in saves.load_saved_files() {
+        runner.import_vfs_file(&file);
+    }
+    game::init_game(&mut runner, &app);
+    runner.prepare_text_presentation();
+    let instructions_per_tick = configure_realtime_execution_rate(&mut runner);
+    let start_tick = runner.guest_tick();
+    eprintln!(
+        "[HEADLESS-TIME] start frontend_ticks={ticks} guest_tick={start_tick} mac_seconds={start_time} input_clock=frontend_ticks instructions_per_tick={instructions_per_tick}"
+    );
+
+    let mut instructions = 0u64;
+    let mut next_event = 0;
+    let mut mouse = HostMouseReleaseLatch::default();
+    let mut same_tick_frames = 0u32;
+    let mut budget_exhausted_frames = 0u32;
+    let mut audio_remainder = 0.0;
+    let mut captured_audio = Vec::new();
+    let mut audio_count = 0u64;
+    let mut audio_hash = 0xcbf2_9ce4_8422_2325u64;
+    let trace = std::env::var_os("SYSTEMLESS_HEADLESS_TIME_TRACE").is_some();
+    for elapsed in 0..ticks {
+        while let Some(event) = script.get(next_event).filter(|e| e.at <= elapsed as usize) {
+            deliver(&mut runner, &mut mouse, event.action);
+            eprintln!("[HEADLESS-TIME] input tick={} {:?}", event.at, event.action);
+            next_event += 1;
+        }
+        // Fractional samples carry between frames; do not round away a small
+        // amount of audio on every tick.
+        let samples = systemless::sound::OUTPUT_RATE as f64 / systemless::runner::DEFAULT_VBL_HZ
+            + audio_remainder;
+        let whole_samples = samples.floor() as usize;
+        audio_remainder = samples - whole_samples as f64;
+        let before_tick = runner.guest_tick();
+        let work = frame(&mut runner, whole_samples);
+        if trace && elapsed.is_multiple_of(60) {
+            use systemless::cpu::Register;
+            eprintln!(
+                "[HEADLESS-TIME-TRACE] frontend={elapsed} guest={} m68k_pc={:08X} sp={:08X} d0={:08X} tracking={} instructions={}",
+                runner.guest_tick(),
+                runner.cpu().read_reg(Register::PC),
+                runner.cpu().read_reg(Register::A7),
+                runner.cpu().read_reg(Register::D0),
+                runner.is_ui_tracking_active(),
+                work.instructions,
+            );
+        }
+        instructions += work.instructions as u64;
+        same_tick_frames += u32::from(runner.guest_tick() == before_tick);
+        budget_exhausted_frames += u32::from(work.budget_exhausted);
+        if work.foreground > 0 {
+            mouse.observe_guest_progress();
+        }
+        if let Some((v, h)) = mouse.take_ready_release() {
+            runner.push_mouse_up(v, h);
+        }
+        captured_audio.clear();
+        runner.drain_audio_into(&mut captured_audio);
+        audio_count += captured_audio.len() as u64;
+        for &sample in &captured_audio {
+            audio_hash = (audio_hash ^ u64::from(sample)).wrapping_mul(0x100_0000_01b3);
+        }
+        if runner.is_halted() {
+            eprintln!(
+                "[HEADLESS-TIME] incomplete frontend_ticks={} instructions={instructions}",
+                elapsed + 1
+            );
+            save_screenshot(&runner, 9999);
+            std::process::exit(1);
+        }
+    }
+    eprintln!(
+        "[HEADLESS-TIME] complete frontend_ticks={ticks} guest_tick={} instructions={instructions} input_events={next_event} same_tick_frames={same_tick_frames} budget_exhausted_frames={budget_exhausted_frames} captured_mono_samples={audio_count} audio_hash={audio_hash:016x}",
+        runner.guest_tick()
+    );
+    if budget_exhausted_frames > 0 {
+        eprintln!(
+            "[HEADLESS-TIME] WARNING: {budget_exhausted_frames} frame(s) exhausted the work budget before reaching their guest tick target; check progress before comparing CPU totals."
+        );
+    }
+    saves.sync_save_files_now(&mut runner);
+    save_screenshot(&runner, 9999);
+    runner.print_pc_histogram(24);
+    runner.print_opcode_histogram(24);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+    use systemless::cpu::Register;
+    use systemless::memory::MemoryBus;
+
+    fn modal_runner() -> FixtureRunner {
+        let mut runner = FixtureRunner::new(
+            8 * 1024 * 1024,
+            systemless::runner::FixtureRunnerConfig::default(),
+        );
+        runner.bus_mut().write_word(0x10000, 0xA991);
+        runner.cpu_mut().write_reg(Register::PC, 0x10000);
+        runner.cpu_mut().write_reg(Register::A7, 0x100000);
+        let mut tracking = systemless::trap::dispatch::DialogTrackingState::default();
+        tracking.dialog_ptr = 0x200000;
+        tracking.bounds = (0, 0, 32, 32);
+        tracking.proc_id = 1;
+        tracking.draw_procs_done = true;
+        tracking.rendered_pixels_final = true;
+        runner.dispatcher_mut().dialog_tracking = Some(tracking);
+        configure_realtime_execution_rate(&mut runner);
+        runner
+    }
+
+    #[test]
+    fn cli_keeps_instruction_and_tick_scripts_separate() {
+        assert!(super::super::Cli::try_parse_from([
+            "systemless",
+            "--headless",
+            "--max-ticks",
+            "60",
+            "--tick-input-script",
+            "ticks.txt",
+            "game.sit"
+        ])
+        .is_ok());
+        for conflicting in ["--max-instructions", "--input-script"] {
+            assert!(super::super::Cli::try_parse_from([
+                "systemless",
+                "--headless",
+                "--max-ticks",
+                "60",
+                conflicting,
+                "100",
+                "game.sit"
+            ])
+            .is_err());
+        }
+        assert!(
+            super::super::Cli::try_parse_from(["systemless", "--max-ticks", "60", "game.sit"])
+                .is_err()
+        );
+        assert!(super::super::Cli::try_parse_from([
+            "systemless",
+            "--headless",
+            "--max-ticks",
+            "0",
+            "game.sit"
+        ])
+        .is_err());
+    }
+
+    #[test]
+    fn frontend_frame_keeps_running_guest_within_one_tick() {
+        let mut runner = FixtureRunner::new(
+            8 * 1024 * 1024,
+            systemless::runner::FixtureRunnerConfig::default(),
+        );
+        let pc = runner.bus_mut().alloc(2);
+        runner.bus_mut().write_word(pc, 0x60FE); // BRA.S *
+        runner.cpu_mut().write_reg(Register::PC, pc);
+        runner.cpu_mut().write_reg(Register::A7, 0x0008_0000);
+        configure_realtime_execution_rate(&mut runner);
+        let start = runner.guest_tick();
+        let work = frame(&mut runner, 0);
+        assert!(work.foreground > 0);
+        assert!(!work.budget_exhausted);
+        assert!(!runner.is_halted());
+        assert_eq!(runner.guest_tick(), start + 1);
+    }
+
+    #[test]
+    fn realtime_initialization_replaces_the_fixture_rate() {
+        let mut runner = FixtureRunner::new(
+            8 * 1024 * 1024,
+            systemless::runner::FixtureRunnerConfig::default(),
+        );
+        let fixture_rate = runner.instructions_per_tick();
+        let realtime_rate = configure_realtime_execution_rate(&mut runner);
+        assert_eq!(realtime_rate, 415_628);
+        assert_ne!(fixture_rate, realtime_rate);
+        assert_eq!(runner.instructions_per_tick(), realtime_rate);
+        let pc = 0x10000;
+        runner.bus_mut().write_word(pc, 0x60FE); // BRA.S *
+        runner.cpu_mut().write_reg(Register::PC, pc);
+        runner.cpu_mut().write_reg(Register::A7, 0x100000);
+        let work = frame(&mut runner, 0);
+        assert!(work.foreground > fixture_rate as usize);
+        assert!(!work.budget_exhausted);
+    }
+
+    #[test]
+    fn foreground_batches_defer_menu_painting_until_frame_presentation() {
+        let mut runner = FixtureRunner::new(
+            8 * 1024 * 1024,
+            systemless::runner::FixtureRunnerConfig::default(),
+        );
+        let pc = runner.bus_mut().alloc(8);
+        let stack = 0x0008_0000;
+        // Install a menu using guest traps, without presenting it yet.
+        let title = runner.bus_mut().alloc(5);
+        runner.bus_mut().write_bytes(title, b"\x04File");
+        runner.cpu_mut().write_reg(Register::PC, pc);
+        runner.cpu_mut().write_reg(Register::A7, stack);
+        runner.bus_mut().write_word(pc, 0xA931); // NewMenu
+        runner.bus_mut().write_long(stack, title);
+        runner.bus_mut().write_word(stack + 4, 1);
+        assert!(runner.run_gui_cpu_slice(1, u32::MAX).1);
+        let menu = runner.bus().read_long(stack + 6);
+        assert_ne!(menu, 0);
+        runner.cpu_mut().write_reg(Register::PC, pc);
+        runner.cpu_mut().write_reg(Register::A7, stack);
+        runner.bus_mut().write_word(pc, 0xA935); // InsertMenu
+        runner.bus_mut().write_word(stack, 0);
+        runner.bus_mut().write_long(stack + 2, menu);
+        assert!(runner.run_gui_cpu_slice(1, u32::MAX).1);
+
+        let screen = runner.bus_mut().alloc(800 * 600);
+        runner.dispatcher_mut().screen_mode = (screen, 800, 800, 600, 8);
+        runner.bus_mut().write_word(0x0BAA, 20);
+        runner.bus_mut().fill_bytes(screen, 800 * 20, 0xAA);
+        // Every foreground iteration samples a byte the menu will paint.
+        // Batch-level composition would change D0 before the frame ends.
+        runner.bus_mut().write_word(pc, 0x1039); // MOVE.B abs.L,D0
+        runner.bus_mut().write_long(pc + 2, screen + 400);
+        runner.bus_mut().write_word(pc + 6, 0x60F8); // BRA.S back to MOVE
+        runner.cpu_mut().write_reg(Register::PC, pc);
+        runner.bus_mut().write_long(0x016A, 0);
+        runner.set_instructions_per_tick((game::MAX_INSTRUCTIONS_PER_FRAME * 2) as u32);
+        let work = frame(&mut runner, 366);
+        assert!(work.foreground > super::super::CPU_BATCH_INSTRUCTIONS);
+        assert!(!runner.is_halted());
+        assert_eq!(runner.cpu().read_reg(Register::D0) & 0xFF, 0xAA);
+        assert_ne!(
+            runner.bus().read_byte(screen + 400),
+            0xAA,
+            "the final presentation must still draw the menu"
+        );
+    }
+
+    #[test]
+    fn retained_modal_wait_matches_desktop_tick_scheduling_without_a_window() {
+        use super::super::{App, FRAME_DURATION};
+        let mut timed = modal_runner();
+        let start = timed.guest_tick();
+        let mut app = App::new("dummy".into(), false, true, false, 8);
+        app.runner = Some(modal_runner());
+        let origin = std::time::Instant::now();
+        app.start_time = Some(App::wall_clock_origin_for_guest_tick(origin, start));
+        for elapsed in 0..10 {
+            let now = origin + FRAME_DURATION * elapsed;
+            app.next_frame_time = Some(now + FRAME_DURATION);
+            app.step_frame_with_clock(|| now);
+            let work = frame(&mut timed, 366);
+            assert_eq!(work.foreground, 1, "one modal refire per frontend tick");
+            assert!(!work.budget_exhausted);
+            let gui = app.runner.as_ref().unwrap();
+            assert_eq!(timed.guest_tick(), start + elapsed + 1);
+            assert_eq!(timed.guest_tick(), gui.guest_tick());
+            for register in [Register::PC, Register::A7] {
+                assert_eq!(timed.cpu().read_reg(register), gui.cpu().read_reg(register));
+            }
+        }
+        assert_eq!(app.total_instructions, 10);
+    }
+
+    #[test]
+    fn input_at_or_after_the_endpoint_is_an_error() {
+        let script = super::super::parse_input_script("60 click 100 200").unwrap();
+        assert!(validate_script(&script, 60).is_err());
+        assert!(validate_script(&script, 59).is_err());
+        assert!(validate_script(&script, 61).is_ok());
+    }
+
+    #[test]
+    fn same_tick_click_preserves_button_down_until_guest_progress() {
+        let mut runner = FixtureRunner::new(
+            8 * 1024 * 1024,
+            systemless::runner::FixtureRunnerConfig::default(),
+        );
+        let mut mouse = HostMouseReleaseLatch::default();
+        for event in super::super::parse_input_script("0 click 100 200").unwrap() {
+            deliver(&mut runner, &mut mouse, event.action);
+        }
+        assert_eq!(runner.bus().read_byte(0x0172), 0);
+        assert!(mouse.take_ready_release().is_none());
+        mouse.observe_guest_progress();
+        let (v, h) = mouse.take_ready_release().unwrap();
+        runner.push_mouse_up(v, h);
+        assert_eq!(runner.bus().read_byte(0x0172), 0x80);
+    }
+}

--- a/src/bin/systemless.rs
+++ b/src/bin/systemless.rs
@@ -16,6 +16,8 @@
 
 #[path = "desktop/desktop_save_store.rs"]
 mod desktop_save_store;
+#[path = "desktop/headless_time.rs"]
+mod headless_time;
 #[cfg(target_os = "macos")]
 #[path = "desktop/host_cursor.rs"]
 mod host_cursor;
@@ -130,6 +132,17 @@ fn foreground_cpu_batch_instructions(powerpc: bool, instructions_per_tick: u32) 
     }
 }
 
+/// Both realtime frontends must use the loaded architecture's execution rate.
+/// Calling GUI slice methods alone does not change the fixture's much smaller
+/// default budget, which would put identical tick-script inputs at different
+/// points in application startup.
+fn configure_realtime_execution_rate(runner: &mut FixtureRunner) -> u32 {
+    let instructions =
+        systemless::runner::default_realtime_instructions_per_tick(runner.is_powerpc_app());
+    runner.set_instructions_per_tick(instructions);
+    instructions
+}
+
 /// A learned crop is discarded when substantial drawing persists in the area
 /// it excludes. This catches apps whose large offscreen playfield is only one
 /// part of a full-screen layout without reacting to a cursor or brief overlay.
@@ -170,6 +183,33 @@ struct Cli {
     #[arg(long, value_name = "N")]
     max_instructions: Option<usize>,
 
+    /// Run headlessly for this many simulated frontend ticks (60.15 Hz),
+    /// using GUI wait/callback scheduling. Defaults to 600 without legacy options.
+    #[arg(
+        long,
+        requires = "headless",
+        conflicts_with_all = ["max_instructions", "input_script"],
+        value_parser = clap::value_parser!(u32).range(1..)
+    )]
+    max_ticks: Option<u32>,
+
+    /// Input script timestamped in elapsed frontend ticks, not instructions
+    #[arg(
+        long,
+        requires = "max_ticks",
+        conflicts_with = "input_script",
+        value_name = "FILE"
+    )]
+    tick_input_script: Option<PathBuf>,
+
+    /// Deterministic Mac-epoch startup seconds for simulated-time headless runs
+    #[arg(
+        long,
+        requires = "headless",
+        conflicts_with_all = ["max_instructions", "input_script"]
+    )]
+    headless_start_time: Option<u32>,
+
     /// Prefer a native PowerPC slice when a classic 68K slice is also available
     #[arg(long, visible_alias = "prefer-ppc")]
     prefer_powerpc: bool,
@@ -201,9 +241,8 @@ struct Cli {
     #[arg(long)]
     fullscreen: bool,
 
-    /// Replay input events from a script during a headless run. Events are
-    /// scheduled by retired instruction count, so a run replays identically
-    /// every time and two builds can be compared on matched work.
+    /// Legacy diagnostic input script timestamped in retired instructions.
+    /// Not a matched-time workload: wait optimizations change when inputs land.
     #[arg(long, value_name = "FILE")]
     input_script: Option<PathBuf>,
 }
@@ -356,12 +395,9 @@ fn window_guest_resize_scale(window: &Window, display_scale: Option<u32>) -> Opt
     )
 }
 
-/// One scripted input, delivered once the run has retired `at`
-/// instructions.
-///
-/// Scheduling on the instruction count rather than wall time is the whole
-/// point: a wall-clock schedule would land differently on a faster build,
-/// which is exactly the comparison these scripts exist to make.
+/// One scripted input. The caller explicitly chooses the clock: retired
+/// instructions for legacy diagnostic scripts, or elapsed simulated frontend
+/// ticks for time-based replays. Neither clock is host wall time.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct ScriptedInput {
     at: usize,
@@ -581,6 +617,15 @@ fn platform_window_attrs(attrs: WindowAttributes) -> WindowAttributes {
 fn service_pending_sound_work(
     runner: &mut FixtureRunner,
     _cpu_deadline: std::time::Instant,
+    slice_budget: usize,
+    total_steps: usize,
+    reserved_sound_steps: &mut usize,
+) -> Option<usize> {
+    service_pending_sound_work_budgeted(runner, slice_budget, total_steps, reserved_sound_steps)
+}
+
+fn service_pending_sound_work_budgeted(
+    runner: &mut FixtureRunner,
     slice_budget: usize,
     total_steps: usize,
     reserved_sound_steps: &mut usize,
@@ -1032,12 +1077,7 @@ impl App {
         runner.prepare_text_presentation();
         runner.set_arrows_as_numpad(self.arrows_as_numpad);
 
-        // Configure the wall-clock-paced GUI from the loaded architecture's
-        // machine profile. Scripted harnesses retain their smaller default
-        // unless they explicitly opt into realtime pacing.
-        let ipt =
-            systemless::runner::default_realtime_instructions_per_tick(runner.is_powerpc_app());
-        runner.set_instructions_per_tick(ipt);
+        let ipt = configure_realtime_execution_rate(&mut runner);
         eprintln!("[SYSTEMLESS] Instructions per tick: {}", ipt);
 
         // Initialize audio output.
@@ -2997,6 +3037,9 @@ fn run_headless(
     script: &[ScriptedInput],
     ui_theme: UiThemeId,
 ) {
+    eprintln!(
+        "[HEADLESS] Legacy instruction-budget diagnostic mode: retained Toolbox waits may re-fire repeatedly; do not use these totals as GUI CPU measurements. Use --max-ticks with --tick-input-script for time-based runs."
+    );
     eprintln!("[HEADLESS] Starting: {}", game_path.display());
     eprintln!("[HEADLESS] Max instructions: {}", max_instructions);
 
@@ -3114,7 +3157,13 @@ fn main() {
     eprintln!("[SYSTEMLESS] Game: {}", game_path.display());
 
     if cli.headless {
-        let script = match cli.input_script.as_deref() {
+        let timed = cli.max_instructions.is_none() && cli.input_script.is_none();
+        let script_path = if timed {
+            cli.tick_input_script.as_deref()
+        } else {
+            cli.input_script.as_deref()
+        };
+        let script = match script_path {
             Some(path) => {
                 let text = std::fs::read_to_string(path).unwrap_or_else(|e| {
                     eprintln!("Error: cannot read input script {}: {e}", path.display());
@@ -3127,14 +3176,26 @@ fn main() {
             }
             None => Vec::new(),
         };
-        run_headless(
-            &game_path,
-            cli.max_instructions.unwrap_or(5_000_000),
-            cli.addressing_24_bit,
-            cli.screen_depth,
-            &script,
-            cli.ui_theme,
-        );
+        if timed {
+            headless_time::run(
+                &game_path,
+                cli.max_ticks.unwrap_or(600),
+                cli.headless_start_time.unwrap_or(3_871_497_600),
+                cli.addressing_24_bit,
+                cli.screen_depth,
+                &script,
+                cli.ui_theme,
+            );
+        } else {
+            run_headless(
+                &game_path,
+                cli.max_instructions.unwrap_or(5_000_000),
+                cli.addressing_24_bit,
+                cli.screen_depth,
+                &script,
+                cli.ui_theme,
+            );
+        }
     } else {
         if cli.input_script.is_some() {
             eprintln!("Error: --input-script requires --headless");
@@ -4266,6 +4327,15 @@ mod tests {
 
     #[test]
     fn step_frame_services_pending_sound_before_late_same_tick_audio_mix() {
+        check_pending_sound_before_audio_mix(false);
+    }
+
+    #[test]
+    fn headless_frame_services_pending_sound_before_audio_mix() {
+        check_pending_sound_before_audio_mix(true);
+    }
+
+    fn check_pending_sound_before_audio_mix(headless: bool) {
         use systemless::cpu::Register;
         use systemless::memory::MemoryBus;
         use systemless::sound::{
@@ -4278,7 +4348,7 @@ mod tests {
         let scheduled_frame_end = now;
         let (mut runner, queued) = gui_runner_with_recording_audio();
         let interrupted_pc = runner.bus_mut().alloc(2);
-        runner.bus_mut().write_word(interrupted_pc, 0x4E71); // foreground NOP
+        runner.bus_mut().write_word(interrupted_pc, 0x60FE); // foreground BRA.S *
         runner.cpu_mut().write_reg(Register::PC, interrupted_pc);
         runner.cpu_mut().write_reg(Register::A7, 0x0008_0000);
 
@@ -4346,7 +4416,11 @@ mod tests {
         app.start_time = Some(scheduled_frame_end);
         app.next_frame_time = Some(scheduled_frame_end);
 
-        app.step_frame();
+        if headless {
+            headless_time::frame(app.runner.as_mut().unwrap(), 366);
+        } else {
+            app.step_frame();
+        }
 
         let queued = queued.borrow();
         assert!(
@@ -4366,6 +4440,15 @@ mod tests {
 
     #[test]
     fn step_frame_services_doubleback_between_late_audio_chunks() {
+        check_doubleback_between_audio_chunks(false);
+    }
+
+    #[test]
+    fn headless_frame_services_doubleback_between_audio_chunks() {
+        check_doubleback_between_audio_chunks(true);
+    }
+
+    fn check_doubleback_between_audio_chunks(headless: bool) {
         use systemless::cpu::Register;
         use systemless::memory::MemoryBus;
         use systemless::sound::{DoubleBufferState, SndChannel, OUTPUT_RATE};
@@ -4375,7 +4458,7 @@ mod tests {
         let now = std::time::Instant::now();
         let (mut runner, queued) = gui_runner_with_recording_audio();
         let interrupted_pc = runner.bus_mut().alloc(2);
-        runner.bus_mut().write_word(interrupted_pc, 0x4E71); // foreground NOP
+        runner.bus_mut().write_word(interrupted_pc, 0x60FE); // foreground BRA.S *
         runner.cpu_mut().write_reg(Register::PC, interrupted_pc);
         runner.cpu_mut().write_reg(Register::A7, 0x0008_0000);
 
@@ -4454,7 +4537,11 @@ mod tests {
         app.start_time = Some(now);
         app.next_frame_time = Some(now);
 
-        app.step_frame();
+        if headless {
+            headless_time::frame(app.runner.as_mut().unwrap(), 366);
+        } else {
+            app.step_frame();
+        }
 
         let queued = queued.borrow();
         assert!(

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -28130,6 +28130,39 @@ mod tests {
     }
 
     #[test]
+    fn time_driven_modal_wait_avoids_instruction_budget_refire_storm() {
+        fn modal_runner() -> FixtureRunner {
+            let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+            runner.bus.write_word(0x10000, 0xA991);
+            runner.m68k.cpu.write_reg(Register::PC, 0x10000);
+            runner.m68k.cpu.write_reg(Register::A7, 0x100000);
+            runner.set_guest_tick_for_test(0);
+            runner.bus.write_long(0x016A, 0);
+            runner.set_instructions_per_tick(10_000);
+            runner.dispatcher.dialog_tracking = Some(dialog_tracking_for_test(0, 0));
+            runner
+        }
+        let mut diagnostic = modal_runner();
+        let mut timed = modal_runner();
+        let (diagnostic_steps, diagnostic_running) = diagnostic.run_steps(20_000, Some(2));
+        let (timed_steps, timed_running) = timed.run_gui_cpu_slice(20_000, 2);
+        assert!(diagnostic_running && timed_running);
+        assert_eq!(diagnostic.guest_tick(), 2);
+        assert_eq!(timed.guest_tick(), 2);
+        assert!(
+            diagnostic_steps > 1_000,
+            "legacy mode consumes synthetic refires"
+        );
+        assert_eq!(timed_steps, 2, "one idle refire per simulated tick");
+        for register in [Register::PC, Register::A7] {
+            assert_eq!(
+                diagnostic.m68k.cpu.read_reg(register),
+                timed.m68k.cpu.read_reg(register)
+            );
+        }
+    }
+
+    #[test]
     fn gui_modaldialog_idle_refire_runs_until_tick_cap() {
         let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
         let base = 0x0001_0000u32;


### PR DESCRIPTION
# Drive headless replays by simulated frontend time and GUI wait scheduling

## Summary

Add `--max-ticks` and `--tick-input-script` for windowless, deterministic-input
replays at fixed simulated frontend time. Reuse the desktop's retained-wait,
timer, sound-callback and execution-rate policies. Preserve the existing
instruction-quota mode as an explicitly labeled diagnostic mode.

This corrects a performance-measurement artifact; it does **not** claim a
windowed CPU improvement, change the guest CPU timing model, or tune the JIT.
Originally based on master `b4bbe723`, including the merged font/presentation work (#1524). Normal merge commit `9f984ae6` now incorporates upstream `b5f4f083` / 0.39.1 and #1595's foreground callback/nested-dialog corrections.
No private macOS performance-counter instrumentation or unrelated performance
candidate is included.

**Refreshed-head checks:** [CI on `9f984ae6`](https://github.com/benletchford/systemless/actions/runs/34197977034) passes Linux build/tests, headless/package checks, licenses, and the nonblocking formatting/clippy job. The earlier MPW-download timeout is not a failure on this head. Historical local test counts and replay checkpoints below are not relabeled as new 0.39.1 measurements.

## How this fits with the other performance work

The font/retained-text overhaul, [Systemless #1524](https://github.com/benletchford/systemless/pull/1524), merged in 0.39.0. The effect sizes below are **SC2K process CPU time for the stated replay**, not GUI Activity Monitor percentages or a cross-workload ranking.

| Change | Relationship | SC2K evidence and rendering era |
|---|---|---|
| [#1596: fixed-time headless scheduling](https://github.com/benletchford/systemless/pull/1596) | Measurement prerequisite; independent of the optimizations | No claimed windowed CPU saving. Corrects artificial retained-wait re-entry in older instruction-quota benchmarks. |
| [#1597: defer sound-slice chrome](https://github.com/benletchford/systemless/pull/1597) | Independent runtime PR; does not require #1421/#1423 or m68k #174 | About **41.0% less CPU**, after #1524, measured on 0.39.0 with #1596's scheduling overlay. Largest demonstrated post-overhaul saving among these open PRs. Not a new 0.39.1 rerun. |
| [#1423: device-colour mirror](https://github.com/benletchford/systemless/pull/1423) | Prerequisite for #1421 | Historical SC2K CPU −0.9%, before #1524, on an earlier implementation/legacy driver. Not current-mirror acceptance. |
| [#1421: theme-artwork cache](https://github.com/benletchford/systemless/pull/1421) | Stacked on and includes #1423 | Historical CPU −20.8%, **including #1423**, before #1524/with the legacy driver. Do not add the two PR percentages. |
| [m68k #174: publication generations](https://github.com/benletchford/m68k-rs/pull/174) | Separate opt-in CPU-core API; needs an audited Systemless integration that is not shipped in these PRs | Historical CPU −4.64% on a local integration before #1524/with the legacy driver; not a current Systemless benefit. |

**[Draft #1598: retained-pixel hashing](https://github.com/benletchford/systemless/pull/1598)** is stacked on #1597, not included in any of the five PRs above. It measured about31.2% additional SC2K CPU reduction on0.39.0 and31.6–40.4% on the refreshed0.39.1 stack; both are after #1524. Clock/load variation means that wider range is not evidence that0.39.1 made the patch better. EV is not cleared: its unrestricted current pair used2.369% more CPU; a severely throttled reverse pair is excluded. The PR remains draft for that check. A separate local bulk retained-fill prototype has **no measured effect size yet**. Sequential reductions apply to remaining work, not by adding percentages; there is no directly measured all-PR total.

### What the text-rendering overhaul changed

#1524 added CPU-side retained high-resolution glyph coverage alongside guest framebuffer bytes. Glyph masks are cached: the new hot work is repeatedly erasing/repainting their pixels and updating subpixel, palette and snapshot state, not necessarily rasterizing font outlines again. GPU presentation does not remove this bookkeeping.

That changes what each optimization can save. #1421 avoids rebuilding themed **background artwork**, but replay still performs observed pixel writes and actual title glyphs are drawn separately. #1423 makes colour resolution cheaper, not retained-pixel bookkeeping. #1597 removes whole redundant paint passes, so it also avoids their new text cost. #1598 and the separate local bulk-fill work target that remaining per-pixel cost directly.

**We have not run a matched before/after-#1524 experiment for the older PRs.** Their percentage changes therefore cannot yet be quantified; the old numbers must not be ranked against the 41%/31% post-overhaul results as if they shared a baseline. More rendering CPU can also dilute a JIT optimization's percentage without making the JIT optimization itself slower. The mechanism explains why priorities changed, but is not proof of a particular slowdown or speedup caused by #1524 alone.

**Theme is another comparison boundary:** the 41% and 31% post-overhaul replays use `classic-system7`. #1421's non-classic theme-artwork cache is bypassed in that path, so it does not add its historical 20.8% saving to those runs. The old `5f21681` CLI default was `systemless-default`; the current CLI default is `classic-system7`. Changes in theme, scheduling and retained rendering must be separated before attributing a changed effect size specifically to #1524.

## Why instruction-bounded headless runs were misleading

Some Toolbox calls retain a native wait instead of returning immediately to
guest code. ModalDialog is one example: the native handler can rewind the
guest PC and wait for another frontend scheduling opportunity. Desktop
execution already recognizes that condition, services the appropriate time
and audio work, and yields.

The old headless `run_steps` path does not use those GUI yield boundaries.
Given a large instruction quota, it can repeatedly re-enter the retained
wait until that quota is spent. Making each such entry cheaper produces a
real saving per call, but at an artificially high call frequency. That is
not evidence of the same saving in a window or during gameplay. One EV
Override replay intended to reach gameplay actually ended in a retained
ship-name dialog; its previous CPU figures are excluded from gameplay claims.

Instruction-indexed input has a second problem: eliminating guest idle
instructions changes when the same numbered instruction is reached in
simulated time. Equal instruction quotas are useful interpreter diagnostics,
but can penalize legitimate idle skipping or compare different game progress.

The replacement holds frontend time and scripted input constant. Acceptance
still requires checking actual game progress, guest ticks, pictures and audio;
equal frontend ticks alone cannot establish equivalent workloads.

## Scheduling and compatibility

- A tick is 1/60.15 simulated seconds. There is no wall-clock sleep, window,
  compositor, or physical audio device. With no legacy options, headless
  defaults to 600 ticks (about ten simulated seconds).
- Initialize the loaded architecture with the same execution rate as the
  GUI: 415,628 instructions/tick for 68K, 1,995,012 for PPC. Calling GUI slice
  methods alone does not replace the fixture's much smaller default rate.
  The initialization is shared with the GUI so these values cannot diverge.
- Each virtual frame requests the next guest tick through bounded foreground
  CPU batches. A short retained-tracking slice ends foreground work for that
  frame. A nontracking short slice with progress can be an ordinary task/engine
  handoff, so it is allowed to continue within the safety bound. Zero progress
  yields rather than spinning.
- Menu tracking may freeze guest TickCount. The frontend clock, input and
  audio still advance. The menu presentation clock advances once per frame.
- Audio samples retain their fractional remainder between frames. Mixing is
  interleaved with guest work; bounded guest sound-callback servicing and the
  desktop's remaining-audio chunk size are reused. Playback/callbacks still
  run without a host audio device.
- Follow the newly merged deferred-presentation path: `run_gui_cpu_slice`
  does not repaint chrome per batch; audio mixing is separate; text
  presentation preparation and composition occur at the end of the frame.
- Use the existing mouse-release latch so a scripted press/release in one
  tick still gives the guest an opportunity to observe button-down.
- Fix the startup Mac clock/initial seed by default; allow an explicit
  `--headless-start-time` override. Save files still need independent pristine
  copies. This is not a guarantee against every source of game nondeterminism.
- Retain `--max-instructions` / `--input-script` behavior and emit a warning
  describing the retained-wait limitation. Tick and instruction modes cannot
  be mixed or silently reinterpret the other's timestamps. Reject a script
  event at or beyond the chosen endpoint rather than silently dropping it.

The instruction safety bound remains an existing machine scheduling policy,
not a realistic cycle cost for every 68K instruction. A halted run exits with
failure. Reports expose frontend/guest clocks, retired instruction work,
delivered inputs, same-guest-tick frames, budget exhaustion and captured mono
audio sample count/digest. Exhaustion is explicitly warned about; it must be
investigated before using a run for a CPU comparison.

## Usage

```sh
systemless --headless --max-ticks 600 game.sit
systemless --headless --max-ticks 4800 --tick-input-script inputs.txt game.sit
```

Input coordinates are vertical, horizontal. For example:

```text
120 mousedown 317 491
122 mouseup 317 491
```

These are elapsed **frontend ticks**, not guest TickCount or host wall time.
Use game-specific, visually verified inputs and fresh copies of the same
archive/saves on both sides of a comparison.

## Verification

**September 8 refresh:** the test counts and gameplay checkpoints below are historical validation on `b4bbe723` / PR head `26e4d7c2`. The refreshed head `9f984ae6` needs combined validation with upstream #1595; no new test or performance result is implied by the clean merge. The prior Linux build/test job passed, but its headless/package job stopped in the external pinned MPW download before those checks ran. That infrastructure failure is not counted as a passing headless/package result.

On b4bbe723 with published m68k 0.13.0, the full library suite passed:
**5,364 passed, 0 failed, 3 ignored**. All nine headless-specific desktop
tests passed. Full desktop suite: **97 passed, 1 failed, 1 ignored**.

The desktop failure is the unchanged upstream
`metal_present::tests::minification_retains_thin_strokes_between_sample_centers`.
It first could not access a Metal device under the local sandbox; with
offscreen GPU access it fails the CPU/GPU pixel-tolerance assertion. It also
fails alone in a fresh process, without running the headless tests. The
Metal source, shader, and software display source match upstream blob hashes
exactly. This is reported rather than hidden by skipping the test. No window
was opened. Whole-tree rustfmt also reports the pre-existing formatting
differences already acknowledged as non-blocking in upstream CI; the new
headless module passes its targeted rustfmt check and `git diff --check`.

Test command (Intel macOS, rustc 1.96.1):

```sh
CARGO_INCREMENTAL=0 cargo test --profile ci-test --locked --offline \
  --features test-support --config profile.ci-test.codegen-units=4 \
  --lib --bin systemless -j1 -- --test-threads=2
```

Production-release checkpoints were revalidated on the pre-refresh driver
with the same published dependencies (private phase counters were present
only in the local measurement build). These were **correctness-only runs**
overlapping test compilation; their CPU totals are excluded from acceptance.

| Replay | Frontend phase | Guest phase ticks | Guest phase instructions | Checkpoints inspected |
|---|---:|---:|---:|---|
| EV Override | 3300–6300 | 3000 | 202,572,307 | Actual flight near Earth, NPCs/asteroids, full shields at entry; not a retained name dialog |
| SimCity 2000 | 1800–4800 | 3000 | 151,529,853 | Empty new city advancing January to October 1900, no budget dialog |

Both deliver every scripted input (16 EV, 8 SC2K), remain running, and report
zero same-tick frames and zero exhausted frame budgets. SC2K's phase guest
instruction count and captured mono audio also match the earlier driver;
fonts and other upstream changes mean old pictures are not substituted for
current checkpoints. These checks verify the replay milestones, not visual
perfection or a CPU saving. No windowed CPU/FPS claim is made.

Focused regressions cover CLI mode separation and invalid endpoints, shared
GUI-rate initialization, one-tick progress, retained-modal GUI/headless PC/SP
and clock agreement, one refire per frontend tick, mouse-release latching,
sound callbacks before subsequent mixing, and deferred menu painting. The
last test has guest code repeatedly read a menu-bar pixel across foreground
batches: it must see the original byte throughout guest execution, and the
final presentation must still paint the menu.

The library regression contrasts the same retained wait under legacy and GUI
scheduling. It illustrates removal of synthetic replay work, not a new game
optimization. Font/presentation changes require fresh gameplay checkpoints;
old replay screenshots are not accepted as current-master validation.

## Limits and lessons

Headless does not reproduce the GUI's real wall-clock cutoff/catch-up behavior,
host rendering, drawable waits or device output. Its CPU seconds are not an
Activity Monitor percentage and its virtual ticks are not measured display
FPS. Captured audio checks cover mono mixed samples, not full stereo/device
equivalence. Checkpoints cannot prove every transient frame.

For a native-style optimization, first remove work that an event-driven app
would not perform. A benchmark that forces an already-parked GUI wait to
re-enter obscures that distinction. Correcting this driver makes subsequent
trap/drawing optimizations testable at a representative call frequency; those
patches and their measured effects belong in separate PRs.
