### PR TITLE
fix(fonts): restore classic Monaco maximum advances

### DIFF
--- a/src/quickdraw/fonts/compatibility/README.md
+++ b/src/quickdraw/fonts/compatibility/README.md
@@ -51,3 +51,11 @@ The source file should hash to `2578381b...` and the component to
 records, in source order, reproduces `geneva9-advances.bin` exactly.
 
 See [OFL.txt](OFL.txt) for the component's copyright and licence notice.
+
+## Monaco maximum advance
+
+The bundled Monaco substitute retains its own outline pixels and per-glyph
+advances. Its `widMax` compatibility metric is derived at each requested size
+from the classic scalable Monaco family's normalized maximum advance of
+1552/2048 em. This is metadata only; no original font software or glyph artwork
+is included.

--- a/src/quickdraw/fonts/compatibility/mod.rs
+++ b/src/quickdraw/fonts/compatibility/mod.rs
@@ -1,11 +1,15 @@
 //! Logical metrics from separately licensed classic-layout data components.
 
-use super::{FONT_APPLICATION, FONT_GENEVA};
+use super::{FONT_APPLICATION, FONT_GENEVA, FONT_MONACO};
 
 pub(super) const FIRST_ASCII_CODE: u8 = 0x20;
 pub(super) const LAST_ASCII_CODE: u8 = 0x7E;
 
 static GENEVA9_ADVANCES: &[u8; 95] = include_bytes!("geneva9-advances.bin");
+// Inside Macintosh: Text (1993), p. 4-91 defines FOND.ffWidMax as the
+// normalized maximum glyph width for a one-point font.
+const MONACO_MAX_ADVANCE_UNITS: i32 = 1552;
+const MONACO_UNITS_PER_EM: i32 = 2048;
 
 pub(super) fn bundled_advances(font_id: i16, size: i16) -> Option<&'static [u8; 95]> {
     if size == 9 && matches!(font_id, FONT_APPLICATION | FONT_GENEVA) {
@@ -13,4 +17,13 @@ pub(super) fn bundled_advances(font_id: i16, size: i16) -> Option<&'static [u8; 
     } else {
         None
     }
+}
+
+pub(super) fn bundled_wid_max(font_id: i16, size: i16) -> Option<i16> {
+    // Monaco's scalable classic-family metadata records a 1552/2048-em
+    // maximum advance. Match outline metric rounding at every requested size.
+    (font_id == FONT_MONACO && size > 0).then(|| {
+        ((MONACO_MAX_ADVANCE_UNITS * i32::from(size) + MONACO_UNITS_PER_EM / 2)
+            / MONACO_UNITS_PER_EM) as i16
+    })
 }

--- a/src/quickdraw/fonts/outline.rs
+++ b/src/quickdraw/fonts/outline.rs
@@ -34,6 +34,7 @@ pub(super) fn face(font_id: i16, size: i16) -> Option<Faces> {
         size,
         bytes,
         super::compatibility::bundled_advances(font_id, size),
+        super::compatibility::bundled_wid_max(font_id, size),
     )?;
     cache.insert((font_id, size), faces);
     Some(faces)
