### PR TITLE
feat(debugger): add opt-in inspection, execution control, and captures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,12 +63,20 @@ jobs:
       - name: Build all targets
         run: cargo build --all-targets --all-features
 
-      # test-support enables the scripted_traces module and its tests.
+      # test-support enables the scripted_traces module and its tests. The
+      # debugger is an opt-in feature, so this run also covers its disabled
+      # path; the next step exercises the enabled one.
       - name: Run library tests
         run: cargo test --lib --features test-support
 
+      - name: Run debugger library tests
+        run: cargo test --lib --features test-support,debug
+
       - name: Run desktop tests
         run: cargo test --locked --bin systemless
+
+      - name: Run debugger desktop tests
+        run: cargo test --locked --bin systemless --features debug-server
 
       # Both Systemless runtime configurations use this exact optimized executable.
       # Keep ordinary library/desktop tests in the checked debug profile above.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,11 @@ jit = ["m68k/jit"]
 # Exposes `scripted_traces`, deterministic trap-replay test scaffolding.
 # Off by default so it stays out of the published public API and docs.
 test-support = []
+# Opt-in debugger and inspection API. Off by default so ordinary builds do
+# not compile the control/inspection foundation or carry its runtime state.
+debug = []
+# Debugger socket transport (Unix-domain sockets). Implies `debug`.
+debug-server = ["debug"]
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = { version = "0.5.2", optional = true }

--- a/src/bin/desktop/debug_server.rs
+++ b/src/bin/desktop/debug_server.rs
@@ -1,0 +1,277 @@
+//! Unix JSON-line transport for [`systemless::debug`]. The library module
+//! documents envelopes and client usage; request types document RPC parameters.
+//! This worker owns socket I/O only. The frontend must pump requests between
+//! runner calls, including while paused or halted.
+
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::fs::FileTypeExt;
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{Receiver, Sender};
+use std::sync::{Arc, Mutex};
+
+use serde::{Deserialize, Serialize};
+use systemless::debug::{handle_debug_request, DebugError, DebugReply, DebugRequest};
+use systemless::runner::FixtureRunner;
+
+const MAX_ENVELOPE_BYTES: usize = 1024 * 1024;
+
+// Socket I/O stays on the worker thread; requests cross to the runner thread
+// and are applied only when the frontend pumps its command-safe point.
+
+struct Envelope {
+    id: u64,
+    request: DebugRequest,
+}
+
+#[derive(Deserialize)]
+struct EnvelopeIn {
+    #[serde(default)]
+    id: u64,
+    request: DebugRequest,
+}
+
+#[derive(Serialize)]
+struct EnvelopeOut {
+    id: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reply: Option<DebugReply>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<DebugError>,
+}
+
+pub struct DebugServer {
+    to_runner: Receiver<Envelope>,
+    from_runner: Sender<Outgoing>,
+}
+
+struct Outgoing {
+    id: u64,
+    result: Result<DebugReply, DebugError>,
+}
+
+impl DebugServer {
+    pub fn bind(path: &Path) -> std::io::Result<Self> {
+        if let Some(parent) = path.parent() {
+            if !parent.as_os_str().is_empty() {
+                std::fs::create_dir_all(parent)?;
+            }
+        }
+        if path.exists() {
+            if std::fs::symlink_metadata(path)?.file_type().is_socket() {
+                std::fs::remove_file(path)?;
+            } else {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::AlreadyExists,
+                    format!("debug socket path {} is occupied", path.display()),
+                ));
+            }
+        }
+        let listener = UnixListener::bind(path)?;
+        let (to_runner_tx, to_runner) = std::sync::mpsc::channel();
+        let (from_runner, from_runner_rx) = std::sync::mpsc::channel();
+        std::thread::Builder::new()
+            .name("systemless-debug".to_string())
+            .spawn(move || accept_loop(listener, to_runner_tx, from_runner_rx))?;
+        eprintln!("[DEBUG] Listening on {}", path.display());
+        Ok(Self {
+            to_runner,
+            from_runner,
+        })
+    }
+
+    pub fn pump(&mut self, runner: &mut FixtureRunner) -> usize {
+        let mut served = 0;
+        while let Ok(envelope) = self.to_runner.try_recv() {
+            served += 1;
+            let _ = self.from_runner.send(Outgoing {
+                id: envelope.id,
+                result: handle_debug_request(runner, envelope.request),
+            });
+        }
+        served
+    }
+}
+
+// One controlling client at a time. Accepting stays on this thread so a second
+// connection is refused with a typed error instead of blocking in the kernel
+// accept queue with no indication of why it is stalled; the served client runs
+// on its own thread. `busy` is the authority on exclusivity, so the reply
+// channel is never contended.
+fn accept_loop(
+    listener: UnixListener,
+    to_runner: Sender<Envelope>,
+    from_runner: Receiver<Outgoing>,
+) {
+    let busy = Arc::new(AtomicBool::new(false));
+    // Receiver is not Sync, so sharing it with the client thread needs a Mutex.
+    // The lock is uncontended in practice: `busy` guarantees at most one client
+    // holds it, for that client's whole connection.
+    let from_runner = Arc::new(Mutex::new(from_runner));
+    for stream in listener.incoming() {
+        let Ok(stream) = stream else {
+            continue;
+        };
+        if busy
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_err()
+        {
+            refuse_client(stream);
+            continue;
+        }
+        let to_runner = to_runner.clone();
+        let from_runner = Arc::clone(&from_runner);
+        let client_busy = Arc::clone(&busy);
+        let served = std::thread::Builder::new()
+            .name("systemless-debug-client".to_string())
+            .spawn(move || {
+                {
+                    let from_runner = from_runner
+                        .lock()
+                        .unwrap_or_else(|poisoned| poisoned.into_inner());
+                    if let Err(error) = handle_client(stream, &to_runner, &from_runner) {
+                        eprintln!("[DEBUG] Client disconnected: {error}");
+                    }
+                }
+                client_busy.store(false, Ordering::SeqCst);
+            });
+        if served.is_err() {
+            busy.store(false, Ordering::SeqCst);
+            eprintln!("[DEBUG] Cannot spawn a client thread; connection dropped");
+        }
+    }
+}
+
+// The refused connection gets the same envelope shape as any other failure, so
+// a client parsing replies sees the reason rather than an unexplained close.
+fn refuse_client(stream: UnixStream) {
+    eprintln!("[DEBUG] Refused a second client: one controlling client at a time");
+    let mut stream = stream;
+    let _ = write_envelope(
+        &EnvelopeOut {
+            id: 0,
+            reply: None,
+            error: Some(DebugError::InvalidState {
+                detail: "a controlling client is already connected; \
+                         the debug socket serves one client at a time"
+                    .to_string(),
+            }),
+        },
+        &mut stream,
+    );
+}
+
+fn handle_client(
+    stream: UnixStream,
+    to_runner: &Sender<Envelope>,
+    from_runner: &Receiver<Outgoing>,
+) -> std::io::Result<()> {
+    let mut writer = stream.try_clone()?;
+    let mut reader = BufReader::new(stream);
+    while let Some(line) = read_capped_line(&mut reader)? {
+        let line = match line {
+            Ok(line) => line,
+            Err(()) => {
+                write_envelope(
+                    &EnvelopeOut {
+                        id: 0,
+                        reply: None,
+                        error: Some(DebugError::TooLarge {
+                            limit: MAX_ENVELOPE_BYTES as u64,
+                            requested: MAX_ENVELOPE_BYTES as u64 + 1,
+                        }),
+                    },
+                    &mut writer,
+                )?;
+                continue;
+            }
+        };
+        if line.trim().is_empty() {
+            continue;
+        }
+        let input: EnvelopeIn = match serde_json::from_str(&line) {
+            Ok(input) => input,
+            Err(error) => {
+                let out = EnvelopeOut {
+                    id: 0,
+                    reply: None,
+                    error: Some(DebugError::InvalidValue {
+                        detail: format!("malformed request envelope: {error}"),
+                    }),
+                };
+                write_envelope(&out, &mut writer)?;
+                continue;
+            }
+        };
+        let id = input.id;
+        if to_runner
+            .send(Envelope {
+                id,
+                request: input.request,
+            })
+            .is_err()
+        {
+            break;
+        }
+        let Ok(outgoing) = from_runner.recv() else {
+            break;
+        };
+        let out = EnvelopeOut {
+            id: outgoing.id,
+            reply: outgoing.result.as_ref().ok().cloned(),
+            error: outgoing.result.as_ref().err().cloned(),
+        };
+        write_envelope(&out, &mut writer)?;
+    }
+    Ok(())
+}
+
+fn read_capped_line(reader: &mut impl BufRead) -> std::io::Result<Option<Result<String, ()>>> {
+    let mut bytes = Vec::new();
+    let mut too_large = false;
+    loop {
+        let available = reader.fill_buf()?;
+        if available.is_empty() {
+            if bytes.is_empty() && !too_large {
+                return Ok(None);
+            }
+            break;
+        }
+        let consumed = available
+            .iter()
+            .position(|byte| *byte == b'\n')
+            .map_or(available.len(), |index| index + 1);
+        if !too_large {
+            let remaining = MAX_ENVELOPE_BYTES.saturating_sub(bytes.len());
+            bytes.extend_from_slice(&available[..consumed.min(remaining)]);
+            too_large = consumed > remaining;
+        }
+        let ended = available[consumed - 1] == b'\n';
+        reader.consume(consumed);
+        if ended {
+            break;
+        }
+    }
+    if too_large {
+        return Ok(Some(Err(())));
+    }
+    String::from_utf8(bytes)
+        .map(|line| Some(Ok(line)))
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))
+}
+
+fn write_envelope(out: &EnvelopeOut, writer: &mut impl Write) -> std::io::Result<()> {
+    let text = serde_json::to_string(out).unwrap_or_else(|error| {
+        serde_json::json!({
+            "id": out.id,
+            "error": {
+                "error": "internal",
+                "detail": format!("reply serialization failed: {error}"),
+            }
+        })
+        .to_string()
+    });
+    writeln!(writer, "{text}")?;
+    writer.flush()
+}

