### PR TITLE
fix: encode current application names as MacRoman

### DIFF
--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -3918,7 +3918,7 @@ impl FixtureRunner {
         self.bus.write_word(addr::CUR_APREF_NUM, 0);
         if let Some(app_path) = self.dispatcher.launched_app_path() {
             let app_name = crate::trap::dispatch::TrapDispatcher::vfs_basename(app_path);
-            let name_bytes = app_name.as_bytes();
+            let name_bytes = crate::mac_roman::encode_mac_roman_lossy(app_name);
             let len = name_bytes.len().min(31);
             self.bus.write_byte(addr::CUR_APNAME, len as u8);
             for (i, &b) in name_bytes.iter().take(len).enumerate() {
@@ -15660,6 +15660,32 @@ mod tests {
         )
         .expect("CurApName is ASCII");
         assert_eq!(cur_ap_name, "Register Helper");
+    }
+
+    #[test]
+    fn init_app_writes_cur_ap_name_as_mac_roman() {
+        use crate::memory::globals::addr;
+
+        let code0 = minimal_code0(0, 0x2000, 0, 0);
+        let fork_bytes = make_resource_fork_bytes(&[(*b"CODE", 0, &code0)]);
+        let fork = ResourceFork::parse(&fork_bytes).expect("parse app fork");
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        runner
+            .dispatcher
+            .set_launched_app_path("Games/Shufflepuck Café v1.0");
+
+        let app = runner.load_app(&fork).expect("load app");
+        runner.init_app(&app);
+
+        assert_eq!(
+            runner.bus.read_pstring(addr::CUR_APNAME),
+            b"Shufflepuck Caf\x8E v1.0",
+            "CurApName is a classic Str31 and must preserve MacRoman filenames"
+        );
+        assert_eq!(
+            crate::trap::dispatch::TrapDispatcher::read_pb_filename(&runner.bus, addr::CUR_APNAME),
+            "Shufflepuck Café v1.0"
+        );
     }
 
     #[test]


### PR DESCRIPTION
`CurApName` is a classic `Str31`, but launch initialization copied the UTF-8 bytes of the VFS path into that low-memory field. Applications that reopen themselves through `CurApName` consequently decoded accented names as two MacRoman characters and received `fnfErr` from `PBOpen`.

Encode the basename as MacRoman before writing `CurApName`. This follows the classic string encoding used by File Manager parameter blocks and preserves the existing 31-byte limit.

Evidence:
- Before: `PBOpen` requested `Shufflepuck Caf√© v1.0`, failed with `fnfErr`, and the game displayed its File Manager `IOErr -43` modal.
- After: `PBOpen` requests `Shufflepuck Café v1.0`; the deterministic run reaches the cafe, selects an opponent, enters the air-hockey table, and accepts mallet input through tick 3039.
- The focused regression verifies the exact MacRoman `CurApName` bytes and round-trips them through the File Manager filename decoder.

Checks:
- `cargo test -p systemless init_app_writes_cur_ap_name_as_mac_roman --lib`
- `cargo test -p systemless pending_launch_application --lib`
- deterministic Shufflepuck Cafe gameplay script through cafe, gameplay, and post-input captures

Closes #1600
