### PR TITLE
fix(desktop): use the Systemless theme by default

### DIFF
--- a/src/bin/systemless.rs
+++ b/src/bin/systemless.rs
@@ -190,7 +190,7 @@ struct Cli {
     #[arg(
         long,
         value_name = "THEME",
-        default_value = "classic-system7",
+        default_value = "systemless-default",
         value_parser = UiThemeId::parse
     )]
     ui_theme: UiThemeId,
@@ -3580,12 +3580,12 @@ mod tests {
     }
 
     #[test]
-    fn cli_defaults_to_automatic_window_size_and_classic_theme() {
+    fn cli_defaults_to_automatic_window_size_and_systemless_theme() {
         let cli = Cli::try_parse_from(["systemless", "game.sit"])
             .expect("default display scale should parse");
         assert_eq!(cli.display_scale, None);
         assert_eq!(cli.screen_depth, None);
-        assert_eq!(cli.ui_theme, UiThemeId::ClassicSystem7);
+        assert_eq!(cli.ui_theme, UiThemeId::SystemlessDefault);
         assert_eq!(
             guest_scaled_physical_size(800, 600, 1),
             winit::dpi::PhysicalSize::new(800, 600)


### PR DESCRIPTION
## Summary

- make the desktop runner select the Systemless presentation theme when `--ui-theme` is omitted
- retain `--ui-theme classic-system7` as an explicit opt-in
- update the desktop CLI regression test to pin the intended default

## Root cause

The desktop CLI declared `classic-system7` as its default and passed that value into the runner during game initialization. That selected both the classic monochrome desktop pattern and the heavier classic dialog frame, causing the reported background and lower-border artifacts together.

## Validation

- `rustfmt --edition 2021 --check < src/bin/systemless.rs`
- `cargo test --bin systemless cli_defaults_to_automatic_window_size_and_systemless_theme`
- `cargo check --bin systemless`

Closes #1654