### PR TITLE
fix(menu): reconcile guest menus before chrome redraw

### DIFF
--- a/src/trap/framebuffer.rs
+++ b/src/trap/framebuffer.rs
@@ -5244,6 +5244,7 @@ impl super::TrapDispatcher {
         self.restore_window_manager_desktop(bus);
 
         if !self.menus.is_empty() && !self.fullscreen_locked && !self.menu_bar_hidden {
+            self.refresh_menus_from_memory(bus);
             self.draw_menu_bar_to_fb(bus);
         }
         // Skip chrome for borderless/dialog window types that have no title bar.

--- a/src/trap/menu.rs
+++ b/src/trap/menu.rs
@@ -1677,8 +1677,10 @@ impl super::TrapDispatcher {
         names
     }
 
-    fn refresh_menus_from_memory(&mut self, bus: &MacMemoryBus) {
-        let menu_list = self.current_menu_list(bus).unwrap_or_default();
+    pub(crate) fn refresh_menus_from_memory(&mut self, bus: &MacMemoryBus) {
+        let Some(menu_list) = self.current_menu_list(bus) else {
+            return;
+        };
         self.apply_menu_list_membership(bus, &menu_list);
         for menu in &mut self.menus {
             refresh_menu_from_memory(bus, menu);
@@ -11384,6 +11386,32 @@ mod tests {
             crate::runner::MenuBarPolicy::GuestControlled
         );
         assert!(!disp.menu_bar_hidden);
+    }
+
+    #[test]
+    fn redraw_chrome_reconciles_menu_membership_before_painting() {
+        let (mut disp, mut cpu, mut bus) = setup_with_port();
+        disp.menu_bar_hidden = false;
+        bus.write_word(crate::memory::globals::addr::MBAR_HEIGHT, 20);
+        let file = new_menu_with_title(&mut disp, &mut cpu, &mut bus, 300, 0x302000, "File");
+        let game = new_menu_with_title(&mut disp, &mut cpu, &mut bus, 301, 0x302020, "Game");
+        insert_menu(&mut disp, &mut cpu, &mut bus, file);
+        insert_menu(&mut disp, &mut cpu, &mut bus, game);
+
+        disp.menus
+            .iter_mut()
+            .find(|menu| menu.handle == file)
+            .unwrap()
+            .visible_in_menu_bar = false;
+
+        disp.redraw_chrome(&mut bus);
+
+        assert!(disp
+            .menus
+            .iter()
+            .find(|menu| menu.handle == file)
+            .unwrap()
+            .visible_in_menu_bar);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- refresh the cached menu presentation from the authoritative guest MenuList before idle chrome repaints
- preserve the cached state when the guest has not installed a current menu list
- add a regression test for stale menu membership during redraw

## Root cause

Factory Demo builds its menu list over the course of its introduction. The cached renderer could retain an intermediate membership state, painting only Apple and Game until the first MenuSelect refreshed the cache. Native menu bridging masked this because it snapshots the guest menu state independently.

## Validation

- `cargo test redraw_chrome_reconciles_menu_membership_before_painting`
- `cargo test redraw_chrome_` (79 passed)
- deterministic Factory menu restoration probe shows Apple, File, Edit, and Game before input
- full Factory gameplay proof starts via visible Game > Begin and reaches live gameplay

`cargo fmt --check` remains blocked by pre-existing formatting differences in unrelated files.

Closes #1666