### PR TITLE
fix: clear patterned margins around fullscreen game surfaces

### DIFF
--- a/src/trap/dialog.rs
+++ b/src/trap/dialog.rs
@@ -10002,7 +10002,7 @@ impl super::TrapDispatcher {
             && (self.menu_bar_hidden || self.fullscreen_locked || menu_bar_height == 0)
     }
 
-    fn screen_is_hidden_menu_game_surface(&self, bus: &MacMemoryBus) -> bool {
+    pub(super) fn screen_is_hidden_menu_game_surface(&self, bus: &MacMemoryBus) -> bool {
         let menu_bar_height = bus.read_word(crate::memory::globals::addr::MBAR_HEIGHT) as i16;
         self.menu_bar_hidden || self.fullscreen_locked || menu_bar_height == 0
     }

--- a/src/trap/framebuffer.rs
+++ b/src/trap/framebuffer.rs
@@ -1152,6 +1152,27 @@ impl super::TrapDispatcher {
         bus: &mut MacMemoryBus,
         rect: (i16, i16, i16, i16),
     ) -> bool {
+        self.fill_kiosk_stage_around_rect_when(bus, rect, self.menu_bar_hidden)
+    }
+
+    pub(super) fn fill_kiosk_stage_around_rect_for_hidden_game_surface(
+        &self,
+        bus: &mut MacMemoryBus,
+        rect: (i16, i16, i16, i16),
+    ) -> bool {
+        self.fill_kiosk_stage_around_rect_when(
+            bus,
+            rect,
+            self.screen_is_hidden_menu_game_surface(bus),
+        )
+    }
+
+    fn fill_kiosk_stage_around_rect_when(
+        &self,
+        bus: &mut MacMemoryBus,
+        rect: (i16, i16, i16, i16),
+        screen_is_hidden: bool,
+    ) -> bool {
         let (screen_base, row_bytes, screen_width, screen_height, pixel_size) =
             self.get_screen_params();
         let (top, left, bottom, right) = rect;
@@ -1162,7 +1183,7 @@ impl super::TrapDispatcher {
             && top >= 0
             && (screen_width - right - left).abs() <= 1
             && (screen_height - bottom - top).abs() <= 1;
-        if !self.menu_bar_hidden
+        if !screen_is_hidden
             || !large
             || !centered
             || (width >= screen_width && height >= screen_height)
@@ -1291,6 +1312,64 @@ impl super::TrapDispatcher {
             }
         }
         margin_index.is_some()
+    }
+
+    pub(super) fn kiosk_stage_margins_are_black_or_standard_desktop(
+        &self,
+        bus: &MacMemoryBus,
+        rect: (i16, i16, i16, i16),
+    ) -> bool {
+        let (screen_base, row_bytes, screen_width, screen_height, pixel_size) =
+            self.get_screen_params();
+        if pixel_size != 8 || self.ui_theme_id() != UiThemeId::ClassicSystem7 {
+            return false;
+        }
+        let (top, left, bottom, right) = rect;
+        if top < 0
+            || left < 0
+            || bottom > screen_height
+            || right > screen_width
+            || top >= bottom
+            || left >= right
+        {
+            return false;
+        }
+
+        let black = Self::logical_black_pixel_index(bus);
+        let white = Self::logical_white_pixel_index(bus);
+        let mut saw_margin = false;
+        let mut pixels = vec![0; screen_width as usize];
+        for y in 0..screen_height {
+            let ranges = if y < top || y >= bottom {
+                [(0, screen_width), (0, 0)]
+            } else {
+                [(0, left), (right, screen_width)]
+            };
+            let pattern = crate::window_manager::STANDARD_DESKTOP_PATTERN
+                [y.rem_euclid(8) as usize];
+            for (start, end) in ranges {
+                let length = end.saturating_sub(start) as usize;
+                if length == 0 {
+                    continue;
+                }
+                saw_margin = true;
+                bus.read_bytes_into(
+                    screen_base + y as u32 * row_bytes + start as u32,
+                    &mut pixels[..length],
+                );
+                for (offset, &pixel) in pixels[..length].iter().enumerate() {
+                    if pixel == black {
+                        continue;
+                    }
+                    let x = start + offset as i16;
+                    let pattern_is_white = (pattern >> (7 - x.rem_euclid(8))) & 1 == 0;
+                    if pixel != white || !pattern_is_white {
+                        return false;
+                    }
+                }
+            }
+        }
+        saw_margin
     }
 
     /// Fill a rectangle in the framebuffer
@@ -5950,6 +6029,122 @@ mod redraw_chrome_tests {
             None,
             "screen chrome must not resolve through an offscreen TheGDevice when MainDevice is NIL"
         );
+    }
+
+    #[test]
+    fn fullscreen_plain_window_stages_retained_copybits_over_partial_desktop_pattern() {
+        let (mut disp, _cpu, mut bus) = setup_with_port();
+        let (screen_base, row_bytes, screen_w, screen_h, pixel_size) = disp.screen_mode;
+        let retained = (60i16, 80i16, 540i16, 720i16);
+
+        // The observed screen has a standard black/white desktop pattern whose
+        // white half has already been partly cleared to black. The retained CopyBits
+        // destination contains all application-owned edge and artwork pixels.
+        TrapDispatcher::fb_fill_pattern_rect(
+            &mut bus,
+            screen_base,
+            row_bytes,
+            pixel_size,
+            screen_w as i16,
+            screen_h as i16,
+            0,
+            0,
+            screen_h as i16,
+            screen_w as i16,
+            crate::window_manager::STANDARD_DESKTOP_PATTERN,
+        );
+        for y in 0..screen_h as i16 {
+            for x in 0..screen_w as i16 {
+                let outside =
+                    y < retained.0 || y >= retained.2 || x < retained.1 || x >= retained.3;
+                if outside && (x + y).rem_euclid(6) == 1 {
+                    bus.write_byte(screen_base + y as u32 * row_bytes + x as u32, 255);
+                }
+            }
+        }
+        TrapDispatcher::fb_fill_rect_index(
+            &mut bus,
+            screen_base,
+            row_bytes,
+            pixel_size,
+            screen_w as i16,
+            screen_h as i16,
+            retained.0,
+            retained.1,
+            retained.2,
+            retained.3,
+            42,
+        );
+        // Application-owned nonblack edge pixels are inside the retained
+        // destination even though a later visual-content crop can exclude them.
+        for y in retained.0..retained.2 {
+            bus.write_byte(screen_base + y as u32 * row_bytes + 714, 43);
+        }
+        let retained_before: Vec<u8> = (retained.0..retained.2)
+            .flat_map(|y| {
+                bus.read_bytes(
+                    screen_base + y as u32 * row_bytes + retained.1 as u32,
+                    (retained.3 - retained.1) as usize,
+                )
+            })
+            .collect();
+
+        // Exact observed ownership: one visible plainDBox has a full-screen
+        // global port while MBarHeight=0 has locked fullscreen presentation.
+        bus.write_long(PORT_PTR + 2, screen_base);
+        bus.write_word(PORT_PTR + 6, row_bytes as u16);
+        bus.write_word(PORT_PTR + 8, (-60i16) as u16);
+        bus.write_word(PORT_PTR + 10, (-80i16) as u16);
+        bus.write_word(PORT_PTR + 12, 540);
+        bus.write_word(PORT_PTR + 14, 720);
+        bus.write_word(PORT_PTR + 16, (-60i16) as u16);
+        bus.write_word(PORT_PTR + 18, (-80i16) as u16);
+        bus.write_word(PORT_PTR + 20, 540);
+        bus.write_word(PORT_PTR + 22, 720);
+        bus.write_byte(PORT_PTR + WINDOW_VISIBLE_OFFSET, 0xFF);
+        set_window_structure_rect(&mut bus, PORT_PTR, (59, 79, 661, 881));
+        bus.write_word(crate::memory::globals::addr::MBAR_HEIGHT, 0);
+        disp.front_window = PORT_PTR;
+        *disp.current_port = PORT_PTR;
+        *disp.window_list = vec![PORT_PTR];
+        disp.window_bounds = (0, 0, screen_h as i16, screen_w as i16);
+        disp.window_proc_id = 2;
+        disp.window_proc_ids.insert(PORT_PTR, 2);
+        disp.menu_bar_hidden = false;
+        disp.fullscreen_locked = true;
+        *disp.device_clut = [[0xFFFF, 0xFFFF, 0xFFFF]; 256];
+        disp.device_clut[43] = [0xFFFF, 0, 0];
+        disp.device_clut[255] = [0, 0, 0];
+        disp.last_screen_copybits_rect = Some(ScreenCopyBitsRect {
+            src_top: 0,
+            src_left: 0,
+            src_bottom: 480,
+            src_right: 640,
+            dst_top: retained.0,
+            dst_left: retained.1,
+            dst_bottom: retained.2,
+            dst_right: retained.3,
+        });
+
+        disp.fill_kiosk_stage_for_centered_game_surface(&mut bus, PORT_PTR);
+
+        assert!(screen_pixel_is_black(&disp, &bus, 1, 0));
+        for y in 0..screen_h as i16 {
+            for x in 0..screen_w as i16 {
+                if y < retained.0 || y >= retained.2 || x < retained.1 || x >= retained.3 {
+                    assert!(screen_pixel_is_black(&disp, &bus, x, y));
+                }
+            }
+        }
+        let retained_after: Vec<u8> = (retained.0..retained.2)
+            .flat_map(|y| {
+                bus.read_bytes(
+                    screen_base + y as u32 * row_bytes + retained.1 as u32,
+                    (retained.3 - retained.1) as usize,
+                )
+            })
+            .collect();
+        assert_eq!(retained_after, retained_before);
     }
 
     #[test]

