### PR TITLE
fix(resource): report application refnum from CurResFile

### DIFF
--- a/src/trap/resource.rs
+++ b/src/trap/resource.rs
@@ -2606,7 +2606,16 @@ impl super::TrapDispatcher {
             // CurResFile ($A994): Returns the current resource-file refnum from the live Resource Manager search state
             (true, 0x194) => {
                 let sp = cpu.read_reg(Register::A7);
-                let refnum = self.current_resource_refnum();
+                let internal_refnum = self.current_resource_refnum();
+                // The initial application resource map uses internal key 0,
+                // while CurApRefNum stores its guest-visible FCB refnum.
+                // CurResFile reports the latter. Inside Macintosh Volume I,
+                // p. I-116.
+                let refnum = if internal_refnum == 0 {
+                    bus.read_word(addr::CUR_APREF_NUM)
+                } else {
+                    internal_refnum
+                };
                 if super::dispatch::trace_resfile_enabled() {
                     eprintln!(
                         "[TRAP] CurResFile -> {} (PC=${:08X})",
@@ -12419,6 +12428,17 @@ mod tests {
         assert_eq!(sp, TEST_SP, "SP should be unchanged");
         let refnum = bus.read_word(sp);
         assert_eq!(refnum, 0);
+    }
+
+    #[test]
+    fn cur_res_file_translates_the_internal_application_map_key_to_its_fcb_refnum() {
+        let (mut disp, mut cpu, mut bus) = setup();
+        bus.write_word(addr::CUR_APREF_NUM, 2);
+
+        call(&mut disp, true, 0x194, &mut cpu, &mut bus).unwrap();
+
+        assert_eq!(cpu.read_reg(Register::A7), TEST_SP);
+        assert_eq!(bus.read_word(TEST_SP), 2);
     }
 
     // ================================================================


### PR DESCRIPTION
Closes #99.

Dark Castle's child startup loads its static-constructor CODE resource and compares `CurResFile` with `HomeResFile` before registering the initializer. Systemless represented the initial application resource map with internal key 0. `HomeResFile` already translated that key to the application's guest-visible FCB reference number, while `CurResFile` exposed the internal key. The resulting `0 != 2` comparison skipped required initialization, and the child returned cleanly before gameplay.

This change makes `CurResFile` report `CurApRefNum` when the current map is the internal application map. Other open resource-file references retain their existing values. `HomeResFile`, application startup, launch parameters, and the normal `_ExitToShell` return path are unchanged. This matches the Resource Manager contract in Inside Macintosh Volume I, p. I-116, where `CurResFile` returns the current resource file's reference number.

The focused regression failed on the exact public base by observing 0 instead of application refnum 2. With the fix, both `CurResFile` and `HomeResFile` return 2. The guest comparison at `$0057868A` sets Z, the branch at `$0057868C` falls through and runs the initialization body, and the prior return at `$00578AD0` does not occur during startup.

Validation:
- Focused application-map `CurResFile` regression — 1 passed
- `cargo test cur_res_file --lib` — 3 passed
- `cargo test home_res_file --lib` — 4 passed
- `cargo test --release --no-default-features trap::resource::tests --lib` — 333 passed, 3 ignored
- Deterministic 24-action Dark Castle replay completed without a halt at tick 2,536 after 56,564,680 guest instructions
- The route reached the score/control menu at tick 1,988 and Great Hall gameplay at tick 2,356
- Holding `w` for 180 ticks changed 2,669 pixels within Duncan's sprite region `(378,310)–(436,408)`
- All four decoded checkpoints were inspected at native 800x600 RGB resolution for artwork, text, palette, layers, and crop; the control menu and complete Great Hall scene render coherently with no clipping or crop anomaly

Provenance:
- Public base: `715d605f9b71bc8672395d54a37a20ebb8081f22`
- Candidate commit: `2ec1e10265c5b9915667cac5ce04685b542e7df8`
- Candidate source diff SHA-256: `0c6702c5fd46ca88c6a48444f655ff1a31e9d39be6a3040bcc36eab5d86e607f`
- Candidate runner SHA-256: `793b3d85e1877f5ecfc5b6d21030dd1aa1d7a79e9aab4702bf4c8e3667631ea9`
- Game archive SHA-256: `ddbb2489d358ea5d9c89b3df44f913facea71b6f1bc3bfe9dc23ad125cb7dcc4`
- Acceptance script SHA-256: `fab8f90aee0cf78ea41143caf14bec3a03febd6a74627adb9f0e990bd2ff00e2`
- Replay transcript SHA-256: `8fa98b01fd30206ee1cc7109ed241c2650f35ee06c11659e28bebf6072d028a8`
- Evidence manifest SHA-256: `1791970d5d02d3e563aa3d1c197e196ccb44aee0d73485f359493f62772b4edb`
- Launch PNG SHA-256: `25ab630c384977ebbfd93a46b2e5fff93a62e44a557045c8099f93f12b22f9a3`
- Menu PNG SHA-256: `9b55cea01efa75335e2c80c82ec92aff7d3151c935ab7dd86617dcb6dd3c668f`
- Great Hall PNG SHA-256: `6fb52ca5227522247fe63c160b66f9ec255fe7a10fd738dc22774524ba28a5fe`
- Post-input PNG SHA-256: `01dfc3412744f4bff90274b8178b5bdced586d5b0f01943643963ab6138ec801`
