### PR TITLE
fix(runner): preserve callbacks during tracking refires

### DIFF
--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -6366,6 +6366,18 @@ impl FixtureRunner {
                                     self.deferred_tracking_refire_pc = Some(pc);
                                     continue;
                                 }
+                                // A retained manager can redirect execution into an
+                                // application callback before it refires. ModalDialog,
+                                // for example, enters a custom CDEF after establishing
+                                // its tracking state. Preserve that guest PC; replacing
+                                // it with the A-line address would skip the callback and
+                                // leave the dialog unable to consume queued input.
+                                let post_dispatch_pc = self.m68k.cpu.read_reg(Register::PC);
+                                if post_dispatch_pc != pc
+                                    && post_dispatch_pc != pc.wrapping_add(2)
+                                {
+                                    continue;
+                                }
                                 // A retained TrackControl may have redirected
                                 // execution into its guest action procedure.
                                 // That callback returns directly to this trap;
@@ -27872,6 +27884,90 @@ mod tests {
             })
         ));
         assert_ne!(runner.m68k.cpu.read_reg(Register::PC), base);
+    }
+
+    #[test]
+    fn modal_dialog_refire_preserves_application_cdef_callback_redirection() {
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        let base = 0x0001_0000u32;
+        let sp = 0x0010_0000u32;
+        let side_effect = 0x0001_2000u32;
+        let dialog_ptr = runner.bus.alloc(200);
+        let control_handle = runner.bus.alloc(4);
+        let control_ptr = runner.bus.alloc(36);
+        let cdef_handle = runner.bus.alloc(4);
+        let cdef_proc = runner.bus.alloc(20);
+
+        runner.bus.write_word(base, 0xA991); // _ModalDialog
+        runner.bus.write_word(cdef_proc, 0x4E56); // LINK A6,#0
+        runner.bus.write_word(cdef_proc + 2, 0);
+        runner.bus.write_word(cdef_proc + 4, 0x33FC); // MOVE.W #$CAFE,(abs).L
+        runner.bus.write_word(cdef_proc + 6, 0xCAFE);
+        runner.bus.write_long(cdef_proc + 8, side_effect);
+        runner.bus.write_word(cdef_proc + 12, 0x4E5E); // UNLK A6
+        runner.bus.write_word(cdef_proc + 14, 0x4E74); // RTD #12
+        runner.bus.write_word(cdef_proc + 16, 12);
+        runner.bus.write_long(cdef_handle, cdef_proc);
+
+        runner.dispatcher.init_cgraf_window(
+            &mut runner.bus,
+            &mut runner.m68k.cpu,
+            dialog_ptr,
+            0,
+            100,
+            120,
+            220,
+            360,
+            "",
+            2,
+            true,
+            false,
+            false,
+            0,
+        );
+        runner.dispatcher.front_window = dialog_ptr;
+        runner.dispatcher.window_bounds = (100, 120, 220, 360);
+        runner.dispatcher.dialog_items.insert(dialog_ptr, Vec::new());
+
+        runner.bus.write_long(control_handle, control_ptr);
+        runner.bus.write_long(control_ptr, 0);
+        runner.bus.write_long(control_ptr + 4, dialog_ptr);
+        runner.bus.write_word(control_ptr + 8, 10);
+        runner.bus.write_word(control_ptr + 10, 10);
+        runner.bus.write_word(control_ptr + 12, 50);
+        runner.bus.write_word(control_ptr + 14, 80);
+        runner.bus.write_byte(control_ptr + 16, 255);
+        runner.bus.write_byte(control_ptr + 17, 0);
+        runner.bus.write_long(control_ptr + 24, cdef_handle);
+        runner.bus.write_long(dialog_ptr + 140, control_handle);
+        runner
+            .dispatcher
+            .control_manager
+            .register(control_handle, control_ptr, 160 << 4, 0);
+
+        let item_hit = runner.bus.alloc(2);
+        runner.bus.write_long(sp, item_hit);
+        runner.bus.write_long(sp + 4, 0);
+        runner.m68k.cpu.write_reg(Register::PC, base);
+        runner.m68k.cpu.write_reg(Register::A7, sp);
+
+        let (steps, running) = runner.run_gui_slice_with_audio(1, 0, 0);
+
+        assert!(running);
+        assert_eq!(steps, 1);
+        assert_eq!(
+            runner.m68k.cpu.read_reg(Register::PC),
+            runner.dispatcher.control_def_trampoline,
+            "ModalDialog must not replace the CDEF callback entry with its refire PC"
+        );
+
+        let (_steps, running) = runner.run_steps(64, None);
+        assert!(running);
+        assert_eq!(
+            runner.bus.read_word(side_effect),
+            0xCAFE,
+            "the application CDEF must execute before ModalDialog refires"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #129.

A retained Toolbox trap could redirect execution into an application callback and then have that callback entry overwritten by the runner's unconditional tracking refire. In Spectre VR, `ModalDialog` scheduled the launcher controls' custom CDEF, but the runner immediately restored the `_ModalDialog` PC; the callback never executed and the visible DEMO control could not consume its queued click.

Preserve a redirected guest PC when it is neither the A-line trap address nor its normal successor. The retained trap refires after the callback returns, keeping the existing tracking lifecycle while allowing application CDEFs and other guest callbacks to run. A focused runner regression establishes a visible dialog with an application CDEF and verifies both the callback entry and its side effect.

Validation:

- `cargo test --locked --profile ci-test --lib runner::tests::modal_dialog_refire_preserves_application_cdef_callback_redirection -- --exact` — 1 passed
- `cargo test --locked --profile ci-test --lib refire -- --nocapture` — 16 passed
- Deterministic Spectre VR replay — 1/1 assertion passed at tick 1084 in 95,687,579 guest instructions
- Archive SHA-256: `a915af0974f0e99dbc01e462e3e5471c42cf817cfc6f9f13bd811b3f9e958dbb`
- Script SHA-256: `a3efe3f2b44c545b81cbbeebc23819cbb099f8ff15a5556ed34dd916d8a515b1`
- Launcher and menu remained byte-identical to the accepted pre-fix capture (`6bad3e6b1b5d60b6305eaf7050755a106300edaf395553b85124c3901ab5a2c2`); all eight illustrated controls and application artwork are intact
- The DEMO click disposed the launcher dialog and reached the live HUD (`e9d3111e12771708953186f6d1b7f5b5fa4a99c2551b0ade64bc04a85ec6880b`), changing 82,167 pixels within the application viewport
- A follow-up Space/cannon input produced a 40,700-pixel arena-only delta while leaving the HUD byte-identical; the resulting native frame (`251baa233e18803efa2b835824a0211bf3ac1f5a2971f8db5649930e614f2c7a`) retained coherent palette, text, layers, and crop
