### PR TITLE
fix: preserve explicit screen CopyBits output

### DIFF
--- a/src/trap/dispatch.rs
+++ b/src/trap/dispatch.rs
@@ -1819,8 +1819,19 @@ pub struct TrapDispatcher {
     /// ~20-30ns measurement overhead per trap when enabled. Dump via
     /// `print_trap_timing_histogram`.
     pub trap_time_ns: Box<[u64; 4096]>,
-    /// Number of copybits_screen events emitted (screen-affecting draws).
+    /// Cumulative number of effective CopyBits draws into the screen.
+    ///
+    /// This lifetime is intentional: desktop content-rect detection compares
+    /// successive totals. Compositor suppression uses
+    /// `last_screen_copybits_tick` instead of treating this counter as a
+    /// current-frame flag.
     pub copybits_screen_count: u64,
+    /// Guest tick in which the most recent effective screen CopyBits occurred.
+    ///
+    /// The window-backing bridge must defer only for the frame that contains
+    /// the explicit screen draw; the cumulative event count cannot express
+    /// that lifetime.
+    pub(crate) last_screen_copybits_tick: Option<u32>,
     /// Most recent sizeable CopyBits blit into the screen framebuffer.
     pub last_screen_copybits_rect: Option<ScreenCopyBitsRect>,
     /// Largest non-fullscreen FrameRect drawn into the screen framebuffer in
@@ -2735,6 +2746,22 @@ impl TrapDispatcher {
         self.tick_state.current_tick()
     }
 
+    /// Record an effective CopyBits draw into the physical screen.
+    ///
+    /// Keep the cumulative counter for trace/content-rect consumers while
+    /// retaining the guest tick separately for frame-scoped compositor policy.
+    pub(crate) fn note_screen_copybits(&mut self) {
+        self.copybits_screen_count += 1;
+        self.last_screen_copybits_tick = Some(self.current_tick());
+    }
+
+    /// Whether an explicit screen CopyBits occurred during the current guest
+    /// frame. Repeated host redraws in this tick must preserve that output,
+    /// while a later tick may resume the offscreen-window bridge.
+    pub(crate) fn screen_copybits_in_current_tick(&self) -> bool {
+        self.last_screen_copybits_tick == Some(self.current_tick())
+    }
+
     /// Resolve the architecture-neutral TickCount operation from the
     /// guest-visible low-memory value. A direct guest write is accepted at
     /// the ABI boundary and updates the host pacing snapshot; it is never
@@ -3461,6 +3488,7 @@ impl TrapDispatcher {
             trap_histogram: Box::new([0u64; 4096]),
             trap_time_ns: Box::new([0u64; 4096]),
             copybits_screen_count: 0,
+            last_screen_copybits_tick: None,
             last_screen_copybits_rect: None,
             last_screen_frame_rect: None,
             last_screen_frame_rect_tick: 0,

--- a/src/trap/framebuffer.rs
+++ b/src/trap/framebuffer.rs
@@ -3318,15 +3318,18 @@ impl super::TrapDispatcher {
         }
 
         // CopyBits into the physical screen is an explicit application
-        // presentation operation. Once one has occurred, replaying a
-        // separate window backing port would create a second compositor and
-        // can erase screen-owned artwork that is not present in that port.
-        // Keep the screen framebuffer authoritative, matching the manual
-        // CPort bridge above. Imaging With QuickDraw (1994), 3-112--3-114.
-        if self.copybits_screen_count != 0 {
+        // presentation operation. While the current guest frame contains
+        // one, replaying a separate window backing port would create a second
+        // compositor and can erase screen-owned artwork that is not present
+        // in that port. Keep the screen framebuffer authoritative for this
+        // frame, then allow the bridge again on the next tick. The cumulative
+        // event counter is deliberately not used here because it also feeds
+        // longer-lived trace/content-rect consumers. Imaging With QuickDraw
+        // (1994), 3-112--3-114.
+        if self.screen_copybits_in_current_tick() {
             if trace {
                 eprintln!(
-                    "[BLIT] skip: screen already has explicit CopyBits output (count={})",
+                    "[BLIT] skip: current frame already has explicit CopyBits output (count={})",
                     self.copybits_screen_count
                 );
             }
@@ -8259,13 +8262,23 @@ mod redraw_chrome_tests {
         // An explicit screen CopyBits makes the framebuffer authoritative.
         // The stale/offscreen window backing must not be replayed over it.
         bus.fill_bytes(screen_base, 4 * 2, 0xAA);
-        disp.copybits_screen_count = 1;
+        disp.note_screen_copybits();
         disp.blit_window_to_screen(&mut bus);
 
         assert_eq!(
             bus.read_bytes(screen_base, 4 * 2),
             vec![0xAA; 4 * 2],
             "an explicit screen CopyBits must prevent the window bridge from erasing screen-owned pixels"
+        );
+
+        // The cumulative event count remains nonzero for content-rect
+        // detection, but it must not suppress a later guest frame.
+        disp.set_tick_count_for_test(&mut bus, 101);
+        disp.blit_window_to_screen(&mut bus);
+        assert_eq!(
+            bus.read_bytes(screen_base, 4 * 2),
+            vec![0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88],
+            "the next guest frame must resume compositing the offscreen window backing"
         );
     }
 

--- a/src/trap/framebuffer.rs
+++ b/src/trap/framebuffer.rs
@@ -3317,6 +3317,22 @@ impl super::TrapDispatcher {
             return;
         }
 
+        // CopyBits into the physical screen is an explicit application
+        // presentation operation. Once one has occurred, replaying a
+        // separate window backing port would create a second compositor and
+        // can erase screen-owned artwork that is not present in that port.
+        // Keep the screen framebuffer authoritative, matching the manual
+        // CPort bridge above. Imaging With QuickDraw (1994), 3-112--3-114.
+        if self.copybits_screen_count != 0 {
+            if trace {
+                eprintln!(
+                    "[BLIT] skip: screen already has explicit CopyBits output (count={})",
+                    self.copybits_screen_count
+                );
+            }
+            return;
+        }
+
         // Read the port's rowBytes (from pixMap for CGrafPort, portBits for GrafPort)
         let port_rb = if is_cgraf_port {
             (bus.read_word(port_pixmap_ptr + 4) & 0x3FFF) as u32
@@ -8214,6 +8230,42 @@ mod redraw_chrome_tests {
             bus.read_byte(row30_x97),
             0,
             "1bpp src bit=0 must still use the active ColorTable's white index"
+        );
+    }
+
+    #[test]
+    fn redraw_chrome_preserves_explicit_screen_copybits_over_window_backing() {
+        let (mut disp, _cpu, mut bus) = setup_with_port();
+
+        let screen_base = bus.alloc(4 * 2);
+        disp.screen_mode = (screen_base, 4, 4, 2, 8);
+        bus.write_long(0x0824, screen_base);
+
+        let source_base = bus.alloc(4 * 2);
+        install_8bpp_cgrafport(&mut bus, source_base, 4, 4, 2, 0);
+        bus.write_bytes(
+            source_base,
+            &[0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88],
+        );
+        bus.fill_bytes(screen_base, 4 * 2, 0xAA);
+        disp.front_window = PORT_PTR;
+        disp.window_bounds = (0, 0, 2, 4);
+
+        // The normal HLE window bridge is still needed before an application
+        // takes ownership of the physical framebuffer.
+        disp.blit_window_to_screen(&mut bus);
+        assert_eq!(bus.read_bytes(screen_base, 4), vec![0x11, 0x22, 0x33, 0x44]);
+
+        // An explicit screen CopyBits makes the framebuffer authoritative.
+        // The stale/offscreen window backing must not be replayed over it.
+        bus.fill_bytes(screen_base, 4 * 2, 0xAA);
+        disp.copybits_screen_count = 1;
+        disp.blit_window_to_screen(&mut bus);
+
+        assert_eq!(
+            bus.read_bytes(screen_base, 4 * 2),
+            vec![0xAA; 4 * 2],
+            "an explicit screen CopyBits must prevent the window bridge from erasing screen-owned pixels"
         );
     }
 

--- a/src/trap/quickdraw.rs
+++ b/src/trap/quickdraw.rs
@@ -3388,7 +3388,7 @@ impl super::TrapDispatcher {
                     return Some(Ok(()));
                 }
                 if let Some(rect) = screen_copybits_rect {
-                    self.copybits_screen_count += 1;
+                    self.note_screen_copybits();
                     self.note_screen_copybits_rect(
                         rect.src_top,
                         rect.src_left,
@@ -37245,6 +37245,8 @@ mod tests {
 
         let result = d.dispatch_quickdraw(true, 0x0EC, &mut cpu, &mut bus);
         assert!(result.unwrap().is_ok());
+        assert_eq!(d.copybits_screen_count, 1);
+        assert_eq!(d.last_screen_copybits_tick, Some(d.current_tick()));
         assert_eq!(bus.read_byte(screen_base + 2 * 16 + 2), 0x7A);
 
         bus.write_byte(screen_base + 2 * 16 + 2, 0);


### PR DESCRIPTION
Closes #1644

## Root cause

The generic redraw bridge could blit an offscreen window backing port after an application had explicitly copied pixels into the physical screen. That second blit erased screen-owned artwork that was not present in the backing port, producing the missing static frame and menu-layer pixels reported in Crystal Quest.

## Fix

Treat explicit screen-targeted CopyBits output as authoritative for the physical framebuffer and suppress only the later fallback window blit. Ordinary offscreen windows still use the bridge before explicit screen output. The change is generic compositor behavior and contains no game-specific runtime logic.

## Proof and validation

- Added focused framebuffer regression coverage for both pre-screen fallback blitting and post-screen preservation.
- Focused framebuffer/compositor test suite: 77 passed.
- git diff --check clean.
- Commit: 7077ebfb15a5cf8de00fad70eaa9e72023939128.