--- a/src/bin/desktop/headless_time.rs
+++ b/src/bin/desktop/headless_time.rs
@@ -51,6 +51,9 @@ fn service_sound(runner: &mut FixtureRunner, total: &mut usize, reserve_used: &m
 /// retained-tracking slice is a yield boundary, not an invitation to re-fire
 /// the same wait. Other short slices can be ordinary engine/task handoffs.
 pub(super) fn frame(runner: &mut FixtureRunner, audio_samples: usize) -> FrameWork {
+    if runner.debug_is_paused() {
+        return FrameWork::default();
+    }
     runner.advance_menu_presentation_clock(super::FRAME_DURATION);
     let target = runner.guest_tick().saturating_add(1);
     let batch =
@@ -102,6 +105,7 @@ pub(super) fn frame(runner: &mut FixtureRunner, audio_samples: usize) -> FrameWo
     service_sound(runner, &mut work.instructions, &mut reserve_used);
     runner.prepare_text_presentation();
     runner.composite_frame();
+    runner.finish_gui_frame();
     work
 }
 
@@ -124,6 +128,7 @@ pub(super) fn run(
     screen_depth: Option<u16>,
     script: &[ScriptedInput],
     theme: UiThemeId,
+    debug_socket: Option<std::path::PathBuf>,
 ) {
     if let Err(error) = validate_script(script, ticks) {
         eprintln!("[HEADLESS-TIME] {error}");
@@ -143,6 +148,7 @@ pub(super) fn run(
     game::init_game(&mut runner, &app);
     runner.prepare_text_presentation();
     let instructions_per_tick = configure_realtime_execution_rate(&mut runner);
+    let mut debug_server = super::bind_headless_debug_server(debug_socket, &mut runner);
     let start_tick = runner.guest_tick();
     eprintln!(
         "[HEADLESS-TIME] start frontend_ticks={ticks} guest_tick={start_tick} mac_seconds={start_time} input_clock=frontend_ticks instructions_per_tick={instructions_per_tick}"
@@ -159,6 +165,9 @@ pub(super) fn run(
     let mut audio_hash = 0xcbf2_9ce4_8422_2325u64;
     let trace = std::env::var_os("SYSTEMLESS_HEADLESS_TIME_TRACE").is_some();
     for elapsed in 0..ticks {
+        if let Some(server) = debug_server.as_mut() {
+            super::wait_for_debug_resume(server, &mut runner);
+        }
         while let Some(event) = script.get(next_event).filter(|e| e.at <= elapsed as usize) {
             deliver(&mut runner, &mut mouse, event.action);
             eprintln!("[HEADLESS-TIME] input tick={} {:?}", event.at, event.action);
@@ -205,6 +214,11 @@ pub(super) fn run(
                 elapsed + 1
             );
             save_screenshot(&runner, 9999);
+            if let Some(server) = debug_server.as_mut() {
+                saves.sync_save_files_now(&mut runner);
+                eprintln!("[HEADLESS-TIME] Debugger remains available after terminal stop (press Ctrl-C to exit)");
+                super::wait_for_debug_resume(server, &mut runner);
+            }
             std::process::exit(1);
         }
     }
@@ -304,6 +318,61 @@ mod tests {
         assert!(!work.budget_exhausted);
         assert!(!runner.is_halted());
         assert_eq!(runner.guest_tick(), start + 1);
+    }
+
+    #[test]
+    #[cfg(feature = "debug")]
+    fn debugger_controls_virtual_frames_and_completes_boundary_captures() {
+        use systemless::debug::{
+            handle_debug_request, CaptureMode, CaptureRequest, ContextSelector, DebugReply,
+            DebugRequest, OperationOutcome, OperationState,
+        };
+        let mut runner = modal_runner();
+        let start_tick = runner.guest_tick();
+        handle_debug_request(&mut runner, DebugRequest::Pause).unwrap();
+        assert_eq!(frame(&mut runner, 366).instructions, 0);
+        assert_eq!(runner.guest_tick(), start_tick);
+
+        handle_debug_request(
+            &mut runner,
+            DebugRequest::Step {
+                context: ContextSelector::Active,
+            },
+        )
+        .unwrap();
+        assert_eq!(frame(&mut runner, 366).instructions, 1);
+        assert!(runner.debug_is_paused());
+
+        let DebugReply::Accepted {
+            operation_id: Some(operation),
+            ..
+        } = handle_debug_request(
+            &mut runner,
+            DebugRequest::RequestCapture {
+                request: CaptureRequest {
+                    mode: CaptureMode::PauseAtBoundary,
+                    include_artifacts: false,
+                    ..CaptureRequest::default()
+                },
+            },
+        )
+        .unwrap()
+        else {
+            panic!("expected capture operation")
+        };
+        assert!(!runner.debug_is_paused());
+        frame(&mut runner, 366);
+        assert!(runner.debug_is_paused());
+        assert!(matches!(
+            handle_debug_request(&mut runner, DebugRequest::GetOperation { id: operation })
+                .unwrap(),
+            DebugReply::Operation(systemless::debug::OperationStatus {
+                state: OperationState::Completed {
+                    result: OperationOutcome::Captured { .. }
+                },
+                ..
+            })
+        ));
     }
 
     #[test]

--- a/src/bin/systemless.rs
+++ b/src/bin/systemless.rs
@@ -34,6 +34,29 @@ mod native_bundle;
 #[path = "desktop/native_menu.rs"]
 mod native_menu;
 
+#[cfg(all(feature = "debug-server", unix))]
+#[path = "desktop/debug_server.rs"]
+mod debug_server;
+#[cfg(not(all(feature = "debug-server", unix)))]
+mod debug_server {
+    use std::path::Path;
+
+    pub struct DebugServer;
+
+    impl DebugServer {
+        pub fn bind(_path: &Path) -> std::io::Result<Self> {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::Unsupported,
+                "debug socket transport requires the `debug-server` feature on a Unix platform",
+            ))
+        }
+
+        pub fn pump(&mut self, _runner: &mut systemless::runner::FixtureRunner) -> usize {
+            0
+        }
+    }
+}
+
 #[cfg(not(target_os = "macos"))]
 use std::num::NonZeroU32;
 use std::path::PathBuf;
@@ -245,6 +268,13 @@ struct Cli {
     /// Not a matched-time workload: wait optimizations change when inputs land.
     #[arg(long, value_name = "FILE")]
     input_script: Option<PathBuf>,
+
+    /// Expose the debugger over a Unix-domain socket. One controlling client
+    /// sends one JSON request per line and receives one JSON reply per line;
+    /// requests are applied on the runner thread between frames. Headless
+    /// runs start paused until the client resumes or steps execution.
+    #[arg(long, value_name = "PATH")]
+    debug_socket: Option<PathBuf>,
 }
 
 fn parse_screen_depth(value: &str) -> Result<u16, String> {
@@ -812,7 +842,9 @@ struct App {
     #[cfg(not(target_os = "macos"))]
     scaled_frame: Vec<u32>,
     runner: Option<FixtureRunner>,
+    debug_server: Option<debug_server::DebugServer>,
     save_store: Option<DesktopSaveStore>,
+    guest_exit_reported: bool,
     game_path: PathBuf,
     initialized: bool,
     total_instructions: u64,
@@ -967,7 +999,9 @@ impl App {
             #[cfg(not(target_os = "macos"))]
             scaled_frame: Vec::new(),
             runner: None,
+            debug_server: None,
             save_store: None,
+            guest_exit_reported: false,
             game_path,
             initialized: false,
             total_instructions: 0,
@@ -2842,6 +2876,9 @@ impl ApplicationHandler for App {
     }
 
     fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
+        if let (Some(server), Some(runner)) = (self.debug_server.as_mut(), self.runner.as_mut()) {
+            server.pump(runner);
+        }
         let now = std::time::Instant::now();
         let next = self.next_frame_time.unwrap_or(now);
 
@@ -2870,13 +2907,18 @@ impl ApplicationHandler for App {
         self.step_frame();
         self.flush_ready_mouse_release();
         if self.guest_requested_exit() {
-            self.sync_save_files(true);
-            eprintln!(
-                "[SYSTEMLESS] Guest exited. Total instructions: {}",
-                self.total_instructions
-            );
-            event_loop.exit();
-            return;
+            if !self.guest_exit_reported {
+                self.sync_save_files(true);
+                eprintln!(
+                    "[SYSTEMLESS] Guest exited. Total instructions: {}",
+                    self.total_instructions
+                );
+                self.guest_exit_reported = true;
+            }
+            if self.debug_server.is_none() {
+                event_loop.exit();
+                return;
+            }
         }
         self.sync_save_files(false);
 
@@ -2917,6 +2959,9 @@ impl ApplicationHandler for App {
         if self.should_render_frame() {
             self.render_frame();
         }
+        if let Some(runner) = self.runner.as_mut() {
+            runner.finish_gui_frame();
+        }
         self.frame_count += 1;
     }
 }
@@ -2930,6 +2975,7 @@ fn run_gui(
     display_scale: Option<u32>,
     ui_theme: UiThemeId,
     fullscreen: bool,
+    debug_socket: Option<PathBuf>,
 ) {
     let event_loop = EventLoop::new().expect("Failed to create event loop");
     eprintln!(
@@ -2951,6 +2997,18 @@ fn run_gui(
         ui_theme,
         fullscreen,
     );
+    if let Some(path) = debug_socket {
+        match debug_server::DebugServer::bind(&path) {
+            Ok(server) => app.debug_server = Some(server),
+            Err(error) => {
+                eprintln!(
+                    "Error: cannot bind debug socket {}: {error}",
+                    path.display()
+                );
+                std::process::exit(1);
+            }
+        }
+    }
     // `run_app` is the first point at which `resumed` can create a native
     // window. Finish archive decompression and guest initialization before
     // entering the event loop so startup never exposes an empty host window.
@@ -3047,6 +3105,35 @@ fn save_screenshot(runner: &FixtureRunner, num: usize) {
     eprintln!("[HEADLESS] Screenshot #{}: {} (ticks={})", num, path, ticks);
 }
 
+// Both headless clocks use the same transport and command-safe point. A debug
+// run starts paused so the simulated clock cannot outrun client attachment.
+fn bind_headless_debug_server(
+    path: Option<PathBuf>,
+    runner: &mut FixtureRunner,
+) -> Option<debug_server::DebugServer> {
+    let path = path?;
+    let server = debug_server::DebugServer::bind(&path).unwrap_or_else(|error| {
+        eprintln!("Error: cannot bind debug socket {}: {error}", path.display());
+        std::process::exit(1);
+    });
+    #[cfg(all(feature = "debug-server", unix))]
+    systemless::debug::handle_debug_request(runner, systemless::debug::DebugRequest::Pause)
+        .expect("initial debugger pause");
+    let _ = runner;
+    eprintln!("[HEADLESS] Debugger paused at startup; connect and resume to execute");
+    Some(server)
+}
+
+fn wait_for_debug_resume(server: &mut debug_server::DebugServer, runner: &mut FixtureRunner) {
+    loop {
+        server.pump(runner);
+        if !runner.debug_is_paused() && !runner.is_halted() {
+            return;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+}
+
 fn run_headless(
     game_path: &std::path::Path,
     max_instructions: usize,
@@ -3054,6 +3141,7 @@ fn run_headless(
     screen_depth: Option<u16>,
     script: &[ScriptedInput],
     ui_theme: UiThemeId,
+    debug_socket: Option<PathBuf>,
 ) {
     eprintln!(
         "[HEADLESS] Legacy instruction-budget diagnostic mode: retained Toolbox waits may re-fire repeatedly; do not use these totals as GUI CPU measurements. Use --max-ticks with --tick-input-script for time-based runs."
@@ -3084,12 +3172,17 @@ fn run_headless(
     }
     game::init_game(&mut runner, &app);
 
+    let mut debug_server = bind_headless_debug_server(debug_socket, &mut runner);
+
     let chunk = 100_000;
     let mut total: usize = 0;
     let mut last_screenshot = 0usize;
     let mut next_event = 0usize;
 
     while total < max_instructions {
+        if let Some(server) = debug_server.as_mut() {
+            wait_for_debug_resume(server, &mut runner);
+        }
         // Deliver everything the script has scheduled at or before this
         // point, then run only as far as the next event so its delivery
         // point comes from the script and not from the chunk size.
@@ -3142,6 +3235,17 @@ fn run_headless(
     save_screenshot(&runner, 9999);
     // Measurement-only: prints nothing unless SYSTEMLESS_WAIT_STATS is set.
     systemless::runner::dump_wait_stats();
+    if debug_server.is_some() && runner.is_halted() {
+        eprintln!(
+            "[HEADLESS] Debugger remains available after terminal stop (press Ctrl-C to exit)"
+        );
+        loop {
+            if let Some(server) = debug_server.as_mut() {
+                server.pump(&mut runner);
+            }
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+    }
 }
 
 fn main() {
@@ -3203,6 +3307,7 @@ fn main() {
                 cli.screen_depth,
                 &script,
                 cli.ui_theme,
+                cli.debug_socket,
             );
         } else {
             run_headless(
@@ -3212,6 +3317,7 @@ fn main() {
                 cli.screen_depth,
                 &script,
                 cli.ui_theme,
+                cli.debug_socket,
             );
         }
     } else {
@@ -3228,6 +3334,7 @@ fn main() {
             cli.display_scale,
             cli.ui_theme,
             cli.fullscreen,
+            cli.debug_socket,
         );
     }
 }

--- a/src/cpu/mod.rs
+++ b/src/cpu/mod.rs
@@ -36,6 +36,8 @@ pub enum Register {
 /// Outcome of a single 68k instruction step. Returned by
 /// [`FixtureRunner::step`](crate::runner::FixtureRunner::step).
 pub enum StepResult {
+    /// Execution is currently blocked by the runner; no instruction retired.
+    Blocked,
     /// The instruction completed normally and execution may continue.
     Ok,
     /// The CPU executed `STOP`, or the wrapper normalized an unsupported

--- a/src/debug/adapters.rs
+++ b/src/debug/adapters.rs
@@ -1,0 +1,974 @@
+use super::error::{DebugError, DebugResult};
+use super::ids::{AddressSpaceId, ContextId};
+use super::model::{
+    AddressAccess, AddressMappingKind, AddressSpaceCapabilities, AddressSpaceDescriptor, ByteOrder,
+    ContextCapabilities, ContextLifecycle, ContextSelector, DebugAddress, DisassemblyLine,
+    ExecutionContextDescriptor, ExecutionLocation, MemoryReadResult, RegisterCategory,
+    RegisterDescriptor, RegisterRole, RegisterSnapshot, RegisterValue, RegisterWidth, StackPreview,
+};
+use crate::memory::MemoryBus;
+use crate::runner::FixtureRunner;
+use ppc::PpcCpu;
+
+/// Read-only access to one execution context. Return owned data, enforce transfer
+/// limits, and route memory/disassembly by explicit address-space ID.
+///
+/// Register a factory with
+/// [`FixtureRunner::debug_register_adapter`]. IDs must match the registration.
+/// Control capabilities require scheduler integration: report retirement through
+/// `debug_note_context_executed_units`, add `debug_context_breakpoint_addresses`
+/// to batch watches, stop before execution with `debug_stop_context_at_breakpoint`,
+/// and complete steps at a safe point with `debug_finish_context_step`.
+/// Advertising a capability alone does not implement execution control.
+pub trait ArchitectureAdapter {
+    fn context(&self) -> ExecutionContextDescriptor;
+
+    fn address_spaces(&self) -> Vec<AddressSpaceDescriptor>;
+    fn address_space_capabilities(
+        &self,
+        space: AddressSpaceId,
+    ) -> DebugResult<AddressSpaceCapabilities>;
+
+    fn location(&self) -> ExecutionLocation;
+
+    fn registers(&self, context: ContextId) -> DebugResult<Vec<RegisterSnapshot>>;
+
+    fn disassemble(
+        &self,
+        context: ContextId,
+        address: DebugAddress,
+        count: u32,
+    ) -> DebugResult<Vec<DisassemblyLine>>;
+
+    fn stack_preview(&self, context: ContextId, words: u32) -> DebugResult<StackPreview>;
+
+    fn read_memory(
+        &self,
+        space: AddressSpaceId,
+        address: u64,
+        length: u64,
+    ) -> DebugResult<MemoryReadResult>;
+}
+
+pub type AdapterFactory =
+    for<'a> fn(&'a FixtureRunner) -> Option<Box<dyn ArchitectureAdapter + 'a>>;
+
+/// Runner-local adapter factory and active-context predicate. Context/space IDs
+/// must be nonzero and unique across registrations. Multiple active predicates
+/// make the `Active` selector unavailable; registration order is not priority.
+#[derive(Clone, Copy, Debug)]
+pub struct AdapterRegistration {
+    pub context: ContextId,
+    pub address_spaces: &'static [AddressSpaceId],
+    pub factory: AdapterFactory,
+    pub is_active: fn(&FixtureRunner) -> bool,
+}
+
+pub const M68K_CONTEXT: ContextId = ContextId(1);
+pub const M68K_SPACE: AddressSpaceId = AddressSpaceId(1);
+pub const PPC_CONTEXT: ContextId = ContextId(2);
+pub const PPC_COMPANION_CONTEXT: ContextId = ContextId(3);
+pub const PPC_COMPANION_SPACE: AddressSpaceId = AddressSpaceId(3);
+pub const PPC_SPACE: AddressSpaceId = AddressSpaceId(2);
+
+pub const MAX_MEMORY_TRANSFER: u64 = 16 * 1024 * 1024;
+pub const MAX_DISASSEMBLY_COUNT: u32 = 4096;
+pub const MAX_STACK_PREVIEW_BYTES: u64 = 64 * 1024;
+pub const MAX_ARTIFACT_TRANSFER: u64 = 32 * 1024 * 1024;
+
+const M68K_REG_D0: u32 = 0;
+const M68K_REG_A0: u32 = 8;
+const M68K_REG_PC: u32 = 16;
+const M68K_REG_SR: u32 = 17;
+const M68K_REG_CCR: u32 = 18;
+const M68K_REG_FP0: u32 = 19;
+const M68K_REG_FPCR: u32 = 27;
+const M68K_REG_FPSR: u32 = 28;
+const M68K_REG_FPIAR: u32 = 29;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ActiveArchitecture {
+    M68k,
+    PowerPc,
+    PowerPcCompanion,
+    Blocked,
+}
+
+fn m68k_flag_descriptions() -> Vec<super::model::RegisterFlag> {
+    use super::model::RegisterFlag;
+    [
+        (15, "T1", "Trace mode 1"),
+        (13, "S", "Supervisor mode"),
+        (10, "I2", "Interrupt mask bit 2"),
+        (9, "I1", "Interrupt mask bit 1"),
+        (8, "I0", "Interrupt mask bit 0"),
+        (4, "X", "Extend"),
+        (3, "N", "Negative"),
+        (2, "Z", "Zero"),
+        (1, "V", "Overflow"),
+        (0, "C", "Carry"),
+    ]
+    .into_iter()
+    .map(|(bit, name, description)| RegisterFlag {
+        bit,
+        name: name.to_string(),
+        description: description.to_string(),
+    })
+    .collect()
+}
+
+fn m68k_context_capabilities() -> ContextCapabilities {
+    ContextCapabilities {
+        pause: true,
+        resume: true,
+        step: true,
+        // CPU-slot stepping is implemented, but transitions through saved
+        // cooperative tasks do not yet carry precise continuation identity.
+        exact_step: false,
+        set_breakpoint: true,
+        read_registers: true,
+        disassembly: true,
+        exact_disassembly: false,
+        stack_preview: true,
+        write_registers: false,
+        read_memory: true,
+        write_memory: false,
+        precise_breakpoints: true,
+        watchpoints: false,
+    }
+}
+
+fn m68k_context_descriptor() -> ExecutionContextDescriptor {
+    ExecutionContextDescriptor {
+        id: M68K_CONTEXT,
+        architecture: "m68k".to_string(),
+        task: None,
+        lifecycle: ContextLifecycle::Active,
+        address_spaces: vec![M68K_SPACE],
+        capabilities: m68k_context_capabilities(),
+    }
+}
+
+fn m68k_space_descriptor() -> AddressSpaceDescriptor {
+    AddressSpaceDescriptor {
+        id: M68K_SPACE,
+        name: "68k-ram".to_string(),
+        address_bits: 32,
+        byte_order: ByteOrder::Big,
+        mapping: AddressMappingKind::Ram,
+        access: AddressAccess {
+            read: true,
+            write: false,
+            execute: true,
+        },
+        supports_translation: false,
+    }
+}
+
+fn ppc_context_capabilities() -> ContextCapabilities {
+    ContextCapabilities {
+        pause: true,
+        resume: true,
+        step: false,
+        exact_step: false,
+        set_breakpoint: false,
+        read_registers: true,
+        disassembly: false,
+        exact_disassembly: false,
+        stack_preview: false,
+        write_registers: false,
+        read_memory: false,
+        write_memory: false,
+        precise_breakpoints: false,
+        watchpoints: false,
+    }
+}
+
+fn ppc_context_descriptor() -> ExecutionContextDescriptor {
+    ExecutionContextDescriptor {
+        id: PPC_CONTEXT,
+        architecture: "ppc".to_string(),
+        task: Some("native-application".to_string()),
+        lifecycle: ContextLifecycle::Active,
+        address_spaces: vec![PPC_SPACE],
+        capabilities: ppc_context_capabilities(),
+    }
+}
+
+fn ppc_space_descriptor() -> AddressSpaceDescriptor {
+    AddressSpaceDescriptor {
+        id: PPC_SPACE,
+        name: "ppc-sections".to_string(),
+        address_bits: 32,
+        byte_order: ByteOrder::Big,
+        mapping: AddressMappingKind::Ram,
+        access: AddressAccess {
+            read: false,
+            write: false,
+            execute: true,
+        },
+        supports_translation: false,
+    }
+}
+
+fn m68k_register_descriptors() -> Vec<RegisterDescriptor> {
+    let mut descriptors = Vec::with_capacity(32);
+    for index in 0..8u32 {
+        descriptors.push(RegisterDescriptor {
+            id: M68K_REG_D0 + index,
+            name: format!("D{index}"),
+            width: RegisterWidth::Bits32,
+            category: RegisterCategory::General,
+            role: None,
+            readable: true,
+            writable: false,
+            flags: Vec::new(),
+        });
+    }
+    for index in 0..8u32 {
+        descriptors.push(RegisterDescriptor {
+            id: M68K_REG_A0 + index,
+            name: format!("A{index}"),
+            width: RegisterWidth::Bits32,
+            category: if index == 7 {
+                RegisterCategory::StackPointer
+            } else {
+                RegisterCategory::Address
+            },
+            role: if index == 7 {
+                Some(RegisterRole::StackPointer)
+            } else if index == 6 {
+                Some(RegisterRole::FramePointer)
+            } else {
+                None
+            },
+            readable: true,
+            writable: false,
+            flags: Vec::new(),
+        });
+    }
+    descriptors.push(RegisterDescriptor {
+        id: M68K_REG_PC,
+        name: "PC".to_string(),
+        width: RegisterWidth::Bits32,
+        category: RegisterCategory::ProgramCounter,
+        role: Some(RegisterRole::ProgramCounter),
+        readable: true,
+        writable: false,
+        flags: Vec::new(),
+    });
+    descriptors.push(RegisterDescriptor {
+        id: M68K_REG_SR,
+        name: "SR".to_string(),
+        width: RegisterWidth::Bits16,
+        category: RegisterCategory::Status,
+        role: Some(RegisterRole::ConditionCodes),
+        readable: true,
+        writable: false,
+        flags: m68k_flag_descriptions(),
+    });
+    descriptors.push(RegisterDescriptor {
+        id: M68K_REG_CCR,
+        name: "CCR".to_string(),
+        width: RegisterWidth::Bits8,
+        category: RegisterCategory::Status,
+        role: Some(RegisterRole::ConditionCodes),
+        readable: true,
+        writable: false,
+        flags: m68k_flag_descriptions(),
+    });
+    for index in 0..8u32 {
+        descriptors.push(RegisterDescriptor {
+            id: M68K_REG_FP0 + index,
+            name: format!("FP{index}"),
+            width: RegisterWidth::Other(80),
+            category: RegisterCategory::FloatingPoint,
+            role: None,
+            readable: true,
+            writable: false,
+            flags: Vec::new(),
+        });
+    }
+    descriptors.push(RegisterDescriptor {
+        id: M68K_REG_FPCR,
+        name: "FPCR".to_string(),
+        width: RegisterWidth::Bits32,
+        category: RegisterCategory::FloatingPoint,
+        role: None,
+        readable: true,
+        writable: false,
+        flags: Vec::new(),
+    });
+    descriptors.push(RegisterDescriptor {
+        id: M68K_REG_FPSR,
+        name: "FPSR".to_string(),
+        width: RegisterWidth::Bits32,
+        category: RegisterCategory::FloatingPoint,
+        role: None,
+        readable: true,
+        writable: false,
+        flags: Vec::new(),
+    });
+    descriptors.push(RegisterDescriptor {
+        id: M68K_REG_FPIAR,
+        name: "FPIAR".to_string(),
+        width: RegisterWidth::Bits32,
+        category: RegisterCategory::FloatingPoint,
+        role: None,
+        readable: true,
+        writable: false,
+        flags: Vec::new(),
+    });
+    descriptors
+}
+
+fn float_x80_bytes(value: &m68k::fpu::FloatX80) -> Vec<u8> {
+    // Preserve the explicit significand and NaN payload rather than converting
+    // through a host float.
+    let mut bytes = Vec::with_capacity(10);
+    bytes.extend_from_slice(&value.sign_exp.to_be_bytes());
+    bytes.extend_from_slice(&value.mantissa.to_be_bytes());
+    bytes
+}
+
+fn m68k_register_snapshots(runner: &FixtureRunner) -> Vec<RegisterSnapshot> {
+    let cpu = runner.cpu();
+    let descriptors = m68k_register_descriptors();
+    descriptors
+        .into_iter()
+        .map(|descriptor| {
+            let value = match descriptor.id {
+                M68K_REG_PC => RegisterValue::unsigned(u64::from(cpu.core.pc), 32),
+                M68K_REG_SR => RegisterValue::unsigned(u64::from(cpu.core.get_sr()), 16),
+                M68K_REG_CCR => RegisterValue::unsigned(u64::from(cpu.core.get_ccr()), 8),
+                M68K_REG_FPCR => RegisterValue::unsigned(u64::from(cpu.core.fpcr), 32),
+                M68K_REG_FPSR => RegisterValue::unsigned(u64::from(cpu.core.fpsr), 32),
+                M68K_REG_FPIAR => RegisterValue::unsigned(u64::from(cpu.core.fpiar), 32),
+                id if (M68K_REG_D0..M68K_REG_D0 + 8).contains(&id) => {
+                    RegisterValue::unsigned(u64::from(cpu.core.d((id - M68K_REG_D0) as usize)), 32)
+                }
+                id if (M68K_REG_A0..M68K_REG_A0 + 8).contains(&id) => {
+                    RegisterValue::unsigned(u64::from(cpu.core.a((id - M68K_REG_A0) as usize)), 32)
+                }
+                id if (M68K_REG_FP0..M68K_REG_FP0 + 8).contains(&id) => {
+                    let index = (id - M68K_REG_FP0) as usize;
+                    RegisterValue::bytes(float_x80_bytes(&cpu.core.fpr[index]), 80)
+                }
+                _ => RegisterValue::unsigned(0, 32),
+            };
+            RegisterSnapshot { descriptor, value }
+        })
+        .collect()
+}
+
+fn ppc_register_descriptors() -> Vec<RegisterDescriptor> {
+    let mut descriptors = Vec::with_capacity(32 + 32 + 6);
+    for index in 0..32u32 {
+        descriptors.push(RegisterDescriptor {
+            id: index,
+            name: format!("r{index}"),
+            width: RegisterWidth::Bits32,
+            category: if index == 1 {
+                RegisterCategory::StackPointer
+            } else {
+                RegisterCategory::General
+            },
+            role: match index {
+                1 => Some(RegisterRole::StackPointer),
+                2 => Some(RegisterRole::Other),
+                _ => None,
+            },
+            readable: true,
+            writable: false,
+            flags: Vec::new(),
+        });
+    }
+    for index in 0..32u32 {
+        descriptors.push(RegisterDescriptor {
+            id: 32 + index,
+            name: format!("f{index}"),
+            width: RegisterWidth::Bits64,
+            category: RegisterCategory::FloatingPoint,
+            role: None,
+            readable: true,
+            writable: false,
+            flags: Vec::new(),
+        });
+    }
+    let specials = [
+        (
+            "pc",
+            RegisterCategory::ProgramCounter,
+            Some(RegisterRole::ProgramCounter),
+        ),
+        (
+            "lr",
+            RegisterCategory::Control,
+            Some(RegisterRole::LinkRegister),
+        ),
+        ("ctr", RegisterCategory::Control, None),
+        (
+            "cr",
+            RegisterCategory::Status,
+            Some(RegisterRole::ConditionCodes),
+        ),
+        ("xer", RegisterCategory::Status, None),
+        ("fpscr", RegisterCategory::FloatingPoint, None),
+        ("msr", RegisterCategory::Status, None),
+    ];
+    for (index, (name, category, role)) in specials.into_iter().enumerate() {
+        descriptors.push(RegisterDescriptor {
+            id: 64 + index as u32,
+            name: name.to_string(),
+            width: RegisterWidth::Bits32,
+            category,
+            role,
+            readable: true,
+            writable: false,
+            flags: Vec::new(),
+        });
+    }
+    descriptors
+}
+
+fn ppc_register_snapshots(cpu: &PpcCpu) -> Vec<RegisterSnapshot> {
+    ppc_register_descriptors()
+        .into_iter()
+        .map(|descriptor| {
+            let value = match descriptor.id {
+                id if id < 32 => RegisterValue::unsigned(u64::from(cpu.gpr[id as usize]), 32),
+                id if id < 64 => RegisterValue::unsigned(cpu.fpr[(id - 32) as usize], 64),
+                id => match id - 64 {
+                    0 => RegisterValue::unsigned(u64::from(cpu.pc), 32),
+                    1 => RegisterValue::unsigned(u64::from(cpu.lr), 32),
+                    2 => RegisterValue::unsigned(u64::from(cpu.ctr), 32),
+                    3 => RegisterValue::unsigned(u64::from(cpu.cr), 32),
+                    4 => RegisterValue::unsigned(u64::from(cpu.xer), 32),
+                    5 => RegisterValue::unsigned(u64::from(cpu.fpscr()), 32),
+                    6 => RegisterValue::unsigned(u64::from(cpu.msr), 32),
+                    _ => RegisterValue::unsigned(0, 32),
+                },
+            };
+            RegisterSnapshot { descriptor, value }
+        })
+        .collect()
+}
+
+pub struct M68kAdapter<'a> {
+    runner: &'a FixtureRunner,
+}
+
+impl<'a> M68kAdapter<'a> {
+    pub fn new(runner: &'a FixtureRunner) -> Self {
+        Self { runner }
+    }
+}
+
+impl ArchitectureAdapter for M68kAdapter<'_> {
+    fn context(&self) -> ExecutionContextDescriptor {
+        m68k_context_descriptor()
+    }
+
+    fn address_spaces(&self) -> Vec<AddressSpaceDescriptor> {
+        vec![m68k_space_descriptor()]
+    }
+
+    fn address_space_capabilities(
+        &self,
+        space: AddressSpaceId,
+    ) -> DebugResult<AddressSpaceCapabilities> {
+        if space != M68K_SPACE {
+            return Err(DebugError::Inaccessible {
+                space,
+                detail: "unknown m68k address space".into(),
+            });
+        }
+        Ok(AddressSpaceCapabilities {
+            read: true,
+            write: false,
+            observational_reads: true,
+            code_cache_invalidation: false,
+            max_transfer_bytes: MAX_MEMORY_TRANSFER,
+        })
+    }
+
+    fn location(&self) -> ExecutionLocation {
+        ExecutionLocation {
+            context: M68K_CONTEXT,
+            address: DebugAddress::new(M68K_SPACE, u64::from(self.runner.cpu().core.pc)),
+        }
+    }
+
+    fn registers(&self, context: ContextId) -> DebugResult<Vec<RegisterSnapshot>> {
+        if context != M68K_CONTEXT {
+            return Err(DebugError::UnknownContext { id: context });
+        }
+        Ok(m68k_register_snapshots(self.runner))
+    }
+
+    fn disassemble(
+        &self,
+        context: ContextId,
+        address: DebugAddress,
+        count: u32,
+    ) -> DebugResult<Vec<DisassemblyLine>> {
+        if context != M68K_CONTEXT {
+            return Err(DebugError::UnknownContext { id: context });
+        }
+        if address.space != M68K_SPACE {
+            return Err(DebugError::Inaccessible {
+                space: address.space,
+                detail: "m68k adapter only disassembles 68k memory".to_string(),
+            });
+        }
+        m68k_disassembly(self.runner, address.offset, count)
+    }
+
+    fn stack_preview(&self, context: ContextId, words: u32) -> DebugResult<StackPreview> {
+        if context != M68K_CONTEXT {
+            return Err(DebugError::UnknownContext { id: context });
+        }
+        m68k_stack_preview(self.runner, u64::from(self.runner.cpu().core.a(7)), words)
+    }
+
+    fn read_memory(
+        &self,
+        space: AddressSpaceId,
+        address: u64,
+        length: u64,
+    ) -> DebugResult<MemoryReadResult> {
+        if space != M68K_SPACE {
+            return Err(DebugError::Inaccessible {
+                space,
+                detail: "m68k adapter only exposes 68k memory".to_string(),
+            });
+        }
+        read_m68k_memory(self.runner, address, length)
+    }
+}
+
+pub struct PpcAdapter<'a> {
+    cpu: &'a PpcCpu,
+    context: ContextId,
+    space: AddressSpaceId,
+    task: &'static str,
+}
+
+impl<'a> PpcAdapter<'a> {
+    pub fn new(
+        cpu: &'a PpcCpu,
+        context: ContextId,
+        space: AddressSpaceId,
+        task: &'static str,
+    ) -> Self {
+        Self {
+            cpu,
+            context,
+            space,
+            task,
+        }
+    }
+
+    fn context_descriptor(&self) -> ExecutionContextDescriptor {
+        let mut descriptor = ppc_context_descriptor();
+        descriptor.id = self.context;
+        descriptor.task = Some(self.task.to_string());
+        descriptor.address_spaces = vec![self.space];
+        descriptor
+    }
+
+    fn space_descriptor(&self) -> AddressSpaceDescriptor {
+        let mut descriptor = ppc_space_descriptor();
+        descriptor.id = self.space;
+        descriptor
+    }
+}
+
+impl ArchitectureAdapter for PpcAdapter<'_> {
+    fn context(&self) -> ExecutionContextDescriptor {
+        self.context_descriptor()
+    }
+
+    fn address_spaces(&self) -> Vec<AddressSpaceDescriptor> {
+        vec![self.space_descriptor()]
+    }
+
+    fn address_space_capabilities(
+        &self,
+        space: AddressSpaceId,
+    ) -> DebugResult<AddressSpaceCapabilities> {
+        if space != self.space {
+            return Err(DebugError::Inaccessible {
+                space,
+                detail: "unknown PowerPC address space".into(),
+            });
+        }
+        Ok(AddressSpaceCapabilities {
+            read: false,
+            write: false,
+            observational_reads: true,
+            code_cache_invalidation: false,
+            max_transfer_bytes: 0,
+        })
+    }
+
+    fn location(&self) -> ExecutionLocation {
+        ExecutionLocation {
+            context: self.context,
+            address: DebugAddress::new(self.space, u64::from(self.cpu.pc)),
+        }
+    }
+
+    fn registers(&self, context: ContextId) -> DebugResult<Vec<RegisterSnapshot>> {
+        if context != self.context {
+            return Err(DebugError::UnknownContext { id: context });
+        }
+        Ok(ppc_register_snapshots(self.cpu))
+    }
+
+    fn disassemble(
+        &self,
+        context: ContextId,
+        address: DebugAddress,
+        _count: u32,
+    ) -> DebugResult<Vec<DisassemblyLine>> {
+        if context != self.context {
+            return Err(DebugError::UnknownContext { id: context });
+        }
+        if address.space != self.space {
+            return Err(DebugError::Inaccessible {
+                space: address.space,
+                detail: "ppc adapter only exposes its registered address space".to_string(),
+            });
+        }
+        Err(DebugError::unsupported("ppc disassembly"))
+    }
+
+    fn stack_preview(&self, _context: ContextId, _words: u32) -> DebugResult<StackPreview> {
+        Err(DebugError::unsupported("ppc stack preview"))
+    }
+
+    fn read_memory(
+        &self,
+        space: AddressSpaceId,
+        _address: u64,
+        _length: u64,
+    ) -> DebugResult<MemoryReadResult> {
+        Err(DebugError::unsupported(format!(
+            "ppc memory inspection in space {space}"
+        )))
+    }
+}
+
+pub struct Adapters<'a> {
+    adapters: Vec<Box<dyn ArchitectureAdapter + 'a>>,
+    active: Option<ContextId>,
+    active_ambiguous: bool,
+    contract_error: Option<DebugError>,
+}
+
+fn m68k_factory(runner: &FixtureRunner) -> Option<Box<dyn ArchitectureAdapter + '_>> {
+    Some(Box::new(M68kAdapter::new(runner)))
+}
+
+fn ppc_factory(runner: &FixtureRunner) -> Option<Box<dyn ArchitectureAdapter + '_>> {
+    runner.debug_ppc_cpu().map(|cpu| {
+        Box::new(PpcAdapter::new(
+            cpu,
+            PPC_CONTEXT,
+            PPC_SPACE,
+            "native-application",
+        )) as Box<dyn ArchitectureAdapter>
+    })
+}
+
+fn companion_factory(runner: &FixtureRunner) -> Option<Box<dyn ArchitectureAdapter + '_>> {
+    runner.debug_ppc_companion_cpu().map(|cpu| {
+        Box::new(PpcAdapter::new(
+            cpu,
+            PPC_COMPANION_CONTEXT,
+            PPC_COMPANION_SPACE,
+            "native-companion",
+        )) as Box<dyn ArchitectureAdapter>
+    })
+}
+
+pub fn builtin_adapter_registrations() -> Vec<AdapterRegistration> {
+    vec![
+        AdapterRegistration {
+            context: M68K_CONTEXT,
+            address_spaces: &[M68K_SPACE],
+            factory: m68k_factory,
+            is_active: |runner| runner.debug_active_architecture() == ActiveArchitecture::M68k,
+        },
+        AdapterRegistration {
+            context: PPC_CONTEXT,
+            address_spaces: &[PPC_SPACE],
+            factory: ppc_factory,
+            is_active: |runner| runner.debug_active_architecture() == ActiveArchitecture::PowerPc,
+        },
+        AdapterRegistration {
+            context: PPC_COMPANION_CONTEXT,
+            address_spaces: &[PPC_COMPANION_SPACE],
+            factory: companion_factory,
+            is_active: |runner| {
+                runner.debug_active_architecture() == ActiveArchitecture::PowerPcCompanion
+            },
+        },
+    ]
+}
+
+impl<'a> Adapters<'a> {
+    pub fn for_runner(runner: &'a FixtureRunner) -> Self {
+        let registrations = runner.debug.adapter_registrations();
+        let mut active = registrations
+            .iter()
+            .filter(|registration| (registration.is_active)(runner))
+            .map(|registration| registration.context);
+        let first_active = active.next();
+        let active_ambiguous = active.next().is_some();
+        let active = (!active_ambiguous).then_some(first_active).flatten();
+        let mut contract_error = None;
+        let adapters = registrations
+            .iter()
+            .filter_map(|registration| {
+                let adapter = (registration.factory)(runner);
+                if let Some(adapter) = adapter.as_ref() {
+                    let context_descriptor = adapter.context();
+                    let context = context_descriptor.id;
+                    let spaces = adapter.address_spaces();
+                    let duplicate_space = spaces
+                        .iter()
+                        .enumerate()
+                        .any(|(index, space)| spaces[..index].iter().any(|prior| prior.id == space.id));
+                    let invalid_id = context == ContextId::UNSPECIFIED
+                        || spaces.iter().any(|space| space.id == AddressSpaceId::UNSPECIFIED);
+                    let registered_spaces_match = registration.address_spaces.len() == spaces.len()
+                        && registration
+                            .address_spaces
+                            .iter()
+                            .all(|id| spaces.iter().any(|space| space.id == *id));
+                    let context_spaces_match = context_descriptor.address_spaces.len() == spaces.len()
+                        && spaces
+                            .iter()
+                            .all(|space| context_descriptor.address_spaces.contains(&space.id));
+                    if invalid_id
+                        || context != registration.context
+                        || !registered_spaces_match
+                        || !context_spaces_match
+                        || duplicate_space
+                    {
+                        contract_error = Some(DebugError::InvalidValue {
+                            detail: format!(
+                                "adapter factory identity does not match registration for context {}",
+                                registration.context
+                            ),
+                        });
+                        return None;
+                    }
+                }
+                adapter
+            })
+            .collect();
+        Self {
+            adapters,
+            active,
+            active_ambiguous,
+            contract_error,
+        }
+    }
+
+    pub fn validate(&self) -> DebugResult<()> {
+        self.contract_error.clone().map_or(Ok(()), Err)
+    }
+
+    fn as_dyn(&self) -> impl Iterator<Item = &dyn ArchitectureAdapter> {
+        self.adapters.iter().map(Box::as_ref)
+    }
+
+    pub fn find(&self, id: ContextId) -> Option<&dyn ArchitectureAdapter> {
+        self.as_dyn().find(|adapter| adapter.context().id == id)
+    }
+
+    pub fn by_space(&self, space: AddressSpaceId) -> Option<&dyn ArchitectureAdapter> {
+        self.as_dyn().find(|adapter| {
+            adapter
+                .address_spaces()
+                .iter()
+                .any(|candidate| candidate.id == space)
+        })
+    }
+
+    pub fn active(&self) -> Option<&dyn ArchitectureAdapter> {
+        self.active.and_then(|id| self.find(id))
+    }
+
+    pub fn resolve(&self, selector: ContextSelector) -> DebugResult<ContextId> {
+        match selector {
+            ContextSelector::Id { id } => {
+                if self.find(id).is_some() {
+                    Ok(id)
+                } else {
+                    Err(DebugError::UnknownContext { id })
+                }
+            }
+            ContextSelector::Active => self
+                .active()
+                .map(|adapter| adapter.context().id)
+                .ok_or_else(|| {
+                    DebugError::invalid_state(if self.active_ambiguous {
+                        "multiple execution contexts claim to be active"
+                    } else {
+                        "no inspectable active context"
+                    })
+                }),
+        }
+    }
+
+    pub fn contexts(&self) -> Vec<ExecutionContextDescriptor> {
+        let active = self.active().map(|adapter| adapter.context().id);
+        self.as_dyn()
+            .map(|adapter| {
+                let mut descriptor = adapter.context();
+                descriptor.lifecycle = if Some(descriptor.id) == active {
+                    ContextLifecycle::Active
+                } else {
+                    ContextLifecycle::Suspended
+                };
+                descriptor
+            })
+            .collect()
+    }
+}
+
+pub(crate) fn read_m68k_memory(
+    runner: &FixtureRunner,
+    address: u64,
+    length: u64,
+) -> DebugResult<MemoryReadResult> {
+    if length > MAX_MEMORY_TRANSFER {
+        return Err(DebugError::TooLarge {
+            limit: MAX_MEMORY_TRANSFER,
+            requested: length,
+        });
+    }
+    if address > u64::from(u32::MAX) || length > u64::from(u32::MAX) {
+        return Err(DebugError::InvalidRange {
+            detail: "68k address space is 32-bit".to_string(),
+        });
+    }
+    let bus = runner.bus();
+    let ram_size = bus.ram_size();
+    let mut truncated = false;
+    let mut bytes = Vec::with_capacity(length as usize);
+    for offset in 0..length {
+        let current = address.wrapping_add(offset);
+        if current > u64::from(u32::MAX) {
+            truncated = true;
+            break;
+        }
+        let translated = bus.translate_guest_address(current as u32);
+        if translated >= ram_size {
+            truncated = true;
+            break;
+        }
+        bytes.push(bus.read_byte(current as u32));
+    }
+    Ok(MemoryReadResult {
+        address: DebugAddress::new(M68K_SPACE, address),
+        bytes,
+        truncated,
+    })
+}
+
+pub(crate) fn m68k_disassembly(
+    runner: &FixtureRunner,
+    address: u64,
+    count: u32,
+) -> DebugResult<Vec<DisassemblyLine>> {
+    if count > MAX_DISASSEMBLY_COUNT {
+        return Err(DebugError::TooLarge {
+            limit: u64::from(MAX_DISASSEMBLY_COUNT),
+            requested: u64::from(count),
+        });
+    }
+    if address > u64::from(u32::MAX) {
+        return Err(DebugError::InvalidRange {
+            detail: "68k address space is 32-bit".to_string(),
+        });
+    }
+    let bus = runner.bus();
+    let ram_size = bus.ram_size();
+    let mut lines = Vec::with_capacity(count as usize);
+    let mut current = address as u32;
+    for _ in 0..count {
+        if bus.translate_guest_address(current) >= ram_size {
+            lines.push(DisassemblyLine {
+                address: DebugAddress::new(M68K_SPACE, u64::from(current)),
+                approximate: true,
+                text: "<unmapped>".to_string(),
+                size: 2,
+                bytes: Vec::new(),
+            });
+            let Some(next) = current.checked_add(2) else {
+                break;
+            };
+            current = next;
+            continue;
+        }
+        let opcode_bytes = read_m68k_memory(runner, u64::from(current), 2)?;
+        if opcode_bytes.bytes.len() != 2 {
+            break;
+        }
+        let opcode = u16::from_be_bytes([opcode_bytes.bytes[0], opcode_bytes.bytes[1]]);
+        let (text, size) = m68k::dasm::disassemble(current, opcode, runner.cpu().core.cpu_type);
+        let size = size.clamp(2, 10);
+        let bytes = read_m68k_memory(runner, u64::from(current), u64::from(size))?.bytes;
+        lines.push(DisassemblyLine {
+            address: DebugAddress::new(M68K_SPACE, u64::from(current)),
+            text,
+            approximate: true,
+            size: size as u8,
+            bytes,
+        });
+        let Some(next) = current.checked_add(size) else {
+            break;
+        };
+        current = next;
+    }
+    Ok(lines)
+}
+
+fn m68k_stack_preview(runner: &FixtureRunner, base: u64, words: u32) -> DebugResult<StackPreview> {
+    let requested = u64::from(words) * 4;
+    if requested > MAX_STACK_PREVIEW_BYTES {
+        return Err(DebugError::TooLarge {
+            limit: MAX_STACK_PREVIEW_BYTES,
+            requested,
+        });
+    }
+    let memory = read_m68k_memory(runner, base, requested)?;
+    Ok(StackPreview {
+        context: M68K_CONTEXT,
+        address: DebugAddress::new(M68K_SPACE, base),
+        bytes: memory.bytes,
+        stride: 4,
+        truncated: memory.truncated,
+    })
+}
+
+pub(crate) fn active_context_and_location(
+    runner: &FixtureRunner,
+) -> (Option<ContextId>, Option<ExecutionLocation>) {
+    let adapters = Adapters::for_runner(runner);
+    match adapters.active() {
+        Some(adapter) => (Some(adapter.context().id), Some(adapter.location())),
+        None => (None, None),
+    }
+}
+
+pub(crate) fn active_context_id(runner: &FixtureRunner) -> Option<ContextId> {
+    Adapters::for_runner(runner)
+        .active()
+        .map(|adapter| adapter.context().id)
+}

--- a/src/debug/capabilities.rs
+++ b/src/debug/capabilities.rs
@@ -1,0 +1,83 @@
+use super::ids::{AddressSpaceId, ContextId, ProviderId};
+use super::model::{
+    AddressSpaceCapabilities, CaptureBoundaryCapabilities, CaptureBoundaryKind, ContextCapabilities,
+};
+use serde::{Deserialize, Serialize};
+
+/// Tagged with `kind`, matching [`ContextSelector`](super::model::ContextSelector):
+/// `{"kind":"context","id":1}` (also `address_space` and `provider`),
+/// `{"kind":"boundary","boundary":"logical_frame_complete"}`, or
+/// `{"kind":"decoder","format":"rgba8"}`. Decoder support is currently absent.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum CapabilityTarget {
+    Context { id: ContextId },
+    AddressSpace { id: AddressSpaceId },
+    Provider { id: ProviderId },
+    Boundary { boundary: CaptureBoundaryKind },
+    Decoder { format: String },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ProviderCapabilities {
+    pub observational: bool,
+    pub snapshots: Vec<super::model::ProviderSnapshotKind>,
+    /// Maximum entries a collection-valued snapshot may carry. A per-provider
+    /// ergonomic bound: high enough that a real collection survives intact.
+    /// Memory is bounded by `max_snapshot_bytes`, not by this count.
+    pub collection_limit: usize,
+    /// Byte budget for a snapshot, mirroring `max_artifact_bytes` for artifacts.
+    /// This is the bound that actually prevents memory blowup; a provider
+    /// truncates on whichever of the two limits trips first.
+    pub max_snapshot_bytes: u64,
+    pub max_artifact_bytes: u64,
+    pub relationships: Vec<String>,
+    pub limitations: Vec<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct DecoderCapabilities {
+    pub formats: Vec<String>,
+    pub max_output_bytes: u64,
+    pub max_recursion: u16,
+    pub max_decode_millis: u32,
+    pub supports_preview: bool,
+    pub limitations: Vec<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum CapabilitySet {
+    Context(ContextCapabilities),
+    AddressSpace(AddressSpaceCapabilities),
+    Provider(ProviderCapabilities),
+    Boundary(CaptureBoundaryCapabilities),
+    Decoder(DecoderCapabilities),
+}
+
+impl Default for ProviderCapabilities {
+    fn default() -> Self {
+        Self {
+            observational: true,
+            snapshots: Vec::new(),
+            collection_limit: super::provider::DEFAULT_COLLECTION_LIMIT,
+            max_snapshot_bytes: super::provider::DEFAULT_SNAPSHOT_BYTES,
+            max_artifact_bytes: 16 * 1024 * 1024,
+            relationships: Vec::new(),
+            limitations: Vec::new(),
+        }
+    }
+}
+
+impl Default for DecoderCapabilities {
+    fn default() -> Self {
+        Self {
+            formats: Vec::new(),
+            max_output_bytes: 64 * 1024 * 1024,
+            max_recursion: 32,
+            max_decode_millis: 2_000,
+            supports_preview: false,
+            limitations: Vec::new(),
+        }
+    }
+}

--- a/src/debug/capture.rs
+++ b/src/debug/capture.rs
@@ -1,0 +1,464 @@
+use super::adapters::active_context_and_location;
+use super::error::{DebugError, DebugResult};
+use super::ids::{ArtifactId, CaptureId, OperationId, ProviderId};
+use super::model::{
+    ArtifactDescriptor, CaptureBoundaryKind, CaptureManifest, DebugExecutionState, OperationOutcome,
+};
+use super::provider::ProviderSnapshot;
+use super::request::{CaptureMode, CaptureRequest, DebugReply};
+use crate::runner::FixtureRunner;
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+
+pub const DEFAULT_CAPTURE_RETENTION: usize = 16;
+pub const MAX_PENDING_CAPTURES: usize = 64;
+pub const MAX_CAPTURE_PROVIDERS: usize = 64;
+pub const MAX_CAPTURE_ARTIFACTS: usize = 64;
+pub const MAX_CAPTURE_ARTIFACT_BYTES: u64 = 64 * 1024 * 1024;
+
+#[derive(Clone, Debug)]
+pub struct RetainedCapture {
+    pub manifest: super::model::CaptureManifest,
+    pub snapshots: Vec<(ProviderId, super::provider::ProviderSnapshot)>,
+    pub artifacts: Vec<(ArtifactId, Vec<u8>)>,
+}
+
+#[derive(Clone, Debug)]
+pub struct CaptureStore {
+    captures: BTreeMap<CaptureId, RetainedCapture>,
+    capture_order: VecDeque<CaptureId>,
+    retention: usize,
+    next_capture_id: u64,
+    next_artifact_id: u64,
+}
+
+impl CaptureStore {
+    pub(crate) fn new() -> Self {
+        Self {
+            captures: BTreeMap::new(),
+            capture_order: VecDeque::new(),
+            retention: DEFAULT_CAPTURE_RETENTION,
+            next_capture_id: 1,
+            next_artifact_id: 1,
+        }
+    }
+
+    pub fn alloc_artifact(&mut self) -> u64 {
+        let id = self.next_artifact_id;
+        self.next_artifact_id = self.next_artifact_id.saturating_add(1);
+        id
+    }
+
+    pub fn len(&self) -> usize {
+        self.captures.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.captures.is_empty()
+    }
+
+    pub(crate) fn alloc_capture(&mut self) -> CaptureId {
+        let id = CaptureId(self.next_capture_id);
+        self.next_capture_id = self.next_capture_id.saturating_add(1);
+        id
+    }
+
+    pub(crate) fn insert(&mut self, capture: RetainedCapture) -> Option<CaptureId> {
+        let id = capture.manifest.id;
+        if let Some(next_artifact_id) = capture
+            .manifest
+            .artifacts
+            .iter()
+            .map(|artifact| artifact.id.0.saturating_add(1))
+            .max()
+        {
+            self.next_artifact_id = self.next_artifact_id.max(next_artifact_id);
+        }
+        self.captures.insert(id, capture);
+        self.capture_order.push_back(id);
+        self.evict_to_retention()
+    }
+
+    fn evict_to_retention(&mut self) -> Option<CaptureId> {
+        let mut evicted = None;
+        while self.capture_order.len() > self.retention {
+            if let Some(oldest) = self.capture_order.pop_front() {
+                self.captures.remove(&oldest);
+                evicted = Some(oldest);
+            }
+        }
+        evicted
+    }
+
+    pub(crate) fn get(&self, id: CaptureId) -> Option<&RetainedCapture> {
+        self.captures.get(&id)
+    }
+
+    pub(crate) fn snapshot(
+        &self,
+        capture: CaptureId,
+        provider: ProviderId,
+    ) -> Option<ProviderSnapshot> {
+        self.get(capture)?
+            .snapshots
+            .iter()
+            .find(|(id, _)| *id == provider)
+            .map(|(_, snapshot)| snapshot.clone())
+    }
+
+    pub(crate) fn artifact(&self, id: ArtifactId) -> Option<(ArtifactDescriptor, Vec<u8>)> {
+        for capture in self.captures.values() {
+            if let Some(descriptor) = capture
+                .manifest
+                .artifacts
+                .iter()
+                .find(|descriptor| descriptor.id == id)
+            {
+                let bytes = capture
+                    .artifacts
+                    .iter()
+                    .find(|(artifact, _)| *artifact == id)
+                    .map(|(_, bytes)| bytes.clone())
+                    .unwrap_or_default();
+                return Some((descriptor.clone(), bytes));
+            }
+        }
+        None
+    }
+
+    pub(crate) fn release(&mut self, id: CaptureId) -> bool {
+        let removed = self.captures.remove(&id).is_some();
+        if removed {
+            self.capture_order.retain(|candidate| *candidate != id);
+        }
+        removed
+    }
+
+    pub(crate) fn manifests(&self) -> Vec<CaptureManifest> {
+        self.capture_order
+            .iter()
+            .filter_map(|id| self.captures.get(id))
+            .map(|capture| capture.manifest.clone())
+            .collect()
+    }
+
+    pub(crate) fn set_retention(&mut self, retention: usize) {
+        self.retention = retention.max(1);
+        self.evict_to_retention();
+    }
+
+    pub(crate) fn drain(&mut self) -> CaptureStore {
+        CaptureStore {
+            captures: std::mem::take(&mut self.captures),
+            capture_order: std::mem::take(&mut self.capture_order),
+            retention: self.retention,
+            next_capture_id: self.next_capture_id,
+            next_artifact_id: self.next_artifact_id,
+        }
+    }
+
+    pub(crate) fn adopt(&mut self, store: CaptureStore) {
+        let store_next_artifact_id = store
+            .captures
+            .values()
+            .flat_map(|capture| capture.manifest.artifacts.iter())
+            .map(|artifact| artifact.id.0.saturating_add(1))
+            .max()
+            .unwrap_or(1);
+        self.captures = store.captures;
+        self.capture_order = store.capture_order;
+        self.retention = store.retention.max(1);
+        self.next_capture_id = self.next_capture_id.max(store.next_capture_id);
+        self.next_artifact_id = self
+            .next_artifact_id
+            .max(store.next_artifact_id)
+            .max(store_next_artifact_id);
+        self.evict_to_retention();
+    }
+}
+
+impl Default for CaptureStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct PendingCapture {
+    pub operation: OperationId,
+    pub capture: CaptureId,
+    pub request: CaptureRequest,
+    pub boundary: CaptureBoundaryKind,
+    pub pause: bool,
+}
+
+pub(crate) fn request_capture(
+    runner: &mut FixtureRunner,
+    mut request: CaptureRequest,
+) -> DebugResult<DebugReply> {
+    request.providers = effective_providers(&request)?;
+    match request.mode {
+        CaptureMode::CurrentState => {
+            let pending = runner.debug.begin_immediate_capture(request);
+            let capture = build_capture(runner, &pending, CaptureBoundaryKind::CommandSafePoint);
+            runner.debug.insert_capture(capture);
+            runner.debug.complete_operation(
+                pending.operation,
+                OperationOutcome::Captured {
+                    capture_id: pending.capture,
+                },
+            );
+            Ok(DebugReply::Accepted {
+                state: runner.debug.execution_state().clone(),
+                operation_id: Some(pending.operation),
+            })
+        }
+        CaptureMode::NextBoundary | CaptureMode::PauseAtBoundary => {
+            if runner.debug.pending_capture_count() >= MAX_PENDING_CAPTURES {
+                return Err(DebugError::TooLarge {
+                    limit: MAX_PENDING_CAPTURES as u64,
+                    requested: runner.debug.pending_capture_count() as u64 + 1,
+                });
+            }
+            let boundary = request
+                .boundary
+                .unwrap_or(CaptureBoundaryKind::LogicalFrameComplete);
+            if !capture_boundary_supported(boundary) {
+                return Err(DebugError::BoundaryUnavailable {
+                    detail: format!("capture boundary {boundary:?} is not observed by this runner"),
+                });
+            }
+            if runner.is_halted() {
+                return Err(DebugError::BoundaryUnavailable {
+                    detail: "a terminal runner cannot reach a future capture boundary".into(),
+                });
+            }
+            if runner.debug.execution_state().is_stepping() {
+                return Err(DebugError::invalid_state(
+                    "cannot wait for a capture boundary while a step is pending",
+                ));
+            }
+            if boundary == CaptureBoundaryKind::CommandSafePoint {
+                let pending = runner.debug.begin_immediate_capture(request);
+                if pending.pause {
+                    let (context, location) = active_context_and_location(runner);
+                    let guest_tick = runner.guest_tick();
+                    let execution_units = runner.total_instructions();
+                    runner.debug.stop_at_capture_boundary(
+                        pending.capture,
+                        context,
+                        location,
+                        Some(guest_tick),
+                        Some(execution_units),
+                    );
+                }
+                let capture = build_capture(runner, &pending, boundary);
+                runner.debug.insert_capture(capture);
+                runner.debug.complete_operation(
+                    pending.operation,
+                    OperationOutcome::Captured {
+                        capture_id: pending.capture,
+                    },
+                );
+                return Ok(DebugReply::Accepted {
+                    state: runner.debug.execution_state().clone(),
+                    operation_id: Some(pending.operation),
+                });
+            }
+            if runner.debug.resume() {
+                runner.debug_release_held_input();
+            }
+            let pending = runner.debug.begin_capture(request, boundary);
+            Ok(DebugReply::Accepted {
+                state: runner.debug.execution_state().clone(),
+                operation_id: Some(pending.operation),
+            })
+        }
+    }
+}
+
+pub(crate) fn capture_boundary_supported(boundary: CaptureBoundaryKind) -> bool {
+    matches!(
+        boundary,
+        CaptureBoundaryKind::CommandSafePoint | CaptureBoundaryKind::LogicalFrameComplete
+    )
+}
+
+pub(crate) fn note_capture_boundary(runner: &mut FixtureRunner, boundary: CaptureBoundaryKind) {
+    let pending = runner.debug.take_pending_captures(boundary);
+    for capture in pending {
+        if capture.pause {
+            let (context, location) = active_context_and_location(runner);
+            let guest_tick = runner.guest_tick();
+            let execution_units = runner.total_instructions();
+            runner.debug.stop_at_capture_boundary(
+                capture.capture,
+                context,
+                location,
+                Some(guest_tick),
+                Some(execution_units),
+            );
+        }
+        let record = build_capture(runner, &capture, boundary);
+        runner.debug.insert_capture(record);
+        runner.debug.complete_operation(
+            capture.operation,
+            OperationOutcome::Captured {
+                capture_id: capture.capture,
+            },
+        );
+    }
+}
+
+fn effective_providers(request: &CaptureRequest) -> DebugResult<Vec<ProviderId>> {
+    let providers = if request.providers.is_empty() {
+        vec![ProviderId(super::provider::provider_ids::GRAPHICS)]
+    } else {
+        request.providers.clone()
+    };
+    if providers.len() > MAX_CAPTURE_PROVIDERS {
+        return Err(DebugError::TooLarge {
+            limit: MAX_CAPTURE_PROVIDERS as u64,
+            requested: providers.len() as u64,
+        });
+    }
+    let mut seen = BTreeSet::new();
+    Ok(providers
+        .into_iter()
+        .filter(|provider| seen.insert(*provider))
+        .collect())
+}
+
+pub(crate) fn boundary_synchronization_notes(boundary: CaptureBoundaryKind) -> Vec<String> {
+    match boundary {
+        CaptureBoundaryKind::CommandSafePoint => vec![
+            "selected provider state is copied at one command-service safe point".to_string(),
+            "host presentation and GPU completion are not implied".to_string(),
+        ],
+        CaptureBoundaryKind::LogicalFrameComplete => vec![
+            "runner frame finalization (chrome redraw and guest audio) has completed".to_string(),
+            "this is not proof that a guest produced a drawing or that a physical display updated"
+                .to_string(),
+        ],
+        _ => vec!["boundary has no synchronization guarantee".to_string()],
+    }
+}
+
+fn build_capture(
+    runner: &mut FixtureRunner,
+    pending: &PendingCapture,
+    boundary: CaptureBoundaryKind,
+) -> RetainedCapture {
+    let request = &pending.request;
+    let mut manifest = CaptureManifest {
+        id: pending.capture,
+        session: runner.debug.session(),
+        boundary,
+        providers: Vec::new(),
+        revision: runner.debug.revision(),
+        stop: match runner.debug.execution_state() {
+            DebugExecutionState::Paused { stop } => Some(stop.id),
+            _ => None,
+        },
+        guest_tick: Some(runner.guest_tick()),
+        execution_units: Some(runner.total_instructions()),
+        artifacts: Vec::new(),
+        omitted: Vec::new(),
+        truncated: false,
+        atomic: true,
+        synchronization: boundary_synchronization_notes(boundary),
+    };
+
+    let mut snapshots: Vec<(ProviderId, ProviderSnapshot)> = Vec::new();
+    let mut artifacts: Vec<(ArtifactId, Vec<u8>)> = Vec::new();
+    let mut artifact_bytes = 0u64;
+    for &provider_id in &request.providers {
+        let Some(provider) = runner.debug.provider(provider_id) else {
+            manifest.atomic = false;
+            manifest
+                .omitted
+                .push(format!("provider {provider_id}: unsupported provider"));
+            continue;
+        };
+        if let Err(error) = provider.validate_boundary(boundary) {
+            manifest.atomic = false;
+            manifest
+                .omitted
+                .push(format!("provider {provider_id}: {error}"));
+            continue;
+        }
+        match provider.snapshot_at(runner, boundary) {
+            Ok(snapshot) => {
+                manifest.truncated |= snapshot.is_truncated();
+                manifest.providers.push(provider_id);
+                snapshots.push((provider_id, snapshot));
+            }
+            Err(error) => {
+                manifest.atomic = false;
+                manifest
+                    .omitted
+                    .push(format!("provider {provider_id}: {error}"));
+            }
+        }
+        if request.include_artifacts {
+            match provider.artifacts_at(runner, boundary) {
+                Ok(provider_artifacts) => {
+                    for artifact in provider_artifacts {
+                        if artifacts.len() >= MAX_CAPTURE_ARTIFACTS {
+                            manifest.atomic = false;
+                            manifest.omitted.push(format!(
+                                "provider {provider_id} artifacts exceed the capture limit of {MAX_CAPTURE_ARTIFACTS}"
+                            ));
+                            break;
+                        }
+                        let limit = provider.capabilities().max_artifact_bytes;
+                        let byte_len = artifact.bytes.len() as u64;
+                        if byte_len > limit {
+                            manifest.atomic = false;
+                            manifest.omitted.push(format!(
+                                "provider {provider_id} artifact is {byte_len} bytes, above its {limit}-byte limit"
+                            ));
+                            continue;
+                        }
+                        let Some(next_artifact_bytes) = artifact_bytes.checked_add(byte_len) else {
+                            manifest.atomic = false;
+                            manifest.omitted.push(format!(
+                                "provider {provider_id} artifacts exceed the capture byte limit"
+                            ));
+                            break;
+                        };
+                        if next_artifact_bytes > MAX_CAPTURE_ARTIFACT_BYTES {
+                            manifest.atomic = false;
+                            manifest.omitted.push(format!(
+                                "provider {provider_id} artifacts exceed the {MAX_CAPTURE_ARTIFACT_BYTES}-byte capture limit"
+                            ));
+                            break;
+                        }
+                        let id = ArtifactId(runner.debug.alloc_artifact());
+                        manifest.artifacts.push(ArtifactDescriptor {
+                            id,
+                            provider: Some(provider_id),
+                            format: artifact.format,
+                            byte_len,
+                            provenance: artifact.provenance,
+                            related: artifact.related,
+                        });
+                        artifacts.push((id, artifact.bytes));
+                        artifact_bytes = next_artifact_bytes;
+                    }
+                }
+                Err(error) => {
+                    manifest.atomic = false;
+                    manifest
+                        .omitted
+                        .push(format!("provider {provider_id} artifacts: {error}"));
+                }
+            }
+        }
+    }
+
+    RetainedCapture {
+        manifest,
+        snapshots,
+        artifacts,
+    }
+}

--- a/src/debug/coordinator.rs
+++ b/src/debug/coordinator.rs
@@ -1,0 +1,787 @@
+use super::capture::{CaptureStore, PendingCapture, RetainedCapture};
+use super::error::{DebugError, DebugResult};
+use super::ids::{
+    AddressSpaceId, ArtifactId, BreakpointId, CaptureId, ContextId, OperationId, ProviderId,
+    SessionId, TypedAllocator,
+};
+use super::model::{
+    CaptureBoundaryKind, DebugExecutionState, DebugNotification, ExecutionLocation,
+    NotificationPayload, OperationOutcome, OperationState, OperationStatus, StopInfo, StopReason,
+};
+use super::request::{BreakpointInfo, BreakpointSpec, CaptureMode, CaptureRequest};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::sync::atomic::{AtomicU64, Ordering};
+static NEXT_SESSION: AtomicU64 = AtomicU64::new(1);
+
+pub const NOTIFICATION_RETENTION: usize = 1024;
+pub const OPERATION_RETENTION: usize = 1024;
+
+#[derive(Clone, Debug)]
+struct PendingStep {
+    operation: OperationId,
+    context: ContextId,
+    units_remaining: u32,
+}
+
+#[derive(Debug)]
+pub struct DebuggerCoordinator {
+    session: SessionId,
+    generation: u64,
+    revision: u64,
+    execution_state: DebugExecutionState,
+    next_stop_id: u64,
+    next_breakpoint_id: TypedAllocator<BreakpointId>,
+    next_operation_id: TypedAllocator<OperationId>,
+    breakpoints: BTreeMap<BreakpointId, BreakpointInfo>,
+    // Stops happen before execution, so resume ignores that breakpoint until
+    // one unit in its context retires.
+    suppressed_breakpoints: BTreeSet<BreakpointId>,
+    pending_step: Option<PendingStep>,
+    operations: BTreeMap<OperationId, OperationState>,
+    operation_order: VecDeque<OperationId>,
+    expired_operation_through: u64,
+    providers: Vec<super::provider::ProviderRegistration>,
+    adapter_registrations: Vec<super::adapters::AdapterRegistration>,
+    capture_store: CaptureStore,
+    pending_captures: Vec<PendingCapture>,
+    notifications: VecDeque<DebugNotification>,
+    next_notification_sequence: u64,
+    terminal_announced: bool,
+    observed_context: Option<ContextId>,
+}
+
+impl DebuggerCoordinator {
+    pub fn fresh() -> Self {
+        let session = SessionId(NEXT_SESSION.fetch_add(1, Ordering::Relaxed));
+        let mut coordinator = Self::new(session);
+        coordinator.generation = session.0;
+        coordinator
+    }
+
+    pub fn new(session: SessionId) -> Self {
+        Self {
+            session,
+            generation: 1,
+            revision: 0,
+            execution_state: DebugExecutionState::Running,
+            next_stop_id: 1,
+            next_breakpoint_id: TypedAllocator::new(),
+            next_operation_id: TypedAllocator::new(),
+            breakpoints: BTreeMap::new(),
+            suppressed_breakpoints: BTreeSet::new(),
+            pending_step: None,
+            operations: BTreeMap::new(),
+            operation_order: VecDeque::new(),
+            expired_operation_through: 0,
+            providers: super::provider::builtin_providers().to_vec(),
+            adapter_registrations: super::adapters::builtin_adapter_registrations(),
+            capture_store: CaptureStore::new(),
+            pending_captures: Vec::new(),
+            notifications: VecDeque::new(),
+            next_notification_sequence: 1,
+            terminal_announced: false,
+            observed_context: None,
+        }
+    }
+
+    pub fn session(&self) -> SessionId {
+        self.session
+    }
+
+    pub fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    pub fn revision(&self) -> u64 {
+        self.revision
+    }
+
+    pub fn execution_state(&self) -> &DebugExecutionState {
+        &self.execution_state
+    }
+
+    pub(crate) fn advance_generation(&mut self) {
+        self.generation = self.generation.saturating_add(1);
+        self.revision = self.revision.saturating_add(1);
+        self.execution_state = DebugExecutionState::Running;
+        self.breakpoints.clear();
+        self.suppressed_breakpoints.clear();
+        self.cancel_pending_step(OperationOutcome::Unavailable {
+            reason: "runner generation changed".into(),
+        });
+        self.fail_pending_captures("runner generation changed");
+        self.operations.clear();
+        self.operation_order.clear();
+        self.expired_operation_through = 0;
+        self.terminal_announced = false;
+        self.observed_context = None;
+        self.push_notification(NotificationPayload::Invalidated {
+            session: self.session,
+        });
+    }
+
+    pub(crate) fn touch(&mut self) -> u64 {
+        self.revision = self.revision.saturating_add(1);
+        self.revision
+    }
+
+    fn stop(
+        &mut self,
+        reason: StopReason,
+        context: Option<ContextId>,
+        location: Option<ExecutionLocation>,
+        guest_tick: Option<u32>,
+        execution_units: Option<u64>,
+    ) -> StopInfo {
+        self.revision = self.revision.saturating_add(1);
+        let stop = StopInfo {
+            id: self.next_stop_id,
+            revision: self.revision,
+            context,
+            location,
+            reason,
+            guest_tick,
+            execution_units,
+        };
+        self.next_stop_id = self.next_stop_id.saturating_add(1);
+        self.execution_state = DebugExecutionState::Paused { stop: stop.clone() };
+        self.push_notification(NotificationPayload::ExecutionStateChanged {
+            state: self.execution_state.clone(),
+        });
+        stop
+    }
+
+    pub fn pause(
+        &mut self,
+        context: Option<ContextId>,
+        location: Option<ExecutionLocation>,
+    ) -> StopInfo {
+        self.pause_at(context, location, None, None)
+    }
+
+    pub fn pause_at(
+        &mut self,
+        context: Option<ContextId>,
+        location: Option<ExecutionLocation>,
+        guest_tick: Option<u32>,
+        execution_units: Option<u64>,
+    ) -> StopInfo {
+        self.cancel_pending_step(OperationOutcome::Cancelled);
+        if let DebugExecutionState::Paused { stop } = &self.execution_state {
+            return stop.clone();
+        }
+        self.stop(
+            StopReason::UserPause,
+            context,
+            location,
+            guest_tick,
+            execution_units,
+        )
+    }
+
+    pub fn resume(&mut self) -> bool {
+        if !self.execution_state.is_paused() {
+            return false;
+        }
+        if let DebugExecutionState::Paused { stop } = &self.execution_state {
+            if let StopReason::PcBreakpoint { id } = stop.reason {
+                if self.breakpoints.contains_key(&id) {
+                    self.suppressed_breakpoints.insert(id);
+                }
+            }
+        }
+        self.cancel_pending_step(OperationOutcome::Cancelled);
+        self.execution_state = DebugExecutionState::Running;
+        self.push_notification(NotificationPayload::ExecutionStateChanged {
+            state: self.execution_state.clone(),
+        });
+        true
+    }
+
+    pub fn is_paused(&self) -> bool {
+        self.execution_state.is_paused()
+    }
+
+    pub fn is_stepping(&self) -> bool {
+        self.pending_step.is_some()
+    }
+
+    pub(crate) fn begin_step(&mut self, context: ContextId) -> OperationId {
+        self.cancel_pending_step(OperationOutcome::Cancelled);
+        if let DebugExecutionState::Paused { stop } = &self.execution_state {
+            if let StopReason::PcBreakpoint { id } = stop.reason {
+                if self.breakpoints.contains_key(&id) {
+                    self.suppressed_breakpoints.insert(id);
+                }
+            }
+        }
+        let operation = self.next_operation_id.alloc();
+        self.operations.insert(operation, OperationState::Pending);
+        self.operation_order.push_back(operation);
+        self.pending_step = Some(PendingStep {
+            operation,
+            context,
+            units_remaining: 1,
+        });
+        self.execution_state = DebugExecutionState::Stepping {
+            operation_id: operation,
+        };
+        self.touch();
+        self.push_notification(NotificationPayload::ExecutionStateChanged {
+            state: self.execution_state.clone(),
+        });
+        operation
+    }
+
+    pub fn step_target_context(&self) -> Option<ContextId> {
+        self.pending_step.as_ref().map(|step| step.context)
+    }
+
+    pub fn step_units_remaining(&self) -> Option<u32> {
+        self.pending_step.as_ref().map(|step| step.units_remaining)
+    }
+
+    pub(crate) fn breakpoint_rearming(&self) -> bool {
+        !self.suppressed_breakpoints.is_empty()
+    }
+
+    pub(crate) fn note_executed_units(&mut self, context: ContextId, units: u32) {
+        if units == 0 {
+            return;
+        }
+        self.suppressed_breakpoints.retain(|id| {
+            self.breakpoints
+                .get(id)
+                .is_some_and(|breakpoint| breakpoint.spec.context != Some(context))
+        });
+        if let Some(step) = self.pending_step.as_mut() {
+            if step.context == context {
+                step.units_remaining = step.units_remaining.saturating_sub(units);
+            }
+        }
+    }
+
+    pub(crate) fn finish_step(
+        &mut self,
+        context: ContextId,
+        location: Option<ExecutionLocation>,
+        guest_tick: Option<u32>,
+        execution_units: Option<u64>,
+    ) -> Option<StopInfo> {
+        let operation = self.pending_step.take()?.operation;
+        let stop = self.stop(
+            StopReason::StepCompleted,
+            Some(context),
+            location,
+            guest_tick,
+            execution_units,
+        );
+        self.complete_operation(
+            operation,
+            OperationOutcome::Completed {
+                stop: Some(stop.clone()),
+            },
+        );
+        Some(stop)
+    }
+
+    pub fn abort_step(&mut self, reason: impl Into<String>) {
+        if let Some(step) = self.pending_step.take() {
+            self.suppressed_breakpoints.clear();
+            self.complete_operation(
+                step.operation,
+                OperationOutcome::Unavailable {
+                    reason: reason.into(),
+                },
+            );
+            self.execution_state = DebugExecutionState::Running;
+            self.push_notification(NotificationPayload::ExecutionStateChanged {
+                state: self.execution_state.clone(),
+            });
+        }
+    }
+
+    fn cancel_pending_step(&mut self, outcome: OperationOutcome) -> bool {
+        let Some(step) = self.pending_step.take() else {
+            return false;
+        };
+        self.suppressed_breakpoints.clear();
+        self.complete_operation(step.operation, outcome);
+        true
+    }
+
+    pub fn insert_breakpoint(&mut self, spec: BreakpointSpec) -> BreakpointInfo {
+        let id = self.next_breakpoint_id.alloc();
+        let info = BreakpointInfo {
+            id,
+            spec,
+            hit_count: 0,
+        };
+        self.breakpoints.insert(id, info.clone());
+        self.touch();
+        info
+    }
+
+    pub fn remove_breakpoint(&mut self, id: BreakpointId) -> bool {
+        let removed = self.breakpoints.remove(&id).is_some();
+        self.suppressed_breakpoints.remove(&id);
+        if removed {
+            self.touch();
+        }
+        removed
+    }
+
+    pub fn set_breakpoint_enabled(
+        &mut self,
+        id: BreakpointId,
+        enabled: bool,
+    ) -> Option<BreakpointInfo> {
+        let info = self.breakpoints.get_mut(&id)?;
+        info.spec.enabled = enabled;
+        let cloned = info.clone();
+        if !enabled {
+            self.suppressed_breakpoints.remove(&id);
+        }
+        self.touch();
+        Some(cloned)
+    }
+
+    pub fn breakpoints(&self) -> Vec<BreakpointInfo> {
+        self.breakpoints.values().cloned().collect()
+    }
+
+    pub(crate) fn breakpoint_watch_addresses(
+        &self,
+        context: ContextId,
+        space: super::ids::AddressSpaceId,
+    ) -> Vec<u64> {
+        let mut addresses = Vec::new();
+        for (id, info) in &self.breakpoints {
+            if !info.spec.enabled
+                || info.spec.context != Some(context)
+                || info.spec.address.space != space
+                || self.suppressed_breakpoints.contains(id)
+            {
+                continue;
+            }
+            addresses.push(info.spec.address.offset);
+        }
+        addresses
+    }
+
+    pub(crate) fn breakpoint_at(
+        &self,
+        context: ContextId,
+        space: super::ids::AddressSpaceId,
+        address: u64,
+    ) -> Option<BreakpointId> {
+        self.breakpoints.iter().find_map(|(id, info)| {
+            (info.spec.enabled
+                && !self.suppressed_breakpoints.contains(id)
+                && info.spec.context == Some(context)
+                && info.spec.address.space == space
+                && info.spec.address.offset == address)
+                .then_some(*id)
+        })
+    }
+
+    fn note_breakpoint_hit(&mut self, id: BreakpointId) -> bool {
+        let Some(info) = self.breakpoints.get_mut(&id) else {
+            return false;
+        };
+        info.hit_count = info.hit_count.saturating_add(1);
+        info.spec.one_shot
+    }
+
+    pub(crate) fn breakpoint_stop(
+        &mut self,
+        id: BreakpointId,
+        context: ContextId,
+        location: Option<ExecutionLocation>,
+        guest_tick: Option<u32>,
+        execution_units: Option<u64>,
+    ) -> StopInfo {
+        let operation = self.pending_step.take().map(|step| step.operation);
+        let remove = self.note_breakpoint_hit(id);
+        if remove {
+            self.breakpoints.remove(&id);
+            self.suppressed_breakpoints.remove(&id);
+        }
+        let stop = self.stop(
+            StopReason::PcBreakpoint { id },
+            Some(context),
+            location,
+            guest_tick,
+            execution_units,
+        );
+        if let Some(operation) = operation {
+            self.complete_operation(
+                operation,
+                OperationOutcome::Completed {
+                    stop: Some(stop.clone()),
+                },
+            );
+        }
+        stop
+    }
+
+    pub(crate) fn note_active_context(&mut self, context: Option<ContextId>) {
+        if self.observed_context != context {
+            self.observed_context = context;
+            self.push_notification(NotificationPayload::ContextChanged { active: context });
+        }
+    }
+
+    pub(crate) fn stop_at_terminal_halt(
+        &mut self,
+        context: Option<ContextId>,
+        location: Option<ExecutionLocation>,
+        guest_tick: Option<u32>,
+        execution_units: Option<u64>,
+    ) -> Option<StopInfo> {
+        if self.terminal_announced {
+            return None;
+        }
+        if let Some(step) = self.pending_step.take() {
+            self.suppressed_breakpoints.clear();
+            self.complete_operation(
+                step.operation,
+                OperationOutcome::Unavailable {
+                    reason: "runner reached a terminal halt".into(),
+                },
+            );
+        }
+        let stop = self.stop(
+            StopReason::TerminalHalt,
+            context,
+            location,
+            guest_tick,
+            execution_units,
+        );
+        self.terminal_announced = true;
+        self.push_notification(NotificationPayload::TerminalState { halted: true });
+        Some(stop)
+    }
+
+    fn create_operation(&mut self) -> OperationId {
+        let id = self.next_operation_id.alloc();
+        self.operations.insert(id, OperationState::Pending);
+        self.operation_order.push_back(id);
+        id
+    }
+
+    pub(crate) fn complete_operation(&mut self, id: OperationId, result: OperationOutcome) {
+        if let Some(state) = self.operations.get_mut(&id) {
+            let cloned = result.clone();
+            *state = OperationState::Completed { result };
+            self.push_notification(NotificationPayload::OperationCompleted {
+                operation_id: id,
+                result: Box::new(cloned),
+            });
+            self.prune_operations();
+        }
+    }
+
+    fn prune_operations(&mut self) {
+        while self
+            .operations
+            .values()
+            .filter(|state| matches!(state, OperationState::Completed { .. }))
+            .count()
+            > OPERATION_RETENTION
+        {
+            let Some(index) = self.operation_order.iter().position(|id| {
+                matches!(
+                    self.operations.get(id),
+                    Some(OperationState::Completed { .. })
+                )
+            }) else {
+                break;
+            };
+            let id = self
+                .operation_order
+                .remove(index)
+                .expect("located operation exists");
+            self.operations.remove(&id);
+            self.expired_operation_through = self.expired_operation_through.max(id.0);
+        }
+    }
+
+    pub fn operation_status(&self, id: OperationId) -> Option<OperationStatus> {
+        self.operations
+            .get(&id)
+            .cloned()
+            .map(|state| OperationStatus { id, state })
+            .or_else(|| {
+                (id.0 <= self.expired_operation_through).then_some(OperationStatus {
+                    id,
+                    state: OperationState::Expired,
+                })
+            })
+    }
+
+    pub fn providers(&self) -> &[super::provider::ProviderRegistration] {
+        &self.providers
+    }
+
+    pub fn provider(&self, id: ProviderId) -> Option<super::provider::ProviderRegistration> {
+        self.providers
+            .iter()
+            .find(|provider| provider.descriptor().id == id)
+            .cloned()
+    }
+
+    pub fn register_provider<P>(&mut self, provider: P) -> DebugResult<()>
+    where
+        P: super::provider::InspectionProvider + 'static,
+    {
+        self.register_provider_arc(std::sync::Arc::new(provider))
+    }
+
+    pub fn register_provider_arc(
+        &mut self,
+        provider: super::provider::ProviderRegistration,
+    ) -> DebugResult<()> {
+        super::provider::validate_provider_contract(provider.as_ref())?;
+        let id = provider.descriptor().id;
+        if self.provider(id).is_some() {
+            return Err(DebugError::InvalidValue {
+                detail: format!("provider {id} is already registered"),
+            });
+        }
+        self.providers.push(provider);
+        Ok(())
+    }
+
+    pub fn adapter_registrations(&self) -> &[super::adapters::AdapterRegistration] {
+        &self.adapter_registrations
+    }
+
+    pub fn register_adapter(
+        &mut self,
+        registration: super::adapters::AdapterRegistration,
+    ) -> DebugResult<()> {
+        if registration.context == ContextId::UNSPECIFIED
+            || registration
+                .address_spaces
+                .iter()
+                .any(|space| *space == AddressSpaceId::UNSPECIFIED)
+            || registration
+                .address_spaces
+                .iter()
+                .enumerate()
+                .any(|(index, space)| registration.address_spaces[..index].contains(space))
+        {
+            return Err(DebugError::InvalidValue {
+                detail: "adapter context and address-space IDs must be non-zero and unique within a registration".into(),
+            });
+        }
+        if self.adapter_registrations.iter().any(|existing| {
+            existing.context == registration.context
+                || existing
+                    .address_spaces
+                    .iter()
+                    .any(|space| registration.address_spaces.contains(space))
+        }) {
+            return Err(DebugError::InvalidValue {
+                detail: "adapter context and address-space IDs must be unique".into(),
+            });
+        }
+        self.adapter_registrations.push(registration);
+        Ok(())
+    }
+
+    pub(crate) fn alloc_artifact(&mut self) -> u64 {
+        self.capture_store.alloc_artifact()
+    }
+
+    fn alloc_capture(&mut self) -> CaptureId {
+        self.capture_store.alloc_capture()
+    }
+
+    pub fn begin_capture(
+        &mut self,
+        request: CaptureRequest,
+        boundary: CaptureBoundaryKind,
+    ) -> PendingCapture {
+        let pending = self.make_capture(request, boundary);
+        self.pending_captures.push(pending.clone());
+        pending
+    }
+
+    pub fn begin_immediate_capture(&mut self, request: CaptureRequest) -> PendingCapture {
+        self.make_capture(request, CaptureBoundaryKind::CommandSafePoint)
+    }
+
+    fn make_capture(
+        &mut self,
+        request: CaptureRequest,
+        boundary: CaptureBoundaryKind,
+    ) -> PendingCapture {
+        let operation = self.create_operation();
+        let capture = self.alloc_capture();
+        let pause = request.mode == CaptureMode::PauseAtBoundary;
+        PendingCapture {
+            operation,
+            capture,
+            request,
+            boundary,
+            pause,
+        }
+    }
+
+    pub(crate) fn take_pending_captures(
+        &mut self,
+        boundary: CaptureBoundaryKind,
+    ) -> Vec<PendingCapture> {
+        let mut taken = Vec::new();
+        let mut remaining = Vec::with_capacity(self.pending_captures.len());
+        for pending in std::mem::take(&mut self.pending_captures) {
+            if pending.boundary == boundary {
+                taken.push(pending);
+            } else {
+                remaining.push(pending);
+            }
+        }
+        self.pending_captures = remaining;
+        taken
+    }
+
+    pub fn cancel_capture(&mut self, operation: OperationId) -> bool {
+        let Some(index) = self
+            .pending_captures
+            .iter()
+            .position(|pending| pending.operation == operation)
+        else {
+            return false;
+        };
+        self.pending_captures.remove(index);
+        self.complete_operation(operation, OperationOutcome::Cancelled);
+        true
+    }
+
+    pub(crate) fn pending_capture_count(&self) -> usize {
+        self.pending_captures.len()
+    }
+
+    pub(crate) fn has_pending_capture_boundary(&self, boundary: CaptureBoundaryKind) -> bool {
+        self.pending_captures
+            .iter()
+            .any(|capture| capture.boundary == boundary)
+    }
+
+    pub(crate) fn fail_pending_captures(&mut self, reason: impl Into<String>) {
+        let reason = reason.into();
+        for pending in std::mem::take(&mut self.pending_captures) {
+            self.complete_operation(
+                pending.operation,
+                OperationOutcome::Unavailable {
+                    reason: reason.clone(),
+                },
+            );
+        }
+    }
+
+    pub(crate) fn stop_at_capture_boundary(
+        &mut self,
+        capture: CaptureId,
+        context: Option<ContextId>,
+        location: Option<ExecutionLocation>,
+        guest_tick: Option<u32>,
+        execution_units: Option<u64>,
+    ) -> StopInfo {
+        self.stop(
+            StopReason::CaptureBoundary { id: capture },
+            context,
+            location,
+            guest_tick,
+            execution_units,
+        )
+    }
+
+    pub fn insert_capture(&mut self, capture: RetainedCapture) -> Option<CaptureId> {
+        let id = capture.manifest.id;
+        let evicted = self.capture_store.insert(capture);
+        self.push_notification(NotificationPayload::CaptureAvailable { id });
+        evicted
+    }
+
+    pub fn extract_capture_store(&mut self) -> CaptureStore {
+        self.fail_pending_captures("runner replacing capture store");
+        self.capture_store.drain()
+    }
+
+    pub fn adopt_capture_store(&mut self, store: CaptureStore) {
+        self.capture_store.adopt(store);
+    }
+
+    pub fn capture(&self, id: CaptureId) -> Option<&RetainedCapture> {
+        self.capture_store.get(id)
+    }
+
+    pub fn capture_snapshot(
+        &self,
+        capture: CaptureId,
+        provider: ProviderId,
+    ) -> Option<super::provider::ProviderSnapshot> {
+        self.capture_store.snapshot(capture, provider)
+    }
+
+    pub fn artifact(&self, id: ArtifactId) -> Option<(super::model::ArtifactDescriptor, Vec<u8>)> {
+        self.capture_store.artifact(id)
+    }
+
+    pub fn release_capture(&mut self, id: CaptureId) -> bool {
+        self.capture_store.release(id)
+    }
+
+    pub fn captures(&self) -> Vec<super::model::CaptureManifest> {
+        self.capture_store.manifests()
+    }
+
+    pub fn set_capture_retention(&mut self, retention: usize) {
+        self.capture_store.set_retention(retention);
+    }
+
+    pub fn push_notification(&mut self, payload: NotificationPayload) -> u64 {
+        let sequence = self.next_notification_sequence;
+        self.next_notification_sequence = self.next_notification_sequence.saturating_add(1);
+        self.notifications
+            .push_back(DebugNotification { sequence, payload });
+        while self.notifications.len() > NOTIFICATION_RETENTION {
+            self.notifications.pop_front();
+        }
+        sequence
+    }
+
+    pub fn notifications_since(&self, after: u64) -> Vec<DebugNotification> {
+        self.notifications
+            .iter()
+            .filter(|notification| notification.sequence > after)
+            .cloned()
+            .collect()
+    }
+
+    pub fn notification_history_available_after(&self, after: u64) -> bool {
+        self.notifications
+            .front()
+            .is_none_or(|first| first.sequence <= after.saturating_add(1))
+    }
+
+    pub fn last_notification_sequence(&self) -> Option<u64> {
+        self.notifications
+            .back()
+            .map(|notification| notification.sequence)
+    }
+}
+
+impl Default for DebuggerCoordinator {
+    fn default() -> Self {
+        Self::new(SessionId(1))
+    }
+}
+
+
+#[cfg(test)]
+#[path = "coordinator_tests.rs"]
+mod tests;

--- a/src/debug/coordinator_tests.rs
+++ b/src/debug/coordinator_tests.rs
@@ -1,0 +1,411 @@
+    use super::*;
+    use crate::debug::ids::{AddressSpaceId, ContextId};
+    use crate::debug::model::{DebugAddress, ExecutionLocation};
+    use crate::debug::request::BreakpointSpec;
+
+    fn location(pc: u32) -> ExecutionLocation {
+        ExecutionLocation {
+            context: ContextId(1),
+            address: DebugAddress::new(AddressSpaceId(1), u64::from(pc)),
+        }
+    }
+
+    #[test]
+    fn pause_and_resume_are_idempotent() {
+        let mut coordinator = DebuggerCoordinator::new(SessionId(1));
+        assert!(
+            coordinator.resume() == false,
+            "running runner is not paused"
+        );
+        coordinator.pause(None, None);
+        assert!(coordinator.is_paused());
+        coordinator.pause(None, None);
+        assert!(coordinator.is_paused());
+        assert!(coordinator.resume());
+        assert!(coordinator.execution_state().is_running());
+        assert!(!coordinator.resume());
+    }
+
+    #[test]
+    fn breakpoints_have_stable_identity_and_counters() {
+        let mut coordinator = DebuggerCoordinator::new(SessionId(1));
+        let a = coordinator.insert_breakpoint(BreakpointSpec::program_counter(0x1000));
+        let b = coordinator.insert_breakpoint(BreakpointSpec::program_counter(0x2000));
+        assert_ne!(a.id, b.id);
+        assert_eq!(coordinator.breakpoints().len(), 2);
+        assert!(!coordinator.note_breakpoint_hit(a.id));
+        assert_eq!(coordinator.breakpoints()[0].hit_count, 1);
+        assert!(coordinator.remove_breakpoint(a.id));
+        assert_eq!(coordinator.breakpoints().len(), 1);
+    }
+
+    #[test]
+    fn notification_sequences_are_gapless() {
+        let mut coordinator = DebuggerCoordinator::new(SessionId(1));
+        let first =
+            coordinator.push_notification(NotificationPayload::TerminalState { halted: false });
+        let second =
+            coordinator.push_notification(NotificationPayload::TerminalState { halted: true });
+        assert_eq!(second, first + 1);
+        assert_eq!(coordinator.notifications_since(first).len(), 1);
+    }
+
+    #[test]
+    fn expired_notification_cursor_is_detectable() {
+        let mut coordinator = DebuggerCoordinator::new(SessionId(1));
+        for _ in 0..=NOTIFICATION_RETENTION {
+            coordinator.push_notification(NotificationPayload::TerminalState { halted: false });
+        }
+        assert!(!coordinator.notification_history_available_after(0));
+        assert!(coordinator.notification_history_available_after(1));
+    }
+
+    #[test]
+    fn capture_retention_evicts_oldest() {
+        let mut coordinator = DebuggerCoordinator::new(SessionId(1));
+        coordinator.set_capture_retention(2);
+        for id in 1..=3u64 {
+            let manifest = super::super::model::CaptureManifest {
+                id: CaptureId(id),
+                session: SessionId(1),
+                boundary: super::super::model::CaptureBoundaryKind::CommandSafePoint,
+                providers: Vec::new(),
+                revision: 0,
+                stop: None,
+                guest_tick: None,
+                execution_units: None,
+                artifacts: Vec::new(),
+                omitted: Vec::new(),
+                truncated: false,
+                atomic: true,
+                synchronization: Vec::new(),
+            };
+            coordinator.insert_capture(RetainedCapture {
+                manifest,
+                snapshots: Vec::new(),
+                artifacts: Vec::new(),
+            });
+        }
+        assert_eq!(coordinator.captures().len(), 2);
+        assert!(coordinator.capture(CaptureId(1)).is_none());
+        assert!(coordinator.capture(CaptureId(3)).is_some());
+    }
+
+    #[test]
+    fn step_completes_after_one_unit_and_reports_an_operation() {
+        let mut coordinator = DebuggerCoordinator::new(SessionId(1));
+        coordinator.pause(None, None);
+        let operation = coordinator.begin_step(ContextId(1));
+        assert!(coordinator.is_stepping());
+        assert_eq!(coordinator.step_units_remaining(), Some(1));
+        assert!(matches!(
+            coordinator.execution_state(),
+            DebugExecutionState::Stepping { operation_id } if *operation_id == operation
+        ));
+
+        coordinator.note_executed_units(ContextId(1), 1);
+        assert_eq!(coordinator.step_units_remaining(), Some(0));
+        let stop = coordinator
+            .finish_step(ContextId(1), Some(location(0x2000)), Some(7), Some(1))
+            .expect("pending step");
+        assert_eq!(stop.reason, StopReason::StepCompleted);
+        assert!(!coordinator.is_stepping());
+        assert!(coordinator.is_paused());
+        // The completed step carries its own stop, so a client can learn the new
+        // location without a follow-up ExecutionStatus request.
+        let Some(OperationState::Completed {
+            result: OperationOutcome::Completed { stop: carried },
+        }) = coordinator
+            .operation_status(operation)
+            .map(|status| status.state)
+        else {
+            panic!("step operation completes with a stop");
+        };
+        let carried = carried.expect("step completion carries its stop");
+        assert_eq!(carried.reason, StopReason::StepCompleted);
+        assert_eq!(carried.id, stop.id);
+        assert_eq!(carried.location, stop.location);
+    }
+
+    #[test]
+    fn completed_steps_obey_operation_retention() {
+        let mut coordinator = DebuggerCoordinator::new(SessionId(1));
+        coordinator.pause(None, None);
+        let mut first = OperationId::UNSPECIFIED;
+        for index in 0..=OPERATION_RETENTION {
+            let operation = coordinator.begin_step(ContextId(1));
+            if index == 0 {
+                first = operation;
+            }
+            coordinator.note_executed_units(ContextId(1), 1);
+            coordinator.finish_step(ContextId(1), None, None, None);
+        }
+        assert!(matches!(
+            coordinator
+                .operation_status(first)
+                .map(|status| status.state),
+            Some(OperationState::Expired)
+        ));
+    }
+
+    #[test]
+    fn pausing_a_pending_step_cancels_its_operation() {
+        let mut coordinator = DebuggerCoordinator::new(SessionId(1));
+        coordinator.pause(None, None);
+        let operation = coordinator.begin_step(ContextId(1));
+        coordinator.pause(None, None);
+        assert!(!coordinator.is_stepping());
+        assert!(matches!(
+            coordinator
+                .operation_status(operation)
+                .map(|status| status.state),
+            Some(OperationState::Completed {
+                result: OperationOutcome::Cancelled
+            })
+        ));
+    }
+
+    #[test]
+    fn resume_suppresses_a_breakpoint_for_exactly_one_unit() {
+        let mut coordinator = DebuggerCoordinator::new(SessionId(1));
+        let mut spec = BreakpointSpec::program_counter(0x1234);
+        spec.context = Some(ContextId(1));
+        let info = coordinator.insert_breakpoint(spec);
+        assert_eq!(
+            coordinator.breakpoint_watch_addresses(ContextId(1), AddressSpaceId::UNSPECIFIED),
+            vec![0x1234]
+        );
+        coordinator.breakpoint_stop(info.id, ContextId(1), Some(location(0x1234)), None, None);
+        assert!(coordinator.is_paused());
+
+        assert!(coordinator.resume());
+        assert!(
+            coordinator
+                .breakpoint_watch_addresses(ContextId(1), AddressSpaceId::UNSPECIFIED)
+                .is_empty(),
+            "breakpoint is suppressed until the guarded unit retires"
+        );
+        coordinator.note_executed_units(ContextId(1), 1);
+        assert_eq!(
+            coordinator.breakpoint_watch_addresses(ContextId(1), AddressSpaceId::UNSPECIFIED),
+            vec![0x1234],
+            "breakpoint is restored after the guarded unit retires"
+        );
+        assert_eq!(
+            coordinator.breakpoint_at(ContextId(1), AddressSpaceId::UNSPECIFIED, 0x1234),
+            Some(info.id)
+        );
+    }
+
+    #[test]
+    fn another_context_does_not_consume_breakpoint_suppression() {
+        let mut coordinator = DebuggerCoordinator::new(SessionId(1));
+        let mut spec = BreakpointSpec::program_counter(0x1234);
+        spec.context = Some(ContextId(1));
+        let info = coordinator.insert_breakpoint(spec);
+        coordinator.breakpoint_stop(info.id, ContextId(1), None, None, None);
+        coordinator.resume();
+        coordinator.note_executed_units(ContextId(2), 1);
+        assert!(coordinator
+            .breakpoint_watch_addresses(ContextId(1), AddressSpaceId::UNSPECIFIED)
+            .is_empty());
+        coordinator.note_executed_units(ContextId(1), 1);
+        assert_eq!(
+            coordinator.breakpoint_watch_addresses(ContextId(1), AddressSpaceId::UNSPECIFIED),
+            vec![0x1234]
+        );
+    }
+
+    #[test]
+    fn stepping_from_a_breakpoint_suppresses_it_for_the_step() {
+        let mut coordinator = DebuggerCoordinator::new(SessionId(1));
+        let mut spec = BreakpointSpec::program_counter(0x1234);
+        spec.context = Some(ContextId(1));
+        let info = coordinator.insert_breakpoint(spec);
+        coordinator.breakpoint_stop(info.id, ContextId(1), Some(location(0x1234)), None, None);
+        coordinator.begin_step(ContextId(1));
+        assert!(
+            coordinator
+                .breakpoint_watch_addresses(ContextId(1), AddressSpaceId::UNSPECIFIED)
+                .is_empty(),
+            "the step must be able to retire the instruction the breakpoint guards"
+        );
+        coordinator.note_executed_units(ContextId(1), 1);
+        assert_eq!(
+            coordinator.breakpoint_watch_addresses(ContextId(1), AddressSpaceId::UNSPECIFIED),
+            vec![0x1234]
+        );
+    }
+
+    #[test]
+    fn disabled_breakpoints_are_not_watched() {
+        let mut coordinator = DebuggerCoordinator::new(SessionId(1));
+        let mut spec = BreakpointSpec::program_counter(0x1000);
+        spec.context = Some(ContextId(1));
+        let info = coordinator.insert_breakpoint(spec);
+        assert!(coordinator.set_breakpoint_enabled(info.id, false).is_some());
+        assert!(coordinator
+            .breakpoint_watch_addresses(ContextId(1), AddressSpaceId::UNSPECIFIED)
+            .is_empty());
+        assert_eq!(
+            coordinator.breakpoint_at(ContextId(1), AddressSpaceId::UNSPECIFIED, 0x1000),
+            None
+        );
+    }
+
+    #[test]
+    fn abort_step_completes_the_operation_as_unavailable() {
+        let mut coordinator = DebuggerCoordinator::new(SessionId(1));
+        coordinator.pause(None, None);
+        let operation = coordinator.begin_step(ContextId(1));
+        coordinator.abort_step("runner halted");
+        assert!(!coordinator.is_stepping());
+        assert_eq!(coordinator.execution_state(), &DebugExecutionState::Running);
+        assert!(matches!(
+            coordinator
+                .operation_status(operation)
+                .map(|status| status.state),
+            Some(OperationState::Completed {
+                result: OperationOutcome::Unavailable { .. }
+            })
+        ));
+    }
+
+    #[test]
+    fn finishing_a_step_without_one_pending_has_no_side_effect() {
+        let mut coordinator = DebuggerCoordinator::new(SessionId(1));
+        let revision = coordinator.revision();
+        let stop = coordinator.finish_step(ContextId(1), Some(location(0x2000)), None, None);
+        assert!(stop.is_none());
+        assert_eq!(coordinator.revision(), revision);
+        assert!(coordinator.execution_state().is_running());
+        assert!(coordinator.notifications_since(0).is_empty());
+    }
+
+    #[test]
+    fn one_shot_breakpoint_is_removed_after_its_hit() {
+        let mut coordinator = DebuggerCoordinator::new(SessionId(1));
+        let mut spec = BreakpointSpec::program_counter(0x1000);
+        spec.one_shot = true;
+        let info = coordinator.insert_breakpoint(spec);
+        coordinator.breakpoint_stop(info.id, ContextId(1), Some(location(0x1000)), None, None);
+        assert!(coordinator.breakpoints().is_empty());
+    }
+
+    #[test]
+    fn terminal_notification_is_latched() {
+        let mut coordinator = DebuggerCoordinator::new(SessionId(1));
+        let first = coordinator.stop_at_terminal_halt(
+            Some(ContextId(1)),
+            Some(location(0x1000)),
+            Some(7),
+            Some(12),
+        );
+        let second = coordinator.stop_at_terminal_halt(None, None, None, None);
+        assert!(first.is_some());
+        assert!(second.is_none());
+        assert!(matches!(
+            coordinator.execution_state(),
+            DebugExecutionState::Paused {
+                stop: StopInfo {
+                    reason: StopReason::TerminalHalt,
+                    execution_units: Some(12),
+                    ..
+                }
+            }
+        ));
+        let terminal: Vec<_> = coordinator
+            .notifications_since(0)
+            .into_iter()
+            .filter(|notification| {
+                matches!(
+                    notification.payload,
+                    NotificationPayload::TerminalState { halted: true }
+                )
+            })
+            .collect();
+        assert_eq!(terminal.len(), 1);
+    }
+
+    #[test]
+    fn pending_captures_are_taken_only_at_their_boundary() {
+        let mut coordinator = DebuggerCoordinator::new(SessionId(1));
+        let request = super::super::request::CaptureRequest {
+            mode: CaptureMode::NextBoundary,
+            boundary: Some(super::super::model::CaptureBoundaryKind::LogicalFrameComplete),
+            providers: Vec::new(),
+            include_artifacts: true,
+        };
+        let pending = coordinator.begin_capture(
+            request.clone(),
+            super::super::model::CaptureBoundaryKind::LogicalFrameComplete,
+        );
+        assert_eq!(coordinator.pending_capture_count(), 1);
+        assert!(coordinator
+            .take_pending_captures(super::super::model::CaptureBoundaryKind::CommandSafePoint)
+            .is_empty());
+        let taken = coordinator
+            .take_pending_captures(super::super::model::CaptureBoundaryKind::LogicalFrameComplete);
+        assert_eq!(taken.len(), 1);
+        assert_eq!(taken[0].capture, pending.capture);
+
+        let second = coordinator.begin_capture(
+            request,
+            super::super::model::CaptureBoundaryKind::LogicalFrameComplete,
+        );
+        assert!(coordinator.cancel_capture(second.operation));
+        assert!(!coordinator.cancel_capture(second.operation));
+        assert!(matches!(
+            coordinator
+                .operation_status(second.operation)
+                .map(|status| status.state),
+            Some(OperationState::Completed {
+                result: OperationOutcome::Cancelled
+            })
+        ));
+    }
+
+    #[test]
+    fn capture_store_round_trips_and_preserves_session_identity() {
+        let mut coordinator = DebuggerCoordinator::new(SessionId(7));
+        let manifest = super::super::model::CaptureManifest {
+            id: coordinator.alloc_capture(),
+            session: SessionId(7),
+            boundary: super::super::model::CaptureBoundaryKind::CommandSafePoint,
+            providers: Vec::new(),
+            revision: 0,
+            stop: None,
+            guest_tick: None,
+            execution_units: None,
+            artifacts: Vec::new(),
+            omitted: Vec::new(),
+            truncated: false,
+            atomic: true,
+            synchronization: Vec::new(),
+        };
+        let id = manifest.id;
+        coordinator.insert_capture(RetainedCapture {
+            manifest,
+            snapshots: Vec::new(),
+            artifacts: Vec::new(),
+        });
+        let store = coordinator.extract_capture_store();
+        assert_eq!(store.len(), 1);
+        assert!(coordinator.captures().is_empty());
+
+        let mut replacement = DebuggerCoordinator::new(SessionId(8));
+        replacement.adopt_capture_store(store);
+        assert_eq!(replacement.captures().len(), 1);
+        assert_eq!(
+            replacement
+                .capture(id)
+                .map(|capture| capture.manifest.session),
+            Some(SessionId(7))
+        );
+        assert_ne!(replacement.alloc_capture(), id);
+        let first_artifact = replacement.alloc_artifact();
+        let store = replacement.extract_capture_store();
+        let mut second_replacement = DebuggerCoordinator::new(SessionId(9));
+        second_replacement.adopt_capture_store(store);
+        assert!(second_replacement.alloc_artifact() > first_artifact);
+    }

--- a/src/debug/error.rs
+++ b/src/debug/error.rs
@@ -1,0 +1,93 @@
+use super::ids::{AddressSpaceId, CaptureId, ContextId, OperationId};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "error", rename_all = "snake_case")]
+pub enum DebugError {
+    Unsupported {
+        operation: String,
+    },
+    InvalidState {
+        detail: String,
+    },
+    StaleReference {
+        detail: String,
+    },
+    InvalidValue {
+        detail: String,
+    },
+    InvalidRange {
+        detail: String,
+    },
+    Inaccessible {
+        space: AddressSpaceId,
+        detail: String,
+    },
+    TooLarge {
+        limit: u64,
+        requested: u64,
+    },
+    BoundaryUnavailable {
+        detail: String,
+    },
+    CaptureExpired {
+        id: CaptureId,
+    },
+    UnknownContext {
+        id: ContextId,
+    },
+    UnknownOperation {
+        id: OperationId,
+    },
+    Internal {
+        detail: String,
+    },
+}
+
+impl DebugError {
+    pub fn unsupported(operation: impl Into<String>) -> Self {
+        DebugError::Unsupported {
+            operation: operation.into(),
+        }
+    }
+
+    pub fn invalid_state(detail: impl Into<String>) -> Self {
+        DebugError::InvalidState {
+            detail: detail.into(),
+        }
+    }
+}
+
+impl fmt::Display for DebugError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DebugError::Unsupported { operation } => {
+                write!(f, "unsupported debug operation: {operation}")
+            }
+            DebugError::InvalidState { detail } => write!(f, "invalid debugger state: {detail}"),
+            DebugError::StaleReference { detail } => {
+                write!(f, "stale debugger reference: {detail}")
+            }
+            DebugError::InvalidValue { detail } => write!(f, "invalid debug value: {detail}"),
+            DebugError::InvalidRange { detail } => write!(f, "invalid debug range: {detail}"),
+            DebugError::Inaccessible { space, detail } => {
+                write!(f, "inaccessible address space {space}: {detail}")
+            }
+            DebugError::TooLarge { limit, requested } => {
+                write!(f, "request too large: limit {limit}, requested {requested}")
+            }
+            DebugError::BoundaryUnavailable { detail } => {
+                write!(f, "capture boundary unavailable: {detail}")
+            }
+            DebugError::CaptureExpired { id } => write!(f, "capture {id} has expired"),
+            DebugError::UnknownContext { id } => write!(f, "unknown context {id}"),
+            DebugError::UnknownOperation { id } => write!(f, "unknown operation {id}"),
+            DebugError::Internal { detail } => write!(f, "internal debugger failure: {detail}"),
+        }
+    }
+}
+
+impl std::error::Error for DebugError {}
+
+pub type DebugResult<T> = Result<T, DebugError>;

--- a/src/debug/handler.rs
+++ b/src/debug/handler.rs
@@ -1,0 +1,463 @@
+use super::adapters::{active_context_and_location, Adapters, MAX_ARTIFACT_TRANSFER};
+use super::capabilities::{CapabilitySet, CapabilityTarget, DecoderCapabilities};
+use super::capture::{boundary_synchronization_notes, capture_boundary_supported, request_capture};
+use super::error::{DebugError, DebugResult};
+use super::ids::ProviderId;
+use super::model::{CaptureBoundaryCapabilities, DebugExecutionState, OperationOutcome};
+#[cfg(test)]
+use super::provider::builtin_providers;
+use super::request::DebugRequest;
+use super::request::{DebugReply, ExecutionStatusReply};
+use crate::runner::FixtureRunner;
+
+fn execution_status(runner: &FixtureRunner) -> DebugResult<ExecutionStatusReply> {
+    let coordinator = &runner.debug;
+    let adapters = Adapters::for_runner(runner);
+    adapters.validate()?;
+    Ok(ExecutionStatusReply {
+        state: coordinator.execution_state().clone(),
+        terminal: runner.is_halted(),
+        active_context: adapters.active().map(|adapter| adapter.context().id),
+        guest_tick: Some(runner.guest_tick()),
+        execution_units: Some(runner.total_instructions()),
+        revision: coordinator.revision(),
+    })
+}
+
+/// Apply a request between scheduler calls on the runner's owning thread.
+/// Returns owned data or records execution intent without running guest code.
+/// For accepted operations, advance the scheduler and poll
+/// [`DebugRequest::GetOperation`]; terminal runners remain inspectable.
+pub fn handle_debug_request(
+    runner: &mut FixtureRunner,
+    request: DebugRequest,
+) -> crate::debug::error::DebugResult<DebugReply> {
+    use DebugRequest::*;
+    match request {
+        InSession {
+            session,
+            generation,
+            request,
+        } => {
+            if session != runner.debug.session() || generation != runner.debug.generation() {
+                return Err(DebugError::StaleReference {
+                    detail: "request belongs to another runner session or generation".into(),
+                });
+            }
+            if matches!(*request, InSession { .. }) {
+                return Err(DebugError::InvalidValue {
+                    detail: "nested session envelopes are unsupported".into(),
+                });
+            }
+            handle_debug_request(runner, *request)
+        }
+        ReadProvider { id } => {
+            let provider = runner
+                .debug
+                .provider(id)
+                .ok_or_else(|| DebugError::unsupported("provider snapshot"))?;
+            Ok(DebugReply::ProviderSnapshot(provider.snapshot_at(
+                runner,
+                super::model::CaptureBoundaryKind::CommandSafePoint,
+            )?))
+        }
+        ReadCaptureProvider { capture, provider } => {
+            if runner.debug.capture(capture).is_none() {
+                return Err(DebugError::CaptureExpired { id: capture });
+            }
+            let snapshot = runner.debug.capture_snapshot(capture, provider).ok_or(
+                DebugError::InvalidValue {
+                    detail: format!("capture {capture} did not retain provider {provider}"),
+                },
+            )?;
+            Ok(DebugReply::ProviderSnapshot(snapshot))
+        }
+        SessionInfo => Ok(DebugReply::SessionInfo(super::request::SessionInfo {
+            session: runner.debug.session(),
+            generation: runner.debug.generation(),
+            active_context: execution_status(runner)?.active_context,
+            terminal: runner.is_halted(),
+        })),
+        ListContexts => {
+            let adapters = Adapters::for_runner(runner);
+            adapters.validate()?;
+            Ok(DebugReply::Contexts(adapters.contexts()))
+        }
+        ListAddressSpaces { context } => {
+            let adapters = Adapters::for_runner(runner);
+            adapters.validate()?;
+            let context = adapters.resolve(context)?;
+            let adapter = adapters
+                .find(context)
+                .ok_or(DebugError::UnknownContext { id: context })?;
+            Ok(DebugReply::AddressSpaces(adapter.address_spaces()))
+        }
+        ListProviders => Ok(DebugReply::Providers(
+            runner
+                .debug
+                .providers()
+                .iter()
+                .map(|provider| provider.descriptor())
+                .collect(),
+        )),
+        GetCapabilities { target } => capability_reply(runner, target),
+        Notifications { after } => {
+            if !runner.debug.notification_history_available_after(after) {
+                return Err(DebugError::StaleReference {
+                    detail: "notification cursor predates retained history; refresh debugger state"
+                        .into(),
+                });
+            }
+            Ok(DebugReply::Notifications(
+                runner.debug.notifications_since(after),
+            ))
+        }
+        ExecutionStatus => Ok(DebugReply::ExecutionStatus(execution_status(runner)?)),
+        Pause => {
+            let (context, location) = active_context_and_location(runner);
+            let guest_tick = runner.guest_tick();
+            let execution_units = runner.total_instructions();
+            runner
+                .debug
+                .pause_at(context, location, Some(guest_tick), Some(execution_units));
+            Ok(DebugReply::Accepted {
+                state: runner.debug.execution_state().clone(),
+                operation_id: None,
+            })
+        }
+        Resume => {
+            if runner.is_halted() {
+                return Err(DebugError::invalid_state("cannot resume a terminal runner"));
+            }
+            if runner.debug.execution_state().is_stepping() {
+                return Err(DebugError::invalid_state(
+                    "cannot resume while a step is pending; pause to cancel the step",
+                ));
+            }
+            if runner.debug.resume() {
+                runner.debug_release_held_input();
+            }
+            Ok(DebugReply::Accepted {
+                state: runner.debug.execution_state().clone(),
+                operation_id: None,
+            })
+        }
+        Step { context } => {
+            if runner.is_halted() {
+                return Err(DebugError::invalid_state("cannot step a terminal runner"));
+            }
+            if !runner.debug.is_paused() {
+                return Err(DebugError::invalid_state("step requires a paused runner"));
+            }
+            let adapters = Adapters::for_runner(runner);
+            adapters.validate()?;
+            let context = adapters.resolve(context)?;
+            let adapter = adapters
+                .find(context)
+                .ok_or(DebugError::UnknownContext { id: context })?;
+            if !adapter.context().capabilities.step {
+                return Err(DebugError::unsupported("step for this execution context"));
+            }
+            if adapters.active().map(|adapter| adapter.context().id) != Some(context) {
+                return Err(DebugError::invalid_state(
+                    "step requires the selected execution context to be active",
+                ));
+            }
+            drop(adapters);
+            let operation_id = runner.debug.begin_step(context);
+            Ok(DebugReply::Accepted {
+                state: DebugExecutionState::Stepping { operation_id },
+                operation_id: Some(operation_id),
+            })
+        }
+        ReadRegisters { context, registers } => {
+            let adapters = Adapters::for_runner(runner);
+            adapters.validate()?;
+            let context = adapters.resolve(context)?;
+            let adapter = adapters
+                .find(context)
+                .ok_or(DebugError::UnknownContext { id: context })?;
+            let mut snapshots = adapter.registers(context)?;
+            if let Some(filter) = registers {
+                snapshots.retain(|snapshot| filter.contains(&snapshot.descriptor.id));
+            }
+            Ok(DebugReply::Registers {
+                context,
+                registers: snapshots,
+            })
+        }
+        ReadMemory {
+            space,
+            address,
+            length,
+        } => {
+            let adapters = Adapters::for_runner(runner);
+            adapters.validate()?;
+            let adapter = adapters.by_space(space).ok_or(DebugError::Inaccessible {
+                space,
+                detail: "unknown address space".to_string(),
+            })?;
+            Ok(DebugReply::Memory(
+                adapter.read_memory(space, address, length)?,
+            ))
+        }
+        Disassemble {
+            context,
+            address,
+            count,
+        } => {
+            let adapters = Adapters::for_runner(runner);
+            adapters.validate()?;
+            let context = adapters.resolve(context)?;
+            let adapter = adapters
+                .find(context)
+                .ok_or(DebugError::UnknownContext { id: context })?;
+            Ok(DebugReply::Disassembly {
+                context,
+                lines: adapter.disassemble(context, address, count)?,
+            })
+        }
+        StackPreview { context, words } => {
+            let adapters = Adapters::for_runner(runner);
+            adapters.validate()?;
+            let context = adapters.resolve(context)?;
+            let adapter = adapters
+                .find(context)
+                .ok_or(DebugError::UnknownContext { id: context })?;
+            Ok(DebugReply::Stack(adapter.stack_preview(context, words)?))
+        }
+        ListBreakpoints => Ok(DebugReply::Breakpoints(runner.debug.breakpoints())),
+        SetBreakpoint { mut spec } => {
+            let adapters = Adapters::for_runner(runner);
+            adapters.validate()?;
+            let enforced_context = match spec.context {
+                Some(id) => id,
+                None => adapters
+                    .active()
+                    .map(|adapter| adapter.context().id)
+                    .ok_or_else(|| DebugError::invalid_state("no active execution context"))?,
+            };
+            let adapter = adapters
+                .find(enforced_context)
+                .ok_or(DebugError::UnknownContext {
+                    id: enforced_context,
+                })?;
+            let descriptor = adapter.context();
+            if !descriptor.capabilities.set_breakpoint {
+                return Err(DebugError::unsupported(format!(
+                    "breakpoint enforcement for context {enforced_context}"
+                )));
+            }
+            let spaces = adapter.address_spaces();
+            if spec.address.space == super::ids::AddressSpaceId::UNSPECIFIED {
+                let mut executable = spaces.iter().filter(|space| space.access.execute);
+                let space = executable.next().ok_or_else(|| {
+                    DebugError::invalid_state("context has no executable address space")
+                })?;
+                if executable.next().is_some() {
+                    return Err(DebugError::InvalidValue {
+                        detail: "breakpoint must name an address space for this context".into(),
+                    });
+                }
+                spec.address.space = space.id;
+            }
+            let space = spaces
+                .iter()
+                .find(|space| space.id == spec.address.space && space.access.execute)
+                .ok_or(DebugError::Inaccessible {
+                    space: spec.address.space,
+                    detail: "address space is not executable in this context".into(),
+                })?;
+            if space.address_bits < 64 && spec.address.offset >= (1u64 << space.address_bits) {
+                return Err(DebugError::InvalidValue {
+                    detail: format!("breakpoint address must fit in {} bits", space.address_bits),
+                });
+            }
+            drop(adapters);
+            spec.context = Some(enforced_context);
+            if runner.debug.breakpoints().iter().any(|existing| {
+                existing.spec.kind == spec.kind
+                    && existing.spec.address == spec.address
+                    && existing.spec.context == spec.context
+            }) {
+                return Err(DebugError::InvalidValue {
+                    detail: "a breakpoint already targets this context and address".to_string(),
+                });
+            }
+            Ok(DebugReply::Breakpoint(runner.debug.insert_breakpoint(spec)))
+        }
+        RemoveBreakpoint { id } => {
+            if runner.debug.remove_breakpoint(id) {
+                Ok(DebugReply::BreakpointRemoved { id })
+            } else {
+                Err(DebugError::InvalidValue {
+                    detail: format!("unknown breakpoint {id}"),
+                })
+            }
+        }
+        SetBreakpointEnabled { id, enabled } => runner
+            .debug
+            .set_breakpoint_enabled(id, enabled)
+            .map(DebugReply::Breakpoint)
+            .ok_or(DebugError::InvalidValue {
+                detail: format!("unknown breakpoint {id}"),
+            }),
+        ListCaptures => Ok(DebugReply::Captures(runner.debug.captures())),
+        RequestCapture { request } => request_capture(runner, request),
+        CancelCapture { operation } => {
+            if runner.debug.cancel_capture(operation) {
+                Ok(DebugReply::Operation(super::model::OperationStatus {
+                    id: operation,
+                    state: super::model::OperationState::Completed {
+                        result: OperationOutcome::Cancelled,
+                    },
+                }))
+            } else {
+                Err(DebugError::UnknownOperation { id: operation })
+            }
+        }
+        GetCapture { id } => match runner.debug.capture(id) {
+            Some(capture) => Ok(DebugReply::Capture(capture.manifest.clone())),
+            None => Err(DebugError::CaptureExpired { id }),
+        },
+        ReleaseCapture { id } => {
+            if runner.debug.release_capture(id) {
+                Ok(DebugReply::CaptureReleased { id })
+            } else {
+                Err(DebugError::CaptureExpired { id })
+            }
+        }
+        GetOperation { id } => runner
+            .debug
+            .operation_status(id)
+            .map(DebugReply::Operation)
+            .ok_or(DebugError::UnknownOperation { id }),
+        GetArtifact { id } => match runner.debug.artifact(id) {
+            Some((descriptor, bytes)) => {
+                if bytes.len() as u64 > MAX_ARTIFACT_TRANSFER {
+                    return Err(DebugError::TooLarge {
+                        limit: MAX_ARTIFACT_TRANSFER,
+                        requested: bytes.len() as u64,
+                    });
+                }
+                Ok(DebugReply::ArtifactData { descriptor, bytes })
+            }
+            None => Err(DebugError::InvalidValue {
+                detail: format!("unknown artifact {id}"),
+            }),
+        },
+        DecodeArtifact { id } => Err(DebugError::unsupported(format!(
+            "artifact decoding for {id}"
+        ))),
+        ResolveSymbol {
+            context,
+            address,
+            window,
+        } => {
+            symbol_context(runner, context)?;
+            let window = window.unwrap_or(super::symbols::DEFAULT_RESOLVE_WINDOW);
+            Ok(DebugReply::Symbol(super::symbols::resolve_containing(
+                runner,
+                address.offset,
+                window,
+            )?))
+        }
+        LookupSymbol { context, name } => {
+            symbol_context(runner, context)?;
+            Ok(DebugReply::Symbols(super::symbols::lookup(
+                runner,
+                super::provider::SYMBOL_SCAN_START,
+                super::provider::SYMBOL_SCAN_LENGTH,
+                &name,
+            )?))
+        }
+    }
+}
+
+/// Symbol recovery reads 68K guest memory, so it requires a resolvable 68K
+/// context. Validating here keeps the scanner free of context concerns.
+fn symbol_context(
+    runner: &FixtureRunner,
+    context: super::model::ContextSelector,
+) -> DebugResult<super::ids::ContextId> {
+    let adapters = Adapters::for_runner(runner);
+    adapters.validate()?;
+    let context = adapters.resolve(context)?;
+    if context != super::adapters::M68K_CONTEXT {
+        return Err(DebugError::unsupported(
+            "MacsBug symbol recovery is available on the 68K context only",
+        ));
+    }
+    Ok(context)
+}
+
+fn capability_reply(runner: &FixtureRunner, target: CapabilityTarget) -> DebugResult<DebugReply> {
+    let set = match target {
+        CapabilityTarget::Context { id } => {
+            let adapters = Adapters::for_runner(runner);
+            adapters.validate()?;
+            let adapter = adapters.find(id).ok_or(DebugError::UnknownContext { id })?;
+            CapabilitySet::Context(adapter.context().capabilities)
+        }
+        CapabilityTarget::AddressSpace { id } => {
+            let adapters = Adapters::for_runner(runner);
+            adapters.validate()?;
+            let adapter = adapters.by_space(id).ok_or(DebugError::Inaccessible {
+                space: id,
+                detail: "unknown address space".to_string(),
+            })?;
+            CapabilitySet::AddressSpace(adapter.address_space_capabilities(id)?)
+        }
+        CapabilityTarget::Provider { id } => {
+            let provider = runner
+                .debug
+                .providers()
+                .iter()
+                .find(|provider| provider.descriptor().id == id)
+                .ok_or(DebugError::InvalidValue {
+                    detail: format!("unknown provider {id}"),
+                })?;
+            CapabilitySet::Provider(provider.capabilities())
+        }
+        CapabilityTarget::Boundary { boundary } => {
+            if !capture_boundary_supported(boundary) {
+                return Err(DebugError::BoundaryUnavailable {
+                    detail: format!("capture boundary {boundary:?} is not observed by this runner"),
+                });
+            }
+            let providers = runner
+                .debug
+                .providers()
+                .iter()
+                .filter(|provider| {
+                    provider
+                        .descriptor()
+                        .required_boundary
+                        .is_none_or(|required| required == boundary)
+                })
+                .map(|provider| provider.descriptor().id)
+                .collect();
+            CapabilitySet::Boundary(CaptureBoundaryCapabilities {
+                kind: boundary,
+                providers,
+                atomic_across_providers: true,
+                limitations: boundary_synchronization_notes(boundary),
+            })
+        }
+        CapabilityTarget::Decoder { .. } => CapabilitySet::Decoder(DecoderCapabilities::default()),
+    };
+    Ok(DebugReply::Capabilities(set))
+}
+
+pub fn builtin_provider_ids() -> Vec<ProviderId> {
+    super::provider::builtin_providers()
+        .iter()
+        .map(|provider| provider.descriptor().id)
+        .collect()
+}
+
+#[cfg(test)]
+
+#[cfg(test)]
+#[path = "handler_tests.rs"]
+mod tests;

--- a/src/debug/handler_tests.rs
+++ b/src/debug/handler_tests.rs
@@ -1,0 +1,1144 @@
+    use super::*;
+    use crate::cpu::Register;
+    use crate::debug::{BreakpointSpec, SessionId};
+    use crate::memory::MemoryBus;
+    use crate::runner::{FixtureRunner, FixtureRunnerConfig};
+
+    use super::super::adapters::{
+        m68k_disassembly, read_m68k_memory, ArchitectureAdapter, PpcAdapter, M68K_CONTEXT,
+        M68K_SPACE, MAX_DISASSEMBLY_COUNT, MAX_MEMORY_TRANSFER, PPC_CONTEXT, PPC_SPACE,
+    };
+    use super::super::ids::AddressSpaceId;
+    use super::super::model::{ContextSelector, DebugAddress, RegisterRole, RegisterValue};
+    use super::super::request::CaptureRequest;
+
+    fn runner() -> FixtureRunner {
+        FixtureRunner::new(0x100000, FixtureRunnerConfig::default())
+    }
+
+    #[test]
+    fn session_and_context_reply_identifies_the_68k_context() {
+        let mut runner = runner();
+        let info = handle_debug_request(&mut runner, DebugRequest::SessionInfo).unwrap();
+        match info {
+            DebugReply::SessionInfo(info) => {
+                assert_ne!(info.session, SessionId::UNSPECIFIED);
+                assert!(info.generation >= 1);
+                assert_eq!(info.active_context, Some(M68K_CONTEXT));
+                assert!(!info.terminal);
+            }
+            other => panic!("unexpected reply: {other:?}"),
+        }
+
+        let contexts = handle_debug_request(&mut runner, DebugRequest::ListContexts).unwrap();
+        match contexts {
+            DebugReply::Contexts(contexts) => {
+                assert!(contexts.iter().any(|context| context.id == M68K_CONTEXT));
+                assert!(!contexts.iter().any(|context| context.id == PPC_CONTEXT));
+            }
+            other => panic!("unexpected reply: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn register_reply_reports_exact_values() {
+        let mut runner = runner();
+        runner.cpu_mut().write_reg(Register::D0, 0xDEAD_BEEF);
+        runner.cpu_mut().write_reg(Register::A7, 0x0002_0000);
+        let reply = handle_debug_request(
+            &mut runner,
+            DebugRequest::ReadRegisters {
+                context: ContextSelector::Active,
+                registers: None,
+            },
+        )
+        .unwrap();
+        let DebugReply::Registers { context, registers } = reply else {
+            panic!("expected registers");
+        };
+        assert_eq!(context, M68K_CONTEXT);
+        let d0 = registers
+            .iter()
+            .find(|snapshot| snapshot.descriptor.name == "D0")
+            .unwrap();
+        assert_eq!(d0.value.as_u64(), Some(0xDEAD_BEEF));
+        let a7 = registers
+            .iter()
+            .find(|snapshot| snapshot.descriptor.name == "A7")
+            .unwrap();
+        assert_eq!(a7.value.as_u64(), Some(0x0002_0000));
+        assert_eq!(a7.descriptor.role, Some(RegisterRole::StackPointer));
+    }
+
+    #[test]
+    fn memory_read_is_observational_and_truncates_at_ram_end() {
+        let mut runner = runner();
+        runner.bus_mut().write_long(0x0F_FFFC, 0x1122_3344);
+        let reply = handle_debug_request(
+            &mut runner,
+            DebugRequest::ReadMemory {
+                space: M68K_SPACE,
+                address: 0x0F_FFFC,
+                length: 8,
+            },
+        )
+        .unwrap();
+        let DebugReply::Memory(result) = reply else {
+            panic!("expected memory");
+        };
+        assert_eq!(result.bytes.len(), 4);
+        assert!(result.truncated);
+        assert_eq!(&result.bytes, &[0x11, 0x22, 0x33, 0x44]);
+    }
+
+    #[test]
+    fn disassembly_reports_nop_with_byte_payload() {
+        let mut runner = runner();
+        runner.bus_mut().write_word(0x2_0000, 0x4E71);
+        runner.bus_mut().write_word(0x2_0002, 0x4E75);
+        let reply = handle_debug_request(
+            &mut runner,
+            DebugRequest::Disassemble {
+                context: ContextSelector::Active,
+                address: DebugAddress::new(M68K_SPACE, 0x2_0000),
+                count: 2,
+            },
+        )
+        .unwrap();
+        let DebugReply::Disassembly { lines, .. } = reply else {
+            panic!("expected disassembly");
+        };
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0].bytes, vec![0x4E, 0x71]);
+        assert_eq!(lines[1].text, "RTS");
+    }
+
+    #[test]
+    fn pause_stops_run_steps_until_resumed() {
+        let mut runner = runner();
+        runner.bus_mut().write_word(0x2_0000, 0x4E71); // NOP
+        runner.cpu_mut().write_reg(Register::PC, 0x2_0000);
+
+        let accepted = handle_debug_request(&mut runner, DebugRequest::Pause).unwrap();
+        assert!(matches!(accepted, DebugReply::Accepted { .. }));
+        let (steps, running) = runner.run_steps(10, None);
+        assert_eq!(steps, 0);
+        assert!(running);
+
+        handle_debug_request(&mut runner, DebugRequest::Resume).unwrap();
+        let (steps, _) = runner.run_steps(1, None);
+        assert!(steps >= 1);
+    }
+
+    #[test]
+    fn pause_and_resume_are_idempotent() {
+        let mut runner = runner();
+        handle_debug_request(&mut runner, DebugRequest::Resume).unwrap();
+        let first = handle_debug_request(&mut runner, DebugRequest::Pause).unwrap();
+        let second = handle_debug_request(&mut runner, DebugRequest::Pause).unwrap();
+        assert_eq!(first, second);
+        handle_debug_request(&mut runner, DebugRequest::Resume).unwrap();
+        handle_debug_request(&mut runner, DebugRequest::Resume).unwrap();
+    }
+
+    #[test]
+    fn step_requires_a_paused_runner_and_retires_one_instruction() {
+        let mut runner = runner();
+        runner.bus_mut().write_word(0x2_0000, 0x4E71); // NOP
+        runner.bus_mut().write_word(0x2_0002, 0x4E71); // NOP
+        runner.cpu_mut().write_reg(Register::PC, 0x2_0000);
+
+        let error = handle_debug_request(
+            &mut runner,
+            DebugRequest::Step {
+                context: ContextSelector::Active,
+            },
+        )
+        .unwrap_err();
+        assert!(matches!(error, DebugError::InvalidState { .. }));
+
+        handle_debug_request(&mut runner, DebugRequest::Pause).unwrap();
+        let accepted = handle_debug_request(
+            &mut runner,
+            DebugRequest::Step {
+                context: ContextSelector::Active,
+            },
+        )
+        .unwrap();
+        let DebugReply::Accepted {
+            state:
+                DebugExecutionState::Stepping {
+                    operation_id: state_operation,
+                },
+            operation_id: Some(operation_id),
+        } = accepted
+        else {
+            panic!("expected an accepted step");
+        };
+        assert_eq!(state_operation, operation_id);
+
+        // The embedding advances the normal scheduler; the runner executes
+        // exactly the one instruction the step authorized and then pauses.
+        let (steps, running) = runner.run_steps(1, None);
+        assert_eq!(steps, 1);
+        assert!(running);
+        assert_eq!(runner.cpu().core.pc, 0x2_0002);
+        assert!(runner.debug.is_paused());
+        match runner.debug.execution_state() {
+            DebugExecutionState::Paused { stop } => {
+                assert_eq!(stop.reason, super::super::model::StopReason::StepCompleted);
+                assert_eq!(stop.execution_units, Some(1));
+                assert_eq!(
+                    stop.location.map(|location| location.address.offset),
+                    Some(0x2_0002)
+                );
+            }
+            other => panic!("expected a paused step, got {other:?}"),
+        }
+        let status =
+            handle_debug_request(&mut runner, DebugRequest::GetOperation { id: operation_id })
+                .unwrap();
+        assert!(matches!(
+            status,
+            DebugReply::Operation(super::super::model::OperationStatus {
+                state: super::super::model::OperationState::Completed { .. },
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn resume_rejects_a_pending_step_and_pause_cancels_it() {
+        let mut runner = runner();
+        handle_debug_request(&mut runner, DebugRequest::Pause).unwrap();
+        let accepted = handle_debug_request(
+            &mut runner,
+            DebugRequest::Step {
+                context: ContextSelector::Active,
+            },
+        )
+        .unwrap();
+        let DebugReply::Accepted {
+            operation_id: Some(operation),
+            ..
+        } = accepted
+        else {
+            panic!("expected step operation");
+        };
+        assert!(matches!(
+            handle_debug_request(&mut runner, DebugRequest::Resume),
+            Err(DebugError::InvalidState { .. })
+        ));
+        handle_debug_request(&mut runner, DebugRequest::Pause).unwrap();
+        let status =
+            handle_debug_request(&mut runner, DebugRequest::GetOperation { id: operation })
+                .unwrap();
+        assert!(matches!(
+            status,
+            DebugReply::Operation(super::super::model::OperationStatus {
+                state: super::super::model::OperationState::Completed {
+                    result: super::super::model::OperationOutcome::Cancelled
+                },
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn step_dispatch_through_a_trap_is_one_unit() {
+        // An A-line trap counts as the step's one unit. Here the dispatch
+        // terminates the runner, so the step operation reports an unavailable
+        // outcome rather than a bogus completion, and no callback body runs.
+        let mut runner = runner();
+        runner.bus_mut().write_word(0x2_0000, 0xA9F4); // _ExitToShell
+        runner.cpu_mut().write_reg(Register::PC, 0x2_0000);
+        handle_debug_request(&mut runner, DebugRequest::Pause).unwrap();
+        let accepted = handle_debug_request(
+            &mut runner,
+            DebugRequest::Step {
+                context: ContextSelector::Active,
+            },
+        )
+        .unwrap();
+        let DebugReply::Accepted {
+            operation_id: Some(operation_id),
+            ..
+        } = accepted
+        else {
+            panic!("expected an accepted step");
+        };
+        let (steps, running) = runner.run_steps(100, None);
+        assert!(!running);
+        assert_eq!(steps, 1);
+        assert!(runner.is_halted());
+        let status =
+            handle_debug_request(&mut runner, DebugRequest::GetOperation { id: operation_id })
+                .unwrap();
+        assert!(matches!(
+            status,
+            DebugReply::Operation(super::super::model::OperationStatus {
+                state: super::super::model::OperationState::Completed {
+                    result: super::super::model::OperationOutcome::Unavailable { .. }
+                },
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn program_counter_breakpoints_stop_before_the_instruction() {
+        let mut runner = runner();
+        runner.bus_mut().write_word(0x2_0000, 0x4E71); // NOP  (skipped)
+        runner.bus_mut().write_word(0x2_0002, 0x4E71); // NOP  (target)
+        runner.bus_mut().write_word(0x2_0004, 0x4E71); // NOP
+        runner.cpu_mut().write_reg(Register::PC, 0x2_0000);
+
+        let reply = handle_debug_request(
+            &mut runner,
+            DebugRequest::SetBreakpoint {
+                spec: BreakpointSpec::program_counter(0x2_0002),
+            },
+        )
+        .unwrap();
+        let DebugReply::Breakpoint(info) = reply else {
+            panic!("expected a breakpoint");
+        };
+
+        let (steps, running) = runner.run_steps(100, None);
+        assert_eq!(steps, 1, "the NOP before the breakpoint retires");
+        assert!(running);
+        assert_eq!(runner.cpu().core.pc, 0x2_0002, "stop before executing");
+        match runner.debug.execution_state() {
+            DebugExecutionState::Paused { stop } => match &stop.reason {
+                super::super::model::StopReason::PcBreakpoint { id } => assert_eq!(*id, info.id),
+                other => panic!("expected a PC breakpoint, got {other:?}"),
+            },
+            other => panic!("expected a pause, got {other:?}"),
+        }
+        let listed = handle_debug_request(&mut runner, DebugRequest::ListBreakpoints).unwrap();
+        let DebugReply::Breakpoints(breakpoints) = listed else {
+            panic!("expected breakpoints");
+        };
+        assert_eq!(breakpoints[0].hit_count, 1);
+
+        // Resume suppresses the breakpoint for exactly one unit so the
+        // guarded instruction retires and the PC advances.
+        handle_debug_request(&mut runner, DebugRequest::Resume).unwrap();
+        let (resumed_steps, _) = runner.run_steps(1, None);
+        assert_eq!(resumed_steps, 1);
+        assert_eq!(runner.cpu().core.pc, 0x2_0004);
+    }
+
+    #[test]
+    fn stepping_from_a_breakpoint_executes_the_guarded_instruction() {
+        let mut runner = runner();
+        runner.bus_mut().write_word(0x2_0000, 0x4E71); // NOP  (target)
+        runner.bus_mut().write_word(0x2_0002, 0x4E71); // NOP
+        runner.cpu_mut().write_reg(Register::PC, 0x2_0000);
+        handle_debug_request(
+            &mut runner,
+            DebugRequest::SetBreakpoint {
+                spec: BreakpointSpec::program_counter(0x2_0000),
+            },
+        )
+        .unwrap();
+
+        let (_, running) = runner.run_steps(100, None);
+        assert!(running);
+        assert_eq!(runner.cpu().core.pc, 0x2_0000);
+        assert!(runner.debug.is_paused());
+
+        handle_debug_request(
+            &mut runner,
+            DebugRequest::Step {
+                context: ContextSelector::Active,
+            },
+        )
+        .unwrap();
+        let (steps, _) = runner.run_steps(100, None);
+        assert_eq!(steps, 1, "the guarded instruction must retire exactly once");
+        assert_ne!(runner.cpu().core.pc, 0x2_0000);
+        assert!(runner.debug.is_paused());
+        match runner.debug.execution_state() {
+            DebugExecutionState::Paused { stop } => {
+                assert_eq!(stop.reason, super::super::model::StopReason::StepCompleted)
+            }
+            other => panic!("expected a paused step, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn breakpoint_suppression_rearms_after_a_self_looping_instruction() {
+        let mut runner = runner();
+        runner.bus_mut().write_word(0x2_0000, 0x60fe); // BRA.S $20000
+        runner.cpu_mut().write_reg(Register::PC, 0x2_0000);
+        handle_debug_request(
+            &mut runner,
+            DebugRequest::SetBreakpoint {
+                spec: BreakpointSpec::program_counter(0x2_0000),
+            },
+        )
+        .unwrap();
+
+        let (initial_steps, _) = runner.run_steps(8, None);
+        assert_eq!(initial_steps, 0);
+        handle_debug_request(&mut runner, DebugRequest::Resume).unwrap();
+        let (resumed_steps, _) = runner.run_steps(8, None);
+        assert_eq!(resumed_steps, 1);
+        assert_eq!(runner.cpu().core.pc, 0x2_0000);
+
+        let (second_stop_steps, _) = runner.run_steps(8, None);
+        assert_eq!(second_stop_steps, 0);
+        assert!(matches!(
+            runner.debug.execution_state(),
+            DebugExecutionState::Paused {
+                stop: super::super::model::StopInfo {
+                    reason: super::super::model::StopReason::PcBreakpoint { .. },
+                    ..
+                }
+            }
+        ));
+    }
+
+    #[test]
+    fn breakpoints_require_an_installed_context_with_control_support() {
+        let mut runner = runner();
+        let reply = handle_debug_request(
+            &mut runner,
+            DebugRequest::SetBreakpoint {
+                spec: BreakpointSpec::program_counter(0x2_0000),
+            },
+        )
+        .unwrap();
+        assert!(matches!(reply, DebugReply::Breakpoint(_)));
+        let mut spec = BreakpointSpec::program_counter(0x2_0000);
+        spec.context = Some(PPC_CONTEXT);
+        assert!(matches!(
+            handle_debug_request(&mut runner, DebugRequest::SetBreakpoint { spec }),
+            Err(DebugError::UnknownContext { id }) if id == PPC_CONTEXT
+        ));
+        assert_eq!(runner.debug.breakpoints().len(), 1);
+    }
+
+    #[test]
+    fn duplicate_breakpoint_targets_are_rejected() {
+        let mut runner = runner();
+        let spec = BreakpointSpec::program_counter(0x2_0000);
+        handle_debug_request(
+            &mut runner,
+            DebugRequest::SetBreakpoint { spec: spec.clone() },
+        )
+        .unwrap();
+        assert!(matches!(
+            handle_debug_request(&mut runner, DebugRequest::SetBreakpoint { spec }),
+            Err(DebugError::InvalidValue { .. })
+        ));
+    }
+
+    #[test]
+    fn cached_references_reject_replacement_sessions_and_generations() {
+        let mut first = runner();
+        let mut replacement = runner();
+        let request = DebugRequest::InSession {
+            session: first.debug.session(),
+            generation: first.debug.generation(),
+            request: Box::new(DebugRequest::ReadRegisters {
+                context: ContextSelector::explicit(M68K_CONTEXT),
+                registers: None,
+            }),
+        };
+        handle_debug_request(&mut first, request.clone()).unwrap();
+        assert!(matches!(
+            handle_debug_request(&mut replacement, request.clone()),
+            Err(DebugError::StaleReference { .. })
+        ));
+        first.debug.advance_generation();
+        assert!(matches!(
+            handle_debug_request(&mut first, request),
+            Err(DebugError::StaleReference { .. })
+        ));
+    }
+
+    #[test]
+    fn pause_blocks_direct_execution_audio_and_frame_work() {
+        let mut runner = runner();
+        runner.bus_mut().write_word(0x20000, 0x4e71);
+        runner.cpu_mut().write_reg(Register::PC, 0x20000);
+        handle_debug_request(&mut runner, DebugRequest::Pause).unwrap();
+        let tick = runner.guest_tick();
+        let memory = runner.bus().ram_slice(0, runner.bus().ram_size()).to_vec();
+        assert!(matches!(runner.step(), crate::cpu::StepResult::Blocked));
+        runner.run().unwrap();
+        assert_eq!(runner.run_pending_sound_work(100), (0, true));
+        runner.mix_audio(100);
+        runner.mix_gui_audio_slice(100);
+        runner.composite_frame();
+        assert_eq!(runner.cpu().core.pc, 0x20000);
+        assert_eq!(runner.guest_tick(), tick);
+        assert_eq!(runner.bus().ram_slice(0, runner.bus().ram_size()), memory);
+    }
+
+    #[test]
+    fn providers_are_owned_bounded_and_observational() {
+        let mut runner = runner();
+        let before = runner.event_manager_snapshot();
+        let memory = runner.bus().ram_slice(0, runner.bus().ram_size()).to_vec();
+        for provider in builtin_providers() {
+            let reply = handle_debug_request(
+                &mut runner,
+                DebugRequest::ReadProvider {
+                    id: provider.descriptor().id,
+                },
+            )
+            .unwrap();
+            serde_json::to_string(&reply).unwrap();
+        }
+        assert_eq!(runner.event_manager_snapshot(), before);
+        assert_eq!(runner.bus().ram_slice(0, runner.bus().ram_size()), memory);
+        for _ in 0..300 {
+            runner
+                .dispatcher_mut()
+                .event_queue
+                .push_back(crate::event_queue::QueuedEvent {
+                    what: 3,
+                    message: 0,
+                    when: 0,
+                    where_v: 0,
+                    where_h: 0,
+                    modifiers: 0,
+                });
+        }
+        let reply = handle_debug_request(
+            &mut runner,
+            DebugRequest::ReadProvider { id: ProviderId(3) },
+        )
+        .unwrap();
+        let DebugReply::ProviderSnapshot(super::super::provider::ProviderSnapshot::Events {
+            state,
+            truncated,
+            ..
+        }) = reply
+        else {
+            panic!("events");
+        };
+        assert!(truncated);
+        assert_eq!(state.queued_event_types.len(), 256);
+        let count = state.queue_len;
+        runner.push_key_down(1, b'b');
+        assert_eq!(state.queue_len, count);
+    }
+
+    #[test]
+    fn execution_publishes_context_and_terminal_notifications() {
+        let mut runner = runner();
+        runner.bus_mut().write_word(0x20000, 0xa9f4);
+        runner.cpu_mut().write_reg(Register::PC, 0x20000);
+        runner.run_steps(1, None);
+        assert!(runner.is_halted());
+
+        let reply =
+            handle_debug_request(&mut runner, DebugRequest::Notifications { after: 0 }).unwrap();
+        let DebugReply::Notifications(notifications) = reply else {
+            panic!("expected notifications");
+        };
+        let context_changes = notifications
+            .iter()
+            .filter(|notification| {
+                matches!(
+                    notification.payload,
+                    super::super::model::NotificationPayload::ContextChanged { .. }
+                )
+            })
+            .count();
+        let terminals = notifications
+            .iter()
+            .filter(|notification| {
+                matches!(
+                    notification.payload,
+                    super::super::model::NotificationPayload::TerminalState { halted: true }
+                )
+            })
+            .count();
+        assert_eq!(context_changes, 1);
+        assert_eq!(terminals, 1);
+    }
+
+    #[test]
+    fn terminal_runner_can_be_inspected_but_not_resumed() {
+        let mut runner = runner();
+        runner.bus_mut().write_word(0x20000, 0xa9f4);
+        runner.cpu_mut().write_reg(Register::PC, 0x20000);
+        runner.run_steps(1, None);
+        assert!(runner.is_halted());
+        handle_debug_request(&mut runner, DebugRequest::Pause).unwrap();
+        assert!(matches!(
+            handle_debug_request(&mut runner, DebugRequest::Resume),
+            Err(DebugError::InvalidState { .. })
+        ));
+        handle_debug_request(
+            &mut runner,
+            DebugRequest::ReadRegisters {
+                context: ContextSelector::Active,
+                registers: None,
+            },
+        )
+        .unwrap();
+        assert!(runner.debug.is_paused());
+    }
+
+    #[test]
+    fn pause_withholds_input_and_resume_releases_held_keys() {
+        let mut runner = runner();
+        runner.push_key_down(0, b'a');
+        handle_debug_request(&mut runner, DebugRequest::Pause).unwrap();
+        let state = runner.event_manager_snapshot();
+        runner.push_key_up(0, b'a');
+        runner.push_key_down(1, b'b');
+        runner.push_mouse_down(10, 20);
+        runner.set_mouse_position(30, 40);
+        assert_eq!(state, runner.event_manager_snapshot());
+        handle_debug_request(&mut runner, DebugRequest::Resume).unwrap();
+        assert_eq!(runner.event_manager_snapshot().key_map, [0; 16]);
+    }
+
+    #[test]
+    fn unavailable_capabilities_and_exact_wide_registers() {
+        let mut runner = runner();
+        let reply = handle_debug_request(
+            &mut runner,
+            DebugRequest::GetCapabilities {
+                target: CapabilityTarget::AddressSpace { id: M68K_SPACE },
+            },
+        )
+        .unwrap();
+        assert!(
+            matches!(reply, DebugReply::Capabilities(CapabilitySet::AddressSpace(caps)) if !caps.write)
+        );
+        assert!(matches!(
+            handle_debug_request(
+                &mut runner,
+                DebugRequest::GetCapabilities {
+                    target: CapabilityTarget::Boundary {
+                        boundary: super::super::model::CaptureBoundaryKind::BackendReadbackReady
+                    }
+                }
+            ),
+            Err(DebugError::BoundaryUnavailable { .. })
+        ));
+        let value = RegisterValue::unsigned(0xffff_ffff_ffff_fffe, 64);
+        let json = serde_json::to_string(&value).unwrap();
+        assert!(json.contains("bytes"));
+        let decoded: RegisterValue = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.as_u64(), Some(0xffff_ffff_ffff_fffe));
+    }
+
+    #[test]
+    fn unknown_space_is_rejected() {
+        let mut runner = runner();
+        let error = handle_debug_request(
+            &mut runner,
+            DebugRequest::ReadMemory {
+                space: AddressSpaceId(999),
+                address: 0,
+                length: 1,
+            },
+        )
+        .unwrap_err();
+        assert!(matches!(error, DebugError::Inaccessible { .. }));
+    }
+
+    #[test]
+    fn ppc_adapter_exposes_registers_and_reports_unsupported_inspection() {
+        let mut cpu = ppc::PpcCpu::new();
+        cpu.gpr[3] = 0x1234_5678;
+        cpu.pc = 0x0000_4000;
+        cpu.fpr[2] = 0x3FF0_0000_0000_0000;
+        let adapter = PpcAdapter::new(&cpu, PPC_CONTEXT, PPC_SPACE, "native-application");
+
+        assert_eq!(adapter.context().id, PPC_CONTEXT);
+        assert_eq!(adapter.address_spaces()[0].id, PPC_SPACE);
+        let registers = adapter.registers(PPC_CONTEXT).unwrap();
+        let r3 = registers
+            .iter()
+            .find(|snapshot| snapshot.descriptor.name == "r3")
+            .unwrap();
+        assert_eq!(r3.value.as_u64(), Some(0x1234_5678));
+        let pc = registers
+            .iter()
+            .find(|snapshot| snapshot.descriptor.name == "pc")
+            .unwrap();
+        assert_eq!(pc.value.as_u64(), Some(0x0000_4000));
+        let f2 = registers
+            .iter()
+            .find(|snapshot| snapshot.descriptor.name == "f2")
+            .unwrap();
+        assert_eq!(f2.value.as_u64(), Some(0x3FF0_0000_0000_0000));
+
+        assert!(adapter.registers(M68K_CONTEXT).is_err());
+        assert!(adapter
+            .disassemble(PPC_CONTEXT, DebugAddress::new(PPC_SPACE, 0), 1)
+            .is_err());
+        assert!(adapter.read_memory(PPC_SPACE, 0, 1).is_err());
+    }
+
+    #[test]
+    fn memory_alias_identity_and_disassembly_limits_are_explicit() {
+        let mut runner = runner();
+        runner.bus_mut().set_addressing_32_bit(false);
+        runner.bus_mut().write_word(0x20000, 0xf200);
+        let memory = read_m68k_memory(&runner, 0xff020000, 2).unwrap();
+        assert_eq!(memory.address.offset, 0xff020000);
+        assert_eq!(memory.bytes, vec![0xf2, 0x00]);
+        let lines = m68k_disassembly(&runner, 0x20000, 1).unwrap();
+        assert!(lines[0].approximate);
+        assert_eq!(
+            lines[0].text,
+            m68k::dasm::disassemble(0x20000, 0xf200, runner.cpu().core.cpu_type).0
+        );
+        assert!(m68k_disassembly(&runner, 0, MAX_DISASSEMBLY_COUNT + 1).is_err());
+        assert!(read_m68k_memory(&runner, 0, MAX_MEMORY_TRANSFER + 1).is_err());
+    }
+
+    #[test]
+    fn capabilities_report_68k_limits() {
+        let mut runner = runner();
+        let reply = handle_debug_request(
+            &mut runner,
+            DebugRequest::GetCapabilities {
+                target: CapabilityTarget::Context { id: M68K_CONTEXT },
+            },
+        )
+        .unwrap();
+        let DebugReply::Capabilities(CapabilitySet::Context(capabilities)) = reply else {
+            panic!("expected context capabilities");
+        };
+        assert!(capabilities.read_registers);
+        assert!(capabilities.pause);
+        assert!(capabilities.step);
+        assert!(!capabilities.exact_step);
+        assert!(capabilities.set_breakpoint);
+        assert!(capabilities.precise_breakpoints);
+        assert!(!capabilities.write_registers);
+    }
+
+    fn capture_request(
+        mode: super::super::request::CaptureMode,
+        boundary: Option<super::super::model::CaptureBoundaryKind>,
+    ) -> CaptureRequest {
+        CaptureRequest {
+            mode,
+            boundary,
+            providers: Vec::new(),
+            include_artifacts: true,
+        }
+    }
+
+    #[test]
+    fn graphics_provider_reports_surfaces_and_immediate_capture_is_retained() {
+        use super::super::model::{CaptureBoundaryKind, OperationOutcome, OperationState};
+        use super::super::provider::provider_ids;
+        let mut runner = runner();
+        runner.bus_mut().write_byte(0, 0xAB);
+
+        let reply = handle_debug_request(
+            &mut runner,
+            DebugRequest::ReadProvider {
+                id: ProviderId(provider_ids::GRAPHICS),
+            },
+        )
+        .unwrap();
+        let DebugReply::ProviderSnapshot(super::super::provider::ProviderSnapshot::Graphics {
+            state,
+            ..
+        }) = reply
+        else {
+            panic!("expected a graphics snapshot");
+        };
+        assert_eq!(state.surfaces.len(), 1);
+        assert_eq!(state.outputs.len(), 1);
+        assert!(state.surfaces[0].width > 0);
+        assert_eq!(state.outputs[0].surfaces, vec![state.surfaces[0].id]);
+        assert!(state.palette_argb.is_some());
+
+        let accepted = handle_debug_request(
+            &mut runner,
+            DebugRequest::RequestCapture {
+                request: capture_request(super::super::request::CaptureMode::CurrentState, None),
+            },
+        )
+        .unwrap();
+        let DebugReply::Accepted {
+            operation_id: Some(operation),
+            ..
+        } = accepted
+        else {
+            panic!("expected an accepted capture");
+        };
+        let status =
+            handle_debug_request(&mut runner, DebugRequest::GetOperation { id: operation })
+                .unwrap();
+        assert!(matches!(
+            status,
+            DebugReply::Operation(super::super::model::OperationStatus {
+                state: OperationState::Completed {
+                    result: OperationOutcome::Captured { .. }
+                },
+                ..
+            })
+        ));
+
+        let list = handle_debug_request(&mut runner, DebugRequest::ListCaptures).unwrap();
+        let DebugReply::Captures(captures) = list else {
+            panic!("expected captures");
+        };
+        assert_eq!(captures.len(), 1);
+        assert_eq!(captures[0].boundary, CaptureBoundaryKind::CommandSafePoint);
+        assert_eq!(captures[0].artifacts.len(), 1);
+        let artifact = captures[0].artifacts[0].clone();
+        assert_eq!(artifact.format.as_deref(), Some("rgba8"));
+        assert!(artifact.provenance.starts_with("guest-framebuffer:"));
+
+        let data = handle_debug_request(&mut runner, DebugRequest::GetArtifact { id: artifact.id })
+            .unwrap();
+        let DebugReply::ArtifactData { descriptor, bytes } = data else {
+            panic!("expected artifact data");
+        };
+        assert_eq!(descriptor.id, artifact.id);
+        assert_eq!(bytes.len() as u64, descriptor.byte_len);
+
+        let snapshot = handle_debug_request(
+            &mut runner,
+            DebugRequest::ReadCaptureProvider {
+                capture: captures[0].id,
+                provider: ProviderId(provider_ids::GRAPHICS),
+            },
+        )
+        .unwrap();
+        assert!(matches!(
+            snapshot,
+            DebugReply::ProviderSnapshot(super::super::provider::ProviderSnapshot::Graphics { .. })
+        ));
+    }
+
+    #[test]
+    fn capture_only_requests_artifacts_from_selected_providers() {
+        use super::super::provider::provider_ids;
+        let mut runner = runner();
+        let request = CaptureRequest {
+            mode: super::super::request::CaptureMode::CurrentState,
+            boundary: None,
+            providers: vec![ProviderId(provider_ids::EVENTS)],
+            include_artifacts: true,
+        };
+        handle_debug_request(&mut runner, DebugRequest::RequestCapture { request }).unwrap();
+        let DebugReply::Captures(captures) =
+            handle_debug_request(&mut runner, DebugRequest::ListCaptures).unwrap()
+        else {
+            panic!("expected captures");
+        };
+        assert_eq!(
+            captures[0].providers,
+            vec![ProviderId(provider_ids::EVENTS)]
+        );
+        assert!(captures[0].artifacts.is_empty());
+    }
+
+    #[test]
+    fn capture_completes_at_the_logical_frame_boundary() {
+        use super::super::model::{CaptureBoundaryKind, OperationOutcome, OperationState};
+        let mut runner = runner();
+        runner.bus_mut().write_word(0x20000, 0x4e71);
+        runner.cpu_mut().write_reg(Register::PC, 0x20000);
+
+        let accepted = handle_debug_request(
+            &mut runner,
+            DebugRequest::RequestCapture {
+                request: capture_request(
+                    super::super::request::CaptureMode::NextBoundary,
+                    Some(CaptureBoundaryKind::LogicalFrameComplete),
+                ),
+            },
+        )
+        .unwrap();
+        let DebugReply::Accepted {
+            operation_id: Some(operation),
+            ..
+        } = accepted
+        else {
+            panic!("expected an accepted capture");
+        };
+        let list = handle_debug_request(&mut runner, DebugRequest::ListCaptures).unwrap();
+        assert!(matches!(list, DebugReply::Captures(captures) if captures.is_empty()));
+        let status =
+            handle_debug_request(&mut runner, DebugRequest::GetOperation { id: operation })
+                .unwrap();
+        assert!(matches!(
+            status,
+            DebugReply::Operation(super::super::model::OperationStatus {
+                state: OperationState::Pending,
+                ..
+            })
+        ));
+
+        runner.run_steps(1, None);
+
+        let list = handle_debug_request(&mut runner, DebugRequest::ListCaptures).unwrap();
+        let DebugReply::Captures(captures) = list else {
+            panic!("expected captures");
+        };
+        assert_eq!(captures.len(), 1);
+        assert_eq!(
+            captures[0].boundary,
+            CaptureBoundaryKind::LogicalFrameComplete
+        );
+        let status =
+            handle_debug_request(&mut runner, DebugRequest::GetOperation { id: operation })
+                .unwrap();
+        assert!(matches!(
+            status,
+            DebugReply::Operation(super::super::model::OperationStatus {
+                state: OperationState::Completed {
+                    result: OperationOutcome::Captured { .. }
+                },
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn pause_at_boundary_captures_then_halts_execution() {
+        use super::super::model::{CaptureBoundaryKind, StopReason};
+        let mut runner = runner();
+        runner.bus_mut().write_word(0x20000, 0x4e71);
+        runner.bus_mut().write_word(0x20002, 0x4e71);
+        runner.cpu_mut().write_reg(Register::PC, 0x20000);
+        handle_debug_request(
+            &mut runner,
+            DebugRequest::RequestCapture {
+                request: capture_request(
+                    super::super::request::CaptureMode::PauseAtBoundary,
+                    Some(CaptureBoundaryKind::LogicalFrameComplete),
+                ),
+            },
+        )
+        .unwrap();
+
+        runner.run_steps(4, None);
+        assert!(runner.debug.is_paused());
+        let stop_id = match runner.debug.execution_state() {
+            DebugExecutionState::Paused { stop } => {
+                assert!(matches!(stop.reason, StopReason::CaptureBoundary { .. }));
+                stop.id
+            }
+            other => panic!("expected a pause, got {other:?}"),
+        };
+        let list = handle_debug_request(&mut runner, DebugRequest::ListCaptures).unwrap();
+        let DebugReply::Captures(captures) = list else {
+            panic!("expected captures");
+        };
+        assert_eq!(captures[0].stop, Some(stop_id));
+        let pc = runner.cpu().core.pc;
+        let (steps, _) = runner.run_steps(4, None);
+        assert_eq!(steps, 0);
+        assert_eq!(runner.cpu().core.pc, pc);
+    }
+
+    #[test]
+    fn captured_artifact_is_immutable_after_resume() {
+        let mut runner = runner();
+        runner.bus_mut().write_byte(0, 0x11);
+        handle_debug_request(
+            &mut runner,
+            DebugRequest::RequestCapture {
+                request: capture_request(super::super::request::CaptureMode::CurrentState, None),
+            },
+        )
+        .unwrap();
+        let list = handle_debug_request(&mut runner, DebugRequest::ListCaptures).unwrap();
+        let DebugReply::Captures(captures) = list else {
+            panic!("expected captures");
+        };
+        let artifact = captures[0].artifacts[0].id;
+        let before =
+            handle_debug_request(&mut runner, DebugRequest::GetArtifact { id: artifact }).unwrap();
+
+        runner.bus_mut().write_byte(0, 0x99);
+        let after =
+            handle_debug_request(&mut runner, DebugRequest::GetArtifact { id: artifact }).unwrap();
+        assert_eq!(before, after);
+    }
+
+    #[test]
+    fn pending_capture_can_be_cancelled() {
+        use super::super::model::{CaptureBoundaryKind, OperationOutcome, OperationState};
+        let mut runner = runner();
+        let accepted = handle_debug_request(
+            &mut runner,
+            DebugRequest::RequestCapture {
+                request: capture_request(
+                    super::super::request::CaptureMode::NextBoundary,
+                    Some(CaptureBoundaryKind::LogicalFrameComplete),
+                ),
+            },
+        )
+        .unwrap();
+        let DebugReply::Accepted {
+            operation_id: Some(operation),
+            ..
+        } = accepted
+        else {
+            panic!("expected an accepted capture");
+        };
+        handle_debug_request(&mut runner, DebugRequest::CancelCapture { operation }).unwrap();
+        let status =
+            handle_debug_request(&mut runner, DebugRequest::GetOperation { id: operation })
+                .unwrap();
+        assert!(matches!(
+            status,
+            DebugReply::Operation(super::super::model::OperationStatus {
+                state: OperationState::Completed {
+                    result: OperationOutcome::Cancelled
+                },
+                ..
+            })
+        ));
+        runner.run_steps(1, None);
+        let list = handle_debug_request(&mut runner, DebugRequest::ListCaptures).unwrap();
+        assert!(matches!(list, DebugReply::Captures(captures) if captures.is_empty()));
+    }
+
+    #[test]
+    fn boundary_capture_rejects_a_pending_step() {
+        use super::super::model::CaptureBoundaryKind;
+        let mut runner = runner();
+        handle_debug_request(&mut runner, DebugRequest::Pause).unwrap();
+        handle_debug_request(
+            &mut runner,
+            DebugRequest::Step {
+                context: ContextSelector::Active,
+            },
+        )
+        .unwrap();
+        let error = handle_debug_request(
+            &mut runner,
+            DebugRequest::RequestCapture {
+                request: capture_request(
+                    super::super::request::CaptureMode::PauseAtBoundary,
+                    Some(CaptureBoundaryKind::CommandSafePoint),
+                ),
+            },
+        )
+        .unwrap_err();
+        assert!(matches!(error, DebugError::InvalidState { .. }));
+        assert!(runner.debug.is_stepping());
+    }
+
+    #[test]
+    fn captures_survive_frontend_runner_replacement() {
+        let mut original = runner();
+        handle_debug_request(
+            &mut original,
+            DebugRequest::RequestCapture {
+                request: capture_request(super::super::request::CaptureMode::CurrentState, None),
+            },
+        )
+        .unwrap();
+        let list = handle_debug_request(&mut original, DebugRequest::ListCaptures).unwrap();
+        let DebugReply::Captures(captures) = list else {
+            panic!("expected captures");
+        };
+        let capture_id = captures[0].id;
+        let session = captures[0].session;
+
+        let store = original.debug_extract_capture_store();
+        assert!(matches!(
+            handle_debug_request(&mut original, DebugRequest::ListCaptures),
+            Ok(DebugReply::Captures(captures)) if captures.is_empty()
+        ));
+
+        let mut replacement = runner();
+        replacement.debug_adopt_capture_store(store);
+        let reply = handle_debug_request(
+            &mut replacement,
+            DebugRequest::GetCapture { id: capture_id },
+        )
+        .unwrap();
+        let DebugReply::Capture(manifest) = reply else {
+            panic!("expected a capture");
+        };
+        assert_eq!(manifest.session, session);
+        assert_eq!(manifest.id, capture_id);
+    }
+
+    #[test]
+    fn unsupported_capture_boundaries_are_rejected() {
+        use super::super::model::CaptureBoundaryKind;
+        let mut runner = runner();
+        assert!(matches!(
+            handle_debug_request(
+                &mut runner,
+                DebugRequest::RequestCapture {
+                    request: capture_request(
+                        super::super::request::CaptureMode::NextBoundary,
+                        Some(CaptureBoundaryKind::BackendReadbackReady),
+                    ),
+                }
+            ),
+            Err(DebugError::BoundaryUnavailable { .. })
+        ));
+        let supported = handle_debug_request(
+            &mut runner,
+            DebugRequest::GetCapabilities {
+                target: CapabilityTarget::Boundary {
+                    boundary: CaptureBoundaryKind::LogicalFrameComplete,
+                },
+            },
+        )
+        .unwrap();
+        let DebugReply::Capabilities(CapabilitySet::Boundary(capabilities)) = supported else {
+            panic!("expected boundary capabilities");
+        };
+        assert!(capabilities.atomic_across_providers);
+        assert!(capabilities
+            .providers
+            .contains(&ProviderId(super::super::provider::provider_ids::GRAPHICS)));
+    }
+
+    #[test]
+    fn terminal_halt_fails_a_pending_capture() {
+        use super::super::model::{CaptureBoundaryKind, OperationOutcome, OperationState};
+        let mut runner = runner();
+        runner.bus_mut().write_word(0x20000, 0xa9f4); // _ExitToShell
+        runner.cpu_mut().write_reg(Register::PC, 0x20000);
+        let accepted = handle_debug_request(
+            &mut runner,
+            DebugRequest::RequestCapture {
+                request: capture_request(
+                    super::super::request::CaptureMode::NextBoundary,
+                    Some(CaptureBoundaryKind::LogicalFrameComplete),
+                ),
+            },
+        )
+        .unwrap();
+        let DebugReply::Accepted {
+            operation_id: Some(operation),
+            ..
+        } = accepted
+        else {
+            panic!("expected an accepted capture");
+        };
+        runner.run_steps(1, None);
+        assert!(runner.is_halted());
+        let status =
+            handle_debug_request(&mut runner, DebugRequest::GetOperation { id: operation })
+                .unwrap();
+        assert!(matches!(
+            status,
+            DebugReply::Operation(super::super::model::OperationStatus {
+                state: OperationState::Completed {
+                    result: OperationOutcome::Unavailable { .. }
+                },
+                ..
+            })
+        ));
+    }

--- a/src/debug/handler_tests.rs
+++ b/src/debug/handler_tests.rs
@@ -1142,3 +1142,25 @@
             })
         ));
     }
+
+    #[test]
+    fn resolve_symbol_window_ending_at_a_return_instruction_does_not_panic() {
+        use super::super::symbols::SymbolResolution;
+        let mut runner = runner();
+        // A window of exactly one RTS ends where `resolve_containing` probes for
+        // a following symbol. The request must answer, not abort the runner.
+        runner.bus_mut().write_word(0x20000, 0x4E75); // RTS
+        let reply = handle_debug_request(
+            &mut runner,
+            DebugRequest::ResolveSymbol {
+                context: ContextSelector::Active,
+                address: DebugAddress::new(M68K_SPACE, 0x20000),
+                window: Some(2),
+            },
+        )
+        .unwrap();
+        match reply {
+            DebugReply::Symbol(SymbolResolution::Unsymbolised { next: None }) => {}
+            other => panic!("expected an unsymbolised result, got {other:?}"),
+        }
+    }

--- a/src/debug/ids.rs
+++ b/src/debug/ids.rs
@@ -1,0 +1,117 @@
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+macro_rules! debug_id {
+    ($(#[$meta:meta])* $name:ident) => {
+        $(#[$meta])*
+        #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+        #[serde(transparent)]
+        pub struct $name(pub u64);
+
+        impl $name {
+            pub const UNSPECIFIED: Self = Self(0);
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "{}#{}", stringify!($name), self.0)
+            }
+        }
+    };
+}
+
+debug_id!(SessionId);
+debug_id!(ContextId);
+debug_id!(AddressSpaceId);
+debug_id!(ProviderId);
+debug_id!(OperationId);
+debug_id!(CaptureId);
+debug_id!(BreakpointId);
+debug_id!(WatchpointId);
+debug_id!(ArtifactId);
+debug_id!(DecodeId);
+
+#[derive(Debug, Default)]
+pub(crate) struct IdAllocator {
+    next: u64,
+}
+
+impl IdAllocator {
+    pub(crate) fn new() -> Self {
+        Self { next: 1 }
+    }
+
+    pub(crate) fn alloc(&mut self) -> u64 {
+        let value = self.next;
+        self.next = self.next.saturating_add(1);
+        value
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct TypedAllocator<Id> {
+    allocator: IdAllocator,
+    _marker: std::marker::PhantomData<Id>,
+}
+
+impl<Id: DebugId> TypedAllocator<Id> {
+    pub(crate) fn new() -> Self {
+        Self {
+            allocator: IdAllocator::new(),
+            _marker: std::marker::PhantomData,
+        }
+    }
+
+    pub(crate) fn alloc(&mut self) -> Id {
+        Id::from_raw(self.allocator.alloc())
+    }
+}
+
+pub(crate) trait DebugId: Copy {
+    fn from_raw(raw: u64) -> Self;
+}
+
+macro_rules! impl_debug_id {
+    ($($name:ident),* $(,)?) => {
+        $(
+            impl DebugId for $name {
+                fn from_raw(raw: u64) -> Self {
+                    Self(raw)
+                }
+            }
+        )*
+    };
+}
+
+impl_debug_id!(
+    SessionId,
+    ContextId,
+    AddressSpaceId,
+    ProviderId,
+    OperationId,
+    CaptureId,
+    BreakpointId,
+    WatchpointId,
+    ArtifactId,
+    DecodeId,
+);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn typed_allocators_mint_distinct_monotonic_ids() {
+        let mut contexts = TypedAllocator::<ContextId>::new();
+        assert_eq!(contexts.alloc(), ContextId(1));
+        assert_eq!(contexts.alloc(), ContextId(2));
+
+        let mut ops = TypedAllocator::<OperationId>::new();
+        assert_eq!(ops.alloc(), OperationId(1));
+    }
+
+    #[test]
+    fn display_includes_type_name() {
+        assert_eq!(ContextId(7).to_string(), "ContextId#7");
+    }
+}

--- a/src/debug/mod.rs
+++ b/src/debug/mod.rs
@@ -1,0 +1,151 @@
+//! Opt-in, runner-local inspection and execution control (`debug` feature).
+//!
+//! Call [`handle_debug_request`] between runner calls on the owning thread.
+//! Requests copy state or record intent; they never execute guest code or wait
+//! for a future boundary. Advance execution through scheduler APIs such as
+//! [`FixtureRunner::run_steps`](crate::runner::FixtureRunner::run_steps), not
+//! the low-level `step()` or `run()` paths. Pause cannot interrupt synchronous
+//! traps or host callbacks already in progress.
+//!
+//! The 68K adapter supports registers, bounded RAM reads, approximate disassembly,
+//! raw stack previews, stepping, and PC breakpoints. PowerPC currently supports
+//! register inspection. Query [`DebugRequest::GetCapabilities`] before relying
+//! on an operation. [`ArchitectureAdapter`] and [`InspectionProvider`] describe
+//! the extension contracts; providers currently cover graphics, windows, and events.
+//!
+//! # Socket usage
+//!
+//! On Unix, build with `cargo build --features debug-server` (which implies
+//! `debug`), then run:
+//!
+//! ```text
+//! systemless game.sit --headless --max-ticks 600 --debug-socket /tmp/systemless.sock
+//! ```
+//!
+//! Both headless clocks support the socket and start paused before scripted
+//! inputs; GUI runs start normally. Pauses consume no frontend ticks. Reaching
+//! the configured headless budget ends the process; a terminal guest halt keeps
+//! inspection available until Ctrl-C (or window close in the GUI).
+//!
+//! One controlling client sends newline-delimited UTF-8 JSON. Each input line
+//! is limited to 1 MiB. Envelope `id` is an echoed correlation number (default
+//! `0`), independent of debugger operation IDs. Requests are serviced between
+//! frames; notifications must be polled, not received as unsolicited messages.
+//! For example, send these lines over a Unix socket client such as `nc -U`:
+//!
+//! ```json
+//! {"id":1,"request":{"op":"session_info"}}
+//! {"id":2,"request":{"op":"read_registers","context":{"kind":"active"},"registers":null}}
+//! {"id":3,"request":{"op":"step","context":{"kind":"active"}}}
+//! ```
+//!
+//! Success envelopes contain `{"id":3,"reply":{"reply":"accepted","value":...}}`;
+//! failures contain `{"id":3,"error":{"error":"invalid_state","detail":...}}`.
+//! Use the returned `operation_id` in `{"id":4,"request":{"op":"get_operation","id":1}}`
+//! (replace `1` with the actual ID). An accepted operation may still be pending
+//! or later fail. [`DebugRequest`] documents fields, units, and control semantics.
+//!
+//! Only one client is served at a time. A second connection is refused with an
+//! `invalid_state` envelope and closed, rather than left waiting.
+//!
+//! # Reply shapes
+//!
+//! [`DebugReply`] serializes as `{"reply":"<variant>","value":<payload>}`. The
+//! payloads a client must destructure to make progress:
+//!
+//! ```json
+//! {"reply":"accepted","value":{"state":{"state":"stepping","operation_id":2},"operation_id":2}}
+//! {"reply":"operation","value":{"id":2,"state":{"state":"completed",
+//!   "result":{"outcome":"completed","stop":{"id":3,"revision":6,"context":1,
+//!     "location":{"context":1,"address":{"space":1,"offset":2163734}},
+//!     "reason":{"reason":"step_completed"},"guest_tick":1704,"execution_units":239650435}}}}}
+//! {"reply":"operation","value":{"id":15,"state":{"state":"completed",
+//!   "result":{"outcome":"captured","capture_id":2}}}}
+//! {"reply":"memory","value":{"address":{"space":1,"offset":66584576},"bytes":[255,255],"truncated":false}}
+//! {"reply":"stack","value":{"context":1,"address":{"space":1,"offset":66518950},
+//!   "bytes":[3,246,255,210],"stride":4,"truncated":false}}
+//! ```
+//!
+//! Three details that clients get wrong:
+//!
+//! - A capture ID arrives as `result.capture_id` on a `captured` outcome, not as
+//!   the operation ID. The operation ID cannot be used to fetch a capture.
+//! - A `completed` step outcome carries `result.stop`, which is the same
+//!   [`StopInfo`] that [`DebugRequest::ExecutionStatus`] would report. Read the
+//!   new location from there instead of issuing a follow-up status request.
+//! - `bytes` fields are JSON arrays of integers, not base64 strings, in every
+//!   reply that carries them.
+//!
+//! IDs and addresses are JSON numbers; byte buffers are arrays of integers,
+//! not base64. Register values wider than 32 bits use big-endian byte arrays to
+//! preserve exact bits. Context selectors use `{"kind":"active"}` or
+//! `{"kind":"id","id":1}`; addresses use `{"space":1,"offset":131072}`.
+//! Discover IDs through session/context/address-space/provider requests. Wrap
+//! live requests in [`DebugRequest::InSession`] to reject stale generations.
+//!
+//! # Captures and embedding
+//!
+//! [`CaptureRequest`] returns an operation ID even for an immediate capture.
+//! Poll until [`OperationOutcome::Captured`] supplies a capture ID, then fetch
+//! its manifest, provider snapshots, and artifact bytes. Captures own their data
+//! and survive resume; inspect manifest omissions/truncation before using them.
+//! The default store retains 16 captures; release them explicitly when finished.
+//! Pending captures fail on terminal halt or generation change. Retained captures
+//! can move to a replacement runner using `debug_extract_capture_store` and
+//! `debug_adopt_capture_store`; their manifests retain the original session.
+//!
+//! GUI and simulated-time frontends call
+//! [`FixtureRunner::finish_gui_frame`](crate::runner::FixtureRunner::finish_gui_frame)
+//! once after each outer frame's audio and compositing. Sound-only slices do not
+//! complete captures. Logical-frame completion guarantees runner finalization,
+//! not physical-display or GPU completion.
+
+pub(crate) mod adapters;
+mod capabilities;
+mod capture;
+mod coordinator;
+mod error;
+mod handler;
+mod ids;
+mod model;
+mod provider;
+mod request;
+mod symbols;
+
+pub use adapters::{
+    ActiveArchitecture, AdapterFactory, AdapterRegistration, ArchitectureAdapter, M68K_CONTEXT,
+    M68K_SPACE, PPC_COMPANION_CONTEXT, PPC_COMPANION_SPACE, PPC_CONTEXT, PPC_SPACE,
+};
+pub use capabilities::{
+    CapabilitySet, CapabilityTarget, DecoderCapabilities, ProviderCapabilities,
+};
+pub(crate) use capture::note_capture_boundary;
+pub use capture::{CaptureStore, PendingCapture, RetainedCapture};
+pub use coordinator::DebuggerCoordinator;
+pub use error::{DebugError, DebugResult};
+pub use handler::{builtin_provider_ids, handle_debug_request};
+pub use ids::{
+    AddressSpaceId, ArtifactId, BreakpointId, CaptureId, ContextId, DecodeId, OperationId,
+    ProviderId, SessionId, WatchpointId,
+};
+pub use model::{
+    AddressAccess, AddressMappingKind, AddressSpaceCapabilities, AddressSpaceDescriptor,
+    ArtifactDescriptor, ByteOrder, CaptureBoundaryCapabilities, CaptureBoundaryKind,
+    CaptureManifest, ContextCapabilities, ContextLifecycle, ContextSelector, DebugAddress,
+    DebugExecutionState, DebugNotification, DecodedArtifact, DisassemblyLine,
+    DisplayOutputDescriptor, ExecutionContextDescriptor, ExecutionLocation, GraphicsSnapshot,
+    GraphicsSurfaceDescriptor, InspectionProviderDescriptor, MemoryReadResult, NotificationPayload,
+    OperationOutcome, OperationState, OperationStatus, PixelFormat, ProviderObjectDescriptor,
+    ProviderSnapshotKind, RegisterCategory, RegisterDescriptor, RegisterFlag, RegisterRole,
+    RegisterSnapshot, RegisterValue, RegisterWidth, StackPreview, StopInfo, StopReason,
+    SurfaceKind,
+};
+pub use provider::{
+    builtin_providers, DeclaredProvider, InspectionProvider, ProviderArtifact,
+    ProviderRegistration, ProviderSnapshot,
+};
+pub use symbols::{SymbolEntry, SymbolResolution, DEFAULT_RESOLVE_WINDOW};
+pub use request::{
+    BreakpointInfo, BreakpointKind, BreakpointSpec, CaptureMode, CaptureRequest, DebugReply,
+    DebugRequest, ExecutionStatusReply, SessionInfo,
+};

--- a/src/debug/model.rs
+++ b/src/debug/model.rs
@@ -1,0 +1,579 @@
+use super::ids::{AddressSpaceId, ArtifactId, CaptureId, ContextId, OperationId, ProviderId};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ByteOrder {
+    Big,
+    Little,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AddressMappingKind {
+    Ram,
+    Rom,
+    Mmio,
+    Unmapped,
+    Unknown,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct AddressAccess {
+    pub read: bool,
+    pub write: bool,
+    pub execute: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct AddressSpaceDescriptor {
+    pub id: AddressSpaceId,
+    pub name: String,
+    pub address_bits: u16,
+    pub byte_order: ByteOrder,
+    pub mapping: AddressMappingKind,
+    pub access: AddressAccess,
+    pub supports_translation: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ContextLifecycle {
+    Active,
+    Suspended,
+    Unavailable,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ExecutionContextDescriptor {
+    pub id: ContextId,
+    pub architecture: String,
+    pub task: Option<String>,
+    pub lifecycle: ContextLifecycle,
+    pub address_spaces: Vec<AddressSpaceId>,
+    pub capabilities: ContextCapabilities,
+}
+
+/// `{"kind":"active"}` resolves at request time; `{"kind":"id","id":1}` names
+/// an installed context. IDs remain stable within a session generation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ContextSelector {
+    Active,
+    Id { id: ContextId },
+}
+
+impl ContextSelector {
+    pub fn active() -> Self {
+        Self::Active
+    }
+
+    pub fn explicit(id: ContextId) -> Self {
+        Self::Id { id }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ContextCapabilities {
+    pub pause: bool,
+    pub resume: bool,
+    pub step: bool,
+    pub exact_step: bool,
+    pub set_breakpoint: bool,
+    pub read_registers: bool,
+    pub disassembly: bool,
+    pub exact_disassembly: bool,
+    pub stack_preview: bool,
+    pub write_registers: bool,
+    pub read_memory: bool,
+    pub write_memory: bool,
+    pub precise_breakpoints: bool,
+    pub watchpoints: bool,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct AddressSpaceCapabilities {
+    pub read: bool,
+    pub write: bool,
+    pub observational_reads: bool,
+    pub code_cache_invalidation: bool,
+    pub max_transfer_bytes: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "reason", rename_all = "snake_case")]
+pub enum StopReason {
+    UserPause,
+    StepCompleted,
+    PcBreakpoint { id: super::ids::BreakpointId },
+    CaptureBoundary { id: CaptureId },
+    UnsupportedTransition,
+    Watchpoint { id: super::ids::WatchpointId },
+    TerminalHalt,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct StopInfo {
+    pub id: u64,
+    pub revision: u64,
+    pub context: Option<ContextId>,
+    pub location: Option<ExecutionLocation>,
+    pub reason: StopReason,
+    pub guest_tick: Option<u32>,
+    pub execution_units: Option<u64>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum DebugExecutionState {
+    Running,
+    Paused { stop: StopInfo },
+    Stepping { operation_id: OperationId },
+}
+
+impl DebugExecutionState {
+    pub fn is_paused(&self) -> bool {
+        matches!(self, DebugExecutionState::Paused { .. })
+    }
+
+    pub fn is_running(&self) -> bool {
+        matches!(self, DebugExecutionState::Running)
+    }
+
+    pub fn is_stepping(&self) -> bool {
+        matches!(self, DebugExecutionState::Stepping { .. })
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct DebugAddress {
+    /// Address-space ID discovered through `ListAddressSpaces`.
+    pub space: AddressSpaceId,
+    /// Byte offset, serialized as a JSON number (not a hexadecimal string).
+    pub offset: u64,
+}
+
+impl DebugAddress {
+    pub fn new(space: AddressSpaceId, offset: u64) -> Self {
+        Self { space, offset }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct ExecutionLocation {
+    pub context: ContextId,
+    pub address: DebugAddress,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RegisterWidth {
+    Bits8,
+    Bits16,
+    Bits32,
+    Bits64,
+    Bits128,
+    Other(u16),
+}
+
+impl RegisterWidth {
+    pub fn bits(self) -> u16 {
+        match self {
+            RegisterWidth::Bits8 => 8,
+            RegisterWidth::Bits16 => 16,
+            RegisterWidth::Bits32 => 32,
+            RegisterWidth::Bits64 => 64,
+            RegisterWidth::Bits128 => 128,
+            RegisterWidth::Other(bits) => bits,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RegisterCategory {
+    General,
+    Address,
+    ProgramCounter,
+    StackPointer,
+    Status,
+    FloatingPoint,
+    Vector,
+    Control,
+    Other,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RegisterRole {
+    ProgramCounter,
+    StackPointer,
+    FramePointer,
+    LinkRegister,
+    ConditionCodes,
+    Other,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct RegisterDescriptor {
+    pub id: u32,
+    pub name: String,
+    pub width: RegisterWidth,
+    pub category: RegisterCategory,
+    pub role: Option<RegisterRole>,
+    pub readable: bool,
+    pub writable: bool,
+    pub flags: Vec<RegisterFlag>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct RegisterFlag {
+    pub bit: u16,
+    pub name: String,
+    pub description: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "encoding", rename_all = "snake_case")]
+pub enum RegisterValue {
+    Unsigned { value: u64, width_bits: u16 },
+    // Big-endian register bytes.
+    Bytes { bytes: Vec<u8>, width_bits: u16 },
+}
+
+impl RegisterValue {
+    pub fn unsigned(value: u64, width_bits: u16) -> Self {
+        if width_bits > 32 {
+            Self::Bytes {
+                bytes: value.to_be_bytes().to_vec(),
+                width_bits,
+            }
+        } else {
+            Self::Unsigned { value, width_bits }
+        }
+    }
+
+    pub fn bytes(bytes: Vec<u8>, width_bits: u16) -> Self {
+        Self::Bytes { bytes, width_bits }
+    }
+
+    pub fn as_u64(&self) -> Option<u64> {
+        match self {
+            RegisterValue::Unsigned { value, .. } => Some(*value),
+            RegisterValue::Bytes { bytes, width_bits } if *width_bits <= 64 && bytes.len() <= 8 => {
+                Some(
+                    bytes
+                        .iter()
+                        .fold(0, |value, byte| (value << 8) | u64::from(*byte)),
+                )
+            }
+            RegisterValue::Bytes { .. } => None,
+        }
+    }
+
+    pub fn width_bits(&self) -> u16 {
+        match self {
+            RegisterValue::Unsigned { width_bits, .. }
+            | RegisterValue::Bytes { width_bits, .. } => *width_bits,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct RegisterSnapshot {
+    pub descriptor: RegisterDescriptor,
+    pub value: RegisterValue,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct DisassemblyLine {
+    pub address: DebugAddress,
+    pub text: String,
+    pub size: u8,
+    pub approximate: bool,
+    pub bytes: Vec<u8>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct StackPreview {
+    pub context: ContextId,
+    /// Lowest address covered by `bytes`, in the context's stack space.
+    pub address: DebugAddress,
+    pub bytes: Vec<u8>,
+    pub stride: u8,
+    pub truncated: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct MemoryReadResult {
+    pub address: DebugAddress,
+    pub bytes: Vec<u8>,
+    pub truncated: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SurfaceKind {
+    GuestFramebuffer,
+    HostPresentationMirror,
+    Texture,
+    BackingBuffer,
+    Other,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PixelFormat {
+    Mono1,
+    Indexed2,
+    Indexed4,
+    Indexed8,
+    Rgb555,
+    Xrgb1555,
+    Rgb888,
+    Xrgb8888,
+    Argb8888,
+    Unknown,
+}
+
+impl PixelFormat {
+    pub fn bits(self) -> Option<u16> {
+        match self {
+            PixelFormat::Mono1 => Some(1),
+            PixelFormat::Indexed2 => Some(2),
+            PixelFormat::Indexed4 => Some(4),
+            PixelFormat::Indexed8 => Some(8),
+            PixelFormat::Rgb555 | PixelFormat::Xrgb1555 => Some(16),
+            PixelFormat::Rgb888 => Some(24),
+            PixelFormat::Xrgb8888 | PixelFormat::Argb8888 => Some(32),
+            PixelFormat::Unknown => None,
+        }
+    }
+
+    pub fn is_indexed(self) -> bool {
+        matches!(
+            self,
+            PixelFormat::Mono1
+                | PixelFormat::Indexed2
+                | PixelFormat::Indexed4
+                | PixelFormat::Indexed8
+        )
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct DisplayOutputDescriptor {
+    pub id: u64,
+    pub name: String,
+    pub width: u32,
+    pub height: u32,
+    pub depth: u16,
+    pub surfaces: Vec<u64>,
+    pub palette_entries: u32,
+    pub source: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct GraphicsSurfaceDescriptor {
+    pub id: u64,
+    pub name: String,
+    pub kind: SurfaceKind,
+    pub width: u32,
+    pub height: u32,
+    pub stride_bytes: u32,
+    pub pixel_format: PixelFormat,
+    pub byte_order: ByteOrder,
+    pub base: Option<DebugAddress>,
+    pub scale: u32,
+    pub has_palette: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct GraphicsSnapshot {
+    pub schema_version: u32,
+    pub outputs: Vec<DisplayOutputDescriptor>,
+    pub surfaces: Vec<GraphicsSurfaceDescriptor>,
+    pub palette_argb: Option<Vec<u32>>,
+    pub truncated: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ProviderObjectDescriptor {
+    pub id: u64,
+    pub kind: String,
+    pub label: String,
+    pub related: Vec<u64>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProviderSnapshotKind {
+    State,
+    Collection,
+    Timeline,
+    Image,
+    Buffer,
+    Record,
+    Diagnostic,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct InspectionProviderDescriptor {
+    pub id: ProviderId,
+    pub name: String,
+    pub schema_version: u32,
+    pub observational: bool,
+    pub snapshots: Vec<ProviderSnapshotKind>,
+    pub collection_limit: usize,
+    pub required_boundary: Option<CaptureBoundaryKind>,
+    pub limitations: Vec<String>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CaptureBoundaryKind {
+    /// Between runner calls; no presentation synchronization is implied.
+    CommandSafePoint,
+    /// After outer-frame chrome redraw and guest audio finalization.
+    LogicalFrameComplete,
+    /// Reserved; currently returns `BoundaryUnavailable` when requested.
+    GuestPresentationRequest,
+    /// Reserved; currently returns `BoundaryUnavailable` when requested.
+    BackendReadbackReady,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct CaptureBoundaryCapabilities {
+    pub kind: CaptureBoundaryKind,
+    pub providers: Vec<ProviderId>,
+    pub atomic_across_providers: bool,
+    pub limitations: Vec<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ArtifactDescriptor {
+    pub id: ArtifactId,
+    pub provider: Option<ProviderId>,
+    pub format: Option<String>,
+    pub byte_len: u64,
+    pub provenance: String,
+    pub related: Vec<u64>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct DecodedArtifact {
+    pub artifact: ArtifactId,
+    pub format: Option<String>,
+    pub metadata: Vec<(String, String)>,
+    pub warnings: Vec<String>,
+    pub preview_dimensions: Option<(u32, u32)>,
+    pub preview_rgba8: Option<Vec<u8>>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct CaptureManifest {
+    pub id: CaptureId,
+    pub session: super::ids::SessionId,
+    pub boundary: CaptureBoundaryKind,
+    pub providers: Vec<ProviderId>,
+    pub revision: u64,
+    pub stop: Option<u64>,
+    pub guest_tick: Option<u32>,
+    pub execution_units: Option<u64>,
+    pub artifacts: Vec<ArtifactDescriptor>,
+    pub omitted: Vec<String>,
+    pub truncated: bool,
+    pub atomic: bool,
+    pub synchronization: Vec<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct DebugNotification {
+    pub sequence: u64,
+    pub payload: NotificationPayload,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum NotificationPayload {
+    ExecutionStateChanged {
+        state: DebugExecutionState,
+    },
+    OperationCompleted {
+        operation_id: OperationId,
+        result: Box<OperationOutcome>,
+    },
+    CaptureAvailable {
+        id: CaptureId,
+    },
+    ContextChanged {
+        active: Option<ContextId>,
+    },
+    Invalidated {
+        session: super::ids::SessionId,
+    },
+    TerminalState {
+        halted: bool,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "outcome", rename_all = "snake_case")]
+pub enum OperationOutcome {
+    /// `stop` carries the stop this operation produced, so a stepping client
+    /// does not need a follow-up `ExecutionStatus` to learn the new location.
+    /// It is null for operations that complete without stopping execution.
+    Completed { stop: Option<StopInfo> },
+    Captured { capture_id: CaptureId },
+    Failed { message: String },
+    Cancelled,
+    Unavailable { reason: String },
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct OperationStatus {
+    pub id: OperationId,
+    pub state: OperationState,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum OperationState {
+    Pending,
+    Completed { result: OperationOutcome },
+    Expired,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn register_value_preserves_exact_bits() {
+        let value = RegisterValue::unsigned(u64::MAX, 64);
+        assert_eq!(value.as_u64(), Some(u64::MAX));
+
+        let wide = RegisterValue::bytes(vec![0xAB; 16], 128);
+        assert_eq!(wide.width_bits(), 128);
+        assert_eq!(wide.as_u64(), None);
+    }
+
+    #[test]
+    fn execution_state_classification() {
+        let stop = StopInfo {
+            id: 1,
+            revision: 0,
+            context: None,
+            location: None,
+            reason: StopReason::UserPause,
+            guest_tick: None,
+            execution_units: None,
+        };
+        assert!(DebugExecutionState::Paused { stop }.is_paused());
+        assert!(DebugExecutionState::Running.is_running());
+        assert!(DebugExecutionState::Stepping {
+            operation_id: OperationId(1)
+        }
+        .is_stepping());
+    }
+}

--- a/src/debug/provider.rs
+++ b/src/debug/provider.rs
@@ -1,0 +1,491 @@
+use super::capabilities::ProviderCapabilities;
+use super::error::{DebugError, DebugResult};
+use super::ids::ProviderId;
+use super::model::{
+    ByteOrder, DisplayOutputDescriptor, GraphicsSnapshot, GraphicsSurfaceDescriptor,
+    InspectionProviderDescriptor, PixelFormat, ProviderSnapshotKind, SurfaceKind,
+};
+use crate::runner::FixtureRunner;
+use std::sync::{Arc, OnceLock};
+
+#[derive(Clone, Debug)]
+pub struct ProviderArtifact {
+    pub format: Option<String>,
+    pub bytes: Vec<u8>,
+    pub provenance: String,
+    pub related: Vec<u64>,
+}
+
+/// Bounded, observational subsystem inspection, registered through
+/// [`FixtureRunner::debug_register_provider`]. Borrow live state only for the
+/// call and return owned snapshots/artifacts; providers may own configuration.
+///
+/// Descriptor and capability metadata must agree. Declare and obey collection
+/// and artifact limits. The descriptor's required boundary applies to both live
+/// reads (command safe point) and captures. Use [`ProviderSnapshot::Custom`] with
+/// a schema version for additional subsystems; capture handling is shared.
+pub trait InspectionProvider: std::fmt::Debug + Send + Sync {
+    fn descriptor(&self) -> InspectionProviderDescriptor;
+    fn capabilities(&self) -> ProviderCapabilities;
+    fn snapshot(&self, runner: &FixtureRunner) -> DebugResult<ProviderSnapshot>;
+    fn artifacts(&self, _runner: &FixtureRunner) -> DebugResult<Vec<ProviderArtifact>> {
+        Ok(Vec::new())
+    }
+}
+
+impl dyn InspectionProvider + '_ {
+    pub(crate) fn validate_boundary(
+        &self,
+        boundary: super::model::CaptureBoundaryKind,
+    ) -> DebugResult<()> {
+        let descriptor = self.descriptor();
+        if let Some(required) = descriptor.required_boundary {
+            if required != boundary {
+                return Err(DebugError::BoundaryUnavailable {
+                    detail: format!("provider {} requires boundary {required:?}", descriptor.id),
+                });
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn snapshot_at(
+        &self,
+        runner: &FixtureRunner,
+        boundary: super::model::CaptureBoundaryKind,
+    ) -> DebugResult<ProviderSnapshot> {
+        self.validate_boundary(boundary)?;
+        self.snapshot(runner)
+    }
+
+    pub(crate) fn artifacts_at(
+        &self,
+        runner: &FixtureRunner,
+        boundary: super::model::CaptureBoundaryKind,
+    ) -> DebugResult<Vec<ProviderArtifact>> {
+        self.validate_boundary(boundary)?;
+        self.artifacts(runner)
+    }
+}
+
+pub type ProviderRegistration = Arc<dyn InspectionProvider>;
+
+pub type SnapshotFn = fn(&FixtureRunner) -> DebugResult<ProviderSnapshot>;
+pub type ArtifactFn = fn(&FixtureRunner) -> DebugResult<Vec<ProviderArtifact>>;
+
+#[derive(Clone, Debug)]
+pub struct DeclaredProvider {
+    descriptor: InspectionProviderDescriptor,
+    capabilities: ProviderCapabilities,
+    snapshot: Option<SnapshotFn>,
+    artifacts: Option<ArtifactFn>,
+}
+
+impl DeclaredProvider {
+    pub fn new(
+        descriptor: InspectionProviderDescriptor,
+        capabilities: ProviderCapabilities,
+    ) -> Self {
+        Self {
+            descriptor,
+            capabilities,
+            snapshot: None,
+            artifacts: None,
+        }
+    }
+
+    pub fn with_snapshot(mut self, snapshot: SnapshotFn) -> Self {
+        self.snapshot = Some(snapshot);
+        self
+    }
+
+    pub fn with_artifacts(mut self, artifacts: ArtifactFn) -> Self {
+        self.artifacts = Some(artifacts);
+        self
+    }
+}
+
+impl InspectionProvider for DeclaredProvider {
+    fn descriptor(&self) -> InspectionProviderDescriptor {
+        self.descriptor.clone()
+    }
+
+    fn capabilities(&self) -> ProviderCapabilities {
+        self.capabilities.clone()
+    }
+
+    fn snapshot(&self, runner: &FixtureRunner) -> DebugResult<ProviderSnapshot> {
+        match self.snapshot {
+            Some(snapshot) => snapshot(runner),
+            None => Err(DebugError::unsupported("provider snapshot")),
+        }
+    }
+
+    fn artifacts(&self, runner: &FixtureRunner) -> DebugResult<Vec<ProviderArtifact>> {
+        match self.artifacts {
+            Some(artifacts) => artifacts(runner),
+            None => Ok(Vec::new()),
+        }
+    }
+}
+
+pub(crate) fn validate_provider_contract(provider: &dyn InspectionProvider) -> DebugResult<()> {
+    let descriptor = provider.descriptor();
+    let capabilities = provider.capabilities();
+    if descriptor.observational != capabilities.observational
+        || descriptor.snapshots != capabilities.snapshots
+        || descriptor.collection_limit != capabilities.collection_limit
+        || descriptor.limitations != capabilities.limitations
+    {
+        return Err(DebugError::InvalidValue {
+            detail: format!(
+                "provider {} descriptor and capabilities metadata disagree",
+                descriptor.id
+            ),
+        });
+    }
+    Ok(())
+}
+
+fn provider(
+    id: u64,
+    name: &str,
+    schema_version: u32,
+    snapshots: Vec<ProviderSnapshotKind>,
+    limitations: &[&str],
+    snapshot: SnapshotFn,
+) -> DeclaredProvider {
+    let mut capabilities = ProviderCapabilities {
+        observational: true,
+        snapshots: snapshots.clone(),
+        ..ProviderCapabilities::default()
+    };
+    capabilities.limitations = limitations.iter().map(|line| line.to_string()).collect();
+    DeclaredProvider::new(
+        InspectionProviderDescriptor {
+            id: ProviderId(id),
+            name: name.to_string(),
+            schema_version,
+            observational: true,
+            snapshots,
+            collection_limit: capabilities.collection_limit,
+            required_boundary: None,
+            limitations: capabilities.limitations.clone(),
+        },
+        capabilities,
+    )
+    .with_snapshot(snapshot)
+}
+
+pub mod provider_ids {
+    pub const GRAPHICS: u64 = 1;
+    pub const WINDOWS: u64 = 2;
+    pub const EVENTS: u64 = 3;
+    pub const SYMBOLS: u64 = 4;
+}
+
+/// Entry cap a provider inherits unless it declares its own. Providers whose
+/// natural collections are larger raise it; the byte budget below is what keeps
+/// a snapshot from growing without bound.
+pub const DEFAULT_COLLECTION_LIMIT: usize = 256;
+/// Default snapshot byte budget. A provider truncates when either this or its
+/// collection limit is reached, whichever comes first.
+pub const DEFAULT_SNAPSHOT_BYTES: u64 = 4 * 1024 * 1024;
+/// A symbol table is naturally thousands of entries; capping it at the default
+/// 256 would discard most of a real one, so it gets its own entry limit and
+/// relies on the byte budget for memory safety.
+pub const SYMBOL_COLLECTION_LIMIT: usize = 16 * 1024;
+pub const MAX_FRAME_ARTIFACT_BYTES: u64 = 32 * 1024 * 1024;
+
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "provider", rename_all = "snake_case")]
+pub enum ProviderSnapshot {
+    Graphics {
+        schema_version: u32,
+        state: GraphicsSnapshot,
+        truncated: bool,
+    },
+    Events {
+        schema_version: u32,
+        state: crate::event_queue::EventManagerSnapshot,
+        truncated: bool,
+    },
+    Windows {
+        schema_version: u32,
+        windows: Vec<crate::runner::WindowSnapshot>,
+        truncated: bool,
+    },
+    Symbols {
+        schema_version: u32,
+        symbols: Vec<super::symbols::SymbolEntry>,
+        truncated: bool,
+    },
+    Custom {
+        id: ProviderId,
+        schema_version: u32,
+        state: serde_json::Value,
+        truncated: bool,
+    },
+}
+
+impl ProviderSnapshot {
+    pub fn is_truncated(&self) -> bool {
+        match self {
+            Self::Graphics { truncated, .. }
+            | Self::Events { truncated, .. }
+            | Self::Windows { truncated, .. }
+            | Self::Symbols { truncated, .. }
+            | Self::Custom { truncated, .. } => *truncated,
+        }
+    }
+}
+
+static BUILTIN_PROVIDERS: OnceLock<Vec<ProviderRegistration>> = OnceLock::new();
+
+pub fn builtin_providers() -> &'static [ProviderRegistration] {
+    BUILTIN_PROVIDERS.get_or_init(|| {
+        let mut providers = vec![
+            provider(provider_ids::GRAPHICS, "graphics", 1,
+                vec![ProviderSnapshotKind::State, ProviderSnapshotKind::Image, ProviderSnapshotKind::Buffer],
+                &["one guest-visible framebuffer and its host mirror; no GPU command or texture list; no physical-display completion guarantee; frame previews support 1/2/4/8/16 bpp"],
+                snapshot_graphics).with_artifacts(artifacts_graphics),
+            provider(provider_ids::WINDOWS, "windows", 1, vec![ProviderSnapshotKind::Collection],
+                &["classic Window Manager records only; region bounding boxes, not full regions"],
+                snapshot_windows),
+            provider(provider_ids::EVENTS, "events", 1, vec![ProviderSnapshotKind::State],
+                &["queue types limited to 256 entries; no queue consumption"],
+                snapshot_events),
+            provider(provider_ids::SYMBOLS, "symbols", 1, vec![ProviderSnapshotKind::Collection],
+                &["MacsBug procedure names are optional compiler output; a binary built or stripped without them yields none",
+                  "68K only; PowerPC code uses an unrelated convention",
+                  "recovered by pattern match, so names may be missed or misidentified",
+                  "a symbol trails the routine it names; it is not that routine's entry point",
+                  "the same routine is often resident twice (a loaded CODE segment and the cached resource copy), so names repeat and only one copy executes",
+                  "scans a bounded low range of guest RAM, not a discovered code segment list"],
+                snapshot_symbols),
+        ];
+        for provider in &mut providers {
+            provider.descriptor.collection_limit = DEFAULT_COLLECTION_LIMIT;
+            provider.capabilities.collection_limit = DEFAULT_COLLECTION_LIMIT;
+        }
+        if let Some(graphics) = providers.iter_mut().find(|provider| {
+            provider.descriptor.id == super::ids::ProviderId(provider_ids::GRAPHICS)
+        }) {
+            graphics.capabilities.max_artifact_bytes = MAX_FRAME_ARTIFACT_BYTES;
+        }
+        if let Some(symbols) = providers.iter_mut().find(|provider| {
+            provider.descriptor.id == super::ids::ProviderId(provider_ids::SYMBOLS)
+        }) {
+            symbols.descriptor.collection_limit = SYMBOL_COLLECTION_LIMIT;
+            symbols.capabilities.collection_limit = SYMBOL_COLLECTION_LIMIT;
+        }
+        for provider in &providers {
+            validate_provider_contract(provider)
+                .expect("builtin provider metadata must be internally consistent");
+        }
+        providers
+            .into_iter()
+            .map(|provider| Arc::new(provider) as ProviderRegistration)
+            .collect()
+    })
+}
+
+fn snapshot_events(runner: &FixtureRunner) -> DebugResult<ProviderSnapshot> {
+    let state = runner.event_manager_snapshot_with_limit(DEFAULT_COLLECTION_LIMIT);
+    let truncated = state.queue_len > state.queued_event_types.len();
+    Ok(ProviderSnapshot::Events {
+        schema_version: 1,
+        state,
+        truncated,
+    })
+}
+
+fn snapshot_graphics(runner: &FixtureRunner) -> DebugResult<ProviderSnapshot> {
+    let state = graphics_snapshot(runner);
+    let truncated = state.truncated;
+    Ok(ProviderSnapshot::Graphics {
+        schema_version: 1,
+        state,
+        truncated,
+    })
+}
+
+/// Range scanned for symbols. Application code is loaded low in the 68K space;
+/// without a discovered segment list this bounded window is the honest default,
+/// and the provider's limitations say so.
+pub const SYMBOL_SCAN_START: u64 = 0;
+pub const SYMBOL_SCAN_LENGTH: u64 = 16 * 1024 * 1024;
+
+fn snapshot_symbols(runner: &FixtureRunner) -> DebugResult<ProviderSnapshot> {
+    let (symbols, truncated) = super::symbols::scan(
+        runner,
+        SYMBOL_SCAN_START,
+        SYMBOL_SCAN_LENGTH,
+        SYMBOL_COLLECTION_LIMIT,
+        DEFAULT_SNAPSHOT_BYTES,
+    )?;
+    Ok(ProviderSnapshot::Symbols {
+        schema_version: 1,
+        symbols,
+        truncated,
+    })
+}
+
+fn snapshot_windows(runner: &FixtureRunner) -> DebugResult<ProviderSnapshot> {
+    let (windows, truncated) = runner.debug_window_snapshot(DEFAULT_COLLECTION_LIMIT);
+    Ok(ProviderSnapshot::Windows {
+        schema_version: 1,
+        windows,
+        truncated,
+    })
+}
+
+fn artifacts_graphics(runner: &FixtureRunner) -> DebugResult<Vec<ProviderArtifact>> {
+    match render_frame_rgba8(runner) {
+        Ok(bytes) => {
+            let (base, _, width, height, _) = runner.debug_screen_mode();
+            Ok(vec![ProviderArtifact {
+                format: Some("rgba8".to_string()),
+                bytes,
+                provenance: format!("guest-framebuffer:{base:#010x}:{width}x{height}"),
+                related: Vec::new(),
+            }])
+        }
+        Err(omission) => Err(DebugError::InvalidValue {
+            detail: omission.note(),
+        }),
+    }
+}
+
+pub fn pixel_format_for_depth(depth: u16) -> PixelFormat {
+    match depth {
+        1 => PixelFormat::Mono1,
+        2 => PixelFormat::Indexed2,
+        4 => PixelFormat::Indexed4,
+        8 => PixelFormat::Indexed8,
+        16 => PixelFormat::Rgb555,
+        24 => PixelFormat::Rgb888,
+        32 => PixelFormat::Xrgb8888,
+        _ => PixelFormat::Unknown,
+    }
+}
+
+fn graphics_snapshot(runner: &FixtureRunner) -> GraphicsSnapshot {
+    let (base, row_bytes, width, height, depth) = runner.debug_screen_mode();
+    let indexed = matches!(depth, 1 | 2 | 4 | 8);
+    let palette_argb = indexed.then(|| runner.debug_palette_argb().to_vec());
+    let architecture = runner.debug_active_architecture();
+    let (source, kind, base) = match architecture {
+        super::adapters::ActiveArchitecture::PowerPc
+        | super::adapters::ActiveArchitecture::PowerPcCompanion => (
+            "native-host-mirror",
+            SurfaceKind::HostPresentationMirror,
+            None,
+        ),
+        super::adapters::ActiveArchitecture::M68k => (
+            "classic-video",
+            SurfaceKind::GuestFramebuffer,
+            Some(super::model::DebugAddress::new(
+                super::adapters::M68K_SPACE,
+                u64::from(base),
+            )),
+        ),
+        super::adapters::ActiveArchitecture::Blocked => ("unresolved", SurfaceKind::Other, None),
+    };
+    let surface = GraphicsSurfaceDescriptor {
+        id: 1,
+        name: "main-framebuffer".to_string(),
+        kind,
+        width: u32::from(width),
+        height: u32::from(height),
+        stride_bytes: row_bytes,
+        pixel_format: pixel_format_for_depth(depth),
+        byte_order: ByteOrder::Big,
+        base,
+        scale: 1,
+        has_palette: indexed,
+    };
+    let output = DisplayOutputDescriptor {
+        id: 1,
+        name: "main-display".to_string(),
+        width: u32::from(width),
+        height: u32::from(height),
+        depth,
+        surfaces: vec![surface.id],
+        palette_entries: if indexed { 256 } else { 0 },
+        source: source.to_string(),
+    };
+    GraphicsSnapshot {
+        schema_version: 1,
+        outputs: vec![output],
+        surfaces: vec![surface],
+        palette_argb,
+        truncated: false,
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum FrameArtifactOmission {
+    Empty,
+    UnsupportedDepth(u16),
+    TooLarge { bytes: u64, limit: u64 },
+}
+
+impl FrameArtifactOmission {
+    pub fn note(self) -> String {
+        match self {
+            FrameArtifactOmission::Empty => "display geometry is empty".to_string(),
+            FrameArtifactOmission::UnsupportedDepth(depth) => {
+                format!("no frame preview for {depth}-bit direct color")
+            }
+            FrameArtifactOmission::TooLarge { bytes, limit } => {
+                format!("frame artifact would be {bytes} bytes, above the {limit}-byte budget")
+            }
+        }
+    }
+}
+
+fn render_frame_rgba8(runner: &FixtureRunner) -> Result<Vec<u8>, FrameArtifactOmission> {
+    let (_, _, width, height, depth) = runner.debug_screen_mode();
+    if width == 0 || height == 0 {
+        return Err(FrameArtifactOmission::Empty);
+    }
+    // The software renderer implements 1/2/4/8/16 bpp. Deeper direct-color
+    // modes have no faithful preview, so no artifact is offered for them.
+    if !matches!(depth, 1 | 2 | 4 | 8 | 16) {
+        return Err(FrameArtifactOmission::UnsupportedDepth(depth));
+    }
+    let byte_len = u64::from(width) * u64::from(height) * 4;
+    if byte_len > MAX_FRAME_ARTIFACT_BYTES {
+        return Err(FrameArtifactOmission::TooLarge {
+            bytes: byte_len,
+            limit: MAX_FRAME_ARTIFACT_BYTES,
+        });
+    }
+    Ok(crate::display::render_screen_with_gamma(
+        runner.bus(),
+        runner.debug_screen_mode(),
+        runner.debug_device_clut(),
+        runner.debug_device_gamma(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builtin_providers_have_unique_ids_and_are_observational() {
+        let providers = builtin_providers();
+        let mut ids: Vec<u64> = providers
+            .iter()
+            .map(|provider| provider.descriptor().id.0)
+            .collect();
+        ids.sort_unstable();
+        ids.dedup();
+        assert_eq!(ids.len(), providers.len());
+        for provider in providers {
+            assert!(provider.descriptor().observational);
+        }
+    }
+}

--- a/src/debug/request.rs
+++ b/src/debug/request.rs
@@ -1,0 +1,390 @@
+use super::capabilities::{CapabilitySet, CapabilityTarget};
+use super::ids::{
+    AddressSpaceId, ArtifactId, BreakpointId, CaptureId, ContextId, OperationId, ProviderId,
+    SessionId,
+};
+use super::model::{
+    AddressSpaceDescriptor, ArtifactDescriptor, CaptureBoundaryKind, CaptureManifest,
+    ContextSelector, DebugAddress, DebugExecutionState, DecodedArtifact, DisassemblyLine,
+    ExecutionContextDescriptor, InspectionProviderDescriptor, MemoryReadResult, OperationStatus,
+    RegisterSnapshot, StackPreview,
+};
+use serde::{Deserialize, Serialize};
+
+/// Serialized as `{"kind":"program_counter"}`; currently the only breakpoint kind.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum BreakpointKind {
+    ProgramCounter,
+}
+
+/// A PC stop before execution. Duplicate context/address targets are rejected.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct BreakpointSpec {
+    pub kind: BreakpointKind,
+    /// Explicit executable space, or space `0` when the context has exactly one.
+    pub address: DebugAddress,
+    /// `None` resolves to the active context when installed.
+    pub context: Option<ContextId>,
+    /// Disabled breakpoints remain listed but do not stop execution.
+    pub enabled: bool,
+    /// Remove this breakpoint after its first hit.
+    pub one_shot: bool,
+}
+
+impl BreakpointSpec {
+    pub fn program_counter(address: u64) -> Self {
+        Self {
+            kind: BreakpointKind::ProgramCounter,
+            address: DebugAddress::new(AddressSpaceId::UNSPECIFIED, address),
+            context: None,
+            enabled: true,
+            one_shot: false,
+        }
+    }
+
+    pub fn program_counter_at(address: DebugAddress) -> Self {
+        Self {
+            kind: BreakpointKind::ProgramCounter,
+            address,
+            context: None,
+            enabled: true,
+            one_shot: false,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct BreakpointInfo {
+    pub id: BreakpointId,
+    pub spec: BreakpointSpec,
+    pub hit_count: u64,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CaptureMode {
+    /// Copy at the current command safe point without changing execution state.
+    CurrentState,
+    /// Resume if necessary and copy at the next selected boundary.
+    NextBoundary,
+    /// Like `NextBoundary`, but pause at the selected boundary before copying.
+    PauseAtBoundary,
+}
+
+/// Select a capture. Rust `Default` does not supply missing required JSON fields:
+/// send `mode`, `providers`, and `include_artifacts`; `boundary` may be null/omitted.
+/// Future-boundary modes reject terminal runners and pending steps.
+/// At most 64 future captures may be pending concurrently.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct CaptureRequest {
+    pub mode: CaptureMode,
+    /// Ignored for `CurrentState`; otherwise defaults to `LogicalFrameComplete`.
+    /// `CommandSafePoint` completes immediately, without resuming a paused runner.
+    pub boundary: Option<CaptureBoundaryKind>,
+    /// Empty selects graphics only. At most 64 IDs; duplicates are coalesced.
+    pub providers: Vec<ProviderId>,
+    /// Retain provider artifacts as well as snapshots; failures appear in omissions.
+    pub include_artifacts: bool,
+}
+
+impl Default for CaptureRequest {
+    fn default() -> Self {
+        Self {
+            mode: CaptureMode::CurrentState,
+            boundary: None,
+            providers: Vec::new(),
+            include_artifacts: true,
+        }
+    }
+}
+
+/// Shared in-process and socket requests, serialized with a snake-case `op` tag.
+/// Optional fields accept null/omission; other fields are required. IDs come from
+/// discovery replies, not transport envelope IDs. See the [module](crate::debug)
+/// for socket framing and a minimal client workflow.
+///
+/// Example payloads (inside the socket envelope's `request` field):
+/// ```json
+/// {"op":"in_session","session":1,"generation":1,"request":{"op":"list_contexts"}}
+/// {"op":"set_breakpoint","spec":{"kind":{"kind":"program_counter"},"address":{"space":1,"offset":131072},"context":1,"enabled":true,"one_shot":false}}
+/// {"op":"request_capture","request":{"mode":"pause_at_boundary","boundary":"logical_frame_complete","providers":[],"include_artifacts":true}}
+/// {"op":"get_capabilities","target":{"kind":"context","id":1}}
+/// ```
+/// Substitute discovered IDs and the desired address for these examples.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "op", rename_all = "snake_case")]
+pub enum DebugRequest {
+    /// Discover session/generation identity, active context, and terminal status.
+    SessionInfo,
+    /// Reject a request if either identity differs from the current runner.
+    /// Obtain both from `SessionInfo`; nesting envelopes is unsupported.
+    InSession {
+        session: SessionId,
+        generation: u64,
+        request: Box<DebugRequest>,
+    },
+    /// Live observational snapshot at the command safe point.
+    ReadProvider {
+        id: ProviderId,
+    },
+    /// Read an owned snapshot retained by a capture, even after resume.
+    ReadCaptureProvider {
+        capture: CaptureId,
+        provider: ProviderId,
+    },
+    /// Discover installed contexts and their current capabilities.
+    ListContexts,
+    /// Discover independently addressable mappings for the selected context.
+    ListAddressSpaces {
+        context: ContextSelector,
+    },
+    /// Discover provider IDs, schemas, collection limits, and boundary requirements.
+    ListProviders,
+    /// Query a context, address space, provider, boundary, or decoder target.
+    /// Targets are tagged with `kind`, like `ContextSelector`:
+    /// `{"kind":"context","id":1}`, `{"kind":"boundary","boundary":"logical_frame_complete"}`.
+    GetCapabilities {
+        target: CapabilityTarget,
+    },
+    /// Current execution state, active context, and guest counters.
+    ExecutionStatus,
+    /// Poll retained notifications with sequence strictly greater than `after`.
+    /// Start at 0 and retain the last received sequence. History is bounded to
+    /// 1024 entries; an expired cursor returns `StaleReference`.
+    Notifications {
+        after: u64,
+    },
+    /// Idempotently pause; cancel a pending step. Pending captures remain queued.
+    Pause,
+    /// Resume and release held host input. Reject terminal runners/pending steps.
+    /// A hit PC breakpoint is suppressed until one unit in its context retires.
+    Resume,
+    /// Require a paused runner and an active context with step support.
+    /// Return an operation ID; the scheduler executes one unit then pauses.
+    /// A 68K unit may dispatch a trap, so this is not exact instruction tracing.
+    /// The completed operation carries the resulting stop, so polling
+    /// `GetOperation` is sufficient to learn the new location.
+    Step {
+        context: ContextSelector,
+    },
+    ReadRegisters {
+        context: ContextSelector,
+        /// Descriptor IDs, not register names. Null/omitted selects all; an empty
+        /// array selects none. Unknown IDs are silently excluded.
+        registers: Option<Vec<u32>>,
+    },
+    /// Observational bytes from a named space; inspect the reply truncation flag.
+    /// 68K reads cover mapped RAM and are limited to 16 MiB per request.
+    ReadMemory {
+        space: AddressSpaceId,
+        /// Byte offset within `space`.
+        address: u64,
+        /// Requested byte count.
+        length: u64,
+    },
+    /// Decode from an explicit executable address space (68K output is approximate).
+    Disassemble {
+        context: ContextSelector,
+        address: DebugAddress,
+        /// Maximum instruction lines, at most 4096 for 68K.
+        count: u32,
+    },
+    /// Raw stack bytes, not an unwound call stack.
+    StackPreview {
+        context: ContextSelector,
+        /// Number of four-byte entries for 68K, at most 16384 (64 KiB).
+        words: u32,
+    },
+    ListBreakpoints,
+    SetBreakpoint {
+        spec: BreakpointSpec,
+    },
+    RemoveBreakpoint {
+        id: BreakpointId,
+    },
+    SetBreakpointEnabled {
+        id: BreakpointId,
+        enabled: bool,
+    },
+    ListCaptures,
+    /// Return `Accepted` with an operation ID; poll `GetOperation` for the capture ID.
+    RequestCapture {
+        request: CaptureRequest,
+    },
+    /// Cancel a pending capture without changing the execution state.
+    CancelCapture {
+        operation: OperationId,
+    },
+    /// Retained manifest, including artifacts, omissions, and truncation flags.
+    GetCapture {
+        id: CaptureId,
+    },
+    /// Release the manifest, snapshots, and all artifacts owned by this capture.
+    ReleaseCapture {
+        id: CaptureId,
+    },
+    /// Poll completion; the last 1024 completed operations are retained.
+    GetOperation {
+        id: OperationId,
+    },
+    /// Return owned bytes and their descriptor (up to 32 MiB); no server file I/O.
+    GetArtifact {
+        id: ArtifactId,
+    },
+    /// Reserved; currently returns `Unsupported`.
+    DecodeArtifact {
+        id: ArtifactId,
+    },
+    /// Attribute `address` to a routine using recovered MacsBug symbols.
+    /// Scans forward, because a symbol trails the routine it names. The reply
+    /// distinguishes a real attribution from an address in an unsymbolised
+    /// routine, which must not be reported under a later routine's name.
+    /// Best effort: see the `symbols` provider's declared limitations.
+    ResolveSymbol {
+        context: ContextSelector,
+        address: DebugAddress,
+        /// Bytes to scan ahead. Null selects the default window.
+        window: Option<u64>,
+    },
+    /// Every symbol exactly matching `name`, in ascending address order.
+    /// Deliberately multi-valued: guest code is routinely resident more than
+    /// once (a loaded CODE segment and the Resource Manager's cached copy of
+    /// the same resource), so a name does not identify one address. Only the
+    /// executing copy is a valid breakpoint target; an empty vector means the
+    /// name was not found.
+    LookupSymbol {
+        context: ContextSelector,
+        name: String,
+    },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct SessionInfo {
+    pub session: SessionId,
+    pub generation: u64,
+    pub active_context: Option<ContextId>,
+    pub terminal: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ExecutionStatusReply {
+    pub state: DebugExecutionState,
+    pub terminal: bool,
+    pub active_context: Option<ContextId>,
+    pub guest_tick: Option<u32>,
+    pub execution_units: Option<u64>,
+    pub revision: u64,
+}
+
+/// Replies serialize as `{"reply":"snake_case_variant","value":...}`.
+/// Socket transport wraps this inside its own `{"id":...,"reply":...}` envelope.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+// Adjacent tagging preserves sequence-valued newtype replies in JSON.
+#[serde(tag = "reply", content = "value", rename_all = "snake_case")]
+pub enum DebugReply {
+    /// Carries the IDs to echo in `InSession`. `active_context` is null before
+    /// first install; terminal runners still reply but accept no mutations.
+    SessionInfo(SessionInfo),
+    /// May be empty. Descriptor IDs are stable within a session generation.
+    Contexts(Vec<ExecutionContextDescriptor>),
+    /// Empty when the context exposes no independently addressable mappings.
+    AddressSpaces(Vec<AddressSpaceDescriptor>),
+    /// Each descriptor declares schema, collection limits, and boundary needs.
+    Providers(Vec<InspectionProviderDescriptor>),
+    /// Observational only; omissions and partial collections are inside the
+    /// snapshot, not a transport error.
+    ProviderSnapshot(super::provider::ProviderSnapshot),
+    /// Per-target capability set; queries against an unknown context error.
+    Capabilities(CapabilitySet),
+    /// `guest_tick`/`execution_units` are null when the runner has not run yet.
+    /// `revision` changes whenever state relevant to clients changes.
+    ExecutionStatus(ExecutionStatusReply),
+    /// Notifications with sequence strictly greater than the requested cursor,
+    /// ascending. May be empty; expired cursors error with `StaleReference`.
+    Notifications(Vec<super::model::DebugNotification>),
+    /// Request accepted; a non-null operation ID must be polled for its outcome.
+    Accepted {
+        state: DebugExecutionState,
+        operation_id: Option<OperationId>,
+    },
+    /// Snapshots carry their descriptor IDs. Requested but unknown IDs are
+    /// silently omitted, so compare against the request rather than expecting
+    /// an error.
+    Registers {
+        context: ContextId,
+        registers: Vec<RegisterSnapshot>,
+    },
+    /// May return fewer bytes than requested; only the `truncated` flag
+    /// distinguishes a short read from an exact fit.
+    Memory(MemoryReadResult),
+    /// May contain fewer lines than requested near unmapped or invalid code.
+    Disassembly {
+        context: ContextId,
+        lines: Vec<DisassemblyLine>,
+    },
+    /// Raw stack bytes, not an unwound call stack; interpret per context.
+    Stack(StackPreview),
+    /// Includes disabled breakpoints; order is not specified.
+    Breakpoints(Vec<BreakpointInfo>),
+    /// Echoes the stored breakpoint, including its server-assigned ID, which
+    /// may differ from identity fields in the spec when duplicates are merged.
+    Breakpoint(BreakpointInfo),
+    /// Echoes the removed ID.
+    BreakpointRemoved {
+        id: BreakpointId,
+    },
+    /// Manifests only; snapshots and artifacts are fetched per provider.
+    Captures(Vec<CaptureManifest>),
+    /// Full manifest including artifacts, omissions, and truncation flags.
+    /// Pending captures only reply here once the operation completes.
+    Capture(CaptureManifest),
+    /// Release is final; further access to the capture errors with
+    /// `CaptureExpired`.
+    CaptureReleased {
+        id: CaptureId,
+    },
+    /// Owned bytes up to 32 MiB; larger artifacts error with `TooLarge`.
+    ArtifactData {
+        descriptor: ArtifactDescriptor,
+        bytes: Vec<u8>,
+    },
+    /// Poll until terminal. `Expired` means it left the 1024-entry retention
+    /// window; `Failed`/`Unavailable` carry reasons in the state, not as
+    /// transport errors. `Completed` carries the resulting stop, if any.
+    Operation(OperationStatus),
+    /// Descriptor only; bytes come from `GetArtifactData`.
+    Artifact(ArtifactDescriptor),
+    /// Reserved; requests currently error with `Unsupported` before this reply
+    /// is ever produced.
+    Decoded(DecodedArtifact),
+    /// Carries whether the address was actually attributed to a routine; an
+    /// unattributed address is a normal outcome for code built or stripped
+    /// without symbols.
+    Symbol(super::symbols::SymbolResolution),
+    /// Every match for a looked-up name, ascending by address. May be empty,
+    /// and may legitimately hold several entries; see `LookupSymbol`.
+    Symbols(Vec<super::symbols::SymbolEntry>),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sequence_replies_serialize_through_transports() {
+        for (reply, tag) in [
+            (DebugReply::Contexts(Vec::new()), "contexts"),
+            (DebugReply::Providers(Vec::new()), "providers"),
+            (DebugReply::Captures(Vec::new()), "captures"),
+            (DebugReply::Breakpoints(Vec::new()), "breakpoints"),
+        ] {
+            let json = serde_json::to_value(&reply).expect("sequence reply serializes");
+            assert_eq!(
+                json.get("reply").and_then(|value| value.as_str()),
+                Some(tag)
+            );
+            assert!(json.get("value").is_some_and(|value| value.is_array()));
+        }
+    }
+}

--- a/src/debug/symbols.rs
+++ b/src/debug/symbols.rs
@@ -63,7 +63,10 @@ fn is_name_byte(byte: u8, first: bool) -> bool {
 /// Decode a symbol at `offset` within `data`, if one is present there.
 /// Requires a terminator instruction in the two bytes before it.
 fn symbol_at(data: &[u8], offset: usize) -> Option<String> {
-    if offset < 2 {
+    // The candidate needs the two-byte terminator before it and the length
+    // byte at `offset`; either read can fall outside the buffer, and callers
+    // legitimately probe one past the end of a truncated window.
+    if offset < 2 || offset >= data.len() {
         return None;
     }
     let previous = u16::from_be_bytes([data[offset - 2], data[offset - 1]]);
@@ -390,5 +393,43 @@ mod tests {
         let mut data = encoded(0x4E75, "GetAnEvent");
         data.truncate(data.len() - 4);
         assert_eq!(symbol_at(&data, 2), None);
+    }
+
+    #[test]
+    fn probing_one_past_the_end_of_the_buffer_is_not_a_symbol() {
+        // `resolve_containing` probes `offset + 2` after a routine end, which is
+        // exactly `data.len()` when that end sits in the final two bytes.
+        let data = 0x4E75u16.to_be_bytes();
+        assert_eq!(symbol_at(&data, data.len()), None);
+        assert_eq!(symbol_at(&data, data.len() + 1), None);
+    }
+
+    #[test]
+    fn resolve_containing_handles_a_window_ending_at_a_return_instruction() {
+        let mut runner = guest_runner();
+        runner
+            .bus_mut()
+            .write_bytes(0x20000, &0x4E75u16.to_be_bytes());
+        // The window is exactly the RTS, so the scan probes for a symbol one
+        // past the end. It must report the unnamed routine instead of panicking.
+        match resolve_containing(&runner, 0x20000, 2).unwrap() {
+            SymbolResolution::Unsymbolised { next: None } => {}
+            other => panic!("expected Unsymbolised without a next symbol, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_containing_handles_a_read_truncated_at_the_end_of_mapped_ram() {
+        let mut runner = guest_runner();
+        let ram_size = u64::from(runner.bus().ram_size());
+        // RTS as the last mapped instruction, then ask for a window that runs
+        // past the end of RAM so the read itself is truncated.
+        runner
+            .bus_mut()
+            .write_bytes(ram_size as u32 - 2, &0x4E75u16.to_be_bytes());
+        match resolve_containing(&runner, ram_size - 4, 8).unwrap() {
+            SymbolResolution::Unsymbolised { next: None } => {}
+            other => panic!("expected Unsymbolised without a next symbol, got {other:?}"),
+        }
     }
 }

--- a/src/debug/symbols.rs
+++ b/src/debug/symbols.rs
@@ -1,0 +1,394 @@
+//! Best-effort MacsBug symbol recovery for 68K guest code.
+//!
+//! Classic 68K compilers could append a procedure name after a routine's final
+//! return instruction. The names are optional debugging output, not part of the
+//! ABI: a binary built without them, or stripped of them, yields nothing here.
+//! PowerPC code uses an unrelated convention and is not covered.
+//!
+//! The symbol therefore *trails* the routine it names. To answer "which routine
+//! contains this address", scan forward to the nearest following symbol, not
+//! backward — [`resolve_containing`] does this.
+//!
+//! Recovery is a pattern match over guest memory, so it is a heuristic. A
+//! terminator instruction is required immediately before a candidate to keep
+//! ordinary string data from matching.
+
+use super::adapters::{read_m68k_memory, M68K_SPACE};
+use super::error::DebugResult;
+use super::model::DebugAddress;
+use crate::runner::FixtureRunner;
+use serde::{Deserialize, Serialize};
+
+/// Instructions a routine can end with, immediately preceding a symbol.
+/// RTS, JMP (A0), UNLK A6, and RTE respectively.
+const TERMINATORS: [u16; 4] = [0x4E75, 0x4ED0, 0x4E5E, 0x4E74];
+
+/// Instructions that actually transfer control out of a routine, used to detect
+/// that a routine ended. Deliberately excludes `UNLK A6`, which precedes the
+/// `RTS` in an ordinary epilogue rather than ending anything: treating it as a
+/// routine end would misreport every normal return.
+const ROUTINE_ENDS: [u16; 3] = [0x4E75, 0x4ED0, 0x4E74];
+
+/// Variable-length format: one byte of `0x80 | length`, then `length`
+/// characters. Shorter runs match too much ordinary data to be worth trusting.
+const MIN_NAME_LEN: usize = 3;
+const MAX_NAME_LEN: usize = 31;
+
+/// Default window for [`resolve_containing`]. Large enough to clear a big
+/// routine, small enough that a miss costs little.
+pub const DEFAULT_RESOLVE_WINDOW: u64 = 64 * 1024;
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct SymbolEntry {
+    /// Address of the symbol's length byte, which is just past the end of the
+    /// routine it names — not the routine's entry point.
+    pub address: DebugAddress,
+    pub name: String,
+}
+
+/// Approximate retained size of one entry, for the snapshot byte budget.
+fn entry_bytes(entry: &SymbolEntry) -> u64 {
+    (std::mem::size_of::<SymbolEntry>() + entry.name.len()) as u64
+}
+
+fn is_name_byte(byte: u8, first: bool) -> bool {
+    let character = byte as char;
+    if first {
+        character.is_ascii_alphabetic() || character == '_'
+    } else {
+        character.is_ascii_alphanumeric() || character == '_' || character == '.'
+    }
+}
+
+/// Decode a symbol at `offset` within `data`, if one is present there.
+/// Requires a terminator instruction in the two bytes before it.
+fn symbol_at(data: &[u8], offset: usize) -> Option<String> {
+    if offset < 2 {
+        return None;
+    }
+    let previous = u16::from_be_bytes([data[offset - 2], data[offset - 1]]);
+    if !TERMINATORS.contains(&previous) {
+        return None;
+    }
+    let length = usize::from(data[offset] & 0x1f);
+    if data[offset] & 0x80 == 0 || !(MIN_NAME_LEN..=MAX_NAME_LEN).contains(&length) {
+        return None;
+    }
+    let name = data.get(offset + 1..offset + 1 + length)?;
+    if !name
+        .iter()
+        .enumerate()
+        .all(|(index, byte)| is_name_byte(*byte, index == 0))
+    {
+        return None;
+    }
+    // Checked ASCII above, so this cannot fail.
+    Some(String::from_utf8(name.to_vec()).ok()?)
+}
+
+/// Scan `[start, start + length)` for symbols, stopping at whichever of
+/// `entry_limit` or `byte_budget` is reached first. The bool reports whether a
+/// limit cut the scan short.
+pub fn scan(
+    runner: &FixtureRunner,
+    start: u64,
+    length: u64,
+    entry_limit: usize,
+    byte_budget: u64,
+) -> DebugResult<(Vec<SymbolEntry>, bool)> {
+    let memory = read_m68k_memory(runner, start, length)?;
+    let data = &memory.bytes;
+    let mut symbols = Vec::new();
+    let mut used = 0u64;
+    let mut truncated = false;
+    for offset in 0..data.len() {
+        let Some(name) = symbol_at(data, offset) else {
+            continue;
+        };
+        let entry = SymbolEntry {
+            address: DebugAddress::new(M68K_SPACE, start + offset as u64),
+            name,
+        };
+        let cost = entry_bytes(&entry);
+        if symbols.len() >= entry_limit || used + cost > byte_budget {
+            truncated = true;
+            break;
+        }
+        used += cost;
+        symbols.push(entry);
+    }
+    // A short read means the range left mapped memory before it was exhausted.
+    Ok((symbols, truncated || memory.truncated))
+}
+
+/// Outcome of attributing an address to a routine.
+///
+/// A plain "nearest following symbol" answer is wrong whenever the address sits
+/// in a routine that carries no symbol: the scan runs past that routine's end
+/// and returns a later routine's name, with nothing to signal the error. These
+/// variants keep the two cases apart.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "outcome", rename_all = "snake_case")]
+pub enum SymbolResolution {
+    /// The address lies in the routine named by `symbol`, `distance` bytes
+    /// before its trailing name.
+    Contained { symbol: SymbolEntry, distance: u64 },
+    /// A routine ended without a trailing symbol before any symbol was reached,
+    /// so the address belongs to an unsymbolised routine. `next` is the first
+    /// symbol seen afterwards and is reported for orientation only — it names a
+    /// later routine, not this one.
+    Unsymbolised { next: Option<SymbolEntry> },
+    /// No symbol at all within the window.
+    NotFound,
+}
+
+/// Attribute `address` to the routine containing it by scanning forward for the
+/// symbol that trails it.
+///
+/// The scan stops trusting its answer once it crosses a routine end that is not
+/// followed by a symbol, because the address's own routine has then finished
+/// unnamed. Without that check an unsymbolised routine silently inherits the
+/// name of whatever routine happens to follow it.
+///
+/// TODO: fold in the jump table at `A5+CurJTOffset`, whose `JMP abs.L` entries
+/// are authoritative routine entry points rather than a heuristic, and use the
+/// loader's segment bases instead of a fixed scan range. Both need the loader to
+/// retain what it currently only traces (`trap::dispatch::record_segment_base`),
+/// which is why this is still pattern matching alone.
+pub fn resolve_containing(
+    runner: &FixtureRunner,
+    address: u64,
+    window: u64,
+) -> DebugResult<SymbolResolution> {
+    let memory = read_m68k_memory(runner, address, window)?;
+    let data = &memory.bytes;
+    let mut ended_unnamed = false;
+    for offset in 0..data.len() {
+        if let Some(name) = symbol_at(data, offset) {
+            let symbol = SymbolEntry {
+                address: DebugAddress::new(M68K_SPACE, address + offset as u64),
+                name,
+            };
+            return Ok(if ended_unnamed {
+                SymbolResolution::Unsymbolised {
+                    next: Some(symbol),
+                }
+            } else {
+                SymbolResolution::Contained {
+                    symbol,
+                    distance: offset as u64,
+                }
+            });
+        }
+        // Instructions are word-aligned on even addresses, so only consider a
+        // routine end where one could actually be encoded.
+        if (address + offset as u64) % 2 == 0 && offset + 2 <= data.len() {
+            let word = u16::from_be_bytes([data[offset], data[offset + 1]]);
+            if ROUTINE_ENDS.contains(&word) && symbol_at(data, offset + 2).is_none() {
+                ended_unnamed = true;
+            }
+        }
+    }
+    Ok(if ended_unnamed {
+        SymbolResolution::Unsymbolised { next: None }
+    } else {
+        SymbolResolution::NotFound
+    })
+}
+
+/// Every symbol named `name` within `[start, start + length)`, ascending by
+/// address. Matching is exact and case-sensitive.
+///
+/// Deliberately returns all matches rather than the first. Guest code is
+/// routinely resident twice — a loaded CODE segment and the Resource Manager's
+/// cached copy of the same resource — so a name maps to several addresses, only
+/// one of which is executing. Returning the lowest would silently hand back a
+/// non-executing copy whenever the cached one happens to load first.
+pub fn lookup(
+    runner: &FixtureRunner,
+    start: u64,
+    length: u64,
+    name: &str,
+) -> DebugResult<Vec<SymbolEntry>> {
+    let memory = read_m68k_memory(runner, start, length)?;
+    let data = &memory.bytes;
+    let mut found = Vec::new();
+    for offset in 0..data.len() {
+        if symbol_at(data, offset).as_deref() == Some(name) {
+            found.push(SymbolEntry {
+                address: DebugAddress::new(M68K_SPACE, start + offset as u64),
+                name: name.to_string(),
+            });
+        }
+    }
+    Ok(found)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::memory::bus::MemoryBus;
+    use crate::runner::FixtureRunnerConfig;
+
+    // `RTS` then a length byte of 0x80|10 then "GetAnEvent", the shape observed
+    // in a real 68K binary.
+    fn encoded(terminator: u16, name: &str) -> Vec<u8> {
+        let mut bytes = terminator.to_be_bytes().to_vec();
+        bytes.push(0x80 | name.len() as u8);
+        bytes.extend_from_slice(name.as_bytes());
+        bytes
+    }
+
+    #[test]
+    fn decodes_a_symbol_after_each_terminator() {
+        for terminator in TERMINATORS {
+            let data = encoded(terminator, "GetAnEvent");
+            assert_eq!(symbol_at(&data, 2).as_deref(), Some("GetAnEvent"));
+        }
+    }
+
+    #[test]
+    fn requires_a_terminator_before_the_name() {
+        // Identical bytes, but preceded by an ordinary instruction: no symbol.
+        let data = encoded(0x4E71, "GetAnEvent");
+        assert_eq!(symbol_at(&data, 2), None);
+    }
+
+    #[test]
+    fn rejects_names_that_are_not_identifiers() {
+        for name in ["9bad", " lead", "has-dash"] {
+            let data = encoded(0x4E75, name);
+            assert_eq!(symbol_at(&data, 2), None, "should reject {name:?}");
+        }
+    }
+
+    #[test]
+    fn rejects_lengths_outside_the_accepted_range() {
+        let short = encoded(0x4E75, "ab");
+        assert_eq!(symbol_at(&short, 2), None);
+        // High bit clear is not a length byte at all.
+        let mut plain = encoded(0x4E75, "Routine");
+        plain[2] &= 0x7f;
+        assert_eq!(symbol_at(&plain, 2), None);
+    }
+
+    fn guest_runner() -> FixtureRunner {
+        FixtureRunner::new(0x100000, FixtureRunnerConfig::default())
+    }
+
+    /// RTS, the name, then padding so the next candidate cannot join them.
+    fn routine(name: &str) -> Vec<u8> {
+        let mut bytes = encoded(0x4E75, name);
+        bytes.extend_from_slice(&[0x4E, 0x71]); // NOP padding
+        bytes
+    }
+
+    #[test]
+    fn scan_reports_truncation_when_the_entry_limit_is_reached() {
+        let mut runner = guest_runner();
+        let mut data = Vec::new();
+        data.extend_from_slice(&routine("Alpha"));
+        data.extend_from_slice(&routine("Beta"));
+        data.extend_from_slice(&routine("Gamma"));
+        runner.bus_mut().write_bytes(0, &data);
+        let (symbols, truncated) =
+            scan(&runner, 0, data.len() as u64, 2, u64::MAX).unwrap();
+        assert_eq!(symbols.len(), 2);
+        assert_eq!(symbols[0].name, "Alpha");
+        assert_eq!(symbols[1].name, "Beta");
+        assert!(truncated);
+    }
+
+    #[test]
+    fn scan_reports_truncation_when_the_byte_budget_is_reached() {
+        let mut runner = guest_runner();
+        let data = routine("Alpha");
+        runner.bus_mut().write_bytes(0, &data);
+        // Budget too small for even one entry.
+        let (symbols, truncated) = scan(&runner, 0, data.len() as u64, 8, 4).unwrap();
+        assert!(symbols.is_empty());
+        assert!(truncated);
+    }
+
+    #[test]
+    fn scan_is_not_truncated_when_limits_are_not_reached() {
+        let mut runner = guest_runner();
+        let data = routine("Alpha");
+        runner.bus_mut().write_bytes(0, &data);
+        let (symbols, truncated) = scan(&runner, 0, data.len() as u64, 8, u64::MAX).unwrap();
+        assert_eq!(symbols.len(), 1);
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn resolve_containing_attributes_the_address_to_the_following_symbol() {
+        let mut runner = guest_runner();
+        let data = routine("GetAnEvent");
+        runner.bus_mut().write_bytes(0, &data);
+        match resolve_containing(&runner, 0, 4096).unwrap() {
+            SymbolResolution::Contained { symbol, distance } => {
+                assert_eq!(symbol.name, "GetAnEvent");
+                assert_eq!(symbol.address.offset, 2); // just past the RTS
+                assert_eq!(distance, 2);
+            }
+            other => panic!("expected Contained, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_containing_reports_an_unsymbolised_routine_rather_than_inheriting_a_name() {
+        let mut runner = guest_runner();
+        let mut data = Vec::new();
+        // First routine ends without a trailing symbol; the next one is named.
+        data.extend_from_slice(&[0x4E, 0x75]); // RTS, routine end, no symbol
+        data.extend_from_slice(&[0x4E, 0x71]); // NOP filler
+        data.extend_from_slice(&encoded(0x4E75, "Named"));
+        runner.bus_mut().write_bytes(0, &data);
+        match resolve_containing(&runner, 0, 4096).unwrap() {
+            SymbolResolution::Unsymbolised { next } => {
+                assert_eq!(next.expect("a later symbol was present").name, "Named");
+            }
+            other => panic!("expected Unsymbolised, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_containing_reports_not_found_when_the_window_has_no_symbols() {
+        let mut runner = guest_runner();
+        // Only filler that is neither a routine end nor a symbol.
+        let data = [0x4Eu8, 0x71, 0x4E, 0x71];
+        runner.bus_mut().write_bytes(0, &data);
+        assert_eq!(resolve_containing(&runner, 0, 4096).unwrap(),
+            SymbolResolution::NotFound);
+    }
+
+    #[test]
+    fn lookup_returns_every_copy_of_a_name_in_ascending_order() {
+        let mut runner = guest_runner();
+        let mut data = Vec::new();
+        data.extend_from_slice(&routine("GetAnEvent"));
+        data.extend_from_slice(&routine("Other"));
+        data.extend_from_slice(&routine("GetAnEvent"));
+        runner.bus_mut().write_bytes(0, &data);
+        let found = lookup(&runner, 0, data.len() as u64, "GetAnEvent").unwrap();
+        assert_eq!(found.len(), 2);
+        assert!(found[0].address.offset < found[1].address.offset);
+        assert!(lookup(&runner, 0, data.len() as u64, "Missing").unwrap().is_empty());
+    }
+
+    #[test]
+    fn an_ordinary_epilogue_is_not_treated_as_an_unnamed_routine_end() {
+        // UNLK A6 immediately precedes RTS in a normal return. It is accepted
+        // before a symbol, but must not count as a routine ending unnamed, or
+        // every symbolised routine would be reported as unsymbolised.
+        assert!(!ROUTINE_ENDS.contains(&0x4E5E));
+        assert!(TERMINATORS.contains(&0x4E5E));
+    }
+
+    #[test]
+    fn truncated_name_at_the_end_of_the_buffer_is_not_a_symbol() {
+        let mut data = encoded(0x4E75, "GetAnEvent");
+        data.truncate(data.len() - 4);
+        assert_eq!(symbol_at(&data, 2), None);
+    }
+}

--- a/src/debug/symbols.rs
+++ b/src/debug/symbols.rs
@@ -34,7 +34,7 @@ const ROUTINE_ENDS: [u16; 3] = [0x4E75, 0x4ED0, 0x4E74];
 const MIN_NAME_LEN: usize = 3;
 const MAX_NAME_LEN: usize = 31;
 
-/// Default window for [`resolve_containing`]. Large enough to clear a big
+/// Default window for `resolve_containing`. Large enough to clear a big
 /// routine, small enough that a miss costs little.
 pub const DEFAULT_RESOLVE_WINDOW: u64 = 64 * 1024;
 

--- a/src/event_queue.rs
+++ b/src/event_queue.rs
@@ -27,7 +27,7 @@ pub struct QueuedEvent {
 /// exposed to guest code. Keeping the full-width message and posting tick
 /// here lets 68K and PowerPC showcase probes assert identical behavior
 /// without reading ABI-specific guest memory layouts.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct EventRecordSnapshot {
     pub what: u16,
     pub message: u32,
@@ -38,7 +38,7 @@ pub struct EventRecordSnapshot {
 }
 
 /// Result from one Event Manager queue probe call.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct EventProbeResult {
     pub available: bool,
     pub record: EventRecordSnapshot,
@@ -48,7 +48,7 @@ pub struct EventProbeResult {
 /// the showcase. Each optional value records the most recent call of that
 /// kind, preserving the returned event type even after a later call consumes
 /// the queue entry.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct EventQueueProbeSnapshot {
     pub post_result: Option<i16>,
     pub event_avail: Option<EventProbeResult>,
@@ -59,7 +59,7 @@ pub struct EventQueueProbeSnapshot {
 /// Architecture-neutral Event Manager state exposed by deterministic fixture
 /// runners. This is intentionally semantic: callers can assert queue order,
 /// live input, lifecycle delivery, and cursor state on either CPU adapter.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct EventManagerSnapshot {
     pub last_record: Option<EventRecordSnapshot>,
     pub queue_probe: EventQueueProbeSnapshot,

--- a/src/execution_native.rs
+++ b/src/execution_native.rs
@@ -129,7 +129,7 @@ impl<T> NativeExecution<T> {
         }
     }
 
-    #[cfg(test)]
+    #[cfg(any(test, feature = "debug"))]
     pub(crate) fn companion(&self) -> Option<&T> {
         self.companion.installed()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,8 @@ pub mod binhex;
 pub mod callback_manager;
 mod control_manager;
 pub mod cpu;
+#[cfg(feature = "debug")]
+pub mod debug;
 pub mod debug_overlay;
 pub mod disk_image;
 pub mod display;

--- a/src/runner/debug_support.rs
+++ b/src/runner/debug_support.rs
@@ -1,0 +1,250 @@
+use super::*;
+
+impl FixtureRunner {
+    pub(super) fn debug_finish_step_if_ready(&mut self) -> bool {
+        if self.debug_step_units_remaining() != Some(0) {
+            return false;
+        }
+        let Some(context) = self.debug.step_target_context() else {
+            return false;
+        };
+        let location = crate::debug::adapters::Adapters::for_runner(self)
+            .find(context)
+            .map(|adapter| adapter.location());
+        self.debug_finish_context_step(context, location)
+    }
+
+    pub(super) fn debug_stop_at_m68k_breakpoint(&mut self, address: u32) -> bool {
+        self.debug_stop_context_at_breakpoint(
+            crate::debug::M68K_CONTEXT,
+            crate::debug::DebugAddress::new(crate::debug::M68K_SPACE, u64::from(address)),
+        )
+    }
+
+    pub(super) fn debug_m68k_breakpoint_addresses(&self) -> Vec<u32> {
+        self.debug_context_breakpoint_addresses(
+            crate::debug::M68K_CONTEXT,
+            crate::debug::M68K_SPACE,
+        )
+        .into_iter()
+        .filter_map(|address| u32::try_from(address.offset).ok())
+        .collect()
+    }
+
+    pub(super) fn debug_note_m68k_executed_units(&mut self, units: usize) {
+        self.debug_note_context_executed_units(
+            crate::debug::M68K_CONTEXT,
+            u32::try_from(units).unwrap_or(u32::MAX),
+        );
+    }
+
+    pub(super) fn debug_note_terminal(&mut self) {
+        let (context, location) = crate::debug::adapters::active_context_and_location(self);
+        let guest_tick = self.guest_tick();
+        let execution_units = self.total_instructions();
+        self.debug
+            .fail_pending_captures("runner reached a terminal halt");
+        self.debug.stop_at_terminal_halt(
+            context,
+            location,
+            Some(guest_tick),
+            Some(execution_units),
+        );
+    }
+
+    pub(super) fn debug_note_active_context(&mut self) {
+        let active = crate::debug::adapters::active_context_id(self);
+        self.debug.note_active_context(active);
+    }
+
+    #[inline]
+    pub(super) fn debug_advance_generation(&mut self) {
+        self.debug.advance_generation();
+    }
+
+    #[inline]
+    pub(super) fn debug_step_units_remaining(&self) -> Option<u32> {
+        self.debug.step_units_remaining()
+    }
+
+    #[inline]
+    pub(super) fn debug_breakpoint_rearming(&self) -> bool {
+        self.debug.breakpoint_rearming()
+    }
+
+    pub(super) fn debug_note_logical_frame_boundary(&mut self) {
+        crate::debug::note_capture_boundary(
+            self,
+            crate::debug::CaptureBoundaryKind::LogicalFrameComplete,
+        );
+    }
+
+    pub(super) fn debug_has_pending_logical_frame_capture(&self) -> bool {
+        self.debug
+            .has_pending_capture_boundary(crate::debug::CaptureBoundaryKind::LogicalFrameComplete)
+    }
+
+    pub fn debug_note_context_executed_units(
+        &mut self,
+        context: crate::debug::ContextId,
+        units: u32,
+    ) {
+        self.debug.note_executed_units(context, units);
+    }
+
+    pub fn debug_finish_context_step(
+        &mut self,
+        context: crate::debug::ContextId,
+        location: Option<crate::debug::ExecutionLocation>,
+    ) -> bool {
+        if self.debug.step_target_context() != Some(context)
+            || self.debug.step_units_remaining() != Some(0)
+        {
+            return false;
+        }
+        let guest_tick = self.guest_tick();
+        let execution_units = self.total_instructions();
+        self.debug
+            .finish_step(context, location, Some(guest_tick), Some(execution_units))
+            .is_some()
+    }
+
+    pub fn debug_stop_context_at_breakpoint(
+        &mut self,
+        context: crate::debug::ContextId,
+        address: crate::debug::DebugAddress,
+    ) -> bool {
+        let Some(id) = self
+            .debug
+            .breakpoint_at(context, address.space, address.offset)
+        else {
+            return false;
+        };
+        let guest_tick = self.guest_tick();
+        let execution_units = self.total_instructions();
+        self.debug.breakpoint_stop(
+            id,
+            context,
+            Some(crate::debug::ExecutionLocation { context, address }),
+            Some(guest_tick),
+            Some(execution_units),
+        );
+        true
+    }
+
+    pub fn debug_context_breakpoint_addresses(
+        &self,
+        context: crate::debug::ContextId,
+        space: crate::debug::AddressSpaceId,
+    ) -> Vec<crate::debug::DebugAddress> {
+        self.debug
+            .breakpoint_watch_addresses(context, space)
+            .into_iter()
+            .map(|offset| crate::debug::DebugAddress::new(space, offset))
+            .collect()
+    }
+
+    pub fn debug_register_adapter(
+        &mut self,
+        registration: crate::debug::AdapterRegistration,
+    ) -> crate::debug::DebugResult<()> {
+        self.debug.register_adapter(registration)
+    }
+
+    pub fn debug_register_provider<P>(&mut self, provider: P) -> crate::debug::DebugResult<()>
+    where
+        P: crate::debug::InspectionProvider + 'static,
+    {
+        self.debug.register_provider(provider)
+    }
+
+    pub fn debug_register_provider_arc(
+        &mut self,
+        provider: crate::debug::ProviderRegistration,
+    ) -> crate::debug::DebugResult<()> {
+        self.debug.register_provider_arc(provider)
+    }
+
+    pub fn debug_active_architecture(&self) -> crate::debug::ActiveArchitecture {
+        let route = self
+            .dispatcher
+            .guest_calls
+            .execution_route(self.native.availability());
+        if route == ExecutionRoute::Blocked {
+            return crate::debug::ActiveArchitecture::Blocked;
+        }
+        if self.dispatcher.guest_calls.has_m68k_execution() {
+            return crate::debug::ActiveArchitecture::M68k;
+        }
+        match route {
+            ExecutionRoute::NativeApplication => crate::debug::ActiveArchitecture::PowerPc,
+            ExecutionRoute::NativeCompanion => crate::debug::ActiveArchitecture::PowerPcCompanion,
+            ExecutionRoute::PrepareCompanion => crate::debug::ActiveArchitecture::Blocked,
+            ExecutionRoute::Classic => crate::debug::ActiveArchitecture::M68k,
+            ExecutionRoute::Blocked => crate::debug::ActiveArchitecture::Blocked,
+        }
+    }
+
+    pub(crate) fn debug_release_held_input(&mut self) {
+        let keys = self.dispatcher.input_state.key_map;
+        if keys.iter().any(|key| *key != 0) || self.dispatcher.input_state.mouse_button {
+            self.debug.touch();
+        }
+        for key in 0..128u8 {
+            if keys[usize::from(key / 8)] & (1 << (key % 8)) != 0 {
+                self.push_key_up(key, 0);
+            }
+        }
+        if self.dispatcher.input_state.mouse_button {
+            let (v, h) = self.dispatcher.mouse_position();
+            self.push_canonical_mouse_up(v, h);
+        }
+    }
+
+    pub fn debug_ppc_companion_cpu(&self) -> Option<&ppc::PpcCpu> {
+        self.native.companion().map(|app| &app.cpu)
+    }
+
+    pub fn debug_ppc_cpu(&self) -> Option<&ppc::PpcCpu> {
+        self.native.application().map(|app| &app.cpu)
+    }
+
+    #[doc(hidden)]
+    pub(crate) fn debug_window_snapshot(&self, limit: usize) -> (Vec<WindowSnapshot>, bool) {
+        let windows = &self.dispatcher.window_list;
+        (
+            crate::window_manager::snapshot_window_stack(
+                &windows[..windows.len().min(limit)],
+                |address| self.bus.read_byte(address),
+            ),
+            windows.len() > limit,
+        )
+    }
+
+    pub(crate) fn debug_screen_mode(&self) -> (u32, u32, u16, u16, u16) {
+        self.dispatcher.screen_mode
+    }
+
+    pub(crate) fn debug_device_clut(&self) -> &[[u16; 3]; 256] {
+        &self.dispatcher.device_clut
+    }
+
+    pub(crate) fn debug_device_gamma(&self) -> &crate::display::DisplayGamma {
+        &self.dispatcher.device_gamma
+    }
+
+    pub(crate) fn debug_palette_argb(&self) -> [u32; 256] {
+        crate::display::argb_palette_from_clut_with_gamma(
+            &self.dispatcher.device_clut,
+            &self.dispatcher.device_gamma,
+        )
+    }
+
+    pub fn debug_extract_capture_store(&mut self) -> crate::debug::CaptureStore {
+        self.debug.extract_capture_store()
+    }
+
+    pub fn debug_adopt_capture_store(&mut self, store: crate::debug::CaptureStore) {
+        self.debug.adopt_capture_store(store);
+    }
+}

--- a/src/runner/debug_support_disabled.rs
+++ b/src/runner/debug_support_disabled.rs
@@ -1,0 +1,40 @@
+use super::*;
+
+impl FixtureRunner {
+    pub(super) fn debug_finish_step_if_ready(&mut self) -> bool {
+        false
+    }
+
+    pub(super) fn debug_stop_at_m68k_breakpoint(&mut self, _address: u32) -> bool {
+        false
+    }
+
+    pub(super) fn debug_note_m68k_executed_units(&mut self, _units: usize) {}
+
+    pub(super) fn debug_note_terminal(&mut self) {}
+
+    pub(super) fn debug_note_active_context(&mut self) {}
+
+    #[inline]
+    pub(super) fn debug_advance_generation(&mut self) {}
+
+    #[inline]
+    pub(super) fn debug_step_units_remaining(&self) -> Option<u32> {
+        None
+    }
+
+    #[inline]
+    pub(super) fn debug_breakpoint_rearming(&self) -> bool {
+        false
+    }
+
+    pub(super) fn debug_m68k_breakpoint_addresses(&self) -> Vec<u32> {
+        Vec::new()
+    }
+
+    pub(super) fn debug_note_logical_frame_boundary(&mut self) {}
+
+    pub(super) fn debug_has_pending_logical_frame_capture(&self) -> bool {
+        false
+    }
+}

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -187,6 +187,11 @@ pub mod interrupt;
 pub mod ppc_exec;
 pub mod vfs;
 
+#[cfg(feature = "debug")]
+mod debug_support;
+#[cfg(not(feature = "debug"))]
+mod debug_support_disabled;
+
 pub(crate) use idle::*;
 pub(crate) use interrupt::*;
 pub(crate) use ppc_exec::*;
@@ -1816,6 +1821,8 @@ pub struct FixtureRunner {
     /// GPU instead of being rasterized into guest memory.
     external_q3_renderer_enabled: bool,
     pending_q3_gpu_frame: Option<PpcQ3GpuFrame>,
+    #[cfg(feature = "debug")]
+    pub(crate) debug: crate::debug::DebuggerCoordinator,
 }
 
 impl FixtureRunner {
@@ -1970,6 +1977,8 @@ impl FixtureRunner {
             q3_completed_frame_index: 0,
             external_q3_renderer_enabled: false,
             pending_q3_gpu_frame: None,
+            #[cfg(feature = "debug")]
+            debug: crate::debug::DebuggerCoordinator::fresh(),
         }
     }
 
@@ -2034,6 +2043,10 @@ impl FixtureRunner {
     /// state. Showcase and embedding tests can use this instead of relying on
     /// rendered pixels or 68K/PPC-specific EventRecord offsets.
     pub fn event_manager_snapshot(&self) -> EventManagerSnapshot {
+        self.event_manager_snapshot_with_limit(usize::MAX)
+    }
+
+    pub(crate) fn event_manager_snapshot_with_limit(&self, limit: usize) -> EventManagerSnapshot {
         let queue = self.process_context.event_queue();
         let ppc_state = self.native.application().map(|app| &app.toolbox_startup);
         let last_record: Option<EventRecordSnapshot> = self
@@ -2060,7 +2073,7 @@ impl FixtureRunner {
             last_record,
             queue_probe,
             queue_len: queue.len(),
-            queued_event_types: queue.iter().map(|event| event.what).collect(),
+            queued_event_types: queue.iter().take(limit).map(|event| event.what).collect(),
             mouse_position: self.dispatcher.mouse_position(),
             mouse_button: self.dispatcher.input_state.mouse_button,
             button_result,
@@ -2171,6 +2184,21 @@ impl FixtureRunner {
         &mut self.bus
     }
 
+    pub fn debug_is_paused(&self) -> bool {
+        self.guest_work_is_suspended()
+    }
+
+    fn guest_work_is_suspended(&self) -> bool {
+        #[cfg(feature = "debug")]
+        {
+            return self.debug.is_paused();
+        }
+        #[cfg(not(feature = "debug"))]
+        {
+            return false;
+        }
+    }
+
     pub fn dispatcher(&self) -> &crate::trap::dispatch::TrapDispatcher {
         &self.dispatcher
     }
@@ -2195,12 +2223,6 @@ impl FixtureRunner {
         )
     }
 
-    /// Return the live Window Manager stack in front-to-back order.
-    ///
-    /// This hidden fixture/diagnostic seam deliberately has the same shape for
-    /// classic and native PowerPC execution.  It lets deterministic tests
-    /// assert z-order, geometry, activation, occlusion-derived visible
-    /// regions, and pending repaint regions without relying on screenshots.
     #[doc(hidden)]
     pub fn window_stack_snapshot(&mut self) -> Vec<WindowSnapshot> {
         crate::window_manager::snapshot_window_stack(&self.dispatcher.window_list, |address| {
@@ -2670,6 +2692,9 @@ impl FixtureRunner {
     /// This remains independent of CPU catch-up limits and frozen app ticks.
     /// Toolbox Essentials (1992), SetMenuFlash, p. 3-142.
     pub fn advance_menu_presentation_clock(&mut self, elapsed: std::time::Duration) {
+        if self.guest_work_is_suspended() {
+            return;
+        }
         let Some(tracking) = self.process_context.menu_tracking() else {
             self.menu_presentation_remainder = 0;
             return;
@@ -2699,6 +2724,9 @@ impl FixtureRunner {
     /// Synchronize deferred PPC visual/VFS state and composite chrome/dialog overlays.
     /// Call before reading raw pixels for screenshots.
     pub fn composite_frame(&mut self) {
+        if self.guest_work_is_suspended() && !self.halted {
+            return;
+        }
         self.sync_ppc_deferred_host_state();
         self.redraw_chrome_outside_idle_journal();
     }
@@ -2767,6 +2795,9 @@ impl FixtureRunner {
     /// reads them directly sees the new coordinates immediately. Leaves
     /// MBState ($0172) untouched. Inside Macintosh Volume II, II-371.
     pub fn set_mouse_position(&mut self, v: i16, h: i16) {
+        if self.guest_work_is_suspended() {
+            return;
+        }
         let (v, h) = self.canonical_mouse_position(v, h);
         self.dispatcher.set_mouse_position(v, h);
         self.sync_mouse_position_lowmem();
@@ -2888,6 +2919,9 @@ impl FixtureRunner {
     /// mouseDown -> FindWindow -> MenuSelect path.  Returns false if the menu
     /// or item is no longer present, enabled, and selectable.
     pub fn select_guest_menu_item(&mut self, menu_id: i16, item_number: i16) -> bool {
+        if self.guest_work_is_suspended() {
+            return false;
+        }
         // Host input is an ABI boundary too: a guest store to `$016A` made
         // since the last trap must be visible before the queued EventRecord
         // receives its `when` timestamp.
@@ -2924,6 +2958,9 @@ impl FixtureRunner {
     /// globals here so that code polling the low-memory locations directly
     /// (instead of calling Button or GetNextEvent) sees the correct state.
     pub fn push_mouse_down(&mut self, v: i16, h: i16) {
+        if self.guest_work_is_suspended() {
+            return;
+        }
         let (v, h) = self.canonical_mouse_position(v, h);
         self.push_canonical_mouse_down(v, h);
     }
@@ -2966,6 +3003,9 @@ impl FixtureRunner {
     /// many loop iterations after a click-up.
     /// Inside Macintosh Volume II, II-371
     pub fn push_mouse_up(&mut self, v: i16, h: i16) {
+        if self.guest_work_is_suspended() {
+            return;
+        }
         let (v, h) = self.canonical_mouse_position(v, h);
         self.push_canonical_mouse_up(v, h);
     }
@@ -3020,6 +3060,9 @@ impl FixtureRunner {
 
     /// Inject a key-down event, applying arrow→numpad remapping if configured.
     pub fn push_key_down(&mut self, mac_key: u8, char_code: u8) {
+        if self.guest_work_is_suspended() {
+            return;
+        }
         let (key, char_code) = self.remap_key(mac_key, char_code);
         self.dispatcher.read_tick_count(&self.bus);
         self.dispatcher.with_process_state(|d| {
@@ -3032,6 +3075,9 @@ impl FixtureRunner {
 
     /// Inject a key-up event, applying arrow→numpad remapping if configured.
     pub fn push_key_up(&mut self, mac_key: u8, char_code: u8) {
+        if self.guest_work_is_suspended() {
+            return;
+        }
         let (key, char_code) = self.remap_key(mac_key, char_code);
         self.dispatcher.read_tick_count(&self.bus);
         let sys_evt_mask = self
@@ -3409,6 +3455,9 @@ impl FixtureRunner {
     /// amortizes tick advancement, halt detection, and trace collection across
     /// the instruction budget.
     pub fn step(&mut self) -> StepResult {
+        if self.guest_work_is_suspended() {
+            return StepResult::Blocked;
+        }
         let result = self.m68k.cpu.step(&mut self.bus);
         self.dispatcher
             .retire_returned_native_trap_call(&mut self.m68k.cpu);
@@ -3754,6 +3803,7 @@ impl FixtureRunner {
             (native, migrated_services)
         });
         assert!(self.native.reset_for_launch(app.ppc.is_some()));
+        self.debug_advance_generation();
         self.process_context.reset_cfm_for_launch();
         if let Some((ppc_app, migrated_services)) = native_launch {
             self.init_ppc_app_with_services(ppc_app, migrated_services);
@@ -4415,6 +4465,9 @@ impl FixtureRunner {
     /// Mix and queue audio samples without full frame finalization.
     /// Used to keep the audio buffer fed during long CPU frames.
     pub fn mix_audio(&mut self, num_samples: usize) {
+        if self.guest_work_is_suspended() {
+            return;
+        }
         self.mix_host_audio(num_samples);
     }
 
@@ -4534,6 +4587,32 @@ impl FixtureRunner {
         }
         debug_assert_ne!(finalization, FrameFinalization::Deferred);
         self.finish_audio_frame(audio_samples, sound_interrupt_dispatched);
+        // The logical-frame capture boundary is defined as the point after
+        // host chrome redraw and guest-audio finalization. Audio-only slices
+        // defer chrome to the frontend's outer composition pass, so they must
+        // not complete it; the frontend does so once per frame via
+        // [`Self::finish_gui_frame`].
+        if finalization == FrameFinalization::Complete {
+            self.finish_logical_frame();
+        }
+    }
+
+    fn finish_logical_frame(&mut self) {
+        if self.guest_work_is_suspended() || self.halted {
+            return;
+        }
+        self.debug_note_logical_frame_boundary();
+    }
+
+    /// Complete an outer GUI frame after audio work, compositing pending captures.
+    pub fn finish_gui_frame(&mut self) {
+        if self.guest_work_is_suspended() || self.halted {
+            return;
+        }
+        if self.debug_has_pending_logical_frame_capture() {
+            self.composite_frame();
+        }
+        self.finish_logical_frame();
     }
 
     fn finish_audio_frame(&mut self, audio_samples: usize, sound_interrupt_dispatched: bool) {
@@ -4566,6 +4645,9 @@ impl FixtureRunner {
     /// doubleback callbacks run between small audio chunks when TickCount is
     /// already caught up to the wall clock.
     pub fn mix_gui_audio_slice(&mut self, audio_samples: usize) {
+        if self.guest_work_is_suspended() {
+            return;
+        }
         self.finish_audio_frame(audio_samples, false);
     }
 
@@ -5645,12 +5727,45 @@ impl FixtureRunner {
         sound_work_only: bool,
         finish_frame: FrameFinalization,
     ) -> (usize, bool) {
+        let result = self.run_steps_internal_impl(
+            max_steps,
+            tick_cap,
+            audio_samples,
+            yield_for_ui,
+            sound_work_only,
+            finish_frame,
+        );
+        // Returning to the embedding is a scheduler safe point. Publish any
+        // context transition that occurred during this execution chunk.
+        self.debug_note_active_context();
+        if self.halted {
+            self.debug_note_terminal();
+        } else {
+            // A step completes only after execution returns to this safe point.
+            self.debug_finish_step_if_ready();
+        }
+        result
+    }
+
+    fn run_steps_internal_impl(
+        &mut self,
+        max_steps: usize,
+        tick_cap: Option<u32>,
+        audio_samples: usize,
+        yield_for_ui: bool,
+        sound_work_only: bool,
+        finish_frame: FrameFinalization,
+    ) -> (usize, bool) {
+        if self.guest_work_is_suspended() {
+            return (0, !self.halted);
+        }
         self.dispatcher.guest_calls.resume_ready_task();
         self.m68k.apply_task_handoff();
         let route = self
             .dispatcher
             .guest_calls
             .execution_route(self.native.availability());
+        self.debug_note_active_context();
         if route == ExecutionRoute::Blocked {
             return (0, !self.halted);
         }
@@ -5680,6 +5795,9 @@ impl FixtureRunner {
                 );
                 count = count.saturating_add(steps);
                 running = still_running;
+                if self.guest_work_is_suspended() || self.debug_step_units_remaining() == Some(0) {
+                    break;
+                }
                 if steps == 0 {
                     break;
                 }
@@ -5786,6 +5904,9 @@ impl FixtureRunner {
         let mut watch_buf = Vec::with_capacity(4);
 
         while count < max_steps && !self.halted && !tick_cap_reached {
+            if self.debug_finish_step_if_ready() {
+                return (count, !self.halted);
+            }
             if sound_work_only
                 && !self.callback_suspends_guest_clock()
                 && (sound_interrupt_dispatched || !self.has_pending_sound_work())
@@ -5840,6 +5961,7 @@ impl FixtureRunner {
 
             if self.m68k.cpu.is_stopped() {
                 self.halted = true;
+                self.debug_note_terminal();
                 self.halted_pc = Some(self.m68k.cpu.read_reg(Register::PC));
                 self.halted_sp = Some(self.m68k.cpu.read_reg(Register::A7));
                 self.halted_d0 = Some(self.m68k.cpu.read_reg(Register::D0));
@@ -6039,6 +6161,7 @@ impl FixtureRunner {
                 {
                     count += 1;
                     self.total_instructions = self.total_instructions.wrapping_add(1);
+                    self.debug_note_m68k_executed_units(1);
                     if self.dispatcher.has_ready_menu_tracking() {
                         if yield_for_ui && self.frozen_ticks.is_none() {
                             self.frozen_ticks = Some(self.guest_tick());
@@ -6078,6 +6201,7 @@ impl FixtureRunner {
                 }
                 self.dump_trace();
                 self.halted = true;
+                self.debug_note_terminal();
                 self.halted_pc = Some(0);
                 self.halted_sp = Some(self.m68k.cpu.read_reg(Register::A7));
                 self.halted_d0 = Some(self.m68k.cpu.read_reg(Register::D0));
@@ -6095,6 +6219,7 @@ impl FixtureRunner {
                 );
                 self.dump_invalid_pc_state();
                 self.halted = true;
+                self.debug_note_terminal();
                 self.halted_pc = Some(pc);
                 self.halted_sp = Some(sp);
                 self.halted_d0 = Some(self.m68k.cpu.read_reg(Register::D0));
@@ -6194,8 +6319,18 @@ impl FixtureRunner {
                 if charging && !self.callback_suspends_guest_clock() {
                     n = n.min((self.tick_budget - 1).max(1) as usize);
                 }
+                if let Some(units) = self.debug_step_units_remaining() {
+                    n = n.min(units.max(1) as usize);
+                }
+                if self.debug_breakpoint_rearming() {
+                    n = n.min(1);
+                }
                 n as u32
             };
+            let entry_pc = self.m68k.cpu.read_reg(Register::PC);
+            if self.debug_stop_at_m68k_breakpoint(entry_pc) {
+                return (count, !self.halted);
+            }
             // PC 0 is always watched: a deep RTS chain unwinding to 0 is
             // the clean-exit signal handled at the top of this loop, and it
             // must halt before low memory gets executed as code. While an
@@ -6212,6 +6347,7 @@ impl FixtureRunner {
             }
             self.dispatcher
                 .append_pending_native_trap_return_pcs(&mut watch_buf);
+            watch_buf.extend(self.debug_m68k_breakpoint_addresses());
             let batch = self.m68k.cpu.run_batch(&mut self.bus, batch_max, &watch_buf);
             self.dispatcher
                 .retire_returned_native_trap_call(&mut self.m68k.cpu);
@@ -6222,6 +6358,7 @@ impl FixtureRunner {
                     batch.exit,
                     BatchExit::AlineTrap { .. } | BatchExit::FlineTrap { .. }
                 ));
+            self.debug_note_m68k_executed_units(executed);
             if executed > 0 {
                 count += executed;
                 self.total_instructions = self.total_instructions.wrapping_add(executed as u64);
@@ -6249,10 +6386,11 @@ impl FixtureRunner {
                 }
             }
             match batch.exit {
-                BatchExit::BudgetExhausted | BatchExit::WatchedPc { .. } => {
-                    // Nothing to do: the loop top re-reads PC and handles
-                    // watched addresses (interrupt-callback resume, clean
-                    // exit at PC 0) exactly like the old per-step checks.
+                BatchExit::BudgetExhausted => {}
+                BatchExit::WatchedPc { pc } => {
+                    if self.debug_stop_at_m68k_breakpoint(pc) {
+                        return (count, !self.halted);
+                    }
                 }
                 BatchExit::FlineTrap { .. } => {
                     // A writable vector 11 is the guest's architectural
@@ -6270,6 +6408,7 @@ impl FixtureRunner {
                     // old flow where the next loop iteration's is_stopped
                     // check caught it.
                     self.halted = true;
+                    self.debug_note_terminal();
                     self.halted_pc = Some(self.m68k.cpu.read_reg(Register::PC));
                     self.halted_sp = Some(self.m68k.cpu.read_reg(Register::A7));
                     self.halted_d0 = Some(self.m68k.cpu.read_reg(Register::D0));
@@ -7097,8 +7236,12 @@ impl FixtureRunner {
         let mut running = true;
         let mut watch_buf = Vec::with_capacity(4);
         while executed < max_steps {
+            if self.debug_finish_step_if_ready() {
+                return Some((executed, true));
+            }
             if self.dispatcher.resume_menu_tracking(&mut self.m68k.cpu, &mut self.bus).is_some() {
                 executed += 1;
+                self.debug_note_m68k_executed_units(1);
                 continue;
             }
             if self.m68k.cpu.read_reg(Register::PC) == pending.return_pc {
@@ -7112,11 +7255,22 @@ impl FixtureRunner {
                 });
                 break;
             }
-            let batch_max = u32::try_from(max_steps - executed).unwrap_or(u32::MAX);
+            let mut batch_max = u32::try_from(max_steps - executed).unwrap_or(u32::MAX);
+            if let Some(units) = self.debug_step_units_remaining() {
+                batch_max = batch_max.min(units.max(1));
+            }
+            if self.debug_breakpoint_rearming() {
+                batch_max = batch_max.min(1);
+            }
+            let entry_pc = self.m68k.cpu.read_reg(Register::PC);
+            if self.debug_stop_at_m68k_breakpoint(entry_pc) {
+                return Some((executed, true));
+            }
             watch_buf.clear();
             watch_buf.push(pending.return_pc);
             self.dispatcher
                 .append_pending_native_trap_return_pcs(&mut watch_buf);
+            watch_buf.extend(self.debug_m68k_breakpoint_addresses());
             let batch = self.m68k.cpu.run_batch(&mut self.bus, batch_max, &watch_buf);
             self.dispatcher
                 .retire_returned_native_trap_call(&mut self.m68k.cpu);
@@ -7126,18 +7280,26 @@ impl FixtureRunner {
                     BatchExit::AlineTrap { .. } | BatchExit::FlineTrap { .. }
                 ));
             executed = executed.saturating_add(retired);
+            self.debug_note_m68k_executed_units(retired);
             match batch.exit {
                 BatchExit::BudgetExhausted => break,
-                BatchExit::WatchedPc { pc } if pc == pending.return_pc => {
-                    running = self.process_context.with_memory_and_cfm(|manager, _| {
-                        self.m68k.complete_pending(
-                            &mut ppc_app.memory,
-                            &mut ppc_app.cpu,
-                            pending,
-                            manager,
-                        )
-                    });
-                    break;
+                BatchExit::WatchedPc { pc } => {
+                    // User breakpoints take precedence over an internal return
+                    // sentinel at the same address.
+                    if self.debug_stop_at_m68k_breakpoint(pc) {
+                        return Some((executed, true));
+                    }
+                    if pc == pending.return_pc {
+                        running = self.process_context.with_memory_and_cfm(|manager, _| {
+                            self.m68k.complete_pending(
+                                &mut ppc_app.memory,
+                                &mut ppc_app.cpu,
+                                pending,
+                                manager,
+                            )
+                        });
+                        break;
+                    }
                 }
                 BatchExit::AlineTrap { opcode } => {
                     if self.m68k.complete_manager_return(&self.bus)
@@ -7178,7 +7340,6 @@ impl FixtureRunner {
                         break;
                     }
                 }
-                BatchExit::WatchedPc { .. } => continue,
                 BatchExit::FlineTrap { .. } => {
                     if !self.dispatcher.fline_vector_is_default(&self.bus) {
                         self.m68k.cpu.core.take_fline_exception(&mut self.bus);
@@ -8964,6 +9125,9 @@ impl FixtureRunner {
     /// Run pending Sound Manager interrupt work without advancing TickCount
     /// or continuing into foreground guest code after the callback returns.
     pub fn run_pending_sound_work(&mut self, max_steps: usize) -> (usize, bool) {
+        if self.guest_work_is_suspended() {
+            return (0, !self.halted);
+        }
         self.fire_pending_ppc_sound_completions();
         self.run_steps_internal(max_steps, None, 0, true, true, FrameFinalization::Complete)
     }
@@ -8974,6 +9138,9 @@ impl FixtureRunner {
     /// the same slice boundary. This does not defer audio or enlarge the guest
     /// callback budget. Use this only when the caller owns outer presentation.
     pub fn run_gui_pending_sound_work(&mut self, max_steps: usize) -> (usize, bool) {
+        if self.guest_work_is_suspended() {
+            return (0, !self.halted);
+        }
         self.fire_pending_ppc_sound_completions();
         self.run_steps_internal(max_steps, None, 0, true, true, FrameFinalization::AudioOnly)
     }
@@ -9015,6 +9182,7 @@ impl FixtureRunner {
             self.bus.read_word(halted_pc)
         );
         self.halted = true;
+        self.debug_note_terminal();
         self.halted_pc = Some(halted_pc);
         self.halted_sp = Some(self.m68k.cpu.read_reg(Register::A7));
         self.halted_d0 = Some(self.m68k.cpu.read_reg(Register::D0));
@@ -11022,6 +11190,9 @@ impl FixtureRunner {
     /// [`halted_pc`](Self::halted_pc) / [`halted_trap`](Self::halted_trap)
     /// accessors.
     pub fn run(&mut self) -> Result<()> {
+        if self.guest_work_is_suspended() {
+            return Ok(());
+        }
         let mut count = 0;
 
         if trace_load_enabled() {
@@ -11080,6 +11251,7 @@ impl FixtureRunner {
             self.dispatcher
                 .retire_returned_native_trap_call(&mut self.m68k.cpu);
             match step_result {
+                StepResult::Blocked => return Ok(()),
                 StepResult::Ok => {}
                 StepResult::Stopped => {
                     if trace_load_enabled() {
@@ -12267,6 +12439,80 @@ mod tests {
         assert_eq!(native.cpu.gpr[3], 0);
         assert_eq!(native.memory.read_u32_be(OUTPUT + 80), Some(address));
         assert_eq!(native.import_count, initial_count + 1);
+    }
+
+    #[test]
+    #[cfg(not(feature = "debug"))]
+    fn debugger_disabled_hooks_are_inert() {
+        let mut runner = FixtureRunner::new(0x100000, FixtureRunnerConfig::default());
+        runner.bus_mut().write_word(0x2_0000, 0x4E71); // NOP
+        runner.cpu_mut().write_reg(Register::PC, 0x2_0000);
+        assert!(!runner.debug_is_paused());
+        assert_eq!(runner.debug_step_units_remaining(), None);
+        assert!(!runner.debug_stop_at_m68k_breakpoint(0x2_0000));
+        assert!(runner.debug_m68k_breakpoint_addresses().is_empty());
+        let (steps, running) = runner.run_steps(1, None);
+        assert_eq!(steps, 1);
+        assert!(running);
+        assert!(!runner.debug_is_paused());
+    }
+
+    #[test]
+    #[cfg(feature = "debug")]
+    fn debug_launch_invalidates_cached_references() {
+        use crate::debug::{handle_debug_request, DebugError, DebugRequest};
+        let app = halted_ppc_app_with_sound(PpcSoundState::default());
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        let request = DebugRequest::InSession {
+            session: runner.debug.session(),
+            generation: runner.debug.generation(),
+            request: Box::new(DebugRequest::ListContexts),
+        };
+        runner.init_app(&app);
+        assert!(matches!(
+            handle_debug_request(&mut runner, request),
+            Err(DebugError::StaleReference { .. })
+        ));
+    }
+
+    #[test]
+    #[cfg(feature = "debug")]
+    fn debug_companion_inspection_uses_its_own_cpu() {
+        use crate::debug::{
+            handle_debug_request, ContextId, ContextSelector, DebugReply, DebugRequest,
+        };
+        let mut native = halted_ppc_app_with_sound(PpcSoundState::default())
+            .ppc
+            .take()
+            .unwrap();
+        native.cpu.gpr[3] = 0x12345678;
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        runner.init_ppc_companion(native);
+        let reply = handle_debug_request(
+            &mut runner,
+            DebugRequest::ReadRegisters {
+                context: ContextSelector::explicit(ContextId(3)),
+                registers: None,
+            },
+        )
+        .unwrap();
+        let DebugReply::Registers { context, registers } = reply else {
+            panic!("registers");
+        };
+        assert_eq!(context, ContextId(3));
+        assert_eq!(
+            registers
+                .iter()
+                .find(|r| r.descriptor.name == "r3")
+                .unwrap()
+                .value
+                .as_u64(),
+            Some(0x12345678)
+        );
+        assert!(runner.debug_ppc_cpu().is_none());
+        handle_debug_request(&mut runner, DebugRequest::Pause).unwrap();
+        assert_eq!(runner.run_pending_sound_work(100), (0, true));
+        assert_eq!(runner.debug_ppc_companion_cpu().unwrap().gpr[3], 0x12345678);
     }
 
     #[test]
@@ -16982,6 +17228,137 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "debug")]
+    fn debugger_controls_a_parked_native_to_68k_callback_and_preserves_its_return() {
+        use crate::debug::{
+            handle_debug_request, BreakpointSpec, ContextSelector, DebugExecutionState,
+            DebugReply, DebugRequest, M68K_CONTEXT,
+        };
+
+        const M68K_ENTRY: u32 = 0x0301_4000;
+        const STACK_BASE: u32 = 0x0303_4000;
+        const INITIAL_SP: u32 = STACK_BASE + 0x80;
+        const RETURN_PC: u32 = 0x0304_4000;
+
+        let app = halted_ppc_app_with_sound(PpcSoundState::default());
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        runner.init_app(&app);
+        let ppc_app = runner.native.application_mut().expect("PPC app");
+        ppc_app.memory.add_region(
+            M68K_ENTRY,
+            vec![
+                0x4e, 0x71, // NOP
+                0x4e, 0x71, // NOP
+                0x4e, 0x75, // RTS
+            ],
+        );
+        ppc_app.memory.add_region(STACK_BASE, vec![0; 0x100]);
+        ppc_app.memory.write_u32_be(INITIAL_SP, RETURN_PC).unwrap();
+        assert!(ppc_app.toolbox_startup.execution.calls().begin_powerpc_to_m68k(
+            crate::guest_call::GuestCallTarget {
+                isa: crate::guest_procedure::GuestIsa::M68k,
+                entry: M68K_ENTRY,
+                rtoc: 0,
+            },
+            M68K_ENTRY,
+            INITIAL_SP,
+            RETURN_PC,
+            INITIAL_SP + 4,
+            crate::guest_call::M68kRegisterState::default(),
+            Some(crate::guest_call::M68kResultSource::Data(0)),
+            PPC_CODE_BASE,
+            0,
+            PpcNativeReturnGpr3::Preserve,
+        ));
+
+        handle_debug_request(&mut runner, DebugRequest::Pause).unwrap();
+        handle_debug_request(
+            &mut runner,
+            DebugRequest::Step {
+                context: ContextSelector::Active,
+            },
+        )
+        .unwrap();
+        let (stepped, running) = runner.run_steps(64, None);
+        assert_eq!(stepped, 1);
+        assert!(running);
+        assert_eq!(runner.m68k.cpu.read_reg(Register::PC), M68K_ENTRY + 2);
+        assert!(runner.debug.is_paused());
+        assert!(!runner.dispatcher.guest_calls.is_empty());
+
+        let DebugReply::Breakpoint(callback_breakpoint) = handle_debug_request(
+            &mut runner,
+            DebugRequest::SetBreakpoint {
+                spec: BreakpointSpec::program_counter(u64::from(M68K_ENTRY + 2)),
+            },
+        )
+        .unwrap()
+        else {
+            panic!("expected callback breakpoint");
+        };
+        handle_debug_request(&mut runner, DebugRequest::Resume).unwrap();
+        let (break_steps, _) = runner.run_steps(64, None);
+        assert_eq!(break_steps, 0);
+        assert!(matches!(
+            runner.debug.execution_state(),
+            DebugExecutionState::Paused { .. }
+        ));
+        handle_debug_request(
+            &mut runner,
+            DebugRequest::RemoveBreakpoint {
+                id: callback_breakpoint.id,
+            },
+        )
+        .unwrap();
+
+        let mut return_spec = BreakpointSpec::program_counter(u64::from(RETURN_PC));
+        return_spec.context = Some(M68K_CONTEXT);
+        let DebugReply::Breakpoint(return_breakpoint) = handle_debug_request(
+            &mut runner,
+            DebugRequest::SetBreakpoint { spec: return_spec },
+        )
+        .unwrap()
+        else {
+            panic!("expected return-sentinel breakpoint");
+        };
+        handle_debug_request(&mut runner, DebugRequest::Resume).unwrap();
+        let (return_steps, _) = runner.run_steps(64, None);
+        assert_eq!(return_steps, 2);
+        assert_eq!(runner.m68k.cpu.read_reg(Register::PC), RETURN_PC);
+        assert!(runner.debug.is_paused());
+        assert!(
+            !runner.dispatcher.guest_calls.is_empty(),
+            "the user breakpoint must win before the internal return retires"
+        );
+
+        handle_debug_request(
+            &mut runner,
+            DebugRequest::RemoveBreakpoint {
+                id: return_breakpoint.id,
+            },
+        )
+        .unwrap();
+        handle_debug_request(&mut runner, DebugRequest::Resume).unwrap();
+        let (_, running) = runner.run_steps(64, None);
+        assert!(running);
+        assert!(runner.dispatcher.guest_calls.is_empty());
+        let DebugReply::Notifications(notifications) = handle_debug_request(
+            &mut runner,
+            DebugRequest::Notifications { after: 0 },
+        )
+        .unwrap()
+        else {
+            panic!("expected debugger notifications");
+        };
+        assert!(notifications.iter().any(|notification| matches!(
+            notification.payload,
+            crate::debug::NotificationPayload::ContextChanged {
+                active: Some(crate::debug::PPC_CONTEXT)
+            }
+        )));
+    }
+
+    #[test]
     fn parked_powerpc_to_68k_call_obeys_guest_vector_10() {
         const M68K_ENTRY: u32 = 0x0301_1000;
         const HANDLER: u32 = 0x0301_1100;
@@ -17111,6 +17488,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "debug")]
     fn parked_native_call_can_enter_powerpc_through_a_68k_routine_descriptor() {
         use crate::guest_procedure::{
             ROUTINE_DESCRIPTOR_HEADER_SIZE, ROUTINE_DESCRIPTOR_MIXED_MODE_TRAP,
@@ -17211,9 +17589,24 @@ mod tests {
         let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
         runner.init_app(&app);
 
-        let (m68k_steps, m68k_running) = runner.run_steps(2, None);
-        assert!(m68k_steps > 0);
+        crate::debug::handle_debug_request(&mut runner, crate::debug::DebugRequest::Pause).unwrap();
+        crate::debug::handle_debug_request(
+            &mut runner,
+            crate::debug::DebugRequest::Step {
+                context: crate::debug::ContextSelector::Active,
+            },
+        )
+        .unwrap();
+        let native_pc_before_step = runner.native.application().unwrap().cpu.pc;
+        let (m68k_steps, m68k_running) = runner.run_steps(64, None);
+        assert_eq!(m68k_steps, 1);
         assert!(m68k_running);
+        assert!(runner.debug.is_paused());
+        assert_eq!(
+            runner.native.application().unwrap().cpu.pc,
+            native_pc_before_step,
+            "the step may establish a native continuation but must not execute it"
+        );
         assert!(
             runner.dispatcher.guest_calls.has_powerpc_from_m68k(),
             "steps={m68k_steps} running={m68k_running} halted={} frames={} active={:?} pending_ppc={:?} pc=${:08x} sp=${:08x}",
@@ -17228,6 +17621,7 @@ mod tests {
             runner.m68k.cpu.read_reg(Register::A7),
         );
 
+        crate::debug::handle_debug_request(&mut runner, crate::debug::DebugRequest::Resume).unwrap();
         let (powerpc_steps, running) = runner.run_steps(64, None);
         assert!(powerpc_steps > 0);
         assert!(running);
@@ -20831,6 +21225,45 @@ mod tests {
             runner.dispatcher().sound_manager.debug_samples_mixed,
             SAMPLES.len() as u64
         );
+    }
+
+    #[test]
+    #[cfg(feature = "debug")]
+    fn debugger_pause_defers_gui_ppc_sound_completion_until_resume() {
+        use crate::debug::{handle_debug_request, DebugRequest};
+
+        const CALLBACK: u32 = PPC_CODE_BASE + 0x1000;
+        let mut sound = PpcSoundState::default();
+        queue_ppc_sound_completion(&mut sound, 0x0300_1000, CALLBACK);
+        let mut app = halted_ppc_app_with_sound(sound);
+        app.ppc.as_mut().unwrap().memory.add_region(
+            CALLBACK,
+            [0x3860_002au32, 0x4e80_0020] // li r3,42; blr
+                .into_iter()
+                .flat_map(u32::to_be_bytes)
+                .collect(),
+        );
+        let mut runner = FixtureRunner::new(8 * 1024 * 1024, FixtureRunnerConfig::default());
+        runner.init_app(&app);
+        handle_debug_request(&mut runner, DebugRequest::Pause).unwrap();
+        let tick = runner.guest_tick();
+        let instructions = runner.total_instructions();
+        for _ in 0..2 {
+            assert_eq!(runner.run_gui_pending_sound_work(100), (0, true));
+        }
+        let native = runner.native.application().unwrap();
+        assert_eq!(native.sound.manager.pending_sound_callbacks.len(), 1);
+        assert!(native.sound.completion_invocations.is_empty());
+        assert_eq!(runner.guest_tick(), tick);
+        assert_eq!(runner.total_instructions(), instructions);
+
+        handle_debug_request(&mut runner, DebugRequest::Resume).unwrap();
+        runner.run_gui_pending_sound_work(100);
+        let native = runner.native.application().unwrap();
+        assert!(native.sound.manager.pending_sound_callbacks.is_empty());
+        assert_eq!(native.sound.completion_invocations.len(), 1);
+        assert_eq!(native.sound.completion_invocations[0].end_r3, 42);
+        assert!(runner.total_instructions() > instructions);
     }
 
     #[test]

--- a/src/window_manager.rs
+++ b/src/window_manager.rs
@@ -42,7 +42,7 @@ pub(crate) fn grow_dimensions_from_drag(
 /// contract only needs to know which screen area is dirty/visible; the guest
 /// region records remain private implementation details.
 #[doc(hidden)]
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct WindowSnapshot {
     pub title: String,
     pub bounds: WindowRect,


### PR DESCRIPTION
With my apologies for the rather large PR. I think this is the minimum size where this makes some sense. FWIW, I've done several 5.6-sol & astra review iterations.

## Summary

This PR implements the first step toward an extensible debugger. It adds an opt-in API for inspecting guest execution and subsystem state, controlling 68K execution, and retaining captures.

The implementation includes:

- 68K register and RAM inspection, approximate disassembly, stack previews, stepping, and program-counter breakpoints.
- PowerPC register inspection with explicit unsupported-operation responses.
- Graphics, window, and event snapshots, including retained framebuffer artifacts.
- An optional Unix socket transport for GUI and both headless modes.
- Headless startup pause, frame-boundary captures, and inspection after terminal guest halts.

Live access stays on the runner thread. Read-only architecture adapters and subsystem providers provide extension points, while debugger state is disabled by default. This establishes the foundation for future tooling; a graphical inspector and broader execution control remain follow-up work.

Validation includes the debugger-enabled library suite, targeted pause and capture regressions, live headless socket checks, and desktop tests with debugging enabled and disabled.

**Architecture**

The debugger is an optional layer around `FixtureRunner`, which remains the owner of guest execution and emulator state. Live debugger requests run on that same thread, between execution slices, avoiding additional locking or concurrent access to guest state.

- **Shared request API.** Typed requests, replies, and errors serve both in-process tools and the Unix socket transport. The socket worker handles I/O; the runner applies requests at safe points.
- **Central coordination.** A runner-local coordinator tracks execution state, breakpoints, pending operations, captures, and notifications. Session and generation identities let clients detect stale references.
- **Architecture adapters.** Read-only adapters expose contexts, registers, address spaces, and inspection capabilities. Execution control stays in scheduler hooks, so additional architectures can advertise control support as their execution loops implement it.
- **Subsystem providers.** Graphics, windows, and events expose owned snapshots through a common provider interface. New subsystems can register providers without adding subsystem-specific logic to the request handler.
- **Explicit capture boundaries.** Captures copy state immediately or at a supported frame boundary. Retained snapshots and artifacts remain readable after execution resumes; future-boundary requests return operation IDs for tracking completion.
- **Opt-in integration.** The `debug` feature enables the foundation; `debug-server` adds the optional transport. Default builds retain inert hooks without carrying debugger state.

This leaves room for a graphical inspector, richer PowerPC support, and additional providers while keeping the current implementation bounded. Pausing takes effect at scheduler safe points and cannot interrupt synchronous host work already in progress.

## Validation

My agents have been able to use it to inspect some things.

## Known limitations:
- The disassembler is a bit broken and should be improved independently.
- no GUI.