### PR TITLE
fix: resolve basic grafport colors to device clut on indexed screen

### DIFF
--- a/src/trap/shapes.rs
+++ b/src/trap/shapes.rs
@@ -1414,12 +1414,19 @@ impl super::TrapDispatcher {
         let fg_idx;
         let bg_idx;
         let mut indexed_clut = None;
-        if matches!(pixel_size, 2 | 4 | 8) && is_color {
-            let pix_map_handle = bus.read_long(port.wrapping_add(2));
-            let port_ctab_handle = if pix_map_handle != 0 {
-                let pix_map_ptr = bus.read_long(pix_map_handle);
-                if pix_map_ptr != 0 {
-                    bus.read_long(pix_map_ptr + 42)
+        if matches!(pixel_size, 2 | 4 | 8) {
+            let is_screen_port = pix_base == self.screen_mode.0
+                && pix_row_bytes == self.screen_mode.1
+                && pixel_size == self.screen_mode.4;
+            let port_ctab_handle = if is_color {
+                let pix_map_handle = bus.read_long(port.wrapping_add(2));
+                if pix_map_handle != 0 {
+                    let pix_map_ptr = bus.read_long(pix_map_handle);
+                    if pix_map_ptr != 0 {
+                        bus.read_long(pix_map_ptr + 42)
+                    } else {
+                        0
+                    }
                 } else {
                     0
                 }
@@ -1430,9 +1437,6 @@ impl super::TrapDispatcher {
             // cscSetEntries updates the hardware palette immediately even when
             // the Color Manager table is stale. Offscreen ports continue to
             // use their own ColorTable.
-            let is_screen_port = pix_base == self.screen_mode.0
-                && pix_row_bytes == self.screen_mode.1
-                && pixel_size == self.screen_mode.4;
             let current_ctab_handle = if port == *self.current_port {
                 self.current_gdevice_ctab_handle(bus)
             } else {
@@ -1471,7 +1475,7 @@ impl super::TrapDispatcher {
                 effective_fg_color,
                 pixel_size,
                 &port_clut,
-                (resolved_color_fields & 0x01) != 0,
+                is_color && (resolved_color_fields & 0x01) != 0,
                 generated_pen_rgb.is_some(),
             );
             bg_idx = indexed_shape_color_index(
@@ -1479,23 +1483,9 @@ impl super::TrapDispatcher {
                 effective_bg_color,
                 pixel_size,
                 &port_clut,
-                (resolved_color_fields & 0x02) != 0,
+                is_color && (resolved_color_fields & 0x02) != 0,
                 generated_back_rgb.is_some(),
             );
-            if trace_dialog_text_enabled() && matches!(op, ShapeOp::Glyph(_)) {
-                eprintln!(
-                    "[DIALOG-TEXT] Glyph colors port=${:08X} fgRGB=({:04X},{:04X},{:04X}) bgRGB=({:04X},{:04X},{:04X}) fgIdx={} bgIdx={}",
-                    port,
-                    self.fg_color.0,
-                    self.fg_color.1,
-                    self.fg_color.2,
-                    self.bg_color.0,
-                    self.bg_color.1,
-                    self.bg_color.2,
-                    fg_idx,
-                    bg_idx,
-                );
-            }
         } else {
             fg_idx = 255;
             bg_idx = 0;
@@ -2110,6 +2100,22 @@ mod tests {
         assert_eq!(
             indexed_shape_color_index(95, (0xF2D7, 0x0856, 0x84EC), 8, &clut, true, true,),
             181
+        );
+    }
+
+    #[test]
+    fn basic_grafport_on_indexed_screen_maps_rgb_to_clut() {
+        let mut clut = [[0, 0, 0]; 256];
+        clut[0] = [0xFFFF, 0xFFFF, 0xFFFF]; // white at index 0
+        clut[30] = [0xFFFF, 0x0000, 0xFFFF]; // magenta at index 30 (not white)
+
+        // In a basic GrafPort, port+84 contains the classic QuickDraw color
+        // constant (e.g. whiteColor = 30), NOT an indexed pixel value.
+        // It must map the port's logical RGB (white) to index 0 using the CLUT,
+        // rather than treating 30 as an already-resolved pixel index.
+        assert_eq!(
+            indexed_shape_color_index(30, (0xFFFF, 0xFFFF, 0xFFFF), 8, &clut, false, false),
+            0
         );
     }
 


### PR DESCRIPTION
Partially addresses #1644. The separate screen-compositing defect remains under review in #1649.

## Root cause

When drawing into an indexed screen framebuffer (`pixel_size` 2, 4, or 8) through a basic `GrafPort` (`is_color == false`), QuickDraw shape and text routines retrieved `port + 80` (`fgColor`) and `port + 84` (`bkColor`). In a basic `GrafPort`, these fields contain classic QuickDraw color constants (such as `whiteColor = 30`), rather than pre-resolved device palette indices. The previous logic only performed CLUT lookups for `CGrafPort` instances, treating basic `GrafPort` field values as literal palette indices if `is_color` was false, or passing unmapped values when `resolved_color_fields` was checked without distinguishing `GrafPort` from `CGrafPort`. On an 8bpp screen, this caused white text backgrounds and shape fills to map to index 30 (magenta) or index 102 (purple) rather than the palette's actual white index (index 0).

## Fix

- Extend CLUT resolution in `draw_generic_shape` to basic `GrafPort` screen-targeted drawing when `pixel_size` is 2, 4, or 8.
- Gate the `resolved_color_fields` bypass so that only `CGrafPort` ports with pre-resolved pixel values bypass the RGB inverse color table lookup. Basic `GrafPort` ports continue to map their logical RGB colors to the device CLUT.
- Added regression test `basic_grafport_on_indexed_screen_maps_rgb_to_clut`.

## Proof and validation

- Ran focused shapes and quickdraw unit tests: all passed cleanly (`trap::shapes` 19 passed, `trap::quickdraw` 727 passed).
- Verified with `cargo check --lib` and `git diff --check`.