### PR TITLE
fix: report resized resource handle sizes

### DIFF
--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -5547,36 +5547,6 @@ impl TrapDispatcher {
         }
     }
 
-    pub(crate) fn resource_handle_memory_size(
-        &self,
-        bus: &MacMemoryBus,
-        handle: u32,
-        ptr: u32,
-    ) -> Option<u32> {
-        let size = bus.get_alloc_size(ptr)?;
-        if let Some((refnum, res_type, res_id)) = self.resource_record_for_handle(handle) {
-            if let Some(data) = self.resource_backing_data.get(&(refnum, res_type, res_id)) {
-                // A resource handle's logical size is the resource's own data
-                // length. The block behind it is padded out to a 4-byte
-                // boundary, but that padding is physical size and GetHandleSize
-                // reports the logical one.
-                // GetHandleSize ($A025)
-                // FUNCTION GetHandleSize (h: Handle): Size;
-                // Inside Macintosh Volume II, II-31; Memory 1992, 2-32
-                // ("the logical size ... not the physical size").
-                //
-                // Rounding up here hands callers that walk a resource as an
-                // array a phantom trailing element. SimCity 2000's far-model
-                // runtime derives its CREL relocation count as
-                // GetHandleSize/2, so a rounded-up size added a zero-offset
-                // entry and relocated the CODE segment's own header, leaving
-                // its jump-table entries permanently unpatched.
-                return Some(data.len() as u32);
-            }
-        }
-        Some(size)
-    }
-
     pub(crate) fn forget_resource_backing_data(
         &mut self,
         refnum: u16,

--- a/src/trap/memory.rs
+++ b/src/trap/memory.rs
@@ -1223,10 +1223,7 @@ impl super::TrapDispatcher {
                     write_memory_result(cpu, bus, NIL_HANDLE_ERR);
                 } else {
                     let ptr = bus.read_long(handle);
-                    let size = self
-                        .resource_handle_memory_size(bus, handle, ptr)
-                        .or_else(|| self.process_handle_size(bus, handle))
-                        .unwrap_or(0);
+                    let size = self.process_handle_size(bus, handle).unwrap_or(0);
                     if trace_sound_enabled() {
                         if let Some((_resource_ptr, res_type, res_id)) =
                             self.loaded_handles.get(&handle).copied()
@@ -7459,6 +7456,92 @@ mod tests {
             cpu.read_reg(Register::D0),
             50,
             "loaded resource handles should expose the resource's exact byte count"
+        );
+    }
+
+    #[test]
+    fn get_handle_size_tracks_resized_resource_handle_logical_size() {
+        // GetHandleSize reports the current logical size of the in-memory
+        // relocatable block. GetResourceSizeOnDisk/SizeResource is the API
+        // that reports the resource's unchanged on-disk size.
+        // GetHandleSize ($A025)
+        // FUNCTION GetHandleSize (h: Handle): Size;
+        // Inside Macintosh: Memory (1992), pp. 2-39--2-40; More Macintosh
+        // Toolbox (1993), p. 1-105.
+        let (mut dispatcher, mut cpu, mut bus) = setup();
+        let mut resource_bytes = vec![0x80; 199];
+        resource_bytes[165..169].copy_from_slice(b"Loca");
+        let data_ptr = bus.alloc(resource_bytes.len() as u32);
+        bus.write_bytes(data_ptr, &resource_bytes);
+        dispatcher.remember_resource_backing_data(0, *b"Xmnu", 131, resource_bytes);
+        let handle =
+            dispatcher.get_or_create_resource_handle_in_file(&mut bus, *b"Xmnu", 131, data_ptr, 0);
+        assert_eq!(dispatcher.handle_state_bits(handle), Some(0x60));
+
+        let resized_ptr = dispatcher.resize_resource_allocation(&mut bus, handle, data_ptr, 256);
+        assert_ne!(resized_ptr, 0);
+        cpu.write_reg(Register::A0, handle);
+        dispatcher
+            .dispatch_memory(false, 0x25, &mut cpu, &mut bus)
+            .expect("GetHandleSize should be handled")
+            .expect("GetHandleSize should succeed");
+        assert_eq!(cpu.read_reg(Register::D0), 256);
+
+        let first_source = bus.alloc(1);
+        bus.write_byte(first_source, 0xFF);
+        cpu.write_reg(Register::A0, first_source);
+        cpu.write_reg(Register::A1, handle);
+        cpu.write_reg(Register::D0, 1);
+        dispatcher
+            .dispatch_memory(true, 0x1EF, &mut cpu, &mut bus)
+            .expect("PtrAndHand should be handled")
+            .expect("PtrAndHand should succeed");
+        assert_eq!(cpu.read_reg(Register::D0), 0);
+        cpu.write_reg(Register::A0, handle);
+        dispatcher
+            .dispatch_memory(false, 0x25, &mut cpu, &mut bus)
+            .expect("GetHandleSize should be handled")
+            .expect("GetHandleSize should succeed");
+        assert_eq!(cpu.read_reg(Register::D0), 257);
+
+        let mut appended_record = [0u8; 34];
+        for (index, byte) in appended_record.iter_mut().enumerate().skip(4) {
+            *byte = index as u8;
+        }
+        let record_source = bus.alloc(appended_record.len() as u32);
+        bus.write_bytes(record_source, &appended_record);
+        cpu.write_reg(Register::A0, record_source);
+        cpu.write_reg(Register::A1, handle);
+        cpu.write_reg(Register::D0, appended_record.len() as u32);
+        dispatcher
+            .dispatch_memory(true, 0x1EF, &mut cpu, &mut bus)
+            .expect("PtrAndHand should be handled")
+            .expect("PtrAndHand should succeed");
+        assert_eq!(cpu.read_reg(Register::D0), 0);
+        assert_eq!(dispatcher.handle_state_bits(handle), Some(0x60));
+
+        cpu.write_reg(Register::A0, handle);
+        dispatcher
+            .dispatch_memory(false, 0x25, &mut cpu, &mut bus)
+            .expect("GetHandleSize should be handled")
+            .expect("GetHandleSize should succeed");
+        let final_size = cpu.read_reg(Register::D0);
+        assert_eq!(final_size, 291);
+        let final_ptr = bus.read_long(handle);
+        assert_eq!(
+            bus.read_bytes(
+                final_ptr + final_size - appended_record.len() as u32,
+                appended_record.len()
+            ),
+            appended_record
+        );
+        assert_eq!(bus.read_bytes(final_ptr + 165, 4), b"Loca");
+        assert_eq!(
+            dispatcher
+                .resource_backing_data
+                .get(&(0, *b"Xmnu", 131))
+                .map(Vec::len),
+            Some(199)
         );
     }
 


### PR DESCRIPTION
Warcraft II grows a loaded menu resource before appending records with `PtrAndHand`. `GetHandleSize` continued to report the resource’s original on-disk length, so the app derived its callback-record pointer from the stale size and read menu text as a function address. It now reports the process allocator’s current logical handle size; disk-size queries remain the responsibility of the Resource Manager APIs.

The regression test reproduces the observed 199-byte backing resource, resize to 256 bytes, and appends to 257 then 291 bytes. It verifies the exact appended tail, preserved resource state, and unchanged backing data, alongside the existing logical-size/padding coverage.

Validation:
- Full `cargo test`: 5,366 library tests, 89 desktop tests, 4 integration tests, and 1 doc test passed; expected local-only tests remained ignored
- Deterministic Warcraft II replay reached the Human Hillsbrad campaign, selected a footman, and moved it to clicked terrain, revealing more of the map
- SimCity 2000 replay rotated its live city viewport and restored the original orientation

Closes #1611