--- a/src/trap/window.rs
+++ b/src/trap/window.rs
@@ -1999,6 +1999,44 @@ impl super::TrapDispatcher {
                 return;
             }
 
+            let (_, _, screen_width, screen_height, _) = self.get_screen_params();
+            let menu_bar_height = bus.read_word(crate::memory::globals::addr::MBAR_HEIGHT) as i16;
+            let fullscreen_plain_owner = front_proc_id == 2
+                && self.fullscreen_locked
+                && menu_bar_height == 0
+                && *self.current_port == window_ptr
+                && self
+                    .window_list
+                    .iter()
+                    .filter(|&&window| self.window_visible(bus, window))
+                    .count()
+                    == 1
+                && front_rect.0 <= 0
+                && front_rect.1 <= 0
+                && front_rect.2 >= screen_height
+                && front_rect.3 >= screen_width
+                && self.resolve_copy_bitmap(bus, window_ptr + 2).base == self.screen_mode.0;
+            if fullscreen_plain_owner {
+                if let Some(rect) = self.last_screen_copybits_rect {
+                    let src_width = rect.src_right.saturating_sub(rect.src_left);
+                    let src_height = rect.src_bottom.saturating_sub(rect.src_top);
+                    let dst_width = rect.dst_right.saturating_sub(rect.dst_left);
+                    let dst_height = rect.dst_bottom.saturating_sub(rect.dst_top);
+                    let destination =
+                        (rect.dst_top, rect.dst_left, rect.dst_bottom, rect.dst_right);
+                    let unscaled = src_width == dst_width && src_height == dst_height;
+                    let safe_margins = self.kiosk_stage_margins_are_uniform(bus, destination)
+                        || self.kiosk_stage_margins_are_black_or_standard_desktop(bus, destination);
+                    if unscaled
+                        && safe_margins
+                        && self
+                            .fill_kiosk_stage_around_rect_for_hidden_game_surface(bus, destination)
+                    {
+                        return;
+                    }
+                }
+            }
+
             if !Self::window_is_document_proc(front_proc_id) {
                 if let (Some(rect), Some(front_structure)) = (
                     self.last_screen_copybits_rect,


### PR DESCRIPTION
## Problem

A full-screen `plainDBox` can own the screen while presenting an unscaled, centered CopyBits surface smaller than the screen. When its Window Manager structure rectangle extends beyond the screen, the compositor rejects the retained CopyBits destination because it cannot contain that structure rectangle. Partially cleared System 7 desktop pattern pixels then remain visible around the application-owned surface.

## Fix

Recognize the retained destination only when all of the following generic ownership and safety conditions hold:

- fullscreen presentation is locked and `MBarHeight` is zero;
- the sole visible front window is a screen-backed `plainDBox` and is the current port;
- the front port covers the screen;
- the retained CopyBits operation is centered, unscaled, large, and inside the screen;
- on an 8-bit Classic System 7 screen, every exterior pixel is either the active logical black index or the active logical white index at the white phase of the standard desktop pattern.

When those conditions hold, the compositor replaces only the exterior margins with the active logical black index. The retained CopyBits destination remains byte-for-byte unchanged. The existing kiosk-stage helper keeps its original host-hidden-menu contract; the broader effective-hidden predicate is isolated to this stronger full-screen-owner path.

This deliberately does not relax document-window, scaled or off-center CopyBits, multiple-window, visible-menu, nonindexed, non-System-7, transient-window, or nonpattern-overlay behavior.

## Validation

The focused exact-state regression passed and recreates the observed ownership state, partially blackened desktop pattern, oversized structure rectangle, active CLUT, retained 640×480 destination, and application-owned colored edge pixels:

- `fullscreen_plain_window_stages_retained_copybits_over_partial_desktop_pattern`: 1 passed, 0 failed.

Eight nearby controls passed across centered kiosk staging, saved CopyBits fallback, transient-frame preservation, missing structure geometry, document-window rejection, stale WindowRecord handling, visible-menu bounds, and off-center guest geometry:

- `kiosk_stage_*`: 3 passed, 0 failed.
- five individually filtered compositor controls: 5 passed, 0 failed.

The canonical gameplay route completed at tick 4,248 after 182,215,954 guest instructions. In both the initial gameplay and post-input decoded 800×600 frames:

- exactly 44,970 former white desktop-pattern pixels became black;
- all 307,200 pixels inside the retained `[80,60,720,540]` destination were unchanged;
- all 172,800 pixels outside that destination were black;
- all 2,356 legitimate colored edge pixels outside the visual crop were preserved;
- the exterior matched the corresponding native reference frame pixel-for-pixel.

The Up control changed exactly 1,318 pixels in the expected exclusive bounding box `[319,233,354,349]`, entirely inside the retained destination, with zero exterior changes. Native-resolution inspection confirmed the palette, room artwork, HUD and text, character and furniture layers, crop, and red frame remain intact without corruption or duplication.

`git diff --check` passes. CI is pending.

Closes #1632
