### PR TITLE
docs: prepare hosted CLA acceptance and administration

### DIFF
--- a/.github/CLA_ADMIN.md
+++ b/.github/CLA_ADMIN.md
@@ -1,0 +1,109 @@
+# CLA administration
+
+Use the hosted [CLA Assistant](https://cla-assistant.io) to collect one-time
+acceptance of [Systemless CLA v1.0](../CLA.md) and check subsequent PRs.
+The public project stays GPL-3.0-or-later; this setup does not change the CLA.
+
+## Activation status
+
+This PR prepares the repository instructions. It does not connect the hosted
+service, import prior agreements, or enable a required status check. Until the
+steps below are complete, maintainers must verify acceptance before merging.
+
+Ben Letchford is responsible for reviewing prior agreements and configuring
+the service. No contributor is assumed to have signed merely because they
+previously contributed.
+
+## One-time setup
+
+1. Create a GitHub Gist owned by the project maintainer, with a single file
+   named `CLA.md` containing the exact current repository agreement.
+   From a clean checkout of the approved default branch, GitHub CLI can do this:
+
+   ```sh
+   gh gist create --public CLA.md --desc "Systemless Contributor Agreement v1.0"
+   ```
+
+   Run this once and retain the resulting URL. Check the published text against
+   the repository file before connecting it. Do not add acceptance instructions
+   or personal information to the agreement itself.
+2. Sign in at [cla-assistant.io](https://cla-assistant.io) with the maintainer
+   account and review the requested GitHub permissions. Link only
+   `benletchford/systemless` to the Gist. No repository PAT or custom GitHub
+   Actions workflow is required for the hosted setup.
+3. Record the Gist URL and revision, the source repository commit, CLA version,
+   and activation date in the private administration record. Keep the Gist text
+   fixed for v1.0. The service tracks Gist revisions and may request fresh
+   acceptance after edits, including cosmetic edits.
+4. Reconcile existing agreements using the procedure below.
+5. Exercise the acceptance flow on a real, unmerged contributor PR. Verify that
+   an unsigned contributor produces a failing CLA status and their own explicit
+   acceptance makes it pass. Verify repeat contributions and a PR with multiple
+   contributors. Unmapped commit authors or co-authors require manual review;
+   do not assume a green status establishes every contributor's rights.
+6. In GitHub repository settings, add the actual status emitted by the service
+   to the required checks for `master`, using a branch rule or ruleset. Select
+   the expected source app if GitHub offers it. Preserve existing protections.
+   Verify that the merge UI blocks an unsigned PR. A green bot comment alone
+   is not merge enforcement.
+7. Export the signature list from the dashboard and retain it privately with
+   the exact agreement revision. Back up exports periodically and before
+   changing providers or the agreement.
+
+After activation, new contributors follow the bot's signing link once.
+Returning contributors covered by that version pass automatically.
+
+## Recognising earlier agreements
+
+Review each original email, signed document, or GitHub acceptance before
+marking someone as covered. Verify identity, the exact terms accepted, and
+whether those terms cover future contributions and the needed commercial
+licensing permissions.
+
+Keep a private register with these fields:
+
+| Field | Purpose |
+| --- | --- |
+| GitHub login and numeric account ID | Match the contributor, including later renames |
+| Agreement version or exact text | Establish which permissions were granted |
+| Original acceptance date | Preserve the actual acceptance history |
+| Evidence location | Locate the original message or document |
+| Scope | Record whether past and future contributions are covered |
+| Reviewed by and review date | Identify who checked the evidence |
+| Service reconciliation method and date | Distinguish imports or exemptions from online signatures |
+
+Use the service's import facility for verified prior acceptances where its
+available format preserves the relevant identity and agreement version.
+Keep the original evidence even after import. Do not invent an online signing
+date, map different terms to v1.0 without review, or upload private correspondence.
+
+If import cannot represent an earlier agreement accurately, retain the evidence
+privately and use a narrowly scoped, documented service exemption where supported.
+An exemption is an administrative decision, not a signature. If neither route
+is suitable, request one-time online acceptance; do not bypass all CLA checks.
+
+Review bot exemptions individually. A bot account does not establish ownership
+or permission for the material it submits. Do not exempt all collaborators,
+all historical contributors, or wildcard usernames.
+
+## Routine handling
+
+- For an unsigned contributor, let the service request acceptance. Do not sign
+  on their behalf.
+- For missing prompts or stale statuses, check the service connection, linked
+  Gist, and GitHub identity, then request a service recheck.
+- If the service is unavailable, hold the merge or record explicit acceptance
+  and use the repository's documented, authorised exception process. Never
+  manufacture a passing status.
+- For substantive CLA changes, version the agreement deliberately, retain the
+  old text and acceptance evidence, update the linked Gist, and verify the new
+  acceptance flow. Earlier agreement rights are not erased by changing providers.
+- Coverage of third-party code, dependencies, and game assets still requires
+  separate licence review; a CLA check is not a complete rights audit.
+
+## References
+
+- [Hosted CLA Assistant documentation](https://github.com/cla-assistant/cla-assistant#readme)
+- [Systemless licensing](../LICENSING.md)
+- The separate [CLA Assistant GitHub Action](https://github.com/contributor-assistant/github-action)
+  is archived. This setup uses the hosted service instead.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,3 +5,15 @@
 ## Validation
 
 <!-- List the checks you ran and any relevant manual testing. -->
+
+## Contributor agreement
+
+First contribution? Please read [CLA.md](https://github.com/benletchford/systemless/blob/master/CLA.md)
+and follow the CLA Assistant prompt when available. Acceptance is needed once
+per contributor for the same agreement version, not once per PR.
+
+Already agreed by email or on GitHub? Let the maintainer know where to find the
+existing agreement without posting private correspondence here. If no bot
+prompt appears, ask the maintainer to confirm acceptance before merge.
+
+<!-- This notice is not an acceptance or signature. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,29 @@ the project.
 
 Existing GPL rights remain unaffected.
 
+### Accept once
+
+Before a contribution is merged, each contributor must explicitly accept
+[CLA version 1.0](./CLA.md). That acceptance covers past, present, and future
+contributions as described in the agreement; you do not need to sign every PR.
+
+When CLA Assistant is enabled, follow its link on your first pull request and
+accept using your own GitHub account. Later PRs are checked automatically for
+the same agreement version. A PR author cannot accept on behalf of other
+contributors unless authorised to do so.
+
+If you have already agreed by email or in a previous GitHub conversation, tell
+the maintainer where that agreement was recorded. Do not post private emails
+or personal information publicly. The maintainer can recognise an existing
+agreement after checking its scope and your identity.
+
+If no CLA Assistant prompt appears, ask the maintainer to confirm your
+acceptance before merge. Opening a PR or leaving this template in place does
+not itself constitute acceptance.
+
+Maintainers: see [CLA administration](./.github/CLA_ADMIN.md) for activation,
+existing agreements, and verification.
+
 If you are not comfortable with those terms, that's completely fine. Please
 open an issue instead and we can discuss the change without accepting
 contributed code.


### PR DESCRIPTION
## Why

Systemless has contributor terms but no documented acceptance process or automated CLA gate. Manually chasing every PR adds administration and makes it harder to identify which contributions are covered for separately licensed releases.

## Changes

- Explain one-time acceptance in CONTRIBUTING.md, including returning contributors, previous agreements, and a fallback when no bot prompt appears.
- Add a short PR-template notice directing contributors to the signing flow without treating the template itself as acceptance.
- Add a maintainer runbook for hosted CLA Assistant: exact-text Gist creation, connection, reconciliation of prior agreements, required checks, and acceptance verification.

The GPL licence and CLA v1.0 text are unchanged. No contributor signatures or exemptions are fabricated. This uses the hosted service, not the archived CLA Assistant GitHub Action.

## Activation required outside this PR

This is repository preparation, not a live CLA integration. Merging alone does not enable automated signing or merge enforcement.

- [x] Create the exact-text CLA Gist and link benletchford/systemless at cla-assistant.io.
- [x] Review original prior agreements and reconcile verified contributors.
- [x] Verify unsigned, signed, returning, and multi-contributor PR behaviour.
- [ ] Require the emitted CLA status for master and confirm unsigned PRs cannot merge.

These steps need the maintainer's service sign-in and repository settings access. Existing agreement evidence was not available for review in this change.

## Validation

- Checked every relative documentation link against the repository tree.
- Confirmed only the three intended Markdown files change.
- Confirmed LICENSE and CLA.md remain unchanged.
- Reviewed setup instructions against the hosted service documentation and its signature-upload implementation.
- Runtime tests not run: documentation only. Hosted acceptance and merge blocking remain untested until activation.