@@ -74,6 +75,7 @@ pub(super) fn rasterize(
     size: i16,
     bytes: &'static [u8],
     compatibility_advances: Option<&'static [u8; 95]>,
+    compatibility_wid_max: Option<i16>,
 ) -> Option<Faces> {
     use skrifa::{
         instance::{LocationRef, Size},
@@ -186,7 +188,20 @@ pub(super) fn rasterize(
             .max()
             .unwrap_or(0),
     );
-    let wid_max = all().map(|g| i16::from(g.advance)).max().unwrap_or(0);
+    let mapped_wid_max = all().map(|g| i16::from(g.advance)).max().unwrap_or(0);
+    // Inside Macintosh: Text (1993), pp. 3-66 and 3-74: GetFontInfo.widMax
+    // is the integer width of the largest glyph in the selected font.
+    let selected_wid_max = if let Some(wid_max) = compatibility_wid_max {
+        wid_max
+    } else if compatibility_advances.is_some() {
+        mapped_wid_max
+    } else {
+        metrics
+            .max_width
+            .map(|width| width.round().clamp(0.0, f32::from(i16::MAX)) as i16)
+            .unwrap_or(mapped_wid_max)
+    };
+    let wid_max = selected_wid_max.max(mapped_wid_max);
     let data = Box::leak(data.into_boxed_slice());
     let face = Box::leak(Box::new(FontFace {
         font_id,
@@ -431,7 +446,7 @@ mod tests {
     #[test]
     fn geneva9_compatibility_keeps_urw_raster_extended_metrics_and_wid_max() {
         let bytes = super::bytes(FONT_GENEVA).expect("bundled Geneva bytes");
-        let (raw, raw_extended) = super::rasterize(FONT_GENEVA, 9, bytes, None).unwrap();
+        let (raw, raw_extended) = super::rasterize(FONT_GENEVA, 9, bytes, None, None).unwrap();
         let (bundled, bundled_extended) = super::face(FONT_GENEVA, 9).unwrap();
 
         assert_eq!(raw.data, bundled.data);
@@ -453,15 +468,50 @@ mod tests {
     }
 
     #[test]
+    fn monaco_compatibility_changes_only_the_selected_maximum_advance() {
+        let bytes = super::bytes(FONT_MONACO).expect("bundled Monaco bytes");
+        for size in [14, 23] {
+            let (raw, raw_extended) =
+                super::rasterize(FONT_MONACO, size, bytes, None, None).unwrap();
+            let (bundled, bundled_extended) = super::face(FONT_MONACO, size).unwrap();
+
+            assert_eq!(raw.data, bundled.data);
+            assert_eq!(raw.glyphs.len(), bundled.glyphs.len());
+            for (raw_glyph, bundled_glyph) in raw.glyphs.iter().zip(bundled.glyphs) {
+                assert_same_glyph_except_advance(raw_glyph, bundled_glyph);
+                assert_eq!(raw_glyph.advance, bundled_glyph.advance);
+            }
+            assert_eq!(raw_extended.data, bundled_extended.data);
+            assert_eq!(raw_extended.glyphs.len(), bundled_extended.glyphs.len());
+            for (raw_glyph, bundled_glyph) in raw_extended
+                .glyphs
+                .iter()
+                .zip(bundled_extended.glyphs)
+            {
+                assert_eq!(raw_glyph.mac_code, bundled_glyph.mac_code);
+                assert_same_glyph_except_advance(&raw_glyph.glyph, &bundled_glyph.glyph);
+                assert_eq!(raw_glyph.glyph.advance, bundled_glyph.glyph.advance);
+            }
+            assert_eq!(
+                bundled.metrics.wid_max,
+                super::super::compatibility::bundled_wid_max(FONT_MONACO, size)
+                    .expect("classic scalable Monaco maximum advance")
+            );
+            assert_ne!(raw.metrics.wid_max, bundled.metrics.wid_max);
+        }
+    }
+
+    #[test]
     fn compatibility_does_not_change_other_bundled_faces_or_guest_sfnt_rasterization() {
         for (font_id, size) in [
             (FONT_GENEVA, 8),
             (FONT_GENEVA, 10),
             (FONT_APPLICATION, 10),
             (FONT_HELVETICA, 9),
+            (FONT_COURIER, 23),
         ] {
             let bytes = super::bytes(font_id).unwrap();
-            let (raw, _) = super::rasterize(font_id, size, bytes, None).unwrap();
+            let (raw, _) = super::rasterize(font_id, size, bytes, None, None).unwrap();
             let (bundled, _) = super::face(font_id, size).unwrap();
             assert_eq!(
                 raw.glyphs
@@ -474,10 +524,11 @@ mod tests {
                     .map(|glyph| glyph.advance)
                     .collect::<Vec<_>>()
             );
+            assert_eq!(raw.metrics.wid_max, bundled.metrics.wid_max);
         }
 
         let guest_bytes = include_bytes!("urw/NimbusMonoPS-Regular.ttf");
-        let (guest, _) = super::rasterize(FONT_GENEVA, 9, guest_bytes, None).unwrap();
+        let (guest, _) = super::rasterize(FONT_GENEVA, 9, guest_bytes, None, None).unwrap();
         assert!(
             guest
                 .glyphs

--- a/src/quickdraw/fonts/resources.rs
+++ b/src/quickdraw/fonts/resources.rs
@@ -284,7 +284,7 @@ pub(super) fn rasterize_resource_outline_face(
         .expect("resource outline font cache poisoned")
         .get(&font_id)
         .copied()?;
-    let (face, extended) = outline::rasterize(font_id, size, bytes, None)?;
+    let (face, extended) = outline::rasterize(font_id, size, bytes, None, None)?;
     RESOURCE_FACES
         .lock()
         .expect("resource font cache poisoned")

--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -30016,6 +30016,50 @@ mod tests {
     }
 
     #[test]
+    fn getfontinfo_widmax_matches_selected_outline_maximum_advance() {
+        use skrifa::MetadataProvider;
+
+        let mut bytes =
+            include_bytes!("../quickdraw/fonts/urw/NimbusMonoPS-Regular.ttf").to_vec();
+        let hhea_offset = (0..u16::from_be_bytes([bytes[4], bytes[5]]) as usize)
+            .find_map(|index| {
+                let record = 12 + index * 16;
+                (&bytes[record..record + 4] == b"hhea").then(|| {
+                    u32::from_be_bytes([
+                        bytes[record + 8],
+                        bytes[record + 9],
+                        bytes[record + 10],
+                        bytes[record + 11],
+                    ]) as usize
+                })
+            })
+            .expect("hhea table");
+        bytes[hhea_offset + 10..hhea_offset + 12].copy_from_slice(&1552u16.to_be_bytes());
+        let font = skrifa::FontRef::new(&bytes).expect("selected outline font");
+        let selected_maximum = font
+            .metrics(skrifa::instance::Size::new(14.0), skrifa::instance::LocationRef::default())
+            .max_width
+            .expect("selected font maximum advance")
+            .round() as i16;
+        let family_id = 30_014;
+        assert!(crate::quickdraw::fonts::register_resource_outline_font(
+            family_id,
+            &bytes
+        ));
+
+        let (mut d, mut cpu, mut bus) = setup();
+        d.tx_font = family_id;
+        d.tx_size = 14;
+        let info_ptr = 0x300000;
+        bus.write_long(TEST_SP, info_ptr);
+        d.dispatch_quickdraw(true, 0x08B, &mut cpu, &mut bus)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(bus.read_word(info_ptr + 4) as i16, selected_maximum);
+    }
+
+    #[test]
     fn test_text_mode() {
         let (mut d, mut cpu, mut bus) = setup();
         bus.write_word(TEST_SP, 2u16); // srcOr


### PR DESCRIPTION
Harpoon computes the Orders wrap capacity from `GetFontInfo.widMax`. Systemless previously derived that value only from rasterized Mac Roman glyph advances, so Monaco 14 reported 8 instead of the selected scalable font's 11-pixel maximum. Harpoon's documented high-resolution adjustment then admitted 116 characters rather than 77, producing 14 overflowing body lines instead of the native 19-line layout.

The selected classic Monaco metadata is internally consistent: `FOND.ffWidMax` and `sfnt.hhea.advanceWidthMax` both record a normalized maximum advance of 1552/2048 em. This change makes outline faces use the authoritative selected-font maximum, retaining the mapped-glyph maximum as a defensive floor. The bundled Monaco substitute applies the same normalized family metric at every requested point size with the existing nearest-pixel rounding contract. This is font-family compatibility metadata, with no game-specific branch.

The compatibility path changes only `widMax`. Bundled glyph advances, extended Mac Roman advances, raster coverage, and presentation pixels remain unchanged. Guest outline fonts use their own `sfnt` maximum, and existing Geneva compatibility advances retain their established metric behavior.

Validation:

- Baseline regression: `GetFontInfo` returned 8 when a selected outline's authoritative maximum rounded to 11; it passes after the change.
- Selected-outline `GetFontInfo` regression: 1 passed.
- Compatibility and unrelated-family controls: 11 passed, including Monaco at 14 and 23 points and an unrelated Courier face.
- Guest-outline controls: 2 passed.
- `StdTxMeas` / `GetFontInfo` consistency control: 1 passed.
- Complete `quickdraw::fonts` suite: 24 passed.
- Canonical Harpoon route completed at tick 1700 after 209,365,523 guest instructions.
- The decoded 800×600 Orders body now has the native 19-line paragraph layout (6 + 5 + 6 + 2). Every line's rightmost ink is within one pixel of the BasiliskII frame. Candidate-vs-oracle difference improved from 15.980625% / MAE 30.6322 to 9.511875% / MAE 17.9971.
- Space still changes 410 pixels. Command-E changes 384,959 pixels and opens Orders.
- The upper tactical map, mini-map, and unit crop are byte-identical to the exact-current baseline. The lower tactical map differs by 79 pixels (0.0808143%) from live route state.

Reproducibility:

- Validated public base: `cd153c0a9ca8cdc929750388354715f154fc9840`
- Candidate commit: `15fbc0b0f`
- Candidate source diff SHA-256: `dbe1759a7c95c478a175cc014fd3c287d72f2a117885b05c875410b397ae6fc5`
- Candidate runner SHA-256: `f23e4c109b0b15381b02e8151d450830ff21dfe5e9eead8aa1c80a80e1bad389`
- Archive SHA-256: `5b475e1d04c65f8795e791976d69488b8b2550d0dd80841b0a8c0a93883ef570`
- Script SHA-256: `143878194b3ae42c1c293250fa877ebeba0a1386908b523533ca9a0e945fa451`
- Candidate Orders PNG SHA-256: `b7f6ade9c1b57432350bba282bfc0aa7afffd7d28aa57cb4b53f04a216562dd2`
- BasiliskII Orders PNG SHA-256: `c0a3d6cd4bf1de1a5aa61d0254f84e730a7c1503f4bde0b95be18f533013ba37`

Closes #1634
