### PR TITLE
fix(dialog): restore the standard system alert icon

### DIFF
--- a/src/trap/dialog.rs
+++ b/src/trap/dialog.rs
@@ -6631,6 +6631,12 @@ impl super::TrapDispatcher {
                                 self.draw_icon(
                                     bus, abs_top, abs_left, abs_bottom, abs_right, icon_ptr,
                                 );
+                            } else if let Some(icon_ptr) =
+                                self.synthesize_system_icon(bus, item.resource_id)
+                            {
+                                self.draw_icon(
+                                    bus, abs_top, abs_left, abs_bottom, abs_right, icon_ptr,
+                                );
                             }
                         }
                     }
@@ -13937,6 +13943,13 @@ impl super::TrapDispatcher {
                         icon_id, h, ptr
                     );
                     h
+                } else if let Some(ptr) = self.synthesize_system_icon(bus, icon_id) {
+                    let h = self.get_or_create_resource_handle(bus, *b"ICON", icon_id, ptr);
+                    eprintln!(
+                        "[TRAP] GetIcon({}) -> system handle=${:08X} ptr=${:08X}",
+                        icon_id, h, ptr
+                    );
+                    h
                 } else {
                     eprintln!("[TRAP] GetIcon({}) -> NIL (not found)", icon_id);
                     0
@@ -17630,6 +17643,42 @@ mod tests {
         data.extend_from_slice(&items_id.to_be_bytes());
         data.extend_from_slice(&stages.to_be_bytes());
         data
+    }
+
+    #[test]
+    fn alert_draws_standard_system_icon_one_when_application_resource_is_missing() {
+        // MTE 1992 pp. 6-153 and 7-63: an iconItem names an ICON
+        // resource. Resource Manager searches the open resource chain, which
+        // includes the System file after the application resource fork.
+        let (mut disp, mut cpu, mut bus) = setup();
+        let alert_id = 3298;
+        let ditl_id = 3299;
+        let icon_id = 1i16.to_be_bytes();
+        let alrt = build_test_alrt((100, 100, 220, 400), ditl_id, 0x5555);
+        let ditl = build_test_ditl_items(&[
+            (0xA0, (16, 16, 48, 48), icon_id.as_slice()),
+            (4, (76, 210, 96, 270), b"OK"),
+        ]);
+        disp.install_test_resource(&mut bus, *b"ALRT", alert_id, &alrt);
+        disp.install_test_resource(&mut bus, *b"DITL", ditl_id, &ditl);
+
+        let (screen_base, row_bytes, _w, _h, pixel_size) = disp.screen_mode;
+        assert_eq!(pixel_size, 8);
+        bus.write_long(TEST_SP, 0);
+        bus.write_word(TEST_SP + 4, alert_id as u16);
+
+        disp.dispatch_dialog(true, 0x185, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            [
+                bus.read_byte(screen_base + 116 * row_bytes + 116),
+                bus.read_byte(screen_base + 147 * row_bytes + 147),
+            ],
+            [0xFF, 0xFF],
+            "ICON 1 should fall through to the standard System alert icon"
+        );
     }
 
     #[test]
@@ -23128,7 +23177,7 @@ mod tests {
         disp.install_test_resource(
             &mut bus,
             *b"ICON",
-            421,
+            1,
             &monochrome_icon_resource_with_points(&[(0, 0), (15, 15), (31, 31)]),
         );
         disp.dialog_items.insert(
@@ -23138,7 +23187,7 @@ mod tests {
                     item_type: 32, // icon item
                     rect: (8, 8, 40, 40),
                     text: String::new(),
-                    resource_id: 421,
+                    resource_id: 1,
                     proc_ptr: 0,
                     sel_start: 0,
                     sel_end: 0,
@@ -37402,6 +37451,21 @@ mod tests {
     // ---- GetIcon ($A9BB) — IM:I I-473 contract ----
 
     #[test]
+    fn get_icon_returns_standard_system_icon_one_after_application_chain_miss() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        bus.write_word(TEST_SP, 1);
+
+        let _ = disp.dispatch_dialog(true, 0x1BB, &mut cpu, &mut bus);
+
+        let handle = bus.read_long(TEST_SP + 2);
+        assert_ne!(handle, 0);
+        let ptr = bus.read_long(handle);
+        assert_eq!(bus.get_alloc_size(ptr), Some(128));
+        assert_eq!(bus.read_long(ptr), 0xFFFF_FFFF);
+        assert_eq!(bus.read_long(ptr + 124), 0xFFFF_FFFF);
+    }
+
+    #[test]
     fn get_icon_returns_nil_when_resource_missing() {
         // IM:I I-473: "If the resource can't be read, GetIcon
         // returns NIL." Critical for apps that defensively check
@@ -37409,7 +37473,7 @@ mod tests {
         // always returned a non-NIL handle to uninitialised
         // memory which broke that branch.
         let (mut disp, mut cpu, mut bus) = setup();
-        bus.write_word(TEST_SP, 1); // iconID = 1, no ICON 1 installed
+        bus.write_word(TEST_SP, 999); // non-system icon ID, no resource installed
         let _ = disp.dispatch_dialog(true, 0x1BB, &mut cpu, &mut bus);
         assert_eq!(
             cpu.read_reg(Register::A7),
@@ -37435,8 +37499,8 @@ mod tests {
         // with a recognisable sentinel pattern so handle deref
         // assertions can verify "this is the right resource."
         let icon_data: Vec<u8> = (0..128).map(|i| (i as u8).wrapping_mul(7)).collect();
-        let res_ptr = disp.install_test_resource(&mut bus, *b"ICON", 128, &icon_data);
-        bus.write_word(TEST_SP, 128);
+        let res_ptr = disp.install_test_resource(&mut bus, *b"ICON", 1, &icon_data);
+        bus.write_word(TEST_SP, 1);
 
         let _ = disp.dispatch_dialog(true, 0x1BB, &mut cpu, &mut bus);
         let handle = bus.read_long(TEST_SP + 2);

--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -1367,6 +1367,11 @@ pub struct TrapDispatcher {
     /// allocation per call would leak a 68-byte block per frame.
     /// Inside Macintosh Volume I, I-474.
     pub(crate) system_cursor_cache: HashMap<i16, u32>,
+    /// Cache of synthetic System-file `'ICON'` resources used by standard
+    /// dialogs. Systemless does not mount a System file, so well-known icons
+    /// are synthesized only after the application resource chain misses.
+    /// Macintosh Toolbox Essentials (1992), pp. 6-153 and 7-63.
+    pub(crate) system_icon_cache: HashMap<i16, u32>,
     /// Cache of synthetic System-file `'clut'` resource pointers for
     /// standard indexed depths. Systemless does not mount the System
     /// resource fork, but some installers call `GetResource('clut', depth)`
@@ -3296,6 +3301,7 @@ impl TrapDispatcher {
             system_str_cache: HashMap::new(),
             system_intl_cache: HashMap::new(),
             system_cursor_cache: HashMap::new(),
+            system_icon_cache: HashMap::new(),
             system_clut_cache: HashMap::new(),
             system_wctb_cache: HashMap::new(),
             system_kchr_cache: HashMap::new(),
@@ -6539,6 +6545,42 @@ impl TrapDispatcher {
         bus.write_word(ptr + 64, hot_v as u16);
         bus.write_word(ptr + 66, hot_h as u16);
         self.system_cursor_cache.insert(cursor_id, ptr);
+        Some(ptr)
+    }
+
+    /// Allocate and cache the standard System-file `'ICON'` resource ID 1.
+    ///
+    /// Dialog `iconItem` records name an ICON resource, and Resource Manager
+    /// searches the open resource chain through the System file when the
+    /// application does not supply it. Systemless has no mounted System file,
+    /// so this preserves that final lookup while leaving application resources
+    /// authoritative. Macintosh Toolbox Essentials (1992), pp. 6-153 and 7-63.
+    pub(crate) fn synthesize_system_icon(
+        &mut self,
+        bus: &mut MacMemoryBus,
+        icon_id: i16,
+    ) -> Option<u32> {
+        if let Some(&ptr) = self.system_icon_cache.get(&icon_id) {
+            return Some(ptr);
+        }
+        let body: &[u8] = match icon_id {
+            1 => &[
+                0xFF, 0xFF, 0xFF, 0xFF, 0x80, 0x7F, 0xFF, 0xFF, 0x80, 0x7F, 0xFF, 0xFF, 0x80, 0x7F,
+                0xFF, 0xFF, 0x80, 0x7F, 0xFF, 0xFF, 0x80, 0x7F, 0xC0, 0xFF, 0x88, 0x7F, 0x00, 0x3F,
+                0x88, 0x7E, 0x00, 0x1F, 0x88, 0x7C, 0x00, 0x0F, 0x80, 0x78, 0x00, 0x07, 0x80, 0x78,
+                0x00, 0x07, 0x80, 0x70, 0x00, 0x03, 0x80, 0x71, 0xDD, 0xC3, 0x80, 0x70, 0x00, 0x03,
+                0x80, 0x70, 0x00, 0x03, 0x80, 0x71, 0xDD, 0x43, 0x80, 0x70, 0x00, 0x03, 0x80, 0x70,
+                0x00, 0x03, 0x80, 0x71, 0xD7, 0x03, 0x80, 0x70, 0x00, 0x03, 0x87, 0xF0, 0x00, 0x03,
+                0x81, 0xF1, 0xEE, 0xC3, 0x81, 0xF0, 0x00, 0x07, 0x81, 0xF0, 0x00, 0x07, 0x81, 0xF0,
+                0x00, 0x0F, 0x81, 0xE0, 0x00, 0x1F, 0x8F, 0x80, 0x00, 0x7F, 0x81, 0xFF, 0xFF, 0xFF,
+                0x81, 0xFF, 0xFF, 0xFF, 0x81, 0xFF, 0xFF, 0xFF, 0x81, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+                0xFF, 0xFF,
+            ],
+            _ => return None,
+        };
+        let ptr = bus.alloc(body.len() as u32);
+        bus.write_bytes(ptr, body);
+        self.system_icon_cache.insert(icon_id, ptr);
         Some(ptr)
     }
 

--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -1835,6 +1835,18 @@ impl super::TrapDispatcher {
                     eprintln!("[RSRC] GetResource('snd ', {}) -> not found", res_id);
                 }
 
+                if res_type == *b"ICON" {
+                    if let Some(ptr) = self.synthesize_system_icon(bus, res_id) {
+                        let handle = self.get_or_create_resource_handle(bus, res_type, res_id, ptr);
+                        cpu.write_reg(Register::A0, handle);
+                        cpu.write_reg(Register::D0, 0);
+                        bus.write_word(0x0A60, 0);
+                        bus.write_long(sp + 6, handle);
+                        cpu.write_reg(Register::A7, sp + 6);
+                        return Some(Ok(()));
+                    }
+                }
+
                 if res_type == *b"STR " {
                     if let Some(ptr) = self.synthesize_system_str(bus, res_id) {
                         let handle = self.get_or_create_resource_handle(bus, res_type, res_id, ptr);
@@ -9841,6 +9853,22 @@ mod tests {
     // ================================================================
     // 1b. GetResource (0x1A0) — not found
     // ================================================================
+    #[test]
+    fn get_resource_returns_standard_system_icon_one_after_application_chain_miss() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        bus.write_word(TEST_SP, 1u16);
+        bus.write_long(TEST_SP + 2, u32::from_be_bytes(*b"ICON"));
+
+        call(&mut disp, true, 0x1A0, &mut cpu, &mut bus).unwrap();
+
+        let handle = bus.read_long(TEST_SP + 6);
+        assert_ne!(handle, 0);
+        let ptr = bus.read_long(handle);
+        assert_eq!(bus.get_alloc_size(ptr), Some(128));
+        assert_eq!(bus.read_long(ptr), 0xFFFF_FFFF);
+        assert_eq!(bus.read_word(0x0A60), 0);
+    }
+
     #[test]
     fn get_resource_miss_returns_nil_with_noerr() {
         let (mut disp, mut cpu, mut bus) = setup();


### PR DESCRIPTION
Closes #1633.

Populous II's initial alert declares a DITL `iconItem` for resource ID 1, but the application supplies neither `cicn` 1 nor `ICON` 1. Classic Resource Manager lookup continues through the System resource file. Because Systemless does not mount that file, the otherwise valid item had no bitmap to draw and the alert showed a blank icon area.

This change adds the canonical standard System alert `ICON` 1 to the existing synthetic System-resource layer. Dialog `iconItem` rendering, `GetIcon`, and `GetResource('ICON', 1)` use it only after the ordinary application resource chain misses. Application-provided `cicn` and `ICON` resources retain precedence, while other resource IDs and DITL item types keep their existing behavior. The synthesized bitmap is cached like the runtime's other standard System resources.

The focused Alert/DITL regression failed on the exact public base with blank sampled pixels `[0, 0]`; it passes with the standard icon's expected black pixels `[255, 255]`. Existing coverage also confirms that an application-provided `ICON` 1 remains authoritative and that unrelated resource misses still return nil.

Validation:
- `cargo test standard_system_icon_one` — 3 passed
- `cargo test get_icon_` — 6 passed
- `cargo test drawdialog_icon_item` — 1 passed
- `cargo test get_resource_miss_returns_nil_with_noerr` — 1 passed
- The exact candidate target reran `alert_draws_standard_system_icon_one_when_application_resource_is_missing` immediately before acceptance — 1 passed, 0 failed
- Deterministic 28-action Populous II replay completed at tick 3,318 after 79,525,306 guest instructions
- All four decoded checkpoints were inspected at native 800x600 RGB resolution for artwork, text, controls, palette, layering, and crop
- The alert changed by exactly 493 pixels, all within the expected 32x32 icon rectangle at `x=258..289, y=263..294`; a decoded 64x64 icon/layout crop is byte-for-byte equal to the Macintosh reference
- Title, gameplay, and post-input PNGs are byte-for-byte unchanged from the exact-current baseline
- A map click at `(431,357)` changed 21,453 pixels (4.469375%, bounded to `x=160..719, y=160..460`) and the simulation continued for 600 ticks

Provenance:
- Public base: `cd153c0a9ca8cdc929750388354715f154fc9840`
- Candidate commit: `9450f9238`
- Candidate source diff SHA-256: `c4be3eba0800e426b829011b3e4cb0ae46dc8480ad82cdad2b9d5d266a67918e`
- Candidate runner SHA-256: `e8934ad6a032d14f7c735213bc30577d866c24121cd65d2a6c8b9d19488d1d66`
- Game archive SHA-256: `622f6965883084769e539765b0b6327a8095161aa23cdd23f46149667db7506a`
- Acceptance script SHA-256: `ef2a17f3249a207fcbd3e87932f3449947c502991ea441fc7a83195144565c9c`
- Replay transcript SHA-256: `0565058d7bb0d110f4d36b2af69c9beb135856fea9b4a4f5da2fe9ca6b374e12`
- Normalized candidate and Macintosh icon-crop SHA-256: `49125384aa2a0d97dfba938c82d9daf87e2281134b48468da76d8347d2ee6470`
- Alert PNG SHA-256: `5522b2e6898f6dabe56d7fb273cc6f656486ba287a4a0638c1d3b115fee3a83c`
- Title PNG SHA-256: `ad8db044c6709f224d8138915708f80b05624d63436a6f7483f33f8e10c132e3`
- Gameplay PNG SHA-256: `1d9d3774bc34c63262f722f1bf98c359768c8709b200f2d8d42185d4c4fd2e43`
- Post-input PNG SHA-256: `9aaa58d86ff394a3b5e8d04cfbb44d1da97f228136e3e5ec0b87bd5aef7c366e`
