### PR TITLE
fix: bound BlockMove memory ranges

### DIFF
--- a/src/memory/bus.rs
+++ b/src/memory/bus.rs
@@ -1151,7 +1151,9 @@ impl MacMemoryBus {
     /// inside RAM and no watchpoint is armed, uses `slice::copy_within`
     /// — one bounds check, memmove-grade throughput. Falls back to
     /// byte-at-a-time (preserving the overlap-handling order from
-    /// Inside Macintosh II-44) when the fast path doesn't apply.
+    /// Inside Macintosh II-44) when the fast path doesn't apply. A request
+    /// that crosses the active address-width boundary or is not fully mapped
+    /// and writable is rejected before that fallback can wrap an address.
     pub fn block_move(&mut self, src: u32, dst: u32, count: u32) {
         // `Size` is a signed Macintosh LONGINT. A negative byte count is
         // invalid; treating its bit pattern as an unsigned length would let
@@ -1161,10 +1163,26 @@ impl MacMemoryBus {
         if (count as i32) <= 0 {
             return;
         }
+        let count_usize = count as usize;
+        // The byte-wise fallback increments guest addresses with wrapping.
+        // Reject an address-width crossing, unmapped source, or unwritable
+        // destination before it can turn a malformed request into writes to
+        // unrelated guest state. Inside Macintosh: Memory (1992),
+        // pp. 2-59--2-60 defines BlockMove as a complete byte-range copy.
+        if self
+            .range_translates_contiguously(src, count_usize)
+            .is_none()
+            || self
+                .range_translates_contiguously(dst, count_usize)
+                .is_none()
+            || !self.is_guest_address_mapped(src, count_usize)
+            || !self.is_guest_address_writable(dst, count_usize)
+        {
+            return;
+        }
         if self.presentation_active() && self.copy_ram_bytes(src, dst, count) {
             return;
         }
-        let count_usize = count as usize;
         let flat_route = self.route(src, count_usize) == GuestMemoryRoute::Flat
             && self.route(dst, count_usize) == GuestMemoryRoute::Flat;
         #[cfg(debug_assertions)]
@@ -3918,6 +3936,35 @@ mod tests {
             0xAA,
             "out-of-bounds copy should report failure before writing"
         );
+    }
+
+    #[test]
+    fn block_move_rejects_ranges_that_wrap_the_24_bit_address_space() {
+        let mut bus = MacMemoryBus::new(0x0100_0000);
+        bus.set_addressing_32_bit(false);
+
+        const SOURCE: u32 = 0x00FF_FFFE;
+        const LOW_MEMORY: u32 = 0x0200;
+        let sentinel = [0xC0, 0xDE, 0xCA, 0xFE];
+        bus.write_bytes(SOURCE, &[1, 2]);
+        bus.write_bytes(LOW_MEMORY, &sentinel);
+
+        bus.block_move(SOURCE, LOW_MEMORY, sentinel.len() as u32);
+
+        assert_eq!(bus.read_bytes(LOW_MEMORY, sentinel.len()), sentinel);
+    }
+
+    #[test]
+    fn block_move_rejects_unmapped_sources_before_writing_code_bytes() {
+        let mut bus = MacMemoryBus::new(64 * 1024);
+        const UNMAPPED_SOURCE: u32 = 0x0100_0000;
+        const CODE: u32 = 0x3000;
+        let sentinel = [0x4E, 0x75, 0x60, 0x00];
+        bus.write_bytes(CODE, &sentinel);
+
+        bus.block_move(UNMAPPED_SOURCE, CODE, sentinel.len() as u32);
+
+        assert_eq!(bus.read_bytes(CODE, sentinel.len()), sentinel);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #613

## Root cause
A malformed `BlockMove` request with a 24-bit-wrapping source/destination span reached the byte-wise fallback. Guest address increments wrapped at the active address-width boundary, allowing a huge copy to overwrite unrelated low memory, including the tick counter and executable code.

## Fix
Preflight the complete source and destination spans before presentation handling or fallback copying. Reject ranges that cross the active address-width boundary, contain unmapped source bytes, or contain an unwritable destination byte. Valid flat, shared, sparse, overlap-safe, and presentation copies retain their existing behavior.

## Reproducible proof
The failure was reproduced at the second `BlockMoveData` call: `PC=$0052DAF0`, `D0=$7F7F8080`, `src=$0055DA3C`, `dst=$FFFFCEF8`; the malformed request previously wrapped through the 24-bit address space and corrupted the tick counter/code. With this generic preflight, the same Warcraft II execution manifest reaches: startup transition (native 800x600 RGB, 248 colors), Shareware title, main menu, Single Player, Human Campaign, the authored Hillsbrad briefing, the first mission, map scroll, and Footman selection. The completed run ends at tick 3088 with no illegal-opcode, invalid-PC, halt, or `RUN_STEPS` failure.

The exact public-safe execution manifest used for that run has SHA-256 `666ac6b0b2b537d7e155f1063fa9168634cc7f874191b91e1f2c8147fc405349`; the public archive SHA-256 is `7b480153a0c15dcb084a201cd53edb35a99bbc0aea250c2e28e807ed6290ef3b`.

Decoded native-frame artifacts (lossless 800x600 RGB PNGs) are identified by SHA-256:
- post-transition: `6485663bcefb576b4325dc78cc6f5af7bddc0e2fd2f5e408f006cd786e94e38e`
- title after Space: `34a2207761335316708413f40716bfb24b9c860610fd531decbbf22058e32a75`
- Hillsbrad briefing: `9a8eb342bbd61b7d69d78a888f9996ba7db4fe518bea289368310214bad0a90b`
- first mission: `8850c549f38ffde38dcc1bf468b7a2e597e21333836b8cfcba15e9af4516d58c`
- after Right map scroll: `ff10127942c84b186e92f07ee18ceedb0524bc20da8e39b6740d0b1b74d71dbe`
- after Footman click: `f0de41e066182a91ba4cc643d44f37e8f1248d8a5b9d98fec7dba143e32ffe4a`

## Regression and validation
- Added atomic regression coverage for 24-bit range wrap and unmapped-source writes.
- `cargo test --lib block_move` (7 passed)
- `cargo test --lib memory::` (383 passed)
- `cargo test --lib` (5,435 passed, 3 ignored)
- `cargo check --no-default-features` passed
- GitHub CI: all checks passed

Public issue and PR contain no private workspace paths or game-specific runtime logic.